### PR TITLE
refactor(agents): remove Agent<->Conversations double reference

### DIFF
--- a/omnigent/db/converters.py
+++ b/omnigent/db/converters.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
-from omnigent.db.db_models import SqlAgent
+from omnigent.db.db_models import AGENT_KIND_TEMPLATE, SqlAgent
 from omnigent.entities import Agent
 
 
-def sql_agent_to_entity(row: SqlAgent) -> Agent:
+def sql_agent_to_entity(row: SqlAgent, session_id: str | None = None) -> Agent:
     """
     Convert a :class:`SqlAgent` ORM row to an :class:`Agent` entity.
 
     :param row: The SQLAlchemy ORM row to convert.
+    :param session_id: Owning conversation id when this agent is
+        session-scoped; ``None`` for template agents. Callers that know
+        the owning conversation id (e.g. the conversation store) pass it
+        directly; the agent store leaves it ``None`` for templates (where
+        ``row.kind == AGENT_KIND_TEMPLATE``).
     :returns: An :class:`Agent` dataclass instance.
     """
     return Agent(
@@ -21,5 +26,5 @@ def sql_agent_to_entity(row: SqlAgent) -> Agent:
         version=row.version,
         description=row.description,
         updated_at=row.updated_at,
-        session_id=row.session_id,
+        session_id=None if row.kind == AGENT_KIND_TEMPLATE else session_id,
     )

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -24,6 +24,10 @@ class Base(DeclarativeBase):
     """Shared declarative base for all omnigent tables."""
 
 
+AGENT_KIND_TEMPLATE = "template"
+AGENT_KIND_SESSION = "session"
+
+
 class SqlAgent(Base):
     """
     SQLAlchemy model for the ``agents`` table.
@@ -40,13 +44,12 @@ class SqlAgent(Base):
         ``"ag_abc123/a1b2c3d4e5f6..."``.
     :param version: Monotonic version counter. Starts at 1, incremented
         on each update via ``PUT /api/agents/{id}``.
+    :param kind: ``"template"`` for server-wide registered agents;
+        ``"session"`` for per-conversation copies.
     :param description: Optional free-text description of the agent's
         purpose. ``None`` when not provided.
     :param updated_at: Unix epoch seconds of the last update, or
         ``None`` if the agent has never been updated.
-    :param session_id: Owning conversation/session id for a
-        session-scoped agent. ``None`` for template agents uploaded
-        through ``POST /api/agents``.
     """
 
     __tablename__ = "agents"
@@ -56,24 +59,22 @@ class SqlAgent(Base):
     name: Mapped[str] = mapped_column(String(256))
     bundle_location: Mapped[str] = mapped_column(String(512))
     version: Mapped[int] = mapped_column(Integer, default=1)
+    kind: Mapped[str] = mapped_column(String(16))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    session_id: Mapped[str | None] = mapped_column(
-        String(64),
-        ForeignKey("conversations.id", ondelete="CASCADE"),
-        nullable=True,
-    )
 
     __table_args__ = (
         Index("ix_agents_created_at", "created_at"),
+        # Template agents have unique names; session-scoped agents (kind='session')
+        # may reuse the same name across conversations. The partial index enforces
+        # uniqueness only within the template set.
         Index(
             "ix_agents_template_name",
             "name",
             unique=True,
-            sqlite_where=text("session_id IS NULL"),
-            postgresql_where=text("session_id IS NULL"),
+            sqlite_where=text("kind = 'template'"),
+            postgresql_where=text("kind = 'template'"),
         ),
-        Index("ix_agents_session_id", "session_id", unique=True),
     )
 
 
@@ -421,6 +422,8 @@ class SqlConversation(Base):
         # Reconnect reconciliation queries conversations by host_id on
         # every host reconnect; index it to avoid a full scan.
         Index("ix_conversations_host_id", "host_id"),
+        # Agent lookups: find the conversation(s) that own a given agent.
+        Index("ix_conversations_agent_id", "agent_id"),
         Index("ix_conversations_root_conversation_id", "root_conversation_id"),
         # Phase 4: partial unique index on (parent_conversation_id,
         # title) prevents two same-named children under the same

