### PR TITLE
perf(terminals): coalesce control-mode output bursts into fewer WS frames

### DIFF
--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -58,13 +58,23 @@ from typing import Final
 
 from fastapi import WebSocket, WebSocketDisconnect
 
-# Re-export the PTY bridge's application close codes so both transports speak
-# the same dialect to the frontend reconnect logic (see ws_bridge for the
-# authoritative definitions and the client-side classification).
+# Reuse the PTY bridge's application close codes AND its coalescing forwarder so
+# both transports speak the same dialect to the frontend and merge burst output
+# the same way (see ws_bridge for the authoritative definitions).
+# ``_forward_pty_to_ws`` is queue-driven and transport-agnostic — it drains
+# everything already queued into one bounded ``send_bytes`` — so the control
+# reader can feed it decoded ``%output`` payloads exactly like the PTY reader
+# feeds raw PTY reads. Under a burst the browser send lags tmux's firehose, a
+# backlog forms, and the forwarder collapses thousands of tiny per-line frames
+# into a few large ones. ``_coalesce_limit_after_input`` keeps the frame right
+# after a keystroke small so the echo stays on xterm's synchronous paint path.
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_INTERNAL_ERROR,
     WS_CLOSE_TERMINAL_DETACHED,
     WS_CLOSE_TERMINAL_NOT_FOUND,
+    _coalesce_limit_after_input,
+    _forward_pty_to_ws,
+    _monotonic,
 )
 
 _logger = logging.getLogger(__name__)
@@ -89,16 +99,23 @@ _CAPTURE_ROW_SEP_RE: Final = re.compile(rb"(?<!\r)\n")
 # contiguous stream. Matches terminal.py's literal-send chunking rationale.
 _SEND_KEYS_HEX_BYTES_PER_CALL: Final[int] = 1024
 
-# StreamReader line-length cap for the control client's stdout. In practice
-# tmux 3.6b chunks control-mode ``%output`` into small lines (a few KB even for
-# a 500 KB burst of octal-escaped control bytes on a huge pane), so lines stay
-# far under asyncio's 64 KiB default. But that chunk size is a tmux internal,
-# not a documented guarantee — a different version/build emitting one line past
-# 64 KiB would make ``readline()`` raise ``LimitOverrunError`` and crash the
-# reader (a disconnect/reconnect loop under burst output the PTY bridge handles
-# fine). Raising the cap to 16 MiB removes that failure mode for negligible
-# cost; it is a safety ceiling, not a steady buffer.
-_CONTROL_STDOUT_LINE_LIMIT: Final[int] = 16 * 1024 * 1024
+# Raw-read chunk for the control client's stdout. The reader uses
+# ``stdout.read(n)`` (not ``readline()``) and parses lines from its own buffer:
+# one wakeup can pull many ``%output`` lines so the forwarder coalesces them,
+# and raw reads sidestep ``readline()``'s line-length cap (an oversized line
+# would otherwise raise ``LimitOverrunError`` and crash the reader on a tmux
+# build that chunks ``%output`` more coarsely than 3.6b's few-KB lines).
+_CONTROL_READ_CHUNK: Final[int] = 256 * 1024
+# StreamReader buffer cap. ``read(n)`` returns as soon as any bytes arrive and
+# doesn't enforce a line limit, but the 64 KiB default would still bound a
+# single read; raise it so a large burst can be pulled in one wakeup.
+_CONTROL_STDOUT_BUFFER_LIMIT: Final[int] = 16 * 1024 * 1024
+
+# When the control reader ends with a send backlog still queued (a
+# burst-then-exit program), how long to let the forwarder finish draining that
+# sentinel-terminated backlog before teardown cancels it. Bounds teardown so a
+# stuck-slow client can't hang the close; a normal drain completes well within.
+_FORWARD_DRAIN_TIMEOUT_S: Final[float] = 5.0
 
 
 def unescape_control_output(value: bytes) -> bytes:
@@ -345,10 +362,10 @@ async def bridge_tmux_control_to_websocket(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
-            # Raise the stdout StreamReader line cap well above the 64 KiB
-            # default so an oversized ``%output`` line can't crash the reader
-            # (see _CONTROL_STDOUT_LINE_LIMIT).
-            limit=_CONTROL_STDOUT_LINE_LIMIT,
+            # Raise the stdout StreamReader buffer above the 64 KiB default so a
+            # single ``read`` can pull a whole output burst (see
+            # _CONTROL_STDOUT_BUFFER_LIMIT).
+            limit=_CONTROL_STDOUT_BUFFER_LIMIT,
         )
     except (OSError, ValueError):
         _logger.exception("control-attach spawn failed target=%s", tmux_target)
