### PR TITLE
fix(ci): isolate label-event concurrency in e2e.yml to prevent automerge from canceling running suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,11 @@ on:
   schedule:
     - cron: "0 9 * * *"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    # No labeled/unlabeled: label events share the same concurrency key as
+    # code-push events and cancel-in-progress would kill a running suite when
+    # e.g. the automerge label is applied. The security-gate re-run path uses
+    # rerun-security-gate.yml instead (same as e2e-ui.yml and integration.yml).
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore: ['web/**', 'tests/e2e_ui/**']
   workflow_dispatch:
     inputs:
@@ -54,11 +58,7 @@ env:
 jobs:
   # Security gate: untrusted PRs wait on the deterministic scan
   # (security-gate.yml); trusted authors and non-PR events pass instantly.
-  # Skip when the automerge label is applied/removed -- safe to short-circuit
-  # here because every non-gate job is transitively downstream of gate, so
-  # no skipped check-run can overwrite an existing result on this SHA.
   gate:
-    if: github.event.label.name != 'automerge'
     uses: ./.github/workflows/security-gate.yml
 
   # Shard matrix (e2e-shard-matrix.sh, shared with e2e-ui.yml). Fork PRs run by

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,11 +19,7 @@ on:
   schedule:
     - cron: "0 9 * * *"
   pull_request:
-    # No labeled/unlabeled: label events share the same concurrency key as
-    # code-push events and cancel-in-progress would kill a running suite when
-    # e.g. the automerge label is applied. The security-gate re-run path uses
-    # rerun-security-gate.yml instead (same as e2e-ui.yml and integration.yml).
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths-ignore: ['web/**', 'tests/e2e_ui/**']
   workflow_dispatch:
     inputs:
@@ -58,7 +54,11 @@ env:
 jobs:
   # Security gate: untrusted PRs wait on the deterministic scan
   # (security-gate.yml); trusted authors and non-PR events pass instantly.
+  # Skip when the automerge label is applied/removed -- safe to short-circuit
+  # here because every non-gate job is transitively downstream of gate, so
+  # no skipped check-run can overwrite an existing result on this SHA.
   gate:
+    if: github.event.label.name != 'automerge'
     uses: ./.github/workflows/security-gate.yml
 
   # Shard matrix (e2e-shard-matrix.sh, shared with e2e-ui.yml). Fork PRs run by

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,11 @@ on:
   schedule:
     - cron: "0 9 * * *"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    # No labeled/unlabeled: label events share the same PR-number concurrency
+    # key as code-push events, so cancel-in-progress would kill a running suite
+    # when e.g. the automerge label is applied mid-run. The security-gate re-run
+    # path uses rerun-security-gate.yml instead (same as e2e-ui.yml / integration.yml).
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore: ['web/**', 'tests/e2e_ui/**']
   workflow_dispatch:
     inputs:
@@ -54,11 +58,7 @@ env:
 jobs:
   # Security gate: untrusted PRs wait on the deterministic scan
   # (security-gate.yml); trusted authors and non-PR events pass instantly.
-  # Skip when the automerge label is applied/removed -- safe to short-circuit
-  # here because every non-gate job is transitively downstream of gate, so
-  # no skipped check-run can overwrite an existing result on this SHA.
   gate:
-    if: github.event.label.name != 'automerge'
     uses: ./.github/workflows/security-gate.yml
 
   # Shard matrix (e2e-shard-matrix.sh, shared with e2e-ui.yml). Fork PRs run by

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,11 +19,11 @@ on:
   schedule:
     - cron: "0 9 * * *"
   pull_request:
-    # No labeled/unlabeled: label events share the same PR-number concurrency
-    # key as code-push events, so cancel-in-progress would kill a running suite
-    # when e.g. the automerge label is applied mid-run. The security-gate re-run
-    # path uses rerun-security-gate.yml instead (same as e2e-ui.yml / integration.yml).
-    types: [opened, synchronize, reopened, ready_for_review]
+    # labeled/unlabeled: kept for the skip-security-scan recovery path
+    # (rerun-security-gate-run.yml re-runs CI/E2E via this trigger when the
+    # relay times out). The concurrency group key appends the label name for
+    # label events so they never cancel a running code-push suite.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths-ignore: ['web/**', 'tests/e2e_ui/**']
   workflow_dispatch:
     inputs:
