### PR TITLE
fix(runtime): route bare claude-* compaction model to Anthropic (#1950)

### DIFF
--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -2388,7 +2388,7 @@ async def compact_conversation_now(
         return CompactionResult(messages=[], summary_metadata=None)
 
     effective_llm_config = _apply_request_model_override(llm_config, model_override)
-    effective_llm_config = _route_databricks_model_for_compaction(effective_llm_config)
+    effective_llm_config = _route_bare_model_for_compaction(effective_llm_config)
     compaction_config = spec.compaction
     if preserve_recent_window is not None:
         # The compaction helper's boundary is inclusive: recent_window=1
@@ -2454,20 +2454,36 @@ async def compact_conversation_now(
     return result
 
 
-def _route_databricks_model_for_compaction(llm_config: LLMConfig) -> LLMConfig:
+def _route_bare_model_for_compaction(llm_config: LLMConfig) -> LLMConfig:
     """
-    Route bare Databricks model ids through the Databricks LLM adapter.
+    Prefix bare model ids so compaction's generic client picks the right provider.
 
-    Normal openai-agents execution handles ``databricks-gpt-*`` via its
-    harness-specific Databricks client. Explicit ``/compact`` uses the
-    generic runtime LLM client; without a provider prefix that client
-    defaults to OpenAI and incorrectly calls api.openai.com.
+    Normal harness execution infers the provider from the harness (e.g.
+    ``claude-sdk`` → Anthropic, ``openai-agents`` → Databricks/OpenAI).
+    Explicit ``/compact`` instead uses the generic runtime LLM client,
+    whose :func:`~omnigent.llms.routing.parse_model_string` defaults any
+    prefix-less id to OpenAI — so a bare ``databricks-*`` or Anthropic
+    ``claude-*`` id gets sent to ``api.openai.com`` and the summarization
+    call fails with a 500 (issue #1950). Already-prefixed ids
+    (``anthropic/…``, ``openai/…``) and bare ``gpt-*`` (correctly OpenAI)
+    are left untouched.
 
     :param llm_config: Effective LLM config for the session.
-    :returns: ``llm_config`` or a copy with ``model='databricks/<id>'``.
+    :returns: ``llm_config`` unchanged, or a copy with a provider-prefixed model.
     """
-    if llm_config.model.startswith("databricks-"):
-        return replace(llm_config, model=f"databricks/{llm_config.model}")
+    model = llm_config.model
+    if "/" in model:
+        # Already provider-prefixed (e.g. "anthropic/claude-…") — trust it.
+        return llm_config
+    if model.startswith("databricks-"):
+        return replace(llm_config, model=f"databricks/{model}")
+    if model.startswith("claude-"):
+        # Bare Anthropic id (e.g. "claude-haiku-4-5-20251001") — route to
+        # Anthropic instead of the prefix-less OpenAI default.
+        return replace(llm_config, model=f"anthropic/{model}")
+    # ponytail: only databricks + anthropic here — the /compact failures seen
+    # in the wild. Other bare non-OpenAI prefixes (deepseek-, moonshot-, …)
+    # would need the same nudge if they ever surface.
     return llm_config
 
 

--- a/tests/runtime/test_compaction.py
+++ b/tests/runtime/test_compaction.py
@@ -27,7 +27,8 @@ from omnigent.runtime.compaction import (
     count_tokens,
     summarize_history,
 )
-from omnigent.spec.types import CompactionConfig
+from omnigent.runtime.workflow import _route_bare_model_for_compaction
+from omnigent.spec.types import CompactionConfig, LLMConfig
 
 # ---------------------------------------------------------------------------
 # LLM client stubs
@@ -1536,3 +1537,37 @@ def test_is_summary_auth_error_distinguishes_401_403() -> None:
     # Non-auth failures fall through to the generic warning path.
     assert _is_summary_auth_error(Exception("connection reset by peer")) is False
     assert _is_summary_auth_error(TimeoutError("read timed out")) is False
+
+
+# ---------------------------------------------------------------------------
+# Compaction model routing (issue #1950)
+# ---------------------------------------------------------------------------
+
+
+def test_route_bare_model_prefixes_anthropic_claude() -> None:
+    """A bare ``claude-*`` id must route to Anthropic, not the OpenAI default.
+
+    Regression for #1950: explicit ``/compact`` on a ``claude-sdk`` agent with a
+    pinned bare Anthropic model (e.g. ``claude-haiku-4-5-20251001``) sent the id
+    to ``api.openai.com`` (routing.py defaults prefix-less ids to OpenAI), so the
+    summarization LLM call 500'd. It must be nudged to ``anthropic/…``.
+    """
+    from omnigent.llms.routing import parse_model_string
+
+    out = _route_bare_model_for_compaction(LLMConfig(model="claude-haiku-4-5-20251001"))
+    assert out.model == "anthropic/claude-haiku-4-5-20251001"
+    # And the generic client now routes it to Anthropic rather than OpenAI.
+    assert parse_model_string(out.model).provider == "anthropic"
+
+
+def test_route_bare_model_preserves_databricks_and_prefixed_ids() -> None:
+    """databricks-* still gets the databricks/ prefix; already-routed ids pass through."""
+    assert (
+        _route_bare_model_for_compaction(LLMConfig(model="databricks-claude-sonnet-4")).model
+        == "databricks/databricks-claude-sonnet-4"
+    )
+    # Already provider-prefixed — left untouched (no double prefixing).
+    for prefixed in ("anthropic/claude-haiku-4-5-20251001", "openai/gpt-4o", "databricks/foo"):
+        assert _route_bare_model_for_compaction(LLMConfig(model=prefixed)).model == prefixed
+    # Bare gpt-* is correctly OpenAI already — unchanged.
+    assert _route_bare_model_for_compaction(LLMConfig(model="gpt-4o")).model == "gpt-4o"


### PR DESCRIPTION
## Related issue

Closes #1950

## Summary

Explicit `/compact` on a `claude-sdk` agent that pins a bare Anthropic model (e.g. `claude-haiku-4-5-20251001`) returned a 500 from the summarization endpoint.

- Compaction's Layer‑2 summarizer runs through the **generic** runtime LLM client, whose `parse_model_string` (`omnigent/llms/routing.py`) defaults any prefix‑less model id to **OpenAI**. So a bare `claude-*` id was sent to `api.openai.com`, which rejects it (`model_not_found`). The summarizer raises, and because explicit `/compact` passes `fail_on_summary_error=True`, `_run_compact_locked` wraps it as `INTERNAL_ERROR` → HTTP 500.
- `_route_databricks_model_for_compaction` already normalized bare `databricks-*` ids for exactly this reason. This generalizes it to `_route_bare_model_for_compaction`, which **also** prefixes a bare `claude-*` id with `anthropic/`. Already provider‑prefixed ids (`anthropic/…`, `openai/…`) and bare `gpt-*` (correctly OpenAI) are left untouched.

Normal `claude-sdk` turns were unaffected because they route through the harness; only the compaction summarizer used the generic client, so `/compact` was the sole broken path.

## Test Plan

- New regression tests in `tests/runtime/test_compaction.py`:
  `test_route_bare_model_prefixes_anthropic_claude` and
  `test_route_bare_model_preserves_databricks_and_prefixed_ids`.
  `uv run pytest tests/runtime/test_compaction.py` → **29 passed**.
- Reproduced end‑to‑end against the real `compact_conversation_now` path with the
  reporter's exact agent (harness `claude-sdk`, `executor.model` pinned, no `llm`
  block), a real SQLite conversation store seeded with a multi‑turn conversation,
  faking **only** the LLM network boundary provider‑accurately (OpenAI 404s the
  foreign model id; Anthropic accepts it). Same script, before/after the fix:

  ```
  BEFORE (unmodified main):
    summarizer dispatched to provider = 'openai'
    /compact RAISED: RuntimeError: 404 … model 'claude-haiku-4-5-20251001' does not exist  → HTTP 500
  AFTER (this PR):
    summarizer dispatched to provider = 'anthropic'
    /compact SUCCEEDED — summary produced
  ```

## Demo

N/A — backend routing fix (no UI surface). See the before/after trace above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests assert the routing normalization (bare `claude-*` → `anthropic/`; `databricks-*`, already‑prefixed, and bare `gpt-*` unchanged). Manually reproduced the 500 on unmodified main and confirmed `/compact` succeeds after the fix by driving the real compaction entry point with the reporter's exact config.

Scope note: routing is the root cause and is sufficient for the common configured‑auth case — `_resolve_summarize_connection` already resolves a spec/global `ApiKeyAuth`. Summarizing when the only credential is an ambient `ANTHROPIC_API_KEY`, or an OAuth/subscription login, remain separate follow‑ups.

## Changelog

`/compact` on a `claude-sdk` agent with a pinned Anthropic model no longer 500s — the compaction summarizer was routing bare `claude-*` ids to OpenAI instead of Anthropic.

This pull request and its description were written by Isaac.
