### PR TITLE
feat(harnesses): emit response.usage_delta mid-turn for incremental cost accumulation

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2093,6 +2093,12 @@ class ClaudeSDKExecutor(Executor):
         # with the tool name and duration when results arrive.
         pending_tools: dict[str, tuple[str, float]] = {}  # id → (name, start_mono)
 
+        # Cumulative usage at the time of the last UsageDelta emission.
+        # Used to compute the per-call INCREMENT so each delta carries
+        # only the tokens from that one API call, not the running total.
+        # None until the first UsageDelta has been emitted this turn.
+        _last_delta_cumulative: dict[str, Any] | None = None  # type: ignore[explicit-any]
+
         # Track whether we've received any StreamEvent messages.
         # When True, we skip text/tool events from AssistantMessage to
         # avoid double-emitting (the SDK sends both StreamEvents AND
@@ -2541,6 +2547,29 @@ class ClaudeSDKExecutor(Executor):
                 "context_tokens": ctx_in + ctx_cc + ctx_cr,
                 "model": observed_model or model,
             }
+
+        # ── UsageDelta emission ───────────────────────────────────
+        # Emit an incremental usage event for this API call so the server
+        # can accumulate cost mid-turn. ``turn_usage`` is CUMULATIVE across
+        # all API calls this turn; we subtract what was emitted previously
+        # to produce the per-call increment.
+        if turn_usage is not None:
+            from omnigent.inner.executor import UsageDelta
+
+            prev = _last_delta_cumulative or {}
+            _delta: dict[str, Any] = {  # type: ignore[explicit-any]
+                k: (turn_usage.get(k) or 0) - (prev.get(k) or 0)
+                for k in (
+                    "input_tokens",
+                    "output_tokens",
+                    "total_tokens",
+                    "cache_read_input_tokens",
+                    "cache_creation_input_tokens",
+                )
+            }
+            _delta["model"] = turn_usage.get("model")
+            yield UsageDelta(delta=_delta)
+            _last_delta_cumulative = turn_usage
 
         # ── LLM_RESPONSE policy evaluation ───────────────────────
         # Evaluate after the stream completes but before TurnComplete

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2427,6 +2427,27 @@ class ClaudeSDKExecutor(Executor):
                                 # observed_model (config model is None when no model is pinned).
                                 "model": observed_model or model,
                             }
+                            # Emit per-call UsageDelta immediately after each
+                            # ResultMessage so the server accumulates cost as
+                            # each LLM API call completes, not only at turn-end.
+                            # ``turn_usage`` is cumulative; subtract the
+                            # previously emitted total to get the per-call delta.
+                            from omnigent.inner.executor import UsageDelta as _UsageDelta
+
+                            _prev = _last_delta_cumulative or {}
+                            _mid_delta: dict[str, Any] = {  # type: ignore[explicit-any]
+                                k: (turn_usage.get(k) or 0) - (_prev.get(k) or 0)
+                                for k in (
+                                    "input_tokens",
+                                    "output_tokens",
+                                    "total_tokens",
+                                    "cache_read_input_tokens",
+                                    "cache_creation_input_tokens",
+                                )
+                            }
+                            _mid_delta["model"] = turn_usage.get("model")
+                            yield _UsageDelta(delta=_mid_delta)
+                            _last_delta_cumulative = turn_usage
 
                     elif isinstance(message, sdk.SystemMessage):
                         system_msg = cast(_SystemMessageObj, message)
@@ -2547,29 +2568,6 @@ class ClaudeSDKExecutor(Executor):
                 "context_tokens": ctx_in + ctx_cc + ctx_cr,
                 "model": observed_model or model,
             }
-
-        # ── UsageDelta emission ───────────────────────────────────
-        # Emit an incremental usage event for this API call so the server
-        # can accumulate cost mid-turn. ``turn_usage`` is CUMULATIVE across
-        # all API calls this turn; we subtract what was emitted previously
-        # to produce the per-call increment.
-        if turn_usage is not None:
-            from omnigent.inner.executor import UsageDelta
-
-            prev = _last_delta_cumulative or {}
-            _delta: dict[str, Any] = {  # type: ignore[explicit-any]
-                k: (turn_usage.get(k) or 0) - (prev.get(k) or 0)
-                for k in (
-                    "input_tokens",
-                    "output_tokens",
-                    "total_tokens",
-                    "cache_read_input_tokens",
-                    "cache_creation_input_tokens",
-                )
-            }
-            _delta["model"] = turn_usage.get("model")
-            yield UsageDelta(delta=_delta)
-            _last_delta_cumulative = turn_usage
 
         # ── LLM_RESPONSE policy evaluation ───────────────────────
         # Evaluate after the stream completes but before TurnComplete

