### PR TITLE
feat(hermes): opt-in ModelGate B1 gate before headless Hermes subprocess spawn

### DIFF
--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -346,7 +346,7 @@ class HermesExecutor(Executor):
         """
         return True
 
-    async def _check_modelgate(self, *, purpose: str, model: str | None) -> str | None:
+    async def _check_modelgate(self, *, purpose: str, model: str) -> str | None:
         """
         Run the ModelGate B1 policy check before spawning a Hermes turn.
 
@@ -356,14 +356,16 @@ class HermesExecutor(Executor):
         interactive ``hermes-admin``/``hermes-agent`` CLI launch, instead of
         re-implementing the policy logic in-process.
 
-        Only called when ``AI_RUN_PURPOSE`` is explicitly set (see
-        :meth:`run_turn`); fails closed (denies) if the check binary is
-        missing or errors, since an explicit purpose tag is a deliberate
-        request for enforcement — silently skipping it would defeat the
-        point.
+        Only called when ``AI_RUN_PURPOSE`` is explicitly present in the
+        environment (see :meth:`run_turn`); fails closed (denies) if the
+        check binary is missing or errors, since an explicit purpose tag is
+        a deliberate request for enforcement — silently skipping it would
+        defeat the point.
 
         :param purpose: The ``AI_RUN_PURPOSE`` value driving this dispatch.
-        :param model: Resolved model identifier, if any.
+        :param model: The model that will actually be in effect for the
+            spawned Hermes process — resolved by :meth:`_resolve_effective_model`,
+            never the possibly-``None`` config/instance override directly.
         :returns: A human-readable denial message if the gate blocks this
             launch, or ``None`` if the launch is allowed.
         """
@@ -404,6 +406,32 @@ class HermesExecutor(Executor):
         )
         return reason
 
+    def _resolve_effective_model(self, explicit_model: str | None) -> str | None:
+        """
+        Resolve the model that will actually be in effect for the Hermes
+        process about to be spawned.
+
+        An explicit override (``config.model`` / ``self._model``, threaded
+        through to the CLI as ``-m``) always wins. Absent one, Hermes falls
+        back to its own ``~/.hermes/config.yaml`` (``model.default``) — the
+        same source :func:`_populate_hermes_home` merges into the
+        per-session ``HERMES_HOME``, so reading it here mirrors what the
+        spawned process will actually resolve instead of guessing "no
+        override" means "no model check needed".
+
+        :param explicit_model: The ``-m``-equivalent override, if any.
+        :returns: The model that will actually be in effect, or ``None`` if
+            it cannot be determined (no override and no configured default).
+        """
+        if explicit_model:
+            return explicit_model
+        model_cfg = _load_user_hermes_config().get("model")
+        if isinstance(model_cfg, dict):
+            default = model_cfg.get("default")
+            if isinstance(default, str) and default:
+                return default
+        return None
+
     async def run_turn(
         self,
         messages: list[Message],
@@ -439,11 +467,27 @@ class HermesExecutor(Executor):
         model = (config.model if config else None) or self._model
 
         # ModelGate B1 gate (opt-in — see module docstring). Only runs when
-        # AI_RUN_PURPOSE is explicitly set; absent that, this is a no-op and
-        # behavior is identical to before this gate existed.
-        purpose = os.environ.get("AI_RUN_PURPOSE")
-        if purpose:
-            gate_denial = await self._check_modelgate(purpose=purpose, model=model)
+        # AI_RUN_PURPOSE is explicitly present in the environment (checked by
+        # key, not truthiness — an explicitly empty value must still gate);
+        # absent the key entirely, this is a no-op and behavior is identical
+        # to before this gate existed.
+        if "AI_RUN_PURPOSE" in os.environ:
+            purpose = os.environ["AI_RUN_PURPOSE"]
+            effective_model = self._resolve_effective_model(model)
+            if effective_model is None:
+                # Fail closed: an explicit purpose tag is a deliberate request
+                # for enforcement. Spawning with an unresolved model would let
+                # Hermes fall through to whatever its own config.yaml default
+                # is without the gate ever having seen it.
+                gate_denial = (
+                    "ModelGate check requires a resolved model, but no explicit "
+                    "model override was given and no default model could be "
+                    "read from ~/.hermes/config.yaml; refusing to launch Hermes "
+                    f"with explicit AI_RUN_PURPOSE={purpose!r} against an "
+                    "unknown effective model."
+                )
+            else:
+                gate_denial = await self._check_modelgate(purpose=purpose, model=effective_model)
             if gate_denial is not None:
                 _logger.warning("Hermes launch blocked by ModelGate: %s", gate_denial)
                 yield ExecutorError(message=gate_denial, retryable=False)

--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -399,12 +399,11 @@ class HermesExecutor(Executor):
         if proc.returncode == 0:
             return None
 
-        reason = (
+        return (
             stderr_bytes.decode("utf-8", errors="replace").strip()
             or stdout_bytes.decode("utf-8", errors="replace").strip()
             or "denied by ModelGate policy"
         )
-        return reason
 
     def _resolve_effective_model(self, explicit_model: str | None) -> str | None:
         """

