### PR TITLE
feat(web): steer a queued message (SDK harnesses)

### DIFF
--- a/tests/e2e_ui/chat/test_queue_steer.py
+++ b/tests/e2e_ui/chat/test_queue_steer.py
@@ -1,0 +1,168 @@
+"""E2E: steering a queued message sends it NOW, mid-turn.
+
+Guards the steer affordance of the client-side queue:
+
+    A first message is sent (and acked), but no ``session.status`` event
+    ever follows, so the session's local status stays "streaming"
+    (busy). A follow-up typed into the composer is then held in the
+    client-side queue — shown in the docked strip, NOT POSTed (the idle
+    auto-flush never fires because idle never comes). Clicking the row's
+    "Steer" button POSTs it immediately — the only thing that could send
+    it here, since the session never went idle.
+
+Why async Playwright (not the sync ``page`` fixture): the route handler
+inspects and fulfills every ``/events`` POST to record which messages the
+SPA sent and when, across interleaved UI actions (send, queue, steer). It
+is a sync test driving the async flow in a fresh thread (see
+:func:`_run_in_fresh_loop`) because the suite's many sync
+pytest-playwright tests leave the main-thread loop in a state where
+pytest-asyncio can't start one.
+
+The route handler fulfills every ``/events`` POST itself, so no real turn
+runs and the test needs no working LLM — it asserts purely on when (and
+whether) the SPA POSTs the steered message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright
+
+_COMPOSER_PLACEHOLDER = "Ask the agent anything…"
+_MSG1 = "sentinel-steer-msg1-2b8d first message, holds the turn open"
+_MSG2 = "sentinel-steer-msg2-6f4a queued then steered"
+
+_EVENTS_RE = re.compile(r"/v1/sessions/([^/]+)/events$")
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* to completion in a dedicated thread with its own event loop.
+
+    The e2e_ui suite runs many pytest-playwright **sync** tests in the same
+    session; once one has run, pytest-asyncio can't start a loop on the main
+    thread. Running the coroutine from a fresh thread via :func:`asyncio.run`
+    sidesteps that. Any exception is captured and re-raised on the calling
+    thread so the test fails normally.
+
+    :param coro: The coroutine to run to completion.
+    :raises BaseException: Whatever the coroutine raised, re-raised here.
+    """
+    captured: dict[str, BaseException] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except BaseException as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
+    """Poll ``predicate`` on the event loop until true or timeout.
+
+    :param predicate: Zero-arg callable returning truthy when satisfied.
+    :param timeout_s: Max seconds to wait before failing the test.
+    :raises AssertionError: If the predicate never becomes truthy.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"condition not met within {timeout_s:.0f}s")
+
+
+def test_steer_sends_queued_message_while_busy(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Steering a queued message POSTs it immediately, mid-turn.
+
+    Failure mode this catches: steer does nothing (message stays queued),
+    or the message is only sent after the turn ends (indistinguishable
+    from auto-flush) — either means the steer path is broken.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_steer(base_url, session_id))
+
+
+async def _drive_steer(base_url: str, session_id: str) -> None:
+    """Async body of the steer test. See the test docstring.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: The seeded, runner-bound session.
+    """
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            # Every (session_id, text) POSTed to a /events endpoint. Each is
+            # acked immediately; no session.status event ever follows, so the
+            # session's local status stays "streaming" (busy) after msg1 —
+            # which is what makes the follow-up queue instead of send.
+            event_posts: list[tuple[str, str]] = []
+
+            async def handle_events(route: Route) -> None:
+                request = route.request
+                match = _EVENTS_RE.search(request.url)
+                assert match is not None, f"unexpected /events url: {request.url}"
+                sid = match.group(1)
+                body = request.post_data_json
+                text = body["data"]["content"][0]["text"]
+                event_posts.append((sid, text))
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            await page.route("**/v1/sessions/*/events", handle_events)
+
+            await page.goto(f"{base_url}/c/{session_id}")
+            composer = page.get_by_label("Message the agent")
+            await page.get_by_placeholder(_COMPOSER_PLACEHOLDER).wait_for(
+                state="visible", timeout=15_000
+            )
+            send_button = page.get_by_role("button", name="Send", exact=True)
+
+            # msg1 → POST + acked; the send flips local status to streaming and
+            # no idle event arrives, so the session stays busy.
+            await composer.fill(_MSG1)
+            await send_button.click()
+            await _wait_until(lambda: any(text == _MSG1 for _, text in event_posts))
+
+            # msg2 → typed while busy → held in the client-side queue, shown in
+            # the docked strip, NOT POSTed (auto-flush only fires on idle, which
+            # never comes here).
+            await composer.fill(_MSG2)
+            await send_button.click()
+            await page.get_by_test_id("composer-queued-strip").wait_for(
+                state="visible", timeout=15_000
+            )
+            assert all(text != _MSG2 for _, text in event_posts), (
+                f"msg2 was POSTed before steer (should be held client-side): {event_posts}"
+            )
+
+            # Steer msg2 → it must POST now, even though the session never went
+            # idle. This is what distinguishes steer from the idle auto-flush:
+            # the only reason msg2 could POST here is the explicit steer.
+            await page.get_by_role("button", name="Send queued message now").click()
+            await _wait_until(lambda: any(text == _MSG2 for _, text in event_posts))
+
+            # The steered message left the queue (strip empties).
+            await page.get_by_test_id("composer-queued-strip").wait_for(
+                state="hidden", timeout=15_000
+            )
+        finally:
+            await browser.close()

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3653,6 +3653,8 @@ export function Composer({
   const flushBoundAgentId = useChatStore((s) => s.boundAgentId);
   const maybeFlushQueuedHead = useChatStore((s) => s.maybeFlushQueuedHead);
   const dequeueMessage = useChatStore((s) => s.dequeueMessage);
+  const steerMessage = useChatStore((s) => s.steerMessage);
+  const isNativeTerminalSession = useChatStore((s) => s.isNativeTerminalSession);
   // Drain the queue whenever idle with a waiting head — level-triggered so a
   // message queued right after the turn ended (or after an SSE reconnect that
   // carries no fresh idle transition) still sends instead of stranding. Hold
@@ -4379,6 +4381,12 @@ export function Composer({
           dequeueMessage(queueId);
           textareaRef.current?.focus();
         }}
+        onSteer={
+          // Steer (send now → server live-injects mid-turn) only where the
+          // harness supports it. Native terminals buffer & drain rather than
+          // inject, so no steer button there until that path lands.
+          isNativeTerminalSession ? undefined : (queueId) => steerMessage(queueId)
+        }
         widthClassName={CHAT_COLUMN_WIDTH}
       />
       {/* Sub-agent context tray — peeks above the card; reserves its own

--- a/web/src/pages/QueuedMessagesStrip.test.tsx
+++ b/web/src/pages/QueuedMessagesStrip.test.tsx
@@ -34,8 +34,6 @@ describe("QueuedMessagesStrip", () => {
     );
     expect(screen.getByText("first")).toBeInTheDocument();
     expect(screen.getByText("second")).toBeInTheDocument();
-    // Each row carries the "Queued" label.
-    expect(screen.getAllByText("Queued")).toHaveLength(2);
   });
 
   it("calls onDelete with the row's queueId when its remove button is clicked", () => {

--- a/web/src/pages/QueuedMessagesStrip.test.tsx
+++ b/web/src/pages/QueuedMessagesStrip.test.tsx
@@ -69,4 +69,28 @@ describe("QueuedMessagesStrip", () => {
     expect(onEdit).toHaveBeenCalledTimes(1);
     expect(onEdit).toHaveBeenCalledWith("q_1");
   });
+
+  it("shows no steer button when onSteer is omitted", () => {
+    render(
+      <QueuedMessagesStrip messages={[msg("q_1", "first")]} onDelete={vi.fn()} onEdit={vi.fn()} />,
+    );
+    expect(screen.queryByRole("button", { name: "Send queued message now" })).toBeNull();
+  });
+
+  it("calls onSteer with the row's queueId when its steer button is clicked", () => {
+    const onSteer = vi.fn();
+    render(
+      <QueuedMessagesStrip
+        messages={[msg("q_1", "first"), msg("q_2", "second")]}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        onSteer={onSteer}
+      />,
+    );
+    const buttons = screen.getAllByRole("button", { name: "Send queued message now" });
+    expect(buttons).toHaveLength(2);
+    fireEvent.click(buttons[1]!);
+    expect(onSteer).toHaveBeenCalledTimes(1);
+    expect(onSteer).toHaveBeenCalledWith("q_2");
+  });
 });

--- a/web/src/pages/QueuedMessagesStrip.tsx
+++ b/web/src/pages/QueuedMessagesStrip.tsx
@@ -1,4 +1,4 @@
-import { ClockIcon, PencilIcon, SendHorizontalIcon, Trash2Icon } from "lucide-react";
+import { ClockIcon, CornerDownRightIcon, PencilIcon, Trash2Icon } from "lucide-react";
 
 import type { QueuedMessage } from "@/store/chatStore";
 import { cn } from "@/lib/utils";
@@ -54,17 +54,17 @@ export function QueuedMessagesStrip({
           >
             <ClockIcon className="size-3.5 shrink-0" aria-hidden="true" />
             <span className="min-w-0 flex-1 truncate">{message.text}</span>
-            <span className="shrink-0 text-muted-foreground/70">Queued</span>
             {/* Always visible (not hover-gated) so the actions are
                 discoverable; they brighten on hover/focus. */}
             {onSteer ? (
               <button
                 type="button"
                 aria-label="Send queued message now"
-                className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition hover:text-foreground focus-visible:text-foreground"
+                className="flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-muted-foreground/60 transition hover:text-foreground focus-visible:text-foreground"
                 onClick={() => onSteer(message.queueId)}
               >
-                <SendHorizontalIcon className="size-3.5" aria-hidden="true" />
+                <CornerDownRightIcon className="size-3.5" aria-hidden="true" />
+                Steer
               </button>
             ) : null}
             <button

--- a/web/src/pages/QueuedMessagesStrip.tsx
+++ b/web/src/pages/QueuedMessagesStrip.tsx
@@ -1,4 +1,4 @@
-import { ClockIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import { ClockIcon, PencilIcon, SendHorizontalIcon, Trash2Icon } from "lucide-react";
 
 import type { QueuedMessage } from "@/store/chatStore";
 import { cn } from "@/lib/utils";
@@ -10,6 +10,12 @@ interface QueuedMessagesStripProps {
   onDelete: (queueId: string) => void;
   /** Pull a queued message back into the composer for editing. */
   onEdit: (queueId: string) => void;
+  /**
+   * Send a queued message now (steer), instead of waiting for the idle flush.
+   * Omitted when the session can't steer mid-turn (e.g. native terminals),
+   * in which case no steer button is shown.
+   */
+  onSteer?: (queueId: string) => void;
   /** Column-width class so the strip lines up with the composer card. */
   widthClassName?: string;
 }
@@ -19,13 +25,14 @@ interface QueuedMessagesStripProps {
  * busy. Peeks above the composer card (`-mb-4` + bottom padding), mirroring
  * `SubagentComposerTray`. Renders nothing when the queue is empty.
  *
- * Each row can be edited (pulled back into the composer) or deleted; steer /
- * reorder land in later changes.
+ * Each row can be steered (sent now), edited (pulled back into the composer),
+ * or deleted; reorder lands in a later change.
  */
 export function QueuedMessagesStrip({
   messages,
   onDelete,
   onEdit,
+  onSteer,
   widthClassName,
 }: QueuedMessagesStripProps) {
   if (messages.length === 0) return null;
@@ -50,6 +57,16 @@ export function QueuedMessagesStrip({
             <span className="shrink-0 text-muted-foreground/70">Queued</span>
             {/* Always visible (not hover-gated) so the actions are
                 discoverable; they brighten on hover/focus. */}
+            {onSteer ? (
+              <button
+                type="button"
+                aria-label="Send queued message now"
+                className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition hover:text-foreground focus-visible:text-foreground"
+                onClick={() => onSteer(message.queueId)}
+              >
+                <SendHorizontalIcon className="size-3.5" aria-hidden="true" />
+              </button>
+            ) : null}
             <button
               type="button"
               aria-label="Edit queued message"

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7497,6 +7497,32 @@ describe("chatStore — client-side message queue", () => {
     expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["first", "third"]);
   });
 
+  it("steerMessage sends the chosen message now and removes it from the queue", () => {
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      send: sendSpy,
+      queuedMessages: [
+        { queueId: "q_1", text: "first", conversationId: "conv_abc" },
+        // A message queued while bound to a different agent still steers to
+        // the agent it was composed for.
+        { queueId: "q_2", text: "second", conversationId: "conv_abc", agentId: "agent_two" },
+      ],
+    });
+
+    // Steer the second (non-head) message: it sends immediately, out of FIFO
+    // order, to the agent captured at enqueue time.
+    useChatStore.getState().steerMessage("q_2");
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["second", "agent_two"]);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["first"]);
+
+    // Steering a missing id is a no-op.
+    useChatStore.getState().steerMessage("q_missing");
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("maybeFlushQueuedHead flushes the head FIFO, one per idle", async () => {
     // Spy on send so the flush's contract (which head, in what order) is
     // asserted without depending on the full bind→/events network path.

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -536,6 +536,13 @@ export interface ChatState {
   /** Remove a queued message by id (the strip's per-row delete). */
   dequeueMessage: (queueId: string) => void;
   /**
+   * Send a queued message NOW instead of waiting for the idle flush (the
+   * strip's per-row steer). Removes it from the queue and POSTs it: on an
+   * SDK harness the server live-injects it into the running turn; the
+   * optimistic bubble promotes on POST. No-op if the id isn't queued.
+   */
+  steerMessage: (queueId: string) => void;
+  /**
    * Drop all queued messages for a conversation. Called when a conversation is
    * deleted so its queue can't linger in memory (it would never flush — you
    * can't be bound to a deleted session).
@@ -858,6 +865,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set((s) => ({
       queuedMessages: s.queuedMessages.filter((m) => m.queueId !== queueId),
     }));
+  },
+
+  steerMessage: (queueId) => {
+    const s = get();
+    const target = s.queuedMessages.find((m) => m.queueId === queueId);
+    const agentId = target?.agentId ?? s.boundAgentId;
+    if (target === undefined || agentId === null) return;
+    // Remove BEFORE the POST so a concurrent flush can't also send it.
+    set({ queuedMessages: s.queuedMessages.filter((m) => m.queueId !== queueId) });
+    void s.send(target.text, agentId, target.files);
   },
 
   clearQueuedMessages: (conversationId) => {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds a per-row **steer** (send-now) button to the composer's "Queued" strip.
  Clicking it POSTs that message **immediately** instead of waiting for the idle
  flush. On an SDK harness the server live-injects it into the running turn (no
  interrupt — it folds in at the agent's next breakpoint); the optimistic bubble
  promotes on POST.
- It sends to the agent captured at enqueue time and can jump ahead of earlier
  queued messages (steer = "this one, now").
- **Scoped to SDK harnesses.** Native terminals buffer & drain rather than
  inject mid-turn, so the steer button is hidden there
  (`isNativeTerminalSession`) until that path lands — tracked in
  `docs/QUEUE_STEER_DESIGN.md`.
- Fourth step of the queue+steer design; native steer + reorder still to come.

## Test Plan

- **Unit** (`web`, vitest): `chatStore.test.ts` covers `steerMessage` (sends the
  chosen message now, to its enqueue-time agent, out of FIFO order; no-op on a
  missing id). `QueuedMessagesStrip.test.tsx` covers the steer button appearing
  only when `onSteer` is provided and invoking it with the row's `queueId`. 255
  passing.
- **Gates**: `npm run type-check`, tests, prettier all pass.

## Demo

<!-- TODO: attach a short clip of steering a queued message mid-turn on an SDK session -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`steerMessage` and the strip's steer button (presence + `queueId` wiring) are
covered by unit tests; the mid-turn delivery reuses the server's existing
live-injection path (`send()` while streaming), already exercised elsewhere.

This pull request and its description were written by Isaac.
