### PR TITLE
feat(web): background-flush queued messages with attachments

### DIFF
--- a/tests/e2e_ui/sessions/test_cross_session_routing.py
+++ b/tests/e2e_ui/sessions/test_cross_session_routing.py
@@ -13,8 +13,10 @@ background-flush model:
 The queue is a per-conversation client-side buffer keyed by ``conversationId``;
 ``flushBackgroundQueues`` POSTs a queued message to its own conversation when
 that conversation is idle in the ``["conversations"]`` cache, regardless of
-which session is being viewed. This test pins both halves: delivered-to-B and
-never-to-A. (The FIFO/idle unit behavior is covered by the ``chatStore`` tests.)
+which session is being viewed. These tests pin both halves: delivered-to-B and
+never-to-A — once for a plain-text follow-up, and once for a follow-up carrying
+an image (upload → ``input_image`` post, both addressed to B). (The FIFO/idle
+unit behavior is covered by the ``chatStore`` tests.)
 
 Why async Playwright (not the sync ``page`` fixture): the test inspects the
 body of every ``/events`` POST via a route handler and asserts on which
@@ -104,6 +106,149 @@ def test_queued_message_stays_bound_to_origin_session(
     """
     base_url, session_a, session_b = seeded_session_pair
     _run_in_fresh_loop(_drive_cross_session_routing(base_url, session_a, session_b))
+
+
+def test_queued_message_with_image_flushes_to_origin(
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """A follow-up with an image queued in B is uploaded then posted to B.
+
+    Background flush mirrors ``send()``'s two-phase sequence for attachments:
+    upload the file (→ real ``file_id``) then POST a message carrying an
+    ``input_image`` block that references it. This pins that an image queued
+    while B is busy is delivered — upload + post — to B once it idles, even
+    with A active, and never leaks the upload or the message into A.
+
+    Failure mode this catches: the queued image is dropped (no upload / no
+    ``input_image`` block) or its upload/post is addressed to the active
+    session A instead of its origin B.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    _run_in_fresh_loop(_drive_cross_session_image_flush(base_url, session_a, session_b))
+
+
+async def _drive_cross_session_image_flush(base_url: str, session_a: str, session_b: str) -> None:
+    """Async body of the queued-image background-flush test.
+
+    :param base_url: Spawned server base URL.
+    :param session_a: The idle session the user switches to.
+    :param session_b: The session the image message is composed in.
+    """
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            # Every (session_id, content-blocks) POSTed to a /events endpoint,
+            # and every session_id an upload (/resources/files) was addressed to.
+            event_posts: list[tuple[str, list[dict[str, Any]]]] = []
+            upload_targets: list[str] = []
+            release_first = asyncio.Event()
+            first_b_post_held = False
+
+            async def handle_uploads(route: Route) -> None:
+                # Record which session each upload hits, then hand back a real
+                # file_id so the follow-up post can reference it.
+                match = re.search(r"/v1/sessions/([^/]+)/resources/files$", route.request.url)
+                assert match is not None, f"unexpected upload url: {route.request.url}"
+                upload_targets.append(match.group(1))
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps(
+                        {
+                            "id": "file_e2e_img",
+                            "name": "shot.png",
+                            "metadata": {"filename": "shot.png", "bytes": 4, "created_at": 0},
+                        }
+                    ),
+                )
+
+            async def handle_events(route: Route) -> None:
+                nonlocal first_b_post_held
+                request = route.request
+                match = _EVENTS_RE.search(request.url)
+                assert match is not None, f"unexpected /events url: {request.url}"
+                session_id = match.group(1)
+                content = request.post_data_json["data"]["content"]
+                event_posts.append((session_id, content))
+                # Hold ONLY B's first message open so B stays busy (streaming)
+                # while the image follow-up is attached and queued.
+                if session_id == session_b and not first_b_post_held:
+                    first_b_post_held = True
+                    await release_first.wait()
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            await page.route("**/v1/sessions/*/resources/files", handle_uploads)
+            await page.route("**/v1/sessions/*/events", handle_events)
+
+            await page.goto(f"{base_url}/c/{session_b}")
+            composer = page.get_by_label("Message the agent")
+            await page.get_by_placeholder(_COMPOSER_PLACEHOLDER).wait_for(
+                state="visible", timeout=15_000
+            )
+            send_button = page.get_by_role("button", name="Send", exact=True)
+
+            # msg1 → POST to B, held open by the route handler → B stays busy.
+            await composer.fill(_MSG1)
+            await send_button.click()
+            await _wait_until(lambda: first_b_post_held)
+
+            # Attach an image + text while B is busy → held in B's client-side
+            # queue. Set the hidden file input directly (the attach button just
+            # click()s it); wait for the chip so the file is registered before
+            # sending.
+            await page.locator('input[type="file"]').set_input_files(
+                {"name": "shot.png", "mimeType": "image/png", "buffer": b"png!"}
+            )
+            await page.get_by_label("Remove shot.png").wait_for(state="visible", timeout=15_000)
+            await composer.fill(_MSG2)
+            await send_button.click()
+            await page.get_by_test_id("composer-queued-strip").wait_for(
+                state="visible", timeout=15_000
+            )
+            # Nothing uploaded or posted for msg2 yet — it's held client-side.
+            assert upload_targets == [], f"image uploaded while queued: {upload_targets}"
+
+            # Switch to idle A (client-side nav preserves the store) and release
+            # B's first POST so B idles → background flush fires.
+            await page.locator(f'a[href="/c/{session_a}"]').click()
+            await page.wait_for_url(re.compile(rf"/c/{re.escape(session_a)}"))
+            release_first.set()
+
+            # Background flush uploads the image to B then posts an input_image
+            # block referencing the returned file_id — all addressed to B.
+            def _msg2_posted() -> bool:
+                return any(
+                    any(b.get("type") == "input_text" and b.get("text") == _MSG2 for b in content)
+                    for _, content in event_posts
+                )
+
+            await _wait_until(_msg2_posted)
+            msg2 = next(
+                content
+                for sid, content in event_posts
+                if sid == session_b
+                and any(b.get("type") == "input_text" and b.get("text") == _MSG2 for b in content)
+            )
+            # The image block precedes the text and carries the uploaded id.
+            image_block = next((b for b in msg2 if b.get("type") == "input_image"), None)
+            assert image_block is not None, f"no input_image block in the flushed post: {msg2}"
+            assert image_block["file_id"] == "file_e2e_img", image_block
+            assert any(b.get("type") == "input_text" and b.get("text") == _MSG2 for b in msg2)
+
+            # The upload and the post both went to B, never to the active A.
+            assert upload_targets == [session_b], (
+                f"image upload must target origin B, got {upload_targets}"
+            )
+            assert all(sid != session_a for sid, _ in event_posts), (
+                f"a message leaked into the active session A: {event_posts}"
+            )
+        finally:
+            await browser.close()
 
 
 async def _drive_cross_session_routing(base_url: str, session_a: str, session_b: str) -> None:

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7858,20 +7858,77 @@ describe("chatStore — background cross-session flush", () => {
     ]);
   });
 
