### PR TITLE
fix(model-catalog): resolve opencode/hermes models in sys_list_models

### DIFF
--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -113,6 +113,22 @@ _PROVIDER_RESOLUTION_HARNESS: dict[str, str] = {
     # mirroring the claude-native -> claude-sdk rule above.
     "antigravity-native": "antigravity",
     "native-antigravity": "antigravity",
+    # OpenCode and Hermes are own-auth, multi-provider CLI harnesses that
+    # share no resolution path with an existing SDK sibling — same shape as
+    # kimi above, so they take the same identity-entry treatment. Omnigent
+    # drives their models via runner ``providers:`` config synthesis, so a
+    # configured provider resolves to a real listing; the identity entry
+    # both surfaces that listing and keeps the misleading "harness has no
+    # model-provider resolution" note off the row when nothing is
+    # configured (it degrades to the honest "no model provider configured"
+    # legacy-auth note instead). Like kimi, they route via the multi-family
+    # (pi-style) branch in ``_provider_from_entry`` — see the note there.
+    "opencode": "opencode",
+    "opencode-native": "opencode",
+    "native-opencode": "opencode",
+    "hermes": "hermes",
+    "hermes-native": "hermes",
+    "native-hermes": "hermes",
 }
 
 # Preferred inline family per single-family harness (pi consumes both).
@@ -533,9 +549,12 @@ def _provider_from_entry(entry: ProviderEntry, harness_type: str) -> ResolvedMod
         return ResolvedModelProvider(
             kind=SUBSCRIPTION_KIND, cli=entry.cli, detail=f"provider {entry.name!r}"
         )
-    # Inline-family kinds: single-family harnesses get exactly their family;
-    # pi takes the first whose credential resolves, anthropic preferred.
-    preferred = _KEY_AUTH_FAMILY[harness_type] if harness_type != "pi" else None
+    # Inline-family kinds: single-family harnesses get exactly their family.
+    # Harnesses absent from the map are multi-family (own-auth) — pi, kimi,
+    # opencode, hermes — and take the first whose credential resolves,
+    # anthropic preferred. ``.get`` (not a subscript) so those absent
+    # harnesses fall through to the multi-family branch instead of raising.
+    preferred = _KEY_AUTH_FAMILY.get(harness_type)
     candidates = (preferred,) if preferred is not None else _FAMILY_PREFERENCE
     for family_name in candidates:
         try:

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -170,6 +170,70 @@ def test_resolve_provider_key_kind_resolves_family_credential(
     assert provider.api_key == "sk-ant-test"
 
 
+@pytest.mark.parametrize(
+    "harness",
+    ["opencode", "opencode-native", "native-opencode", "hermes", "hermes-native", "native-hermes"],
+)
+def test_resolve_provider_own_auth_harness_resolves_configured_key_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, harness: str
+) -> None:
+    """OpenCode / Hermes resolve a configured provider like kimi, not ``none``.
+
+    These are own-auth, multi-provider CLI harnesses with no SDK sibling;
+    they take the same identity-entry treatment as kimi. A configured
+    default key provider must resolve to a real ``key`` listing via the
+    multi-family branch — a regression here (e.g. the pre-fix
+    ``_KEY_AUTH_FAMILY`` subscript) would collapse the row to ``none`` and
+    ``sys_list_models`` would hide the models Omnigent can actually drive.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    :param harness: The own-auth harness spelling under test.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    _isolate_config(
+        monkeypatch,
+        tmp_path,
+        "providers:\n"
+        "  anthropic:\n"
+        "    kind: key\n"
+        "    default: true\n"
+        "    anthropic:\n"
+        "      base_url: https://api.anthropic.com\n"
+        "      api_key: $ANTHROPIC_API_KEY\n",
+    )
+    provider = resolve_model_provider(_worker_spec(harness), harness)
+    assert provider.kind == "key", f"harness {harness}: {provider}"
+    assert provider.family == "anthropic"
+    assert provider.api_key == "sk-ant-test"
+
+
+@pytest.mark.parametrize(
+    "harness",
+    ["opencode-native", "hermes-native"],
+)
+def test_resolve_provider_own_auth_harness_unconfigured_is_honest_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, harness: str
+) -> None:
+    """Unconfigured OpenCode / Hermes report an honest ``none``, not "unknown".
+
+    Before the identity entry these harnesses fell through to the
+    "harness ... has no model-provider resolution" branch — misleading,
+    since Omnigent *can* drive their models given a configured provider.
+    With nothing configured the row must instead carry the honest
+    legacy-auth "no model provider configured" note.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    :param harness: The own-auth harness spelling under test.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    provider = resolve_model_provider(_worker_spec(harness), harness)
+    assert provider.kind == "none"
+    assert provider.detail == "no model provider configured"
+    assert "has no model-provider resolution" not in provider.detail
+
+
 def test_resolve_provider_subscription_default(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Problem

`sys_list_models` reported `source: none` with the misleading note **"harness has no model-provider resolution"** for `opencode-native` and `hermes-native`, because those harnesses were absent from the `_PROVIDER_RESOLUTION_HARNESS` map in `omnigent/model_catalog.py`.

This is purely a catalog/display gap — Omnigent **can** drive these harnesses' models via runner `providers:` config synthesis — so the `none` verdict was wrong and hid models the tool could actually enumerate.

## Fix

- **Add identity entries** for the opencode (`opencode`, `opencode-native`, `native-opencode`) and hermes (`hermes`, `hermes-native`, `native-hermes`) spellings, following the existing **kimi precedent**: own-auth, multi-provider CLI harnesses that share no resolution path with an SDK sibling get an identity entry so map-iterating callers (`list_models_for_worker`) don't fall through to the noisy "unknown harness" branch.
  - With a provider configured, they now resolve to a **real listing**.
  - Unconfigured, they degrade to the honest `"no model provider configured"` note instead of the misleading `"has no model-provider resolution"` one.
- **Harden `_provider_from_entry`**: switch the `_KEY_AUTH_FAMILY` subscript to `.get()` so harnesses absent from that map (pi, kimi, opencode, hermes) route via the multi-family (pi-style) branch instead of raising a `KeyError` that the outer guard would collapse into a misleading `"provider resolution failed"` none. This also fixes a latent kimi bug on the same path.

`forge` is intentionally **not** added here — it is not a registered harness on `main` (it ships in a separate PR), and adding it would break the harness-enumeration invariant tests.

## Trace (before → after)

Bare `opencode-native` / `hermes-native` spec, nothing configured:

| | note |
|---|---|
| before | `no usable model provider (harness 'opencode-native' has no model-provider resolution) — dispatches to this worker cannot run here` |
| after | `no usable model provider (no model provider configured) — dispatches to this worker cannot run here` |

With a configured default `key` provider, both now resolve to `kind=key` (family anthropic, real base_url) → a live `/v1/models` listing, where before the identity gap short-circuited to `none`.

## Tests

- New parametrized tests in `tests/test_model_catalog.py` covering all six spellings resolving a configured key provider (multi-family / KeyError-regression guard) and the honest-`none` unconfigured case.
- Ran the full `tests/onboarding` (**705 passed**) and `tests/server` (**2078 passed, 1 skipped, 3 xfailed**) groups, plus model-catalog / list_models / harness-enumeration invariant tests including `test_configured_harness_map_covers_all_spellings` (**192 passed** in that batch). ruff + pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)