### PR TITLE
feat(web): client-side message queue with auto-flush on idle

### DIFF
--- a/tests/e2e_ui/sessions/test_cross_session_routing.py
+++ b/tests/e2e_ui/sessions/test_cross_session_routing.py
@@ -1,38 +1,31 @@
-"""E2E: a queued message is delivered to the session it was composed in.
+"""E2E: a message queued in one session never leaks into another.
 
-Guards the cross-session message-routing regression:
+Guards the cross-session message-routing regression under the client-side
+queue model:
 
-    Session B's runner is slow to come up, so B's first message POST
-    stays in flight. A second message typed into B queues behind it on
-    the SPA's module-level send chain. While the chain is stalled the
-    user switches to a different, already-running session A. The queued
-    second message MUST still be POSTed to B — the session it was
-    composed in — not to whatever session is active when the chain
-    finally unblocks.
+    Session B is busy (its first message's POST is held open, so B stays
+    "streaming"), so a follow-up typed into B is held in B's client-side
+    queue — NOT POSTed. While it waits there, the user switches to a
+    different, idle session A. The queued message MUST stay bound to B: it
+    must never be POSTed to A (the now-active session).
 
-The bug routed the second message to A because the POST target was
-re-resolved from the live ``conversationId`` only AFTER the chain
-unblocked (``chatStore.ensureBoundSession``), by which point the user
-had navigated to A. The fix pins the destination at submit time.
+The queue is a per-conversation client-side buffer: ``maybeFlushQueuedHead``
+only flushes the head whose ``conversationId`` matches the bound session, so a
+message composed in B cannot be addressed to A. This test pins that no-leak
+guarantee. (The positive path — a queued head flushing to its own session on
+idle, in FIFO order — is covered by the ``chatStore`` unit tests.)
 
-Why async Playwright (not the sync ``page`` fixture the other e2e_ui
-tests use): the repro requires B's first ``POST /events`` to stay
-outstanding WHILE the test performs more UI actions (type + send the
-second message, then switch sessions). Holding a request open across
-interleaved page actions needs a deferred ``route.continue_`` /
-``route.fulfill``, which only the async API supports — a sync route
-handler blocks the single greenlet and would deadlock. It is a sync
-test that drives the async flow in a fresh thread (see
-:func:`_run_in_fresh_loop`) rather than a pytest-asyncio test: the
-suite's many sync pytest-playwright tests leave the main-thread loop in
-a state where pytest-asyncio can't start one. The session switch is
-driven via the in-app sidebar link (client-side navigation), NOT
-``page.goto`` — a full reload would reset the JS module state (the send
-chain) and dissolve the very race under test.
-
-The route handler fulfills every ``/events`` POST itself, so no real
-turn runs and the test needs no working LLM — it asserts purely on
-where the SPA addressed each POST.
+Why async Playwright (not the sync ``page`` fixture): the test inspects the
+body of every ``/events`` POST via a route handler and asserts on which
+session each was addressed to, across interleaved UI actions (send, switch
+sessions, switch back). The route handler fulfills every POST itself, so no
+real turn runs and the test needs no working LLM. It is a sync test driving
+the async flow in a fresh thread (see :func:`_run_in_fresh_loop`) because the
+suite's many sync pytest-playwright tests leave the main-thread loop in a
+state where pytest-asyncio can't start one. Session switches are driven via
+the in-app sidebar link (client-side navigation), NOT ``page.goto`` — a full
+reload would reset the JS module state (the client-side queue lives in the
+store) and dissolve the scenario under test.
 """
 
 from __future__ import annotations
@@ -99,10 +92,10 @@ async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
     raise AssertionError(f"condition not met within {timeout_s:.0f}s")
 
 
-def test_queued_send_routes_to_origin_session_not_active_session(
+def test_queued_message_stays_bound_to_origin_session(
     seeded_session_pair: tuple[str, str, str],
 ) -> None:
-    """Second message queued in B reaches B after switching to A.
+    """A follow-up queued in B reaches B, never the active session A.
 
     Failure mode this catches: the queued ``_MSG2`` POST is addressed to
     session A (the now-active session) instead of session B (where it was
@@ -116,7 +109,7 @@ async def _drive_cross_session_routing(base_url: str, session_a: str, session_b:
     """Async body of the cross-session routing test. See the test docstring.
 
     :param base_url: Spawned server base URL.
