### PR TITLE
fix(harness): keep human approval waits alive

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -122,6 +122,14 @@ _TURN_CONTEXT_DESYNC_CODE = "runner_turn_context_desync"
 # Env var name kept for the ops knob; ``<= 0`` disables.
 _TURN_IDLE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_TIMEOUT_S", "600"))
 
+# Human approval / elicitation waits are real progress blockers, not wedged
+# model/tool silence. While a turn is explicitly parked on one of these waits,
+# use this longer ceiling for the idle watchdog. The deciding policy or
+# elicitation owner remains responsible for resolving/expiring the request.
+_TURN_AWAITING_HUMAN_TIMEOUT_S = float(
+    os.environ.get("HARNESS_TURN_AWAITING_HUMAN_TIMEOUT_S", "86400")
+)
+
 # Absolute per-turn ceiling: a hard cap on TOTAL turn duration, backstop
 # to the idle watchdog above. The idle watchdog never trips a turn that
 # keeps emitting, so a runaway-but-active loop (e.g. an infinite tool
@@ -461,6 +469,24 @@ class TurnContext:
             self._reset_idle_watchdog()
         self._event_queue.put_nowait(event)
 
+    def _idle_watchdog_delay(self) -> float:
+        """
+        Return the idle-watchdog window appropriate for this turn state.
+
+        Normal turns use :data:`_TURN_IDLE_TIMEOUT_S`; turns explicitly
+        awaiting a human approval/elicitation use the longer
+        :data:`_TURN_AWAITING_HUMAN_TIMEOUT_S` so an unanswered approval
+        prompt does not look like a wedged model/tool call.
+        """
+        if self._pending_elicitations or self._pending_policy_evaluations:
+            return _TURN_AWAITING_HUMAN_TIMEOUT_S
+        return _TURN_IDLE_TIMEOUT_S
+
+    def _refresh_idle_watchdog(self) -> None:
+        """Reschedule the idle watchdog for the current wait state."""
+        if self._reset_idle_watchdog is not None:
+            self._reset_idle_watchdog()
+
     async def dispatch_tool(self, call_id: str, name: str, arguments: str, agent: str) -> str:
         """
         Emit a server-dispatched tool call and park until the result.
@@ -551,6 +577,7 @@ class TurnContext:
         """
         future: asyncio.Future[ElicitationResult] = asyncio.get_running_loop().create_future()
         self._pending_elicitations[elicitation_id] = future
