### PR TITLE
feat(cli): add omni session export --id <session_id>

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5552,6 +5552,7 @@ def session(ctx: click.Context) -> None:
     Examples:
       omnigent session export --id conv_abc123
       omnigent session export --id conv_abc123 --output transcript.jsonl
+      omnigent session export --id conv_abc123 --server https://myserver.com
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
@@ -5571,16 +5572,17 @@ def session(ctx: click.Context) -> None:
     "output",
     default=None,
     metavar="FILE",
-    help=("Output file path.  Defaults to <SESSION_ID>.jsonl in the current directory."),
+    help="Output file path.  Defaults to <SESSION_ID>.jsonl in the current directory.",
 )
 @click.option(
-    "--database-uri",
-    "database_uri",
+    "--server",
     default=None,
-    metavar="URI",
-    help=("SQLAlchemy database URI for the session store.  [default: local omnigent database]"),
+    help=(
+        "Omnigent server URL. "
+        "Defaults to the configured server, or a local server already running."
+    ),
 )
-def session_export(session_id: str, output: str | None, database_uri: str | None) -> None:
+def session_export(session_id: str, output: str | None, server: str | None) -> None:
     """Export a session transcript to a portable JSONL file.
 
     Each line of the output is a JSON object.  The first line carries
@@ -5593,46 +5595,52 @@ def session_export(session_id: str, output: str | None, database_uri: str | None
     Examples:
       omnigent session export --id conv_abc123
       omnigent session export --id conv_abc123 --output my_session.jsonl
-      omnigent session export --id conv_abc123 --database-uri sqlite:////path/to/chat.db
+      omnigent session export --id conv_abc123 --server https://myserver.com
     """
-    from dataclasses import asdict
+    import httpx
 
-    from omnigent.stores.conversation_store.sqlalchemy_store import (
-        SqlAlchemyConversationStore,
-    )
+    cfg = _load_effective_config()
+    base_url = _resolve_attach_server(server, cfg.get("server"))
+    if base_url is None:
+        startup = ensure_local_omnigent_server()
+        base_url = startup.url
 
-    db_uri = database_uri or _default_db_uri()
-    store = SqlAlchemyConversationStore(db_uri)
-
-    conv = store.get_conversation(session_id)
-    if conv is None:
-        raise click.ClickException(f"Session {session_id!r} not found.")
-
+    base_url = base_url.rstrip("/")
     out_path = Path(output) if output else Path(f"{session_id}.jsonl")
 
-    n_items = 0
-    with out_path.open("w", encoding="utf-8") as fh:
-        # First line: session metadata so importers can recreate the
-        # conversation row before replaying items.
-        meta_record = {"record_type": "session_meta", **asdict(conv)}
-        fh.write(json.dumps(meta_record, default=str) + "\n")
+    with httpx.Client(base_url=base_url, timeout=30.0) as client:
+        # Fetch session metadata (items fetched separately via pagination).
+        resp = client.get(
+            f"/v1/sessions/{session_id}",
+            params={"include_items": "false", "include_liveness": "false"},
+        )
+        if resp.status_code == 404:
+            raise click.ClickException(f"Session {session_id!r} not found.")
+        resp.raise_for_status()
+        session_data = resp.json()
 
-        # Remaining lines: items in ascending position order, paginated
-        # so very large sessions don't require loading everything at once.
-        after: str | None = None
-        while True:
-            page = store.list_items(session_id, limit=500, after=after, order="asc")
-            for item in page.data:
-                item_record = {
-                    "record_type": "item",
-                    "created_at": item.created_at,
-                    **item.to_api_dict(),
-                }
-                fh.write(json.dumps(item_record, default=str) + "\n")
-                n_items += 1
-            if not page.has_more:
-                break
-            after = page.last_id
+        n_items = 0
+        with out_path.open("w", encoding="utf-8") as fh:
+            # First line: session metadata.
+            meta_record = {"record_type": "session_meta", **session_data}
+            fh.write(json.dumps(meta_record) + "\n")
+
+            # Remaining lines: items in ascending order, paginated.
+            after: str | None = None
+            while True:
+                params: dict[str, str | int] = {"limit": 500, "order": "asc"}
+                if after:
+                    params["after"] = after
+                items_resp = client.get(f"/v1/sessions/{session_id}/items", params=params)
+                items_resp.raise_for_status()
+                page = items_resp.json()
+                for item in page["data"]:
+                    item_record = {"record_type": "item", **item}
+                    fh.write(json.dumps(item_record) + "\n")
+                    n_items += 1
+                if not page.get("has_more"):
+                    break
+                after = page.get("last_id")
 
     click.echo(f"Exported {n_items} item(s) from {session_id} to {out_path}")
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1199,6 +1199,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "qwen",
         "resume",
         "run",
