### PR TITLE
fix(members): show friendly message in single-user/header mode

### DIFF
--- a/web/src/pages/MembersPage.test.tsx
+++ b/web/src/pages/MembersPage.test.tsx
@@ -15,10 +15,18 @@ import type { AccountListEntry } from "@/lib/accountsApi";
 import * as accountsApi from "@/lib/accountsApi";
 import * as identity from "@/lib/identity";
 
-const mocks = vi.hoisted(() => ({ accountsEnabled: true }));
+const mocks = vi.hoisted(() => ({
+  accountsEnabled: true,
+  loginUrl: null as string | null,
+  serverVersion: "0.3.0.dev0" as string | null,
+}));
 
 vi.mock("@/lib/CapabilitiesContext", () => ({
-  useServerInfo: () => ({ accounts_enabled: mocks.accountsEnabled }),
+  useServerInfo: () => ({
+    accounts_enabled: mocks.accountsEnabled,
+    login_url: mocks.loginUrl,
+    server_version: mocks.serverVersion,
+  }),
 }));
 vi.mock("@/lib/identity", () => ({
   resolveIdentity: vi.fn(),
@@ -52,6 +60,8 @@ function renderPage() {
 
 beforeEach(() => {
   mocks.accountsEnabled = true;
+  mocks.loginUrl = null;
+  mocks.serverVersion = "0.3.0.dev0";
   vi.mocked(identity.resolveIdentity).mockResolvedValue("admin");
   vi.mocked(identity.getCurrentIsAdmin).mockReturnValue(true);
   vi.mocked(accountsApi.listUsers).mockResolvedValue([]);
@@ -183,12 +193,32 @@ describe("MembersPage actions", () => {
   });
 });
 
+describe("MembersPage in plain header/single-user mode", () => {
+  beforeEach(() => {
+    // Single-user mode: no accounts, no IdP (login_url is null). The
+    // /auth/users endpoint does not exist, so the page must skip the fetch
+    // and show a "not available" message instead.
+    mocks.accountsEnabled = false;
+    mocks.loginUrl = null;
+    mocks.serverVersion = "0.3.0.dev0";
+  });
+
+  it("shows a not-available message and never calls listUsers", async () => {
+    renderPage();
+    expect(
+      await screen.findByText("Member management is not available in single-user mode."),
+    ).toBeInTheDocument();
+    expect(accountsApi.listUsers).not.toHaveBeenCalled();
+  });
+});
+
 describe("MembersPage under OIDC (read-only)", () => {
   beforeEach(() => {
-    // OIDC: accounts disabled → no password-based management. The list still
-    // renders (admins can see who's provisioned), but every management
-    // affordance is gone.
+    // OIDC: accounts disabled but login_url is non-null (IdP present).
+    // The list still renders (admins can see who's provisioned), but every
+    // management affordance is gone.
     mocks.accountsEnabled = false;
+    mocks.loginUrl = "/auth/login";
   });
 
   it("lists users but offers no management actions", async () => {

--- a/web/src/pages/MembersPage.tsx
+++ b/web/src/pages/MembersPage.tsx
@@ -55,6 +55,14 @@ export function MembersPage() {
   // accounts mode — OIDC identities are owned by the IdP, so under OIDC
   // this page is a read-only user list (no action column, no modals).
   const manageable = info !== "loading" && info.accounts_enabled;
+  // Plain header/single-user mode: no auth endpoints exist. server_version
+  // distinguishes a live single-user server from a failed /v1/info probe
+  // (which uses the same accounts_enabled:false / login_url:null sentinel).
+  const isSingleUser =
+    info !== "loading" &&
+    !info.accounts_enabled &&
+    info.login_url === null &&
+    info.server_version !== null;
   const [meIsAdmin, setMeIsAdmin] = useState<boolean | null>(null);
   const [meId, setMeId] = useState<string | null>(null);
   const [users, setUsers] = useState<AccountListEntry[] | null>(null);
@@ -82,12 +90,11 @@ export function MembersPage() {
     setUsers(list);
   }, []);
 
-  // Initial load: identity probe + members list. The identity probe
-  // gates the UI (non-admins see "no access"); the list is what we
-  // render the table from. Uses the mode-agnostic `/v1/me` identity
-  // (via resolveIdentity) rather than the accounts-only `/auth/me`, so
-  // the page also works under OIDC where `/auth/me` doesn't exist.
+  // Initial load: identity probe + members list. Skipped in single-user
+  // mode since no auth endpoints exist. isSingleUser is a stable boolean
+  // so it is safe as a dep without risking infinite re-renders.
   useEffect(() => {
+    if (isSingleUser) return;
     void (async () => {
       const userId = await resolveIdentity();
       if (userId === null) {
@@ -101,11 +108,9 @@ export function MembersPage() {
       setMeIsAdmin(isAdmin);
       if (isAdmin) await refresh();
     })();
-  }, [refresh]);
+  }, [refresh, isSingleUser]);
 
-  // Plain header/single-user mode: no accounts, no IdP. The /auth/users
-  // endpoint doesn't exist, so skip the fetch entirely.
-  if (info !== "loading" && !info.accounts_enabled && info.login_url === null) {
+  if (isSingleUser) {
     return (
       <div className="mx-auto w-full max-w-2xl px-6 py-12">
         <h1 className="mb-2 text-2xl font-semibold">Members</h1>
@@ -117,6 +122,8 @@ export function MembersPage() {
   }
 
   // Pre-admin-check render: blank loading state. min-h-full so the
+  // AppShell's outlet container governs height — we're a child view,
+  // not a full-page replacement. min-h-full so the
   // AppShell's outlet container governs height — we're a child view,
   // not a full-page replacement.
   if (meIsAdmin === null) {

--- a/web/src/pages/MembersPage.tsx
+++ b/web/src/pages/MembersPage.tsx
@@ -103,6 +103,19 @@ export function MembersPage() {
     })();
   }, [refresh]);
 
+  // Plain header/single-user mode: no accounts, no IdP. The /auth/users
+  // endpoint doesn't exist, so skip the fetch entirely.
+  if (info !== "loading" && !info.accounts_enabled && info.login_url === null) {
+    return (
+      <div className="mx-auto w-full max-w-2xl px-6 py-12">
+        <h1 className="mb-2 text-2xl font-semibold">Members</h1>
+        <p className="text-sm text-muted-foreground">
+          Member management is not available in single-user mode.
+        </p>
+      </div>
+    );
+  }
+
   // Pre-admin-check render: blank loading state. min-h-full so the
   // AppShell's outlet container governs height — we're a child view,
   // not a full-page replacement.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The Members page showed a misleading "Could not load members. You may not have admin permission, or the server is unreachable." error in plain header/single-user mode (no accounts, no OIDC).
- In this mode there is no `/auth/users` endpoint, so the fetch returned 404 and hit the error path.
- Added an early return after all React hooks when `accounts_enabled` is false and `login_url` is null, rendering a clear "Member management is not available in single-user mode." message instead.

## Test Plan

- Start the server in plain header mode (no `--accounts` flag, no OIDC config).
- Navigate to `/settings/members`.
- Verify the page shows "Member management is not available in single-user mode." instead of the auth error.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually: in single-user/header mode the page renders the "not available" message without triggering a network fetch to the non-existent `/auth/users` endpoint.

## Changelog

Members page now shows a clear "not available in single-user mode" message instead of a confusing auth error when running without accounts or OIDC.