### PR TITLE
fix(triage): prioritise load over LLM rank when assigning issues and PR reviewers

### DIFF
--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -210,16 +210,15 @@ module.exports = async ({ github, context, core }) => {
     }
   const loadOf = (u) => load.get(u.toLowerCase()) || 0;
 
-  // Helper: take the N most-preferred from a list. Sort key is (rank, load,
-  // random): LLM area-fit rank first (lower = better; Infinity for unranked, so
-  // an all-unranked list -- no rank file -- sorts purely by load, i.e. today's
-  // behavior), then fewest open review requests, then a pre-rolled random value
-  // to break any remaining same-rank-same-load tie. The `!==` guards avoid
-  // subtracting two Infinities (which would be NaN).
+  // Helper: take the N most-preferred from a list. Sort key is (load, rank,
+  // random): fewest open review requests first so workload stays balanced;
+  // LLM area-fit rank breaks ties within the same load bucket; a pre-rolled
+  // random value breaks any remaining tie. The `!==` guards avoid subtracting
+  // two Infinities (which would be NaN).
   const takeLowest = (list, n) => {
     const keyed = list.map((u) => ({ u, r: rankOf(u), l: loadOf(u), j: Math.random() }));
     keyed.sort((a, b) =>
-      a.r !== b.r ? a.r - b.r : a.l !== b.l ? a.l - b.l : a.j - b.j
+      a.l !== b.l ? a.l - b.l : a.r !== b.r ? a.r - b.r : a.j - b.j
     );
     return keyed.slice(0, n).map((x) => x.u);
   };

--- a/.github/workflows/auto-assign-reviewer.test.js
+++ b/.github/workflows/auto-assign-reviewer.test.js
@@ -285,41 +285,39 @@ function assert(name, cond, detail) {
   assert("capped overflow is warned",
     r.warnings.some((w) => /capping push-down/.test(w)), JSON.stringify(r.warnings));
 
-  // 17. LLM ranking overrides load within the candidate pool: dhruv0811 has the
-  //     lowest load (would win on load alone), but the rank prefers dbczumar, an
-  //     inner owner -- so dbczumar is chosen.
+  // 17. Load beats LLM rank: dhruv0811 has the lowest load (0) and wins even
+  //     though the rank prefers dbczumar (rank 0 but load 1).
   r = await run({
     files: ["omnigent/inner/foo.py"],
     load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
     rank: ["dbczumar", "TomeHirata", "SabhyaC26", "dhruv0811"],
   });
-  assert("LLM rank beats load within the area pool",
-    JSON.stringify(r.added) === JSON.stringify(["dbczumar"]), JSON.stringify(r));
+  assert("load beats LLM rank within the area pool",
+    JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]), JSON.stringify(r));
 
   // 18. Allowlist enforcement: a rank naming someone who does NOT own the touched
   //     area (PattaraS is a maintainer + pool member, but not an inner owner) is
-  //     ignored for that entry; the ranking only reorders actual candidates, so
-  //     the next ranked inner owner (dbczumar) wins -- never PattaraS.
+  //     ignored; the ranking only reorders actual candidates. Load is primary, so
+  //     dhruv0811 (load 0) wins over dbczumar (load 1) -- never PattaraS.
   r = await run({
     files: ["omnigent/inner/foo.py"],
     load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1, PattaraS: 0 },
     rank: ["PattaraS", "dbczumar", "TomeHirata", "SabhyaC26", "dhruv0811"],
   });
   assert("LLM rank cannot route outside the area owners",
-    JSON.stringify(r.added) === JSON.stringify(["dbczumar"]) && !r.added.includes("PattaraS"),
+    JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]) && !r.added.includes("PattaraS"),
     JSON.stringify(r));
 
