### PR TITLE
fix(harnesses): stand per-turn watchdogs down while a turn is parked on a human

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -42,7 +42,7 @@ import logging
 import os
 import time
 import uuid
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal
 
@@ -99,6 +99,14 @@ _SHUTDOWN_GRACE_S = 4.5
 # (now rare) expiry the fallback below is phase-aware — TOOL_CALL fails CLOSED
 # (DENY), advisory LLM/TOOL_RESULT phases fail OPEN (ALLOW).
 _POLICY_EVAL_TIMEOUT_S = 86400.0
+
+# Cap on how long ``elicit`` parks awaiting a human reply — the same
+# ask_timeout-scale budget as ``_POLICY_EVAL_TIMEOUT_S``. The per-turn
+# watchdogs stand down while a turn is parked on a human (see
+# ``TurnContext._parked_on_human``), so every such park needs its own
+# explicit human-scale bound or an orphaned elicitation would park the
+# turn forever.
+_ELICITATION_TIMEOUT_S = 86400.0
 
 # Per-turn IDLE watchdog: max gap WITHOUT progress before a wedged
 # ``run_turn`` becomes ``response.failed`` (vs heartbeating forever).
@@ -421,6 +429,12 @@ class TurnContext:
         # event so a long-but-active turn isn't killed mid-turn.
         # ``None`` disables it (watchdog off, or outside a guarded run).
         self._reset_idle_watchdog: Callable[[], None] | None = None
+        # Park bracketing hooks. ``_guarded_run_turn`` sets these so
+        # ``_parked_on_human`` can suspend/resume the per-turn watchdogs
+        # around a wait on a human (elicitation reply, ASK policy
+        # verdict). ``None`` outside a guarded run.
+        self._park_watchdogs_begin: Callable[[], None] | None = None
+        self._park_watchdogs_end: Callable[[], None] | None = None
 
     def emit(self, event: HarnessStreamEvent) -> None:
         """
@@ -514,6 +528,29 @@ class TurnContext:
             # leak memory across turns.
             self._pending_tool_calls.pop(call_id, None)
 
+    @contextlib.contextmanager
+    def _parked_on_human(self) -> Iterator[None]:
+        """
+        Suspend the per-turn watchdogs while parked on a human.
+
+        Brackets a wait whose duration is the human's to spend (an
+        elicitation reply, an ASK policy verdict): the idle watchdog
+        would otherwise read the zero-emit wait as a wedged turn, and
+        the absolute ceiling would bill it as machine time. Re-reads
+        the end hook in ``finally`` because ``_guarded_run_turn``
+        detaches both hooks once its timeout contexts unwind — a late
+        resume must not reschedule a finished timeout.
+        """
+        begin = self._park_watchdogs_begin
+        if begin is not None:
+            begin()
+        try:
+            yield
+        finally:
+            end = self._park_watchdogs_end
+            if begin is not None and end is not None:
+                end()
+
     async def elicit(
         self, elicitation_id: str, params: ElicitationRequestParams
     ) -> ElicitationResult:
@@ -533,6 +570,8 @@ class TurnContext:
         :returns: The MCP-shaped
             :class:`ElicitationResult` reply.
         :raises asyncio.CancelledError: If the turn is cancelled.
+        :raises asyncio.TimeoutError: If no reply arrives within the
+            day-long ``_ELICITATION_TIMEOUT_S`` cap.
         """
         future: asyncio.Future[ElicitationResult] = asyncio.get_running_loop().create_future()
         self._pending_elicitations[elicitation_id] = future
@@ -544,7 +583,8 @@ class TurnContext:
             )
         )
         try:
-            return await future
+            with self._parked_on_human():
+                return await asyncio.wait_for(future, timeout=_ELICITATION_TIMEOUT_S)
         finally:
             self._pending_elicitations.pop(elicitation_id, None)
 
@@ -642,7 +682,8 @@ class TurnContext:
             )
         )
         try:
-            return await asyncio.wait_for(future, timeout=_POLICY_EVAL_TIMEOUT_S)
+            with self._parked_on_human():
+                return await asyncio.wait_for(future, timeout=_POLICY_EVAL_TIMEOUT_S)
         except asyncio.TimeoutError:
             # Phase-aware default: advisory LLM phases and TOOL_RESULT (the
             # tool already ran) fail OPEN so a missing verdict never hangs the
@@ -1451,9 +1492,15 @@ class HarnessApp:
           whole window. This replaces the prior fixed *cumulative* cap,
           which guillotined long-but-healthy turns mid-stream.
         - ABSOLUTE (:data:`_TURN_ABSOLUTE_TIMEOUT_S`): a hard ceiling on
-          total duration, never rescheduled. Backstops the idle watchdog
-          against a runaway-but-active loop the idle one never sees as
-          stuck.
+          total *machine* time, never rescheduled by progress. Backstops
+          the idle watchdog against a runaway-but-active loop the idle
+          one never sees as stuck.
+
+        Both stand down while the turn is parked on a human (see
+        :meth:`TurnContext._parked_on_human`): the idle deadline is
+        suspended and the absolute ceiling is pushed out by the parked
+        duration, so a slow human answer is never billed as a wedged or
+        runaway turn.
 
         Either expiry surfaces a wedged/runaway ``run_turn`` as
         ``response.failed``.
@@ -1466,17 +1513,59 @@ class HarnessApp:
         # ``asyncio.timeout(None)`` is a no-op, so ``<= 0`` disables each.
         idle_wd = asyncio.timeout(idle_timeout if idle_timeout > 0 else None)
         absolute_wd = asyncio.timeout(absolute_timeout if absolute_timeout > 0 else None)
+        loop = asyncio.get_running_loop()
+        # Depth of active waits on a human (elicitation reply, ASK policy
+        # verdict). While > 0 both watchdogs stand down: the wait is
+        # healthy but zero-emit and open-ended, so its duration is the
+        # human's to spend, not machine time. Each park carries its own
+        # day-long cap, so the stand-down is bounded.
+        park_depth = 0
+        park_started = 0.0
+        absolute_deadline: float | None = None
+
         if idle_timeout > 0:
-            loop = asyncio.get_running_loop()
 
             def _reset() -> None:
                 # Push ONLY the idle deadline ``idle_timeout`` s past now
-                # (the absolute ceiling is never rescheduled). Called from
-                # ``ctx.emit`` during ``run_turn`` (inside the active
-                # context), so the reschedule is always valid.
-                idle_wd.reschedule(loop.time() + idle_timeout)
+                # (the absolute ceiling is never rescheduled by progress).
+                # Called from ``ctx.emit`` during ``run_turn`` (inside the
+                # active context), so the reschedule is always valid. A
+                # background emit during a park must not re-arm the
+                # suspended deadline — the park's resume re-arms it.
+                if park_depth == 0:
+                    idle_wd.reschedule(loop.time() + idle_timeout)
 
             ctx._reset_idle_watchdog = _reset
+
+        def _park_begin() -> None:
+            nonlocal park_depth, park_started, absolute_deadline
+            park_depth += 1
+            if park_depth > 1:
+                return
+            park_started = loop.time()
+            if idle_timeout > 0:
+                idle_wd.reschedule(None)
+            if absolute_timeout > 0:
+                absolute_deadline = absolute_wd.when()
+                absolute_wd.reschedule(None)
+
+        def _park_end() -> None:
+            nonlocal park_depth, absolute_deadline
+            park_depth -= 1
+            if park_depth > 0:
+                return
+            parked = loop.time() - park_started
+            # The ceiling keeps its full machine-time budget: its deadline
+            # moves out by exactly the parked duration, no more — a
+            # runaway loop that resumes after the park is still capped.
+            if absolute_timeout > 0 and absolute_deadline is not None:
+                absolute_wd.reschedule(absolute_deadline + parked)
+                absolute_deadline = None
+            if idle_timeout > 0:
+                idle_wd.reschedule(loop.time() + idle_timeout)
+
+        ctx._park_watchdogs_begin = _park_begin
+        ctx._park_watchdogs_end = _park_end
         try:
             # Absolute outer, idle inner: ``.expired()`` on each tells which
             # ceiling tripped so the error message is accurate.