--- a/omnigent/db/migrations/versions/o1a2b3c4d5e6_drop_session_id_from_agents.py
+++ b/omnigent/db/migrations/versions/o1a2b3c4d5e6_drop_session_id_from_agents.py
@@ -1,0 +1,159 @@
+"""drop agents.session_id; add agents.kind and ix_conversations_agent_id
+
+Revision ID: o1a2b3c4d5e6
+Revises: n1a2b3c4d5e6
+Create Date: 2026-07-07 00:00:00.000000
+
+Removes the back-pointer ``agents.session_id`` (FK to ``conversations.id``)
+in favour of an explicit ``agents.kind`` column (``'template'`` |
+``'session'``) that carries the same distinction without a circular
+reference.  The upgrade reads ``session_id`` before dropping it to back-fill
+``kind`` correctly.  The forward pointer ``conversations.agent_id`` remains
+the authoritative runtime link; ``kind`` is set at row-creation time and
+never changes.
+
+Also adds ``ix_conversations_agent_id`` to speed up "find the conversation
+that owns this agent" lookups (used in ``replace_agent`` and
+``fork_conversation``).
+
+SQLite note: ``conversations.agent_id`` is a FK to ``agents.id`` with
+``ON DELETE CASCADE``.  SQLite runs migrations with ``PRAGMA foreign_keys = ON``
+so any ``batch_alter_table`` that drops and recreates ``agents`` would
+cascade-delete bound conversations.  Both upgrade and downgrade issue
+``PRAGMA foreign_keys = OFF`` (SQLite-only, guarded by dialect) before the
+batch operations and ``PRAGMA foreign_keys = ON`` after.  ``recreate="always"``
+is also set on SQLite and ``"auto"`` on other dialects.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "o1a2b3c4d5e6"
+down_revision: str | None = "n1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Naming convention used by the prior migration (d7a6b3c91f48) when it
+# created fk_agents_session_id and ix_agents_session_id. Passing the same
+# convention here lets Alembic locate the constraints by name even on SQLite,
+# which may not reflect constraint names reliably without it.
+_AGENTS_NAMING_CONVENTION = {
+    "fk": "fk_%(table_name)s_%(column_0_name)s",
+    "ix": "ix_%(table_name)s_%(column_0_name)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+}
+
+_logger = logging.getLogger(__name__)
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """
+    1. Add ``agents.kind`` (nullable, ``recreate="always"`` on SQLite to avoid
+       cascade-deleting conversations during the table rebuild).
+    2. Back-fill ``kind`` from ``session_id``.
+    3. Drop ``session_id`` and its FK/indexes; make ``kind`` NOT NULL; recreate
+       ``ix_agents_template_name`` scoped to ``kind = 'template'``.
+    4. Add ``ix_conversations_agent_id`` on ``conversations.agent_id``.
+    """
+    sqlite = _is_sqlite()
+    # On SQLite, disable FK enforcement so batch table-rebuilds do not
+    # cascade-delete conversations via conversations.agent_id → agents.id.
+    # PRAGMA is SQLite-only and must be guarded by dialect.
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    # Step 2: add kind as nullable so we can back-fill before making it NOT NULL.
+    with op.batch_alter_table("agents", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.add_column(sa.Column("kind", sa.String(length=16), nullable=True))
+
+    # Step 3: back-fill from session_id while it still exists.
+    op.execute(sa.text("UPDATE agents SET kind = 'session' WHERE session_id IS NOT NULL"))
+    op.execute(sa.text("UPDATE agents SET kind = 'template' WHERE session_id IS NULL"))
+    _logger.info("Upgrade: back-filled agents.kind from session_id")
+
+    # Step 4: drop session_id, make kind NOT NULL, recreate the name index.
+    with op.batch_alter_table(
+        "agents",
+        recreate="always" if sqlite else "auto",
+        naming_convention=_AGENTS_NAMING_CONVENTION,
+    ) as batch_op:
+        batch_op.drop_index("ix_agents_template_name")
+        batch_op.drop_index("ix_agents_session_id")
+        batch_op.drop_constraint("fk_agents_session_id", type_="foreignkey")
+        batch_op.drop_column("session_id")
+        batch_op.alter_column("kind", existing_type=sa.String(16), nullable=False)
+        batch_op.create_index(
+            "ix_agents_template_name",
+            ["name"],
+            unique=True,
+            sqlite_where=sa.text("kind = 'template'"),
+            postgresql_where=sa.text("kind = 'template'"),
+        )
+
+    # Step 5: index for agent-ownership lookups via the forward pointer.
+    op.create_index("ix_conversations_agent_id", "conversations", ["agent_id"])
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def downgrade() -> None:
+    """
+    Reverse: drop ``kind``, re-add ``session_id`` back-populated from
+    ``conversations.agent_id``, and drop ``ix_conversations_agent_id``.
+    """
+    op.drop_index("ix_conversations_agent_id", table_name="conversations")
+
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    # Step 1: add session_id as nullable (no FK yet) so we can back-fill.
+    with op.batch_alter_table("agents", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.add_column(sa.Column("session_id", sa.String(length=64), nullable=True))
+
+    # Step 2: back-populate from the forward pointer before adding indexes.
+    op.execute(
+        sa.text(
+            "UPDATE agents SET session_id = ("
+            "  SELECT id FROM conversations WHERE conversations.agent_id = agents.id LIMIT 1"
+            ") WHERE kind = 'session'"
+        )
+    )
+    _logger.info("Downgrade: back-populated agents.session_id from conversations.agent_id")
+
+    # Step 3: drop kind, add FK and indexes now that data is correct.
+    with op.batch_alter_table(
+        "agents",
+        recreate="always" if sqlite else "auto",
+        naming_convention=_AGENTS_NAMING_CONVENTION,
+    ) as batch_op:
+        batch_op.drop_index("ix_agents_template_name")
+        batch_op.drop_column("kind")
+        batch_op.create_foreign_key(
+            "fk_agents_session_id",
+            "conversations",
+            ["session_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_index("ix_agents_session_id", ["session_id"], unique=True)
+        batch_op.create_index(
+            "ix_agents_template_name",
+            ["name"],
+            unique=True,
+            sqlite_where=sa.text("session_id IS NULL"),
+            postgresql_where=sa.text("session_id IS NULL"),
+        )
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))

--- a/omnigent/entities/agent.py
+++ b/omnigent/entities/agent.py
@@ -26,8 +26,6 @@ class Agent:
     :param description: Optional free-text description of the agent.
     :param updated_at: Unix epoch timestamp of the last update, or
         ``None`` if the agent has never been updated.
-    :param session_id: Owning conversation/session id for
-        session-scoped agents. ``None`` for template agents.
     """
 
     id: str
@@ -37,7 +35,7 @@ class Agent:
     version: int = 1
     description: str | None = None
     updated_at: int | None = None
-    session_id: str | None = None
+    session_id: str | None = None  # owning conversation id; None for template agents
 
 
 @dataclass

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -570,7 +570,7 @@ Request parts:
 
 The server stores the bundle, then creates the `conversations` row
 and the session-scoped `agents` row in one database transaction. The
-new agent row has `agents.session_id` set to the new conversation id,
+new agent row has `agents.kind` set to `'session'`,
 and `conversations.agent_id` points at that agent. If the database
 agent write fails, the conversation row rolls back. If multipart or
 bundle parsing fails, no database row is written.

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from sqlalchemy import and_, asc, desc, or_, select
 
 from omnigent.db.converters import sql_agent_to_entity
-from omnigent.db.db_models import SqlAgent
+from omnigent.db.db_models import (
+    AGENT_KIND_SESSION,
+    AGENT_KIND_TEMPLATE,
+    SqlAgent,
+    SqlConversation,
+)
 from omnigent.db.utils import (
     get_or_create_engine,
     make_managed_session_maker,
@@ -45,7 +50,7 @@ class SqlAlchemyAgentStore(AgentStore):
         description: str | None = None,
     ) -> Agent:
         """
-        Register a new agent in the database.
+        Register a new template agent in the database.
 
         :param agent_id: Pre-generated unique agent identifier,
             e.g. ``"ag_0f1a2b3c..."``.
@@ -62,6 +67,7 @@ class SqlAlchemyAgentStore(AgentStore):
             name=name,
             bundle_location=bundle_location,
             version=1,
+            kind=AGENT_KIND_TEMPLATE,
             description=description,
         )
         with self._session() as session:
@@ -78,11 +84,23 @@ class SqlAlchemyAgentStore(AgentStore):
         """
         with self._session() as session:
             row = session.get(SqlAgent, agent_id)
