### PR TITLE
fix(cli): guard headless -p turns against a lost terminal SSE event

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2166,13 +2166,41 @@ async def _query_sessions_once(
     # interactive REPL is immune by construction (it renders a ``failed``
     # status as a transient error and polls the snapshot as a backstop),
     # so this brings headless ``-p`` to parity.
+    # Race-window guard for the first turn, mirroring the multi-turn loop's
+    # ``_PER_TURN_TIMEOUT_S`` below (defined here too since this call
+    # precedes that loop). Two failure modes are already reconciled via
+    # ``_persisted_turn_text`` above: an ``OmnigentError`` (session flipped
+    # to ``failed``) and an empty ``result.text`` (subscribe-after-post
+    # race where the SSE subscription missed ``response.completed`` but
+    # the connection closed promptly). A THIRD variant of the same race is
+    # NOT an error and does NOT close the connection: the runner's
+    # terminal event is dropped, but the stream's periodic heartbeats
+    # (``session.heartbeat``, not a turn-terminal event) keep arriving on
+    # schedule forever, so ``SessionsChat.send`` never raises and never
+    # returns — it awaits a terminal event that will never come. Without a
+    # bound here, a lost terminal event hangs the CLI indefinitely even
+    # though the runner already completed and persisted the turn
+    # server-side. ``asyncio.wait_for`` cancels the underlying ``send()``
+    # generator on timeout, which runs its ``finally`` and closes the SSE
+    # subscription cleanly.
+    _PER_TURN_TIMEOUT_S = 120.0  # race-window guard per synthesis turn
     try:
-        result = await chat.query(prompt)
+        result = await asyncio.wait_for(chat.query(prompt), timeout=_PER_TURN_TIMEOUT_S)
     except ClientOmnigentError:
         reconciled = await _persisted_turn_text(client, bound.id)
         if reconciled is not None:
             return reconciled
         raise
+    except TimeoutError:
+        reconciled = await _persisted_turn_text(client, bound.id)
+        if reconciled is not None:
+            return reconciled
+        raise RuntimeError(
+            f"Turn did not complete within {_PER_TURN_TIMEOUT_S:.0f}s and no "
+            "persisted assistant text was found to reconcile against "
+            "(subscribe-after-post race: the terminal event was lost and "
+            "the runner appears not to have completed either)."
+        ) from None
     all_text_parts: list[str] = []
     if result.text:
         all_text_parts.append(result.text)
@@ -2218,7 +2246,8 @@ async def _query_sessions_once(
     # even when await_turn times out (sub-agents still running), unlike the
     # last_turn_saw_waiting flag which would incorrectly exit on timeout.
     _STATUS_PROBE_TIMEOUT_S = 5.0  # brief window; status events arrive fast
-    _PER_TURN_TIMEOUT_S = 120.0  # race-window guard per synthesis turn
+    # _PER_TURN_TIMEOUT_S is defined above, ahead of the first-turn query,
+    # so it also guards that call; reused here for the extra-turns loop.
     _LOOP_TIMEOUT_S = 1800.0  # 30 min total
 
     async def _drain_extra_turns() -> None:

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -107,6 +107,17 @@ _REMOTE_RUNNER_STOP_GRACE_SECONDS = 8.0
 # tracks the end of the conversation, not its start.
 _RECONCILE_ITEMS_LIMIT = 100
 
+# Race-window guard for each headless ``-p`` turn wait (the first turn
+# and the extra-turns loop). Expiry alone does not end the turn — the
+# session status decides whether to keep waiting (turn still running)
+# or reconcile against the durable transcript (terminal event lost).
+# Module-level so tests can patch it.
+_PER_TURN_TIMEOUT_S = 120.0
+
+# Overall budget for following one headless ``-p`` session to idle
+# (first-turn recovery and the extra-turns loop share it).
+_LOOP_TIMEOUT_S = 1800.0  # 30 min total
+
 # Optional bearer token for remote omnigent servers that sit
 # behind an auth proxy (for example Databricks Apps). When set, the
 # CLI sends ``Authorization: Bearer <value>`` on every HTTP request it
@@ -2166,24 +2177,22 @@ async def _query_sessions_once(
     # interactive REPL is immune by construction (it renders a ``failed``
     # status as a transient error and polls the snapshot as a backstop),
     # so this brings headless ``-p`` to parity.
-    # Race-window guard for the first turn, mirroring the multi-turn loop's
-    # ``_PER_TURN_TIMEOUT_S`` below (defined here too since this call
-    # precedes that loop). Two failure modes are already reconciled via
-    # ``_persisted_turn_text`` above: an ``OmnigentError`` (session flipped
-    # to ``failed``) and an empty ``result.text`` (subscribe-after-post
-    # race where the SSE subscription missed ``response.completed`` but
-    # the connection closed promptly). A THIRD variant of the same race is
-    # NOT an error and does NOT close the connection: the runner's
-    # terminal event is dropped, but the stream's periodic heartbeats
-    # (``session.heartbeat``, not a turn-terminal event) keep arriving on
-    # schedule forever, so ``SessionsChat.send`` never raises and never
-    # returns — it awaits a terminal event that will never come. Without a
+    # Race-window guard for the first turn, mirroring the multi-turn
+    # loop's use of ``_PER_TURN_TIMEOUT_S`` below. Two failure modes are
+    # already reconciled via ``_persisted_turn_text``: an
+    # ``OmnigentError`` (session flipped to ``failed``) and an empty
+    # ``result.text`` (subscribe-after-post race where the SSE
+    # subscription missed ``response.completed`` but the connection
+    # closed promptly). A THIRD variant of the same race is NOT an error
+    # and does NOT close the connection: the runner's terminal event is
+    # dropped, but the stream's periodic heartbeats (``session.heartbeat``,
+    # not a turn-terminal event) keep arriving on schedule forever, so
+    # ``SessionsChat.send`` never raises and never returns. Without a
     # bound here, a lost terminal event hangs the CLI indefinitely even
     # though the runner already completed and persisted the turn
     # server-side. ``asyncio.wait_for`` cancels the underlying ``send()``
     # generator on timeout, which runs its ``finally`` and closes the SSE
     # subscription cleanly.
-    _PER_TURN_TIMEOUT_S = 120.0  # race-window guard per synthesis turn
     try:
         result = await asyncio.wait_for(chat.query(prompt), timeout=_PER_TURN_TIMEOUT_S)
     except ClientOmnigentError:
@@ -2192,6 +2201,28 @@ async def _query_sessions_once(
             return reconciled
         raise
     except TimeoutError:
+        # The guard tripping does NOT mean the turn is over: a healthy
+        # first turn can simply outlast it (long generation, slow
+        # tools), and the server persists each assistant item as it
+        # completes, so reconciling immediately would return a
+        # mid-turn fragment as if it were the final answer. The session
+        # status distinguishes the two cases: keep waiting while the
+        # runner reports the turn in flight (mirroring the extra-turns
+        # loop below, which refreshes and continues on ``await_turn``
+        # timeouts), and reconcile only once the session is no longer
+        # running or the overall budget expires. ``await_turn`` here is
+        # a status-change waiter; its text (at most the tail of the
+        # turn, since the subscription is fresh) is discarded because
+        # the transcript read below returns the whole turn's output.
+        # An async orchestrator stays ``running`` until its sub-agents
+        # and synthesis finish, so this also follows those to idle.
+        with contextlib.suppress(TimeoutError):
+            async with asyncio.timeout(_LOOP_TIMEOUT_S):
+                while True:
+                    await chat.refresh()
+                    if chat.status not in ("running", "launching"):
+                        break
+                    await chat.await_turn(timeout=_PER_TURN_TIMEOUT_S)
         reconciled = await _persisted_turn_text(client, bound.id)
         if reconciled is not None:
             return reconciled
@@ -2246,9 +2277,8 @@ async def _query_sessions_once(
     # even when await_turn times out (sub-agents still running), unlike the
     # last_turn_saw_waiting flag which would incorrectly exit on timeout.
     _STATUS_PROBE_TIMEOUT_S = 5.0  # brief window; status events arrive fast
-    # _PER_TURN_TIMEOUT_S is defined above, ahead of the first-turn query,
-    # so it also guards that call; reused here for the extra-turns loop.
-    _LOOP_TIMEOUT_S = 1800.0  # 30 min total
+    # ``_PER_TURN_TIMEOUT_S`` / ``_LOOP_TIMEOUT_S`` are module-level;
+    # they also guard the first-turn query above.
 
     async def _drain_extra_turns() -> None:
         # Probe: collect synthesis text or status events that arrive quickly.

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -3682,6 +3682,105 @@ async def test_query_sessions_once_multi_turn_async_orchestrator(
     assert "Looks good." in result
 
 
+async def _never_return(_prompt: str) -> QueryResult:
+    """Simulate the lost-terminal-event race: heartbeats keep the SSE
+    iterator alive, so ``query`` neither returns nor raises."""
+    await asyncio.Event().wait()
+    raise AssertionError("unreachable")
+
+
+async def test_query_sessions_once_reconciles_on_lost_terminal_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The third race variant — ``query`` never returns because the terminal
+    event was lost while heartbeats keep the subscription alive — recovers
+    the persisted text once the guard fires and the session reports idle.
+
+    If this fails, a lost terminal event hangs headless ``-p`` forever.
+    """
+    monkeypatch.setattr(chat_module, "_PER_TURN_TIMEOUT_S", 0.05)
+    client = _FakeAPClient([_item_user("say hi"), _item_assistant("hi there")])
+    result = await asyncio.wait_for(_run_one_shot(client, _never_return, monkeypatch), timeout=10)
+    assert result == "hi there"
+
+
+async def test_query_sessions_once_raises_on_lost_terminal_event_without_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A guard trip on an idle session with no persisted output raises loud.
+
+    If this fails, a turn that genuinely produced nothing would be
+    reported as a silent empty success after the guard fires.
+    """
+    monkeypatch.setattr(chat_module, "_PER_TURN_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(chat_module, "_LOOP_TIMEOUT_S", 5.0)
+    client = _FakeAPClient([_item_user("say hi")])
+    with pytest.raises(RuntimeError, match=r"no\s+persisted assistant text"):
+        await asyncio.wait_for(_run_one_shot(client, _never_return, monkeypatch), timeout=10)
+
+
+async def test_query_sessions_once_slow_first_turn_not_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A healthy first turn that outlasts the guard is not cut short.
+
+    The server persists each assistant item as it completes, so a
+    mid-turn fragment is already readable when the guard fires. The
+    recovery path must keep waiting while the session reports
+    ``running`` and reconcile only once it goes idle — returning the
+    whole turn's output, not the fragment.
+
+    If this fails, headless ``-p`` silently truncates any first turn
+    longer than the guard window (exit 0, partial answer).
+    """
+    monkeypatch.setattr(chat_module, "_PER_TURN_TIMEOUT_S", 0.05)
+    client = _FakeAPClient(
+        [_item_user("do the big refactor"), _item_assistant("intermediate note")]
+    )
+
+    class _SlowTurnChat:
+        """Turn still in flight when the guard fires; finishes two
+        status polls later, appending its final message to the
+        transcript like the server's incremental item persistence."""
+
+        def __init__(self, **_kwargs: object) -> None:
+            self._polls_left = 2
+            self._status = "running"
+
+        @property
+        def status(self) -> str:
+            return self._status
+
+        async def refresh(self) -> None:
+            pass
+
+        async def query(self, prompt: str) -> QueryResult:
+            return await _never_return(prompt)
+
+        async def await_turn(self, *, timeout: float | None = None) -> QueryResult:
+            self._polls_left -= 1
+            if self._polls_left <= 0:
+                client.sessions._items.append(_item_assistant("FULL final answer"))
+                self._status = "idle"
+            return QueryResult(text="", files=[])
+
+    monkeypatch.setattr("omnigent_client.SessionsChat", _SlowTurnChat)
+    result = await asyncio.wait_for(
+        _query_sessions_once(
+            client=client,
+            agent_name="hello_world",
+            tool_handler=None,
+            prompt="do the big refactor",
+            session_bundle=b"bundle-bytes",
+            session_bundle_filename="agent.tar.gz",
+            runner_id="runner_test",
+        ),
+        timeout=10,
+    )
+    assert result is not None
+    assert "FULL final answer" in result
+
+
 async def test_persisted_turn_text_anchors_on_last_user_message() -> None:
     """Only the current turn's assistant output is returned, not a prior turn's.
 


### PR DESCRIPTION
Fixes #1985.

## Summary

- `_query_sessions_once`'s first-turn `chat.query(prompt)` call had no timeout, so a third, previously-unhandled variant of the documented subscribe-after-post race could hang the headless `omnigent run -p "..."` CLI path forever, even though the turn completed and was persisted correctly server-side.
- The two already-handled variants of this race (an `OmnigentError` from a runner disconnect, or a clean-but-empty `result.text`) both reconcile against the persisted transcript via `_persisted_turn_text`. This third variant doesn't error and doesn't return — the SSE connection's periodic `session.heartbeat` events keep the subscription's async iterator alive indefinitely even after the real terminal event is lost, so `SessionsChat.send` just waits forever.
- Wraps the first-turn query in `asyncio.wait_for`, reusing the `_PER_TURN_TIMEOUT_S` constant already established later in this same function as a "race-window guard" for the multi-turn synthesis loop, and reconciles a timeout the same way the other two variants already are.

See #1985 for the full root-cause trace (protocol-level replay, runner/scaffold instrumentation, and confirmation the session always reaches `status: idle` server-side even when the CLI hangs).

## Test plan

- [x] `uv run --extra dev pytest tests/cli/test_chat.py` — 104 passed; the 4 pre-existing failures (`test_materialize_bundle_overrides_brain_harness[...]`) reproduce identically against unmodified `main` and are unrelated (a YAML-parsing issue with a bundled example resource, unrelated to this change).
- [x] `uv run --extra dev ruff check omnigent/chat.py` — clean.
- [x] `uv run --extra dev mypy omnigent/chat.py` — no new errors (the one pre-existing error at line 3598 is unrelated `subprocess.Popen` overload noise, present on unmodified `main`).
- [x] Manually reproduced the hang against `--harness codex` (~1 in 3 attempts before this fix), then ran 13 consecutive headless `-p` invocations against the fixed code with zero hangs, correct output every time.

---

## Maintainer update (@dhruv0811)

Rebased onto current `main` (`dc374b10b`) and added a follow-up commit. The original commit is unchanged in substance; only its SHA moved with the rebase.

**Why the follow-up:** the `wait_for` bound alone cannot distinguish a lost terminal event from a healthy turn that simply outlasts the guard. The server persists assistant items incrementally, so reconciling immediately on timeout would return a mid-turn fragment as the final answer, trading the hang for silent truncation (exit 0, partial output) on any first turn longer than 120s.

`fix(cli): make the headless first-turn guard status-aware` addresses that: on timeout it keeps waiting while the session still reports the turn in flight (mirroring the extra-turns loop's refresh-and-continue) and reconciles against the durable transcript only once the session is no longer running. Constants are hoisted to module level so tests can patch them. Only a turn with no persisted output after the deadline raises.

**Verification on current `main`:**

- Reproduced the hang first, then confirmed the fix, using a reproducer that fakes only the SSE transport so the real `send()` / `_collect_query` / `_query_sessions_once` all run. Identical harness, only `chat.py` swapped:

  | | `chat.query` | headless `-p` |
  |---|---|---|
  | clean `main` | hangs | **hangs forever** |
  | with both commits | hangs (by design) | **correct text in 1.0s** |

  `chat.query` still hanging is intentional: the wait is bounded at the caller rather than by changing SDK semantics.

- `pytest tests/cli/test_chat.py` — 118 passed (the 4 failures noted in the original test plan no longer reproduce on current `main`).
- The 3 added tests fail on clean `main` and pass with the fix, covering lost-event recovery, the no-persisted-output raise, and slow-turn-not-truncated.
- `pytest tests/cli/` — 98 failures on clean `main` → 95 with the change. No regressions; the delta is exactly the new tests. The remaining 95 are environmental in my local setup and sit in untouched files.
- `pytest tests/frontends/sdk/test_sessions_chat.py tests/repl/test_sessions_chat_adapter.py` — 67 passed.
- `ruff check` clean; `pyrefly check omnigent/chat.py` — 0 errors.
- `chat.query` has exactly one production caller in `omnigent/`, the one guarded here, so no sibling path is left unbounded. The REPL calls `send()` directly with its own rendering and polling, which is why it was never affected.

Test coverage for the follow-up: unit tests added (3), plus the manual reproduction above. The race is timing-dependent and not deterministically reproducible in CI, so the tests drive the recovery path through a shortened, patchable guard rather than losing a real terminal event.