+        self._refresh_idle_watchdog()
         self.emit(
             ElicitationRequestEvent(
                 type="response.elicitation_request",
@@ -562,6 +589,7 @@ class TurnContext:
             return await future
         finally:
             self._pending_elicitations.pop(elicitation_id, None)
+            self._refresh_idle_watchdog()
 
     async def next_injection(self, timeout: float | None = None) -> CreateResponseRequest | None:
         """
@@ -648,6 +676,7 @@ class TurnContext:
         """
         future: asyncio.Future[PolicyVerdictPayload] = asyncio.get_running_loop().create_future()
         self._pending_policy_evaluations[evaluation_id] = future
+        self._refresh_idle_watchdog()
         self.emit(
             PolicyEvaluationRequestEvent(
                 type="policy_evaluation.requested",
@@ -681,6 +710,7 @@ class TurnContext:
             )
         finally:
             self._pending_policy_evaluations.pop(evaluation_id, None)
+            self._refresh_idle_watchdog()
 
     def _complete_policy_evaluation(
         self, evaluation_id: str, verdict: PolicyVerdictPayload
@@ -1504,7 +1534,11 @@ class HarnessApp:
                 # (the absolute ceiling is never rescheduled). Called from
                 # ``ctx.emit`` during ``run_turn`` (inside the active
                 # context), so the reschedule is always valid.
-                idle_wd.reschedule(loop.time() + idle_timeout)
+                delay = ctx._idle_watchdog_delay()
+                if delay > 0:
+                    idle_wd.reschedule(loop.time() + delay)
+                else:
+                    idle_wd.reschedule(None)
 
             ctx._reset_idle_watchdog = _reset
         try:
@@ -1514,6 +1548,12 @@ class HarnessApp:
                 await self.run_turn(request, ctx)
         except TimeoutError as exc:
             if idle_wd.expired():
+                if ctx._pending_elicitations or ctx._pending_policy_evaluations:
+                    raise RuntimeError(
+                        "turn exceeded the "
+                        f"{_TURN_AWAITING_HUMAN_TIMEOUT_S:.0f}s awaiting-human watchdog "
+                        "(pending human approval/elicitation did not resolve)"
+                    ) from exc
                 _logger.warning(
                     "run_turn for %s made no progress for %.0fs (idle turn watchdog); "
                     "marking the turn failed",

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -122,20 +122,19 @@ _TURN_CONTEXT_DESYNC_CODE = "runner_turn_context_desync"
 # Env var name kept for the ops knob; ``<= 0`` disables.
 _TURN_IDLE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_TIMEOUT_S", "600"))
 
-# Human approval / elicitation waits are real progress blockers, not wedged
-# model/tool silence. While a turn is explicitly parked on one of these waits,
-# use this longer ceiling for the idle watchdog. The deciding policy or
-# elicitation owner remains responsible for resolving/expiring the request.
-_TURN_AWAITING_HUMAN_TIMEOUT_S = float(
-    os.environ.get("HARNESS_TURN_AWAITING_HUMAN_TIMEOUT_S", "86400")
-)
-
 # Absolute per-turn ceiling: a hard cap on TOTAL turn duration, backstop
 # to the idle watchdog above. The idle watchdog never trips a turn that
 # keeps emitting, so a runaway-but-active loop (e.g. an infinite tool
 # loop emitting steadily) needs this. Generous so it never clips a real
 # long turn. ``<= 0`` disables. Whichever of (idle, absolute) trips first.
 _TURN_ABSOLUTE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "3600"))
+
+# Human approval / elicitation waits are real progress blockers, not wedged
+# model/tool silence. While explicitly parked, extend the idle watchdog to the
+# absolute ceiling by default; the absolute watchdog remains the hard total cap.
+_TURN_AWAITING_HUMAN_TIMEOUT_S = float(
+    os.environ.get("HARNESS_TURN_AWAITING_HUMAN_TIMEOUT_S", str(_TURN_ABSOLUTE_TIMEOUT_S))
+)
 
 
 @dataclass(frozen=True)
@@ -1530,7 +1529,7 @@ class HarnessApp:
             loop = asyncio.get_running_loop()
 
             def _reset() -> None:
-                # Push ONLY the idle deadline ``idle_timeout`` s past now
+                # Push ONLY the idle deadline for the current turn state past now
                 # (the absolute ceiling is never rescheduled). Called from
                 # ``ctx.emit`` during ``run_turn`` (inside the active
                 # context), so the reschedule is always valid.

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -320,6 +320,15 @@ def use_elicitation(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
+def use_elicitation_short_watchdog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Spawn the elicitation harness with a 2s idle watchdog."""
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "elicitation")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "2")
+    monkeypatch.setenv("HARNESS_TURN_AWAITING_HUMAN_TIMEOUT_S", "10")
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "10")
+
+
+@pytest.fixture
 def use_cancellable(monkeypatch: pytest.MonkeyPatch) -> None:
     """Spawn the cancellable fixture harness for this test."""
     monkeypatch.setenv("HARNESS_TEST_FIXTURE", "cancellable")
@@ -1316,6 +1325,59 @@ async def test_session_approval_event_resolves_elicitation(
         text_deltas = [e for e in events if e.event == "response.output_text.delta"]
         assert len(text_deltas) == 1
         assert text_deltas[0].data["delta"] == "action:accept"
+    finally:
+        await side_client.aclose()
+
+
+async def test_pending_elicitation_outlives_idle_watchdog(
+    use_elicitation_short_watchdog: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    A turn parked on human approval must not trip the normal idle watchdog.
+
+    The harness emits ``response.elicitation_request`` and then waits on the
+    approval Future. The test intentionally leaves that Future pending longer
+    than ``HARNESS_TURN_TIMEOUT_S`` (2s) before resolving it. A regression
+    ends the stream with ``response.failed`` before the approval can land.
+    """
+    conv_id = "conv_session_elicit_idle_watchdog"
+    stream_client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    side_client = _make_side_client(str(manager.socket_path(conv_id)))
+    events: list[_ParsedSSEEvent] = []
+    start_body = {
+        "type": "message",
+        "role": "user",
+        "model": "test-agent",
+        "content": [],
+    }
+    try:
+        async with asyncio.timeout(20):
+            async with stream_client.stream(
+                "POST",
+                f"/v1/sessions/{conv_id}/events",
+                json=start_body,
+            ) as response:
+                replied = False
+                async for event in _stream_iter(response):
+                    events.append(event)
+                    if not replied and event.event == "response.elicitation_request":
+                        await asyncio.sleep(2.5)
+                        reply = await side_client.post(
+                            f"/v1/sessions/{conv_id}/events",
+                            json={
+                                "type": "approval",
+                                "elicitation_id": "elicit_test_1",
+                                "action": "accept",
+                            },
+                        )
+                        assert reply.status_code == 204
+                        replied = True
+        event_types = [event.event for event in events]
+        assert event_types[-1] == "response.completed", event_types
+        assert "response.failed" not in event_types
+        text_deltas = [e for e in events if e.event == "response.output_text.delta"]
+        assert text_deltas[-1].data["delta"] == "action:accept"
     finally:
         await side_client.aclose()
 


### PR DESCRIPTION
## Related issue

Closes #4854

## Summary

A turn waiting for an elicitation reply or policy verdict emits only heartbeats, so the normal idle watchdog can mistake a legitimate human wait for a wedged turn. This change reschedules the idle watchdog while either request is pending, then restores the normal idle window when the wait ends.

The awaiting-human window defaults to the existing absolute per-turn ceiling: 3600 seconds total by default. `HARNESS_TURN_AWAITING_HUMAN_TIMEOUT_S` can set a shorter operational limit, but it cannot extend a turn beyond `HARNESS_TURN_ABSOLUTE_TIMEOUT_S`. The absolute safety cap is unchanged.

ELI5: ordinary silence still fails after 10 minutes; a visible approval prompt gets the remainder of the one-hour total turn budget.

```text
normal turn --600s idle--> failed as wedged
     |
     +-- approval pending --> awaiting-human idle window
                              |
                              +-- reply --> normal idle window
                              +-- absolute turn ceiling --> failed
```

## Test Plan

- `uv run --group test pytest tests/runtime/harnesses/test_scaffold.py -q` — 32 passed.
- `uv run --group lint ruff check omnigent/runtime/harnesses/_scaffold.py tests/runtime/harnesses/test_scaffold.py` — passed.
- `uv run --group lint ruff format --check omnigent/runtime/harnesses/_scaffold.py tests/runtime/harnesses/test_scaffold.py` — passed.
- `uv run --no-sync pre-commit run --files omnigent/runtime/harnesses/_scaffold.py tests/runtime/harnesses/test_scaffold.py` after syncing lint/test/all dependencies — passed.
- `git diff upstream/main...HEAD --check` — passed.

## Demo

N/A — no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new scaffold test leaves an elicitation pending for 2.5 seconds against a 2-second normal idle window, then approves it and verifies the turn completes. Existing tests continue to cover true idle and absolute-timeout failures.

## Changelog

Approval prompts no longer fail when they outlive the normal harness idle window.