### PR TITLE
feat: add Nimble Extract-backed web_fetch (fetch_provider: nimble)

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2208,6 +2208,18 @@ async def _execute_web_fetch_tool(
     if not query:
         return "Error: 'query' parameter is required."
     url = args.get("url")
+
+    # Nimble Extract-backed path: when the spec selects ``fetch_provider: nimble``
+    # and a URL is provided, fetch it directly via Nimble Extract (JavaScript
+    # render + anti-bot + geo-targeting) instead of spawning the shell-based
+    # ``__web_researcher`` sub-agent. Without a URL there is nothing to extract,
+    # so fall through to the researcher (which searches, then fetches).
+    fetch_config = _web_fetch_config_from_spec(agent_spec)
+    if fetch_config.get("fetch_provider") == "nimble" and url:
+        from omnigent.tools.builtins.web_fetch_nimble import _fetch_nimble
+
+        return await asyncio.to_thread(_fetch_nimble, str(url), fetch_config)
+
     prompt = build_web_fetch_prompt(str(query), str(url) if url else None)
 
     # Embed task_id so each web_fetch from the same parent gets a
@@ -2228,6 +2240,29 @@ async def _execute_web_fetch_tool(
         publish_event=publish_event,
         session_inbox=session_inbox,
     )
+
+
+def _web_fetch_config_from_spec(agent_spec: Any | None) -> dict[str, str]:
+    """
+    Return the ``web_fetch`` builtin's config dict from the parent spec.
+
+    Mirrors :func:`_web_search_config_from_spec`: scans ``spec.tools.builtins``
+    for the entry named ``"web_fetch"`` and returns its ``config``
+    (``fetch_provider`` + credentials). Empty dict when the builtin is declared
+    as a bare string or absent.
+
+    :param agent_spec: Parent agent's spec, or ``None``.
+    :returns: The web_fetch config dict, e.g.
+        ``{"fetch_provider": "nimble", "api_key": "..."}``.
+    """
+    if agent_spec is None:
+        return {}
+    tools = getattr(agent_spec, "tools", None)
+    builtins = getattr(tools, "builtins", None) or []
+    for entry in builtins:
+        if getattr(entry, "name", None) == "web_fetch":
+            return getattr(entry, "config", None) or {}
+    return {}
 
 
 def _web_search_config_from_spec(agent_spec: Any | None) -> dict[str, str]:

--- a/omnigent/tools/builtins/web_fetch_nimble.py
+++ b/omnigent/tools/builtins/web_fetch_nimble.py
@@ -1,0 +1,147 @@
+"""Nimble Extract-backed ``web_fetch``.
+
+Backs the ``web_fetch`` builtin when the agent spec selects
+``fetch_provider: nimble``. Uses Nimble's Extract endpoint
+(``POST /v1/extract``) to fetch a single URL with JavaScript rendering,
+anti-bot handling, and optional geo-targeting, returning the page as
+Markdown — a real upgrade over the default researcher sub-agent's
+``curl`` / DuckDuckGo path when the goal is to read a specific URL.
+
+Configured in the agent spec::
+
+    tools:
+      builtins:
+        - name: web_fetch
+          fetch_provider: nimble
+          api_key: ${NIMBLE_API_KEY}
+          # optional:
+          # render: true        # JavaScript rendering (default: true)
+          # country: US          # geo-targeting / proxy country
+
+Without ``fetch_provider: nimble`` the builtin keeps its existing
+behaviour (a research sub-agent). See
+``omnigent/runner/tool_dispatch.py::_execute_web_fetch_tool`` for the
+dispatch branch.
+
+See https://docs.nimbleway.com/api-reference/extract
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+# Any: Nimble's JSON response is a heterogeneous dict with string keys
+# and mixed value types (str, dict, list, None).
+from typing import Any
+
+import httpx
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_NIMBLE_EXTRACT_URL = "https://sdk.nimbleway.com/v1/extract"
+
+# Identifies this integration to Nimble via the ``X-Client-Source`` header that
+# Nimble's own SDKs send (e.g. langchain-nimble sends ``"langchain-nimble"``),
+# so traffic from the Omnigent provider is attributable. Same convention as
+# ``web_search_nimble``.
+_CLIENT_SOURCE = "omnigent"
+
+# Cap the returned content so a very large page cannot blow the model's
+# context window. Extract returns full page content; the model only needs
+# enough to answer.
+_MAX_CONTENT_CHARS = 50_000
+
+
+def _extract_url() -> str:
+    """Resolve the Nimble Extract URL; ``OMNIGENT_NIMBLE_EXTRACT_URL`` overrides for tests."""
+    return os.environ.get("OMNIGENT_NIMBLE_EXTRACT_URL", _DEFAULT_NIMBLE_EXTRACT_URL)
+
+
+def _resolve_render(config: dict[str, str]) -> bool:
+    """
+    Parse the optional ``render`` flag from spec config.
+
+    Spec config values arrive as strings (the parser coerces every value to
+    ``str``), so ``render: true`` in YAML reaches here as ``"true"``. Defaults
+    to ``True`` — JavaScript rendering is the point of using Extract.
+
+    :param config: Spec-level config; ``render`` may be missing or a str.
+    :returns: Whether to render JavaScript.
+    """
+    raw = config.get("render")
+    if raw is None:
+        return True
+    return str(raw).strip().lower() not in ("false", "0", "no", "off")
+
+
+def _fetch_nimble(url: str, config: dict[str, str]) -> str:
+    """
+    Fetch a URL via Nimble Extract and return its content as text.
+
+    :param url: The target URL to fetch.
+    :param config: Spec-level config; ``api_key`` (required), optional
+        ``render`` (JavaScript rendering, default on) and ``country``
+        (geo-targeting / proxy country).
+    :returns: The page content (Markdown preferred, HTML fallback) prefixed
+        with the final URL, or an error message. Never raises.
+    """
+    api_key = config.get("api_key")
+    if not api_key:
+        return "Error: api_key must be provided in the web_fetch config in config.yaml."
+
+    body: dict[str, Any] = {
+        "url": url,
+        "render": _resolve_render(config),
+        "formats": ["markdown"],
+    }
+    country = config.get("country")
+    if country:
+        body["country"] = country
+
+    try:
+        resp = httpx.post(
+            _extract_url(),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "X-Client-Source": _CLIENT_SOURCE,
+            },
+            json=body,
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        return f"Nimble extract error: HTTP {exc.response.status_code}"
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        return f"Nimble extract error: {exc}"
+
+    return _format_extract(resp.json(), url)
+
+
+def _format_extract(data: dict[str, Any], requested_url: str) -> str:
+    """
+    Format Nimble's ``/v1/extract`` response into readable text for the LLM.
+
+    Nimble returns ``{"data": {"markdown": str | None, "html": str | None,
+    ...}, "url": str, "status": str, ...}``. Prefer ``markdown`` (LLM-native),
+    fall back to ``html``. Truncate to keep the model context bounded.
+
+    :param data: The parsed JSON response from Nimble.
+    :param requested_url: The URL originally requested (fallback if the
+        response omits the final URL).
+    :returns: The page content prefixed with its source URL, or a short
+        status message when no content was extracted.
+    """
+    content = data.get("data") or {}
+    body = content.get("markdown") or content.get("html") or ""
+    final_url = data.get("url") or requested_url
+
+    if not body.strip():
+        status = data.get("status", "unknown")
+        return f"No content extracted from {final_url} (status: {status})."
+
+    if len(body) > _MAX_CONTENT_CHARS:
+        body = body[:_MAX_CONTENT_CHARS] + "\n\n[content truncated]"
+
+    return f"Source: {final_url}\n\n{body}"

--- a/tests/e2e/test_web_fetch_nimble_e2e.py
+++ b/tests/e2e/test_web_fetch_nimble_e2e.py
@@ -1,0 +1,174 @@
+"""E2E test: ``web_fetch`` backed by Nimble Extract (``fetch_provider: nimble``).
+
+An agent with ``web_fetch`` + ``fetch_provider: nimble`` fetches a URL, and the
+runner dispatches to the Nimble Extract path (``_execute_web_fetch_tool`` →
+``web_fetch_nimble._fetch_nimble``). A local HTTP stub stands in for Nimble's
+``/v1/extract`` API — the runner subprocess is pointed at it via
+``OMNIGENT_NIMBLE_EXTRACT_URL`` (set at import time so the session-scoped
+server/runner subprocesses inherit it), so no live Nimble key is needed.
+
+Like the repo's other spec-level builtin e2e tests (see
+``tests/e2e/test_file_tools.py``), this **requires a real LLM** and skips under
+the mock LLM: the mock adapter can't resolve a builtin's callable, so the agent
+must run against a real model that decides to call ``web_fetch`` itself.
+
+Usage::
+
+    pytest tests/e2e/test_web_fetch_nimble_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+import uuid
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+import pytest
+
+from tests.e2e.conftest import (
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    send_user_message_to_session,
+)
+
+
+def _reserve_port() -> int:
+    """Reserve a free localhost port for the Extract stub."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
+
+
+# Point the (session-scoped) runner subprocess at our local Extract stub. Set at
+# import time — before collection finishes and the server/runner fixtures spawn —
+# so the child processes inherit the override from os.environ.
+_STUB_PORT = _reserve_port()
+os.environ["OMNIGENT_NIMBLE_EXTRACT_URL"] = f"http://127.0.0.1:{_STUB_PORT}/v1/extract"
+
+_EXTRACT_MARKDOWN = "# Stubbed Nimble Extract\n\nWEB_FETCH_NIMBLE_E2E page body."
+_received_requests: list[dict[str, object]] = []
+
+
+class _ExtractStubHandler(BaseHTTPRequestHandler):
+    """Minimal stand-in for Nimble ``POST /v1/extract``."""
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            body = {}
+        _received_requests.append({"headers": dict(self.headers), "body": body})
+
+        payload = json.dumps(
+            {
+                "data": {"markdown": _EXTRACT_MARKDOWN},
+                "url": body.get("url", ""),
+                "status": "success",
+                "task_id": "stub",
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args: object) -> None:  # keep test output quiet
+        del args
+
+
+@pytest.fixture
+def extract_stub() -> Iterator[list[dict[str, object]]]:
+    """Run the local Extract stub for the duration of the test."""
+    _received_requests.clear()
+    server = HTTPServer(("127.0.0.1", _STUB_PORT), _ExtractStubHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield _received_requests
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_web_fetch_nimble_extract_happy_path(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    using_mock_llm: bool,
+    extract_stub: list[dict[str, object]],
+) -> None:
+    """
+    A real-LLM agent with ``web_fetch`` + ``fetch_provider: nimble`` fetches a URL
+    via Nimble Extract and completes.
+
+    Verifies the chain agent → web_fetch → runner dispatch → Nimble Extract
+    (stub) → result → completion, and that the request carried the
+    ``X-Client-Source`` identity header.
+    """
+    if using_mock_llm:
+        pytest.skip(
+            "requires real LLM (spec-level builtin tools don't resolve under the mock LLM)"
+        )
+
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"nimble-fetch-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model="gpt-4.1-mini",
+        profile="",
+        prompt=(
+            "You read web pages. When asked to read a URL, call the web_fetch "
+            "tool with that url and report what the page says."
+        ),
+        extra_config={
+            "tools": {
+                "builtins": [
+                    {
+                        "name": "web_fetch",
+                        "fetch_provider": "nimble",
+                        "api_key": "test-key",
+                    },
+                ],
+            },
+        },
+    )
+
+    session_id = create_runner_bound_session(
+        http_client, agent_name=agent_name, runner_id=live_runner_id
+    )
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Use web_fetch to read https://example.com and report what it says.",
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=response_id, timeout=180
+    )
+
+    assert body["status"] == "completed", (
+        f"Response status is {body['status']!r}, expected 'completed'. "
+        f"Output: {body.get('output', [])}"
+    )
+
+    # The runner dispatched web_fetch to Nimble Extract (not the sub-agent), and
+    # the request carried the X-Client-Source identity header.
+    assert extract_stub, "Nimble Extract stub was never called — nimble path not taken."
+    last = extract_stub[-1]
+    headers = last["headers"]
+    assert isinstance(headers, dict)
+    assert headers.get("X-Client-Source") == "omnigent", (
+        f"Expected X-Client-Source 'omnigent', got {headers.get('X-Client-Source')!r}"
+    )
+    request_body = last["body"]
+    assert isinstance(request_body, dict)
+    assert request_body.get("url") == "https://example.com"

--- a/tests/runner/test_web_fetch_nimble_dispatch.py
+++ b/tests/runner/test_web_fetch_nimble_dispatch.py
@@ -1,0 +1,129 @@
+"""Dispatch tests for the Nimble Extract-backed ``web_fetch`` path.
+
+These lock in the expectations behind the ``fetch_provider: nimble`` branch in
+``_execute_web_fetch_tool``: with a URL and the nimble provider selected, the
+call resolves to Nimble Extract (no sub-agent spawn); otherwise the existing
+``__web_researcher`` sub-agent path is preserved (zero regression).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from omnigent.runner.tool_dispatch import (
+    _ALL_LOCAL_TOOLS,
+    _execute_web_fetch_tool,
+    _web_fetch_config_from_spec,
+    should_dispatch_locally,
+)
+
+
+def _spec_with_web_fetch(config: dict[str, str]) -> SimpleNamespace:
+    """Minimal agent_spec stub: a single ``web_fetch`` builtin carrying ``config``."""
+    return SimpleNamespace(
+        tools=SimpleNamespace(
+            builtins=[SimpleNamespace(name="web_fetch", config=config)],
+        ),
+    )
+
+
+def test_web_fetch_is_runner_local() -> None:
+    """``web_fetch`` dispatches locally (regression guard for the base wiring)."""
+    assert "web_fetch" in _ALL_LOCAL_TOOLS
+    assert should_dispatch_locally("web_fetch") is True
+
+
+def test_config_from_spec_reads_nimble_config() -> None:
+    """The config helper returns the ``web_fetch`` builtin's config dict."""
+    spec = _spec_with_web_fetch({"fetch_provider": "nimble", "api_key": "k"})
+    assert _web_fetch_config_from_spec(spec) == {"fetch_provider": "nimble", "api_key": "k"}
+
+
+def test_config_from_spec_empty_when_absent() -> None:
+    """No ``web_fetch`` entry → empty config."""
+    spec = SimpleNamespace(tools=SimpleNamespace(builtins=[]))
+    assert _web_fetch_config_from_spec(spec) == {}
+
+
+def test_nimble_path_extracts_when_url_present() -> None:
+    """fetch_provider=nimble + a URL → Nimble Extract, and NO researcher spawn."""
+    spec = _spec_with_web_fetch({"fetch_provider": "nimble", "api_key": "k"})
+    fake = MagicMock()
+    fake.json.return_value = {
+        "data": {"markdown": "# Hello"},
+        "url": "https://example.com",
+        "status": "success",
+    }
+    with (
+        patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post,
+        patch(
+            "omnigent.runner.tool_dispatch._execute_subagent_tool",
+            new=AsyncMock(return_value="SUBAGENT"),
+        ) as mock_sub,
+    ):
+        mock_post.return_value = fake
+        result = asyncio.run(
+            _execute_web_fetch_tool(
+                {"query": "hi", "url": "https://example.com"},
+                server_client=None,
+                conversation_id="c",
+                agent_spec=spec,
+                task_id="t",
+            )
+        )
+
+    assert mock_post.call_count == 1, "nimble path must call Nimble Extract"
+    assert mock_sub.call_count == 0, "nimble path must not spawn the researcher sub-agent"
+    assert "# Hello" in result
+
+
+def test_nimble_path_falls_back_to_subagent_without_url() -> None:
+    """fetch_provider=nimble but no URL → researcher sub-agent (nothing to extract)."""
+    spec = _spec_with_web_fetch({"fetch_provider": "nimble", "api_key": "k"})
+    with (
+        patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post,
+        patch(
+            "omnigent.runner.tool_dispatch._execute_subagent_tool",
+            new=AsyncMock(return_value="SUBAGENT"),
+        ) as mock_sub,
+    ):
+        result = asyncio.run(
+            _execute_web_fetch_tool(
+                {"query": "hi"},
+                server_client=None,
+                conversation_id="c",
+                agent_spec=spec,
+                task_id="t",
+            )
+        )
+
+    assert mock_post.call_count == 0, "no URL → must not call Extract"
+    assert mock_sub.call_count == 1
+    assert result == "SUBAGENT"
+
+
+def test_no_provider_preserves_subagent_path() -> None:
+    """No ``fetch_provider`` → existing researcher path, even with a URL (zero regression)."""
+    spec = _spec_with_web_fetch({})
+    with (
+        patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post,
+        patch(
+            "omnigent.runner.tool_dispatch._execute_subagent_tool",
+            new=AsyncMock(return_value="SUBAGENT"),
+        ) as mock_sub,
+    ):
+        result = asyncio.run(
+            _execute_web_fetch_tool(
+                {"query": "hi", "url": "https://example.com"},
+                server_client=None,
+                conversation_id="c",
+                agent_spec=spec,
+                task_id="t",
+            )
+        )
+
+    assert mock_post.call_count == 0, "no provider → must not call Extract"
+    assert mock_sub.call_count == 1
+    assert result == "SUBAGENT"

