### PR TITLE
fix(claude-native): self-heal transcript forwarder so Chat UI receives assistant turns

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -4047,6 +4047,7 @@ def _claude_terminal_request(
     args = augment_claude_args(
         claude_args,
         bridge_dir=bridge_dir,
+        python_executable=sys.executable,
         ap_server_url=ap_server_url,
         ap_auth_headers=ap_auth_headers,
         api_key_helper=claude_config.api_key_helper if claude_config is not None else None,

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -18,9 +18,11 @@ from typing import Any
 import httpx
 
 from omnigent._native_post_delivery import (
+    RepostResult,
     append_dead_letter,
     post_external_session_status,
     post_may_have_been_delivered,
+    replay_dead_letters,
 )
 from omnigent.claude_native_bridge import (
     BRIDGE_ID_LABEL_KEY,
@@ -221,6 +223,12 @@ _SUBAGENT_IDLE_QUIESCENCE_S = 5.0
 _SUBAGENT_META_GLOB = "agent-*.meta.json"
 _DEFAULT_POLL_INTERVAL_S = 0.25
 _POST_TIMEOUT_S = 10.0
+# Startup dead-letter replay budget (#1579). Bounded so a large dead-letter file
+# or a slow/hung server cannot stall forwarder startup.
+_REPLAY_MAX_RECORDS = 500
+_REPLAY_POST_TIMEOUT_SECONDS = 5.0
+_REPLAY_DEADLINE_SECONDS = 30.0
+_POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 _MAX_SEEN_SOURCE_IDS = 2000
 _CURSOR_FINGERPRINT_BYTES = 256
 _FORK_COMMAND_NAMES = frozenset({"/branch", "/fork"})
@@ -684,6 +692,65 @@ class _PostRetryTracker:
         )
 
 
+async def _replay_dead_letters_on_startup(
+    client: httpx.AsyncClient,
+    bridge_dir: Path,
+) -> None:
+    """
+    Re-POST proven-undelivered dead-lettered forwards on forwarder startup (#1579).
+
+    Best-effort recovery for the realistic case — the host/server returned after
+    an outage or a restart. Never raises: a replay failure must not block live
+    forwarding.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param bridge_dir: Native Claude bridge directory holding the dead-letter files.
+    :returns: None.
+    """
+
+    async def _repost(record: dict[str, object]) -> RepostResult:
+        session_id = record["session_id"]
+        event_type = record["event_type"]
+        payload = record["payload"]
+        assert isinstance(session_id, str)
+        assert isinstance(event_type, str)
+        assert isinstance(payload, dict)
+        try:
+            resp = await client.post(
+                f"/v1/sessions/{url_component(session_id)}/events",
+                json={"type": event_type, "data": payload},
+                timeout=_REPLAY_POST_TIMEOUT_SECONDS,
+            )
+        except httpx.HTTPError as exc:
+            delivered_ambiguous = (
+                event_type == "external_conversation_item"
+                and post_may_have_been_delivered(exc)
+            )
+            return RepostResult(
+                delivered=False,
+                delivered_ambiguous=delivered_ambiguous,
+                http_status=None,
+            )
+        delivered = resp.status_code < 400
+        return RepostResult(
+            delivered=delivered,
+            delivered_ambiguous=False,
+            http_status=None if delivered else resp.status_code,
+        )
+
+    try:
+        await replay_dead_letters(
+            bridge_dir,
+            repost=_repost,
+            retryable_status_codes=_POST_RETRY_STATUS_CODES,
+            logger_name=__name__,
+            max_records=_REPLAY_MAX_RECORDS,
+            deadline_seconds=_REPLAY_DEADLINE_SECONDS,
+        )
+    except Exception:  # noqa: BLE001 — replay must never block forwarder startup.
+        _logger.warning("Claude forwarder dead-letter replay failed", exc_info=True)
+
+
 async def forward_claude_transcript_to_session(
     *,
     base_url: str,
@@ -770,6 +837,7 @@ async def forward_claude_transcript_to_session(
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
+        await _replay_dead_letters_on_startup(client, bridge_dir)
         while True:
             try:
                 current_session_id = read_active_session_id(bridge_dir) or session_id

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -394,7 +394,7 @@ async def _start_claude_transcript_forwarder_if_needed(
 
     from omnigent.claude_native_forwarder import supervise_forwarder
     from omnigent.cli_auth import databricks_request_headers
-    from omnigent.runner._entry import _RunnerDatabricksAuth, _make_auth_token_factory
+    from omnigent.runner._entry import _make_auth_token_factory, _RunnerDatabricksAuth
 
     server_url = os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767")
     auth_factory = _make_auth_token_factory()
@@ -416,12 +416,98 @@ async def _start_claude_transcript_forwarder_if_needed(
     )
     _register_auto_forwarder_task(session_id, forwarder_task)
     _logger.info(
-        "Started claude transcript forwarder for session %s bridge_dir=%s task=%s",
+        "Started claude transcript forwarder for session %s task=%s",
         session_id,
-        bridge_dir,
         forwarder_task.get_name(),
     )
     return True
+
+
+def _session_items_include_assistant(items: list[dict[str, Any]]) -> bool:
+    """
+    Return whether committed session items already include assistant turns.
+
+    Used when healing a dead forwarder with no persisted cursor: a cold-resumed
+    session already mirrors prior assistant history in Omnigent, so the forwarder
+    should seek past the synthesized transcript prefix. A fresh session whose
+    assistant output exists only in the local transcript must replay from the
+    start so Chat can catch up.
+
+    :param items: Flat session item dicts from ``GET /v1/sessions/{id}/items``.
+    :returns: ``True`` when at least one item has role ``assistant``.
+    """
+    return any(isinstance(item, dict) and item.get("role") == "assistant" for item in items)
+
+
+async def _claude_forwarder_start_at_end_for_heal(
+    server_client: httpx.AsyncClient,
+    session_id: str,
+    bridge_dir: Path,
+) -> bool:
+    """
+    Resume-aware ``start_at_end`` when restarting a dead claude forwarder.
+
+    Mirrors ``_auto_create_claude_terminal``'s ``resume_external_session_id``
+    decision read-only. When a persisted forwarder cursor exists,
+    ``start_at_end`` is ignored by ``supervise_forwarder``; otherwise a cold
+    resume must seek past the replayed transcript while a fresh session whose
+    assistant turns never reached Omnigent must replay from the beginning.
+
+    :param server_client: Omnigent server client for session/item lookup.
+    :param session_id: Omnigent session/conversation id.
+    :param bridge_dir: Native Claude bridge directory.
+    :returns: ``True`` when a cold forwarder should skip an existing transcript
+        prefix; ``False`` when it should replay from the start.
+    """
+    from omnigent.claude_native_forwarder import _read_forward_state
+
+    if _read_forward_state(bridge_dir) is not None:
+        return False
+
+    workspace = Path(
+        os.environ.get("OMNIGENT_RUNNER_WORKSPACE", str(Path.cwd()))
+    ).resolve()
+
+    try:
+        resp = await server_client.get(
+            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}",
+            timeout=10.0,
+        )
+    except httpx.HTTPError:
+        return False
+    if resp.status_code != 200:
+        return False
+    snap = resp.json()
+    external_session_id = snap.get("external_session_id")
+    if not isinstance(external_session_id, str) or not external_session_id:
+        return False
+
+    from omnigent.claude_native import (
+        _CLAUDE_SESSION_ID_RE,
+        _claude_project_dir_for_cwd,
+        _claude_transcript_records_from_session_items,
+        _fetch_all_session_items_for_claude_resume,
+    )
+
+    if not _CLAUDE_SESSION_ID_RE.fullmatch(external_session_id):
+        return False
+    transcript_path = _claude_project_dir_for_cwd(workspace) / f"{external_session_id}.jsonl"
+    if not (transcript_path.is_file() and transcript_path.stat().st_size > 0):
+        return False
+
+    try:
+        items = await _fetch_all_session_items_for_claude_resume(server_client, session_id)
+    except Exception:  # noqa: BLE001 — best-effort heal decision
+        return False
+    records = _claude_transcript_records_from_session_items(
+        items,
+        session_id=session_id,
+        external_session_id=external_session_id,
+        cwd=workspace,
+    )
+    if not records:
+        return False
+    return _session_items_include_assistant(items)
 
 
 async def _ensure_claude_forwarder_for_session(
@@ -452,10 +538,15 @@ async def _ensure_claude_forwarder_for_session(
         session_id=session_id,
     )
     bridge_dir = bridge_dir_for_bridge_id(bridge_id or session_id)
+    start_at_end = await _claude_forwarder_start_at_end_for_heal(
+        server_client,
+        session_id,
+        bridge_dir,
+    )
     await _start_claude_transcript_forwarder_if_needed(
         session_id,
         bridge_dir,
-        start_at_end=False,
+        start_at_end=start_at_end,
     )
 
 
@@ -5498,7 +5589,7 @@ async def _auto_create_claude_terminal(
     # which launch Claude in a brand-new, untrusted directory.
     ensure_claude_workspace_trusted(Path(workspace))
 
-    from omnigent.runner._entry import _make_auth_token_factory, _RunnerDatabricksAuth
+    from omnigent.runner._entry import _make_auth_token_factory
 
     # The Omnigent server URL + auth are needed in two places below: the
     # PermissionRequest hook (so Claude's approval prompts route to the
@@ -16652,7 +16743,7 @@ def create_runner_app(
         if terminal_registry is None:
             return
         if terminal_registry.get(conv_id, terminal_name, "main") is not None:
-            if harness_name == "claude-native":
+            if terminal_name == "claude":
                 await _ensure_claude_forwarder_for_session(
                     conv_id,
                     server_client=server_client,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -464,9 +464,7 @@ async def _claude_forwarder_start_at_end_for_heal(
     if _read_forward_state(bridge_dir) is not None:
         return False
 
-    workspace = Path(
-        os.environ.get("OMNIGENT_RUNNER_WORKSPACE", str(Path.cwd()))
-    ).resolve()
+    workspace = Path(os.environ.get("OMNIGENT_RUNNER_WORKSPACE", str(Path.cwd()))).resolve()
 
     try:
         resp = await server_client.get(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -367,6 +367,98 @@ def _register_auto_forwarder_task(session_id: str, task: asyncio.Task[Any]) -> N
     task.add_done_callback(_evict)
 
 
+async def _start_claude_transcript_forwarder_if_needed(
+    session_id: str,
+    bridge_dir: Path,
+    *,
+    start_at_end: bool,
+) -> bool:
+    """
+    Start ``supervise_forwarder`` when no live task is registered for *session_id*.
+
+    Daemon-owned claude-native sessions rely on the runner for transcript
+    forwarding (the CLI sets ``run_transcript_forwarder=False``). If the
+    forwarder task died (runner restart, supervisor crash) while the tmux pane
+    is still live, Chat stays empty while the Terminal tab keeps working.
+
+    :param session_id: Omnigent session/conversation id.
+    :param bridge_dir: Native Claude bridge directory to tail.
+    :param start_at_end: Passed to ``supervise_forwarder``; only affects a
+        cold bridge with no persisted cursor.
+    :returns: ``True`` when a new forwarder task was started; ``False`` when
+        one was already live.
+    """
+    incumbent = _AUTO_FORWARDER_TASKS.get(session_id)
+    if incumbent is not None and not incumbent.done():
+        return False
+
+    from omnigent.claude_native_forwarder import supervise_forwarder
+    from omnigent.cli_auth import databricks_request_headers
+    from omnigent.runner._entry import _RunnerDatabricksAuth, _make_auth_token_factory
+
+    server_url = os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767")
+    auth_factory = _make_auth_token_factory()
+    auth_token = auth_factory() if auth_factory is not None else None
+    runner_headers = databricks_request_headers(server_url, bearer_token=auth_token)
+    runner_auth = _RunnerDatabricksAuth(auth_factory)
+
+    forwarder_task = asyncio.create_task(
+        supervise_forwarder(
+            base_url=server_url,
+            headers=runner_headers,
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=start_at_end,
+            auth=runner_auth,
+        ),
+        name=f"claude-forwarder-{session_id}",
+    )
+    _register_auto_forwarder_task(session_id, forwarder_task)
+    _logger.info(
+        "Started claude transcript forwarder for session %s bridge_dir=%s task=%s",
+        session_id,
+        bridge_dir,
+        forwarder_task.get_name(),
+    )
+    return True
+
+
+async def _ensure_claude_forwarder_for_session(
+    session_id: str,
+    *,
+    server_client: httpx.AsyncClient,
+    resource_registry: SessionResourceRegistry | None,
+) -> None:
+    """
+    Ensure a live transcript forwarder exists for a claude-native session.
+
+    :param session_id: Omnigent session/conversation id.
+    :param server_client: Omnigent server client for bridge-id lookup.
+    :param resource_registry: Session resource registry; ``None`` skips.
+    :returns: None.
+    """
+    if resource_registry is None:
+        return
+    terminal_registry = resource_registry.terminal_registry
+    if terminal_registry is None:
+        return
+    if terminal_registry.get(session_id, "claude", "main") is None:
+        return
+    from omnigent.claude_native_bridge import bridge_dir_for_bridge_id
+
+    bridge_id = await _claude_native_bridge_id_for_session(
+        server_client=server_client,
+        session_id=session_id,
+    )
+    bridge_dir = bridge_dir_for_bridge_id(bridge_id or session_id)
+    await _start_claude_transcript_forwarder_if_needed(
+        session_id,
+        bridge_dir,
+        start_at_end=False,
+    )
+
+
 # Background tasks that re-pop a still-pending cost-budget approval on a
 # terminal client that attaches after the ASK fired. Kept referenced so
 # they aren't garbage-collected before they run.
@@ -5431,7 +5523,6 @@ async def _auto_create_claude_terminal(
     from omnigent.cli_auth import databricks_request_headers
 
     _runner_headers = databricks_request_headers(server_url, bearer_token=_auth_token)
-    _runner_auth = _RunnerDatabricksAuth(_auth_factory)
 
     from omnigent.claude_launcher import resolve_claude_launch
     from omnigent.claude_native import (
@@ -5723,6 +5814,7 @@ async def _auto_create_claude_terminal(
     claude_args = augment_claude_args(
         base_claude_args,
         bridge_dir=bridge_dir,
+        python_executable=sys.executable,
         ap_server_url=server_url,
         ap_auth_headers=_runner_headers,
         bundle_dir=bundle_dir,
@@ -5873,26 +5965,14 @@ async def _auto_create_claude_terminal(
     # ``False`` correctly forwards everything from the beginning. This
     # mirrors the CLI client's ``prepared.cold_resumed`` handling in
     # ``claude_native.py``.
-    from omnigent.claude_native_forwarder import supervise_forwarder
-
-    _forwarder_task = asyncio.create_task(
-        supervise_forwarder(
-            base_url=server_url,
-            headers=_runner_headers,
-            session_id=session_id,
-            bridge_dir=bridge_dir,
-            agent_name="claude-native-ui",
-            start_at_end=resume_external_session_id is not None,
-            auth=_runner_auth,
-        ),
-        name=f"claude-forwarder-{session_id}",
-    )
-    _register_auto_forwarder_task(session_id, _forwarder_task)
-    _logger.info(
-        "Auto-created claude terminal + forwarder for session %s; "
-        "forwarder_task=%s elapsed_ms=%.0f",
+    await _start_claude_transcript_forwarder_if_needed(
         session_id,
-        _forwarder_task.get_name(),
+        bridge_dir,
+        start_at_end=resume_external_session_id is not None,
+    )
+    _logger.info(
+        "Auto-created claude terminal + forwarder for session %s; elapsed_ms=%.0f",
+        session_id,
         (time.monotonic() - started_at) * 1000,
     )
     return terminal_view
@@ -15937,6 +16017,11 @@ def create_runner_app(
                         session_id,
                         claude_terminal_id,
                     )
+                    await _ensure_claude_forwarder_for_session(
+                        session_id,
+                        server_client=server_client,
+                        resource_registry=resource_registry,
+                    )
                     return JSONResponse(
                         status_code=200,
                         content=session_resource_view_to_dict(existing),
@@ -16567,6 +16652,12 @@ def create_runner_app(
         if terminal_registry is None:
             return
         if terminal_registry.get(conv_id, terminal_name, "main") is not None:
+            if harness_name == "claude-native":
+                await _ensure_claude_forwarder_for_session(
+                    conv_id,
+                    server_client=server_client,
+                    resource_registry=resource_registry,
+                )
             return  # a pane is still registered — nothing to heal
         _logger.info(
             "native pane missing for conv=%s harness=%s; re-ensuring before turn (#1349)",

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -17288,15 +17288,17 @@ async def test_start_claude_transcript_forwarder_if_needed_starts_when_missing(
     supervisor task died while tmux is still live, this helper must start a new
     one without double-registering a live incumbent.
     """
-    import omnigent.runner.app as runner_app_mod
+    from omnigent.runner import app as runner_app
 
     session_id = "conv_fwd_restart"
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
     started: list[dict[str, object]] = []
+    run = _ForwarderRun()
 
     async def _fake_supervise(**kwargs: object) -> None:
         started.append(kwargs)
+        run.task = asyncio.current_task()
         await asyncio.Event().wait()
 
     monkeypatch.setattr(
@@ -17306,7 +17308,7 @@ async def test_start_claude_transcript_forwarder_if_needed_starts_when_missing(
     monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
 
     try:
-        assert await runner_app_mod._start_claude_transcript_forwarder_if_needed(
+        assert await runner_app._start_claude_transcript_forwarder_if_needed(
             session_id,
             bridge_dir,
             start_at_end=False,
@@ -17317,18 +17319,15 @@ async def test_start_claude_transcript_forwarder_if_needed_starts_when_missing(
         assert started[0]["bridge_dir"] == bridge_dir
 
         # Second call is a no-op while the first task is still live.
-        assert not await runner_app_mod._start_claude_transcript_forwarder_if_needed(
+        assert not await runner_app._start_claude_transcript_forwarder_if_needed(
             session_id,
             bridge_dir,
             start_at_end=False,
         )
         assert len(started) == 1
     finally:
-        task = runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
-        if task is not None:
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+        runner_app._AUTO_FORWARDER_TASKS.pop(session_id, None)
+        await _drain_forwarder_runs([run])
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -17277,6 +17277,61 @@ async def test_cancel_auto_forwarder_task_cancels_and_awaits_registered_task() -
 
 
 @pytest.mark.asyncio
+async def test_start_claude_transcript_forwarder_if_needed_starts_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A dead forwarder slot is repopulated so Chat can mirror terminal output.
+
+    Daemon-owned claude-native sessions defer forwarding to the runner; if the
+    supervisor task died while tmux is still live, this helper must start a new
+    one without double-registering a live incumbent.
+    """
+    import omnigent.runner.app as runner_app_mod
+
+    session_id = "conv_fwd_restart"
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    started: list[dict[str, object]] = []
+
+    async def _fake_supervise(**kwargs: object) -> None:
+        started.append(kwargs)
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_forwarder.supervise_forwarder",
+        _fake_supervise,
+    )
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+
+    try:
+        assert await runner_app_mod._start_claude_transcript_forwarder_if_needed(
+            session_id,
+            bridge_dir,
+            start_at_end=False,
+        )
+        await asyncio.sleep(0)
+        assert len(started) == 1
+        assert started[0]["session_id"] == session_id
+        assert started[0]["bridge_dir"] == bridge_dir
+
+        # Second call is a no-op while the first task is still live.
+        assert not await runner_app_mod._start_claude_transcript_forwarder_if_needed(
+            session_id,
+            bridge_dir,
+            start_at_end=False,
+        )
+        assert len(started) == 1
+    finally:
+        task = runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+@pytest.mark.asyncio
 async def test_register_auto_forwarder_task_replaces_incumbent_and_survives_stale_evict() -> None:
     """
     Re-registration cancels the incumbent; its done-callback can't evict the successor.

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -6941,7 +6941,9 @@ async def test_replay_dead_letters_on_startup_reposts_proven_undelivered(
     posted: list[dict[str, object]] = []
 
     class _Client:
-        async def post(self, url: str, *, json: dict[str, object], timeout: float) -> httpx.Response:
+        async def post(
+            self, url: str, *, json: dict[str, object], timeout: float
+        ) -> httpx.Response:
             posted.append({"url": url, "json": json, "timeout": timeout})
             return httpx.Response(200, request=httpx.Request("POST", url))
 
@@ -6979,7 +6981,9 @@ async def test_replay_dead_letters_on_startup_skips_ambiguous(
     called = False
 
     class _Client:
-        async def post(self, url: str, *, json: dict[str, object], timeout: float) -> httpx.Response:
+        async def post(
+            self, url: str, *, json: dict[str, object], timeout: float
+        ) -> httpx.Response:
             nonlocal called
             called = True
             return httpx.Response(200, request=httpx.Request("POST", url))

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -6913,3 +6913,78 @@ async def test_forwarder_emits_turn_start_running_with_response_id(tmp_path: Pat
         and body["body"]["data"]["item_type"] == "function_call"
     )
     assert function_call["body"]["data"]["response_id"] == running_rid
+
+
+@pytest.mark.asyncio
+async def test_replay_dead_letters_on_startup_reposts_proven_undelivered(
+    tmp_path: Path,
+) -> None:
+    """
+    On startup, a proven-undelivered record is re-POSTed and removed (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for the bridge dir.
+    :returns: None.
+    """
+    from omnigent._native_post_delivery import append_dead_letter
+
+    append_dead_letter(
+        tmp_path,
+        session_id="conv_claude1",
+        event_type="external_conversation_item",
+        payload={"item_type": "message"},
+        reason="proven-undelivered transport failure after retries",
+        delivered_ambiguous=False,
+        http_status=None,
+        transport_error="ConnectError",
+    )
+
+    posted: list[dict[str, object]] = []
+
+    class _Client:
+        async def post(self, url: str, *, json: dict[str, object], timeout: float) -> httpx.Response:
+            posted.append({"url": url, "json": json, "timeout": timeout})
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+    await forwarder._replay_dead_letters_on_startup(_Client(), tmp_path)  # type: ignore[arg-type]
+
+    assert len(posted) == 1
+    assert posted[0]["json"] == {
+        "type": "external_conversation_item",
+        "data": {"item_type": "message"},
+    }
+    assert not (tmp_path / "dead_letter.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_replay_dead_letters_on_startup_skips_ambiguous(
+    tmp_path: Path,
+) -> None:
+    """
+    On startup, an ambiguous record is never re-POSTed and is retained (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for the bridge dir.
+    :returns: None.
+    """
+    from omnigent._native_post_delivery import append_dead_letter
+
+    append_dead_letter(
+        tmp_path,
+        session_id="conv_claude1",
+        event_type="external_conversation_item",
+        payload={"item_type": "message"},
+        reason="ambiguous transport failure (may already be committed)",
+        delivered_ambiguous=True,
+    )
+
+    called = False
+
+    class _Client:
+        async def post(self, url: str, *, json: dict[str, object], timeout: float) -> httpx.Response:
+            nonlocal called
+            called = True
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+    await forwarder._replay_dead_letters_on_startup(_Client(), tmp_path)  # type: ignore[arg-type]
+
+    assert called is False
+    assert (tmp_path / "dead_letter.jsonl").exists()


### PR DESCRIPTION
## Related issue

Closes #880

## Summary

With `omnigent claude` (daemon-owned native harness), assistant turns render in the real terminal and the web UI **Terminal** tab, but the **Chat** tab stays empty — only `changed` metadata events arrive on the sidebar WebSocket. Chat content is delivered via the transcript forwarder (`POST external_*` → SSE `/stream`), which the runner must supervise when the daemon starts Claude with `run_transcript_forwarder=False`.

This PR:

- **Self-heals the forwarder** — `_start_claude_transcript_forwarder_if_needed()` and `_ensure_claude_forwarder_for_session()` restart the forwarder when tmux is live but the task has died (terminal ensure, auto-create, and before each web Chat turn).
- **Pins hook subprocesses to `sys.executable`** — `augment_claude_args(..., python_executable=sys.executable)` in runner and `claude_native` so hook scripts run under the same Python as omnigent (avoids silent hook failures when `python` on PATH differs).
- **Replays dead-lettered posts on forwarder startup** — mirrors the codex forwarder pattern so transient POST failures do not permanently drop assistant content.

**ELI5:** Terminal tab is a live screen share; Chat tab needs a background translator (forwarder) that reads Claude's transcript and posts it to the server. If that translator crashes while tmux keeps running, Chat goes blank. This fix restarts the translator when needed and replays anything it failed to deliver.

```mermaid
sequenceDiagram
    participant Web as Web UI Chat
    participant Runner as Runner (daemon)
    participant Fwd as Transcript forwarder
    participant Tmux as Claude (tmux)
    participant API as Session API

    Web->>Runner: POST turn
    Runner->>Runner: ensure forwarder alive
    Runner->>Tmux: inject prompt
    Tmux-->>Fwd: hooks / transcript file
    Fwd->>API: POST external_* events
    API-->>Web: SSE /stream (assistant content)
```

## Test Plan

- [x] `pytest tests/test_claude_native_forwarder.py` — 113 passed
- [x] `pytest tests/runner/test_app_sessions_native.py -k forwarder` — 8 passed (includes new `test_start_claude_transcript_forwarder_if_needed_starts_when_missing`)
- [x] `OMNIGENT_E2E_CLAUDE_NATIVE=1 pytest tests/e2e/test_host_claude_native_e2e.py` — 3 passed (assistant items via `/items`, no double-forwarder)
- [ ] Manual WSL2 repro from #880 (Terminal + Chat both show assistant response) — not run in this environment

## Demo

N/A — backend / harness fix; no UI changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

E2E (`test_host_claude_native_e2e.py`) exercises the full daemon → forwarder → `/items` path on Linux. WSL2 + Windows-browser manual repro from the issue reporter is still outstanding.

## Changelog

`omnigent claude` web Chat now streams assistant responses again when the transcript forwarder stops unexpectedly.