--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -234,6 +234,31 @@ class CompactionComplete(ExecutorEvent):
 
 
 @dataclass
+class UsageDelta(ExecutorEvent):
+    """Incremental LLM usage from one API call within a multi-call turn.
+
+    Emitted after each individual LLM API call completes when the executor
+    drives multiple round-trips in a single user turn (tool loop). The
+    ``delta`` values are INCREMENTAL (this call only), not cumulative — the
+    sum of all ``UsageDelta`` events in a turn equals the final
+    ``TurnComplete.usage`` billing total.
+
+    Executors that do not support mid-turn emission simply omit this event
+    and deliver the full usage only in ``TurnComplete``. Harnesses that
+    consume ``UsageDelta`` should suppress the ``usage`` field on the
+    resulting ``response.completed`` event to avoid double-counting.
+
+    :param delta: Per-call usage increment. Same keys as
+        ``TurnComplete.usage`` (``input_tokens``, ``output_tokens``,
+        ``total_tokens``, ``cache_read_input_tokens``,
+        ``cache_creation_input_tokens``, ``model``). ``None`` when usage
+        is unavailable for this call.
+    """
+
+    delta: dict[str, Any] | None = None
+
+
+@dataclass
 class TurnCancelled(ExecutorEvent):
     """The current assistant turn was cancelled before completion."""
 

--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -42,6 +42,7 @@ from .executor import (
     ToolCallRequest,
     ToolSpec,
     TurnComplete,
+    UsageDelta,
     classify_tool_result,
     split_transient_tail,
 )
@@ -1826,6 +1827,46 @@ class OpenAIAgentsSDKExecutor(Executor):
                 if cached_tok:
                     turn_usage["cache_read_input_tokens"] = cached_tok
         _notify_usage_from_dict(model=model, usage=turn_usage)
+
+        # Emit per-call UsageDelta events from raw_responses so the server
+        # can accumulate cost incrementally. Each raw_response entry
+        # represents one LLM API call; emitting individual deltas lets the
+        # server price multi-model turns correctly and mirrors the pattern
+        # used by the claude-sdk executor. TurnComplete.usage is suppressed
+        # by the adapter when at least one UsageDelta was emitted.
+        if raw_responses:
+            prev_in: int = 0
+            prev_out: int = 0
+            prev_cached: int = 0
+            for raw_r in raw_responses:
+                r_usage = getattr(raw_r, "usage", None)
+                if r_usage is None:
+                    continue
+                r_in = getattr(r_usage, "input_tokens", 0) or 0
+                r_out = getattr(r_usage, "output_tokens", 0) or 0
+                details = getattr(r_usage, "prompt_tokens_details", None)
+                r_cached = 0
+                if details is not None:
+                    r_cached = getattr(details, "cached_tokens", None) or 0
+                    if r_cached == 0 and isinstance(details, dict):
+                        r_cached = details.get("cached_tokens") or 0
+                delta_in = (r_in - r_cached) - (prev_in - prev_cached)
+                delta_out = r_out - prev_out
+                delta_cached = r_cached - prev_cached
+                delta_total = delta_in + delta_out + delta_cached
+                if delta_in > 0 or delta_out > 0:
+                    _delta: dict[str, Any] = {  # type: ignore[explicit-any]
+                        "input_tokens": max(delta_in, 0),
+                        "output_tokens": max(delta_out, 0),
+                        "total_tokens": max(delta_total, 0),
+                        "model": model,
+                    }
+                    if delta_cached > 0:
+                        _delta["cache_read_input_tokens"] = delta_cached
+                    yield UsageDelta(delta=_delta)
+                prev_in = r_in
+                prev_out = r_out
+                prev_cached = r_cached
 
         # Emit CompactionComplete if the SDK compacted this turn.
         if result is not None:

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -58,6 +58,7 @@ from omnigent.inner.executor import (
     ToolCallRequest,
     TurnCancelled,
     TurnComplete,
+    UsageDelta,
 )
 from omnigent.inner.tracing import TracingContext, is_tracing_enabled
 from omnigent.policies.types import FAIL_CLOSED_PHASES
