### PR TITLE
ci: cache parity sidecar binary across PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,23 @@ jobs:
         with:
           enable-cache: true
 
+      # Cache the compiled binary across PRs. Key on sidecar source + lock so
+      # any PR that hasn't touched the sidecar skips the entire Rust build.
+      - name: Cache sidecar binary
+        id: sidecar-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
+        with:
+          path: .tmp-codex-parity-target/debug/codex-parity-sidecar
+          key: codex-parity-sidecar-bin-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock', 'tests/codex_parity/sidecar/Cargo.toml', 'tests/codex_parity/sidecar/src/main.rs') }}
+
       - name: Set up Rust toolchain
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
 
-      - name: Cache Rust build
+      - name: Cache Rust build artifacts
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
         with:
           path: .tmp-codex-parity-target
@@ -255,6 +266,7 @@ jobs:
         run: uv sync --locked --extra all --extra dev
 
       - name: Build parity sidecar
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         run: |
           cargo build \
             --manifest-path tests/codex_parity/sidecar/Cargo.toml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
         with:
           path: .tmp-codex-parity-target/debug/codex-parity-sidecar
-          key: codex-parity-sidecar-bin-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock', 'tests/codex_parity/sidecar/Cargo.toml', 'tests/codex_parity/sidecar/src/main.rs') }}
+          key: codex-parity-sidecar-bin-${{ contains(github.event.pull_request.labels.*.name, 'force-rebuild-sidecar') && github.run_id || 'v1' }}-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/**') }}
 
       - name: Set up Rust toolchain
         if: steps.sidecar-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -107,20 +107,27 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
+      # Cache the compiled binary across PRs. Key on sidecar source + lock so
+      # any PR that hasn't touched the sidecar skips the entire Rust build.
+      - name: Cache sidecar binary
+        id: sidecar-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
+        with:
+          path: .tmp-codex-parity-target/debug/codex-parity-sidecar
+          key: codex-parity-sidecar-bin-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock', 'tests/codex_parity/sidecar/Cargo.toml', 'tests/codex_parity/sidecar/src/main.rs') }}
       - name: Set up Rust toolchain
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
-      # Pin the toolchain for a stable cache fingerprint, key on the sidecar
-      # Cargo.lock. A warm hit reuses every dep and only relinks the workspace
-      # crate (~40s); a cold miss is the full ~7min compile (rare -- the lock
-      # is near-static). Same key as ci.yml's codex-parity job, so they share.
-      - name: Cache Rust build
+      - name: Cache Rust build artifacts
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
         with:
           path: .tmp-codex-parity-target
           key: codex-parity-sidecar-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock') }}
       - name: Build parity sidecar
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         run: |
           cargo build \
             --manifest-path tests/codex_parity/sidecar/Cargo.toml \

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
         with:
           path: .tmp-codex-parity-target/debug/codex-parity-sidecar
-          key: codex-parity-sidecar-bin-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock', 'tests/codex_parity/sidecar/Cargo.toml', 'tests/codex_parity/sidecar/src/main.rs') }}
+          key: codex-parity-sidecar-bin-${{ contains(github.event.pull_request.labels.*.name, 'force-rebuild-sidecar') && github.run_id || 'v1' }}-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/**') }}
       - name: Set up Rust toolchain
         if: steps.sidecar-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable

--- a/.github/workflows/flake-stress-ui.yml
+++ b/.github/workflows/flake-stress-ui.yml
@@ -190,20 +190,33 @@ jobs:
           sudo apt-get install -y bubblewrap tmux
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
+      # Cache the compiled binary across PRs (mirrors e2e-ui.yml / ci.yml).
+      - name: Cache sidecar binary
+        id: sidecar-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
+        with:
+          path: .tmp-codex-parity-target/debug/codex-parity-sidecar
+          key: codex-parity-sidecar-bin-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock', 'tests/codex_parity/sidecar/Cargo.toml', 'tests/codex_parity/sidecar/src/main.rs') }}
+
       - name: Set up Rust toolchain
-        # The mocked_native_codex_goal_session fixture builds the Codex parity
-        # sidecar via `cargo build`; pin the toolchain for a stable cache key
-        # (mirrors e2e-ui.yml / ci.yml's codex-parity job).
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
 
-      - name: Cache Rust build
+      - name: Cache Rust build artifacts
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
         with:
           path: .tmp-codex-parity-target
-          # Identical key to e2e-ui.yml / ci.yml so a populated cache restores.
           key: codex-parity-sidecar-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock') }}
+
+      - name: Build parity sidecar
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo build \
+            --manifest-path tests/codex_parity/sidecar/Cargo.toml \
+            --target-dir .tmp-codex-parity-target
 
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -258,6 +271,7 @@ jobs:
         env:
           TEST_TARGET: ${{ github.event.inputs.test_target }}
           EXTRA_ARGS: ${{ github.event.inputs.extra_pytest_args }}
+          CODEX_PARITY_SIDECAR_BIN: ${{ github.workspace }}/.tmp-codex-parity-target/debug/codex-parity-sidecar
         run: |
           mkdir -p artifacts "artifacts/basetemp-${{ matrix.attempt }}"
           # shellcheck disable=SC2086

--- a/.github/workflows/flake-stress-ui.yml
+++ b/.github/workflows/flake-stress-ui.yml
@@ -196,7 +196,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
         with:
           path: .tmp-codex-parity-target/debug/codex-parity-sidecar
-          key: codex-parity-sidecar-bin-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock', 'tests/codex_parity/sidecar/Cargo.toml', 'tests/codex_parity/sidecar/src/main.rs') }}
+          key: codex-parity-sidecar-bin-${{ contains(github.event.pull_request.labels.*.name, 'force-rebuild-sidecar') && github.run_id || 'v1' }}-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/**') }}
 
       - name: Set up Rust toolchain
         if: steps.sidecar-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The `build codex-parity sidecar` step was taking ~3 min on every PR because the Rust build target cache uses an exact key on `Cargo.lock` — GitHub only shares caches from the base branch to a PR, not between sibling PRs, so most PRs got a cold miss.
- Switch to caching just the compiled ~10 MB binary (not the full target dir), keyed on all sidecar source files (`tests/codex_parity/sidecar/**`). This cache is shared from `main` → all PRs, so any PR that hasn't touched the sidecar skips the entire Rust build.
- On a cache hit, Rust toolchain setup and `cargo build` are skipped entirely. On a miss, the existing incremental build-artifacts cache still applies.
- Also adds `CODEX_PARITY_SIDECAR_BIN` to flake-stress-ui so the pytest fixture doesn't re-invoke `cargo build` when the binary is already present.
- **Cache opt-out:** add the `force-rebuild-sidecar` label to a PR — this injects `github.run_id` into the cache key, guaranteeing a fresh build for that run.

## Test Plan

**This PR is itself the first test.** The first run will be a cache miss (binary not yet cached) — the full build runs and populates the cache. Once merged to `main`, every subsequent PR that hasn't changed the sidecar source will get a cache hit and skip the build.

To verify the hit path after merge:
1. Open a new PR — the `Cache sidecar binary` step should report a hit; `Set up Rust toolchain` / `Cache Rust build artifacts` / `Build parity sidecar` should all be skipped.
2. The job should complete in ~30 s instead of ~3–4 min.

To test the opt-out: add the `force-rebuild-sidecar` label to a PR and re-run CI — the build should run unconditionally regardless of the cached binary.

## Demo

N/A — CI-only change.

## Type of change

- [x] Test / CI

## Test coverage

- [x] Not applicable

## Coverage notes

CI caching change — no application logic modified.