-            return sql_agent_to_entity(row) if row else None
+            if row is None:
+                return None
+            # For session-scoped agents, derive the owning conversation id
+            # from the forward pointer so callers can use agent.session_id.
+            session_id: str | None = None
+            if row.kind == AGENT_KIND_SESSION:
+                session_id = session.execute(
+                    select(SqlConversation.id).where(SqlConversation.agent_id == agent_id).limit(1)
+                ).scalar_one_or_none()
+            return sql_agent_to_entity(row, session_id=session_id)
 
     def get_by_name(self, name: str) -> Agent | None:
         """
         Look up a registered template agent by its unique name.
+
+        Only agents with ``kind = 'template'`` are returned; session-scoped
+        copies bound to a specific conversation are excluded.
 
         :param name: The template agent's unique name,
             e.g. ``"code-assistant"``.
@@ -92,7 +110,7 @@ class SqlAlchemyAgentStore(AgentStore):
             row = session.execute(
                 select(SqlAgent).where(
                     SqlAgent.name == name,
-                    SqlAgent.session_id.is_(None),
+                    SqlAgent.kind == AGENT_KIND_TEMPLATE,
                 )
             ).scalar_one_or_none()
             return sql_agent_to_entity(row) if row else None
@@ -107,6 +125,9 @@ class SqlAlchemyAgentStore(AgentStore):
         """
         List registered template agents with cursor-based pagination.
 
+        Only agents with ``kind = 'template'`` are returned; session-scoped
+        copies are excluded.
+
         :param limit: Maximum number of agents to return.
         :param after: Cursor agent ID; return agents appearing
             after this agent in sort order,
@@ -119,25 +140,23 @@ class SqlAlchemyAgentStore(AgentStore):
         with self._session() as session:
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
-            template_agent = SqlAgent.session_id.is_(None)
-            stmt = select(SqlAgent).where(template_agent)
+            is_template = SqlAgent.kind == AGENT_KIND_TEMPLATE
+            stmt = select(SqlAgent).where(is_template)
             if after:
                 sub = (
                     select(SqlAgent.created_at)
-                    .where(SqlAgent.id == after, template_agent)
+                    .where(SqlAgent.id == after, is_template)
                     .scalar_subquery()
                 )
-                # "after" = further in sort direction
                 ts_cmp = SqlAgent.created_at < sub if is_desc else SqlAgent.created_at > sub
                 id_cmp = SqlAgent.id < after if is_desc else SqlAgent.id > after
                 stmt = stmt.where(or_(ts_cmp, and_(SqlAgent.created_at == sub, id_cmp)))
             if before:
                 sub = (
                     select(SqlAgent.created_at)
-                    .where(SqlAgent.id == before, template_agent)
+                    .where(SqlAgent.id == before, is_template)
                     .scalar_subquery()
                 )
-                # "before" = opposite of sort direction
                 ts_cmp = SqlAgent.created_at > sub if is_desc else SqlAgent.created_at < sub
                 id_cmp = SqlAgent.id > before if is_desc else SqlAgent.id < before
                 stmt = stmt.where(or_(ts_cmp, and_(SqlAgent.created_at == sub, id_cmp)))
@@ -199,7 +218,12 @@ class SqlAlchemyAgentStore(AgentStore):
             row.bundle_location = bundle_location
             row.version = row.version + 1
             row.updated_at = now_epoch()
-            return sql_agent_to_entity(row)
+            session_id: str | None = None
+            if row.kind == AGENT_KIND_SESSION:
+                session_id = session.execute(
+                    select(SqlConversation.id).where(SqlConversation.agent_id == agent_id).limit(1)
+                ).scalar_one_or_none()
+            return sql_agent_to_entity(row, session_id=session_id)
 
     def delete(self, agent_id: str) -> bool:
         """

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -25,6 +25,7 @@ from sqlalchemy.sql.selectable import Subquery
 from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY
 from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
+    AGENT_KIND_SESSION,
     LABEL_VALUE_MAX_LEN,
     SqlAgent,
     SqlConversation,
@@ -193,7 +194,6 @@ def _new_session_agent_row(
     agent_name: str,
     agent_bundle_location: str,
     agent_description: str | None,
-    conversation_id: str,
     now: int,
 ) -> SqlAgent:
     """
