### PR TITLE
feat(web): add UI font family setting to Appearance

### DIFF
--- a/tests/e2e_ui/sessions/test_ui_font_family.py
+++ b/tests/e2e_ui/sessions/test_ui_font_family.py
@@ -1,0 +1,99 @@
+"""E2E: the Settings → Appearance font-family field re-fonts the UI and persists.
+
+The font-family control lives on the Settings page (``pages/SettingsPage.tsx``,
+``UiFontFamilyControl``): a free-text input (Cursor-style) plus a ``Reset``
+button under a ``role="group"`` labelled "Font family". Typing a name writes the
+choice to ``localStorage["omnigent:ui-font-family"]`` and applies it as the
+``--ui-font-family`` custom property on ``<html>`` (see
+``lib/uiFontPreferences.ts``). A blank field is "System default": the property is
+removed and the ``html`` rule falls back to ``var(--font-sans)``.
+
+Because the whole rem-based UI inherits its font from the root ``html`` rule
+(``font-family: var(--ui-font-family, var(--font-sans))``), setting that one
+variable re-fonts the entire chrome. The value is applied before first paint in
+``main.tsx`` so a reload doesn't flash the default first.
+
+No LLM turn is involved.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+STORAGE_KEY = "omnigent:ui-font-family"
+
+
+def _ui_font_family(page: Page) -> str:
+    """The ``--ui-font-family`` custom property applied to ``<html>``."""
+    return page.evaluate(
+        "() => getComputedStyle(document.documentElement)"
+        ".getPropertyValue('--ui-font-family').trim()"
+    )
+
+
+def _stored_family(page: Page) -> str | None:
+    """The persisted font-family preference, or None when unset (default)."""
+    return page.evaluate(f"() => window.localStorage.getItem('{STORAGE_KEY}')")
+
+
+def _open_appearance(page: Page, base_url: str) -> None:
+    """Navigate to the Settings Appearance section and wait for the control."""
+    page.goto(f"{base_url}/settings/appearance")
+    expect(page.get_by_role("group", name="Font family")).to_be_visible(timeout=30_000)
+
+
+def test_ui_font_family_applies_and_persists(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """Typing a family updates the applied property + value live and survives reload.
+
+    A fresh context has no stored preference → empty field, no ``--ui-font-family``
+    override (the UI uses the system stack). Typing a name applies the property and
+    persists the choice; a page reload restores it (no reset, no flash to default).
+    """
+    base_url, _session_id = seeded_session
+    _open_appearance(page, base_url)
+
+    value = page.get_by_test_id("ui-font-family-input")
+
+    # Fresh context → empty field, nothing stored, no override applied.
+    expect(value).to_have_value("")
+    assert _stored_family(page) is None, "expected no persisted family on a fresh load"
+    assert _ui_font_family(page) == "", "fresh load should apply no family override"
+
+    # → "Georgia": the field, the applied property, and storage all move together.
+    value.fill("Georgia")
+    expect(value).to_have_value("Georgia")
+    assert _stored_family(page) == '"Georgia"', "the typed family was not persisted"
+    assert _ui_font_family(page) == "Georgia", "root family did not track the typed name"
+
+    # The choice survives a full reload (persisted + re-applied before paint).
+    page.reload()
+    expect(page.get_by_role("group", name="Font family")).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id("ui-font-family-input")).to_have_value("Georgia")
+    assert _ui_font_family(page) == "Georgia", "family was not restored after reload"
+
+
+def test_ui_font_family_reset_restores_system_default(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """The Reset button clears the override and returns to the system default."""
+    base_url, _session_id = seeded_session
+
+    # Seed a family before the app boots so the override is applied on load.
+    page.goto(base_url)
+    page.evaluate(f"() => window.localStorage.setItem('{STORAGE_KEY}', '\"Georgia\"')")
+    _open_appearance(page, base_url)
+
+    value = page.get_by_test_id("ui-font-family-input")
+    reset = page.get_by_test_id("ui-font-family-reset")
+
+    # The seeded family renders and is applied to the root.
+    expect(value).to_have_value("Georgia")
+    assert _ui_font_family(page) == "Georgia"
+
+    # → Reset: the field clears, the override is removed, and the key is cleared.
+    reset.click()
+    expect(value).to_have_value("")
+    assert _ui_font_family(page) == "", "the family override was not removed on reset"
+    assert _stored_family(page) is None, "reset did not clear the persisted family"

--- a/tests/e2e_ui/sessions/test_ui_font_family.py
+++ b/tests/e2e_ui/sessions/test_ui_font_family.py
@@ -42,9 +42,7 @@ def _open_appearance(page: Page, base_url: str) -> None:
     expect(page.get_by_role("group", name="Font family")).to_be_visible(timeout=30_000)
 
 
-def test_ui_font_family_applies_and_persists(
-    page: Page, seeded_session: tuple[str, str]
-) -> None:
+def test_ui_font_family_applies_and_persists(page: Page, seeded_session: tuple[str, str]) -> None:
     """Typing a family updates the applied property + value live and survives reload.
 
     A fresh context has no stored preference → empty field, no ``--ui-font-family``

