### PR TITLE
fix(runner): return structured result instead of KeyError on environment shell timeout

### DIFF
--- a/omnigent/entities/environment_filesystem.py
+++ b/omnigent/entities/environment_filesystem.py
@@ -249,14 +249,14 @@ class ShellResult:
 
     :param stdout: Standard output of the command.
     :param stderr: Standard error of the command.
-    :param exit_code: Process exit code.
+    :param exit_code: Process exit code, or ``None`` when no status exists.
     :param timed_out: Whether the command was killed by timeout.
     :param cwd: Working directory the command ran in, if known.
     """
 
     stdout: str
     stderr: str
-    exit_code: int
+    exit_code: int | None
     timed_out: bool
     cwd: str | None = None
 

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1347,6 +1347,7 @@ def _shell_impl(
         return {
             "stdout": _truncate_output(stdout, "stdout", max_output),
             "stderr": _truncate_output(stderr, "stderr", max_output),
+            "exit_code": None,
             "timed_out": True,
             "error": f"Command timed out after {timeout} seconds",
             "shell": shell_path,

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import base64
+import shutil
 import tracemalloc
 from pathlib import Path
 
-from omnigent.inner.os_env import _read_impl, build_helper_env
+from omnigent.inner.os_env import _read_impl, _shell_impl, build_helper_env
 from omnigent.inner.sandbox import SandboxPolicy
 from omnigent.runner.identity import (
     OMNIGENT_SESSION_ENV_VALUE,
@@ -109,6 +110,30 @@ def test_build_helper_env_active_passes_omnigent_session_marker() -> None:
     env = build_helper_env(parent, _active_policy())
 
     assert env[OMNIGENT_SESSION_ENV_VAR] == OMNIGENT_SESSION_ENV_VALUE
+
+
+# ---------------------------------------------------------------------------
+# _shell_impl — timeout result shape
+# ---------------------------------------------------------------------------
+
+
+def test_shell_impl_timeout_includes_exit_code(tmp_path: Path) -> None:
+    """Timed-out shell commands still return the documented result fields."""
+    shell_path = shutil.which("bash") or shutil.which("sh")
+    assert shell_path is not None
+
+    result = _shell_impl(
+        command="sleep 2",
+        timeout=1,
+        shell_path=shell_path,
+        cwd=tmp_path,
+    )
+
+    assert result["stdout"] == ""
+    assert result["stderr"] == ""
+    assert result["exit_code"] is None
+    assert result["timed_out"] is True
+    assert result["error"] == "Command timed out after 1 seconds"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -647,6 +647,25 @@ async def test_shell_nonzero_exit(
 
 
 @pytest.mark.asyncio
+async def test_shell_timeout_returns_structured_result(
+    client: httpx.AsyncClient,
+) -> None:
+    """POST /shell returns the timeout result instead of raising."""
+    resp = await client.post(
+        f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}/shell",
+        json={"command": "sleep 2", "timeout": 1},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "session.environment.shell_result"
+    assert body["stdout"] == ""
+    assert body["stderr"] == ""
+    assert body["exit_code"] is None
+    assert body["timed_out"] is True
+    assert body["cwd"] is not None
+
+
+@pytest.mark.asyncio
 async def test_shell_missing_command_returns_400(
     client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
## Summary

A timed-out `POST /resources/environments/{id}/shell` request returned a runner 500 instead of the structured timeout result: `run_environment_shell()` in `runner/app.py` unconditionally reads `result["exit_code"]`, but on `subprocess.TimeoutExpired` the dict returned by `_shell_impl()` in `inner/os_env.py` contains `stdout`, `stderr`, `timed_out`, `error`, `shell`, `cwd` — and no `exit_code` key → `KeyError`.

## Fix

Producer-side, so all consumers benefit: `_shell_impl()` now includes `exit_code: None` in the timeout result (a timeout has no completed process status), and `ShellResult.exit_code` is widened to `int | None` accordingly. No inspected consumer relied on the key being absent.

## Tests

New (both fail with `KeyError: 'exit_code'` before the fix, verified by stashing):
- `test_shell_impl_timeout_includes_exit_code`
- `test_shell_timeout_returns_structured_result`

`tests/inner/test_os_env.py` + `tests/runner/test_environment_filesystem.py`: 72 passed. `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
