### PR TITLE
fix(harness-caps): only declare streaming=False where live-verified (revert #1990 over-reach)

### DIFF
--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -239,12 +239,12 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         interrupt=True,
         streaming=True,
     ),
-    # pi/cursor/kiro/goose/qwen/kimi/hermes are transcript-mirror natives: their
-    # forwarder posts each COMPLETE assistant message (external_conversation_item),
-    # never token-level external_output_text_delta, so the web UI sees the reply
-    # complete-only, not streamed. streaming=False reflects that (bench-verified
-    # for kiro-native; the others share the same forwarder shape — 0 delta posts).
-    # Contrast claude/codex/antigravity, whose forwarders do post deltas.
+    # streaming is declared True unless a live bench run proves a harness does
+    # NOT emit token-level deltas. Only kiro-native is so proven (0 deltas over
+    # a full SSE capture); a static "forwarder posts no external_output_text_delta"
+    # grep is NOT sufficient — pi-native has no such delta-posting forwarder yet
+    # streams 7 deltas live (its Pi extension emits them by another path), so
+    # the grep-based flip was wrong for it. The rest stay True until live-verified.
     "pi-native": _C(
         _IM.NATIVE_TUI,
         _EL.NONE,
@@ -254,7 +254,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _AU.SESSION_SCOPED_CONFIG,
         subagents=False,
         interrupt=True,
-        streaming=False,
+        streaming=True,
     ),
     "cursor-native": _C(
         _IM.NATIVE_TUI,
@@ -265,9 +265,11 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _AU.OWN_AUTH,
         subagents=False,
         interrupt=True,
-        streaming=False,
+        streaming=True,
     ),
     # kiro_native_permissions.py: "TUI ACP recorder -> web elicitation".
+    # streaming=False is LIVE-VERIFIED: a full SSE capture recorded 0 text
+    # deltas; the whole reply arrives as one response.output_item.done.
     "kiro-native": _C(
         _IM.NATIVE_TUI,
         _EL.APPROVAL_MIRROR,
@@ -299,7 +301,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _AU.OWN_AUTH,
         subagents=False,
         interrupt=True,
-        streaming=False,
+        streaming=True,
     ),
     "qwen-native": _C(
         _IM.NATIVE_TUI,
@@ -310,7 +312,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _AU.OWN_AUTH,
         subagents=False,
         interrupt=True,
-        streaming=False,
+        streaming=True,
     ),
     "kimi-native": _C(
         _IM.NATIVE_TUI,
@@ -321,7 +323,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _AU.SESSION_SCOPED_CONFIG,
         subagents=False,
         interrupt=True,
-        streaming=False,
+        streaming=True,
     ),
     "opencode-native": _C(
         _IM.NATIVE_SERVER,
@@ -343,7 +345,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _AU.OWN_AUTH,
         subagents=False,
         interrupt=True,
-        streaming=False,
+        streaming=True,
     ),
     # SDK / subprocess harnesses (run the vendor model directly). The first four
     # are bench-verified interrupt=streaming=True.

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -243,8 +243,8 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
     # NOT emit token-level deltas. Only kiro-native is so proven (0 deltas over
     # a full SSE capture); a static "forwarder posts no external_output_text_delta"
     # grep is NOT sufficient — pi-native has no such delta-posting forwarder yet
-    # streams 7 deltas live (its Pi extension emits them by another path), so
-    # the grep-based flip was wrong for it. The rest stay True until live-verified.
+    # streams 7 deltas live (by what path was not traced), so the grep-based
+    # flip was wrong for it. The rest stay True until live-verified.
     "pi-native": _C(
         _IM.NATIVE_TUI,
         _EL.NONE,

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -256,6 +256,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         interrupt=True,
         streaming=True,
     ),
+    # streaming=False is LIVE-VERIFIED: a bench run observed 0 text deltas.
     "cursor-native": _C(
         _IM.NATIVE_TUI,
         _EL.APPROVAL_MIRROR,
@@ -265,7 +266,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _AU.OWN_AUTH,
         subagents=False,
         interrupt=True,
-        streaming=True,
+        streaming=False,
     ),
     # kiro_native_permissions.py: "TUI ACP recorder -> web elicitation".
     # streaming=False is LIVE-VERIFIED: a full SSE capture recorded 0 text
@@ -303,6 +304,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         interrupt=True,
         streaming=True,
     ),