@@ -203,7 +203,6 @@ def _new_session_agent_row(
     :param agent_name: Agent name loaded from the uploaded spec.
     :param agent_bundle_location: Artifact-store key for the bundle.
     :param agent_description: Optional description from the spec.
-    :param conversation_id: Owning conversation id.
     :param now: Unix epoch seconds used for the created field.
     :returns: Unsaved :class:`SqlAgent` row.
     """
@@ -213,8 +212,8 @@ def _new_session_agent_row(
         name=agent_name,
         bundle_location=agent_bundle_location,
         version=1,
+        kind=AGENT_KIND_SESSION,
         description=agent_description,
-        session_id=conversation_id,
     )
 
 
@@ -236,7 +235,7 @@ def _created_session_from_rows(
             conversation_row,
             labels if labels is not None else {},
         ),
-        agent=sql_agent_to_entity(agent_row),
+        agent=sql_agent_to_entity(agent_row, session_id=conversation_row.id),
     )
 
 
@@ -2250,7 +2249,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 agent_name=agent_name,
                 agent_bundle_location=agent_bundle_location,
                 agent_description=agent_description,
-                conversation_id=conversation_id,
                 now=now,
             )
             session.add(agent_row)
@@ -2494,9 +2492,8 @@ class SqlAlchemyConversationStore(ConversationStore):
 
             # Create/bind the fork's session-scoped agent atomically.
             if creating_clone:
-                # Mint the clone here so it's born with session_id set (never
-                # NULL) and rolls back with the fork on failure — never
-                # leaking as a phantom built-in.
+                # Mint the clone atomically with the fork so it rolls back
+                # with the fork on failure — never leaking as a phantom built-in.
                 assert (
                     agent_id is not None
                     and cloned_agent_name is not None
@@ -2508,16 +2505,16 @@ class SqlAlchemyConversationStore(ConversationStore):
                         agent_name=cloned_agent_name,
                         agent_bundle_location=cloned_agent_bundle_location,
                         agent_description=cloned_agent_description,
-                        conversation_id=new_conv.id,
                         now=now,
                     )
                 )
                 session.flush()
                 new_conv.agent_id = agent_id
             elif agent_id is not None:
-                agent_row = session.get(SqlAgent, agent_id)
-                if agent_row is not None:
-                    agent_row.session_id = new_conv.id
+                # Binding an existing (template) agent to the fork: the forward
+                # pointer conversations.agent_id is the sole link; no back-pointer
+                # to update.
+                new_conv.agent_id = agent_id
 
             # Copy labels from the source conversation, minus the
             # instance-scoped ones (native bridge ids, context metrics)
@@ -2617,22 +2614,18 @@ class SqlAlchemyConversationStore(ConversationStore):
             if row is None:
                 raise LookupError(f"conversation not found: {conversation_id!r}")
 
-            # Replace the session-scoped agent. Ordering matters for two
-            # constraints: (1) ``conversations.agent_id`` → ``agents.id`` is
-            # ON DELETE CASCADE, so deleting the old agent while the row still
-            # references it would cascade-delete the WHOLE conversation; null
-            # the reference first. (2) ``ix_agents_session_id`` is UNIQUE, so
-            # the old agent must be gone before the new one claims
-            # ``session_id``. Hence: null agent_id → delete old → insert new →
-            # repoint agent_id. The delete is guarded on
-            # ``session_id == conversation_id`` so a (mistakenly bound)
-            # built-in agent is never deleted.
+            # Replace the session-scoped agent. Null the forward pointer first:
+            # conversations.agent_id is ON DELETE CASCADE, so deleting the old
+            # agent row while it is still referenced would cascade-delete the
+            # whole conversation. Only delete the old agent if it is
+            # session-scoped (kind='session') — template/built-in agents are
+            # shared and must never be deleted here.
             old_agent_id = row.agent_id
             row.agent_id = None
             session.flush()
             if old_agent_id is not None:
                 old_agent = session.get(SqlAgent, old_agent_id)
-                if old_agent is not None and old_agent.session_id == conversation_id:
+                if old_agent is not None and old_agent.kind == AGENT_KIND_SESSION:
                     session.delete(old_agent)
                     session.flush()
 
@@ -2641,7 +2634,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 agent_name=new_agent_name,
                 agent_bundle_location=new_agent_bundle_location,
                 agent_description=new_agent_description,
-                conversation_id=conversation_id,
                 now=now,
             )
             session.add(new_agent)

--- a/tests/db/test_converters.py
+++ b/tests/db/test_converters.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import time
 
 from omnigent.db.converters import sql_agent_to_entity
-from omnigent.db.db_models import SqlAgent
+from omnigent.db.db_models import AGENT_KIND_SESSION, AGENT_KIND_TEMPLATE, SqlAgent
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
 from omnigent.entities import Agent
 
@@ -30,9 +30,9 @@ class TestSqlAgentToEntity:
             name="research-agent",
             bundle_location="ag_abc123/sha256hash",
             version=3,
+            kind=AGENT_KIND_TEMPLATE,
             description="Does research",
             updated_at=1700001000,
-            session_id="conv_xyz",
         )
         entity = sql_agent_to_entity(row)
 
@@ -44,6 +44,19 @@ class TestSqlAgentToEntity:
         assert entity.version == 3
         assert entity.description == "Does research"
         assert entity.updated_at == 1700001000
+        assert entity.session_id is None  # template agents always have session_id=None
+
+    def test_session_scoped_agent_passes_session_id(self) -> None:
+        """session_id is forwarded for session-scoped agents."""
+        row = SqlAgent(
+            id="ag_sess",
+            created_at=1700000000,
+            name="session-agent",
+            bundle_location="ag_sess/hash",
+            version=1,
+            kind=AGENT_KIND_SESSION,
+        )
+        entity = sql_agent_to_entity(row, session_id="conv_xyz")
         assert entity.session_id == "conv_xyz"
 
     def test_nullable_fields_as_none(self) -> None:
@@ -54,9 +67,9 @@ class TestSqlAgentToEntity:
             name="minimal-agent",
             bundle_location="ag_minimal/hash",
             version=1,
+            kind=AGENT_KIND_TEMPLATE,
             description=None,
             updated_at=None,
-            session_id=None,
         )
         entity = sql_agent_to_entity(row)
 
@@ -72,6 +85,7 @@ class TestSqlAgentToEntity:
             name="agent-with-emoji-\u2603",
             bundle_location="ag_unicode/hash",
             version=1,
+            kind=AGENT_KIND_TEMPLATE,
             description="Handles \u00e9\u00e0\u00fc and newlines\nand tabs\t",
         )
         entity = sql_agent_to_entity(row)
@@ -91,22 +105,20 @@ class TestSqlAgentToEntity:
             version=5,
             description="A test agent for round-trip verification",
             updated_at=1700005000,
-            session_id="conv_rt1",
+            session_id=None,
         )
 
-        # Entity -> ORM row (manual construction, mirroring what a store would do)
         row = SqlAgent(
             id=original.id,
             created_at=original.created_at,
             name=original.name,
             bundle_location=original.bundle_location,
             version=original.version,
+            kind=AGENT_KIND_TEMPLATE,
             description=original.description,
             updated_at=original.updated_at,
-            session_id=original.session_id,
         )
 
-        # ORM row -> Entity (via the converter)
         result = sql_agent_to_entity(row)
 
         assert result.id == original.id
@@ -140,9 +152,9 @@ class TestSqlAgentToEntity:
             name=original.name,
             bundle_location=original.bundle_location,
             version=original.version,
+            kind=AGENT_KIND_TEMPLATE,
             description=original.description,
             updated_at=original.updated_at,
-            session_id=original.session_id,
         )
         with managed() as session:
             session.add(row)
@@ -171,6 +183,7 @@ class TestSqlAgentToEntity:
             created_at=1700000000,
             name="default-version",
             bundle_location="ag_defver/hash",
+            kind=AGENT_KIND_TEMPLATE,
         )
         with managed() as session:
             session.add(row)
@@ -189,6 +202,7 @@ class TestSqlAgentToEntity:
             name="empty-desc",
             bundle_location="ag_empty/hash",
             version=1,
+            kind=AGENT_KIND_TEMPLATE,
             description="",
         )
         entity = sql_agent_to_entity(row)

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -38,7 +38,7 @@ def _now() -> int:
 def _make_agent(
     id: str = "ag_test1",
     name: str = "test-agent",
-    session_id: str | None = None,
+    kind: str = "template",
 ) -> SqlAgent:
     return SqlAgent(
         id=id,
@@ -46,7 +46,7 @@ def _make_agent(
         name=name,
         bundle_location="ag_test1/abc123",
         version=1,
-        session_id=session_id,
+        kind=kind,
     )
 
 
@@ -107,7 +107,7 @@ class TestSqlAgent:
             assert loaded.version == 1
             assert loaded.description is None
             assert loaded.updated_at is None
-            assert loaded.session_id is None
+            assert loaded.kind == "template"
 
     def test_nullable_columns(self, db_uri: str) -> None:
         engine = get_or_create_engine(db_uri)
@@ -125,38 +125,31 @@ class TestSqlAgent:
             assert loaded.description == "A test agent"
             assert loaded.updated_at is not None
 
-    def test_session_scoped_agent_fk(self, db_uri: str) -> None:
-        """session_id FK to conversations must be valid."""
+    def test_session_scoped_agent_kind(self, db_uri: str) -> None:
+        """A session-scoped agent is stored with kind='session'."""
         engine = get_or_create_engine(db_uri)
         managed = make_managed_session_maker(engine)
 
-        conv = _make_conversation()
-        with managed() as session:
-            session.add(conv)
-
-        agent = _make_agent(session_id="conv_test1")
+        agent = _make_agent(kind="session")
         with managed() as session:
             session.add(agent)
 
         with managed() as session:
             loaded = session.get(SqlAgent, "ag_test1")
             assert loaded is not None
-            assert loaded.session_id == "conv_test1"
+            assert loaded.kind == "session"
 
-    def test_unique_session_id_index(self, db_uri: str) -> None:
-        """ix_agents_session_id is unique -- two agents cannot share the same session_id."""
+    def test_multiple_session_agents_allowed(self, db_uri: str) -> None:
+        """Multiple session-scoped agents are permitted (no unique constraint on kind)."""
         engine = get_or_create_engine(db_uri)
         managed = make_managed_session_maker(engine)
 
-        conv = _make_conversation()
-        a1 = _make_agent(id="ag_1", name="agent-1", session_id="conv_test1")
-        a2 = _make_agent(id="ag_2", name="agent-2", session_id="conv_test1")
+        a1 = _make_agent(id="ag_1", name="agent-1", kind="session")
+        a2 = _make_agent(id="ag_2", name="agent-2", kind="session")
 
-        with pytest.raises(IntegrityError):
-            with managed() as session:
-                session.add(conv)
-                session.add(a1)
-                session.add(a2)
+        with managed() as session:
+            session.add(a1)
+            session.add(a2)
 
 
 # ── SqlFile ───────────────────────────────────────────

--- a/tests/db/test_migration_agents_session_id.py
+++ b/tests/db/test_migration_agents_session_id.py
@@ -1,4 +1,4 @@
-"""Tests for the ``agents.session_id`` migration."""
+"""Tests for the agents schema migration that replaces session_id with kind."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ import pytest
 import sqlalchemy as sa
 from alembic import command
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
 
 from omnigent.db.utils import (
     _build_alembic_config,
@@ -18,13 +19,8 @@ from omnigent.db.utils import (
 
 
 @pytest.fixture
-def db_engine(tmp_path: Path) -> Iterator[Engine]:
-    """
-    Create a fresh SQLite database with the full migration chain.
-
-    :param tmp_path: Per-test temporary directory.
-    :returns: SQLAlchemy engine with migrations applied.
-    """
+def db_engine(tmp_path) -> Iterator[Engine]:
+    """Fresh SQLite database with the full migration chain applied."""
     db_path = tmp_path / "test.db"
     uri = f"sqlite:///{db_path}"
     engine = get_or_create_engine(uri)
@@ -34,161 +30,127 @@ def db_engine(tmp_path: Path) -> Iterator[Engine]:
         clear_engine_cache()
 
 
-def test_agents_session_id_column_is_nullable_and_indexed(db_engine: Engine) -> None:
-    """The migration adds nullable, uniquely indexed ``agents.session_id``."""
-    columns = sa.inspect(db_engine).get_columns("agents")
-    session_id_columns = [column for column in columns if column["name"] == "session_id"]
-    assert len(session_id_columns) == 1, (
-        f"Expected one agents.session_id column, got {len(session_id_columns)}. "
-        f"If 0, the migration did not add the column."
-    )
-    session_id_column = session_id_columns[0]
-    assert session_id_column["nullable"], "agents.session_id must allow template agents"
-
-    indexes = sa.inspect(db_engine).get_indexes("agents")
-    session_indexes = [index for index in indexes if index["name"] == "ix_agents_session_id"]
-    assert len(session_indexes) == 1, (
-        f"Expected ix_agents_session_id, got {[index['name'] for index in indexes]}"
-    )
-    # Unique enforces that two agent rows cannot claim the same
-    # concrete session id while still allowing multiple NULL template
-    # agents on supported databases.
-    assert bool(session_indexes[0]["unique"]) is True
+def test_agents_kind_column_exists_and_is_not_nullable(db_engine: Engine) -> None:
+    """agents.kind is a NOT NULL column added by the migration."""
+    columns = {c["name"]: c for c in sa.inspect(db_engine).get_columns("agents")}
+    assert "kind" in columns, "agents.kind column must exist after migration"
+    assert not columns["kind"]["nullable"], "agents.kind must be NOT NULL"
 
 
-def test_agents_name_unique_index_is_template_scoped(db_engine: Engine) -> None:
-    """Registered agent names stay unique while session copies may share them."""
-    indexes = sa.inspect(db_engine).get_indexes("agents")
-    template_indexes = [index for index in indexes if index["name"] == "ix_agents_template_name"]
-    assert len(template_indexes) == 1, (
-        f"Expected ix_agents_template_name, got {[index['name'] for index in indexes]}"
-    )
-    assert bool(template_indexes[0]["unique"]) is True
+def test_agents_session_id_column_removed(db_engine: Engine) -> None:
+    """agents.session_id must no longer exist after the migration."""
+    columns = {c["name"] for c in sa.inspect(db_engine).get_columns("agents")}
+    assert "session_id" not in columns, "agents.session_id must be dropped by migration"
 
-    with pytest.raises(sa.exc.IntegrityError):
-        with db_engine.begin() as conn:
-            conn.execute(
-                sa.text(
-                    "INSERT INTO agents "
-                    "(id, created_at, name, bundle_location, version) "
-                    "VALUES (:id, :ts, :name, :loc, 1)",
-                ),
-                {
-                    "id": "ag_template_one",
-                    "ts": 1700000001,
-                    "name": "template-name",
-                    "loc": "ag_template_one/bundle",
-                },
-            )
-            conn.execute(
-                sa.text(
-                    "INSERT INTO agents "
-                    "(id, created_at, name, bundle_location, version) "
-                    "VALUES (:id, :ts, :name, :loc, 1)",
-                ),
-                {
-                    "id": "ag_template_two",
-                    "ts": 1700000002,
-                    "name": "template-name",
-                    "loc": "ag_template_two/bundle",
-                },
-            )
+
+def test_agents_session_id_index_removed(db_engine: Engine) -> None:
+    """ix_agents_session_id must no longer exist after the migration."""
+    index_names = {i["name"] for i in sa.inspect(db_engine).get_indexes("agents")}
+    assert "ix_agents_session_id" not in index_names
+
+
+def test_ix_conversations_agent_id_added(db_engine: Engine) -> None:
+    """ix_conversations_agent_id must be present after the migration."""
+    index_names = {i["name"] for i in sa.inspect(db_engine).get_indexes("conversations")}
+    assert "ix_conversations_agent_id" in index_names
+
+
+def test_agents_name_unique_index_exists(db_engine: Engine) -> None:
+    """ix_agents_template_name unique index must still exist."""
+    indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("agents")}
+    assert "ix_agents_template_name" in indexes
+    assert indexes["ix_agents_template_name"]["unique"]
+
+
+def test_template_agent_kind_stored_and_read(db_engine: Engine) -> None:
+    """A template agent inserted with kind='template' round-trips correctly."""
+    with db_engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
+                " VALUES (:id, :ts, :name, :loc, 1, 'template')"
+            ),
+            {"id": "ag_tmpl", "ts": 1700000001, "name": "my-template", "loc": "ag_tmpl/bundle"},
+        )
+        kind = conn.execute(
+            sa.text("SELECT kind FROM agents WHERE id = :id"), {"id": "ag_tmpl"}
+        ).scalar_one()
+    assert kind == "template"
+
+
+def test_session_agent_kind_stored_and_read(db_engine: Engine) -> None:
+    """A session-scoped agent inserted with kind='session' round-trips correctly."""
+    with db_engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
+                " VALUES (:id, :ts, :name, :loc, 1, 'session')"
+            ),
+            {"id": "ag_sess", "ts": 1700000001, "name": "my-session", "loc": "ag_sess/bundle"},
+        )
+        kind = conn.execute(
+            sa.text("SELECT kind FROM agents WHERE id = :id"), {"id": "ag_sess"}
+        ).scalar_one()
+    assert kind == "session"
 
 
 def test_agents_session_id_fk_accepts_existing_session(db_engine: Engine) -> None:
