### PR TITLE
fix(harness-bench): classify full-server token-provisioning failures + document transport coverage

### DIFF
--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -311,6 +311,39 @@ deltas as `UNSUPPORTED`, not `PARTIAL`. This bit the transcript-mirror natives
 message rather than streaming deltas: they declare `streaming=False` →
 `UNSUPPORTED`, matching what the probe observes.
 
+## Which transport exercises which dimension
+
+Not every dimension is observable on every transport, so a `·` (SKIPPED) in a
+default run often means "this transport can't exercise it here," not "the
+harness lacks it." Two dimensions in particular only get a real verdict on the
+`full-server` transport:
+
+| Dimension | sdk-inproc | full-server | native-tui |
+|---|---|---|---|
+| Basic turn, Streaming, Model override, Interrupt | ✓ | ✓ | ✓ |
+| **Tool calling** | · (harness dispatches tools internally) | ✓ (server-dispatched builtin) | · (not yet wired) |
+| **Policy DENY** | · (wrap-direct: no tool-call policy hook) | ✓ (spec-baked deny, enforced) | · (not yet wired) |
+
+So to see Tool calling and Policy DENY actually proven, run the SDK harnesses
+over `full-server`:
+
+```
+python -m tests.harness_bench --harness claude-sdk --profile oss --transport full-server
+```
+
+Live-verified: `claude-sdk` completes the full matrix on `full-server` —
+Tool calling `✓` and Policy DENY `✓` (the deny is delivered and the blocked
+call does not stall the turn). The default `--profile oss` run shows `·` for
+those two columns only because it uses `sdk-inproc` (for SDK harnesses) and
+`native-tui` (for natives), neither of which routes a tool call through a
+server policy evaluation.
+
+`full-server` covers **SDK harnesses only** — it registers the harness via an
+agent bundle, which is the SDK-wrap path; native harnesses need the host-daemon
+provisioning the `native-tui` driver owns. So Tool calling / Policy DENY for
+native harnesses remain genuinely unwired (a follow-up), distinct from the
+sdk-inproc `·` which is a transport limitation with `full-server` as the answer.
+
 ## Open items
 
 - Exact `BenchProfile` field set and whether it subsumes `HarnessProbe` or wraps
@@ -319,3 +352,12 @@ message rather than streaming deltas: they declare `streaming=False` →
   an exported CSV so the sheet stays canonical during transition.
 - Native transport drivers are the larger half of the work; sequence them by
   which harnesses matter most for the matrix.
+- `full-server` cannot yet provision codex / pi gateway auth (their basic turn
+  fails with an empty/absent gateway token), so Tool calling / Policy DENY are
+  only live-proven on `claude-sdk` today; wiring codex/pi full-server auth would
+  extend that coverage. (The token-provisioning failure is classified as a SKIP,
+  not a false capability drift.)
+- Tool calling / Policy DENY on the `native-tui` transport are unwired — native
+  tool calls are the vendor's own and a native deny is a vendor permission
+  decision, not a server-dispatched `function_call_output`; observing them needs
+  new driver work.

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -91,6 +91,15 @@ _INFRA_ERROR_MARKERS: tuple[str, ...] = (
     # Sequencing, not capability: a prior turn on the shared session had not
     # fully settled. Reported SKIPPED so it never reads as a capability gap.
     "already processing",
+    # Token provisioning failed before the harness could reach the model — an
+    # environment/auth gap (a missing/empty gateway token, a provider auth
+    # command that produced nothing), not a capability the harness lacks.
+    # Seen on full-server for codex ("provider auth command ... empty token")
+    # and pi ("could not fetch a gateway token").
+    "could not fetch a gateway token",
+    "provider auth command",
+    "empty token",
+    "Failed to resolve external API key auth",
 )
 
 
@@ -125,6 +134,19 @@ def infra_failure_reason(result: TurnResult) -> str | None:
             )
     if "already processing" in text:
         return "session busy from a prior turn (sequencing, not a capability gap)"
+    if any(
+        marker in text
+        for marker in (
+            "could not fetch a gateway token",
+            "provider auth command",
+            "empty token",
+            "Failed to resolve external API key auth",
+        )
+    ):
+        return (
+            "gateway/provider token could not be provisioned for this transport "
+            "(environment/auth gap, not a capability the harness lacks)"
+        )
     if "unexpected status" in text:
         return "gateway returned an unexpected status (environment/auth issue)"
     return "environment/connectivity error reaching the gateway"

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -173,16 +173,29 @@ class FullServerDriver:
     @staticmethod
     def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
         """Return a skip reason if this driver cannot run *profile*, else ``None``."""
+        # full-server registers the harness via an agent bundle (the SDK-wrap
+        # path); a native harness needs the host-daemon/tmux provisioning only
+        # the native-tui driver does, so it cannot run here even under an
+        # explicit --transport full-server override.
+        if profile.transport == "native-tui":
+            return (
+                f"{profile.harness!r} is a native-tui harness; the full-server transport "
+                "registers via an agent bundle and cannot drive it (use --transport native-tui)"
+            )
         if not databricks_profile:
             return "no --profile / databricks profile provided; full-server needs a gateway route"
         if lookup_databricks_host(databricks_profile) is None:
             return (
                 f"databricks profile {databricks_profile!r} missing/hostless in ~/.databrickscfg"
             )