-  // 19. Unranked candidates (rank omits them) sort after ranked ones but still by
-  //     load: rank lists only SabhyaC26 (highest load); the rest are unranked, so
-  //     SabhyaC26 -- despite load 5 -- is preferred because a finite rank beats
-  //     Infinity. Confirms the rank-primary / load-secondary ordering.
+  // 19. Load is primary even when only one candidate is ranked: rank lists only
+  //     SabhyaC26 (load 5); dhruv0811 is unranked but has load 0, so dhruv0811
+  //     wins. Confirms the load-primary / rank-secondary ordering.
   r = await run({
     files: ["omnigent/inner/foo.py"],
     load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
     rank: ["SabhyaC26"],
   });
-  assert("a ranked high-load owner beats unranked low-load owners",
-    JSON.stringify(r.added) === JSON.stringify(["SabhyaC26"]), JSON.stringify(r));
+  assert("unranked low-load owner beats ranked high-load owner",
+    JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]), JSON.stringify(r));
 
   // 20. Adoption still overrides the LLM rank: a linked-issue maintainer assignee
   //     (TomeHirata) is adopted as reviewer even when the rank prefers someone

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -533,12 +533,12 @@ jobs:
                   if a.get("login"):
                       load[a["login"]] += 1
 
-          # Sort by (rank, load, login): LLM rank first, then fewest open issues,
-          # then a stable alphabetical tie-break (deterministic, unlike a random
-          # one — matches the previous round-robin's determinism guarantee).
+          # Sort by (load, rank, login): fewest open assigned issues first so
+          # the workload stays balanced; LLM rank breaks ties within the same
+          # load bucket; alphabetical login is the final deterministic tiebreak.
           candidates = sorted(
               candidates,
-              key=lambda u: (rank_of.get(u, float("inf")), load[u], u),
+              key=lambda u: (load[u], rank_of.get(u, float("inf")), u),
           )
           assignee = candidates[0] if candidates else ""
           if assignee:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -503,10 +503,10 @@ jobs:
             maintainer_assigned=true
           fi
 
-          # Otherwise, assign an owner for P0/P1 issues: the LLM's top-ranked area
-          # owner, breaking ties by open-assigned-issue load (fairness). Symmetric
-          # with the PR reviewer path (rank primary, load secondary). Skipped if
-          # the maintainer-author was already assigned above.
+          # Otherwise, assign an owner for P0/P1 issues: the least-loaded area
+          # owner, with LLM rank as a tiebreaker (load primary, rank secondary).
+          # Symmetric with the PR reviewer path. Skipped if the maintainer-author
+          # was already assigned above.
           priority=$(jq -r '.priority // empty' /tmp/triage_result.json)
           if [ "$maintainer_assigned" = "false" ] && { [ "$priority" = "P0-critical" ] || [ "$priority" = "P1-high" ]; }; then
             # Open-issue load per candidate (fewest assigned open issues wins ties).


### PR DESCRIPTION
## Related issue

N/A

## Summary

The triage assignment sort key was `(rank, load, login)` — LLM rank was primary, so the first owner listed in `areas.json` always won regardless of how many open issues they already had. With many overlapping areas all listing the same person first, load became effectively irrelevant.

Swap both assignment paths to `(load, rank, login)`:
- **Issue triage** (`issue-triage.yml`): P0/P1 assignee selection
- **PR reviewer** (`auto-assign-reviewer.js`): `takeLowest` helper

Load is now the primary signal; LLM rank breaks ties within the same load bucket; login (alphabetical / random) is the final tiebreak.

## Test Plan

- Verified the sort-key change is consistent between both files
- Existing `areas.test.js` and auto-assign-reviewer unit tests cover the assignment logic
- Current load snapshot: `dhruv0811` had 33 open assigned issues vs `TomeHirata` at 6 — with this fix the least-loaded area owner wins

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Existing tests cover this change
- [x] Manual verification completed

## Coverage notes

Logic change is a one-line sort-key swap in each file; covered by the existing auto-assign-reviewer fixture tests and manually verified against the live issue load distribution.