### PR TITLE
feat(web): background cross-session flush of queued messages

### DIFF
--- a/tests/e2e_ui/sessions/test_cross_session_routing.py
+++ b/tests/e2e_ui/sessions/test_cross_session_routing.py
@@ -1,19 +1,20 @@
-"""E2E: a message queued in one session never leaks into another.
+"""E2E: a queued message is delivered to its origin session, never another.
 
-Guards the cross-session message-routing regression under the client-side
-queue model:
+Guards cross-session message routing under the client-side queue +
+background-flush model:
 
     Session B is busy (its first message's POST is held open, so B stays
     "streaming"), so a follow-up typed into B is held in B's client-side
-    queue — NOT POSTed. While it waits there, the user switches to a
-    different, idle session A. The queued message MUST stay bound to B: it
-    must never be POSTed to A (the now-active session).
+    queue — NOT POSTed. The user switches to a different, idle session A.
+    Once B's turn settles and B reads idle, **background flush** delivers
+    the queued message to B — its origin — even though A is now active. It
+    must go to B and never leak into A.
 
-The queue is a per-conversation client-side buffer: ``maybeFlushQueuedHead``
-only flushes the head whose ``conversationId`` matches the bound session, so a
-message composed in B cannot be addressed to A. This test pins that no-leak
-guarantee. (The positive path — a queued head flushing to its own session on
-idle, in FIFO order — is covered by the ``chatStore`` unit tests.)
+The queue is a per-conversation client-side buffer keyed by ``conversationId``;
+``flushBackgroundQueues`` POSTs a queued message to its own conversation when
+that conversation is idle in the ``["conversations"]`` cache, regardless of
+which session is being viewed. This test pins both halves: delivered-to-B and
+never-to-A. (The FIFO/idle unit behavior is covered by the ``chatStore`` tests.)
 
 Why async Playwright (not the sync ``page`` fixture): the test inspects the
 body of every ``/events`` POST via a route handler and asserts on which
