### PR TITLE
[codex] Keep Hermes subprocess turns alive during long waits

### DIFF
--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -99,6 +99,11 @@ class ExecutorEvent:
 
 
 @dataclass
+class ExecutorProgress(ExecutorEvent):
+    """Non-text progress marker for long executor waits."""
+
+
+@dataclass
 class TextChunk(ExecutorEvent):
     """Streaming text output.
 

--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -39,6 +39,7 @@ Env vars read at construction:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -55,6 +56,7 @@ from omnigent.inner.executor import (
     ExecutorConfig,
     ExecutorError,
     ExecutorEvent,
+    ExecutorProgress,
     Message,
     TextChunk,
     ToolSpec,
@@ -66,6 +68,7 @@ _logger = logging.getLogger(__name__)
 # Maximum seconds to wait for a Hermes subprocess to complete a single turn.
 # Complex tasks (multi-tool-calling loops) may take several minutes.
 _HERMES_TURN_TIMEOUT_S = 600.0
+_HERMES_SUBPROCESS_PROGRESS_INTERVAL_S = 15.0
 
 # Regex to extract the session_id from Hermes' quiet-mode output line.
 # Matches lines like ``session_id: 20260620_142506_c51451``.
@@ -500,10 +503,31 @@ class HermesExecutor(Executor):
                 env=proc_env,
             )
 
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(),
-                timeout=_HERMES_TURN_TIMEOUT_S,
-            )
+            communicate_task = asyncio.create_task(proc.communicate())
+            deadline = asyncio.get_running_loop().time() + _HERMES_TURN_TIMEOUT_S
+            while True:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    communicate_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await communicate_task
+                    raise asyncio.TimeoutError
+                interval = min(_HERMES_SUBPROCESS_PROGRESS_INTERVAL_S, remaining)
+                try:
+                    stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                        asyncio.shield(communicate_task),
+                        timeout=interval,
+                    )
+                    break
+                except asyncio.TimeoutError:
+                    if communicate_task.done():
+                        raise
+                    if asyncio.get_running_loop().time() >= deadline:
+                        communicate_task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await communicate_task
+                        raise
+                    yield ExecutorProgress()
         except asyncio.TimeoutError:
             _logger.warning("Hermes subprocess timed out after %ss", _HERMES_TURN_TIMEOUT_S)
             yield ExecutorError(

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -37,6 +37,7 @@ import contextlib
 import json
 import logging
 import secrets
+import time
 import uuid
 from collections import deque
 from collections.abc import Callable
@@ -51,6 +52,7 @@ from omnigent.inner.executor import (
     ExecutorConfig,
     ExecutorError,
     ExecutorEvent,
+    ExecutorProgress,
     Message,
     ReasoningChunk,
     TextChunk,
@@ -67,11 +69,13 @@ from omnigent.server.schemas import (
     CreateResponseRequest,
     ElicitationRequestParams,
     InjectionConsumedEvent,
+    InProgressEvent,
     OutputItemDoneEvent,
     OutputTextDeltaEvent,
     ReasoningStartedEvent,
     ReasoningSummaryTextDeltaEvent,
     ReasoningTextDeltaEvent,
+    ResponseObject,
 )
 
 _logger = logging.getLogger(__name__)
@@ -843,7 +847,19 @@ class ExecutorAdapter(HarnessApp):
         :param ctx: The per-turn context; events are pushed onto
             its queue.
         """
