### PR TITLE
feat(doc-sync): label site PRs with release version and assign reviewer

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -201,25 +201,30 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
-      # Derive the per-minor docs staging branch from the runtime version. main
-      # carries X.Y.Z.dev0, so 0.5.0.dev0 → "0.5-docs". All docs for the 0.5 line
-      # (incl. patches) stage on this one branch until release publishes it.
+      # Derive the per-minor docs staging branch and the release version from the
+      # runtime version. main carries X.Y.Z.dev0, so 0.5.0.dev0 → branch "0.5-docs"
+      # and label "v0.5.0". All docs for the 0.5 line (incl. patches) stage on the
+      # one branch until release publishes it; the vX.Y.Z label lets maintainers
+      # filter the staged PRs by the release they'll ship in.
       - name: Resolve docs branch
         id: docsbranch
         if: steps.plan.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
         run: |
           set -euo pipefail
-          minor="$(python3 - <<'PYEOF'
-          import pathlib, re
+          python3 - <<'PYEOF'
+          import os, pathlib, re
           text = pathlib.Path("omnigent/version.py").read_text()
-          m = re.search(r'VERSION\s*=\s*["\']([0-9]+)\.([0-9]+)', text)
+          m = re.search(r'VERSION\s*=\s*["\']([0-9]+)\.([0-9]+)\.([0-9]+)', text)
           if not m:
-              raise SystemExit("could not parse X.Y from omnigent/version.py")
-          print(f"{m.group(1)}.{m.group(2)}")
+              raise SystemExit("could not parse X.Y.Z from omnigent/version.py")
+          major, minor, patch = m.groups()
+          branch = f"{major}.{minor}-docs"
+          version = f"v{major}.{minor}.{patch}"
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write(f"branch={branch}\n")
+              fh.write(f"version={version}\n")
+          print(f"::notice::Docs stage on branch {branch} (release {version})")
           PYEOF
-          )"
-          echo "branch=${minor}-docs" >> "$GITHUB_OUTPUT"
-          echo "::notice::Docs stage on branch ${minor}-docs"
 
       - name: Set up Python
         if: steps.plan.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
@@ -635,6 +640,7 @@ jobs:
           PR_NUMBER: ${{ steps.plan.outputs.pr }}
           REVIEWER: ${{ steps.sitepr.outputs.reviewer }}
           DOCS_BRANCH: ${{ steps.docsbranch.outputs.branch }}
+          VERSION_LABEL: ${{ steps.docsbranch.outputs.version }}
         run: |
           set -euo pipefail
           BRANCH="auto/docs/pr-${PR_NUMBER}"
@@ -685,17 +691,27 @@ jobs:
           # bot commits.
           git push --force "$PUSH_URL" "$BRANCH"
 
+          # The vX.Y.Z label marks which release the staged docs will ship in, so
+          # maintainers can filter the site PRs by release. Ensure it exists (with
+          # automated-docs) before applying it below.
+          gh label create automated-docs --repo "$SITE_REPO_SLUG" --color 0E8A16 \
+            --description "Automated documentation update" 2>/dev/null || true
+          gh label create "$VERSION_LABEL" --repo "$SITE_REPO_SLUG" --color FBCA04 \
+            --description "Docs staged for the ${VERSION_LABEL} release" 2>/dev/null || true
+
           EXISTING="$(gh pr list --repo "$SITE_REPO_SLUG" --head "$BRANCH" --state open \
               --json number --jq '.[0].number // empty' 2>/dev/null || true)"
           if [ -n "$EXISTING" ]; then
-            gh pr edit "$EXISTING" --repo "$SITE_REPO_SLUG" --body-file /tmp/site_pr_body.md || true
+            # --add-label backfills PRs opened before the label existed; it's a no-op
+            # when already present.
+            gh pr edit "$EXISTING" --repo "$SITE_REPO_SLUG" \
+              --add-label "automated-docs" --add-label "$VERSION_LABEL" \
+              --body-file /tmp/site_pr_body.md || true
             echo "Updated site PR #$EXISTING."
           else