-        # Reuse the wrap driver's CLI gate (same binary requirement).
-        from tests.harness_bench.driver import SdkInprocDriver
+        # Same CLI gate as the wrap driver (same binary requirement), but skip
+        # its transport check — that is sdk-inproc-specific and would misreport
+        # the driver name; the native case is already handled above.
+        from tests.e2e._harness_probes import cli_unavailable_reason
 
-        return SdkInprocDriver.unavailable(profile, databricks_profile=databricks_profile)
+        if profile.cli_binary is not None:
+            return cli_unavailable_reason(profile.cli_binary)
+        return None
 
     def __enter__(self) -> FullServerDriver:
         self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -125,6 +125,17 @@ def test_infra_failure_reason_classifies_auth_and_ignores_capability_gaps() -> N
     # A successful turn is never an infra failure.
     assert infra_failure_reason(TurnResult(completed=True, text="ok")) is None
 
+    # Token-provisioning failures on full-server (codex/pi) are env/auth gaps,
+    # not capability gaps -> must yield a skip reason, never a false UNSUPPORTED
+    # that drifts against a SUPPORTED declaration.
+    for msg in (
+        "inner executor error: provider auth command `sh` produced an empty token",
+        "PiExecutor(gateway=True) could not fetch a gateway token for the workspace host.",
+        "Failed to resolve external API key auth",
+    ):
+        result = TurnResult(failed=True, error={"message": msg})
+        assert infra_failure_reason(result) is not None, msg
+
 
 async def test_offline_render_produces_matrix() -> None:
     matrix = await run_bench(_OFFICIAL, live=False)

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -309,3 +309,26 @@ def test_native_tui_registered_and_gates() -> None:
 
     # No profile → the same capability-neutral skip contract as other drivers.
     assert NativeTuiDriver.unavailable(claude_native, databricks_profile=None) is not None
+
+
+def test_full_server_skips_native_with_accurate_message() -> None:
+    """full-server rejects a native profile by naming the native transport.
+
+    A native harness forced onto full-server (via --transport) cannot run
+    there (bundle registration, not host-daemon provisioning). The skip must
+    name native-tui as the answer, not misreport the 'sdk-inproc' driver.
+    """
+    from tests.harness_bench.full_server_driver import FullServerDriver
+
+    # Real native profiles carry transport="native-tui" (set in the manifest);
+    # that is what the full-server gate keys on.
+    claude_native = BenchProfile(
+        harness="claude-native",
+        model="m",
+        env_prefix="HARNESS_CLAUDE_NATIVE_",
+        marker="X",
+        transport="native-tui",
+    )
+    reason = FullServerDriver.unavailable(claude_native, databricks_profile="oss")
+    assert reason is not None
+    assert "native-tui" in reason and "sdk-inproc" not in reason


### PR DESCRIPTION
## Summary

Comes out of running the SDK harnesses over the `full-server` transport to
answer "is Policy DENY actually tested?". Two outcomes:

1. **Proven:** `claude-sdk` on `full-server` completes the full matrix —
   **Tool calling `✓` and Policy DENY `✓`** (the tool-call deny is delivered
   and the blocked call does not stall the turn). This is the transport that
   exercises those two dimensions; a default `--profile oss` run shows them as
   `·` only because it uses `sdk-inproc` / `native-tui`, neither of which
   routes a tool call through a server policy evaluation.

2. **A false-drift bug, fixed:** `codex` and `pi` fail `basic_turn` on
   `full-server` with a provider/gateway token-provisioning error
   (`provider auth command \`sh\` produced an empty token`; `could not fetch a
   gateway token`). `infra_failure_reason` did not recognize those phrasings,
   so the turn read as `UNSUPPORTED` and drifted (`!!✓>✗`) against the
   `SUPPORTED` declaration. That is an environment/auth gap in the full-server
   spawn path, not a capability the harness lacks. This PR classifies those
   failures as infra SKIPs (matching how a 403 / connectivity error is already
   handled), so they no longer read as a false capability drift.

## Changes

- `driver.py`: add the token-provisioning phrasings to `_INFRA_ERROR_MARKERS`
  with a dedicated skip reason.
- `test_bench.py`: extend the infra-classification test with the codex/pi
  token-provisioning messages.
- `docs/harness-bench-design.md`: add a transport-vs-dimension coverage table
  (which transport exercises Tool calling / Policy DENY), the
  `--transport full-server` recipe, the live-verified claude-sdk result, and
  open items for the codex/pi full-server auth gap and the native-tui
  tool/policy gap.

## Test Plan

- Live: `python -m tests.harness_bench --harness claude-sdk --profile oss --transport full-server`
  -> full matrix, Tool calling `✓`, Policy DENY `✓` (enforced), no drift.
- Live: the same run over codex/pi now reports their basic-turn failure as a
  SKIP (env/auth), not a `!!✓>✗` drift.
- Offline: `pytest tests/harness_bench/test_bench.py` -> 51 passed / 14 skipped
  (the extended infra test included).
- `ruff check` clean.

## Demo

N/A -- test bench / CLI matrix output + docs.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix
- [x] Documentation

## Test coverage

- [x] Automated tests added/updated
- [x] Manual verification completed

## Coverage notes

Manual verification: the full-server live runs need a Databricks gateway
profile (oss), which CI does not have; they were run by hand (recipe above).
The infra-classification unit test — which is what locks in the fix — runs in
CI.
