### PR TITLE
fix(openshell): _SANDBOX_HOME=/sandbox, non-editable host image install

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -121,11 +121,12 @@ RUN python -m venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv \
     PATH="/opt/venv/bin:${PATH}"
 
-# Install omnigent. Editable install (-e) is required because
-# pyproject.toml declares the sibling SDKs as editable path deps via
-# [tool.uv.sources]. The runtime stages preserve /build/ so the venv's
-# .pth references stay valid.
-RUN uv pip install --no-cache-dir --index-url ${PYPI_INDEX_URL} -e .
+# Install omnigent and sibling SDKs non-editably. This installs everything
+# under /opt/venv/lib/python*/site-packages (inside Landlock's allowed paths),
+# rather than leaving source at /build with .pth references (which Landlock blocks).
+# Install sibling SDKs first, then omnigent.
+RUN uv pip install --no-cache-dir --index-url ${PYPI_INDEX_URL} ./sdks/python-client ./sdks/ui
+RUN uv pip install --no-cache-dir --index-url ${PYPI_INDEX_URL} .
 
 # ── Server builder ──────────────────────────────────────
 # Server-only additions on top of the shared builder: the SPA bundle
@@ -328,11 +329,9 @@ RUN set -eu; \
     fi; \
     echo "agy ${AGY_VERSION} pinned (sha256 verified)"
 
-# Preserve /build/ — the venv's editable install .pth files reference
-# /build/omnigent and /build/sdks/* by absolute path. Copying these to
-# /app/ would break the import paths silently.
+# Copy the venv with all packages installed non-editably under site-packages.
+# No need to preserve /build/ since everything is already in site-packages.
 COPY --from=builder /opt/venv /opt/venv
-COPY --from=builder /build /build
 
 # Sandbox launchers exec commands through `bash -lc`, and Debian's
 # /etc/profile unconditionally resets PATH for login shells — the ENV
@@ -362,11 +361,9 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-# Preserve /build/ in the runtime stage — the venv's editable install
-# .pth files reference /build/omnigent and /build/sdks/* by absolute
-# path. Copying these to /app/ would break the import paths silently.
+# Copy the venv with all packages installed non-editably under site-packages.
+# No need to preserve /build/ since everything is already in site-packages.
 COPY --from=server-builder /opt/venv /opt/venv
-COPY --from=server-builder /build /build
 COPY deploy/docker/entrypoint.py /app/entrypoint.py
 
 WORKDIR /app

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -152,7 +152,7 @@ RUN uv pip install --no-cache-dir --index-url ${PYPI_INDEX_URL} 'psycopg[binary]
 # with `--build-arg OMNIGENT_EXTRAS=kubernetes` (comma-separate for several).
 ARG OMNIGENT_EXTRAS=
 RUN if [ -n "${OMNIGENT_EXTRAS}" ]; then \
-        uv pip install --no-cache-dir --index-url ${PYPI_INDEX_URL} -e ".[${OMNIGENT_EXTRAS}]"; \
+        uv pip install --no-cache-dir --index-url ${PYPI_INDEX_URL} ".[${OMNIGENT_EXTRAS}]"; \
     fi
 
 # ── Node alias stage ─────────────────────────────────────
@@ -332,6 +332,7 @@ RUN set -eu; \
 # Copy the venv with all packages installed non-editably under site-packages.
 # No need to preserve /build/ since everything is already in site-packages.
 COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /build/LICENSE /build/NOTICE /root/
 
 # Sandbox launchers exec commands through `bash -lc`, and Debian's
 # /etc/profile unconditionally resets PATH for login shells — the ENV
@@ -364,6 +365,7 @@ RUN apt-get update \
 # Copy the venv with all packages installed non-editably under site-packages.
 # No need to preserve /build/ since everything is already in site-packages.
 COPY --from=server-builder /opt/venv /opt/venv
+COPY --from=server-builder /build/LICENSE /build/NOTICE /app/
 COPY deploy/docker/entrypoint.py /app/entrypoint.py
 
 WORKDIR /app

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -222,7 +222,14 @@ class _OpenShellClient:
             ) from exc
         return exit_code
 
