### PR TITLE
ci(codex-parity): cache the sidecar binary and skip recompiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,11 +229,20 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache Rust build
+      - name: Capture Rust version
+        id: rustc
+        run: echo "version=$(rustc --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+
+      # The sidecar source is frozen and its deps are rev-pinned, so the binary is
+      # a pure function of sidecar/** + the toolchain. Cache the built binary (not
+      # the 1.6 GB target dir) and skip the ~3 min compile below on a hit; the key
+      # self-invalidates when the source, Cargo.lock, or rustc changes.
+      - name: Cache parity sidecar binary
+        id: sidecar-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
         with:
-          path: .tmp-codex-parity-target
-          key: codex-parity-sidecar-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock') }}
+          path: .tmp-codex-parity-target/debug/codex-parity-sidecar
+          key: codex-parity-bin-${{ runner.os }}-${{ steps.rustc.outputs.version }}-${{ hashFiles('tests/codex_parity/sidecar/**') }}
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -255,6 +264,7 @@ jobs:
         run: uv sync --locked --extra all --extra dev
 
       - name: Build parity sidecar
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         run: |
           cargo build \
             --manifest-path tests/codex_parity/sidecar/Cargo.toml \


### PR DESCRIPTION
## Related issue

N/A

## Summary

The `codex-parity` CI job recompiles the Rust sidecar (~73 crates, ~3 min) on every run, even though the sidecar source is frozen (introduced once in #556, never changed since) and its deps are all rev-pinned.

The old `Cache Rust build` step cached the whole 1.6 GB `--target-dir`. On [a recent run](https://github.com/omnigent-ai/omnigent/actions/runs/28773389725/job/85311910898) it reported `Cache hit` but Cargo still re-fingerprinted and rebuilt all crates from scratch — a classic `actions/cache`-for-Cargo footgun where a restored target dir doesn't produce a compile hit.

This PR instead:
- Caches just the built binary (`.tmp-codex-parity-target/debug/codex-parity-sidecar`), keyed on `sidecar/**` + the `rustc` version.
- Skips the `cargo build` step entirely on a cache hit.

The binary is a pure function of the (frozen) source + toolchain, so warm runs drop from ~4 min to ~15s. The key self-invalidates the moment someone edits the sidecar source, `Cargo.lock`, or the toolchain changes, so correctness is preserved. The tests already consume the binary via `CODEX_PARITY_SIDECAR_BIN` (a direct path), so nothing else in the job depends on the rest of the target dir.

No new action dependency — reuses the `actions/cache` already pinned in `ci.yml`.

## Test Plan

- YAML validated locally (`yaml.safe_load`).
- Correctness follows from the cache-key inputs: first run after this lands is a miss (builds + saves the binary); subsequent runs with unchanged `sidecar/**` + toolchain hit and skip the compile. Editing any sidecar file changes the key and forces a rebuild.
- Will confirm the cache-miss → cache-hit transition on CI for this PR.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CI-config change with no runtime surface. Verified by validating the YAML and reasoning through the cache-key semantics; the existing `codex-parity` pytest suite exercises the resulting binary unchanged. Will watch this PR's own CI to confirm the build step is skipped on the second run.