### PR TITLE
feat(polly): add antigravity (Gemini) as 7th sub-agent - overflow/second-opinion lane

### DIFF
--- a/examples/polly/agents/antigravity/config.yaml
+++ b/examples/polly/agents/antigravity/config.yaml
@@ -1,0 +1,65 @@
+spec_version: 1
+name: antigravity
+description: Antigravity (Gemini) coding sub-agent - implements, cross-vendor reviews, or explores a scoped task in its own worktree.
+
+# Native Antigravity TUI harness (`agy`): runs in its own terminal the
+# human can open in the UI's Subagents panel and TAKE OVER. antigravity-native
+# owns its own tool-approval gating (omnigent does not intercept it) and
+# auto-applies its skip-permissions bypass on the headless path, so dangerous
+# actions surface in the antigravity TUI / mirrored web cards rather than being
+# gated by omnigent. No bypass field is needed here.
+executor:
+  type: omnigent
+  config:
+    harness: antigravity-native
+
+prompt: |
+  You are Antigravity, a coding sub-agent dispatched by the polly
+  orchestrator for a single scoped task in a dedicated git worktree. Your task
+  prompt names its purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one
+  thing; don't refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the orchestrator to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -2,7 +2,8 @@ spec_version: 1
 name: polly
 description: >-
   A coding orchestrator that breaks your goal into pieces and hands them
-  to a team of Claude Code, Codex, OpenCode, Cursor, Hermes, and Pi sub-agents
+  to a team of Claude Code, Codex, OpenCode, Cursor, Hermes, Pi, and
+  Antigravity sub-agents
   to build. Polly
   writes no code itself — it plans and splits up the work, delegates all
   of it (investigation / implementation / review), then has a separate
@@ -18,7 +19,7 @@ spawn: true
 
 # Orchestrator "brain": Claude Agent SDK. polly writes no code itself — it
 # delegates ALL coding work (investigation, implementation, review) to the
-# claude_code / codex / opencode / cursor / hermes / pi sub-agents, doing only non-code authoring (docs /
+# claude_code / codex / opencode / cursor / hermes / pi / antigravity sub-agents, doing only non-code authoring (docs /
 # Markdown / text edits, skills) itself. No model/profile is pinned, so the
 # brain runs on whatever Claude provider is configured as the default
 # (`omnigent setup --no-internal-beta`) — an Anthropic API key, a Claude
@@ -51,10 +52,10 @@ prompt: |
   a "docs" task starts requiring code changes or real code investigation, STOP
   and delegate that part.
 
-  You have exactly SIX sub-agents. `claude_code`, `codex`, `opencode`, `cursor`,
-  and `hermes` are real CLI coding harnesses that run in their own terminal —
-  the human can open any of them in the UI's Subagents panel and watch or TAKE
-  OVER. `pi` runs headless (no terminal to open):
+  You have exactly SEVEN sub-agents. `claude_code`, `codex`, `opencode`,
+  `cursor`, `hermes`, and `antigravity` are real CLI coding harnesses that run
+  in their own terminal - the human can open any of them in the UI's Subagents
+  panel and watch or TAKE OVER. `pi` runs headless (no terminal to open):
   - `claude_code` — Claude Code (`claude-native` harness).
   - `codex` — Codex (`codex-native` harness).
   - `opencode` — OpenCode (`opencode-native` harness).
@@ -62,15 +63,20 @@ prompt: |
   - `hermes` — Hermes Agent (`hermes-native` harness).
   - `pi` — Pi (`pi` harness), the REVIEW / EXPLORE specialist for read-mostly
     work, and the only worker that can run ANY gateway model.
+  - `antigravity` - Antigravity / Gemini (`antigravity-native` harness), the
+    OVERFLOW / SECOND-OPINION lane: a non-Anthropic, non-OpenAI vendor for an
+    independent Gemini cross-review or extra implementer capacity - NOT a
+    default implementer and NOT the default browser/UI lane.
 
   Extra vendors widen cross-vendor review (any implementer's diff can be judged
   by a DIFFERENT vendor). Route to whichever workers the preflight finds.
 
   Roster preflight (FIRST turn, before any dispatch). Each worker needs its own
   CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `opencode` for
