### PR TITLE
fix(harness-bench): streaming=False declares UNSUPPORTED, not PARTIAL

### DIFF
--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -263,6 +263,54 @@ is not.
   gated on CLI + creds, P0 blocking, P1 report-only. Follows the existing
   nightly/flake-stress pattern rather than blocking every PR on live turns.
 
+## Running the bench and reading the result
+
+```
+# Offline: the declared matrix, no creds, every harness. Fast.
+python -m tests.harness_bench
+
+# Live: probe one harness against a gateway profile.
+python -m tests.harness_bench --harness codex-native --profile oss
+
+# Live: probe every official harness (SDK + native) sequentially.
+python -m tests.harness_bench --profile oss
+
+# A community harness that ships its own BenchProfile.
+python -m tests.harness_bench --harness mypkg.harness:PROFILE --profile oss
+```
+
+**You do not need to live-probe every harness on every host — and you cannot.**
+Each native harness needs its own vendor CLI logged in (a login the bench
+cannot provision), so no single host has them all. The two layers split the
+work:
+
+- **Offline conformance** already covers every harness in CI — registration,
+  the declared matrix, capability derivation. No host access needed.
+- **Live probes** only answer "does observed behavior match the declaration?"
+  You get value from live-probing a harness where the declaration is unverified
+  or might be wrong — not from chasing 100% coverage on one box.
+
+Run the full set on whatever host you have (`--profile oss`); harnesses whose
+vendor CLI is absent or logged out **skip cleanly** (they do not fail or abort
+the run). Read two signals only: any `!!` DRIFT, and any harness you *can* run
+that shows an unexpected `✗` / `·`. A single live run is a spot-check, not a
+gate — live probes are non-deterministic (model behavior, timing), so re-run
+before treating one `·`/timeout as a regression. Drift coverage is cumulative:
+each host that has harness X logged in contributes a live check for X.
+
+## Streaming is a binary declared capability
+
+A recurring subtlety worth stating: the `streaming` capability is **binary** —
+a harness either forwards token-level deltas (`SUPPORTED`) or it does not
+(`UNSUPPORTED`). `PARTIAL` is a *probe observation only*: the streaming probe
+returns it for the ambiguous coalesced-single-delta case against a `SUPPORTED`
+declaration. It is **never a declared value**. Declaring a non-streaming
+harness as `PARTIAL` drifts against reality, because the probe reports zero
+deltas as `UNSUPPORTED`, not `PARTIAL`. This bit the transcript-mirror natives
+(kiro/goose/qwen/hermes/cursor/kimi/pi), which deliver each complete assistant
+message rather than streaming deltas: they declare `streaming=False` →
+`UNSUPPORTED`, matching what the probe observes.
+
 ## Open items
 
 - Exact `BenchProfile` field set and whether it subsumes `HarnessProbe` or wraps

--- a/tests/harness_bench/manifest.py
+++ b/tests/harness_bench/manifest.py
@@ -100,13 +100,10 @@ def _declared_from_capabilities(harness: str) -> dict[str, Verdict]:
 
     caps = harness_capabilities().get(harness)
     if caps is not None:
-        # streaming is a binary capability: True → the harness streams token
-        # deltas (SUPPORTED); False → it does not (UNSUPPORTED). PARTIAL is a
-        # probe *observation* only — the streaming probe returns it for the
-        # ambiguous coalesced-single-delta case against a SUPPORTED declaration
-        # — never a declared value. Declaring False as PARTIAL would drift
-        # against a non-streaming harness, which the probe reports UNSUPPORTED
-        # (0 deltas), not PARTIAL.
+        # streaming is binary: True → SUPPORTED, False → UNSUPPORTED. PARTIAL is
+        # a probe observation (coalesced single delta), never a declared value —
+        # declaring False as PARTIAL would drift against a harness the probe
+        # reports UNSUPPORTED (0 deltas).
         declared["streaming"] = Verdict.SUPPORTED if caps.streaming else Verdict.UNSUPPORTED
         # interrupt: True → SUPPORTED; False → UNSUPPORTED.
         declared["interrupt"] = Verdict.SUPPORTED if caps.interrupt else Verdict.UNSUPPORTED

--- a/tests/harness_bench/manifest.py
+++ b/tests/harness_bench/manifest.py
@@ -100,8 +100,14 @@ def _declared_from_capabilities(harness: str) -> dict[str, Verdict]:
 
     caps = harness_capabilities().get(harness)
     if caps is not None:
-        # streaming: True → deltas (SUPPORTED); False → complete-only (PARTIAL).
-        declared["streaming"] = Verdict.SUPPORTED if caps.streaming else Verdict.PARTIAL
+        # streaming is a binary capability: True → the harness streams token
+        # deltas (SUPPORTED); False → it does not (UNSUPPORTED). PARTIAL is a
+        # probe *observation* only — the streaming probe returns it for the
+        # ambiguous coalesced-single-delta case against a SUPPORTED declaration
+        # — never a declared value. Declaring False as PARTIAL would drift
+        # against a non-streaming harness, which the probe reports UNSUPPORTED
+        # (0 deltas), not PARTIAL.
+        declared["streaming"] = Verdict.SUPPORTED if caps.streaming else Verdict.UNSUPPORTED
         # interrupt: True → SUPPORTED; False → UNSUPPORTED.
         declared["interrupt"] = Verdict.SUPPORTED if caps.interrupt else Verdict.UNSUPPORTED
 

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -68,10 +68,8 @@ def test_declared_covers_every_p0_dimension(profile: BenchProfile) -> None:
 
 
 def test_streaming_capability_declares_binary_verdict() -> None:
-    # streaming is binary: True → SUPPORTED, False → UNSUPPORTED. It must never
-    # declare PARTIAL — that is a probe observation (coalesced single delta), and
-    # declaring it would drift against a non-streaming harness (0 deltas →
-    # observed UNSUPPORTED). Guards the kiro-native class of drift.
+    # Guards the kiro-native drift: streaming declares binary (True→SUPPORTED,
+    # False→UNSUPPORTED), never PARTIAL.
     from omnigent.harness_plugins import harness_capabilities
     from tests.harness_bench.manifest import _declared_from_capabilities
 

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -67,6 +67,27 @@ def test_declared_covers_every_p0_dimension(profile: BenchProfile) -> None:
             )
 
 
+def test_streaming_capability_declares_binary_verdict() -> None:
+    # streaming is binary: True → SUPPORTED, False → UNSUPPORTED. It must never
+    # declare PARTIAL — that is a probe observation (coalesced single delta), and
+    # declaring it would drift against a non-streaming harness (0 deltas →
+    # observed UNSUPPORTED). Guards the kiro-native class of drift.
+    from omnigent.harness_plugins import harness_capabilities
+    from tests.harness_bench.manifest import _declared_from_capabilities
+
+    caps = harness_capabilities()
+    for harness, cap in caps.items():
+        declared = _declared_from_capabilities(harness).get("streaming")
+        if declared is None:
+            continue
+        expected = Verdict.SUPPORTED if cap.streaming else Verdict.UNSUPPORTED
+        assert declared is expected, (
+            f"{harness!r}: streaming={cap.streaming} should declare {expected.name}, "
+            f"got {declared.name}"
+        )
+        assert declared is not Verdict.PARTIAL, f"{harness!r}: PARTIAL is never a declared verdict"
+
+
 def test_reconcile_flags_concrete_mismatch() -> None:
     assert reconcile(Verdict.UNSUPPORTED, Verdict.SUPPORTED) is Verdict.DRIFT
     assert reconcile(Verdict.SUPPORTED, Verdict.UNSUPPORTED) is Verdict.DRIFT


### PR DESCRIPTION
## Summary

A follow-up to #1990. That PR corrected the transcript-mirror natives to
`streaming=False`, but a live `kiro-native` run showed the DRIFT was still
present — just shifted: `!!~>✗` (declared PARTIAL, observed UNSUPPORTED). The
manifest mapped `streaming=False` → `PARTIAL`, while the streaming probe
reports a zero-delta harness as `UNSUPPORTED`. PARTIAL ≠ UNSUPPORTED, so it
still reconciled to drift.

The fix is a semantic alignment: **`streaming` is a binary declared
capability** — `True` → `SUPPORTED`, `False` → `UNSUPPORTED`. `PARTIAL` is a
probe *observation* (the streaming probe returns it for the ambiguous
coalesced-single-delta case against a `SUPPORTED` declaration), never a
declared value. Mapping `False` → `PARTIAL` was the bug: it drifts against any
genuinely non-streaming harness, which the probe reports as `UNSUPPORTED`
(0 deltas), not `PARTIAL`.

Live-verified: `kiro-native` now renders a clean `✗` for Streaming with no
drift (`exit 0`), where before it was `!!~>✗`.

## Test Plan

- Live: `python -m tests.harness_bench --harness kiro-native --profile oss` ->
  Streaming `✗` (declared UNSUPPORTED, observed UNSUPPORTED), no drift, exit 0.
- Added `test_streaming_capability_declares_binary_verdict`: asserts every
  harness's declared streaming verdict is SUPPORTED (True) or UNSUPPORTED
  (False), and never PARTIAL. Guards the kiro-native class of drift.
- Offline suite: 51 passed / 14 skipped.
- `ruff check` clean.

## Demo

N/A -- test bench / CLI matrix output.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix
- [ ] Breaking change
- [x] Documentation

## Test coverage

- [x] Automated tests added/updated
- [x] Manual verification completed

## Coverage notes

Manual verification: kiro-native's clean no-drift result was confirmed on the
oss gateway profile with a logged-in kiro-cli (which CI does not have). The
offline suite (including the new binary-verdict guard) runs in CI.
