### PR TITLE
fix(claude-native): stop false "terminal not ready" on mid-turn inject

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -124,6 +124,10 @@ _TMUX_SEND_TIMEOUT_S = 5.0
 # The glyph persists while Claude is busy responding, so its presence
 # means "input box mounted" (not "idle"), which is what injection needs.
 _CLAUDE_PROMPT_GLYPH = "❯"
+# Box-drawing glyphs Claude Code's input-box frame is made of. A line of
+# these below ``❯`` marks the live input box (see ``_is_box_rule``),
+# distinguishing it from a bare prompt echoed into scrollback.
+_BOX_RULE_CHARS = frozenset("─━╭╮╰╯│┃╌╍")
 # How many trailing non-empty lines to scan for the prompt glyph. The
 # input box sits near the bottom of the pane; scanning only the tail
 # avoids false positives from the glyph appearing in scrollback output.
@@ -131,6 +135,12 @@ _CLAUDE_PROMPT_GLYPH = "❯"
 # people's statuslines run ~3 lines — so the ``❯`` row isn't the last
 # non-empty line.
 _PROMPT_SCAN_TAIL_LINES = 5
+# Injecting a message mid-turn grows the footer with running-state rows
+# (a ``○ Explore …`` subagent line, extra spinners) that push ``❯`` above
+# the window above. We trust a glyph this deep only when it's framed by a
+# box rule (the live input box), so this wider window can't false-match a
+# bare ``❯`` echoed into scrollback output.
+_PROMPT_SCAN_TAIL_LINES_FRAMED = 8
 _CLAUDE_READY_POLL_INTERVAL_S = 0.15
 _PASTE_SETTLE_S = 0.1  # let the TUI commit a paste before the separate submit Enter
 # How long to wait for the pasted draft to visibly land in Claude's
@@ -2831,11 +2841,43 @@ def _claude_prompt_rendered(pane: str) -> bool:
     positives from the glyph appearing in scrollback (e.g. echoed in a
     prior response), since the live input box always sits at the bottom.
 
+    A mid-turn injection grows the footer with running-state rows (a
+    ``○ Explore …`` subagent line, extra spinners) that can push ``❯``
+    past that window. To reach it without also matching a scrollback
+    echo, a glyph in the wider :data:`_PROMPT_SCAN_TAIL_LINES_FRAMED`
+    window counts only when it's framed by a box rule — the ``────``
+    closing line the live input box always renders below ``❯`` but a
+    bare echoed prompt never has.
+
     :param pane: Captured pane text from :func:`_capture_pane`.
     :returns: ``True`` when the input box appears mounted.
     """
     non_empty = [line for line in pane.splitlines() if line.strip()]
-    return any(_CLAUDE_PROMPT_GLYPH in line for line in non_empty[-_PROMPT_SCAN_TAIL_LINES:])
+    if any(_CLAUDE_PROMPT_GLYPH in line for line in non_empty[-_PROMPT_SCAN_TAIL_LINES:]):
+        return True
+    # Deeper in the tail, trust the glyph only when a box rule sits below
+    # it — the live input box's closing frame, absent from scrollback.
+    tail = non_empty[-_PROMPT_SCAN_TAIL_LINES_FRAMED:]
+    for idx, line in enumerate(tail):
+        if _CLAUDE_PROMPT_GLYPH in line and any(_is_box_rule(rule) for rule in tail[idx + 1 :]):
+            return True
+    return False
+
+
+def _is_box_rule(line: str) -> bool:
+    """
+    Return whether a line is a TUI box-drawing horizontal rule.
+
+    Claude Code frames its input box with rows of ``─`` (plus corner
+    glyphs). Such a rule below ``❯`` marks the live input box, letting
+    the readiness scan reach a prompt buried under a tall running-turn
+    footer without matching a bare ``❯`` echoed into scrollback.
+
+    :param line: A single pane line, e.g. ``"──────────"``.
+    :returns: ``True`` when the line is predominantly box-rule glyphs.
+    """
+    stripped = line.strip()
+    return len(stripped) >= 3 and all(ch in _BOX_RULE_CHARS for ch in stripped)
 
 
 def _submit_needle(content: str) -> str:

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4852,6 +4852,55 @@ def test_claude_prompt_rendered_sees_prompt_above_default_footer() -> None:
     assert _claude_prompt_rendered(pane) is True
 
 
+def test_claude_prompt_rendered_sees_prompt_above_running_turn_footer() -> None:
+    """
+    The readiness scan reaches the prompt above a tall running-turn footer.
+
+    When a web-UI message is injected while Claude is mid-turn, the footer
+    grows extra status rows below the input box — a running-subagent line
+    (``○ Explore …``) on top of the usual box rule, model, auto-mode, and
+    branch rows. That pushes the live ``❯`` row to the 6th non-empty line
+    from the bottom, one past the old 5-line window, so the readiness gate
+    timed out and the web UI rendered a spurious "did not become ready"
+    runtime-error card even though the terminal was healthy.
+    """
+    pane = "\n".join(
+        [
+            "────────────────────────────────────────",  # input box top rule
+            "❯ ",  # the live prompt row (6th non-empty line from bottom)
+            "────────────────────────────────────────",  # box closing rule
+            "  Opus 4.8 (1M context) | thinking medium",  # model + effort line
+            "  ⏵⏵ auto mode on (shift+tab to cycle)",  # permission-mode hint
+            "  main",  # branch label
+            "  ○ Explore  Find session sidebar state… 1m 4s",  # subagent status
+        ]
+    )
+    assert _claude_prompt_rendered(pane) is True
+
+
+def test_claude_prompt_rendered_ignores_unframed_glyph_deep_in_tail() -> None:
+    """
+    A glyph in the wider window without a box rule below is not trusted.
+
+    The framed window that lets the scan reach a prompt under a tall
+    running-turn footer must not resurrect the scrollback false positive:
+    a ``❯`` echoed into prior output sits in the wider window too, but
+    without the input box's closing ``────`` rule beneath it. Only plain
+    output follows here, so the gate must still report "not ready".
+    """
+    pane = "\n".join(
+        [
+            "❯ old prompt echo",  # 6th non-empty line from bottom, no rule below
+            "output line 1",
+            "output line 2",
+            "output line 3",
+            "output line 4",
+            "output line 5",
+        ]
+    )
+    assert _claude_prompt_rendered(pane) is False
+
+
 def _write_deltas_lines(bridge_dir: Path, lines: list[str]) -> None:
     """
     Append raw JSONL lines to the bridge deltas file.