--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -34,6 +34,20 @@ Env vars read at construction:
 - ``HARNESS_HERMES_BUNDLE_DIR`` — absolute path to the agent bundle's
   extracted root.  Unset for agents without a bundled-skills directory.
 - ``HARNESS_HERMES_AGENT_NAME`` — agent display name (reserved for future use).
+
+ModelGate B1 gate (opt-in, off by default):
+
+- ``AI_RUN_PURPOSE`` — when set, ``run_turn`` shells out to the ModelGate
+  check binary (``ops/modelgate/modelgate.py``'s ``resolve_llm_policy``,
+  the same policy ``/opt/bin/ai-run`` enforces for interactive
+  ``hermes-admin``/``hermes-agent`` launches) before spawning the Hermes
+  subprocess. A DENY verdict short-circuits the turn with an
+  :class:`ExecutorError` instead of spawning. When unset (the default for
+  every existing headless dispatch path today), no check runs and behavior
+  is unchanged from before this gate existed.
+- ``HERMES_MODELGATE_CHECK_BIN`` — override path to the check binary.
+  Defaults to ``/opt/bin/modelgate-check`` (installed by
+  ``scripts/deploy-modelgate.sh`` in the ``omnigent-polly-dev-repo``).
 """
 
 from __future__ import annotations
@@ -66,6 +80,10 @@ _logger = logging.getLogger(__name__)
 # Maximum seconds to wait for a Hermes subprocess to complete a single turn.
 # Complex tasks (multi-tool-calling loops) may take several minutes.
 _HERMES_TURN_TIMEOUT_S = 600.0
+
+# ModelGate B1 (opt-in): see module docstring's "ModelGate B1 gate" section.
+_DEFAULT_MODELGATE_CHECK_BIN = "/opt/bin/modelgate-check"
+_MODELGATE_CHECK_TIMEOUT_S = 10.0
 
 # Regex to extract the session_id from Hermes' quiet-mode output line.
 # Matches lines like ``session_id: 20260620_142506_c51451``.
@@ -328,6 +346,64 @@ class HermesExecutor(Executor):
         """
         return True
 
