### PR TITLE
fix(ci): isolate label-event concurrency in e2e.yml to prevent automerge canceling running suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: "0 9 * * *"
   pull_request:
+    # labeled/unlabeled: kept for the skip-security-scan recovery path
+    # (rerun-security-gate-run.yml falls back to this trigger). The concurrency
+    # group key isolates label events so they never cancel a code-push run.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths-ignore: ['web/**', 'tests/e2e_ui/**']
   workflow_dispatch:
@@ -34,8 +37,9 @@ on:
 
 concurrency:
   # PRs key by number, dispatch by branch (so re-runs cancel); schedule keys
-  # by SHA so each merge to `main` gets its own run.
-  group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}
+  # by SHA so each merge to `main` gets its own run. Label events append the
+  # label name so they get an isolated slot and never cancel a code-push run.
+  group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}-${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name || 'run' }}
   cancel-in-progress: true
 
 permissions:
@@ -54,11 +58,14 @@ env:
 jobs:
   # Security gate: untrusted PRs wait on the deterministic scan
   # (security-gate.yml); trusted authors and non-PR events pass instantly.
-  # Skip when the automerge label is applied/removed -- safe to short-circuit
-  # here because every non-gate job is transitively downstream of gate, so
-  # no skipped check-run can overwrite an existing result on this SHA.
+  # Short-circuit for label events that aren't skip-security-scan (e.g.
+  # automerge): those run in their own isolated concurrency slot (above) and
+  # don't need the full suite — just exit fast.
   gate:
-    if: github.event.label.name != 'automerge'
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'skip-security-scan'
     uses: ./.github/workflows/security-gate.yml
 
   # Shard matrix (e2e-shard-matrix.sh, shared with e2e-ui.yml). Fork PRs run by


### PR DESCRIPTION
## Related issue

N/A (supersedes #2005)

## Summary

Applying the `automerge` label mid-run triggered a new `e2e.yml` run sharing the same PR-number concurrency key. With `cancel-in-progress: true`, this killed the in-progress suite leaving no E2E result.

Two-part fix:

- **Concurrency key isolation**: append the label name for label events (`-automerge`, `-skip-security-scan`, etc.), or `-run` for all other events. Each label now gets its own isolated concurrency slot and can never preempt a `synchronize`/`push` run.
- **Fast exit for irrelevant labels**: add `if:` on the `gate` job to short-circuit when the label is not `skip-security-scan` (e.g. `automerge`). Those runs exit immediately in their isolated slot rather than spinning up the full suite.

`labeled`/`unlabeled` stay in the trigger — they are the fallback recovery path for `skip-security-scan` referenced in `rerun-security-gate-run.yml` line 105.

## Test Plan

- Applying `automerge` to a PR with a running E2E suite will no longer trigger a cancellation — it fires into a separate `-automerge` concurrency slot and exits immediately at the gate `if:`.
- `skip-security-scan` label events still trigger the full suite (gate `if:` passes through).

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Not applicable

## Coverage notes

CI-only change. Verified by tracing the concurrency key logic and gate condition against the three label scenarios: `automerge` (isolated + fast exit), `skip-security-scan` (isolated + full run), unrelated labels (isolated + fast exit).