### PR TITLE
feat(harness-bench): full-server default + --fast, parallel runs, rich progress, transport labels

### DIFF
--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -306,10 +306,15 @@ The MVP and most of phase-2 are landed. What exists on `main` today:
 
 ### Not yet wired
 
-- **Tool calling / Policy DENY on `native-tui`** — native tool calls are the
-  vendor's own and a native deny is a vendor permission decision, not a
-  server-dispatched `function_call_output`; observing them needs new driver
-  work. (SDK harnesses have these via `full-server`.)
+- **Bench observation of Tool calling / Policy DENY on `native-tui`** — a
+  *driver gap, not a native-harness limitation*. Native harnesses do call tools
+  and enforce permissions; the bench cannot yet observe it on this transport.
+  A native tool call is the vendor's own tool (Bash/Read/...), not a
+  server-dispatched `function_call_output` the bench can force, and a native
+  deny is a vendor permission decision, not a server-side policy evaluation the
+  probe can assert against. So both cells show `·` (not measured), never `✗`.
+  Wiring the observation needs new driver work. (SDK harnesses get these via
+  `full-server`.)
 - **P1 dimensions** — steering, live-queue, resume/fork, elicitation ASK,
   reasoning, images, cost, compaction. Probes not written yet (report
   `UNKNOWN`).
@@ -382,15 +387,22 @@ stream, the bench flags a real drift on the next run, rather than a false
 ## Which transport exercises which dimension
 
 Not every dimension is observable on every transport, so a `·` (SKIPPED) in a
-run often means "this transport can't exercise it here," not "the harness lacks
-it." Two dimensions in particular only get a real verdict on the `full-server`
-transport:
+run always means "the bench did not measure this here," never "the harness
+lacks it." Two dimensions in particular only get a real verdict on the
+`full-server` transport:
 
 | Dimension | sdk-inproc (`--fast`) | full-server (default) | native-tui |
 |---|---|---|---|
 | Basic turn, Streaming, Model override, Interrupt | ✓ | ✓ | ✓ |
-| **Tool calling** | · (harness dispatches tools internally) | ✓ (server-dispatched builtin) | · (not yet wired) |
-| **Policy DENY** | · (wrap-direct: no tool-call policy hook) | ✓ (spec-baked deny, enforced) | · (not yet wired) |
+| **Tool calling** | · (harness dispatches tools internally) | ✓ (server-dispatched builtin) | · (bench can't observe vendor tools yet) |
+| **Policy DENY** | · (wrap-direct: no tool-call policy hook) | ✓ (spec-baked deny, enforced) | · (bench can't observe vendor deny yet) |
+
+The `native-tui` `·` is a *bench observation gap, not a native-harness
+limitation*: native harnesses do call tools and enforce permissions, but a
+native tool call is the vendor's own (Bash/Read/...) and a native deny is a
+vendor permission decision, neither of which is the server-dispatched,
+policy-gated call the probe watches for. Giving those cells a real verdict
+needs new driver work, not a change to the harnesses.
 
 Because `full-server` sees everything `sdk-inproc` does *plus* these two, it is
 the **default** for SDK harnesses — a plain live run proves Tool calling and
@@ -409,10 +421,11 @@ evaluation.
 
 `full-server` covers **SDK harnesses only** — it registers the harness via an
 agent bundle, which is the SDK-wrap path; native harnesses need the host-daemon
-provisioning the `native-tui` driver owns. So Tool calling / Policy DENY for
-native harnesses remain genuinely unwired (a follow-up), distinct from the
-`--fast` (sdk-inproc) `·` which is a transport limitation the default
-`full-server` run already answers.
+provisioning the `native-tui` driver owns. So Tool calling / Policy DENY on
+native harnesses are not observed by *any* transport yet — a bench follow-up,
+not a native-harness gap — distinct from the `--fast` (sdk-inproc) `·`, which
+is a transport limitation the default `full-server` run already answers for SDK
+harnesses.
 
 ## Plugin seamlessness: where it is and isn't
 
@@ -469,10 +482,13 @@ agree with it.
   hardcoded `_ensure_default_*_agent()` list in `server/app.py` with a loop over
   `native_agents()`, so any native harness (in-repo or plugin) registers
   automatically. This is the fix for the plugin-seamlessness seam above.
-- **Tool calling / Policy DENY on `native-tui`** — unwired; native tool calls
-  are the vendor's own and a native deny is a vendor permission decision, not a
-  server-dispatched `function_call_output`. Needs new driver work. (SDK
-  harnesses have these via `full-server`.)
+- **Bench observation of Tool calling / Policy DENY on `native-tui`** — a
+  driver gap, not a native-harness limitation: native harnesses call tools and
+  enforce permissions, but a native tool call is the vendor's own and a native
+  deny is a vendor permission decision, not the server-dispatched
+  `function_call_output` the probe watches for. The cells show `·` (not
+  measured), never `✗`. Needs new driver work. (SDK harnesses get these via
+  `full-server`.)
 - **Per-harness native provisioning gaps** the bench has surfaced but not yet
   resolved: goose-native returns a 500 on the terminal-ensure endpoint;
   hermes-native's forwarder does not wire up (a lazy-chat / first-turn gate to

--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -247,8 +247,10 @@ class StreamingProbe(CapabilityProbe):
 
 ## Transport drivers: the real ceiling on "all dimensions"
 
-Behavioral probes run through a **transport driver** selected per run
-(`--transport`) or from each profile's declared transport. A probe calls
+Behavioral probes run through a **transport driver** resolved from the
+harness *family* plus flags: SDK harnesses default to `full-server` (`--fast`
+picks `sdk-inproc`), natives use `native-tui`, and `--transport NAME` overrides
+the family for any harness. A probe calls
 *semantic* methods on the driver (`run_basic_turn`, `run_streaming_turn`,
 `run_tool_turn(deny=...)`, `run_interrupt_turn`); the driver owns the
 *mechanism* and the probe owns the *interpretation*, so one probe runs across
@@ -277,7 +279,7 @@ The MVP and most of phase-2 are landed. What exists on `main` today:
   `misc` pytest group), and the six P0 live probes (basic turn, streaming,
   tool calling, policy DENY, model override, interrupt) with the `DRIFT`
   column.
-- **Three transport drivers**, selectable via `--transport`:
+- **Three transport drivers**, selected by harness *family* with flag overrides:
   - `sdk-inproc` — drives a harness wrap subprocess directly (the four P0 SDK
     harnesses: claude-sdk, codex, pi, openai-agents).
   - `full-server` — a real server + runner; the only transport that exercises
@@ -285,6 +287,14 @@ The MVP and most of phase-2 are landed. What exists on `main` today:
     calls (SDK harnesses only — it registers via an agent bundle).
   - `native-tui` — a resident vendor CLI in a runner-owned tmux pane, driven
     over the session HTTP surface via a host daemon.
+
+  SDK harnesses default to **`full-server`** — the fullest coverage, and a
+  strict superset of what `sdk-inproc` observes (everything sdk-inproc does,
+  *plus* Tool calling + Policy DENY). `--fast` opts the SDK family down to
+  `sdk-inproc` when you want to skip the server boot (those two dimensions then
+  report `·`). Native harnesses have a single transport `--fast` does not touch.
+  An explicit `--transport NAME` overrides the family default for any harness
+  and is mutually exclusive with `--fast`.
 - **Capability-derived matrix** — descriptive columns and declared verdicts
   come from `harness_capabilities()` (the seam; see
   `designs/harness-capabilities-bench-seam.md`), so a harness added to the
@@ -372,35 +382,37 @@ stream, the bench flags a real drift on the next run, rather than a false
 ## Which transport exercises which dimension
 
 Not every dimension is observable on every transport, so a `·` (SKIPPED) in a
-default run often means "this transport can't exercise it here," not "the
-harness lacks it." Two dimensions in particular only get a real verdict on the
-`full-server` transport:
+run often means "this transport can't exercise it here," not "the harness lacks
+it." Two dimensions in particular only get a real verdict on the `full-server`
+transport:
 
-| Dimension | sdk-inproc | full-server | native-tui |
+| Dimension | sdk-inproc (`--fast`) | full-server (default) | native-tui |
 |---|---|---|---|
 | Basic turn, Streaming, Model override, Interrupt | ✓ | ✓ | ✓ |
 | **Tool calling** | · (harness dispatches tools internally) | ✓ (server-dispatched builtin) | · (not yet wired) |
 | **Policy DENY** | · (wrap-direct: no tool-call policy hook) | ✓ (spec-baked deny, enforced) | · (not yet wired) |
 
-So to see Tool calling and Policy DENY actually proven, run the SDK harnesses
-over `full-server`:
+Because `full-server` sees everything `sdk-inproc` does *plus* these two, it is
+the **default** for SDK harnesses — a plain live run proves Tool calling and
+Policy DENY out of the box:
 
 ```
-python -m tests.harness_bench --harness claude-sdk --profile oss --transport full-server
+python -m tests.harness_bench --harness claude-sdk --profile oss
 ```
 
 Live-verified: `claude-sdk` completes the full matrix on `full-server` —
 Tool calling `✓` and Policy DENY `✓` (the deny is delivered and the blocked
-call does not stall the turn). The default `--profile oss` run shows `·` for
-those two columns only because it uses `sdk-inproc` (for SDK harnesses) and
-`native-tui` (for natives), neither of which routes a tool call through a
-server policy evaluation.
+call does not stall the turn). Add `--fast` to trade that coverage for a quicker
+run on `sdk-inproc`; those two columns then show `·`, since neither `sdk-inproc`
+nor `native-tui` (for natives) routes a tool call through a server policy
+evaluation.
 
 `full-server` covers **SDK harnesses only** — it registers the harness via an
 agent bundle, which is the SDK-wrap path; native harnesses need the host-daemon
 provisioning the `native-tui` driver owns. So Tool calling / Policy DENY for
 native harnesses remain genuinely unwired (a follow-up), distinct from the
-sdk-inproc `·` which is a transport limitation with `full-server` as the answer.
+`--fast` (sdk-inproc) `·` which is a transport limitation the default
+`full-server` run already answers.
 
 ## Plugin seamlessness: where it is and isn't
 

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -8,29 +8,66 @@ against a self-declared profile to surface drift. Design and rationale:
 ## Run it
 
 ```bash
-# List official harnesses.
+# List official harnesses (name, resolved transport, model).
 python -m tests.harness_bench --list
 
-# Offline (declared) matrix — no turns, no creds.
+# Offline (declared) matrix -- no turns, no creds.
 python -m tests.harness_bench
 
 # Live probe one harness against a gateway profile.
 python -m tests.harness_bench --harness codex --profile my-profile
 
-# Live probe every official harness.
-python -m tests.harness_bench --profile my-profile
+# Live probe every official harness, several at a time, with a live table.
+python -m tests.harness_bench --profile my-profile --jobs 4 --rich
 ```
 
-Output formats (mutually exclusive):
+A non-zero exit means a `DRIFT` cell was found (observed behavior disagrees
+with the declared matrix).
 
-- default: an aligned, ANSI-colored terminal table (color auto-disables
-  when piped or with `--no-color`), followed by a Notes section explaining
-  every non-supported cell so a `·` is never opaque.
+### Flags
+
+- `--profile NAME` -- Databricks gateway profile. Enables the live layer;
+  without it the bench renders the declared matrix offline.
+- `--harness NAME` -- probe one harness (repeatable). An official name, or a
+  `module:attr` / `module.ATTR` reference to a community `BenchProfile`.
+  Defaults to every official harness.
+- `--fast` -- run SDK harnesses on `sdk-inproc` instead of the `full-server`
+  default: skips the server boot for a quicker run, at the cost of the Tool
+  calling + Policy DENY dimensions (they report `·`). No effect on natives.
+  Mutually exclusive with `--transport`.
+- `--transport NAME` -- force a specific transport driver (`sdk-inproc`,
+  `full-server`, `native-tui`), overriding the family default.
+- `--jobs N` / `-j N` -- run up to N harnesses concurrently (default 1).
+  Probes within a harness stay sequential; 3-4 is a reasonable ceiling on one
+  host. Report order always matches input order.
+- `--rich` / `--no-rich` -- force / disable the live progress table (auto: rich
+  on a TTY, plain per-line output otherwise).
+- `--report PATH` -- also write the final matrix to PATH; format follows
+  `--json` / `--markdown`, else inferred from the extension.
+
+### Output formats (mutually exclusive)
+
+- default: an aligned, ANSI-colored terminal table (color auto-disables when
+  piped or with `--no-color`), followed by a Notes section explaining every
+  non-supported cell so a `·` is never opaque.
 - `--markdown`: the GitHub-flavored table for docs / PRs.
 - `--json`: machine-readable, for diffing runs or regenerating docs.
 
-A non-zero exit means a `DRIFT` cell was found (observed behavior
-disagrees with the declared matrix).
+Each row is labelled with the transport that actually ran it, e.g.
+`claude-sdk [full-server]`, `kimi-native [native]`.
+
+## Transport selection
+
+A profile's `transport` field is the harness *family* marker, not the literal
+driver the run uses:
+
+- **SDK-family** harnesses default to **`full-server`** -- the fullest
+  coverage, and a strict superset of what `sdk-inproc` observes (everything
+  sdk-inproc does, plus Tool calling + Policy DENY as server-dispatched,
+  policy-gated calls). `--fast` opts them down to `sdk-inproc`.
+- **native** harnesses use `native-tui` (a resident vendor CLI in a
+  runner-owned tmux pane); `--fast` does not apply.
+- `--transport NAME` overrides the family default for any harness.
 
 ## What it reports (P0 dimensions)
 
@@ -38,37 +75,52 @@ disagrees with the declared matrix).
 `model_override`. Verdicts map to the support-matrix glyphs
 (`✓ ~ ✗ — ?`), plus `·` skipped and `!! DRIFT`.
 
+Tool calling and Policy DENY only get a real verdict on `full-server` (a
+server-dispatched builtin under a spec-baked deny policy); on `sdk-inproc` and
+`native-tui` they report `·`. That is why full-server is the SDK default.
+
 ## Layout
 
 | File | Role |
 | --- | --- |
 | `verdict.py` | `Verdict` / `Priority` / `ProbeResult` and the `reconcile` drift check |
 | `profile.py` | `BenchProfile` (per-harness self-declaration) + name resolution |
-| `manifest.py` | Official profiles, built from `tests/e2e/_harness_probes.py` |
-| `driver.py` | `SdkInprocDriver` — spawns a harness wrap, drives turns over SSE |
+| `manifest.py` | Official profiles, derived from the capability model + `tests/e2e/_harness_probes.py` |
+| `transport.py` | `Driver` protocol, driver registry, family/flag transport resolution |
+| `driver.py` | `SdkInprocDriver` (harness wrap over SSE) + `ProvisioningError` |
+| `full_server.py` | `SharedFullServer` -- real server+runner lifecycle + agent/session registration |
+| `full_server_driver.py` | `FullServerDriver` -- runs probes against a (owned or shared) full server |
+| `native_tui_driver.py` | `NativeTuiDriver` -- vendor CLI in tmux via a host daemon; native vendor auto-derivation |
 | `probes/` | One module per dimension; `ALL_PROBES` is the registry |
-| `bench.py` | Orchestrator: probes × harnesses → `BenchMatrix` |
-| `report.py` | Markdown / JSON renderers |
+| `events.py` | Structured `BenchEvent`s + `ProgressSink` / `LineSink` |
+| `richreport.py` | `rich.Live` progress table (optional-dep; falls back to `LineSink`) |
+| `bench.py` | Orchestrator: probes x harnesses -> `BenchMatrix`, `--jobs`, shared-server wiring |
+| `report.py` | Terminal / Markdown / JSON renderers |
 | `test_bench.py` | Offline conformance (always) + live layer (gated on `--profile`) |
 
 ## Add a harness
 