@@ -174,17 +175,22 @@ async def _drive_cross_session_routing(base_url: str, session_a: str, session_b:
 
             # Switch to the idle session A via the sidebar link — a client-side
             # navigation that preserves the store (a full reload would drop the
-            # queue). msg2 must NOT flush into A.
+            # queue).
             await page.locator(f'a[href="/c/{session_a}"]').click()
             await page.wait_for_url(re.compile(rf"/c/{re.escape(session_a)}"))
-            # Release B's first POST so the send lifecycle can settle; the queued
-            # msg2 is bound to B, so switching to A must not flush it there.
+            # Release B's first POST so its turn settles and B reads idle in the
+            # conversations cache — the trigger for background flush.
             release_first.set()
-            # Give any errant flush a chance to fire before asserting the
-            # negative (the queue head is bound to B, so nothing should POST).
-            await asyncio.sleep(1.0)
-            assert all(text != _MSG2 for _, text in event_posts), (
-                f"msg2 leaked out of B while A was active: {event_posts}"
+
+            # Background flush now delivers the queued msg2 to B (its origin),
+            # even though A is the active session — the key guarantee. It must
+            # go to B, never to A.
+            await _wait_until(lambda: any(text == _MSG2 for _, text in event_posts))
+            msg2_targets = [sid for sid, text in event_posts if text == _MSG2]
+            assert msg2_targets == [session_b], (
+                f"msg2 was composed in session B ({session_b}) and must be "
+                f"delivered there via background flush, but POST targets were "
+                f"{msg2_targets}."
             )
             assert all(sid != session_a for sid, _ in event_posts), (
                 f"a message leaked into the active session A: {event_posts}"

--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -43,6 +43,7 @@ import {
 } from "./lib/routing";
 import { initChatStore } from "./store/chatStore";
 import "./index.css";
+import { QueueFlushProvider } from "./hooks/QueueFlushProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
 
 export type { OmnigentHostConfig } from "./lib/host";
@@ -205,7 +206,9 @@ function OmnigentProviders({
                   <EmbedCapabilitiesProvider>
                     <SessionUpdatesProvider>
                       <RunnerHealthProvider>
-                        <App basename={basename} />
+                        <QueueFlushProvider>
+                          <App basename={basename} />
+                        </QueueFlushProvider>
                       </RunnerHealthProvider>
                     </SessionUpdatesProvider>
                   </EmbedCapabilitiesProvider>

--- a/web/src/hooks/QueueFlushProvider.tsx
+++ b/web/src/hooks/QueueFlushProvider.tsx
@@ -1,0 +1,48 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+
+import { useChatStore } from "@/store/chatStore";
+
+/**
+ * Drives the background flush of the client-side message queue.
+ *
+ * The composer's own effect flushes the queue for the conversation the user is
+ * *viewing*. This provider covers the rest: a message queued in a conversation
+ * the user has navigated away from (whose SSE stream is gone) still needs to
+ * send when that conversation next goes idle.
+ *
+ * It calls `flushBackgroundQueues` — which reads each queued conversation's
+ * status from the live `["conversations"]` cache and POSTs the head of any that
+ * are idle — whenever either the queue or that cache changes. Mounted app-wide
+ * so it fires regardless of the current route. Level-triggered and idempotent
+ * (the action skips the active conversation and no-ops when nothing is ready),
+ * so over-firing is harmless.
+ */
+export function QueueFlushProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+  const queuedMessages = useChatStore((s) => s.queuedMessages);
+  const flushBackgroundQueues = useChatStore((s) => s.flushBackgroundQueues);
+
+  // Re-evaluate whenever the queue itself changes (e.g. a message enqueued in
+  // another conversation, or one drained here).
+  useEffect(() => {
+    flushBackgroundQueues();
+  }, [queuedMessages, flushBackgroundQueues]);
+
+  // Re-evaluate whenever the sidebar/conversations cache changes — this is how
+  // a navigated-away conversation's idle transition (WS overlay or poll)
+  // reaches us without its live SSE stream.
+  useEffect(() => {
+    const cache = queryClient.getQueryCache();
+    const unsubscribe = cache.subscribe((event) => {
+      const key = event.query.queryKey;
+      if (Array.isArray(key) && key[0] === "conversations") {
+        flushBackgroundQueues();
+      }
+    });
+    return unsubscribe;
+  }, [queryClient, flushBackgroundQueues]);
+
+  return <>{children}</>;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "./components/theme/ThemeProvider";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { ImageLightboxProvider } from "./components/ImageLightbox";
 import { RunnerHealthProvider } from "./hooks/RunnerHealthProvider";
+import { QueueFlushProvider } from "./hooks/QueueFlushProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
 import { resolveServerInfo, type ServerInfo } from "./lib/capabilities";
 import { CapabilitiesProvider } from "./lib/CapabilitiesContext";
@@ -86,7 +87,9 @@ void _bootProbe.then((info) => {
                 <BrowserRouter>
                   <SessionUpdatesProvider>
                     <RunnerHealthProvider>
-                      <App />
+                      <QueueFlushProvider>
+                        <App />
+                      </QueueFlushProvider>
                     </RunnerHealthProvider>
                   </SessionUpdatesProvider>
                 </BrowserRouter>

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7687,3 +7687,111 @@ describe("chatStore — client-side message queue", () => {
     expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["stranded?", "agent_xyz"]);
   });
 });
+
+describe("chatStore — background cross-session flush", () => {
+  /** /events POSTs the flush fired, as (conversationId, text) pairs. */
+  const eventPosts = (): Array<{ id: string; text: string }> =>
+    fetchMock.mock.calls
+      .filter(
+        ([u, init]) =>
+          typeof u === "string" &&
+          /\/v1\/sessions\/([^/]+)\/events$/.test(u) &&
+          (init as RequestInit | undefined)?.method === "POST",
+      )
+      .map(([u, init]) => {
+        const id = /\/v1\/sessions\/([^/]+)\/events$/.exec(u as string)![1]!;
+        const body = JSON.parse((init as RequestInit).body as string);
+        const text = (body.data?.content ?? []).find(
+          (b: { type: string }) => b.type === "input_text",
+        )?.text;
+        return { id, text };
+      });
+
+  it("flushes an idle non-active conversation's head via postEvent", async () => {
+    // Viewing conv_active; conv_bg is idle in the sidebar cache with a queue.
+    seedConversationsCache([conv("conv_active", "running"), conv("conv_bg", "idle")]);
+    useChatStore.setState({
+      conversationId: "conv_active",
+      queuedMessages: [
+        { queueId: "q_1", text: "bg-first", conversationId: "conv_bg" },
+        { queueId: "q_2", text: "bg-second", conversationId: "conv_bg" },
+      ],
+    });
+
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+
+    // One POST to conv_bg (FIFO head only); its head left the queue, tail stays.
+    expect(eventPosts()).toEqual([{ id: "conv_bg", text: "bg-first" }]);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["bg-second"]);
+  });
+
+  it("does not flush a non-active conversation that is not idle", async () => {
+    seedConversationsCache([conv("conv_active", "idle"), conv("conv_bg", "running")]);
+    useChatStore.setState({
+      conversationId: "conv_active",
+      queuedMessages: [{ queueId: "q_1", text: "wait", conversationId: "conv_bg" }],
+    });
+
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+
+    expect(eventPosts()).toEqual([]);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["wait"]);
+  });
+
+  it("skips the active conversation (owned by the foreground flush)", async () => {
+    // conv_active is idle with a queue, but background flush must leave it to
+    // maybeFlushQueuedHead — otherwise both paths would race the same message.
+    seedConversationsCache([conv("conv_active", "idle")]);
+    useChatStore.setState({
+      conversationId: "conv_active",
+      queuedMessages: [{ queueId: "q_1", text: "mine", conversationId: "conv_active" }],
+    });
+
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+
+    expect(eventPosts()).toEqual([]);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["mine"]);
+  });
+
+  it("leaves a message queued when its background POST fails", async () => {
+    seedConversationsCache([conv("conv_active", "running"), conv("conv_bg", "idle")]);
+    useChatStore.setState({
+      conversationId: "conv_active",
+      queuedMessages: [{ queueId: "q_1", text: "retry-me", conversationId: "conv_bg" }],
+    });
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/conv_bg\/events$/.test(url) && init?.method === "POST") {
+        return mockResponse({}, { ok: false, status: 500 });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+    await tick();
+
+    // POST failed → the message is re-queued for the next trigger to retry.
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["retry-me"]);
+  });
+
+  it("skips a message with attachments (foreground flush owns those)", async () => {
+    seedConversationsCache([conv("conv_active", "running"), conv("conv_bg", "idle")]);
+    const file = new File(["x"], "a.txt", { type: "text/plain" });
+    useChatStore.setState({
+      conversationId: "conv_active",
+      queuedMessages: [
+        { queueId: "q_1", text: "has-file", conversationId: "conv_bg", files: [file] },
+      ],
+    });
+
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+
+    expect(eventPosts()).toEqual([]);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["has-file"]);
+  });
+});

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7778,6 +7778,68 @@ describe("chatStore — background cross-session flush", () => {
     expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["retry-me"]);
   });
 
