### PR TITLE
fix(harnesses): reap the runner subprocess when spawn is cancelled mid-bind

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1045,41 +1045,62 @@ class HarnessProcessManager:
             stderr=None,
             env=effective_env,
         )
-        await _wait_for_bind(process, endpoint, harness, conversation_id)
+        try:
+            await _wait_for_bind(process, endpoint, harness, conversation_id)
 
-        # ``base_url`` is required for relative-URL routing; the
-        # actual host portion is irrelevant under uds transport,
-        # but httpx insists on a syntactically-valid URL. The
-        # default httpx read-timeout (5s) is too short for SSE
-        # streams that may pause for tens of seconds during
-        # tool dispatch round-trips (action_required → AP
-        # call_tool → PATCH → resume); use a generous fixed
-        # timeout that still surfaces a genuinely-stuck harness.
-        client = httpx.AsyncClient(
-            transport=endpoint.make_transport(),
-            base_url=endpoint.base_url,
-            # S1 (security): present the per-spawn bearer token (Windows only)
-            # so the harness scaffold accepts this client and rejects any
-            # unauthenticated local peer on the loopback-TCP channel. Empty on
-            # POSIX, where the uid-isolated UDS is the access boundary.
-            headers=({"Authorization": f"Bearer {auth_token}"} if auth_token else {}),
-            # See the comment above the constant for rationale.
-            # Connect/write/pool keep the 5s default so a vanished
-            # harness still surfaces quickly; read=None defers
-            # liveness to the heartbeat path.
-            timeout=httpx.Timeout(5.0, read=None),
-        )
-        return _SubprocessEntry(
-            process=process,
-            client=client,
-            endpoint=endpoint,
-            harness=harness,
-            # Record the model this subprocess was spawned with so a later
-            # turn requesting a different model (e.g. after ``/model``)
-            # triggers a respawn in ``get_client`` — the model is a fixed
-            # process env var, not re-read per turn.
-            model=(env or {}).get(_model_env_key(harness)),
-        )
+            # ``base_url`` is required for relative-URL routing; the
+            # actual host portion is irrelevant under uds transport,
+            # but httpx insists on a syntactically-valid URL. The
+            # default httpx read-timeout (5s) is too short for SSE
+            # streams that may pause for tens of seconds during
+            # tool dispatch round-trips (action_required → AP
+            # call_tool → PATCH → resume); use a generous fixed
+            # timeout that still surfaces a genuinely-stuck harness.
+            client = httpx.AsyncClient(
+                transport=endpoint.make_transport(),
+                base_url=endpoint.base_url,
+                # S1 (security): present the per-spawn bearer token (Windows only)
+                # so the harness scaffold accepts this client and rejects any
+                # unauthenticated local peer on the loopback-TCP channel. Empty on
+                # POSIX, where the uid-isolated UDS is the access boundary.
+                headers=({"Authorization": f"Bearer {auth_token}"} if auth_token else {}),
+                # See the comment above the constant for rationale.
+                # Connect/write/pool keep the 5s default so a vanished
+                # harness still surfaces quickly; read=None defers
+                # liveness to the heartbeat path.
+                timeout=httpx.Timeout(5.0, read=None),
+            )
+            return _SubprocessEntry(
+                process=process,
+                client=client,
+                endpoint=endpoint,
+                harness=harness,
+                # Record the model this subprocess was spawned with so a later
+                # turn requesting a different model (e.g. after ``/model``)
+                # triggers a respawn in ``get_client`` — the model is a fixed
+                # process env var, not re-read per turn.
+                model=(env or {}).get(_model_env_key(harness)),
+            )
+        except BaseException:
+            # From spawn onward the process must have exactly one owner:
+            # either it reaches the caller (who registers it in ``_entries``)
+            # or it dies here. A cancellation landing in ``_wait_for_bind``
+            # (e.g. the turn task cancelled during cold start) would
+            # otherwise leak a live runner that ``release`` no-ops on and
+            # the idle reaper — which only walks ``_entries`` — never sees.
+            if process.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+                # Shield the corpse-wait so a second cancellation cannot
+                # abandon the reap halfway; the pending cancellation is
+                # re-raised below regardless.
+                with contextlib.suppress(BaseException):
+                    await asyncio.shield(process.wait())
+            with contextlib.suppress(Exception):
+                close_subprocess_transport(process)
+            with contextlib.suppress(Exception):
+                endpoint.cleanup()
+            raise
 
     async def _close_entry(self, entry: _SubprocessEntry) -> None:
         """

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -1025,3 +1025,120 @@ async def test_orphan_sweep_escalates_to_sigkill(
 
     assert calls == 2
     assert killed == [(12345, signal.SIGTERM), (12345, signal.SIGKILL)]
+
+
+# ── Mid-spawn cancellation ──────────────────────────────────────
+
+
+async def test_mid_spawn_cancellation_reaps_subprocess(
+    manager: HarnessProcessManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Cancelling ``get_client`` while the spawn is still waiting for
+    the runner to bind must kill the just-spawned subprocess.
+
+    The subprocess exists from ``create_subprocess_exec`` onward but
+    is only registered in ``_entries`` after ``_spawn_entry``
+    returns; a cancellation landing inside ``_wait_for_bind`` used
+    to leak it — unregistered, so ``release()`` no-ops and the idle
+    reaper never sees it.
+    """
+    from omnigent.runtime.harnesses import process_manager as pm_mod
+
+    await manager.start()
+    try:
+        spawned: list[asyncio.subprocess.Process] = []
+        real_exec = asyncio.create_subprocess_exec
+
+        async def capturing_exec(*args: object, **kwargs: object) -> asyncio.subprocess.Process:
+            process = await real_exec(*args, **kwargs)  # type: ignore[arg-type]
+            spawned.append(process)
+            return process
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", capturing_exec)
+
+        in_bind = asyncio.Event()
+
+        async def hanging_bind(*args: object, **kwargs: object) -> None:
+            in_bind.set()
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(pm_mod, "_wait_for_bind", hanging_bind)
+
+        task = asyncio.create_task(manager.get_client("conv_leak", "test"))
+        await asyncio.wait_for(in_bind.wait(), timeout=10.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert spawned, "spawn was never reached"
+        process = spawned[0]
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5.0)
+        finally:
+            # Never leak the subprocess out of the test, even when
+            # the assertion below is about to fail on main.
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
+        assert process.returncode is not None
+        assert not manager.has_session("conv_leak")
+    finally:
+        await manager.shutdown()
+
+
+async def test_mid_spawn_double_cancellation_still_reaps(
+    manager: HarnessProcessManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A second cancellation arriving while the first one's cleanup is
+    reaping the subprocess must not abort the reap: the corpse-wait
+    is shielded, so the process is still collected and the task
+    still ends cancelled.
+    """
+    from omnigent.runtime.harnesses import process_manager as pm_mod
+
+    await manager.start()
+    try:
+        spawned: list[asyncio.subprocess.Process] = []
+        real_exec = asyncio.create_subprocess_exec
+
+        async def capturing_exec(*args: object, **kwargs: object) -> asyncio.subprocess.Process:
+            process = await real_exec(*args, **kwargs)  # type: ignore[arg-type]
+            spawned.append(process)
+            return process
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", capturing_exec)
+
+        in_bind = asyncio.Event()
+
+        async def hanging_bind(*args: object, **kwargs: object) -> None:
+            in_bind.set()
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(pm_mod, "_wait_for_bind", hanging_bind)
+
+        task = asyncio.create_task(manager.get_client("conv_leak2", "test"))
+        await asyncio.wait_for(in_bind.wait(), timeout=10.0)
+        task.cancel()
+        # Let the first cancellation reach the cleanup path, then
+        # cancel again so the second one lands on its awaits.
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert spawned, "spawn was never reached"
+        process = spawned[0]
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5.0)
+        finally:
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
+        assert process.returncode is not None
+        assert not manager.has_session("conv_leak2")
+    finally:
+        await manager.shutdown()


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Cancelling a turn task while `_spawn_entry` is still waiting in `_wait_for_bind` (session delete during cold start, sub-agent teardown, AP shutdown) leaked the just-spawned runner subprocess: it exists from `create_subprocess_exec` onward but is only registered in `_entries` after `_spawn_entry` returns, so `release()` no-ops on the conversation and the idle reaper — which only walks `_entries` — never sees it. The orphan (~100 MB per the regression test's own peak-RSS meter) lives until the AP daemon itself exits.
- Fix: wrap everything after the spawn in `try/except BaseException` and reap on any unwind — kill, shield the corpse-wait against a second cancellation, close the subprocess transport, remove the socket file, re-raise. The bind-timeout path already kills before raising; this extends the same ownership discipline to cancellation and any other unwind.

ELI5: the manager phones up a chef (spawns a runner) and only writes him into the staff register once he walks in. If the customer cancels while the chef is still on his way, the manager used to just walk off — the chef still arrives, is on nobody's register, and stands in the kitchen forever. Now the manager waits at the door and politely sends him home.

```
create_subprocess_exec ──► _wait_for_bind ──► register in _entries
        │                       │ (1-30s of await points)
        │                       └── CancelledError lands here
        └── process is ALIVE but on no register:
            release() no-ops · reaper can't see it · leaks until AP exits
```

Why the guard is airtight: between `_wait_for_bind` returning and registration in `get_client` there is no await point, so cancellation can only land inside the guarded region. Already-dead arrivals (exited-during-spawn, bind timeout) skip the kill via the `returncode` check.

## Test Plan

- New regression test `test_mid_spawn_cancellation_reaps_subprocess`: hangs `_wait_for_bind`, cancels `get_client` mid-spawn, asserts the captured subprocess is reaped and the session is unregistered. Red on `main` (times out waiting for the process to die; pytest's peak-RSS meter shows the leaked runner at ~109 MB), green with the fix.
- `test_mid_spawn_double_cancellation_still_reaps`: a second cancellation landing during cleanup must not abandon the reap (covers the `asyncio.shield` on the corpse-wait).
- Full `tests/runtime/harnesses/` suite: 126 passed.

## Demo

Red → green on the regression test (the ~109 MB peak-RSS delta in the red run is the leaked runner itself):
<img width="2400" height="1352" alt="omnigent-1982-demo" src="https://github.com/user-attachments/assets/647e779f-0e01-4716-a0f0-c7197afd843e" />


```text
# main @ b9332cc6 — RED: cancelled mid-spawn, the subprocess survives
$ python -m pytest tests/runtime/harnesses/test_process_manager.py -k mid_spawn -q
E               TimeoutError          # process.wait() times out — leaked runner still alive
+  109.0 MB  test_mid_spawn_cancellation_reaps_subprocess   # peak-RSS: the orphan's footprint
2 failed, 30 deselected in 10.15s

# with this PR — GREEN: the corpse-wait completes instantly
$ python -m pytest tests/runtime/harnesses/test_process_manager.py -k mid_spawn -q
2 passed, 30 deselected in 0.04s
$ python -m pytest tests/runtime/harnesses/ -q
126 passed, 1 warning in 44.65s
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two new tests drive the cancellation path end-to-end against a real spawned runner; the existing process-manager suite covers the untouched success/timeout paths.

## Changelog

Cancelling or deleting a session during agent cold start no longer leaks the harness subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