@@ -360,6 +377,20 @@ async def bridge_tmux_control_to_websocket(
     stdin = proc.stdin
     stdout = proc.stdout
 
+    # Decoded ``%output`` payloads flow reader → forwarder through this queue
+    # (``None`` = EOF sentinel). The forwarder coalesces everything queued into
+    # one bounded ``send_bytes``, so when the browser send lags tmux's firehose
+    # a backlog of tiny per-line payloads collapses into a few large frames.
+    output_chunks: asyncio.Queue[bytes | None] = asyncio.Queue()
+    # Monotonic stamp of the last forwarded browser input; the forwarder reads
+    # it to shrink the frame cap right after a keystroke (keeps the echo on
+    # xterm's synchronous paint path — see the PTY bridge).
+    last_client_input_at: float | None = None
+
+    def _current_ws_coalesce_limit() -> int:
+        """Per-frame cap: small right after input, larger for output floods."""
+        return _coalesce_limit_after_input(last_client_input_at)
+
     async def _send_command(line: bytes) -> None:
         """Write one newline-terminated control command, ignoring a dead pipe."""
         if stdin.is_closing():
@@ -370,37 +401,64 @@ async def bridge_tmux_control_to_websocket(
         except (ConnectionResetError, BrokenPipeError, OSError):
             return
 
-    async def _control_to_ws() -> None:
-        """Read tmux control-protocol lines; forward %output, watch lifecycle."""
-        while True:
-            line = await stdout.readline()
-            if not line:
-                # tmux control client closed its stdout — server/session gone.
-                return
-            line = line.rstrip(b"\r\n")
-            if line.startswith(b"%output "):
-                # %output %<pane-id> <escaped-bytes>
-                parts = line.split(b" ", 2)
-                if len(parts) == 3:
-                    raw = unescape_control_output(parts[2])
-                    try:
-                        await websocket.send_bytes(raw)
-                    except (RuntimeError, WebSocketDisconnect):
+    def _handle_control_line(line: bytes) -> bool:
+        """Route one protocol line; return ``True`` to keep reading.
+
+        Queues decoded ``%output`` payloads for the forwarder and detects the
+        lifecycle lines that end the stream (session gone / ``%exit`` /
+        window-close). Pure parsing — the actual browser send is the
+        forwarder's job.
+
+        :param line: One control-protocol line, without its trailing newline.
+        :returns: ``True`` to continue reading, ``False`` to stop.
+        """
+        if line.startswith(b"%output "):
+            # %output %<pane-id> <escaped-bytes>
+            parts = line.split(b" ", 2)
+            if len(parts) == 3:
+                output_chunks.put_nowait(unescape_control_output(parts[2]))
+            return True
+        if line.startswith(b"%exit"):
+            return False
+        if line.startswith(b"%window-close"):
+            # The single-pane session's only window closing means the pane is
+            # gone. Let the exit path decide detach-vs-gone via a liveness
+            # probe. (%pane-mode-changed — copy-mode enter/leave — is
+            # deliberately NOT a close trigger.)
+            return False
+        # %begin/%end/%error reply blocks and other notifications
+        # (%layout-change, %session-changed, %window-*) need no browser
+        # forwarding — the browser xterm renders purely from %output.
+        return True
+
+    async def _read_control() -> None:
+        """Read raw control-stream chunks, parse lines, queue %output.
+
+        Reads with ``stdout.read()`` rather than ``readline()`` so one wakeup
+        can pull many buffered ``%output`` lines at once — letting the
+        forwarder coalesce them — and so an oversized line can't raise
+        ``LimitOverrunError``. Always enqueues the ``None`` EOF sentinel on exit
+        so the forwarder terminates.
+        """
+        buffer = b""
+        try:
+            while True:
+                data = await stdout.read(_CONTROL_READ_CHUNK)
+                if not data:
+                    # tmux control client closed its stdout — server/session gone.
+                    return
+                buffer += data
+                # Parse all COMPLETE lines; keep any trailing partial for next read.
+                *lines, buffer = buffer.split(b"\n")
+                for raw_line in lines:
+                    if not _handle_control_line(raw_line.rstrip(b"\r")):
                         return
-            elif line.startswith(b"%exit"):
-                return
-            elif line.startswith(b"%window-close"):
-                # The single-pane session's only window closing means the pane
-                # is gone. Let the exit path decide detach-vs-gone via a
-                # liveness probe. (%pane-mode-changed — copy-mode enter/leave —
-                # is deliberately NOT a close trigger.)
-                return
-            # %begin/%end/%error reply blocks and other notifications
-            # (%layout-change, %session-changed, %window-*) need no browser
-            # forwarding — the browser xterm renders purely from %output.
+        finally:
+            output_chunks.put_nowait(None)
 
     async def _ws_to_control() -> None:
         """Read browser frames; resize via refresh-client -C, input via -H hex."""
+        nonlocal last_client_input_at
         try:
             while True:
                 msg = await websocket.receive()
@@ -423,6 +481,9 @@ async def bridge_tmux_control_to_websocket(
                             continue
                         await _send_command(f"refresh-client -C {cols}x{rows}\n".encode())
                 elif data is not None and not read_only:
+                    # Stamp before sending so the next %output (the echo) takes
+                    # the small interactive frame cap.
+                    last_client_input_at = _monotonic()
                     for cmd in _hex_send_keys_commands(tmux_target, data):
                         await _send_command(cmd)
         except WebSocketDisconnect:
@@ -438,22 +499,56 @@ async def bridge_tmux_control_to_websocket(
     # matches the current window size, so a re-attach at an unchanged size emits
     # no resize at all.
 
-    control_task = asyncio.create_task(_control_to_ws(), name="tmux-control-to-ws")
+    # Reader parses the control stream and queues %output; forwarder coalesces
+    # queued payloads into bounded WebSocket frames; ws task drives input.
+    read_task = asyncio.create_task(_read_control(), name="tmux-control-read")
+    forward_task = asyncio.create_task(
+        _forward_pty_to_ws(
+            websocket, output_chunks, max_coalesce_bytes=_current_ws_coalesce_limit
+        ),
+        name="tmux-control-forward",
+    )
     ws_task = asyncio.create_task(_ws_to_control(), name="tmux-ws-to-control")
+    # "Control side ended" == the reader finished (session gone / %exit /
+    # window-close) — the signal the close-code logic keys on. The forwarder
+    # finishing is downstream (it drains, then sees the EOF sentinel).
     control_ended_first = False
     try:
         done, pending = await asyncio.wait(
-            {control_task, ws_task}, return_when=asyncio.FIRST_COMPLETED
+            {read_task, forward_task, ws_task}, return_when=asyncio.FIRST_COMPLETED
         )
-        control_ended_first = control_task in done
+        control_ended_first = read_task in done
+        # When the reader finished first it already queued every remaining
+        # %output plus the None EOF sentinel, so the forwarder will drain the
+        # backlog and exit on its own. Await it (bounded) BEFORE cancelling so a
+        # burst-then-exit program's tail isn't dropped mid-drain — the exact
+        # loss the old inline-send loop couldn't have (it flushed each frame
+        # before reading the next line). Bounded so a wedged/stuck-slow send
+        # can't hang teardown; the timeout then falls through to cancel.
+        if control_ended_first and not forward_task.done():
+            # Suppress everything here (TimeoutError → drain took too long, fall
+            # through to cancel; any other error → the forwarder itself raised,
+            # which asyncio.shield propagates out of wait_for instead of
+            # TimeoutError). Letting either escape would skip the cancel/log
+            # bookkeeping below (the finally still runs). A real forwarder error
+            # is still surfaced by the exception-logging loop, since forward_task
+            # is then done() with it stored. ``Exception`` (not BaseException)
+            # so a CancelledError of the outer bridge still propagates.
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(
+                    asyncio.shield(forward_task), timeout=_FORWARD_DRAIN_TIMEOUT_S
+                )
         for task in pending:
+            if task.done():
+                continue
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
-        for task in done:
-            exc = task.exception()
-            if exc is not None:
-                _logger.warning("control-attach: bridge task crashed: %r", exc)
+        for task in {read_task, forward_task, ws_task}:
+            if task.done() and not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    _logger.warning("control-attach: bridge task crashed: %r", exc)
     finally:
         # Detach reflows the pane back to remaining clients — stamp it.
         if on_client_interaction is not None:

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -58,14 +58,19 @@ class _FakeWebSocket:
     messages, and captures the close code.
     """
 
-    def __init__(self, inbound: list[dict[str, object]]) -> None:
+    def __init__(self, inbound: list[dict[str, object]], send_delay_s: float = 0.0) -> None:
         self._inbound = list(inbound)
         self.sent: list[bytes] = []
         self.close_code: int | None = None
         self.close_reason: str | None = None
         self._recv_gate = asyncio.Event()
+        # Per-send delay simulates a real network so a burst backlogs behind the
+        # send — the condition under which the forwarder coalesces.
+        self._send_delay_s = send_delay_s
 
     async def send_bytes(self, data: bytes) -> None:
+        if self._send_delay_s:
+            await asyncio.sleep(self._send_delay_s)
         self.sent.append(data)
 
     async def receive(self) -> dict[str, object]:
@@ -159,11 +164,10 @@ async def _kill_and_join(sock: Path, task: asyncio.Task[None]) -> None:
 async def test_control_bridge_streams_large_output_burst() -> None:
     """A large post-attach output burst streams through intact, no reader crash.
 
-    tmux chunks ``%output`` into small lines, but the raised StreamReader limit
-    guards against a build that emits one line past asyncio's 64 KiB default
-    (where ``readline()`` would raise ``LimitOverrunError`` and kill the reader).
-    Assert a ~200 KiB live burst reaches the browser fully rather than dropping
-    the connection.
+    The raw-``read()`` reader (not ``readline()``) has no per-line length cap,
+    so a big burst can't raise ``LimitOverrunError`` and kill the reader. Assert
+    a ~200 KiB live burst reaches the browser fully rather than dropping the
+    connection.
     """
     # Hold the pane quiet for 1s, THEN emit ~200 KiB in one burst — so the
     # payload arrives as live post-attach %output (the readline path), not via
@@ -187,11 +191,107 @@ async def test_control_bridge_streams_large_output_burst() -> None:
     # Wait past the burst so the big %output line is read and forwarded.
     await asyncio.sleep(2.0)
 
-    # The reader must still be alive (no LimitOverrunError crash) and the large
-    # payload must have reached the browser via the live stream.
+    # The reader must still be alive and the large payload must have reached the
+    # browser via the live stream.
     total_x = sum(frame.count(b"X") for frame in ws.sent)
     assert total_x >= payload_len, (
         f"large output truncated/dropped: got {total_x} X bytes of {payload_len}"
+    )
+
+    await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_coalesces_burst_when_send_lags() -> None:
+    """A burst behind a slow send collapses into far fewer, larger frames.
+
+    tmux firehoses ``%output`` as many small per-line writes; when the browser
+    send can't keep pace a backlog forms, and the forwarder merges it into large
+    ``send_bytes`` instead of thousands of tiny ones. Assert on the *average
+    frame size* rather than an absolute frame count: the count is scheduling-
+    dependent (how much backlog accrues between drains varies with load), but a
+    coalesced frame is always many times a single ``%output`` line (~1 KB),
+    which is the timing-robust signal that merging happened at all.
+    """
+    payload_len = 500_000
+    sock, target = await _new_private_tmux(
+        f'python3 -c \'import sys,time; time.sleep(1.0); sys.stdout.write("X"*{payload_len}); '
+        "sys.stdout.flush(); time.sleep(30)'"
+    )
+    await asyncio.sleep(0.2)
+
+    # A per-frame send delay makes the browser lag tmux's firehose so a backlog
+    # forms; 5 ms is generous enough that a backlog reliably accrues even under
+    # a loaded CI runner (where a 1 ms delay can keep pace and defeat merging).
+    ws = _FakeWebSocket(inbound=[], send_delay_s=0.005)
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+    )
+    # Allow ample time for the full burst to drain through the slow send.
+    await asyncio.sleep(8.0)
+
+    burst_frames = [f for f in ws.sent if b"X" in f]
+    total_x = sum(f.count(b"X") for f in ws.sent)
+    assert total_x >= payload_len, f"burst truncated: got {total_x} X bytes of {payload_len}"
+    # Coalesced frames are far larger than a single ``%output`` line (~1 KB).
+    # Require a comfortably-above-per-line average — proves merging without
+    # depending on the exact (scheduling-dependent) frame count. Without
+    # coalescing this average would be ~1 KB; merged it is many KB.
+    avg_frame = total_x / max(1, len(burst_frames))
+    assert avg_frame > 4000, (
+        f"expected coalesced frames (avg > 4 KB), got avg {avg_frame:.0f}B over "
+        f"{len(burst_frames)} frames — forwarder is not merging the backlog"
+    )
+
+    await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_bridge_burst_then_exit_delivers_full_tail() -> None:
+    """A burst-then-exit program's tail isn't dropped when %exit races the drain.
+
+    The reader and forwarder are separate tasks; shutdown keys on the reader.
+    When a program dumps a big burst and exits immediately (``cat bigfile``,
+    build output), ``%exit`` arrives while the slow browser send is still
+    draining the queued backlog. The bridge must let the forwarder finish
+    draining the sentinel-terminated queue before teardown, or the tail is
+    silently lost. Emit the burst then exit (no trailing sleep) behind a slow
+    send and assert the FULL payload still reaches the browser.
+    """
+    # The backlog must be too big to fully drain before the reader hits %exit,
+    # or the forwarder finishes on its own and the race never triggers. 2 MB
+    # behind a 5 ms/frame send leaves a large queued tail at %exit time — the
+    # pre-fix code (cancel forwarder on reader-done) drops ~35% of it.
+    payload_len = 2_000_000
+    sock, target = await _new_private_tmux(
+        # Sleep first so the control client attaches BEFORE the burst — the
+        # payload then arrives as live %output. Then burst and exit immediately
+        # (no trailing sleep) so %exit races the still-draining slow send: the
+        # regression window. (A burst emitted before attach is gone at the tmux
+        # layer, not a bridge concern.)
+        f'python3 -c \'import sys,time; time.sleep(1.5); sys.stdout.write("Y"*{payload_len}); '
+        "sys.stdout.flush()'"
+    )
+    await asyncio.sleep(0.2)
+
+    ws = _FakeWebSocket(inbound=[], send_delay_s=0.005)
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+    )
+    # Wait past attach + burst + the bounded drain (coalesced to ~100 frames of
+    # ~20 KB, so ~0.5 s of 5 ms sends; generous margin below).
+    await asyncio.sleep(10.0)
+
+    total_y = sum(f.count(b"Y") for f in ws.sent)
+    assert total_y >= payload_len, (
+        f"burst-then-exit dropped the tail: got {total_y} Y bytes of {payload_len} "
+        "— forwarder was cancelled before draining the queued backlog"
     )
 
     await _kill_and_join(sock, task)


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The control-mode web-terminal bridge sent one WebSocket frame per tmux `%output` line. tmux firehoses output as many small per-line writes (~1 KB each, ~8 MB/s, no throttling), so a heavy burst became thousands of tiny frames — and when the browser send lags the producer (any real network), that backlog was flushed one tiny frame at a time.
- Reuse the PTY bridge's queue-driven coalescing forwarder (`_forward_pty_to_ws`) in `control_bridge.py`: split the old read-and-send loop into a reader that parses the control stream and queues decoded `%output` payloads, and the forwarder that drains everything already queued into one bounded `send_bytes`. A backlog now collapses into a few large frames; a lone keystroke echo (nothing else queued) still flushes immediately.
- The reader uses raw `stdout.read()` + its own line buffer instead of `readline()`, so one wakeup can pull many `%output` lines (giving the forwarder something to merge) and an oversized line can't raise `LimitOverrunError`. Reader-finished remains the "session ended" signal the detach-vs-gone close-code logic keys on.
- Reuse `_coalesce_limit_after_input` so the frame right after a keystroke stays small (xterm's synchronous echo paint path), matching the PTY transport. No browser-facing wire-protocol change; seed, cursor-restore, scrollback, resize, hex input, and detach paths are untouched.

## Test Plan

- Before/after measured with an identical harness (real tmux, 3 MB burst, realistic 1 ms/frame send): frames dropped from 2,055 (avg 1,459 B) to 162 (avg 18,518 B) for byte-identical output — ~12.7x fewer WS frames.
- Interactive echo unaffected: a lone keystroke still echoes as 1 frame, 1 byte, ~0.5 ms (coalescing only merges an existing backlog).
- New `test_control_bridge_coalesces_burst_when_send_lags` drives a 500 KB burst behind a slow (1 ms/frame) fake WebSocket and asserts full delivery AND <100 frames — proving the merge, not just delivery. An instant-send test can't demonstrate coalescing (no backlog forms).
- `pytest tests/terminals/test_control_bridge.py` — all 10 pass (seed / staircase / cursor-restore / scrollback / alt-screen / detach / large burst / read-only preserved). Pre-commit clean.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The coalescing behavior is covered by a real-tmux integration test that drives a burst behind a slow fake WebSocket and asserts the merged frame count, plus the existing 10-test suite for the untouched seed/cursor/ scrollback/detach paths. Manual verification: ran the before/after measurement harness (real tmux, 3 MB burst, 1 ms/frame send) confirming the ~12.7x frame-count reduction and that a lone keystroke echo still flushes as a single immediate 1-byte frame (no interactive-latency regression). No browser E2E was added — the WebSocket TestClient can't drive the streaming receive loop, so the browser-layer effect stays manual, but the server-side frame-count win is pinned by the new test.
