### PR TITLE
refactor(native): extract shared session-adoption parsers from live forwarders

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -33,7 +33,6 @@ import hashlib
 import json
 import os
 import queue
-import re
 import secrets
 import shlex
 import stat
@@ -58,6 +57,122 @@ from omnigent.kiro_native_bridge import bridge_root as kiro_bridge_root
 if TYPE_CHECKING:
     from omnigent.llms.context_window import ModelPricing
 
+from omnigent.claude_transcript_parser import (
+    _BASH_INPUT_RE as _BASH_INPUT_RE,
+)
+from omnigent.claude_transcript_parser import (
+    _BASH_STDERR_RE as _BASH_STDERR_RE,
+)
+from omnigent.claude_transcript_parser import (
+    _BASH_STDOUT_RE as _BASH_STDOUT_RE,
+)
+from omnigent.claude_transcript_parser import (
+    _CLAUDE_CLI_DROPPED_COMMANDS as _CLAUDE_CLI_DROPPED_COMMANDS,
+)
+from omnigent.claude_transcript_parser import (
+    _CLAUDE_CLI_SURFACED_COMMANDS as _CLAUDE_CLI_SURFACED_COMMANDS,
+)
+from omnigent.claude_transcript_parser import (
+    _CLI_SCAFFOLDING_MARKERS as _CLI_SCAFFOLDING_MARKERS,
+)
+from omnigent.claude_transcript_parser import (
+    _COMMAND_ARGS_RE as _COMMAND_ARGS_RE,
+)
+from omnigent.claude_transcript_parser import (
+    _COMMAND_NAME_RE as _COMMAND_NAME_RE,
+)
+from omnigent.claude_transcript_parser import (
+    _COMMAND_STDOUT_RE as _COMMAND_STDOUT_RE,
+)
+from omnigent.claude_transcript_parser import (
+    _CONTEXT_OVERFLOW_RE as _CONTEXT_OVERFLOW_RE,
+)
+from omnigent.claude_transcript_parser import (
+    _CONTEXT_OVERFLOW_REPLACEMENT as _CONTEXT_OVERFLOW_REPLACEMENT,
+)
+
+# Re-exported from the shared transcript parser (extracted for session adoption;
+# see omnigent.claude_transcript_parser). The redundant ``as`` aliases mark these
+# as intentional re-exports so callers and tests keep importing them from the
+# bridge unchanged.
+from omnigent.claude_transcript_parser import (
+    ClaudeTranscriptItem as ClaudeTranscriptItem,
+)
+from omnigent.claude_transcript_parser import (
+    TranscriptReadResult as TranscriptReadResult,
+)
+from omnigent.claude_transcript_parser import (
+    _assistant_message_item as _assistant_message_item,
+)
+from omnigent.claude_transcript_parser import (
+    _assistant_text_from_transcript_line as _assistant_text_from_transcript_line,
+)
+from omnigent.claude_transcript_parser import (
+    _assistant_transcript_items_from_entry as _assistant_transcript_items_from_entry,
+)
+from omnigent.claude_transcript_parser import (
+    _attachment_transcript_items_from_entry as _attachment_transcript_items_from_entry,
+)
+from omnigent.claude_transcript_parser import (
+    _JsonlReadResult as _JsonlReadResult,
+)
+from omnigent.claude_transcript_parser import (
+    _JsonlRecord as _JsonlRecord,
+)
+from omnigent.claude_transcript_parser import (
+    _local_command_transcript_items_from_entry as _local_command_transcript_items_from_entry,
+)
+from omnigent.claude_transcript_parser import (
+    _model_from_transcript_entry as _model_from_transcript_entry,
+)
+from omnigent.claude_transcript_parser import (
+    _parent_or_record_source_key as _parent_or_record_source_key,
+)
+from omnigent.claude_transcript_parser import (
+    _parse_slash_command_record as _parse_slash_command_record,
+)
+from omnigent.claude_transcript_parser import (
+    _read_complete_jsonl_records as _read_complete_jsonl_records,
+)
+from omnigent.claude_transcript_parser import (
+    _response_id_from_source as _response_id_from_source,
+)
+from omnigent.claude_transcript_parser import (
+    _SlashCommandPayload as _SlashCommandPayload,
+)
+from omnigent.claude_transcript_parser import (
+    _source_id as _source_id,
+)
+from omnigent.claude_transcript_parser import (
+    _terminal_command_items_from_content as _terminal_command_items_from_content,
+)
+from omnigent.claude_transcript_parser import (
+    _tool_result_output as _tool_result_output,
+)
+from omnigent.claude_transcript_parser import (
+    _transcript_items_from_entry as _transcript_items_from_entry,
+)
+from omnigent.claude_transcript_parser import (
+    _transcript_source_key as _transcript_source_key,
+)
+from omnigent.claude_transcript_parser import (
+    _usage_from_transcript_entry as _usage_from_transcript_entry,
+)
+from omnigent.claude_transcript_parser import (
+    _user_transcript_items_from_entry as _user_transcript_items_from_entry,
+)
+from omnigent.claude_transcript_parser import (
+    read_assistant_text_since as read_assistant_text_since,
+)
+from omnigent.claude_transcript_parser import (
+    read_transcript_items_from_offset as read_transcript_items_from_offset,
+)
+from omnigent.claude_transcript_parser import (
+    read_transcript_items_since as read_transcript_items_since,
+)
+from omnigent.claude_transcript_parser import (
+    read_transcript_items_since_with_position as read_transcript_items_since_with_position,
+)
 from omnigent.inner.bundle_skills import claude_native_skill_args
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.os_env import OSEnvironment, create_os_environment
@@ -286,57 +401,6 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
 
 
 @dataclass(frozen=True)
-class ClaudeTranscriptItem:
-    """
-    One Omnigent conversation item parsed from Claude's JSONL log.
-
-    :param source_id: Stable idempotency key derived from the Claude
-        transcript record UUID and content block position, e.g.
-        ``"747e:0:function_call"``.
-    :param item_type: Omnigent conversation item type, e.g.
-        ``"message"`` or ``"function_call"``.
-    :param data: Item payload shaped like ``SessionEventInput.data``.
-    :param response_id: Synthetic response id used to group the
-        Claude turn in AP/web UI rendering.
-    """
-
-    source_id: str
-    item_type: str
-    data: dict[str, Any]
-    response_id: str
-
-
-@dataclass(frozen=True)
-class TranscriptReadResult:
-    """
-    Result of reading Claude transcript JSONL records.
-
-    :param line_cursor: Count of complete newline-terminated records
-        consumed from the transcript, e.g. ``12``.
-    :param byte_offset: Byte offset immediately after the last
-        complete record consumed, e.g. ``4096``. A partial trailing
-        line is not included.
-    :param current_response_id: Response id for a Claude assistant
-        turn that remains active across polls.
-    :param items: Parsed Omnigent conversation items from the
-        complete records after the caller's cursor.
-    :param latest_usage: Token-usage from the most recent assistant
-        entry with a ``message.usage`` block. Keys: ``context_tokens``,
-        ``input_tokens``, ``output_tokens``. ``None`` when no such
-        entry was scanned.
-    :param latest_model: ``message.model`` from the most recent
-        assistant entry, or ``None``.
-    """
-
-    line_cursor: int
-    byte_offset: int
-    current_response_id: str | None
-    items: list[ClaudeTranscriptItem]
-    latest_usage: dict[str, int] | None = None
-    latest_model: str | None = None
-
-
-@dataclass(frozen=True)
 class ClaudeHookRecord:
     """
     One complete hook JSONL record read from ``hooks.jsonl``.
@@ -434,43 +498,6 @@ class HookReadResult:
     event_cursor: int
     byte_offset: int
     records: list[ClaudeHookRecord]
-
-
-@dataclass(frozen=True)
-class _JsonlRecord:
-    """
-    One complete newline-terminated JSONL record.
-
-    :param line_number: One-based line number relative to the reader's
-        line cursor, e.g. ``5``.
-    :param byte_offset: Byte offset where the record starts.
-    :param next_byte_offset: Byte offset immediately after the
-        newline-terminated record.
-    :param text: UTF-8 decoded JSONL text including the trailing
-        newline, or ``None`` when the complete record was not valid
-        UTF-8 and should advance cursors without being parsed.
-    """
-
-    line_number: int
-    byte_offset: int
-    next_byte_offset: int
-    text: str | None
-
-
-@dataclass(frozen=True)
-class _JsonlReadResult:
-    """
-    Complete-record read result for an append-only JSONL file.
-
-    :param line_cursor: Count of complete records consumed.
-    :param byte_offset: Byte offset after the last complete record.
-    :param records: Complete records read after the requested byte
-        offset.
-    """
-
-    line_cursor: int
-    byte_offset: int
-    records: list[_JsonlRecord]
 
 
 @dataclass(frozen=True)
@@ -1657,217 +1684,6 @@ def _local_command_name(content: str) -> str | None:
     return name or None
 
 
-def read_assistant_text_since(
-    transcript_path: Path,
-    start_line: int,
-) -> tuple[int, list[str]]:
-    """
-    Read assistant text blocks appended after a transcript cursor.
-
-    :param transcript_path: Claude transcript path, e.g.
-        ``"/home/user/.claude/projects/x/session.jsonl"``.
-    :param start_line: Zero-based line cursor captured before a
-        message is injected into the Claude terminal.
-    :returns: ``(new_cursor, text_chunks)``.
-    """
-    texts: list[str] = []
-    cursor = 0
-    try:
-        with transcript_path.open("r", encoding="utf-8") as handle:
-            for cursor, line in enumerate(handle, start=1):
-                if cursor <= start_line:
-                    continue
-                text = _assistant_text_from_transcript_line(line)
-                if text:
-                    texts.append(text)
-    except FileNotFoundError:
-        return start_line, []
-    return cursor, texts
-
-
-def read_transcript_items_since(
-    transcript_path: Path,
-    start_line: int,
-    *,
-    agent_name: str,
-    current_response_id: str | None = None,
-) -> tuple[int, str | None, list[ClaudeTranscriptItem]]:
-    """
-    Read Claude transcript records as Omnigent conversation items.
-
-    Claude Code writes append-only JSONL records whose ``message``
-    payloads include user prompts, assistant text, native tool calls,
-    and native tool results. This parser intentionally ignores
-    metadata records (title, file-history, permission mode, system
-    bookkeeping) and raw ``thinking`` blocks, while translating the
-    user-visible semantic records into Omnigent item types the web UI
-    already understands.
-
-    :param transcript_path: Claude transcript path, e.g.
-        ``"/home/user/.claude/projects/x/session.jsonl"``.
-    :param start_line: One-based line cursor. Lines at or before
-        this cursor are skipped.
-    :param agent_name: Agent/model name stamped on assistant and
-        tool-call items, e.g. ``"claude-native-ui"``.
-    :param current_response_id: Response id for an in-progress
-        Claude assistant turn from a previous poll.
-    :returns: ``(new_cursor, current_response_id, items)``.
-    """
-    result = read_transcript_items_since_with_position(
-        transcript_path,
-        start_line,
-        agent_name=agent_name,
-        current_response_id=current_response_id,
-    )
-    return result.line_cursor, result.current_response_id, result.items
-
-
-def read_transcript_items_since_with_position(
-    transcript_path: Path,
-    start_line: int,
-    *,
-    agent_name: str,
-    current_response_id: str | None = None,
-) -> TranscriptReadResult:
-    """
-    Read transcript items from a line cursor and return byte position.
-
-    This compatibility reader supports existing durable state that
-    only stored a line cursor. It scans the file once, parses only
-    complete newline-terminated records after ``start_line``, and
-    returns the byte offset so future polls can seek directly.
-
-    :param transcript_path: Claude transcript path, e.g.
-        ``"/home/user/.claude/projects/x/session.jsonl"``.
-    :param start_line: One-based line cursor. Lines at or before
-        this cursor are skipped.
-    :param agent_name: Agent/model name stamped on assistant and
-        tool-call items, e.g. ``"claude-native-ui"``.
-    :param current_response_id: Response id for an in-progress
-        Claude assistant turn from a previous poll.
-    :returns: Parsed items plus line and byte cursors.
-    """
-    read_result = _read_complete_jsonl_records(
-        transcript_path,
-        byte_offset=0,
-        start_line=0,
-        emit_after_line=start_line,
-    )
-    items: list[ClaudeTranscriptItem] = []
-    active_response_id = current_response_id
-    latest_usage: dict[str, int] | None = None
-    latest_model: str | None = None
-    for record in read_result.records:
-        if record.text is None:
-            continue
-        try:
-            entry = json.loads(record.text)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(entry, dict):
-            continue
-        active_response_id, parsed = _transcript_items_from_entry(
-            entry,
-            line_number=record.line_number,
-            record_offset=None,
-            agent_name=agent_name,
-            current_response_id=active_response_id,
-        )
-        items.extend(parsed)
-        usage = _usage_from_transcript_entry(entry)
-        if usage is not None:
-            latest_usage = usage
-        model = _model_from_transcript_entry(entry)
-        if model is not None:
-            latest_model = model
-    return TranscriptReadResult(
-        line_cursor=read_result.line_cursor,
-        byte_offset=read_result.byte_offset,
-        current_response_id=active_response_id,
-        items=items,
-        latest_usage=latest_usage,
-        latest_model=latest_model,
-    )
-
-
-def read_transcript_items_from_offset(
-    transcript_path: Path,
-    byte_offset: int,
-    *,
-    start_line: int,
-    agent_name: str,
-    current_response_id: str | None = None,
-    include_sidechains: bool = False,
-) -> TranscriptReadResult:
-    """
-    Read transcript items appended after a byte offset.
-
-    Only complete newline-terminated JSONL records are parsed. If
-    Claude is midway through writing a trailing JSON record, the
-    returned byte offset remains before that partial line so the next
-    poll retries it after completion.
-
-    :param transcript_path: Claude transcript path, e.g.
-        ``"/home/user/.claude/projects/x/session.jsonl"``.
-    :param byte_offset: Byte offset already consumed, e.g. ``4096``.
-    :param start_line: Count of complete records already consumed.
-        Used only to keep legacy line cursors and diagnostics
-        monotonic while byte offsets drive the actual seek.
-    :param agent_name: Agent/model name stamped on assistant and
-        tool-call items, e.g. ``"claude-native-ui"``.
-    :param current_response_id: Response id for an in-progress
-        Claude assistant turn from a previous poll.
-    :param include_sidechains: Pass ``True`` when reading a
-        sub-agent's own ``agent-<id>.jsonl`` — every record there is
-        a sidechain by Claude's definition, and dropping them would
-        leave the sub-agent's child Omnigent conversation empty. The
-        default ``False`` keeps the parent-transcript path
-        unchanged.
-    :returns: Parsed items plus updated line and byte cursors.
-    """
-    read_result = _read_complete_jsonl_records(
-        transcript_path,
-        byte_offset=byte_offset,
-        start_line=start_line,
-    )
-    items: list[ClaudeTranscriptItem] = []
-    active_response_id = current_response_id
-    latest_usage: dict[str, int] | None = None
-    latest_model: str | None = None
-    for record in read_result.records:
-        if record.text is None:
-            continue
-        try:
-            entry = json.loads(record.text)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(entry, dict):
-            continue
-        active_response_id, parsed = _transcript_items_from_entry(
-            entry,
-            line_number=record.line_number,
-            record_offset=record.byte_offset,
-            agent_name=agent_name,
-            current_response_id=active_response_id,
-            include_sidechains=include_sidechains,
-        )
-        items.extend(parsed)
-        usage = _usage_from_transcript_entry(entry)
-        if usage is not None:
-            latest_usage = usage
-        model = _model_from_transcript_entry(entry)
-        if model is not None:
-            latest_model = model
-    return TranscriptReadResult(
-        line_cursor=read_result.line_cursor,
-        byte_offset=read_result.byte_offset,
-        current_response_id=active_response_id,
-        items=items,
-        latest_usage=latest_usage,
-        latest_model=latest_model,
-    )
-
-
 # Per-model pricing memo for transcript cost computation. Deliberately
 # NOT ``functools.lru_cache``: a transient ``fetch_model_pricing`` failure
 # returns ``None``, and lru_cache would pin that ``None`` for the model's
@@ -2277,83 +2093,6 @@ def _hook_record_from_jsonl_record(record: _JsonlRecord) -> ClaudeHookRecord:
         task_subject=task_subject,
         task_status=task_status,
         background_task_count=background_task_count,
-    )
-
-
-def _read_complete_jsonl_records(
-    path: Path,
-    *,
-    byte_offset: int,
-    start_line: int,
-    emit_after_line: int | None = None,
-) -> _JsonlReadResult:
-    """
-    Read complete newline-terminated records from a JSONL file.
-
-    The reader seeks to ``byte_offset`` and stops before a trailing
-    partial line. That partial line's bytes are retried by the next
-    poll after the writer appends its newline.
-
-    :param path: JSONL file path.
-    :param byte_offset: Byte offset where reading should begin,
-        e.g. ``4096``.
-    :param start_line: Count of complete records before
-        ``byte_offset``, e.g. ``12``.
-    :param emit_after_line: When provided, complete records at or
-        before this line number are counted for cursor migration but
-        not decoded or stored.
-    :returns: Complete records plus updated line and byte cursors.
-    """
-    if byte_offset < 0:
-        raise ValueError(f"byte_offset must be non-negative, got {byte_offset}")
-    if start_line < 0:
-        raise ValueError(f"start_line must be non-negative, got {start_line}")
-    records: list[_JsonlRecord] = []
-    cursor = start_line
-    position = byte_offset
-    try:
-        with path.open("rb") as handle:
-            handle.seek(0, os.SEEK_END)
-            file_size = handle.tell()
-            if byte_offset > file_size:
-                handle.seek(0)
-                cursor = 0
-                position = 0
-            else:
-                handle.seek(byte_offset)
-            while True:
-                record_start = position
-                raw = handle.readline()
-                if not raw:
-                    break
-                if not raw.endswith(b"\n"):
-                    break
-                position = handle.tell()
-                cursor += 1
-                if emit_after_line is not None and cursor <= emit_after_line:
-                    continue
-                try:
-                    text = raw.decode("utf-8")
-                except UnicodeDecodeError:
-                    text = None
-                records.append(
-                    _JsonlRecord(
-                        line_number=cursor,
-                        byte_offset=record_start,
-                        next_byte_offset=position,
-                        text=text,
-                    )
-                )
-    except FileNotFoundError:
-        return _JsonlReadResult(
-            line_cursor=start_line,
-            byte_offset=byte_offset,
-            records=[],
-        )
-    return _JsonlReadResult(
-        line_cursor=cursor,
-        byte_offset=position,
-        records=records,
     )
 
 
@@ -3807,28 +3546,6 @@ def _write_jsonrpc(
             print(raw, flush=True)
 
 
-def _model_from_transcript_entry(entry: dict[str, Any]) -> str | None:
-    """
-    Return ``message.model`` from an assistant transcript record.
-
-    Surfaced on :class:`TranscriptReadResult.latest_model` for
-    diagnostics. The ring's denominator comes from the statusLine
-    stdin (see :func:`read_claude_context_state`); the JSONL model
-    name is no longer used to size the ring.
-
-    :param entry: One decoded transcript JSONL record.
-    :returns: API model name, or ``None`` for non-assistant entries
-        and entries missing the field.
-    """
-    message = entry.get("message")
-    if not isinstance(message, dict) or message.get("role") != "assistant":
-        return None
-    model = message.get("model")
-    if isinstance(model, str) and model:
-        return model
-    return None
-
-
 def read_claude_context_state(bridge_dir: Path) -> dict[str, Any] | None:
     """
     Read the most recent statusLine snapshot from ``context.json``.
@@ -3946,823 +3663,6 @@ def read_user_effort_level() -> str | None:
     if isinstance(effort, str) and effort in CLAUDE_EFFORTS:
         return effort
     return None
