### PR TITLE
fix(spec): expand env vars in tools.builtins config

### DIFF
--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -151,7 +151,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
     raw_tools = raw.get("tools")
     llm = _parse_llm(raw_llm, expand_env=expand_env)
     interaction = _parse_interaction(raw.get("interaction"))
-    tools_config = _parse_tools_config(raw_tools)
+    tools_config = _parse_tools_config(raw_tools, expand_env=expand_env)
     executor = _parse_executor(raw_executor, expand_env=expand_env)
     # ── Consolidate llm: → executor ────────────────────────────────
     # ``executor.model`` and ``executor.connection`` are the primary
@@ -346,6 +346,8 @@ def _parse_interaction(
 
 def _parse_tools_config(
     raw: dict[str, Any] | None,
+    *,
+    expand_env: bool = True,
 ) -> ToolsConfig:
     """
     Parse the ``tools:`` block from config.yaml into a
@@ -355,6 +357,8 @@ def _parse_tools_config(
         ``None`` if the block was absent. Example:
         ``{"agents": ["summarizer", "code-reviewer"],
         "timeout": 60}``.
+    :param expand_env: Whether to expand ``${VAR}`` references in
+        builtin tool config values. ``False`` keeps literals as-is.
     :returns: A populated :class:`ToolsConfig`. Returns defaults
         when *raw* is ``None``.
     """
@@ -362,7 +366,7 @@ def _parse_tools_config(
         return ToolsConfig()
     timeout = int(raw["timeout"]) if "timeout" in raw else 60
     retry = _parse_retry(raw.get("retry"))
-    builtins = _parse_builtin_tools(raw.get("builtins", []))
+    builtins = _parse_builtin_tools(raw.get("builtins", []), expand_env=expand_env)
     sandbox = _parse_sandbox_config(raw.get("sandbox"))
     return ToolsConfig(
         agents=raw.get("agents", []),
@@ -408,6 +412,8 @@ def _parse_sandbox_config(
 
 def _parse_builtin_tools(
     raw: list[str | dict[str, Any]],
+    *,
+    expand_env: bool = True,
 ) -> list[BuiltinToolConfig]:
     """
     Parse the ``tools.builtins`` list into
@@ -423,6 +429,8 @@ def _parse_builtin_tools(
             engine_id: ${GOOGLE_SEARCH_ENGINE_ID}
 
     :param raw: The raw ``builtins`` list from config.yaml.
+    :param expand_env: Whether to expand ``${VAR}`` references in
+        config values. ``False`` keeps literals as-is (scaffolding).
     :returns: A list of :class:`BuiltinToolConfig` instances.
     :raises OmnigentError: If a dict entry is missing ``name``.
     """
@@ -439,6 +447,8 @@ def _parse_builtin_tools(
                 )
             # Everything except 'name' is tool-specific config.
             config = {str(k): str(v) for k, v in entry.items() if k != "name"}
+            if expand_env:
+                config = expand_env_vars(config)
             result.append(
                 BuiltinToolConfig(
                     name=str(name),

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -2099,6 +2099,78 @@ def test_parse_builtins_dict_missing_name(tmp_path: Path) -> None:
         parse(tmp_path)
 
 
+def test_parse_builtins_env_var_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``${VAR}`` references in tools.builtins config values are expanded."""
+    monkeypatch.setenv("SERPAPI_KEY", "sk-serp-secret")
+    monkeypatch.setenv("SEARCH_ENGINE_ID", "eng-42")
+    config = {
+        "spec_version": 1,
+        "tools": {
+            "builtins": [
+                {
+                    "name": "web_search",
+                    "api_key": "${SERPAPI_KEY}",
+                    "engine_id": "${SEARCH_ENGINE_ID}",
+                },
+            ],
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+
+    assert len(spec.tools.builtins) == 1
+    entry = spec.tools.builtins[0]
+    assert entry.config == {"api_key": "sk-serp-secret", "engine_id": "eng-42"}
+
+
+def test_parse_builtins_env_var_unresolved_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unresolved ``${VAR}`` in tools.builtins config raises OmnigentError."""
+    monkeypatch.delenv("SERPAPI_KEY", raising=False)
+    config = {
+        "spec_version": 1,
+        "tools": {
+            "builtins": [
+                {
+                    "name": "web_search",
+                    "api_key": "${SERPAPI_KEY}",
+                },
+            ],
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=r"Unresolved environment variable"):
+        parse(tmp_path)
+
+
+def test_parse_builtins_env_var_expand_env_false_keeps_literal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``expand_env=False`` leaves ``${VAR}`` references as-is in builtins config."""
+    monkeypatch.delenv("SERPAPI_KEY", raising=False)
+    config = {
+        "spec_version": 1,
+        "tools": {
+            "builtins": [
+                {
+                    "name": "web_search",
+                    "api_key": "${SERPAPI_KEY}",
+                },
+            ],
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path, expand_env=False)
+
+    assert spec.tools.builtins[0].config == {"api_key": "${SERPAPI_KEY}"}
+
+
 def test_parse_executor_config(tmp_path: Path) -> None:
     """Executor block with explicit timeout and max_iterations."""
     config = {


### PR DESCRIPTION
## Related issue

Closes #2050

## Summary

- `_parse_builtin_tools()` built the per-tool config dict with a plain dict comprehension — no `expand_env_vars` call — so `${VAR}` references in `tools.builtins` entries (e.g. `api_key: ${PERPLEXITY_API_KEY}`) survived verbatim and reached the backend as literal strings, causing 401s.
- Env expansion was already applied to `llm.connection` (~L297) and inline MCP `headers`/`env` (`_parse_inline_mcp_servers`, `expand_env=True`); `tools.builtins` was the only gap.
- Fix: call `expand_env_vars(config)` on the per-tool config dict inside `_parse_builtin_tools`, gated on the same `expand_env` flag used everywhere else.

## Test Plan

Three unit tests added to `tests/spec/`:

1. `test_builtin_tool_env_var_expanded` — `${VAR}` in a builtin config field resolves to the env value when `expand_env=True`.
2. `test_builtin_tool_env_var_not_expanded_when_flag_off` — literal string is preserved when `expand_env=False` (default path in tests).
3. `test_builtin_tool_env_var_missing_raises` — an unset `${VAR}` raises the expected error rather than silently sending the literal.

```
uv run pytest tests/spec/ -q
```

## Demo

N/A — backend parser fix, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The three new unit tests in `tests/spec/` cover the expansion path, the no-expand path, and the missing-var error. The fix is a one-call change mirroring existing `expand_env_vars` usage in the same file, so integration/e2e coverage is not needed beyond what already exists.

## Changelog

`${ENV_VAR}` references in `tools.builtins` entries (e.g. `api_key`) are now expanded at parse time, consistent with `llm.connection` and inline MCP config.