+  it("does not re-POST a just-failed conversation within its cooldown", async () => {
+    // Guards the retry-storm case: a persistently-failing idle conversation
+    // must not be hammered when the queue-change effect re-fires immediately.
+    seedConversationsCache([conv("conv_active", "running"), conv("conv_bg", "idle")]);
+    useChatStore.setState({
+      conversationId: "conv_active",
+      queuedMessages: [{ queueId: "q_1", text: "flaky", conversationId: "conv_bg" }],
+    });
+    let posts = 0;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/conv_bg\/events$/.test(url) && init?.method === "POST") {
+        posts += 1;
+        return mockResponse({}, { ok: false, status: 503 });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    // First flush POSTs once and fails → re-queued + cooldown set.
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+    await tick();
+    expect(posts).toBe(1);
+
+    // Immediate re-triggers (mirroring the effect firing on every re-queue)
+    // must NOT POST again while the conversation is in cooldown.
+    useChatStore.getState().flushBackgroundQueues();
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+    expect(posts).toBe(1);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["flaky"]);
+  });
+
+  it("re-queues a failed head ahead of its own successors (FIFO preserved)", async () => {
+    // conv_bg has two queued messages; only the head fails. It must land back
+    // in front of its successor, not behind it.
+    seedConversationsCache([conv("conv_active", "running"), conv("conv_bg", "idle")]);
+    useChatStore.setState({
+      conversationId: "conv_active",
+      queuedMessages: [
+        { queueId: "q_1", text: "bg-first", conversationId: "conv_bg" },
+        { queueId: "q_2", text: "bg-second", conversationId: "conv_bg" },
+      ],
+    });
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/conv_bg\/events$/.test(url) && init?.method === "POST") {
+        return mockResponse({}, { ok: false, status: 500 });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+    await tick();
+
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual([
+      "bg-first",
+      "bg-second",
+    ]);
+  });
+
   it("skips a message with attachments (foreground flush owns those)", async () => {
     seedConversationsCache([conv("conv_active", "running"), conv("conv_bg", "idle")]);
     const file = new File(["x"], "a.txt", { type: "text/plain" });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -73,6 +73,7 @@ import { createPresenceIdleTracker } from "@/lib/presenceIdle";
 import { parseEvent, parseSseStream, type SseStreamResult } from "@/lib/sse";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
+import type { ConversationsInfiniteData } from "@/lib/sessionListCache";
 import { useTerminalActivityStore } from "./terminalActivity";
 import {
   terminalInfoFromResource,
@@ -557,6 +558,16 @@ export interface ChatState {
    */
   maybeFlushQueuedHead: () => void;
   /**
+   * Flush queued messages for conversations OTHER than the active one, whose
+   * status in the `["conversations"]` cache is idle. The active conversation is
+   * owned by {@link maybeFlushQueuedHead}; this covers a queue whose session the
+   * user has navigated away from (its SSE stream is gone, so it can't drain
+   * itself). POSTs one message per idle conversation per call, via `postEvent`
+   * (no active-session state touched, no optimistic bubble — it re-hydrates on
+   * return). Level-triggered + idempotent; safe to over-fire.
+   */
+  flushBackgroundQueues: () => void;
+  /**
    * Invoke a skill by posting a ``slash_command`` event — the same wire
    * shape the REPL sends. The server resolves the skill, persists the
    * visible receipt + hidden ``<skill>`` meta message, and forwards the
@@ -908,6 +919,58 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // Remove it BEFORE the POST so a re-entrant flush can't double-send.
     set({ queuedMessages: s.queuedMessages.filter((m) => m.queueId !== head.queueId) });
     void s.send(head.text, head.agentId ?? s.boundAgentId, head.files);
+  },
+
+  flushBackgroundQueues: () => {
+    const s = get();
+    if (queryClient === null || s.queuedMessages.length === 0) return;
+
+    // Conversations (other than the active one) that have a queued message.
+    // The active conversation is owned by maybeFlushQueuedHead.
+    const candidateIds = new Set(
+      s.queuedMessages.map((m) => m.conversationId).filter((id) => id !== s.conversationId),
+    );
+    if (candidateIds.size === 0) return;
+
+    // Per-conversation status from the sidebar cache (kept live by the WS
+    // /v1/sessions/updates overlay + poll), so we can tell whether a
+    // navigated-away conversation is idle without its SSE stream.
+    const statusById = new Map<string, string | undefined>();
+    for (const [, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+      queryKey: ["conversations"],
+    })) {
+      for (const page of data?.pages ?? []) {
+        for (const row of page.data) {
+          if (candidateIds.has(row.id) && !statusById.has(row.id)) {
+            statusById.set(row.id, row.status);
+          }
+        }
+      }
+    }
+
+    // One message per idle conversation per call: POSTing makes it busy, so the
+    // next idle (via WS/poll) triggers this again for the next message (FIFO).
+    for (const conversationId of candidateIds) {
+      if (statusById.get(conversationId) !== "idle") continue;
+      const head = get().queuedMessages.find((m) => m.conversationId === conversationId);
+      // Files are left for the foreground flush — background covers text only
+      // (attachments are in-memory and the user is likely still near that chat).
+      if (head === undefined || (head.files && head.files.length > 0)) continue;
+
+      // Remove BEFORE the POST so a re-entrant trigger can't double-send.
+      set((st) => ({
+        queuedMessages: st.queuedMessages.filter((m) => m.queueId !== head.queueId),
+      }));
+      // No optimistic bubble — we're not viewing this conversation; it
+      // re-hydrates from the snapshot on return. Re-queue on failure so the
+      // next trigger retries; one failure must not block other conversations.
+      void postEvent(conversationId, {
+        type: "message",
+        data: { role: "user", content: [{ type: "input_text", text: head.text }] },
+      }).catch(() => {
+        set((st) => ({ queuedMessages: [...st.queuedMessages, head] }));
+      });
+    }
   },
 
   send: async (text, agentId, files, opts) => {

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -656,6 +656,16 @@ let sendChain: Promise<void> = Promise.resolve();
 let flashTimer: ReturnType<typeof setTimeout> | null = null;
 const workspaceInvalidationTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+// Background-flush throttle, kept OUT of store state so it can't re-trigger the
+// queue effect. A conversation currently mid-POST (inFlight) or in its
+// post-failure cooldown is skipped, so `flushBackgroundQueues` can't spin into
+// a tight retry loop against a persistently-failing idle conversation — a
+// failed POST leaves it idle in the cache, which would otherwise re-fire on
+// every re-queue. Cooldown paces retries to roughly the sidebar poll cadence.
+const BACKGROUND_FLUSH_COOLDOWN_MS = 5_000;
+const backgroundFlushInFlight = new Set<string>();
+const backgroundFlushCooldownUntil = new Map<string, number>();
+
 // Must match the @keyframes user-msg-flash duration in index.css.
 const FLASH_DURATION_MS = 800;
 const WORKSPACE_INVALIDATION_DEBOUNCE_MS = 750;
@@ -701,6 +711,8 @@ export function initChatStore(client: QueryClient): void {
     clearTimeout(timer);
   }
   workspaceInvalidationTimers.clear();
+  backgroundFlushInFlight.clear();
+  backgroundFlushCooldownUntil.clear();
   queryClient = client;
 }
 
@@ -934,7 +946,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     // Per-conversation status from the sidebar cache (kept live by the WS
     // /v1/sessions/updates overlay + poll), so we can tell whether a
-    // navigated-away conversation is idle without its SSE stream.
+    // navigated-away conversation is idle without its SSE stream. A conversation
+    // scrolled past the loaded pages has no row here → treated as not-idle and
+    // left for the foreground flush when the user navigates back to it.
     const statusById = new Map<string, string | undefined>();
     for (const [, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
       queryKey: ["conversations"],
@@ -950,26 +964,53 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     // One message per idle conversation per call: POSTing makes it busy, so the
     // next idle (via WS/poll) triggers this again for the next message (FIFO).
+    const now = Date.now();
     for (const conversationId of candidateIds) {
       if (statusById.get(conversationId) !== "idle") continue;
+      // Skip a conversation mid-POST or in its post-failure cooldown so a
+      // persistent failure can't spin this into a tight retry loop (the effect
+      // re-fires on every re-queue, and a failed POST leaves the row idle).
+      if (backgroundFlushInFlight.has(conversationId)) continue;
+      const cooldownUntil = backgroundFlushCooldownUntil.get(conversationId);
+      if (cooldownUntil !== undefined && cooldownUntil > now) continue;
       const head = get().queuedMessages.find((m) => m.conversationId === conversationId);
       // Files are left for the foreground flush — background covers text only
       // (attachments are in-memory and the user is likely still near that chat).
       if (head === undefined || (head.files && head.files.length > 0)) continue;
 
       // Remove BEFORE the POST so a re-entrant trigger can't double-send.
+      backgroundFlushInFlight.add(conversationId);
       set((st) => ({
         queuedMessages: st.queuedMessages.filter((m) => m.queueId !== head.queueId),
       }));
       // No optimistic bubble — we're not viewing this conversation; it
-      // re-hydrates from the snapshot on return. Re-queue on failure so the
-      // next trigger retries; one failure must not block other conversations.
+      // re-hydrates from the snapshot on return. On failure re-queue at the
+      // head (preserving this conversation's FIFO order) and set a cooldown so
+      // the next trigger backs off instead of hammering a failing runner.
       void postEvent(conversationId, {
         type: "message",
         data: { role: "user", content: [{ type: "input_text", text: head.text }] },
-      }).catch(() => {
-        set((st) => ({ queuedMessages: [...st.queuedMessages, head] }));
-      });
+      })
+        .catch(() => {
+          backgroundFlushCooldownUntil.set(
+            conversationId,
+            Date.now() + BACKGROUND_FLUSH_COOLDOWN_MS,
+          );
+          set((st) => {
+            const idx = st.queuedMessages.findIndex((m) => m.conversationId === conversationId);
+            const at = idx === -1 ? st.queuedMessages.length : idx;
+            return {
+              queuedMessages: [
+                ...st.queuedMessages.slice(0, at),
+                head,
+                ...st.queuedMessages.slice(at),
+              ],
+            };
+          });
+        })
+        .finally(() => {
+          backgroundFlushInFlight.delete(conversationId);
+        });
     }
   },
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- A message queued in conversation **B** now flushes when **B** goes idle, even
  while you're viewing a different conversation **A**. Previously it sat until you
  returned to B — navigating away aborts B's SSE stream, so the foreground flush
  couldn't observe B's status. This was the deferred item from the queue work.
- New store action **`flushBackgroundQueues`**: for each conversation with queued
  messages that isn't the active one, read its status from the live
  `["conversations"]` cache (kept fresh by the WS `/v1/sessions/updates` overlay +
  poll) and, if idle, POST the head via **`postEvent`** — a stateless primitive
  that touches no active-session state (no optimistic bubble; the message
  re-hydrates on return to B). One message per idle conversation per call (FIFO);
  re-queues on POST failure to retry on the next trigger.
- New app-wide **`QueueFlushProvider`** triggers it on queue changes and on any
  `["conversations"]` cache change (the signal that a navigated-away conversation
  went idle). The foreground `maybeFlushQueuedHead` still owns the *active*
  conversation — the two are complementary and never race the same message.

### Scope notes

- **Text-only for now.** A queued message with attachments is left to the
  foreground flush (attachments are in-memory and the user is likely still near
  that chat). Noted in the code.

## Test Plan

- **Unit** (`web`, vitest): 5 new `chatStore` tests — flushes an idle non-active
  conversation's head via `postEvent`; no flush when not idle; skips the active
  conversation (foreground owns it); re-queues on POST failure; skips
  attachments. 317 passing across store + strip + composer suites.
- **e2e**: updated `tests/e2e_ui/sessions/test_cross_session_routing.py` — queue
  in B (busy) → switch to A → B settles/idles → the message is delivered to **B**
  via background flush, **never** to A. Ran locally against a built web UI: 1
  passed.
- **Gates**: `npm run type-check`, tests, prettier, ruff all pass.

## Demo

<!-- TODO: attach a clip — queue a follow-up in B, switch to A, watch B receive it when it finishes -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Background-flush logic is covered by store unit tests (idle/non-idle, active-skip,
failure re-queue, attachment-skip) and end-to-end by the cross-session routing
test (delivered-to-origin, never-to-active).

This pull request and its description were written by Isaac.