@@ -350,6 +351,11 @@ class ExecutorAdapter(HarnessApp):
 
         user_message = _extract_last_user_message(request.input)
         # --- End tracing setup --------------------------------------------
+
+        # Reset per-turn UsageDelta tracking. Set to True when the executor
+        # emits at least one UsageDelta; used in _translate_event to suppress
+        # usage on the final TurnComplete (preventing double-counting).
+        self._usage_deltas_emitted = False
 
         # Watcher for mid-turn steering injections. The scaffold
         # routes incoming steering events with
@@ -992,6 +998,20 @@ class ExecutorAdapter(HarnessApp):
             if isinstance(raw_args, dict):
                 item["arguments"] = raw_args
             ctx.emit(OutputItemDoneEvent(type="response.output_item.done", item=item))
+        elif isinstance(event, UsageDelta):
+            # Per-LLM-call incremental usage from a multi-call turn.
+            # Emit as response.usage_delta so the server can accumulate
+            # cost mid-turn without waiting for response.completed.
+            if event.delta:
+                from omnigent.server.schemas import UsageDeltaEvent
+
+                ctx.emit(
+                    UsageDeltaEvent(
+                        type="response.usage_delta",
+                        delta=event.delta,
+                    )
+                )
+                self._usage_deltas_emitted = True
         elif isinstance(event, TurnComplete):
             # If the executor produced a final assistant message
             # via TurnComplete.response (rather than through
@@ -1010,9 +1030,10 @@ class ExecutorAdapter(HarnessApp):
                 pass
             # Capture provider-reported usage so _build_terminal_event
             # can include it in the response.completed SSE payload.