### PR DESCRIPTION
## Related issue

N/A

## Summary

Injecting a web-UI message **while Claude Code is mid-turn** made the web UI render a spurious `Claude Code terminal did not become ready within 30.0s` runtime-error card — even though the terminal was healthy and the prompt was on screen.

- The readiness gate scrapes the tmux pane and looks for the `❯` input glyph in the **last 5 non-empty lines**. A mid-turn injection grows the footer with running-state rows (a `○ Explore …` subagent line, extra spinners) that push `❯` to the **6th** line from the bottom — one past the window. The gate times out and raises, surfacing as the error card.
- Simply widening the window would resurrect an old false positive: a `❯` echoed into scrollback sits at the same depth and must **not** be trusted. The two are only distinguishable **structurally** — the live input box always renders a `────` box rule directly below `❯`, which a scrollback echo never has.
- Fix keeps the 5-line fast path, and additionally trusts a glyph in a wider **8-line** window only when a box rule sits below it (`_is_box_rule`).

## Test Plan

- Added `test_claude_prompt_rendered_sees_prompt_above_running_turn_footer` — reproduces the reported pane (❯ 6th-from-bottom under a tall running-turn footer); fails on old code with `assert False is True`, passes with the fix.
- Added `test_claude_prompt_rendered_ignores_unframed_glyph_deep_in_tail` — a `❯` echo 6th-from-bottom with only plain output below stays `False`, proving the box-rule guard (not the wider window) is what admits the real prompt.
- Existing `test_..._only_trusts_prompt_glyph_in_pane_tail` (scrollback-echo rejection) and `test_..._sees_prompt_above_default_footer` still pass.
- `python -m pytest tests/test_claude_native_bridge.py -k "prompt_rendered or only_trusts_prompt_glyph or inject_user_message"` → all green (3 unrelated MCP-server tests fail identically on a clean tree — pre-existing, verified via `git stash`).
- `ruff check` + `ruff format --check` clean on both files.

## Demo

N/A — non-visual bridge logic.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: reconstructed the exact pane from the reported conversation's error card and confirmed the old scan window (`_PROMPT_SCAN_TAIL_LINES = 5`) misses the `❯` at depth 6, while the framed 8-line path finds it. Unit tests lock in both the positive (tall running footer) and negative (unframed scrollback echo) cases.

## Changelog

Stop rendering a false "terminal did not become ready" error when sending a message to Claude Code mid-turn

This pull request and its description were written by Isaac.
