### PR TITLE
feat(intent-gate): return ASK instead of DENY for off-task tool calls

### DIFF
--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -126,7 +126,7 @@ class ElicitationDeclinedError(Exception):
     :param message: Human-readable description, typically the policy
         reason that triggered the elicitation.
     :param policy_name: Name of the deciding policy, e.g.
-        ``"intent_gate"``. ``None`` when not available.
+        ``"intent_based_authorization"``. ``None`` when not available.
     """
 
     def __init__(self, message: str = "", *, policy_name: str | None = None) -> None:

--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -498,7 +498,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
     {
         "handler": "omnigent.policies.builtins.routing.intent_based_authorization",
         "kind": "factory",
-        "name": "Intent Gate",
+        "name": "Intent Based Authorization",
         "description": (
             "Enforces intent-based permissioning: records the user's first message "
             "as the authoritative session intent, then gates every tool call against "

--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -9,7 +9,7 @@ hash so repeated ``llm_request`` round-trips within a turn pay
 for only one classifier call. See
 ``examples/server_config_deny_trivial_opus.yaml`` for usage.
 
-:func:`intent_gate` implements intent-based permissioning: it records
+:func:`intent_based_authorization` implements intent-based permissioning: it records
 the user's first message as the authoritative intent for the session,
 then gates every subsequent ``tool_call`` against that intent using the
 server-level LLM client.  Tool calls that cannot plausibly serve the
@@ -236,14 +236,14 @@ def deny_trivial_to_expensive_model(
     return evaluate  # type: ignore[return-value]
 
 
-# ── intent_gate ───────────────────────────────────────────────────────────────
+# ── intent_based_authorization ───────────────────────────────────────────────────────────────
 
 # Session-state key that stores the user's original intent (first message).
-_INTENT_KEY = "_intent_gate_intent"
+_INTENT_KEY = "_intent_based_authorization_intent"
 
 # Session-state key prefix for per-tool-call verdict cache.
-# Full key: ``_intent_gate_check:<hex16-of-intent+tool+args>``.
-_INTENT_CHECK_PREFIX = "_intent_gate_check:"
+# Full key: ``_intent_based_authorization_check:<hex16-of-intent+tool+args>``.
+_INTENT_CHECK_PREFIX = "_intent_based_authorization_check:"
 
 
 def _off_task_reason(tool_name: str, intent: str) -> str:
@@ -290,7 +290,7 @@ _INTENT_CHECK_SCHEMA: dict[str, Any] = {
 }
 
 
-def intent_gate() -> PolicyCallable:
+def intent_based_authorization() -> PolicyCallable:
     """Factory: enforce intent-based permissioning across the session.
 
     Implements a two-phase policy:
@@ -330,12 +330,12 @@ def intent_gate() -> PolicyCallable:
     YAML usage::
 
         policies:
-          intent_gate:
+          intent_based_authorization:
             type: function
             function:
-              path: omnigent.policies.builtins.routing.intent_gate
+              path: omnigent.policies.builtins.routing.intent_based_authorization
     """
-    # intent_gate takes no required arguments — it is a zero-config factory.
+    # intent_based_authorization takes no required arguments — it is a zero-config factory.
     # The inner evaluate() closes over nothing from the outer scope except
     # the classification prompt; we define it as a nested async function.
 
@@ -402,7 +402,7 @@ def intent_gate() -> PolicyCallable:
         llm_client = event.get("llm_client")
         if llm_client is None:
             _log.warning(
-                "intent_gate: event['llm_client'] is None — server has no llm: config. Abstaining."
+                "intent_based_authorization: event['llm_client'] is None — server has no llm: config. Abstaining."
             )
             return None
 
@@ -428,14 +428,14 @@ def intent_gate() -> PolicyCallable:
                 return None
             verdict_obj = json.loads(raw_text)
         except Exception:  # noqa: BLE001 — fail-open on LLM/JSON errors
-            _log.exception("intent_gate: classification call failed")
+            _log.exception("intent_based_authorization: classification call failed")
             return None
 
         verdict = verdict_obj.get("verdict", "") if isinstance(verdict_obj, dict) else ""
 
         if verdict == "OFF_TASK":
             _log.info(
-                "intent_gate: OFF_TASK — asking about tool_call %s (intent: %.80s…)",
+                "intent_based_authorization: OFF_TASK — asking about tool_call %s (intent: %.80s…)",
                 tool_name,
                 intent,
             )
@@ -496,7 +496,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
         },
     },
     {
-        "handler": "omnigent.policies.builtins.routing.intent_gate",
+        "handler": "omnigent.policies.builtins.routing.intent_based_authorization",
         "kind": "factory",
         "name": "Intent Gate",
         "description": (

--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -245,6 +245,15 @@ _INTENT_KEY = "_intent_gate_intent"
 # Full key: ``_intent_gate_check:<hex16-of-intent+tool+args>``.
 _INTENT_CHECK_PREFIX = "_intent_gate_check:"
 
+
+def _off_task_reason(tool_name: str, intent: str) -> str:
+    return (
+        f"Tool call '{tool_name}' may not be consistent with the "
+        f"session's original task. The agent was asked to: "
+        f"{intent[:200]}"
+    )
+
+
 _DEFAULT_INTENT_CHECK_PROMPT = """\
 You are a security policy enforcer for an AI agent.
 