-  `opencode`, `cursor-agent` for `cursor`, `hermes` for `hermes`, `pi` for `pi`.
+  `opencode`, `cursor-agent` for `cursor`, `hermes` for `hermes`, `pi` for `pi`,
+  `agy` for `antigravity`.
   Before delegating anything, run exactly ONE
-  `sys_os_shell("command -v claude codex opencode cursor-agent hermes pi || true")`. A worker is AVAILABLE
+  `sys_os_shell("command -v claude codex opencode cursor-agent hermes pi agy || true")`. A worker is AVAILABLE
   only if its binary resolved in that output; record the available set and route
   work ONLY to available workers for the entire run. Do this in the same first
   turn you start planning (the preflight `sys_os_shell` call counts as acting —
@@ -146,17 +152,21 @@ prompt: |
   edit (no code) you make yourself per the rule above. If the human says
   "launch agents",
   "use claude code", "use codex", "use opencode", "use cursor", "use hermes",
-  or "use pi", that is a literal instruction to dispatch them. `claude_code`,
+  "use pi", or "use antigravity", that is a literal instruction to dispatch
+  them. `claude_code`,
   `codex`, `opencode`, `cursor`, and `hermes` are the primary implementers —
   pick per task: `claude_code` for multi-file / refactor / test-writing work,
   `codex` for narrow, well-scoped changes, and `opencode` / `cursor` / `hermes`
   when another implement/review vendor is wanted. Route `review` / `explore` /
   `search` tasks to `pi` (or a different-vendor implementer) when a third
-  perspective or a specific model is wanted.
+  perspective or a specific model is wanted. Route to `antigravity` (Gemini) as
+  an OVERFLOW implementer only when the primary vendors are busy/unavailable, or
+  as a deliberate different-vendor SECOND OPINION on review; it is not a default
+  pick and not the browser/UI lane.
 
   Cross-vendor verification is the point: review is ALWAYS done by a DIFFERENT
   vendor than the implementer — e.g. `claude_code`'s PR is reviewed by any of
-  `codex` / `opencode` / `cursor` / `hermes` / `pi`, and vice versa. Give the
+  `codex` / `opencode` / `cursor` / `hermes` / `pi` / `antigravity`, and vice versa. Give the
   reviewer ONLY the diff +
   contract; never point it at the implementer's worktree. Only the implementer
   ever opens a PR (the reviewer just reports), so a reviewer's stray edits
@@ -184,7 +194,7 @@ prompt: |
   terminal via `sys_terminal_launch` (it accepts a `cwd` override so you can run
   it inside a per-task worktree). NEVER use this terminal to launch coding
   agents / sub-agents — all delegation goes through `sys_session_send` to
-  `claude_code` / `codex` / `opencode` / `cursor` / `hermes` / `pi`.
+  `claude_code` / `codex` / `opencode` / `cursor` / `hermes` / `pi` / `antigravity`.
 
   For external context and deterministic status, use the `gh` CLI (via
   `sys_os_shell`) for github.com. Reach for such tools sparingly — only to
@@ -244,7 +254,8 @@ prompt: |
     useful, cancel it instead of leaving it running while you re-dispatch. Call
     `sys_cancel_task` with `task_id` set to that sub-agent's recorded
     `conversation_id`. `claude_code` workers are hard-stopped and will wake you
-    with a cancelled inbox item; `pi`, `opencode`, `cursor`, and `hermes` workers
+    with a cancelled inbox item; `pi`, `opencode`, `cursor`, `hermes`, and
+    `antigravity` workers
     honor the interrupt and stop; `codex` cancellation is currently best-effort,
     so do not assume its worker is gone unless the tool result or inbox confirms
     it.
@@ -288,8 +299,10 @@ terminals:
 
 tools:
   # Coding sub-agents — see agents/<name>/. claude_code, codex, opencode,
-  # cursor, and hermes are real CLI coding harnesses; pi is a headless
-  # multi-model worker. Each implements, reviews (cross-vendor), and explores.
+  # cursor, hermes, and antigravity are real CLI coding harnesses; pi is a
+  # headless multi-model worker. antigravity (Gemini) is the OVERFLOW /
+  # SECOND-OPINION lane, not a default implementer or the browser/UI lane. Each
+  # implements, reviews (cross-vendor), and explores.
   agents:
     - claude_code
     - codex
@@ -297,6 +310,7 @@ tools:
     - cursor
     - hermes
     - pi
+    - antigravity
 
 # Mechanism-layer enforcement — runner-side tool gate, no server change.
 guardrails:

--- a/examples/polly/skills/cross-review/SKILL.md
+++ b/examples/polly/skills/cross-review/SKILL.md
@@ -17,10 +17,10 @@ anyone needs to read through.
    don't involve the reviewer yet.
 3. Dispatch a DIFFERENT-vendor sub-agent as reviewer: pick any AVAILABLE worker
    whose vendor differs from the implementer's — `claude_code`, `codex`,
-   `opencode`, `cursor`, `hermes`, or `pi` (e.g. Claude built it → any of
-   `codex` / `opencode` / `cursor` / `hermes` / `pi`, and so on). Use a
+   `opencode`, `cursor`, `hermes`, `pi`, or `antigravity` (e.g. Claude built it → any of
+   `codex` / `opencode` / `cursor` / `hermes` / `pi` / `antigravity`, and so on). Use a
    task-based title such as `review-auth-refactor`, never the raw vendor name:
-   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"pi", title="review-<task_slug>",
+   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"pi"|"antigravity", title="review-<task_slug>",
    args={purpose: "review", input: "<the diff> + <the acceptance contract>.
    Review ONLY against the contract. Report blocking / non-blocking /
    suggestions. Do not edit code."})`. Give it the diff as text — do NOT point
@@ -55,7 +55,7 @@ anyone needs to read through.
   human at the plan gate.
 - Give the reviewer ONLY the diff + contract — never the implementer's
   transcript or worktree. The cross-vendor independence is the whole point.
-- Review is a coding sub-agent (`claude_code`/`codex`/`opencode`/`cursor`/`hermes`/`pi`) dispatched with
+- Review is a coding sub-agent (`claude_code`/`codex`/`opencode`/`cursor`/`hermes`/`pi`/`antigravity`) dispatched with
   `purpose: "review"` — a DIFFERENT vendor from the one that built the diff. It
   reports issues and never edits; only the implementer opens a PR, so a stray
   reviewer edit never reaches the deliverable.

--- a/examples/polly/skills/fanout/SKILL.md
+++ b/examples/polly/skills/fanout/SKILL.md
@@ -14,7 +14,7 @@ dependency).
    Record the worktree path + branch in the registry
    (`.polly/registry.json`).
 2. Dispatch one implementation sub-agent per task, scoped to its worktree:
-   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes", title="<task_slug>",
+   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"antigravity", title="<task_slug>",
    args={purpose: "implement", input: "<task + acceptance contract +
    worktree path>"})`. Use a short task-based title such as `auth-refactor` or
    `fix-sse-error`, never the raw vendor name. State the scope and that it must

--- a/examples/polly/skills/investigate/SKILL.md
+++ b/examples/polly/skills/investigate/SKILL.md
@@ -12,8 +12,8 @@ repository-specific technical question.
 ## Procedure
 1. Decompose the question into one or more bounded investigation tasks. Prefer
    two independent lenses for ambiguous or high-stakes questions.
-2. Dispatch each task to `claude_code`, `codex`, `opencode`, `cursor`, `hermes`, or `pi`:
-   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"pi",
+2. Dispatch each task to `claude_code`, `codex`, `opencode`, `cursor`, `hermes`, `pi`, or `antigravity`:
+   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"pi"|"antigravity",
    title="explore-<task_slug>", args={purpose: "explore", input: "<question +
    exact scope + evidence requested>"})`. Use a task-based title such as
    `explore-ci-flake`, never the raw vendor name. Use `purpose: "search"` only

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -3,9 +3,9 @@
 polly is the standalone multi-agent coding orchestrator (successor to the
 deleted nessie example, whose deep structural pins were folded in here).
 Loads the bundle and asserts the distinctive wiring stays intact: the
-claude-sdk orchestrator brain, the six cross-vendor coding sub-agents
-(claude_code / codex / opencode / cursor / hermes / pi, which implement, review,
-and explore),
+claude-sdk orchestrator brain, the seven cross-vendor coding sub-agents
+(claude_code / codex / opencode / cursor / hermes / pi / antigravity, which
+implement, review, and explore),
 the three spine skills, and the bounds/blast-radius guardrails. Pure spec-load
 — no LLM, no credentials.
 
@@ -69,18 +69,21 @@ def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
 
 def test_coding_subagents(polly_spec: AgentSpec) -> None:
     """
-    The bundle has exactly six coding sub-agents: ``claude_code`` (claude-native),
+    The bundle has exactly seven coding sub-agents: ``claude_code`` (claude-native),
     ``codex`` (codex-native), ``opencode`` (opencode-native), ``cursor``
-    (cursor-native), and ``hermes`` (hermes-native) on the native terminal
-    harnesses, plus ``pi`` (pi) as the headless multi-model worker. All
-    implement, review, and explore. The native harnesses render terminal-first
-    (Chat / Terminal pill) so the human can watch or take over.
+    (cursor-native), ``hermes`` (hermes-native), and ``antigravity``
+    (antigravity-native) on the native terminal harnesses, plus ``pi`` (pi) as
+    the headless multi-model worker. All implement, review, and explore. The
+    native harnesses render terminal-first (Chat / Terminal pill) so the human
+    can watch or take over. ``antigravity`` (Gemini) is the overflow /
+    second-opinion lane, not a default implementer.
 
     A missing/renamed agent means fewer implementers, and same-vendor harnesses
     would break cross-vendor review — polly's differentiator.
     """
     fam = {a.name: a.executor.config.get("harness") for a in polly_spec.sub_agents}
     assert sorted(polly_spec.tools.agents) == [
+        "antigravity",
         "claude_code",
         "codex",
         "cursor",
@@ -94,9 +97,10 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
     assert fam["cursor"] == "cursor-native"
     assert fam["hermes"] == "hermes-native"
     assert fam["pi"] == "pi"
-    # Six distinct vendors → any implementer's diff is reviewable by another.
-    assert len(set(fam.values())) == 6
-    for name in ("claude_code", "codex", "opencode", "cursor", "hermes", "pi"):
+    assert fam["antigravity"] == "antigravity-native"
+    # Seven distinct vendors → any implementer's diff is reviewable by another.
+    assert len(set(fam.values())) == 7
+    for name in ("claude_code", "codex", "opencode", "cursor", "hermes", "pi", "antigravity"):
         prompt = (_POLLY_BUNDLE / "agents" / name / "config.yaml").read_text(encoding="utf-8")
         assert "IMPLEMENT — write real product code" in prompt
         assert "REVIEW — verify another agent's diff" in prompt
@@ -295,8 +299,10 @@ def test_investigation_skill_delegates_read_only_work() -> None:
 
     assert "Use for any read-only task: investigation, debugging, audit" in compact
     assert (
-        "Dispatch each task to `claude_code`, `codex`, `opencode`, `cursor`, `hermes`, or `pi`: "
-        '`sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"pi", '
+        "Dispatch each task to `claude_code`, `codex`, `opencode`, `cursor`, "
+        "`hermes`, `pi`, or `antigravity`: "
+        '`sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"'
+        '|"hermes"|"pi"|"antigravity", '
         'title="explore-<task_slug>", '
         'args={purpose: "explore", input: "<question + exact scope + evidence requested>"})`'
     ) in compact
@@ -400,6 +406,6 @@ def test_function_policies_have_nonempty_arguments(polly_spec: AgentSpec) -> Non
             )
             checked += 1
     # orchestrator: blast_radius + spawn_bounds + headless_subagent_purpose_guard
-    # = 3; sub-agents: blast_radius x6 (claude_code, codex, opencode, cursor,
-    # hermes, pi) = 6 -> 9 total. Fewer = a policy dropped.
-    assert checked == 9, f"expected 9 function policies in the bundle, inspected {checked}"
+    # = 3; sub-agents: blast_radius x7 (claude_code, codex, opencode, cursor,
+    # hermes, pi, antigravity) = 7 -> 10 total. Fewer = a policy dropped.
+    assert checked == 10, f"expected 10 function policies in the bundle, inspected {checked}"


### PR DESCRIPTION
## Summary

Adds a 7th polly coding sub-agent **`antigravity`**, wrapping the existing `antigravity-native` harness (`agy` CLI / Gemini). It is scoped deliberately as an **OVERFLOW / SECOND-OPINION lane** - a non-Anthropic, non-OpenAI vendor for an independent Gemini cross-review or extra implementer capacity. It is **not** a default implementer and **not** the default browser/UI lane, but it **is** added to the cross-review reviewer matrix so any implementer's diff can be judged by a Gemini vendor.

## Changes

**New worker** - `examples/polly/agents/antigravity/config.yaml`
- Copied from `cursor`'s native-TUI template (no `bypass` field; `antigravity-native` owns its own approval gating and auto-applies skip-permissions on the headless path).
- `name: antigravity`, `harness: antigravity-native`, prompt first line reworded.
- IMPLEMENT / REVIEW / EXPLORE prompt blocks kept **byte-identical** to cursor's (the gating test pins those three blocks). `os_env` and `guardrails.blast_radius` (`gate_pushes: false`) identical to cursor's.

**Orchestrator** - `examples/polly/config.yaml`
- `SIX` -> `SEVEN` sub-agents; antigravity added to the vendor list, brain comment, terminal-harness set, per-worker bullet list, preflight (`agy` in both prose and the `command -v ...` string), cross-review matrix, delegation guardrail, cancellation note (honors interrupt), and `tools.agents`.
- Kept **out** of the "primary implementers" sentence; added an explicit overflow/second-opinion routing rule instead.
- `max_dispatches_per_turn` left at 6 (unchanged).

**Skills** - antigravity added to the reviewer / dispatch vendor unions so it's routable:
- `skills/cross-review/SKILL.md`, `skills/fanout/SKILL.md`, `skills/investigate/SKILL.md`.

**Gating test** - `tests/e2e/omnigent/test_example_polly.py`
- `test_coding_subagents`: `antigravity` added to the sorted worker list, `fam['antigravity'] == 'antigravity-native'`, distinct-harness count `6 -> 7`, prompt-check loop tuple, docstrings (`six` -> `seven`).
- Two mirror updates required to keep the suite green (neither weakens an assertion): the `investigate` skill's pinned dispatch string now includes antigravity, and the function-policy count `9 -> 10` (the 7th worker adds one `blast_radius` policy, counted dynamically over all sub-agents).

## Validation

- `tests/e2e/omnigent/test_example_polly.py`: **13 passed**.
- `tests/server/test_builtin_bundles.py` + `tests/runner/test_native_subagent_harness_resolution.py`: **18 passed** (their roster checks use subset `<=` and stay green).
- Spec loads with **7 workers**; `antigravity -> antigravity-native`; 7 distinct harnesses.
- `ruff check` clean on the test file.
- Em/en dashes: my newly-authored lines use plain hyphens. The only em dashes in the new agent file are inside the byte-identical cursor prompt block that the gating test pins.

Do **not** merge - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)