--- a/tests/tools/builtins/test_web_fetch_nimble.py
+++ b/tests/tools/builtins/test_web_fetch_nimble.py
@@ -1,0 +1,175 @@
+"""Tests for the Nimble Extract-backed ``web_fetch`` backend."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from omnigent.tools.builtins.web_fetch_nimble import (
+    _fetch_nimble,
+    _format_extract,
+    _resolve_render,
+)
+
+
+def test_missing_api_key_returns_error() -> None:
+    """Without api_key the backend returns a clear error, never raises."""
+    result = _fetch_nimble("https://example.com", {})
+    assert "api_key" in result
+
+
+def test_extract_sends_bearer_client_source_and_body() -> None:
+    """api_key → Bearer header, X-Client-Source is set, body carries url/render/formats."""
+    fake = MagicMock()
+    fake.json.return_value = {
+        "data": {"markdown": "# Doc"},
+        "url": "https://example.com",
+        "status": "success",
+    }
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        _fetch_nimble("https://example.com", {"api_key": "spec-key"})
+
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer spec-key", (
+        f"Expected spec config api_key in header, got {headers['Authorization']!r}"
+    )
+    assert headers["X-Client-Source"] == "omnigent", (
+        f"Expected X-Client-Source 'omnigent', got {headers.get('X-Client-Source')!r}"
+    )
+    body = mock_post.call_args.kwargs["json"]
+    assert body["url"] == "https://example.com"
+    assert body["render"] is True
+    assert body["formats"] == ["markdown"]
+
+
+def test_markdown_preferred_and_source_prefixed() -> None:
+    """Markdown is preferred over HTML and the final URL is prefixed as a source."""
+    fake = MagicMock()
+    fake.json.return_value = {
+        "data": {"markdown": "# Title\ntext", "html": "<h1>Title</h1>"},
+        "url": "https://example.com",
+    }
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = _fetch_nimble("https://example.com", {"api_key": "k"})
+
+    assert "# Title" in result
+    assert "<h1>" not in result, "Markdown must be preferred over HTML."
+    assert "https://example.com" in result
+
+
+def test_html_fallback_when_no_markdown() -> None:
+    """When markdown is absent, HTML is used as the fallback body."""
+    fake = MagicMock()
+    fake.json.return_value = {
+        "data": {"markdown": None, "html": "<p>Body</p>"},
+        "url": "https://example.com",
+    }
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = _fetch_nimble("https://example.com", {"api_key": "k"})
+
+    assert "<p>Body</p>" in result
+
+
+def test_no_content_returns_status_message() -> None:
+    """An empty extraction returns a short status message (with the status)."""
+    fake = MagicMock()
+    fake.json.return_value = {
+        "data": {"markdown": None, "html": None},
+        "url": "https://example.com",
+        "status": "blocked",
+    }
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = _fetch_nimble("https://example.com", {"api_key": "k"})
+
+    assert "No content" in result
+    assert "blocked" in result
+
+
+def test_http_error_returns_string_not_raised() -> None:
+    """An HTTP error (e.g. 403) is returned as a string, never raised."""
+    fake = MagicMock()
+    fake.status_code = 403
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.side_effect = httpx.HTTPStatusError("403", request=MagicMock(), response=fake)
+        result = _fetch_nimble("https://example.com", {"api_key": "k"})
+
+    assert "Nimble extract error" in result
+    assert "403" in result
+
+
+def test_connect_error_returns_string() -> None:
+    """A transport error is returned as a string, never raised."""
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.side_effect = httpx.ConnectError("boom")
+        result = _fetch_nimble("https://example.com", {"api_key": "k"})
+
+    assert "Nimble extract error" in result
+
+
+def test_country_added_when_present() -> None:
+    """A ``country`` config value is forwarded to the request body for geo-targeting."""
+    fake = MagicMock()
+    fake.json.return_value = {"data": {"markdown": "x"}, "url": "https://example.com"}
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        _fetch_nimble("https://example.com", {"api_key": "k", "country": "US"})
+
+    body = mock_post.call_args.kwargs["json"]
+    assert body["country"] == "US"
+
+
+def test_country_omitted_by_default() -> None:
+    """No ``country`` → no geo field in the body (non-enterprise-safe default)."""
+    fake = MagicMock()
+    fake.json.return_value = {"data": {"markdown": "x"}, "url": "https://example.com"}
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        _fetch_nimble("https://example.com", {"api_key": "k"})
+
+    assert "country" not in mock_post.call_args.kwargs["json"]
+
+
+def test_render_config_parsing() -> None:
+    """``render`` config (a str from the spec parser) is coerced; default is True."""
+    assert _resolve_render({}) is True
+    assert _resolve_render({"render": "true"}) is True
+    assert _resolve_render({"render": "false"}) is False
+    assert _resolve_render({"render": "0"}) is False
+    assert _resolve_render({"render": "no"}) is False
+    assert _resolve_render({"render": "off"}) is False
+
+
+def test_render_false_sent_in_body() -> None:
+    """``render: false`` reaches the request body as a bool False."""
+    fake = MagicMock()
+    fake.json.return_value = {"data": {"markdown": "x"}, "url": "https://example.com"}
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        _fetch_nimble("https://example.com", {"api_key": "k", "render": "false"})
+
+    assert mock_post.call_args.kwargs["json"]["render"] is False
+
+
+def test_truncation_caps_content() -> None:
+    """A very large page is truncated so it cannot blow the model context."""
+    fake = MagicMock()
+    fake.json.return_value = {"data": {"markdown": "x" * 60_000}, "url": "https://example.com"}
+    with patch("omnigent.tools.builtins.web_fetch_nimble.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = _fetch_nimble("https://example.com", {"api_key": "k"})
+
+    assert "[content truncated]" in result
+    assert len(result) < 55_000
+
+
+def test_format_extract_direct() -> None:
+    """``_format_extract`` prefers markdown and prefixes the final URL."""
+    out = _format_extract(
+        {"data": {"markdown": "hello"}, "url": "https://final.example"}, "https://req.example"
+    )
+    assert out == "Source: https://final.example\n\nhello"


### PR DESCRIPTION
## Related issue

N/A — extends the merged Nimble `web_search` provider (#55) with an Extract-backed `web_fetch`.

## Summary

- Adds an opt-in Nimble Extract backend to the `web_fetch` builtin, selected via `fetch_provider: nimble` in the agent spec — mirroring the existing `search_provider: nimble` for `web_search`.
- With a URL, `web_fetch` fetches the page through Nimble's `POST /v1/extract` (JavaScript render + anti-bot + geo-targeting) and returns Markdown — an upgrade over the default researcher sub-agent's `curl`/DuckDuckGo path for reading a specific URL.
- Fully additive: without `fetch_provider: nimble`, or without a URL, the existing sub-agent behaviour is unchanged.
- Raw `httpx` (no SDK dependency), `api_key` from spec config, errors returned as strings, returned content capped, and an `X-Client-Source` header identifying the integration (same convention as the `web_search` backend).

### ELI5

`web_fetch` today spawns a helper agent that shells out to `curl` and scrapes DuckDuckGo. If you set `fetch_provider: nimble` and give it a URL, it instead asks Nimble to fetch that exact page — running JavaScript, handling bot-walls — and returns clean Markdown. If you don't opt in, nothing changes.

### How it dispatches

```
web_fetch(query, url)
  └─ runner _execute_web_fetch_tool
       ├─ fetch_provider == "nimble" AND url present ──► Nimble POST /v1/extract ──► Markdown
       └─ otherwise ─────────────────────────────────► __web_researcher sub-agent (unchanged)
```

Config:

```yaml
tools:
  builtins:
    - name: web_fetch
      fetch_provider: nimble
      api_key: ${NIMBLE_API_KEY}
      # optional: render: true (default) · country: US
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Commands run:

- `uv run pytest tests/tools/builtins/test_web_fetch_nimble.py tests/runner/test_web_fetch_nimble_dispatch.py` → **19 passed**. Backend unit tests (Bearer + `X-Client-Source` header, request body, Markdown-preferred/HTML-fallback mapping, error-as-string, content cap, `render`/`country` config parsing) plus runner-dispatch tests (with `fetch_provider: nimble` + a URL the call routes to Extract and does **not** spawn the sub-agent; without the provider or without a URL, the sub-agent path is preserved).
- `uv run pytest tests/tools/builtins/test_web_search.py tests/runner/test_web_search_local_dispatch.py tests/tools/builtins/test_web_fetch_nimble.py tests/runner/test_web_fetch_nimble_dispatch.py` → **68 passed** (regression co-run — the shared `web_fetch` / `web_search` dispatch is unaffected).
- `tests/e2e/test_web_fetch_nimble_e2e.py` — added, mirroring the repo's spec-level-builtin e2e convention (e.g. `tests/e2e/test_file_tools.py`): it drives `web_fetch` with `fetch_provider: nimble` against a local Extract stub, and is skipped under the mock LLM (which can't resolve spec-level builtins). I verified it collects and skips cleanly under the mock LLM this cycle; I have not run it end-to-end against a live LLM.
- `uv run ruff check` + `uv run ruff format --check` on the changed files, and `uv run pre-commit run --files ...` → all pass.
- **Live smoke** (the evidence behind the *Manual verification completed* box): fetched `https://example.com` through `/v1/extract` with a real key and received the page rendered as Markdown (HTTP 200), using Extract's standard options (`render: true`, `formats: ["markdown"]`).

Files: `omnigent/tools/builtins/web_fetch_nimble.py` (new backend), `omnigent/runner/tool_dispatch.py` (the `fetch_provider` branch + a `_web_fetch_config_from_spec` helper), and the three test files above.
