### PR TITLE
feat(terminals): add tmux control-mode web-terminal transport

### DIFF
--- a/omnigent/entities/session_resources.py
+++ b/omnigent/entities/session_resources.py
@@ -159,8 +159,29 @@ def terminal_resource_view(session_id: str, entry: TerminalListEntry) -> Session
             "running": entry.instance.running,
             "tmux_socket": str(entry.instance.socket_path),
             "tmux_target": entry.instance.tmux_target,
+            # Effective web-attach transport (``"pty"`` / ``"control"``) absent
+            # a per-attach ``?transport=`` override, so the browser can pick
+            # the matching mouse/selection behavior. Control mode lets xterm
+            # own scrollback + selection; PTY mode still needs the modifier
+            # workarounds + hint bar.
+            "terminal_transport": _resolve_transport_for_view(entry),
         },
     )
+
+
+def _resolve_transport_for_view(entry: TerminalListEntry) -> str:
+    """Resolve a terminal's default web-attach transport for metadata.
+
+    Mirrors :func:`omnigent.inner.terminal.resolve_terminal_transport` with no
+    per-attach override — the spec's declared transport, else the global
+    default. Imported lazily to keep this projection import-light.
+
+    :param entry: The terminal registry entry to project.
+    :returns: ``"pty"`` or ``"control"``.
+    """
+    from omnigent.inner.terminal import resolve_terminal_transport
+
+    return resolve_terminal_transport(spec_transport=entry.instance.terminal_transport)
 
 
 def _terminal_environment_resource(

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -728,6 +728,13 @@ class TerminalEnvSpec:
         into ``no server running``. Opt-in because it changes the
         ``has-session``-means-alive contract; enabled for the claude-native
         agent terminal (#540), whose liveness is decided by ``#{pane_dead}``.
+    :param terminal_transport: How the web UI attaches to this terminal:
+        ``"control"`` (``tmux -C`` control mode, giving the browser xterm
+        native scrollback + selection — the default) or ``"pty"`` (the legacy
+        forked-``tmux attach`` PTY stream). ``None`` defers to the global
+        default, which is control mode unless ``terminal.transport`` in
+        ``~/.omnigent/config.yaml`` opts out to ``pty``. A per-attach
+        ``?transport=`` query overrides both.
     """
 
     command: str | None = None
@@ -744,6 +751,7 @@ class TerminalEnvSpec:
     tmux_allow_passthrough: bool = False
     tmux_start_on_attach: bool = False
     keep_alive_after_exit: bool = False
+    terminal_transport: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -55,6 +55,130 @@ logger = logging.getLogger(__name__)
 
 _TMUX_CONFIG_PATH = os.devnull
 _TMUX_CONVERSATION_LINK_OPTION = "@omnigent-conversation-link"
+
+# Web-terminal attach transports. ``pty`` forks a full ``tmux attach`` client
+# and streams the rendered screen (see terminals/ws_bridge.py); ``control``
+# attaches a ``tmux -C`` control-mode client and streams per-pane ``%output``
+# so the browser xterm owns scrollback + selection (see
+# terminals/control_bridge.py). Both speak the identical browser wire protocol
+# so they are interchangeable per attach.
+TERMINAL_TRANSPORT_PTY = "pty"
+TERMINAL_TRANSPORT_CONTROL = "control"
+_VALID_TERMINAL_TRANSPORTS = frozenset({TERMINAL_TRANSPORT_PTY, TERMINAL_TRANSPORT_CONTROL})
+# Values that select the PTY path in the config file, beyond the canonical
+# ``pty`` name — the common falsy spellings so ``transport: false`` / ``: off``
+# reads as PTY. Any other value (including ``control`` and truthy spellings)
+# falls through to the control default.
+_TRANSPORT_PTY_ALIASES = frozenset({TERMINAL_TRANSPORT_PTY, "0", "false", "no", "off"})
+# Config-file location for the global default (``~/.omnigent/config.yaml``,
+# honoring ``OMNIGENT_CONFIG_HOME`` for test isolation — same resolution the
+# runner and CLI use). The transport lives under the ``terminal:`` table as
+# ``terminal.transport``.
+_CONFIG_HOME_ENV_VAR = "OMNIGENT_CONFIG_HOME"
+_TERMINAL_CONFIG_TABLE = "terminal"
+_TERMINAL_TRANSPORT_CONFIG_KEY = "transport"
+
+
+def _global_config_path() -> Path:
+    """Return the global Omnigent config path visible to this process.
+
+    Mirrors :func:`omnigent.runner._entry._runner_config_path` (kept local to
+    avoid an inner→runner import): honors :envvar:`OMNIGENT_CONFIG_HOME` for
+    test isolation and subprocess consistency, else ``~/.omnigent/config.yaml``.
+
+    :returns: Config path, e.g. ``Path("~/.omnigent/config.yaml")``.
+    """
+    config_home = os.environ.get(_CONFIG_HOME_ENV_VAR)
+    if config_home:
+        return Path(config_home).expanduser() / "config.yaml"
+    return Path.home() / ".omnigent" / "config.yaml"
+
+
+def _global_terminal_transport_default() -> str:
+    """Resolve the process-wide default web-terminal transport from config.
+
+    Reads ``terminal.transport`` from ``~/.omnigent/config.yaml`` at call time
+    (not import time) so a config edit takes effect on the next attach without
+    a restart, and tests can point :envvar:`OMNIGENT_CONFIG_HOME` at a scratch
+    config. Control mode is the default; set ``terminal.transport`` to a PTY
+    alias to opt out. Recognized values (case-insensitive):
+
+    - Missing / ``control`` / ``1`` / ``true`` / ``yes`` / ``on`` → ``control``.
+    - ``pty`` / ``0`` / ``false`` / ``no`` / ``off`` → ``pty``.
+    - Anything else → ``control`` (the default), so a typo can't strand an
+      operator on the legacy path.
+
+    A missing file, unreadable file, malformed YAML, or missing key all fall
+    back to the control default — reading the transport must never crash an
+    attach.
+
+    :returns: ``"control"`` or ``"pty"``.
+    """
+    raw = _read_terminal_transport_config()
+    if raw is not None and raw.strip().lower() in _TRANSPORT_PTY_ALIASES:
+        return TERMINAL_TRANSPORT_PTY
+    return TERMINAL_TRANSPORT_CONTROL
+
+
+def _read_terminal_transport_config() -> str | None:
+    """Read ``terminal.transport`` from the global config, or ``None``.
+
+    Best-effort: any failure (missing/unreadable file, non-mapping YAML,
+    absent table/key, non-string value) returns ``None`` so the caller uses
+    the control default. Never raises.
+
+    :returns: The raw configured transport string, or ``None`` when unset.
+    """
+    import yaml
+
+    path = _global_config_path()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    table = raw.get(_TERMINAL_CONFIG_TABLE)
+    if not isinstance(table, dict):
+        return None
+    value = table.get(_TERMINAL_TRANSPORT_CONFIG_KEY)
+    return value if isinstance(value, str) else None
+
+
+def resolve_terminal_transport(
+    *,
+    override: str | None = None,
+    spec_transport: str | None = None,
+) -> str:
+    """Pick the web-terminal attach transport for one attach.
+
+    Resolution order (first match wins):
+
+    1. ``override`` — a per-attach ``?transport=control|pty`` query, letting a
+       dev A/B two open terminals side by side right now.
+    2. ``spec_transport`` — the per-terminal / per-harness
+       :attr:`TerminalEnvSpec.terminal_transport`, the gradual-rollout dial.
+    3. The global default from :func:`_global_terminal_transport_default`
+       — ``control`` unless ``terminal.transport`` in ``~/.omnigent/config.yaml``
+       opts out to ``pty``.
+
+    Unrecognized values at any level are ignored (fall through) so a stray
+    query string can never break an attach.
+
+    :param override: Per-attach transport request, e.g. ``"control"``.
+    :param spec_transport: The terminal spec's declared transport, or ``None``.
+    :returns: ``"control"`` or ``"pty"``.
+    """
+    for candidate in (override, spec_transport):
+        if candidate is not None and candidate.strip().lower() in _VALID_TERMINAL_TRANSPORTS:
+            return candidate.strip().lower()
+    return _global_terminal_transport_default()
+
+
 _TMUX_START_ON_ATTACH_CHANNEL = "omnigent-start-on-attach"
 # Each terminal instance lives in a private tmpdir with this prefix
 # (see ``create_terminal_instance``). The owner-pid marker inside it
@@ -784,6 +908,11 @@ class TerminalInstance:
     # Enabled for the claude-native agent terminal so a single inner-CLI exit no
     # longer reaps the server and cascades into ``no server running`` (#540).
     keep_alive_after_exit: bool = False
+    # Preferred web-attach transport for this terminal (``"pty"`` /
+    # ``"control"``), or ``None`` to defer to the global default. Read by the
+    # attach routes via :func:`resolve_terminal_transport`; does not affect how
+    # the tmux server itself is launched.
+    terminal_transport: str | None = None
     running: bool = False
     launch_cwd: str | None = None
     # Owned per-launch egress proxy. ``None`` when the sandbox
@@ -1840,6 +1969,7 @@ def create_terminal_instance(
         tmux_allow_passthrough=spec.tmux_allow_passthrough,
         tmux_start_on_attach=spec.tmux_start_on_attach,
         keep_alive_after_exit=spec.keep_alive_after_exit,
+        terminal_transport=spec.terminal_transport,
     )
 
     return TerminalCreateResult(instance=instance, cwd=cwd)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -82,6 +82,7 @@ from omnigent.runner.resource_registry import (
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager, NoLiveHarnessError
 from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
 from omnigent.spec.types import AgentSpec, LocalToolInfo, SkillSpec
+from omnigent.terminals.control_bridge import bridge_tmux_control_to_websocket
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_TERMINAL_NOT_FOUND,
     bridge_tmux_pty_to_websocket,
@@ -16864,6 +16865,7 @@ def create_runner_app(
         session_id: str,
         terminal_id: str,
         read_only: bool = Query(default=False),
+        transport: str | None = Query(default=None),
     ) -> None:
         """Attach to a terminal resource by id via WebSocket.
 
@@ -16926,7 +16928,21 @@ def create_runner_app(
         )
         _COST_POPUP_REPOP_TASKS.add(_repop_task)
         _repop_task.add_done_callback(_COST_POPUP_REPOP_TASKS.discard)
-        await bridge_tmux_pty_to_websocket(
+        from omnigent.inner.terminal import (
+            TERMINAL_TRANSPORT_CONTROL,
+            resolve_terminal_transport,
+        )
+
+        resolved_transport = resolve_terminal_transport(
+            override=transport,
+            spec_transport=entry.instance.terminal_transport,
+        )
+        bridge = (
+            bridge_tmux_control_to_websocket
+            if resolved_transport == TERMINAL_TRANSPORT_CONTROL
+            else bridge_tmux_pty_to_websocket
+        )
+        await bridge(
             websocket,
             socket_path=str(entry.instance.socket_path),
             tmux_target=entry.instance.tmux_target,

--- a/omnigent/server/routes/terminal_attach.py
+++ b/omnigent/server/routes/terminal_attach.py
@@ -88,6 +88,7 @@ from omnigent.server.auth import LEVEL_OWNER, LEVEL_READ, AuthProvider
 from omnigent.server.routes._auth_helpers import require_access
 from omnigent.stores import ConversationStore
 from omnigent.stores.permission_store import PermissionStore
+from omnigent.terminals.control_bridge import bridge_tmux_control_to_websocket
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_INTERNAL_ERROR,
     WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -133,19 +134,24 @@ def create_terminal_attach_router(
         session_id: str,
         terminal_id: str,
         read_only: bool = Query(default=False),
+        transport: str | None = Query(default=None),
     ) -> None:
         """
         Attach to a terminal by resource id via WebSocket.
 
         Proxies to the runner's resource-addressed WS endpoint when a
         runner tunnel factory is installed, or falls back to resolving
-        the terminal id locally and bridging the PTY in-process.
+        the terminal id locally and bridging in-process.
 
         :param websocket: The accepted FastAPI :class:`WebSocket`.
         :param session_id: Session/conversation identifier.
         :param terminal_id: Opaque terminal resource id,
             e.g. ``"terminal_bash_s1"``.
         :param read_only: Pass ``-r`` to tmux when ``True``.
+        :param transport: Optional per-attach transport override
+            (``"control"`` / ``"pty"``); forwarded to the runner and used to
+            pick the control-mode vs PTY bridge in-process. ``None`` defers to
+            the terminal spec / global default.
         """
         from omnigent.entities.session_resources import (
             resolve_terminal_entry_by_resource_id,
@@ -165,11 +171,10 @@ def create_terminal_attach_router(
         if ws_factory is not None:
             from urllib.parse import urlencode
 
-            qs = urlencode(
-                {
-                    "read_only": "true" if read_only else "false",
-                }
-            )
+            qs_params = {"read_only": "true" if read_only else "false"}
+            if transport is not None:
+                qs_params["transport"] = transport
+            qs = urlencode(qs_params)
             runner_path = (
                 f"/v1/sessions/{session_id}/resources/terminals/{terminal_id}/attach?{qs}"
             )
@@ -235,8 +240,16 @@ def create_terminal_attach_router(
             )
             return
 
+        from omnigent.inner.terminal import (
+            TERMINAL_TRANSPORT_CONTROL,
+            resolve_terminal_transport,
+        )
         from omnigent.runtime import telemetry
 
+        resolved_transport = resolve_terminal_transport(
+            override=transport,
+            spec_transport=entry.instance.terminal_transport,
+        )
         with telemetry.span(
             "terminal.attach",
             attributes={
@@ -244,9 +257,15 @@ def create_terminal_attach_router(
                 "terminal.id": terminal_id,
                 "terminal.read_only": read_only,
                 "terminal.mode": "in-process",
+                "terminal.transport": resolved_transport,
             },
         ):
-            await bridge_tmux_pty_to_websocket(
+            bridge = (
+                bridge_tmux_control_to_websocket
+                if resolved_transport == TERMINAL_TRANSPORT_CONTROL
+                else bridge_tmux_pty_to_websocket
+            )
+            await bridge(
                 websocket,
                 socket_path=str(entry.instance.socket_path),
                 tmux_target=entry.instance.tmux_target,

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -1,0 +1,496 @@
+"""Shared tmux control-mode (``tmux -C``) ↔ WebSocket bridge.
+
+Alternative transport to :mod:`omnigent.terminals.ws_bridge`. Where the PTY
+bridge forks a full ``tmux attach`` client and streams the rendered screen,
+this bridge attaches a *control-mode* client and consumes tmux's line protocol:
+
+- ``%output <pane-id> <octal-escaped-bytes>`` — the raw bytes the program in a
+  pane just produced, forwarded to the browser xterm.js as binary frames. The
+  browser terminal therefore owns the character grid, scrollback, and text
+  selection (tmux's own status line / copy-mode chrome is never streamed to a
+  control client), which is what gives native scrolling and copy in the web UI.
+- ``%begin <t> <n> <flags>`` … ``%end``/``%error <t> <n> <flags>`` — bracketed
+  reply blocks for commands the bridge sends, correlated by command number.
+- ``%exit`` / ``%window-close`` / ``%layout-change`` — lifecycle + structure.
+
+Design notes learned from the protocol (see ``control_bridge`` spike):
+
+- Attach with ``-C`` (NOT ``-CC``): ``-CC`` requires the parent be a real
+  terminal and the client exits immediately when stdin/stdout are pipes. ``-C``
+  gives the same protocol with echo already off, which is what we want for a
+  programmatic consumer reading/writing pipes.
+- A control client only receives ``%output`` produced *after* it attaches, so
+  the bridge seeds the browser terminal with ``capture-pane -e -p`` (escapes
+  preserved) once on connect, then streams subsequent ``%output``.
+- Browser input bytes are injected with ``send-keys -H <hh> <hh> ...``
+  (space-separated hex, one token per byte). Feeding raw ESC/control bytes into
+  a ``send-keys -l`` command line corrupts the line-based command parser and
+  the client exits; the hex channel is byte-exact for ESC sequences, control
+  chars, and UTF-8 multibyte alike.
+
+The browser-facing wire protocol is identical to the PTY bridge (binary frames
+out = raw pane bytes; text frames in = JSON ``{"type":"resize",...}``; binary
+frames in = input bytes), so the two transports are interchangeable behind the
+same ``/attach`` WebSocket and a client cannot tell which one served it.
+
+Known limitation vs the PTY bridge: tmux's own overlays (``display-popup``,
+copy-mode, status line) are NOT delivered to a control-mode client, so the
+native cost-approval popup (:mod:`omnigent.native_cost_popup`) does not render
+in a control-mode browser terminal. That popup is a secondary convenience for
+users working in a real native TTY; the web ApprovalCard (SSE-driven) remains
+the primary approval surface and is unaffected. The harnesses' own input,
+paste, and readiness logic run tmux commands directly against the socket
+(``send-keys``/``load-buffer``/``capture-pane``) and are independent of the
+attach transport, so they behave identically under either bridge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import re
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Final
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+# Re-export the PTY bridge's application close codes so both transports speak
+# the same dialect to the frontend reconnect logic (see ws_bridge for the
+# authoritative definitions and the client-side classification).
+from omnigent.terminals.ws_bridge import (
+    WS_CLOSE_INTERNAL_ERROR,
+    WS_CLOSE_TERMINAL_DETACHED,
+    WS_CLOSE_TERMINAL_NOT_FOUND,
+)
+
+_logger = logging.getLogger(__name__)
+
+__all__ = [
+    "bridge_tmux_control_to_websocket",
+    "unescape_control_output",
+]
+
+# tmux octal-escapes bytes < 0x20 and backslash in %output values as ``\ooo``.
+_OCTAL_ESCAPE_RE: Final = re.compile(rb"\\([0-7]{3})")
+
+# ``capture-pane -p`` joins rows with a bare LF. Match an LF not already
+# preceded by CR so the CRLF rewrite is idempotent (a future tmux emitting
+# CRLF is left untouched).
+_CAPTURE_ROW_SEP_RE: Final = re.compile(rb"(?<!\r)\n")
+
+# tmux's client→server protocol rejects a single command larger than its 16KB
+# imsg cap. ``send-keys -H`` expands each input byte to 3 chars ("xx "), so cap
+# the bytes per send-keys invocation well under the limit. 1024 bytes ≈ 3KB
+# packed; tmux applies successive invocations in order so the pane sees one
+# contiguous stream. Matches terminal.py's literal-send chunking rationale.
+_SEND_KEYS_HEX_BYTES_PER_CALL: Final[int] = 1024
+
+# StreamReader line-length cap for the control client's stdout. In practice
+# tmux 3.6b chunks control-mode ``%output`` into small lines (a few KB even for
+# a 500 KB burst of octal-escaped control bytes on a huge pane), so lines stay
+# far under asyncio's 64 KiB default. But that chunk size is a tmux internal,
+# not a documented guarantee — a different version/build emitting one line past
+# 64 KiB would make ``readline()`` raise ``LimitOverrunError`` and crash the
+# reader (a disconnect/reconnect loop under burst output the PTY bridge handles
+# fine). Raising the cap to 16 MiB removes that failure mode for negligible
+# cost; it is a safety ceiling, not a steady buffer.
+_CONTROL_STDOUT_LINE_LIMIT: Final[int] = 16 * 1024 * 1024
+
+
+def unescape_control_output(value: bytes) -> bytes:
+    """Un-escape a ``%output`` value back to raw pane bytes.
+
+    tmux escapes bytes below ASCII space and the backslash itself as a
+    three-digit octal sequence ``\\ooo``; every other byte passes through
+    verbatim. The decoded result is a raw terminal byte stream (not guaranteed
+    valid UTF-8) suitable to write straight into xterm.js.
+
+    :param value: The escaped bytes following ``%output <pane-id> `` on one
+        protocol line, e.g. ``rb"\\033[31mRED\\033[0m\\015\\012"``.
+    :returns: The raw bytes, e.g. ``b"\\x1b[31mRED\\x1b[0m\\r\\n"``.
+    """
+    return _OCTAL_ESCAPE_RE.sub(lambda m: bytes([int(m.group(1), 8)]), value)
+
+
+def _hex_send_keys_commands(target: str, data: bytes) -> list[bytes]:
+    """Build ``send-keys -H`` control-mode command line(s) for raw input bytes.
+
+    :param target: The tmux target the keys are sent to, e.g. ``"main"``.
+    :param data: Raw input bytes from the browser (keystrokes, paste, mouse
+        reports, ESC sequences).
+    :returns: One or more newline-terminated command lines, each carrying at
+        most :data:`_SEND_KEYS_HEX_BYTES_PER_CALL` bytes as space-separated hex.
+    """
+    commands: list[bytes] = []
+    for start in range(0, len(data), _SEND_KEYS_HEX_BYTES_PER_CALL):
+        chunk = data[start : start + _SEND_KEYS_HEX_BYTES_PER_CALL]
+        hexs = " ".join(f"{b:02x}" for b in chunk)
+        commands.append(f"send-keys -t {target} -H {hexs}\n".encode())
+    return commands
+
+
+async def _run_tmux_capture(socket_path: str, tmux_target: str) -> bytes | None:
+    """Capture the current pane screen (with escapes) to seed the browser view.
+
+    A control client only receives ``%output`` produced after it attaches, so
+    the pane's pre-attach content must be seeded explicitly. ``-e`` preserves
+    SGR/color escapes so the seed paints identically to the live pane.
+
+    ``capture-pane -p`` separates rows with a **bare LF** (``\\n``, no carriage
+    return). Written verbatim into xterm.js each LF moves the cursor down but
+    not to column 0, so every row starts where the previous one ended — the
+    whole seed staircases to the right. We rewrite each row separator to
+    ``\\r\\n`` so the grid paints flush-left, matching the live ``%output``
+    stream (which already carries CRLF). Home + clear (``\\x1b[H\\x1b[2J``) is
+    prepended so the seed lands on a clean screen at the top-left.
+
+    ``capture-pane`` records only the cell contents, not the cursor. Writing
+    the seed leaves the browser cursor wherever the last row ended, not where
+    the application actually parked it (e.g. inside a prompt input box). We
+    query ``#{cursor_x}`` / ``#{cursor_y}`` and append a CUP escape so the
+    cursor is restored to its real position, and honor ``#{cursor_flag}`` so a
+    hidden cursor stays hidden.
+
+    **Scrollback**, conditioned on the screen mode:
+
+    - **Primary screen** (a shell, the polly REPL): capture from the start of
+      history (``-S -``) so the browser recovers the full scrollback, not just
+      the visible screen. The extra history lines scroll into xterm's own
+      scrollback as they're written; the cursor CUP is screen-relative so it
+      still lands correctly on the visible grid.
+    - **Alternate screen** (claude, codex, vim): capture the visible screen
+      only. The alternate buffer has no scrollback, and ``-S -`` would leak the
+      stale *primary*-screen history from before the app switched buffers —
+      lines that were never part of the app's UI — corrupting the seed. tmux's
+      ``#{alternate_on}`` distinguishes the two.
+
+    :param socket_path: tmux server socket path.
+    :param tmux_target: The ``-t`` target, e.g. ``"main"``.
+    :returns: The captured bytes to write into xterm, or ``None`` on failure
+        (the caller proceeds without a seed rather than aborting the attach).
+    """
+    tmux = shutil.which("tmux")
+    if tmux is None:
+        return None
+    meta = await _capture_pane_metadata(tmux, socket_path, tmux_target)
+    # Only extend the capture into history when on the primary screen; on the
+    # alternate screen ``-S -`` leaks stale primary history (see docstring).
+    capture_args = ["capture-pane", "-e", "-p", "-t", tmux_target]
+    if meta is not None and not meta.alternate_on:
+        capture_args += ["-S", "-"]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            tmux,
+            "-S",
+            socket_path,
+            *capture_args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await proc.communicate()
+    except (OSError, ValueError):
+        return None
+    if proc.returncode != 0:
+        return None
+    # ``capture-pane -p`` emits one LF per row — INCLUDING a trailing LF after
+    # the final row. Writing that trailing separator paints the last row and
+    # then advances the cursor past it, which on a full-height pane scrolls the
+    # whole screen up by one line (the "extra line" / off-by-one). Strip the
+    # single trailing newline so the last row is painted with no line break
+    # after it; the cursor-restore escape then lands on the correct row.
+    body = stdout[:-1] if stdout.endswith(b"\n") else stdout
+    # Normalize the remaining bare-LF row separators to CRLF (see docstring) and
+    # paint onto a cleared screen from the home cursor so the seed can't
+    # staircase.
+    normalized = _CAPTURE_ROW_SEP_RE.sub(b"\r\n", body)
+    cursor = _cursor_restore_escape(meta)
+    return b"\x1b[H\x1b[2J" + normalized + cursor
+
+
+@dataclass(frozen=True)
+class _PaneMetadata:
+    """Pane state needed to reconstruct the seed: cursor + screen mode.
+
+    :param cursor_x: 0-based cursor column from ``#{cursor_x}``.
+    :param cursor_y: 0-based cursor row from ``#{cursor_y}``.
+    :param cursor_visible: Whether ``#{cursor_flag}`` reported the cursor shown.
+    :param alternate_on: Whether the pane is on the alternate screen
+        (``#{alternate_on}`` == 1).
+    """
+
+    cursor_x: int
+    cursor_y: int
+    cursor_visible: bool
+    alternate_on: bool
+
+
+async def _capture_pane_metadata(
+    tmux: str, socket_path: str, tmux_target: str
+) -> _PaneMetadata | None:
+    """Query cursor position, cursor visibility, and alt-screen state.
+
+    One ``display-message`` fetches every field the seed needs. Returns
+    ``None`` on any failure — the caller degrades gracefully (skips the
+    history extension and the cursor restore) rather than aborting the attach.
+
+    :param tmux: Absolute path to the tmux binary.
+    :param socket_path: tmux server socket path.
+    :param tmux_target: The ``-t`` target, e.g. ``"main"``.
+    :returns: The parsed :class:`_PaneMetadata`, or ``None`` if unavailable.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            tmux,
+            "-S",
+            socket_path,
+            "display-message",
+            "-p",
+            "-t",
+            tmux_target,
+            "#{cursor_x},#{cursor_y},#{cursor_flag},#{alternate_on}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await proc.communicate()
+    except (OSError, ValueError):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        x_str, y_str, flag_str, alt_str = stdout.decode().strip().split(",")
+        return _PaneMetadata(
+            cursor_x=int(x_str),
+            cursor_y=int(y_str),
+            cursor_visible=flag_str.strip() == "1",
+            alternate_on=alt_str.strip() == "1",
+        )
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+def _cursor_restore_escape(meta: _PaneMetadata | None) -> bytes:
+    """Build the escape that restores the pane cursor after a seed.
+
+    :param meta: Pane metadata from :func:`_capture_pane_metadata`, or ``None``.
+    :returns: A CUP escape (``\\x1b[{row};{col}H``, 1-based) plus a show/hide
+        escape matching the pane's cursor visibility, or ``b""`` when *meta* is
+        ``None`` (a missing cursor restore is cosmetic, never fatal).
+    """
+    if meta is None:
+        return b""
+    # tmux cursor_x/y are 0-based; CUP is 1-based.
+    cup = f"\x1b[{meta.cursor_y + 1};{meta.cursor_x + 1}H".encode()
+    visibility = b"\x1b[?25h" if meta.cursor_visible else b"\x1b[?25l"
+    return cup + visibility
+
+
+async def bridge_tmux_control_to_websocket(
+    websocket: WebSocket,
+    *,
+    socket_path: str,
+    tmux_target: str,
+    read_only: bool,
+    on_client_interaction: Callable[[], None] | None = None,
+) -> None:
+    """Bridge a tmux control-mode client to an already-accepted *websocket*.
+
+    Drop-in alternative to
+    :func:`omnigent.terminals.ws_bridge.bridge_tmux_pty_to_websocket` with the
+    same signature and browser wire protocol. Caller must have called
+    ``websocket.accept()``. On exit (any branch) the control client is torn
+    down and the websocket closed best-effort with the shared 4404/4405 codes.
+
+    :param websocket: An accepted FastAPI :class:`WebSocket`.
+    :param socket_path: Filesystem path to the tmux server socket.
+    :param tmux_target: The ``-t`` target string identifying the session.
+    :param read_only: When ``True``, attach with ``-r`` *and* drop inbound
+        binary input frames at the application layer (defense in depth).
+    :param on_client_interaction: Optional callback fired on every client
+        interaction (connect, disconnect, each input/resize frame) so the
+        idle watcher can discount client-driven repaints. See the PTY bridge
+        for the full rationale.
+    """
+    # Attaching reflows the pane to this client's size — stamp it as a client
+    # interaction so the idle watcher discounts the resulting repaint.
+    if on_client_interaction is not None:
+        on_client_interaction()
+
+    tmux = shutil.which("tmux")
+    if tmux is None:
+        _logger.error("tmux not found on PATH; cannot control-attach target=%s", tmux_target)
+        with contextlib.suppress(RuntimeError):
+            await websocket.close(code=WS_CLOSE_INTERNAL_ERROR, reason="tmux not found")
+        return
+
+    # Seed the browser terminal with the current screen BEFORE attaching so no
+    # pre-attach content is missing. Failure is non-fatal — a live pane redraw
+    # will repaint it shortly.
+    seed = await _run_tmux_capture(socket_path, tmux_target)
+    if seed:
+        with contextlib.suppress(RuntimeError, WebSocketDisconnect):
+            await websocket.send_bytes(seed)
+
+    argv = [tmux, "-S", socket_path, "-f", "/dev/null", "-C", "attach"]
+    if read_only:
+        argv.append("-r")
+    argv += ["-t", tmux_target]
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            # Raise the stdout StreamReader line cap well above the 64 KiB
+            # default so an oversized ``%output`` line can't crash the reader
+            # (see _CONTROL_STDOUT_LINE_LIMIT).
+            limit=_CONTROL_STDOUT_LINE_LIMIT,
+        )
+    except (OSError, ValueError):
+        _logger.exception("control-attach spawn failed target=%s", tmux_target)
+        with contextlib.suppress(RuntimeError):
+            await websocket.close(code=WS_CLOSE_INTERNAL_ERROR, reason="control attach failed")
+        return
+
+    assert proc.stdin is not None and proc.stdout is not None
+    stdin = proc.stdin
+    stdout = proc.stdout
+
+    async def _send_command(line: bytes) -> None:
+        """Write one newline-terminated control command, ignoring a dead pipe."""
+        if stdin.is_closing():
+            return
+        try:
+            stdin.write(line)
+            await stdin.drain()
+        except (ConnectionResetError, BrokenPipeError, OSError):
+            return
+
+    async def _control_to_ws() -> None:
+        """Read tmux control-protocol lines; forward %output, watch lifecycle."""
+        while True:
+            line = await stdout.readline()
+            if not line:
+                # tmux control client closed its stdout — server/session gone.
+                return
+            line = line.rstrip(b"\r\n")
+            if line.startswith(b"%output "):
+                # %output %<pane-id> <escaped-bytes>
+                parts = line.split(b" ", 2)
+                if len(parts) == 3:
+                    raw = unescape_control_output(parts[2])
+                    try:
+                        await websocket.send_bytes(raw)
+                    except (RuntimeError, WebSocketDisconnect):
+                        return
+            elif line.startswith(b"%exit"):
+                return
+            elif line.startswith(b"%window-close"):
+                # The single-pane session's only window closing means the pane
+                # is gone. Let the exit path decide detach-vs-gone via a
+                # liveness probe. (%pane-mode-changed — copy-mode enter/leave —
+                # is deliberately NOT a close trigger.)
+                return
+            # %begin/%end/%error reply blocks and other notifications
+            # (%layout-change, %session-changed, %window-*) need no browser
+            # forwarding — the browser xterm renders purely from %output.
+
+    async def _ws_to_control() -> None:
+        """Read browser frames; resize via refresh-client -C, input via -H hex."""
+        try:
+            while True:
+                msg = await websocket.receive()
+                if on_client_interaction is not None:
+                    on_client_interaction()
+                if msg.get("type") == "websocket.disconnect":
+                    return
+                text = msg.get("text")
+                data = msg.get("bytes")
+                if text is not None:
+                    try:
+                        ctl = json.loads(text)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    if isinstance(ctl, dict) and ctl.get("type") == "resize":
+                        try:
+                            cols = int(ctl["cols"])
+                            rows = int(ctl["rows"])
+                        except (KeyError, TypeError, ValueError):
+                            continue
+                        await _send_command(f"refresh-client -C {cols}x{rows}\n".encode())
+                elif data is not None and not read_only:
+                    for cmd in _hex_send_keys_commands(tmux_target, data):
+                        await _send_command(cmd)
+        except WebSocketDisconnect:
+            return
+
+    # Do NOT prime a default size. A control client leaves the window size
+    # untouched until it issues its first ``refresh-client -C``, so priming
+    # 80x24 here would shrink the window on attach and then grow it again the
+    # instant the browser reports its real dimensions — two spurious SIGWINCHes
+    # per attach (visible as a resize bounce every time the terminal is
+    # re-mounted, e.g. toggling transcript mode). Instead we wait for the
+    # browser's first resize message; tmux dedupes a ``refresh-client -C`` that
+    # matches the current window size, so a re-attach at an unchanged size emits
+    # no resize at all.
+
+    control_task = asyncio.create_task(_control_to_ws(), name="tmux-control-to-ws")
+    ws_task = asyncio.create_task(_ws_to_control(), name="tmux-ws-to-control")
+    control_ended_first = False
+    try:
+        done, pending = await asyncio.wait(
+            {control_task, ws_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        control_ended_first = control_task in done
+        for task in pending:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        for task in done:
+            exc = task.exception()
+            if exc is not None:
+                _logger.warning("control-attach: bridge task crashed: %r", exc)
+    finally:
+        # Detach reflows the pane back to remaining clients — stamp it.
+        if on_client_interaction is not None:
+            on_client_interaction()
+        # Detach the control client: an empty command line detaches cleanly.
+        await _send_command(b"\n")
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(proc.wait(), timeout=2.0)
+        if proc.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+        with contextlib.suppress(RuntimeError):
+            if control_ended_first:
+                # The control client ended: distinguish a genuine session-gone
+                # (%exit with a dead/absent pane) from a mere detach. Reuse the
+                # PTY bridge's pane-dead probe for a single source of truth.
+                from omnigent.terminals.ws_bridge import (
+                    _check_pane_dead_definitive,
+                    _tmux_session_alive,
+                )
+
+                pane_dead = await _check_pane_dead_definitive(socket_path, tmux_target)
+                if pane_dead is True or (
+                    pane_dead is None and not await _tmux_session_alive(socket_path, tmux_target)
+                ):
+                    await websocket.close(
+                        code=WS_CLOSE_TERMINAL_NOT_FOUND,
+                        reason="terminal session ended",
+                    )
+                else:
+                    await websocket.close(
+                        code=WS_CLOSE_TERMINAL_DETACHED,
+                        reason="terminal detached",
+                    )
+            else:
+                await websocket.close()

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -16,10 +16,63 @@ import pytest
 import omnigent.inner.terminal as terminal_mod
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
 from omnigent.inner.terminal import (
+    TERMINAL_TRANSPORT_CONTROL,
+    TERMINAL_TRANSPORT_PTY,
     TerminalInstance,
     create_terminal_instance,
+    resolve_terminal_transport,
 )
 from omnigent.runner.identity import RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR
+
+
+def _write_transport_config(config_home: Path, value: str | None) -> None:
+    """Write ``terminal.transport: <value>`` into a scratch config.yaml.
+
+    :param config_home: Directory used as ``OMNIGENT_CONFIG_HOME``.
+    :param value: Transport value to persist, or ``None`` to write a config
+        with no ``terminal`` table.
+    """
+    body = "" if value is None else f"terminal:\n  transport: {value}\n"
+    (config_home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def test_resolve_terminal_transport_precedence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Override beats spec, spec beats config, config opts out of the control default."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+    # No config file at all → control mode is the default.
+    assert resolve_terminal_transport() == TERMINAL_TRANSPORT_CONTROL
+
+    # A config with no terminal table → still control.
+    _write_transport_config(tmp_path, None)
+    assert resolve_terminal_transport() == TERMINAL_TRANSPORT_CONTROL
+
+    # terminal.transport opts OUT to the legacy PTY path.
+    _write_transport_config(tmp_path, "pty")
+    assert resolve_terminal_transport() == TERMINAL_TRANSPORT_PTY
+    _write_transport_config(tmp_path, "false")
+    assert resolve_terminal_transport() == TERMINAL_TRANSPORT_PTY
+
+    # A control/ truthy value keeps control mode.
+    _write_transport_config(tmp_path, "control")
+    assert resolve_terminal_transport() == TERMINAL_TRANSPORT_CONTROL
+
+    # Spec beats config: config opts out globally, but this terminal forces control.
+    _write_transport_config(tmp_path, "pty")
+    assert resolve_terminal_transport(spec_transport="control") == TERMINAL_TRANSPORT_CONTROL
+
+    # Per-attach override beats spec.
+    assert (
+        resolve_terminal_transport(override="pty", spec_transport="control")
+        == TERMINAL_TRANSPORT_PTY
+    )
+    # Unrecognized override values fall through to the spec rather than break.
+    assert (
+        resolve_terminal_transport(override="garbage", spec_transport="pty")
+        == TERMINAL_TRANSPORT_PTY
+    )
 
 
 @dataclass

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -2248,6 +2248,9 @@ class _StubTerminalInstance:
         self.os_env = None
         self.socket_path = Path("/tmp/omnigent-test-tmux.sock")
         self.tmux_target = "main"
+        # ``terminal_resource_view`` reads this to project the effective
+        # web-attach transport into metadata; ``None`` => the global default.
+        self.terminal_transport = None
         # Records on_activity callbacks the dispatch wires up so a fresh
         # launch's pane-activity watcher start is observable (and so the
         # call doesn't AttributeError against this stub).

--- a/tests/runner/test_terminal_resource_attach_ws.py
+++ b/tests/runner/test_terminal_resource_attach_ws.py
@@ -106,7 +106,9 @@ def test_runner_resource_attach_spawns_tmux_for_running_terminal(
 
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
-            "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach"
+            # ``?transport=pty`` pins this to the PTY bridge (the one that forks
+            # tmux attach) independent of the global control-mode default.
+            "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach?transport=pty"
         ):
             pass
 
@@ -166,12 +168,67 @@ def test_runner_resource_attach_passes_read_only_to_tmux(
 
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
-            "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach?read_only=true"
+            "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach"
+            "?read_only=true&transport=pty"
         ):
             pass
 
     assert "-r" in captured["argv"], (
         f"Expected -r with read_only=true, got argv={captured['argv']!r}"
+    )
+
+
+def test_runner_resource_attach_selects_control_bridge_on_transport_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``?transport=control`` dispatches to the control-mode bridge, not the PTY one.
+
+    Both bridges share the same signature and browser wire protocol, so the
+    route just picks one. Patch each to record which was invoked and close the
+    socket cleanly, then assert on the selection per query.
+
+    :param tmp_path: Pytest tmp directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    registry = TerminalRegistry()
+    _seed_registry(registry, "conv_abc", _make_running_instance("bash", "s1", tmp_path))
+    app = create_runner_app(
+        terminal_registry=registry,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    calls: list[str] = []
+
+    async def fake_control(websocket, **_kwargs):  # type: ignore[no-untyped-def]
+        calls.append("control")
+        await websocket.close()
+
+    async def fake_pty(websocket, **_kwargs):  # type: ignore[no-untyped-def]
+        calls.append("pty")
+        await websocket.close()
+
+    monkeypatch.setattr("omnigent.runner.app.bridge_tmux_control_to_websocket", fake_control)
+    monkeypatch.setattr("omnigent.runner.app.bridge_tmux_pty_to_websocket", fake_pty)
+    # Point config resolution at an empty scratch dir so the no-query case is
+    # deterministic regardless of the developer's real ~/.omnigent/config.yaml.
+    # With no terminal.transport configured, control mode is the product default.
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+    base = "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach"
+    client = TestClient(app)
+    with contextlib.suppress(WebSocketDisconnect):
+        with client.websocket_connect(f"{base}?transport=control"):
+            pass
+    with contextlib.suppress(WebSocketDisconnect):
+        with client.websocket_connect(f"{base}?transport=pty"):
+            pass
+    with contextlib.suppress(WebSocketDisconnect):
+        with client.websocket_connect(base):  # no query → control default
+            pass
+
+    assert calls == ["control", "pty", "control"], (
+        f"transport query did not select the expected bridge: {calls!r}"
     )
 
 
@@ -390,7 +447,7 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
     # First attach: dead pane → recreate → bridge the fresh pane.
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
-            "/v1/sessions/conv_abc/resources/terminals/terminal_tui_main/attach"
+            "/v1/sessions/conv_abc/resources/terminals/terminal_tui_main/attach?transport=pty"
         ):
             pass
 
@@ -412,7 +469,7 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
     # unconditionally, killing the user's running REPL on every attach.
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
-            "/v1/sessions/conv_abc/resources/terminals/terminal_tui_main/attach"
+            "/v1/sessions/conv_abc/resources/terminals/terminal_tui_main/attach?transport=pty"
         ):
             pass
 
@@ -521,7 +578,7 @@ def test_runner_resource_attach_recreates_dead_qwen_terminal(
 
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
-            "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach"
+            "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach?transport=pty"
         ):
             pass
 
@@ -531,7 +588,7 @@ def test_runner_resource_attach_recreates_dead_qwen_terminal(
 
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
-            "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach"
+            "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach?transport=pty"
         ):
             pass
 

--- a/tests/server/routes/test_terminal_attach.py
+++ b/tests/server/routes/test_terminal_attach.py
@@ -684,8 +684,10 @@ async def test_attach_terminal_local_fallback_spawns_tmux(
 
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
+            # ``?transport=pty`` pins this to the PTY bridge (which forks tmux
+            # attach) independent of the global control-mode default.
             "/v1/sessions/conv_local_attach/resources/terminals/terminal_bash_s1/attach"
-            "?read_only=true"
+            "?read_only=true&transport=pty"
         ):
             pass
 

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -1,0 +1,396 @@
+"""
+Unit + integration tests for :mod:`omnigent.terminals.control_bridge`.
+
+Covers the pure helpers (``unescape_control_output`` octal round-trip,
+``_hex_send_keys_commands`` chunking) and an end-to-end drive of
+``bridge_tmux_control_to_websocket`` against a real private tmux server via a
+fake WebSocket: seed-on-attach, ``%output`` streaming of ``send-keys`` input,
+and the detach close code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from omnigent.terminals.control_bridge import (
+    _SEND_KEYS_HEX_BYTES_PER_CALL,
+    _hex_send_keys_commands,
+    bridge_tmux_control_to_websocket,
+    unescape_control_output,
+)
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+
+def test_unescape_control_output_round_trips_control_bytes() -> None:
+    """tmux octal escapes (\\ooo) decode back to raw ESC/CR/LF bytes."""
+    assert unescape_control_output(rb"\033[31mRED\033[0m\015\012") == b"\x1b[31mRED\x1b[0m\r\n"
+    # A literal backslash is escaped as \134 and must decode back to one byte.
+    assert unescape_control_output(rb"a\134b") == b"a\\b"
+    # Printable bytes pass through untouched.
+    assert unescape_control_output(b"plain text 123") == b"plain text 123"
+
+
+def test_hex_send_keys_commands_encodes_and_chunks() -> None:
+    """Input bytes become space-separated hex, split under the per-call cap."""
+    cmds = _hex_send_keys_commands("main", b"\x1b[A")
+    assert cmds == [b"send-keys -t main -H 1b 5b 41\n"]
+
+    big = b"\x00" * (_SEND_KEYS_HEX_BYTES_PER_CALL + 5)
+    cmds = _hex_send_keys_commands("main", big)
+    assert len(cmds) == 2
+    # First chunk carries exactly the cap's worth of "00" tokens.
+    assert cmds[0].count(b"00") == _SEND_KEYS_HEX_BYTES_PER_CALL
+    assert cmds[1].count(b"00") == 5
+
+
+class _FakeWebSocket:
+    """Minimal WebSocket stand-in driving bridge_tmux_control_to_websocket.
+
+    Records outbound binary frames, feeds a scripted sequence of inbound
+    messages, and captures the close code.
+    """
+
+    def __init__(self, inbound: list[dict[str, object]]) -> None:
+        self._inbound = list(inbound)
+        self.sent: list[bytes] = []
+        self.close_code: int | None = None
+        self.close_reason: str | None = None
+        self._recv_gate = asyncio.Event()
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    async def receive(self) -> dict[str, object]:
+        if self._inbound:
+            return self._inbound.pop(0)
+        # Block forever once scripted input is exhausted so the bridge's other
+        # task (control→ws) decides when the attach ends.
+        await self._recv_gate.wait()
+        return {"type": "websocket.disconnect"}
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.close_code = code
+        self.close_reason = reason
+
+
+async def _new_private_tmux(inner: str) -> tuple[Path, str]:
+    """Create a private single-pane tmux server like terminal.py:launch."""
+    tmux = shutil.which("tmux")
+    assert tmux
+    tmpdir = Path(tempfile.mkdtemp(prefix="cc-test-"))
+    sock = tmpdir / "tmux.sock"
+    proc = await asyncio.create_subprocess_exec(
+        tmux,
+        "-S",
+        str(sock),
+        "-f",
+        os.devnull,
+        "set-option",
+        "-g",
+        "history-limit",
+        "10000",
+        ";",
+        "new-session",
+        "-d",
+        "-s",
+        "main",
+        "-x",
+        "80",
+        "-y",
+        "24",
+        inner,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, err = await proc.communicate()
+    assert proc.returncode == 0, err.decode()
+    return sock, "main"
+
+
+async def _kill_tmux(sock: Path) -> None:
+    tmux = shutil.which("tmux")
+    if tmux is None:
+        return
+    with contextlib.suppress(Exception):
+        proc = await asyncio.create_subprocess_exec(
+            tmux,
+            "-S",
+            str(sock),
+            "kill-server",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.communicate()
+    shutil.rmtree(sock.parent, ignore_errors=True)
+
+
+async def _kill_and_join(sock: Path, task: asyncio.Task[None]) -> None:
+    """Kill the tmux server and wind the bridge task down cleanly.
+
+    Killing the server closes the control client's stdout, so the bridge
+    exits on its own; we wait a bounded time, then cancel as a fallback and
+    await the cancellation propagating. Shared teardown for the end-to-end
+    tests so each doesn't repeat the kill/join dance.
+
+    :param sock: tmux socket whose server to kill.
+    :param task: The running ``bridge_tmux_control_to_websocket`` task.
+    """
+    await _kill_tmux(sock)
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(task, timeout=5)
+    if not task.done():
+        task.cancel()
+        # ``await`` blocks until the cancelled task finishes unwinding — the
+        # return value is discarded but the wait is the point.
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_streams_large_output_burst() -> None:
+    """A large post-attach output burst streams through intact, no reader crash.
+
+    tmux chunks ``%output`` into small lines, but the raised StreamReader limit
+    guards against a build that emits one line past asyncio's 64 KiB default
+    (where ``readline()`` would raise ``LimitOverrunError`` and kill the reader).
+    Assert a ~200 KiB live burst reaches the browser fully rather than dropping
+    the connection.
+    """
+    # Hold the pane quiet for 1s, THEN emit ~200 KiB in one burst — so the
+    # payload arrives as live post-attach %output (the readline path), not via
+    # the capture-pane seed.
+    payload_len = 200_000
+    sock, target = await _new_private_tmux(
+        f'python3 -c \'import sys,time; time.sleep(1.0); sys.stdout.write("X"*{payload_len}); '
+        "sys.stdout.flush(); time.sleep(30)'"
+    )
+    # Attach while the pane is still quiet (before the burst fires).
+    await asyncio.sleep(0.2)
+
+    ws = _FakeWebSocket(inbound=[])
+
+    async def _run() -> None:
+        await bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+
+    task = asyncio.create_task(_run())
+    # Wait past the burst so the big %output line is read and forwarded.
+    await asyncio.sleep(2.0)
+
+    # The reader must still be alive (no LimitOverrunError crash) and the large
+    # payload must have reached the browser via the live stream.
+    total_x = sum(frame.count(b"X") for frame in ws.sent)
+    assert total_x >= payload_len, (
+        f"large output truncated/dropped: got {total_x} X bytes of {payload_len}"
+    )
+
+    await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_seeds_streams_and_detaches() -> None:
+    """End-to-end: seed the pre-attach screen, stream typed input, detach clean."""
+    # `cat` echoes input back to the pane (→ %output); the printf lands before
+    # attach so it can only reach the browser via the capture-pane seed.
+    sock, target = await _new_private_tmux("printf 'SEEDED-LINE\\n'; cat")
+    await asyncio.sleep(0.3)  # let the printf render before we attach
+
+    ws = _FakeWebSocket(
+        inbound=[
+            {"type": "websocket.receive", "text": '{"type":"resize","cols":100,"rows":30}'},
+            {"type": "websocket.receive", "bytes": b"typed-input\r"},
+        ]
+    )
+
+    async def _run() -> None:
+        await bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+
+    task = asyncio.create_task(_run())
+    # Give it time to seed, resize, inject input, and observe the echo.
+    await asyncio.sleep(1.2)
+
+    joined = b"".join(ws.sent)
+    assert b"SEEDED-LINE" in joined, "seed-on-attach did not paint pre-attach screen"
+    assert b"typed-input" in joined, "send-keys input was not echoed via %output"
+
+    # The seed frame must not carry bare-LF row separators: capture-pane -p
+    # joins rows with a lone \n, which would staircase the whole screen to the
+    # right in xterm. The bridge rewrites them to CRLF and prepends home+clear.
+    seed_frame = ws.sent[0]
+    assert seed_frame.startswith(b"\x1b[H\x1b[2J"), "seed did not start with home+clear"
+    assert b"\n" not in seed_frame.replace(b"\r\n", b""), (
+        "seed frame contains a bare LF — rows will staircase in xterm"
+    )
+
+    # Kill the server → the control client's stdout closes → bridge exits.
+    await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_seed_restores_cursor_position() -> None:
+    """The seed ends with a CUP escape putting the cursor where the app left it.
+
+    capture-pane records only cell contents, not the cursor, so the seed must
+    reposition it explicitly or the browser cursor sits at the end of the
+    seeded text instead of inside the app's prompt.
+    """
+    from omnigent.terminals.control_bridge import _run_tmux_capture
+
+    # Park the cursor at row 9, col 8 (1-based) and hold the pane open.
+    sock, target = await _new_private_tmux(
+        'python3 -c \'import sys,time; sys.stdout.write("a\\r\\nb\\r\\n\\x1b[9;8H"); '
+        "sys.stdout.flush(); time.sleep(30)'"
+    )
+    await asyncio.sleep(0.4)
+    try:
+        seed = await _run_tmux_capture(str(sock), target)
+        assert seed is not None
+        # tmux reports 0-based cursor_x=7, cursor_y=8 → CUP is 1-based [9;8H.
+        assert b"\x1b[9;8H" in seed, f"cursor CUP escape missing from seed: {seed[-24:]!r}"
+        # Visible cursor → show-cursor tail.
+        assert seed.endswith(b"\x1b[?25h"), f"seed did not end with show-cursor: {seed[-12:]!r}"
+    finally:
+        await _kill_tmux(sock)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_seed_full_height_pane_does_not_scroll_or_shift_cursor() -> None:
+    """A full-height pane seed must render row1 at top and the cursor in place.
+
+    capture-pane -p emits a trailing LF after the final row; writing it on a
+    full-height pane scrolls the whole screen up one line (the "extra line"
+    off-by-one) and shifts the restored cursor. Render the seed through a real
+    VT emulator (pyte) and assert no scroll + exact cursor position.
+    """
+    import pyte
+
+    from omnigent.terminals.control_bridge import _run_tmux_capture
+
+    # Fill all 24 rows (row1..row24) and park the cursor at row24 col6.
+    sock, target = await _new_private_tmux(
+        "python3 -c 'import sys,time\n"
+        'sys.stdout.write("\\x1b[?1049h")\n'
+        'for r in range(1,25): sys.stdout.write(f"\\x1b[{r};1Hrow{r}")\n'
+        'sys.stdout.write("\\x1b[24;6H")\n'
+        "sys.stdout.flush(); time.sleep(30)'"
+    )
+    await asyncio.sleep(0.4)
+    try:
+        seed = await _run_tmux_capture(str(sock), target)
+        assert seed is not None
+        screen = pyte.Screen(80, 24)
+        stream = pyte.ByteStream(screen)
+        stream.feed(seed)
+        display = screen.display
+        # No scroll-up: the top row is still row1, the bottom is row24.
+        assert display[0].startswith("row1"), f"top row scrolled off: {display[0]!r}"
+        assert display[23].startswith("row24"), f"bottom row wrong: {display[23]!r}"
+        # Cursor restored to the app's position (0-based (23, 5) for [24;6H).
+        assert (screen.cursor.y, screen.cursor.x) == (23, 5), (
+            f"cursor off: got ({screen.cursor.y}, {screen.cursor.x}), expected (23, 5)"
+        )
+    finally:
+        await _kill_tmux(sock)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_seed_recovers_primary_screen_scrollback() -> None:
+    """On the primary screen the seed captures full history, not just the screen."""
+    from omnigent.terminals.control_bridge import _run_tmux_capture
+
+    sock, target = await _new_private_tmux("bash --norc")
+    await asyncio.sleep(0.2)
+    tmux = shutil.which("tmux")
+    assert tmux
+    # Emit 100 history lines — far more than the 24-row visible screen.
+    proc = await asyncio.create_subprocess_exec(
+        tmux,
+        "-S",
+        str(sock),
+        "send-keys",
+        "-t",
+        target,
+        "-l",
+        "for i in $(seq 1 100); do echo hist-$i; done",
+    )
+    await proc.communicate()
+    proc = await asyncio.create_subprocess_exec(
+        tmux, "-S", str(sock), "send-keys", "-t", target, "Enter"
+    )
+    await proc.communicate()
+    await asyncio.sleep(0.6)
+    try:
+        seed = await _run_tmux_capture(str(sock), target)
+        assert seed is not None
+        # Full history recovered (a visible-only capture would show ~23 lines).
+        assert seed.count(b"hist-") >= 100, (
+            f"scrollback not recovered: only {seed.count(b'hist-')} history lines"
+        )
+    finally:
+        await _kill_tmux(sock)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_seed_alternate_screen_does_not_leak_primary_history() -> None:
+    """On the alternate screen the seed must not include stale primary history.
+
+    ``capture-pane -S -`` on an alt-screen pane returns the primary buffer's
+    scrollback from before the app switched — lines that were never part of
+    the app's UI. The bridge must capture the visible screen only there.
+    """
+    from omnigent.terminals.control_bridge import _run_tmux_capture
+
+    # 50 primary-screen "OLD" lines, then enter the alternate screen and draw.
+    sock, target = await _new_private_tmux(
+        "python3 -c 'import sys,time\n"
+        'for i in range(50): sys.stdout.write(f"OLD-{i}\\r\\n")\n'
+        'sys.stdout.write("\\x1b[?1049h")\n'
+        'for r in range(1,25): sys.stdout.write(f"\\x1b[{r};1HALT-row{r}")\n'
+        "sys.stdout.flush(); time.sleep(30)'"
+    )
+    await asyncio.sleep(0.5)
+    try:
+        seed = await _run_tmux_capture(str(sock), target)
+        assert seed is not None
+        assert seed.count(b"OLD-") == 0, (
+            f"alt-screen seed leaked {seed.count(b'OLD-')} stale primary-history lines"
+        )
+        assert b"ALT-row" in seed, "alt-screen visible content missing from seed"
+    finally:
+        await _kill_tmux(sock)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_read_only_drops_input() -> None:
+    """read_only=True must not inject typed bytes into the pane."""
+    sock, target = await _new_private_tmux("cat")
+    await asyncio.sleep(0.2)
+
+    ws = _FakeWebSocket(inbound=[{"type": "websocket.receive", "bytes": b"should-not-appear\r"}])
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=True
+        )
+    )
+    await asyncio.sleep(0.8)
+    assert b"should-not-appear" not in b"".join(ws.sent)
+
+    await _kill_and_join(sock, task)

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -333,6 +333,26 @@ describe("TerminalSession", () => {
     session.dispose();
   });
 
+  it("does not re-send a resize when the fitted size is unchanged", () => {
+    // WHY: the WS-open handler and the ResizeObserver both drive sendResize on
+    // mount, and jsdom's fit() yields a stable size, so without deduping the
+    // control transport would receive a redundant refresh-client -C. Drive the
+    // observer callback (the real re-fit path) after open and assert exactly
+    // one resize frame total.
+    const { socket, session } = makeSession();
+    const observer = FakeResizeObserver.instances[0];
+
+    socket.open(); // first (and only distinct) resize
+    observer.cb(); // same size → must be deduped
+    observer.cb();
+
+    const resizeFrames = socket.sent.filter(
+      (m) => typeof m === "string" && m.includes('"type":"resize"'),
+    );
+    expect(resizeFrames).toHaveLength(1);
+    session.dispose();
+  });
+
   it("surfaces close code + reason and error transitions", () => {
     // WHY: the closed variant carries the WS code so consumers can tell a
     // deliberate close from a transport drop; the error handler maps to

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -298,6 +298,14 @@ export class TerminalSession {
   private lastUserInputAt = 0;
   /** Guards {@link dispose} so calling it twice is a safe no-op. */
   private disposed = false;
+  /**
+   * Last ``cols×rows`` actually sent to the server, or ``null`` before the
+   * first resize. {@link sendResize} skips a send when the fitted dimensions
+   * are unchanged so the WS-open + ResizeObserver double-fire on mount (and a
+   * transient re-fit) don't emit a redundant resize — which, on the tmux
+   * control transport, would otherwise be an avoidable ``refresh-client -C``.
+   */
+  private lastSentSize: { cols: number; rows: number } | null = null;
 
   /**
    * Construct, attach to the DOM, and open the WebSocket.
@@ -312,6 +320,12 @@ export class TerminalSession {
    *     server. This is a best-effort UI activity signal, not a shell
    *     job-state oracle.
    * :param onInput: Called when user input is sent to the terminal.
+   * :param nativeSelection: When ``true`` (control-mode transport), xterm
+   *     owns the character buffer and mouse, so plain click-drag selects and
+   *     the browser's own copy works — the ``macOptionClickForcesSelection``
+   *     workaround and the custom ``copy`` listener are skipped. When
+   *     ``false`` (PTY transport, the default), tmux runs with ``mouse on``
+   *     and captures drags, so both workarounds stay wired.
    */
   constructor(
     container: HTMLElement,
@@ -320,6 +334,7 @@ export class TerminalSession {
     isDark = false,
     onActivity?: TerminalActivityListener,
     onInput?: TerminalInputListener,
+    nativeSelection = false,
   ) {
     this.term = new Terminal({
       // Match the system mono stack at the configured base size. The
@@ -337,17 +352,14 @@ export class TerminalSession {
       // cell's foreground luminance only when it lacks contrast against
       // its actual background.
       minimumContrastRatio: 4.5,
-      // The attached tmux session runs with `mouse on` (terminal.py) so
-      // the wheel pages through scrollback. The downside is tmux then
+      // PTY transport only: the attached tmux session runs with `mouse on`
+      // (terminal.py) so the wheel pages through scrollback, but tmux then
       // captures every mouse drag for its own copy-mode, so a plain
-      // click-drag never produces a browser text selection — the user
-      // can't select-and-copy. xterm's escape hatch is
-      // `shouldForceSelection`: on non-Mac it honors Shift-drag for
-      // free, but on Mac it forces a native selection only when
-      // `macOptionClickForcesSelection` is enabled AND the user holds
-      // Option. Without this flag Mac users have no way to select at
-      // all. Enabling it lets ⌥-drag select, then ⌘-C copies.
-      macOptionClickForcesSelection: true,
+      // click-drag never produces a browser text selection. xterm's escape
+      // hatch `macOptionClickForcesSelection` lets Mac users ⌥-drag to select,
+      // then ⌘-C copies. In control mode xterm owns the mouse and plain drag
+      // selects natively, so the forced-selection workaround is unnecessary.
+      macOptionClickForcesSelection: !nativeSelection,
       // Opt into xterm's proposed APIs, matching openui's terminal setup.
       allowProposedApi: true,
     });
@@ -546,6 +558,15 @@ export class TerminalSession {
     } catch {
       return;
     }
-    this.ws.send(JSON.stringify({ type: "resize", cols: this.term.cols, rows: this.term.rows }));
+    const { cols, rows } = this.term;
+    // Skip a no-op resize: the WS-open handler and the ResizeObserver both
+    // call this on mount, and a transient re-fit can land the same size. On
+    // the control transport an unchanged size is a wasted round-trip (tmux
+    // recomputes layout for the new value regardless), so dedupe here.
+    if (this.lastSentSize && this.lastSentSize.cols === cols && this.lastSentSize.rows === rows) {
+      return;
+    }
+    this.lastSentSize = { cols, rows };
+    this.ws.send(JSON.stringify({ type: "resize", cols, rows }));
   }
 }

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -20,6 +20,8 @@ import {
 
 const terminalSessionMock = vi.hoisted(() => ({
   instances: [] as Array<{
+    url: string;
+    nativeSelection: boolean;
     onState: (state: ConnectionState) => void;
     dispose: ReturnType<typeof vi.fn>;
     setTheme: ReturnType<typeof vi.fn>;
@@ -36,10 +38,16 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
 
     constructor(
       _container: HTMLDivElement,
-      _url: string,
+      url: string,
       onState: (state: ConnectionState) => void,
+      _isDark?: boolean,
+      _onActivity?: () => void,
+      _onInput?: () => void,
+      nativeSelection = false,
     ) {
       terminalSessionMock.instances.push({
+        url,
+        nativeSelection,
         onState,
         dispose: this.dispose,
         setTheme: this.setTheme,
@@ -74,6 +82,24 @@ describe("buildAttachPath", () => {
     );
   });
 
+  it("appends ?transport= when a transport override is given", () => {
+    expect(buildAttachPath("conv_abc", "terminal_bash_s1", false, "control")).toBe(
+      "/v1/sessions/conv_abc/resources/terminals/terminal_bash_s1/attach?transport=control",
+    );
+  });
+
+  it("combines read_only and transport params", () => {
+    const path = buildAttachPath("conv_abc", "terminal_bash_s1", true, "control");
+    expect(path).toContain("read_only=true");
+    expect(path).toContain("transport=control");
+  });
+
+  it("omits ?transport when no override is given", () => {
+    expect(buildAttachPath("conv_abc", "terminal_bash_s1", false).includes("transport")).toBe(
+      false,
+    );
+  });
+
   it("url-encodes the session and terminal ids", () => {
     const path = buildAttachPath("conv with space", "terminal/odd:id", false);
     expect(path).toContain("/v1/sessions/conv%20with%20space/");
@@ -94,6 +120,31 @@ describe("buildAttachPath", () => {
     // a leading slash is required for that concatenation to be
     // correct against any page origin.
     expect(buildAttachPath("conv_abc", "terminal_bash_s1", false).startsWith("/")).toBe(true);
+  });
+});
+
+describe("control-mode transport", () => {
+  it("forwards ?transport=control and enables native selection when transport=control", async () => {
+    render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" transport="control" />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    const inst = terminalSessionMock.instances[0];
+    expect(inst.url).toContain("transport=control");
+    expect(inst.nativeSelection).toBe(true);
+  });
+
+  it("hides the selection hint bar in control mode", async () => {
+    render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" transport="control" />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    expect(screen.queryByTestId("terminal-selection-hint")).toBeNull();
+  });
+
+  it("keeps the hint bar and PTY behavior by default (no transport prop)", async () => {
+    render(<TerminalView sessionId="conv_abc" terminalId="terminal_bash_s1" />);
+    await waitFor(() => expect(terminalSessionMock.instances).toHaveLength(1));
+    const inst = terminalSessionMock.instances[0];
+    expect(inst.url).not.toContain("transport");
+    expect(inst.nativeSelection).toBe(false);
+    expect(screen.getByTestId("terminal-selection-hint")).toBeInTheDocument();
   });
 });
 

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -65,6 +65,16 @@ interface TerminalViewProps {
   onResume?: () => void | Promise<void>;
   /** Whether the optional resume action is currently in flight. */
   resumePending?: boolean;
+  /**
+   * Web-attach transport for this terminal (``"control"`` / ``"pty"``),
+   * from the terminal resource's ``metadata.terminal_transport``. Control
+   * mode gives the browser xterm native scrollback + selection, so the
+   * mouse/selection workarounds and the hint bar are dropped. ``undefined``
+   * (or ``"pty"``) keeps the legacy PTY behavior. When set, it is also
+   * forwarded to the server as ``?transport=`` so the attach matches the
+   * behavior the UI renders for.
+   */
+  transport?: "control" | "pty";
 }
 
 export function TerminalView({
@@ -76,7 +86,11 @@ export function TerminalView({
   onInput,
   onResume,
   resumePending = false,
+  transport,
 }: TerminalViewProps) {
+  // Control mode: xterm owns the buffer + mouse, so plain drag selects and
+  // the normal copy gesture works — no forced-selection modifier, no hint bar.
+  const controlMode = transport === "control";
   const [state, setState] = useState<ConnectionState>({ kind: "connecting" });
   const [connectAttempt, setConnectAttempt] = useState(0);
   const [resumeError, setResumeError] = useState<string | null>(null);
@@ -167,11 +181,12 @@ export function TerminalView({
         if (cancelled) return;
         terminalSession = new TerminalSession(
           node,
-          buildAttachUrl(sessionId, terminalId, readOnly),
+          buildAttachUrl(sessionId, terminalId, readOnly, transport),
           notifyState,
           isDarkRef.current,
           notifyActivity,
           notifyInput,
+          controlMode,
         );
         sessionRef.current = terminalSession;
       });
@@ -182,7 +197,16 @@ export function TerminalView({
         onStateChangeRef.current?.(null);
       };
     },
-    [sessionId, terminalId, readOnly, notifyState, notifyActivity, notifyInput],
+    [
+      sessionId,
+      terminalId,
+      readOnly,
+      transport,
+      controlMode,
+      notifyState,
+      notifyActivity,
+      notifyInput,
+    ],
   );
 
   // Push theme changes into the live session without remounting.
@@ -263,18 +287,20 @@ export function TerminalView({
       <div className="min-h-0 flex-1 overflow-hidden p-1">
         <div key={connectAttempt} ref={attachSession} className="h-full w-full overflow-hidden" />
       </div>
-      {/* The attached tmux session runs with `mouse on`, so a plain
-          click-drag is captured by tmux (copy-mode) instead of making a
-          browser selection — the user can't select-and-copy without a
-          modifier. The modifier and copy key are
-          platform-specific, and there's no other discoverable cue, so
-          surface it as a persistent hint. */}
-      <div
-        data-testid="terminal-selection-hint"
-        className="shrink-0 select-none px-2 py-1 text-[10px] text-muted-foreground/70"
-      >
-        {selectionHintText(isMacPlatform())}
-      </div>
+      {/* PTY transport only: the attached tmux session runs with `mouse on`,
+          so a plain click-drag is captured by tmux (copy-mode) instead of
+          making a browser selection — the user can't select-and-copy without a
+          platform-specific modifier, and there's no other discoverable cue, so
+          surface it as a persistent hint. Control mode gives xterm native
+          selection, so the hint is unnecessary and omitted. */}
+      {!controlMode && (
+        <div
+          data-testid="terminal-selection-hint"
+          className="shrink-0 select-none px-2 py-1 text-[10px] text-muted-foreground/70"
+        >
+          {selectionHintText(isMacPlatform())}
+        </div>
+      )}
       {state.kind !== "connected" && (
         <StatusOverlay
           state={state}
@@ -411,18 +437,29 @@ function resumeErrorText(error: unknown): string {
  *     e.g. ``"terminal_bash_s1"``.
  * :param readOnly: If true, requests a read-only attach. Forwarded
  *     to the server as ``?read_only=true``.
+ * :param transport: Optional per-attach transport override
+ *     (``"control"`` / ``"pty"``), forwarded as ``?transport=``. Lets a
+ *     terminal be A/B'd against the other mode side by side; ``undefined``
+ *     lets the server pick from the terminal spec / global default.
  * :returns: The path-and-query portion of the WS URL, e.g.
  *     ``"/v1/sessions/.../resources/terminals/.../attach"``.
  */
-export function buildAttachPath(sessionId: string, terminalId: string, readOnly: boolean): string {
+export function buildAttachPath(
+  sessionId: string,
+  terminalId: string,
+  readOnly: boolean,
+  transport?: string,
+): string {
   const path =
     `/v1/sessions/${encodeURIComponent(sessionId)}` +
     `/resources/terminals/${encodeURIComponent(terminalId)}/attach`;
-  // Only emit the query param when set — the server defaults to
-  // false, so the common case keeps URLs short and stable for
-  // anything that greps the access log.
-  const qs = readOnly ? "?read_only=true" : "";
-  return `${path}${qs}`;
+  // Only emit query params when set — the server defaults keep the common
+  // case's URLs short and stable for anything that greps the access log.
+  const params = new URLSearchParams();
+  if (readOnly) params.set("read_only", "true");
+  if (transport) params.set("transport", transport);
+  const qs = params.toString();
+  return qs ? `${path}?${qs}` : path;
 }
 
 /**
@@ -435,10 +472,16 @@ export function buildAttachPath(sessionId: string, terminalId: string, readOnly:
  * :param sessionId: Session/conversation identifier.
  * :param terminalId: Opaque terminal resource id.
  * :param readOnly: If true, requests a read-only attach.
+ * :param transport: Optional per-attach transport override.
  * :returns: The fully-qualified ``ws(s)://`` URL.
  */
-function buildAttachUrl(sessionId: string, terminalId: string, readOnly: boolean): string {
+function buildAttachUrl(
+  sessionId: string,
+  terminalId: string,
+  readOnly: boolean,
+  transport?: string,
+): string {
   // Delegates origin/prefix resolution to the embed host when present
   // (standalone falls back to the current page's origin).
-  return resolveWebSocketUrl(buildAttachPath(sessionId, terminalId, readOnly));
+  return resolveWebSocketUrl(buildAttachPath(sessionId, terminalId, readOnly, transport));
 }

--- a/web/src/hooks/useTerminals.test.ts
+++ b/web/src/hooks/useTerminals.test.ts
@@ -88,6 +88,40 @@ describe("terminalInfoFromResource", () => {
     });
     expect(info).toBeNull();
   });
+
+  it("lifts metadata.terminal_transport, defaulting to undefined for unknown values", () => {
+    const control = terminalInfoFromResource({
+      id: "terminal_bash_s1",
+      type: "terminal",
+      name: "bash:s1",
+      metadata: { terminal_transport: "control" },
+    });
+    expect(control?.transport).toBe("control");
+
+    const pty = terminalInfoFromResource({
+      id: "terminal_bash_s1",
+      type: "terminal",
+      name: "bash:s1",
+      metadata: { terminal_transport: "pty" },
+    });
+    expect(pty?.transport).toBe("pty");
+
+    // Absent or unrecognized → undefined (frontend treats as legacy PTY).
+    const legacy = terminalInfoFromResource({
+      id: "terminal_bash_s1",
+      type: "terminal",
+      name: "bash:s1",
+      metadata: {},
+    });
+    expect(legacy?.transport).toBeUndefined();
+    const junk = terminalInfoFromResource({
+      id: "terminal_bash_s1",
+      type: "terminal",
+      name: "bash:s1",
+      metadata: { terminal_transport: "garbage" },
+    });
+    expect(junk?.transport).toBeUndefined();
+  });
 });
 
 describe("fetchTerminals", () => {

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -24,6 +24,14 @@ export interface TerminalInfo {
   session: string;
   /** Whether the underlying tmux session is currently running. */
   running: boolean;
+  /**
+   * Web-attach transport for this terminal, from
+   * ``metadata.terminal_transport``: ``"control"`` (tmux control mode —
+   * native browser scrollback + selection) or ``"pty"`` (the legacy forked
+   * ``tmux attach`` stream). ``undefined`` when the server omits it (older
+   * server / treat as PTY).
+   */
+  transport?: "control" | "pty";
 }
 
 /**
@@ -203,6 +211,8 @@ export function terminalInfoFromResource(resource: Record<string, unknown>): Ter
   const terminalName = metadata.terminal_name;
   const sessionKey = metadata.session_key;
   const running = metadata.running;
+  const rawTransport = metadata.terminal_transport;
+  const transport = rawTransport === "control" || rawTransport === "pty" ? rawTransport : undefined;
   const fallbackName = resource.name;
   return {
     id,
@@ -219,6 +229,7 @@ export function terminalInfoFromResource(resource: Record<string, unknown>): Ter
           : "",
     session: typeof sessionKey === "string" ? sessionKey : "",
     running: typeof running === "boolean" ? running : false,
+    transport,
   };
 }
 

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -164,6 +164,7 @@ export function MainTerminalView({
                     sessionId={conversationId}
                     terminalId={activeTerminal.id}
                     readOnly={readOnly}
+                    transport={activeTerminal.transport}
                     onStateChange={(state) => {
                       setTerminalConnectionState(activeTerminal.id, state);
                     }}

--- a/web/src/shell/TerminalsPanel.tsx
+++ b/web/src/shell/TerminalsPanel.tsx
@@ -240,6 +240,7 @@ export function TerminalsPanel({
                 sessionId={conversationId}
                 terminalId={activeTerminal.id}
                 readOnly={readOnly}
+                transport={activeTerminal.transport}
                 onStateChange={(state) => {
                   setTerminalConnectionState(activeTerminal.id, state);
                 }}


### PR DESCRIPTION
## Related issue

N/A

## Summary

TLDR: use [`tmux -CC` mode](https://github.com/tmux/tmux/wiki/Control-Mode) to manage terminal

- Add `omnigent/terminals/control_bridge.py`: a `tmux -C` control-mode bridge that streams per-pane `%output` into the browser xterm, so the browser owns scrollback and text selection natively (fixing the scroll/copy pains of the PTY `tmux attach` transport, which let tmux own the viewport and capture the mouse).
- Select the transport per attach via `resolve_terminal_transport()` (`omnigent/inner/terminal.py`): per-attach `?transport=` query › per-terminal `TerminalEnvSpec.terminal_transport` › global default. Control mode is the default; `OMNIGENT_TERMINAL_CONTROL_MODE` opts out back to `pty`. The legacy PTY bridge is untouched, so the modes run side by side and revert is a config flip.
- Wire both attach call sites (server fallback `terminal_attach.py`, runner `runner/app.py`) to pick the bridge; forward `?transport=` over the runner WS tunnel; stamp `terminal.transport` on telemetry.
- Surface the resolved transport per terminal in resource metadata (`session_resources.py`) so the web UI (`TerminalView`/`useTerminals`) switches mouse/selection behavior and drops the hint bar in control mode, and dedupes redundant resize frames (`TerminalSession`).
- Seed-on-attach fidelity: a control client only receives `%output` after it attaches, so the bridge seeds the current screen via `capture-pane -e`. Normalize bare-LF row separators to CRLF (fixes the staircase), strip the trailing separator (fixes the full-height off-by-one scroll), restore cursor position + visibility, and capture `-S -` scrollback only on the primary screen (alt-screen `-S -` would leak stale primary history).

## Test Plan

- `pytest tests/terminals/test_control_bridge.py` — 8 tests against a real private tmux server: octal un-escape, `send-keys -H` chunking, seed streaming + detach close code, CRLF/no-staircase, cursor restore, full-height no-scroll (verified via a pyte VT emulator), primary scrollback recovery, and alt-screen no-history-leak.
- `pytest tests/inner/test_terminal.py::test_resolve_terminal_transport_precedence` and the runner route-dispatch test — transport selection precedence and `?transport=` bridge routing end to end.
- `vitest` for `TerminalView` / `TerminalSession` / `useTerminals` — transport plumbing, native-selection + hint-bar gating, resize dedupe.
- Manual: drove the polly claude-sdk REPL and a claude/codex full-screen session through the web UI, toggling transcript/chat and back, to confirm no staircase, no off-by-one line, correct cursor, and recovered scrollback. Reproduced each seed bug against real tmux before fixing.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The control bridge and transport selection are covered by real-tmux integration tests (seed rendering asserted through a pyte VT emulator) and frontend unit tests. Manual verification covered the parts no automated test exercises: a live browser reconnect against the polly REPL (primary screen) and claude/codex (alternate screen), confirming the seed renders without staircase, extra line, cursor drift, or leaked history. No full browser E2E was added; the WebSocket TestClient can't drive the streaming receive loop, so that path stays manual for now.