+    # streaming=False is LIVE-VERIFIED: a bench run observed 0 text deltas.
     "qwen-native": _C(
         _IM.NATIVE_TUI,
         _EL.APPROVAL_MIRROR,
@@ -312,7 +314,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _AU.OWN_AUTH,
         subagents=False,
         interrupt=True,
-        streaming=True,
+        streaming=False,
     ),
     "kimi-native": _C(
         _IM.NATIVE_TUI,

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -129,12 +129,28 @@ class NativeVendor:
     :param own_auth: ``True`` when the vendor logs in itself (auth is not
         ``OMNIGENT_CREDENTIAL``), so the bench cannot provision it — runnable
         only on a host where the vendor CLI is already logged in.
+    :param lazy_chat: ``True`` when the vendor's ``external_session_id`` (its
+        chat/thread id) is created by the FIRST message rather than at TUI
+        launch (cursor writes its chat store lazily on the first message). For
+        such a vendor the driver must NOT gate provisioning on
+        ``external_session_id`` — that id cannot exist until a turn is posted,
+        so waiting for it pre-turn deadlocks. Thread-at-launch vendors
+        (claude/codex) leave this ``False`` and are gated normally.
     """
 
     harness: str
     agent_name: str
     terminal_name: str
     own_auth: bool = False
+    lazy_chat: bool = False
+
+
+# Vendors whose external_session_id is created by the first message, not at TUI
+# launch (see NativeVendor.lazy_chat). A delivery-mechanism fact not derivable
+# from the capability model, so it is an explicit set. cursor is confirmed
+# (its forwarder discovers the chat store written on the first message); others
+# are added only once live-verified to behave this way.
+_LAZY_CHAT_HARNESSES: frozenset[str] = frozenset({"cursor-native"})
 
 
 def native_vendor(harness: str) -> NativeVendor | None:
@@ -162,6 +178,7 @@ def native_vendor(harness: str) -> NativeVendor | None:
         agent_name=f"{harness}-ui",
         terminal_name=harness.removesuffix("-native"),
         own_auth=caps.auth is not AuthModel.OMNIGENT_CREDENTIAL,
+        lazy_chat=harness in _LAZY_CHAT_HARNESSES,
     )
 
 
@@ -323,9 +340,14 @@ class NativeTuiDriver:
             timeout=90.0,
         )
         ensure.raise_for_status()
-        # Gate on the forwarder wiring up: it stamps external_session_id (the
-        # vendor thread id) on the session once the TUI creates its thread.
-        # Posting a turn before this races ahead of the forwarder subscription.
+        # A lazy-chat vendor (cursor) does not create its external_session_id
+        # until the first message lands, so it cannot be gated on here — waiting
+        # pre-turn would deadlock. The terminal is ensured; the first probe turn
+        # triggers the chat, and the forwarder discovers it then. Thread-at-launch
+        # vendors (claude/codex) stamp external_session_id at TUI launch, so gate
+        # on it to avoid racing a turn ahead of the forwarder subscription.
+        if self._vendor.lazy_chat:
+            return
         deadline = time.monotonic() + _FORWARDER_READY_TIMEOUT_S
         while time.monotonic() < deadline:
             snap = self._client.get(f"/v1/sessions/{session_id}")


### PR DESCRIPTION
## Summary

Corrects the native `streaming` declarations to match **live-observed
behavior**, and fixes a driver bug that was blocking one of those observations.
(The PR grew past its original title — see the two parts below.)

### Part 1 — streaming declared only where live-verified

#1990 set `streaming=False` for seven transcript-mirror natives from a static
grep. A live bench run disproved the grep for **pi-native** (no delta-posting
forwarder, yet it streams 7 deltas live → `!!✗>✓` drift). A grep is not sound
evidence that a harness does *not* stream.

New rule: **declare `streaming=False` only from a live observation of 0 text
deltas.** Resulting declarations, each backed by a real run on this host:

- `kiro-native` → `False` (0 deltas, full SSE capture)
- `cursor-native` → `False` (0 deltas — see Part 2; it became observable once
  the lazy-chat driver fix let it provision)
- `qwen-native` → `False` (0 deltas, observed in the all-native run)
- `pi-native`, `goose-native`, `kimi-native`, `hermes-native`,
  `claude-native`, `codex-native`, `antigravity-native` → `True`
  (pi/claude/codex observed streaming; goose/kimi/hermes not observable on this
  host — left at the honest `True` default so the bench flags a real drift if
  any turns out not to stream, rather than a false `False` that drifts the
  moment it *does* stream).

So **three** natives are `False` (kiro, cursor, qwen), all live-verified — not
one. (An earlier draft of this description said "only kiro"; that predated the
cursor/qwen observations below.)

### Part 2 — lazy-chat driver fix (why cursor is now observable)

cursor-native previously could not provision: "native forwarder did not wire up
within 90s (no external_session_id)". Root cause: cursor creates its chat id
(`external_session_id`) lazily, only after the **first message** lands
(`cursor_native_forwarder.py`), but the driver gated provisioning on that id
*before* posting any turn — a deadlock. claude/codex stamp it at TUI launch, so
the gate worked for them.

Fix: a per-vendor `lazy_chat` flag (`NativeVendor`); for lazy-chat vendors the
driver skips the pre-turn `external_session_id` gate and lets the first probe
turn create the chat. cursor is the only known lazy-chat native today.
Live-verified: cursor-native now provisions and runs (Basic / Model override /
Interrupt SUPPORTED), and its Streaming observed 0 deltas → the `False` above.

## Test Plan

- Live (oss profile, logged-in vendor CLIs): cursor-native and qwen-native both
  observed Streaming = 0 deltas (UNSUPPORTED); with `streaming=False` neither
  drifts. pi-native observed streaming (7 deltas) → `True`, no drift.
  cursor-native provisions and runs after the lazy-chat fix (was a 90s timeout).
- Verified declarations: `kiro-native`, `cursor-native`, `qwen-native` are
  `False` (all live-observed 0 deltas); all other natives `True`.
- Offline: `pytest tests/test_harness_capabilities.py tests/harness_bench/test_bench.py`
  -> 60 passed / 14 skipped. `ruff check` clean.

## Demo

N/A -- capability declarations + test-bench driver.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation

## Test coverage

- [x] Automated tests added/updated
- [x] Manual verification completed

## Coverage notes

Manual verification: cursor/qwen/pi/kiro streaming was observed live on the oss
gateway with the vendor CLIs logged in on this host (CI has neither creds nor
those logins). The offline capability + bench tests run in CI.
