### PR TITLE
feat(claude-native): add Fable and both Sonnet generations to model selection

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -151,14 +151,15 @@ _UCODE_CLAUDE_TIER_TO_ENV: dict[str, str] = {
 }
 # The 4 family aliases above pin one model ID each. Claude Code has exactly
 # one more independently-selectable /model picker slot beyond those
-# families — ANTHROPIC_CUSTOM_MODEL_OPTION — used here to surface a second
-# Sonnet generation (e.g. Sonnet 4.6) alongside the "sonnet" alias pinned to
-# the newest Sonnet, for workspaces where both are in active use.
+# families — ANTHROPIC_CUSTOM_MODEL_OPTION — used here to surface Sonnet 5
+# as an opt-in *alongside* the "sonnet" alias, which stays pinned to the
+# workspace's existing default Sonnet (4.6). This keeps the default Sonnet
+# unchanged and adds the newer generation as a separate, explicit choice.
 # See https://code.claude.com/docs/en/model-config#custom-model-options
 _ANTHROPIC_CUSTOM_MODEL_OPTION_ENV = "ANTHROPIC_CUSTOM_MODEL_OPTION"
 _ANTHROPIC_CUSTOM_MODEL_OPTION_NAME_ENV = "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME"
-_UCODE_CLAUDE_CUSTOM_TIER = "sonnet_4_6"
-_UCODE_CLAUDE_CUSTOM_TIER_LABEL = "Sonnet 4.6"
+_UCODE_CLAUDE_CUSTOM_TIER = "sonnet_5"
+_UCODE_CLAUDE_CUSTOM_TIER_LABEL = "Sonnet 5"
 _DEFAULT_UCODE_AUTH_REFRESH_INTERVAL_MS = 900_000
 _SESSION_LABELS = {
     "omnigent.ui": "terminal",

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -149,6 +149,16 @@ _UCODE_CLAUDE_TIER_TO_ENV: dict[str, str] = {
     "sonnet": _ANTHROPIC_DEFAULT_SONNET_MODEL_ENV,
     "haiku": _ANTHROPIC_DEFAULT_HAIKU_MODEL_ENV,
 }
+# The 4 family aliases above pin one model ID each. Claude Code has exactly
+# one more independently-selectable /model picker slot beyond those
+# families — ANTHROPIC_CUSTOM_MODEL_OPTION — used here to surface a second
+# Sonnet generation (e.g. Sonnet 4.6) alongside the "sonnet" alias pinned to
+# the newest Sonnet, for workspaces where both are in active use.
+# See https://code.claude.com/docs/en/model-config#custom-model-options
+_ANTHROPIC_CUSTOM_MODEL_OPTION_ENV = "ANTHROPIC_CUSTOM_MODEL_OPTION"
+_ANTHROPIC_CUSTOM_MODEL_OPTION_NAME_ENV = "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME"
+_UCODE_CLAUDE_CUSTOM_TIER = "sonnet_4_6"
+_UCODE_CLAUDE_CUSTOM_TIER_LABEL = "Sonnet 4.6"
 _DEFAULT_UCODE_AUTH_REFRESH_INTERVAL_MS = 900_000
 _SESSION_LABELS = {
     "omnigent.ui": "terminal",
@@ -1449,6 +1459,10 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
         model_id = workspace_state.claude_models.get(tier)
         if model_id:
             env[env_var] = model_id
+    custom_model_id = workspace_state.claude_models.get(_UCODE_CLAUDE_CUSTOM_TIER)
+    if custom_model_id:
+        env[_ANTHROPIC_CUSTOM_MODEL_OPTION_ENV] = custom_model_id
+        env[_ANTHROPIC_CUSTOM_MODEL_OPTION_NAME_ENV] = _UCODE_CLAUDE_CUSTOM_TIER_LABEL
     # When ucode caches no model, default it so Claude Code doesn't fall back
     # to its host-config model (an Anthropic-direct id the gateway rejects).
     return ClaudeNativeUcodeConfig(

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -3612,17 +3612,19 @@ def _model_alias_for(model: str | None) -> str | None:
 
     The web model picker speaks Claude Code's version-agnostic aliases
     (``"fable"`` / ``"opus"`` / ``"sonnet"`` / ``"haiku"``), plus the one
-    extra concrete-id slot ``"sonnet_4_6"`` (see
-    :data:`omnigent.claude_native._UCODE_CLAUDE_CUSTOM_TIER`) for the older
-    Sonnet generation kept selectable alongside the newest one; the
+    extra concrete-id slot ``"sonnet_5"`` (see
+    :data:`omnigent.claude_native._UCODE_CLAUDE_CUSTOM_TIER`) for the newer
+    Sonnet generation offered alongside the default ``"sonnet"`` tier; the
     transcript records the resolved concrete id (e.g.
-    ``"claude-opus-4-8"`` or ``"databricks-claude-sonnet-4-6"``).
+    ``"claude-opus-4-8"`` or ``"databricks-claude-sonnet-5"``).
     Mapping to the tier keeps the mirrored value in the picker's
-    vocabulary and makes a web→TUI round-trip a no-op.
+    vocabulary and makes a web→TUI round-trip a no-op. The older Sonnet
+    (``sonnet-4-6``) collapses to the generic ``"sonnet"`` alias — it is the
+    default that row is bound to.
 
     :param model: Concrete model id from the transcript, e.g.
         ``"claude-opus-4-8"``; ``None`` when none observed yet.
-    :returns: ``"fable"`` / ``"opus"`` / ``"sonnet"`` / ``"sonnet_4_6"`` /
+    :returns: ``"fable"`` / ``"opus"`` / ``"sonnet"`` / ``"sonnet_5"`` /
         ``"haiku"`` when the id carries a known tier token, else ``None``
         (the caller skips the post rather than surface an id the picker
         can't render).
@@ -3630,8 +3632,8 @@ def _model_alias_for(model: str | None) -> str | None:
     if not model:
         return None
     lowered = model.lower()
-    if "sonnet-4-6" in lowered or "sonnet_4_6" in lowered:
-        return "sonnet_4_6"
+    if "sonnet-5" in lowered or "sonnet_5" in lowered:
+        return "sonnet_5"
     for tier in ("fable", "opus", "sonnet", "haiku"):
         if tier in lowered:
             return tier

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -3611,7 +3611,10 @@ def _model_alias_for(model: str | None) -> str | None:
     Collapse a concrete Claude model id to the picker's tier alias.
 
     The web model picker speaks Claude Code's version-agnostic aliases
-    (``"fable"`` / ``"opus"`` / ``"sonnet"`` / ``"haiku"``); the
+    (``"fable"`` / ``"opus"`` / ``"sonnet"`` / ``"haiku"``), plus the one
+    extra concrete-id slot ``"sonnet_4_6"`` (see
+    :data:`omnigent.claude_native._UCODE_CLAUDE_CUSTOM_TIER`) for the older
+    Sonnet generation kept selectable alongside the newest one; the
     transcript records the resolved concrete id (e.g.
     ``"claude-opus-4-8"`` or ``"databricks-claude-sonnet-4-6"``).
     Mapping to the tier keeps the mirrored value in the picker's
@@ -3619,14 +3622,16 @@ def _model_alias_for(model: str | None) -> str | None:
 
     :param model: Concrete model id from the transcript, e.g.
         ``"claude-opus-4-8"``; ``None`` when none observed yet.
-    :returns: ``"fable"`` / ``"opus"`` / ``"sonnet"`` / ``"haiku"``
-        when the id carries a known tier token, else ``None`` (the
-        caller skips the post rather than surface an id the picker
+    :returns: ``"fable"`` / ``"opus"`` / ``"sonnet"`` / ``"sonnet_4_6"`` /
+        ``"haiku"`` when the id carries a known tier token, else ``None``
+        (the caller skips the post rather than surface an id the picker
         can't render).
     """
     if not model:
         return None
     lowered = model.lower()
+    if "sonnet-4-6" in lowered or "sonnet_4_6" in lowered:
+        return "sonnet_4_6"
     for tier in ("fable", "opus", "sonnet", "haiku"):
         if tier in lowered:
             return tier

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -76,7 +76,13 @@ _LLM_TASK_TOKENS = ("chat", "completion")
 # Subscription CLIs expose no listing API: curated ids matching the bundled
 # catalog pin (claude) and the codex ids the codebase already references.
 _SUBSCRIPTION_STATIC_MODELS: dict[str, tuple[str, ...]] = {
-    "claude": ("claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"),
+    "claude": (
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+    ),
     "codex": ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"),
 }
 

--- a/omnigent/onboarding/ucode_state.py
+++ b/omnigent/onboarding/ucode_state.py
@@ -58,11 +58,11 @@ class UcodeWorkspaceState:
         ``"https://example.databricks.com"``.
     :param claude_models: Mapping of tier to model id,
         e.g. ``{"opus": "databricks-claude-opus-4-7", "sonnet": "..."}``.
-        An optional ``"sonnet_4_6"`` key pins Claude Code's one custom
+        An optional ``"sonnet_5"`` key pins Claude Code's one custom
         ``/model`` picker slot (see
-        :data:`omnigent.claude_native._UCODE_CLAUDE_CUSTOM_TIER`) to a
-        second Sonnet generation, for workspaces where two Sonnet versions
-        are in active use side by side.
+        :data:`omnigent.claude_native._UCODE_CLAUDE_CUSTOM_TIER`) to the
+        newer Sonnet generation, offered as an opt-in alongside the default
+        ``"sonnet"`` tier, for workspaces that serve both side by side.
     :param codex_models: Ordered list of Codex model ids available on this
         workspace, e.g. ``["databricks-gpt-5-5"]``.
     :param base_urls: Mapping of tool name to base URL,

--- a/omnigent/onboarding/ucode_state.py
+++ b/omnigent/onboarding/ucode_state.py
@@ -58,6 +58,11 @@ class UcodeWorkspaceState:
         ``"https://example.databricks.com"``.
     :param claude_models: Mapping of tier to model id,
         e.g. ``{"opus": "databricks-claude-opus-4-7", "sonnet": "..."}``.
+        An optional ``"sonnet_4_6"`` key pins Claude Code's one custom
+        ``/model`` picker slot (see
+        :data:`omnigent.claude_native._UCODE_CLAUDE_CUSTOM_TIER`) to a
+        second Sonnet generation, for workspaces where two Sonnet versions
+        are in active use side by side.
     :param codex_models: Ordered list of Codex model ids available on this
         workspace, e.g. ``["databricks-gpt-5-5"]``.
     :param base_urls: Mapping of tool name to base URL,

--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -7,13 +7,14 @@ from urllib.parse import urlparse
 
 from playwright.sync_api import Page, Route, expect
 
-# Capability order, most powerful first; "sonnet_4_6" is Claude Code's one
-# custom /model slot pinned to the older Sonnet generation.
+# Capability order, most powerful first. The default "sonnet" alias stays
+# bound to Sonnet 4.6; "sonnet_5" is Claude Code's one custom /model slot,
+# an opt-in for the newer Sonnet offered alongside it.
 _EXPECTED_ROWS = [
     ("fable", "Fable"),
     ("opus", "Opus"),
-    ("sonnet", "Sonnet 5"),
-    ("sonnet_4_6", "Sonnet 4.6"),
+    ("sonnet", "Sonnet 4.6"),
+    ("sonnet_5", "Sonnet 5"),
     ("haiku", "Haiku"),
 ]
 
@@ -25,7 +26,7 @@ def _patch_session_as_claude_native(page: Page, session_id: str) -> list[dict]:
     boot against the real app/server. This route patch changes only ``GET``
     and ``PATCH /v1/sessions/{session_id}`` responses as seen by the browser,
     simulating the snapshot of a claude-native (Claude Code terminal) session
-    bound to a concrete Sonnet 4.6 gateway model.
+    bound to a concrete Sonnet 5 gateway model.
 
     :param page: Playwright page before navigation.
     :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
@@ -62,9 +63,9 @@ def _patch_session_as_claude_native(page: Page, session_id: str) -> list[dict]:
             "omnigent.wrapper": "claude-code-native-ui",
         }
         payload["harness"] = "claude"
-        # A concrete older-generation id: must light up the "Sonnet 4.6" row,
-        # not the generic "sonnet" row (both ids contain "sonnet").
-        payload["llm_model"] = "databricks-claude-sonnet-4-6"
+        # A concrete newer-generation id: must light up the opt-in "Sonnet 5"
+        # row, not the default "sonnet" row (both ids contain "sonnet").
+        payload["llm_model"] = "databricks-claude-sonnet-5"
         latest_payload = dict(payload)
         route.fulfill(
             status=200,
@@ -80,12 +81,13 @@ def test_claude_native_picker_lists_fable_and_both_sonnets(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """The picker offers Fable, Opus, Sonnet 5, Sonnet 4.6, and Haiku.
+    """The picker offers Fable, Opus, Sonnet 4.6, Sonnet 5, and Haiku.
 
-    Covers the user-facing change: Fable returns to the list, and the two
-    Sonnet generations are separate, version-labelled rows. The bound
-    Sonnet 4.6 model must highlight its own row rather than the generic
-    Sonnet row — the substring-disambiguation this change adds.
+    Covers the user-facing change: Fable returns to the list, and the newer
+    Sonnet is added as a separate opt-in row without moving the default
+    "sonnet" alias. The bound Sonnet 5 model must highlight its own opt-in
+    row rather than the default Sonnet row — the substring-disambiguation
+    this change adds.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` for a real server-backed
@@ -108,19 +110,19 @@ def test_claude_native_picker_lists_fable_and_both_sonnets(
         expect(row).to_have_attribute("data-model-id", model_id)
         expect(row).to_contain_text(label)
 
-    # The bound databricks-claude-sonnet-4-6 model implicitly selects its own
-    # row; the generic "sonnet" row (Sonnet 5) must not light up too.
-    sonnet_46_row = page.locator('[data-testid="model-picker-item"][data-model-id="sonnet_4_6"]')
-    expect(sonnet_46_row).to_have_attribute("data-active", "true")
-    sonnet_5_row = page.locator('[data-testid="model-picker-item"][data-model-id="sonnet"]')
-    expect(sonnet_5_row).not_to_have_attribute("data-active", "true")
+    # The bound databricks-claude-sonnet-5 model implicitly selects the opt-in
+    # row; the default "sonnet" row (Sonnet 4.6) must not light up too.
+    sonnet_5_row = page.locator('[data-testid="model-picker-item"][data-model-id="sonnet_5"]')
+    expect(sonnet_5_row).to_have_attribute("data-active", "true")
+    sonnet_default_row = page.locator('[data-testid="model-picker-item"][data-model-id="sonnet"]')
+    expect(sonnet_default_row).not_to_have_attribute("data-active", "true")
 
 
-def test_claude_native_sonnet_4_6_selection_persists(
+def test_claude_native_sonnet_5_selection_persists(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Picking Sonnet 4.6 PATCHes its id and the trigger shows the label.
+    """Picking Sonnet 5 PATCHes its id and the trigger shows the label.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` for a real server-backed
@@ -143,7 +145,7 @@ def test_claude_native_sonnet_4_6_selection_persists(
             and response.status == 200
         )
     ):
-        page.locator('[data-testid="model-picker-item"][data-model-id="sonnet_4_6"]').click()
+        page.locator('[data-testid="model-picker-item"][data-model-id="sonnet_5"]').click()
 
-    assert patch_bodies[-1] == {"model_override": "sonnet_4_6"}
-    expect(trigger).to_contain_text("Sonnet 4.6")
+    assert patch_bodies[-1] == {"model_override": "sonnet_5"}
+    expect(trigger).to_contain_text("Sonnet 5")

--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -1,0 +1,149 @@
+"""E2E: claude-native model picker offers Fable and both Sonnet generations."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+# Capability order, most powerful first; "sonnet_4_6" is Claude Code's one
+# custom /model slot pinned to the older Sonnet generation.
+_EXPECTED_ROWS = [
+    ("fable", "Fable"),
+    ("opus", "Opus"),
+    ("sonnet", "Sonnet 5"),
+    ("sonnet_4_6", "Sonnet 4.6"),
+    ("haiku", "Haiku"),
+]
+
+
+def _patch_session_as_claude_native(page: Page, session_id: str) -> list[dict]:
+    """Patch the browser's session snapshot into a claude-native response.
+
+    The server fixture seeds a normal ``hello_world`` session so the page can
+    boot against the real app/server. This route patch changes only ``GET``
+    and ``PATCH /v1/sessions/{session_id}`` responses as seen by the browser,
+    simulating the snapshot of a claude-native (Claude Code terminal) session
+    bound to a concrete Sonnet 4.6 gateway model.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
+    :returns: Captured PATCH request bodies.
+    """
+    latest_payload: dict | None = None
+    patch_bodies: list[dict] = []
+
+    def _handle(route: Route) -> None:
+        nonlocal latest_payload
+        request = route.request
+        parsed = urlparse(request.url)
+        if parsed.path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+
+        headers = {"content-type": "application/json"}
+        if request.method == "GET":
+            response = route.fetch()
+            payload = response.json()
+            headers = {**response.headers, **headers}
+        elif request.method == "PATCH":
+            request_body = json.loads(request.post_data or "{}")
+            patch_bodies.append(request_body)
+            payload = dict(latest_payload or {})
+            if "model_override" in request_body:
+                payload["model_override"] = request_body["model_override"]
+        else:
+            route.continue_()
+            return
+
+        payload["labels"] = {
+            **payload.get("labels", {}),
+            "omnigent.wrapper": "claude-code-native-ui",
+        }
+        payload["harness"] = "claude"
+        # A concrete older-generation id: must light up the "Sonnet 4.6" row,
+        # not the generic "sonnet" row (both ids contain "sonnet").
+        payload["llm_model"] = "databricks-claude-sonnet-4-6"
+        latest_payload = dict(payload)
+        route.fulfill(
+            status=200,
+            headers=headers,
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions/**", _handle)
+    return patch_bodies
+
+
+def test_claude_native_picker_lists_fable_and_both_sonnets(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The picker offers Fable, Opus, Sonnet 5, Sonnet 4.6, and Haiku.
+
+    Covers the user-facing change: Fable returns to the list, and the two
+    Sonnet generations are separate, version-labelled rows. The bound
+    Sonnet 4.6 model must highlight its own row rather than the generic
+    Sonnet row — the substring-disambiguation this change adds.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser snapshot is patched to claude-native.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _patch_session_as_claude_native(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    trigger = page.get_by_test_id("agent-picker-trigger")
+    expect(trigger).to_be_visible(timeout=15_000)
+    trigger.click()
+
+    rows = page.locator('[data-testid="model-picker-item"]')
+    expect(rows).to_have_count(len(_EXPECTED_ROWS))
+    for index, (model_id, label) in enumerate(_EXPECTED_ROWS):
+        row = rows.nth(index)
+        expect(row).to_have_attribute("data-model-id", model_id)
+        expect(row).to_contain_text(label)
+
+    # The bound databricks-claude-sonnet-4-6 model implicitly selects its own
+    # row; the generic "sonnet" row (Sonnet 5) must not light up too.
+    sonnet_46_row = page.locator('[data-testid="model-picker-item"][data-model-id="sonnet_4_6"]')
+    expect(sonnet_46_row).to_have_attribute("data-active", "true")
+    sonnet_5_row = page.locator('[data-testid="model-picker-item"][data-model-id="sonnet"]')
+    expect(sonnet_5_row).not_to_have_attribute("data-active", "true")
+
+
+def test_claude_native_sonnet_4_6_selection_persists(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Picking Sonnet 4.6 PATCHes its id and the trigger shows the label.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser snapshot is patched to claude-native.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    patch_bodies = _patch_session_as_claude_native(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    trigger = page.get_by_test_id("agent-picker-trigger")
+    expect(trigger).to_be_visible(timeout=15_000)
+    trigger.click()
+
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "PATCH"
+            and urlparse(response.url).path == f"/v1/sessions/{session_id}"
+            and response.status == 200
+        )
+    ):
+        page.locator('[data-testid="model-picker-item"][data-model-id="sonnet_4_6"]').click()
+
+    assert patch_bodies[-1] == {"model_override": "sonnet_4_6"}
+    expect(trigger).to_contain_text("Sonnet 4.6")

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -3625,7 +3625,9 @@ async def test_sys_list_models_dispatches_locally_with_static_provider(
     # The curated claude aliases survive the claude-family filter — the
     # exact ids an orchestrator may pass back as args.model.
     assert [m["id"] for m in worker["models"]] == [
+        "claude-fable-5",
         "claude-opus-4-8",
+        "claude-sonnet-5",
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
     ]

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -385,6 +385,48 @@ def test_ucode_config_for_profile_sets_only_present_tier_env_vars(
     assert "ANTHROPIC_DEFAULT_HAIKU_MODEL" not in config.env
 
 
+def test_ucode_config_for_profile_sets_custom_model_option_for_second_sonnet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A ``claude_models["sonnet_4_6"]`` entry pins Claude Code's one custom
+    ``/model`` slot (``ANTHROPIC_CUSTOM_MODEL_OPTION``), alongside the
+    ``sonnet`` tier alias pinned to the newest Sonnet — letting both
+    generations stay independently selectable while both are in use.
+    """
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    workspace_state = UcodeWorkspaceState(
+        workspace_url="https://example.databricks.com",
+        claude_models={
+            "sonnet": "databricks-claude-sonnet-5",
+            "sonnet_4_6": "databricks-claude-sonnet-4-6",
+        },
+        agents={
+            "claude": UcodeAgentState(
+                model="databricks-claude-sonnet-5",
+                base_url="https://example.databricks.com/ai-gateway/anthropic",
+                auth_command="printf token",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.get_workspace_url_for_profile",
+        lambda profile: "https://example.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_state.read_ucode_state",
+        lambda workspace_url: workspace_state,
+    )
+
+    config = claude_native._ucode_config_for_profile("test-profile")
+
+    assert config is not None
+    assert config.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "databricks-claude-sonnet-5"
+    assert config.env["ANTHROPIC_CUSTOM_MODEL_OPTION"] == "databricks-claude-sonnet-4-6"
+    assert config.env["ANTHROPIC_CUSTOM_MODEL_OPTION_NAME"] == "Sonnet 4.6"
+
+
 def test_ucode_config_for_profile_omits_model_tier_vars_when_no_claude_models(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -389,22 +389,23 @@ def test_ucode_config_for_profile_sets_custom_model_option_for_second_sonnet(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A ``claude_models["sonnet_4_6"]`` entry pins Claude Code's one custom
-    ``/model`` slot (``ANTHROPIC_CUSTOM_MODEL_OPTION``), alongside the
-    ``sonnet`` tier alias pinned to the newest Sonnet — letting both
-    generations stay independently selectable while both are in use.
+    A ``claude_models["sonnet_5"]`` entry pins Claude Code's one custom
+    ``/model`` slot (``ANTHROPIC_CUSTOM_MODEL_OPTION``) to the newer Sonnet,
+    offered as an opt-in *alongside* the ``sonnet`` tier alias, which stays
+    on the workspace's existing default Sonnet (4.6). The default is
+    unchanged; Sonnet 5 is an additional, explicit choice.
     """
     from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
 
     workspace_state = UcodeWorkspaceState(
         workspace_url="https://example.databricks.com",
         claude_models={
-            "sonnet": "databricks-claude-sonnet-5",
-            "sonnet_4_6": "databricks-claude-sonnet-4-6",
+            "sonnet": "databricks-claude-sonnet-4-6",
+            "sonnet_5": "databricks-claude-sonnet-5",
         },
         agents={
             "claude": UcodeAgentState(
-                model="databricks-claude-sonnet-5",
+                model="databricks-claude-sonnet-4-6",
                 base_url="https://example.databricks.com/ai-gateway/anthropic",
                 auth_command="printf token",
             )
@@ -422,9 +423,9 @@ def test_ucode_config_for_profile_sets_custom_model_option_for_second_sonnet(
     config = claude_native._ucode_config_for_profile("test-profile")
 
     assert config is not None
-    assert config.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "databricks-claude-sonnet-5"
-    assert config.env["ANTHROPIC_CUSTOM_MODEL_OPTION"] == "databricks-claude-sonnet-4-6"
-    assert config.env["ANTHROPIC_CUSTOM_MODEL_OPTION_NAME"] == "Sonnet 4.6"
+    assert config.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "databricks-claude-sonnet-4-6"
+    assert config.env["ANTHROPIC_CUSTOM_MODEL_OPTION"] == "databricks-claude-sonnet-5"
+    assert config.env["ANTHROPIC_CUSTOM_MODEL_OPTION_NAME"] == "Sonnet 5"
 
 
 def test_ucode_config_for_profile_omits_model_tier_vars_when_no_claude_models(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -3429,18 +3429,21 @@ def test_model_alias_for_collapses_concrete_id_to_tier_alias() -> None:
     """
     assert forwarder._model_alias_for("claude-opus-4-8") == "opus"
     assert forwarder._model_alias_for("anthropic/claude-opus-4-7") == "opus"
-    assert forwarder._model_alias_for("anthropic/claude-sonnet-5") == "sonnet"
+    # The default Sonnet (4.6) collapses to the generic "sonnet" alias — the
+    # row it is bound to.
+    assert forwarder._model_alias_for("databricks-claude-sonnet-4-6") == "sonnet"
+    assert forwarder._model_alias_for("claude-sonnet-4-6") == "sonnet"
     assert forwarder._model_alias_for("claude-haiku-4-5") == "haiku"
     # Fable (the tier above Opus) collapses to its own alias — a miss
     # here means a TUI switch to claude-fable-5 never reaches the picker.
     assert forwarder._model_alias_for("claude-fable-5") == "fable"
     assert forwarder._model_alias_for("databricks-claude-fable-5") == "fable"
-    # Sonnet 4.6 routes to its own picker slot, not the generic "sonnet"
+    # Sonnet 5 routes to its own opt-in picker slot, not the generic "sonnet"
     # row — both ids contain the substring "sonnet", so a miss here means
-    # a TUI switch to the older Sonnet generation would wrongly light up
-    # the newest-Sonnet row instead.
-    assert forwarder._model_alias_for("databricks-claude-sonnet-4-6") == "sonnet_4_6"
-    assert forwarder._model_alias_for("claude-sonnet-4-6") == "sonnet_4_6"
+    # a TUI switch to the newer Sonnet generation would wrongly light up
+    # the default-Sonnet row instead.
+    assert forwarder._model_alias_for("anthropic/claude-sonnet-5") == "sonnet_5"
+    assert forwarder._model_alias_for("databricks-claude-sonnet-5") == "sonnet_5"
     # Unknown family or empty → None (don't surface an unrenderable id).
     assert forwarder._model_alias_for("gpt-5-4-mini") is None
     assert forwarder._model_alias_for("") is None
@@ -3521,7 +3524,7 @@ async def test_forwarder_mirrors_tui_model_switch_after_baseline(tmp_path: Path)
 
         # User switches model inside the terminal.
         with transcript_path.open("a", encoding="utf-8") as fh:
-            fh.write(_assistant("a2", "claude-sonnet-4-6", "switched") + "\n")
+            fh.write(_assistant("a2", "claude-sonnet-5", "switched") + "\n")
         requests.clear()
         await forwarder._forward_available_items(
             client=client,
@@ -3535,8 +3538,8 @@ async def test_forwarder_mirrors_tui_model_switch_after_baseline(tmp_path: Path)
 
     model_posts = [r for r in requests if r["type"] == "external_model_change"]
     assert len(model_posts) == 1
-    assert model_posts[0]["data"] == {"model": "sonnet_4_6"}
-    assert dedupe.posted_model == "sonnet_4_6"
+    assert model_posts[0]["data"] == {"model": "sonnet_5"}
+    assert dedupe.posted_model == "sonnet_5"
 
 
 @pytest.mark.asyncio
@@ -3615,20 +3618,20 @@ async def test_forwarder_retries_model_post_after_transient_failure(tmp_path: Pa
         assert model_posts == []
         assert dedupe.posted_model == "opus"
 
-        # Poll 2: user switches to sonnet 4.6; the POST fails transiently.
+        # Poll 2: user switches to Sonnet 5; the POST fails transiently.
         with transcript_path.open("a", encoding="utf-8") as fh:
-            fh.write(_assistant("a2", "claude-sonnet-4-6") + "\n")
+            fh.write(_assistant("a2", "claude-sonnet-5") + "\n")
         await _poll()
-        assert model_posts == [{"model": "sonnet_4_6"}]  # attempted once
+        assert model_posts == [{"model": "sonnet_5"}]  # attempted once
         assert dedupe.posted_model == "opus"  # NOT advanced — POST failed
-        assert dedupe.observed_model == "sonnet_4_6"  # but remembered
+        assert dedupe.observed_model == "sonnet_5"  # but remembered
 
         # Poll 3: a plain user turn (no message.model) still retries.
         with transcript_path.open("a", encoding="utf-8") as fh:
             fh.write(_user("u1") + "\n")
         await _poll()
-        assert model_posts == [{"model": "sonnet_4_6"}, {"model": "sonnet_4_6"}]  # retried
-        assert dedupe.posted_model == "sonnet_4_6"  # now committed
+        assert model_posts == [{"model": "sonnet_5"}, {"model": "sonnet_5"}]  # retried
+        assert dedupe.posted_model == "sonnet_5"  # now committed
 
 
 def test_validated_transcript_state_resets_legacy_byte_cursor_without_fingerprint(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -3429,12 +3429,18 @@ def test_model_alias_for_collapses_concrete_id_to_tier_alias() -> None:
     """
     assert forwarder._model_alias_for("claude-opus-4-8") == "opus"
     assert forwarder._model_alias_for("anthropic/claude-opus-4-7") == "opus"
-    assert forwarder._model_alias_for("databricks-claude-sonnet-4-6") == "sonnet"
+    assert forwarder._model_alias_for("anthropic/claude-sonnet-5") == "sonnet"
     assert forwarder._model_alias_for("claude-haiku-4-5") == "haiku"
     # Fable (the tier above Opus) collapses to its own alias — a miss
     # here means a TUI switch to claude-fable-5 never reaches the picker.
     assert forwarder._model_alias_for("claude-fable-5") == "fable"
     assert forwarder._model_alias_for("databricks-claude-fable-5") == "fable"
+    # Sonnet 4.6 routes to its own picker slot, not the generic "sonnet"
+    # row — both ids contain the substring "sonnet", so a miss here means
+    # a TUI switch to the older Sonnet generation would wrongly light up
+    # the newest-Sonnet row instead.
+    assert forwarder._model_alias_for("databricks-claude-sonnet-4-6") == "sonnet_4_6"
+    assert forwarder._model_alias_for("claude-sonnet-4-6") == "sonnet_4_6"
     # Unknown family or empty → None (don't surface an unrenderable id).
     assert forwarder._model_alias_for("gpt-5-4-mini") is None
     assert forwarder._model_alias_for("") is None
@@ -3529,8 +3535,8 @@ async def test_forwarder_mirrors_tui_model_switch_after_baseline(tmp_path: Path)
 
     model_posts = [r for r in requests if r["type"] == "external_model_change"]
     assert len(model_posts) == 1
-    assert model_posts[0]["data"] == {"model": "sonnet"}
-    assert dedupe.posted_model == "sonnet"
+    assert model_posts[0]["data"] == {"model": "sonnet_4_6"}
+    assert dedupe.posted_model == "sonnet_4_6"
 
 
 @pytest.mark.asyncio
@@ -3609,20 +3615,20 @@ async def test_forwarder_retries_model_post_after_transient_failure(tmp_path: Pa
         assert model_posts == []
         assert dedupe.posted_model == "opus"
 
-        # Poll 2: user switches to sonnet; the POST fails transiently.
+        # Poll 2: user switches to sonnet 4.6; the POST fails transiently.
         with transcript_path.open("a", encoding="utf-8") as fh:
             fh.write(_assistant("a2", "claude-sonnet-4-6") + "\n")
         await _poll()
-        assert model_posts == [{"model": "sonnet"}]  # attempted once
+        assert model_posts == [{"model": "sonnet_4_6"}]  # attempted once
         assert dedupe.posted_model == "opus"  # NOT advanced — POST failed
-        assert dedupe.observed_model == "sonnet"  # but remembered
+        assert dedupe.observed_model == "sonnet_4_6"  # but remembered
 
         # Poll 3: a plain user turn (no message.model) still retries.
         with transcript_path.open("a", encoding="utf-8") as fh:
             fh.write(_user("u1") + "\n")
         await _poll()
-        assert model_posts == [{"model": "sonnet"}, {"model": "sonnet"}]  # retried
-        assert dedupe.posted_model == "sonnet"  # now committed
+        assert model_posts == [{"model": "sonnet_4_6"}, {"model": "sonnet_4_6"}]  # retried
+        assert dedupe.posted_model == "sonnet_4_6"  # now committed
 
 
 def test_validated_transcript_state_resets_legacy_byte_cursor_without_fingerprint(

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -725,7 +725,9 @@ def test_subscription_listing_is_static_and_unverified(
     assert listing.verified is False
     # Exactly the curated claude tiers — these are aliases, not a live list.
     assert [m.id for m in listing.models] == [
+        "claude-fable-5",
         "claude-opus-4-8",
+        "claude-sonnet-5",
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
     ]
@@ -980,7 +982,7 @@ def test_catalog_isolates_per_worker_failures(
     # The subscription rows (claude worker + the claude-sdk brain) are
     # unaffected by the gateway outage.
     assert catalog["worker"]["source"] == "static"
-    assert next(m["id"] for m in catalog["worker"]["models"]) == "claude-opus-4-8"
+    assert next(m["id"] for m in catalog["worker"]["models"]) == "claude-fable-5"
     assert catalog["self"]["source"] == "static"
     # The broken worker degrades informatively instead of crashing the tool.
     assert catalog["codex"]["source"] == "none"

--- a/web/src/lib/claudeNativeModels.ts
+++ b/web/src/lib/claudeNativeModels.ts
@@ -12,14 +12,15 @@ export const CLAUDE_NATIVE_MODELS = [
   // Ordered by capability tier, most powerful first.
   { id: "fable", label: "Fable" },
   { id: "opus", label: "Opus" },
-  // The "sonnet" alias tracks the newest Sonnet; labelled with its
-  // version so it reads unambiguously next to the pinned older row.
-  { id: "sonnet", label: "Sonnet 5" },
-  // Older Sonnet generation, kept selectable alongside "sonnet" while
-  // both remain in active use across workspaces/regions. Backed by
-  // Claude Code's one custom /model slot (ANTHROPIC_CUSTOM_MODEL_OPTION),
-  // not a family alias.
-  { id: "sonnet_4_6", label: "Sonnet 4.6" },
+  // The "sonnet" alias stays pinned to the workspace's existing default
+  // Sonnet (4.6); relabelled from the bare "Sonnet" only so it reads
+  // unambiguously next to the opt-in row below. Its model binding is
+  // unchanged — picking this row resolves exactly as it did before.
+  { id: "sonnet", label: "Sonnet 4.6" },
+  // Newer Sonnet, offered as an explicit opt-in via Claude Code's one
+  // custom /model slot (ANTHROPIC_CUSTOM_MODEL_OPTION) — not a family
+  // alias, and it does NOT change the default "sonnet" binding above.
+  { id: "sonnet_5", label: "Sonnet 5" },
   { id: "haiku", label: "Haiku" },
 ] as const;
 

--- a/web/src/lib/claudeNativeModels.ts
+++ b/web/src/lib/claudeNativeModels.ts
@@ -10,14 +10,15 @@
  */
 export const CLAUDE_NATIVE_MODELS = [
   // Ordered by capability tier, most powerful first.
-  // Fable temporarily withheld while Anthropic has Fable access disabled.
-  // { id: "fable", label: "Fable" },
+  { id: "fable", label: "Fable" },
   { id: "opus", label: "Opus" },
-  { id: "sonnet", label: "Sonnet" },
-  // Older Sonnet generation, kept selectable alongside "sonnet" (which
-  // tracks the newest one) while both remain in active use across
-  // workspaces/regions. Backed by Claude Code's one custom /model slot
-  // (ANTHROPIC_CUSTOM_MODEL_OPTION), not a family alias.
+  // The "sonnet" alias tracks the newest Sonnet; labelled with its
+  // version so it reads unambiguously next to the pinned older row.
+  { id: "sonnet", label: "Sonnet 5" },
+  // Older Sonnet generation, kept selectable alongside "sonnet" while
+  // both remain in active use across workspaces/regions. Backed by
+  // Claude Code's one custom /model slot (ANTHROPIC_CUSTOM_MODEL_OPTION),
+  // not a family alias.
   { id: "sonnet_4_6", label: "Sonnet 4.6" },
   { id: "haiku", label: "Haiku" },
 ] as const;
@@ -26,12 +27,10 @@ export const CLAUDE_NATIVE_MODELS = [
  * Is `model` something a Claude Code (claude-native) session can actually
  * run — i.e. a Claude model rather than a foreign harness's id?
  *
- * Accepts the version-agnostic aliases (`opus` / `sonnet` / `haiku`) and
- * any fully-qualified Anthropic id (anything containing `claude`, e.g.
- * `claude-fable-5`, `anthropic/claude-opus-4-8`,
- * `databricks-claude-sonnet-4-6`). The bare `fable` alias no longer
- * matches while Fable is withheld, but pinned `claude-fable-5` sessions
- * still pass via the `claude` branch. Rejects everything else — notably the
+ * Accepts the version-agnostic aliases (`fable` / `opus` / `sonnet` /
+ * `haiku`) and any fully-qualified Anthropic id (anything containing
+ * `claude`, e.g. `claude-fable-5`, `anthropic/claude-opus-4-8`,
+ * `databricks-claude-sonnet-4-6`). Rejects everything else — notably the
  * Codex / OpenAI defaults (`gpt-5.4`, `gpt-5.4-mini`, …) that leak into the
  * cross-harness global picker selection.
  *

--- a/web/src/lib/claudeNativeModels.ts
+++ b/web/src/lib/claudeNativeModels.ts
@@ -14,6 +14,11 @@ export const CLAUDE_NATIVE_MODELS = [
   // { id: "fable", label: "Fable" },
   { id: "opus", label: "Opus" },
   { id: "sonnet", label: "Sonnet" },
+  // Older Sonnet generation, kept selectable alongside "sonnet" (which
+  // tracks the newest one) while both remain in active use across
+  // workspaces/regions. Backed by Claude Code's one custom /model slot
+  // (ANTHROPIC_CUSTOM_MODEL_OPTION), not a family alias.
+  { id: "sonnet_4_6", label: "Sonnet 4.6" },
   { id: "haiku", label: "Haiku" },
 ] as const;
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4994,9 +4994,17 @@ export function shouldShowCodexGoalControl(
  * Highlight a model row when ``selectedModel`` is null by matching the
  * bound spec ``llmModel`` to its tier alias (e.g.
  * ``"anthropic/claude-opus-4-8"`` matches ``"opus"``).
+ *
+ * Sonnet 4.6 is special-cased both ways: its concrete id ("...-sonnet-4-6")
+ * would otherwise substring-match the generic "sonnet" row (since "sonnet"
+ * is itself a substring), and its own row's id ("sonnet_4_6") never
+ * literally appears in a hyphenated concrete id.
  */
 export function isModelImplicitlySelected(modelId: string, llmModel: string | null): boolean {
   if (!llmModel) return false;
+  const isSonnet46 = llmModel.includes("sonnet-4-6") || llmModel.includes("sonnet_4_6");
+  if (modelId === "sonnet_4_6") return isSonnet46;
+  if (modelId === "sonnet" && isSonnet46) return false;
   return llmModel === modelId || llmModel.endsWith(`/${modelId}`) || llmModel.includes(modelId);
 }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4995,16 +4995,17 @@ export function shouldShowCodexGoalControl(
  * bound spec ``llmModel`` to its tier alias (e.g.
  * ``"anthropic/claude-opus-4-8"`` matches ``"opus"``).
  *
- * Sonnet 4.6 is special-cased both ways: its concrete id ("...-sonnet-4-6")
+ * Sonnet 5 is special-cased both ways: its concrete id ("...-sonnet-5")
  * would otherwise substring-match the generic "sonnet" row (since "sonnet"
- * is itself a substring), and its own row's id ("sonnet_4_6") never
- * literally appears in a hyphenated concrete id.
+ * is itself a substring), and its own opt-in row id ("sonnet_5") never
+ * literally appears in a hyphenated concrete id. The default "sonnet" row
+ * stays bound to the older Sonnet (4.6), which collapses to it normally.
  */
 export function isModelImplicitlySelected(modelId: string, llmModel: string | null): boolean {
   if (!llmModel) return false;
-  const isSonnet46 = llmModel.includes("sonnet-4-6") || llmModel.includes("sonnet_4_6");
-  if (modelId === "sonnet_4_6") return isSonnet46;
-  if (modelId === "sonnet" && isSonnet46) return false;
+  const isSonnet5 = llmModel.includes("sonnet-5") || llmModel.includes("sonnet_5");
+  if (modelId === "sonnet_5") return isSonnet5;
+  if (modelId === "sonnet" && isSonnet5) return false;
   return llmModel === modelId || llmModel.endsWith(`/${modelId}`) || llmModel.includes(modelId);
 }
 

--- a/web/src/pages/modelPicker.test.ts
+++ b/web/src/pages/modelPicker.test.ts
@@ -45,11 +45,11 @@ describe("CLAUDE_NATIVE_MODELS", () => {
     // the installed version supports, so the list never drifts. Guard
     // against a regression back to version-numbered IDs.
     const ids = CLAUDE_NATIVE_MODELS.map((m) => m.id);
-    // Capability order, most powerful first. Fable is temporarily withheld.
-    // "sonnet_4_6" is the one exception: Claude Code's single custom
-    // /model slot pinned to a concrete older Sonnet generation, kept
-    // selectable alongside the "sonnet" alias while both are in use.
-    expect(ids).toEqual(["opus", "sonnet", "sonnet_4_6", "haiku"]);
+    // Capability order, most powerful first. "sonnet_4_6" is the one
+    // exception: Claude Code's single custom /model slot pinned to a
+    // concrete older Sonnet generation, kept selectable alongside the
+    // "sonnet" alias while both are in use.
+    expect(ids).toEqual(["fable", "opus", "sonnet", "sonnet_4_6", "haiku"]);
     for (const id of ids) {
       if (id === "sonnet_4_6") continue;
       expect(id).not.toMatch(/\d/); // an alias carries no version digits
@@ -58,8 +58,9 @@ describe("CLAUDE_NATIVE_MODELS", () => {
 
   it("labels each alias by tier", () => {
     expect(CLAUDE_NATIVE_MODELS.map((m) => m.label)).toEqual([
+      "Fable",
       "Opus",
-      "Sonnet",
+      "Sonnet 5",
       "Sonnet 4.6",
       "Haiku",
     ]);

--- a/web/src/pages/modelPicker.test.ts
+++ b/web/src/pages/modelPicker.test.ts
@@ -45,13 +45,13 @@ describe("CLAUDE_NATIVE_MODELS", () => {
     // the installed version supports, so the list never drifts. Guard
     // against a regression back to version-numbered IDs.
     const ids = CLAUDE_NATIVE_MODELS.map((m) => m.id);
-    // Capability order, most powerful first. "sonnet_4_6" is the one
-    // exception: Claude Code's single custom /model slot pinned to a
-    // concrete older Sonnet generation, kept selectable alongside the
-    // "sonnet" alias while both are in use.
-    expect(ids).toEqual(["fable", "opus", "sonnet", "sonnet_4_6", "haiku"]);
+    // Capability order, most powerful first. "sonnet_5" is the one
+    // exception: Claude Code's single custom /model slot, an opt-in for the
+    // newer Sonnet offered alongside the default "sonnet" alias (which stays
+    // bound to 4.6). The default alias is unchanged.
+    expect(ids).toEqual(["fable", "opus", "sonnet", "sonnet_5", "haiku"]);
     for (const id of ids) {
-      if (id === "sonnet_4_6") continue;
+      if (id === "sonnet_5") continue;
       expect(id).not.toMatch(/\d/); // an alias carries no version digits
     }
   });
@@ -60,8 +60,8 @@ describe("CLAUDE_NATIVE_MODELS", () => {
     expect(CLAUDE_NATIVE_MODELS.map((m) => m.label)).toEqual([
       "Fable",
       "Opus",
-      "Sonnet 5",
       "Sonnet 4.6",
+      "Sonnet 5",
       "Haiku",
     ]);
   });
@@ -98,7 +98,8 @@ describe("isModelImplicitlySelected", () => {
     // version (4.7) must not break matching — both resolve to the tier.
     expect(isModelImplicitlySelected("opus", "anthropic/claude-opus-4-8")).toBe(true);
     expect(isModelImplicitlySelected("opus", "anthropic/claude-opus-4-7")).toBe(true);
-    expect(isModelImplicitlySelected("sonnet", "anthropic/claude-sonnet-5")).toBe(true);
+    // The default "sonnet" row is bound to 4.6, so a 4.6 pin lights it up.
+    expect(isModelImplicitlySelected("sonnet", "anthropic/claude-sonnet-4-6")).toBe(true);
     // Fable's concrete id (claude-fable-5) must light up the "fable" row.
     expect(isModelImplicitlySelected("fable", "anthropic/claude-fable-5")).toBe(true);
     // ucode gateway IDs carry the tier token too, so the same row lights up.
@@ -110,14 +111,15 @@ describe("isModelImplicitlySelected", () => {
     expect(isModelImplicitlySelected("opus", "opus")).toBe(true);
   });
 
-  it("routes Sonnet 4.6 to its own row instead of the generic Sonnet row", () => {
-    // Both ids happen to contain the substring "sonnet", so the generic
-    // "sonnet" row must not also light up for a 4.6 pin.
-    expect(isModelImplicitlySelected("sonnet_4_6", "anthropic/claude-sonnet-4-6")).toBe(true);
-    expect(isModelImplicitlySelected("sonnet", "anthropic/claude-sonnet-4-6")).toBe(false);
-    expect(isModelImplicitlySelected("sonnet_4_6", "databricks-claude-sonnet-4-6")).toBe(true);
-    // A 4.6 id must not light up the "sonnet_4_6" row for the newest Sonnet.
-    expect(isModelImplicitlySelected("sonnet_4_6", "anthropic/claude-sonnet-5")).toBe(false);
+  it("routes Sonnet 5 to its own opt-in row instead of the default Sonnet row", () => {
+    // Both ids happen to contain the substring "sonnet", so the default
+    // "sonnet" row (4.6) must not also light up for a Sonnet 5 pin.
+    expect(isModelImplicitlySelected("sonnet_5", "anthropic/claude-sonnet-5")).toBe(true);
+    expect(isModelImplicitlySelected("sonnet", "anthropic/claude-sonnet-5")).toBe(false);
+    expect(isModelImplicitlySelected("sonnet_5", "databricks-claude-sonnet-5")).toBe(true);
+    // The default 4.6 lights the generic "sonnet" row, never the opt-in row.
+    expect(isModelImplicitlySelected("sonnet", "anthropic/claude-sonnet-4-6")).toBe(true);
+    expect(isModelImplicitlySelected("sonnet_5", "anthropic/claude-sonnet-4-6")).toBe(false);
   });
 
   it("does not cross-match a different tier", () => {

--- a/web/src/pages/modelPicker.test.ts
+++ b/web/src/pages/modelPicker.test.ts
@@ -46,14 +46,23 @@ describe("CLAUDE_NATIVE_MODELS", () => {
     // against a regression back to version-numbered IDs.
     const ids = CLAUDE_NATIVE_MODELS.map((m) => m.id);
     // Capability order, most powerful first. Fable is temporarily withheld.
-    expect(ids).toEqual(["opus", "sonnet", "haiku"]);
+    // "sonnet_4_6" is the one exception: Claude Code's single custom
+    // /model slot pinned to a concrete older Sonnet generation, kept
+    // selectable alongside the "sonnet" alias while both are in use.
+    expect(ids).toEqual(["opus", "sonnet", "sonnet_4_6", "haiku"]);
     for (const id of ids) {
+      if (id === "sonnet_4_6") continue;
       expect(id).not.toMatch(/\d/); // an alias carries no version digits
     }
   });
 
   it("labels each alias by tier", () => {
-    expect(CLAUDE_NATIVE_MODELS.map((m) => m.label)).toEqual(["Opus", "Sonnet", "Haiku"]);
+    expect(CLAUDE_NATIVE_MODELS.map((m) => m.label)).toEqual([
+      "Opus",
+      "Sonnet",
+      "Sonnet 4.6",
+      "Haiku",
+    ]);
   });
 });
 
@@ -88,7 +97,7 @@ describe("isModelImplicitlySelected", () => {
     // version (4.7) must not break matching — both resolve to the tier.
     expect(isModelImplicitlySelected("opus", "anthropic/claude-opus-4-8")).toBe(true);
     expect(isModelImplicitlySelected("opus", "anthropic/claude-opus-4-7")).toBe(true);
-    expect(isModelImplicitlySelected("sonnet", "anthropic/claude-sonnet-4-6")).toBe(true);
+    expect(isModelImplicitlySelected("sonnet", "anthropic/claude-sonnet-5")).toBe(true);
     // Fable's concrete id (claude-fable-5) must light up the "fable" row.
     expect(isModelImplicitlySelected("fable", "anthropic/claude-fable-5")).toBe(true);
     // ucode gateway IDs carry the tier token too, so the same row lights up.
@@ -98,6 +107,16 @@ describe("isModelImplicitlySelected", () => {
 
   it("matches when llmModel is already the bare alias", () => {
     expect(isModelImplicitlySelected("opus", "opus")).toBe(true);
+  });
+
+  it("routes Sonnet 4.6 to its own row instead of the generic Sonnet row", () => {
+    // Both ids happen to contain the substring "sonnet", so the generic
+    // "sonnet" row must not also light up for a 4.6 pin.
+    expect(isModelImplicitlySelected("sonnet_4_6", "anthropic/claude-sonnet-4-6")).toBe(true);
+    expect(isModelImplicitlySelected("sonnet", "anthropic/claude-sonnet-4-6")).toBe(false);
+    expect(isModelImplicitlySelected("sonnet_4_6", "databricks-claude-sonnet-4-6")).toBe(true);
+    // A 4.6 id must not light up the "sonnet_4_6" row for the newest Sonnet.
+    expect(isModelImplicitlySelected("sonnet_4_6", "anthropic/claude-sonnet-5")).toBe(false);
   });
 
   it("does not cross-match a different tier", () => {


### PR DESCRIPTION
## Related issue

Closes #2026

## Summary

- Adds `claude-fable-5` and `claude-sonnet-5` to the curated Claude subscription
  model list (`_SUBSCRIPTION_STATIC_MODELS`), keeping `claude-sonnet-4-6` since
  Sonnet 4.6 remains the only Sonnet available in some regions/workspaces.
- Surfaces **Sonnet 4.6 as a distinct picker option** alongside Sonnet 5.
  Claude Code's `/model` picker has one fixed alias per family plus exactly one
  custom slot (`ANTHROPIC_CUSTOM_MODEL_OPTION`); the newest Sonnet keeps the
  `sonnet` family alias (labelled "Sonnet 5") and 4.6 takes the custom slot, so
  neither generation shadows the other.
- Re-enables the **Fable** picker row now that Anthropic has restored Fable
  access.

### How the two Sonnets flow through

```
ucode state.json claude_models          Claude Code env            picker row
  "sonnet":     claude-sonnet-5    →  ANTHROPIC_DEFAULT_SONNET_MODEL  →  Sonnet 5
  "sonnet_4_6": claude-sonnet-4-6  →  ANTHROPIC_CUSTOM_MODEL_OPTION   →  Sonnet 4.6
```

Both ids contain the substring `"sonnet"`, so the tier-collapsing helpers
(`_model_alias_for`, `isModelImplicitlySelected`) now check for the 4.6 spelling
before the generic match — otherwise a 4.6 pick would light up the Sonnet 5 row.

## Test Plan

- `uv run pytest tests/test_model_catalog.py tests/test_claude_native.py tests/test_claude_native_forwarder.py tests/runner/test_runner_dispatch.py -q` — all pass (411 + 40), including a new test for the `ANTHROPIC_CUSTOM_MODEL_OPTION` env wiring.
- `npx vitest run src/pages/modelPicker.test.ts src/pages/ChatPage.composer.test.tsx` — 65/65 pass, including new disambiguation cases for `sonnet_4_6` vs `sonnet`.
- `npx tsc --noEmit` — clean.
- `uv run pytest tests/e2e_ui/chat/test_claude_model_picker.py` — new Playwright
  e2e_ui test, 2/2 pass against the real built SPA + server: asserts the five
  picker rows/labels, that a bound `databricks-claude-sonnet-4-6` model
  highlights the Sonnet 4.6 row (not the generic Sonnet row), and that picking
  Sonnet 4.6 PATCHes `model_override` and updates the trigger label.
- Live end-to-end: booted an isolated local server + host, launched a real
  claude-native session, opened the picker (screenshot below), selected
  "Sonnet 4.6", and confirmed the composer reflects the pick.

## Demo

Live claude-native session with the picker open — Fable / Opus / Sonnet 5 /
Sonnet 4.6 (active) / Haiku:

<img width="3024" height="1610" alt="omnigent-model-picker-final" src="https://github.com/user-attachments/assets/fbdc45ed-276c-48b6-9815-43bdbcfed684" />


<!-- drag omnigent-model-picker-final.png here -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: drove the real app end-to-end (local server + host +
live Claude Code session) to confirm the picker renders all five rows and a
Sonnet 4.6 selection applies and persists. The env-var handoff to Claude Code's
own in-terminal `/model` picker depends on ucode publishing a `sonnet_4_6` key
in `claude_models`, which is a follow-up in the ucode repo — until then the
custom-slot code path is a no-op (covered by unit test).

## Changelog

The Claude model picker now offers Fable and both Sonnet generations (Sonnet 5 and Sonnet 4.6) as separate selections
