### PR TITLE
feat(web): enable steer for native terminal sessions

### DIFF
--- a/docs/QUEUE_STEER_DESIGN.md
+++ b/docs/QUEUE_STEER_DESIGN.md
@@ -69,25 +69,35 @@ consume-timing dependency entirely.
 
 Steer always POSTs immediately; how it lands depends on the harness:
 
+Steer always POSTs immediately (client-side, no runner change); how it lands
+depends on the harness. The steer button is shown for **all** native sessions —
+the runner delivers uniformly (POST → buffer → drain → hand to app, all natives'
+`run_turn` return right after delivery), and the app decides what to do with a
+message that arrives mid-response:
+
 | Harness | Steer delivery | Mid-turn? |
 |---------|----------------|-----------|
 | claude-sdk / codex-sdk / pi-sdk | runner **live injection** (`_live_response_id` gate) | ✅ deterministic |
 | cursor-sdk / copilot-sdk | buffer & drain | ❌ next turn |
-| **codex-native** | explicit **`turn/steer`** RPC when a turn is active | ✅ deterministic |
-| **claude-native** (and paste-based natives) | runner drains → `send-keys` into the **live pane**; the app treats the paste as a steer | ⚠️ best-effort (drain-vs-response race) |
+| **codex-native** | explicit **`turn/steer`** RPC when a turn is active | ✅ deterministic *(verified)* |
+| **claude-native** | `send-keys` into the **live pane**; the TUI folds the paste into the response | ✅ verified (best-effort timing) |
+| cursor-native / pi-native / hermes-native | paste / inbox-queue into the app | ⚠️ app-defined — **not yet verified live** |
+| opencode-native | HTTP prompt; the native server has **no steer endpoint** → queued as a new prompt | ❌ next turn (verified) |
+| qwen / goose / kimi / kiro / antigravity -native | paste / file / RPC into the app | ⚠️ app-defined — not yet verified live |
 
-> **TODO:** sanity-check the remaining harnesses (cursor-native, pi-native,
-> qwen-native, opencode-native, goose-native, hermes-native, kimi-native,
-> antigravity-native, kiro-native, …) — confirm whether each is deterministic
-> (`turn/steer`-style RPC) or best-effort (paste into live pane) before relying on
-> steer behavior.
+> **TODO:** verify live-steer behavior for cursor-native, pi-native,
+> hermes-native, opencode-native (and the remaining natives). The steer button
+> is already shown for them — the mechanism works uniformly — but whether the
+> app folds the message in mid-response vs. at the next turn is confirmed only
+> for claude-native + codex-native so far.
 
-**No runner change is required for native steer** — native `run_turn` clears the
-turn right after the paste, so the drain fires the next message quickly and it
-lands in the live pane, where the native app does its own steering. Frame the UX
+**No runner change is required for native steer** — every native `run_turn`
+returns right after delivering the input (decoupled from the response), so the
+drain fires the next message quickly and it reaches the app while the prior
+response is likely still running; the app does its own steering. Frame the UX
 honestly: *"send now; the agent folds it into current work if it can"* — which is
 exactly how native type-ahead already feels. Do **not** promise deterministic