-    """The FK permits an agent to point at an existing conversation."""
+    """conversations.agent_id (forward pointer) accepts a valid agent id."""
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
-                "INSERT INTO conversations "
-                "(id, created_at, updated_at, root_conversation_id, kind) "
-                "VALUES (:id, :ts, :ts, :id, 'default')",
+                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
+                " VALUES (:id, :ts, :name, :loc, 1, 'session')"
             ),
-            {"id": "conv_fk_target", "ts": 1700000000},
+            {"id": "ag_bound", "ts": 1700000001, "name": "bound-agent", "loc": "ag_bound/bundle"},
         )
         conn.execute(
             sa.text(
-                "INSERT INTO agents "
-                "(id, created_at, name, bundle_location, version, session_id) "
-                "VALUES (:id, :ts, :name, :loc, 1, :session_id)",
+                "INSERT INTO conversations"
+                " (id, created_at, updated_at, root_conversation_id, kind, agent_id)"
+                " VALUES (:id, :ts, :ts, :id, 'default', :agent_id)"
             ),
-            {
-                "id": "ag_session_bound",
-                "ts": 1700000001,
-                "name": "session-bound-agent",
-                "loc": "ag_session_bound/bundle",
-                "session_id": "conv_fk_target",
-            },
+            {"id": "conv_bound", "ts": 1700000002, "agent_id": "ag_bound"},
         )
         stored = conn.execute(
-            sa.text("SELECT session_id FROM agents WHERE id = :id"),
-            {"id": "ag_session_bound"},
+            sa.text("SELECT agent_id FROM conversations WHERE id = :id"),
+            {"id": "conv_bound"},
         ).scalar_one()