-  it("skips a message with attachments (foreground flush owns those)", async () => {
+  it("uploads an attachment then posts an image block referencing its file_id", async () => {
+    // Mirrors send()'s two-phase sequence: upload the file → post the message
+    // with the server-assigned file_id, one in-flight guard spanning both.
     seedConversationsCache([conv("conv_active", "running"), conv("conv_bg", "idle")]);
-    const file = new File(["x"], "a.txt", { type: "text/plain" });
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_bg/resources/files") && init?.method === "POST") {
+        return mockResponse({
+          id: "file_bg_1",
+          name: "shot.png",
+          metadata: { filename: "shot.png", bytes: 4, created_at: 0 },
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const file = new File(["png!"], "shot.png", { type: "image/png" });
     useChatStore.setState({
       conversationId: "conv_active",
       queuedMessages: [
-        { queueId: "q_1", text: "has-file", conversationId: "conv_bg", files: [file] },
+        { queueId: "q_1", text: "see this", conversationId: "conv_bg", files: [file] },
       ],
     });
 
     useChatStore.getState().flushBackgroundQueues();
     await tick();
+    await tick();
 
-    expect(eventPosts()).toEqual([]);
-    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["has-file"]);
+    // The /events POST carries the image block (real id) followed by the text.
+    const post = fetchMock.mock.calls.find(
+      ([u, init]) =>
+        String(u).endsWith("/v1/sessions/conv_bg/events") &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(post).toBeDefined();
+    const content = JSON.parse((post![1] as RequestInit).body as string).data.content;
+    expect(content).toEqual([
+      { type: "input_image", file_id: "file_bg_1", filename: "shot.png" },
+      { type: "input_text", text: "see this" },
+    ]);
+    expect(useChatStore.getState().queuedMessages).toEqual([]);
+  });
+
+  it("re-queues the message when the attachment upload fails", async () => {
+    // A failure in the upload phase must re-queue + cool down exactly like a
+    // failed POST — the guard spans upload and post together.
+    seedConversationsCache([conv("conv_active", "running"), conv("conv_bg", "idle")]);
+    let events = 0;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_bg/resources/files") && init?.method === "POST") {
+        return mockResponse({}, { ok: false, status: 500 });
+      }
+      if (/\/v1\/sessions\/conv_bg\/events$/.test(url) && init?.method === "POST") {
+        events += 1;
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const file = new File(["x"], "a.png", { type: "image/png" });
+    useChatStore.setState({
+      conversationId: "conv_active",
+      queuedMessages: [
+        { queueId: "q_1", text: "with-image", conversationId: "conv_bg", files: [file] },
+      ],
+    });
+
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+    await tick();
+
+    // Upload failed → no message posted, and the item is re-queued to retry.
+    expect(events).toBe(0);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["with-image"]);
   });
 });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -562,9 +562,10 @@ export interface ChatState {
    * status in the `["conversations"]` cache is idle. The active conversation is
    * owned by {@link maybeFlushQueuedHead}; this covers a queue whose session the
    * user has navigated away from (its SSE stream is gone, so it can't drain
-   * itself). POSTs one message per idle conversation per call, via `postEvent`
-   * (no active-session state touched, no optimistic bubble — it re-hydrates on
-   * return). Level-triggered + idempotent; safe to over-fire.
+   * itself). Sends one message per idle conversation per call: uploads any
+   * attachments then posts via `postEvent` — the same two-phase sequence
+   * send() runs (no active-session state touched, no optimistic bubble — it
+   * re-hydrates on return). Level-triggered + idempotent; safe to over-fire.
    */
   flushBackgroundQueues: () => void;
   /**
@@ -974,23 +975,43 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const cooldownUntil = backgroundFlushCooldownUntil.get(conversationId);
       if (cooldownUntil !== undefined && cooldownUntil > now) continue;
       const head = get().queuedMessages.find((m) => m.conversationId === conversationId);
-      // Files are left for the foreground flush — background covers text only
-      // (attachments are in-memory and the user is likely still near that chat).
-      if (head === undefined || (head.files && head.files.length > 0)) continue;
+      if (head === undefined) continue;
 
-      // Remove BEFORE the POST so a re-entrant trigger can't double-send.
+      // Remove BEFORE the work starts so a re-entrant trigger can't double-send.
       backgroundFlushInFlight.add(conversationId);
       set((st) => ({
         queuedMessages: st.queuedMessages.filter((m) => m.queueId !== head.queueId),
       }));
+      // Upload any attachments, then post the message referencing their
+      // server-assigned file_ids — the same two-phase sequence send() runs
+      // (no combined endpoint exists: /resources/files stores the blob and
+      // returns an id, /events posts a message that points at that id). Both
+      // awaits sit under the one in-flight guard and the one catch, so a
+      // failure in either phase re-queues and backs off together.
+      //
       // No optimistic bubble — we're not viewing this conversation; it
       // re-hydrates from the snapshot on return. On failure re-queue at the
       // head (preserving this conversation's FIFO order) and set a cooldown so
       // the next trigger backs off instead of hammering a failing runner.
-      void postEvent(conversationId, {
-        type: "message",
-        data: { role: "user", content: [{ type: "input_text", text: head.text }] },
-      })
+      void (async () => {
+        const fileBlocks: ContentBlock[] = [];
+        for (const file of head.files ?? []) {
+          const uploaded = await uploadFile(conversationId, file);
+          fileBlocks.push(
+            file.type.startsWith("image/")
+              ? { type: "input_image", file_id: uploaded.id, filename: uploaded.filename }
+              : { type: "input_file", file_id: uploaded.id, filename: uploaded.filename },
+          );
+        }
+        const content: ContentBlock[] = [
+          ...fileBlocks,
+          ...(head.text.trim() ? [{ type: "input_text" as const, text: head.text }] : []),
+        ];
+        await postEvent(conversationId, {
+          type: "message",
+          data: { role: "user", content },
+        });
+      })()
         .catch(() => {
           backgroundFlushCooldownUntil.set(
             conversationId,


### PR DESCRIPTION
## Related issue

Follow-up to #2029 (background cross-session flush).

## Summary

- Background cross-session flush now sends queued messages **with attachments**
  (images, files), not just text. Previously `flushBackgroundQueues` skipped any
  queued message that carried files, so an image queued in a conversation you'd
  navigated away from sat until you returned to it.
- The fix mirrors `send()`'s two-phase sequence: **upload each attachment via
  `uploadFile`** (→ server-assigned `file_id`), build `input_image`/`input_file`
  blocks, then **post the message referencing them via `postEvent`**. There's no
  combined endpoint — `/resources/files` stores the blob and returns an id,
  `/events` posts a message that points at that id — so, exactly like the normal
  path, this is upload-then-post.
- **Both awaits sit under the one in-flight guard and the one `catch`**, so a
  failure in *either* the upload or the post phase re-queues the head
  (FIFO-preserving) and sets the same cooldown — no second guard, no double-send.
- Removing the `files` skip also closes the head-blocking edge Polly flagged on
  #2029: an image at the head of an idle conversation's queue now drains instead
  of stalling the text messages behind it.

## Test Plan

- **Unit** (`web`, vitest): 2 new `chatStore` tests replacing the old
  attachment-skip test — upload-then-post emits an `input_image` block with the
  real `file_id` and clears the queue; an upload-phase failure posts nothing and
  re-queues the message. 321 passing across store + strip + composer suites.
- **E2E** (`tests/e2e_ui/sessions/test_cross_session_routing.py`): new
  `test_queued_message_with_image_flushes_to_origin` — attach an image + text to
  B while B is busy, switch to idle A, release B; asserts the flush uploads the
  image to B then posts an `input_image` block with the returned `file_id`, and
  that neither the upload nor the message leaks into A. Both tests in the file
  pass locally (2 passed).
- Existing background-flush unit tests (idle/non-idle, active-skip, POST-failure
  cooldown, FIFO re-queue) unchanged and green.
- **Gates**: `npm run type-check`, unit tests, prettier, ruff all pass; web build ok.

## Demo

<!-- TODO: attach a clip — queue an image in B while it's busy, switch to A, watch B receive the image when it finishes -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Upload→post sequencing and the shared upload/post failure path are covered by the
two new store unit tests and end-to-end by the new cross-session image e2e; the
delivered-to-origin routing invariant remains covered by the existing text e2e.

This pull request and its description were written by Isaac.
