### PR TITLE
fix(claude-native): give the evaluate-policy hook the day-long timeout

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1211,6 +1211,14 @@ def build_hook_settings(
         evaluate_policy_hook: dict[str, Any] = {
             "type": "command",
             "command": shlex.join(evaluate_policy_command_parts),
+            # A TOOL_CALL/REQUEST policy ASK parks server-side until a human
+            # answers (up to the policy's ``ask_timeout``), and the client
+            # waits the full day for that verdict — so, like ``permission_hook``
+            # above, this command hook needs the day-long timeout. Without it
+            # Claude Code's ~60s command-hook default kills the subprocess long
+            # before the user answers, capping every admin-policy ASK at 60s
+            # (and in bypassPermissions mode this is the sole human gate).
+            "timeout": 86400,
         }
         # In bypassPermissions mode PermissionRequest never fires, so
         # AskUserQuestion needs its own PreToolUse hook to surface the

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2149,6 +2149,48 @@ def test_augment_claude_args_registers_permission_command_hook(
     assert "omnigent.claude_native_status" in settings["statusLine"]["command"]
 
 
+def test_augment_claude_args_evaluate_policy_hook_has_day_long_timeout(
+    tmp_path: Path,
+) -> None:
+    """
+    The evaluate-policy command hook must carry the same day-long timeout
+    as the permission hook.
+
+    A TOOL_CALL/REQUEST policy ASK parks server-side until a human resolves
+    it (up to the deciding policy's ``ask_timeout``), and the evaluate-policy
+    client waits the full day for that verdict. But the hook is a command
+    hook, so without an explicit ``timeout`` Claude Code's ~60s default kills
+    the subprocess long before the human answers — capping every admin-policy
+    ASK (e.g. a cost-budget gate) at 60s. In acceptEdits/bypassPermissions
+    mode, where PermissionRequest never fires, this is the sole human gate.
+    Must stay in lockstep with ``permission_hook``'s 86400 so no layer caps
+    the wait first.
+    """
+    args = augment_claude_args(
+        (),
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+        ap_server_url="http://127.0.0.1:8787/",
+        ap_auth_headers={"Authorization": "Bearer xyz"},
+    )
+    settings = json.loads(args[args.index("--settings") + 1])
+    evaluate_hooks = [
+        hook
+        for phase in ("PreToolUse", "PostToolUse", "UserPromptSubmit")
+        for entry in settings["hooks"].get(phase, [])
+        for hook in entry["hooks"]
+        if "evaluate-policy" in hook["command"]
+    ]
+    assert evaluate_hooks, "expected at least one evaluate-policy hook to be registered"
+    for hook in evaluate_hooks:
+        assert hook["type"] == "command"
+        assert hook["timeout"] == 86400, (
+            "evaluate-policy hook must carry the day-long timeout so a parked "
+            "policy ASK is not killed by Claude Code's ~60s command-hook default; "
+            f"got {hook.get('timeout')!r}."
+        )
+
+
 def test_augment_claude_args_registers_user_prompt_submit_policy_hook(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The evaluate-policy command hook (`build_hook_settings` in `claude_native_bridge.py`) had no explicit `timeout`, so Claude Code's ~60s command-hook default kills the hook subprocess. But a TOOL_CALL/REQUEST policy ASK parks server-side until a human answers — up to the deciding policy's `ask_timeout` (default one day) — and the evaluate-policy client already waits the full day (`_EVALUATE_POLICY_TIMEOUT_S = 86400`). So every admin-policy ASK (e.g. a cost-budget gate) was silently capped at 60s.
- In `acceptEdits`/`bypassPermissions` mode, where `PermissionRequest` never fires, this evaluate-policy gate is the **sole** human approval point — so the 60s cap means the hook-timeout fallback decides the policy before the operator can respond.
- Fix: add `timeout: 86400`, matching the sibling `permission_hook` (which already carries it for exactly this reason). It was the only one of the three command hooks left on Claude Code's default.

ELI5: the hook that waits for a human to approve a policy prompt didn't tell Claude Code how long to wait, so Claude Code killed it after ~60s — long before the person could answer. The permission hook right next to it already says "wait a day"; this one just forgot to.

```
three command hooks in build_hook_settings:
  permission_hook       → timeout: 86400   ✓ (waits for the human)
  AskUserQuestion hook   → timeout: 10      ✓ (short by design)
  evaluate_policy_hook   → (none) → ~60s default   ✗  ← this PR
```

The real ceiling stays the policy's own `ask_timeout`; this just stops the command-hook layer from capping the wait first.

## Test Plan

- New unit test `test_augment_claude_args_evaluate_policy_hook_has_day_long_timeout`: asserts every registered evaluate-policy hook (PreToolUse/PostToolUse/UserPromptSubmit) carries `timeout == 86400`. Red on `main` (`KeyError: 'timeout'` — the key is absent), green with the fix.
- `tests/test_claude_native_bridge.py` otherwise unchanged; the two `serve_mcp`/`relay` failures on my machine are pre-existing (they spawn a real subprocess that doesn't come up in my local sandbox) and reproduce identically with this change stashed — unrelated to this hook change.

## Demo

Red → green on the unit test. Red run is the pre-fix source with this PR's test: the evaluate-policy hook dict has no `timeout` key (`KeyError`), while the sibling `permission_hook` already carries 86400.

![red-to-green evaluate-policy hook timeout test](https://raw.githubusercontent.com/tomsen-ai/omnigent/pr-demo-assets/demos/omnigent-2012-demo.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit test drives `augment_claude_args` and asserts the timeout on every evaluate-policy hook registration; it fails on `main` and passes with the fix. The end-to-end "human answers after 60s" path depends on Claude Code's command-hook kill behaviour and isn't unit-testable here, but the fix mirrors the already-shipped `permission_hook` timeout.

## Changelog

Admin policy approval prompts (e.g. cost-budget gates) in native Claude sessions no longer time out after ~60s before the operator can respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
