### PR TITLE
fix(web): allow free editing of the UI font size input

### DIFF
--- a/tests/e2e_ui/sessions/test_ui_font_size.py
+++ b/tests/e2e_ui/sessions/test_ui_font_size.py
@@ -102,3 +102,44 @@ def test_ui_font_size_steppers_clamp_at_bounds(
     expect(value).to_have_value("12")
     expect(decrease).to_be_disabled()
     expect(increase).to_be_enabled()
+
+
+def test_ui_font_size_input_allows_free_editing(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """Typing in the box doesn't clamp mid-edit; blur settles the final value.
+
+    Regression guard: the box binds to a free-form draft, so backspacing "13"
+    down to "1" (below the 12px min) must SHOW "1" without snapping to 12 or
+    persisting the transient value. Retyping a valid size applies it live, and
+    blurring a still-out-of-range draft clamps to the minimum.
+    """
+    base_url, _session_id = seeded_session
+
+    # Seed a two-digit size so deleting a digit lands on a below-min "1".
+    page.goto(base_url)
+    page.evaluate(f"() => window.localStorage.setItem('{STORAGE_KEY}', '13')")
+    _open_appearance(page, base_url)
+
+    value = page.get_by_test_id("ui-font-size-input")
+    expect(value).to_have_value("13")
+
+    # Backspace to "1": the box holds the partial value; nothing clamps or
+    # re-persists while the draft is out of range.
+    value.click()
+    value.press("End")
+    value.press("Backspace")
+    expect(value).to_have_value("1")
+    assert _stored_size(page) == "13", "a mid-edit below-min draft must not persist"
+
+    # Finish typing a valid size — it applies live and persists.
+    value.press("8")
+    expect(value).to_have_value("18")
+    assert _stored_size(page) == "18"
+    assert _ui_font_scale(page) == "1.125"
+
+    # A still-out-of-range draft clamps to the minimum on blur.
+    value.fill("1")
+    value.blur()
+    expect(value).to_have_value("12")
+    assert _stored_size(page) == "12"

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -95,7 +95,13 @@ beforeEach(() => {
   mocks.me = { id: "alice", is_admin: false };
   mocks.conversations = [];
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  // Reset the font-size preference + applied scale so the Appearance tests
+  // don't leak persisted state or the --ui-font-scale variable into each other.
+  localStorage.clear();
+  document.documentElement.style.removeProperty("--ui-font-scale");
+});
 
 describe("SettingsPage", () => {
   it("renders the Appearance section and applies a theme on card click", () => {
@@ -135,6 +141,52 @@ describe("SettingsPage", () => {
     // At the 12px min, only the decrease button is disabled.
     expect(screen.getByTestId("ui-font-size-dec")).toBeDisabled();
     expect(screen.getByTestId("ui-font-size-inc")).not.toBeDisabled();
+  });
+
+  it("lets you clear and retype the font size without clamping mid-edit", () => {
+    localStorage.setItem("omnigent:ui-font-size", "13");
+    renderPage("/settings/appearance");
+    const input = screen.getByTestId("ui-font-size-input") as HTMLInputElement;
+    expect(input.value).toBe("13");
+
+    // Deleting a digit leaves "1" — below the 12px min. The box must SHOW "1"
+    // (free editing) without snapping to 12 or persisting the transient value.
+    fireEvent.change(input, { target: { value: "1" } });
+    expect(input.value).toBe("1");
+    expect(localStorage.getItem("omnigent:ui-font-size")).toBe("13");
+    expect(document.documentElement.style.getPropertyValue("--ui-font-scale")).toBe("");
+
+    // Finishing the number to a valid size applies it live and persists it.
+    fireEvent.change(input, { target: { value: "18" } });
+    expect(input.value).toBe("18");
+    expect(localStorage.getItem("omnigent:ui-font-size")).toBe("18");
+    // 18 / 16 base = 1.125.
+    expect(document.documentElement.style.getPropertyValue("--ui-font-scale")).toBe("1.125");
+  });
+
+  it("clamps a below-min entry to the minimum on blur", () => {
+    localStorage.setItem("omnigent:ui-font-size", "16");
+    renderPage("/settings/appearance");
+    const input = screen.getByTestId("ui-font-size-input") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "1" } });
+    fireEvent.blur(input);
+    // On blur the draft settles to the clamped minimum.
+    expect(input.value).toBe("12");
+    expect(localStorage.getItem("omnigent:ui-font-size")).toBe("12");
+  });
+
+  it("reverts an empty entry to the committed size on blur", () => {
+    localStorage.setItem("omnigent:ui-font-size", "15");
+    renderPage("/settings/appearance");
+    const input = screen.getByTestId("ui-font-size-input") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "" } });
+    expect(input.value).toBe("");
+    fireEvent.blur(input);
+    // An empty field restores the last committed value rather than a bogus one.
+    expect(input.value).toBe("15");
+    expect(localStorage.getItem("omnigent:ui-font-size")).toBe("15");
   });
 
   it("defaults bare /settings to Account when a login session exists, else Appearance", async () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -204,14 +204,43 @@ function AppearanceSection() {
  * per-device readability pref that doesn't conflict with host theming.
  */
 function UiFontSizeControl() {
+  // `px` is the committed value: clamped, persisted, and applied to the UI.
+  // `draft` is the raw text in the box, kept separate so mid-edit states the
+  // committed value can't hold — a transient out-of-range number (e.g. "1" on
+  // the way to "18") or an empty field while retyping — don't get clamped on
+  // every keystroke. We only commit while typing when the draft is already a
+  // valid in-range size; blur/Enter clamps and re-syncs the text.
   const [px, setPx] = useState(() => readUiFontSizePx());
+  const [draft, setDraft] = useState(() => String(px));
 
-  const update = useCallback((next: number) => {
+  const commit = useCallback((next: number) => {
     const clamped = clampUiFontSizePx(next);
     setPx(clamped);
+    setDraft(String(clamped));
     writeUiFontSizePx(clamped);
     applyUiFontScale(clamped);
   }, []);
+
+  const onDraftChange = useCallback((text: string) => {
+    setDraft(text);
+    // Apply live only once the field holds a valid, in-range whole number;
+    // leave partial/out-of-range/empty drafts untouched until blur.
+    if (/^\d+$/.test(text)) {
+      const value = Number(text);
+      if (value >= UI_FONT_SIZE_MIN && value <= UI_FONT_SIZE_MAX) {
+        setPx(value);
+        writeUiFontSizePx(value);
+        applyUiFontScale(value);
+      }
+    }
+  }, []);
+
+  // Clamp and re-sync the text to the committed value. An empty or invalid
+  // draft reverts to the last committed size rather than a bogus one.
+  const commitDraft = useCallback(() => {
+    const value = Number(draft);
+    commit(Number.isFinite(value) && draft.trim() !== "" ? value : px);
+  }, [commit, draft, px]);
 
   const atMin = px <= UI_FONT_SIZE_MIN;
   const atMax = px >= UI_FONT_SIZE_MAX;
@@ -238,7 +267,7 @@ function UiFontSizeControl() {
           label="Decrease font size"
           testId="ui-font-size-dec"
           disabled={atMin}
-          onClick={() => update(px - UI_FONT_SIZE_STEP)}
+          onClick={() => commit(px - UI_FONT_SIZE_STEP)}
         >
           <MinusIcon className="size-4" />
         </StepperButton>
@@ -252,10 +281,11 @@ function UiFontSizeControl() {
             aria-label="Font size in pixels"
             data-testid="ui-font-size-input"
             className="w-8 bg-transparent text-center text-sm font-medium tabular-nums outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-            value={px}
-            onChange={(e) => {
-              const next = Number(e.target.value);
-              if (Number.isFinite(next)) update(next);
+            value={draft}
+            onChange={(e) => onDraftChange(e.target.value)}
+            onBlur={commitDraft}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.currentTarget.blur();
             }}
           />
         </div>
@@ -263,7 +293,7 @@ function UiFontSizeControl() {
           label="Increase font size"
           testId="ui-font-size-inc"
           disabled={atMax}
-          onClick={() => update(px + UI_FONT_SIZE_STEP)}
+          onClick={() => commit(px + UI_FONT_SIZE_STEP)}
         >
           <PlusIcon className="size-4" />
         </StepperButton>


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes an editing dead-end in the **Appearance → Font size** control (follow-up to #2040). The box bound directly to the clamped, committed value and clamped on **every keystroke**, so backspacing `13` down to `1` snapped straight to the 12px minimum — you couldn't clear the field or type toward a value like `18`.

The fix decouples the box's **displayed text** (a free-form draft) from the **committed value**:
- Type freely — the box shows whatever you enter, including a transient below-min `1` or an empty field while retyping.
- Applies **live** only once the draft is a valid, in-range whole number (so dragging through valid sizes still updates instantly).
- Clamps + re-syncs on **blur / Enter** — a below-min entry settles to `12`, an empty/invalid one reverts to the last committed size.
- The `−`/`+` steppers still commit and keep the text in sync.

## Test Plan

- `npm --prefix web run type-check` — clean.
- `npm --prefix web exec -- vitest run src/pages/SettingsPage.test.tsx src/lib/uiFontPreferences.test.ts` — 24 passing. New cases: clear/retype holds a transient below-min value without clamping or persisting; a valid draft applies live; below-min clamps to the min on blur; an empty entry reverts to the committed size on blur.
- `npm --prefix web run build` / prettier / oxlint — clean.
- Manual (dev server): Settings → Appearance → select `13`, backspace to `1` — the box holds `1` (no snap), typing `18` applies live, and clicking away with an out-of-range value clamps to `12`.

## Demo

<!-- TODO(@SabhyaC26): attach a short screen recording of clearing/retyping the font-size box (holds the partial value, no mid-edit clamp, blur settles the final value). -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Component tests (`SettingsPage.test.tsx`) cover free editing without mid-edit clamping, live-apply on a valid draft, and blur clamping/reverting; the `afterEach` now resets the persisted size + applied `--ui-font-scale` so the Appearance tests stay independent. A Playwright test (`tests/e2e_ui/sessions/test_ui_font_size.py`) reproduces the exact reported scenario end-to-end (backspace `13`→`1` holds, retype→`18` applies, blur clamps to `12`). Manual verification covered the live typing feel that isn't observable in jsdom.

## Changelog

Fix the Appearance font-size input so you can clear and retype a value instead of it clamping mid-edit