@@ -1532,9 +1621,12 @@ class HarnessApp:
             # ``response.cancelled`` event.
             raise
         finally:
-            # Detach the reset hook before the timeout context unwinds so
-            # a stray late ``emit`` can't reschedule a finished timeout.
+            # Detach the hooks before the timeout contexts unwind so a
+            # stray late ``emit`` or park resume can't reschedule a
+            # finished timeout.
             ctx._reset_idle_watchdog = None
+            ctx._park_watchdogs_begin = None
+            ctx._park_watchdogs_end = None
             # Sentinel that tells ``_stream_turn`` to stop reading
             # the queue and emit the terminal event.
             ctx._event_queue.put_nowait(None)

--- a/tests/runtime/harnesses/_test_scaffold_harnesses.py
+++ b/tests/runtime/harnesses/_test_scaffold_harnesses.py
@@ -123,6 +123,56 @@ class _ElicitationHarness(HarnessApp):
         )
 
 
+class _ElicitThenRunawayHarness(HarnessApp):
+    """
+    Parks on an elicitation, then busy-loops forever emitting deltas.
+
+    Exercises the boundary of the park exemption: standing the
+    watchdogs down while parked on a human must not hand a
+    runaway-but-active turn extra machine time — after the park
+    resumes, the absolute ceiling must still fire on its original
+    (shifted, not enlarged) budget.
+    """
+
+    _tick_seconds: float = 0.1
+
+    async def run_turn(self, request: CreateResponseRequest, ctx: TurnContext) -> None:
+        del request
+        await ctx.elicit(
+            elicitation_id="elicit_test_1",
+            params=ElicitationRequestParams(mode="form", message="approve?"),
+        )
+        i = 0
+        while True:  # runaway: active forever, never completes
+            ctx.emit(OutputTextDeltaEvent(type="response.output_text.delta", delta=f"tick-{i} "))
+            i += 1
+            await asyncio.sleep(self._tick_seconds)
+
+
+class _PolicyParkHarness(HarnessApp):
+    """
+    Parks on ``ctx.evaluate_policy`` (a human-answered ASK), then
+    emits the verdict action as a text delta.
+
+    Exercises the wait-on-a-human path: the turn emits nothing while
+    the evaluation Future is parked, so the per-turn watchdogs must
+    not count the wait as the turn being wedged or runaway.
+    """
+
+    async def run_turn(self, request: CreateResponseRequest, ctx: TurnContext) -> None:
+        del request
+        verdict = await ctx.evaluate_policy(
+            "poleval_test_1",
+            "PHASE_TOOL_CALL",
+            {"name": "dangerous_tool", "arguments": {}},
+        )
+        ctx.emit(
+            OutputTextDeltaEvent(
+                type="response.output_text.delta", delta=f"verdict:{verdict.action}"
+            )
+        )
+
+
 class _CancellableHarness(HarnessApp):
     """
     Sleeps in a poll loop checking ``ctx.cancelled`` every 50ms,
@@ -433,6 +483,8 @@ _FIXTURES: dict[str, type[HarnessApp]] = {
     "usage": _UsageHarness,
     "tool_dispatch": _ToolDispatchHarness,
     "elicitation": _ElicitationHarness,
+    "policy_park": _PolicyParkHarness,
+    "elicit_then_runaway": _ElicitThenRunawayHarness,
     "cancellable": _CancellableHarness,
     "injection": _InjectionHarness,
     "native_tool": _NativeToolEmittingHarness,

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -373,6 +373,36 @@ def use_busy_absolute_cap(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "2")
 
 
+@pytest.fixture
+def use_elicitation_idle_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Elicitation harness with a 2s idle watchdog (read at import)."""
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "elicitation")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "2")
+
+
+@pytest.fixture
+def use_elicitation_absolute_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Elicitation harness; idle high so only the 2s absolute ceiling can fire."""
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "elicitation")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "10")
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "2")
+
+
+@pytest.fixture
+def use_policy_park_idle_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Policy-park harness with a 2s idle watchdog (read at import)."""
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "policy_park")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "2")
+
+
+@pytest.fixture
+def use_elicit_then_runaway_absolute_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Park-then-runaway harness; idle high so only the 2s absolute ceiling can fire."""
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "elicit_then_runaway")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "10")
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "2")
+
+
 # ── Native function_call emission ──────────────────────────────
 
 
@@ -767,6 +797,191 @@ async def test_per_turn_absolute_watchdog_caps_runaway_active_turn(
     # wedged) — distinguishes this from the idle/wedged path.
     assert "response.output_text.delta" in event_types, (
         f"Expected progress deltas before the absolute cap; got {event_types!r}."
+    )
+
+
+async def _run_turn_answering_park_late(
+    manager: HarnessProcessManager,
+    conv_id: str,
+    *,
+    park_event: str,
+    reply_body: dict[str, object],
+    answer_after_s: float,
+) -> list[_ParsedSSEEvent]:
+    """Start a turn, answer its human park only after ``answer_after_s``.
+
+    Drives a fixture harness that parks on a human (elicitation or
+    policy ASK): waits for ``park_event`` on the stream, sleeps past the
+    watchdog window under test — a human taking longer than the watchdog
+    to decide — then posts ``reply_body`` and drains the stream.
+
+    :returns: All streamed events, for terminal/delta assertions.
+    """
+    stream_client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    side_client = _make_side_client(str(manager.socket_path(conv_id)))
+    body = {"type": "message", "role": "user", "model": "test-agent", "content": []}
+    events: list[_ParsedSSEEvent] = []
+    try:
+        # Bounds a hang; the slow path here is the deliberate sleep.
+        async with asyncio.timeout(30):
+            async with stream_client.stream(
+                "POST", f"/v1/sessions/{conv_id}/events", json=body
+            ) as response:
+                replied = False
+                async for event in _stream_iter(response):
+                    events.append(event)
+                    if not replied and event.event == park_event:
+                        replied = True
+                        await asyncio.sleep(answer_after_s)
+                        # No status assert: on the unfixed path the turn is
+                        # already dead by now and the reply 404s; the terminal
+                        # event carries the actual verdict.
+                        await side_client.post(f"/v1/sessions/{conv_id}/events", json=reply_body)
+    finally:
+        await side_client.aclose()
+    return events
+
+
+async def test_idle_watchdog_spares_turn_parked_on_elicitation(
+    use_elicitation_idle_cap: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    A turn parked on an elicitation must survive a human answering
+    slower than the idle window.
+
+    An elicitation (approval card) blocks until the human replies —
+    by contract as long as the policy ``ask_timeout`` (a day) — and
+    emits nothing while parked. The idle watchdog must not read that
+    silence as a wedged turn: here the human takes ~3.2s against a 2s
+    idle window, and the turn must still complete with the reply.
+    """
+    events = await _run_turn_answering_park_late(
+        manager,
+        "conv_elicit_idle_park",
+        park_event="response.elicitation_request",
+        reply_body={"type": "approval", "elicitation_id": "elicit_test_1", "action": "accept"},
+        answer_after_s=3.2,
+    )
+    event_types = [e.event for e in events]
+    assert event_types[-1] == "response.completed", (
+        f"A turn parked on a human must outlive the idle watchdog; got "
+        f"terminal {event_types[-1]!r} (full: {event_types!r}). "
+        f"response.failed means the idle watchdog counted the human's "
+        f"thinking time as the turn being wedged."
+    )
+    deltas = [e.data["delta"] for e in events if e.event == "response.output_text.delta"]
+    assert deltas == ["action:accept"], (
+        f"The late human reply must still reach the parked turn; got {deltas!r}."
+    )
+
+
+async def test_absolute_watchdog_spares_turn_parked_on_elicitation(
+    use_elicitation_absolute_cap: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    A turn parked on an elicitation must survive a human answering
+    slower than the absolute ceiling.
+
+    The absolute ceiling is never rescheduled by emits, so it is the
+    binding cap on a human park even when the idle watchdog spares it
+    (idle is set high here so only the ceiling can fire). Time parked
+    on a human must not count against the ceiling's machine-time
+    budget: the human takes ~3.2s against a 2s ceiling, and the turn
+    must still complete with the reply.
+    """
+    events = await _run_turn_answering_park_late(
+        manager,
+        "conv_elicit_absolute_park",
+        park_event="response.elicitation_request",
+        reply_body={"type": "approval", "elicitation_id": "elicit_test_1", "action": "accept"},
+        answer_after_s=3.2,
+    )
+    event_types = [e.event for e in events]
+    assert event_types[-1] == "response.completed", (
+        f"A turn parked on a human must outlive the absolute ceiling; got "
+        f"terminal {event_types[-1]!r} (full: {event_types!r}). "
+        f"response.failed means park time was billed to the ceiling's "
+        f"machine-time budget."
+    )
+    deltas = [e.data["delta"] for e in events if e.event == "response.output_text.delta"]
+    assert deltas == ["action:accept"], (
+        f"The late human reply must still reach the parked turn; got {deltas!r}."
+    )
+
+
+async def test_absolute_watchdog_still_caps_runaway_after_park(
+    use_elicit_then_runaway_absolute_cap: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    The park exemption must not enlarge the absolute machine-time budget.
+
+    The park only *shifts* the ceiling's deadline by the parked
+    duration — it never adds budget. This harness parks ~1s on an
+    elicitation (exempt), then busy-loops forever: the ceiling must
+    still fire once its original 2s of machine time is spent, so the
+    runaway is capped at ~3s wall clock, not spared.
+    """
+    events = await _run_turn_answering_park_late(
+        manager,
+        "conv_runaway_after_park",
+        park_event="response.elicitation_request",
+        reply_body={"type": "approval", "elicitation_id": "elicit_test_1", "action": "accept"},
+        answer_after_s=1.0,
+    )
+    event_types = [e.event for e in events]
+    assert event_types[-1] == "response.failed", (
+        f"A runaway turn must still hit the absolute ceiling after a park; "
+        f"got terminal {event_types[-1]!r}. response.completed/no-terminal "
+        f"means the park exemption handed the runaway extra budget."
+    )
+    # The error must name the ABSOLUTE watchdog — proves the ceiling
+    # resumed with its shifted deadline rather than being disarmed.
+    error = events[-1].data["response"]["error"]
+    assert error is not None and "absolute" in error["message"], (
+        f"Failure must come from the absolute ceiling; got {error!r}."
+    )
+    # The runaway actively streamed after the park before being capped.
+    assert "response.output_text.delta" in event_types, (
+        f"Expected post-park runaway deltas before the cap; got {event_types!r}."
+    )
+
+
+async def test_idle_watchdog_spares_turn_parked_on_policy_ask(
+    use_policy_park_idle_cap: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    A turn parked on a policy ASK verdict must survive a human
+    answering slower than the idle window.
+
+    ``evaluate_policy`` parks up to the policy ``ask_timeout`` (a day)
+    awaiting a human verdict and emits nothing meanwhile — the same
+    zero-emit park as an elicitation, on the other park primitive. The
+    verdict arrives ~3.2s in against a 2s idle window; the turn must
+    complete carrying the verdict, not fail as wedged.
+    """
+    events = await _run_turn_answering_park_late(
+        manager,
+        "conv_policy_idle_park",
+        park_event="policy_evaluation.requested",
+        reply_body={
+            "type": "policy_verdict",
+            "evaluation_id": "poleval_test_1",
+            "action": "POLICY_ACTION_ALLOW",
+        },
+        answer_after_s=3.2,
+    )
+    event_types = [e.event for e in events]
+    assert event_types[-1] == "response.completed", (
+        f"A turn parked on a policy ASK must outlive the idle watchdog; got "
+        f"terminal {event_types[-1]!r} (full: {event_types!r})."
+    )
+    deltas = [e.data["delta"] for e in events if e.event == "response.output_text.delta"]
+    assert deltas == ["verdict:POLICY_ACTION_ALLOW"], (
+        f"The late verdict must still reach the parked turn; got {deltas!r}."
     )
 
 


### PR DESCRIPTION
## Related issue

N/A — found by auditing the ask-gate invariant ("an ASK blocks until a human answers") across every layer that waits on a human. #2012 aligned the claude-native command-hook layer with that invariant; this PR aligns the last two layers on the scaffold side.

## Summary

- A turn parked on a human — an elicitation (approval card) reply or an ASK policy verdict — emits nothing while it waits, and is allowed to wait as long as the policy `ask_timeout` (a day, `_POLICY_EVAL_TIMEOUT_S`).
- Both per-turn watchdogs billed that wait as machine time: the idle watchdog failed the turn after 240s of silence, and the absolute ceiling (never rescheduled by progress) failed it after 3600s even when the idle one spared it. The shortest layer silently became the real approval window.
- Fix: bracket both park primitives (`TurnContext.elicit`, `TurnContext.evaluate_policy`) with a suspend/resume of the watchdogs. The idle deadline stands down while parked and re-arms on resume; the absolute ceiling's deadline shifts out by exactly the parked duration — its machine-time budget never grows, so a runaway loop that resumes after a park is still capped. `elicit` gains the same day-long cap `evaluate_policy` already had, so an orphaned park stays bounded now that the watchdogs no longer backstop it.

ELI5: the per-turn watchdogs are the machine's chess clock. When it's the human's move (an approval card is on the table), the machine's clock must pause — the human's thinking time is not the machine's time to lose.

```mermaid
sequenceDiagram
    participant T as run_turn
    participant W as watchdogs (idle 240s / absolute 3600s)
    participant U as human
    T->>W: turn starts (both armed)
    T->>U: elicitation / ASK verdict requested
    Note over W: park begins → both stand down
    U-->>T: reply (minutes … up to ask_timeout)
    Note over W: resume → idle re-arms, absolute deadline shifts by parked time
    T->>W: machine time resumes on the original budget
```

## Test Plan

- Red first on `main`: the three new park tests fail with `response.failed` — idle: `made no progress for 2s (idle turn watchdog)`; absolute: `exceeded the 2s absolute turn ceiling` (idle set high so only the ceiling can fire, pinning the failure to the right watchdog). A fixture harness parks on an elicitation / policy ASK and the test answers only after the shrunk watchdog window.
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev python -m pytest tests/runtime/harnesses/test_scaffold.py tests/runtime/harnesses/test_scaffold_policy_evaluation.py -q` — 43 passed (four new tests plus all pre-existing watchdog tests).
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev python -m pytest tests/runtime/harnesses/test_executor_adapter.py -q` — 37 passed.
- The four new tests ran 3× in isolation to check for flake — stable.
- `pre-commit run` on the touched files — clean.

## Demo

Red → green on the new park tests. Red run is on `main` (fix reverted): all three human-park tests fail as the watchdogs bill the human's thinking time; the runaway guard passes on both sides.

![red-to-green park watchdog tests](https://raw.githubusercontent.com/tomsen-ai/omnigent/pr-demo-assets/demos/omnigent-2020-demo.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`test_absolute_watchdog_still_caps_runaway_after_park` pins the boundary of the exemption: a turn that parks and then runs away is still failed by the absolute ceiling on its shifted (not enlarged) deadline — the park never grants extra machine time.

## Changelog

Approval cards and ASK policy gates now wait for your answer as long as the policy allows — a slow human reply no longer fails the turn as wedged or runaway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

