### PR TITLE
fix(policies): show PoliciesPage in single-user/header mode

### DIFF
--- a/web/src/pages/PoliciesPage.test.tsx
+++ b/web/src/pages/PoliciesPage.test.tsx
@@ -15,6 +15,20 @@ import * as identity from "@/lib/identity";
 import * as defaultPolicies from "@/hooks/useDefaultPolicies";
 import * as policies from "@/hooks/usePolicies";
 
+const serverInfoMocks = vi.hoisted(() => ({
+  accountsEnabled: true,
+  loginUrl: null as string | null,
+  serverVersion: "0.3.0.dev0" as string | null,
+}));
+
+vi.mock("@/lib/CapabilitiesContext", () => ({
+  useServerInfo: () => ({
+    accounts_enabled: serverInfoMocks.accountsEnabled,
+    login_url: serverInfoMocks.loginUrl,
+    server_version: serverInfoMocks.serverVersion,
+  }),
+}));
+
 const addMutate = vi.fn();
 const updateMutate = vi.fn();
 const deleteMutate = vi.fn();
@@ -73,6 +87,9 @@ function renderPage() {
 }
 
 beforeEach(() => {
+  serverInfoMocks.accountsEnabled = true;
+  serverInfoMocks.loginUrl = null;
+  serverInfoMocks.serverVersion = "0.3.0.dev0";
   vi.mocked(identity.resolveIdentity).mockResolvedValue("admin");
   vi.mocked(identity.getCurrentIsAdmin).mockReturnValue(true);
   setPolicies([]);
@@ -192,5 +209,29 @@ describe("PoliciesPage actions", () => {
       { name: "block_canada", type: "python", handler: "omnigent.policies.block_canada" },
       expect.anything(),
     );
+  });
+});
+
+describe("PoliciesPage single-user mode", () => {
+  beforeEach(() => {
+    serverInfoMocks.accountsEnabled = false;
+    serverInfoMocks.loginUrl = null;
+    serverInfoMocks.serverVersion = "0.3.0.dev0";
+  });
+
+  it("shows the full page without the admin gate (empty state)", async () => {
+    renderPage();
+    expect(await screen.findByText(/No global policies configured/)).toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("You don't have permission to manage global policies."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows policies list directly without probing identity", async () => {
+    setPolicies([policy({ id: "p1", name: "block_canada", enabled: true })]);
+    renderPage();
+    expect(await screen.findByText("block_canada")).toBeInTheDocument();
+    expect(identity.resolveIdentity).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/hooks/useDefaultPolicies";
 import { usePolicyRegistry, type PolicyRegistryEntry } from "@/hooks/usePolicies";
 import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
+import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { coercePolicyParams } from "@/lib/policyParams";
 
 // ---------------------------------------------------------------------------
@@ -350,6 +351,15 @@ function AddDefaultPolicyDialog({
 // ---------------------------------------------------------------------------
 
 export function PoliciesPage() {
+  const info = useServerInfo();
+  // Plain header/single-user mode: no auth endpoints exist. server_version
+  // distinguishes a live single-user server from a failed /v1/info probe
+  // (which uses the same accounts_enabled:false / login_url:null sentinel).
+  const isSingleUser =
+    info !== "loading" &&
+    !info.accounts_enabled &&
+    info.login_url === null &&
+    info.server_version !== null;
   const [meIsAdmin, setMeIsAdmin] = useState<boolean | null>(null);
   const { data: policies = [], refetch } = useDefaultPolicies();
   const { data: registry = [] } = usePolicyRegistry();
@@ -368,17 +378,18 @@ export function PoliciesPage() {
   }, [refetch]);
 
   // Admin probe via the mode-agnostic `/v1/me` identity (works under OIDC
-  // too, unlike the accounts-only `/auth/me`). resolveIdentity handles the
-  // login redirect when unauthenticated, so we only set the admin flag here.
+  // too, unlike the accounts-only `/auth/me`). Skipped in single-user mode
+  // because no auth endpoints exist and the backend skips admin enforcement.
   useEffect(() => {
+    if (isSingleUser) return;
     void (async () => {
       const userId = await resolveIdentity();
       if (userId === null) return;
       setMeIsAdmin(getCurrentIsAdmin());
     })();
-  }, []);
+  }, [isSingleUser]);
 
-  if (meIsAdmin === null) {
+  if (!isSingleUser && meIsAdmin === null) {
     return (
       <div className="flex min-h-full items-center justify-center text-sm text-muted-foreground">
         Loading...
@@ -386,7 +397,7 @@ export function PoliciesPage() {
     );
   }
 
-  if (meIsAdmin === false) {
+  if (!isSingleUser && meIsAdmin === false) {
     return (
       <div className="mx-auto w-full max-w-2xl px-6 py-12">
         <h1 className="mb-2 text-2xl font-semibold">Global Policies</h1>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -64,9 +64,8 @@ import { type CliStatus, getCliStatus, isElectronShell, resetCliPath } from "@/l
 import { cn } from "@/lib/utils";
 
 // Admin-only management surfaces, rendered as the Members / Policies settings
-// sub-categories. Lazy-loaded so non-accounts deploys (where these sections
-// never appear) don't pull them into the settings chunk — mirrors the
-// route-level lazy loading these had when they were standalone pages.
+// sub-categories. Visible to admins in all modes (accounts, OIDC, single-user).
+// Lazy-loaded to keep the settings chunk small.
 const MembersPage = lazy(() =>
   import("@/pages/MembersPage").then((m) => ({ default: m.MembersPage })),
 );


### PR DESCRIPTION
## Related issue

N/A

## Summary

- In header/single-user mode the backend skips admin enforcement (`permission_store is None`), but the frontend was still waiting on an identity probe that never resolves `is_admin`, leaving the PoliciesPage stuck on "Loading..." or showing "You don't have permission to manage global policies."
- Mirror the MembersPage pattern: derive `isSingleUser` from `useServerInfo()` and bypass the admin gate entirely when true, so the page renders immediately without probing identity.
- Also updates a stale comment in `SettingsPage.tsx` that claimed these sections never appear in non-accounts deploys.

## Test Plan

- Unit tests added in `PoliciesPage.test.tsx` for the single-user path: verifies the full page renders (empty state + policies list) without showing loading/permission error, and that `resolveIdentity` is not called.
- Existing gating tests (loading, non-admin blocked, unauthenticated redirect) remain passing.
- Manual verification: start server without accounts/OIDC config and navigate to `/settings/policies` — page now shows instead of the permission error.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: confirmed the page renders in single-user mode (no accounts, no OIDC) instead of blocking with the permission message. E2E coverage of the admin-gated surface is impractical (noted in the existing test file comment).

## Changelog

Global Policies settings page now appears correctly in single-user/header auth mode instead of showing a "no permission" error.