### PR TITLE
fix(web): prevent editor crash on blockquote with inline-only content

### DIFF
--- a/web/src/shell/MarkdownRichTextViewer.blockquoteCrash.test.ts
+++ b/web/src/shell/MarkdownRichTextViewer.blockquoteCrash.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test: opening a markdown file that contains a blockquote whose
+ * content is a lone inline image (`> ![x](img)`) or an empty blockquote (`>`)
+ * used to crash the whole editor panel.
+ *
+ * `@tiptap/markdown` (beta) parses those into a blockquote holding an inline
+ * `image` (or nothing), which violates the blockquote's `block+` content
+ * model. ProseMirror builds the initial document with `nodeFromJSON`, which
+ * does NOT validate content, so the invalid doc loads silently — then the
+ * first edit transaction that touches the blockquote calls `contentMatchAt`
+ * on it and throws ("Called contentMatchAt on a node with invalid content").
+ * The viewer's React panel boundary caught the throw and rendered a crash
+ * instead of the file.
+ *
+ * These tests use the EXACT extension stack from MarkdownRichTextViewer so a
+ * regression re-introducing invalid blockquote content fails here. Only the
+ * image extension's HTTP boundary (fetchFileContent) is mocked.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
+import { TaskItem, TaskList } from "@tiptap/extension-list";
+import { Markdown } from "@tiptap/markdown";
+import { createWorkspaceImageExtension, ImageAwareLink } from "./TipTapWorkspaceImage";
+import { GitHubAlertBlockquote } from "./TipTapGitHubAlert";
+import { HtmlPassthrough } from "./TipTapHtmlPassthrough";
+
+vi.mock("@/hooks/useFileContent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/useFileContent")>();
+  return { ...actual, fetchFileContent: vi.fn().mockResolvedValue(undefined) };
+});
+
+// jsdom leaves these undefined; the image node view needs both.
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+beforeEach(() => {
+  URL.createObjectURL = vi.fn(() => "blob:mock");
+  URL.revokeObjectURL = vi.fn();
+});
+
+let editor: Editor | null = null;
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  vi.clearAllMocks();
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+/** Editor with the viewer's full extension stack. */
+function makeEditor(markdown: string): Editor {
+  return new Editor({
+    element: document.createElement("div"),
+    extensions: [
+      StarterKit.configure({ link: false, blockquote: false }),
+      TaskList,
+      TaskItem.configure({ nested: true }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableCell,
+      TableHeader,
+      ImageAwareLink.configure({ openOnClick: false, autolink: false }),
+      GitHubAlertBlockquote,
+      HtmlPassthrough,
+      Markdown,
+      createWorkspaceImageExtension("conv_test", "README.md"),
+    ],
+    content: markdown,
+    contentType: "markdown",
+  });
+}
+
+/**
+ * Simulate the user clicking into the blockquote and typing — the edit
+ * transaction that tripped the crash. `insertText` at position 2 lands inside
+ * the (previously invalid) blockquote and runs the fit that called
+ * contentMatchAt.
+ */
+function typeInsideFirstNode(ed: Editor): void {
+  ed.view.dispatch(ed.state.tr.insertText("a", 2));
+}
+
+describe("blockquote crash", () => {
+  // Inputs that previously crashed the editor: a quote whose only content is an
+  // inline image, an empty quote, and an image-only quote followed by a block.
+  const CRASHERS = ["> ![diagram](diagram.png)", ">", "> ![a](1.png)\n\ntext after"];
+
+  it.each(CRASHERS)("parses %j into a schema-valid document", (md) => {
+    editor = makeEditor(md);
+    // Node.check() recurses the whole tree and throws on invalid content;
+    // before the fix this threw for the blockquote.
+    expect(() => editor!.state.doc.check()).not.toThrow();
+  });
+
+  it.each(CRASHERS)("survives an edit transaction without crashing: %j", (md) => {
+    editor = makeEditor(md);
+    expect(() => typeInsideFirstNode(editor!)).not.toThrow();
+  });
+
+  it("wraps a lone blockquote image in a paragraph (valid block+ content)", () => {
+    editor = makeEditor("> ![diagram](diagram.png)");
+    const quote = editor.state.doc.child(0);
+    expect(quote.type.name).toBe("blockquote");
+    expect(quote.child(0).type.name).toBe("paragraph");
+    expect(quote.child(0).child(0).type.name).toBe("image");
+    expect(quote.child(0).child(0).attrs.src).toBe("diagram.png");
+  });
+
+  it("keeps a lone-image blockquote byte-faithful on round-trip", () => {
+    const md = "> ![diagram](diagram.png)";
+    editor = makeEditor(md);
+    expect(editor.getMarkdown().trim()).toBe(md);
+  });
+});

--- a/web/src/shell/TipTapGitHubAlert.test.ts
+++ b/web/src/shell/TipTapGitHubAlert.test.ts
@@ -14,7 +14,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
 import StarterKit from "@tiptap/starter-kit";
-import { extractAlert, GitHubAlertBlockquote } from "./TipTapGitHubAlert";
+import { extractAlert, GitHubAlertBlockquote, toBlockContent } from "./TipTapGitHubAlert";
 
 let editor: Editor | null = null;
 afterEach(() => {
@@ -78,6 +78,42 @@ describe("extractAlert", () => {
       extractAlert([{ type: "paragraph", content: [{ type: "text", text: "see [!NOTE] inline" }] }])
         .alertType,
     ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toBlockContent — keeps blockquote content valid (block+).
+// ---------------------------------------------------------------------------
+
+describe("toBlockContent", () => {
+  it("wraps a lone inline image in a paragraph", () => {
+    const image = { type: "image", attrs: { src: "x.png" } };
+    expect(toBlockContent([image])).toEqual([{ type: "paragraph", content: [image] }]);
+  });
+
+  it("returns one empty paragraph for empty content (empty blockquote)", () => {
+    expect(toBlockContent([])).toEqual([{ type: "paragraph" }]);
+  });
+
+  it("passes block children through untouched", () => {
+    const blocks = [
+      { type: "paragraph", content: [{ type: "text", text: "a" }] },
+      { type: "bulletList", content: [] },
+    ];
+    expect(toBlockContent(blocks)).toEqual(blocks);
+  });
+
+  it("coalesces a run of inline nodes into a single paragraph", () => {
+    const a = { type: "text", text: "a" };
+    const img = { type: "image", attrs: { src: "x.png" } };
+    const b = { type: "text", text: "b" };
+    expect(toBlockContent([a, img, b])).toEqual([{ type: "paragraph", content: [a, img, b] }]);
+  });
+
+  it("splits inline runs around interleaved blocks", () => {
+    const img = { type: "image", attrs: { src: "x.png" } };
+    const para = { type: "paragraph", content: [{ type: "text", text: "body" }] };
+    expect(toBlockContent([img, para])).toEqual([{ type: "paragraph", content: [img] }, para]);
   });
 });
 

--- a/web/src/shell/TipTapGitHubAlert.ts
+++ b/web/src/shell/TipTapGitHubAlert.ts
@@ -41,6 +41,56 @@ interface ExtractedAlert {
 }
 
 /**
+ * Node types that are inline in the editor schema. Everything else parsed as a
+ * blockquote child is block-level. `image` counts because the workspace image
+ * extension configures it `inline: true`.
+ */
+const INLINE_TYPES = new Set(["text", "image", "hardBreak"]);
+
+/**
+ * Coerce parsed blockquote children into valid `block+` content.
+ *
+ * `@tiptap/markdown` (beta) can hand back bare inline nodes for a blockquote
+ * whose content is a lone inline atom — `> ![img](x)` yields a single image
+ * with no wrapping paragraph — and yields nothing at all for an empty quote
+ * (`>`). A blockquote's content expression is `block+`, so both shapes make
+ * the parsed document schema-invalid. Because ProseMirror builds the initial
+ * doc via `nodeFromJSON` (which does NOT validate content), the bad doc loads
+ * silently; the first edit transaction that touches the blockquote then calls
+ * `contentMatchAt` on it and throws ("Called contentMatchAt on a node with
+ * invalid content"), which the editor's React panel boundary catches — the
+ * whole file view crashes instead of rendering.
+ *
+ * Wrapping each run of loose inline nodes in a paragraph, and guaranteeing at
+ * least one block, keeps the document valid and byte-faithful on round-trip
+ * (the serialiser re-emits `> ![img](x)` from the wrapping paragraph).
+ *
+ * :param children: Parsed block/inline children of the blockquote token.
+ * :returns: Equivalent content that satisfies the blockquote's `block+` model.
+ */
+export function toBlockContent(children: JSONContent[]): JSONContent[] {
+  const blocks: JSONContent[] = [];
+  let inlineRun: JSONContent[] = [];
+  const flushInline = () => {
+    if (inlineRun.length > 0) {
+      blocks.push({ type: "paragraph", content: inlineRun });
+      inlineRun = [];
+    }
+  };
+  for (const child of children) {
+    if (child.type != null && INLINE_TYPES.has(child.type)) {
+      inlineRun.push(child);
+    } else {
+      flushInline();
+      blocks.push(child);
+    }
+  }
+  flushInline();
+  // block+ requires at least one block; an empty quote keeps one empty paragraph.
+  return blocks.length > 0 ? blocks : [{ type: "paragraph" }];
+}
+
+/**
  * Detect and strip a GitHub alert marker from parsed blockquote children.
  *
  * Handles both source shapes: the marker sharing the first paragraph with
@@ -119,7 +169,14 @@ export const GitHubAlertBlockquote = Blockquote.extend({
   parseMarkdown: (token, helpers) => {
     const parseBlockChildren = helpers.parseBlockChildren ?? helpers.parseChildren;
     const { alertType, children } = extractAlert(parseBlockChildren(token.tokens || []));
-    return helpers.createNode("blockquote", alertType ? { alertType } : undefined, children);
+    // toBlockContent guards against @tiptap/markdown emitting inline-only or
+    // empty blockquote content, which would make the doc schema-invalid and
+    // crash the editor on the first edit.
+    return helpers.createNode(
+      "blockquote",
+      alertType ? { alertType } : undefined,
+      toBlockContent(children),
+    );
   },
   renderMarkdown: (node, h) => {
     if (!node.content) {


### PR DESCRIPTION
## What

Opening a markdown file that contains a blockquote whose only content is a
lone inline image (`> ![x](img)`) — or an empty blockquote (`>`) — crashed the
markdown editor's panel, taking down the whole file view.

## Root cause

`@tiptap/markdown` (beta) parses those constructs into a `blockquote` node that
holds an inline `image` (or nothing at all). A blockquote's content expression
is `block+`, so both shapes are **schema-invalid**. ProseMirror builds the
initial document with `nodeFromJSON`, which does **not** validate content, so
the invalid doc loads silently. The first edit transaction that touches the
blockquote then calls `contentMatchAt` on it and throws:

```
Called contentMatchAt on a node with invalid content
  at Node.contentMatchAt → Node.canReplace → … → dispatchTransaction
```

The editor's React panel boundary catches the throw and renders a crash
instead of the file.

## Fix

Normalize `GitHubAlertBlockquote`'s parsed children to valid `block+` content
(`toBlockContent`): wrap each run of loose inline nodes in a paragraph and
guarantee at least one block. The parsed document is then always schema-valid,
and round-trips stay byte-faithful (`> ![x](img)` re-serialises from the
wrapping paragraph).

## Testing

- New `toBlockContent` unit tests (lone image → wrapped, empty → one paragraph,
  block passthrough, inline-run coalescing, interleaved split).
- New `MarkdownRichTextViewer.blockquoteCrash.test.ts` regression, using the
  viewer's full extension stack: the incident inputs now parse to a
  schema-valid doc and survive an edit transaction. Verified red→green — the
  regression fails on the pre-fix code with the exact production errors
  (`Invalid content for node blockquote: <image>` / `<>` and
  `Called contentMatchAt on a node with invalid content`).
- Full `web` suite green (`npx vitest run`).

This pull request and its description were written by Isaac.
