### PR TITLE
fix(electron): reload desktop window when workspace SSO session expires

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -33,6 +33,7 @@ const { pathToFileURL } = require("node:url");
 const { registerLocalhostCors } = require("./localhost_cors");
 const { normalizeUrl, expandDatabricksWorkspaceUrl } = require("./url");
 const { registerWorkspaceChromeHide } = require("./workspace-chrome");
+const { registerSessionExpiryReload } = require("./session-expiry");
 const omnigentCli = require("./omnigent_cli");
 const serverManager = require("./server_manager");
 
@@ -383,6 +384,39 @@ function isLocalhostTrustedOrigin(origin) {
  */
 function registerLocalhostAccess() {
   registerLocalhostCors(session.defaultSession, isLocalhostTrustedOrigin);
+}
+
+// Per-window timestamp of the last expired-session reload, so a host whose SSO
+// stays expired doesn't reload-loop. An expired session redirects EVERY API
+// call to the login page (many redirects per second — and the reload itself
+// triggers fresh API calls), so a "once until next navigation" guard would
+// clear on its own reload and loop. A minimum interval caps reloads to one per
+// window per interval regardless: enough to re-run the host's auth challenge,
+// never a tight loop. In the normal case the gate full-page-redirects the
+// reload's top-level navigation to its login page, so no further API calls
+// (hence no further redirects) fire anyway.
+const _lastExpiryReloadAt = new WeakMap();
+const _EXPIRY_RELOAD_MIN_INTERVAL_MS = 15_000;
+
+/**
+ * Recover the desktop window when the workspace SSO session expires.
+ *
+ * When the auth gate redirects a connected server's API call to its login
+ * page, reload every window pinned to that origin so the gate can re-challenge
+ * — see session-expiry.js. A desktop user has no address bar to refresh out of
+ * the resulting "Failed to load" state manually, so the shell does it.
+ */
+function registerSessionExpiryAccess() {
+  registerSessionExpiryReload(session.defaultSession, isPinnedServerUrl, (origin) => {
+    const now = Date.now();
+    for (const [win, state] of windows) {
+      if (state.origin !== origin) continue;
+      const last = _lastExpiryReloadAt.get(win) ?? 0;
+      if (now - last < _EXPIRY_RELOAD_MIN_INTERVAL_MS) continue;
+      _lastExpiryReloadAt.set(win, now);
+      win.webContents.reload();
+    }
+  });
 }
 
 /**
@@ -1956,6 +1990,7 @@ if (!gotLock) {
     applyDockIcon();
     registerPermissions();
     registerLocalhostAccess();
+    registerSessionExpiryAccess();
     registerWebAuthn();
     registerIpc();
     buildMenu();

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -410,7 +410,7 @@ function registerSessionExpiryAccess() {
   registerSessionExpiryReload(session.defaultSession, isPinnedServerUrl, (origin) => {
     const now = Date.now();
     for (const [win, state] of windows) {
-      if (state.origin !== origin) continue;
+      if (state.origin !== origin || win.isDestroyed()) continue;
       const last = _lastExpiryReloadAt.get(win) ?? 0;
       if (now - last < _EXPIRY_RELOAD_MIN_INTERVAL_MS) continue;
       _lastExpiryReloadAt.set(win, now);

--- a/web/electron/src/session-expiry.js
+++ b/web/electron/src/session-expiry.js
@@ -1,0 +1,75 @@
+// Recovering the desktop window when its outer auth session expires.
+//
+// A workspace-hosted Omnigent sits behind the Databricks SSO gate. When that
+// session's cookie lapses, the gate answers the SPA's API calls with a 303
+// redirect to its own ``login.html`` instead of the expected JSON. The SPA
+// can't parse the login page as data and dies on a "Failed to load: Fetch
+// request failed due to expired user session" error — and a desktop user has
+// no address bar to force a refresh out of it.
+//
+// The shell sees the raw redirect (independent of whichever server bundle is
+// loaded), so it recovers here: on a login-page redirect for a connected
+// server, reload the window. That re-issues the top-level navigation the SSO
+// gate inspects, so it can re-challenge and re-mint the session.
+//
+// Kept Electron-free at its core (isLoginRedirect) so the matching logic is
+// unit-testable (test/session-expiry.test.js) without booting the app.
+
+/**
+ * Whether a webRequest redirect is the auth gate bouncing an expired session
+ * to its login page. Keyed on the redirect *target* pathname ending in
+ * ``login.html`` — the one unambiguous signal from a real expired session
+ * (see the module header). A same-origin API-to-API redirect, or any redirect
+ * not landing on the login page, is left alone.
+ *
+ * @param {{ statusCode?: number, redirectURL?: string }} details A webRequest
+ *   ``onBeforeRedirect`` detail object (or the fields it carries).
+ * @returns {boolean}
+ */
+function isLoginRedirect(details) {
+  const status = details?.statusCode ?? 0;
+  if (status < 300 || status >= 400) return false;
+  let pathname;
+  try {
+    pathname = new URL(details.redirectURL).pathname;
+  } catch {
+    return false;
+  }
+  return pathname.endsWith("/login.html") || pathname === "login.html";
+}
+
+/**
+ * Wire expired-session recovery onto a session's redirect stream.
+ *
+ * Uses ``onBeforeRedirect`` — an observe-only event with no other listener in
+ * this shell (Electron allows one listener per webRequest event per session,
+ * and localhost_cors.js claims the others). On a login-page redirect whose
+ * originating request targeted a connected server origin, the matching windows
+ * are reloaded. Guarded to one reload per window between successful loads (via
+ * the caller's ``reloadWindowsForOrigin``) so a persistently expired host does
+ * not reload-loop.
+ *
+ * @param {Electron.Session} ses The session whose redirects to watch.
+ * @param {(origin: string) => boolean} isConnectedServerOrigin Whether an
+ *   origin belongs to a server some window is connected to.
+ * @param {(origin: string) => void} reloadWindowsForOrigin Reload every window
+ *   pinned to the given origin (the caller owns the once-per-window guard).
+ */
+function registerSessionExpiryReload(ses, isConnectedServerOrigin, reloadWindowsForOrigin) {
+  ses.webRequest.onBeforeRedirect((details) => {
+    if (!isLoginRedirect(details)) return;
+    let origin;
+    try {
+      origin = new URL(details.url).origin;
+    } catch {
+      return;
+    }
+    if (!isConnectedServerOrigin(origin)) return;
+    reloadWindowsForOrigin(origin);
+  });
+}
+
+module.exports = {
+  isLoginRedirect,
+  registerSessionExpiryReload,
+};

--- a/web/electron/test/session-expiry.test.js
+++ b/web/electron/test/session-expiry.test.js
@@ -1,0 +1,147 @@
+// Unit tests for expired-session recovery (src/session-expiry.js), run with
+// `node --test` (no extra deps). Covers the pure redirect matcher and the
+// onBeforeRedirect wiring against a fake webRequest.
+//
+// The real signal (from a live expired Databricks SSO session): every API
+// call gets a 303 redirect to the gate's `login.html`. The shell reloads the
+// window on that so the gate can re-challenge, since a desktop user has no
+// address bar to refresh manually.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { isLoginRedirect, registerSessionExpiryReload } = require("../src/session-expiry");
+
+describe("isLoginRedirect", () => {
+  it("matches a 303 redirect to the login page", () => {
+    assert.equal(
+      isLoginRedirect({
+        statusCode: 303,
+        redirectURL: "https://dbc-x.cloud.databricks.com/login.html?next_url=%2Fajax-api%2F2.0",
+      }),
+      true,
+    );
+  });
+
+  it("matches other 3xx codes to the login page", () => {
+    assert.equal(
+      isLoginRedirect({ statusCode: 302, redirectURL: "https://ws.databricks.com/login.html" }),
+      true,
+    );
+  });
+
+  it("ignores a redirect that is not to the login page", () => {
+    // An ordinary same-origin API-to-API redirect must be left alone.
+    assert.equal(
+      isLoginRedirect({ statusCode: 303, redirectURL: "https://ws.databricks.com/ajax-api/2.0/x" }),
+      false,
+    );
+  });
+
+  it("ignores non-redirect status codes", () => {
+    assert.equal(
+      isLoginRedirect({ statusCode: 200, redirectURL: "https://ws.databricks.com/login.html" }),
+      false,
+    );
+  });
+
+  it("ignores a missing or unparseable redirect URL", () => {
+    assert.equal(isLoginRedirect({ statusCode: 303 }), false);
+    assert.equal(isLoginRedirect({ statusCode: 303, redirectURL: "not a url" }), false);
+  });
+
+  it("does not match a path that merely contains 'login.html' mid-path", () => {
+    // Only a pathname ending in /login.html counts, so an unrelated route
+    // like /docs/login.html.md or a query-only match won't trip it.
+    assert.equal(
+      isLoginRedirect({
+        statusCode: 303,
+        redirectURL: "https://ws.databricks.com/x?p=/login.html",
+      }),
+      false,
+    );
+  });
+});
+
+/** A fake session whose onBeforeRedirect listener can be driven by tests. */
+function fakeSession() {
+  let listener = null;
+  return {
+    webRequest: {
+      onBeforeRedirect: (cb) => {
+        listener = cb;
+      },
+    },
+    emit: (details) => listener?.(details),
+  };
+}
+
+describe("registerSessionExpiryReload", () => {
+  const LOGIN_REDIRECT = {
+    url: "https://ws.databricks.com/ajax-api/2.0/omnigents/v1/sessions",
+    statusCode: 303,
+    redirectURL: "https://ws.databricks.com/login.html?next_url=%2Fajax-api",
+  };
+
+  it("reloads the connected origin on a login redirect", () => {
+    const ses = fakeSession();
+    const reloaded = [];
+    registerSessionExpiryReload(
+      ses,
+      (origin) => origin === "https://ws.databricks.com",
+      (origin) => reloaded.push(origin),
+    );
+
+    ses.emit(LOGIN_REDIRECT);
+
+    assert.deepEqual(reloaded, ["https://ws.databricks.com"]);
+  });
+
+  it("ignores a login redirect for an origin no window is connected to", () => {
+    const ses = fakeSession();
+    const reloaded = [];
+    registerSessionExpiryReload(
+      ses,
+      () => false, // nothing is a connected server
+      (origin) => reloaded.push(origin),
+    );
+
+    ses.emit(LOGIN_REDIRECT);
+
+    assert.deepEqual(reloaded, []);
+  });
+
+  it("ignores a non-login redirect", () => {
+    const ses = fakeSession();
+    const reloaded = [];
+    registerSessionExpiryReload(
+      ses,
+      () => true,
+      (origin) => reloaded.push(origin),
+    );
+
+    ses.emit({
+      url: "https://ws.databricks.com/ajax-api/2.0/x",
+      statusCode: 303,
+      redirectURL: "https://ws.databricks.com/ajax-api/2.0/y",
+    });
+
+    assert.deepEqual(reloaded, []);
+  });
+
+  it("ignores a login redirect whose originating URL is unparseable", () => {
+    // A malformed request URL must not throw out of the listener; it's
+    // simply skipped (no origin to attribute the reload to).
+    const ses = fakeSession();
+    const reloaded = [];
+    registerSessionExpiryReload(
+      ses,
+      () => true,
+      (origin) => reloaded.push(origin),
+    );
+
+    ses.emit({ ...LOGIN_REDIRECT, url: "not a url" });
+
+    assert.deepEqual(reloaded, []);
+  });
+});


### PR DESCRIPTION
## Related issue

N/A

## Summary

A workspace-hosted Omnigent sits behind the Databricks SSO gate. When that outer session's cookie lapses, the gate answers the SPA's API calls with a **303 redirect to its own `login.html`** instead of the expected JSON. The SPA can't parse the login page as data and dies on a `Failed to load: Fetch request failed due to expired user session` panel — and a desktop user has no address bar to force a refresh out of it.

The fix lives in the **Electron shell**, which sees the raw redirect via `session.webRequest.onBeforeRedirect` regardless of which server bundle is loaded:

- New Electron-free module `web/electron/src/session-expiry.js` — `isLoginRedirect()` recognizes a 3xx redirect whose target pathname ends in `/login.html`, and `registerSessionExpiryReload()` wires it to the session's `onBeforeRedirect` stream. We could ideally treat any 303 to a connected origin as a session expiry, but keeping the `/login.html` match is an additional guardrail against reloading on unrelated redirects.
- `main.js` reloads every window pinned to the connected server origin on such a redirect, re-issuing the top-level navigation the SSO gate inspects so it can re-challenge and re-mint the session.
- A per-window minimum reload interval (15s) caps reloads so a persistently expired host can't reload-loop.

Because detection is at the shell's network layer, the fix is server-agnostic and ships in the desktop app itself.

## Test Plan

- **Unit** (`web/electron/test/session-expiry.test.js`, `node --test`): 10 cases covering `isLoginRedirect` (3xx→login.html matches; non-login redirect, non-3xx status, missing/unparseable URL, and mid-path `login.html` all ignored) and `registerSessionExpiryReload` wiring (reloads connected origin; ignores unconnected origin, non-login redirect, and unparseable originating URL). Full `web/electron` suite passes (66 tests).
- **Manual (live)**: launched the desktop app and connected/authenticated to a real Databricks workspace, then removed the `DBAUTH` cookie via the inspector to expire the SSO session.
  - *Before the fix*: the app got stuck on `Failed to load: Fetch request failed due expired user session` with no way to recover.
  - *After the fix*: the window automatically reloads to the login screen, letting the SSO gate re-challenge.

## Demo

Before the fix -> App gets stuck with error
<img width="400" height="300" alt="before_1" src="https://github.com/user-attachments/assets/be8d5102-85a9-4ee2-bdc2-c60f0f09e042" /><img width="400" height="300" alt="before_2" src="https://github.com/user-attachments/assets/23291033-8f67-4f30-abcc-9cee2fb5505f" />

After the fix -> App reloads automatically to login page
<img width="400" height="300" alt="after" src="https://github.com/user-attachments/assets/29dd91d7-5f62-4296-b642-489b9b077254" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manually tested before/after with demo screenshots
- [ ] E2E tests added / updated

## Coverage notes

The redirect→reload wiring can only be exercised end-to-end by driving the real Electron app, for which this repo has no Playwright harness (the `tests/e2e_ui` suite is browser-based and can't launch the shell). The detection and wiring logic is therefore unit-tested via `node --test` against a fake session, and the end-to-end behavior was verified manually against a live workspace (see Test Plan).