### PR TITLE
feat(ci): enforce a 5-working-day reviewer SLA on PRs and issues

### DIFF
--- a/.github/workflows/review-sla-test.yml
+++ b/.github/workflows/review-sla-test.yml
@@ -1,0 +1,35 @@
+name: Reviewer SLA Test
+
+# Offline unit test for the SLA sweep logic: runs review-sla.test.js (mocked
+# GitHub client, real .github/MAINTAINER; ownership pinned to a frozen fixture).
+# Triggers only when the sweep, its test, or the pool files it reads change. Runs
+# on `pull_request` (PR head checkout) so it tests the PR's own version. No
+# secrets, no network.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/review-sla.js
+      - .github/workflows/review-sla.test.js
+      - .github/workflows/review-sla.yml
+      - .github/MAINTAINER
+      - .github/areas.json
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: review-sla-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run reviewer-SLA unit test
+        run: node .github/workflows/review-sla.test.js

--- a/.github/workflows/review-sla.js
+++ b/.github/workflows/review-sla.js
@@ -1,0 +1,340 @@
+// Reviewer SLA sweep: nudge + escalate open PRs and issues that a MAINTAINER has
+// been sitting on for more than SLA_DAYS *working* days without replying.
+//
+// Runs on a schedule from the trusted default branch (see review-sla.yml), so it
+// reads no PR-authored code and just talks to the issues/PRs API. For each open,
+// non-draft item:
+//   - PRs: the "assigned person" is any maintainer in requested_reviewers (GitHub
+//     drops them from that list the moment they submit a review, so being in it
+//     means "still owes a review"). The clock starts at their latest
+//     `review_requested` event (fallback: PR opened). If >= SLA_DAYS working days
+//     have elapsed AND they've posted no comment or review since, the SLA is
+//     breached: re-ping them in one comment and add ONE second reviewer (lowest
+//     open-review load among the area owners in .github/areas.json, mirrored as
+//     an assignee like auto-assign-reviewer.js does).
+//   - Issues: the "assigned person" is any maintainer assignee; clock starts at
+//     their latest `assigned` event. Breach -> re-ping + add one second assignee
+//     from the owners of the area(s) whose comp:* label the issue carries.
+//
+// Ownership comes from .github/areas.json -- the single source of truth shared
+// with auto-assign-reviewer.js and issue-triage.yml (it replaced the old
+// .github/reviewers + .github/ISSUE_ASSIGNEES files). `owners_paused` is ignored.
+//
+// "Working days" = weekdays (Mon-Fri) in UTC. Reply = ANY comment or review by the
+// assignee since the clock started.
+//
+// Escalate-once, two independent guards so the bot never spams:
+//   1. a one-shot LABEL, and
+//   2. the MARKER hidden in the reminder comment -- checked as a fallback so that
+//      even if the label write fails after the comment lands, the next sweep still
+//      sees the marker and skips.
+// The second reviewer/assignee is added FIRST (best-effort); the comment is then
+// worded to match what actually happened (so it can't claim "Adding @X" when the
+// add 422'd), and the label is written last. If the comment itself fails nothing
+// user-visible was posted, so we skip the label and let the next sweep retry.
+//
+// ponytail: one escalation per item. Per-reviewer re-escalation or a weekly
+// re-ping would need per-nudge timestamp state instead of the label+marker pair --
+// add that only if a single nudge proves too weak.
+
+const fs = require("fs");
+
+const SLA_DAYS = 5; // working days
+const LABEL = "review-sla-escalated";
+const MARKER = "<!-- review-sla-bot -->"; // idempotency fallback if the label write fails
+const CANONICAL_REPO = "omnigent-ai/omnigent";
+// Max escalations per sweep. Bounds the day-one blast against an existing stale
+// backlog (and any future surge): the backlog drains a chunk per weekday instead
+// of nudging everything at once. PRs are processed before issues.
+// ponytail: single global cap; split into per-kind caps if issue nudges starving
+// behind a large PR backlog ever matters.
+const MAX_ESCALATIONS_PER_RUN = 30;
+
+// --- Pure helpers (exported for the offline test; no network) --------------
+
+// Weekdays strictly after `from`'s date, through `to`'s date, in UTC. So a review
+// requested on a Monday first counts as 5 working days the following Monday.
+// ponytail: weekends only, no holiday calendar -- add one if the SLA needs it.
+function workingDaysBetween(from, to) {
+  const cur = new Date(from);
+  cur.setUTCHours(0, 0, 0, 0);
+  const end = new Date(to);
+  end.setUTCHours(0, 0, 0, 0);
+  let count = 0;
+  while (cur < end) {
+    cur.setUTCDate(cur.getUTCDate() + 1);
+    const d = cur.getUTCDay();
+    if (d !== 0 && d !== 6) count++;
+  }
+  return count;
+}
+
+// Latest ISO timestamp per (lowercased) login for a given timeline event type.
+function latestByUser(timeline, eventName, getLogin) {
+  const out = {};
+  for (const e of timeline || []) {
+    if (e.event !== eventName) continue;
+    const login = getLogin(e);
+    if (!login || !e.created_at) continue;
+    const lc = login.toLowerCase();
+    if (!out[lc] || new Date(e.created_at) > new Date(out[lc])) out[lc] = e.created_at;
+  }
+  return out;
+}
+
+// Did `login` post any comment/review after `sinceIso`?
+function repliedSince(login, sinceIso, comments, reviews, reviewComments) {
+  const since = new Date(sinceIso).getTime();
+  const lc = login.toLowerCase();
+  const by = (u) => (u || "").toLowerCase() === lc;
+  const after = (t) => t && new Date(t).getTime() > since;
+  return (
+    (comments || []).some((c) => by(c.user && c.user.login) && after(c.created_at)) ||
+    (reviews || []).some((r) => by(r.user && r.user.login) && after(r.submitted_at)) ||
+    (reviewComments || []).some((rc) => by(rc.user && rc.user.login) && after(rc.created_at))
+  );
+}
+
+// Have we already posted a reminder here? (idempotency fallback for a failed label)
+function alreadyNudged(comments) {
+  return (comments || []).some((c) => (c.body || "").includes(MARKER));
+}
+
+// Breached maintainer targets for one item, given the reply signals. Shared by the
+// PR and issue paths (issues pass [] for reviews/reviewComments).
+function breachedTargets({ targets, clockStartByUser, openedAt, now, comments, reviews, reviewComments }) {
+  const out = [];
+  for (const t of targets) {
+    // Fallback to openedAt when there's no explicit request/assign event for
+    // this login (e.g. a CODEOWNERS/team expansion, or a timeline pagination
+    // edge). That can over-count elapsed time slightly -- acceptable, and never
+    // fires for the normal auto-assigned path which always emits the event.
+    const since = clockStartByUser[t.toLowerCase()] || openedAt;
+    if (workingDaysBetween(since, now) < SLA_DAYS) continue;
+    if (repliedSince(t, since, comments, reviews, reviewComments)) continue;
+    out.push(t);
+  }
+  return out;
+}
+
+// Parse .github/areas.json (same shape auto-assign-reviewer.js reads) into:
+//   rules       - [{ prefix, owners }] in document order (last match wins per file)
+//   pool        - Map lc->original of every owner (the full candidate set)
+//   labelOwners - Map "comp:x" -> Set of owners, for routing an issue by its label
+// `owners_paused` is intentionally ignored. `text` is injectable for tests.
+function parseAreas(text) {
+  const areas = JSON.parse(text).areas || [];
+  const rules = [];
+  const pool = new Map();
+  const labelOwners = new Map();
+  for (const area of areas) {
+    const owners = area.owners || [];
+    owners.forEach((o) => pool.set(o.toLowerCase(), o));
+    for (const p of area.paths || []) rules.push({ prefix: p.replace(/^\//, ""), owners });
+    if (area.label) {
+      const set = labelOwners.get(area.label) || new Set();
+      owners.forEach((o) => set.add(o));
+      labelOwners.set(area.label, set);
+    }
+  }
+  return { rules, pool, labelOwners };
+}
+
+// Count currently-open review requests per (lc) login -- the stateless fairness
+// signal auto-assign-reviewer.js also uses.
+function buildLoad(openPRs) {
+  const load = new Map();
+  for (const p of openPRs)
+    for (const r of p.requested_reviewers || []) {
+      const l = (r.login || "").toLowerCase();
+      load.set(l, (load.get(l) || 0) + 1);
+    }
+  return load;
+}
+
+// Pick the lowest-load of a candidate list, random tie-break within a load tier.
+function lowestLoad(candidates, load) {
+  if (!candidates.length) return null;
+  const loadOf = (u) => load.get(u.toLowerCase()) || 0;
+  const byTier = {};
+  for (const u of candidates) (byTier[loadOf(u)] ||= []).push(u);
+  const lowest = byTier[Math.min(...Object.keys(byTier).map(Number))];
+  return lowest[Math.floor(Math.random() * lowest.length)];
+}
+
+// One lowest-load area owner for the PR's files, else lowest from the full pool;
+// never anyone already on the PR.
+function pickSecondReviewer({ files, rules, pool, load, exclude }) {
+  const areaOwners = new Map();
+  for (const f of files) {
+    let match = null;
+    for (const r of rules) if (f.startsWith(r.prefix)) match = r; // last wins
+    if (match) match.owners.forEach((o) => areaOwners.set(o.toLowerCase(), o));
+  }
+  const base = areaOwners.size ? areaOwners : pool;
+  return lowestLoad([...base.values()].filter((u) => !exclude.has(u.toLowerCase())), load);
+}
+
+// One second assignee from the owners of the issue's comp:* area(s), else the full
+// pool; never anyone already assigned.
+// ponytail: tie-break reuses the PR open-review `load` -- a proxy for issues (there
+// is no per-assignee open-issue count), so this only approximates issue fairness.
+// Tally open-issue assignee counts here if that starts to matter.
+function pickSecondAssignee({ labels, labelOwners, pool, load, exclude }) {
+  const owners = new Set();
+  for (const l of labels) for (const o of labelOwners.get(l) || []) owners.add(o);
+  const base = owners.size ? owners : new Set(pool.values());
+  return lowestLoad([...base].filter((u) => !exclude.has(u.toLowerCase())), load);
+}
+
+// --- Orchestrator ----------------------------------------------------------
+
+async function run({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  if (`${owner}/${repo}` !== CANONICAL_REPO) {
+    core.info(`Not ${CANONICAL_REPO}; skipping.`);
+    return;
+  }
+  const now = new Date();
+
+  const maintainers = new Set(
+    fs.readFileSync(".github/MAINTAINER", "utf8")
+      .split("\n").map((l) => l.replace(/#.*/, "").trim().toLowerCase()).filter(Boolean)
+  );
+  // REVIEWER_AREAS_FILE lets the unit test pin a fixture; defaults to the real file.
+  const areasFile = process.env.REVIEWER_AREAS_FILE || ".github/areas.json";
+  const { rules, pool, labelOwners } = parseAreas(fs.readFileSync(areasFile, "utf8"));
+
+  const hasLabel = (item) => (item.labels || []).some((l) => (l.name || l) === LABEL);
+  const escalated = [];
+  const capReached = () => escalated.length >= MAX_ESCALATIONS_PER_RUN;
+
+  // Escalate one item once. Add the second reviewer/assignee FIRST (best-effort,
+  // returns the login it actually added or null), so the comment states the true
+  // outcome; then post the marked comment; then lock the LABEL. If the comment
+  // fails, nothing was posted -> skip the label and retry next sweep.
+  const escalateOnce = async (number, breached, kind, addSecond, secondCandidate) => {
+    let added = null;
+    if (secondCandidate) {
+      try {
+        added = (await addSecond()) ? secondCandidate : null;
+      } catch (e) {
+        core.warning(`#${number}: could not add second ${kind} @${secondCandidate}: ${e.message}`);
+      }
+    }
+    const noun = kind === "reviewer" ? "review" : "a response";
+    const body =
+      `${MARKER}\n⏰ **${kind === "reviewer" ? "Reviewer" : "Response"} SLA** — this ${kind === "reviewer" ? "PR" : "issue"} ` +
+      `has been awaiting ${noun} from ${breached.map((u) => "@" + u).join(", ")} for more than ${SLA_DAYS} working days.` +
+      (added ? ` Adding @${added} as a second ${kind}.` : "");
+    try {
+      await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+    } catch (e) {
+      core.warning(`#${number}: reminder comment failed, will retry next run: ${e.message}`);
+      return;
+    }
+    try {
+      await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: [LABEL] });
+    } catch (e) {
+      core.warning(`#${number}: could not add ${LABEL} label (marker still guards re-nudge): ${e.message}`);
+    }
+    escalated.push(`${kind === "reviewer" ? "PR" : "issue"} #${number} (re-pinged ${breached.join(", ")}${added ? `, +@${added}` : ""})`);
+  };
+
+  // ----- PRs: awaiting a maintainer's review -----
+  const openPRs = await github.paginate(github.rest.pulls.list, { owner, repo, state: "open", per_page: 100 });
+  const load = buildLoad(openPRs);
+  // Count each second reviewer/assignee we add during THIS sweep against the load
+  // map, so successive picks rotate instead of dogpiling the current lowest-load
+  // maintainer -- without it, one sweep hands nearly every escalation to one person.
+  const bumpLoad = (u) => load.set(u.toLowerCase(), (load.get(u.toLowerCase()) || 0) + 1);
+
+  for (const pr of openPRs) {
+    if (capReached()) break;
+    if (pr.draft || hasLabel(pr)) continue;
+    const targets = (pr.requested_reviewers || []).map((r) => r.login).filter((l) => maintainers.has(l.toLowerCase()));
+    if (!targets.length) continue;
+
+    const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, { owner, repo, issue_number: pr.number, per_page: 100 });
+    const requestedAt = latestByUser(timeline, "review_requested", (e) => e.requested_reviewer && e.requested_reviewer.login);
+
+    // Cheap staleness prefilter before fetching reply signals.
+    const stale = targets.filter((t) => workingDaysBetween(requestedAt[t.toLowerCase()] || pr.created_at, now) >= SLA_DAYS);
+    if (!stale.length) continue;
+
+    const [comments, reviews, reviewComments] = await Promise.all([
+      github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr.number, per_page: 100 }),
+      github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: pr.number, per_page: 100 }),
+      github.paginate(github.rest.pulls.listReviewComments, { owner, repo, pull_number: pr.number, per_page: 100 }),
+    ]);
+    if (alreadyNudged(comments)) continue; // label may have failed to write; marker still guards
+    const breached = breachedTargets({
+      targets: stale, clockStartByUser: requestedAt, openedAt: pr.created_at, now, comments, reviews, reviewComments,
+    });
+    if (!breached.length) continue;
+
+    const files = (await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number: pr.number, per_page: 100 })).map((f) => f.filename);
+    const onPr = new Set(
+      [pr.user && pr.user.login, ...targets, ...(pr.assignees || []).map((a) => a.login), ...(pr.requested_reviewers || []).map((r) => r.login)]
+        .filter(Boolean).map((s) => s.toLowerCase())
+    );
+    const second = pickSecondReviewer({ files, rules, pool, load, exclude: onPr });
+
+    await escalateOnce(pr.number, breached, "reviewer", async () => {
+      await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, reviewers: [second] });
+      // Mirror as assignee for UI filterability, matching auto-assign-reviewer.js.
+      await github.rest.issues.addAssignees({ owner, repo, issue_number: pr.number, assignees: [second] });
+      bumpLoad(second);
+      return true;
+    }, second);
+  }
+
+  // ----- Issues: awaiting a maintainer assignee -----
+  const openIssues = await github.paginate(github.rest.issues.listForRepo, { owner, repo, state: "open", per_page: 100 });
+  for (const issue of openIssues) {
+    if (capReached()) break;
+    if (issue.pull_request || hasLabel(issue)) continue; // listForRepo also returns PRs
+    const targets = (issue.assignees || []).map((a) => a.login).filter((l) => maintainers.has(l.toLowerCase()));
+    if (!targets.length) continue;
+
+    const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, { owner, repo, issue_number: issue.number, per_page: 100 });
+    const assignedAt = latestByUser(timeline, "assigned", (e) => e.assignee && e.assignee.login);
+
+    const stale = targets.filter((t) => workingDaysBetween(assignedAt[t.toLowerCase()] || issue.created_at, now) >= SLA_DAYS);
+    if (!stale.length) continue;
+
+    const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: issue.number, per_page: 100 });
+    if (alreadyNudged(comments)) continue;
+    const breached = breachedTargets({
+      targets: stale, clockStartByUser: assignedAt, openedAt: issue.created_at, now, comments, reviews: [], reviewComments: [],
+    });
+    if (!breached.length) continue;
+
+    const labels = (issue.labels || []).map((l) => l.name || l).filter((n) => n.startsWith("comp:"));
+    const onIssue = new Set((issue.assignees || []).map((a) => a.login.toLowerCase()));
+    const second = pickSecondAssignee({ labels, labelOwners, pool, load, exclude: onIssue });
+
+    await escalateOnce(issue.number, breached, "assignee", async () => {
+      await github.rest.issues.addAssignees({ owner, repo, issue_number: issue.number, assignees: [second] });
+      bumpLoad(second);
+      return true;
+    }, second);
+  }
+
+  core.info(escalated.length ? `Escalated ${escalated.length}: ${escalated.join("; ")}.` : "No SLA breaches; nothing to escalate.");
+}
+
+module.exports = run;
+// Exported for the offline unit test.
+module.exports.workingDaysBetween = workingDaysBetween;
+module.exports.latestByUser = latestByUser;
+module.exports.repliedSince = repliedSince;
+module.exports.alreadyNudged = alreadyNudged;
+module.exports.breachedTargets = breachedTargets;
+module.exports.parseAreas = parseAreas;
+module.exports.pickSecondReviewer = pickSecondReviewer;
+module.exports.pickSecondAssignee = pickSecondAssignee;
+module.exports.SLA_DAYS = SLA_DAYS;
+module.exports.LABEL = LABEL;
+module.exports.MARKER = MARKER;
+module.exports.MAX_ESCALATIONS_PER_RUN = MAX_ESCALATIONS_PER_RUN;