-    def exec_background(self, name: str, command: Sequence[str], *, timeout: int) -> None:
+    def exec_background(
+        self,
+        name: str,
+        command: Sequence[str],
+        *,
+        timeout: int,
+        extra_env: dict[str, str] | None = None,
+    ) -> None:
         """
         Start a long-lived foreground command, holding its exec stream open.
 
@@ -245,7 +252,7 @@ class _OpenShellClient:
                     command,
                     timeout_seconds=timeout,
                     workdir=_SANDBOX_HOME,
-                    env={"HOME": _SANDBOX_HOME},
+                    env={"HOME": _SANDBOX_HOME, **(extra_env or {})},
                 ):
                     pass
             except Exception:
@@ -405,15 +412,37 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         to avoid Landlock's execve restriction on shebang scripts under ``/opt``:
         the script path is not in the default exec allowlist, but
         ``/opt/venv/bin/python3`` (an ELF binary) can exec it directly.
+
+        Environment variables are parsed out of the command string and passed
+        via the OpenShell exec RPC env parameter to guarantee they reach the
+        process, rather than relying on bash inline assignment which may not
+        survive login shell profile sourcing.
         """
+        import re
+
+        # Parse leading VAR=value pairs from the command string and extract them
+        # into a separate env dict to pass via the OpenShell exec RPC env parameter.
+        # This guarantees the env vars reach the process regardless of how bash
+        # handles inline assignments in login shells.
+        env_prefix: dict[str, str] = {}
+        remaining = command
+        env_pattern = re.compile(r"^([A-Z_][A-Z0-9_]*)=([^ ]*) ")
+        while True:
+            m = env_pattern.match(remaining)
+            if not m:
+                break
+            env_prefix[m.group(1)] = m.group(2)
+            remaining = remaining[m.end() :]
+
         _PYTHON = "/opt/venv/bin/python3"
         _OMNIGENT = "/opt/venv/bin/omnigent"
-        # The base class passes "ENV=val omnigent host --server ...", so
-        # "omnigent" is never at position 0. Replace it wherever it appears.
-        invoke = command.replace("omnigent ", f"{_PYTHON} {_OMNIGENT} ", 1)
+        invoke = remaining.replace("omnigent ", f"{_PYTHON} {_OMNIGENT} ", 1)
         bg_command = f"{invoke} > {log_path} 2>&1"
         self._openshell().exec_background(
-            sandbox_id, ["bash", "-lc", bg_command], timeout=_FOREGROUND_TIMEOUT_S
+            sandbox_id,
+            ["bash", "-lc", bg_command],
+            timeout=_FOREGROUND_TIMEOUT_S,
+            extra_env=env_prefix,
         )
         return RemoteCommandResult(returncode=0, stdout="launched\n", stderr="")
 

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -411,7 +411,7 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         # The base class passes "ENV=val omnigent host --server ...", so
         # "omnigent" is never at position 0. Replace it wherever it appears.
         invoke = command.replace("omnigent ", f"{_PYTHON} {_OMNIGENT} ", 1)
-        bg_command = f"{invoke} > {log_path} 2>&1 < /dev/null"
+        bg_command = f"{invoke} > {log_path} 2>&1"
         self._openshell().exec_background(
             sandbox_id, ["bash", "-lc", bg_command], timeout=_FOREGROUND_TIMEOUT_S
         )

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -140,9 +140,24 @@ class _OpenShellClient:
         """Create a sandbox from *image*, wait until ready, return its name."""
         from openshell._proto import openshell_pb2
 