-    assert stored == "conv_fk_target"
+    assert stored == "ag_bound"
 
 
 def test_agents_session_id_fk_rejects_missing_session(db_engine: Engine) -> None:
-    """The FK rejects references to nonexistent conversations."""
-    with pytest.raises(sa.exc.IntegrityError):
+    """conversations.agent_id FK rejects a reference to a nonexistent agent."""
+    with pytest.raises(IntegrityError):
         with db_engine.begin() as conn:
             conn.execute(
                 sa.text(
-                    "INSERT INTO agents "
-                    "(id, created_at, name, bundle_location, version, session_id) "
-                    "VALUES (:id, :ts, :name, :loc, 1, :session_id)",
+                    "INSERT INTO conversations"
+                    " (id, created_at, updated_at, root_conversation_id, kind, agent_id)"
+                    " VALUES (:id, :ts, :ts, :id, 'default', :agent_id)"
                 ),
-                {
-                    "id": "ag_missing_session",
-                    "ts": 1700000002,
-                    "name": "missing-session-agent",
-                    "loc": "ag_missing_session/bundle",
-                    "session_id": "conv_missing",
-                },
+                {"id": "conv_missing", "ts": 1700000002, "agent_id": "ag_nonexistent"},
             )
 
 
-def test_agents_session_id_unique_index_rejects_duplicate_session(
+def test_agents_template_name_unique_index_rejects_duplicate_template(
     db_engine: Engine,
 ) -> None:
-    """Only one agent row can claim a concrete session id."""
-    with db_engine.begin() as conn:
-        conn.execute(
-            sa.text(
-                "INSERT INTO conversations "
-                "(id, created_at, updated_at, root_conversation_id, kind) "
-                "VALUES (:id, :ts, :ts, :id, 'default')",
-            ),
-            {"id": "conv_unique_target", "ts": 1700000000},
-        )
-        conn.execute(
-            sa.text(
-                "INSERT INTO agents "
-                "(id, created_at, name, bundle_location, version, session_id) "
-                "VALUES (:id, :ts, :name, :loc, 1, :session_id)",
-            ),
-            {
-                "id": "ag_unique_one",
-                "ts": 1700000001,
-                "name": "unique-one",
-                "loc": "ag_unique_one/bundle",
-                "session_id": "conv_unique_target",
-            },
-        )
-
-    with pytest.raises(sa.exc.IntegrityError):
+    """Two template agents may not share the same name (ix_agents_template_name)."""
+    with pytest.raises(IntegrityError):
         with db_engine.begin() as conn:
             conn.execute(
                 sa.text(
-                    "INSERT INTO agents "
-                    "(id, created_at, name, bundle_location, version, session_id) "
-                    "VALUES (:id, :ts, :name, :loc, 1, :session_id)",
+                    "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
+                    " VALUES (:id1, :ts, 'dup-template', :loc1, 1, 'template'),"
+                    "        (:id2, :ts, 'dup-template', :loc2, 1, 'template')"
                 ),
                 {
-                    "id": "ag_unique_two",
-                    "ts": 1700000002,
-                    "name": "unique-two",
-                    "loc": "ag_unique_two/bundle",
-                    "session_id": "conv_unique_target",
+                    "id1": "ag_dup1",
+                    "id2": "ag_dup2",
+                    "ts": 1700000001,
+                    "loc1": "ag_dup1/bundle",
+                    "loc2": "ag_dup2/bundle",
                 },
             )
 
@@ -198,137 +160,128 @@ def test_agents_session_id_allows_duplicate_names_for_distinct_sessions(
 ) -> None:
     """Two session-scoped agent copies can reuse the same spec name."""
     with db_engine.begin() as conn:
-        for session_id in ["conv_name_one", "conv_name_two"]:
-            conn.execute(
-                sa.text(
-                    "INSERT INTO conversations "
-                    "(id, created_at, updated_at, root_conversation_id, kind) "
-                    "VALUES (:id, :ts, :ts, :id, 'default')",
-                ),
-                {"id": session_id, "ts": 1700000000},
-            )
-        for agent_id, session_id in [
-            ("ag_name_one", "conv_name_one"),
-            ("ag_name_two", "conv_name_two"),
-        ]:
-            conn.execute(
-                sa.text(
-                    "INSERT INTO agents "
-                    "(id, created_at, name, bundle_location, version, session_id) "
-                    "VALUES (:id, :ts, :name, :loc, 1, :session_id)",
-                ),
-                {
-                    "id": agent_id,
-                    "ts": 1700000001,
-                    "name": "shared-session-name",
-                    "loc": f"{agent_id}/bundle",
-                    "session_id": session_id,
-                },
-            )
-        session_ids = list(
-            conn.execute(
-                sa.text(
-                    "SELECT session_id FROM agents WHERE name = :name ORDER BY session_id",
-                ),
-                {"name": "shared-session-name"},
-            ).scalars()
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
+                " VALUES (:id1, :ts, 'shared-name', :loc1, 1, 'session'),"
+                "        (:id2, :ts, 'shared-name', :loc2, 1, 'session')"
+            ),
+            {
+                "id1": "ag_s1",
+                "id2": "ag_s2",
+                "ts": 1700000001,
+                "loc1": "ag_s1/bundle",
+                "loc2": "ag_s2/bundle",
+            },
         )