--- a/tests/e2e_ui/sessions/test_ui_font_family.py
+++ b/tests/e2e_ui/sessions/test_ui_font_family.py
@@ -60,16 +60,19 @@ def test_ui_font_family_applies_and_persists(page: Page, seeded_session: tuple[s
     assert _ui_font_family(page) == "", "fresh load should apply no family override"
 
     # → "Georgia": the field, the applied property, and storage all move together.
+    # The applied value leads with the chosen family and appends the system stack
+    # (so an uninstalled/partial name degrades to the default sans, not serif), so
+    # the resolved custom property starts with — rather than equals — "Georgia".
     value.fill("Georgia")
     expect(value).to_have_value("Georgia")
     assert _stored_family(page) == '"Georgia"', "the typed family was not persisted"
-    assert _ui_font_family(page) == "Georgia", "root family did not track the typed name"
+    assert _ui_font_family(page).startswith("Georgia"), "root family did not track the typed name"
 
     # The choice survives a full reload (persisted + re-applied before paint).
     page.reload()
     expect(page.get_by_role("group", name="Font family")).to_be_visible(timeout=30_000)
     expect(page.get_by_test_id("ui-font-family-input")).to_have_value("Georgia")
-    assert _ui_font_family(page) == "Georgia", "family was not restored after reload"
+    assert _ui_font_family(page).startswith("Georgia"), "family was not restored after reload"
 
 
 def test_ui_font_family_reset_restores_system_default(
@@ -86,9 +89,10 @@ def test_ui_font_family_reset_restores_system_default(
     value = page.get_by_test_id("ui-font-family-input")
     reset = page.get_by_test_id("ui-font-family-reset")
 
-    # The seeded family renders and is applied to the root.
+    # The seeded family renders and is applied to the root (leading the appended
+    # system-stack fallback, so the resolved value starts with "Georgia").
     expect(value).to_have_value("Georgia")
-    assert _ui_font_family(page) == "Georgia"
+    assert _ui_font_family(page).startswith("Georgia")
 
     # → Reset: the field clears, the override is removed, and the key is cleared.
     reset.click()

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -109,6 +109,11 @@
    * the whole rem-based UI scales. Overridden at runtime on documentElement. */
   --ui-font-scale: 1;
 
+  /* User-controlled UI font family (see Appearance settings /
+   * lib/uiFontPreferences.ts). Deliberately left unset here so the `html` rule's
+   * `var(--ui-font-family, var(--font-sans))` falls back to the system stack;
+   * the Appearance setting sets it at runtime on documentElement. */
+
   /* ---- Inset system -------------------------------------------------------
    * Single source of truth for how far content must stay clear of screen
    * chrome. The SAME bundle runs in a browser, in Electron, and inside the
@@ -722,7 +727,12 @@
     overflow: hidden;
   }
   html {
-    @apply font-sans;
+    /* Font family for the whole inherited UI. Can't `@apply font-sans`: Tailwind
+     * v4's `@theme inline` inlines the literal stack, so a runtime `--font-sans`
+     * override is a no-op. Read a dedicated `--ui-font-family` (set on
+     * documentElement by the Appearance setting / lib/uiFontPreferences.ts)
+     * with the system stack as the fallback when it's unset. */
+    font-family: var(--ui-font-family, var(--font-sans));
     /* Root size for the whole rem-based UI. `1em` resolves against the
      * browser default so a customized default is preserved; --ui-font-scale
      * layers the user's Appearance choice on top. */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -738,6 +738,15 @@
      * layers the user's Appearance choice on top. */
     font-size: calc(1em * var(--ui-font-scale));
   }
+  /* Code surfaces stay on the mono stack, immune to the UI --ui-font-family
+   * override above. The Appearance font-family setting is UI chrome only; the
+   * Monaco editor and xterm terminals are code fonts, owned by a separate
+   * (future) code-font setting. Monaco/xterm already pin their own font, so this
+   * is a guard against inheritance leaking in through any unpinned descendant. */
+  .monaco-editor,
+  .xterm {
+    font-family: var(--font-mono);
+  }
   /* Text selection — brand pink highlight. Light: gentle wash + dark pink
    * text. Dark: solid brand pink background + white text. */
   ::selection {

--- a/web/src/lib/uiFontPreferences.test.ts
+++ b/web/src/lib/uiFontPreferences.test.ts
@@ -1,18 +1,24 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  applyUiFontFamily,
   applyUiFontScale,
+  readUiFontFamily,
   readUiFontSizePx,
+  UI_FONT_FAMILY_DEFAULT,
   UI_FONT_SIZE_DEFAULT,
   UI_FONT_SIZE_MAX,
   UI_FONT_SIZE_MIN,
+  writeUiFontFamily,
   writeUiFontSizePx,
 } from "./uiFontPreferences";
 
 const STORAGE_KEY = "omnigent:ui-font-size";
+const FAMILY_STORAGE_KEY = "omnigent:ui-font-family";
 
 afterEach(() => {
   localStorage.clear();
   document.documentElement.style.removeProperty("--ui-font-scale");
+  document.documentElement.style.removeProperty("--ui-font-family");
 });
 
 describe("uiFontPreferences", () => {
@@ -63,5 +69,76 @@ describe("uiFontPreferences", () => {
     applyUiFontScale(99);
     // Clamped to the 20px max → 20 / 16 = 1.25.
     expect(document.documentElement.style.getPropertyValue("--ui-font-scale")).toBe("1.25");
+  });
+});
+
+describe("uiFontPreferences — family", () => {
+  it("returns the empty default when nothing is stored", () => {
+    expect(readUiFontFamily()).toBe(UI_FONT_FAMILY_DEFAULT);
+    expect(readUiFontFamily()).toBe("");
+  });
+
+  it("round-trips a valid family name", () => {
+    writeUiFontFamily("Inter");
+    expect(readUiFontFamily()).toBe("Inter");
+    expect(localStorage.getItem(FAMILY_STORAGE_KEY)).toBe(JSON.stringify("Inter"));
+  });
+
+  it("preserves spaces, commas and quotes in a font stack", () => {
+    // A multi-family stack must survive normalization intact (the guard only
+    // strips declaration-breaking chars, not the punctuation stacks rely on).
+    writeUiFontFamily('"Times New Roman", serif');
+    expect(readUiFontFamily()).toBe('"Times New Roman", serif');
+  });
+
+  it("trims surrounding whitespace", () => {
+    writeUiFontFamily("  Georgia  ");
+    expect(readUiFontFamily()).toBe("Georgia");
+  });
+
+  it("clears the preference when written empty or whitespace-only", () => {
+    writeUiFontFamily("Inter");
+    expect(localStorage.getItem(FAMILY_STORAGE_KEY)).not.toBeNull();
+    writeUiFontFamily("   ");
+    // Empty input removes the key rather than storing a blank string.
+    expect(localStorage.getItem(FAMILY_STORAGE_KEY)).toBeNull();
+    expect(readUiFontFamily()).toBe("");
+  });
+
+  it("strips characters that could break the CSS declaration", () => {
+    // `;{}` and control chars can't be allowed to escape the custom-property
+    // value; everything else about the name (here the leading font) is kept.
+    writeUiFontFamily("Arial;}body{");
+    expect(readUiFontFamily()).toBe("Arialbody");
+  });
+
+  it("falls back to the default on a value longer than the cap", () => {
+    writeUiFontFamily("x".repeat(200));
+    expect(readUiFontFamily()).toBe(UI_FONT_FAMILY_DEFAULT);
+    expect(localStorage.getItem(FAMILY_STORAGE_KEY)).toBeNull();
+  });
+
+  it("falls back to the default on malformed JSON", () => {
+    // Corrupt localStorage should not break app boot.
+    localStorage.setItem(FAMILY_STORAGE_KEY, "}{not json");
+    expect(readUiFontFamily()).toBe(UI_FONT_FAMILY_DEFAULT);
+  });
+
+  it("falls back to the default on a non-string value", () => {
+    localStorage.setItem(FAMILY_STORAGE_KEY, JSON.stringify(42));
+    expect(readUiFontFamily()).toBe(UI_FONT_FAMILY_DEFAULT);
+  });
+
+  it("applies the family as a custom property on the document root", () => {
+    applyUiFontFamily("Inter");
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("Inter");
+  });
+
+  it("removes the custom property when applied empty (System default)", () => {
+    applyUiFontFamily("Inter");
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("Inter");
+    applyUiFontFamily("");
+    // Removing the property lets the html rule fall back to var(--font-sans).
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("");
   });
 });

--- a/web/src/lib/uiFontPreferences.test.ts
+++ b/web/src/lib/uiFontPreferences.test.ts
@@ -129,14 +129,20 @@ describe("uiFontPreferences — family", () => {
     expect(readUiFontFamily()).toBe(UI_FONT_FAMILY_DEFAULT);
   });
 
-  it("applies the family as a custom property on the document root", () => {
+  it("applies the family with the system stack appended as a fallback", () => {
+    // The system stack is appended so an uninstalled/partial name degrades to
+    // the app's default sans, not the browser's default serif.
     applyUiFontFamily("Inter");
-    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("Inter");
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe(
+      "Inter, var(--font-sans)",
+    );
   });
 
   it("removes the custom property when applied empty (System default)", () => {
     applyUiFontFamily("Inter");
-    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("Inter");
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe(
+      "Inter, var(--font-sans)",
+    );
     applyUiFontFamily("");
     // Removing the property lets the html rule fall back to var(--font-sans).
     expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("");

--- a/web/src/lib/uiFontPreferences.ts
+++ b/web/src/lib/uiFontPreferences.ts
@@ -1,4 +1,4 @@
-// Persisted, app-global preference for the UI font size.
+// Persisted, app-global preferences for the UI font — size and family.
 //
 // The web UI is Tailwind v4, which sizes typography AND spacing in `rem`, so
 // scaling the root `<html>` font-size reflows the entire UI uniformly. Rather
@@ -8,6 +8,13 @@
 // multiply into. The base rule uses `calc(1em * var(--ui-font-scale))`, so the
 // user's browser-default size is preserved and the displayed px maps 1:1 for
 // the default-16px case.
+//
+// Font family works the analogous way with `--ui-font-family`. Note it can't
+// reuse `--font-sans`: Tailwind v4's `@theme inline` block inlines the literal
+// stack into the `font-sans` utility instead of a `var()` reference, so setting
+// `--font-sans` at runtime is a no-op. The `html` rule reads
+// `var(--ui-font-family, var(--font-sans))`, so an unset family falls back to
+// the system stack and any value we set on documentElement wins.
 
 const STORAGE_KEY = "omnigent:ui-font-size";
 
@@ -72,4 +79,86 @@ export function applyUiFontScale(px: number): void {
   if (typeof document === "undefined") return;
   const scale = clampUiFontSizePx(px) / BASE_FONT_SIZE_PX;
   document.documentElement.style.setProperty("--ui-font-scale", String(scale));
+}
+
+// ---- Font family ---------------------------------------------------------
+
+const FONT_FAMILY_STORAGE_KEY = "omnigent:ui-font-family";
+
+/** Empty string = "System default": no override, falls back to `--font-sans`. */
+export const UI_FONT_FAMILY_DEFAULT = "";
+
+/** Longest family name we'll accept — a guard against a corrupt/oversized entry. */
+const UI_FONT_FAMILY_MAX_LENGTH = 100;
+
+/**
+ * Normalize a raw family name into a value safe to persist and to set as a CSS
+ * custom property: trimmed, with characters that could terminate the
+ * declaration or open a new one (`;{}` and control chars) stripped. Over-long
+ * input collapses to the default. Returns "" for anything that isn't a usable
+ * family, so callers treat empty as "System default".
+ */
+function normalizeUiFontFamily(value: unknown): string {
+  if (typeof value !== "string") return UI_FONT_FAMILY_DEFAULT;
+  // eslint-disable-next-line no-control-regex -- intentionally stripping control chars
+  const cleaned = value.replace(/[;{}\x00-\x1f\x7f]/g, "").trim();
+  if (!cleaned || cleaned.length > UI_FONT_FAMILY_MAX_LENGTH) {
+    return UI_FONT_FAMILY_DEFAULT;
+  }
+  return cleaned;
+}
+
+/**
+ * Read the persisted UI font family.
+ *
+ * Returns "" (System default) when nothing is stored, on a server render (no
+ * `window`), or when the stored value is missing/malformed — never throws, so a
+ * corrupt entry can't break app boot.
+ */
+export function readUiFontFamily(): string {
+  if (typeof window === "undefined") return UI_FONT_FAMILY_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(FONT_FAMILY_STORAGE_KEY);
+    if (!raw) return UI_FONT_FAMILY_DEFAULT;
+    const parsed: unknown = JSON.parse(raw);
+    return normalizeUiFontFamily(parsed);
+  } catch {
+    return UI_FONT_FAMILY_DEFAULT;
+  }
+}
+
+/**
+ * Persist the UI font family. An empty (or all-stripped) name clears the
+ * preference — reverting to System default — rather than storing a blank. Swallows
+ * quota/access errors so a failed write can't break the app.
+ */
+export function writeUiFontFamily(name: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const normalized = normalizeUiFontFamily(name);
+    if (!normalized) {
+      window.localStorage.removeItem(FONT_FAMILY_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(FONT_FAMILY_STORAGE_KEY, JSON.stringify(normalized));
+  } catch {
+    // localStorage quota or access errors shouldn't break the app.
+  }
+}
+
+/**
+ * Apply the given family to the DOM by setting the `--ui-font-family` variable
+ * on the document root; the `html` rule in index.css reads it with a
+ * `var(--ui-font-family, var(--font-sans))` fallback, so the whole inherited UI
+ * re-fonts. An empty name removes the property, restoring the system stack. This
+ * is the single source of the DOM side-effect.
+ */
+export function applyUiFontFamily(name: string): void {
+  if (typeof document === "undefined") return;
+  const normalized = normalizeUiFontFamily(name);
+  if (!normalized) {
+    document.documentElement.style.removeProperty("--ui-font-family");
+    return;
+  }
+  document.documentElement.style.setProperty("--ui-font-family", normalized);
 }

--- a/web/src/lib/uiFontPreferences.ts
+++ b/web/src/lib/uiFontPreferences.ts
@@ -148,10 +148,16 @@ export function writeUiFontFamily(name: string): void {
 
 /**
  * Apply the given family to the DOM by setting the `--ui-font-family` variable
- * on the document root; the `html` rule in index.css reads it with a
- * `var(--ui-font-family, var(--font-sans))` fallback, so the whole inherited UI
- * re-fonts. An empty name removes the property, restoring the system stack. This
- * is the single source of the DOM side-effect.
+ * on the document root; the `html` rule in index.css reads it as the whole UI's
+ * font. An empty name removes the property, restoring the system stack.
+ *
+ * The chosen family is applied WITH the system stack appended
+ * (`<name>, var(--font-sans)`) so a name that isn't installed — or a partial one
+ * typed so far — degrades to the app's default sans rather than the browser's
+ * default serif. (The `var(--ui-font-family, …)` fallback in the CSS only fires
+ * when the property is unset, not when it holds an unusable name, so the
+ * fallback has to live inside the value too.) This is the single source of the
+ * DOM side-effect.
  */
 export function applyUiFontFamily(name: string): void {
   if (typeof document === "undefined") return;
@@ -160,5 +166,5 @@ export function applyUiFontFamily(name: string): void {
     document.documentElement.style.removeProperty("--ui-font-family");
     return;
   }
-  document.documentElement.style.setProperty("--ui-font-family", normalized);
+  document.documentElement.style.setProperty("--ui-font-family", `${normalized}, var(--font-sans)`);
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -14,7 +14,12 @@ import { CapabilitiesProvider } from "./lib/CapabilitiesContext";
 import { resolveIdentity } from "./lib/identity";
 import { initNativeInsets } from "./lib/nativeInsets";
 import { initBrowserTelemetry } from "./lib/telemetry";
-import { applyUiFontScale, readUiFontSizePx } from "./lib/uiFontPreferences";
+import {
+  applyUiFontFamily,
+  applyUiFontScale,
+  readUiFontFamily,
+  readUiFontSizePx,
+} from "./lib/uiFontPreferences";
 import { initChatStore } from "./store/chatStore";
 import "./index.css";
 
@@ -49,8 +54,9 @@ void resolveIdentity();
 // No-op off the iOS shell (the inset vars stay at their env()-only defaults).
 initNativeInsets();
 
-// Apply the saved UI font size before first paint so there's no size flash.
+// Apply the saved UI font size and family before first paint so there's no flash.
 applyUiFontScale(readUiFontSizePx());
+applyUiFontFamily(readUiFontFamily());
 
 // Probe /v1/info BEFORE the first render so the route table knows
 // whether to mount accounts routes. The probe is unauthed and the

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -137,6 +137,41 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("ui-font-size-inc")).not.toBeDisabled();
   });
 
+  it("shows the empty font family default and applies + persists a typed name", () => {
+    localStorage.clear();
+    document.documentElement.style.removeProperty("--ui-font-family");
+    renderPage("/settings/appearance");
+    const input = screen.getByTestId("ui-font-family-input") as HTMLInputElement;
+    // No stored preference → empty input, System-default placeholder, no override.
+    expect(input.value).toBe("");
+    expect(input.placeholder).toBe("System default");
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("");
+    // Reset has nothing to do at the default.
+    expect(screen.getByTestId("ui-font-family-reset")).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "Inter" } });
+    expect(input.value).toBe("Inter");
+    // The choice is persisted so it survives a refresh...
+    expect(localStorage.getItem("omnigent:ui-font-family")).toBe(JSON.stringify("Inter"));
+    // ...and applied live to the document root.
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("Inter");
+    expect(screen.getByTestId("ui-font-family-reset")).not.toBeDisabled();
+  });
+
+  it("reset restores the system default font family", () => {
+    localStorage.setItem("omnigent:ui-font-family", JSON.stringify("Georgia"));
+    renderPage("/settings/appearance");
+    const input = screen.getByTestId("ui-font-family-input") as HTMLInputElement;
+    // The control reflects the stored preference on mount.
+    expect(input.value).toBe("Georgia");
+
+    fireEvent.click(screen.getByTestId("ui-font-family-reset"));
+    // Reset clears the field, the applied property, and the stored key.
+    expect(input.value).toBe("");
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("");
+    expect(localStorage.getItem("omnigent:ui-font-family")).toBeNull();
+  });
+
   it("defaults bare /settings to Account when a login session exists, else Appearance", async () => {
     // Login session (accounts OR OIDC) → Account leads, so /settings lands on it.
     renderPage("/settings");

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -153,8 +153,11 @@ describe("SettingsPage", () => {
     expect(input.value).toBe("Inter");
     // The choice is persisted so it survives a refresh...
     expect(localStorage.getItem("omnigent:ui-font-family")).toBe(JSON.stringify("Inter"));
-    // ...and applied live to the document root.
-    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe("Inter");
+    // ...and applied live to the document root, with the system stack appended
+    // so an uninstalled/partial name degrades to the default sans, not serif.
+    expect(document.documentElement.style.getPropertyValue("--ui-font-family")).toBe(
+      "Inter, var(--font-sans)",
+    );
     expect(screen.getByTestId("ui-font-family-reset")).not.toBeDisabled();
   });
 

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -60,12 +60,16 @@ import { absoluteTime } from "@/lib/relativeTime";
 import { useSettingsRoute } from "@/shell/settingsNav";
 import { type ThemeMode, normalizeThemeMode } from "@/components/theme/themeMode";
 import {
+  applyUiFontFamily,
   applyUiFontScale,
   clampUiFontSizePx,
+  readUiFontFamily,
   readUiFontSizePx,
+  UI_FONT_FAMILY_DEFAULT,
   UI_FONT_SIZE_MAX,
   UI_FONT_SIZE_MIN,
   UI_FONT_SIZE_STEP,
+  writeUiFontFamily,
   writeUiFontSizePx,
 } from "@/lib/uiFontPreferences";
 import { useIsEmbedded } from "@/lib/embedded";
@@ -192,6 +196,8 @@ function AppearanceSection() {
         </div>
 
         <UiFontSizeControl />
+
+        <UiFontFamilyControl />
       </div>
     </Section>
   );
@@ -267,6 +273,63 @@ function UiFontSizeControl() {
         >
           <PlusIcon className="size-4" />
         </StepperButton>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * UI font family picker. Free-text (Cursor-style): type any font installed on
+ * this device; blank means "System default", which falls back to the existing
+ * --font-sans stack. Applies live and persists on every change via the
+ * --ui-font-family variable (see lib/uiFontPreferences.ts). Like the size
+ * control it stays visible when embedded — a per-device readability pref that
+ * doesn't conflict with host theming.
+ */
+function UiFontFamilyControl() {
+  const [family, setFamily] = useState(() => readUiFontFamily());
+
+  const update = useCallback((next: string) => {
+    setFamily(next);
+    writeUiFontFamily(next);
+    applyUiFontFamily(next);
+  }, []);
+
+  const isDefault = family.trim() === UI_FONT_FAMILY_DEFAULT;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+      <div className="flex flex-col">
+        <span className="text-sm font-medium">Font family</span>
+        <span className="text-sm text-muted-foreground">
+          Use any font installed on this device. Leave blank for the system default.
+        </span>
+      </div>
+      <div role="group" aria-label="Font family" className="flex items-center gap-2">
+        <Input
+          type="text"
+          aria-label="UI font family"
+          data-testid="ui-font-family-input"
+          placeholder="System default"
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          className="h-9 w-56"
+          value={family}
+          onChange={(e) => update(e.target.value)}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-testid="ui-font-family-reset"
+          // Nothing to reset at the default; hidden keeps the row tidy.
+          disabled={isDefault}
+          className={cn("h-9", isDefault && "invisible")}
+          onClick={() => update(UI_FONT_FAMILY_DEFAULT)}
+        >
+          Reset
+        </Button>
       </div>
     </div>
   );

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -299,13 +299,16 @@ function UiFontFamilyControl() {
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
-      <div className="flex flex-col">
+      {/* Take the remaining width (and let the longer description wrap within
+          this column) so the input stays inline instead of dropping to its own
+          row — matches the font-size row's alignment. */}
+      <div className="flex min-w-0 flex-1 flex-col">
         <span className="text-sm font-medium">Font family</span>
         <span className="text-sm text-muted-foreground">
           Use any font installed on this device. Leave blank for the system default.
         </span>
       </div>
-      <div role="group" aria-label="Font family" className="flex items-center gap-2">
+      <div role="group" aria-label="Font family" className="flex shrink-0 items-center gap-2">
         <Input
           type="text"
           aria-label="UI font family"

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -308,7 +308,21 @@ function UiFontFamilyControl() {
           Use any font installed on this device. Leave blank for the system default.
         </span>
       </div>
+      {/* Reset sits left of the input so the input is the rightmost element and
+          its right edge lines up flush with the font-size stepper above.
+          `invisible` (not removed) at the default keeps the row from shifting. */}
       <div role="group" aria-label="Font family" className="flex shrink-0 items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-testid="ui-font-family-reset"
+          disabled={isDefault}
+          className={cn("h-9", isDefault && "invisible")}
+          onClick={() => update(UI_FONT_FAMILY_DEFAULT)}
+        >
+          Reset
+        </Button>
         <Input
           type="text"
           aria-label="UI font family"
@@ -321,18 +335,6 @@ function UiFontFamilyControl() {
           value={family}
           onChange={(e) => update(e.target.value)}
         />
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          data-testid="ui-font-family-reset"
-          // Nothing to reset at the default; hidden keeps the row tidy.
-          disabled={isDefault}
-          className={cn("h-9", isDefault && "invisible")}
-          onClick={() => update(UI_FONT_FAMILY_DEFAULT)}
-        >
-          Reset
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Related issue

N/A — follow-up to #2040 (UI font size setting).

## Summary

- Adds a **UI font family** control to Settings → Appearance, right beside the
  font-size stepper. It's a free-text field (Cursor-style): type any font
  installed on the device; leave it blank for the system default.
- The choice re-fonts the whole UI chrome, is persisted per-device in
  `localStorage`, and is applied before first paint so a reload doesn't flash
  the default.
- Mirrors the just-merged font-size setting (#2040): same preference module
  (`lib/uiFontPreferences.ts`), same before-paint apply in `main.tsx`, same
  `AppearanceSection` row layout. The theme picker and font-size stepper are
  unchanged.

**Why a new CSS variable (the gotcha):** it can't reuse `--font-sans`.
Tailwind v4's `@theme inline` block inlines the literal stack into the
`font-sans` utility rather than a `var()` reference (verified in the compiled
CSS: `.font-sans{font-family:ui-sans-serif,system-ui,…}`), so a runtime
`--font-sans` override is a no-op. Instead the `html` rule reads
`font-family: var(--ui-font-family, var(--font-sans))`, and the preference
module sets `--ui-font-family` on `documentElement`. Unset → falls back to the
existing system stack (default unchanged); set → wins and the whole inherited
UI re-fonts.

Known minor limitation: the two `.font-heading` elements (dialog/card titles)
compile to `font-family: var(--font-sans)`, so they keep the system stack
rather than the custom family. Acceptable for this UI-chrome-only change; code
font (Monaco/xterm) is intentionally out of scope for a future PR.

## Test Plan

Run from `web/`:

- `npm run type-check` — clean.
- `npm exec -- vitest run src/lib/uiFontPreferences.test.ts src/pages/SettingsPage.test.tsx` — 34 passed.
- `npm run build` — succeeds; compiled CSS confirms the new rule:
  `html{font-family:var(--ui-font-family,var(--font-sans));font-size:calc(1em * var(--ui-font-scale))}`.
- `npm exec -- prettier --check` + `npm exec -- oxlint` on changed files — clean
  (only a pre-existing, unrelated `_bootProbe` warning in `main.tsx`).
- **Live smoke (headless Chromium against `npm run dev`):** on
  `/settings/appearance`, the field starts empty with no `--ui-font-family`
  override; typing `Georgia` sets the property, persists `"Georgia"`, and flips
  the computed `document.body` font-family from the system stack to `Georgia`
  (whole-UI re-font by inheritance); a reload restores it before paint; **Reset**
  removes the override and the stored key, returning to the system stack.

## Demo

Screenshot — the whole chrome re-fonted to a serif (Georgia) with the field +
Reset visible:

<!-- TODO(human): drag-and-drop the screen recording / screenshot here. A PNG
     was captured locally at the "Georgia applied" state; please attach a short
     screen recording showing the live re-font + reset for the changelog. -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

- **Unit** (`web/src/lib/uiFontPreferences.test.ts`): default is empty
  (System default), round-trips a name, preserves stacks like
  `"Times New Roman", serif`, trims whitespace, clears the key on empty input,
  strips declaration-breaking `;{}`/control chars, caps over-long input, and
  falls back on malformed/non-string JSON; `applyUiFontFamily` sets and removes
  the `--ui-font-family` property.
- **Component** (`web/src/pages/SettingsPage.test.tsx`): default empty field +
  "System default" placeholder + disabled Reset; typing a name persists +
  applies live; Reset clears the field, property, and stored key.
- **E2E** (`tests/e2e_ui/sessions/test_ui_font_family.py`, modeled on
  `test_ui_font_size.py`): change updates the applied `--ui-font-family` on
  `<html>` and persists across a reload; Reset restores the default. The Python
  e2e suite (Playwright + live server) wasn't run in this environment; selectors
  and assertions were verified against the component markup via the live
  headless smoke test described in the Test Plan.

## Changelog

Set a custom UI font family in Settings → Appearance (type any installed font; blank = system default).