@@ -38,8 +38,9 @@ on:
 
 concurrency:
   # PRs key by number, dispatch by branch (so re-runs cancel); schedule keys
-  # by SHA so each merge to `main` gets its own run.
-  group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}
+  # by SHA so each merge to `main` gets its own run. Label events append the
+  # label name so they never share a slot with a code-push run.
+  group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}-${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name || 'run' }}
   cancel-in-progress: true
 
 permissions:
@@ -58,7 +59,13 @@ env:
 jobs:
   # Security gate: untrusted PRs wait on the deterministic scan
   # (security-gate.yml); trusted authors and non-PR events pass instantly.
+  # Skip for label events unrelated to skip-security-scan (e.g. automerge) so
+  # they don't spin up the full suite in their isolated concurrency slot.
   gate:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'skip-security-scan'
     uses: ./.github/workflows/security-gate.yml
 
   # Shard matrix (e2e-shard-matrix.sh, shared with e2e-ui.yml). Fork PRs run by

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2975,6 +2975,7 @@ def server(
         port = _picked
 
     import uvicorn
+    import uvicorn.server
 
     from omnigent.runner.transports.ws_tunnel.limits import (
         RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
@@ -3223,34 +3224,59 @@ def server(
         # this foreground server instead of tearing it down on a spurious
         # sig mismatch.
         register_local_server(port)
+
+    class _ShutdownSignalingServer(uvicorn.server.Server):
+        """uvicorn.Server that signals active SSE subscribers before the
+        graceful-shutdown wait starts.
+
+        uvicorn calls ``Server.shutdown()`` in this order:
+          1. close listening sockets / call connection.shutdown()
+          2. ``asyncio.wait_for(_wait_tasks_to_complete(), timeout=…)``
+          3. force-cancel remaining tasks on timeout
+          4. run the ASGI lifespan shutdown handler
+
+        The ASGI lifespan ``finally`` block runs at step 4 — too late. SSE
+        generators waiting on a heartbeat tick are already force-cancelled by
+        step 3, which produces spurious ``CancelledError`` tracebacks.
+        Overriding here lets us drain SSE streams before step 2 so they exit
+        cleanly within the graceful window.
+        """
+
+        async def shutdown(self, sockets=None) -> None:  # type: ignore[override]
+            from omnigent.runtime import session_stream as _session_stream
+
+            _session_stream.shutdown_all()
+            await super().shutdown(sockets)
+
+    _config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        log_config=_server_uvicorn_log_config(),
+        ws_max_size=RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+        # Server side of the runner/host tunnels' protocol keepalive, aligned
+        # to the 90 s app-level budget instead of uvicorn's 20 s default that
+        # drops a busy-but-healthy tunnel with 1011 — issue #1116.
+        #
+        # uvicorn's ws_ping_* is server-global (no per-route override), so this
+        # 30 s/90 s budget also applies to the app's other WebSocket routes —
+        # /v1/sessions/updates (browser stream) and .../terminals/{id}/attach.
+        # Deliberate and acceptable: for an IDLE such socket the protocol
+        # PING/PONG is the only half-open detector (the sessions-updates
+        # heartbeat is a server->client send, and an idle terminal has no
+        # traffic), so widening it means a dead idle browser/terminal socket is
+        # reaped at worst ~120 s (30 s interval + 90 s timeout) instead of
+        # ~40 s — a slightly later half-open cleanup (e.g. the out-of-process
+        # terminal-attach proxy holds its runner socket + tmux child ~80 s
+        # longer), bounded and eventually reaped, not a leak or correctness
+        # change. The tunnels are the sockets that actually need the looser
+        # budget (issue #1116).
+        ws_ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+        ws_ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+        timeout_graceful_shutdown=_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
+    )
     try:
-        uvicorn.run(
-            app,
-            host=host,
-            port=port,
-            log_config=_server_uvicorn_log_config(),
-            ws_max_size=RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
-            # Server side of the runner/host tunnels' protocol keepalive, aligned
-            # to the 90 s app-level budget instead of uvicorn's 20 s default that
-            # drops a busy-but-healthy tunnel with 1011 — issue #1116.
-            #
-            # uvicorn's ws_ping_* is server-global (no per-route override), so this
-            # 30 s/90 s budget also applies to the app's other WebSocket routes —
-            # /v1/sessions/updates (browser stream) and .../terminals/{id}/attach.
-            # Deliberate and acceptable: for an IDLE such socket the protocol
-            # PING/PONG is the only half-open detector (the sessions-updates
-            # heartbeat is a server->client send, and an idle terminal has no
-            # traffic), so widening it means a dead idle browser/terminal socket is
-            # reaped at worst ~120 s (30 s interval + 90 s timeout) instead of
-            # ~40 s — a slightly later half-open cleanup (e.g. the out-of-process
-            # terminal-attach proxy holds its runner socket + tmux child ~80 s
-            # longer), bounded and eventually reaped, not a leak or correctness
-            # change. The tunnels are the sockets that actually need the looser
-            # budget (issue #1116).
-            ws_ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
-            ws_ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
-            timeout_graceful_shutdown=_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
-        )
+        _ShutdownSignalingServer(_config).run()
     finally:
         if _is_canonical_local_server:
             clear_local_server_record()

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -233,11 +233,14 @@ _DAEMON_RECONNECT_GRACE_S = 5.0
 _DAEMON_REUSE_MIN_AGE_S = 6.0
 
 # How long uvicorn waits for active connections (WebSocket, SSE) after
-# SIGTERM before force-closing them.  30 s gives in-flight responses time
-# to drain while still guaranteeing the port is released promptly.
+# SIGTERM before force-closing them.  SSE streams signal themselves via
+# session_stream.shutdown_all() in the lifespan handler, so the main
+# remaining consumers of this window are WebSocket tunnels that need a
+# moment to drain.  5 s is enough for a clean tunnel teardown while
+# keeping Ctrl-C feeling instant.
 # Overridable via OMNIGENT_SERVER_SHUTDOWN_TIMEOUT_S for deployments that
 # need a longer drain window (e.g. large file uploads).
-_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S_DEFAULT = 30
+_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S_DEFAULT = 5
 _SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S = int(
     os.environ.get(
         "OMNIGENT_SERVER_SHUTDOWN_TIMEOUT_S",

--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -26,6 +26,7 @@ Consumer (SSE endpoint, async):
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import threading
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
@@ -123,6 +124,22 @@ def close(conversation_id: str) -> None:
         subs = list(_subscribers.get(conversation_id, ()))
     for queue, loop in subs:
         loop.call_soon_threadsafe(queue.put_nowait, _DONE)
+
+
+def shutdown_all() -> None:
+    """Signal all active subscribers across every conversation to exit.
+
+    Broadcasts the end-of-stream sentinel to every queued subscriber so
+    SSE generators return at their next iteration without waiting for a
+    heartbeat timeout or forced task cancellation. Must be called from
+    the asyncio event loop (e.g. the server lifespan shutdown handler);
+    sync callers should use :func:`close` per-conversation instead.
+    """
+    with _lock:
+        all_subs = [entry for subs in _subscribers.values() for entry in subs]
+    for queue, _ in all_subs:
+        with contextlib.suppress(asyncio.QueueFull):
+            queue.put_nowait(_DONE)
 
 
 async def subscribe(

--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -26,7 +26,6 @@ Consumer (SSE endpoint, async):
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import threading
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
@@ -131,15 +130,16 @@ def shutdown_all() -> None:
 
     Broadcasts the end-of-stream sentinel to every queued subscriber so
     SSE generators return at their next iteration without waiting for a
-    heartbeat timeout or forced task cancellation. Must be called from
-    the asyncio event loop (e.g. the server lifespan shutdown handler);
-    sync callers should use :func:`close` per-conversation instead.
+    heartbeat timeout or forced task cancellation. Called from the asyncio
+    event loop (``_ShutdownSignalingServer.shutdown`` in ``cli.py``) before
+    uvicorn's graceful-shutdown wait starts, so streams drain within the
+    window rather than being force-cancelled. Sync callers should use
+    :func:`close` per-conversation instead.
     """
     with _lock:
         all_subs = [entry for subs in _subscribers.values() for entry in subs]
     for queue, _ in all_subs:
-        with contextlib.suppress(asyncio.QueueFull):
-            queue.put_nowait(_DONE)
+        queue.put_nowait(_DONE)
 
 
 async def subscribe(

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1257,6 +1257,15 @@ def create_app(
         try:
             yield
         finally:
+            # Signal all active SSE subscribers to exit their generator
+            # loops cleanly before uvicorn's graceful-shutdown timer fires.
+            # Without this, every open session stream waits for its next
+            # heartbeat (up to 15 s) before noticing the server is going
+            # away, causing uvicorn to force-cancel them and log spurious
+            # "Exception in ASGI application" tracebacks.
+            from omnigent.runtime import session_stream as _session_stream
+
+            _session_stream.shutdown_all()
             metrics_publish_task.cancel()
             with suppress(asyncio.CancelledError):
                 await metrics_publish_task

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1257,15 +1257,6 @@ def create_app(
         try:
             yield
         finally:
-            # Signal all active SSE subscribers to exit their generator
-            # loops cleanly before uvicorn's graceful-shutdown timer fires.
-            # Without this, every open session stream waits for its next
-            # heartbeat (up to 15 s) before noticing the server is going
-            # away, causing uvicorn to force-cancel them and log spurious
-            # "Exception in ASGI application" tracebacks.
-            from omnigent.runtime import session_stream as _session_stream
-
-            _session_stream.shutdown_all()
             metrics_publish_task.cancel()
             with suppress(asyncio.CancelledError):
                 await metrics_publish_task


### PR DESCRIPTION
## Related issue

N/A — supersedes #2005

## Summary

- **Problem**: `e2e.yml` shared a PR-number concurrency key between code-push events (`synchronize`) and label events (`labeled`/`unlabeled`). When the `automerge` label was applied mid-run, the new workflow run shared the same concurrency key as the running suite and `cancel-in-progress: true` killed it.
- **Why not just remove `labeled`/`unlabeled`**: These triggers are the fallback recovery path for `skip-security-scan` — if `rerun-security-gate-run.yml` times out, `e2e.yml` re-fires and re-polls the security gate (see `rerun-security-gate-run.yml` line 105). Removing them (the approach in #2005) breaks that path.
- **Fix**: Two complementary changes in `.github/workflows/e2e.yml`:
  1. **Concurrency group key** — append the label name for `labeled`/`unlabeled` events, so each label gets its own isolated slot (`-automerge`, `-skip-security-scan`) that never collides with the code-push slot (`-run`). Applying `automerge` no longer cancels a running `synchronize` suite.
  2. **`gate` job `if:` condition** — short-circuit for label events that are not `skip-security-scan`, so runs triggered by unrelated labels (e.g. `automerge`) are fast no-ops rather than spinning up the full E2E suite.

## Test Plan

- Apply the `automerge` label to a PR mid-run and confirm the running E2E suite is **not** cancelled (different concurrency key suffix).
- Apply `skip-security-scan` label and confirm the workflow runs fully (gate `if:` passes, suite executes).
- Push a commit (`synchronize`) and confirm normal E2E run completes.
- Apply an unrelated label and confirm the workflow run skips immediately at the `gate` job.

## Demo

N/A — CI configuration change, no visual output.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

CI workflow change — verified by inspecting the concurrency key expressions and `if:` condition logic. The `automerge` label event now gets concurrency key suffix `-automerge` while `synchronize` gets `-run`, so they cannot cancel each other.

## Changelog

<!-- CI-only change — deleting this section -->