### PR TITLE
ci(e2e-ui): cache the sidecar binary and skip recompiles

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -111,16 +111,23 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
-      # Pin the toolchain for a stable cache fingerprint, key on the sidecar
-      # Cargo.lock. A warm hit reuses every dep and only relinks the workspace
-      # crate (~40s); a cold miss is the full ~7min compile (rare -- the lock
-      # is near-static). Same key as ci.yml's codex-parity job, so they share.
-      - name: Cache Rust build
+      - name: Capture Rust version
+        id: rustc
+        run: echo "version=$(rustc --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+      # The sidecar source is frozen and its deps are rev-pinned, so the binary
+      # is a pure function of sidecar/** + the toolchain. Cache the built binary
+      # (not the 1.6 GB target dir) and skip the ~7 min compile below on a hit;
+      # the key self-invalidates when the source, Cargo.lock, or rustc changes.
+      # Same key as ci.yml's codex-parity job -- ci.yml runs on push to main and
+      # populates the main-scoped cache that this PR-only workflow restores from.
+      - name: Cache parity sidecar binary
+        id: sidecar-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
         with:
-          path: .tmp-codex-parity-target
-          key: codex-parity-sidecar-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock') }}
+          path: .tmp-codex-parity-target/debug/codex-parity-sidecar
+          key: codex-parity-bin-${{ runner.os }}-${{ steps.rustc.outputs.version }}-${{ hashFiles('tests/codex_parity/sidecar/**') }}
       - name: Build parity sidecar
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
         run: |
           cargo build \
             --manifest-path tests/codex_parity/sidecar/Cargo.toml \


### PR DESCRIPTION
## Related issue

N/A

## Summary

The `build codex-parity sidecar` job in `e2e-ui.yml` recompiles the Rust sidecar (~1100 crates) from scratch on nearly every PR run — [run 28785211576](https://github.com/omnigent-ai/omnigent/actions/runs/28785211576/job/85350143123) took **6m51s** on the `Build parity sidecar` step alone. It never gets a warm cache, and the reason is **cache-scope isolation**, not a stale key (the `Cargo.lock` is frozen — unchanged since #556).

Root cause, confirmed against the live cache list — every sidecar cache is scoped to `refs/pull/NNNN/merge`, none to `refs/heads/main`:

- The job triggers **only on `pull_request`**, so each run writes its cache to `refs/pull/<this-PR>/merge`. GitHub only lets a PR restore caches from **its own ref or the base branch (main)** — never another PR's. Since this workflow never runs on push-to-main, **no main-scoped cache is ever produced**, so every PR's first run is a guaranteed cold miss.
- Each entry cached the whole **1.6 GB `--target-dir`**, which churns out of the 10 GB repo cache under LRU — so even same-PR re-runs frequently miss.
- Even on a target-dir hit, Cargo re-fingerprints and rebuilds anyway (the classic `actions/cache`-for-Cargo footgun documented in #2016).

This PR mirrors the fix #2016 already applied to `ci.yml`'s `codex-parity` job:

- Caches just the ~10 MB **binary** (`.tmp-codex-parity-target/debug/codex-parity-sidecar`), keyed on `sidecar/**` + the `rustc` version.
- **Skips `cargo build` entirely on a cache hit.**
- Uses the **same key** as `ci.yml` — and `ci.yml` runs on push to `main`, so the main-scoped `codex-parity-bin` cache it produces becomes restorable by this PR-only workflow. That's the missing link that makes warm hits possible here at all.

Warm runs drop from ~7 min to just the artifact download/upload (~15–25s). The key self-invalidates the moment anyone edits the sidecar source, `Cargo.lock`, or the toolchain changes, so correctness is preserved.

No new action dependency — reuses the `actions/cache` already pinned in the workflow.

## Test Plan

- YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"` → OK).
- `pre-commit run --files .github/workflows/e2e-ui.yml` → passes (yaml syntax, EOF, whitespace).
- Correctness follows from the cache-key inputs: the first run after this lands is a miss (builds + saves the binary under the shared key); subsequent runs with unchanged `sidecar/**` + toolchain hit and skip the compile. Because the key matches `ci.yml`'s (which runs on main), PRs restore the main-scoped binary produced there.
- Will confirm the cache-miss → cache-hit transition (build step skipped) on this PR's own CI.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CI-config change with no runtime surface. Verified by validating the YAML, running pre-commit, and reasoning through the cache-key/scope semantics; the existing `codex-parity` pytest suite exercises the resulting binary unchanged (the tests consume it via `CODEX_PARITY_SIDECAR_BIN`, a direct path). Will watch this PR's CI to confirm the build step is skipped on the second run.
