### PR TITLE
fix(setup): avoid termios setup crash on Windows

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -677,8 +677,10 @@ def _ensure_secure_dir(target: Path) -> None:
     each ancestor from that trusted parent down to ``target``,
     creating new ones with mode 0o700 and rejecting any existing
     ancestor that is a symlink, not a directory, owned by a different
-    uid, or has group/other permission bits set. Wrong-but-repairable
-    modes on dirs we own are reset to 0o700.
+    uid, or has group/other permission bits set where POSIX uid/mode
+    semantics are available. Wrong-but-repairable POSIX modes on dirs we own
+    are reset to 0o700. On Windows, where Python exposes no POSIX uid/mode
+    ownership model, directory protection relies on the OS ACLs instead.
 
     :param target: Final bridge directory path to ensure, e.g.
         ``Path("/tmp/omnigent-501/claude-native/abc")``.
@@ -694,7 +696,8 @@ def _ensure_secure_dir(target: Path) -> None:
     if cur != trusted_parent:
         raise RuntimeError(f"bridge dir {target!s} is not under trusted parent {trusted_parent!s}")
     ancestors.reverse()
-    my_uid = getattr(os, "getuid", lambda: -1)()
+    getuid = getattr(os, "getuid", None)
+    my_uid = getuid() if getuid is not None else None
     for ancestor in ancestors:
         try:
             os.mkdir(ancestor, mode=0o700)
@@ -706,12 +709,12 @@ def _ensure_secure_dir(target: Path) -> None:
             raise RuntimeError(f"refusing to use bridge ancestor {ancestor!s}: is a symlink")
         if not stat.S_ISDIR(st.st_mode):
             raise RuntimeError(f"refusing to use bridge ancestor {ancestor!s}: not a directory")
-        if st.st_uid != my_uid:
+        if my_uid is not None and st.st_uid != my_uid:
             raise RuntimeError(
                 f"refusing to use bridge ancestor {ancestor!s}: owned by uid "
                 f"{st.st_uid}, not current user ({my_uid})"
             )
-        if (st.st_mode & 0o077) != 0:
+        if my_uid is not None and (st.st_mode & 0o077) != 0:
             os.chmod(ancestor, 0o700)
 
 

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -46,9 +46,7 @@ _logger = logging.getLogger(__name__)
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_HERMES_NATIVE_BRIDGE_DIR"
 
-_BRIDGE_ROOT = (
-    Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{stable_user_id()}" / "hermes-native"
-)
+_BRIDGE_ROOT = Path(tempfile.gettempdir()) / f"omnigent-{stable_user_id()}" / "hermes-native"
 _TMUX_FILE = "tmux.json"
 _TMUX_READY_TIMEOUT_S = 30.0
 _TMUX_SEND_TIMEOUT_S = 10.0

--- a/omnigent/kimi_native_bridge.py
+++ b/omnigent/kimi_native_bridge.py
@@ -26,9 +26,7 @@ from omnigent._platform import stable_user_id
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_KIMI_NATIVE_BRIDGE_DIR"
 
-_BRIDGE_ROOT = (
-    Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{stable_user_id()}" / "kimi-native"
-)
+_BRIDGE_ROOT = Path(tempfile.gettempdir()) / f"omnigent-{stable_user_id()}" / "kimi-native"
 _TMUX_FILE = "tmux.json"
 # Omnigent routing details the kimi hook subprocess reads to reach the server.
 # Mirrors claude-native's ``permission_hook.json`` (server URL + auth headers +

--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -19,9 +19,7 @@ from omnigent._platform import stable_user_id
 KIRO_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_KIRO_NATIVE_BRIDGE_DIR"
 KIRO_ACP_RECORD_PATH_ENV_VAR = "KIRO_ACP_RECORD_PATH"
 
-_BRIDGE_ROOT = (
-    Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{stable_user_id()}" / "kiro-native"
-)
+_BRIDGE_ROOT = Path(tempfile.gettempdir()) / f"omnigent-{stable_user_id()}" / "kiro-native"
 _TMUX_FILE = "tmux.json"
 _FORWARDER_READY_FILE = "kiro_session_forwarder_ready.json"
 _ACP_RECORD_FILE = "kiro_acp_record.jsonl"

--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -35,6 +35,8 @@ from rich.cells import cell_len
 from rich.console import Console
 from rich.text import Text
 
+from omnigent._platform import IS_WINDOWS
+
 # Reuse the REPL theme picker's palette verbatim so the selector is
 # visually identical to ``_theme_picker.py`` (``_ACCENT`` / ``_MUTED``).
 ACCENT = "#F43BA6"