-    :param session_a: The running session the user switches to.
+    :param session_a: The idle session the user switches to.
     :param session_b: The session both messages are composed in.
     """
     async with async_playwright() as pw:
@@ -125,8 +118,8 @@ async def _drive_cross_session_routing(base_url: str, session_a: str, session_b:
         try:
             # Every (session_id, text) POSTed to a /events endpoint.
             event_posts: list[tuple[str, str]] = []
-            # Released to let B's first POST (msg1) finally complete; until
-            # then it stays in flight and the send chain is stalled.
+            # Held so B's first POST stays in flight → the local send lifecycle
+            # keeps B "streaming", so the follow-up queues instead of sending.
             release_first = asyncio.Event()
             first_b_post_held = False
 
@@ -139,8 +132,8 @@ async def _drive_cross_session_routing(base_url: str, session_a: str, session_b:
                 body = request.post_data_json
                 text = body["data"]["content"][0]["text"]
                 event_posts.append((session_id, text))
-                # Hold ONLY B's first message open so a second send queues
-                # behind it on the chain while we switch sessions.
+                # Hold ONLY B's first message open, so B stays busy (streaming)
+                # while the follow-up is typed and queued.
                 if session_id == session_b and not first_b_post_held:
                     first_b_post_held = True
                     await release_first.wait()
@@ -152,56 +145,47 @@ async def _drive_cross_session_routing(base_url: str, session_a: str, session_b:
 
             await page.route("**/v1/sessions/*/events", handle_events)
 
-            # Start in session B (initial load may reload freely — the send
-            # chain only matters once we begin sending).
+            # Start in session B.
             await page.goto(f"{base_url}/c/{session_b}")
             # Locate the textarea by its stable aria-label, not the
-            # placeholder — the placeholder text changes once a turn starts
-            # streaming ("Send a follow-up (queued)…"), which would break a
-            # placeholder-pinned locator for the second send.
+            # placeholder — the placeholder changes once a turn starts
+            # streaming ("Send a follow-up (queued)…").
             composer = page.get_by_label("Message the agent")
-            # The "Ask the agent anything…" placeholder only renders in the
-            # idle/enabled state, so waiting on it confirms the chat surface
-            # is ready to accept input (not "Waiting for agents…").
             await page.get_by_placeholder(_COMPOSER_PLACEHOLDER).wait_for(
                 state="visible", timeout=15_000
             )
             send_button = page.get_by_role("button", name="Send", exact=True)
 
-            # msg1 → POST to B, held open by the route handler above.
+            # msg1 → POST to B, held open by the route handler → B stays busy.
             await composer.fill(_MSG1)
             await send_button.click()
             await _wait_until(lambda: first_b_post_held)
 
-            # msg2 → parked behind msg1 on the module-level send chain. The
-            # composer keeps a working Send button while it holds a draft.
+            # msg2 → typed while B is busy → held in B's client-side queue,
+            # shown in the docked strip, NOT POSTed.
             await composer.fill(_MSG2)
             await send_button.click()
-
-            # No msg2 POST has fired yet — it is blocked on the stalled chain.
-            # (If it had, serialization is broken and the repro is invalid.)
+            await page.get_by_test_id("composer-queued-strip").wait_for(
+                state="visible", timeout=15_000
+            )
             assert all(text != _MSG2 for _, text in event_posts), (
-                f"msg2 POSTed before the chain unblocked: {event_posts}"
+                f"msg2 was POSTed while queued (should be held client-side): {event_posts}"
             )
 
-            # Switch to the running session A via the sidebar link — a
-            # client-side navigation that preserves the JS send chain (a full
-            # page reload would reset it and dissolve the race).
+            # Switch to the idle session A via the sidebar link — a client-side
+            # navigation that preserves the store (a full reload would drop the
+            # queue). msg2 must NOT flush into A.
             await page.locator(f'a[href="/c/{session_a}"]').click()
             await page.wait_for_url(re.compile(rf"/c/{re.escape(session_a)}"))
-
-            # Release B's first POST → the chain unblocks and msg2 is sent.
+            # Release B's first POST so the send lifecycle can settle; the queued
+            # msg2 is bound to B, so switching to A must not flush it there.
             release_first.set()
-
-            # msg2 must be delivered to B (origin), never to A (now active).
-            await _wait_until(lambda: any(text == _MSG2 for _, text in event_posts))
-            msg2_targets = [sid for sid, text in event_posts if text == _MSG2]
-            assert msg2_targets == [session_b], (
-                f"msg2 was composed in session B ({session_b}) and must be "
-                f"delivered there, but POST targets were {msg2_targets}. A "
-                f"target of {session_a} (session A) is the cross-session leak."
+            # Give any errant flush a chance to fire before asserting the
+            # negative (the queue head is bound to B, so nothing should POST).
+            await asyncio.sleep(1.0)
+            assert all(text != _MSG2 for _, text in event_posts), (
+                f"msg2 leaked out of B while A was active: {event_posts}"
             )
-            # And nothing leaked into the running session A at all.
             assert all(sid != session_a for sid, _ in event_posts), (
                 f"a message leaked into the active session A: {event_posts}"
             )

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -34,6 +34,7 @@ import {
   type SessionListWireItem,
 } from "@/lib/sessionListCache";
 import { stopSession } from "@/lib/sessionsApi";
+import { useChatStore } from "@/store/chatStore";
 import type { Session } from "@/lib/types";
 import { useSessionUpdatesConnected } from "./useSessionUpdatesConnected";
 import { markConversationSeen } from "./useUnseenConversations";
@@ -286,6 +287,9 @@ export async function deleteConversation(id: string, deleteBranch = false): Prom
     method: "DELETE",
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  // Drop any client-side queued messages for the now-deleted session; bound to
+  // a dead conversation, they could never flush.
+  useChatStore.getState().clearQueuedMessages(id);
 }
 
 /**

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1188,3 +1188,38 @@ describe("Composer sub-agent tray", () => {
     expect(screen.getByText(/Chatting with sub-agent/)).toBeTruthy();
   });
 });
+
+describe("Composer — queued-message flush gating", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    useChatStore.setState({ queuedMessages: [] });
+  });
+
+  // Regression (Polly review 3a): the level-triggered flush effect must NOT
+  // drain the queue while the session is unreachable — flushing would POST
+  // into a void, bypassing onSend's reconnect dialog. It must drain once
+  // reachable again.
+  it("holds the queue while unreachable, then flushes when reachable", async () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      conversationId: "conv_test",
+      boundAgentId: "agent_xyz",
+      status: "idle",
+      sessionStatus: "idle",
+      send: sendSpy,
+      queuedMessages: [{ queueId: "q_1", text: "held", conversationId: "conv_test" }],
+    });
+
+    // Idle + a waiting head, but unreachable → the effect must not flush.
+    const { rerender } = render(<Composer {...composerProps({ unreachable: true })} />);
+    await waitFor(() => expect(sendSpy).not.toHaveBeenCalled());
+    expect(useChatStore.getState().queuedMessages).toHaveLength(1);
+
+    // Becomes reachable → the effect re-fires and drains the head.
+    rerender(<Composer {...composerProps({ unreachable: false })} />);
+    await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1));
+    expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["held", "agent_xyz"]);
+    expect(useChatStore.getState().queuedMessages).toHaveLength(0);
+  });
+});

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -60,6 +60,7 @@ import { parseSystemMessage } from "@/lib/systemMessage";
 import { Button } from "@/components/ui/button";
 import { OttoIcon } from "@/components/icons/OttoIcon";
 import { cn } from "@/lib/utils";
+import { QueuedMessagesStrip } from "@/pages/QueuedMessagesStrip";
 import { validateAttachments } from "@/lib/attachments";
 import { useSurfaceFrontmost } from "@/hooks/useNativeServerSwitcher";
 import {
@@ -968,6 +969,18 @@ export function ChatPage() {
     // a void.
     if (urlConvId && isUnreachable) {
       setReconnectDialogOpen(true);
+      return;
+    }
+    // Busy → hold the message in the client-side queue (shown in the strip
+    // above the composer) instead of POSTing now. The queue head is flushed
+    // FIFO when the session next goes idle. Only queue for an already-bound
+    // conversation; a brand-new chat (no conversationId) always sends so the
+    // session gets created.
+    const chat = useChatStore.getState();
+    const isBusy =
+      chat.status === "streaming" || ["running", "waiting"].includes(chat.sessionStatus);
+    if (isBusy && chat.conversationId !== null) {
+      chat.enqueueMessage(text, files);
       return;
     }
     void useChatStore.getState().send(text, agentId, files, {
@@ -3635,6 +3648,15 @@ export function Composer({
   // module scope (not useRef) because Composer unmounts during the
   // loading gate between session switches.
   const conversationId = useChatStore((s) => s.conversationId);
+  const queuedMessages = useChatStore((s) => s.queuedMessages);
+  const sessionStatus = useChatStore((s) => s.sessionStatus);
+  const maybeFlushQueuedHead = useChatStore((s) => s.maybeFlushQueuedHead);
+  // Drain the queue whenever idle with a waiting head — level-triggered so a
+  // message queued right after the turn ended (or after an SSE reconnect that
+  // carries no fresh idle transition) still sends instead of stranding.
+  useEffect(() => {
+    maybeFlushQueuedHead();
+  }, [status, sessionStatus, queuedMessages, conversationId, maybeFlushQueuedHead]);
   const { goal: codexGoal, setGoal: setCodexGoal } = useCodexGoalState(
     conversationId,
     showCodexGoal,
@@ -4321,6 +4343,13 @@ export function Composer({
             e.target.value = "";
           }
         }}
+      />
+      {/* Queued messages — peeks above the card like the sub-agent tray.
+          Lists follow-ups held while the agent is busy; drains FIFO on idle.
+          Scope to this conversation so a queue held elsewhere never leaks in. */}
+      <QueuedMessagesStrip
+        messages={queuedMessages.filter((m) => m.conversationId === conversationId)}
+        widthClassName={CHAT_COLUMN_WIDTH}
       />
       {/* Sub-agent context tray — peeks above the card; reserves its own
           layout slot so the card sits below it (see SubagentComposerTray).

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3650,17 +3650,29 @@ export function Composer({
   const conversationId = useChatStore((s) => s.conversationId);
   const queuedMessages = useChatStore((s) => s.queuedMessages);
   const sessionStatus = useChatStore((s) => s.sessionStatus);
+  const flushBoundAgentId = useChatStore((s) => s.boundAgentId);
   const maybeFlushQueuedHead = useChatStore((s) => s.maybeFlushQueuedHead);
   // Drain the queue whenever idle with a waiting head — level-triggered so a
   // message queued right after the turn ended (or after an SSE reconnect that
   // carries no fresh idle transition) still sends instead of stranding. Hold
   // while unreachable: flushing would POST into a void (no executor / no host
   // to wake), bypassing onSend's reconnect dialog. The next reachable render
-  // re-fires this effect and drains.
+  // re-fires this effect and drains. `boundAgentId` is a dep because the flush
+  // needs it: on navigate-back the binding lands after the status settles, and
+  // without this dep the effect wouldn't re-fire to drain a queue for the
+  // returned-to conversation.
   useEffect(() => {
     if (unreachable) return;
     maybeFlushQueuedHead();
-  }, [status, sessionStatus, queuedMessages, conversationId, unreachable, maybeFlushQueuedHead]);
+  }, [
+    status,
+    sessionStatus,
+    queuedMessages,
+    conversationId,
+    flushBoundAgentId,
+    unreachable,
+    maybeFlushQueuedHead,
+  ]);
   const { goal: codexGoal, setGoal: setCodexGoal } = useCodexGoalState(
     conversationId,
     showCodexGoal,

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3653,10 +3653,14 @@ export function Composer({
   const maybeFlushQueuedHead = useChatStore((s) => s.maybeFlushQueuedHead);
   // Drain the queue whenever idle with a waiting head — level-triggered so a
   // message queued right after the turn ended (or after an SSE reconnect that
-  // carries no fresh idle transition) still sends instead of stranding.
+  // carries no fresh idle transition) still sends instead of stranding. Hold
+  // while unreachable: flushing would POST into a void (no executor / no host
+  // to wake), bypassing onSend's reconnect dialog. The next reachable render
+  // re-fires this effect and drains.
   useEffect(() => {
+    if (unreachable) return;
     maybeFlushQueuedHead();
-  }, [status, sessionStatus, queuedMessages, conversationId, maybeFlushQueuedHead]);
+  }, [status, sessionStatus, queuedMessages, conversationId, unreachable, maybeFlushQueuedHead]);
   const { goal: codexGoal, setGoal: setCodexGoal } = useCodexGoalState(
     conversationId,
     showCodexGoal,

--- a/web/src/pages/QueuedMessagesStrip.test.tsx
+++ b/web/src/pages/QueuedMessagesStrip.test.tsx
@@ -1,0 +1,32 @@
+// Tests for QueuedMessagesStrip — the presentational strip above the composer
+// listing messages queued while the agent is busy. It's a pure prop-driven
+// component (no store access), so we exercise it with plain props.
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { QueuedMessage } from "@/store/chatStore";
+import { QueuedMessagesStrip } from "./QueuedMessagesStrip";
+
+const msg = (queueId: string, text: string): QueuedMessage => ({
+  queueId,
+  text,
+  conversationId: "conv_abc",
+});
+
+afterEach(cleanup);
+
+describe("QueuedMessagesStrip", () => {
+  it("renders nothing when the queue is empty", () => {
+    const { container } = render(<QueuedMessagesStrip messages={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders one row per queued message, in order", () => {
+    render(<QueuedMessagesStrip messages={[msg("q_1", "first"), msg("q_2", "second")]} />);
+    expect(screen.getByText("first")).toBeInTheDocument();
+    expect(screen.getByText("second")).toBeInTheDocument();
+    // Each row carries the "Queued" label.
+    expect(screen.getAllByText("Queued")).toHaveLength(2);
+  });
+});

--- a/web/src/pages/QueuedMessagesStrip.tsx
+++ b/web/src/pages/QueuedMessagesStrip.tsx
@@ -1,0 +1,47 @@
+import { ClockIcon } from "lucide-react";
+
+import type { QueuedMessage } from "@/store/chatStore";
+import { cn } from "@/lib/utils";
+
+interface QueuedMessagesStripProps {
+  /** Messages waiting to be flushed, in FIFO order (head first). */
+  messages: QueuedMessage[];
+  /** Column-width class so the strip lines up with the composer card. */
+  widthClassName?: string;
+}
+
+/**
+ * Docked strip above the composer listing messages queued while the agent is
+ * busy. Peeks above the composer card (`-mb-4` + bottom padding), mirroring
+ * `SubagentComposerTray`. Renders nothing when the queue is empty.
+ *
+ * Read-only in this iteration — per-row actions (delete / edit / steer /
+ * reorder) land in later changes.
+ */
+export function QueuedMessagesStrip({ messages, widthClassName }: QueuedMessagesStripProps) {
+  if (messages.length === 0) return null;
+  return (
+    <div
+      data-testid="composer-queued-strip"
+      className={cn(
+        "mx-auto -mb-4 flex w-full flex-col rounded-t-2xl bg-tray/40 px-4 pt-1.5 pb-5.5",
+        widthClassName,
+      )}
+    >
+      {/* Cap the list height and scroll when the queue is long, so a big
+          backlog never pushes the composer off-screen. ~5 rows tall. */}
+      <div className="flex max-h-32 flex-col gap-1 overflow-y-auto">
+        {messages.map((message) => (
+          <div
+            key={message.queueId}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground"
+          >
+            <ClockIcon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span className="min-w-0 flex-1 truncate">{message.text}</span>
+            <span className="shrink-0 text-muted-foreground/70">Queued</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -350,6 +350,7 @@ beforeEach(() => {
     conversationId: null,
     blocks: [],
     pendingUserMessages: [],
+    queuedMessages: [],
     // Reset the per-conversation stash too, or a stash entry left by one
     // navigation test leaks into the next (the entry survives switchTo by
     // design — that's the whole point — so beforeEach must clear it).
@@ -7450,5 +7451,128 @@ describe("chatStore — policy deny renders once", () => {
     expect(
       await run({ delta: "[Denied by policy: over budget]", message_id: "deny_abc", index: 0 }),
     ).toBe(1);
+  });
+});
+
+describe("chatStore — client-side message queue", () => {
+  it("enqueueMessage holds the message client-side without POSTing while busy", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    // Busy: the enqueue-time flush must NOT fire, so both messages stay queued.
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      status: "streaming",
+      sessionStatus: "running",
+      send: sendSpy,
+    });
+    useChatStore.getState().enqueueMessage("first", undefined);
+    useChatStore.getState().enqueueMessage("second", undefined);
+
+    const state = useChatStore.getState();
+    expect(state.queuedMessages.map((m) => m.text)).toEqual(["first", "second"]);
+    expect(state.queuedMessages.every((m) => m.conversationId === "conv_abc")).toBe(true);
+    // Nothing is sent to the server while the agent is busy.
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it("enqueueMessage is a no-op with no bound conversation", () => {
+    useChatStore.setState({ conversationId: null });
+    useChatStore.getState().enqueueMessage("orphan", undefined);
+    expect(useChatStore.getState().queuedMessages).toEqual([]);
+  });
+
+  it("maybeFlushQueuedHead flushes the head FIFO, one per idle", async () => {
+    // Spy on send so the flush's contract (which head, in what order) is
+    // asserted without depending on the full bind→/events network path.
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      status: "idle",
+      sessionStatus: "idle",
+      send: sendSpy,
+      queuedMessages: [
+        { queueId: "q_1", text: "first", conversationId: "conv_abc" },
+        { queueId: "q_2", text: "second", conversationId: "conv_abc" },
+      ],
+    });
+
+    // Idle + head present → head ("first") is removed and sent; tail remains.
+    useChatStore.getState().maybeFlushQueuedHead();
+    await tick();
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["second"]);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["first", "agent_xyz"]);
+
+    // Next idle → the next message flushes; queue empties.
+    useChatStore.getState().maybeFlushQueuedHead();
+    await tick();
+    expect(useChatStore.getState().queuedMessages).toEqual([]);
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+    expect(sendSpy.mock.calls[1]!.slice(0, 2)).toEqual(["second", "agent_xyz"]);
+  });
+
+  it("does not flush a queue owned by a different conversation", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      status: "idle",
+      sessionStatus: "idle",
+      send: sendSpy,
+      queuedMessages: [{ queueId: "q_1", text: "elsewhere", conversationId: "conv_other" }],
+    });
+    useChatStore.getState().maybeFlushQueuedHead();
+    // The head belongs to conv_other, so it stays put.
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["elsewhere"]);
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not flush while busy (streaming or running/waiting)", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const base = {
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      send: sendSpy,
+      queuedMessages: [{ queueId: "q_1", text: "wait", conversationId: "conv_abc" }],
+    };
+
+    // Local send still in flight.
+    useChatStore.setState({ ...base, status: "streaming", sessionStatus: "idle" });
+    useChatStore.getState().maybeFlushQueuedHead();
+    // Server-side turn still running.
+    useChatStore.setState({ ...base, status: "idle", sessionStatus: "running" });
+    useChatStore.getState().maybeFlushQueuedHead();
+    // Draining background work.
+    useChatStore.setState({ ...base, status: "idle", sessionStatus: "waiting" });
+    useChatStore.getState().maybeFlushQueuedHead();
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["wait"]);
+  });
+
+  // Regression: a message queued while the agent was ALREADY idle (the send
+  // routed to the queue on a stale busy read, but no future idle edge follows)
+  // must still flush. Edge-triggering on the idle SSE event stranded it — the
+  // bug this level-triggered design fixes.
+  it("flushes a message queued while already idle (no future idle edge)", async () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      status: "idle",
+      sessionStatus: "idle",
+      send: sendSpy,
+      queuedMessages: [],
+    });
+
+    // Enqueue while idle — enqueueMessage triggers a flush itself, so no
+    // session_status event is needed to unstick it.
+    useChatStore.getState().enqueueMessage("stranded?", undefined);
+    await tick();
+
+    expect(useChatStore.getState().queuedMessages).toEqual([]);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["stranded?", "agent_xyz"]);
   });
 });

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7523,9 +7523,78 @@ describe("chatStore — client-side message queue", () => {
       queuedMessages: [{ queueId: "q_1", text: "elsewhere", conversationId: "conv_other" }],
     });
     useChatStore.getState().maybeFlushQueuedHead();
-    // The head belongs to conv_other, so it stays put.
+    // The only queued message belongs to conv_other, so nothing flushes here.
     expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["elsewhere"]);
     expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  // Regression: the queue is one flat array across conversations. An undrained
+  // message from another conversation must NOT block the bound conversation's
+  // messages — flush the first message OF THE BOUND CONVERSATION, not the global
+  // array head. A head-only guard stranded the local messages forever.
+  it("flushes past a foreign head to reach the bound conversation's message", async () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      status: "idle",
+      sessionStatus: "idle",
+      send: sendSpy,
+      queuedMessages: [
+        // Foreign message sits at index 0 (queued in conv_other, never drained).
+        { queueId: "q_1", text: "foreign", conversationId: "conv_other" },
+        { queueId: "q_2", text: "mine-1", conversationId: "conv_abc" },
+        { queueId: "q_3", text: "mine-2", conversationId: "conv_abc" },
+      ],
+    });
+
+    useChatStore.getState().maybeFlushQueuedHead();
+    await tick();
+    // The bound conversation's FIRST message flushes; the foreign head is left
+    // untouched, and the bound conversation's FIFO order is preserved.
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["mine-1", "agent_xyz"]);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual([
+      "foreign",
+      "mine-2",
+    ]);
+  });
+
+  // Regression: a message flushes to the agent it was COMPOSED for, even if the
+  // binding changed (e.g. a /model switch) between enqueue and drain.
+  it("flushes to the agent captured at enqueue time, not the current binding", async () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    // Bound to agent_one when queuing.
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_one",
+      status: "streaming",
+      sessionStatus: "running",
+      send: sendSpy,
+    });
+    useChatStore.getState().enqueueMessage("composed for one", undefined);
+    expect(useChatStore.getState().queuedMessages[0]!.agentId).toBe("agent_one");
+
+    // Binding changes to agent_two, then the session idles and flushes.
+    useChatStore.setState({ boundAgentId: "agent_two", status: "idle", sessionStatus: "idle" });
+    useChatStore.getState().maybeFlushQueuedHead();
+    await tick();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["composed for one", "agent_one"]);
+  });
+
+  it("clearQueuedMessages drops only the given conversation's messages", () => {
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      queuedMessages: [
+        { queueId: "q_1", text: "a1", conversationId: "conv_abc" },
+        { queueId: "q_2", text: "b1", conversationId: "conv_other" },
+        { queueId: "q_3", text: "a2", conversationId: "conv_abc" },
+      ],
+    });
+    useChatStore.getState().clearQueuedMessages("conv_abc");
+    // Only conv_other's message survives.
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["b1"]);
   });
 
   it("does not flush while busy (streaming or running/waiting)", () => {

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -162,6 +162,12 @@ export interface QueuedMessage {
   files?: File[];
   /** Owning conversation, so a switch/idle only flushes its own queue. */
   conversationId: string;
+  /**
+   * Agent bound when the message was queued, so it flushes to the agent it was
+   * composed for even if the binding changed meanwhile (e.g. a `/model` switch).
+   * Falls back to the current `boundAgentId` when absent.
+   */
+  agentId?: string;
 }
 
 /**
@@ -528,6 +534,12 @@ export interface ChatState {
    */
   enqueueMessage: (text: string, files?: File[]) => void;
   /**
+   * Drop all queued messages for a conversation. Called when a conversation is
+   * deleted so its queue can't linger in memory (it would never flush — you
+   * can't be bound to a deleted session).
+   */
+  clearQueuedMessages: (conversationId: string) => void;
+  /**
    * Flush the queue head if the session is idle and ready. Level-triggered:
    * safe to call on any state change (idempotent — no-ops when busy, when the
    * queue is empty, or when the head isn't for the bound conversation). POSTing
@@ -818,14 +830,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
   historyGeneration: 0,
 
   enqueueMessage: (text, files) => {
-    const conversationId = get().conversationId;
+    const { conversationId, boundAgentId } = get();
     if (conversationId === null) return;
     queueSeq += 1;
     const queueId = `q_${queueSeq}`;
     set((s) => ({
       queuedMessages: [
         ...s.queuedMessages,
-        { queueId, text, conversationId, ...(files && files.length > 0 ? { files } : {}) },
+        {
+          queueId,
+          text,
+          conversationId,
+          ...(boundAgentId !== null ? { agentId: boundAgentId } : {}),
+          ...(files && files.length > 0 ? { files } : {}),
+        },
       ],
     }));
     // A message queued while the agent is idle (a race where the send routed
@@ -834,14 +852,21 @@ export const useChatStore = create<ChatState>((set, get) => ({
     get().maybeFlushQueuedHead();
   },
 
+  clearQueuedMessages: (conversationId) => {
+    set((s) => {
+      if (!s.queuedMessages.some((m) => m.conversationId === conversationId)) return {};
+      return {
+        queuedMessages: s.queuedMessages.filter((m) => m.conversationId !== conversationId),
+      };
+    });
+  },
+
   maybeFlushQueuedHead: () => {
     const s = get();
-    const head = s.queuedMessages[0];
-    // Only when fully idle (both the local send lifecycle AND the server-side
-    // session status), for the bound conversation, with an agent to send to.
+    // Only when fully idle: both the local send lifecycle AND the server-side
+    // session status. No agent → nothing to send to.
     if (
-      head === undefined ||
-      head.conversationId !== s.conversationId ||
+      s.conversationId === null ||
       s.boundAgentId === null ||
       s.status === "streaming" ||
       s.sessionStatus === "running" ||
@@ -849,9 +874,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
     ) {
       return;
     }
-    // Remove the head BEFORE the POST so a re-entrant flush can't double-send.
-    set({ queuedMessages: s.queuedMessages.slice(1) });
-    void s.send(head.text, s.boundAgentId, head.files);
+    // Flush the FIRST message OF THE BOUND CONVERSATION (FIFO within it), not
+    // the global array head. The queue is one flat array across conversations,
+    // so an undrained message from another conversation can sit at index 0; a
+    // head-only guard would let it block this conversation's messages forever.
+    const head = s.queuedMessages.find((m) => m.conversationId === s.conversationId);
+    if (head === undefined) return;
+    // Remove it BEFORE the POST so a re-entrant flush can't double-send.
+    set({ queuedMessages: s.queuedMessages.filter((m) => m.queueId !== head.queueId) });
+    void s.send(head.text, head.agentId ?? s.boundAgentId, head.files);
   },
 
   send: async (text, agentId, files, opts) => {

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -144,6 +144,27 @@ export interface PendingUserMessage {
 }
 
 /**
+ * A message the user submitted while the agent was busy. It is held
+ * client-side — NOT yet POSTed — and shown in the docked queue strip above
+ * the composer until the agent goes idle, when the head is flushed FIFO (one
+ * per turn). This is the opposite of {@link PendingUserMessage}, which is
+ * already POSTed and renders as an optimistic bubble in the transcript.
+ *
+ * In-memory only: a hard reload clears the queue, so `files` can be held
+ * directly (no serialization concern).
+ */
+export interface QueuedMessage {
+  /** Client-only id, e.g. `q_1`. */
+  queueId: string;
+  /** Fully-assembled message text (mentions/quotes already applied). */
+  text: string;
+  /** Attachments to send with the message. */
+  files?: File[];
+  /** Owning conversation, so a switch/idle only flushes its own queue. */
+  conversationId: string;
+}
+
+/**
  * A conversation's in-flight optimistic bubbles, stashed so they survive
  * in-app navigation. See {@link ChatState.pendingByConversation}.
  */
@@ -222,6 +243,12 @@ export interface ChatState {
   blocks: AnyBlock[];
   /** User messages POSTed but not yet acked via session.input.consumed. */
   pendingUserMessages: PendingUserMessage[];
+  /**
+   * Messages submitted while the agent is busy, held client-side (not yet
+   * POSTed) and shown in the composer's queue strip. The head is flushed
+   * FIFO — one per turn — when the session goes idle. In-memory only.
+   */
+  queuedMessages: QueuedMessage[];
   /**
    * In-flight optimistic bubbles stashed per conversation so they survive
    * in-app navigation (`switchTo`), keyed by conversation id.
@@ -495,6 +522,20 @@ export interface ChatState {
   // Actions.
   send: (text: string, agentId: string, files?: File[], opts?: SendOptions) => Promise<void>;
   /**
+   * Queue a message client-side instead of POSTing it now, for a send made
+   * while the agent is busy. The head is flushed automatically (FIFO, one per
+   * turn) when the session next goes idle — see the `session_status` handler.
+   */
+  enqueueMessage: (text: string, files?: File[]) => void;
+  /**
+   * Flush the queue head if the session is idle and ready. Level-triggered:
+   * safe to call on any state change (idempotent — no-ops when busy, when the
+   * queue is empty, or when the head isn't for the bound conversation). POSTing
+   * the head starts a turn → the session goes busy → this no-ops until the next
+   * idle, so the queue drains FIFO one per turn.
+   */
+  maybeFlushQueuedHead: () => void;
+  /**
    * Invoke a skill by posting a ``slash_command`` event — the same wire
    * shape the REPL sends. The server resolves the skill, persists the
    * visible receipt + hidden ``<skill>`` meta message, and forwards the
@@ -573,6 +614,7 @@ export interface ChatState {
 
 let queryClient: QueryClient | null = null;
 let pendingSeq = 0;
+let queueSeq = 0;
 // Tail of the send chain. Each `send` waits on the previous send's network
 // work before issuing its own POST, so rapid-fire messages reach the server
 // in submission order. Concurrent `fetch` POSTs have no ordering guarantee,
@@ -735,6 +777,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   redirectToConversationId: null,
   blocks: [],
   pendingUserMessages: [],
+  queuedMessages: [],
   pendingByConversation: {},
   activeResponse: null,
   interruptedResponseIds: [],
@@ -773,6 +816,43 @@ export const useChatStore = create<ChatState>((set, get) => ({
   sandboxStatus: null,
   abortController: null,
   historyGeneration: 0,
+
+  enqueueMessage: (text, files) => {
+    const conversationId = get().conversationId;
+    if (conversationId === null) return;
+    queueSeq += 1;
+    const queueId = `q_${queueSeq}`;
+    set((s) => ({
+      queuedMessages: [
+        ...s.queuedMessages,
+        { queueId, text, conversationId, ...(files && files.length > 0 ? { files } : {}) },
+      ],
+    }));
+    // A message queued while the agent is idle (a race where the send routed
+    // to the queue but the turn had already ended) would otherwise wait for an
+    // idle edge that never comes — flush now.
+    get().maybeFlushQueuedHead();
+  },
+
+  maybeFlushQueuedHead: () => {
+    const s = get();
+    const head = s.queuedMessages[0];
+    // Only when fully idle (both the local send lifecycle AND the server-side
+    // session status), for the bound conversation, with an agent to send to.
+    if (
+      head === undefined ||
+      head.conversationId !== s.conversationId ||
+      s.boundAgentId === null ||
+      s.status === "streaming" ||
+      s.sessionStatus === "running" ||
+      s.sessionStatus === "waiting"
+    ) {
+      return;
+    }
+    // Remove the head BEFORE the POST so a re-entrant flush can't double-send.
+    set({ queuedMessages: s.queuedMessages.slice(1) });
+    void s.send(head.text, s.boundAgentId, head.files);
+  },
 
   send: async (text, agentId, files, opts) => {
     if (!agentId) {
@@ -3741,6 +3821,11 @@ export function handleSessionEvent(event: StreamEvent): void {
           });
         }
       }
+      // Draining the queue is level-triggered (a React effect calls
+      // maybeFlushQueuedHead on every status/queue change), NOT edge-triggered
+      // here — a single "flush on the idle event" is fragile: a message queued
+      // just after the idle edge, or an SSE reconnect that replays state
+      // without a fresh transition, would strand the queue forever.
       return;
     }
     case "session_input_consumed":


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Follow-ups typed **while the agent is busy** are now held in a **client-side
  queue** shown in a docked "Queued" strip above the composer, instead of being
  POSTed immediately. The queue head flushes **FIFO (one per turn)** when the
  session goes idle. Idle sends are unchanged (still POST immediately).
- The flush is **level-triggered** — a store action (`maybeFlushQueuedHead`)
  re-evaluated on every status/queue change and on enqueue — so a message queued
  just after a turn ends, or after an SSE reconnect that carries no fresh idle
  transition, still sends instead of stranding (the bug an edge-triggered
  "flush on the idle event" would have).
- Works uniformly for SDK and native harnesses (both surface idle/busy via
  `sessionStatus`). In-memory only — a hard reload clears the queue.
- First step of the queue+steer design (`docs/QUEUE_STEER_DESIGN.md`). Per-message
  actions (delete / edit / steer / reorder) land in follow-up PRs.

## Test Plan

- **Unit** (`web`, vitest): `chatStore.test.ts` covers enqueue-while-busy (no
  POST), FIFO flush one-per-idle, conversation scoping, no-flush-while-busy, and
  a **regression test** for the queued-while-already-idle stranding bug (verified
  it fails without the level-triggered fix). `QueuedMessagesStrip.test.tsx` covers
  render/empty-state. 246 passing.
- **Manual**: on a busy session, typed several follow-ups → stacked in the strip,
  none sent; on idle they drained one-by-one into committed bubbles. Verified on a
  claude-native session (including the reconnect/queue-while-idle path).
- **Gates**: `npm run type-check`, `npm run test`, `pre-commit run` all pass.

## Demo

<!-- TODO: attach screen recording of queuing follow-ups while busy + auto-drain on idle -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Store logic (enqueue, FIFO flush, idle-race regression) is covered by unit tests;
the strip component has render tests. Manual verification exercised the live
busy→queue→idle→drain flow on a native session.

This pull request and its description were written by Isaac.
