### PR TITLE
fix(sessions): map cached child-session status to completed/in_progress in REST snapshot

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12815,6 +12815,22 @@ def _latest_message_preview(
 _UI_ADDED_AGENT_TITLE_PREFIX = "ui"
 
 
+def _child_session_current_task_status_from_cached_status(status: object) -> str | None:
+    """
+    Map cached session lifecycle status onto child-summary task status.
+
+    :param status: Cached ``session.status`` value.
+    :returns: Public ``ChildSessionSummary.current_task_status`` value.
+    """
+    if status in ("running", "waiting"):
+        return "in_progress"
+    if status == "idle":
+        return "completed"
+    if status == "failed":
+        return "failed"
+    return None
+
+
 def _child_session_summary_from_conversation(
     conv: Conversation,
     parent_session_id: str,
@@ -12881,9 +12897,9 @@ def _child_session_summary_from_conversation(
     else:
         busy = False
     last_task_error = _last_task_error_from_labels(labels)
-    current_task_status = (
-        "failed" if cached_status == "failed" or last_task_error is not None else None
-    )
+    current_task_status = _child_session_current_task_status_from_cached_status(cached_status)
+    if last_task_error is not None:
+        current_task_status = "failed"
 
     # For Codex children, fall back to the prompt label as preview when the
     # real transcript has not arrived yet — avoids synthesizing a user message

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -611,6 +611,55 @@ async def test_child_sessions_busy_reflects_relay_status_cache(
         sessions_module._session_status_cache.pop(child.id, None)
 
 
+@pytest.mark.parametrize(
+    ("cached_status", "expected_task_status"),
+    [
+        ("running", "in_progress"),
+        ("waiting", "in_progress"),
+        ("idle", "completed"),
+        ("failed", "failed"),
+    ],
+)
+async def test_child_sessions_current_task_status_reflects_relay_status_cache(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    cached_status: str,
+    expected_task_status: str,
+) -> None:
+    """
+    ``current_task_status`` mirrors the child lifecycle cache.
+
+    The REST snapshot should use the same public task-status vocabulary as
+    live ``session.child_session.updated`` fan-out events: active children
+    are ``in_progress``, idle children are ``completed``, and failed children
+    are ``failed``.
+
+    :param client: The test HTTP client.
+    :param db_uri: Per-test SQLite database URI.
+    :param cached_status: Status value to inject into the cache.
+    :param expected_task_status: Expected ``current_task_status`` in the summary.
+    """
+    from omnigent.server.routes import sessions as sessions_module
+
+    session = await _create_parent_session(client)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    child = _seed_child(
+        conv_store=conv_store,
+        parent_id=session["id"],
+        title="researcher:auth",
+        agent_id=session["agent_id"],
+    )
+
+    sessions_module._session_status_cache[child.id] = cached_status
+    try:
+        resp = await client.get(f"/v1/sessions/{session['id']}/child_sessions")
+        assert resp.status_code == 200
+        row = resp.json()["data"][0]
+        assert row["current_task_status"] == expected_task_status
+    finally:
+        sessions_module._session_status_cache.pop(child.id, None)
+
+
 async def test_child_sessions_truncates_long_message_preview(
     client: httpx.AsyncClient,
     db_uri: str,


### PR DESCRIPTION
## Summary

`GET /sessions/{id}/child_sessions` (and the stream snapshot-on-connect, which uses the same helper) could never report `current_task_status == "completed"`: `_child_session_summary_from_conversation()` mapped the cached session status only to `"failed"` or `None`, while the live SSE fan-out in `runner/app.py` maps `running`/`waiting` → `in_progress`, `idle` → `completed`, `failed` → `failed`. So a finished sub-agent showed as **Idle** after any REST fetch or reconnect instead of **Done**.

## Fix

- Add `_child_session_current_task_status_from_cached_status()` on the server side mirroring the live fan-out mapping (kept local to avoid a server → runner import of a private helper).
- Preserve the existing durable-error behavior: a `last_task_error` label still forces `"failed"`.

## Tests

- New: `test_child_sessions_current_task_status_reflects_relay_status_cache` — fails before the fix (`None` vs `in_progress`/`completed`), passes after. Covers `running` → `in_progress`, `idle` → `completed`, `failed` → `failed`.
- Full `tests/server/integration/test_sessions_child_sessions.py` passes (43 passed), plus the related runner fan-out status tests.
- `ruff` + `pre-commit` clean.

Fixes #1965

🤖 Generated with [Claude Code](https://claude.com/claude-code)