-mid-turn for paste-based natives.
+mid-turn for the unverified natives.
 
 **Steer is not interrupt.** In every case above, steer *does not cancel* the
 running turn — the message is folded in at the agent's next natural breakpoint

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3654,7 +3654,6 @@ export function Composer({
   const maybeFlushQueuedHead = useChatStore((s) => s.maybeFlushQueuedHead);
   const dequeueMessage = useChatStore((s) => s.dequeueMessage);
   const steerMessage = useChatStore((s) => s.steerMessage);
-  const isNativeTerminalSession = useChatStore((s) => s.isNativeTerminalSession);
   // Drain the queue whenever idle with a waiting head — level-triggered so a
   // message queued right after the turn ended (or after an SSE reconnect that
   // carries no fresh idle transition) still sends instead of stranding. Hold
@@ -4381,12 +4380,7 @@ export function Composer({
           dequeueMessage(queueId);
           textareaRef.current?.focus();
         }}
-        onSteer={
-          // Steer (send now → server live-injects mid-turn) only where the
-          // harness supports it. Native terminals buffer & drain rather than
-          // inject, so no steer button there until that path lands.
-          isNativeTerminalSession ? undefined : (queueId) => steerMessage(queueId)
-        }
+        onSteer={(queueId) => steerMessage(queueId)}
         widthClassName={CHAT_COLUMN_WIDTH}
       />
       {/* Sub-agent context tray — peeks above the card; reserves its own

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7523,6 +7523,24 @@ describe("chatStore — client-side message queue", () => {
     expect(sendSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("steerMessage works on a native-terminal session (harness-agnostic)", () => {
+    // Steer is offered for native sessions too: the runner delivers the POSTed
+    // message via buffer→drain and the native app folds it in. steerMessage
+    // itself doesn't branch on the harness — it just sends now.
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      boundAgentId: "agent_xyz",
+      isNativeTerminalSession: true,
+      send: sendSpy,
+      queuedMessages: [{ queueId: "q_1", text: "steer me", conversationId: "conv_abc" }],
+    });
+    useChatStore.getState().steerMessage("q_1");
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["steer me", "agent_xyz"]);
+    expect(useChatStore.getState().queuedMessages).toEqual([]);
+  });
+
   it("maybeFlushQueuedHead flushes the head FIFO, one per idle", async () => {
     // Spy on send so the flush's contract (which head, in what order) is
     // asserted without depending on the full bind→/events network path.


### PR DESCRIPTION
## Related issue

N/A


## Summary

- Show the queued-message **Steer** button on **native terminal sessions** too,
  not just SDK. Removes the `isNativeTerminalSession` gate on `onSteer` (and its
  now-unused store subscription).
- The runner delivers a steered message **uniformly** for every native harness:
  POST → buffer → drain → hand to the app. Each native `run_turn` returns right
  after delivering the input (decoupled from the response), so the next message
  reaches the app while the prior response is likely still running — the app
  then folds it in. `steerMessage` is harness-agnostic; it just POSTs now.
- **No runner change** — this is a one-line client ungate, matching the design
  doc's conclusion.

### Per-harness behavior

| Harness | Mid-turn steer? |
|---------|-----------------|
| codex-native | ✅ deterministic — `turn/steer` RPC when a turn is active *(verified)* |
| claude-native | ✅ TUI folds the pane paste into the response *(verified)* |
| cursor / pi / hermes -native | ⚠️ app-defined — button shown, **not yet verified live** |
| opencode-native | ❌ no steer endpoint → queued as a new prompt (still "send now") |
| qwen / goose / kimi / kiro / antigravity -native | ⚠️ app-defined — not yet verified live |

Honest UX for all: *"send now; the agent folds it into current work when it can."*
The `docs/QUEUE_STEER_DESIGN.md` steer table + a TODO track the unverified ones.

## Test Plan

- **Unit** (`web`, vitest): added a `steerMessage` test on a native session
  (`isNativeTerminalSession: true`) confirming it still POSTs — the action is
  harness-agnostic. Existing steer + strip tests unchanged. 256 passing.
- **Native e2e is infeasible** in the e2e_ui harness (no `claude`/`codex` CLI +
  tmux; e2e runs an `openai-agents` agent — same caveat the existing
  `test_queued_message_lifecycle.py` documents). Native reconcile is covered by
  the `pending_inputs` + `session.input.consumed` unit suites.
- **Gates**: `npm run type-check`, tests, prettier all pass.

## Demo

<!-- TODO: attach a short clip of steering a queued message on a claude-native / codex-native session -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The ungate is covered by a harness-agnostic `steerMessage` unit test; native
mid-turn delivery reuses the existing buffer→drain + reconcile paths (unit-tested
separately). Live per-harness behavior verified for claude/codex-native; others
tracked as a TODO in the design doc.

This pull request and its description were written by Isaac.