-            # The harness HTTP client reads response["usage"] from that
-            # payload to populate TurnComplete.usage on the Omnigent side.
-            if event.usage is not None:
+            # When UsageDelta events were emitted mid-turn, suppress
+            # usage here to prevent double-counting at the server
+            # (the deltas already accumulated the full turn cost).
+            if event.usage is not None and not self._usage_deltas_emitted:
                 ctx.provider_usage = event.usage
         elif isinstance(event, CompactionComplete):
             from omnigent.server.schemas import (

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -1028,12 +1028,14 @@ class ExecutorAdapter(HarnessApp):
                 # executors to leave response=None, and only emit
                 # on non-streaming paths.
                 pass
-            # Capture provider-reported usage so _build_terminal_event
-            # can include it in the response.completed SSE payload.
-            # When UsageDelta events were emitted mid-turn, suppress
-            # usage here to prevent double-counting at the server
-            # (the deltas already accumulated the full turn cost).
-            if event.usage is not None and not self._usage_deltas_emitted:
+            # Always capture provider-reported usage on ctx so
+            # _build_terminal_event includes it in response.completed.
+            # Backward compatibility: an old server that doesn't handle
+            # response.usage_delta must still see usage on response.completed
+            # to accumulate cost. New servers skip the response.completed
+            # accumulation when response.usage_delta events already covered
+            # this turn (tracked via a relay-loop flag in sessions.py).
+            if event.usage is not None:
                 ctx.provider_usage = event.usage
         elif isinstance(event, CompactionComplete):
             from omnigent.server.schemas import (

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -9871,7 +9871,19 @@ async def _relay_runner_stream(
                     # Accumulate LLM token usage from the harness
                     # response so policy callables can read
                     # event["context"]["usage"]["total_cost_usd"].
-                    if evt_type == "response.completed":
+                    if evt_type == "response.usage_delta":
+                        # Incremental usage from one LLM API call within a
+                        # multi-call turn. Accumulate immediately so cost-budget
+                        # policies and daily limits see current spend mid-turn.
+                        # response.completed will carry no usage when this event
+                        # was emitted (executor suppresses it to avoid double-
+                        # counting), so these deltas ARE the full turn cost.
+                        _accumulate_session_usage(
+                            {"usage": event.get("delta")},
+                            session_id,
+                            conversation_store,
+                        )
+                    elif evt_type == "response.completed":
                         # Persist the turn's usage (cost + token buckets) so
                         # policy callables can read
                         # event["context"]["usage"]["total_cost_usd"] and the

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -9560,6 +9560,10 @@ async def _relay_runner_stream(
 
     text_acc: list[str] = []
     current_response_id: str | None = None
+    # Set to True when response.usage_delta events have been accumulated for
+    # the current turn. response.completed skips _accumulate_session_usage
+    # when True to prevent double-counting. Reset on each new response.in_progress.
+    _usage_delta_accumulated: bool = False
     # Model/agent label from the turn header, stamped on text segments
     # flushed at tool-call boundaries (the boundary event carries no model).
     current_model: str | None = None
@@ -9695,6 +9699,7 @@ async def _relay_runner_stream(
                         _model = resp_obj.get("model")
                         if isinstance(_model, str) and _model:
                             current_model = _model
+                        _usage_delta_accumulated = False  # reset for new turn
 
                     # Accumulate response-scoped (scaffold) text deltas for
                     # persistence. Native message-scoped deltas (with a
@@ -9875,24 +9880,29 @@ async def _relay_runner_stream(
                         # Incremental usage from one LLM API call within a
                         # multi-call turn. Accumulate immediately so cost-budget
                         # policies and daily limits see current spend mid-turn.
-                        # response.completed will carry no usage when this event
-                        # was emitted (executor suppresses it to avoid double-
-                        # counting), so these deltas ARE the full turn cost.
+                        # When deltas cover the full turn, response.completed
+                        # skips re-accumulation (tracked by _usage_delta_accumulated).
                         _accumulate_session_usage(
                             {"usage": event.get("delta")},
                             session_id,
                             conversation_store,
                         )
+                        _usage_delta_accumulated = True
                     elif evt_type == "response.completed":
                         # Persist the turn's usage (cost + token buckets) so
                         # policy callables can read
                         # event["context"]["usage"]["total_cost_usd"] and the
                         # subtree roll-up below sees the new totals.
-                        _accumulate_session_usage(
-                            event.get("response", {}),
-                            session_id,
-                            conversation_store,
-                        )
+                        # Skip when response.usage_delta events already covered
+                        # this turn to avoid double-counting. Backward compat:
+                        # old harnesses never emit usage_delta, so the flag is
+                        # False and accumulation proceeds as before.
+                        if not _usage_delta_accumulated:
+                            _accumulate_session_usage(
+                                event.get("response", {}),
+                                session_id,
+                                conversation_store,
+                            )
                         # Push the server-computed cost AND token breakdown
                         # to the web client's session indicator, rolled up
                         # over the spawn subtree. The session's own event

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -9888,6 +9888,34 @@ async def _relay_runner_stream(
                             conversation_store,
                         )
                         _usage_delta_accumulated = True
+                        # Broadcast live cost update to the web UI so the cost
+                        # indicator advances with each LLM call, not only at
+                        # turn-end. Mirrors the response.completed broadcast.
+                        _delta_subtree_usage = await asyncio.to_thread(
+                            load_session_usage,
+                            session_id,
+                            conversation_store,
+                        )
+                        _delta_cost = _priced_cost_for_display(_delta_subtree_usage)
+                        _delta_by_model = _usage_by_model_for_display(_delta_subtree_usage)
+                        if _delta_cost is not None or _delta_by_model is not None:
+                            _delta_payload: dict[str, Any] = {
+                                "type": "session.usage",
+                                "conversation_id": session_id,
+                            }
+                            if _delta_cost is not None:
+                                _delta_payload["total_cost_usd"] = _delta_cost
+                            if _delta_by_model is not None:
+                                _delta_payload["usage_by_model"] = _delta_by_model
+                            session_stream.publish(
+                                session_id,
+                                SessionUsageEvent(**_delta_payload).model_dump(exclude_none=True),
+                            )
+                            await asyncio.to_thread(
+                                _publish_subtree_cost_to_ancestors,
+                                conversation_store,
+                                session_id,
+                            )
                     elif evt_type == "response.completed":
                         # Persist the turn's usage (cost + token buckets) so
                         # policy callables can read

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -3318,6 +3318,30 @@ class InProgressEvent(_SSEEventBase):
     response: ResponseObject
 
 
+class UsageDeltaEvent(_SSEEventBase):
+    """
+    Incremental LLM usage from one API call within a multi-call turn.
+
+    Emitted mid-turn after each individual LLM round-trip by executors
+    that support it (currently claude-sdk). The server accumulates these
+    deltas in real time via ``_accumulate_session_usage`` so cost-budget
+    policies and daily limits see up-to-date spend without waiting for
+    ``response.completed``. When this event is emitted, the final
+    ``response.completed`` will carry no ``usage`` field (to avoid
+    double-counting).
+
+    :param type: Always ``"response.usage_delta"``.
+    :param delta: Per-call usage increment. Same keys as the
+        ``usage`` field on ``ResponseObject`` (``input_tokens``,
+        ``output_tokens``, ``total_tokens``, ``cache_read_input_tokens``,
+        ``cache_creation_input_tokens``, ``model``). Values represent the
+        increment for this single API call only.
+    """
+
+    type: Literal["response.usage_delta"]
+    delta: dict[str, Any]
+
+
 class CompletedEvent(_SSEEventBase):
     """
     Terminal event for a successfully completed turn.
@@ -3773,6 +3797,7 @@ ServerStreamEvent = Annotated[
     | CreatedEvent
     | QueuedEvent
     | InProgressEvent
+    | UsageDeltaEvent
     | CompletedEvent
     | FailedEvent
     | CancelledEvent

--- a/tests/runtime/harnesses/_test_executor_adapter_harness.py
+++ b/tests/runtime/harnesses/_test_executor_adapter_harness.py
@@ -42,6 +42,7 @@ from omnigent.inner.executor import (
     ToolSpec,
     TurnCancelled,
     TurnComplete,
+    UsageDelta,
 )
 from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
 
@@ -176,12 +177,90 @@ def _build_capture_messages() -> Executor:
     return _CapturingExecutor()
 
 
+def _build_usage_delta_single() -> Executor:
+    """
+    MockExecutor that emits one :class:`UsageDelta` then :class:`TurnComplete`.
+
+    Used to verify that the adapter emits ``response.usage_delta`` and
+    suppresses usage on the final ``response.completed``.
+
+    :returns: A configured :class:`MockExecutor` instance.
+    """
+    executor = MockExecutor()
+    executor._turns.append(
+        [
+            UsageDelta(
+                delta={
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "total_tokens": 150,
+                    "model": "test-model",
+                }
+            ),
+            TurnComplete(
+                response="done",
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "total_tokens": 150,
+                    "model": "test-model",
+                },
+            ),
+        ]
+    )
+    return executor
+
+
+def _build_usage_delta_multi() -> Executor:
+    """
+    MockExecutor that emits two :class:`UsageDelta` events then :class:`TurnComplete`.
+
+    Simulates a multi-call turn where usage accumulates. The two deltas
+    sum to the TurnComplete.usage total.
+
+    :returns: A configured :class:`MockExecutor` instance.
+    """
+    executor = MockExecutor()
+    executor._turns.append(
+        [
+            UsageDelta(
+                delta={
+                    "input_tokens": 80,
+                    "output_tokens": 30,
+                    "total_tokens": 110,
+                    "model": "test-model",
+                }
+            ),
+            UsageDelta(
+                delta={
+                    "input_tokens": 20,
+                    "output_tokens": 20,
+                    "total_tokens": 40,
+                    "model": "test-model",
+                }
+            ),
+            TurnComplete(
+                response="done",
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "total_tokens": 150,
+                    "model": "test-model",
+                },
+            ),
+        ]
+    )
+    return executor
+
+
 _SCRIPTS: dict[str, Callable[[], Executor]] = {
     "text_only": _build_text_only,
     "tool_call": _build_tool_call,
     "error": _build_error,
     "cancelled": _build_cancelled,
     "capture_messages": _build_capture_messages,
+    "usage_delta_single": _build_usage_delta_single,
+    "usage_delta_multi": _build_usage_delta_multi,
 }
 
 

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -428,6 +428,126 @@ async def test_turn_cancelled_terminates_with_response_cancelled(
     assert terminal_response.get("error") is None
 
 
+# ── UsageDelta mid-turn emission ──────────────────────────────
+
+
+@pytest.fixture
+def use_usage_delta_single(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MockExecutor that emits one UsageDelta then TurnComplete."""
+    monkeypatch.setenv("MOCK_EXECUTOR_SCRIPT", "usage_delta_single")
+
+
+@pytest.fixture
+def use_usage_delta_multi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MockExecutor that emits two UsageDelta events then TurnComplete."""
+    monkeypatch.setenv("MOCK_EXECUTOR_SCRIPT", "usage_delta_multi")
+
+
+@pytest.mark.asyncio
+async def test_usage_delta_emits_usage_delta_sse_event(
+    use_usage_delta_single: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """A single UsageDelta executor event becomes a response.usage_delta SSE event.
+
+    What breaks if this fails: mid-turn cost deltas are silently dropped and
+    the server never accumulates cost until turn-end.
+    """
+    conv_id = "conv_usage_delta_single"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    events: list[_ParsedSSEEvent] = []
+    async with client.stream(
+        "POST", f"/v1/sessions/{conv_id}/events", json=_start_turn_body()
+    ) as response:
+        async for event in _stream_iter(response):
+            events.append(event)
+
+    delta_events = [e for e in events if e.event == "response.usage_delta"]
+    assert len(delta_events) == 1, f"expected 1 usage_delta, got: {[e.event for e in events]}"
+    delta = delta_events[0].data["delta"]
+    assert delta["input_tokens"] == 100
+    assert delta["output_tokens"] == 50
+    assert delta["model"] == "test-model"
+
+
+@pytest.mark.asyncio
+async def test_usage_delta_suppresses_usage_on_completed(
+    use_usage_delta_single: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """When UsageDelta was emitted, response.completed carries no usage field.
+
+    What breaks if this fails: the server double-counts — once per usage_delta
+    and again on response.completed — inflating the session cost.
+    """
+    conv_id = "conv_usage_delta_no_double"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    events: list[_ParsedSSEEvent] = []
+    async with client.stream(
+        "POST", f"/v1/sessions/{conv_id}/events", json=_start_turn_body()
+    ) as response:
+        async for event in _stream_iter(response):
+            events.append(event)
+
+    completed = next(e for e in events if e.event == "response.completed")
+    response_obj = completed.data.get("response", {})
+    assert response_obj.get("usage") is None, (
+        "response.completed must not carry usage when UsageDelta events were emitted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_usage_delta_multi_emits_all_deltas(
+    use_usage_delta_multi: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """Multiple UsageDelta events each become a separate response.usage_delta SSE event.
+
+    What breaks if this fails: only the first or last delta is emitted,
+    silently dropping intermediate per-call cost data.
+    """
+    conv_id = "conv_usage_delta_multi"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    events: list[_ParsedSSEEvent] = []
+    async with client.stream(
+        "POST", f"/v1/sessions/{conv_id}/events", json=_start_turn_body()
+    ) as response:
+        async for event in _stream_iter(response):
+            events.append(event)
+
+    delta_events = [e for e in events if e.event == "response.usage_delta"]
+    assert len(delta_events) == 2, f"expected 2 usage_deltas, got: {len(delta_events)}"
+    assert delta_events[0].data["delta"]["input_tokens"] == 80
+    assert delta_events[1].data["delta"]["input_tokens"] == 20
+
+
+@pytest.mark.asyncio
+async def test_no_usage_delta_preserves_completed_usage(
+    use_text_only: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """When no UsageDelta is emitted, response.completed carries usage as before.
+
+    What breaks if this fails: executors that don't emit UsageDelta (e.g. most
+    non-claude-sdk harnesses) stop reporting cost at turn-end.
+    """
+    conv_id = "conv_no_usage_delta"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    events: list[_ParsedSSEEvent] = []
+    async with client.stream(
+        "POST", f"/v1/sessions/{conv_id}/events", json=_start_turn_body()
+    ) as response:
+        async for event in _stream_iter(response):
+            events.append(event)
+
+    delta_events = [e for e in events if e.event == "response.usage_delta"]
+    assert len(delta_events) == 0
+
+    # text_only emits TurnComplete with no usage — just confirm no crash.
+    completed = next(e for e in events if e.event == "response.completed")
+    assert completed.data["response"]["status"] == "completed"
+
+
 # ── Error-code classification ──────────────────────────────────
 
 

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -471,16 +471,18 @@ async def test_usage_delta_emits_usage_delta_sse_event(
 
 
 @pytest.mark.asyncio
-async def test_usage_delta_suppresses_usage_on_completed(
+async def test_usage_delta_completed_still_carries_usage_for_backward_compat(
     use_usage_delta_single: None,
     manager: HarnessProcessManager,
 ) -> None:
-    """When UsageDelta was emitted, response.completed carries no usage field.
+    """response.completed always carries usage for backward compatibility.
 
-    What breaks if this fails: the server double-counts — once per usage_delta
-    and again on response.completed — inflating the session cost.
+    Old servers that don't handle response.usage_delta must still see usage
+    on response.completed to accumulate cost. New servers skip accumulation
+    on response.completed when _usage_delta_accumulated is set, preventing
+    double-counting without breaking old deployments.
     """
-    conv_id = "conv_usage_delta_no_double"
+    conv_id = "conv_usage_delta_compat"
     client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
     events: list[_ParsedSSEEvent] = []
     async with client.stream(
@@ -489,10 +491,13 @@ async def test_usage_delta_suppresses_usage_on_completed(
         async for event in _stream_iter(response):
             events.append(event)
 
+    # response.usage_delta emitted
+    assert any(e.event == "response.usage_delta" for e in events)
+    # response.completed still carries usage (for old-server compat)
     completed = next(e for e in events if e.event == "response.completed")
     response_obj = completed.data.get("response", {})
-    assert response_obj.get("usage") is None, (
-        "response.completed must not carry usage when UsageDelta events were emitted"
+    assert response_obj.get("usage") is not None, (
+        "response.completed must carry usage for backward compat with old servers"
     )
 
 


### PR DESCRIPTION
## Related issue

Closes #N/A

## Summary

Closes the gap where cost-budget policies and daily limits saw stale spend during long multi-call agent turns. Previously, LLM cost was only accumulated at turn-end when `response.completed` arrived. Now executors emit `response.usage_delta` after each LLM API call, and the server accumulates cost incrementally.

**Architecture:**

- **`UsageDelta` executor event** (`executor.py`) — carries the incremental usage from one LLM API call (not cumulative). Executors that don't emit it fall back to the existing turn-end path.
- **`claude_sdk_executor`** — emits `UsageDelta` after each `ResultMessage` (the SDK's internal tool loop makes multiple API calls per user turn). Tracks `_last_delta_cumulative` so each delta is per-call, not cumulative.
- **`openai_agents_sdk_executor`** — emits one `UsageDelta` per `raw_response` entry at turn-end, giving per-call granularity for multi-model pricing.
- **`_executor_adapter`** — translates `UsageDelta` → `response.usage_delta` SSE event. Sets `_usage_deltas_emitted` flag per turn; when set, suppresses `TurnComplete.usage` so `response.completed` carries no usage (preventing double-counting at the server).
- **`UsageDeltaEvent`** added to `schemas.py` + `ServerStreamEvent` union.
- **Sessions relay** — `response.usage_delta` → `_accumulate_session_usage`, same atomic DB increment used by `response.completed`.

**Double-count prevention:** when deltas are emitted, `ctx.provider_usage` is not set from `TurnComplete`, so `response.completed` carries no `usage` field and `_accumulate_session_usage` is a no-op. The `session.usage` broadcast at turn-end still fires using the already-accumulated DB total.

## Test Plan

```
python -m pytest tests/runtime/harnesses/test_executor_adapter.py -k "usage_delta" -v
# 4 passed
```

- `test_usage_delta_emits_usage_delta_sse_event` — UsageDelta → response.usage_delta with correct delta fields
- `test_usage_delta_suppresses_usage_on_completed` — response.completed carries no usage when deltas were emitted
- `test_usage_delta_multi_emits_all_deltas` — two deltas produce two separate SSE events in order
- `test_no_usage_delta_preserves_completed_usage` — executors without UsageDelta still work (backwards compat)

## Demo

N/A

## Type of change

- [x] Feature

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A