+    async def _check_modelgate(self, *, purpose: str, model: str | None) -> str | None:
+        """
+        Run the ModelGate B1 policy check before spawning a Hermes turn.
+
+        Mirrors ``/opt/bin/ai-run``'s pre-launch gate: shells out to the
+        same check binary so this headless dispatch path honors the
+        identical tier policy (``ops/modelgate/modelgate.py``) as an
+        interactive ``hermes-admin``/``hermes-agent`` CLI launch, instead of
+        re-implementing the policy logic in-process.
+
+        Only called when ``AI_RUN_PURPOSE`` is explicitly set (see
+        :meth:`run_turn`); fails closed (denies) if the check binary is
+        missing or errors, since an explicit purpose tag is a deliberate
+        request for enforcement — silently skipping it would defeat the
+        point.
+
+        :param purpose: The ``AI_RUN_PURPOSE`` value driving this dispatch.
+        :param model: Resolved model identifier, if any.
+        :returns: A human-readable denial message if the gate blocks this
+            launch, or ``None`` if the launch is allowed.
+        """
+        check_bin = os.environ.get("HERMES_MODELGATE_CHECK_BIN", _DEFAULT_MODELGATE_CHECK_BIN)
+        if not os.path.exists(check_bin):
+            return (
+                f"ModelGate check binary not found at {check_bin!r}; refusing to "
+                f"launch Hermes with an explicit AI_RUN_PURPOSE={purpose!r} unverified. "
+                "Unset AI_RUN_PURPOSE, or install ModelGate "
+                "(scripts/deploy-modelgate.sh), to proceed."
+            )
+
+        argv = [check_bin, "hermes"]
+        if model:
+            argv += ["-m", model]
+        gate_env = {**os.environ, "AI_RUN_PURPOSE": purpose}
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=gate_env,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=_MODELGATE_CHECK_TIMEOUT_S
+            )
+        except (OSError, asyncio.TimeoutError) as exc:
+            return f"ModelGate check failed to run ({exc}); refusing to launch Hermes."
+
+        if proc.returncode == 0:
+            return None
+
+        reason = (
+            stderr_bytes.decode("utf-8", errors="replace").strip()
+            or stdout_bytes.decode("utf-8", errors="replace").strip()
+            or "denied by ModelGate policy"
+        )
+        return reason
+
     async def run_turn(
         self,
         messages: list[Message],
@@ -361,6 +437,17 @@ class HermesExecutor(Executor):
 
         # Resolve model from config override, then instance default
         model = (config.model if config else None) or self._model
+
+        # ModelGate B1 gate (opt-in — see module docstring). Only runs when
+        # AI_RUN_PURPOSE is explicitly set; absent that, this is a no-op and
+        # behavior is identical to before this gate existed.
+        purpose = os.environ.get("AI_RUN_PURPOSE")
+        if purpose:
+            gate_denial = await self._check_modelgate(purpose=purpose, model=model)
+            if gate_denial is not None:
+                _logger.warning("Hermes launch blocked by ModelGate: %s", gate_denial)
+                yield ExecutorError(message=gate_denial, retryable=False)
+                return
 
         # Determine session key for this conversation
         session_key = self._session_key(messages)


### PR DESCRIPTION
## Summary

- `hermes_executor.py`'s `run_turn()` spawns the Hermes CLI headlessly (Polly/WebUI dispatch path) without going through `/opt/bin/ai-run`'s ModelGate check, unlike the interactive `hermes-admin`/`hermes-agent` wrappers which already call `modelgate-check` before launch.
- Adds an **opt-in** gate: when the process env has `AI_RUN_PURPOSE` set, `HermesExecutor._check_modelgate()` shells out to the same `/opt/bin/modelgate-check` binary `ai-run` uses (backed by `ops/modelgate/modelgate.py`'s `resolve_llm_policy`) before spawning the Hermes subprocess. A DENY verdict yields an `ExecutorError` instead of spawning — no hang, no timeout, a clear reason string.
- When `AI_RUN_PURPOSE` is unset — every existing headless dispatch path today — `_check_modelgate` is never called and behavior is unchanged (verified below).
- Override knob: `HERMES_MODELGATE_CHECK_BIN` (defaults to `/opt/bin/modelgate-check`).

## Files changed

- `omnigent/inner/hermes_executor.py`: module docstring (+gate description), two new constants (`_DEFAULT_MODELGATE_CHECK_BIN`, `_MODELGATE_CHECK_TIMEOUT_S`), new `HermesExecutor._check_modelgate()` method, and a 6-line opt-in call site in `run_turn()` right after model resolution and before subprocess spawn.

No other files in this repo were touched.

## Proof

**(a) purpose='smoke' + model='glm-5.2' → BLOCKED, no hang:**
```
denial = await ex._check_modelgate(purpose="smoke", model="glm-5.2")
# => 'modelgate-check: BLOCKED — smoke work must use low tier\n  agent=hermes tier=high purpose=smoke\n  model=glm-5.2'
```

**(b) no AI_RUN_PURPOSE set → non-regression, gate never invoked:**
Patched `_check_modelgate` to raise `AssertionError` if called, ran `run_turn()` end-to-end against a stub `hermes` binary with `AI_RUN_PURPOSE` unset:
```
(b) event kinds: ['TextChunk', 'TurnComplete']
(b) NON-REGRESSION OK: gate never invoked, turn completed normally
```

**(c) purpose='smoke' + model='glm-4.7' → ALLOWED:**
```
denial = await ex._check_modelgate(purpose="smoke", model="glm-4.7")
# => None
```

Ran on the target VPS against the already-deployed `/opt/bin/modelgate-check` (installed by `omnigent-polly-dev-repo/scripts/deploy-modelgate.sh`).

## Test plan

- [x] `python3 -m py_compile omnigent/inner/hermes_executor.py`
- [x] Proof (a): explicit smoke+glm-5.2 dispatch blocked with clear message
- [x] Proof (b): default (no flag) dispatch unaffected — gate code path not entered
- [x] Proof (c): explicit smoke+glm-4.7 dispatch allowed
- [ ] Full end-to-end Polly dispatch through the live runner (not exercised in this PR — needs `AI_RUN_PURPOSE` threaded into the runner's env by whoever wires up the calling side; see caveat below)

## Caveat / follow-up

`AI_RUN_PURPOSE` is not currently threaded from Polly's `sys_session_send(purpose=...)` tool-call arg down into the runner's process env for the `hermes` (headless `CLI_SUBPROCESS`) harness — that field is today consumed only by `headless_subagent_purpose_guard` at the orchestrator-dispatch layer (see companion config PR in `omnigent-polly-dev-repo`) and never persisted/forwarded to the spawn env, unlike `model_override` which has an explicit per-harness env-var plumbing path (`_HARNESS_MODEL_ENV_KEY` in `omnigent/runner/app.py`). Wiring an actual dispatch-time `purpose` through that chain end-to-end (`tool_dispatch.py` → session persistence → `_build_spawn_env_from_spec` → `HARNESS_HERMES_PURPOSE`) is a larger, more invasive change across this shared dev+prod repo and is deliberately left out of this PR to keep the change surgical and zero-risk. For now, `AI_RUN_PURPOSE` is set directly in the runner process's environment for an explicit smoke-test proof (as done above); it is never set by any current code path, so today's default behavior is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)