@@ -399,6 +401,9 @@ def select(
     mask = _normalize_selectable(options, selectable)
 
     if not sys.stdin.isatty():
+        return _select_fallback(title, options, default=default, selectable=mask)
+
+    if IS_WINDOWS:
         return _select_fallback(title, options, default=default, selectable=mask)
 
     import termios

--- a/omnigent/onboarding/wizard.py
+++ b/omnigent/onboarding/wizard.py
@@ -26,6 +26,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
 
+from omnigent._platform import IS_WINDOWS
+
 console = Console()
 
 # ANSI helpers - used in arrow-menu labels (rendered via sys.stdout.write,
@@ -75,7 +77,22 @@ def _arrow_menu(
 
     # Fall back to number input if not a real terminal.
     if not sys.stdin.isatty():
-        return _arrow_menu_fallback(options, default=default, disabled=disabled, multi=multi)
+        return _arrow_menu_fallback(
+            options,
+            default=default,
+            disabled=disabled,
+            multi=multi,
+            allow_back=allow_back,
+        )
+
+    if IS_WINDOWS:
+        return _arrow_menu_fallback(
+            options,
+            default=default,
+            disabled=disabled,
+            multi=multi,
+            allow_back=allow_back,
+        )
 
     import select as _select
     import termios
@@ -222,18 +239,23 @@ def _arrow_menu_fallback(
     default: int = 0,
     disabled: set[int] | None = None,
     multi: bool = False,
+    allow_back: bool = True,
 ) -> int | list[int]:
     """Non-interactive fallback when stdin is not a tty."""
     disabled = disabled or set()
     for i, label in enumerate(options):
         marker = " [unavailable]" if i in disabled else ""
         console.print(f"  {i + 1}. {label}{marker}")
+    if allow_back:
+        console.print("  q. Go back")
     console.print()
 
     if multi:
         while True:
             available = ",".join(str(i + 1) for i in range(len(options)) if i not in disabled)
             raw = str(click.prompt("Select (comma-separated)", default=available))
+            if allow_back and raw.strip().lower() == "q":
+                raise _GoBack
             try:
                 indices = [int(x.strip()) - 1 for x in raw.split(",")]
                 if all(0 <= i < len(options) and i not in disabled for i in indices) and indices:
@@ -244,6 +266,8 @@ def _arrow_menu_fallback(
     else:
         while True:
             raw = str(click.prompt("Choice", default=str(default + 1)))
+            if allow_back and raw.strip().lower() == "q":
+                raise _GoBack
             try:
                 idx = int(raw) - 1
                 if 0 <= idx < len(options) and idx not in disabled:
@@ -281,6 +305,19 @@ def _text_prompt(
     """
     # Non-tty fallback -- just use click.prompt.
     if not sys.stdin.isatty():
+        raw = str(
+            click.prompt(
+                label,
+                default=default or "",
+                show_default=bool(default),
+                hide_input=hide_input,
+            )
+        )
+        if not raw.strip() and not default:
+            raise _GoBack
+        return raw.strip() or default or ""
+
+    if IS_WINDOWS:
         raw = str(
             click.prompt(
                 label,

--- a/omnigent/qwen_native_bridge.py
+++ b/omnigent/qwen_native_bridge.py
@@ -35,6 +35,7 @@ import secrets
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from datetime import datetime, timezone
@@ -51,9 +52,7 @@ BRIDGE_DIR_ENV_VAR = "HARNESS_QWEN_NATIVE_BRIDGE_DIR"
 #: qwen recording (resume would mint a new id and lose history).
 _QWEN_SESSION_NAMESPACE = uuid.UUID("6b6f3d2e-9a1c-5e84-bf0a-1d7c5a2e9f43")
 
-_BRIDGE_ROOT = (
-    Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{stable_user_id()}" / "qwen-native"
-)
+_BRIDGE_ROOT = Path(tempfile.gettempdir()) / f"omnigent-{stable_user_id()}" / "qwen-native"
 _TMUX_FILE = "tmux.json"
 #: JSONL command file qwen watches (``--input-file``); we append to it.
 _INPUT_FILE = "qwen_in.jsonl"

--- a/tests/onboarding/test_interactive.py
+++ b/tests/onboarding/test_interactive.py
@@ -93,6 +93,19 @@ def test_select_fallback_returns_chosen_index(
     assert "2. beta" in out
 
 
+def test_select_uses_numbered_fallback_on_windows_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TTY selection still works on Windows, where raw-termios menus are unavailable."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(interactive, "IS_WINDOWS", True)
+    _feed(monkeypatch, ["2"])
+
+    result = interactive.select("Pick one", ["alpha", "beta"])
+
+    assert result == 1
+
+
 def test_select_fallback_reprompts_on_invalid_then_accepts(
     non_tty: None,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/onboarding/test_wizard.py
+++ b/tests/onboarding/test_wizard.py
@@ -1,0 +1,57 @@
+"""Tests for the legacy onboarding wizard terminal helpers."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from omnigent.onboarding import wizard
+
+
+def _feed(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
+    """Route *lines* to ``click.prompt`` as if typed at the console."""
+    fed = iter(lines)
+
+    def _fake_prompt(_text: str) -> str:
+        return next(fed)
+
+    monkeypatch.setattr("click.termui.visible_prompt_func", _fake_prompt)
+
+
+def test_arrow_menu_uses_numbered_fallback_on_windows_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TTY wizard menus still work on Windows, where raw-termios menus are unavailable."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(wizard, "IS_WINDOWS", True)
+    _feed(monkeypatch, ["2"])
+
+    result = wizard._arrow_menu(["alpha", "beta"])
+
+    assert result == 1
+
+
+def test_arrow_menu_fallback_preserves_back_navigation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fallback wizard menus preserve the TTY path's Esc-to-go-back behavior."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    _feed(monkeypatch, ["q"])
+
+    with pytest.raises(wizard._GoBack):
+        wizard._arrow_menu(["alpha", "beta"])
+
+
+def test_arrow_menu_fallback_q_is_invalid_when_back_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``q`` only goes back when the caller opted into back navigation."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    _feed(monkeypatch, ["q", "2"])
+
+    result = wizard._arrow_menu(["alpha", "beta"], allow_back=False)
+
+    assert result == 1
+    assert "Invalid selection." in capsys.readouterr().out

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -73,7 +73,11 @@ def subprocess_bridge_root() -> Iterator[Path]:
         ``python -m omnigent.claude_native_bridge`` accepts bridge
         writes without inheriting pytest monkeypatches.
     """
-    production_root = Path("/tmp") / f"omnigent-{os.getuid()}" / "claude-native"
+    production_root = (
+        Path(tempfile.gettempdir())
+        / f"omnigent-{claude_native_bridge.stable_user_id()}"
+        / "claude-native"
+    )
     production_root.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(production_root.parent, 0o700)
     os.chmod(production_root, 0o700)
@@ -334,6 +338,21 @@ def test_prepare_bridge_dir_refuses_symlinked_ancestor(
     # Confirm the bearer token did NOT land in the attacker-controlled
     # directory — the refusal happened before any file write.
     assert not (attacker_dir / "bridge.json").exists()
+
+
+def test_ensure_secure_dir_succeeds_without_getuid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows lacks ``os.getuid()``; bridge dir creation must still work."""
+    monkeypatch.delattr(os, "getuid", raising=False)
+
+    bridge_dir = tmp_path / "bridge-without-getuid"
+
+    claude_native_bridge._ensure_secure_dir(bridge_dir)
+    claude_native_bridge._ensure_secure_dir(bridge_dir)
+
+    assert bridge_dir.is_dir()
 
 
 def test_trusted_parent_accepts_qwen_native_bridge_dir(
@@ -2354,7 +2373,10 @@ def test_mcp_server_initialize_omits_blocked_channel_capability(
     Code would refuse to start with that capability advertised under
     org policy, breaking the native wrapper.
     """
-    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", Path("/tmp"))
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._TRUSTED_PARENT",
+        Path(tempfile.gettempdir()),
+    )
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", subprocess_bridge_root)
     bridge_dir = prepare_bridge_dir("conv_abc", workspace=tmp_path)
     proc = subprocess.Popen(
@@ -3280,7 +3302,10 @@ async def test_channel_server_relays_active_omnigent_tools(
     This fails if Claude Code can receive web-channel inputs but cannot
     call the Omnigent tools made available to the server-side agent.
     """
-    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", Path("/tmp"))
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._TRUSTED_PARENT",
+        Path(tempfile.gettempdir()),
+    )
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", subprocess_bridge_root)
     bridge_dir = prepare_bridge_dir("conv_tools", workspace=tmp_path)
     proc = subprocess.Popen(
@@ -3487,7 +3512,10 @@ async def test_serve_mcp_survives_handler_exception_and_keeps_serving(
     ``-32000: Connection closed``). Without the guard, the decode error kills
     ``_serve_mcp`` and the ``tools/list`` read below times out.
     """
-    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", Path("/tmp"))
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._TRUSTED_PARENT",
+        Path(tempfile.gettempdir()),
+    )
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", subprocess_bridge_root)
     bridge_dir = prepare_bridge_dir("conv_crash", workspace=tmp_path)
 


### PR DESCRIPTION
On Windows, `omnigent setup` could crash as soon as it reached the interactive harness picker because the TTY menu path imported the POSIX-only termios/tty modules. The user-visible failure was `ModuleNotFoundError: No module named 'termios'`, after the setup banner and preflight warning had already printed.

Route Windows setup menus through the existing numbered fallback instead of the raw termios path, including the legacy wizard helpers and their back-navigation behavior. Also remove the remaining POSIX os.getuid() assumptions from native bridge temp-root setup so Windows installs do not fail while importing those bridge modules.

Tested with the focused Windows startup regressions: python -m pytest tests/onboarding/test_interactive.py tests/onboarding/test_wizard.py tests/test_claude_native_bridge.py::test_ensure_secure_dir_succeeds_without_getuid tests/test_qwen_native_bridge.py -q -k "not rejects_symlinked_ancestor"