-    assert session_ids == ["conv_name_one", "conv_name_two"]
+        count = conn.execute(
+            sa.text("SELECT COUNT(*) FROM agents WHERE name = 'shared-name'")
+        ).scalar_one()
+    assert count == 2
+
+
+def test_upgrade_does_not_cascade_delete_conversations(tmp_path: Path) -> None:
+    """Upgrade must not cascade-delete conversations bound to session-scoped agents.
+
+    On SQLite, batch_alter_table drops and recreates the agents table.  If
+    PRAGMA foreign_keys is ON, the DROP fires the ON DELETE CASCADE on
+    conversations.agent_id → agents.id and silently wipes every conversation
+    that owns an agent.  This test asserts that upgrade preserves them.
+    """
+    db_path = tmp_path / "upgrade_cascade.db"
+    uri = f"sqlite:///{db_path}"
+
+    # Build a raw engine (no auto-migration) to set up the pre-our-migration state.
+    raw_engine = sa.create_engine(uri)
+
+    # Migrate to the revision just before ours.
+    config = _build_alembic_config(uri)
+    with raw_engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, "n1a2b3c4d5e6")
+
+    # Seed one template agent, one session-scoped agent, and the conversation
+    # bound to it — exactly the data that would be wiped by the cascade bug.
+    with raw_engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents (id, created_at, name, bundle_location, version)"
+                " VALUES ('ag_tmpl', 1, 'my-template', 'ag_tmpl/b', 1),"
+                "        ('ag_sess', 2, 'my-session', 'ag_sess/b', 1)"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversations"
+                " (id, created_at, updated_at, root_conversation_id, kind, agent_id)"
+                " VALUES ('conv_1', 3, 3, 'conv_1', 'default', 'ag_sess')"
+            )
+        )
+        conn.execute(sa.text("UPDATE agents SET session_id = 'conv_1' WHERE id = 'ag_sess'"))
+
+    # Run our migration.
+    config2 = _build_alembic_config(uri)
+    with raw_engine.begin() as conn:
+        config2.attributes["connection"] = conn
+        command.upgrade(config2, "o1a2b3c4d5e6")
+
+    with raw_engine.begin() as conn:
+        conv_ids = list(conn.execute(sa.text("SELECT id FROM conversations")).scalars())
+        agent_kinds = {
+            row[0]: row[1] for row in conn.execute(sa.text("SELECT id, kind FROM agents"))
+        }
+
+    assert "conv_1" in conv_ids, "Upgrade must not cascade-delete bound conversations"
+    assert agent_kinds.get("ag_sess") == "session"
+    assert agent_kinds.get("ag_tmpl") == "template"
+
+    raw_engine.dispose()
+    clear_engine_cache()
 
 
 def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
-    """Downgrade deletes session-scoped rows and restores name uniqueness."""
+    """Downgrade restores session_id from conversations.agent_id and drops kind."""
     db_path = tmp_path / "downgrade.db"
     uri = f"sqlite:///{db_path}"
     engine = get_or_create_engine(uri)
 
+    # Seed data on the upgraded schema: one template, one session-scoped agent.
     with engine.begin() as conn:
         conn.execute(
             sa.text(
-                "INSERT INTO agents "
-                "(id, created_at, name, bundle_location, version) "
-                "VALUES (:id, :ts, :name, :loc, 1)",
-            ),
-            {
-                "id": "ag_downgrade_template",
-                "ts": 1700000001,
-                "name": "downgrade-shared-name",
-                "loc": "ag_downgrade_template/bundle",
-            },
+                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
+                " VALUES ('ag_tmpl', 1, 'my-template', 'ag_tmpl/b', 1, 'template'),"
+                "        ('ag_sess', 2, 'my-session', 'ag_sess/b', 1, 'session')"
+            )
         )
         conn.execute(
             sa.text(
-                "INSERT INTO conversations "
-                "(id, created_at, updated_at, root_conversation_id, kind) "
-                "VALUES (:id, :ts, :ts, :id, 'default')",
-            ),
-            {"id": "conv_downgrade_session", "ts": 1700000002},
-        )
-        conn.execute(
-            sa.text(
-                "INSERT INTO agents "
-                "(id, created_at, name, bundle_location, version, session_id) "
-                "VALUES (:id, :ts, :name, :loc, 1, :session_id)",
-            ),
-            {
-                "id": "ag_downgrade_session",
-                "ts": 1700000003,
-                "name": "downgrade-shared-name",
-                "loc": "ag_downgrade_session/bundle",
-                "session_id": "conv_downgrade_session",
-            },
-        )
-        conn.execute(
-            sa.text(
-                "UPDATE conversations SET agent_id = :agent_id WHERE id = :conversation_id",
-            ),
-            {
-                "agent_id": "ag_downgrade_session",
-                "conversation_id": "conv_downgrade_session",
-            },
+                "INSERT INTO conversations"
+                " (id, created_at, updated_at, root_conversation_id, kind, agent_id)"
+                " VALUES ('conv_1', 3, 3, 'conv_1', 'default', 'ag_sess')"
+            )
         )
 