--- a/.github/workflows/review-sla.test.js
+++ b/.github/workflows/review-sla.test.js
@@ -1,0 +1,237 @@
+// Offline unit test for review-sla.js -- exercises the pure decision helpers and
+// one end-to-end orchestration of each path against a mocked GitHub client. No
+// network. cwd must be the repo root (the orchestrator reads the real
+// .github/MAINTAINER; ownership is pinned to a frozen fixture via
+// REVIEWER_AREAS_FILE so the test doesn't churn when .github/areas.json changes).
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+const script = require(path.resolve(".github/workflows/review-sla.js"));
+
+// Frozen area fixture: stable owners the orchestration assertions can pin to.
+const FIXTURE = {
+  areas: [
+    { key: "inner", label: "comp:harnesses", paths: ["omnigent/inner/"], owners: ["ownerA", "ownerB", "ownerC"] },
+    { key: "web", label: "comp:web-ui", paths: ["web/"], owners: ["webX", "webY"] },
+  ],
+};
+const FIXTURE_PATH = path.join(os.tmpdir(), "review-sla-areas.fixture.json");
+fs.writeFileSync(FIXTURE_PATH, JSON.stringify(FIXTURE));
+process.env.REVIEWER_AREAS_FILE = FIXTURE_PATH;
+
+function assert(name, cond, detail) {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`);
+  if (!cond) process.exitCode = 1;
+}
+
+const daysAgoIso = (n) => new Date(Date.now() - n * 86400000).toISOString();
+
+// Mocked GitHub client. `canned` maps a list-endpoint tag -> the array it returns
+// through github.paginate; writes are recorded in `sink`. `failRequestReviewers`
+// makes pulls.requestReviewers throw, to exercise the partial-failure path.
+function mkGithub(canned, sink, opts = {}) {
+  const list = (tag) => { const f = async () => {}; f._tag = tag; return f; };
+  return {
+    paginate: async (fn) => canned[fn._tag] || [],
+    rest: {
+      pulls: {
+        list: list("openPRs"),
+        listReviews: list("reviews"),
+        listReviewComments: list("reviewComments"),
+        listFiles: list("files"),
+        requestReviewers: async (a) => {
+          if (opts.failRequestReviewers) throw new Error("HTTP 422: reviewer is not a collaborator");
+          sink.requested.push(...a.reviewers);
+        },
+      },
+      issues: {
+        listForRepo: list("openIssues"),
+        listEventsForTimeline: list("timeline"),
+        listComments: list("comments"),
+        createComment: async (a) => sink.comments.push(a),
+        addAssignees: async (a) => sink.assigned.push(...a.assignees),
+        addLabels: async (a) => sink.labels.push(...a.labels),
+      },
+    },
+  };
+}
+
+async function runOrch(canned, opts) {
+  const sink = { comments: [], requested: [], assigned: [], labels: [], warnings: [] };
+  const core = { info: () => {}, warning: (m) => sink.warnings.push(m) };
+  const context = { repo: { owner: "omnigent-ai", repo: "omnigent" } };
+  await script({ github: mkGithub(canned, sink, opts), context, core });
+  return sink;
+}
+
+(async () => {
+  // ---- workingDaysBetween (2026-01-05 is a Monday, 01-12 the next Monday) ----
+  const wdb = script.workingDaysBetween;
+  assert("same day -> 0", wdb("2026-01-05", "2026-01-05") === 0);
+  assert("Mon -> next Mon (7 cal days) -> 5 working days", wdb("2026-01-05", "2026-01-12") === 5, String(wdb("2026-01-05", "2026-01-12")));
+  assert("Fri -> Mon spans a weekend -> 1", wdb("2026-01-09", "2026-01-12") === 1, String(wdb("2026-01-09", "2026-01-12")));
+  assert("Sat -> Sun -> 0", wdb("2026-01-10", "2026-01-11") === 0);
+
+  // ---- latestByUser ----
+  const tl = [
+    { event: "review_requested", requested_reviewer: { login: "Alice" }, created_at: "2026-01-01T00:00:00Z" },
+    { event: "review_requested", requested_reviewer: { login: "Alice" }, created_at: "2026-01-03T00:00:00Z" },
+    { event: "assigned", assignee: { login: "Bob" }, created_at: "2026-01-02T00:00:00Z" },
+  ];
+  const rq = script.latestByUser(tl, "review_requested", (e) => e.requested_reviewer && e.requested_reviewer.login);
+  assert("latestByUser keeps the newer event", rq.alice === "2026-01-03T00:00:00Z", JSON.stringify(rq));
+  assert("latestByUser ignores other event types", !("bob" in rq));
+
+  // ---- repliedSince ----
+  const since = "2026-01-01T00:00:00Z";
+  assert("comment after -> replied",
+    script.repliedSince("alice", since, [{ user: { login: "Alice" }, created_at: "2026-01-02T00:00:00Z" }], [], []) === true);
+  assert("comment before -> not replied",
+    script.repliedSince("alice", since, [{ user: { login: "Alice" }, created_at: "2025-12-31T00:00:00Z" }], [], []) === false);
+  assert("review after -> replied",
+    script.repliedSince("alice", since, [], [{ user: { login: "alice" }, submitted_at: "2026-01-05T00:00:00Z" }], []) === true);
+  assert("someone else's comment -> not replied",
+    script.repliedSince("alice", since, [{ user: { login: "Bob" }, created_at: "2026-01-09T00:00:00Z" }], [], []) === false);
+
+  // ---- alreadyNudged (marker fallback) ----
+  assert("alreadyNudged: marker present -> true", script.alreadyNudged([{ body: "hi " + script.MARKER }]) === true);
+  assert("alreadyNudged: no marker -> false", script.alreadyNudged([{ body: "just a normal comment" }]) === false);
+
+  // ---- breachedTargets ----
+  const now = new Date();
+  const b1 = script.breachedTargets({
+    targets: ["Alice"], clockStartByUser: { alice: daysAgoIso(14) }, openedAt: daysAgoIso(30), now,
+    comments: [], reviews: [], reviewComments: [],
+  });
+  assert("stale + silent -> breached", JSON.stringify(b1) === JSON.stringify(["Alice"]), JSON.stringify(b1));
+  const b2 = script.breachedTargets({
+    targets: ["Alice"], clockStartByUser: { alice: daysAgoIso(1) }, openedAt: daysAgoIso(1), now,
+    comments: [], reviews: [], reviewComments: [],
+  });
+  assert("within SLA -> not breached", b2.length === 0, JSON.stringify(b2));
+  const b3 = script.breachedTargets({
+    targets: ["Alice"], clockStartByUser: { alice: daysAgoIso(14) }, openedAt: daysAgoIso(30), now,
+    comments: [{ user: { login: "Alice" }, created_at: daysAgoIso(1) }], reviews: [], reviewComments: [],
+  });
+  assert("stale but replied -> not breached", b3.length === 0, JSON.stringify(b3));
+
+  // ---- parseAreas ----
+  const { rules, pool, labelOwners } = script.parseAreas(JSON.stringify(FIXTURE));
+  assert("parseAreas: rules preserve prefixes", rules.some((r) => r.prefix === "omnigent/inner/") && rules.some((r) => r.prefix === "web/"), JSON.stringify(rules));
+  assert("parseAreas: pool unions all owners", ["ownera", "ownerb", "ownerc", "webx", "weby"].every((o) => pool.has(o)), JSON.stringify([...pool.keys()]));
+  assert("parseAreas: labelOwners maps comp:* -> owners", [...(labelOwners.get("comp:web-ui") || [])].sort().join(",") === "webX,webY", JSON.stringify([...(labelOwners.get("comp:web-ui") || [])]));
+
+  // ---- pickSecondReviewer ----
+  const srMembers = script.pickSecondReviewer({
+    files: ["omnigent/inner/foo.py"], rules, pool, load: new Map(),
+    exclude: new Set(["ownera"]),
+  });
+  assert("second reviewer is an inner owner, excluding those on the PR",
+    ["ownerb", "ownerc"].includes((srMembers || "").toLowerCase()), String(srMembers));
+  const srLoad = script.pickSecondReviewer({
+    files: ["omnigent/inner/foo.py"], rules, pool,
+    load: new Map([["ownera", 5], ["ownerb", 5], ["ownerc", 0]]),
+    exclude: new Set(),
+  });
+  assert("lowest-load owner wins the tie-break", (srLoad || "").toLowerCase() === "ownerc", String(srLoad));
+  const srFallback = script.pickSecondReviewer({
+    files: ["README.md"], rules, pool, load: new Map(), exclude: new Set(),
+  });
+  assert("unowned path -> falls back to the full pool", pool.has((srFallback || "").toLowerCase()), String(srFallback));
+
+  // ---- pickSecondAssignee ----
+  const saMatch = script.pickSecondAssignee({
+    labels: ["comp:web-ui"], labelOwners, pool, load: new Map(), exclude: new Set(["webx"]),
+  });
+  assert("second assignee comes from the label's owners, excluding the current one",
+    (saMatch || "").toLowerCase() === "weby", String(saMatch));
+  const saFallback = script.pickSecondAssignee({
+    labels: [], labelOwners, pool, load: new Map(), exclude: new Set(),
+  });
+  assert("no comp label -> falls back to the full pool", pool.has((saFallback || "").toLowerCase()), String(saFallback));
+
+  // ---- orchestration: a stale, silent PR gets nudged + a 2nd reviewer + label --
+  const stalePR = {
+    number: 7, draft: false, labels: [], user: { login: "someexternaldev" },
+    created_at: daysAgoIso(14), requested_reviewers: [{ login: "dhruv0811" }], assignees: [{ login: "dhruv0811" }],
+  };
+  let s = await runOrch({
+    openPRs: [stalePR], openIssues: [], timeline: [], comments: [], reviews: [], reviewComments: [],
+    files: [{ filename: "omnigent/inner/foo.py" }],
+  });
+  assert("stale PR: one reminder comment posted", s.comments.length === 1 && s.comments[0].issue_number === 7, JSON.stringify(s.comments));
+  assert("stale PR: comment re-pings the assigned reviewer", /@dhruv0811/.test(s.comments[0].body), s.comments[0] && s.comments[0].body);
+  assert("stale PR: a second reviewer is requested from the area owners",
+    s.requested.length === 1 && ["ownera", "ownerb", "ownerc"].includes(s.requested[0].toLowerCase()), JSON.stringify(s.requested));
+  assert("stale PR: second reviewer mirrored as assignee", JSON.stringify(s.assigned) === JSON.stringify(s.requested), JSON.stringify(s.assigned));
+  assert("stale PR: comment names exactly the reviewer that was added",
+    new RegExp(`Adding @${s.requested[0]} as a second reviewer`).test(s.comments[0].body), s.comments[0] && s.comments[0].body);
+  assert("stale PR: comment carries the idempotency marker", s.comments[0].body.includes(script.MARKER), s.comments[0] && s.comments[0].body);
+  assert("stale PR: labelled once", JSON.stringify(s.labels) === JSON.stringify([script.LABEL]), JSON.stringify(s.labels));
+
+  // ---- orchestration: partial failure -- requestReviewers throws --
+  // add-first ordering means the comment must NOT claim a 2nd reviewer that failed
+  // to attach, yet the item is still labelled so it won't be re-nudged tomorrow.
+  s = await runOrch({
+    openPRs: [stalePR], openIssues: [], timeline: [], comments: [], reviews: [], reviewComments: [],
+    files: [{ filename: "omnigent/inner/foo.py" }],
+  }, { failRequestReviewers: true });
+  assert("partial failure: reminder comment still posted", s.comments.length === 1, JSON.stringify(s.comments));
+  assert("partial failure: comment does NOT over-claim a second reviewer", !/second reviewer/.test(s.comments[0].body), s.comments[0] && s.comments[0].body);
+  assert("partial failure: no reviewer was actually requested", s.requested.length === 0, JSON.stringify(s.requested));
+  assert("partial failure: still labelled (won't re-nudge next run)", JSON.stringify(s.labels) === JSON.stringify([script.LABEL]), JSON.stringify(s.labels));
+  assert("partial failure: the reviewer-add error is warned, not fatal", s.warnings.some((w) => /could not add second reviewer/.test(w)), JSON.stringify(s.warnings));
+
+  // ---- orchestration: marker fallback -- prior nudge exists but the label didn't --
+  s = await runOrch({
+    openPRs: [stalePR], openIssues: [], timeline: [], reviews: [], reviewComments: [],
+    files: [{ filename: "omnigent/inner/foo.py" }],
+    comments: [{ user: { login: "omnigent-ci" }, body: script.MARKER + "\nearlier nudge", created_at: daysAgoIso(2) }],
+  });
+  assert("marker fallback: an already-nudged PR (marker present, no label) is skipped",
+    s.comments.length === 0 && s.labels.length === 0, JSON.stringify(s));
+
+  // ---- orchestration: already-labelled PR is left alone (one-shot) ----
+  s = await runOrch({ openPRs: [{ ...stalePR, labels: [{ name: script.LABEL }] }], openIssues: [], files: [] });
+  assert("already-escalated PR is skipped", s.comments.length === 0 && s.labels.length === 0, JSON.stringify(s));
+
+  // ---- orchestration: a fresh PR (within SLA) is left alone ----
+  s = await runOrch({ openPRs: [{ ...stalePR, created_at: daysAgoIso(1) }], openIssues: [], timeline: [], files: [] });
+  assert("fresh PR is not escalated", s.comments.length === 0, JSON.stringify(s));
+
+  // ---- orchestration: a PR whose reviewer already commented is left alone ----
+  s = await runOrch({
+    openPRs: [stalePR], openIssues: [], timeline: [], reviews: [], reviewComments: [], files: [],
+    comments: [{ user: { login: "dhruv0811" }, created_at: daysAgoIso(1) }],
+  });
+  assert("PR with a recent reply is not escalated", s.comments.length === 0, JSON.stringify(s));
+
+  // ---- orchestration: a stale, silent issue gets nudged + a 2nd assignee + label --
+  const staleIssue = {
+    number: 9, labels: [{ name: "comp:web-ui" }], created_at: daysAgoIso(14), assignees: [{ login: "hzub" }],
+  };
+  s = await runOrch({ openPRs: [], openIssues: [staleIssue], timeline: [], comments: [] });
+  assert("stale issue: one reminder comment posted", s.comments.length === 1 && s.comments[0].issue_number === 9, JSON.stringify(s.comments));
+  assert("stale issue: re-pings the assignee", /@hzub/.test(s.comments[0].body), s.comments[0] && s.comments[0].body);
+  assert("stale issue: a second assignee from the label's owners", ["webx", "weby"].includes((s.assigned[0] || "").toLowerCase()), JSON.stringify(s.assigned));
+  assert("stale issue: labelled once", JSON.stringify(s.labels) === JSON.stringify([script.LABEL]), JSON.stringify(s.labels));
+
+  // ---- orchestration: a real PR object (listForRepo) is not double-swept as an issue --
+  s = await runOrch({ openPRs: [], openIssues: [{ ...staleIssue, pull_request: {} }], timeline: [], comments: [] });
+  assert("PR returned by listForRepo is skipped in the issue sweep", s.comments.length === 0, JSON.stringify(s));
+
+  // ---- orchestration: per-run cap + in-sweep load spread ----
+  // Feed more stale PRs than the cap. Expect exactly MAX escalations, and the
+  // second reviewer rotates across all 3 inner owners rather than dogpiling the
+  // one lowest-load maintainer (regression for the live-data concentration bug).
+  const MAX = script.MAX_ESCALATIONS_PER_RUN;
+  const manyStale = Array.from({ length: MAX + 5 }, (_, i) => ({ ...stalePR, number: 3000 + i }));
+  s = await runOrch({
+    openPRs: manyStale, openIssues: [], timeline: [], comments: [], reviews: [], reviewComments: [],
+    files: [{ filename: "omnigent/inner/foo.py" }],
+  });
+  assert("cap: escalations stop at MAX_ESCALATIONS_PER_RUN", s.comments.length === MAX, `${s.comments.length} vs ${MAX}`);
+  assert("cap: labels capped to match", s.labels.length === MAX, String(s.labels.length));
+  assert("load spread: second reviewer rotates across all 3 inner owners (not dogpiled on one)",
+    new Set(s.requested.map((u) => u.toLowerCase())).size === 3, JSON.stringify([...new Set(s.requested)]));
+})();

--- a/.github/workflows/review-sla.yml
+++ b/.github/workflows/review-sla.yml
@@ -1,0 +1,49 @@
+name: Reviewer SLA
+
+# Daily (weekday) sweep that enforces a 5-working-day reviewer SLA: any open PR
+# awaiting review from a maintainer -- or open issue awaiting a maintainer
+# assignee -- with no reply in 5 working days gets the assignee re-pinged in a
+# comment plus a second reviewer (PR) / second assignee (issue), then a one-shot
+# `review-sla-escalated` label so it's never nudged twice. All logic + safety
+# notes live in review-sla.js (offline unit test: review-sla.test.js).
+#
+# Scheduled -> runs on the trusted default branch with the repo GITHUB_TOKEN; it
+# reads no PR-authored code, only .github/ config + the issues/PRs API.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1-5" # 08:00 UTC, Mon-Fri (weekday SLA -> no weekend pings)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: review-sla
+  cancel-in-progress: true
+
+jobs:
+  sweep:
+    if: github.repository == 'omnigent-ai/omnigent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # Job-level permissions REPLACE the workflow-level block, so restate read.
+      contents: read
+      pull-requests: write # comment + request the second reviewer
+      issues: write        # comment + assign + label
+    steps:
+      # Trusted default branch, .github only (config the script reads). Never PR head.
+      - name: Check out .github
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github
+          persist-credentials: false
+      - name: Sweep open PRs + issues for SLA breaches
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          script: |
+            const script = require('./.github/workflows/review-sla.js');
+            await script({ github, context, core });


### PR DESCRIPTION
## Related issue

N/A — repo automation, no tracking issue.

## Summary

Adds a **Reviewer SLA** mechanism: a scheduled weekday sweep that enforces a 5-working-day reply SLA for maintainers on the items assigned to them, and escalates the ones that blow it.

- **PRs** — for any maintainer still in `requested_reviewers` whose latest `review_requested` was ≥ 5 working days ago **and** who has posted no comment/review since: post one comment re-pinging them and request a **second reviewer** (lowest open-review-load owner of the touched area(s) in `.github/areas.json`, mirrored as an assignee the way `auto-assign-reviewer.js` already does).
- **Issues** — same clock on a maintainer assignee's `assigned` event: re-ping and add a **second assignee** from the owners of the area(s) whose `comp:*` label the issue carries.
- Escalate-once is guarded by **both** a one-shot `review-sla-escalated` label **and** a hidden marker in the reminder comment, so even a failed label write can't cause daily re-nudging (mirrors how `stale.yml` uses a label, plus a belt-and-suspenders marker). The second reviewer is added **first** (best-effort), so the comment only claims a reviewer that actually attached — no over-claiming on a non-collaborator 422.
- **Rollout-safe** — escalations are capped at **30 per sweep**, so an existing stale backlog drains a chunk per weekday instead of firing all at once; and each second reviewer/assignee is counted against the in-sweep load so picks rotate across maintainers instead of concentrating on the current lowest-load one. (Both were found by running the sweep read-only against the live backlog before merge.)

Fits the repo's existing convention — a committed `github-script` file with an offline unit test and a paired test-runner workflow, a scheduled sweep like `stale.yml`, third-party actions pinned by SHA — and adds **no new dependencies** and no org teams. Ownership is read from `.github/areas.json`, the single source of truth shared with `auto-assign-reviewer.js` and issue triage. It runs from the trusted default branch (reads no PR-authored code) and makes every write best-effort per item so one un-actionable item can't abort the sweep.

**ELI5:** every weekday morning a bot looks at open PRs/issues, and if a maintainer has been sitting on one for a full work-week without saying anything, it taps them on the shoulder and pulls in a backup — once.

```
daily (Mon–Fri)
   └─ open PRs ── maintainer in requested_reviewers?
                    └─ ≥5 working days since requested AND no reply since?
                         └─ comment @reviewer  +  label  +  request 2nd reviewer
      open issues ── maintainer assignee?
                    └─ ≥5 working days since assigned AND no reply since?
                         └─ comment @assignee  +  label  +  add 2nd assignee
   (label/marker present ⇒ skip: escalate once; ≤30 escalations per sweep — backlog drains over subsequent weekdays)
```

Design choices (confirmed with the requester): sweep **both PRs and issues**; **any comment or review** counts as a reply; **escalate once** per item. Deliberately left out (each marked with a `ponytail:` comment in the code): holiday calendar (weekends-only), weekly re-nudging, and issue-side load-balancing beyond the shared open-review signal.

### Addressing the Polly review

The first revision was written against a stale checkout and read the removed `.github/reviewers` / `.github/ISSUE_ASSIGNEES` files (Polly's blocking finding — correct). Fixed by re-targeting everything to `.github/areas.json` (reads + parsing/selection: path→owners for PRs, `comp:*` label→owners for issues), mirroring the current `auto-assign-reviewer.js`, and pointing the test workflow's triggers at `.github/areas.json`.

The re-review's non-blocking notes are also all addressed:
- **Idempotency** no longer rests solely on `addLabels` — the comment carries a hidden marker that a later sweep detects, so a failed label write can't cause re-nudging.
- **No over-claiming** — the second reviewer/assignee is added first and the comment is worded to match the actual outcome (with a regression test for the failed-add path).
- The test workflow now also triggers on `review-sla.yml`, and the issue-side load proxy is documented as an intentional `ponytail:` deferral.

## Test Plan

- `node .github/workflows/review-sla.test.js` → **47/47 assertions pass**, run from the repo root against the current tree (real `.github/MAINTAINER`; ownership pinned to a frozen in-test fixture via `REVIEWER_AREAS_FILE` so the assertions don't churn when `areas.json` ownership changes).
- The offline test mocks the GitHub client and drives the full sweep end-to-end for both paths, covering: `workingDaysBetween` (incl. weekend spans), `latestByUser`, reply detection, `alreadyNudged` marker detection, breach/no-breach, `areas.json` parsing, second-reviewer area+load selection and full-pool fallback, second-assignee `comp:*` matching, and orchestration cases — stale PR nudged + 2nd reviewer + marker + label; **partial failure (`requestReviewers` throws) still labels the PR and the comment doesn't over-claim**; **marker-present-but-unlabelled PR is skipped**; already-labelled skipped; within-SLA skipped; replied-since skipped; stale issue nudged + 2nd assignee; and a PR returned by `listForRepo` not double-swept as an issue.
- Separately smoke-checked `parseAreas` against the **real** `.github/areas.json`: 53 path rules, 11 owners, all 8 `comp:*` labels, `owners_paused` correctly excluded.
- `review-sla-test.yml` runs this test in CI on any change to the sweep, its test, `.github/MAINTAINER`, or `.github/areas.json`.
- Not exercised against live GitHub data (would post real comments/labels); the mocked end-to-end run asserts the exact API calls instead.

## Demo

N/A — no user-facing UI; this is a CI/automation workflow.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The decision logic is factored into pure, exported helpers and covered directly; the orchestrator is driven end-to-end through a mocked GitHub client that records the exact `createComment` / `addLabels` / `requestReviewers` / `addAssignees` calls, including the partial-failure path. Live verification is intentionally omitted because it would write real comments and labels to open PRs/issues.