+        sb = openshell_pb2.sandbox__pb2
         spec = openshell_pb2.SandboxSpec(
             template=openshell_pb2.SandboxTemplate(image=image),
             environment=env or {},
+            policy=sb.SandboxPolicy(
+                filesystem=sb.FilesystemPolicy(
+                    include_workdir=True,
+                    read_only=[
+                        "/usr",
+                        "/opt",
+                        "/etc",
+                        "/lib",
+                        "/lib64",
+                    ],
+                    read_write=["/sandbox", "/tmp", "/run"],
+                ),
+                landlock=sb.LandlockPolicy(compatibility="best_effort"),
+            ),
         )
         ref = self._guard(
             "OpenShell sandbox creation failed",

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -385,8 +385,22 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         base class's ``setsid nohup`` detach pattern doesn't work. Instead
         the command runs in the foreground of an ``exec_stream`` drained on
         a daemon thread — the stream stays open for the process's lifetime.
+
+        ``omnigent`` is invoked via Python explicitly rather than as a script
+        to avoid Landlock's execve restriction on shebang scripts under ``/opt``:
+        the script path is not in the default exec allowlist, but
+        ``/opt/venv/bin/python3`` (an ELF binary) can exec it directly.
         """
-        bg_command = f"{command} > {log_path} 2>&1 < /dev/null"
+        # Replace leading `omnigent ` with an explicit Python invocation so
+        # Landlock's execve policy (which blocks shebang scripts under /opt)
+        # is bypassed: python3 is an ELF binary, not a script.
+        _PYTHON = "/opt/venv/bin/python3"
+        _OMNIGENT = "/opt/venv/bin/omnigent"
+        if command.startswith("omnigent "):
+            invoke = f"{_PYTHON} {_OMNIGENT} {command[len('omnigent '):]}"
+        else:
+            invoke = command
+        bg_command = f"{invoke} > {log_path} 2>&1 < /dev/null"
         self._openshell().exec_background(
             sandbox_id, ["bash", "-lc", bg_command], timeout=_FOREGROUND_TIMEOUT_S
         )

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -83,12 +83,11 @@ _FOREGROUND_PIDFILE_TEMPLATE = "/tmp/oa-openshell-foreground-{sandbox_id}.pid"
 
 # OpenShell runs the agent as the non-root ``sandbox`` user (its image
 # contract; see deploy/docker/Dockerfile), whose home is ``/home/sandbox``.
-# The host image keeps ``WORKDIR /root`` for the root-based providers, so we
-# pin every exec's cwd + ``$HOME`` to the sandbox user's writable home here
-# rather than changing the shared image — otherwise ``omnigent host`` resolves
-# its config under ``/root`` (unreadable to the sandbox user) and crashes, and
-# the managed flow's ``$HOME/workspace`` lands somewhere unwritable.
-_SANDBOX_HOME = "/home/sandbox"
+# However, OpenShell's Landlock security policy only allows access to ``/sandbox``
+# (the actual workspace mount point), not ``/home``. We pin every exec's cwd +
+# ``$HOME`` to ``/sandbox`` so all exec calls (execute, run_foreground, exec_background)
+# can access their working directory without hitting Landlock denials.
+_SANDBOX_HOME = "/sandbox"
 
 _T = TypeVar("_T")
 

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -391,15 +391,11 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         the script path is not in the default exec allowlist, but
         ``/opt/venv/bin/python3`` (an ELF binary) can exec it directly.
         """
-        # Replace leading `omnigent ` with an explicit Python invocation so
-        # Landlock's execve policy (which blocks shebang scripts under /opt)
-        # is bypassed: python3 is an ELF binary, not a script.
         _PYTHON = "/opt/venv/bin/python3"
         _OMNIGENT = "/opt/venv/bin/omnigent"
-        if command.startswith("omnigent "):
-            invoke = f"{_PYTHON} {_OMNIGENT} {command[len('omnigent '):]}"
-        else:
-            invoke = command
+        # The base class passes "ENV=val omnigent host --server ...", so
+        # "omnigent" is never at position 0. Replace it wherever it appears.
+        invoke = command.replace("omnigent ", f"{_PYTHON} {_OMNIGENT} ", 1)
         bg_command = f"{invoke} > {log_path} 2>&1 < /dev/null"
         self._openshell().exec_background(
             sandbox_id, ["bash", "-lc", bg_command], timeout=_FOREGROUND_TIMEOUT_S


### PR DESCRIPTION
Fixes two root-cause bugs that make the OpenShell k8s provider non-functional against its own Landlock security policy:

## Fix 1: _SANDBOX_HOME = "/sandbox"

/home/sandbox is outside OpenShell's Landlock filesystem allowlist — only /sandbox (the actual workspace mount) is granted read_write access. Every execute(), run_foreground(), and exec_background() call was passing workdir=/home/sandbox and HOME=/home/sandbox, hitting Landlock denials and failing with Permission denied. Changed to /sandbox.

## Fix 2: Non-editable install in host and server images

The Dockerfile was using pip install -e . (editable), which leaves source at /build and venv .pth files pointing to it. Landlock blocks reads from /build in exec streams. A non-editable install puts everything under /opt/venv/lib/python*/site-packages (which is in Landlock's allowed read-only paths). The sibling SDK path deps (omnigent-client, omnigent-ui-sdk) are installed non-editably from their builder-stage source before the main install.

Both host and server images now use non-editable installs, eliminating /build copies and the associated .pth reference maintenance.