-
-
-def _usage_from_transcript_entry(entry: dict[str, Any]) -> dict[str, int] | None:
-    """
-    Extract token-usage from one Claude assistant transcript entry.
-
-    ``context_tokens`` is ``input + cache_creation + cache_read`` — the
-    bytes that will reappear in the next call's prompt. Output tokens
-    are reported separately since they don't shift the prompt forward.
-
-    :param entry: One decoded transcript JSONL record.
-    :returns: ``{"context_tokens", "input_tokens", "output_tokens"}``
-        when the record is an assistant entry with usage; ``None``
-        otherwise.
-    """
-    message = entry.get("message")
-    if not isinstance(message, dict) or message.get("role") != "assistant":
-        return None
-    usage = message.get("usage")
-    if not isinstance(usage, dict):
-        return None
-    input_tokens = usage.get("input_tokens")
-    output_tokens = usage.get("output_tokens")
-    cache_creation = usage.get("cache_creation_input_tokens")
-    cache_read = usage.get("cache_read_input_tokens")
-    if not isinstance(input_tokens, int):
-        return None
-    if not isinstance(output_tokens, int):
-        output_tokens = 0
-    cc = cache_creation if isinstance(cache_creation, int) else 0
-    cr = cache_read if isinstance(cache_read, int) else 0
-    result: dict[str, int] = {
-        "context_tokens": input_tokens + cc + cr,
-        "input_tokens": input_tokens,
-        "output_tokens": output_tokens,
-    }
-    if cc:
-        result["cache_creation_input_tokens"] = cc
-    if cr:
-        result["cache_read_input_tokens"] = cr
-    return result
-
-
-def _assistant_text_from_transcript_line(line: str) -> str | None:
-    """
-    Extract assistant text from one Claude transcript JSONL line.
-
-    :param line: Raw JSONL record.
-    :returns: Assistant text, or ``None`` when the record is not an
-        assistant text message.
-    """
-    try:
-        entry = json.loads(line)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(entry, dict):
-        return None
-    message = entry.get("message")
-    if not isinstance(message, dict) or message.get("role") != "assistant":
-        return None
-    content = message.get("content")
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return None
-    parts: list[str] = []
-    for block in content:
-        if isinstance(block, dict) and block.get("type") == "text":
-            text = block.get("text")
-            if isinstance(text, str) and text:
-                parts.append(text)
-    return "".join(parts) or None
-
-
-def _transcript_items_from_entry(
-    entry: dict[str, Any],
-    *,
-    line_number: int,
-    record_offset: int | None = None,
-    agent_name: str,
-    current_response_id: str | None,
-    include_sidechains: bool = False,
-) -> tuple[str | None, list[ClaudeTranscriptItem]]:
-    """
-    Convert one Claude transcript entry into Omnigent conversation items.
-
-    :param entry: Decoded JSON object from one transcript line.
-    :param line_number: One-based transcript line number.
-    :param record_offset: Byte offset where the transcript record
-        starts. Used for stable fallback source ids when Claude omits
-        ``uuid`` and ``requestId``.
-    :param agent_name: Agent/model name for assistant/tool items.
-    :param current_response_id: Response id for the active Claude
-        assistant turn, if a previous poll already started one.
-    :param include_sidechains: When ``False`` (the default) any record
-        with ``isSidechain: true`` is dropped — that's the right
-        behavior when reading the parent's main transcript, where
-        sub-agent records are inlined as sidechains and must not
-        appear in the parent's Omnigent conversation. When ``True`` the
-        flag is ignored — required when reading a sub-agent's own
-        ``agent-<id>.jsonl`` (every record there is a sidechain by
-        definition) so the sub-agent's items reach the child AP
-        conversation. Caller is responsible for matching the flag to
-        the file shape.
-    :returns: Updated active response id and parsed items.
-    """
-    if not include_sidechains and entry.get("isSidechain") is True:
-        return current_response_id, []
-    if entry.get("type") == "attachment":
-        return _attachment_transcript_items_from_entry(
-            entry,
-            line_number=line_number,
-            record_offset=record_offset,
-            current_response_id=current_response_id,
-        )
-    if entry.get("subtype") == "local_command":
-        return _local_command_transcript_items_from_entry(
-            entry,
-            line_number=line_number,
-            record_offset=record_offset,
-            current_response_id=current_response_id,
-        )
-    message = entry.get("message")
-    if not isinstance(message, dict):
-        return current_response_id, []
-    role = message.get("role")
-    if role == "user":
-        return _user_transcript_items_from_entry(
-            entry,
-            line_number=line_number,
-            record_offset=record_offset,
-            agent_name=agent_name,
-            current_response_id=current_response_id,
-        )
-    if role == "assistant":
-        return _assistant_transcript_items_from_entry(
-            entry,
-            line_number=line_number,
-            record_offset=record_offset,
-            agent_name=agent_name,
-            current_response_id=current_response_id,
-        )
-    return current_response_id, []
-
-
-def _attachment_transcript_items_from_entry(
-    entry: dict[str, Any],
-    *,
-    line_number: int,
-    record_offset: int | None,
-    current_response_id: str | None,
-) -> tuple[str | None, list[ClaudeTranscriptItem]]:
-    """
-    Parse user-visible Claude attachment transcript entries.
-
-    Claude records prompts typed while an assistant turn is busy as
-    ``attachment.type == "queued_command"`` rather than a normal
-    ``role=user`` message. Treat prompt-mode queued commands as user
-    messages so interruption inputs such as ``"STOP"`` appear in the
-    Omnigent transcript and reset the active assistant response.
-
-    :param entry: Decoded Claude transcript record.
-    :param line_number: One-based transcript line number.
-    :param record_offset: Byte offset where the transcript record
-        starts, or ``None`` for legacy line-cursor reads.
-    :param current_response_id: Response id for the active assistant
-        turn. Ignored attachment metadata preserves this value.
-    :returns: Updated active response id and parsed items.
-    """
-    attachment = entry.get("attachment")
-    if not isinstance(attachment, dict):
-        return current_response_id, []
-    if attachment.get("type") != "queued_command":
-        return current_response_id, []
-    if attachment.get("commandMode") != "prompt":
-        return current_response_id, []
-    prompt = attachment.get("prompt")
-    if not isinstance(prompt, str) or not prompt:
-        return current_response_id, []
-    source_key = _transcript_source_key(entry, line_number, record_offset)
-    item = ClaudeTranscriptItem(
-        source_id=_source_id(source_key, 0, "message"),
-        item_type="message",
-        data={
-            "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
-        },
-        response_id=_response_id_from_source(source_key),
-    )
-    return None, [item]
-
-
-# Slash-command marker handling. Claude Code's embedded TUI emits
-# multiple ``role=user`` records per operator action: a ``<command-
-# name>`` echo, a sibling ``isMeta=true`` ``<local-command-caveat>``,
-# a follow-up ``<local-command-stdout>`` (and friends), plus
-# ``<bash-*>`` records when the operator types ``!cmd``. All are
-# CLI scaffolding, not user-typed content — rendering any of them as
-# a user bubble shows raw markup to a web viewer.
-# Today: drop isMeta + every CLI-scaffolding-prefixed record; for
-# ``<command-name>`` records also surface Skills as ``slash_command``
-# items. The original blanket drop was reverted because it
-# hid Skills; we keep the broad scaffolding filter and just
-# selectively re-surface the Skill case.
-_COMMAND_NAME_RE = re.compile(r"<command-name>(.*?)</command-name>", re.DOTALL)
-_COMMAND_ARGS_RE = re.compile(r"<command-args>(.*?)</command-args>", re.DOTALL)
-_COMMAND_STDOUT_RE = re.compile(r"<local-command-stdout>(.*?)</local-command-stdout>", re.DOTALL)
-_BASH_INPUT_RE = re.compile(r"<bash-input>(.*?)</bash-input>", re.DOTALL)
-_BASH_STDOUT_RE = re.compile(r"<bash-stdout>(.*?)</bash-stdout>", re.DOTALL)
-_BASH_STDERR_RE = re.compile(r"<bash-stderr>(.*?)</bash-stderr>", re.DOTALL)
-
-# Markers that prefix a ``role=user`` record produced by Claude
-# Code's CLI scaffolding (not user-typed content). ``<command-
-# name>`` is handled separately by the slash-command parser;
-# ``<bash-*>`` records are handled separately as ``terminal_command``
-# items; the rest must always drop.
-_CLI_SCAFFOLDING_MARKERS: tuple[str, ...] = (
-    "<command-message>",
-    "<command-args>",
-    "<local-command-caveat>",
-    "<local-command-stdout>",
-    "<local-command-stderr>",
-)
-
-# Claude Code's CLI built-ins (no leading ``/``). Each name is
-# classified as either:
-#
-# - DROPPED — pure UI affordances (``/help``, ``/login``) and local
-#   config (``/permissions``, ``/add-dir``). No conversation-visible
-#   effect; surfacing them in the web UI is noise.
-# - SURFACED — commands that change the next turn's behavior or the
-#   conversation state (``/effort high``, ``/clear``, ``/compact``,
-#   ``/model``, ``/ultrareview``). A web observer needs to see these,
-#   otherwise the next assistant turn appears to shift unprompted.
-#
-# Unknown names fall through to the Skill branch — a safer default
-# than silently hiding them.
-_CLAUDE_CLI_DROPPED_COMMANDS: frozenset[str] = frozenset(
-    {
-        "add-dir",
-        "agents",
-        "bug",
-        "config",
-        "cost",
-        "doctor",
-        "exit",
-        "fast",
-        "feedback",
-        "help",
-        "hooks",
-        "ide",
-        "login",
-        "logout",
-        "mcp",
-        "memory",
-        "onboarding",
-        "permissions",
-        "plugin",
-        "quiet",
-        "quit",
-        "release-notes",
-        "resume",
-        "save",
-        "status",
-        "terminal-setup",
-        "upgrade",
-        "verbose",
-    }
-)
-_CLAUDE_CLI_SURFACED_COMMANDS: frozenset[str] = frozenset(
-    {
-        "clear",
-        "compact",
-        "effort",
-        "model",
-        "ultrareview",
-    }
-)
-
-
-@dataclass(frozen=True)
-class _SlashCommandPayload:
-    """
-    Parsed content of a slash-command ``role=user`` transcript record.
-
-    :param name: Command name with leading ``/`` stripped, e.g.
-        ``"dev-productivity:simplify"``.
-    :param arguments: Verbatim ``<command-args>`` text; empty when none.
-    :param output: Verbatim ``<local-command-stdout>`` text, or ``None``.
-    """
-
-    name: str
-    arguments: str
-    output: str | None
-
-
-def _parse_slash_command_record(content: str) -> _SlashCommandPayload | None:
-    """
-    Parse a Claude Code slash-command marker blob.
-
-    Returns ``None`` on a missing/empty/unclosed ``<command-name>``
-    tag rather than raising — a single corrupt JSONL line must not
-    kill the transcript poll loop.
-
-    :param content: ``message.content`` string from a ``role=user``
-        Claude Code JSONL record.
-    :returns: Parsed payload, or ``None`` when no name could be
-        extracted.
-    """
-    name_match = _COMMAND_NAME_RE.search(content)
-    if name_match is None:
-        return None
-    raw_name = name_match.group(1).strip()
-    if not raw_name:
-        return None
-    # Strip leading ``/`` so renderers can add their own prefix without double-rendering.
-    name = raw_name.lstrip("/")
-    if not name:
-        return None
-    args_match = _COMMAND_ARGS_RE.search(content)
-    arguments = args_match.group(1).strip() if args_match else ""
-    stdout_match = _COMMAND_STDOUT_RE.search(content)
-    output = stdout_match.group(1) if stdout_match else None
-    return _SlashCommandPayload(name=name, arguments=arguments, output=output)
-
-
-def _local_command_transcript_items_from_entry(
-    entry: dict[str, Any],
-    *,
-    line_number: int,
-    record_offset: int | None,
-    current_response_id: str | None,
-) -> tuple[str | None, list[ClaudeTranscriptItem]]:
-    """
-    Parse a top-level Claude ``local_command`` transcript entry.
-
-    Newer Claude Code builds can record shell-mode ``!cmd`` activity
-    as top-level transcript records with ``subtype="local_command"``
-    and a string ``content`` field instead of wrapping the same markup
-    inside ``message.role=user``. Only ``<bash-*>`` records are
-    conversation-visible here; slash-command local records are still
-    handled by hook/fork detection and otherwise ignored.
-
-    :param entry: Decoded Claude transcript record.
-    :param line_number: One-based transcript line number.
-    :param record_offset: Byte offset where the transcript record
-        starts, or ``None`` for legacy line-cursor reads.
-    :param current_response_id: Response id for an in-progress shell
-        command group, if the input record was parsed in an earlier
-        line.
-    :returns: Updated active response id and parsed terminal-command
-        items.
-    """
-    content = entry.get("content")
-    if not isinstance(content, str) or not content:
-        return current_response_id, []
-    source_key = _transcript_source_key(entry, line_number, record_offset)
-    fallback_response_id = _response_id_from_source(source_key)
-    response_id = (
-        fallback_response_id
-        if _BASH_INPUT_RE.search(content) is not None
-        else current_response_id or fallback_response_id
-    )
-    items = _terminal_command_items_from_content(
-        content,
-        source_key=source_key,
-        response_id=response_id,
-    )
-    if not items:
-        return current_response_id, []
-    return response_id, items
-
-
-def _terminal_command_items_from_content(
-    content: str,
-    *,
-    source_key: str,
-    response_id: str,
-) -> list[ClaudeTranscriptItem]:
-    """
-    Parse Claude shell-mode markup into terminal-command items.
-
-    Claude may emit shell input and output as separate records or as
-    one record containing multiple ``<bash-*>`` tags. This helper
-    emits at most one input item and one output item, preserving their
-    order in the source record and giving both the same response id so
-    the server transcript groups an invocation with its result.
-
-    :param content: Transcript markup, e.g.
-        ``"<bash-input>pwd</bash-input><bash-stdout>/tmp</bash-stdout>"``.
-    :param source_key: Base transcript record key used to construct
-        source ids, e.g. ``"rec_abc123"``.
-    :param response_id: Synthetic response id for this terminal
-        command group, e.g. ``"resp_claude_abc123"``.
-    :returns: Parsed ``terminal_command`` items. Empty when no shell
-        markers are present.
-    """
-    if not any(marker in content for marker in ("<bash-input>", "<bash-stdout>", "<bash-stderr>")):
-        return []
-    input_match = _BASH_INPUT_RE.search(content)
-    stdout_match = _BASH_STDOUT_RE.search(content)
-    stderr_match = _BASH_STDERR_RE.search(content)
-    items: list[ClaudeTranscriptItem] = []
-    item_index = 0
-    if input_match is not None:
-        items.append(
-            ClaudeTranscriptItem(
-                source_id=_source_id(source_key, item_index, "terminal_command"),
-                item_type="terminal_command",
-                data={"kind": "input", "input": input_match.group(1)},
-                response_id=response_id,
-            )
-        )
-        item_index += 1
-    if stdout_match is not None or stderr_match is not None:
-        items.append(
-            ClaudeTranscriptItem(
-                source_id=_source_id(source_key, item_index, "terminal_command"),
-                item_type="terminal_command",
-                data={
-                    "kind": "output",
-                    "stdout": stdout_match.group(1) if stdout_match is not None else None,
-                    "stderr": stderr_match.group(1) if stderr_match is not None else None,
-                },
-                response_id=response_id,
-            )
-        )
-    return items
-
-
-def _user_transcript_items_from_entry(
-    entry: dict[str, Any],
-    *,
-    line_number: int,
-    record_offset: int | None,
-    agent_name: str,
-    current_response_id: str | None,
-) -> tuple[str | None, list[ClaudeTranscriptItem]]:
-    """
-    Parse a Claude ``role=user`` transcript entry.
-
-    :param entry: Decoded Claude transcript record.
-    :param line_number: One-based transcript line number.
-    :param record_offset: Byte offset where the transcript record
-        starts, or ``None`` for legacy line-cursor reads.
-    :param agent_name: Agent/model name attached to ``slash_command``
-        items so the web UI can attribute the invocation.
-    :param current_response_id: Response id for the active assistant
-        turn; tool results keep this id.
-    :returns: Updated active response id and parsed user/tool-result
-        items.
-    """
-    # ``isMeta=true`` carries CLI scaffolding like
-    # ``<local-command-caveat>``; no user-visible content.
-    if entry.get("isMeta") is True:
-        return current_response_id, []
-    message = entry["message"]
-    content = message.get("content") if isinstance(message, dict) else None
-    source_key = _transcript_source_key(entry, line_number, record_offset)
-    fallback_response_id = _response_id_from_source(source_key)
-    items: list[ClaudeTranscriptItem] = []
-
-    if isinstance(content, str):
-        if not content:
-            return current_response_id, []
-        stripped = content.lstrip()
-        # Skill invocations with args ship the tag order
-        # ``<command-message>…<command-name>…<command-args>…`` — i.e.
-        # ``<command-name>`` is NOT the first tag. Detect it anywhere
-        # in the content, not just at the start.
-        if "<command-name>" in stripped:
-            payload = _parse_slash_command_record(content)
-            # Drop unparseable markup rather than letting it fall through
-            # to the user-bubble path — that rendered the markup verbatim
-            # in the original bug.
-            if payload is None or payload.name in _CLAUDE_CLI_DROPPED_COMMANDS:
-                return current_response_id, []
-            kind = "command" if payload.name in _CLAUDE_CLI_SURFACED_COMMANDS else "skill"
-            data: dict[str, Any] = {
-                "agent": agent_name,
-                "kind": kind,
-                "name": payload.name,
-                "arguments": payload.arguments,
-            }
-            if payload.output is not None:
-                data["output"] = payload.output
-            items.append(
-                ClaudeTranscriptItem(
-                    source_id=_source_id(source_key, 0, "slash_command"),
-                    item_type="slash_command",
-                    data=data,
-                    response_id=fallback_response_id,
-                )
-            )
-            # Slash command opens a new logical turn; subsequent
-            # assistant text must inherit this id so it clusters with
-            # the indicator, not the prior bubble.
-            return fallback_response_id, items
-        # ``!cmd`` terminal commands may arrive here in older Claude
-        # builds; newer builds use top-level ``local_command`` records.
-        # In both shapes, surface the command and result as their own
-        # transcript group instead of inheriting the previous assistant
-        # response id.
-        terminal_response_id = (
-            fallback_response_id
-            if _BASH_INPUT_RE.search(content) is not None
-            else current_response_id or fallback_response_id
-        )
-        terminal_items = _terminal_command_items_from_content(
-            content,
-            source_key=source_key,
-            response_id=terminal_response_id,
-        )
-        if terminal_items:
-            return terminal_response_id, terminal_items
-        # Other CLI-scaffolding records (stdout/stderr from /effort, etc.)
-        # arrive as standalone ``role=user`` records and must drop instead
-        # of leaking as user bubbles.
-        if any(stripped.startswith(m) for m in _CLI_SCAFFOLDING_MARKERS):
-            return current_response_id, []
-        items.append(
-            ClaudeTranscriptItem(
-                source_id=_source_id(source_key, 0, "message"),
-                item_type="message",
-                data={
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": content}],
-                },
-                response_id=fallback_response_id,
-            )
-        )
-        return None, items
-
-    if not isinstance(content, list):
-        return current_response_id, []
-
-    user_blocks: list[dict[str, Any]] = []
-    saw_user_text = False
-    item_index = 0
-    for block in content:
-        if not isinstance(block, dict):
-            continue
-        block_type = block.get("type")
-        if block_type == "text":
-            text = block.get("text")
-            if not isinstance(text, str) or not text:
-                continue
-            # Defensively guard against slash-command markup or other
-            # CLI-scaffolding markers ever arriving in list-form
-            # content. Today these only ship in string content (the
-            # branch above), but Claude Code's JSONL format is not
-            # under our control — without this filter, a format
-            # change would regress to rendering ``<command-name>…``
-            # markup as a user bubble.
-            stripped = text.lstrip()
-            if "<command-name>" in stripped or any(
-                stripped.startswith(m) for m in _CLI_SCAFFOLDING_MARKERS
-            ):
-                continue
-            user_blocks.append({"type": "input_text", "text": text})
-            saw_user_text = True
-            continue
-        if block_type != "tool_result":
-            continue
-        call_id = block.get("tool_use_id")
-        if not isinstance(call_id, str) or not call_id:
-            continue
-        response_id = current_response_id or _response_id_from_source(
-            _parent_or_record_source_key(entry, line_number, record_offset)
-        )
-        items.append(
-            ClaudeTranscriptItem(
-                source_id=_source_id(source_key, item_index, "function_call_output"),
-                item_type="function_call_output",
-                data={
-                    "call_id": call_id,
-                    "output": _tool_result_output(entry, block),
-                },
-                response_id=response_id,
-            )
-        )
-        item_index += 1
-
-    if user_blocks:
-        items.insert(
-            0,
-            ClaudeTranscriptItem(
-                source_id=_source_id(source_key, item_index, "message"),
-                item_type="message",
-                data={
-                    "role": "user",
-                    "content": user_blocks,
-                },
-                response_id=fallback_response_id,
-            ),
-        )
-    return (None if saw_user_text else current_response_id), items
-
-
-def _assistant_transcript_items_from_entry(
-    entry: dict[str, Any],
-    *,
-    line_number: int,
-    record_offset: int | None,
-    agent_name: str,
-    current_response_id: str | None,
-) -> tuple[str | None, list[ClaudeTranscriptItem]]:
-    """
-    Parse a Claude ``role=assistant`` transcript entry.
-
-    :param entry: Decoded Claude transcript record.
-    :param line_number: One-based transcript line number.
-    :param record_offset: Byte offset where the transcript record
-        starts, or ``None`` for legacy line-cursor reads.
-    :param agent_name: Agent/model name for assistant/tool items.
-    :param current_response_id: Response id for the active Claude
-        assistant turn.
-    :returns: Updated active response id and parsed assistant/tool
-        items.
-    """
-    message = entry["message"]
-    content = message.get("content") if isinstance(message, dict) else None
-    source_key = _transcript_source_key(entry, line_number, record_offset)
-    response_id = current_response_id or _response_id_from_source(source_key)
-    items: list[ClaudeTranscriptItem] = []
-
-    if isinstance(content, str):
-        if content:
-            items.append(
-                _assistant_message_item(
-                    source_key=source_key,
-                    item_index=0,
-                    agent_name=agent_name,
-                    response_id=response_id,
-                    text=content,
-                )
-            )
-        return response_id, items
-
-    if not isinstance(content, list):
-        return current_response_id, []
-
-    for item_index, block in enumerate(content):
-        if not isinstance(block, dict):
-            continue
-        block_type = block.get("type")
-        if block_type == "text":
-            text = block.get("text")
-            if isinstance(text, str) and text:
-                items.append(
-                    _assistant_message_item(
-                        source_key=source_key,
-                        item_index=item_index,
-                        agent_name=agent_name,
-                        response_id=response_id,
-                        text=text,
-                    )
-                )
-            continue
-        if block_type == "tool_use":
-            tool_id = block.get("id")
-            name = block.get("name")
-            if not isinstance(tool_id, str) or not tool_id:
-                continue
-            if not isinstance(name, str) or not name:
-                continue
-            arguments = block.get("input")
-            if not isinstance(arguments, dict):
-                arguments = {}
-            items.append(
-                ClaudeTranscriptItem(
-                    source_id=_source_id(source_key, item_index, "function_call"),
-                    item_type="function_call",
-                    data={
-                        "agent": agent_name,
-                        "name": name,
-                        "arguments": json.dumps(arguments, separators=(",", ":")),
-                        "call_id": tool_id,
-                    },
-                    response_id=response_id,
-                )
-            )
-    return response_id if items else current_response_id, items
-
-
-_CONTEXT_OVERFLOW_RE = re.compile(
-    r"^prompt is too long",
-    re.IGNORECASE,
-)
-
-_CONTEXT_OVERFLOW_REPLACEMENT = (
-    "Context limit reached — the conversation has grown too long for "
-    "the model’s context window. Use /compact to summarize and free up "
-    "space, or /clear to start a new conversation."
-)
-
-
-def _assistant_message_item(
-    *,
-    source_key: str,
-    item_index: int,
-    agent_name: str,
-    response_id: str,
-    text: str,
-) -> ClaudeTranscriptItem:
-    """
-    Build an assistant message item from one Claude text block.
-
-    :param source_key: Base transcript record key.
-    :param item_index: Content block index inside the record.
-    :param agent_name: Agent/model name for the assistant message.
-    :param response_id: Response id grouping the Claude turn.
-    :param text: Assistant text block.
-    :returns: Parsed transcript item.
-    """
-    display_text = text
-    if _CONTEXT_OVERFLOW_RE.match(text.strip()):
-        display_text = _CONTEXT_OVERFLOW_REPLACEMENT
-    return ClaudeTranscriptItem(
-        source_id=_source_id(source_key, item_index, "message"),
-        item_type="message",
-        data={
-            "role": "assistant",
-            "agent": agent_name,
-            "content": [{"type": "output_text", "text": display_text}],
-        },
-        response_id=response_id,
-    )
-
-
-def _tool_result_output(entry: dict[str, Any], block: dict[str, Any]) -> str:
-    """
-    Return the UI-facing output string for a Claude tool result.
-
-    :param entry: Decoded Claude transcript record containing
-        optional ``toolUseResult`` metadata.
-    :param block: ``tool_result`` content block from ``message``.
-    :returns: String output for a ``function_call_output`` item.
-    """
-    content = block.get("content")
-    if isinstance(content, str):
-        return content
-    if content is not None:
-        return json.dumps(content, separators=(",", ":"))
-    tool_use_result = entry.get("toolUseResult")
-    if isinstance(tool_use_result, str):
-        return tool_use_result
-    if tool_use_result is not None:
-        return json.dumps(tool_use_result, separators=(",", ":"))
-    return ""
-
-
-def _transcript_source_key(
-    entry: dict[str, Any],
-    line_number: int,
-    record_offset: int | None = None,
-) -> str:
-    """
-    Return the stable key for a Claude transcript record.
-
-    :param entry: Decoded Claude transcript record.
-    :param line_number: One-based transcript line number.
-    :param record_offset: Byte offset where the transcript record
-        starts, or ``None`` when unavailable.
-    :returns: Claude UUID/request id, byte-offset fallback, or a
-        legacy line-number fallback.
-    """
-    for key in ("uuid", "requestId"):
-        value = entry.get(key)
-        if isinstance(value, str) and value:
-            return value
-    if record_offset is not None:
-        return f"byte-{record_offset}"
-    return f"line-{line_number}"
-
-
-def _parent_or_record_source_key(
-    entry: dict[str, Any],
-    line_number: int,
-    record_offset: int | None = None,
-) -> str:
-    """
-    Return a parent key for tool results when Claude supplies one.
-
-    :param entry: Decoded Claude transcript record.
-    :param line_number: One-based transcript line number.
-    :param record_offset: Byte offset where the transcript record
-        starts, or ``None`` when unavailable.
-    :returns: Parent UUID when present, otherwise the record key.
-    """
-    parent = entry.get("parentUuid")
-    if isinstance(parent, str) and parent:
-        return parent
-    return _transcript_source_key(entry, line_number, record_offset)
-
-
-def _response_id_from_source(source: str) -> str:
-    """
-    Derive a deterministic Omnigent response id from a Claude source key.
-
-    :param source: Claude UUID/request id/line key.
-    :returns: String id with the standard ``resp_`` prefix.
-    """
-    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:32]
-    return f"resp_claude_{digest}"
-
-
-def _source_id(source_key: str, item_index: int, item_type: str) -> str:
-    """
-    Build a per-item idempotency key for a transcript-derived item.
-
-    :param source_key: Base Claude record key.
-    :param item_index: Content block index inside the record.
-    :param item_type: Omnigent item type.
-    :returns: Stable source id string.
-    """
-    return f"{source_key}:{item_index}:{item_type}"
 
 
 def _wait_for_server_info(bridge_dir: Path, *, timeout_s: float) -> dict[str, Any]:

--- a/omnigent/claude_transcript_parser.py
+++ b/omnigent/claude_transcript_parser.py
@@ -1,0 +1,1239 @@
+"""Pure Claude Code transcript → Omnigent conversation-item parser.
+
+Factored out of :mod:`omnigent.claude_native_bridge` so the same durable
+transcript parser — byte-offset cursors, sidechain handling, slash-command and
+terminal-command translation, tool-call/result mapping, and per-entry usage/model
+extraction — can be reused by session adoption (importing a native Claude session
+from its JSONL transcript) without a second, simplified parser.
+
+Everything here is side-effect-free apart from reading the transcript file the
+caller names: it takes native Claude JSONL records and returns
+:class:`ClaudeTranscriptItem` values. No polling, no DB, no network, no bridge
+state. :mod:`omnigent.claude_native_bridge` re-exports these names so existing
+callers and tests keep importing them from the bridge unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ClaudeTranscriptItem:
+    """
+    One Omnigent conversation item parsed from Claude's JSONL log.
+
+    :param source_id: Stable idempotency key derived from the Claude
+        transcript record UUID and content block position, e.g.
+        ``"747e:0:function_call"``.
+    :param item_type: Omnigent conversation item type, e.g.
+        ``"message"`` or ``"function_call"``.
+    :param data: Item payload shaped like ``SessionEventInput.data``.
+    :param response_id: Synthetic response id used to group the
+        Claude turn in AP/web UI rendering.
+    """
+
+    source_id: str
+    item_type: str
+    data: dict[str, Any]
+    response_id: str
+
+
+@dataclass(frozen=True)
+class TranscriptReadResult:
+    """
+    Result of reading Claude transcript JSONL records.
+
+    :param line_cursor: Count of complete newline-terminated records
+        consumed from the transcript, e.g. ``12``.
+    :param byte_offset: Byte offset immediately after the last
+        complete record consumed, e.g. ``4096``. A partial trailing
+        line is not included.
+    :param current_response_id: Response id for a Claude assistant
+        turn that remains active across polls.
+    :param items: Parsed Omnigent conversation items from the
+        complete records after the caller's cursor.
+    :param latest_usage: Token-usage from the most recent assistant
+        entry with a ``message.usage`` block. Keys: ``context_tokens``,
+        ``input_tokens``, ``output_tokens``. ``None`` when no such
+        entry was scanned.
+    :param latest_model: ``message.model`` from the most recent
+        assistant entry, or ``None``.
+    """
+
+    line_cursor: int
+    byte_offset: int
+    current_response_id: str | None
+    items: list[ClaudeTranscriptItem]
+    latest_usage: dict[str, int] | None = None
+    latest_model: str | None = None
+
+
+@dataclass(frozen=True)
+class _JsonlRecord:
+    """
+    One complete newline-terminated JSONL record.
+
+    :param line_number: One-based line number relative to the reader's
+        line cursor, e.g. ``5``.
+    :param byte_offset: Byte offset where the record starts.
+    :param next_byte_offset: Byte offset immediately after the
+        newline-terminated record.
+    :param text: UTF-8 decoded JSONL text including the trailing
+        newline, or ``None`` when the complete record was not valid
+        UTF-8 and should advance cursors without being parsed.
+    """
+
+    line_number: int
+    byte_offset: int
+    next_byte_offset: int
+    text: str | None
+
+
+@dataclass(frozen=True)
+class _JsonlReadResult:
+    """
+    Complete-record read result for an append-only JSONL file.
+
+    :param line_cursor: Count of complete records consumed.
+    :param byte_offset: Byte offset after the last complete record.
+    :param records: Complete records read after the requested byte
+        offset.
+    """
+
+    line_cursor: int
+    byte_offset: int
+    records: list[_JsonlRecord]
+
+
+def read_assistant_text_since(
+    transcript_path: Path,
+    start_line: int,
+) -> tuple[int, list[str]]:
+    """
+    Read assistant text blocks appended after a transcript cursor.
+
+    :param transcript_path: Claude transcript path, e.g.
+        ``"/home/user/.claude/projects/x/session.jsonl"``.
+    :param start_line: Zero-based line cursor captured before a
+        message is injected into the Claude terminal.
+    :returns: ``(new_cursor, text_chunks)``.
+    """
+    texts: list[str] = []
+    cursor = 0
+    try:
+        with transcript_path.open("r", encoding="utf-8") as handle:
+            for cursor, line in enumerate(handle, start=1):
+                if cursor <= start_line:
+                    continue
+                text = _assistant_text_from_transcript_line(line)
+                if text:
+                    texts.append(text)
+    except FileNotFoundError:
+        return start_line, []
+    return cursor, texts
+
+
+def read_transcript_items_since(
+    transcript_path: Path,
+    start_line: int,
+    *,
+    agent_name: str,
+    current_response_id: str | None = None,
+) -> tuple[int, str | None, list[ClaudeTranscriptItem]]:
+    """
+    Read Claude transcript records as Omnigent conversation items.
+
+    Claude Code writes append-only JSONL records whose ``message``
+    payloads include user prompts, assistant text, native tool calls,
+    and native tool results. This parser intentionally ignores
+    metadata records (title, file-history, permission mode, system
+    bookkeeping) and raw ``thinking`` blocks, while translating the
+    user-visible semantic records into Omnigent item types the web UI
+    already understands.
+
+    :param transcript_path: Claude transcript path, e.g.
+        ``"/home/user/.claude/projects/x/session.jsonl"``.
+    :param start_line: One-based line cursor. Lines at or before
+        this cursor are skipped.
+    :param agent_name: Agent/model name stamped on assistant and
+        tool-call items, e.g. ``"claude-native-ui"``.
+    :param current_response_id: Response id for an in-progress
+        Claude assistant turn from a previous poll.
+    :returns: ``(new_cursor, current_response_id, items)``.
+    """
+    result = read_transcript_items_since_with_position(
+        transcript_path,
+        start_line,
+        agent_name=agent_name,
+        current_response_id=current_response_id,
+    )
+    return result.line_cursor, result.current_response_id, result.items
+
+
+def read_transcript_items_since_with_position(
+    transcript_path: Path,
+    start_line: int,
+    *,
+    agent_name: str,
+    current_response_id: str | None = None,
+) -> TranscriptReadResult:
+    """
+    Read transcript items from a line cursor and return byte position.
+
+    This compatibility reader supports existing durable state that
+    only stored a line cursor. It scans the file once, parses only
+    complete newline-terminated records after ``start_line``, and
+    returns the byte offset so future polls can seek directly.
+
+    :param transcript_path: Claude transcript path, e.g.
+        ``"/home/user/.claude/projects/x/session.jsonl"``.
+    :param start_line: One-based line cursor. Lines at or before
+        this cursor are skipped.
+    :param agent_name: Agent/model name stamped on assistant and
+        tool-call items, e.g. ``"claude-native-ui"``.
+    :param current_response_id: Response id for an in-progress
+        Claude assistant turn from a previous poll.
+    :returns: Parsed items plus line and byte cursors.
+    """
+    read_result = _read_complete_jsonl_records(
+        transcript_path,
+        byte_offset=0,
+        start_line=0,
+        emit_after_line=start_line,
+    )
+    items: list[ClaudeTranscriptItem] = []
+    active_response_id = current_response_id
+    latest_usage: dict[str, int] | None = None
+    latest_model: str | None = None
+    for record in read_result.records:
+        if record.text is None:
+            continue
+        try:
+            entry = json.loads(record.text)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        active_response_id, parsed = _transcript_items_from_entry(
+            entry,
+            line_number=record.line_number,
+            record_offset=None,
+            agent_name=agent_name,
+            current_response_id=active_response_id,
+        )
+        items.extend(parsed)
+        usage = _usage_from_transcript_entry(entry)
+        if usage is not None:
+            latest_usage = usage
+        model = _model_from_transcript_entry(entry)
+        if model is not None:
+            latest_model = model
+    return TranscriptReadResult(
+        line_cursor=read_result.line_cursor,
+        byte_offset=read_result.byte_offset,
+        current_response_id=active_response_id,
+        items=items,
+        latest_usage=latest_usage,
+        latest_model=latest_model,
+    )
+
+
+def read_transcript_items_from_offset(
+    transcript_path: Path,
+    byte_offset: int,
+    *,
+    start_line: int,
+    agent_name: str,
+    current_response_id: str | None = None,
+    include_sidechains: bool = False,
+) -> TranscriptReadResult:
+    """
+    Read transcript items appended after a byte offset.
+
+    Only complete newline-terminated JSONL records are parsed. If
+    Claude is midway through writing a trailing JSON record, the
+    returned byte offset remains before that partial line so the next
+    poll retries it after completion.
+
+    :param transcript_path: Claude transcript path, e.g.
+        ``"/home/user/.claude/projects/x/session.jsonl"``.
+    :param byte_offset: Byte offset already consumed, e.g. ``4096``.
+    :param start_line: Count of complete records already consumed.
+        Used only to keep legacy line cursors and diagnostics
+        monotonic while byte offsets drive the actual seek.
+    :param agent_name: Agent/model name stamped on assistant and
+        tool-call items, e.g. ``"claude-native-ui"``.
+    :param current_response_id: Response id for an in-progress
+        Claude assistant turn from a previous poll.
+    :param include_sidechains: Pass ``True`` when reading a
+        sub-agent's own ``agent-<id>.jsonl`` — every record there is
+        a sidechain by Claude's definition, and dropping them would
+        leave the sub-agent's child Omnigent conversation empty. The
+        default ``False`` keeps the parent-transcript path
+        unchanged.
+    :returns: Parsed items plus updated line and byte cursors.
+    """
+    read_result = _read_complete_jsonl_records(
+        transcript_path,
+        byte_offset=byte_offset,
+        start_line=start_line,
+    )
+    items: list[ClaudeTranscriptItem] = []
+    active_response_id = current_response_id
+    latest_usage: dict[str, int] | None = None
+    latest_model: str | None = None
+    for record in read_result.records:
+        if record.text is None:
+            continue
+        try:
+            entry = json.loads(record.text)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        active_response_id, parsed = _transcript_items_from_entry(
+            entry,
+            line_number=record.line_number,
+            record_offset=record.byte_offset,
+            agent_name=agent_name,
+            current_response_id=active_response_id,
+            include_sidechains=include_sidechains,
+        )
+        items.extend(parsed)
+        usage = _usage_from_transcript_entry(entry)
+        if usage is not None:
+            latest_usage = usage
+        model = _model_from_transcript_entry(entry)
+        if model is not None:
+            latest_model = model
+    return TranscriptReadResult(
+        line_cursor=read_result.line_cursor,
+        byte_offset=read_result.byte_offset,
+        current_response_id=active_response_id,
+        items=items,
+        latest_usage=latest_usage,
+        latest_model=latest_model,
+    )
+
+
+def _read_complete_jsonl_records(
+    path: Path,
+    *,
+    byte_offset: int,
+    start_line: int,
+    emit_after_line: int | None = None,
+) -> _JsonlReadResult:
+    """
+    Read complete newline-terminated records from a JSONL file.
+
+    The reader seeks to ``byte_offset`` and stops before a trailing
+    partial line. That partial line's bytes are retried by the next
+    poll after the writer appends its newline.
+
+    :param path: JSONL file path.
+    :param byte_offset: Byte offset where reading should begin,
+        e.g. ``4096``.
+    :param start_line: Count of complete records before
+        ``byte_offset``, e.g. ``12``.
+    :param emit_after_line: When provided, complete records at or
+        before this line number are counted for cursor migration but
+        not decoded or stored.
+    :returns: Complete records plus updated line and byte cursors.
+    """
+    if byte_offset < 0:
+        raise ValueError(f"byte_offset must be non-negative, got {byte_offset}")
+    if start_line < 0:
+        raise ValueError(f"start_line must be non-negative, got {start_line}")
+    records: list[_JsonlRecord] = []
+    cursor = start_line
+    position = byte_offset
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            file_size = handle.tell()
+            if byte_offset > file_size:
+                handle.seek(0)
+                cursor = 0
+                position = 0
+            else:
+                handle.seek(byte_offset)
+            while True:
+                record_start = position
+                raw = handle.readline()
+                if not raw:
+                    break
+                if not raw.endswith(b"\n"):
+                    break
+                position = handle.tell()
+                cursor += 1
+                if emit_after_line is not None and cursor <= emit_after_line:
+                    continue
+                try:
+                    text = raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    text = None
+                records.append(
+                    _JsonlRecord(
+                        line_number=cursor,
+                        byte_offset=record_start,
+                        next_byte_offset=position,
+                        text=text,
+                    )
+                )
+    except FileNotFoundError:
+        return _JsonlReadResult(
+            line_cursor=start_line,
+            byte_offset=byte_offset,
+            records=[],
+        )
+    return _JsonlReadResult(
+        line_cursor=cursor,
+        byte_offset=position,
+        records=records,
+    )
+
+
+def _model_from_transcript_entry(entry: dict[str, Any]) -> str | None:
+    """
+    Return ``message.model`` from an assistant transcript record.
+
+    Surfaced on :class:`TranscriptReadResult.latest_model` for
+    diagnostics. The ring's denominator comes from the statusLine
+    stdin (see :func:`read_claude_context_state`); the JSONL model
+    name is no longer used to size the ring.
+
+    :param entry: One decoded transcript JSONL record.
+    :returns: API model name, or ``None`` for non-assistant entries
+        and entries missing the field.
+    """
+    message = entry.get("message")
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return None
+    model = message.get("model")
+    if isinstance(model, str) and model:
+        return model
+    return None
+
+
+def _usage_from_transcript_entry(entry: dict[str, Any]) -> dict[str, int] | None:
+    """
+    Extract token-usage from one Claude assistant transcript entry.
+
+    ``context_tokens`` is ``input + cache_creation + cache_read`` — the
+    bytes that will reappear in the next call's prompt. Output tokens
+    are reported separately since they don't shift the prompt forward.
+
+    :param entry: One decoded transcript JSONL record.
+    :returns: ``{"context_tokens", "input_tokens", "output_tokens"}``
+        when the record is an assistant entry with usage; ``None``
+        otherwise.
+    """
+    message = entry.get("message")
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    input_tokens = usage.get("input_tokens")
+    output_tokens = usage.get("output_tokens")
+    cache_creation = usage.get("cache_creation_input_tokens")
+    cache_read = usage.get("cache_read_input_tokens")
+    if not isinstance(input_tokens, int):
+        return None
+    if not isinstance(output_tokens, int):
+        output_tokens = 0
+    cc = cache_creation if isinstance(cache_creation, int) else 0
+    cr = cache_read if isinstance(cache_read, int) else 0
+    result: dict[str, int] = {
+        "context_tokens": input_tokens + cc + cr,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+    }
+    if cc:
+        result["cache_creation_input_tokens"] = cc
+    if cr:
+        result["cache_read_input_tokens"] = cr
+    return result
+
+
+def _assistant_text_from_transcript_line(line: str) -> str | None:
+    """
+    Extract assistant text from one Claude transcript JSONL line.
+
+    :param line: Raw JSONL record.
+    :returns: Assistant text, or ``None`` when the record is not an
+        assistant text message.
+    """
+    try:
+        entry = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(entry, dict):
+        return None
+    message = entry.get("message")
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return None
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                parts.append(text)
+    return "".join(parts) or None
+
+
+def _transcript_items_from_entry(
+    entry: dict[str, Any],
+    *,
+    line_number: int,
+    record_offset: int | None = None,
+    agent_name: str,
+    current_response_id: str | None,
+    include_sidechains: bool = False,
+) -> tuple[str | None, list[ClaudeTranscriptItem]]:
+    """
+    Convert one Claude transcript entry into Omnigent conversation items.
+
+    :param entry: Decoded JSON object from one transcript line.
+    :param line_number: One-based transcript line number.
+    :param record_offset: Byte offset where the transcript record
+        starts. Used for stable fallback source ids when Claude omits
+        ``uuid`` and ``requestId``.
+    :param agent_name: Agent/model name for assistant/tool items.
+    :param current_response_id: Response id for the active Claude
+        assistant turn, if a previous poll already started one.
+    :param include_sidechains: When ``False`` (the default) any record
+        with ``isSidechain: true`` is dropped — that's the right
+        behavior when reading the parent's main transcript, where
+        sub-agent records are inlined as sidechains and must not
+        appear in the parent's Omnigent conversation. When ``True`` the
+        flag is ignored — required when reading a sub-agent's own
+        ``agent-<id>.jsonl`` (every record there is a sidechain by
+        definition) so the sub-agent's items reach the child AP
+        conversation. Caller is responsible for matching the flag to
+        the file shape.
+    :returns: Updated active response id and parsed items.
+    """
+    if not include_sidechains and entry.get("isSidechain") is True:
+        return current_response_id, []
+    if entry.get("type") == "attachment":
+        return _attachment_transcript_items_from_entry(
+            entry,
+            line_number=line_number,
+            record_offset=record_offset,
+            current_response_id=current_response_id,
+        )
+    if entry.get("subtype") == "local_command":
+        return _local_command_transcript_items_from_entry(
+            entry,
+            line_number=line_number,
+            record_offset=record_offset,
+            current_response_id=current_response_id,
+        )
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return current_response_id, []
+    role = message.get("role")
+    if role == "user":
+        return _user_transcript_items_from_entry(
+            entry,
+            line_number=line_number,
+            record_offset=record_offset,
+            agent_name=agent_name,
+            current_response_id=current_response_id,
+        )
+    if role == "assistant":
+        return _assistant_transcript_items_from_entry(
+            entry,
+            line_number=line_number,
+            record_offset=record_offset,
+            agent_name=agent_name,
+            current_response_id=current_response_id,
+        )
+    return current_response_id, []
+
+
+def _attachment_transcript_items_from_entry(
+    entry: dict[str, Any],
+    *,
+    line_number: int,
+    record_offset: int | None,
+    current_response_id: str | None,
+) -> tuple[str | None, list[ClaudeTranscriptItem]]:
+    """
+    Parse user-visible Claude attachment transcript entries.
+
+    Claude records prompts typed while an assistant turn is busy as
+    ``attachment.type == "queued_command"`` rather than a normal
+    ``role=user`` message. Treat prompt-mode queued commands as user
+    messages so interruption inputs such as ``"STOP"`` appear in the
+    Omnigent transcript and reset the active assistant response.
+
+    :param entry: Decoded Claude transcript record.
+    :param line_number: One-based transcript line number.
+    :param record_offset: Byte offset where the transcript record
+        starts, or ``None`` for legacy line-cursor reads.
+    :param current_response_id: Response id for the active assistant
+        turn. Ignored attachment metadata preserves this value.
+    :returns: Updated active response id and parsed items.
+    """
+    attachment = entry.get("attachment")
+    if not isinstance(attachment, dict):
+        return current_response_id, []
+    if attachment.get("type") != "queued_command":
+        return current_response_id, []
+    if attachment.get("commandMode") != "prompt":
+        return current_response_id, []
+    prompt = attachment.get("prompt")
+    if not isinstance(prompt, str) or not prompt:
+        return current_response_id, []
+    source_key = _transcript_source_key(entry, line_number, record_offset)
+    item = ClaudeTranscriptItem(
+        source_id=_source_id(source_key, 0, "message"),
+        item_type="message",
+        data={
+            "role": "user",
+            "content": [{"type": "input_text", "text": prompt}],
+        },
+        response_id=_response_id_from_source(source_key),
+    )
+    return None, [item]
+
+
+# Slash-command marker handling. Claude Code's embedded TUI emits
+# multiple ``role=user`` records per operator action: a ``<command-
+# name>`` echo, a sibling ``isMeta=true`` ``<local-command-caveat>``,
+# a follow-up ``<local-command-stdout>`` (and friends), plus
+# ``<bash-*>`` records when the operator types ``!cmd``. All are
+# CLI scaffolding, not user-typed content — rendering any of them as
+# a user bubble shows raw markup to a web viewer.
+# Today: drop isMeta + every CLI-scaffolding-prefixed record; for
+# ``<command-name>`` records also surface Skills as ``slash_command``
+# items. The original blanket drop was reverted because it
+# hid Skills; we keep the broad scaffolding filter and just
+# selectively re-surface the Skill case.
+_COMMAND_NAME_RE = re.compile(r"<command-name>(.*?)</command-name>", re.DOTALL)
+_COMMAND_ARGS_RE = re.compile(r"<command-args>(.*?)</command-args>", re.DOTALL)
+_COMMAND_STDOUT_RE = re.compile(r"<local-command-stdout>(.*?)</local-command-stdout>", re.DOTALL)
+_BASH_INPUT_RE = re.compile(r"<bash-input>(.*?)</bash-input>", re.DOTALL)
+_BASH_STDOUT_RE = re.compile(r"<bash-stdout>(.*?)</bash-stdout>", re.DOTALL)
+_BASH_STDERR_RE = re.compile(r"<bash-stderr>(.*?)</bash-stderr>", re.DOTALL)
+
+# Markers that prefix a ``role=user`` record produced by Claude
+# Code's CLI scaffolding (not user-typed content). ``<command-
+# name>`` is handled separately by the slash-command parser;
+# ``<bash-*>`` records are handled separately as ``terminal_command``
+# items; the rest must always drop.
+_CLI_SCAFFOLDING_MARKERS: tuple[str, ...] = (
+    "<command-message>",
+    "<command-args>",
+    "<local-command-caveat>",
+    "<local-command-stdout>",
+    "<local-command-stderr>",
+)
+
+# Claude Code's CLI built-ins (no leading ``/``). Each name is
+# classified as either:
+#
+# - DROPPED — pure UI affordances (``/help``, ``/login``) and local
+#   config (``/permissions``, ``/add-dir``). No conversation-visible
+#   effect; surfacing them in the web UI is noise.
+# - SURFACED — commands that change the next turn's behavior or the
+#   conversation state (``/effort high``, ``/clear``, ``/compact``,
+#   ``/model``, ``/ultrareview``). A web observer needs to see these,
+#   otherwise the next assistant turn appears to shift unprompted.
+#
+# Unknown names fall through to the Skill branch — a safer default
+# than silently hiding them.
+_CLAUDE_CLI_DROPPED_COMMANDS: frozenset[str] = frozenset(
+    {
+        "add-dir",
+        "agents",
+        "bug",
+        "config",
+        "cost",
+        "doctor",
+        "exit",
+        "fast",
+        "feedback",
+        "help",
+        "hooks",
+        "ide",
+        "login",
+        "logout",
+        "mcp",
+        "memory",
+        "onboarding",
+        "permissions",
+        "plugin",
+        "quiet",
+        "quit",
+        "release-notes",
+        "resume",
+        "save",
+        "status",
+        "terminal-setup",
+        "upgrade",
+        "verbose",
+    }
+)
+_CLAUDE_CLI_SURFACED_COMMANDS: frozenset[str] = frozenset(
+    {
+        "clear",
+        "compact",
+        "effort",
+        "model",
+        "ultrareview",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _SlashCommandPayload:
+    """
+    Parsed content of a slash-command ``role=user`` transcript record.
+
+    :param name: Command name with leading ``/`` stripped, e.g.
+        ``"dev-productivity:simplify"``.
+    :param arguments: Verbatim ``<command-args>`` text; empty when none.
+    :param output: Verbatim ``<local-command-stdout>`` text, or ``None``.
+    """
+
+    name: str
+    arguments: str
+    output: str | None
+
+
+def _parse_slash_command_record(content: str) -> _SlashCommandPayload | None:
+    """
+    Parse a Claude Code slash-command marker blob.
+
+    Returns ``None`` on a missing/empty/unclosed ``<command-name>``
+    tag rather than raising — a single corrupt JSONL line must not
+    kill the transcript poll loop.
+
+    :param content: ``message.content`` string from a ``role=user``
+        Claude Code JSONL record.
+    :returns: Parsed payload, or ``None`` when no name could be
+        extracted.
+    """
+    name_match = _COMMAND_NAME_RE.search(content)
+    if name_match is None:
+        return None
+    raw_name = name_match.group(1).strip()
+    if not raw_name:
+        return None
+    # Strip leading ``/`` so renderers can add their own prefix without double-rendering.
+    name = raw_name.lstrip("/")
+    if not name:
+        return None
+    args_match = _COMMAND_ARGS_RE.search(content)
+    arguments = args_match.group(1).strip() if args_match else ""
+    stdout_match = _COMMAND_STDOUT_RE.search(content)
+    output = stdout_match.group(1) if stdout_match else None
+    return _SlashCommandPayload(name=name, arguments=arguments, output=output)
+
+
+def _local_command_transcript_items_from_entry(
+    entry: dict[str, Any],
+    *,
+    line_number: int,
+    record_offset: int | None,
+    current_response_id: str | None,
+) -> tuple[str | None, list[ClaudeTranscriptItem]]:
+    """
+    Parse a top-level Claude ``local_command`` transcript entry.
+
+    Newer Claude Code builds can record shell-mode ``!cmd`` activity
+    as top-level transcript records with ``subtype="local_command"``
+    and a string ``content`` field instead of wrapping the same markup
+    inside ``message.role=user``. Only ``<bash-*>`` records are
+    conversation-visible here; slash-command local records are still
+    handled by hook/fork detection and otherwise ignored.
+
+    :param entry: Decoded Claude transcript record.
+    :param line_number: One-based transcript line number.
+    :param record_offset: Byte offset where the transcript record
+        starts, or ``None`` for legacy line-cursor reads.
+    :param current_response_id: Response id for an in-progress shell
+        command group, if the input record was parsed in an earlier
+        line.
+    :returns: Updated active response id and parsed terminal-command
+        items.
+    """
+    content = entry.get("content")
+    if not isinstance(content, str) or not content:
+        return current_response_id, []
+    source_key = _transcript_source_key(entry, line_number, record_offset)
+    fallback_response_id = _response_id_from_source(source_key)
+    response_id = (
+        fallback_response_id
+        if _BASH_INPUT_RE.search(content) is not None
+        else current_response_id or fallback_response_id
+    )
+    items = _terminal_command_items_from_content(
+        content,
+        source_key=source_key,
+        response_id=response_id,
+    )
+    if not items:
+        return current_response_id, []
+    return response_id, items
+
+
+def _terminal_command_items_from_content(
+    content: str,
+    *,
+    source_key: str,
+    response_id: str,
+) -> list[ClaudeTranscriptItem]:
+    """
+    Parse Claude shell-mode markup into terminal-command items.
+
+    Claude may emit shell input and output as separate records or as
+    one record containing multiple ``<bash-*>`` tags. This helper
+    emits at most one input item and one output item, preserving their
+    order in the source record and giving both the same response id so
+    the server transcript groups an invocation with its result.
+
+    :param content: Transcript markup, e.g.
+        ``"<bash-input>pwd</bash-input><bash-stdout>/tmp</bash-stdout>"``.
+    :param source_key: Base transcript record key used to construct
+        source ids, e.g. ``"rec_abc123"``.
+    :param response_id: Synthetic response id for this terminal
+        command group, e.g. ``"resp_claude_abc123"``.
+    :returns: Parsed ``terminal_command`` items. Empty when no shell
+        markers are present.
+    """
+    if not any(marker in content for marker in ("<bash-input>", "<bash-stdout>", "<bash-stderr>")):
+        return []
+    input_match = _BASH_INPUT_RE.search(content)
+    stdout_match = _BASH_STDOUT_RE.search(content)
+    stderr_match = _BASH_STDERR_RE.search(content)
+    items: list[ClaudeTranscriptItem] = []
+    item_index = 0
+    if input_match is not None:
+        items.append(
+            ClaudeTranscriptItem(
+                source_id=_source_id(source_key, item_index, "terminal_command"),
+                item_type="terminal_command",
+                data={"kind": "input", "input": input_match.group(1)},
+                response_id=response_id,
+            )
+        )
+        item_index += 1
+    if stdout_match is not None or stderr_match is not None:
+        items.append(
+            ClaudeTranscriptItem(
+                source_id=_source_id(source_key, item_index, "terminal_command"),
+                item_type="terminal_command",
+                data={
+                    "kind": "output",
+                    "stdout": stdout_match.group(1) if stdout_match is not None else None,
+                    "stderr": stderr_match.group(1) if stderr_match is not None else None,
+                },
+                response_id=response_id,
+            )
+        )
+    return items
+
+
+def _user_transcript_items_from_entry(
+    entry: dict[str, Any],
+    *,
+    line_number: int,
+    record_offset: int | None,
+    agent_name: str,
+    current_response_id: str | None,
+) -> tuple[str | None, list[ClaudeTranscriptItem]]:
+    """
+    Parse a Claude ``role=user`` transcript entry.
+
+    :param entry: Decoded Claude transcript record.
+    :param line_number: One-based transcript line number.
+    :param record_offset: Byte offset where the transcript record
+        starts, or ``None`` for legacy line-cursor reads.
+    :param agent_name: Agent/model name attached to ``slash_command``
+        items so the web UI can attribute the invocation.
+    :param current_response_id: Response id for the active assistant
+        turn; tool results keep this id.
+    :returns: Updated active response id and parsed user/tool-result
+        items.
+    """
+    # ``isMeta=true`` carries CLI scaffolding like
+    # ``<local-command-caveat>``; no user-visible content.
+    if entry.get("isMeta") is True:
+        return current_response_id, []
+    message = entry["message"]
+    content = message.get("content") if isinstance(message, dict) else None
+    source_key = _transcript_source_key(entry, line_number, record_offset)
+    fallback_response_id = _response_id_from_source(source_key)
+    items: list[ClaudeTranscriptItem] = []
+
+    if isinstance(content, str):
+        if not content:
+            return current_response_id, []
+        stripped = content.lstrip()
+        # Skill invocations with args ship the tag order
+        # ``<command-message>…<command-name>…<command-args>…`` — i.e.
+        # ``<command-name>`` is NOT the first tag. Detect it anywhere
+        # in the content, not just at the start.
+        if "<command-name>" in stripped:
+            payload = _parse_slash_command_record(content)
+            # Drop unparseable markup rather than letting it fall through
+            # to the user-bubble path — that rendered the markup verbatim
+            # in the original bug.
+            if payload is None or payload.name in _CLAUDE_CLI_DROPPED_COMMANDS:
+                return current_response_id, []
+            kind = "command" if payload.name in _CLAUDE_CLI_SURFACED_COMMANDS else "skill"
+            data: dict[str, Any] = {
+                "agent": agent_name,
+                "kind": kind,
+                "name": payload.name,
+                "arguments": payload.arguments,
+            }
+            if payload.output is not None:
+                data["output"] = payload.output
+            items.append(
+                ClaudeTranscriptItem(
+                    source_id=_source_id(source_key, 0, "slash_command"),
+                    item_type="slash_command",
+                    data=data,
+                    response_id=fallback_response_id,
+                )
+            )
+            # Slash command opens a new logical turn; subsequent
+            # assistant text must inherit this id so it clusters with
+            # the indicator, not the prior bubble.
+            return fallback_response_id, items
+        # ``!cmd`` terminal commands may arrive here in older Claude
+        # builds; newer builds use top-level ``local_command`` records.
+        # In both shapes, surface the command and result as their own
+        # transcript group instead of inheriting the previous assistant
+        # response id.
+        terminal_response_id = (
+            fallback_response_id
+            if _BASH_INPUT_RE.search(content) is not None
+            else current_response_id or fallback_response_id
+        )
+        terminal_items = _terminal_command_items_from_content(
+            content,
+            source_key=source_key,
+            response_id=terminal_response_id,
+        )
+        if terminal_items:
+            return terminal_response_id, terminal_items
+        # Other CLI-scaffolding records (stdout/stderr from /effort, etc.)
+        # arrive as standalone ``role=user`` records and must drop instead
+        # of leaking as user bubbles.
+        if any(stripped.startswith(m) for m in _CLI_SCAFFOLDING_MARKERS):
+            return current_response_id, []
+        items.append(
+            ClaudeTranscriptItem(
+                source_id=_source_id(source_key, 0, "message"),
+                item_type="message",
+                data={
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": content}],
+                },
+                response_id=fallback_response_id,
+            )
+        )
+        return None, items
+
+    if not isinstance(content, list):
+        return current_response_id, []
+
+    user_blocks: list[dict[str, Any]] = []
+    saw_user_text = False
+    item_index = 0
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text = block.get("text")
+            if not isinstance(text, str) or not text:
+                continue
+            # Defensively guard against slash-command markup or other
+            # CLI-scaffolding markers ever arriving in list-form
+            # content. Today these only ship in string content (the
+            # branch above), but Claude Code's JSONL format is not
+            # under our control — without this filter, a format
+            # change would regress to rendering ``<command-name>…``
+            # markup as a user bubble.
+            stripped = text.lstrip()
+            if "<command-name>" in stripped or any(
+                stripped.startswith(m) for m in _CLI_SCAFFOLDING_MARKERS
+            ):
+                continue
+            user_blocks.append({"type": "input_text", "text": text})
+            saw_user_text = True
+            continue
+        if block_type != "tool_result":
+            continue
+        call_id = block.get("tool_use_id")
+        if not isinstance(call_id, str) or not call_id:
+            continue
+        response_id = current_response_id or _response_id_from_source(
+            _parent_or_record_source_key(entry, line_number, record_offset)
+        )
+        items.append(
+            ClaudeTranscriptItem(
+                source_id=_source_id(source_key, item_index, "function_call_output"),
+                item_type="function_call_output",
+                data={
+                    "call_id": call_id,
+                    "output": _tool_result_output(entry, block),
+                },
+                response_id=response_id,
+            )
+        )
+        item_index += 1
+
+    if user_blocks:
+        items.insert(
+            0,
+            ClaudeTranscriptItem(
+                source_id=_source_id(source_key, item_index, "message"),
+                item_type="message",
+                data={
+                    "role": "user",
+                    "content": user_blocks,
+                },
+                response_id=fallback_response_id,
+            ),
+        )
+    return (None if saw_user_text else current_response_id), items
+
+
+def _assistant_transcript_items_from_entry(
+    entry: dict[str, Any],
+    *,
+    line_number: int,
+    record_offset: int | None,
+    agent_name: str,
+    current_response_id: str | None,
+) -> tuple[str | None, list[ClaudeTranscriptItem]]:
+    """
+    Parse a Claude ``role=assistant`` transcript entry.
+
+    :param entry: Decoded Claude transcript record.
+    :param line_number: One-based transcript line number.
+    :param record_offset: Byte offset where the transcript record
+        starts, or ``None`` for legacy line-cursor reads.
+    :param agent_name: Agent/model name for assistant/tool items.
+    :param current_response_id: Response id for the active Claude
+        assistant turn.
+    :returns: Updated active response id and parsed assistant/tool
+        items.
+    """
+    message = entry["message"]
+    content = message.get("content") if isinstance(message, dict) else None
+    source_key = _transcript_source_key(entry, line_number, record_offset)
+    response_id = current_response_id or _response_id_from_source(source_key)
+    items: list[ClaudeTranscriptItem] = []
+
+    if isinstance(content, str):
+        if content:
+            items.append(
+                _assistant_message_item(
+                    source_key=source_key,
+                    item_index=0,
+                    agent_name=agent_name,
+                    response_id=response_id,
+                    text=content,
+                )
+            )
+        return response_id, items
+
+    if not isinstance(content, list):
+        return current_response_id, []
+
+    for item_index, block in enumerate(content):
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                items.append(
+                    _assistant_message_item(
+                        source_key=source_key,
+                        item_index=item_index,
+                        agent_name=agent_name,
+                        response_id=response_id,
+                        text=text,
+                    )
+                )
+            continue
+        if block_type == "tool_use":
+            tool_id = block.get("id")
+            name = block.get("name")
+            if not isinstance(tool_id, str) or not tool_id:
+                continue
+            if not isinstance(name, str) or not name:
+                continue
+            arguments = block.get("input")
+            if not isinstance(arguments, dict):
+                arguments = {}
+            items.append(
+                ClaudeTranscriptItem(
+                    source_id=_source_id(source_key, item_index, "function_call"),
+                    item_type="function_call",
+                    data={
+                        "agent": agent_name,
+                        "name": name,
+                        "arguments": json.dumps(arguments, separators=(",", ":")),
+                        "call_id": tool_id,
+                    },
+                    response_id=response_id,
+                )
+            )
+    return response_id if items else current_response_id, items
+
+
+_CONTEXT_OVERFLOW_RE = re.compile(
+    r"^prompt is too long",
+    re.IGNORECASE,
+)
+
+_CONTEXT_OVERFLOW_REPLACEMENT = (
+    "Context limit reached — the conversation has grown too long for "
+    "the model’s context window. Use /compact to summarize and free up "
+    "space, or /clear to start a new conversation."
+)
+
+
+def _assistant_message_item(
+    *,
+    source_key: str,
+    item_index: int,
+    agent_name: str,
+    response_id: str,
+    text: str,
+) -> ClaudeTranscriptItem:
+    """
+    Build an assistant message item from one Claude text block.
+
+    :param source_key: Base transcript record key.
+    :param item_index: Content block index inside the record.
+    :param agent_name: Agent/model name for the assistant message.
+    :param response_id: Response id grouping the Claude turn.
+    :param text: Assistant text block.
+    :returns: Parsed transcript item.
+    """
+    display_text = text
+    if _CONTEXT_OVERFLOW_RE.match(text.strip()):
+        display_text = _CONTEXT_OVERFLOW_REPLACEMENT
+    return ClaudeTranscriptItem(
+        source_id=_source_id(source_key, item_index, "message"),
+        item_type="message",
+        data={
+            "role": "assistant",
+            "agent": agent_name,
+            "content": [{"type": "output_text", "text": display_text}],
+        },
+        response_id=response_id,
+    )
+
+
+def _tool_result_output(entry: dict[str, Any], block: dict[str, Any]) -> str:
+    """
+    Return the UI-facing output string for a Claude tool result.
+
+    :param entry: Decoded Claude transcript record containing
+        optional ``toolUseResult`` metadata.
+    :param block: ``tool_result`` content block from ``message``.
+    :returns: String output for a ``function_call_output`` item.
+    """
+    content = block.get("content")
+    if isinstance(content, str):
+        return content
+    if content is not None:
+        return json.dumps(content, separators=(",", ":"))
+    tool_use_result = entry.get("toolUseResult")
+    if isinstance(tool_use_result, str):
+        return tool_use_result
+    if tool_use_result is not None:
+        return json.dumps(tool_use_result, separators=(",", ":"))
+    return ""
+
+
+def _transcript_source_key(
+    entry: dict[str, Any],
+    line_number: int,
+    record_offset: int | None = None,
+) -> str:
+    """
+    Return the stable key for a Claude transcript record.
+
+    :param entry: Decoded Claude transcript record.
+    :param line_number: One-based transcript line number.
+    :param record_offset: Byte offset where the transcript record
+        starts, or ``None`` when unavailable.
+    :returns: Claude UUID/request id, byte-offset fallback, or a
+        legacy line-number fallback.
+    """
+    for key in ("uuid", "requestId"):
+        value = entry.get(key)
+        if isinstance(value, str) and value:
+            return value
+    if record_offset is not None:
+        return f"byte-{record_offset}"
+    return f"line-{line_number}"
+
+
+def _parent_or_record_source_key(
+    entry: dict[str, Any],
+    line_number: int,
+    record_offset: int | None = None,
+) -> str:
+    """
+    Return a parent key for tool results when Claude supplies one.
+
+    :param entry: Decoded Claude transcript record.
+    :param line_number: One-based transcript line number.
+    :param record_offset: Byte offset where the transcript record
+        starts, or ``None`` when unavailable.
+    :returns: Parent UUID when present, otherwise the record key.
+    """
+    parent = entry.get("parentUuid")
+    if isinstance(parent, str) and parent:
+        return parent
+    return _transcript_source_key(entry, line_number, record_offset)
+
+
+def _response_id_from_source(source: str) -> str:
+    """
+    Derive a deterministic Omnigent response id from a Claude source key.
+
+    :param source: Claude UUID/request id/line key.
+    :returns: String id with the standard ``resp_`` prefix.
+    """
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:32]
+    return f"resp_claude_{digest}"
+
+
+def _source_id(source_key: str, item_index: int, item_type: str) -> str:
+    """
+    Build a per-item idempotency key for a transcript-derived item.
+
+    :param source_key: Base Claude record key.
+    :param item_index: Content block index inside the record.
+    :param item_type: Omnigent item type.
+    :returns: Stable source id string.
+    """
+    return f"{source_key}:{item_index}:{item_type}"

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import json
 import logging
-from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -48,6 +47,100 @@ from omnigent.codex_native_elicitation import (
 )
 from omnigent.codex_native_elicitation import (
     is_codex_request_id as _is_codex_request_id,
+)
+
+# Re-exported from the shared Codex item parser (extracted for session adoption;
+# see omnigent.codex_native_items). The redundant ``as`` aliases mark these as
+# intentional re-exports so callers and tests keep importing them from this module.
+from omnigent.codex_native_items import (
+    _CODEX_AUTH_ERROR_FRAGMENTS as _CODEX_AUTH_ERROR_FRAGMENTS,
+)
+from omnigent.codex_native_items import (
+    _CODEX_AUTH_ERROR_INFO as _CODEX_AUTH_ERROR_INFO,
+)
+from omnigent.codex_native_items import (
+    _CODEX_AUTH_HTTP_STATUS as _CODEX_AUTH_HTTP_STATUS,
+)
+from omnigent.codex_native_items import (
+    _CODEX_ERROR_ITEM_TYPE as _CODEX_ERROR_ITEM_TYPE,
+)
+from omnigent.codex_native_items import (
+    _CODEX_ERROR_KIND_AUTH as _CODEX_ERROR_KIND_AUTH,
+)
+from omnigent.codex_native_items import (
+    _CODEX_ERROR_KIND_GENERIC as _CODEX_ERROR_KIND_GENERIC,
+)
+from omnigent.codex_native_items import (
+    _CODEX_REAUTH_HINT as _CODEX_REAUTH_HINT,
+)
+from omnigent.codex_native_items import (
+    _CODEX_SANDBOX_BYPASS_GUIDANCE as _CODEX_SANDBOX_BYPASS_GUIDANCE,
+)
+from omnigent.codex_native_items import (
+    _CODEX_SANDBOX_NAMESPACE_ERROR_MARKER as _CODEX_SANDBOX_NAMESPACE_ERROR_MARKER,
+)
+from omnigent.codex_native_items import (
+    _TOOL_ITEM_BUILDERS as _TOOL_ITEM_BUILDERS,
+)
+from omnigent.codex_native_items import (
+    _TOOL_ITEM_TYPES as _TOOL_ITEM_TYPES,
+)
+from omnigent.codex_native_items import (
+    _augment_sandbox_namespace_error as _augment_sandbox_namespace_error,
+)
+from omnigent.codex_native_items import (
+    _classify_codex_error as _classify_codex_error,
+)
+from omnigent.codex_native_items import (
+    _codex_tool_call_from_item as _codex_tool_call_from_item,
+)
+from omnigent.codex_native_items import (
+    _CodexTerminalError as _CodexTerminalError,
+)
+from omnigent.codex_native_items import (
+    _CodexToolCall as _CodexToolCall,
+)
+from omnigent.codex_native_items import (
+    _CodexTurnStatusEdge as _CodexTurnStatusEdge,
+)
+from omnigent.codex_native_items import (
+    _command_execution_tool_call as _command_execution_tool_call,
+)
+from omnigent.codex_native_items import (
+    _error_item_from_turn as _error_item_from_turn,
+)
+from omnigent.codex_native_items import (
+    _error_payload_message as _error_payload_message,
+)
+from omnigent.codex_native_items import (
+    _file_change_tool_call as _file_change_tool_call,
+)
+from omnigent.codex_native_items import (
+    _image_generation_tool_call as _image_generation_tool_call,
+)
+from omnigent.codex_native_items import (
+    _image_view_tool_call as _image_view_tool_call,
+)
+from omnigent.codex_native_items import (
+    _omnigent_status_from_resume_turn as _omnigent_status_from_resume_turn,
+)
+from omnigent.codex_native_items import (
+    _source_id as _source_id,
+)
+from omnigent.codex_native_items import (
+    _terminal_error_from_turn as _terminal_error_from_turn,
+)
+from omnigent.codex_native_items import (
+    _ToolItemBuilder as _ToolItemBuilder,
+)
+from omnigent.codex_native_items import (
+    _turn_id_from_payload as _turn_id_from_payload,
+)
+from omnigent.codex_native_items import (
+    _web_search_tool_call as _web_search_tool_call,
+)
+from omnigent.codex_native_items import (
+    iter_resume_items as iter_resume_items,
 )
 from omnigent.entities.session_resources import terminal_resource_id
 
@@ -152,50 +245,6 @@ _CODEX_ELICITATION_REQUEST_METHODS = frozenset(
     }
 )
 
-# Turn-error surfacing. A failed Codex turn arrives as ``turn/completed``
-# (or ``turn/failed``) with ``turn.status == "failed"`` and a ``turn.error``
-# object ``{message, codexErrorInfo?, additionalDetails?}``; keying status off
-# the method alone mapped such turns to ``idle`` — a "silent success". The
-# forwarder inspects ``turn.status``/``turn.error``, forces ``failed``, and
-# surfaces the reason. As a fallback it also catches an ``error`` ThreadItem in
-# ``turn.items``: both shapes exist in the app-server type system and the wire
-# shape varies by version, so detecting either keeps the fix robust.
-#
-# ``codexErrorInfo`` is the app-server's structured classification (e.g.
-# ``unauthorized``, ``usage_limit_exceeded``); auth-class values get a re-auth
-# hint. httpStatusCode 401/403 is treated as auth too. Values are stored and
-# compared case-insensitively: the app-server enum serializes as lowercase
-# snake_case (``unauthorized``), but older/alternate spellings (``Unauthorized``)
-# are matched too.
-_CODEX_ERROR_ITEM_TYPE = "error"
-_CODEX_AUTH_ERROR_INFO = frozenset({"unauthorized"})
-_CODEX_AUTH_HTTP_STATUS = frozenset({401, 403})
-# Message-substring fallback for app-server versions that omit codexErrorInfo.
-# Surface-only, so recall is favored over precision: a false positive only
-# appends a re-auth hint to an already-failed turn.
-_CODEX_AUTH_ERROR_FRAGMENTS = (
-    "401",
-    "403",
-    "unauthorized",
-    "authentication",
-    "not logged in",
-    "not authenticated",
-    "log in",
-    "login",
-    "sign in",
-    "re-authenticate",
-    "reauthenticate",
-    "credentials",
-    "access token",
-    "token expired",
-    "expired token",
-    "session expired",
-    "api key",
-)
-_CODEX_ERROR_KIND_AUTH = "auth"
-_CODEX_ERROR_KIND_GENERIC = "generic"
-_CODEX_REAUTH_HINT = "Codex needs you to re-authenticate. Run `codex login` and retry."
-
 
 @dataclass
 class _ForwarderTarget:
@@ -218,25 +267,6 @@ class _ForwarderTarget:
     delta_coalescer: _OutputTextDeltaCoalescer
     usage_coalescer: _SessionUsageCoalescer
     elicitation_tracker: _CodexElicitationTaskTracker
-
-
-@dataclass(frozen=True)
-class _CodexToolCall:
-    """
-    Normalized view of one completed Codex built-in tool call.
-
-    :param call_id: Codex item id reused as the Omnigent call id, e.g.
-        ``"call_abc"``.
-    :param name: Omnigent function-call name, e.g. ``"shell"``.
-    :param arguments: Tool arguments dict, e.g. ``{"command": "pwd"}``.
-    :param output: Tool result text rendered as the
-        ``function_call_output``, e.g. ``"/repo\n"``.
-    """
-
-    call_id: str
-    name: str
-    arguments: dict[str, Any]
-    output: str
 
 
 @dataclass
@@ -764,150 +794,6 @@ class _CodexForwarderState:
         mode = raw_mode.get("mode")
         if isinstance(mode, str) and mode:
             self.collaboration_mode = mode
-
-
-@dataclass(frozen=True)
-class _CodexTerminalError:
-    """
-    A turn-level failure surfaced from a Codex turn.
-
-    Produced by :func:`_terminal_error_from_turn` from ``turn.error`` or an
-    ``error`` ThreadItem. Forces the turn's Omnigent status to ``failed`` and
-    lets :func:`_post_turn_status_edge` surface the reason (and a re-auth hint
-    for auth-classified errors).
-
-    :param message: Human-readable error text, e.g.
-        ``"401 Unauthorized: ChatGPT login expired"``.
-    :param kind: Classification, either ``"auth"`` or ``"generic"``.
-    """
-
-    message: str
-    kind: str
-
-    @property
-    def is_auth(self) -> bool:
-        """:returns: ``True`` when the error was classified as auth-related."""
-        return self.kind == _CODEX_ERROR_KIND_AUTH
-
-
-def _classify_codex_error(error: dict[str, Any], message: str) -> str:
-    """
-    Classify a Codex ``turn.error`` / ``error`` item as auth-related or generic.
-
-    Prefers the structured ``codexErrorInfo`` (an ``unauthorized`` variant,
-    case-insensitive, or an httpStatusCode of 401/403); falls back to substring
-    matching against :data:`_CODEX_AUTH_ERROR_FRAGMENTS` for versions/shapes
-    that omit it.
-
-    :param error: The ``turn.error`` object.
-    :param message: Its already-extracted message text.
-    :returns: :data:`_CODEX_ERROR_KIND_AUTH` or
-        :data:`_CODEX_ERROR_KIND_GENERIC`.
-    """
-    info = error.get("codexErrorInfo")
-    variant: str | None = None
-    http_status: Any = None
-    if isinstance(info, str):
-        variant = info
-    elif isinstance(info, dict):
-        variant = info.get("type") or info.get("kind") or info.get("variant")
-        http_status = info.get("httpStatusCode")
-    variant_is_auth = variant is not None and variant.lower() in _CODEX_AUTH_ERROR_INFO
-    if variant_is_auth or http_status in _CODEX_AUTH_HTTP_STATUS:
-        return _CODEX_ERROR_KIND_AUTH
-    lowered = message.lower()
-    if any(fragment in lowered for fragment in _CODEX_AUTH_ERROR_FRAGMENTS):
-        return _CODEX_ERROR_KIND_AUTH
-    return _CODEX_ERROR_KIND_GENERIC
-
-
-def _error_payload_message(payload: dict[str, Any]) -> str:
-    """
-    Extract a non-empty message from a Codex ``turn.error`` or ``error`` item.
-
-    Both shapes have surfaced the text under a few keys across app-server
-    versions; reads the first non-empty one, falling back to a stable string
-    so the surfaced error is never blank.
-
-    :param payload: A ``turn.error`` object or an ``error`` ThreadItem.
-    :returns: Non-empty error text.
-    """
-    for key in ("message", "error", "text", "detail"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    return "Codex turn ended with an unspecified error."
-
-
-def _error_item_from_turn(turn: dict[str, Any]) -> dict[str, Any] | None:
-    """
-    Return the first ``error`` ThreadItem in ``turn.items``, if any.
-
-    :param turn: A Codex turn object.
-    :returns: The first item whose ``type`` is :data:`_CODEX_ERROR_ITEM_TYPE`,
-        or ``None``.
-    """
-    items = turn.get("items")
-    if not isinstance(items, list):
-        return None
-    for item in items:
-        if isinstance(item, dict) and item.get("type") == _CODEX_ERROR_ITEM_TYPE:
-            return item
-    return None
-
-
-def _terminal_error_from_turn(params: dict[str, Any]) -> _CodexTerminalError | None:
-    """
-    Return the turn-level failure carried by a Codex turn, if any.
-
-    Prefers ``turn.error`` (the protocol's ``TurnError`` on a failed turn) and
-    falls back to an ``error`` ThreadItem in ``turn.items`` — both shapes exist
-    in the app-server type system and the wire shape varies by version. Single
-    source of truth reused by the live terminal edge and the ``thread/resume``
-    parity path.
-
-    :param params: Codex turn params, e.g. a ``turn/completed`` payload or a
-        single ``thread/resume`` turn wrapped as ``{"turn": <turn>}``.
-    :returns: The classified terminal error, or ``None`` when the turn did not
-        fail.
-    """
-    turn = params.get("turn")
-    if not isinstance(turn, dict):
-        return None
-    payload = turn.get("error")
-    if not isinstance(payload, dict):
-        payload = _error_item_from_turn(turn)
-    if payload is None:
-        return None
-    message = _error_payload_message(payload)
-    return _CodexTerminalError(message=message, kind=_classify_codex_error(payload, message))
-
-
-@dataclass(frozen=True)
-class _CodexTurnStatusEdge:
-    """
-    Omnigent session-status edge derived from Codex turn lifecycle state.
-
-    :param status: Omnigent session status, e.g. ``"running"`` or ``"idle"``.
-    :param turn_id: Codex turn id that caused the edge, e.g.
-        ``"turn_abc123"``.
-    :param source: Lifecycle source that produced the edge, e.g.
-        ``"turn/started"``.
-    :param error: Turn-level error forcing this edge to ``failed``,
-        or ``None`` for ordinary lifecycle edges. Surfaced as the status
-        output by :func:`_post_turn_status_edge`.
-    """
-
-    status: str
-    turn_id: str | None
-    source: str
-    error: _CodexTerminalError | None = None
-
-
-# Codex ``item/completed`` item types that represent a built-in tool call.
-# Each maps to a builder that extracts a normalized :class:`_CodexToolCall`.
-# ``_TOOL_ITEM_BUILDERS`` is populated after the builders are defined.
-_ToolItemBuilder = Callable[[str, dict[str, Any]], "_CodexToolCall | None"]
 
 
 @dataclass(frozen=True)
@@ -2071,33 +1957,20 @@ async def _replay_resume_response(
         return
     thread_id = thread.get("id")
     thread_id = thread_id if isinstance(thread_id, str) and thread_id else None
-    for turn in turns:
-        if not isinstance(turn, dict):
-            continue
-        turn_id = _turn_id_from_payload(turn)
-        items = turn.get("items")
-        if not turn_id or not isinstance(items, list):
-            continue
-        for item in items:
-            if not isinstance(item, dict):
-                continue
-            await _handle_event(
-                client,
-                session_id=session_id,
-                bridge_dir=bridge_dir,
-                event={
-                    "method": "item/completed",
-                    "params": {
-                        "threadId": thread_id,
-                        "turnId": turn_id,
-                        "item": item,
-                    },
-                },
-                usage_coalescer=usage_coalescer,
-                elicitation_tracker=elicitation_tracker,
-                expected_thread_id=thread_id,
-                forwarder_state=forwarder_state,
-            )
+    # ``iter_resume_items`` walks the same envelope and wraps each item as the
+    # ``item/completed`` event the live stream delivers, so replay and session
+    # adoption share one normalization + dedup path.
+    for event_thread_id, event in iter_resume_items(response):
+        await _handle_event(
+            client,
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            event=event,
+            usage_coalescer=usage_coalescer,
+            elicitation_tracker=elicitation_tracker,
+            expected_thread_id=event_thread_id,
+            forwarder_state=forwarder_state,
+        )
     await _post_resume_terminal_status(
         client,
         session_id=session_id,
@@ -2178,33 +2051,6 @@ def _resume_terminal_status_edge_for_latest_turn(
             source="thread/resume:turn-error" if error is not None else "thread/resume",
             error=error,
         )
-    return None
-
-
-def _omnigent_status_from_resume_turn(turn: dict[str, Any]) -> str | None:
-    """
-    Convert an explicit Codex resume turn status to Omnigent session status.
-
-    Applies the same ``turn.error`` check as the live terminal path
-    (:func:`_terminal_turn_status_edge`) so a resumed turn that carried an
-    error maps to ``failed`` even if its recorded status is not — the
-    resume-path side of the "silent success" fix.
-
-    :param turn: Codex resume turn object, e.g.
-        ``{"id": "turn_123", "status": "completed"}``.
-    :returns: Omnigent status literal for terminal turns, or ``None`` for active
-        or unrecognized statuses.
-    """
-    # A ``turn.error`` forces ``failed`` regardless of the recorded status.
-    if _terminal_error_from_turn({"turn": turn}) is not None:
-        return "failed"
-    status = turn.get("status")
-    if isinstance(status, dict):
-        status = status.get("type") or status.get("status")
-    if status in {"completed", "interrupted", "cancelled", "canceled"}:
-        return "idle"
-    if status in {"failed", "errored"}:
-        return "failed"
     return None
 
 
@@ -4853,238 +4699,6 @@ async def _post_review_mode_marker(
     )
 
 
-def _codex_tool_call_from_item(item: dict[str, Any]) -> _CodexToolCall | None:
-    """
-    Translate a completed Codex tool item into a normalized tool call.
-
-    :param item: Codex tool item from an ``item/completed`` notification,
-        e.g. ``{"type": "commandExecution", "id": "call_abc", ...}``.
-    :returns: Normalized tool call, or ``None`` for a malformed item that
-        should be dropped rather than mirrored with invented fields.
-    """
-    call_id = item.get("id")
-    item_type = item.get("type")
-    if not isinstance(call_id, str) or not call_id:
-        _logger.warning("Codex tool item missing string id: type=%s", item_type)
-        return None
-    builder = _TOOL_ITEM_BUILDERS.get(item_type) if isinstance(item_type, str) else None
-    if builder is None:
-        return None
-    return builder(call_id, item)
-
-
-# Codex runs each model-issued shell command inside its OWN bwrap command
-# sandbox. In a hardened container that disallows unprivileged user namespaces,
-# that sandbox cannot start and every command hard-fails with this raw bwrap
-# error, with no hint at how to recover. Detect the marker and append actionable
-# guidance so a top-level session degrades with direction instead of an opaque
-# failure. The codex
-# ``--approval-mode`` presets do NOT disable this sandbox — only the "Full
-# access" preset's ``danger-full-access`` (or a config ``sandbox_mode``) does.
-_CODEX_SANDBOX_NAMESPACE_ERROR_MARKER = "No permissions to create new namespace"
-_CODEX_SANDBOX_BYPASS_GUIDANCE = (
-    "Omnigent: Codex's command sandbox could not start because this container "
-    "disallows unprivileged user namespaces, so the command did not run. To run "
-    'shell commands here, start a new Codex session with the "Full access" '
-    "approval preset (New chat → Advanced settings), or set "
-    'sandbox_mode = "danger-full-access" in ~/.codex/config.toml on the runner.'
-)
-
-
-def _augment_sandbox_namespace_error(output_text: str) -> str:
-    """Append recovery guidance when a Codex shell command failed because its
-    own command sandbox could not start (no unprivileged user namespaces).
-
-    Returns *output_text* unchanged when the bwrap-namespace marker is absent,
-    so ordinary command output is never altered. See issue #657.
-
-    :param output_text: Aggregated command output, any exit-code suffix already
-        appended, e.g. ``"bwrap: No permissions ...\\n[exit code: 1]"``.
-    :returns: The output with a trailing guidance paragraph, or unchanged.
-    """
-    if _CODEX_SANDBOX_NAMESPACE_ERROR_MARKER not in output_text:
-        return output_text
-    return f"{output_text}\n\n{_CODEX_SANDBOX_BYPASS_GUIDANCE}"
-
-
-def _command_execution_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
-    """
-    Build a tool call from a Codex ``commandExecution`` item.
-
-    :param call_id: Codex item id, e.g. ``"call_abc"``.
-    :param item: Codex ``commandExecution`` item, e.g.
-        ``{"command": "/bin/zsh -lc 'pwd'", "cwd": "/repo",
-        "aggregatedOutput": "/repo\n", "exitCode": 0}``.
-    :returns: Normalized tool call, or ``None`` when the command is
-        missing.
-    """
-    command = item.get("command")
-    if not isinstance(command, str) or not command:
-        _logger.warning("Codex commandExecution missing command: call_id=%s", call_id)
-        return None
-    arguments: dict[str, Any] = {"command": command}
-    cwd = item.get("cwd")
-    if isinstance(cwd, str) and cwd:
-        arguments["cwd"] = cwd
-    output = item.get("aggregatedOutput")
-    # A command that prints nothing (e.g. ``touch x``) legitimately has no
-    # aggregated output; Codex reports that as "" or null. AP's
-    # function_call_output requires a string, so "" is the faithful
-    # representation of "no output captured" here — not an invented default.
-    output_text = output if isinstance(output, str) else ""
-    exit_code = item.get("exitCode")
-    # Codex reports a non-zero exit separately from stdout/stderr; surface
-    # it inline so a failed command does not look successful in the UI.
-    if isinstance(exit_code, int) and exit_code != 0:
-        suffix = f"[exit code: {exit_code}]"
-        output_text = f"{output_text}\n{suffix}" if output_text else suffix
-    # Turn codex's opaque "sandbox can't start" bwrap failure into actionable
-    # recovery guidance; a no-op for any other output.
-    output_text = _augment_sandbox_namespace_error(output_text)
-    return _CodexToolCall(call_id=call_id, name="shell", arguments=arguments, output=output_text)
-
-
-def _file_change_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
-    """
-    Build a tool call from a Codex ``fileChange`` item.
-
-    :param call_id: Codex item id, e.g. ``"call_abc"``.
-    :param item: Codex ``fileChange`` item, e.g.
-        ``{"changes": [{"path": "/repo/x.py", "kind": {"type": "add"},
-        "diff": "print('hi')\n"}], "status": "completed"}``.
-    :returns: Normalized tool call, or ``None`` when no changes are
-        present.
-    """
-    changes = item.get("changes")
-    if not isinstance(changes, list) or not changes:
-        _logger.warning("Codex fileChange missing changes: call_id=%s", call_id)
-        return None
-    summary_lines: list[str] = []
-    for change in changes:
-        if not isinstance(change, dict):
-            continue
-        path = change.get("path")
-        kind = change.get("kind")
-        kind_type = kind.get("type") if isinstance(kind, dict) else None
-        label = kind_type if isinstance(kind_type, str) and kind_type else "change"
-        summary_lines.append(f"{label} {path}")
-    output_text = "\n".join(summary_lines)
-    return _CodexToolCall(
-        call_id=call_id,
-        name="apply_patch",
-        arguments={"changes": changes},
-        output=output_text,
-    )
-
-
-def _web_search_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
-    """
-    Build a tool call from a Codex ``webSearch`` item.
-
-    Codex does not surface the search results, so the queries it ran are
-    the only result data available and are used as the output text.
-
-    :param call_id: Codex item id, e.g. ``"ws_abc"``.
-    :param item: Codex ``webSearch`` item, e.g.
-        ``{"query": "python latest version",
-        "action": {"type": "search", "queries": ["python latest"]}}``.
-    :returns: Normalized tool call, or ``None`` when no query is present.
-    """
-    query = item.get("query")
-    action = item.get("action")
-    queries = action.get("queries") if isinstance(action, dict) else None
-    query_list = [q for q in queries if isinstance(q, str)] if isinstance(queries, list) else []
-    if not query_list and isinstance(query, str) and query:
-        query_list = [query]
-    if not query_list:
-        _logger.warning("Codex webSearch missing query: call_id=%s", call_id)
-        return None
-    return _CodexToolCall(
-        call_id=call_id,
-        name="web_search",
-        arguments={"query": query_list[0]},
-        output="\n".join(query_list),
-    )
-
-
-def _image_view_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
-    """
-    Build a tool call from a Codex ``imageView`` item.
-
-    Codex emits an ``imageView`` item when the model opens a local image
-    (e.g. a screenshot on disk) to look at it. The only datum is the
-    absolute path, so it becomes both the argument and the mirrored
-    output — the web UI cannot read a runner-local path, so the path is
-    the faithful record of which image was viewed.
-
-    :param call_id: Codex item id, e.g. ``"img_abc"``.
-    :param item: Codex ``imageView`` item, e.g.
-        ``{"type": "imageView", "id": "img_abc", "path": "/repo/shot.png"}``.
-    :returns: Normalized tool call, or ``None`` when the path is missing.
-    """
-    path = item.get("path")
-    if not isinstance(path, str) or not path:
-        _logger.warning("Codex imageView missing path: call_id=%s", call_id)
-        return None
-    return _CodexToolCall(
-        call_id=call_id,
-        name="view_image",
-        arguments={"path": path},
-        output=path,
-    )
-
-
-def _image_generation_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
-    """
-    Build a tool call from a Codex ``imageGeneration`` item.
-
-    Codex emits an ``imageGeneration`` item when the model generates an
-    image. The raw ``result`` payload (base64 image bytes) is deliberately
-    NOT mirrored — the web UI has no assistant-side image rendering and a
-    multi-megabyte base64 string would only bloat the transcript. Instead
-    the card carries the human-meaningful metadata: the revised prompt as
-    the argument and the status plus on-disk save path as the output.
-
-    :param call_id: Codex item id, e.g. ``"imggen_abc"``.
-    :param item: Codex ``imageGeneration`` item, e.g.
-        ``{"type": "imageGeneration", "id": "imggen_abc",
-        "status": "completed", "revisedPrompt": "a red bicycle",
-        "result": "<base64>", "savedPath": "/repo/out.png"}``.
-    :returns: Normalized tool call, or ``None`` when the status is missing.
-    """
-    status = item.get("status")
-    if not isinstance(status, str) or not status:
-        _logger.warning("Codex imageGeneration missing status: call_id=%s", call_id)
-        return None
-    arguments: dict[str, Any] = {}
-    revised_prompt = item.get("revisedPrompt")
-    if isinstance(revised_prompt, str) and revised_prompt:
-        arguments["revised_prompt"] = revised_prompt
-    output_lines = [f"status: {status}"]
-    saved_path = item.get("savedPath")
-    if isinstance(saved_path, str) and saved_path:
-        output_lines.append(f"saved to {saved_path}")
-    return _CodexToolCall(
-        call_id=call_id,
-        name="generate_image",
-        arguments=arguments,
-        output="\n".join(output_lines),
-    )
-
-
-# Codex built-in tool item types this forwarder mirrors into Omnigent history.
-# ``mcpToolCall`` is intentionally absent: its event shape has not been
-# verified, so it is logged-but-skipped rather than mirrored with guessed
-# fields. Add it here once its real shape is captured.
-_TOOL_ITEM_BUILDERS: dict[str, _ToolItemBuilder] = {
-    "commandExecution": _command_execution_tool_call,
-    "fileChange": _file_change_tool_call,
-    "webSearch": _web_search_tool_call,
-    "imageView": _image_view_tool_call,
-    "imageGeneration": _image_generation_tool_call,
-}
-_TOOL_ITEM_TYPES = frozenset(_TOOL_ITEM_BUILDERS)
-
 # Codex ``/review`` enter/exit thread items. The web UI has no dedicated
 # review-mode affordance, so these are mirrored as a visible assistant-message
 # marker (see :func:`_post_review_mode_marker`).
@@ -5977,19 +5591,6 @@ def _post_retry_delay(attempt: int) -> float:
     return _POST_RETRY_DELAY_SECONDS * attempt
 
 
-def _turn_id_from_payload(payload: object) -> str | None:
-    """
-    Extract a turn id from a Codex payload.
-
-    :param payload: Codex notification params or nested turn object.
-    :returns: Turn id, or ``None`` when absent.
-    """
-    if not isinstance(payload, dict):
-        return None
-    value = payload.get("id") or payload.get("turnId")
-    return value if isinstance(value, str) and value else None
-
-
 def _turn_status_from_params(params: dict[str, Any]) -> str | None:
     """
     Extract a Codex turn status from terminal notification params.
@@ -6419,25 +6020,6 @@ def _response_id(params: dict[str, Any]) -> str:
     if isinstance(turn_id, str) and turn_id:
         return f"codex_{turn_id}"
     return "codex_native"
-
-
-def _source_id(params: dict[str, Any], item: dict[str, Any]) -> str:
-    """
-    Build a stable per-record label for one Codex item.
-
-    Only used for debug-log correlation — it is not sent to the server
-    and is not a dedup key (the server persists external items with a
-    random primary key).
-
-    :param params: Codex notification params.
-    :param item: Codex item payload.
-    :returns: Record label, e.g. ``"turn_abc:item_xyz"``.
-    """
-    turn_id = params.get("turnId")
-    item_id = item.get("id")
-    left = turn_id if isinstance(turn_id, str) and turn_id else "thread"
-    right = item_id if isinstance(item_id, str) and item_id else "item"
-    return f"{left}:{right}"
 
 
 def _completed_item_key(

--- a/omnigent/codex_native_items.py
+++ b/omnigent/codex_native_items.py
@@ -1,0 +1,566 @@
+"""Pure Codex app-server item / turn translation helpers.
+
+Factored out of :mod:`omnigent.codex_native_forwarder` so the same normalization
+— built-in tool-call extraction, turn-level terminal-error classification, resume
+turn → Omnigent status derivation, stable turn/source ids, and the
+``thread/resume`` item iteration — can be reused by session adoption without a
+second, simplified parser. Every function here is side-effect-free (no IO, no DB,
+no network); it maps native Codex payload dicts to normalized values. The
+forwarder re-exports these names so existing callers and tests keep importing them
+from :mod:`omnigent.codex_native_forwarder` unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+
+# Turn-error surfacing. A failed Codex turn arrives as ``turn/completed``
+# (or ``turn/failed``) with ``turn.status == "failed"`` and a ``turn.error``
+# object ``{message, codexErrorInfo?, additionalDetails?}``; keying status off
+# the method alone mapped such turns to ``idle`` — a "silent success". The
+# forwarder inspects ``turn.status``/``turn.error``, forces ``failed``, and
+# surfaces the reason. As a fallback it also catches an ``error`` ThreadItem in
+# ``turn.items``: both shapes exist in the app-server type system and the wire
+# shape varies by version, so detecting either keeps the fix robust.
+#
+# ``codexErrorInfo`` is the app-server's structured classification (e.g.
+# ``unauthorized``, ``usage_limit_exceeded``); auth-class values get a re-auth
+# hint. httpStatusCode 401/403 is treated as auth too. Values are stored and
+# compared case-insensitively: the app-server enum serializes as lowercase
+# snake_case (``unauthorized``), but older/alternate spellings (``Unauthorized``)
+# are matched too.
+_CODEX_ERROR_ITEM_TYPE = "error"
+_CODEX_AUTH_ERROR_INFO = frozenset({"unauthorized"})
+_CODEX_AUTH_HTTP_STATUS = frozenset({401, 403})
+# Message-substring fallback for app-server versions that omit codexErrorInfo.
+# Surface-only, so recall is favored over precision: a false positive only
+# appends a re-auth hint to an already-failed turn.
+_CODEX_AUTH_ERROR_FRAGMENTS = (
+    "401",
+    "403",
+    "unauthorized",
+    "authentication",
+    "not logged in",
+    "not authenticated",
+    "log in",
+    "login",
+    "sign in",
+    "re-authenticate",
+    "reauthenticate",
+    "credentials",
+    "access token",
+    "token expired",
+    "expired token",
+    "session expired",
+    "api key",
+)
+_CODEX_ERROR_KIND_AUTH = "auth"
+_CODEX_ERROR_KIND_GENERIC = "generic"
+_CODEX_REAUTH_HINT = "Codex needs you to re-authenticate. Run `codex login` and retry."
+
+
+@dataclass(frozen=True)
+class _CodexToolCall:
+    """
+    Normalized view of one completed Codex built-in tool call.
+
+    :param call_id: Codex item id reused as the Omnigent call id, e.g.
+        ``"call_abc"``.
+    :param name: Omnigent function-call name, e.g. ``"shell"``.
+    :param arguments: Tool arguments dict, e.g. ``{"command": "pwd"}``.
+    :param output: Tool result text rendered as the
+        ``function_call_output``, e.g. ``"/repo\n"``.
+    """
+
+    call_id: str
+    name: str
+    arguments: dict[str, Any]
+    output: str
+
+
+@dataclass(frozen=True)
+class _CodexTerminalError:
+    """
+    A turn-level failure surfaced from a Codex turn.
+
+    Produced by :func:`_terminal_error_from_turn` from ``turn.error`` or an
+    ``error`` ThreadItem. Forces the turn's Omnigent status to ``failed`` and
+    lets :func:`_post_turn_status_edge` surface the reason (and a re-auth hint
+    for auth-classified errors).
+
+    :param message: Human-readable error text, e.g.
+        ``"401 Unauthorized: ChatGPT login expired"``.
+    :param kind: Classification, either ``"auth"`` or ``"generic"``.
+    """
+
+    message: str
+    kind: str
+
+    @property
+    def is_auth(self) -> bool:
+        """:returns: ``True`` when the error was classified as auth-related."""
+        return self.kind == _CODEX_ERROR_KIND_AUTH
+
+
+def _classify_codex_error(error: dict[str, Any], message: str) -> str:
+    """
+    Classify a Codex ``turn.error`` / ``error`` item as auth-related or generic.
+
+    Prefers the structured ``codexErrorInfo`` (an ``unauthorized`` variant,
+    case-insensitive, or an httpStatusCode of 401/403); falls back to substring
+    matching against :data:`_CODEX_AUTH_ERROR_FRAGMENTS` for versions/shapes
+    that omit it.
+
+    :param error: The ``turn.error`` object.
+    :param message: Its already-extracted message text.
+    :returns: :data:`_CODEX_ERROR_KIND_AUTH` or
+        :data:`_CODEX_ERROR_KIND_GENERIC`.
+    """
+    info = error.get("codexErrorInfo")
+    variant: str | None = None
+    http_status: Any = None
+    if isinstance(info, str):
+        variant = info
+    elif isinstance(info, dict):
+        variant = info.get("type") or info.get("kind") or info.get("variant")
+        http_status = info.get("httpStatusCode")
+    variant_is_auth = variant is not None and variant.lower() in _CODEX_AUTH_ERROR_INFO
+    if variant_is_auth or http_status in _CODEX_AUTH_HTTP_STATUS:
+        return _CODEX_ERROR_KIND_AUTH
+    lowered = message.lower()
+    if any(fragment in lowered for fragment in _CODEX_AUTH_ERROR_FRAGMENTS):
+        return _CODEX_ERROR_KIND_AUTH
+    return _CODEX_ERROR_KIND_GENERIC
+
+
+def _error_payload_message(payload: dict[str, Any]) -> str:
+    """
+    Extract a non-empty message from a Codex ``turn.error`` or ``error`` item.
+
+    Both shapes have surfaced the text under a few keys across app-server
+    versions; reads the first non-empty one, falling back to a stable string
+    so the surfaced error is never blank.
+
+    :param payload: A ``turn.error`` object or an ``error`` ThreadItem.
+    :returns: Non-empty error text.
+    """
+    for key in ("message", "error", "text", "detail"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "Codex turn ended with an unspecified error."
+
+
+def _error_item_from_turn(turn: dict[str, Any]) -> dict[str, Any] | None:
+    """
+    Return the first ``error`` ThreadItem in ``turn.items``, if any.
+
+    :param turn: A Codex turn object.
+    :returns: The first item whose ``type`` is :data:`_CODEX_ERROR_ITEM_TYPE`,
+        or ``None``.
+    """
+    items = turn.get("items")
+    if not isinstance(items, list):
+        return None
+    for item in items:
+        if isinstance(item, dict) and item.get("type") == _CODEX_ERROR_ITEM_TYPE:
+            return item
+    return None
+
+
+def _terminal_error_from_turn(params: dict[str, Any]) -> _CodexTerminalError | None:
+    """
+    Return the turn-level failure carried by a Codex turn, if any.
+
+    Prefers ``turn.error`` (the protocol's ``TurnError`` on a failed turn) and
+    falls back to an ``error`` ThreadItem in ``turn.items`` — both shapes exist
+    in the app-server type system and the wire shape varies by version. Single
+    source of truth reused by the live terminal edge and the ``thread/resume``
+    parity path.
+
+    :param params: Codex turn params, e.g. a ``turn/completed`` payload or a
+        single ``thread/resume`` turn wrapped as ``{"turn": <turn>}``.
+    :returns: The classified terminal error, or ``None`` when the turn did not
+        fail.
+    """
+    turn = params.get("turn")
+    if not isinstance(turn, dict):
+        return None
+    payload = turn.get("error")
+    if not isinstance(payload, dict):
+        payload = _error_item_from_turn(turn)
+    if payload is None:
+        return None
+    message = _error_payload_message(payload)
+    return _CodexTerminalError(message=message, kind=_classify_codex_error(payload, message))
+
+
+@dataclass(frozen=True)
+class _CodexTurnStatusEdge:
+    """
+    Omnigent session-status edge derived from Codex turn lifecycle state.
+
+    :param status: Omnigent session status, e.g. ``"running"`` or ``"idle"``.
+    :param turn_id: Codex turn id that caused the edge, e.g.
+        ``"turn_abc123"``.
+    :param source: Lifecycle source that produced the edge, e.g.
+        ``"turn/started"``.
+    :param error: Turn-level error forcing this edge to ``failed``,
+        or ``None`` for ordinary lifecycle edges. Surfaced as the status
+        output by :func:`_post_turn_status_edge`.
+    """
+
+    status: str
+    turn_id: str | None
+    source: str
+    error: _CodexTerminalError | None = None
+
+
+# Codex ``item/completed`` item types that represent a built-in tool call.
+# Each maps to a builder that extracts a normalized :class:`_CodexToolCall`.
+# ``_TOOL_ITEM_BUILDERS`` is populated after the builders are defined.
+_ToolItemBuilder = Callable[[str, dict[str, Any]], "_CodexToolCall | None"]
+
+
+def _omnigent_status_from_resume_turn(turn: dict[str, Any]) -> str | None:
+    """
+    Convert an explicit Codex resume turn status to Omnigent session status.
+
+    Applies the same ``turn.error`` check as the live terminal path
+    (:func:`_terminal_turn_status_edge`) so a resumed turn that carried an
+    error maps to ``failed`` even if its recorded status is not — the
+    resume-path side of the "silent success" fix.
+
+    :param turn: Codex resume turn object, e.g.
+        ``{"id": "turn_123", "status": "completed"}``.
+    :returns: Omnigent status literal for terminal turns, or ``None`` for active
+        or unrecognized statuses.
+    """
+    # A ``turn.error`` forces ``failed`` regardless of the recorded status.
+    if _terminal_error_from_turn({"turn": turn}) is not None:
+        return "failed"
+    status = turn.get("status")
+    if isinstance(status, dict):
+        status = status.get("type") or status.get("status")
+    if status in {"completed", "interrupted", "cancelled", "canceled"}:
+        return "idle"
+    if status in {"failed", "errored"}:
+        return "failed"
+    return None
+
+
+def _codex_tool_call_from_item(item: dict[str, Any]) -> _CodexToolCall | None:
+    """
+    Translate a completed Codex tool item into a normalized tool call.
+
+    :param item: Codex tool item from an ``item/completed`` notification,
+        e.g. ``{"type": "commandExecution", "id": "call_abc", ...}``.
+    :returns: Normalized tool call, or ``None`` for a malformed item that
+        should be dropped rather than mirrored with invented fields.
+    """
+    call_id = item.get("id")
+    item_type = item.get("type")
+    if not isinstance(call_id, str) or not call_id:
+        _logger.warning("Codex tool item missing string id: type=%s", item_type)
+        return None
+    builder = _TOOL_ITEM_BUILDERS.get(item_type) if isinstance(item_type, str) else None
+    if builder is None:
+        return None
+    return builder(call_id, item)
+
+
+# Codex runs each model-issued shell command inside its OWN bwrap command
+# sandbox. In a hardened container that disallows unprivileged user namespaces,
+# that sandbox cannot start and every command hard-fails with this raw bwrap
+# error, with no hint at how to recover. Detect the marker and append actionable
+# guidance so a top-level session degrades with direction instead of an opaque
+# failure. The codex
+# ``--approval-mode`` presets do NOT disable this sandbox — only the "Full
+# access" preset's ``danger-full-access`` (or a config ``sandbox_mode``) does.
+_CODEX_SANDBOX_NAMESPACE_ERROR_MARKER = "No permissions to create new namespace"
+_CODEX_SANDBOX_BYPASS_GUIDANCE = (
+    "Omnigent: Codex's command sandbox could not start because this container "
+    "disallows unprivileged user namespaces, so the command did not run. To run "
+    'shell commands here, start a new Codex session with the "Full access" '
+    "approval preset (New chat → Advanced settings), or set "
+    'sandbox_mode = "danger-full-access" in ~/.codex/config.toml on the runner.'
+)
+
+
+def _augment_sandbox_namespace_error(output_text: str) -> str:
+    """Append recovery guidance when a Codex shell command failed because its
+    own command sandbox could not start (no unprivileged user namespaces).
+
+    Returns *output_text* unchanged when the bwrap-namespace marker is absent,
+    so ordinary command output is never altered. See issue #657.
+
+    :param output_text: Aggregated command output, any exit-code suffix already
+        appended, e.g. ``"bwrap: No permissions ...\\n[exit code: 1]"``.
+    :returns: The output with a trailing guidance paragraph, or unchanged.
+    """
+    if _CODEX_SANDBOX_NAMESPACE_ERROR_MARKER not in output_text:
+        return output_text
+    return f"{output_text}\n\n{_CODEX_SANDBOX_BYPASS_GUIDANCE}"
+
+
+def _command_execution_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
+    """
+    Build a tool call from a Codex ``commandExecution`` item.
+
+    :param call_id: Codex item id, e.g. ``"call_abc"``.
+    :param item: Codex ``commandExecution`` item, e.g.
+        ``{"command": "/bin/zsh -lc 'pwd'", "cwd": "/repo",
+        "aggregatedOutput": "/repo\n", "exitCode": 0}``.
+    :returns: Normalized tool call, or ``None`` when the command is
+        missing.
+    """
+    command = item.get("command")
+    if not isinstance(command, str) or not command:
+        _logger.warning("Codex commandExecution missing command: call_id=%s", call_id)
+        return None
+    arguments: dict[str, Any] = {"command": command}
+    cwd = item.get("cwd")
+    if isinstance(cwd, str) and cwd:
+        arguments["cwd"] = cwd
+    output = item.get("aggregatedOutput")
+    # A command that prints nothing (e.g. ``touch x``) legitimately has no
+    # aggregated output; Codex reports that as "" or null. AP's
+    # function_call_output requires a string, so "" is the faithful
+    # representation of "no output captured" here — not an invented default.
+    output_text = output if isinstance(output, str) else ""
+    exit_code = item.get("exitCode")
+    # Codex reports a non-zero exit separately from stdout/stderr; surface
+    # it inline so a failed command does not look successful in the UI.
+    if isinstance(exit_code, int) and exit_code != 0:
+        suffix = f"[exit code: {exit_code}]"
+        output_text = f"{output_text}\n{suffix}" if output_text else suffix
+    # Turn codex's opaque "sandbox can't start" bwrap failure into actionable
+    # recovery guidance; a no-op for any other output.
+    output_text = _augment_sandbox_namespace_error(output_text)
+    return _CodexToolCall(call_id=call_id, name="shell", arguments=arguments, output=output_text)
+
+
+def _file_change_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
+    """
+    Build a tool call from a Codex ``fileChange`` item.
+
+    :param call_id: Codex item id, e.g. ``"call_abc"``.
+    :param item: Codex ``fileChange`` item, e.g.
+        ``{"changes": [{"path": "/repo/x.py", "kind": {"type": "add"},
+        "diff": "print('hi')\n"}], "status": "completed"}``.
+    :returns: Normalized tool call, or ``None`` when no changes are
+        present.
+    """
+    changes = item.get("changes")
+    if not isinstance(changes, list) or not changes:
+        _logger.warning("Codex fileChange missing changes: call_id=%s", call_id)
+        return None
+    summary_lines: list[str] = []
+    for change in changes:
+        if not isinstance(change, dict):
+            continue
+        path = change.get("path")
+        kind = change.get("kind")
+        kind_type = kind.get("type") if isinstance(kind, dict) else None
+        label = kind_type if isinstance(kind_type, str) and kind_type else "change"
+        summary_lines.append(f"{label} {path}")
+    output_text = "\n".join(summary_lines)
+    return _CodexToolCall(
+        call_id=call_id,
+        name="apply_patch",
+        arguments={"changes": changes},
+        output=output_text,
+    )
+
+
+def _web_search_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
+    """
+    Build a tool call from a Codex ``webSearch`` item.
+
+    Codex does not surface the search results, so the queries it ran are
+    the only result data available and are used as the output text.
+
+    :param call_id: Codex item id, e.g. ``"ws_abc"``.
+    :param item: Codex ``webSearch`` item, e.g.
+        ``{"query": "python latest version",
+        "action": {"type": "search", "queries": ["python latest"]}}``.
+    :returns: Normalized tool call, or ``None`` when no query is present.
+    """
+    query = item.get("query")
+    action = item.get("action")
+    queries = action.get("queries") if isinstance(action, dict) else None
+    query_list = [q for q in queries if isinstance(q, str)] if isinstance(queries, list) else []
+    if not query_list and isinstance(query, str) and query:
+        query_list = [query]
+    if not query_list:
+        _logger.warning("Codex webSearch missing query: call_id=%s", call_id)
+        return None
+    return _CodexToolCall(
+        call_id=call_id,
+        name="web_search",
+        arguments={"query": query_list[0]},
+        output="\n".join(query_list),
+    )
+
+
+def _image_view_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
+    """
+    Build a tool call from a Codex ``imageView`` item.
+
+    Codex emits an ``imageView`` item when the model opens a local image
+    (e.g. a screenshot on disk) to look at it. The only datum is the
+    absolute path, so it becomes both the argument and the mirrored
+    output — the web UI cannot read a runner-local path, so the path is
+    the faithful record of which image was viewed.
+
+    :param call_id: Codex item id, e.g. ``"img_abc"``.
+    :param item: Codex ``imageView`` item, e.g.
+        ``{"type": "imageView", "id": "img_abc", "path": "/repo/shot.png"}``.
+    :returns: Normalized tool call, or ``None`` when the path is missing.
+    """
+    path = item.get("path")
+    if not isinstance(path, str) or not path:
+        _logger.warning("Codex imageView missing path: call_id=%s", call_id)
+        return None
+    return _CodexToolCall(
+        call_id=call_id,
+        name="view_image",
+        arguments={"path": path},
+        output=path,
+    )
+
+
+def _image_generation_tool_call(call_id: str, item: dict[str, Any]) -> _CodexToolCall | None:
+    """
+    Build a tool call from a Codex ``imageGeneration`` item.
+
+    Codex emits an ``imageGeneration`` item when the model generates an
+    image. The raw ``result`` payload (base64 image bytes) is deliberately
+    NOT mirrored — the web UI has no assistant-side image rendering and a
+    multi-megabyte base64 string would only bloat the transcript. Instead
+    the card carries the human-meaningful metadata: the revised prompt as
+    the argument and the status plus on-disk save path as the output.
+
+    :param call_id: Codex item id, e.g. ``"imggen_abc"``.
+    :param item: Codex ``imageGeneration`` item, e.g.
+        ``{"type": "imageGeneration", "id": "imggen_abc",
+        "status": "completed", "revisedPrompt": "a red bicycle",
+        "result": "<base64>", "savedPath": "/repo/out.png"}``.
+    :returns: Normalized tool call, or ``None`` when the status is missing.
+    """
+    status = item.get("status")
+    if not isinstance(status, str) or not status:
+        _logger.warning("Codex imageGeneration missing status: call_id=%s", call_id)
+        return None
+    arguments: dict[str, Any] = {}
+    revised_prompt = item.get("revisedPrompt")
+    if isinstance(revised_prompt, str) and revised_prompt:
+        arguments["revised_prompt"] = revised_prompt
+    output_lines = [f"status: {status}"]
+    saved_path = item.get("savedPath")
+    if isinstance(saved_path, str) and saved_path:
+        output_lines.append(f"saved to {saved_path}")
+    return _CodexToolCall(
+        call_id=call_id,
+        name="generate_image",
+        arguments=arguments,
+        output="\n".join(output_lines),
+    )
+
+
+# Codex built-in tool item types this forwarder mirrors into Omnigent history.
+# ``mcpToolCall`` is intentionally absent: its event shape has not been
+# verified, so it is logged-but-skipped rather than mirrored with guessed
+# fields. Add it here once its real shape is captured.
+_TOOL_ITEM_BUILDERS: dict[str, _ToolItemBuilder] = {
+    "commandExecution": _command_execution_tool_call,
+    "fileChange": _file_change_tool_call,
+    "webSearch": _web_search_tool_call,
+    "imageView": _image_view_tool_call,
+    "imageGeneration": _image_generation_tool_call,
+}
+_TOOL_ITEM_TYPES = frozenset(_TOOL_ITEM_BUILDERS)
+
+
+def _turn_id_from_payload(payload: object) -> str | None:
+    """
+    Extract a turn id from a Codex payload.
+
+    :param payload: Codex notification params or nested turn object.
+    :returns: Turn id, or ``None`` when absent.
+    """
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("id") or payload.get("turnId")
+    return value if isinstance(value, str) and value else None
+
+
+def _source_id(params: dict[str, Any], item: dict[str, Any]) -> str:
+    """
+    Build a stable per-record label for one Codex item.
+
+    Only used for debug-log correlation — it is not sent to the server
+    and is not a dedup key (the server persists external items with a
+    random primary key).
+
+    :param params: Codex notification params.
+    :param item: Codex item payload.
+    :returns: Record label, e.g. ``"turn_abc:item_xyz"``.
+    """
+    turn_id = params.get("turnId")
+    item_id = item.get("id")
+    left = turn_id if isinstance(turn_id, str) and turn_id else "thread"
+    right = item_id if isinstance(item_id, str) and item_id else "item"
+    return f"{left}:{right}"
+
+
+def iter_resume_items(response: dict[str, Any]) -> Iterator[tuple[str | None, dict[str, Any]]]:
+    """Yield ``(thread_id, item/completed event)`` for each item in a resume response.
+
+    Pure iteration over a Codex ``thread/resume`` response envelope: it walks
+    ``result.thread.turns[*].items[*]`` and wraps each item as the same
+    ``item/completed`` event the live stream delivers, so a caller can feed each
+    one through the normal event handler and dedup gate. Yields nothing when the
+    envelope lacks a well-formed ``result.thread.turns`` list.
+
+    :param response: Codex ``thread/resume`` response envelope.
+    :returns: Iterator of ``(thread_id, event)`` pairs, in turn/item order.
+    """
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return
+    thread = result.get("thread")
+    if not isinstance(thread, dict):
+        return
+    turns = thread.get("turns")
+    if not isinstance(turns, list):
+        return
+    thread_id = thread.get("id")
+    thread_id = thread_id if isinstance(thread_id, str) and thread_id else None
+    for turn in turns:
+        if not isinstance(turn, dict):
+            continue
+        turn_id = _turn_id_from_payload(turn)
+        items = turn.get("items")
+        if not turn_id or not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            yield (
+                thread_id,
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": thread_id,
+                        "turnId": turn_id,
+                        "item": item,
+                    },
+                },
+            )

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -52,16 +52,26 @@ import httpx
 
 from omnigent import hermes_native_status
 from omnigent.hermes_native_items import (
+    _ATTACHMENT_MARKER_RE as _ATTACHMENT_MARKER_RE,
+)
+from omnigent.hermes_native_items import (
+    _SKILL_INVOKE_RE as _SKILL_INVOKE_RE,
+)
+from omnigent.hermes_native_items import (
     HermesMirrorItem,
     assistant_row_has_tool_calls,
     message_to_items,
 )
 
 # Backwards-compatible private aliases. The pure ``messages``-row → item
-# conversion now lives in :mod:`omnigent.hermes_native_items` (shared with
-# session adoption); these keep the forwarder's original private names working
-# for internal callers and existing tests that reference ``f._MirrorItem`` /
-# ``f._message_to_items`` / ``f._assistant_row_has_tool_calls``.
+# conversion (and its two content-scrubbing regexes) now lives in
+# :mod:`omnigent.hermes_native_items` (shared with session adoption); these keep
+# every moved symbol importable under its original forwarder name for internal
+# callers and existing tests that reference ``f._MirrorItem`` /
+# ``f._message_to_items`` / ``f._assistant_row_has_tool_calls`` /
+# ``f._ATTACHMENT_MARKER_RE`` / ``f._SKILL_INVOKE_RE``. ``_ATTACHMENT_MARKER_RE``
+# and ``_SKILL_INVOKE_RE`` are imported above so they are already re-exported;
+# these assignments cover the renamed public helpers.
 _MirrorItem = HermesMirrorItem
 _message_to_items = message_to_items
 _assistant_row_has_tool_calls = assistant_row_has_tool_calls

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -43,7 +43,6 @@ import contextlib
 import json
 import logging
 import os
-import re
 import sqlite3
 import time
 from dataclasses import dataclass
@@ -52,6 +51,20 @@ from pathlib import Path
 import httpx
 
 from omnigent import hermes_native_status
+from omnigent.hermes_native_items import (
+    HermesMirrorItem,
+    assistant_row_has_tool_calls,
+    message_to_items,
+)
+
+# Backwards-compatible private aliases. The pure ``messages``-row → item
+# conversion now lives in :mod:`omnigent.hermes_native_items` (shared with
+# session adoption); these keep the forwarder's original private names working
+# for internal callers and existing tests that reference ``f._MirrorItem`` /
+# ``f._message_to_items`` / ``f._assistant_row_has_tool_calls``.
+_MirrorItem = HermesMirrorItem
+_message_to_items = message_to_items
+_assistant_row_has_tool_calls = assistant_row_has_tool_calls
 
 _logger = logging.getLogger(__name__)
 
@@ -96,18 +109,6 @@ def _warn_sqlite_once(context: str, exc: sqlite3.Error) -> None:
     _warned_sqlite_errors.add(key)
     _logger.warning("hermes forwarder sqlite error during %s: %s", context, exc)
 
-
-# The executor injects ``[Attached: <path>]`` markers for web-UI attachments
-# before pasting into the TUI; strip them from the mirrored bubble (the path is
-# an internal bridge detail).
-_ATTACHMENT_MARKER_RE = re.compile(r"\[Attached:[^\]]*\]")
-
-# Hermes injects skill content as a user message prefixed with this marker.
-# The full skill prompt is not useful in the web UI — replace it with a
-# short summary so the chat view stays clean.
-_SKILL_INVOKE_RE = re.compile(
-    r'^\[IMPORTANT: The user has invoked the "(?P<name>[^"]+)" skill',
-)
 
 #: Maximum characters for a tool output mirrored into the web UI chat view.
 #: Longer outputs are truncated so skill loads and other verbose results don't
@@ -432,118 +433,6 @@ def _same_path(a: str, b: str) -> bool:
         return a == b
 
 
-@dataclass
-class _MirrorItem:
-    """One conversation item ready to POST, plus the message id that produced it."""
-
-    msg_id: int
-    item_type: str
-    item_data: dict[str, object]
-    response_id: str
-
-
-def _message_to_items(
-    msg_id: int,
-    role: object,
-    content: object,
-    tool_calls: object,
-    tool_call_id: object,
-    tool_name: object,  # noqa: ARG001 — reserved for future use (e.g. logging)
-    agent_name: str,
-) -> list[_MirrorItem]:
-    """Convert one ``messages`` row to mirror items.
-
-    An assistant row with ``tool_calls`` emits a ``function_call`` item per
-    call, followed by a ``message`` item if it also has prose content. A tool
-    row emits a ``function_call_output`` item. Returns an empty list to skip.
-    """
-    if not isinstance(role, str):
-        return []
-    text = ""
-    if isinstance(content, str):
-        text = _ATTACHMENT_MARKER_RE.sub("", content).strip()
-    response_id = f"hermes:{msg_id}"
-
-    if role == "user":
-        if not text:
-            return []
-        # Hermes injects skill content as a user message — replace with
-        # a short summary so the chat view stays readable.
-        skill_match = _SKILL_INVOKE_RE.match(text)
-        if skill_match:
-            text = f"/{skill_match.group('name')}"
-        return [
-            _MirrorItem(
-                msg_id=msg_id,
-                item_type="message",
-                item_data={"role": "user", "content": [{"type": "input_text", "text": text}]},
-                response_id=response_id,
-            )
-        ]
-
-    if role == "assistant":
-        items: list[_MirrorItem] = []
-        # Parse tool_calls JSON — assistant rows may include tool call requests.
-        if isinstance(tool_calls, str) and tool_calls:
-            try:
-                calls = json.loads(tool_calls)
-            except (json.JSONDecodeError, ValueError):
-                calls = []
-            if isinstance(calls, list):
-                for call in calls:
-                    if not isinstance(call, dict):
-                        continue
-                    call_id = call.get("call_id") or call.get("id") or ""
-                    func = call.get("function", {})
-                    name = func.get("name", "") if isinstance(func, dict) else ""
-                    arguments = func.get("arguments", "{}") if isinstance(func, dict) else "{}"
-                    if call_id and name:
-                        items.append(
-                            _MirrorItem(
-                                msg_id=msg_id,
-                                item_type="function_call",
-                                item_data={
-                                    "agent": agent_name,
-                                    "name": name,
-                                    "arguments": arguments,
-                                    "call_id": call_id,
-                                },
-                                response_id=response_id,
-                            )
-                        )
-        # Also emit a message item if there's prose content.
-        if text:
-            items.append(
-                _MirrorItem(
-                    msg_id=msg_id,
-                    item_type="message",
-                    item_data={
-                        "role": "assistant",
-                        "agent": agent_name,
-                        "content": [{"type": "output_text", "text": text}],
-                    },
-                    response_id=response_id,
-                )
-            )
-        return items
-
-    if role == "tool":
-        # Tool result row — emit function_call_output.
-        if isinstance(tool_call_id, str) and tool_call_id:
-            output = text or ""
-            return [
-                _MirrorItem(
-                    msg_id=msg_id,
-                    item_type="function_call_output",
-                    item_data={"call_id": tool_call_id, "output": output},
-                    response_id=response_id,
-                )
-            ]
-        return []
-
-    return []
-
-
 def _read_new_items(
     db_path: Path, hermes_session_id: str, last_id: int, agent_name: str
 ) -> list[_MirrorItem]:
@@ -577,25 +466,6 @@ def _read_new_items(
         else:
             items.append(_MirrorItem(msg_id=msg_id, item_type="", item_data={}, response_id=""))
     return items
-
-
-def _assistant_row_has_tool_calls(tool_calls: object) -> bool:
-    """Whether an assistant ``messages`` row carries a non-empty ``tool_calls`` list.
-
-    Hermes writes one ``messages`` row per agentic step (complete, append-only —
-    rows are never updated in place, which is why message mirroring keys off
-    ``id > last_id``). An assistant row with one or more tool calls means the loop
-    continues (a tool result + further assistant step follow); a row with no tool
-    calls is the loop's terminal step — the model returning its final answer.
-    Mirrors the ``tool_calls`` parsing in :func:`_message_to_items`.
-    """
-    if not isinstance(tool_calls, str) or not tool_calls.strip():
-        return False
-    try:
-        calls = json.loads(tool_calls)
-    except (json.JSONDecodeError, ValueError):
-        return False
-    return isinstance(calls, list) and len(calls) > 0
 
 
 def _count_completed_turns(db_path: Path, hermes_session_id: str) -> int:

--- a/omnigent/hermes_native_items.py
+++ b/omnigent/hermes_native_items.py
@@ -1,0 +1,163 @@
+"""Pure Hermes ``messages``-row → Omnigent conversation-item translation.
+
+This is the parser source of truth for the hermes-native harness, factored out of
+:mod:`omnigent.hermes_native_forwarder` so the same conversion can be reused by
+session adoption (importing a native Hermes session's history) without a second,
+simplified transcript parser. Everything here is side-effect-free: it takes plain
+Python values already read from Hermes' SQLite ``state.db`` and returns
+:class:`HermesMirrorItem` values. No IO, no polling, no DB, no network.
+
+The live forwarder keeps ownership of the SQLite query + poll loop; it imports
+:func:`message_to_items` / :func:`assistant_row_has_tool_calls` and converts each
+row it reads. Adoption reads a bounded range and converts it through the same
+helpers, so the mirrored chat and the imported history stay byte-identical.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+# The executor injects ``[Attached: <path>]`` markers for web-UI attachments
+# before pasting into the TUI; strip them from the mirrored bubble (the path is
+# an internal bridge detail).
+_ATTACHMENT_MARKER_RE = re.compile(r"\[Attached:[^\]]*\]")
+
+# Hermes injects skill content as a user message prefixed with this marker.
+# The full skill prompt is not useful in the web UI — replace it with a
+# short summary so the chat view stays clean.
+_SKILL_INVOKE_RE = re.compile(
+    r'^\[IMPORTANT: The user has invoked the "(?P<name>[^"]+)" skill',
+)
+
+
+@dataclass
+class HermesMirrorItem:
+    """One conversation item ready to POST, plus the message id that produced it."""
+
+    msg_id: int
+    item_type: str
+    item_data: dict[str, object]
+    response_id: str
+
+
+def message_to_items(
+    msg_id: int,
+    role: object,
+    content: object,
+    tool_calls: object,
+    tool_call_id: object,
+    tool_name: object,  # noqa: ARG001 — reserved for future use (e.g. logging)
+    agent_name: str,
+) -> list[HermesMirrorItem]:
+    """Convert one ``messages`` row to mirror items.
+
+    An assistant row with ``tool_calls`` emits a ``function_call`` item per
+    call, followed by a ``message`` item if it also has prose content. A tool
+    row emits a ``function_call_output`` item. Returns an empty list to skip.
+    """
+    if not isinstance(role, str):
+        return []
+    text = ""
+    if isinstance(content, str):
+        text = _ATTACHMENT_MARKER_RE.sub("", content).strip()
+    response_id = f"hermes:{msg_id}"
+
+    if role == "user":
+        if not text:
+            return []
+        # Hermes injects skill content as a user message — replace with
+        # a short summary so the chat view stays readable.
+        skill_match = _SKILL_INVOKE_RE.match(text)
+        if skill_match:
+            text = f"/{skill_match.group('name')}"
+        return [
+            HermesMirrorItem(
+                msg_id=msg_id,
+                item_type="message",
+                item_data={"role": "user", "content": [{"type": "input_text", "text": text}]},
+                response_id=response_id,
+            )
+        ]
+
+    if role == "assistant":
+        items: list[HermesMirrorItem] = []
+        # Parse tool_calls JSON — assistant rows may include tool call requests.
+        if isinstance(tool_calls, str) and tool_calls:
+            try:
+                calls = json.loads(tool_calls)
+            except (json.JSONDecodeError, ValueError):
+                calls = []
+            if isinstance(calls, list):
+                for call in calls:
+                    if not isinstance(call, dict):
+                        continue
+                    call_id = call.get("call_id") or call.get("id") or ""
+                    func = call.get("function", {})
+                    name = func.get("name", "") if isinstance(func, dict) else ""
+                    arguments = func.get("arguments", "{}") if isinstance(func, dict) else "{}"
+                    if call_id and name:
+                        items.append(
+                            HermesMirrorItem(
+                                msg_id=msg_id,
+                                item_type="function_call",
+                                item_data={
+                                    "agent": agent_name,
+                                    "name": name,
+                                    "arguments": arguments,
+                                    "call_id": call_id,
+                                },
+                                response_id=response_id,
+                            )
+                        )
+        # Also emit a message item if there's prose content.
+        if text:
+            items.append(
+                HermesMirrorItem(
+                    msg_id=msg_id,
+                    item_type="message",
+                    item_data={
+                        "role": "assistant",
+                        "agent": agent_name,
+                        "content": [{"type": "output_text", "text": text}],
+                    },
+                    response_id=response_id,
+                )
+            )
+        return items
+
+    if role == "tool":
+        # Tool result row — emit function_call_output.
+        if isinstance(tool_call_id, str) and tool_call_id:
+            output = text or ""
+            return [
+                HermesMirrorItem(
+                    msg_id=msg_id,
+                    item_type="function_call_output",
+                    item_data={"call_id": tool_call_id, "output": output},
+                    response_id=response_id,
+                )
+            ]
+        return []
+
+    return []
+
+
+def assistant_row_has_tool_calls(tool_calls: object) -> bool:
+    """Whether an assistant ``messages`` row carries a non-empty ``tool_calls`` list.
+
+    Hermes writes one ``messages`` row per agentic step (complete, append-only —
+    rows are never updated in place, which is why message mirroring keys off
+    ``id > last_id``). An assistant row with one or more tool calls means the loop
+    continues (a tool result + further assistant step follow); a row with no tool
+    calls is the loop's terminal step — the model returning its final answer.
+    Mirrors the ``tool_calls`` parsing in :func:`message_to_items`.
+    """
+    if not isinstance(tool_calls, str) or not tool_calls.strip():
+        return False
+    try:
+        calls = json.loads(tool_calls)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    return isinstance(calls, list) and len(calls) > 0

--- a/tests/test_native_adoption_parsers.py
+++ b/tests/test_native_adoption_parsers.py
@@ -1,0 +1,324 @@
+"""Characterization tests for the shared native-session parsers.
+
+Slice 1 of session adoption extracted the pure ``native record -> Omnigent item``
+translation logic out of the three live forwarders into standalone modules
+(:mod:`omnigent.hermes_native_items`, :mod:`omnigent.claude_transcript_parser`,
+:mod:`omnigent.codex_native_items`). These tests import the helpers *directly from
+the new modules* — the way session adoption will — and pin their exact output for
+representative native records, locking in behavior byte-for-byte with what the
+inline forwarder path produced. The existing forwarder suites still exercise the
+same helpers through the forwarders; this file is the standalone contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+from omnigent import claude_transcript_parser as claude
+from omnigent import codex_native_items as codex
+from omnigent import hermes_native_items as hermes
+
+# --------------------------------------------------------------------------- #
+# Hermes: messages-row -> mirror items
+# --------------------------------------------------------------------------- #
+
+
+def test_hermes_user_message_item() -> None:
+    items = hermes.message_to_items(7, "user", "hello world", None, None, None, "ag")
+    assert items == [
+        hermes.HermesMirrorItem(
+            msg_id=7,
+            item_type="message",
+            item_data={"role": "user", "content": [{"type": "input_text", "text": "hello world"}]},
+            response_id="hermes:7",
+        )
+    ]
+
+
+def test_hermes_user_strips_attachment_marker_and_summarizes_skill() -> None:
+    attached = hermes.message_to_items(
+        1, "user", "look [Attached: /x/y.png] here", None, None, None, "ag"
+    )
+    assert attached[0].item_data["content"][0]["text"] == "look  here"
+
+    skill = hermes.message_to_items(
+        2,
+        "user",
+        '[IMPORTANT: The user has invoked the "deep-research" skill and ...',
+        None,
+        None,
+        None,
+        "ag",
+    )
+    assert skill[0].item_data["content"][0]["text"] == "/deep-research"
+
+
+def test_hermes_assistant_tool_calls_then_text() -> None:
+    tool_calls = json.dumps(
+        [{"call_id": "c1", "function": {"name": "shell", "arguments": '{"cmd":"ls"}'}}]
+    )
+    items = hermes.message_to_items(9, "assistant", "done", tool_calls, None, None, "ag")
+    assert [i.item_type for i in items] == ["function_call", "message"]
+    assert items[0].item_data == {
+        "agent": "ag",
+        "name": "shell",
+        "arguments": '{"cmd":"ls"}',
+        "call_id": "c1",
+    }
+    assert items[1].item_data == {
+        "role": "assistant",
+        "agent": "ag",
+        "content": [{"type": "output_text", "text": "done"}],
+    }
+
+
+def test_hermes_tool_row_and_skips() -> None:
+    tool = hermes.message_to_items(3, "tool", "output text", None, "call-1", "shell", "ag")
+    assert tool == [
+        hermes.HermesMirrorItem(
+            msg_id=3,
+            item_type="function_call_output",
+            item_data={"call_id": "call-1", "output": "output text"},
+            response_id="hermes:3",
+        )
+    ]
+    # Empty user text, unknown role, and tool row without id all skip.
+    assert hermes.message_to_items(4, "user", "", None, None, None, "ag") == []
+    assert hermes.message_to_items(5, "system", "x", None, None, None, "ag") == []
+    assert hermes.message_to_items(6, "tool", "x", None, "", None, "ag") == []
+
+
+def test_hermes_assistant_row_has_tool_calls() -> None:
+    assert hermes.assistant_row_has_tool_calls(None) is False
+    assert hermes.assistant_row_has_tool_calls("") is False
+    assert hermes.assistant_row_has_tool_calls("[]") is False
+    assert hermes.assistant_row_has_tool_calls("not json") is False
+    assert hermes.assistant_row_has_tool_calls(json.dumps([{"id": "c1"}])) is True
+
+
+# --------------------------------------------------------------------------- #
+# Claude: transcript entry -> conversation items
+# --------------------------------------------------------------------------- #
+
+
+def test_claude_assistant_text_and_tool_use() -> None:
+    entry = {
+        "uuid": "u-assist",
+        "message": {
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [
+                {"type": "text", "text": "Working on it"},
+                {"type": "tool_use", "id": "call_1", "name": "Bash", "input": {"command": "pwd"}},
+            ],
+        },
+    }
+    rid, items = claude._transcript_items_from_entry(
+        entry,
+        line_number=1,
+        record_offset=0,
+        agent_name="claude-native-ui",
+        current_response_id=None,
+    )
+    assert [i.item_type for i in items] == ["message", "function_call"]
+    assert items[0].data == {
+        "role": "assistant",
+        "agent": "claude-native-ui",
+        "content": [{"type": "output_text", "text": "Working on it"}],
+    }
+    assert items[1].data == {
+        "agent": "claude-native-ui",
+        "name": "Bash",
+        "arguments": '{"command":"pwd"}',
+        "call_id": "call_1",
+    }
+    # Both items share the response id derived from the record source key.
+    assert rid == items[0].response_id == items[1].response_id
+
+
+def test_claude_user_message_and_tool_result() -> None:
+    user = {"uuid": "u1", "message": {"role": "user", "content": "hi there"}}
+    _, items = claude._transcript_items_from_entry(
+        user, line_number=1, record_offset=0, agent_name="ag", current_response_id=None
+    )
+    assert items[0].item_type == "message"
+    assert items[0].data == {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "hi there"}],
+    }
+
+    tool_result = {
+        "uuid": "u2",
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "call_1", "content": "/repo"}],
+        },
+    }
+    _, out = claude._transcript_items_from_entry(
+        tool_result, line_number=2, record_offset=10, agent_name="ag", current_response_id="resp_x"
+    )
+    assert out[0].item_type == "function_call_output"
+    assert out[0].data == {"call_id": "call_1", "output": "/repo"}
+    assert out[0].response_id == "resp_x"
+
+
+def test_claude_sidechain_dropped_by_default() -> None:
+    entry = {"isSidechain": True, "message": {"role": "assistant", "content": "hidden"}}
+    rid, items = claude._transcript_items_from_entry(
+        entry, line_number=1, record_offset=0, agent_name="ag", current_response_id="resp_keep"
+    )
+    assert items == []
+    assert rid == "resp_keep"
+    # With include_sidechains the same record yields the assistant message.
+    _, kept = claude._transcript_items_from_entry(
+        entry,
+        line_number=1,
+        record_offset=0,
+        agent_name="ag",
+        current_response_id=None,
+        include_sidechains=True,
+    )
+    assert kept[0].item_type == "message"
+
+
+def test_claude_source_key_and_response_id_are_deterministic() -> None:
+    assert claude._transcript_source_key({"uuid": "abc"}, 1, 99) == "abc"
+    assert claude._transcript_source_key({}, 1, 99) == "byte-99"
+    assert claude._transcript_source_key({}, 5, None) == "line-5"
+    rid = claude._response_id_from_source("abc")
+    assert rid.startswith("resp_claude_") and claude._response_id_from_source("abc") == rid
+
+
+def test_claude_read_from_offset_over_a_file(tmp_path) -> None:
+    path = tmp_path / "session.jsonl"
+    records = [
+        {"uuid": "r1", "message": {"role": "user", "content": "first"}},
+        {"uuid": "r2", "message": {"role": "assistant", "model": "m", "content": "reply"}},
+    ]
+    path.write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+    result = claude.read_transcript_items_from_offset(path, 0, start_line=0, agent_name="ag")
+    assert [i.item_type for i in result.items] == ["message", "message"]
+    assert result.items[0].data["role"] == "user"
+    assert result.items[1].data["role"] == "assistant"
+    assert result.latest_model == "m"
+    assert result.byte_offset == path.stat().st_size
+
+
+# --------------------------------------------------------------------------- #
+# Codex: item normalization, terminal status, resume iteration
+# --------------------------------------------------------------------------- #
+
+
+def test_codex_command_execution_tool_call() -> None:
+    tc = codex._codex_tool_call_from_item(
+        {
+            "type": "commandExecution",
+            "id": "c1",
+            "command": "pwd",
+            "cwd": "/repo",
+            "aggregatedOutput": "/repo\n",
+            "exitCode": 0,
+        }
+    )
+    assert tc == codex._CodexToolCall(
+        call_id="c1", name="shell", arguments={"command": "pwd", "cwd": "/repo"}, output="/repo\n"
+    )
+    # Non-zero exit code is surfaced inline.
+    failed = codex._codex_tool_call_from_item(
+        {
+            "type": "commandExecution",
+            "id": "c2",
+            "command": "false",
+            "aggregatedOutput": "",
+            "exitCode": 1,
+        }
+    )
+    assert failed.output == "[exit code: 1]"
+
+
+def test_codex_web_search_and_image_tool_calls() -> None:
+    ws = codex._codex_tool_call_from_item(
+        {"type": "webSearch", "id": "w1", "action": {"queries": ["a", "b"]}}
+    )
+    assert ws.name == "web_search" and ws.arguments == {"query": "a"} and ws.output == "a\nb"
+
+    view = codex._codex_tool_call_from_item({"type": "imageView", "id": "i1", "path": "/x.png"})
+    assert view.name == "view_image" and view.output == "/x.png"
+
+    # Unknown / malformed items drop rather than mirror invented fields.
+    assert codex._codex_tool_call_from_item({"type": "mcpToolCall", "id": "m1"}) is None
+    assert codex._codex_tool_call_from_item({"type": "commandExecution", "id": "c3"}) is None
+
+
+def test_codex_terminal_error_classification() -> None:
+    auth = codex._terminal_error_from_turn({"turn": {"error": {"message": "401 Unauthorized"}}})
+    assert auth is not None and auth.kind == "auth" and auth.is_auth is True
+
+    generic = codex._terminal_error_from_turn(
+        {"turn": {"error": {"message": "disk full", "codexErrorInfo": {"type": "io"}}}}
+    )
+    assert generic is not None and generic.kind == "generic"
+
+    # Falls back to an ``error`` ThreadItem in turn.items.
+    item_err = codex._terminal_error_from_turn(
+        {"turn": {"items": [{"type": "error", "message": "boom"}]}}
+    )
+    assert item_err is not None and item_err.message == "boom"
+
+    assert codex._terminal_error_from_turn({"turn": {"items": []}}) is None
+
+
+def test_codex_omnigent_status_from_resume_turn() -> None:
+    assert codex._omnigent_status_from_resume_turn({"status": "completed"}) == "idle"
+    assert codex._omnigent_status_from_resume_turn({"status": "interrupted"}) == "idle"
+    assert codex._omnigent_status_from_resume_turn({"status": "failed"}) == "failed"
+    # A turn error forces failed even on a "completed" status.
+    assert (
+        codex._omnigent_status_from_resume_turn({"status": "completed", "error": {"message": "x"}})
+        == "failed"
+    )
+    assert codex._omnigent_status_from_resume_turn({"status": "in_progress"}) is None
+
+
+def test_codex_turn_id_and_source_id() -> None:
+    assert codex._turn_id_from_payload({"id": "turn_1"}) == "turn_1"
+    assert codex._turn_id_from_payload({"turnId": "turn_2"}) == "turn_2"
+    assert codex._turn_id_from_payload({}) is None
+    assert codex._source_id({"turnId": "t"}, {"id": "it"}) == "t:it"
+    assert codex._source_id({}, {}) == "thread:item"
+
+
+def test_codex_iter_resume_items() -> None:
+    response = {
+        "result": {
+            "thread": {
+                "id": "thread_9",
+                "turns": [
+                    {
+                        "id": "turn_1",
+                        "items": [
+                            {"type": "agentMessage", "id": "a1", "text": "hi"},
+                            {"type": "commandExecution", "id": "c1", "command": "ls"},
+                        ],
+                    },
+                    {
+                        "id": "turn_2",
+                        "items": [{"type": "agentMessage", "id": "a2", "text": "bye"}],
+                    },
+                ],
+            }
+        }
+    }
+    events = list(codex.iter_resume_items(response))
+    assert [tid for tid, _ in events] == ["thread_9", "thread_9", "thread_9"]
+    assert events[0][1] == {
+        "method": "item/completed",
+        "params": {
+            "threadId": "thread_9",
+            "turnId": "turn_1",
+            "item": {"type": "agentMessage", "id": "a1", "text": "hi"},
+        },
+    }
+    # A malformed envelope yields nothing (no terminal-status inference).
+    assert list(codex.iter_resume_items({"result": {}})) == []
+    assert list(codex.iter_resume_items({})) == []

--- a/tests/test_native_adoption_parsers.py
+++ b/tests/test_native_adoption_parsers.py
@@ -12,11 +12,142 @@ same helpers through the forwarders; this file is the standalone contract.
 
 from __future__ import annotations
 
+import importlib
 import json
+
+import pytest
 
 from omnigent import claude_transcript_parser as claude
 from omnigent import codex_native_items as codex
 from omnigent import hermes_native_items as hermes
+
+# --------------------------------------------------------------------------- #
+# Re-export contract: every symbol moved into a shared parser module in Slice 1
+# must stay importable under its ORIGINAL forwarder/bridge name (zero-behaviour
+# transition contract). This locks the "moved-without-alias" regression class —
+# a symbol relocated to the new module but not re-exported would break a live
+# `from omnigent.<forwarder> import <sym>` caller.
+# --------------------------------------------------------------------------- #
+
+# Original name on the forwarder/bridge -> attribute expected on the shared module
+# it now lives in. ``None`` means the same name exists on the shared module too;
+# a string means the shared module renamed it (Hermes' public dataclass/helpers).
+_HERMES_REEXPORTS = {
+    "_MirrorItem": "HermesMirrorItem",
+    "_message_to_items": "message_to_items",
+    "_assistant_row_has_tool_calls": "assistant_row_has_tool_calls",
+    "_ATTACHMENT_MARKER_RE": None,
+    "_SKILL_INVOKE_RE": None,
+}
+
+_CLAUDE_REEXPORTS = [
+    "ClaudeTranscriptItem",
+    "TranscriptReadResult",
+    "_JsonlRecord",
+    "_JsonlReadResult",
+    "_read_complete_jsonl_records",
+    "read_assistant_text_since",
+    "read_transcript_items_since",
+    "read_transcript_items_since_with_position",
+    "read_transcript_items_from_offset",
+    "_model_from_transcript_entry",
+    "_usage_from_transcript_entry",
+    "_assistant_text_from_transcript_line",
+    "_transcript_items_from_entry",
+    "_attachment_transcript_items_from_entry",
+    "_local_command_transcript_items_from_entry",
+    "_terminal_command_items_from_content",
+    "_user_transcript_items_from_entry",
+    "_assistant_transcript_items_from_entry",
+    "_assistant_message_item",
+    "_tool_result_output",
+    "_SlashCommandPayload",
+    "_parse_slash_command_record",
+    "_transcript_source_key",
+    "_parent_or_record_source_key",
+    "_response_id_from_source",
+    "_source_id",
+    "_COMMAND_NAME_RE",
+    "_COMMAND_ARGS_RE",
+    "_COMMAND_STDOUT_RE",
+    "_BASH_INPUT_RE",
+    "_BASH_STDOUT_RE",
+    "_BASH_STDERR_RE",
+    "_CLI_SCAFFOLDING_MARKERS",
+    "_CLAUDE_CLI_DROPPED_COMMANDS",
+    "_CLAUDE_CLI_SURFACED_COMMANDS",
+    "_CONTEXT_OVERFLOW_RE",
+    "_CONTEXT_OVERFLOW_REPLACEMENT",
+]
+
+_CODEX_REEXPORTS = [
+    "_CODEX_ERROR_ITEM_TYPE",
+    "_CODEX_AUTH_ERROR_INFO",
+    "_CODEX_AUTH_HTTP_STATUS",
+    "_CODEX_AUTH_ERROR_FRAGMENTS",
+    "_CODEX_ERROR_KIND_AUTH",
+    "_CODEX_ERROR_KIND_GENERIC",
+    "_CODEX_REAUTH_HINT",
+    "_CodexToolCall",
+    "_CodexTerminalError",
+    "_classify_codex_error",
+    "_error_payload_message",
+    "_error_item_from_turn",
+    "_terminal_error_from_turn",
+    "_CodexTurnStatusEdge",
+    "_ToolItemBuilder",
+    "_omnigent_status_from_resume_turn",
+    "_CODEX_SANDBOX_NAMESPACE_ERROR_MARKER",
+    "_CODEX_SANDBOX_BYPASS_GUIDANCE",
+    "_augment_sandbox_namespace_error",
+    "_codex_tool_call_from_item",
+    "_command_execution_tool_call",
+    "_file_change_tool_call",
+    "_web_search_tool_call",
+    "_image_view_tool_call",
+    "_image_generation_tool_call",
+    "_TOOL_ITEM_BUILDERS",
+    "_TOOL_ITEM_TYPES",
+    "_turn_id_from_payload",
+    "_source_id",
+    "iter_resume_items",
+]
+
+
+@pytest.mark.parametrize("original_name,shared_name", sorted(_HERMES_REEXPORTS.items()))
+def test_hermes_forwarder_reexports_moved_symbols(
+    original_name: str, shared_name: str | None
+) -> None:
+    fwd = importlib.import_module("omnigent.hermes_native_forwarder")
+    items = importlib.import_module("omnigent.hermes_native_items")
+    assert hasattr(fwd, original_name), (
+        f"{original_name} was moved to hermes_native_items but is no longer importable "
+        f"from hermes_native_forwarder — restore the re-export alias."
+    )
+    assert getattr(fwd, original_name) is getattr(items, shared_name or original_name)
+
+
+@pytest.mark.parametrize("name", sorted(_CLAUDE_REEXPORTS))
+def test_claude_bridge_reexports_moved_symbols(name: str) -> None:
+    bridge = importlib.import_module("omnigent.claude_native_bridge")
+    parser = importlib.import_module("omnigent.claude_transcript_parser")
+    assert hasattr(bridge, name), (
+        f"{name} was moved to claude_transcript_parser but is no longer importable "
+        f"from claude_native_bridge — restore the re-export alias."
+    )
+    assert getattr(bridge, name) is getattr(parser, name)
+
+
+@pytest.mark.parametrize("name", sorted(_CODEX_REEXPORTS))
+def test_codex_forwarder_reexports_moved_symbols(name: str) -> None:
+    fwd = importlib.import_module("omnigent.codex_native_forwarder")
+    items = importlib.import_module("omnigent.codex_native_items")
+    assert hasattr(fwd, name), (
+        f"{name} was moved to codex_native_items but is no longer importable "
+        f"from codex_native_forwarder — restore the re-export alias."
+    )
+    assert getattr(fwd, name) is getattr(items, name)
+
 
 # --------------------------------------------------------------------------- #
 # Hermes: messages-row -> mirror items


### PR DESCRIPTION
## Summary

Foundation slice for **session adoption** (importing existing native harness sessions into Omnigent conversations — see `designs/session-adoption.md`). This PR is a **pure refactor with zero behavior change**: it extracts the inline "native record → Omnigent conversation item" translation out of the three live forwarders into shared, side-effect-free modules, so that adoption can reuse the *exact same* parsers the live forwarders use (rather than reimplementing them).

## What changed

Extracted pure parsers, rewrote each forwarder to call them, and **re-exported every moved symbol under its original name** so existing callers/tests are untouched:

| New module | Extracted from | Key exports |
|---|---|---|
| `omnigent/hermes_native_items.py` | `hermes_native_forwarder.py` | `HermesMirrorItem`, `message_to_items`, `assistant_row_has_tool_calls` |
| `omnigent/claude_transcript_parser.py` | `claude_native_bridge.py` | `read_transcript_items_from_offset`/`_since`/`_since_with_position`, `read_assistant_text_since`, JSONL record readers, entry→items builders, usage/model extraction |
| `omnigent/codex_native_items.py` | `codex_native_forwarder.py` | tool-call normalization + builders, terminal-error classification, resume-status edges, and the new pure `iter_resume_items(response)` |

`codex_native_forwarder._replay_resume_response` now drives replay through `iter_resume_items` (the same normalization path adoption will use). The new modules are pure — no IO/DB/network/polling (Claude's transcript file reads are the one inherent exception).

## Verification

- **705 passed** across all Hermes/Claude/Codex forwarder + bridge suites — **unchanged** (the only test file added is the new `tests/test_native_adoption_parsers.py`).
- **16 characterization tests** feed representative native records through each extracted helper and assert byte-identical outputs.
- **72 re-export regression tests** assert every moved symbol is importable from its original module path and is the same object — locking the "moved-without-alias" bug class permanently.
- Independent cross-vendor review confirmed the extraction is logically identical (straight code motion) and caught + verified-fixed a missing-re-export gap.
- ruff + full pre-commit: pass.

No behavior change; no existing test modified. Later slices (server adoption API, per-harness discover/adopt/resume, web UI) build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
