### PR TITLE
fix(model_registry): Add fable 5 to static listing for claude native CLI

### DIFF
--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -76,7 +76,7 @@ _LLM_TASK_TOKENS = ("chat", "completion")
 # Subscription CLIs expose no listing API: curated ids matching the bundled
 # catalog pin (claude) and the codex ids the codebase already references.
 _SUBSCRIPTION_STATIC_MODELS: dict[str, tuple[str, ...]] = {
-    "claude": ("claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"),
+    "claude": ("claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5", "claude-fable-5"),
     "codex": ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"),
 }
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -3628,6 +3628,7 @@ async def test_sys_list_models_dispatches_locally_with_static_provider(
         "claude-opus-4-8",
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
+        "claude-fable-5",
     ]
     assert worker["note"]
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -728,6 +728,7 @@ def test_subscription_listing_is_static_and_unverified(
         "claude-opus-4-8",
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
+        "claude-fable-5",
     ]
     assert "CLI login" in listing.note
 


### PR DESCRIPTION
## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
For claude-native harness we use the static list of models that is checked against (as there is not an API to pull from). This means that adding `model: claude-fable-5` to a config.yaml can be refused by the orchestrating agent, even though it works. 

Adding to the list here enables it to pass the model as available via `sys_list_models` 

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->
Existing test updated

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->
Prior to change: 
<img width="621" height="341" alt="Screenshot 2026-07-06 at 10 07 39 am" src="https://github.com/user-attachments/assets/73403d8b-51f8-42aa-9e6a-85b68245b737" />

After change:
<img width="481" height="255" alt="Screenshot 2026-07-06 at 10 06 24 am" src="https://github.com/user-attachments/assets/4287b0c9-ebd9-477c-a46a-2125a316c6f0" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
Added claude-fable-5 to static list for `claude-native` harness 