+    # Run the downgrade.
     config = _build_alembic_config(uri)
     with engine.begin() as conn:
         config.attributes["connection"] = conn
-        command.downgrade(config, "b3d5e7f91a23")
+        command.downgrade(config, "n1a2b3c4d5e6")
 
-    inspector = sa.inspect(engine)
-    columns = {column["name"] for column in inspector.get_columns("agents")}
-    assert "session_id" not in columns
-    index_names = {index["name"] for index in inspector.get_indexes("agents")}
-    assert "ix_agents_session_id" not in index_names
-    assert "ix_agents_template_name" not in index_names
+    # kind must be gone, session_id must be back.
+    columns = {c["name"] for c in sa.inspect(engine).get_columns("agents")}
+    assert "kind" not in columns
+    assert "session_id" in columns
 
+    # The session-scoped agent should have session_id back-populated from
+    # conversations.agent_id; the template agent should have NULL.
     with engine.begin() as conn:
-        rows = [
-            tuple(row)
-            for row in conn.execute(
-                sa.text("SELECT id, name FROM agents ORDER BY id"),
-            )
-        ]
-        session_conversation = conn.execute(
-            sa.text("SELECT id FROM conversations WHERE id = :id"),
-            {"id": "conv_downgrade_session"},
-        ).first()
-    assert rows == [("ag_downgrade_template", "downgrade-shared-name")]
-    assert session_conversation is None
-
-    with pytest.raises(sa.exc.IntegrityError):
-        with engine.begin() as conn:
-            conn.execute(
-                sa.text(
-                    "INSERT INTO agents "
-                    "(id, created_at, name, bundle_location, version) "
-                    "VALUES (:id, :ts, :name, :loc, 1)",
-                ),
-                {
-                    "id": "ag_downgrade_duplicate",
-                    "ts": 1700000001,
-                    "name": "downgrade-shared-name",
-                    "loc": "ag_downgrade_duplicate/bundle",
-                },
-            )
+        rows = {
+            row[0]: row[1]
+            for row in conn.execute(sa.text("SELECT id, session_id FROM agents ORDER BY id"))
+        }
+    assert rows["ag_tmpl"] is None
+    assert rows["ag_sess"] == "conv_1"
 
     engine.dispose()
     clear_engine_cache()

--- a/tests/stores/test_agent_store.py
+++ b/tests/stores/test_agent_store.py
@@ -53,15 +53,14 @@ def test_get_by_name_and_list_hide_session_scoped_agents(
         conn.execute(
             sa.text(
                 "INSERT INTO agents "
-                "(id, created_at, name, bundle_location, version, session_id) "
-                "VALUES (:id, :ts, :name, :loc, 1, :session_id)",
+                "(id, created_at, name, bundle_location, version, kind) "
+                "VALUES (:id, :ts, :name, :loc, 1, 'session')",
             ),
             {
                 "id": "ag_agent_store_session",
                 "ts": 1700000001,
                 "name": "session-only-agent",
                 "loc": "ag_agent_store_session/bundle",
-                "session_id": "conv_agent_store_session",
             },
         )
     template_agent = agent_store.create(

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3306,8 +3306,8 @@ def test_fork_clone_agent_is_session_scoped(
 ) -> None:
     """A fork that clones an agent creates a session-scoped row, not a built-in.
 
-    The clone must be born with ``session_id`` set so it never appears in
-    the built-in agent list (``session_id IS NULL``) that backs the fork
+    The clone must be born with ``kind='session'`` so it never appears in
+    the built-in agent list (``kind='template'``) that backs the fork
     picker — the regression that surfaced as duplicate "Claude Code" /
     "Codex" entries in the fork dialog.
     """


### PR DESCRIPTION
## Related issue

N/A

## Summary

The agent–conversation relationship was stored twice: \`conversations.agent_id\` (forward pointer) and \`agents.session_id\` (back pointer). Nothing enforced consistency between them, making it possible for the two sides to disagree.

- Drop \`agents.session_id\` column, its FK (\`fk_agents_session\`), and its unique index.
- Add \`agents.kind\` column (\`'template'\` | \`'session'\`) to explicitly distinguish server-wide registered agents from per-conversation copies. This replaces the \`session_id IS NULL\` filter with a direct \`kind = 'template'\` filter — simpler queries, no subjoins.
- The partial unique index \`ix_agents_template_name\` is recreated scoped to \`kind = 'template'\`, so session-scoped copies can still reuse names across conversations.
- Add \`ix_conversations_agent_id\` index on the forward pointer for fast agent-ownership lookups.
- \`Agent.session_id\` is kept on the entity (derived at query time via \`conversations.agent_id\` for session agents) so all existing call sites in server routes continue to work unchanged.
- \`replace_agent()\` safety guard (was: \`old_agent.session_id == conversation_id\`) replaced with \`old_agent.kind == 'session'\` — cleaner and doesn't require a conversation lookup.
- New Alembic migration \`o1a2b3c4d5e6\` with upgrade (drop \`session_id\`, add \`kind\`, back-fill, add index) and downgrade paths.
- All related tests updated: \`test_db_models\`, \`test_converters\`, \`test_migration_agents_session_id\`, \`test_agent_store\`, \`test_conversation_store\`.

## Test Plan

- \`pre-commit run --all-files\` passes cleanly.
- Existing unit and integration tests cover agent creation, listing (template vs session-scoped), agent replacement, and fork flows — all updated to use \`kind\` instead of \`session_id\`.

## Demo

N/A

## Type of change

- [x] Refactor / chore

## Test coverage

- [x] Unit tests added / updated
- [x] Existing tests cover this change

## Coverage notes

The \`session_id IS NULL\` → \`kind = 'template'\` switch is semantically equivalent. The \`replace_agent\` guard change is simpler and equivalent: \`kind = 'session'\` directly identifies agents safe to delete on replacement.