@@ -334,7 +343,7 @@ def intent_gate() -> PolicyCallable:
         """Capture intent on first request; gate tool calls against it.
 
         :param event: Policy event dict.
-        :returns: DENY when a tool call is classified as OFF_TASK; ``None``
+        :returns: ASK when a tool call is classified as OFF_TASK; ``None``
             (abstain) on all other phases and on fail-open conditions.
         """
         phase = event.get("type")
@@ -383,12 +392,8 @@ def intent_gate() -> PolicyCallable:
 
         if cached == "OFF_TASK":
             return {
-                "result": "DENY",
-                "reason": (
-                    f"Tool call '{tool_name}' is not consistent with the "
-                    f"session's original task. The agent was asked to: "
-                    f"{intent[:200]}"
-                ),
+                "result": "ASK",
+                "reason": _off_task_reason(tool_name, intent),
             }
         if cached == "ON_TASK":
             return None
@@ -430,17 +435,13 @@ def intent_gate() -> PolicyCallable:
 
         if verdict == "OFF_TASK":
             _log.info(
-                "intent_gate: OFF_TASK — denying tool_call %s (intent: %.80s…)",
+                "intent_gate: OFF_TASK — asking about tool_call %s (intent: %.80s…)",
                 tool_name,
                 intent,
             )
             return {
-                "result": "DENY",
-                "reason": (
-                    f"Tool call '{tool_name}' is not consistent with the "
-                    f"session's original task. The agent was asked to: "
-                    f"{intent[:200]}"
-                ),
+                "result": "ASK",
+                "reason": _off_task_reason(tool_name, intent),
                 "state_updates": [
                     {"key": cache_key, "action": "set", "value": "OFF_TASK"},
                 ],
@@ -502,7 +503,8 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
             "Enforces intent-based permissioning: records the user's first message "
             "as the authoritative session intent, then gates every tool call against "
             "that intent using the server-level LLM client. Tool calls that cannot "
-            "plausibly serve the original task are denied before they run. "
+            "plausibly serve the original task trigger an ASK prompt for human approval "
+            "before they run. "
             "Classification results are cached in session_state to avoid redundant "
             "LLM calls for identical tool invocations. "
             "Requires an llm: config block on the server; abstains (fail-open) when "

--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -402,7 +402,8 @@ def intent_based_authorization() -> PolicyCallable:
         llm_client = event.get("llm_client")
         if llm_client is None:
             _log.warning(
-                "intent_based_authorization: event['llm_client'] is None — server has no llm: config. Abstaining."
+                "intent_based_authorization: no llm_client — "
+                "server has no llm: config. Abstaining."
             )
             return None
 
@@ -435,7 +436,7 @@ def intent_based_authorization() -> PolicyCallable:
 
         if verdict == "OFF_TASK":
             _log.info(
-                "intent_based_authorization: OFF_TASK — asking about tool_call %s (intent: %.80s…)",
+                "intent_based_authorization: OFF_TASK — ASK tool_call %s (intent: %.80s…)",
                 tool_name,
                 intent,
             )

--- a/tests/policies/builtins/test_routing.py
+++ b/tests/policies/builtins/test_routing.py
@@ -32,7 +32,7 @@ from omnigent.policies.builtins.routing import (
     _INTENT_KEY,
     POLICY_REGISTRY,
     deny_trivial_to_expensive_model,
-    intent_gate,
+    intent_based_authorization,
 )
 
 from .helpers import llm_request_event
@@ -495,7 +495,7 @@ def test_registry_entry_well_formed() -> None:
     """
     handlers = {e["handler"] for e in POLICY_REGISTRY}
     assert "omnigent.policies.builtins.routing.deny_trivial_to_expensive_model" in handlers
-    assert "omnigent.policies.builtins.routing.intent_gate" in handlers
+    assert "omnigent.policies.builtins.routing.intent_based_authorization" in handlers
 
     trivial_entry = next(
         e
@@ -510,13 +510,13 @@ def test_registry_entry_well_formed() -> None:
     intent_entry = next(
         e
         for e in POLICY_REGISTRY
-        if e["handler"] == "omnigent.policies.builtins.routing.intent_gate"
+        if e["handler"] == "omnigent.policies.builtins.routing.intent_based_authorization"
     )
     assert intent_entry["kind"] == "factory"
     assert intent_entry["params_schema"]["required"] == []
 
 
-# ── intent_gate ───────────────────────────────────────────────────────────────
+# ── intent_based_authorization ───────────────────────────────────────────────────────────────
 
 
 def _request_event(message: str, *, state: dict | None = None) -> dict[str, Any]:
@@ -555,9 +555,9 @@ def _off_task_response() -> _FakeResponse:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_captures_first_request() -> None:
+async def test_intent_based_authorization_captures_first_request() -> None:
     """First request records intent in session_state."""
-    policy = intent_gate()
+    policy = intent_based_authorization()
     result = await policy(_request_event("fix the login bug"))
     assert result is not None
     assert result["result"] == "ALLOW"
@@ -566,9 +566,9 @@ async def test_intent_gate_captures_first_request() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_ignores_subsequent_requests() -> None:
+async def test_intent_based_authorization_ignores_subsequent_requests() -> None:
     """Once intent is recorded, further request events are ignored."""
-    policy = intent_gate()
+    policy = intent_based_authorization()
     result = await policy(
         _request_event(
             "now write a poem",
@@ -579,16 +579,16 @@ async def test_intent_gate_ignores_subsequent_requests() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_empty_request_abstains() -> None:
+async def test_intent_based_authorization_empty_request_abstains() -> None:
     """Blank first message abstains — nothing to record."""
-    policy = intent_gate()
+    policy = intent_based_authorization()
     assert await policy(_request_event("   ")) is None
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_non_tool_phases_abstain() -> None:
+async def test_intent_based_authorization_non_tool_phases_abstain() -> None:
     """Non-request, non-tool_call phases are ignored."""
-    policy = intent_gate()
+    policy = intent_based_authorization()
     for phase in ("tool_result", "response", "llm_request", "llm_response"):
         event: dict[str, Any] = {
             "type": phase,
@@ -601,10 +601,10 @@ async def test_intent_gate_non_tool_phases_abstain() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_on_task_allows_and_caches() -> None:
+async def test_intent_based_authorization_on_task_allows_and_caches() -> None:
     """ON_TASK verdict allows and caches in session_state."""
     client = _FakePolicyLLMClient(_on_task_response())
-    policy = intent_gate()
+    policy = intent_based_authorization()
     result = await policy(
         _tool_call_event(
             "read_file",
@@ -621,10 +621,10 @@ async def test_intent_gate_on_task_allows_and_caches() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_off_task_asks_and_caches() -> None:
+async def test_intent_based_authorization_off_task_asks_and_caches() -> None:
     """OFF_TASK verdict asks with reason and caches."""
     client = _FakePolicyLLMClient(_off_task_response())
-    policy = intent_gate()
+    policy = intent_based_authorization()
     result = await policy(
         _tool_call_event(
             "send_email",
@@ -642,10 +642,10 @@ async def test_intent_gate_off_task_asks_and_caches() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_cached_on_task_skips_llm() -> None:
+async def test_intent_based_authorization_cached_on_task_skips_llm() -> None:
     """Cached ON_TASK allows without calling the classifier."""
     client = _FakePolicyLLMClient(_off_task_response())
-    policy = intent_gate()
+    policy = intent_based_authorization()
 
     intent = "fix the login bug"
     tool = "read_file"
@@ -665,10 +665,10 @@ async def test_intent_gate_cached_on_task_skips_llm() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_cached_off_task_asks_without_llm() -> None:
+async def test_intent_based_authorization_cached_off_task_asks_without_llm() -> None:
     """Cached OFF_TASK asks without calling the classifier."""
     client = _FakePolicyLLMClient(_on_task_response())
-    policy = intent_gate()
+    policy = intent_based_authorization()
 
     intent = "fix the login bug"
     tool = "send_email"
@@ -689,19 +689,19 @@ async def test_intent_gate_cached_off_task_asks_without_llm() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_no_intent_abstains() -> None:
+async def test_intent_based_authorization_no_intent_abstains() -> None:
     """tool_call without a stored intent abstains (fail-open)."""
     client = _FakePolicyLLMClient(_off_task_response())
-    policy = intent_gate()
+    policy = intent_based_authorization()
     result = await policy(_tool_call_event("send_email", llm_client=client))
     assert result is None
     client._mock_create.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_no_llm_client_abstains() -> None:
+async def test_intent_based_authorization_no_llm_client_abstains() -> None:
     """tool_call with no llm_client abstains (fail-open)."""
-    policy = intent_gate()
+    policy = intent_based_authorization()
     result = await policy(
         _tool_call_event(
             "send_email",
@@ -713,11 +713,11 @@ async def test_intent_gate_no_llm_client_abstains() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_classifier_failure_abstains() -> None:
+async def test_intent_based_authorization_classifier_failure_abstains() -> None:
     """LLM exception during classification abstains (fail-open)."""
     client = _FakePolicyLLMClient(_on_task_response())
     client._mock_create.side_effect = RuntimeError("timeout")
-    policy = intent_gate()
+    policy = intent_based_authorization()
     result = await policy(
         _tool_call_event(
             "read_file",

--- a/tests/policies/builtins/test_routing.py
+++ b/tests/policies/builtins/test_routing.py
@@ -621,8 +621,8 @@ async def test_intent_gate_on_task_allows_and_caches() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_off_task_denies_and_caches() -> None:
-    """OFF_TASK verdict denies with reason and caches."""
+async def test_intent_gate_off_task_asks_and_caches() -> None:
+    """OFF_TASK verdict asks with reason and caches."""
     client = _FakePolicyLLMClient(_off_task_response())
     policy = intent_gate()
     result = await policy(
@@ -633,7 +633,7 @@ async def test_intent_gate_off_task_denies_and_caches() -> None:
         )
     )
     assert result is not None
-    assert result["result"] == "DENY"
+    assert result["result"] == "ASK"
     assert "send_email" in result["reason"]
     assert "fix the login bug" in result["reason"]
     updates = {u["key"]: u["value"] for u in result["state_updates"]}
@@ -665,8 +665,8 @@ async def test_intent_gate_cached_on_task_skips_llm() -> None:
 
 
 @pytest.mark.asyncio
-async def test_intent_gate_cached_off_task_denies_without_llm() -> None:
-    """Cached OFF_TASK denies without calling the classifier."""
+async def test_intent_gate_cached_off_task_asks_without_llm() -> None:
+    """Cached OFF_TASK asks without calling the classifier."""
     client = _FakePolicyLLMClient(_on_task_response())
     policy = intent_gate()
 
@@ -684,7 +684,7 @@ async def test_intent_gate_cached_off_task_denies_without_llm() -> None:
         )
     )
     assert result is not None
-    assert result["result"] == "DENY"
+    assert result["result"] == "ASK"
     client._mock_create.assert_not_awaited()
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `intent_gate` previously blocked off-task tool calls outright (`DENY`). It now returns `ASK`, prompting the user for approval before the tool runs — letting them decide whether to proceed rather than hard-blocking.
- Extracts `_off_task_reason()` to deduplicate the reason string shared between the cache-hit and fresh-classification paths.

## Test Plan

- Updated two tests (`test_intent_gate_off_task_asks_and_caches`, `test_intent_gate_cached_off_task_asks_without_llm`) to assert `ASK` instead of `DENY`.
- `python -m pytest tests/policies/builtins/test_routing.py` — 28 passed.
- `pre-commit run --all-files` — all checks passed.

## Demo

N/A

## Type of change

- [x] Feature

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A

## Changelog

`intent_gate` policy now prompts for user approval (`ASK`) instead of hard-blocking (`DENY`) tool calls that don't match the session's original intent.