-            gh label create automated-docs --repo "$SITE_REPO_SLUG" --color 0E8A16 \
-              --description "Automated documentation update" 2>/dev/null || true
             if gh pr create --repo "$SITE_REPO_SLUG" --base "$DOCS_BRANCH" --head "$BRANCH" \
                 --title "docs: document ${CODE_REPO}#${PR_NUMBER}" \
-                --label automated-docs --body-file /tmp/site_pr_body.md; then
+                --label automated-docs --label "$VERSION_LABEL" --body-file /tmp/site_pr_body.md; then
               EXISTING="$(gh pr list --repo "$SITE_REPO_SLUG" --head "$BRANCH" --state open \
                   --json number --jq '.[0].number // empty' 2>/dev/null || true)"
               echo "Opened site PR for $BRANCH."
@@ -704,13 +720,17 @@ jobs:
             fi
           fi
 
-          # Always attempt the review request, decoupled from PR creation so a
-          # non-addable reviewer can't fail the open. GitHub returns 422 for users it
-          # can't add (non-collaborators / concealed org members); tolerate it — the
-          # reviewer is also @-mentioned in the body as a durable fallback ping.
+          # Always attempt the review request + assignment, decoupled from PR creation
+          # so a non-addable reviewer can't fail the open. GitHub returns 422 for users
+          # it can't add (non-collaborators / concealed org members); tolerate it — the
+          # reviewer is also @-mentioned in the body as a durable fallback ping. The two
+          # calls are independent so one failing doesn't skip the other. Assigning makes
+          # the PR filterable by assignee from the site's PR list.
           if [ -n "${REVIEWER}" ] && [ -n "${EXISTING}" ]; then
             gh pr edit "$EXISTING" --repo "$SITE_REPO_SLUG" --add-reviewer "${REVIEWER}" \
               || echo "::notice::Could not request review from ${REVIEWER} (not addable); they're @-mentioned in the PR body."
+            gh pr edit "$EXISTING" --repo "$SITE_REPO_SLUG" --add-assignee "${REVIEWER}" \
+              || echo "::notice::Could not assign ${REVIEWER} (not addable); they're @-mentioned in the PR body."
           fi
 
       - name: Note draft skipped (no site token)


### PR DESCRIPTION
## Related issue

N/A — CI/workflow tweak, no associated issue.

## Summary

The doc-sync workflow drafts omnigent-site doc PRs that all target the
per-minor `X.Y-docs` staging branch and carried only the `automated-docs`
label, so maintainers had no easy way to filter them by the release they'll
ship in. This adds two conveniences to the site PRs:

- **`vX.Y.Z` release label** — derived from `omnigent/version.py` in the
  existing "Resolve docs branch" step (`0.5.0.dev0` → branch `0.5-docs` +
  label `v0.5.0`), applied on both the create and update paths. `--add-label`
  backfills PRs opened before the label existed.
- **Reviewer as assignee** — the resolved reviewer (the merging maintainer,
  falling back to the author) is now added as an assignee alongside the
  existing review request, so the PR is filterable by assignee from the
  site's PR list.

Both label-create and the assignee/reviewer calls stay idempotent and
best-effort: GitHub rejects non-collaborators with 422, which is tolerated
exactly as the review request already was.

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/doc-sync.yml'))"` — YAML parses.
- `pre-commit run --files .github/workflows/doc-sync.yml` — all hooks pass.
- Reviewed the version-parse logic: the regex now captures `X.Y.Z` from
  `VERSION = "0.5.0.dev0"`, yielding branch `0.5-docs` (unchanged) and label
  `v0.5.0`.

The workflow only runs on merge to `main` with LLM credentials + the
omnigent-site App token present, so it can't be exercised end-to-end from a
PR; verified statically instead.

## Demo

N/A — non-visual CI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by YAML-parsing the workflow, running pre-commit, and tracing the
version-parse / label / assignee logic by hand. The doc-sync job only fires
on merges to `main` with secrets available, so there's no PR-time harness to
run it against; GitHub Actions workflows aren't covered by the repo's
automated test suite.

## Changelog

<!-- CI-only change, no user-facing impact. -->
