### PR TITLE
ci(images): store Docker build cache in GHCR, not the Actions pool

### DIFF
--- a/.github/workflows/oss-publish-images.yml
+++ b/.github/workflows/oss-publish-images.yml
@@ -190,16 +190,21 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Store the BuildKit layer cache as a dedicated GHCR image tag rather
+          # than in the 10 GB Actions cache pool, which the Docker layers alone
+          # (`mode=max`, three multi-arch builds) can fill on their own, evicting
+          # every other workflow's caches. A registry cache does not count
+          # against that pool and has no 7-day eviction.
+          cache-from: type=registry,ref=ghcr.io/omnigent-ai/omnigent-server:buildcache
+          cache-to: type=registry,ref=ghcr.io/omnigent-ai/omnigent-server:buildcache,mode=max
           provenance: false
           sbom: true
 
       # Host image: same Dockerfile, `host` target, also multi-arch (amd64 +
       # arm64). The harness CLIs it bakes in all ship arm64 — claude-code and
       # codex publish linux-arm64 npm binaries, pi is pure-JS. Runs after the
-      # server build so it reuses the shared builder-stage layers from the gha
-      # cache (cached per platform).
+      # server build so it reuses the shared builder-stage layers: read the
+      # server buildcache too, and write its own so host-specific layers cache.
       - name: Build and push host image
         id: build-host
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
@@ -210,15 +215,18 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.host_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=registry,ref=ghcr.io/omnigent-ai/omnigent-host:buildcache
+            type=registry,ref=ghcr.io/omnigent-ai/omnigent-server:buildcache
+          cache-to: type=registry,ref=ghcr.io/omnigent-ai/omnigent-host:buildcache,mode=max
           provenance: false
           sbom: true
 
       # OpenShell server variant: the default server image plus the
       # openshell SDK extra (OMNIGENT_EXTRAS=openshell). Used by the
-      # deploy/kubernetes/overlays/openshell kustomize overlay. Reuses
-      # the shared builder-stage layers from the gha cache.
+      # deploy/kubernetes/overlays/openshell kustomize overlay. Reads the
+      # server buildcache to reuse the shared builder-stage layers, and writes
+      # its own for the openshell-specific layers.
       - name: Build and push openshell server image
         id: build-openshell
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
@@ -230,8 +238,10 @@ jobs:
           tags: ${{ steps.tags.outputs.openshell_tags }}
           build-args: |
             OMNIGENT_EXTRAS=openshell
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=registry,ref=ghcr.io/omnigent-ai/omnigent-server-openshell:buildcache
+            type=registry,ref=ghcr.io/omnigent-ai/omnigent-server:buildcache
+          cache-to: type=registry,ref=ghcr.io/omnigent-ai/omnigent-server-openshell:buildcache,mode=max
           provenance: false
           sbom: true
     outputs:


### PR DESCRIPTION
## Related issue

N/A

## Summary

The three multi-arch image builds in `oss-publish-images.yml` each stored their BuildKit layer cache in the **GitHub Actions cache pool** via `cache-to: type=gha,mode=max`. That pool has a **fixed 10 GB per-repo cap** (not configurable, LRU-evicted). Auditing it showed these Docker layers alone occupy **~5 GB / 10 GB** (95 `buildkit-blob-*` entries) — because `mode=max` caches every *intermediate* layer, across three `linux/amd64,linux/arm64` builds. They crowd out and evict every other workflow's caches (the codex-parity sidecar binary, venv, Playwright browsers), which then rebuild cold.

This PR moves the Docker build cache **out of the Actions pool** and into GHCR as a dedicated `:buildcache` image tag per image:

- `cache-from`/`cache-to: type=registry,ref=ghcr.io/omnigent-ai/<image>:buildcache,mode=max`
- A registry cache **does not count against the 10 GB Actions cap** and has **no 7-day eviction** — it frees ~5 GB for the caches that belong there.
- **Prereqs already met** — the job logs in to `ghcr.io` (`docker/login-action`), has `packages: write`, and already pushes these images to GHCR. No new secrets/permissions.

To preserve the cross-image layer reuse the single shared `type=gha` scope gave for free, the **host** and **openshell** builds read the **server** `:buildcache` in addition to their own (multi-line `cache-from`), and each writes its own tag for image-specific layers.

This is the companion to #2028: that PR wired the codex-parity sidecar to share ci.yml's main-scoped binary cache, but it can only stay resident if the pool isn't full. Removing the ~5 GB of Docker blobs is what gives it (and the other caches) durable headroom.

## Test Plan

- YAML validated locally (`yaml.safe_load`) and `pre-commit run --files` passes.
- Cannot exercise on a PR: `oss-publish-images.yml` triggers only on `push: [main]` / `v*` tags. Correctness follows from the `docker/build-push-action` registry-cache contract + the already-present GHCR login/`packages: write`.
- **Post-merge verification:** first main run writes the `:buildcache` tags (cold); the *next* main run should restore from them (BuildKit "importing cache manifest" / CACHED layers in the build log). Will confirm ~5 GB drops out of the Actions cache pool (`gh api .../actions/cache/usage`) and that a `:buildcache` tag appears under each GHCR package.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CI/image-publish config change with no runtime surface. Verified by validating YAML, running pre-commit, and confirming the GHCR login + `packages: write` prereqs are already present. The image build/push itself is unchanged (same Dockerfile, targets, tags, platforms) — only the cache backend moves. Will watch the first two post-merge main runs to confirm the cold-write → warm-restore transition and the freed Actions-pool space.