-        if isinstance(event, TextChunk):
+        if isinstance(event, ExecutorProgress):
+            ctx.emit(
+                InProgressEvent(
+                    type="response.in_progress",
+                    response=ResponseObject(
+                        id=ctx.response_id,
+                        status="in_progress",
+                        model=self._current_agent or "unknown",
+                        created_at=int(time.time()),
+                    ),
+                )
+            )
+        elif isinstance(event, TextChunk):
             ctx.emit(
                 OutputTextDeltaEvent(
                     type="response.output_text.delta",

--- a/tests/inner/test_hermes_executor.py
+++ b/tests/inner/test_hermes_executor.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from omnigent.inner import hermes_executor as hermes_executor_module
 from omnigent.inner.executor import (
     ExecutorConfig,
     ExecutorError,
@@ -33,6 +34,10 @@ from omnigent.inner.hermes_executor import (
     _populate_hermes_home,
     _strip_hermes_metadata,
 )
+from omnigent.runtime.harnesses import _scaffold
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+from omnigent.runtime.harnesses._scaffold import TurnContext
+from omnigent.server.schemas import CreateResponseRequest
 
 # ---------------------------------------------------------------------------
 # Helper function tests
@@ -492,4 +497,52 @@ async def test_run_turn_passes_hermes_home_env(
 
         _, call_kwargs = mock_create.call_args
         assert "env" in call_kwargs
-        assert call_kwargs["env"]["HERMES_HOME"] == str(executor._hermes_home)
+    assert call_kwargs["env"]["HERMES_HOME"] == str(executor._hermes_home)
+
+
+@pytest.mark.asyncio
+async def test_run_turn_long_subprocess_progress_keeps_scaffold_watchdog_alive(
+    executor: HermesExecutor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A long Hermes subprocess must not look idle to the scaffold watchdog."""
+
+    class _SlowHermesProcess:
+        returncode = 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            await asyncio.sleep(0.12)
+            return b"session_id: 20260705_slow_progress\n", b""
+
+    monkeypatch.setattr(_scaffold, "_TURN_IDLE_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(_scaffold, "_TURN_ABSOLUTE_TIMEOUT_S", 5.0)
+    monkeypatch.setattr(hermes_executor_module, "_HERMES_TURN_TIMEOUT_S", 1.0)
+    monkeypatch.setattr(
+        hermes_executor_module,
+        "_HERMES_SUBPROCESS_PROGRESS_INTERVAL_S",
+        0.02,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=_SlowHermesProcess()),
+    )
+
+    adapter = ExecutorAdapter(executor_factory=lambda: executor, harness_label="Hermes")
+    ctx = TurnContext(
+        response_id="resp_hermes_slow_progress",
+        event_queue=asyncio.Queue(),
+        cancelled=asyncio.Event(),
+    )
+    request = CreateResponseRequest(model="hermes-test", input="Hi")
+
+    await adapter._guarded_run_turn(request, ctx)  # type: ignore[attr-defined]
+
+    event_types: list[str | None] = []
+    while not ctx._event_queue.empty():
+        event = ctx._event_queue.get_nowait()
+        event_types.append(getattr(event, "type", None))
+
+    assert "response.in_progress" in event_types
+    assert "response.output_text.delta" not in event_types


### PR DESCRIPTION
## Related issue
N/A

## Summary
- Fix Hermes executor turns that look idle while `hermes chat -q` is still doing real work in a subprocess.
- Add a non-text `ExecutorProgress` marker and translate it to an existing `response.in_progress` SSE event, so the scaffold idle watchdog sees progress without leaking fake text to clients.
- Keep Hermes' own subprocess timeout as the hard 600s budget by polling `proc.communicate()` in bounded intervals instead of awaiting one blocking `wait_for`.

The originally proposed `ctx.set_state(...)` fix would not work here: `TurnContext` has no `set_state` method, and `HermesExecutor.run_turn()` does not receive a `TurnContext`; the executor can only yield `ExecutorEvent` values that the `ExecutorAdapter` translates upstream.

```mermaid
flowchart LR
  H[HermesExecutor waits on subprocess] --> P[ExecutorProgress]
  P --> A[ExecutorAdapter]
  A --> I[response.in_progress]
  I --> W[scaffold idle watchdog reset]
```

## Test Plan
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev pytest tests/inner/test_hermes_executor.py::test_run_turn_long_subprocess_progress_keeps_scaffold_watchdog_alive -q`
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev pytest tests/inner/test_hermes_executor.py -q`
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev pytest tests/runtime/harnesses/test_executor_adapter.py -q`
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev pytest tests/runtime/harnesses/test_scaffold.py -q`
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev ruff check .`
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev ruff format --check .`

Typecheck note: `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev mypy omnigent/inner/executor.py omnigent/inner/hermes_executor.py omnigent/runtime/harnesses/_executor_adapter.py` currently fails on pre-existing local strictness errors in these modules (`explicit-any`, generic `dict`, unused ignores, and an OTel span arg-type), not on this change.

## Demo
N/A

## Type change
- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage
- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover change
- [ ] Not applicable

## Coverage notes
Manually verified the new RED test fails before the fix with the scaffold idle watchdog and passes after the Hermes progress marker is translated into a non-text SSE event.

## Changelog
Hermes-backed turns now keep long-running subprocess work alive without tripping the harness idle watchdog.
