### PR TITLE
fix(python-client): dispatch compaction terminal events and route child approval verdicts via target_session_id

### DIFF
--- a/sdks/python-client/omnigent_client/_events.py
+++ b/sdks/python-client/omnigent_client/_events.py
@@ -271,6 +271,11 @@ class CompactionInProgress:
 class CompactionCompleted:
     """``response.compaction.completed`` — compaction finished successfully."""
 
+    total_tokens: int | None = None
+    summary: str | None = None
+    summary_model: str | None = None
+    compacted_messages: list[dict[str, object]] | None = None
+
 
 @dataclass
 class CompactionFailed:

--- a/sdks/python-client/omnigent_client/_responses.py
+++ b/sdks/python-client/omnigent_client/_responses.py
@@ -21,6 +21,8 @@ import httpx
 from ._errors import ToolCallDenied, raise_for_status, require_json_object, response_body
 from ._events import (
     ClientTaskCancel,
+    CompactionCompleted,
+    CompactionFailed,
     CompactionInProgress,
     ElicitationRequest,
     ErrorEvent,
@@ -43,6 +45,7 @@ from ._events import (
 )
 from ._sse import parse_sse_stream
 from ._tool_handler import (
+    CompactionEndCtx,
     CompactionStartCtx,
     ElicitationRequestCtx,
     FileOutputCtx,
@@ -275,6 +278,31 @@ class ResponsesNamespace:
 
                     elif isinstance(event, CompactionInProgress):
                         await _call_hook(hooks.on_compaction_start, CompactionStartCtx())
+
+                    elif isinstance(event, CompactionCompleted):
+                        item: dict[str, object] = {
+                            "type": "response.compaction.completed",
+                            "status": "completed",
+                            "total_tokens": event.total_tokens,
+                        }
+                        if event.summary is not None:
+                            item["summary"] = event.summary
+                        if event.summary_model is not None:
+                            item["summary_model"] = event.summary_model
+                        if event.compacted_messages is not None:
+                            item["compacted_messages"] = event.compacted_messages
+                        await _call_hook(hooks.on_compaction_end, CompactionEndCtx(item=item))
+
+                    elif isinstance(event, CompactionFailed):
+                        await _call_hook(
+                            hooks.on_compaction_end,
+                            CompactionEndCtx(
+                                item={
+                                    "type": "response.compaction.failed",
+                                    "status": "failed",
+                                },
+                            ),
+                        )
 
                     elif isinstance(event, ToolCall):
                         is_client_side = (
@@ -899,9 +927,8 @@ async def _post_elicitation_result(
 
     :param http: Shared HTTPX client.
     :param base_url: Server base URL.
-    :param session_id: Session/conversation id that emitted the
-        elicitation. The resolve URL is scoped to this session so
-        the server can apply normal session authorization.
+    :param session_id: Session/conversation id that owns the
+        elicitation's resolve endpoint.
     :param elicitation_id: Server-assigned elicitation id.
     :param accepted: Hook verdict — ``True`` → ``"accept"``,
         ``False`` → ``"decline"``.
@@ -959,8 +986,8 @@ async def _handle_elicitation_request(
     :param response_id: Root response id (the parked workflow);
         carried into the ctx for the hook's audit/logging only.
     :param session_id: Session/conversation id that emitted the
-        elicitation. The verdict is posted back as a session
-        ``approval`` event.
+        elicitation. Mirrored child prompts override this with the
+        event's ``target_session_id`` when posting the verdict.
     """
     ctx = ElicitationRequestCtx(
         elicitation_id=event.elicitation_id,
@@ -972,6 +999,14 @@ async def _handle_elicitation_request(
         content_preview=event.content_preview,
         response_id=response_id,
         url=event.url,
+        target_session_id=event.target_session_id,
     )
     accepted = await _invoke_elicitation_hook(hooks, ctx)
-    await _post_elicitation_result(http, base_url, session_id, event.elicitation_id, accepted)
+    target_session_id = event.target_session_id or session_id
+    await _post_elicitation_result(
+        http,
+        base_url,
+        target_session_id,
+        event.elicitation_id,
+        accepted,
+    )

--- a/sdks/python-client/omnigent_client/_sse.py
+++ b/sdks/python-client/omnigent_client/_sse.py
@@ -16,6 +16,8 @@ from omnigent.server import schemas as _srv_events
 from ._events import (
     NATIVE_TOOL_TYPES,
     ClientTaskCancel,
+    CompactionCompleted,
+    CompactionFailed,
     CompactionInProgress,
     ElicitationRequest,
     ErrorEvent,
@@ -79,6 +81,8 @@ _T_RESPONSE_OUTPUT_FILE_DONE = _wire_type(_srv_events.OutputFileDoneEvent)
 _T_RESPONSE_RETRY = _wire_type(_srv_events.RetryEvent)
 _T_RESPONSE_ERROR = _wire_type(_srv_events.ErrorEvent)
 _T_RESPONSE_COMPACTION_IN_PROGRESS = _wire_type(_srv_events.CompactionInProgressEvent)
+_T_RESPONSE_COMPACTION_COMPLETED = _wire_type(_srv_events.CompactionCompletedEvent)
+_T_RESPONSE_COMPACTION_FAILED = _wire_type(_srv_events.CompactionFailedEvent)
 _T_RESPONSE_CLIENT_TASK_CANCEL = _wire_type(_srv_events.ClientTaskCancelEvent)
 _T_RESPONSE_ELICITATION_REQUEST = _wire_type(_srv_events.ElicitationRequestEvent)
 
@@ -235,6 +239,23 @@ def _parse_event(event_type: str, data: dict[str, Any]) -> StreamEvent | None:
     # Compaction
     if event_type == _T_RESPONSE_COMPACTION_IN_PROGRESS:
         return CompactionInProgress()
+    if event_type == _T_RESPONSE_COMPACTION_COMPLETED:
+        raw_total_tokens = data.get("total_tokens")
+        raw_summary = data.get("summary")
+        raw_summary_model = data.get("summary_model")
+        raw_compacted_messages = data.get("compacted_messages")
+        return CompactionCompleted(
+            total_tokens=raw_total_tokens
+            if isinstance(raw_total_tokens, int) and not isinstance(raw_total_tokens, bool)
+            else None,
+            summary=raw_summary if isinstance(raw_summary, str) else None,
+            summary_model=raw_summary_model if isinstance(raw_summary_model, str) else None,
+            compacted_messages=raw_compacted_messages
+            if isinstance(raw_compacted_messages, list)
+            else None,
+        )
+    if event_type == _T_RESPONSE_COMPACTION_FAILED:
+        return CompactionFailed()
 
     # Async client-tool cancel notification
     if event_type == _T_RESPONSE_CLIENT_TASK_CANCEL:
@@ -252,7 +273,7 @@ def _parse_event(event_type: str, data: dict[str, Any]) -> StreamEvent | None:
     # mirrors MCP's ``ElicitRequestFormParams`` field-for-field;
     # we surface it as a typed event so the stream consumer can
     # route it to the elicitation hook (not into a ToolHandler).
-    if event_type == "response.elicitation_request":
+    if event_type == _T_RESPONSE_ELICITATION_REQUEST:
         elicitation_id = data.get("elicitation_id")
         if not isinstance(elicitation_id, str) or not elicitation_id:
             _log.warning(
@@ -268,6 +289,7 @@ def _parse_event(event_type: str, data: dict[str, Any]) -> StreamEvent | None:
             )
             return None
         requested_schema = params.get("requestedSchema")
+        target_session_id = params.get("target_session_id")
         return ElicitationRequest(
             elicitation_id=elicitation_id,
             message=str(params.get("message") or ""),
@@ -281,6 +303,9 @@ def _parse_event(event_type: str, data: dict[str, Any]) -> StreamEvent | None:
             policy_name=str(params.get("policy_name") or ""),
             content_preview=str(params.get("content_preview") or ""),
             url=str(params["url"]) if isinstance(params.get("url"), str) else None,
+            target_session_id=target_session_id
+            if isinstance(target_session_id, str) and target_session_id
+            else None,
         )
 
     # Unknown event — skip gracefully for forward-compatibility

--- a/sdks/python-client/omnigent_client/_tool_handler.py
+++ b/sdks/python-client/omnigent_client/_tool_handler.py
@@ -229,6 +229,9 @@ class ElicitationRequestCtx:
     :param response_id: The in-progress response id — for
         logging / audit purposes only. The client handles the
         elicitation reply POST automatically.
+    :param target_session_id: Session whose resolve endpoint owns
+        the elicitation. Set for mirrored child-session prompts;
+        ``None`` means resolve against the stream's session.
     """
 
     elicitation_id: str
@@ -240,6 +243,7 @@ class ElicitationRequestCtx:
     content_preview: str
     response_id: str
     url: str | None = None
+    target_session_id: str | None = None
 
 
 @dataclass

--- a/tests/frontends/sdk/test_async_client_tool_sdk.py
+++ b/tests/frontends/sdk/test_async_client_tool_sdk.py
@@ -29,7 +29,13 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 
 import pytest
-from omnigent_client._events import ClientTaskCancel, ToolCall, ToolResult
+from omnigent_client._events import (
+    ClientTaskCancel,
+    CompactionCompleted,
+    CompactionFailed,
+    ToolCall,
+    ToolResult,
+)
 from omnigent_client._sse import parse_sse_stream
 
 
@@ -46,6 +52,46 @@ async def _bytes(*frames: bytes) -> AsyncIterator[bytes]:
     """
     for frame in frames:
         yield frame
+
+
+@pytest.mark.asyncio
+async def test_sse_parser_emits_compaction_completed_with_total_tokens() -> None:
+    """
+    ``response.compaction.completed`` must surface as a typed event
+    with the server's optional ``total_tokens`` payload preserved.
+    Otherwise legacy stream consumers that started a compaction
+    spinner never receive the terminal success signal.
+    """
+    frame = (
+        b"event: response.compaction.completed\n"
+        b'data: {"type": "response.compaction.completed", "total_tokens": 8421}\n'
+        b"\n"
+    )
+
+    events = []
+    async for event in parse_sse_stream(_bytes(frame)):
+        events.append(event)
+
+    assert len(events) == 1, f"Expected one compaction event; got {events!r}"
+    assert isinstance(events[0], CompactionCompleted)
+    assert events[0].total_tokens == 8421
+
+
+@pytest.mark.asyncio
+async def test_sse_parser_emits_compaction_failed() -> None:
+    """
+    ``response.compaction.failed`` must surface as a typed event so
+    clients can dismiss in-progress compaction state when the server
+    leaves conversation history unchanged.
+    """
+    frame = b'event: response.compaction.failed\ndata: {"type": "response.compaction.failed"}\n\n'
+
+    events = []
+    async for event in parse_sse_stream(_bytes(frame)):
+        events.append(event)
+
+    assert len(events) == 1, f"Expected one compaction event; got {events!r}"
+    assert isinstance(events[0], CompactionFailed)
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/policies/test_sdk_elicitation_wiring.py
+++ b/tests/runtime/policies/test_sdk_elicitation_wiring.py
@@ -169,6 +169,7 @@ def test_sse_parses_elicitation_request_event() -> None:
     assert event.phase == "tool_call"
     assert event.policy_name == "ask_search"
     assert event.content_preview == "q=classified"
+    assert event.target_session_id is None
 
 
 def test_sse_elicitation_request_tolerates_missing_extras() -> None:
@@ -259,6 +260,56 @@ def test_sse_parses_regular_function_call_as_toolcall() -> None:
 
 
 # ── _handle_elicitation_request: hook + POST wiring ────────
+
+
+@pytest.mark.asyncio
+async def test_target_session_id_routes_elicitation_verdict_to_child_session() -> None:
+    """
+    Mirrored child prompts carry ``params.target_session_id``. The
+    legacy responses stream must preserve that field into the hook
+    context and POST the verdict to the child session's resolve URL,
+    not the ancestor stream's own session id.
+    """
+    http = _FakeHttpClient()
+    seen: list[ElicitationRequestCtx] = []
+
+    async def _hook(ctx: ElicitationRequestCtx) -> bool:
+        seen.append(ctx)
+        return True
+
+    raw = {
+        "type": "response.elicitation_request",
+        "elicitation_id": "elicit_child",
+        "method": "elicitation/create",
+        "params": {
+            "mode": "form",
+            "message": "approve child tool?",
+            "requestedSchema": {},
+            "phase": "tool_call",
+            "policy_name": "child_gate",
+            "content_preview": "child work",
+            "target_session_id": "conv_child",
+        },
+    }
+    event = _sse._parse_event("response.elicitation_request", raw)
+    assert isinstance(event, ElicitationRequest)
+    assert event.target_session_id == "conv_child"
+
+    await _responses._handle_elicitation_request(
+        http,  # type: ignore[arg-type]
+        "http://localhost:8000",
+        StreamHooks(on_elicitation_request=_hook),
+        event,
+        response_id="resp_parent",
+        session_id="conv_parent",
+    )
+
+    assert len(seen) == 1
+    assert seen[0].target_session_id == "conv_child"
+    assert http.post_calls[0]["url"] == (
+        "http://localhost:8000/v1/sessions/conv_child/elicitations/elicit_child/resolve"
+    )
+    assert http.post_calls[0]["json"] == {"action": "accept"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two related bugs in the legacy Python client SSE stream (`omnigent_client`):

1. **Compaction terminal events were never dispatched.** The server emits `response.compaction.completed` / `response.compaction.failed`, the web client parses both, and the SDK's event dataclasses and `on_compaction_end` hook already existed — but `_sse.py` only parsed `response.compaction.in_progress`. Legacy clients would fire `on_compaction_start` and then never see completion or failure, leaving compaction state hanging and failed compactions unobservable.

2. **Child approval verdicts were posted to the wrong session.** The server annotates ancestor-mirrored child elicitations with `params.target_session_id` (the web client uses it), but `_sse.py` dropped the field and `_responses.py` posted the verdict to the stream's own `session_id`. Server-side `_resolve_elicitation` only resolves the parked Future when the owner session matches, so sub-agent approval prompts resolved through a legacy Python stream blocked forever.

## Fix

- Parse `CompactionCompleted` (with `total_tokens`, `summary`, `summary_model`, `compacted_messages`) and `CompactionFailed` in `_sse.py`; dispatch both through the existing `on_compaction_end` hook.
- Parse `params.target_session_id` into `ElicitationRequest` / `ElicitationRequestCtx` and post the verdict to `target_session_id or session_id`.
- Backwards compatible: absent `target_session_id` behaves exactly as before; new dataclass fields default to `None`.

## Tests

New tests (all fail before the fix, verified by stashing):
- `test_sse_parser_emits_compaction_completed_with_total_tokens`
- `test_sse_parser_emits_compaction_failed`
- `test_target_session_id_routes_elicitation_verdict_to_child_session`

`tests/frontends/sdk/test_async_client_tool_sdk.py` + `tests/runtime/policies/test_sdk_elicitation_wiring.py`: 43 passed. `ruff` + `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