+        "session",
         "sandbox",
         "server",
         "setup",
@@ -5540,6 +5541,100 @@ def resume(
         target=target,
         server=_resolve_server_url(server) if server else server,
     )
+
+
+@cli.group("session", invoke_without_command=True)
+@click.pass_context
+def session(ctx: click.Context) -> None:
+    """Manage Omnigent sessions.
+
+    \b
+    Examples:
+      omnigent session export --id conv_abc123
+      omnigent session export --id conv_abc123 --output transcript.jsonl
+    """
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@session.command("export")
+@click.option(
+    "--id",
+    "session_id",
+    required=True,
+    metavar="SESSION_ID",
+    help="Session ID to export, e.g. conv_abc123.",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output",
+    default=None,
+    metavar="FILE",
+    help=("Output file path.  Defaults to <SESSION_ID>.jsonl in the current directory."),
+)
+@click.option(
+    "--database-uri",
+    "database_uri",
+    default=None,
+    metavar="URI",
+    help=("SQLAlchemy database URI for the session store.  [default: local omnigent database]"),
+)
+def session_export(session_id: str, output: str | None, database_uri: str | None) -> None:
+    """Export a session transcript to a portable JSONL file.
+
+    Each line of the output is a JSON object.  The first line carries
+    the session metadata (``"record_type": "session_meta"``); every
+    subsequent line is one conversation item
+    (``"record_type": "item"``).  The file preserves full turn order
+    and can be re-imported with a future ``omnigent session import``.
+
+    \b
+    Examples:
+      omnigent session export --id conv_abc123
+      omnigent session export --id conv_abc123 --output my_session.jsonl
+      omnigent session export --id conv_abc123 --database-uri sqlite:////path/to/chat.db
+    """
+    from dataclasses import asdict
+
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    db_uri = database_uri or _default_db_uri()
+    store = SqlAlchemyConversationStore(db_uri)
+
+    conv = store.get_conversation(session_id)
+    if conv is None:
+        raise click.ClickException(f"Session {session_id!r} not found.")
+
+    out_path = Path(output) if output else Path(f"{session_id}.jsonl")
+
+    n_items = 0
+    with out_path.open("w", encoding="utf-8") as fh:
+        # First line: session metadata so importers can recreate the
+        # conversation row before replaying items.
+        meta_record = {"record_type": "session_meta", **asdict(conv)}
+        fh.write(json.dumps(meta_record, default=str) + "\n")
+
+        # Remaining lines: items in ascending position order, paginated
+        # so very large sessions don't require loading everything at once.
+        after: str | None = None
+        while True:
+            page = store.list_items(session_id, limit=500, after=after, order="asc")
+            for item in page.data:
+                item_record = {
+                    "record_type": "item",
+                    "created_at": item.created_at,
+                    **item.to_api_dict(),
+                }
+                fh.write(json.dumps(item_record, default=str) + "\n")
+                n_items += 1
+            if not page.has_more:
+                break
+            after = page.last_id
+
+    click.echo(f"Exported {n_items} item(s) from {session_id} to {out_path}")
 
 
 # Shared option help for ``run`` and the harness commands. These are the same

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5599,6 +5599,8 @@ def session_export(session_id: str, output: str | None, server: str | None) -> N
     """
     import httpx
 
+    from omnigent.chat import _remote_headers
+
     cfg = _load_effective_config()
     base_url = _resolve_attach_server(server, cfg.get("server"))
     if base_url is None:
@@ -5608,7 +5610,9 @@ def session_export(session_id: str, output: str | None, server: str | None) -> N
     base_url = base_url.rstrip("/")
     out_path = Path(output) if output else Path(f"{session_id}.jsonl")
 
-    with httpx.Client(base_url=base_url, timeout=30.0) as client:
+    with httpx.Client(
+        base_url=base_url, headers=_remote_headers(server_url=base_url), timeout=30.0
+    ) as client:
         # Fetch session metadata (items fetched separately via pagination).
         resp = client.get(
             f"/v1/sessions/{session_id}",

--- a/tests/host/test_cli_session_export.py
+++ b/tests/host/test_cli_session_export.py
@@ -4,62 +4,76 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
+import httpx
+import respx
 from click.testing import CliRunner
 
 from omnigent.cli import cli
-from omnigent.entities.conversation import MessageData, NewConversationItem
-from omnigent.stores.conversation_store.sqlalchemy_store import (
-    SqlAlchemyConversationStore,
-)
+
+_BASE = "http://localhost:6767"
+
+_SESSION_META = {
+    "id": "conv_abc123",
+    "title": "test session",
+    "status": "idle",
+    "created_at": 1700000000,
+    "updated_at": 1700000001,
+    "agent_id": None,
+    "agent_name": None,
+    "items": [],
+}
+
+_ITEMS_PAGE = {
+    "data": [
+        {
+            "id": "msg_1",
+            "type": "message",
+            "status": "completed",
+            "response_id": "resp_1",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+        },
+        {
+            "id": "msg_2",
+            "type": "message",
+            "status": "completed",
+            "response_id": "resp_1",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hi there"}],
+            "model": "my-agent",
+        },
+    ],
+    "first_id": "msg_1",
+    "last_id": "msg_2",
+    "has_more": False,
+}
 
 
-def _add_items(store: SqlAlchemyConversationStore, conv_id: str) -> None:
-    store.append(
-        conv_id,
-        [
-            NewConversationItem(
-                type="message",
-                response_id="resp_1",
-                data=MessageData(
-                    role="user",
-                    content=[{"type": "input_text", "text": "hello"}],
-                ),
-            ),
-            NewConversationItem(
-                type="message",
-                response_id="resp_1",
-                data=MessageData(
-                    role="assistant",
-                    content=[{"type": "output_text", "text": "hi there"}],
-                    agent="my-agent",
-                ),
-            ),
-        ],
-    )
+def _patch_server(base_url: str = _BASE) -> Any:
+    """Patch the CLI so it uses *base_url* without spawning a real server."""
+    return patch("omnigent.cli._resolve_attach_server", return_value=base_url)
 
 
-def test_session_export_writes_jsonl(db_uri: str, tmp_path: Path) -> None:
+@respx.mock
+def test_session_export_writes_jsonl(tmp_path: Path) -> None:
     """Export writes one session_meta line then one item line per item."""
-    store = SqlAlchemyConversationStore(db_uri)
-    conv = store.create_conversation(kind="default", title="test session")
-    _add_items(store, conv.id)
+    respx.get(f"{_BASE}/v1/sessions/conv_abc123").mock(
+        return_value=httpx.Response(200, json=_SESSION_META)
+    )
+    respx.get(f"{_BASE}/v1/sessions/conv_abc123/items").mock(
+        return_value=httpx.Response(200, json=_ITEMS_PAGE)
+    )
 
     out_file = tmp_path / "out.jsonl"
     runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        [
-            "session",
-            "export",
-            "--id",
-            conv.id,
-            "--output",
-            str(out_file),
-            "--database-uri",
-            db_uri,
-        ],
-    )
+    with _patch_server():
+        result = runner.invoke(
+            cli,
+            ["session", "export", "--id", "conv_abc123", "--output", str(out_file)],
+        )
 
     assert result.exit_code == 0, result.output
     assert out_file.exists()
@@ -69,86 +83,143 @@ def test_session_export_writes_jsonl(db_uri: str, tmp_path: Path) -> None:
 
     meta = lines[0]
     assert meta["record_type"] == "session_meta"
-    assert meta["id"] == conv.id
+    assert meta["id"] == "conv_abc123"
     assert meta["title"] == "test session"
 
     item_lines = lines[1:]
     assert all(r["record_type"] == "item" for r in item_lines)
-    roles = [r.get("role") for r in item_lines]
-    assert roles == ["user", "assistant"]
+    assert [r["role"] for r in item_lines] == ["user", "assistant"]
     assert item_lines[1]["content"] == [{"type": "output_text", "text": "hi there"}]
 
 
-def test_session_export_default_filename(db_uri: str, tmp_path: Path) -> None:
+@respx.mock
+def test_session_export_default_filename(tmp_path: Path) -> None:
     """Without --output, the file is named <session_id>.jsonl in cwd."""
-    store = SqlAlchemyConversationStore(db_uri)
-    conv = store.create_conversation(kind="default")
+    respx.get(f"{_BASE}/v1/sessions/conv_abc123").mock(
+        return_value=httpx.Response(200, json=_SESSION_META)
+    )
+    respx.get(f"{_BASE}/v1/sessions/conv_abc123/items").mock(
+        return_value=httpx.Response(200, json={**_ITEMS_PAGE, "data": [], "has_more": False})
+    )
 
     runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        result = runner.invoke(
-            cli,
-            ["session", "export", "--id", conv.id, "--database-uri", db_uri],
-        )
+    with runner.isolated_filesystem(temp_dir=tmp_path), _patch_server():
+        result = runner.invoke(cli, ["session", "export", "--id", "conv_abc123"])
         assert result.exit_code == 0, result.output
-        default_path = Path(f"{conv.id}.jsonl")
+        default_path = Path("conv_abc123.jsonl")
         assert default_path.exists()
         lines = [json.loads(line) for line in default_path.read_text().splitlines() if line]
-    # session_meta line only (no items added)
+
     assert len(lines) == 1
     assert lines[0]["record_type"] == "session_meta"
-    assert lines[0]["id"] == conv.id
+    assert lines[0]["id"] == "conv_abc123"
 
 
-def test_session_export_missing_session_errors(db_uri: str, tmp_path: Path) -> None:
+@respx.mock
+def test_session_export_missing_session_errors(tmp_path: Path) -> None:
     """Export of an unknown session id exits non-zero with a clear message."""
-    runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        [
-            "session",
-            "export",
-            "--id",
-            "conv_doesnotexist",
-            "--output",
-            str(tmp_path / "out.jsonl"),
-            "--database-uri",
-            db_uri,
-        ],
+    respx.get(f"{_BASE}/v1/sessions/conv_doesnotexist").mock(
+        return_value=httpx.Response(404, json={"error": "not found"})
     )
+
+    runner = CliRunner()
+    with _patch_server():
+        result = runner.invoke(
+            cli,
+            [
+                "session",
+                "export",
+                "--id",
+                "conv_doesnotexist",
+                "--output",
+                str(tmp_path / "out.jsonl"),
+            ],
+        )
+
     assert result.exit_code != 0
     assert "conv_doesnotexist" in result.output
 
 
-def test_session_export_items_ordered_ascending(db_uri: str, tmp_path: Path) -> None:
-    """Items in the JSONL appear in ascending position order."""
-    store = SqlAlchemyConversationStore(db_uri)
-    conv = store.create_conversation(kind="default")
-    _add_items(store, conv.id)
+@respx.mock
+def test_session_export_items_ordered_ascending(tmp_path: Path) -> None:
+    """Items in the JSONL appear in ascending position order (user then assistant)."""
+    respx.get(f"{_BASE}/v1/sessions/conv_abc123").mock(
+        return_value=httpx.Response(200, json=_SESSION_META)
+    )
+    respx.get(f"{_BASE}/v1/sessions/conv_abc123/items").mock(
+        return_value=httpx.Response(200, json=_ITEMS_PAGE)
+    )
 
     out_file = tmp_path / "ordered.jsonl"
     runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        [
-            "session",
-            "export",
-            "--id",
-            conv.id,
-            "--output",
-            str(out_file),
-            "--database-uri",
-            db_uri,
-        ],
-    )
+    with _patch_server():
+        result = runner.invoke(
+            cli,
+            ["session", "export", "--id", "conv_abc123", "--output", str(out_file)],
+        )
     assert result.exit_code == 0, result.output
 
     records = [json.loads(line) for line in out_file.read_text().splitlines() if line]
     item_records = [r for r in records if r["record_type"] == "item"]
-    ids = [r["id"] for r in item_records]
-    # items should be distinct and match what the store holds
-    assert len(ids) == 2
-    assert ids[0] != ids[1]
-    # first item is user, second is assistant
+    assert len(item_records) == 2
     assert item_records[0]["role"] == "user"
     assert item_records[1]["role"] == "assistant"
+
+
+@respx.mock
+def test_session_export_pagination(tmp_path: Path) -> None:
+    """Export follows has_more cursors to fetch all pages."""
+    page1 = {
+        "data": [
+            {
+                "id": "msg_1",
+                "type": "message",
+                "status": "completed",
+                "response_id": "r1",
+                "role": "user",
+                "content": [],
+            }
+        ],
+        "first_id": "msg_1",
+        "last_id": "msg_1",
+        "has_more": True,
+    }
+    page2 = {
+        "data": [
+            {
+                "id": "msg_2",
+                "type": "message",
+                "status": "completed",
+                "response_id": "r1",
+                "role": "assistant",
+                "content": [],
+                "model": "ag",
+            }
+        ],
+        "first_id": "msg_2",
+        "last_id": "msg_2",
+        "has_more": False,
+    }
+    respx.get(f"{_BASE}/v1/sessions/conv_abc123").mock(
+        return_value=httpx.Response(200, json=_SESSION_META)
+    )
+    # First call (no after param) → page1; second call (after=msg_1) → page2.
+    items_route = respx.get(f"{_BASE}/v1/sessions/conv_abc123/items")
+    items_route.side_effect = [
+        httpx.Response(200, json=page1),
+        httpx.Response(200, json=page2),
+    ]
+
+    out_file = tmp_path / "paged.jsonl"
+    runner = CliRunner()
+    with _patch_server():
+        result = runner.invoke(
+            cli,
+            ["session", "export", "--id", "conv_abc123", "--output", str(out_file)],
+        )
+    assert result.exit_code == 0, result.output
+
+    records = [json.loads(line) for line in out_file.read_text().splitlines() if line]
+    item_records = [r for r in records if r["record_type"] == "item"]
+    assert len(item_records) == 2
+    assert [r["id"] for r in item_records] == ["msg_1", "msg_2"]

--- a/tests/host/test_cli_session_export.py
+++ b/tests/host/test_cli_session_export.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from omnigent.cli import cli
@@ -50,13 +49,22 @@ def test_session_export_writes_jsonl(db_uri: str, tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["session", "export", "--id", conv.id, "--output", str(out_file), "--database-uri", db_uri],
+        [
+            "session",
+            "export",
+            "--id",
+            conv.id,
+            "--output",
+            str(out_file),
+            "--database-uri",
+            db_uri,
+        ],
     )
 
     assert result.exit_code == 0, result.output
     assert out_file.exists()
 
-    lines = [json.loads(l) for l in out_file.read_text().splitlines() if l]
+    lines = [json.loads(line) for line in out_file.read_text().splitlines() if line]
     assert len(lines) == 3  # 1 meta + 2 items
 
     meta = lines[0]
@@ -85,7 +93,7 @@ def test_session_export_default_filename(db_uri: str, tmp_path: Path) -> None:
         assert result.exit_code == 0, result.output
         default_path = Path(f"{conv.id}.jsonl")
         assert default_path.exists()
-        lines = [json.loads(l) for l in default_path.read_text().splitlines() if l]
+        lines = [json.loads(line) for line in default_path.read_text().splitlines() if line]
     # session_meta line only (no items added)
     assert len(lines) == 1
     assert lines[0]["record_type"] == "session_meta"
@@ -122,11 +130,20 @@ def test_session_export_items_ordered_ascending(db_uri: str, tmp_path: Path) -> 
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["session", "export", "--id", conv.id, "--output", str(out_file), "--database-uri", db_uri],
+        [
+            "session",
+            "export",
+            "--id",
+            conv.id,
+            "--output",
+            str(out_file),
+            "--database-uri",
+            db_uri,
+        ],
     )
     assert result.exit_code == 0, result.output
 
-    records = [json.loads(l) for l in out_file.read_text().splitlines() if l]
+    records = [json.loads(line) for line in out_file.read_text().splitlines() if line]
     item_records = [r for r in records if r["record_type"] == "item"]
     ids = [r["id"] for r in item_records]
     # items should be distinct and match what the store holds

--- a/tests/host/test_cli_session_export.py
+++ b/tests/host/test_cli_session_export.py
@@ -1,0 +1,137 @@
+"""Unit tests for ``omnigent session export``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from omnigent.cli import cli
+from omnigent.entities.conversation import MessageData, NewConversationItem
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+
+def _add_items(store: SqlAlchemyConversationStore, conv_id: str) -> None:
+    store.append(
+        conv_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_1",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "hello"}],
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="resp_1",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "hi there"}],
+                    agent="my-agent",
+                ),
+            ),
+        ],
+    )
+
+
+def test_session_export_writes_jsonl(db_uri: str, tmp_path: Path) -> None:
+    """Export writes one session_meta line then one item line per item."""
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(kind="default", title="test session")
+    _add_items(store, conv.id)
+
+    out_file = tmp_path / "out.jsonl"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["session", "export", "--id", conv.id, "--output", str(out_file), "--database-uri", db_uri],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert out_file.exists()
+
+    lines = [json.loads(l) for l in out_file.read_text().splitlines() if l]
+    assert len(lines) == 3  # 1 meta + 2 items
+
+    meta = lines[0]
+    assert meta["record_type"] == "session_meta"
+    assert meta["id"] == conv.id
+    assert meta["title"] == "test session"
+
+    item_lines = lines[1:]
+    assert all(r["record_type"] == "item" for r in item_lines)
+    roles = [r.get("role") for r in item_lines]
+    assert roles == ["user", "assistant"]
+    assert item_lines[1]["content"] == [{"type": "output_text", "text": "hi there"}]
+
+
+def test_session_export_default_filename(db_uri: str, tmp_path: Path) -> None:
+    """Without --output, the file is named <session_id>.jsonl in cwd."""
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(kind="default")
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(
+            cli,
+            ["session", "export", "--id", conv.id, "--database-uri", db_uri],
+        )
+        assert result.exit_code == 0, result.output
+        default_path = Path(f"{conv.id}.jsonl")
+        assert default_path.exists()
+        lines = [json.loads(l) for l in default_path.read_text().splitlines() if l]
+    # session_meta line only (no items added)
+    assert len(lines) == 1
+    assert lines[0]["record_type"] == "session_meta"
+    assert lines[0]["id"] == conv.id
+
+
+def test_session_export_missing_session_errors(db_uri: str, tmp_path: Path) -> None:
+    """Export of an unknown session id exits non-zero with a clear message."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "session",
+            "export",
+            "--id",
+            "conv_doesnotexist",
+            "--output",
+            str(tmp_path / "out.jsonl"),
+            "--database-uri",
+            db_uri,
+        ],
+    )
+    assert result.exit_code != 0
+    assert "conv_doesnotexist" in result.output
+
+
+def test_session_export_items_ordered_ascending(db_uri: str, tmp_path: Path) -> None:
+    """Items in the JSONL appear in ascending position order."""
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation(kind="default")
+    _add_items(store, conv.id)
+
+    out_file = tmp_path / "ordered.jsonl"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["session", "export", "--id", conv.id, "--output", str(out_file), "--database-uri", db_uri],
+    )
+    assert result.exit_code == 0, result.output
+
+    records = [json.loads(l) for l in out_file.read_text().splitlines() if l]
+    item_records = [r for r in records if r["record_type"] == "item"]
+    ids = [r["id"] for r in item_records]
+    # items should be distinct and match what the store holds
+    assert len(ids) == 2
+    assert ids[0] != ids[1]
+    # first item is user, second is assistant
+    assert item_records[0]["role"] == "user"
+    assert item_records[1]["role"] == "assistant"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Dropped the back-pointer `agents.session_id` column (a FK to `conversations.id`) in favour of the forward pointer `conversations.agent_id`, which is the single source of truth for ownership.
- An agent is now classified as session-scoped if any conversation row references it via `conversations.agent_id`; this is discovered at query time with a `NOT EXISTS` subquery rather than a nullable FK column on the agent side.
- The partial unique index `ix_agents_template_name` (previously scoped to `session_id IS NULL`) is recreated as a plain unique index; `ix_agents_session_id` is dropped entirely.

**ELI5:** Before this change, there were two columns pointing between agents and conversations: `agents.session_id → conversations.id` and `conversations.agent_id → agents.id`. Keeping both in sync is error-prone. This PR removes the agent-side back-pointer, leaving only the conversation-side forward pointer as the source of truth.

\`\`\`
Before:
  agents.session_id ─────────────┐
                                 ▼
  conversations.agent_id ──> agents.id

After:
  conversations.agent_id ──> agents.id   (only one reference)
\`\`\`

## Test Plan

- \`pre-commit run --all-files\` passes cleanly.
- Existing unit and integration tests for agent store logic cover \`get_by_name\` and \`list\` (both now use NOT EXISTS subqueries).
- Alembic migration \`o1a2b3c4d5e6\` includes both \`upgrade()\` (drops column + old indexes, recreates plain unique index) and \`downgrade()\` (re-adds column, back-populates from \`conversations.agent_id\`, restores partial indexes).

## Demo

N/A — no UI / frontend change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The \`get_by_name\` and \`list\` query logic is exercised by existing agent-store integration tests. The migration itself is a schema-only change with no new business logic beyond the back-populate in \`downgrade()\`.