### PR TITLE
fix(nessie): remove example commands from blast_radius policy name

### DIFF
--- a/omnigent/policies/builtins/orchestration.py
+++ b/omnigent/policies/builtins/orchestration.py
@@ -624,7 +624,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
     {
         "handler": "omnigent.policies.builtins.orchestration.blast_radius",
         "kind": "factory",
-        "name": "Block Dangerous Shell Commands (force-push, rm -rf)",
+        "name": "Block Dangerous Shell Commands",
         "description": "Classifies shell commands (sys_os_shell, Claude/Codex native Bash, "
         "and Pi native bash) as safe, risky (ASK), or catastrophic (DENY) to prevent "
         "destructive operations like force-push or rm -rf /",


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The `blast_radius` policy's `name` field read as an incomplete sentence: `"Block Dangerous Shell Commands force-push, rm -rf"`.
- Trimmed to `"Block Dangerous Shell Commands"` — the `description` field already lists the specific examples (`force-push`, `rm -rf /`), so the name was redundant.

## Test Plan

- No logic changed; this is a string literal in the policy registry.
- Verified the description field still documents the specific commands.

## Demo

N/A

## Type of change

- [x] Refactor / chore

## Test coverage

- [x] Not applicable

## Coverage notes

String-only change to a display name in `POLICY_REGISTRY`; no code paths affected.