-- **Official:** add a `BenchProfile` to `manifest.py` (base fields come
+- **Official SDK:** add a `BenchProfile` to `manifest.py` (base fields come
   from `_harness_probes.HARNESS_PROBES`). No probe or driver edits.
+- **Native:** nothing to add -- every harness the capability model marks
+  `NATIVE_TUI` (in-repo or a community plugin) is auto-derived into the matrix
+  and drivable by name; `native_vendor()` derives what the driver needs.
 - **Community / out-of-repo:** ship a `BenchProfile` and select it by
   reference: `--harness mypkg.harness:PROFILE`. No bench edits.
 
 ## Add a dimension
 
 Add a `CapabilityProbe` subclass under `probes/`, list it in
-`probes/__init__.py:ALL_PROBES`, and add its declared verdict to the
-profiles. Probes are harness-agnostic — they only call the driver.
+`probes/__init__.py:ALL_PROBES`, and add its declared verdict to the profiles
+(or derive it from the capability model in `manifest.py`). Probes are
+harness-agnostic -- they only call the driver's semantic methods.
 
 ## Scope
 
-Phase-1 MVP: the six P0 dimensions above, the `sdk-inproc` transport
-driver, and the four official SDK harnesses (claude-sdk, codex, pi,
-openai-agents). Phase-2 (per the design doc): native transport drivers
-(tmux / app-server / HTTP-SSE), the remaining SDK + native harnesses, and
-the P1 dimensions (steering, live-queue, resume/fork, elicitation,
-reasoning, images, cost, compaction).
+Live today: the six P0 dimensions above; all three transports (`sdk-inproc`,
+`full-server`, `native-tui`); the four official SDK harnesses (claude-sdk,
+codex, pi, openai-agents) plus every registered native. Not yet wired (see the
+design doc's open items): Tool calling / Policy DENY on `native-tui`,
+registry-driven server-side native-agent seeding, and the P1 dimensions
+(steering, live-queue, resume/fork, elicitation, reasoning, images, cost,
+compaction).

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -56,6 +56,11 @@ with the declared matrix).
 Each row is labelled with the transport that actually ran it, e.g.
 `claude-sdk [full-server]`, `kimi-native [native]`.
 
+Under `--rich`, the live table (on stderr) already shows the grid, so the
+stdout report drops the grid and prints only the legend + notes -- no duplicate
+table. When stdout is redirected to a file, the report keeps the full grid so
+the file is self-contained.
+
 ## Transport selection
 
 A profile's `transport` field is the harness *family* marker, not the literal

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -75,9 +75,22 @@ driver the run uses:
 `model_override`. Verdicts map to the support-matrix glyphs
 (`✓ ~ ✗ — ?`), plus `·` skipped and `!! DRIFT`.
 
-Tool calling and Policy DENY only get a real verdict on `full-server` (a
-server-dispatched builtin under a spec-baked deny policy); on `sdk-inproc` and
-`native-tui` they report `·`. That is why full-server is the SDK default.
+A `·` always means "the bench did not measure this here", never "the harness
+lacks it". In particular Tool calling and Policy DENY only get a real verdict
+on `full-server` (a server-dispatched builtin under a spec-baked deny policy),
+so they show `·` on `sdk-inproc` and `native-tui`:
+
+- **Native harnesses show `·` for Tool calling / Policy DENY, and that is not a
+  native limitation.** Native harnesses do call tools and enforce permissions;
+  the bench just cannot observe it on `native-tui` yet. A native tool call is
+  the vendor's own tool (Bash/Read/...), not a server-dispatched builtin the
+  bench can force, and a native deny is a vendor permission decision, not a
+  server-side policy evaluation the probe can assert against. Giving those two
+  cells a real verdict needs new driver work (an open item), not a change to
+  the harnesses.
+- **SDK harnesses show `·` only under `--fast`** (the wrap-direct `sdk-inproc`
+  path has no tool-call policy hook); the default `full-server` run proves both
+  as `✓`. That is why full-server is the SDK default.
 
 ## Layout
 
@@ -120,7 +133,8 @@ harness-agnostic -- they only call the driver's semantic methods.
 Live today: the six P0 dimensions above; all three transports (`sdk-inproc`,
 `full-server`, `native-tui`); the four official SDK harnesses (claude-sdk,
 codex, pi, openai-agents) plus every registered native. Not yet wired (see the
-design doc's open items): Tool calling / Policy DENY on `native-tui`,
+design doc's open items): **bench observation** of Tool calling / Policy DENY
+on `native-tui` (a driver gap, not a native-harness limitation),
 registry-driven server-side native-agent seeding, and the P1 dimensions
 (steering, live-queue, resume/fork, elicitation, reasoning, images, cost,
 compaction).

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -25,6 +25,7 @@ import asyncio
 import sys
 
 from tests.harness_bench.bench import run_bench
+from tests.harness_bench.events import LineSink
 from tests.harness_bench.manifest import OFFICIAL_PROFILES
 from tests.harness_bench.profile import BenchProfile, resolve_profile
 from tests.harness_bench.report import render_json, render_markdown, render_table
@@ -203,12 +204,13 @@ def _select_progress_sink(rich_flag: bool | None):
     auto (rich on a TTY, plain otherwise). Falls back to the plain
     :class:`LineSink` whenever rich is unavailable or not a terminal.
     """
-    from tests.harness_bench.events import LineSink
 
     def _line(msg: str) -> None:
         print(msg, file=sys.stderr, flush=True)
 
     if rich_flag is not False:
+        # richreport is imported lazily: it is the only place that touches the
+        # optional `rich` dependency, so a plain/no-rich run never imports it.
         from tests.harness_bench.richreport import rich_sink_or_none
 
         rich_sink = rich_sink_or_none(force=bool(rich_flag))

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -206,7 +206,12 @@ def main(argv: list[str] | None = None) -> int:
         # Default: terminal table. Color only when stdout is a real TTY and
         # not suppressed, so piping to a file / pager stays plain.
         color = sys.stdout.isatty() and not args.no_color
-        output = render_table(matrix, color=color, declared=declared)
+        # If the rich live table already painted the grid to this same terminal,
+        # drop the grid from the stdout report (keep the legend + notes) so the
+        # matrix is not printed twice. When stdout is redirected, print it in
+        # full -- the file needs the grid the on-screen table did not capture.
+        grid = not (_grid_already_shown(sink) and sys.stdout.isatty())
+        output = render_table(matrix, color=color, declared=declared, grid=grid)
     print(output, end="")
 
     if args.report:
@@ -214,6 +219,16 @@ def main(argv: list[str] | None = None) -> int:
 
     # A drift is a non-zero exit so CI / scripts notice without parsing output.
     return 1 if matrix.has_drift else 0
+
+
+def _grid_already_shown(sink) -> bool:
+    """Whether the progress sink already painted the glyph grid to the terminal.
+
+    True only for the rich live table (which sets ``drew_grid = True``); the
+    plain :class:`LineSink` and a silent run do not, so their report prints the
+    grid in full.
+    """
+    return bool(getattr(sink, "drew_grid", False))
 
 
 def _select_progress_sink(rich_flag: bool | None):

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -8,8 +8,13 @@ Examples::
     # Dry (offline) render — declared matrix, no turns, no creds.
     python -m tests.harness_bench
 
-    # Live probe one harness against a gateway profile.
+    # Live probe one harness against a gateway profile (SDK → full-server,
+    # the default: covers Tool calling + Policy DENY).
     python -m tests.harness_bench --harness codex --profile my-profile
+
+    # Quicker run: SDK harnesses on sdk-inproc (skips the server boot; no
+    # Tool calling / Policy DENY coverage).
+    python -m tests.harness_bench --harness codex --profile my-profile --fast
 
     # Live probe all official harnesses, JSON out.
     python -m tests.harness_bench --profile my-profile --json
@@ -29,7 +34,7 @@ from tests.harness_bench.events import LineSink
 from tests.harness_bench.manifest import OFFICIAL_PROFILES
 from tests.harness_bench.profile import BenchProfile, resolve_profile
 from tests.harness_bench.report import render_json, render_markdown, render_table
-from tests.harness_bench.transport import driver_registry
+from tests.harness_bench.transport import driver_registry, resolve_transport_name
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -65,13 +70,23 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_false",
         help="Force the offline (declared-only) render.",
     )
-    parser.add_argument(
+    transport_grp = parser.add_mutually_exclusive_group()
+    transport_grp.add_argument(
         "--transport",
         metavar="NAME",
         default=None,
         help="Transport driver override (e.g. 'sdk-inproc', 'full-server'). "
-        "Wins over each profile's declared transport. Defaults to the "
-        "profile's transport.",
+        "Wins over the family default. By default SDK harnesses run on "
+        "full-server (fullest coverage: Tool calling + Policy DENY); natives "
+        "run on native-tui.",
+    )
+    transport_grp.add_argument(
+        "--fast",
+        action="store_true",
+        help="Run SDK harnesses on sdk-inproc instead of the full-server "
+        "default: skips the server boot for a quicker run, at the cost of the "
+        "Tool calling + Policy DENY dimensions (reported SKIPPED). No effect on "
+        "native harnesses. Mutually exclusive with --transport.",
     )
     fmt = parser.add_mutually_exclusive_group()
     fmt.add_argument(
@@ -128,8 +143,11 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv if argv is not None else sys.argv[1:])
 
     if args.list:
+        # Show the transport a default run would pick (SDK family → full-server),
+        # not the raw family marker, so --list matches what actually runs.
         for name, profile in sorted(OFFICIAL_PROFILES.items()):
-            print(f"{name}\t{profile.transport}\t{profile.model}")
+            transport = resolve_transport_name(profile, override=None, fast=False)
+            print(f"{name}\t{transport}\t{profile.model}")
         return 0
 
     try:
@@ -170,6 +188,7 @@ def main(argv: list[str] | None = None) -> int:
             databricks_profile=args.profile,
             live=live,
             transport=args.transport,
+            fast=args.fast,
             progress=sink,
             jobs=args.jobs,
         )

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -82,6 +82,37 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--no-color", action="store_true", help="Disable ANSI color in the terminal table."
     )
+    parser.add_argument(
+        "--jobs",
+        "-j",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Run up to N harnesses concurrently (default 1 = sequential). "
+        "Probes within a harness stay sequential. Higher N cuts wall-clock but "
+        "raises process / gateway load; 3-4 is a reasonable ceiling on one host.",
+    )
+    rich_grp = parser.add_mutually_exclusive_group()
+    rich_grp.add_argument(
+        "--rich",
+        dest="rich",
+        action="store_true",
+        default=None,
+        help="Force the live rich progress table (needs a TTY + rich).",
+    )
+    rich_grp.add_argument(
+        "--no-rich",
+        dest="rich",
+        action="store_false",
+        help="Force plain per-line progress (no live table).",
+    )
+    parser.add_argument(
+        "--report",
+        metavar="PATH",
+        default=None,
+        help="Also write the final matrix to PATH. Format follows --json / "
+        "--markdown, else inferred from the extension (.json / .md), else plain text.",
+    )
     parser.add_argument("--list", action="store_true", help="List official harnesses and exit.")
     return parser.parse_args(argv)
 
@@ -115,17 +146,22 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
+    if args.jobs < 1:
+        print("--jobs must be >= 1", file=sys.stderr)
+        return 2
+
     # Live if explicitly forced, or implied by a supplied profile.
     live = args.live if args.live is not None else bool(args.profile)
     if live and not args.profile:
         print("--live requires --profile <name>", file=sys.stderr)
         return 2
 
-    # Live runs make network calls that can take tens of seconds per turn.
-    # Stream progress to stderr (report goes to stdout) so the run is not
-    # silent; offline is fast enough to stay quiet.
-    def _progress(line: str) -> None:
-        print(line, file=sys.stderr, flush=True)
+    # Progress sink: only for a live run (offline is instant). Prefer the rich
+    # live table when a TTY + rich are available (or --rich forces it), else
+    # fall back to plain per-line output on stderr (the report goes to stdout).
+    sink = None
+    if live:
+        sink = _select_progress_sink(args.rich)
 
     matrix = asyncio.run(
         run_bench(
@@ -133,9 +169,13 @@ def main(argv: list[str] | None = None) -> int:
             databricks_profile=args.profile,
             live=live,
             transport=args.transport,
-            progress=_progress if live else None,
+            progress=sink,
+            jobs=args.jobs,
         )
     )
+    if sink is not None:
+        sink.close()
+
     # Offline (not live) has nothing observed, so show the declared matrix.
     declared = not live
     if args.json:
@@ -148,8 +188,53 @@ def main(argv: list[str] | None = None) -> int:
         color = sys.stdout.isatty() and not args.no_color
         output = render_table(matrix, color=color, declared=declared)
     print(output, end="")
+
+    if args.report:
+        _write_report(args.report, matrix, json_flag=args.json, markdown_flag=args.markdown)
+
     # A drift is a non-zero exit so CI / scripts notice without parsing output.
     return 1 if matrix.has_drift else 0
+
+
+def _select_progress_sink(rich_flag: bool | None):
+    """Pick the progress sink for a live run.
+
+    ``rich_flag``: ``True`` forces rich, ``False`` forces plain, ``None`` =
+    auto (rich on a TTY, plain otherwise). Falls back to the plain
+    :class:`LineSink` whenever rich is unavailable or not a terminal.
+    """
+    from tests.harness_bench.events import LineSink
+
+    def _line(msg: str) -> None:
+        print(msg, file=sys.stderr, flush=True)
+
+    if rich_flag is not False:
+        from tests.harness_bench.richreport import rich_sink_or_none
+
+        rich_sink = rich_sink_or_none(force=bool(rich_flag))
+        if rich_sink is not None:
+            return rich_sink
+        if rich_flag is True:
+            print("--rich requested but rich/TTY unavailable; using plain output", file=sys.stderr)
+    return LineSink(_line)
+
+
+def _write_report(path: str, matrix, *, json_flag: bool, markdown_flag: bool) -> None:
+    """Write the matrix to *path*; format from flags, else the extension."""
+    if json_flag:
+        content = render_json(matrix)
+    elif markdown_flag:
+        content = render_markdown(matrix, declared=False)
+    elif path.endswith(".json"):
+        content = render_json(matrix)
+    elif path.endswith((".md", ".markdown")):
+        content = render_markdown(matrix, declared=False)
+    else:
+        # Plain, un-colored grid — a file should never carry ANSI codes.
+        content = render_table(matrix, color=False, declared=False)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content if content.endswith("\n") else content + "\n")
+    print(f"report written to {path}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -16,6 +16,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from tests.harness_bench.driver import ProvisioningError
 from tests.harness_bench.events import (
     HarnessFinished,
     HarnessSkipped,
@@ -230,10 +231,16 @@ async def run_harness(
         # __aenter__ may have already spawned the server + daemon and opened a
         # client before raising, so tear those down here or they leak for the
         # rest of the run (_teardown null-checks each, so a half-provisioned
-        # driver is safe to tear down). Log the traceback: this branch also
-        # catches genuine driver bugs (e.g. an AssertionError), which must not
-        # vanish silently behind a green-looking skip.
-        _logger.warning("provisioning failed for %s", profile.harness, exc_info=True)
+        # driver is safe to tear down).
+        #
+        # An expected ProvisioningError (a known-unrunnable environment) logs
+        # only its reason — the matrix already shows the skip. Any *other*
+        # exception is a possible driver bug (e.g. an AssertionError), so keep
+        # its full traceback rather than letting it vanish behind a green skip.
+        if isinstance(exc, ProvisioningError):
+            _logger.info("skipping %s: %s", profile.harness, exc)
+        else:
+            _logger.warning("provisioning failed for %s", profile.harness, exc_info=True)
         with contextlib.suppress(Exception):
             await driver_cm.__aexit__(type(exc), exc, exc.__traceback__)
         reason = f"provisioning failed: {exc}"

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -20,10 +20,12 @@ from tests.harness_bench.events import (
     HarnessFinished,
     HarnessSkipped,
     HarnessStarted,
+    LineSink,
     ProbeFinished,
     ProbeStarted,
     ProgressSink,
 )
+from tests.harness_bench.full_server import SharedFullServer
 from tests.harness_bench.probes import ALL_PROBES, CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.transport import resolve_driver_class
@@ -151,8 +153,6 @@ def _as_sink(progress: Progress | ProgressSink | None) -> ProgressSink | None:
         return None
     if isinstance(progress, ProgressSink):
         return progress
-    from tests.harness_bench.events import LineSink
-
     return LineSink(progress)  # a bare callable → line output
 
 
@@ -356,8 +356,6 @@ async def _maybe_shared_full_server(
             if resolve_driver_class(p, override=transport).transport == "full-server"
         ]
         if len(full) > 1:
-            from tests.harness_bench.full_server_driver import SharedFullServer
-
             shared = SharedFullServer(databricks_profile)
             await asyncio.to_thread(shared.__enter__)
     try:

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -29,7 +29,7 @@ from tests.harness_bench.events import (
 from tests.harness_bench.full_server import SharedFullServer
 from tests.harness_bench.probes import ALL_PROBES, CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
-from tests.harness_bench.transport import resolve_driver_class
+from tests.harness_bench.transport import resolve_driver_class, resolve_transport_name
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict, reconcile
 
 _logger = logging.getLogger(__name__)
@@ -71,11 +71,18 @@ class CellResult:
 
 @dataclass(frozen=True)
 class HarnessReport:
-    """Every cell for one harness, plus a whole-harness skip reason."""
+    """Every cell for one harness, plus a whole-harness skip reason.
+
+    :param transport: The transport that actually ran this harness (the
+        *resolved* driver, e.g. ``full-server`` for an SDK harness on the
+        default), which can differ from ``profile.transport`` — that field is
+        the harness *family* marker, not the effective driver.
+    """
 
     profile: BenchProfile
     cells: list[CellResult]
     skipped_reason: str | None = None
+    transport: str | None = None
 
     @property
     def has_drift(self) -> bool:
@@ -126,6 +133,7 @@ def _uniform_report(
     observed: ProbeResult,
     *,
     skipped_reason: str | None = None,
+    transport: str | None = None,
 ) -> HarnessReport:
     """A report where every applicable probe shares one *observed* result.
 
@@ -141,7 +149,9 @@ def _uniform_report(
         )
         for probe in probes
     ]
-    return HarnessReport(profile=profile, cells=cells, skipped_reason=skipped_reason)
+    return HarnessReport(
+        profile=profile, cells=cells, skipped_reason=skipped_reason, transport=transport
+    )
 
 
 def _as_sink(progress: Progress | ProgressSink | None) -> ProgressSink | None:
@@ -199,14 +209,24 @@ async def run_harness(
     sink = _as_sink(progress)
 
     if not live:
-        return _uniform_report(profile, probes, ProbeResult.skipped("offline (declared shown)"))
+        # Offline: still resolve the transport a live run *would* pick, so the
+        # declared matrix labels each row with its effective transport.
+        resolved = resolve_transport_name(profile, override=transport, fast=fast)
+        return _uniform_report(
+            profile, probes, ProbeResult.skipped("offline (declared shown)"), transport=resolved
+        )
 
     driver_cls = resolve_driver_class(profile, override=transport, fast=fast)
+    resolved_transport = driver_cls.transport
     unavailable = driver_cls.unavailable(profile, databricks_profile=databricks_profile)
     if unavailable is not None:
-        _emit(sink, HarnessSkipped(profile.harness, unavailable))
+        _emit(sink, HarnessSkipped(profile.harness, unavailable, resolved_transport))
         return _uniform_report(
-            profile, probes, ProbeResult.skipped(unavailable), skipped_reason=unavailable
+            profile,
+            probes,
+            ProbeResult.skipped(unavailable),
+            skipped_reason=unavailable,
+            transport=resolved_transport,
         )
 
     assert databricks_profile is not None  # guaranteed by the unavailable() check
@@ -244,8 +264,14 @@ async def run_harness(
         with contextlib.suppress(Exception):
             await driver_cm.__aexit__(type(exc), exc, exc.__traceback__)
         reason = f"provisioning failed: {exc}"
-        _emit(sink, HarnessSkipped(profile.harness, reason))
-        return _uniform_report(profile, probes, ProbeResult.skipped(reason), skipped_reason=reason)
+        _emit(sink, HarnessSkipped(profile.harness, reason, resolved_transport))
+        return _uniform_report(
+            profile,
+            probes,
+            ProbeResult.skipped(reason),
+            skipped_reason=reason,
+            transport=resolved_transport,
+        )
     try:
         driver = entered
         prereq_skip: str | None = None
@@ -276,7 +302,7 @@ async def run_harness(
     finally:
         await driver_cm.__aexit__(None, None, None)
     _emit(sink, HarnessFinished(profile.harness))
-    return HarnessReport(profile=profile, cells=cells)
+    return HarnessReport(profile=profile, cells=cells, transport=resolved_transport)
 
 
 async def run_bench(

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -1,9 +1,11 @@
 """The bench orchestrator: run probes across harnesses into a matrix.
 
-Sequential by design. Each harness spawns one wrap subprocess with a
-single in-flight turn per conversation, so its probes run one after
-another over a shared driver; harnesses run one at a time to keep the
-subprocess and gateway load bounded.
+Probes *within* a harness are sequential — they share one driver/session with
+a single in-flight turn per conversation. Harnesses run one at a time by
+default (``jobs=1``); ``jobs>1`` runs up to N concurrently, bounded by a
+semaphore, to cut wall-clock while keeping process/gateway load capped. Under a
+parallel run, full-server harnesses share one server+runner (see
+:func:`_maybe_shared_full_server`) rather than each booting their own.
 """
 
 from __future__ import annotations
@@ -167,6 +169,7 @@ async def run_harness(
     live: bool = True,
     transport: str | None = None,
     progress: Progress | ProgressSink | None = None,
+    shared_full_server=None,
 ) -> HarnessReport:
     """Run every applicable probe against one harness.
 
@@ -181,6 +184,11 @@ async def run_harness(
         declared transport when set (see :func:`resolve_driver_class`).
     :param progress: A :class:`ProgressSink` (structured events), a plain
         per-line callback (adapted), or ``None`` (silent).
+    :param shared_full_server: An optional shared
+        :class:`~tests.harness_bench.full_server_driver.SharedFullServer` to
+        register this harness on, instead of the driver spawning its own
+        server+runner. Only used when the resolved driver is the full-server
+        driver; ignored otherwise.
     :returns: The :class:`HarnessReport`.
     """
     probes = probes if probes is not None else ALL_PROBES
@@ -200,7 +208,14 @@ async def run_harness(
     assert databricks_profile is not None  # guaranteed by the unavailable() check
     _emit(sink, HarnessStarted(profile.harness, driver_cls.transport, profile.model))
     cells: list[CellResult] = []
-    driver_cm = driver_cls(profile, databricks_profile=databricks_profile)
+    # Only the full-server driver accepts a shared server; pass it through when
+    # this harness resolved to that transport, else construct plainly.
+    if shared_full_server is not None and driver_cls.transport == "full-server":
+        driver_cm = driver_cls(
+            profile, databricks_profile=databricks_profile, shared=shared_full_server
+        )
+    else:
+        driver_cm = driver_cls(profile, databricks_profile=databricks_profile)
     try:
         entered = await driver_cm.__aenter__()
     except Exception as exc:
@@ -270,40 +285,83 @@ async def run_bench(
         original sequential behavior. ``>1`` runs up to *jobs* harnesses at
         once, bounded by a semaphore. Probes *within* a harness always run
         sequentially — they share one driver/session with a single in-flight
-        turn — so concurrency is only across harnesses. Each harness owns its
-        own server/runner (or wrap subprocess + host daemon), so they do not
-        share transport state; the cap keeps process/port and gateway load
-        bounded rather than spawning every harness at once. Report order
-        always matches *profiles* order regardless of finish order.
+        turn — so concurrency is only across harnesses. Report order always
+        matches *profiles* order regardless of finish order.
+
+        For full-server harnesses under ``jobs`` > 1, one shared server+runner
+        is spawned and every full-server harness registers its own agent +
+        session on it (the runner resolves the harness per session), instead of
+        each harness booting its own server. native-tui harnesses still
+        self-provision (each needs its own host daemon).
     """
-    if jobs <= 1:
-        reports = [
-            await run_harness(
-                p,
-                probes=probes,
-                databricks_profile=databricks_profile,
-                live=live,
-                transport=transport,
-                progress=progress,
-            )
+    async with _maybe_shared_full_server(
+        profiles, databricks_profile=databricks_profile, live=live, transport=transport, jobs=jobs
+    ) as shared:
+        if jobs <= 1:
+            reports = [
+                await run_harness(
+                    p,
+                    probes=probes,
+                    databricks_profile=databricks_profile,
+                    live=live,
+                    transport=transport,
+                    progress=progress,
+                    shared_full_server=shared,
+                )
+                for p in profiles
+            ]
+            return BenchMatrix(reports=reports)
+
+        semaphore = asyncio.Semaphore(jobs)
+
+        async def _one(p: BenchProfile) -> HarnessReport:
+            async with semaphore:
+                return await run_harness(
+                    p,
+                    probes=probes,
+                    databricks_profile=databricks_profile,
+                    live=live,
+                    transport=transport,
+                    progress=progress,
+                    shared_full_server=shared,
+                )
+
+        # gather preserves input order, so the matrix stays in *profiles* order
+        # even though harnesses finish out of order.
+        reports = await asyncio.gather(*(_one(p) for p in profiles))
+        return BenchMatrix(reports=list(reports))
+
+
+@contextlib.asynccontextmanager
+async def _maybe_shared_full_server(
+    profiles: list[BenchProfile],
+    *,
+    databricks_profile: str | None,
+    live: bool,
+    transport: str | None,
+    jobs: int,
+):
+    """Yield a shared full-server for parallel full-server runs, else ``None``.
+
+    Only stands one up when it actually helps: a live, parallel run with more
+    than one harness that resolves to the full-server transport. Otherwise
+    yields ``None`` and each harness provisions as before (a solo full-server
+    run still owns its own server, unchanged).
+    """
+    shared = None
+    if live and jobs > 1 and databricks_profile is not None:
+        full = [
+            p
             for p in profiles
+            if resolve_driver_class(p, override=transport).transport == "full-server"
         ]
-        return BenchMatrix(reports=reports)
+        if len(full) > 1:
+            from tests.harness_bench.full_server_driver import SharedFullServer
 
-    semaphore = asyncio.Semaphore(jobs)
-
-    async def _one(p: BenchProfile) -> HarnessReport:
-        async with semaphore:
-            return await run_harness(
-                p,
-                probes=probes,
-                databricks_profile=databricks_profile,
-                live=live,
-                transport=transport,
-                progress=progress,
-            )
-
-    # gather preserves input order in its result list, so the matrix stays in
-    # *profiles* order even though harnesses finish out of order.
-    reports = await asyncio.gather(*(_one(p) for p in profiles))
-    return BenchMatrix(reports=list(reports))
+            shared = SharedFullServer(databricks_profile)
+            await asyncio.to_thread(shared.__enter__)
+    try:
+        yield shared
+    finally:
+        if shared is not None:
+            await asyncio.to_thread(shared.__exit__, None, None, None)

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -8,11 +8,20 @@ subprocess and gateway load bounded.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from tests.harness_bench.events import (
+    HarnessFinished,
+    HarnessSkipped,
+    HarnessStarted,
+    ProbeFinished,
+    ProbeStarted,
+    ProgressSink,
+)
 from tests.harness_bench.probes import ALL_PROBES, CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.transport import resolve_driver_class
@@ -20,10 +29,9 @@ from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Ve
 
 _logger = logging.getLogger(__name__)
 
-# A progress sink: the bench calls it with human-readable status lines as it
-# spawns harnesses and runs probes. ``None`` (the default) stays silent, which
-# is what the pytest layer wants; the CLI passes a stderr writer so a live run
-# is not silent for minutes.
+# Back-compat: a plain per-line progress callback. The orchestrator now emits
+# structured events to a ProgressSink; callers that still pass a line callback
+# get it adapted to a LineSink. ``None`` stays silent (the pytest layer).
 Progress = Callable[[str], None]
 
 # The prerequisite probe: if it does not pass, the harness cannot be exercised
@@ -131,9 +139,24 @@ def _uniform_report(
     return HarnessReport(profile=profile, cells=cells, skipped_reason=skipped_reason)
 
 
-def _emit(progress: Progress | None, message: str) -> None:
-    if progress is not None:
-        progress(message)
+def _as_sink(progress: Progress | ProgressSink | None) -> ProgressSink | None:
+    """Normalize the ``progress`` argument to a :class:`ProgressSink`.
+
+    Accepts a structured sink (used as-is), a plain line callback (adapted to a
+    :class:`~tests.harness_bench.events.LineSink`), or ``None`` (silent).
+    """
+    if progress is None:
+        return None
+    if isinstance(progress, ProgressSink):
+        return progress
+    from tests.harness_bench.events import LineSink
+
+    return LineSink(progress)  # a bare callable → line output
+
+
+def _emit(sink: ProgressSink | None, event) -> None:
+    if sink is not None:
+        sink.emit(event)
 
 
 async def run_harness(
@@ -143,7 +166,7 @@ async def run_harness(
     databricks_profile: str | None = None,
     live: bool = True,
     transport: str | None = None,
-    progress: Progress | None = None,
+    progress: Progress | ProgressSink | None = None,
 ) -> HarnessReport:
     """Run every applicable probe against one harness.
 
@@ -156,11 +179,12 @@ async def run_harness(
         anything — used for a fast ``--list``/dry render.
     :param transport: ``--transport`` override; wins over the profile's
         declared transport when set (see :func:`resolve_driver_class`).
-    :param progress: Optional status sink called with human-readable lines
-        as the harness spawns and each probe runs. ``None`` stays silent.
+    :param progress: A :class:`ProgressSink` (structured events), a plain
+        per-line callback (adapted), or ``None`` (silent).
     :returns: The :class:`HarnessReport`.
     """
     probes = probes if probes is not None else ALL_PROBES
+    sink = _as_sink(progress)
 
     if not live:
         return _uniform_report(profile, probes, ProbeResult.skipped("offline (declared shown)"))
@@ -168,17 +192,13 @@ async def run_harness(
     driver_cls = resolve_driver_class(profile, override=transport)
     unavailable = driver_cls.unavailable(profile, databricks_profile=databricks_profile)
     if unavailable is not None:
-        _emit(progress, f"[{profile.harness}] skipped: {unavailable}")
+        _emit(sink, HarnessSkipped(profile.harness, unavailable))
         return _uniform_report(
             profile, probes, ProbeResult.skipped(unavailable), skipped_reason=unavailable
         )
 
     assert databricks_profile is not None  # guaranteed by the unavailable() check
-    _emit(
-        progress,
-        f"[{profile.harness}] provisioning {driver_cls.transport} transport "
-        f"(model={profile.model}); first turn may take ~10-30s...",
-    )
+    _emit(sink, HarnessStarted(profile.harness, driver_cls.transport, profile.model))
     cells: list[CellResult] = []
     driver_cm = driver_cls(profile, databricks_profile=databricks_profile)
     try:
@@ -199,7 +219,7 @@ async def run_harness(
         with contextlib.suppress(Exception):
             await driver_cm.__aexit__(type(exc), exc, exc.__traceback__)
         reason = f"provisioning failed: {exc}"
-        _emit(progress, f"[{profile.harness}] skipped: {reason}")
+        _emit(sink, HarnessSkipped(profile.harness, reason))
         return _uniform_report(profile, probes, ProbeResult.skipped(reason), skipped_reason=reason)
     try:
         driver = entered
@@ -210,18 +230,18 @@ async def run_harness(
                 continue
             if prereq_skip is not None:
                 observed = ProbeResult.skipped(prereq_skip)
-                _emit(progress, f"[{profile.harness}]   {probe.title}: skipped (prerequisite)")
             else:
-                _emit(progress, f"[{profile.harness}]   {probe.title}: running...")
+                _emit(sink, ProbeStarted(profile.harness, probe.name, probe.title))
                 try:
                     observed = await probe.run(driver, profile)
                 except Exception as exc:
                     observed = ProbeResult(Verdict.UNKNOWN, note=f"probe raised: {exc!r}")
-                _emit(
-                    progress,
-                    f"[{profile.harness}]   {probe.title}: {observed.verdict.name}"
-                    + (f" ({observed.note})" if observed.note else ""),
-                )
+            _emit(
+                sink,
+                ProbeFinished(
+                    profile.harness, probe.name, probe.title, observed.verdict, observed.note
+                ),
+            )
             cell = _cell(probe, profile, observed)
             cells.append(cell)
             # If the prerequisite turn did not pass, short-circuit the rest:
@@ -230,6 +250,7 @@ async def run_harness(
                 prereq_skip = f"prerequisite '{probe.title}' did not pass ({observed.note})"
     finally:
         await driver_cm.__aexit__(None, None, None)
+    _emit(sink, HarnessFinished(profile.harness))
     return HarnessReport(profile=profile, cells=cells)
 
 
@@ -240,18 +261,49 @@ async def run_bench(
     databricks_profile: str | None = None,
     live: bool = True,
     transport: str | None = None,
-    progress: Progress | None = None,
+    progress: Progress | ProgressSink | None = None,
+    jobs: int = 1,
 ) -> BenchMatrix:
-    """Run the bench across *profiles*, sequentially, into a :class:`BenchMatrix`."""
-    reports = [
-        await run_harness(
-            p,
-            probes=probes,
-            databricks_profile=databricks_profile,
-            live=live,
-            transport=transport,
-            progress=progress,
-        )
-        for p in profiles
-    ]
-    return BenchMatrix(reports=reports)
+    """Run the bench across *profiles* into a :class:`BenchMatrix`.
+
+    :param jobs: Max harnesses to run concurrently. ``1`` (default) is the
+        original sequential behavior. ``>1`` runs up to *jobs* harnesses at
+        once, bounded by a semaphore. Probes *within* a harness always run
+        sequentially — they share one driver/session with a single in-flight
+        turn — so concurrency is only across harnesses. Each harness owns its
+        own server/runner (or wrap subprocess + host daemon), so they do not
+        share transport state; the cap keeps process/port and gateway load
+        bounded rather than spawning every harness at once. Report order
+        always matches *profiles* order regardless of finish order.
+    """
+    if jobs <= 1:
+        reports = [
+            await run_harness(
+                p,
+                probes=probes,
+                databricks_profile=databricks_profile,
+                live=live,
+                transport=transport,
+                progress=progress,
+            )
+            for p in profiles
+        ]
+        return BenchMatrix(reports=reports)
+
+    semaphore = asyncio.Semaphore(jobs)
+
+    async def _one(p: BenchProfile) -> HarnessReport:
+        async with semaphore:
+            return await run_harness(
+                p,
+                probes=probes,
+                databricks_profile=databricks_profile,
+                live=live,
+                transport=transport,
+                progress=progress,
+            )
+
+    # gather preserves input order in its result list, so the matrix stays in
+    # *profiles* order even though harnesses finish out of order.
+    reports = await asyncio.gather(*(_one(p) for p in profiles))
+    return BenchMatrix(reports=list(reports))

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -168,6 +168,7 @@ async def run_harness(
     databricks_profile: str | None = None,
     live: bool = True,
     transport: str | None = None,
+    fast: bool = False,
     progress: Progress | ProgressSink | None = None,
     shared_full_server=None,
 ) -> HarnessReport:
@@ -181,7 +182,9 @@ async def run_harness(
         cell ``SKIPPED`` with an "offline" note) without spawning
         anything — used for a fast ``--list``/dry render.
     :param transport: ``--transport`` override; wins over the profile's
-        declared transport when set (see :func:`resolve_driver_class`).
+        family default (see :func:`resolve_driver_class`).
+    :param fast: ``--fast`` — downgrade the SDK family to sdk-inproc (skip the
+        server boot, trading Tool calling + Policy DENY coverage).
     :param progress: A :class:`ProgressSink` (structured events), a plain
         per-line callback (adapted), or ``None`` (silent).
     :param shared_full_server: An optional shared
@@ -197,7 +200,7 @@ async def run_harness(
     if not live:
         return _uniform_report(profile, probes, ProbeResult.skipped("offline (declared shown)"))
 
-    driver_cls = resolve_driver_class(profile, override=transport)
+    driver_cls = resolve_driver_class(profile, override=transport, fast=fast)
     unavailable = driver_cls.unavailable(profile, databricks_profile=databricks_profile)
     if unavailable is not None:
         _emit(sink, HarnessSkipped(profile.harness, unavailable))
@@ -276,6 +279,7 @@ async def run_bench(
     databricks_profile: str | None = None,
     live: bool = True,
     transport: str | None = None,
+    fast: bool = False,
     progress: Progress | ProgressSink | None = None,
     jobs: int = 1,
 ) -> BenchMatrix:
@@ -295,7 +299,12 @@ async def run_bench(
         self-provision (each needs its own host daemon).
     """
     async with _maybe_shared_full_server(
-        profiles, databricks_profile=databricks_profile, live=live, transport=transport, jobs=jobs
+        profiles,
+        databricks_profile=databricks_profile,
+        live=live,
+        transport=transport,
+        fast=fast,
+        jobs=jobs,
     ) as shared:
         if jobs <= 1:
             reports = [
@@ -305,6 +314,7 @@ async def run_bench(
                     databricks_profile=databricks_profile,
                     live=live,
                     transport=transport,
+                    fast=fast,
                     progress=progress,
                     shared_full_server=shared,
                 )
@@ -322,6 +332,7 @@ async def run_bench(
                     databricks_profile=databricks_profile,
                     live=live,
                     transport=transport,
+                    fast=fast,
                     progress=progress,
                     shared_full_server=shared,
                 )
@@ -339,6 +350,7 @@ async def _maybe_shared_full_server(
     databricks_profile: str | None,
     live: bool,
     transport: str | None,
+    fast: bool,
     jobs: int,
 ):
     """Yield a shared full-server for parallel full-server runs, else ``None``.
@@ -353,7 +365,7 @@ async def _maybe_shared_full_server(
         full = [
             p
             for p in profiles
-            if resolve_driver_class(p, override=transport).transport == "full-server"
+            if resolve_driver_class(p, override=transport, fast=fast).transport == "full-server"
         ]
         if len(full) > 1:
             shared = SharedFullServer(databricks_profile)

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -29,6 +29,19 @@ from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 from tests.e2e._harness_probes import cli_unavailable_reason
 from tests.harness_bench.profile import BenchProfile
 
+
+class ProvisioningError(RuntimeError):
+    """An *expected* provisioning failure that should skip the harness quietly.
+
+    Raised by a driver's ``__aenter__`` when the environment cannot bring a
+    harness up through no fault of the bench — e.g. an own-auth native whose
+    vendor CLI is installed but not logged in, so its forwarder never wires up.
+    The orchestrator turns this into a capability-neutral skip and logs only the
+    reason (no traceback), reserving the full stack for *unexpected* exceptions
+    that signal a genuine driver bug.
+    """
+
+
 # Proto-style policy verdict strings the wrap's policy_verdict event accepts.
 POLICY_ALLOW = "POLICY_ACTION_ALLOW"
 POLICY_DENY = "POLICY_ACTION_DENY"

--- a/tests/harness_bench/events.py
+++ b/tests/harness_bench/events.py
@@ -100,6 +100,10 @@ class LineSink:
     unchanged. ``write`` defaults to stderr (the report goes to stdout).
     """
 
+    # Per-line progress does not paint the grid, so the stdout report still
+    # prints it in full (see the rich sink's ``drew_grid = True``).
+    drew_grid = False
+
     def __init__(self, write) -> None:  # write: Callable[[str], None]
         self._write = write
 

--- a/tests/harness_bench/events.py
+++ b/tests/harness_bench/events.py
@@ -34,10 +34,15 @@ class HarnessStarted:
 
 @dataclass(frozen=True)
 class HarnessSkipped:
-    """A harness was skipped whole (unavailable, or provisioning failed)."""
+    """A harness was skipped whole (unavailable, or provisioning failed).
+
+    ``transport`` is the resolved transport the skip applies to (``None`` when
+    it could not be resolved), so a live row can still be labelled with it.
+    """
 
     harness: str
     reason: str
+    transport: str | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/harness_bench/events.py
+++ b/tests/harness_bench/events.py
@@ -1,0 +1,129 @@
+"""Structured progress events for a bench run.
+
+The bench emits a small stream of typed events as it works — one harness
+starts, a probe starts, a probe finishes with a verdict, a harness finishes.
+A *sink* (``ProgressSink``) consumes them. This is the seam that lets the CLI
+render progress in more than one way without the orchestrator knowing how:
+
+- :class:`LineSink` prints the plain ``[harness] Probe: VERDICT`` lines to a
+  writer (the default; what CI / a piped run wants).
+- a rich live-table sink (see :mod:`tests.harness_bench.richreport`) draws one
+  row per harness with per-dimension cells that fill in as events arrive.
+
+Events carry structured fields (harness id, probe name/title, verdict, note),
+not pre-rendered strings, so a sink can lay them out however it likes and a
+parallel run can interleave multiple harnesses' events cleanly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from tests.harness_bench.verdict import Verdict
+
+
+@dataclass(frozen=True)
+class HarnessStarted:
+    """A harness began provisioning its transport."""
+
+    harness: str
+    transport: str
+    model: str
+
+
+@dataclass(frozen=True)
+class HarnessSkipped:
+    """A harness was skipped whole (unavailable, or provisioning failed)."""
+
+    harness: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ProbeStarted:
+    """A probe began running against a harness."""
+
+    harness: str
+    probe: str
+    title: str
+
+
+@dataclass(frozen=True)
+class ProbeFinished:
+    """A probe produced a verdict (or was skipped as a prerequisite casualty)."""
+
+    harness: str
+    probe: str
+    title: str
+    verdict: Verdict
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class HarnessFinished:
+    """A harness completed all its probes."""
+
+    harness: str
+
+
+BenchEvent = HarnessStarted | HarnessSkipped | ProbeStarted | ProbeFinished | HarnessFinished
+
+
+@runtime_checkable
+class ProgressSink(Protocol):
+    """Consumes :data:`BenchEvent`\\ s as a bench run emits them.
+
+    ``emit`` is called from the orchestrator (possibly from several concurrent
+    harness tasks under ``--jobs`` > 1), so a sink that mutates shared state
+    must tolerate interleaved calls. The built-in sinks are called on one
+    event loop thread, so no locking is needed there.
+    """
+
+    def emit(self, event: BenchEvent) -> None:
+        """Handle one event."""
+
+    def close(self) -> None:
+        """Finalize (flush a live display, etc.). Called once at run end."""
+
+
+class LineSink:
+    """A :class:`ProgressSink` that writes the plain per-probe status lines.
+
+    This is the default, TTY-agnostic renderer — the same output the bench
+    emitted before structured events existed, so a piped or CI run is
+    unchanged. ``write`` defaults to stderr (the report goes to stdout).
+    """
+
+    def __init__(self, write) -> None:  # write: Callable[[str], None]
+        self._write = write
+
+    def emit(self, event: BenchEvent) -> None:
+        if isinstance(event, HarnessStarted):
+            self._write(
+                f"[{event.harness}] provisioning {event.transport} transport "
+                f"(model={event.model}); first turn may take ~10-30s..."
+            )
+        elif isinstance(event, HarnessSkipped):
+            self._write(f"[{event.harness}] skipped: {event.reason}")
+        elif isinstance(event, ProbeStarted):
+            self._write(f"[{event.harness}]   {event.title}: running...")
+        elif isinstance(event, ProbeFinished):
+            suffix = f" ({event.note})" if event.note else ""
+            self._write(f"[{event.harness}]   {event.title}: {event.verdict.name}{suffix}")
+        # HarnessFinished is silent in line mode (the per-probe lines suffice).
+
+    def close(self) -> None:
+        pass
+
+
+__all__ = [
+    "BenchEvent",
+    "HarnessFinished",
+    "HarnessSkipped",
+    "HarnessStarted",
+    "LineSink",
+    "ProbeFinished",
+    "ProbeStarted",
+    "ProgressSink",
+]

--- a/tests/harness_bench/full_server.py
+++ b/tests/harness_bench/full_server.py
@@ -1,0 +1,311 @@
+"""Shared full-server infrastructure: spawn a real Omnigent server + runner.
+
+Split from :mod:`tests.harness_bench.full_server_driver` so the *server
+lifecycle* (spawning the server/runner, minting a bearer, registering bench
+agents + sessions) lives apart from the *driver* that runs probes against it.
+Two consumers use this:
+
+- :class:`~tests.harness_bench.full_server_driver.FullServerDriver` — one
+  harness per :class:`SharedFullServer` (solo run), or several harnesses on one
+  shared server (parallel run; see ``bench.run_bench``).
+- :mod:`tests.harness_bench.native_tui_driver` reuses the lower-level spawn
+  helpers (:func:`spawn_omnigent_server`, :func:`_mint_bearer`,
+  :func:`_find_free_port`) for its own server + host-daemon topology.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import tarfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN, token_bound_runner_id
+from tests._helpers.compat import (
+    apply_runner_env,
+    apply_server_env,
+    compat_runner_cwd,
+    compat_server_cwd,
+    runner_executable,
+    server_executable,
+)
+from tests.e2e.helpers import lookup_databricks_host
+from tests.harness_bench.profile import BenchProfile
+
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+_HEALTH_TIMEOUT_S = 90.0
+_POLL_INTERVAL_S = 0.2
+
+# The builtin the tool/policy probes drive: read-only, zero setup, server-
+# dispatched, and gated at the tool_call phase. Its denial output carries
+# _DENY_REASON so a blocked call is unambiguous.
+_TOOL_NAME = "list_files"
+_DENY_REASON = "bench-policy-deny"
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _mint_bearer(profile: str) -> str:
+    """Mint a Databricks bearer for *profile* via the CLI (isolated from ambient token env).
+
+    ``env -u DATABRICKS_TOKEN -u DATABRICKS_BEARER`` guards against a stale
+    ambient credential shadowing profile auth (see omnigent issue #1781).
+    """
+    proc = subprocess.run(
+        ["databricks", "auth", "token", "--profile", profile, "--output", "json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+        env={
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABRICKS_TOKEN", "DATABRICKS_BEARER")
+        },
+    )
+    return str(json.loads(proc.stdout)["access_token"])
+
+
+def spawn_omnigent_server(
+    tmp: Path, port: int, base_env: dict[str, str], binding_token: str
+) -> subprocess.Popen[bytes]:
+    """Spawn an ``omnigent server`` subprocess writing state under *tmp*.
+
+    Shared by the full-server and native-tui drivers (both need the same
+    server; only what connects to it differs — a bare runner vs a host
+    daemon). Writes ``server.log`` / ``bench.db`` / ``artifacts`` under *tmp*.
+    """
+    db_path = tmp / "bench.db"
+    artifact_dir = tmp / "artifacts"
+    artifact_dir.mkdir(exist_ok=True)
+    log = tmp / "server.log"
+    args = [
+        server_executable(),
+        "-m",
+        "omnigent.cli",
+        "server",
+        "--port",
+        str(port),
+        "--database-uri",
+        f"sqlite:///{db_path}",
+        "--artifact-location",
+        str(artifact_dir),
+    ]
+    return subprocess.Popen(
+        args,
+        env={**base_env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token},
+        cwd=compat_server_cwd(),
+        stdout=log.open("wb"),
+        stderr=subprocess.STDOUT,
+    )
+
+
+def _spawn_bench_runner(
+    tmp: Path, base_env: dict[str, str], runner_id: str, binding_token: str, base_url: str
+) -> subprocess.Popen[bytes]:
+    """Spawn a bench runner bound to *base_url* (the full-server execution sandbox)."""
+    log = tmp / "runner.log"
+    runner_env = apply_runner_env(
+        {
+            **base_env,
+            "OMNIGENT_RUNNER_ID": runner_id,
+            "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+            "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+            "RUNNER_SERVER_URL": base_url,
+        }
+    )
+    return subprocess.Popen(
+        [runner_executable(), "-m", "omnigent.runner._entry"],
+        env=runner_env,
+        cwd=compat_runner_cwd(),
+        stdout=log.open("wb"),
+        stderr=subprocess.STDOUT,
+    )
+
+
+def _wait_server_runner_ready(base_url: str, runner_id: str) -> None:
+    """Poll until the server is healthy and *runner_id* reports online."""
+    deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+    while time.monotonic() < deadline:
+        try:
+            health = httpx.get(f"{base_url}/health", timeout=2)
+            status = httpx.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
+            if (
+                health.status_code == 200
+                and status.status_code == 200
+                and status.json().get("online") is True
+            ):
+                return
+        except httpx.HTTPError:
+            # Connection refused / read errors are expected while the server
+            # and runner are still coming up; keep polling until the timeout.
+            pass
+        time.sleep(_POLL_INTERVAL_S)
+    raise RuntimeError(
+        f"server+runner not ready within {_HEALTH_TIMEOUT_S}s; logs near {base_url}"
+    )
+
+
+def _build_bench_agent_config(
+    profile: BenchProfile, db_profile: str, *, deny: bool
+) -> dict[str, Any]:
+    """The agent spec for a bench harness: the harness + the read-only builtin,
+    plus (when *deny*) a baked tool_call-phase deny on that builtin."""
+    name = f"bench-{profile.harness}" + ("-deny" if deny else "")
+    config: dict[str, Any] = {
+        "spec_version": 1,
+        "name": name,
+        "prompt": "You are a helpful assistant used for capability testing.",
+        "executor": {
+            "type": "omnigent",
+            "model": profile.model,
+            "profile": db_profile,
+            "config": {"harness": profile.harness},
+        },
+        # A read-only builtin the server dispatches (and gates at the tool_call
+        # phase). The tool/policy probes drive a call to it; harmless for basic
+        # turns (the model just won't call it).
+        "tools": {"builtins": [_TOOL_NAME]},
+    }
+    if deny:
+        config["guardrails"] = {
+            "policies": {
+                "deny_tool": {
+                    "type": "function",
+                    "function": {
+                        "path": "omnigent.policies.function.make_fixed_action_callable",
+                        "arguments": {
+                            "action": "deny",
+                            "reason": _DENY_REASON,
+                            "on_phases": ["tool_call"],
+                            "on_tools": [_TOOL_NAME],
+                        },
+                    },
+                }
+            }
+        }
+    return config
+
+
+def _bundle_agent_config(config: dict[str, Any]) -> bytes:
+    """Gzip-tar a spec_version agent config as the ``config.yaml`` bundle member."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        payload = yaml.safe_dump(config).encode()
+        info = tarfile.TarInfo("config.yaml")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+class SharedFullServer:
+    """One server + one runner shared by several full-server harnesses.
+
+    The Omnigent server is multi-agent/multi-session, and a single runner
+    resolves the harness type per session from that session's agent spec (see
+    ``runner/app.py``). So N SDK harnesses do NOT each need their own
+    server+runner — they can each register as their own agent + session on one
+    shared pair, with the runner spawning the right harness subprocess per
+    session. Under ``--jobs`` > 1 this replaces N server boots + N runners with
+    one, cutting the heaviest, slowest part of full-server startup.
+
+    Sync context manager (spawn/health-wait are blocking); the orchestrator
+    bridges it via ``asyncio.to_thread``. ``register_agent`` / ``create_session``
+    are the per-harness operations a ``FullServerDriver`` calls against it.
+    """
+
+    def __init__(self, db_profile: str) -> None:
+        self._db_profile = db_profile
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._runner: subprocess.Popen[bytes] | None = None
+        self.client: httpx.Client | None = None
+        self.runner_id = ""
+        self.base_url = ""
+        self._tmp = Path("/tmp") / f"omni-bench-fs-shared-{uuid.uuid4().hex[:8]}"
+
+    def __enter__(self) -> SharedFullServer:
+        self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)
+        host = lookup_databricks_host(self._db_profile)
+        assert host is not None
+        bearer = _mint_bearer(self._db_profile)
+        port = _find_free_port()
+        self.base_url = f"http://localhost:{port}"
+        binding_token = uuid.uuid4().hex
+        self.runner_id = token_bound_runner_id(binding_token)
+        base_env = {
+            **os.environ,
+            "OPENAI_API_KEY": bearer,
+            "OPENAI_BASE_URL": f"{host}/serving-endpoints",
+            "DATABRICKS_CONFIG_PROFILE": self._db_profile,
+        }
+        apply_server_env(base_env, _REPO_ROOT)
+        self._proc = spawn_omnigent_server(self._tmp, port, base_env, binding_token)
+        self._runner = _spawn_bench_runner(
+            self._tmp, base_env, self.runner_id, binding_token, self.base_url
+        )
+        _wait_server_runner_ready(self.base_url, self.runner_id)
+        self.client = httpx.Client(
+            base_url=self.base_url,
+            timeout=300.0,
+            headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+        )
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        if self.client is not None:
+            self.client.close()
+        for proc in (self._runner, self._proc):
+            if proc is not None and proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    proc.wait(timeout=8)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def register_agent(self, profile: BenchProfile, *, deny: bool) -> str:
+        """Register a bench agent for *profile*; return its agent name."""
+        assert self.client is not None
+        config = _build_bench_agent_config(profile, self._db_profile, deny=deny)
+        resp = self.client.post(
+            "/v1/sessions",
+            data={"metadata": json.dumps({})},
+            files={"bundle": ("agent.tar.gz", _bundle_agent_config(config), "application/gzip")},
+        )
+        if resp.status_code not in (200, 201, 409):
+            raise RuntimeError(f"agent register failed: {resp.status_code} {resp.text[:400]}")
+        return str(config["name"])
+
+    def create_session(self, agent_name: str) -> str:
+        """Create a runner-bound session for a registered agent name."""
+        assert self.client is not None
+        listing = self.client.get("/v1/sessions", params={"agent_name": agent_name, "limit": 1})
+        listing.raise_for_status()
+        agent_id = str(listing.json()["data"][0]["agent_id"])
+        created = self.client.post("/v1/sessions", json={"agent_id": agent_id})
+        created.raise_for_status()
+        session_id = str(created.json()["id"])
+        bound = self.client.patch(f"/v1/sessions/{session_id}", json={"runner_id": self.runner_id})
+        bound.raise_for_status()
+        return session_id
+
+
+__all__ = [
+    "SharedFullServer",
+    "spawn_omnigent_server",
+]

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -29,40 +29,23 @@ bench's probes run through this driver, not just its gated tests.
 from __future__ import annotations
 
 import asyncio
-import json
-import os
-import signal
-import subprocess
 import threading
 import time
-import uuid
-from pathlib import Path
 from typing import Any
 
 import httpx
 
-from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN, token_bound_runner_id
-from tests._helpers.compat import (
-    apply_runner_env,
-    apply_server_env,
-    compat_runner_cwd,
-    compat_server_cwd,
-    runner_executable,
-    server_executable,
-)
+from tests.e2e._harness_probes import cli_unavailable_reason
 from tests.e2e.helpers import lookup_databricks_host
 from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.full_server import (
+    _DENY_REASON,
+    _POLL_INTERVAL_S,
+    _TOOL_NAME,
+    SharedFullServer,
+)
 from tests.harness_bench.profile import BenchProfile
 
-_REPO_ROOT = str(Path(__file__).resolve().parents[2])
-_HEALTH_TIMEOUT_S = 90.0
-_POLL_INTERVAL_S = 0.2
-
-# The builtin the tool/policy probes drive: read-only, zero setup, server-
-# dispatched, and gated at the tool_call phase. Its denial output carries
-# _DENY_REASON so a blocked call is unambiguous.
-_TOOL_NAME = "list_files"
-_DENY_REASON = "bench-policy-deny"
 _TOOL_PROMPT = f"List the files using the {_TOOL_NAME} tool, then tell me how many there are."
 
 # The server persists an interrupted turn as a synthetic user message whose
@@ -77,264 +60,6 @@ _STREAM_PROMPT = (
     "Count from 1 to 30 in words, one number per line, and add a short note after each."
 )
 _TERMINAL_EVENTS = frozenset({"response.completed", "response.failed", "response.cancelled"})
-
-
-def _find_free_port() -> int:
-    import socket
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return int(s.getsockname()[1])
-
-
-def _mint_bearer(profile: str) -> str:
-    """Mint a Databricks bearer for *profile* via the CLI (isolated from ambient token env).
-
-    ``env -u DATABRICKS_TOKEN -u DATABRICKS_BEARER`` guards against a stale
-    ambient credential shadowing profile auth (see omnigent issue #1781).
-    """
-    proc = subprocess.run(
-        ["databricks", "auth", "token", "--profile", profile, "--output", "json"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=True,
-        env={
-            k: v
-            for k, v in os.environ.items()
-            if k not in ("DATABRICKS_TOKEN", "DATABRICKS_BEARER")
-        },
-    )
-    return str(json.loads(proc.stdout)["access_token"])
-
-
-def spawn_omnigent_server(
-    tmp: Path, port: int, base_env: dict[str, str], binding_token: str
-) -> subprocess.Popen[bytes]:
-    """Spawn an ``omnigent server`` subprocess writing state under *tmp*.
-
-    Shared by the full-server and native-tui drivers (both need the same
-    server; only what connects to it differs — a bare runner vs a host
-    daemon). Writes ``server.log`` / ``bench.db`` / ``artifacts`` under *tmp*.
-    """
-    db_path = tmp / "bench.db"
-    artifact_dir = tmp / "artifacts"
-    artifact_dir.mkdir(exist_ok=True)
-    log = tmp / "server.log"
-    args = [
-        server_executable(),
-        "-m",
-        "omnigent.cli",
-        "server",
-        "--port",
-        str(port),
-        "--database-uri",
-        f"sqlite:///{db_path}",
-        "--artifact-location",
-        str(artifact_dir),
-    ]
-    return subprocess.Popen(
-        args,
-        env={**base_env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token},
-        cwd=compat_server_cwd(),
-        stdout=log.open("wb"),
-        stderr=subprocess.STDOUT,
-    )
-
-
-def _build_bench_agent_config(
-    profile: BenchProfile, db_profile: str, *, deny: bool
-) -> dict[str, Any]:
-    """The agent spec for a bench harness: the harness + the read-only builtin,
-    plus (when *deny*) a baked tool_call-phase deny on that builtin."""
-    name = f"bench-{profile.harness}" + ("-deny" if deny else "")
-    config: dict[str, Any] = {
-        "spec_version": 1,
-        "name": name,
-        "prompt": "You are a helpful assistant used for capability testing.",
-        "executor": {
-            "type": "omnigent",
-            "model": profile.model,
-            "profile": db_profile,
-            "config": {"harness": profile.harness},
-        },
-        # A read-only builtin the server dispatches (and gates at the tool_call
-        # phase). The tool/policy probes drive a call to it; harmless for basic
-        # turns (the model just won't call it).
-        "tools": {"builtins": [_TOOL_NAME]},
-    }
-    if deny:
-        config["guardrails"] = {
-            "policies": {
-                "deny_tool": {
-                    "type": "function",
-                    "function": {
-                        "path": "omnigent.policies.function.make_fixed_action_callable",
-                        "arguments": {
-                            "action": "deny",
-                            "reason": _DENY_REASON,
-                            "on_phases": ["tool_call"],
-                            "on_tools": [_TOOL_NAME],
-                        },
-                    },
-                }
-            }
-        }
-    return config
-
-
-def _bundle_agent_config(config: dict[str, Any]) -> bytes:
-    """Gzip-tar a spec_version agent config as the ``config.yaml`` bundle member."""
-    import io
-    import tarfile
-
-    import yaml
-
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        payload = yaml.safe_dump(config).encode()
-        info = tarfile.TarInfo("config.yaml")
-        info.size = len(payload)
-        tar.addfile(info, io.BytesIO(payload))
-    return buf.getvalue()
-
-
-class SharedFullServer:
-    """One server + one runner shared by several full-server harnesses.
-
-    The Omnigent server is multi-agent/multi-session, and a single runner
-    resolves the harness type per session from that session's agent spec (see
-    ``runner/app.py``). So N SDK harnesses do NOT each need their own
-    server+runner — they can each register as their own agent + session on one
-    shared pair, with the runner spawning the right harness subprocess per
-    session. Under ``--jobs`` > 1 this replaces N server boots + N runners with
-    one, cutting the heaviest, slowest part of full-server startup.
-
-    Sync context manager (spawn/health-wait are blocking); the orchestrator
-    bridges it via ``asyncio.to_thread``. ``register_agent`` / ``create_session``
-    are the per-harness operations a :class:`FullServerDriver` calls against it.
-    """
-
-    def __init__(self, db_profile: str) -> None:
-        self._db_profile = db_profile
-        self._proc: subprocess.Popen[bytes] | None = None
-        self._runner: subprocess.Popen[bytes] | None = None
-        self.client: httpx.Client | None = None
-        self.runner_id = ""
-        self.base_url = ""
-        self._tmp = Path("/tmp") / f"omni-bench-fs-shared-{uuid.uuid4().hex[:8]}"
-
-    def __enter__(self) -> SharedFullServer:
-        self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)
-        host = lookup_databricks_host(self._db_profile)
-        assert host is not None
-        bearer = _mint_bearer(self._db_profile)
-        port = _find_free_port()
-        self.base_url = f"http://localhost:{port}"
-        binding_token = uuid.uuid4().hex
-        self.runner_id = token_bound_runner_id(binding_token)
-        base_env = {
-            **os.environ,
-            "OPENAI_API_KEY": bearer,
-            "OPENAI_BASE_URL": f"{host}/serving-endpoints",
-            "DATABRICKS_CONFIG_PROFILE": self._db_profile,
-        }
-        apply_server_env(base_env, _REPO_ROOT)
-        self._proc = spawn_omnigent_server(self._tmp, port, base_env, binding_token)
-        self._runner = _spawn_bench_runner(
-            self._tmp, base_env, self.runner_id, binding_token, self.base_url
-        )
-        _wait_server_runner_ready(self.base_url, self.runner_id)
-        self.client = httpx.Client(
-            base_url=self.base_url,
-            timeout=300.0,
-            headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
-        )
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        if self.client is not None:
-            self.client.close()
-        for proc in (self._runner, self._proc):
-            if proc is not None and proc.poll() is None:
-                proc.send_signal(signal.SIGTERM)
-                try:
-                    proc.wait(timeout=8)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-        import shutil
-
-        shutil.rmtree(self._tmp, ignore_errors=True)
-
-    def register_agent(self, profile: BenchProfile, *, deny: bool) -> str:
-        """Register a bench agent for *profile*; return its agent name."""
-        assert self.client is not None
-        config = _build_bench_agent_config(profile, self._db_profile, deny=deny)
-        resp = self.client.post(
-            "/v1/sessions",
-            data={"metadata": json.dumps({})},
-            files={"bundle": ("agent.tar.gz", _bundle_agent_config(config), "application/gzip")},
-        )
-        if resp.status_code not in (200, 201, 409):
-            raise RuntimeError(f"agent register failed: {resp.status_code} {resp.text[:400]}")
-        return str(config["name"])
-
-    def create_session(self, agent_name: str) -> str:
-        """Create a runner-bound session for a registered agent name."""
-        assert self.client is not None
-        listing = self.client.get("/v1/sessions", params={"agent_name": agent_name, "limit": 1})
-        listing.raise_for_status()
-        agent_id = str(listing.json()["data"][0]["agent_id"])
-        created = self.client.post("/v1/sessions", json={"agent_id": agent_id})
-        created.raise_for_status()
-        session_id = str(created.json()["id"])
-        bound = self.client.patch(f"/v1/sessions/{session_id}", json={"runner_id": self.runner_id})
-        bound.raise_for_status()
-        return session_id
-
-
-def _spawn_bench_runner(
-    tmp: Path, base_env: dict[str, str], runner_id: str, binding_token: str, base_url: str
-) -> subprocess.Popen[bytes]:
-    """Spawn a bench runner bound to *base_url* (shared by the full-server path)."""
-    log = tmp / "runner.log"
-    runner_env = apply_runner_env(
-        {
-            **base_env,
-            "OMNIGENT_RUNNER_ID": runner_id,
-            "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
-            "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
-            "RUNNER_SERVER_URL": base_url,
-        }
-    )
-    return subprocess.Popen(
-        [runner_executable(), "-m", "omnigent.runner._entry"],
-        env=runner_env,
-        cwd=compat_runner_cwd(),
-        stdout=log.open("wb"),
-        stderr=subprocess.STDOUT,
-    )
-
-
-def _wait_server_runner_ready(base_url: str, runner_id: str) -> None:
-    """Poll until the server is healthy and *runner_id* reports online."""
-    deadline = time.monotonic() + _HEALTH_TIMEOUT_S
-    while time.monotonic() < deadline:
-        try:
-            health = httpx.get(f"{base_url}/health", timeout=2)
-            status = httpx.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
-            if (
-                health.status_code == 200
-                and status.status_code == 200
-                and status.json().get("online") is True
-            ):
-                return
-        except httpx.HTTPError:
-            pass
-        time.sleep(_POLL_INTERVAL_S)
-    raise RuntimeError(
-        f"server+runner not ready within {_HEALTH_TIMEOUT_S}s; logs near {base_url}"
-    )
 
 
 class FullServerDriver:
@@ -395,8 +120,6 @@ class FullServerDriver:
         # Same CLI gate as the wrap driver (same binary requirement), but skip
         # its transport check — that is sdk-inproc-specific and would misreport
         # the driver name; the native case is already handled above.
-        from tests.e2e._harness_probes import cli_unavailable_reason
-
         if profile.cli_binary is not None:
             return cli_unavailable_reason(profile.cli_binary)
         return None

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -142,6 +142,201 @@ def spawn_omnigent_server(
     )
 
 
+def _build_bench_agent_config(
+    profile: BenchProfile, db_profile: str, *, deny: bool
+) -> dict[str, Any]:
+    """The agent spec for a bench harness: the harness + the read-only builtin,
+    plus (when *deny*) a baked tool_call-phase deny on that builtin."""
+    name = f"bench-{profile.harness}" + ("-deny" if deny else "")
+    config: dict[str, Any] = {
+        "spec_version": 1,
+        "name": name,
+        "prompt": "You are a helpful assistant used for capability testing.",
+        "executor": {
+            "type": "omnigent",
+            "model": profile.model,
+            "profile": db_profile,
+            "config": {"harness": profile.harness},
+        },
+        # A read-only builtin the server dispatches (and gates at the tool_call
+        # phase). The tool/policy probes drive a call to it; harmless for basic
+        # turns (the model just won't call it).
+        "tools": {"builtins": [_TOOL_NAME]},
+    }
+    if deny:
+        config["guardrails"] = {
+            "policies": {
+                "deny_tool": {
+                    "type": "function",
+                    "function": {
+                        "path": "omnigent.policies.function.make_fixed_action_callable",
+                        "arguments": {
+                            "action": "deny",
+                            "reason": _DENY_REASON,
+                            "on_phases": ["tool_call"],
+                            "on_tools": [_TOOL_NAME],
+                        },
+                    },
+                }
+            }
+        }
+    return config
+
+
+def _bundle_agent_config(config: dict[str, Any]) -> bytes:
+    """Gzip-tar a spec_version agent config as the ``config.yaml`` bundle member."""
+    import io
+    import tarfile
+
+    import yaml
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        payload = yaml.safe_dump(config).encode()
+        info = tarfile.TarInfo("config.yaml")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+class SharedFullServer:
+    """One server + one runner shared by several full-server harnesses.
+
+    The Omnigent server is multi-agent/multi-session, and a single runner
+    resolves the harness type per session from that session's agent spec (see
+    ``runner/app.py``). So N SDK harnesses do NOT each need their own
+    server+runner — they can each register as their own agent + session on one
+    shared pair, with the runner spawning the right harness subprocess per
+    session. Under ``--jobs`` > 1 this replaces N server boots + N runners with
+    one, cutting the heaviest, slowest part of full-server startup.
+
+    Sync context manager (spawn/health-wait are blocking); the orchestrator
+    bridges it via ``asyncio.to_thread``. ``register_agent`` / ``create_session``
+    are the per-harness operations a :class:`FullServerDriver` calls against it.
+    """
+
+    def __init__(self, db_profile: str) -> None:
+        self._db_profile = db_profile
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._runner: subprocess.Popen[bytes] | None = None
+        self.client: httpx.Client | None = None
+        self.runner_id = ""
+        self.base_url = ""
+        self._tmp = Path("/tmp") / f"omni-bench-fs-shared-{uuid.uuid4().hex[:8]}"
+
+    def __enter__(self) -> SharedFullServer:
+        self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)
+        host = lookup_databricks_host(self._db_profile)
+        assert host is not None
+        bearer = _mint_bearer(self._db_profile)
+        port = _find_free_port()
+        self.base_url = f"http://localhost:{port}"
+        binding_token = uuid.uuid4().hex
+        self.runner_id = token_bound_runner_id(binding_token)
+        base_env = {
+            **os.environ,
+            "OPENAI_API_KEY": bearer,
+            "OPENAI_BASE_URL": f"{host}/serving-endpoints",
+            "DATABRICKS_CONFIG_PROFILE": self._db_profile,
+        }
+        apply_server_env(base_env, _REPO_ROOT)
+        self._proc = spawn_omnigent_server(self._tmp, port, base_env, binding_token)
+        self._runner = _spawn_bench_runner(
+            self._tmp, base_env, self.runner_id, binding_token, self.base_url
+        )
+        _wait_server_runner_ready(self.base_url, self.runner_id)
+        self.client = httpx.Client(
+            base_url=self.base_url,
+            timeout=300.0,
+            headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+        )
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        if self.client is not None:
+            self.client.close()
+        for proc in (self._runner, self._proc):
+            if proc is not None and proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    proc.wait(timeout=8)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def register_agent(self, profile: BenchProfile, *, deny: bool) -> str:
+        """Register a bench agent for *profile*; return its agent name."""
+        assert self.client is not None
+        config = _build_bench_agent_config(profile, self._db_profile, deny=deny)
+        resp = self.client.post(
+            "/v1/sessions",
+            data={"metadata": json.dumps({})},
+            files={"bundle": ("agent.tar.gz", _bundle_agent_config(config), "application/gzip")},
+        )
+        if resp.status_code not in (200, 201, 409):
+            raise RuntimeError(f"agent register failed: {resp.status_code} {resp.text[:400]}")
+        return str(config["name"])
+
+    def create_session(self, agent_name: str) -> str:
+        """Create a runner-bound session for a registered agent name."""
+        assert self.client is not None
+        listing = self.client.get("/v1/sessions", params={"agent_name": agent_name, "limit": 1})
+        listing.raise_for_status()
+        agent_id = str(listing.json()["data"][0]["agent_id"])
+        created = self.client.post("/v1/sessions", json={"agent_id": agent_id})
+        created.raise_for_status()
+        session_id = str(created.json()["id"])
+        bound = self.client.patch(f"/v1/sessions/{session_id}", json={"runner_id": self.runner_id})
+        bound.raise_for_status()
+        return session_id
+
+
+def _spawn_bench_runner(
+    tmp: Path, base_env: dict[str, str], runner_id: str, binding_token: str, base_url: str
+) -> subprocess.Popen[bytes]:
+    """Spawn a bench runner bound to *base_url* (shared by the full-server path)."""
+    log = tmp / "runner.log"
+    runner_env = apply_runner_env(
+        {
+            **base_env,
+            "OMNIGENT_RUNNER_ID": runner_id,
+            "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+            "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+            "RUNNER_SERVER_URL": base_url,
+        }
+    )
+    return subprocess.Popen(
+        [runner_executable(), "-m", "omnigent.runner._entry"],
+        env=runner_env,
+        cwd=compat_runner_cwd(),
+        stdout=log.open("wb"),
+        stderr=subprocess.STDOUT,
+    )
+
+
+def _wait_server_runner_ready(base_url: str, runner_id: str) -> None:
+    """Poll until the server is healthy and *runner_id* reports online."""
+    deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+    while time.monotonic() < deadline:
+        try:
+            health = httpx.get(f"{base_url}/health", timeout=2)
+            status = httpx.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
+            if (
+                health.status_code == 200
+                and status.status_code == 200
+                and status.json().get("online") is True
+            ):
+                return
+        except httpx.HTTPError:
+            pass
+        time.sleep(_POLL_INTERVAL_S)
+    raise RuntimeError(
+        f"server+runner not ready within {_HEALTH_TIMEOUT_S}s; logs near {base_url}"
+    )
+
+
 class FullServerDriver:
     """Drive turns through a live Omnigent server + runner.
 
@@ -153,22 +348,31 @@ class FullServerDriver:
 
     transport = "full-server"
 
-    def __init__(self, profile: BenchProfile, *, databricks_profile: str) -> None:
+    def __init__(
+        self,
+        profile: BenchProfile,
+        *,
+        databricks_profile: str,
+        shared: SharedFullServer | None = None,
+    ) -> None:
         self._profile = profile
         self._db_profile = databricks_profile
-        self._proc: subprocess.Popen[bytes] | None = None
-        self._runner: subprocess.Popen[bytes] | None = None
-        self._logs: list[Path] = []
-        self._client: httpx.Client | None = None
-        self._session_id: str | None = None
+        # When *shared* is given (a parallel run), this driver registers its
+        # agent + session on that one server+runner and spawns nothing itself.
+        # When None (a solo / --jobs 1 run), it owns a private SharedFullServer
+        # for back-compat with the original one-server-per-harness behavior.
+        self._shared = shared
+        self._owns_shared = shared is None
         # A second agent+session whose spec bakes a tool_call deny policy,
         # created lazily for the policy probe (the REST policy endpoint's
         # handler allowlist excludes make_fixed_action_callable, so the deny
         # must ride in the agent spec instead).
         self._deny_session_id: str | None = None
-        self._runner_id = ""
-        self._base_url = ""
-        self._tmp = Path("/tmp") / f"omni-bench-fs-{uuid.uuid4().hex[:8]}"
+        self._session_id: str | None = None
+
+    @property
+    def _client(self) -> httpx.Client | None:
+        return self._shared.client if self._shared is not None else None
 
     @staticmethod
     def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
@@ -198,51 +402,18 @@ class FullServerDriver:
         return None
 
     def __enter__(self) -> FullServerDriver:
-        self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)
-        host = lookup_databricks_host(self._db_profile)
-        assert host is not None  # guaranteed by unavailable()
-        bearer = _mint_bearer(self._db_profile)
-        port = _find_free_port()
-        self._base_url = f"http://localhost:{port}"
-
-        binding_token = uuid.uuid4().hex
-        runner_id = token_bound_runner_id(binding_token)
-
-        base_env = {
-            **os.environ,
-            "OPENAI_API_KEY": bearer,
-            "OPENAI_BASE_URL": f"{host}/serving-endpoints",
-            "DATABRICKS_CONFIG_PROFILE": self._db_profile,
-        }
-        apply_server_env(base_env, _REPO_ROOT)
-
-        self._proc = self._spawn_server(port, base_env, binding_token)
-        self._runner = self._spawn_runner(base_env, runner_id, binding_token)
-        self._wait_ready(runner_id)
-
-        self._client = httpx.Client(
-            base_url=self._base_url,
-            timeout=300.0,
-            headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
-        )
-        self._runner_id = runner_id
-        agent_name = self._register_agent(deny=False)
-        self._session_id = self._create_session(agent_name, runner_id)
+        if self._shared is None:
+            self._shared = SharedFullServer(self._db_profile)
+            self._shared.__enter__()
+        agent_name = self._shared.register_agent(self._profile, deny=False)
+        self._session_id = self._shared.create_session(agent_name)
         return self
 
     def __exit__(self, *exc: object) -> None:
-        if self._client is not None:
-            self._client.close()
-        for proc in (self._runner, self._proc):
-            if proc is not None and proc.poll() is None:
-                proc.send_signal(signal.SIGTERM)
-                try:
-                    proc.wait(timeout=8)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-        import shutil
-
-        shutil.rmtree(self._tmp, ignore_errors=True)
+        # Only tear down the server we own; an injected shared server is the
+        # orchestrator's to close after all harnesses finish.
+        if self._owns_shared and self._shared is not None:
+            self._shared.__exit__(*exc)
 
     # ── async driver protocol ────────────────────────────────
     # This driver's provisioning and turns are synchronous (subprocess spawn,
@@ -269,137 +440,17 @@ class FullServerDriver:
     async def run_interrupt_turn(self) -> TurnResult:
         return await asyncio.to_thread(self.interrupt_probe_turn)
 
-    # ── spawn ────────────────────────────────────────────────
-
-    def _spawn_server(
-        self, port: int, base_env: dict[str, str], binding_token: str
-    ) -> subprocess.Popen[bytes]:
-        proc = spawn_omnigent_server(self._tmp, port, base_env, binding_token)
-        self._logs.append(self._tmp / "server.log")
-        return proc
-
-    def _spawn_runner(
-        self, base_env: dict[str, str], runner_id: str, binding_token: str
-    ) -> subprocess.Popen[bytes]:
-        log = self._tmp / "runner.log"
-        self._logs.append(log)
-        runner_env = apply_runner_env(
-            {
-                **base_env,
-                "OMNIGENT_RUNNER_ID": runner_id,
-                "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
-                "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
-                "RUNNER_SERVER_URL": self._base_url,
-            }
-        )
-        return subprocess.Popen(
-            [runner_executable(), "-m", "omnigent.runner._entry"],
-            env=runner_env,
-            cwd=compat_runner_cwd(),
-            stdout=log.open("wb"),
-            stderr=subprocess.STDOUT,
-        )
-
-    def _wait_ready(self, runner_id: str) -> None:
-        deadline = time.monotonic() + _HEALTH_TIMEOUT_S
-        while time.monotonic() < deadline:
-            try:
-                health = httpx.get(f"{self._base_url}/health", timeout=2)
-                status = httpx.get(f"{self._base_url}/v1/runners/{runner_id}/status", timeout=2)
-                if (
-                    health.status_code == 200
-                    and status.status_code == 200
-                    and status.json().get("online") is True
-                ):
-                    return
-            except httpx.HTTPError:
-                # Connection refused / read errors are expected while the
-                # server and runner are still coming up; keep polling until
-                # they answer or the timeout below fires.
-                pass
-            time.sleep(_POLL_INTERVAL_S)
-        raise RuntimeError(
-            f"server+runner not ready within {_HEALTH_TIMEOUT_S}s; logs in {self._tmp}"
-        )
-
     # ── agent + session ──────────────────────────────────────
-
-    def _register_agent(self, *, deny: bool) -> str:
-        import io
-        import tarfile
-
-        import yaml
-
-        assert self._client is not None
-        name = f"bench-{self._profile.harness}" + ("-deny" if deny else "")
-        config: dict[str, Any] = {
-            "spec_version": 1,
-            "name": name,
-            "prompt": "You are a helpful assistant used for capability testing.",
-            "executor": {
-                "type": "omnigent",
-                "model": self._profile.model,
-                "profile": self._db_profile,
-                "config": {"harness": self._profile.harness},
-            },
-            # A read-only builtin the server dispatches (and gates at the
-            # tool_call phase). The tool/policy probes drive a call to it;
-            # it is harmless for basic turns (the model just won't call it).
-            "tools": {"builtins": [_TOOL_NAME]},
-        }
-        if deny:
-            # Bake a tool_call-phase deny on the builtin so the server blocks
-            # the call the way production policy enforcement does.
-            config["guardrails"] = {
-                "policies": {
-                    "deny_tool": {
-                        "type": "function",
-                        "function": {
-                            "path": "omnigent.policies.function.make_fixed_action_callable",
-                            "arguments": {
-                                "action": "deny",
-                                "reason": _DENY_REASON,
-                                "on_phases": ["tool_call"],
-                                "on_tools": [_TOOL_NAME],
-                            },
-                        },
-                    }
-                }
-            }
-        # spec_version bundles load via the directory spec loader, which
-        # recognizes tools.builtins and expects the member named config.yaml.
-        buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-            payload = yaml.safe_dump(config).encode()
-            info = tarfile.TarInfo("config.yaml")
-            info.size = len(payload)
-            tar.addfile(info, io.BytesIO(payload))
-        resp = self._client.post(
-            "/v1/sessions",
-            data={"metadata": json.dumps({})},
-            files={"bundle": ("agent.tar.gz", buf.getvalue(), "application/gzip")},
-        )
-        if resp.status_code not in (200, 201, 409):
-            raise RuntimeError(f"agent register failed: {resp.status_code} {resp.text[:400]}")
-        return name
-
-    def _create_session(self, agent_name: str, runner_id: str) -> str:
-        assert self._client is not None
-        listing = self._client.get("/v1/sessions", params={"agent_name": agent_name, "limit": 1})
-        listing.raise_for_status()
-        agent_id = str(listing.json()["data"][0]["agent_id"])
-        created = self._client.post("/v1/sessions", json={"agent_id": agent_id})
-        created.raise_for_status()
-        session_id = str(created.json()["id"])
-        bound = self._client.patch(f"/v1/sessions/{session_id}", json={"runner_id": runner_id})
-        bound.raise_for_status()
-        return session_id
+    # The server/runner lifecycle and agent/session registration live on
+    # SharedFullServer now; this driver delegates so a solo run and a parallel
+    # (shared-server) run go through the same path.
 
     def _ensure_deny_session(self) -> str:
         """Lazily register the deny agent and its session; return the session id."""
+        assert self._shared is not None
         if self._deny_session_id is None:
-            name = self._register_agent(deny=True)
-            self._deny_session_id = self._create_session(name, self._runner_id)
+            name = self._shared.register_agent(self._profile, deny=True)
+            self._deny_session_id = self._shared.create_session(name)
         return self._deny_session_id
 
     # ── tool / policy probe ──────────────────────────────────

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -74,7 +74,7 @@ from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e._harness_probes import cli_unavailable_reason
 from tests.e2e.helpers import lookup_databricks_host
-from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.driver import ProvisioningError, TurnResult
 from tests.harness_bench.full_server import (
     _find_free_port,
     _mint_bearer,
@@ -353,7 +353,7 @@ class NativeTuiDriver:
             if snap.status_code == 200 and snap.json().get("external_session_id"):
                 return
             time.sleep(_POLL_INTERVAL_S)
-        raise RuntimeError(
+        raise ProvisioningError(
             f"native forwarder did not wire up within {_FORWARDER_READY_TIMEOUT_S}s "
             f"(no external_session_id); logs in {self._tmp}"
         )

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
 import signal
 import subprocess
 import threading
@@ -61,6 +62,8 @@ from typing import Any
 
 import httpx
 
+from omnigent.harness_capabilities import AuthModel, IntegrationMode
+from omnigent.harness_plugins import harness_capabilities
 from omnigent.host.daemon_launch import (
     launch_or_reuse_daemon_runner,
     wait_for_host_online,
@@ -69,9 +72,10 @@ from omnigent.host.daemon_launch import (
 from omnigent.native_terminal import bind_session_runner
 from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
+from tests.e2e._harness_probes import cli_unavailable_reason
 from tests.e2e.helpers import lookup_databricks_host
 from tests.harness_bench.driver import TurnResult
-from tests.harness_bench.full_server_driver import (
+from tests.harness_bench.full_server import (
     _find_free_port,
     _mint_bearer,
     spawn_omnigent_server,
@@ -163,9 +167,6 @@ def native_vendor(harness: str) -> NativeVendor | None:
     ``native-server`` harnesses (e.g. opencode-native) are a different
     transport and return ``None``.
     """
-    from omnigent.harness_capabilities import AuthModel, IntegrationMode
-    from omnigent.harness_plugins import harness_capabilities
-
     caps = harness_capabilities().get(harness)
     if caps is None or caps.integration_mode is not IntegrationMode.NATIVE_TUI:
         return None
@@ -221,8 +222,6 @@ class NativeTuiDriver:
         # host; the bench cannot provision a login. Presence on PATH is the
         # cheapest precondition we can check — a missing login still fails the
         # live turn, reported as a capability-neutral skip by the probes.
-        from tests.e2e._harness_probes import cli_unavailable_reason
-
         binary = profile.cli_binary
         if binary is not None:
             reason = cli_unavailable_reason(binary)
@@ -441,8 +440,6 @@ class NativeTuiDriver:
                     proc.wait(timeout=8)
                 except subprocess.TimeoutExpired:
                     proc.kill()
-        import shutil
-
         shutil.rmtree(self._tmp, ignore_errors=True)
 
     # ── turns ────────────────────────────────────────────────

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -232,7 +232,18 @@ class NativeTuiDriver:
     # ── async driver protocol ────────────────────────────────
 
     async def __aenter__(self) -> NativeTuiDriver:
-        await asyncio.to_thread(self._provision)
+        try:
+            await asyncio.to_thread(self._provision)
+        except httpx.HTTPError as exc:
+            # Native provisioning drives a live vendor CLI + a server-native
+            # terminal, so an HTTP failure here (e.g. a 500 from terminal-ensure
+            # when the vendor cannot start a thread) is an environment/server-
+            # state gap, not a bench bug. Re-raise as ProvisioningError so the
+            # orchestrator skips this harness quietly (reason shown in its row)
+            # instead of dumping a traceback. A programming error (AssertionError
+            # on a misconfigured profile, etc.) is not an HTTPError, so it still
+            # propagates loud.
+            raise ProvisioningError(f"native provisioning HTTP error: {exc}") from exc
         return self
 
     async def __aexit__(self, *exc: object) -> None:
@@ -407,7 +418,9 @@ class NativeTuiDriver:
                 # Connection refused while the server boots; keep polling.
                 pass
             time.sleep(_POLL_INTERVAL_S)
-        raise RuntimeError(f"server not healthy within {_HEALTH_TIMEOUT_S}s; logs in {self._tmp}")
+        raise ProvisioningError(
+            f"server not healthy within {_HEALTH_TIMEOUT_S}s; logs in {self._tmp}"
+        )
 
     def _wait_host_online(self) -> str:
         assert self._client is not None
@@ -419,7 +432,7 @@ class NativeTuiDriver:
                 if online:
                     return str(online[0]["host_id"])
             time.sleep(_POLL_INTERVAL_S)
-        raise RuntimeError(f"no host came online within {_HOST_ONLINE_TIMEOUT_S}s")
+        raise ProvisioningError(f"no host came online within {_HOST_ONLINE_TIMEOUT_S}s")
 
     def _agent_id(self, agent_name: str) -> str:
         assert self._client is not None
@@ -428,7 +441,9 @@ class NativeTuiDriver:
         for agent in resp.json()["data"]:
             if agent.get("name") == agent_name:
                 return str(agent["id"])
-        raise RuntimeError(f"{agent_name!r} not auto-registered on the server")
+        # A native agent the server did not seed (the hardcoded seeding seam):
+        # an environment gap, not a bench bug, so skip this harness quietly.
+        raise ProvisioningError(f"{agent_name!r} not auto-registered on the server")
 
     def _teardown(self) -> None:
         if self._client is not None:

--- a/tests/harness_bench/report.py
+++ b/tests/harness_bench/report.py
@@ -82,7 +82,9 @@ def _cell_glyph_for_grid(cell: CellResult, declared: bool = False) -> str:
     return cell.verdict.glyph
 
 
-def render_table(matrix: BenchMatrix, *, color: bool = False, declared: bool = False) -> str:
+def render_table(
+    matrix: BenchMatrix, *, color: bool = False, declared: bool = False, grid: bool = True
+) -> str:
     """Render *matrix* as an aligned column grid for terminal reading.
 
     :param color: When true, colorize each glyph with ANSI (green supported,
@@ -91,6 +93,10 @@ def render_table(matrix: BenchMatrix, *, color: bool = False, declared: bool = F
     :param declared: When true (offline mode), render each cell's *declared*
         verdict glyph instead of the observed/reconciled one, so the dry
         matrix shows the capabilities the profile claims rather than ``·``.
+    :param grid: When false, omit the heading + glyph grid and emit only the
+        footer (legend, drift, notes, skips). The CLI uses this when the rich
+        live table already painted the grid to the same terminal, so the report
+        adds the per-cell explanations without re-printing the grid.
     """
     titles = [p.title for p in ALL_PROBES]
     names = [p.name for p in ALL_PROBES]
@@ -133,8 +139,13 @@ def render_table(matrix: BenchMatrix, *, color: bool = False, declared: bool = F
         ]
         lines.append("  ".join(row))
 
-    heading = "Harness capability matrix" + (" (declared, not observed)" if declared else "")
-    out = [heading, "", *lines, "", _legend()]
+    if grid:
+        heading = "Harness capability matrix" + (" (declared, not observed)" if declared else "")
+        out = [heading, "", *lines, "", _legend()]
+    else:
+        # The rich live table already showed the grid on this terminal; emit
+        # only the footer so we add the legend + explanations, not a duplicate.
+        out = [_legend()]
 
     drift = _drift_lines(matrix)
     if drift:

--- a/tests/harness_bench/report.py
+++ b/tests/harness_bench/report.py
@@ -38,6 +38,24 @@ _ANSI: dict[Verdict, str] = {
 # render is not 24 identical lines.
 _OFFLINE_NOTE = "offline (declared shown)"
 
+# Short transport labels for the harness column, so each row is self-describing
+# about which transport produced it (e.g. `claude-sdk [full-server]`). The
+# native-tui driver is abbreviated to `native` to match how it is spoken about.
+_TRANSPORT_LABEL = {"native-tui": "native"}
+
+
+def _harness_label(report: HarnessReport) -> str:
+    """Harness name plus its resolved transport, e.g. ``codex [full-server]``.
+
+    Uses the transport that actually ran (``report.transport``), which for an
+    SDK harness on the default is ``full-server`` — not ``profile.transport``,
+    the family marker. Falls back to the bare name when unknown (never resolved).
+    """
+    transport = report.transport
+    if not transport:
+        return report.profile.harness
+    return f"{report.profile.harness} [{_TRANSPORT_LABEL.get(transport, transport)}]"
+
 
 def _colorize(text: str, verdict: Verdict, color: bool) -> str:
     if not color:
@@ -78,7 +96,8 @@ def render_table(matrix: BenchMatrix, *, color: bool = False, declared: bool = F
     names = [p.name for p in ALL_PROBES]
 
     # Column widths from the visible (uncolored) content.
-    harness_w = max(len("Harness"), *(len(r.profile.harness) for r in matrix.reports))
+    labels = {id(r): _harness_label(r) for r in matrix.reports}
+    harness_w = max(len("Harness"), *(len(v) for v in labels.values()))
     glyphs: dict[tuple[int, str], str] = {}
     verdicts: dict[tuple[int, str], Verdict] = {}
     for r in matrix.reports:
@@ -107,7 +126,7 @@ def render_table(matrix: BenchMatrix, *, color: bool = False, declared: bool = F
     rule = "  ".join(["-" * harness_w, *["-" * w for w in col_w]])
     lines = [header, rule]
     for r in matrix.reports:
-        row = [r.profile.harness.ljust(harness_w)]
+        row = [labels[id(r)].ljust(harness_w)]
         row += [
             _center(glyphs[(id(r), n)], w, verdicts[(id(r), n)])
             for n, w in zip(names, col_w, strict=False)
@@ -163,7 +182,7 @@ def render_markdown(matrix: BenchMatrix, *, declared: bool = False) -> str:
     for report in matrix.reports:
         by_name = {c.probe_name: c for c in report.cells}
         cells = [_cell_glyph(by_name[n], declared) if n in by_name else "?" for n in names]
-        lines.append(f"| `{report.profile.harness}` | " + " | ".join(cells) + " |")
+        lines.append(f"| `{_harness_label(report)}` | " + " | ".join(cells) + " |")
 
     heading = "# Harness capability matrix" + (" (declared, not observed)" if declared else "")
     out = [heading, "", *lines, "", _legend()]
@@ -236,7 +255,10 @@ def render_json(matrix: BenchMatrix) -> str:
 def _report_json(report: HarnessReport) -> dict[str, Any]:
     return {
         "harness": report.profile.harness,
+        # The family marker the profile declares, plus the transport that
+        # actually ran (differs for an SDK harness on the full-server default).
         "transport": report.profile.transport,
+        "resolved_transport": report.transport,
         "model": report.profile.model,
         "owner": report.profile.owner,
         "auth": report.profile.auth,

--- a/tests/harness_bench/richreport.py
+++ b/tests/harness_bench/richreport.py
@@ -37,6 +37,10 @@ _VERDICT_GLYPH: dict[Verdict, str] = {
 _PENDING = "[dim]·[/dim]"
 _RUNNING = "[cyan]…[/cyan]"
 
+# Short transport labels for the harness column (native-tui → native), matching
+# the static report renderer.
+_TRANSPORT_LABEL = {"native-tui": "native"}
+
 
 def rich_sink_or_none(*, force: bool = False):
     """Return a rich live sink, or ``None`` if rich/TTY is unavailable.
@@ -72,6 +76,7 @@ class _RichLiveSink:
         # harness → {dim_title: markup}; insertion order = display order.
         self._rows: dict[str, dict[str, str]] = {}
         self._notes: dict[str, str] = {}
+        self._transport: dict[str, str] = {}  # harness → resolved transport label
         self._live = Live(self._render(), console=console, refresh_per_second=8)
         self._live.start()
 
@@ -87,17 +92,25 @@ class _RichLiveSink:
             table.add_column(dim, justify="center")
         for harness, cells in self._rows.items():
             note = self._notes.get(harness)
-            label = f"{harness}" + (f"  [dim]({note})[/dim]" if note else "")
+            transport = self._transport.get(harness)
+            label = harness
+            if transport:
+                label += f" [dim]\\[{_TRANSPORT_LABEL.get(transport, transport)}][/dim]"
+            if note:
+                label += f"  [dim]({note})[/dim]"
             table.add_row(label, *(cells[dim] for dim in self._dimensions))
         return table
 
     def emit(self, event: BenchEvent) -> None:
         if isinstance(event, HarnessStarted):
             self._rows.setdefault(event.harness, self._blank_row())
+            self._transport[event.harness] = event.transport
         elif isinstance(event, HarnessSkipped):
             self._rows.setdefault(event.harness, self._blank_row())
             # A whole-harness skip: every dimension is ·, reason on the label.
             self._notes[event.harness] = event.reason.split(";")[0][:60]
+            if event.transport:
+                self._transport[event.harness] = event.transport
         elif isinstance(event, ProbeStarted):
             row = self._rows.setdefault(event.harness, self._blank_row())
             row[self._dim_by_name.get(event.probe, event.title)] = _RUNNING

--- a/tests/harness_bench/richreport.py
+++ b/tests/harness_bench/richreport.py
@@ -67,6 +67,10 @@ class _RichLiveSink:
     every cell ``·`` with the reason as a trailing note.
     """
 
+    # This sink paints the full glyph grid to the terminal, so the CLI can skip
+    # re-printing it in the stdout report (see __main__._grid_already_shown).
+    drew_grid = True
+
     def __init__(self, console) -> None:
         from rich.live import Live
 

--- a/tests/harness_bench/richreport.py
+++ b/tests/harness_bench/richreport.py
@@ -1,0 +1,117 @@
+"""A rich live-progress sink for a bench run.
+
+Draws a table that updates in place as events arrive: one row per harness,
+one column per capability dimension, each cell showing the probe's live state
+(a spinner while running, then the verdict glyph). Under a parallel run
+(``--jobs`` > 1) several rows advance at once, which is exactly what the live
+table is for.
+
+Only usable on a TTY with ``rich`` installed. :func:`rich_sink_or_none`
+returns ``None`` when either precondition is missing, so the CLI falls back to
+the plain :class:`~tests.harness_bench.events.LineSink`.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.events import (
+    BenchEvent,
+    HarnessSkipped,
+    HarnessStarted,
+    ProbeFinished,
+    ProbeStarted,
+)
+from tests.harness_bench.probes import ALL_PROBES
+from tests.harness_bench.verdict import Verdict
+
+# Cell state → what the table shows. Verdicts reuse the report glyphs; the two
+# transient states (pending/running) are bench-live only.
+_VERDICT_GLYPH: dict[Verdict, str] = {
+    Verdict.SUPPORTED: "[green]✓[/green]",
+    Verdict.PARTIAL: "[yellow]~[/yellow]",
+    Verdict.UNSUPPORTED: "[red]✗[/red]",
+    Verdict.NOT_APPLICABLE: "[dim]—[/dim]",
+    Verdict.UNKNOWN: "[dim]?[/dim]",
+    Verdict.SKIPPED: "[dim]·[/dim]",
+    Verdict.DRIFT: "[bold red]!![/bold red]",
+}
+_PENDING = "[dim]·[/dim]"
+_RUNNING = "[cyan]…[/cyan]"
+
+
+def rich_sink_or_none(*, force: bool = False):
+    """Return a rich live sink, or ``None`` if rich/TTY is unavailable.
+
+    :param force: Build the sink even if stdout is not a TTY (for tests /
+        explicit ``--rich``). Normally the caller only asks for this when a
+        terminal is detected.
+    """
+    try:
+        from rich.console import Console
+    except ImportError:
+        return None
+    console = Console(stderr=True)
+    if not force and not console.is_terminal:
+        return None
+    return _RichLiveSink(console)
+
+
+class _RichLiveSink:
+    """A :class:`~tests.harness_bench.events.ProgressSink` backed by ``rich.Live``.
+
+    Holds a ``{harness: {dimension: cell-markup}}`` grid and re-renders a table
+    on every event. Rows appear as harnesses start; a whole-harness skip marks
+    every cell ``·`` with the reason as a trailing note.
+    """
+
+    def __init__(self, console) -> None:
+        from rich.live import Live
+
+        self._console = console
+        self._dimensions = [p.title for p in ALL_PROBES]
+        self._dim_by_name = {p.name: p.title for p in ALL_PROBES}
+        # harness → {dim_title: markup}; insertion order = display order.
+        self._rows: dict[str, dict[str, str]] = {}
+        self._notes: dict[str, str] = {}
+        self._live = Live(self._render(), console=console, refresh_per_second=8)
+        self._live.start()
+
+    def _blank_row(self) -> dict[str, str]:
+        return dict.fromkeys(self._dimensions, _PENDING)
+
+    def _render(self):
+        from rich.table import Table
+
+        table = Table(title="Harness capability matrix (live)", expand=False)
+        table.add_column("Harness", no_wrap=True)
+        for dim in self._dimensions:
+            table.add_column(dim, justify="center")
+        for harness, cells in self._rows.items():
+            note = self._notes.get(harness)
+            label = f"{harness}" + (f"  [dim]({note})[/dim]" if note else "")
+            table.add_row(label, *(cells[dim] for dim in self._dimensions))
+        return table
+
+    def emit(self, event: BenchEvent) -> None:
+        if isinstance(event, HarnessStarted):
+            self._rows.setdefault(event.harness, self._blank_row())
+        elif isinstance(event, HarnessSkipped):
+            self._rows.setdefault(event.harness, self._blank_row())
+            # A whole-harness skip: every dimension is ·, reason on the label.
+            self._notes[event.harness] = event.reason.split(";")[0][:60]
+        elif isinstance(event, ProbeStarted):
+            row = self._rows.setdefault(event.harness, self._blank_row())
+            row[self._dim_by_name.get(event.probe, event.title)] = _RUNNING
+        elif isinstance(event, ProbeFinished):
+            row = self._rows.setdefault(event.harness, self._blank_row())
+            row[self._dim_by_name.get(event.probe, event.title)] = _VERDICT_GLYPH.get(
+                event.verdict, _PENDING
+            )
+        # HarnessFinished needs no cell change (all its probes already landed).
+        self._live.update(self._render())
+
+    def close(self) -> None:
+        self._live.update(self._render())
+        self._live.stop()
+
+
+__all__ = ["rich_sink_or_none"]

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -525,6 +525,68 @@ async def test_provisioning_failure_skips_and_tears_down(monkeypatch: pytest.Mon
     assert torn_down == [True], "provisioning-failure path must tear down the driver"
 
 
+async def test_expected_provisioning_error_logged_quietly(
+    monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """A ProvisioningError skips at INFO (no traceback); a generic error warns.
+
+    The branch split keeps the matrix readable: a known-unrunnable environment
+    (own-auth native not logged in) logs only its reason, while an unexpected
+    exception keeps its full stack so a genuine driver bug can't hide behind a
+    green-looking skip.
+    """
+    import logging
+
+    from tests.harness_bench.driver import ProvisioningError
+
+    def _driver_raising(exc: Exception):
+        class _D:
+            transport = "stub"
+
+            def __init__(self, profile, *, databricks_profile: str) -> None:
+                pass
+
+            @staticmethod
+            def unavailable(profile, *, databricks_profile):
+                return None
+
+            async def __aenter__(self):
+                raise exc
+
+            async def __aexit__(self, *e: object) -> None:
+                pass
+
+        return _D
+
+    profile = BenchProfile(harness="stub", model="m", env_prefix="HARNESS_STUB_", marker="X")
+
+    # Expected failure → a single INFO record, no exception/traceback attached.
+    monkeypatch.setattr(
+        "tests.harness_bench.bench.resolve_driver_class",
+        lambda p, *, override=None, fast=False: _driver_raising(
+            ProvisioningError("cli not logged in")
+        ),
+    )
+    with caplog.at_level(logging.INFO, logger="tests.harness_bench.bench"):
+        await run_harness(profile, databricks_profile="oss", live=True)
+    provisioning_logs = [r for r in caplog.records if "stub" in r.getMessage()]
+    assert provisioning_logs, "expected a log line for the skip"
+    assert all(r.levelno == logging.INFO and r.exc_info is None for r in provisioning_logs)
+
+    # Unexpected failure → WARNING with the traceback attached.
+    caplog.clear()
+    monkeypatch.setattr(
+        "tests.harness_bench.bench.resolve_driver_class",
+        lambda p, *, override=None, fast=False: _driver_raising(RuntimeError("boom")),
+    )
+    with caplog.at_level(logging.INFO, logger="tests.harness_bench.bench"):
+        await run_harness(profile, databricks_profile="oss", live=True)
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings and any(r.exc_info is not None for r in warnings), (
+        "an unexpected provisioning failure must keep its traceback"
+    )
+
+
 # ── native-tui transport (offline) ──────────────────────────────
 
 

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -299,7 +299,6 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
     agent+session on it.
     """
     import tests.harness_bench.bench as bench_mod
-    import tests.harness_bench.full_server_driver as fs_mod
     from tests.harness_bench.driver import TurnResult
 
     built: list[object] = []
@@ -355,7 +354,8 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
         async def run_interrupt_turn(self) -> TurnResult:
             return TurnResult(cancelled=True)
 
-    monkeypatch.setattr(fs_mod, "SharedFullServer", _FakeShared)
+    # bench imports SharedFullServer into its own namespace, so patch it there.
+    monkeypatch.setattr(bench_mod, "SharedFullServer", _FakeShared)
     monkeypatch.setattr(bench_mod, "resolve_driver_class", lambda p, *, override: _FSDriver)
 
     profiles = [

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -161,6 +161,45 @@ async def test_offline_render_produces_matrix() -> None:
     assert by_harness["claude-native"]["resolved_transport"] == "native-tui"
 
 
+def test_grid_already_shown_only_for_grid_drawing_sink() -> None:
+    """_grid_already_shown is True only for a sink that painted the grid."""
+    from tests.harness_bench.__main__ import _grid_already_shown
+    from tests.harness_bench.events import LineSink
+
+    assert _grid_already_shown(None) is False
+    assert _grid_already_shown(LineSink(lambda _m: None)) is False
+
+    class _GridSink:
+        drew_grid = True
+
+    assert _grid_already_shown(_GridSink()) is True
+
+
+async def test_render_table_grid_false_drops_grid_keeps_footer() -> None:
+    """grid=False omits the heading + glyph rows but keeps the legend/notes.
+
+    This is what the CLI emits when the rich live table already painted the grid
+    on the same terminal: the report should add the per-cell explanations, not
+    reprint the grid.
+    """
+    from tests.harness_bench.report import render_table
+
+    matrix = await run_bench(_OFFICIAL, live=False)
+    full = render_table(matrix, declared=True, grid=True)
+    footer = render_table(matrix, declared=True, grid=False)
+
+    # The full render has the heading + a harness row; the footer-only render
+    # has neither, but both carry the legend.
+    assert "Harness capability matrix" in full
+    assert "claude-sdk" in full
+    assert "Harness capability matrix" not in footer
+    assert "claude-sdk" not in footer
+    assert "Legend:" in footer
+    # The offline note is suppressed, so a declared render's footer is just the
+    # legend -- no dangling "Notes:" header.
+    assert footer.strip().startswith("Legend:")
+
+
 # ── Progress events / rich / parallel / report (offline) ─────────
 
 

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -148,9 +148,17 @@ async def test_offline_render_produces_matrix() -> None:
     assert "Harness capability matrix" in md
     for profile in _OFFICIAL:
         assert profile.harness in md
-    # JSON is well-formed and carries every harness.
+    # The harness column is labelled with the *resolved* transport: an SDK
+    # harness shows its full-server default (not the sdk-inproc family marker),
+    # a native shows the short `native` label.
+    assert "`claude-sdk [full-server]`" in md
+    assert "`claude-native [native]`" in md
+    # JSON is well-formed and carries every harness, plus the resolved transport.
     payload = json.loads(render_json(matrix))
     assert {h["harness"] for h in payload["harnesses"]} == {p.harness for p in _OFFICIAL}
+    by_harness = {h["harness"]: h for h in payload["harnesses"]}
+    assert by_harness["claude-sdk"]["resolved_transport"] == "full-server"
+    assert by_harness["claude-native"]["resolved_transport"] == "native-tui"
 
 
 # ── Progress events / rich / parallel / report (offline) ─────────

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -659,6 +659,41 @@ def test_transport_resolution_family_default_and_fast() -> None:
     assert resolve_transport_name(sdk, override="native-tui", fast=True) == "native-tui"
 
 
+async def test_native_provisioning_http_error_becomes_provisioning_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An HTTP failure in native provisioning surfaces as a ProvisioningError.
+
+    goose-native's terminal-ensure can 500 (the vendor cannot start a thread) —
+    an environment/server-state gap, not a bench bug. __aenter__ must convert
+    the raw httpx error into a ProvisioningError so run_harness logs it quietly
+    (one INFO line) instead of dumping a traceback.
+    """
+    import httpx
+
+    from tests.harness_bench.driver import ProvisioningError
+    from tests.harness_bench.native_tui_driver import NativeTuiDriver
+
+    profile = BenchProfile(
+        harness="claude-native",
+        model="m",
+        env_prefix="HARNESS_CLAUDE_NATIVE_",
+        marker="X",
+        transport="native-tui",
+    )
+    driver = NativeTuiDriver(profile, databricks_profile="oss")
+
+    def _boom() -> None:
+        request = httpx.Request("POST", "http://localhost/resources/terminals")
+        response = httpx.Response(500, request=request)
+        raise httpx.HTTPStatusError("500", request=request, response=response)
+
+    monkeypatch.setattr(driver, "_provision", _boom)
+    with pytest.raises(ProvisioningError) as exc_info:
+        await driver.__aenter__()
+    assert "500" in str(exc_info.value)
+
+
 def test_full_server_skips_native_with_accurate_message() -> None:
     """full-server rejects a native profile by naming the native transport.
 

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -291,6 +291,92 @@ async def test_run_bench_jobs_preserves_order(monkeypatch: pytest.MonkeyPatch) -
     assert [r.profile.harness for r in matrix.reports] == ["fake-0", "fake-1", "fake-2"]
 
 
+async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A parallel full-server run builds ONE shared server, reused by every harness.
+
+    Verifies the shared-server optimization: instead of N server+runner boots,
+    one SharedFullServer is entered once and each harness registers its own
+    agent+session on it.
+    """
+    import tests.harness_bench.bench as bench_mod
+    import tests.harness_bench.full_server_driver as fs_mod
+    from tests.harness_bench.driver import TurnResult
+
+    built: list[object] = []
+
+    class _FakeShared:
+        def __init__(self, db_profile: str) -> None:
+            built.append(self)
+            self.registered: list[str] = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            pass
+
+        def register_agent(self, profile, *, deny: bool) -> str:
+            self.registered.append(profile.harness)
+            return f"bench-{profile.harness}"
+
+        def create_session(self, agent_name: str) -> str:
+            return f"sess-{agent_name}"
+
+    # A full-server driver that records which shared server it was handed.
+    class _FSDriver:
+        transport = "full-server"
+
+        def __init__(self, profile, *, databricks_profile: str, shared=None) -> None:
+            self._profile = profile
+            self._shared = shared
+
+        @staticmethod
+        def unavailable(profile, *, databricks_profile):
+            return None
+
+        async def __aenter__(self):
+            assert self._shared is not None  # parallel run injected the shared server
+            self._shared.register_agent(self._profile, deny=False)
+            self._shared.create_session(f"bench-{self._profile.harness}")
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            pass
+
+        async def run_basic_turn(self, marker: str) -> TurnResult:
+            return TurnResult(completed=True, text=marker)
+
+        async def run_streaming_turn(self) -> TurnResult:
+            return TurnResult(completed=True, text_delta_count=3)
+
+        async def run_tool_turn(self, *, deny: bool) -> TurnResult:
+            return TurnResult(completed=True, tool_call_denied=deny)
+
+        async def run_interrupt_turn(self) -> TurnResult:
+            return TurnResult(cancelled=True)
+
+    monkeypatch.setattr(fs_mod, "SharedFullServer", _FakeShared)
+    monkeypatch.setattr(bench_mod, "resolve_driver_class", lambda p, *, override: _FSDriver)
+
+    profiles = [
+        BenchProfile(
+            harness=f"fs-{i}",
+            model="m",
+            env_prefix=f"HARNESS_FS{i}_",
+            marker="X",
+            transport="full-server",
+        )
+        for i in range(3)
+    ]
+    matrix = await run_bench(
+        profiles, databricks_profile="oss", live=True, jobs=3, transport="full-server"
+    )
+    # Exactly one shared server, and all three harnesses registered on it.
+    assert len(built) == 1
+    assert sorted(built[0].registered) == ["fs-0", "fs-1", "fs-2"]
+    assert [r.profile.harness for r in matrix.reports] == ["fs-0", "fs-1", "fs-2"]
+
+
 def test_cli_writes_report_file(tmp_path) -> None:
     """`--report PATH` writes the matrix; format follows the extension."""
     from tests.harness_bench.__main__ import main

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -213,7 +213,9 @@ async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None
             return TurnResult(cancelled=True)
 
     monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr(bench_mod, "resolve_driver_class", lambda p, *, override: _OKDriver)
+    monkeypatch.setattr(
+        bench_mod, "resolve_driver_class", lambda p, *, override=None, fast=False: _OKDriver
+    )
     try:
         profile = BenchProfile(
             harness="fake-sdk", model="m", env_prefix="HARNESS_FAKE_SDK_", marker="FAKE_OK"
@@ -236,7 +238,9 @@ async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None
     # A bare callable is adapted to a LineSink (structured events → lines).
     lines: list[str] = []
     monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr(bench_mod, "resolve_driver_class", lambda p, *, override: _OKDriver)
+    monkeypatch.setattr(
+        bench_mod, "resolve_driver_class", lambda p, *, override=None, fast=False: _OKDriver
+    )
     try:
         await run_harness(profile, databricks_profile="oss", live=True, progress=lines.append)
     finally:
@@ -282,7 +286,9 @@ async def test_run_bench_jobs_preserves_order(monkeypatch: pytest.MonkeyPatch) -
         async def run_interrupt_turn(self) -> TurnResult:
             return TurnResult(cancelled=True)
 
-    monkeypatch.setattr(bench_mod, "resolve_driver_class", lambda p, *, override: _SlowDriver)
+    monkeypatch.setattr(
+        bench_mod, "resolve_driver_class", lambda p, *, override=None, fast=False: _SlowDriver
+    )
     profiles = [
         BenchProfile(harness=f"fake-{i}", model="m", env_prefix=f"HARNESS_F{i}_", marker="X")
         for i in range(3)
@@ -356,7 +362,9 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
 
     # bench imports SharedFullServer into its own namespace, so patch it there.
     monkeypatch.setattr(bench_mod, "SharedFullServer", _FakeShared)
-    monkeypatch.setattr(bench_mod, "resolve_driver_class", lambda p, *, override: _FSDriver)
+    monkeypatch.setattr(
+        bench_mod, "resolve_driver_class", lambda p, *, override=None, fast=False: _FSDriver
+    )
 
     profiles = [
         BenchProfile(
@@ -507,7 +515,7 @@ async def test_provisioning_failure_skips_and_tears_down(monkeypatch: pytest.Mon
     )
     monkeypatch.setattr(
         "tests.harness_bench.bench.resolve_driver_class",
-        lambda p, *, override: _FailingDriver,
+        lambda p, *, override=None, fast=False: _FailingDriver,
     )
 
     report = await run_harness(profile, databricks_profile="oss", live=True)
@@ -549,6 +557,36 @@ def test_native_tui_registered_and_gates() -> None:
 
     # No profile → the same capability-neutral skip contract as other drivers.
     assert NativeTuiDriver.unavailable(claude_native, databricks_profile=None) is not None
+
+
+def test_transport_resolution_family_default_and_fast() -> None:
+    """SDK family defaults to full-server; --fast downgrades it; natives unaffected.
+
+    This is the core of the "full-server by default, --fast to opt out" model:
+    the profile's transport is a family marker, and the effective driver comes
+    from family + flags (see resolve_transport_name).
+    """
+    from tests.harness_bench.transport import resolve_transport_name
+
+    sdk = BenchProfile(
+        harness="codex", model="m", env_prefix="X_", marker="X", transport="sdk-inproc"
+    )
+    native = BenchProfile(
+        harness="claude-native", model="m", env_prefix="X_", marker="X", transport="native-tui"
+    )
+
+    # SDK family: full-server by default, sdk-inproc under --fast.
+    assert resolve_transport_name(sdk, override=None, fast=False) == "full-server"
+    assert resolve_transport_name(sdk, override=None, fast=True) == "sdk-inproc"
+
+    # native: a single transport --fast does not touch.
+    assert resolve_transport_name(native, override=None, fast=False) == "native-tui"
+    assert resolve_transport_name(native, override=None, fast=True) == "native-tui"
+
+    # An explicit --transport wins over both the default and --fast, for any
+    # family (the caller validates the name against the registry separately).
+    assert resolve_transport_name(sdk, override="sdk-inproc", fast=False) == "sdk-inproc"
+    assert resolve_transport_name(sdk, override="native-tui", fast=True) == "native-tui"
 
 
 def test_full_server_skips_native_with_accurate_message() -> None:

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -153,6 +153,160 @@ async def test_offline_render_produces_matrix() -> None:
     assert {h["harness"] for h in payload["harnesses"]} == {p.harness for p in _OFFICIAL}
 
 
+# ── Progress events / rich / parallel / report (offline) ─────────
+
+
+async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None:
+    """run_harness emits typed events; a bare-callable progress adapts to LineSink.
+
+    Uses a fake driver so no creds/subprocess are needed: a basic turn passes,
+    which lets every probe run and produce a ProbeFinished.
+    """
+    import tests.harness_bench.bench as bench_mod
+    from tests.harness_bench.driver import TurnResult
+    from tests.harness_bench.events import (
+        HarnessFinished,
+        HarnessStarted,
+        ProbeFinished,
+        ProbeStarted,
+        ProgressSink,
+    )
+
+    class _CaptureSink:
+        def __init__(self) -> None:
+            self.events: list = []
+
+        def emit(self, event) -> None:
+            self.events.append(event)
+
+        def close(self) -> None:
+            pass
+
+    assert isinstance(_CaptureSink(), ProgressSink)  # structural conformance
+
+    class _OKDriver:
+        transport = "sdk-inproc"
+
+        def __init__(self, profile: BenchProfile, *, databricks_profile: str) -> None:
+            pass
+
+        @staticmethod
+        def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            pass
+
+        async def run_basic_turn(self, marker: str) -> TurnResult:
+            return TurnResult(completed=True, text=marker)
+
+        async def run_streaming_turn(self) -> TurnResult:
+            return TurnResult(completed=True, text_delta_count=5)
+
+        async def run_tool_turn(self, *, deny: bool) -> TurnResult:
+            return TurnResult(completed=True)
+
+        async def run_interrupt_turn(self) -> TurnResult:
+            return TurnResult(cancelled=True)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(bench_mod, "resolve_driver_class", lambda p, *, override: _OKDriver)
+    try:
+        profile = BenchProfile(
+            harness="fake-sdk", model="m", env_prefix="HARNESS_FAKE_SDK_", marker="FAKE_OK"
+        )
+        sink = _CaptureSink()
+        await run_harness(profile, databricks_profile="oss", live=True, progress=sink)
+    finally:
+        monkeypatch.undo()
+
+    kinds = [type(e).__name__ for e in sink.events]
+    assert kinds[0] == "HarnessStarted"
+    assert isinstance(sink.events[0], HarnessStarted)
+    assert kinds[-1] == "HarnessFinished"
+    assert isinstance(sink.events[-1], HarnessFinished)
+    # Every probe that ran emits a started+finished pair.
+    assert any(isinstance(e, ProbeStarted) for e in sink.events)
+    finished = [e for e in sink.events if isinstance(e, ProbeFinished)]
+    assert {e.probe for e in finished} >= {"basic_turn", "streaming"}
+
+    # A bare callable is adapted to a LineSink (structured events → lines).
+    lines: list[str] = []
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(bench_mod, "resolve_driver_class", lambda p, *, override: _OKDriver)
+    try:
+        await run_harness(profile, databricks_profile="oss", live=True, progress=lines.append)
+    finally:
+        monkeypatch.undo()
+    assert any("Basic turn" in ln for ln in lines)
+
+
+async def test_run_bench_jobs_preserves_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--jobs > 1 runs harnesses concurrently but keeps report order == input order."""
+    import asyncio as _asyncio
+
+    import tests.harness_bench.bench as bench_mod
+    from tests.harness_bench.driver import TurnResult
+
+    class _SlowDriver:
+        transport = "sdk-inproc"
+
+        def __init__(self, profile: BenchProfile, *, databricks_profile: str) -> None:
+            self._h = profile.harness
+
+        @staticmethod
+        def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
+            return None
+
+        async def __aenter__(self):
+            # Reverse-stagger the delay so, without order preservation, finish
+            # order would differ from input order.
+            await _asyncio.sleep(0.02 if self._h.endswith("1") else 0.01)
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            pass
+
+        async def run_basic_turn(self, marker: str) -> TurnResult:
+            return TurnResult(completed=True, text=marker)
+
+        async def run_streaming_turn(self) -> TurnResult:
+            return TurnResult(completed=True, text_delta_count=3)
+
+        async def run_tool_turn(self, *, deny: bool) -> TurnResult:
+            return TurnResult(completed=True)
+
+        async def run_interrupt_turn(self) -> TurnResult:
+            return TurnResult(cancelled=True)
+
+    monkeypatch.setattr(bench_mod, "resolve_driver_class", lambda p, *, override: _SlowDriver)
+    profiles = [
+        BenchProfile(harness=f"fake-{i}", model="m", env_prefix=f"HARNESS_F{i}_", marker="X")
+        for i in range(3)
+    ]
+    matrix = await run_bench(profiles, databricks_profile="oss", live=True, jobs=3)
+    assert [r.profile.harness for r in matrix.reports] == ["fake-0", "fake-1", "fake-2"]
+
+
+def test_cli_writes_report_file(tmp_path) -> None:
+    """`--report PATH` writes the matrix; format follows the extension."""
+    from tests.harness_bench.__main__ import main
+
+    md = tmp_path / "matrix.md"
+    rc = main(["--no-live", "--report", str(md)])
+    assert rc == 0
+    text = md.read_text()
+    assert "Harness capability matrix" in text and "| Harness |" in text
+
+    js = tmp_path / "matrix.json"
+    main(["--no-live", "--report", str(js)])
+    payload = json.loads(js.read_text())
+    assert payload.get("harnesses")
+
+
 # ── Live layer (gated) ──────────────────────────────────────────
 
 

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -170,7 +170,6 @@ async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None
     Uses a fake driver so no creds/subprocess are needed: a basic turn passes,
     which lets every probe run and produce a ProbeFinished.
     """
-    import tests.harness_bench.bench as bench_mod
     from tests.harness_bench.driver import TurnResult
     from tests.harness_bench.events import (
         HarnessFinished,
@@ -222,7 +221,8 @@ async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None
 
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(
-        bench_mod, "resolve_driver_class", lambda p, *, override=None, fast=False: _OKDriver
+        "tests.harness_bench.bench.resolve_driver_class",
+        lambda p, *, override=None, fast=False: _OKDriver,
     )
     try:
         profile = BenchProfile(
@@ -247,7 +247,8 @@ async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None
     lines: list[str] = []
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(
-        bench_mod, "resolve_driver_class", lambda p, *, override=None, fast=False: _OKDriver
+        "tests.harness_bench.bench.resolve_driver_class",
+        lambda p, *, override=None, fast=False: _OKDriver,
     )
     try:
         await run_harness(profile, databricks_profile="oss", live=True, progress=lines.append)
@@ -260,7 +261,6 @@ async def test_run_bench_jobs_preserves_order(monkeypatch: pytest.MonkeyPatch) -
     """--jobs > 1 runs harnesses concurrently but keeps report order == input order."""
     import asyncio as _asyncio
 
-    import tests.harness_bench.bench as bench_mod
     from tests.harness_bench.driver import TurnResult
 
     class _SlowDriver:
@@ -295,7 +295,8 @@ async def test_run_bench_jobs_preserves_order(monkeypatch: pytest.MonkeyPatch) -
             return TurnResult(cancelled=True)
 
     monkeypatch.setattr(
-        bench_mod, "resolve_driver_class", lambda p, *, override=None, fast=False: _SlowDriver
+        "tests.harness_bench.bench.resolve_driver_class",
+        lambda p, *, override=None, fast=False: _SlowDriver,
     )
     profiles = [
         BenchProfile(harness=f"fake-{i}", model="m", env_prefix=f"HARNESS_F{i}_", marker="X")
@@ -312,7 +313,6 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
     one SharedFullServer is entered once and each harness registers its own
     agent+session on it.
     """
-    import tests.harness_bench.bench as bench_mod
     from tests.harness_bench.driver import TurnResult
 
     built: list[object] = []
@@ -369,9 +369,10 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
             return TurnResult(cancelled=True)
 
     # bench imports SharedFullServer into its own namespace, so patch it there.
-    monkeypatch.setattr(bench_mod, "SharedFullServer", _FakeShared)
+    monkeypatch.setattr("tests.harness_bench.bench.SharedFullServer", _FakeShared)
     monkeypatch.setattr(
-        bench_mod, "resolve_driver_class", lambda p, *, override=None, fast=False: _FSDriver
+        "tests.harness_bench.bench.resolve_driver_class",
+        lambda p, *, override=None, fast=False: _FSDriver,
     )
 
     profiles = [

--- a/tests/harness_bench/transport.py
+++ b/tests/harness_bench/transport.py
@@ -20,9 +20,18 @@ A kwargs-carrying ``run_turn`` could not bridge these: e.g. streaming is only
 observable on full-server via a separate SSE subscription, so "basic turn"
 and "streaming turn" must be *distinct* calls, not one call with a flag.
 
-Transport selection: each :class:`BenchProfile` declares a default
-``transport``; a ``--transport`` CLI override wins over it globally (see
-:func:`resolve_driver_class`).
+Transport selection (see :func:`resolve_driver_class`). A profile's
+``transport`` field is the harness *family* marker, not the literal driver:
+
+- **SDK-family** harnesses (``sdk-inproc``/``full-server``) default to
+  ``full-server`` — the fullest coverage, the only transport that exercises
+  Tool calling + Policy DENY, and a strict superset of what ``sdk-inproc``
+  observes. ``--fast`` downgrades them to ``sdk-inproc``, trading that
+  coverage for skipping the server boot.
+- **native** harnesses (``native-tui``) have exactly one transport; ``--fast``
+  does not apply to them.
+
+A ``--transport`` override wins over both, for any family.
 """
 
 from __future__ import annotations
@@ -95,19 +104,45 @@ def driver_registry() -> dict[str, type]:
     }
 
 
-def resolve_driver_class(profile: BenchProfile, *, override: str | None) -> type:
-    """Resolve the driver class for *profile*.
+# The SDK harness family: transports that drive an SDK-wrap harness. They
+# observe the same core dimensions; full-server additionally reaches Tool
+# calling + Policy DENY (server-dispatched) and is a strict coverage superset,
+# so it is the default. --fast picks the cheaper sdk-inproc within this family.
+_SDK_FAMILY = frozenset({"sdk-inproc", "full-server"})
+_SDK_DEFAULT = "full-server"
+_SDK_FAST = "sdk-inproc"
 
-    *override* (the ``--transport`` flag) wins over the profile's declared
-    ``transport`` when set. Raises :class:`KeyError` for an unknown transport
-    so a typo fails loud rather than silently falling back.
+
+def resolve_transport_name(profile: BenchProfile, *, override: str | None, fast: bool) -> str:
+    """Resolve the effective transport *name* for *profile* from family + flags.
+
+    Precedence: an explicit ``--transport`` *override* wins over everything.
+    Otherwise the profile's ``transport`` names a family: an SDK-family harness
+    resolves to ``full-server`` (default, fullest coverage) or ``sdk-inproc``
+    (under *fast*); a native harness has a single transport that ``--fast``
+    does not touch.
 
     :param profile: The harness under test.
-    :param override: A transport name from ``--transport``, or ``None`` to use
-        the profile's declared transport.
-    :returns: The driver class to instantiate.
+    :param override: ``--transport`` value, or ``None``.
+    :param fast: The ``--fast`` flag — downgrade the SDK family to sdk-inproc.
+    :returns: The resolved transport name (a key into :func:`driver_registry`).
     """
-    name = override or profile.transport
+    if override is not None:
+        return override
+    if profile.transport in _SDK_FAMILY:
+        return _SDK_FAST if fast else _SDK_DEFAULT
+    return profile.transport
+
+
+def resolve_driver_class(
+    profile: BenchProfile, *, override: str | None = None, fast: bool = False
+) -> type:
+    """Resolve the driver *class* for *profile* (see :func:`resolve_transport_name`).
+
+    Raises :class:`KeyError` for an unknown transport so a typo fails loud
+    rather than silently falling back.
+    """
+    name = resolve_transport_name(profile, override=override, fast=fast)
     registry = driver_registry()
     if name not in registry:
         raise KeyError(
@@ -116,4 +151,4 @@ def resolve_driver_class(profile: BenchProfile, *, override: str | None) -> type
     return registry[name]
 
 
-__all__ = ["Driver", "driver_registry", "resolve_driver_class"]
+__all__ = ["Driver", "driver_registry", "resolve_driver_class", "resolve_transport_name"]


### PR DESCRIPTION
## Summary

Makes the harness bench pleasant to run across many harnesses at once, and
honest about what each run actually exercised. Built on a structured
progress-event seam so the pieces compose. Six commits, each self-contained:

### 1. Structured progress events (`events.py`)
The orchestrator emits typed `BenchEvent`s (`HarnessStarted`/`Skipped`,
`ProbeStarted`/`Finished`, `HarnessFinished`) to a `ProgressSink`, not
pre-rendered strings. The old per-line output is preserved via `LineSink`, and
a bare-callable `progress=` is auto-adapted, so this is fully back-compat.

### 2. Rich live progress (`--rich` / `--no-rich`, `richreport.py`)
A `ProgressSink` backed by `rich.Live`: one row per harness, one column per
dimension, cells filling in as probes finish (spinner then verdict glyph).
Auto-selected on a TTY when rich is available (`rich>=14` is already a dep);
falls back to `LineSink` under a pipe / CI. Shines under `--jobs`, where
several rows advance at once.

### 3. Bounded parallel (`--jobs N` / `-j`, default 1)
Runs up to N harnesses concurrently via a semaphore. Probes *within* a harness
stay sequential (shared driver/session, single in-flight turn); concurrency is
across harnesses. `asyncio.gather` preserves input order, so the matrix stays
in `--harness` order regardless of finish order. `--jobs 1` is the original
sequential behavior.

### 4. Shared server for parallel full-server runs
The Omnigent server is multi-agent/multi-session and one runner resolves the
harness per session from its agent spec, so N SDK harnesses do not each need
their own server+runner: they can share **one** pair, each registering its own
agent+session.

- New `SharedFullServer` (in `full_server.py`) owns the server+runner lifecycle
  and agent/session registration, split out of `FullServerDriver`. The driver
  file is now just the driver plus its probe helpers; the module seam reads as
  "the server" vs "the driver that runs probes against it".
- `FullServerDriver` takes an optional `shared=`: injected means it registers
  on the shared server and spawns nothing; `None` means it owns a private one
  (the old one-server-per-harness path, unchanged for `--jobs 1`).
- `run_bench` stands up one `SharedFullServer` for a live parallel run with more
  than one full-server harness, passes it to each, and tears it down after.
  native-tui harnesses still self-provision (each needs its own host daemon).

Cuts full-server startup (server boot + health-wait) from N times to once for a
parallel SDK run; gateway load is unchanged (same total turns).

### 5. full-server is the default; `--fast` opts out
full-server is a strict coverage superset for SDK harnesses: it observes
everything `sdk-inproc` does (basic / streaming / interrupt / model-override)
*plus* the two dimensions `sdk-inproc` cannot reach, Tool calling and Policy
DENY, as server-dispatched, policy-gated calls. So a plain live run now proves
those two out of the box.

- Transport is resolved from the harness *family* plus flags
  (`resolve_transport_name`): SDK family defaults to `full-server`; `--fast`
  picks `sdk-inproc` (skips the server boot, and Tool calling + Policy DENY
  then report `·`, which those probes already emit on the wrap-direct path, so
  no false DRIFT); native harnesses have a single transport `--fast` does not
  touch. `--transport NAME` still overrides the family and is mutually
  exclusive with `--fast`.
- `profile.transport` stays the family marker (the applicability gate keys on
  it), so nothing about probe applicability changes. `--list` prints the
  resolved default so it matches what runs.

### 6. Quiet expected skips; label rows with their resolved transport
- A parallel run dumped full tracebacks for own-auth natives whose forwarder
  never wires up (an expected, already-handled skip). New `ProvisioningError`
  marks an *expected* provisioning failure: `run_harness` logs it as one INFO
  line (reason only), while any other exception keeps its full traceback so a
  genuine driver bug cannot hide behind a green-looking skip. Matrix output is
  unchanged either way.
- Each matrix row is now labelled with the transport that actually ran, e.g.
  `claude-sdk [full-server]`, `kimi-native [native]`. It uses the *resolved*
  transport, not `profile.transport` (the family marker), or it would mislabel
  the exact rows worth clarifying. Shown in the terminal table, Markdown, and
  the rich live table; `render_json` adds a distinct `resolved_transport` field
  alongside the family `transport`.

Docs (`docs/harness-bench-design.md`) and the directory README are refreshed to
match: transport-selection prose, the which-transport-exercises-what table, the
run examples, and the file layout.

## Test Plan

- Offline: `pytest tests/harness_bench/test_bench.py` -> 58 passed / 14
  skipped, `ruff check` / `ruff format` clean. New tests cover: structured-event
  emission + `LineSink` adaptation; `--jobs` order preservation under staggered
  finishes; `--report` writes markdown + json; a parallel full-server run builds
  exactly one `SharedFullServer` with all harnesses registered on it; the
  transport-resolution family/`--fast`/override matrix; the
  `ProvisioningError`-quiet-vs-traceback branch split; and the resolved-transport
  row labels in Markdown + JSON.
- Live (gateway `oss` profile, on a host with the SDK harnesses + several
  natives logged in):
  - `--profile oss --jobs 4 --rich`: all four SDK harnesses ran on the shared
    full-server concurrently with Tool calling and Policy DENY both `✓`; no
    DRIFT in any cell. cursor/kiro/qwen-native streaming `✗` matched their
    live-verified declared UNSUPPORTED. own-auth natives (goose/kimi/hermes)
    skipped cleanly with no traceback noise.
  - `--fast` flips the SDK rows to `sdk-inproc` with Tool calling / Policy DENY
    as `·`, as designed.

## Demo

CLI / terminal output (non-web change, so `N/A` for a video). Abbreviated
matrix from a live `--profile oss --jobs 4` run (rows trimmed), showing the
transport labels, the full-server default proving Tool calling + Policy DENY
for SDK harnesses, and clean skips for the natives the host can't provision:

```
Harness                       Basic turn  Streaming  Tool calling  Policy DENY  Model override  Interrupt
----------------------------  ----------  ---------  ------------  -----------  --------------  ---------
claude-sdk [full-server]          ✓           ✓           ✓             ✓             ✓             ✓
pi [full-server]                  ✓           ✓           ✓             ✓             ✓             ✓
claude-native [native]            ✓           ✓           ·             ·             ✓             ✓
cursor-native [native]            ✓           ✗           ·             ·             ✓             ✓
antigravity-native [native]       ·           ·           ·             ·             ·             ·
goose-native [native]             ·           ·           ·             ·             ·             ·

Legend: `✓` SUPPORTED · `~` PARTIAL · `✗` UNSUPPORTED · `—` NOT_APPLICABLE · `?` UNKNOWN · `·` SKIPPED · `!!` DRIFT

Skipped harnesses:
- `antigravity-native`: 'antigravity' CLI is not on PATH
- `goose-native`: provisioning failed: native provisioning HTTP error: 500 ... /resources/terminals
```

Notes on reading it: SDK rows show `[full-server]` (the default) with Tool
calling + Policy DENY proven; native rows show `·` for those two because the
bench cannot observe vendor tools/deny on native-tui yet (a driver gap, not a
native limitation); `cursor-native` Streaming `✗` matches its live-verified
declared UNSUPPORTED; own-auth natives the host can't log in skip cleanly with
no traceback. Under `--rich` this renders as a live table that fills in as
probes finish; a plain pipe / CI falls back to the grid above.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix
- [x] Documentation

## Test coverage

- [x] Automated tests added/updated
- [x] Manual verification completed

## Coverage notes

Parallel ordering, shared-server wiring, transport resolution, event emission,
report writing, the provisioning-skip branch split, and row labelling are
covered offline with fake drivers (no creds). Rich live rendering and the real
live `--jobs 4` parallel run against harnesses were verified by hand (they need
a TTY / gateway creds, which CI lacks); the fallback and offline paths run in
CI.
