### PR TITLE
feat: add web_map builtin backed by Nimble Map

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -254,6 +254,11 @@ _WEB_FETCH_TOOLS = frozenset({"web_fetch"})
 # web_search known-failure.
 _WEB_SEARCH_TOOLS = frozenset({"web_search"})
 
+# Priority 5f.1c: web_map — website URL discovery via Nimble's Map endpoint.
+# Runner-local so a non-OpenAI model's web_map call resolves to WebMapTool.invoke
+# (POST /v1/map), the same posture as web_search.
+_WEB_MAP_TOOLS = frozenset({"web_map"})
+
 # Priority 5f.2: sys_list_models — runner-local because provider resolution
 # reads the runner host's config/credentials, same as the spawn paths.
 _LIST_MODELS_TOOLS = frozenset({"sys_list_models"})
@@ -461,6 +466,7 @@ _ALL_LOCAL_TOOLS = (
     | _SESSION_QUERY_TOOLS
     | _WEB_FETCH_TOOLS
     | _WEB_SEARCH_TOOLS
+    | _WEB_MAP_TOOLS
     | _TIMER_TOOLS
     | _TASK_LIFECYCLE_TOOLS
     | _SKILL_TOOLS
@@ -2307,6 +2313,62 @@ async def _execute_web_search_tool(
     return await asyncio.to_thread(tool.invoke, json.dumps(args), ctx)
 
 
+def _web_map_config_from_spec(agent_spec: Any | None) -> dict[str, str]:
+    """
+    Return the ``web_map`` builtin's config dict from the parent spec.
+
+    Mirrors :func:`_web_search_config_from_spec`: scans ``spec.tools.builtins``
+    for the entry named ``"web_map"`` and returns its ``config`` (credentials +
+    optional ``limit``). Empty dict when the builtin is a bare string or absent.
+
+    :param agent_spec: Parent agent's spec, or ``None``.
+    :returns: The web_map config dict, e.g. ``{"api_key": "...", "limit": "50"}``.
+    """
+    if agent_spec is None:
+        return {}
+    tools = getattr(agent_spec, "tools", None)
+    builtins = getattr(tools, "builtins", None) or []
+    for entry in builtins:
+        if getattr(entry, "name", None) == "web_map":
+            return getattr(entry, "config", None) or {}
+    return {}
+
+
+async def _execute_web_map_tool(
+    args: dict[str, Any],
+    *,
+    agent_spec: Any | None,
+    conversation_id: str | None = None,
+    task_id: str | None = None,
+    agent_id: str | None = None,
+) -> str:
+    """
+    Dispatch a ``web_map`` tool call to Nimble's Map endpoint.
+
+    Builds ``WebMapTool`` from the spec's ``web_map`` builtin config and runs its
+    synchronous ``invoke`` off the event loop (the backend makes a blocking HTTP
+    call), mirroring :func:`_execute_web_search_tool`.
+
+    :param args: Parsed LLM arguments — ``url`` (required).
+    :param agent_spec: Parent agent's spec; carries the web_map config.
+    :param conversation_id: Parent session id, threaded into the context.
+    :param task_id: Calling task id, threaded into the context.
+    :param agent_id: Calling agent id, threaded into the context.
+    :returns: The formatted link list, or an error string.
+    """
+    from omnigent.tools.base import ToolContext
+    from omnigent.tools.builtins.web_map import WebMapTool
+
+    config = _web_map_config_from_spec(agent_spec)
+    tool = WebMapTool(config=config)
+    ctx = ToolContext(
+        task_id=task_id or "web_map",
+        agent_id=agent_id or "web_map",
+        conversation_id=conversation_id,
+    )
+    return await asyncio.to_thread(tool.invoke, json.dumps(args), ctx)
+
+
 def _has_subagent(
     sub_agent_name: str,
     agent_spec: Any | None,
@@ -4123,6 +4185,14 @@ async def execute_tool(
             )
         elif tool_name in _WEB_SEARCH_TOOLS:
             output = await _execute_web_search_tool(
+                args,
+                agent_spec=agent_spec,
+                conversation_id=conversation_id,
+                task_id=task_id,
+                agent_id=agent_id,
+            )
+        elif tool_name in _WEB_MAP_TOOLS:
+            output = await _execute_web_map_tool(
                 args,
                 agent_spec=agent_spec,
                 conversation_id=conversation_id,

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -61,6 +61,7 @@ from omnigent.tools.builtins.timer import (
     SysTimerSetTool,
 )
 from omnigent.tools.builtins.update_comment import UpdateCommentTool
+from omnigent.tools.builtins.web_map import WebMapTool
 from omnigent.tools.builtins.web_search import WebSearchTool
 
 __all__ = [
@@ -87,6 +88,7 @@ __all__ = [
     "SysTimerCancelTool",
     "SysTimerSetTool",
     "UpdateCommentTool",
+    "WebMapTool",
     "WebSearchTool",
     "any_skill_has_resources",
     "find_skill_by_name",
@@ -185,6 +187,7 @@ def _create_export_agent(config: dict[str, str]) -> Tool:
 _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     # User-enablable tools (factory present).
     "web_search": lambda config: WebSearchTool(config=config),
+    "web_map": lambda config: WebMapTool(config=config),
     "upload_file": _create_upload_file,
     "list_files": _create_list_files,
     "download_file": _create_download_file,

--- a/omnigent/tools/builtins/web_map.py
+++ b/omnigent/tools/builtins/web_map.py
@@ -1,0 +1,204 @@
+"""Built-in tool: web_map — website URL discovery via Nimble.
+
+Maps the URLs on a website using Nimble's Map endpoint (``POST /v1/map``),
+returning a list of discovered links (with titles where available). Useful for
+finding pages on a site before fetching them with ``web_fetch``.
+
+Configured in the agent spec::
+
+    tools:
+      builtins:
+        - name: web_map
+          api_key: ${NIMBLE_API_KEY}
+          # optional:
+          # limit: 50            # max links to return (default 50)
+
+See https://docs.nimbleway.com/api-reference/map
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+# Any: Nimble's JSON response is a heterogeneous dict with string keys and
+# mixed value types (str, list, dict, bool, None).
+from typing import Any
+
+import httpx
+
+from omnigent.tools.base import Tool, ToolContext
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_NIMBLE_MAP_URL = "https://sdk.nimbleway.com/v1/map"
+
+# Identifies this integration to Nimble via the ``X-Client-Source`` header that
+# Nimble's own SDKs send (same convention as the web_search / web_fetch backends).
+_CLIENT_SOURCE = "omnigent"
+
+# Default cap on returned links so a large site cannot blow the model context.
+_DEFAULT_LIMIT = 50
+
+# Nimble's Map endpoint crawls the site to discover URLs and can take ~100s even
+# for a small site, so it needs a generous read timeout. The Nimble SDK's own
+# ``map()`` exposes a per-request timeout override for the same reason.
+_MAP_TIMEOUT_S = 180.0
+
+_DESCRIPTION = (
+    "Discover the URLs on a website — returns a list of links found by mapping "
+    "the site. Use to find pages on a site before fetching them with web_fetch."
+)
+
+
+def _map_url() -> str:
+    """Resolve the Nimble Map URL; ``OMNIGENT_NIMBLE_MAP_URL`` overrides for tests."""
+    return os.environ.get("OMNIGENT_NIMBLE_MAP_URL", _DEFAULT_NIMBLE_MAP_URL)
+
+
+def _resolve_limit(config: dict[str, str]) -> int:
+    """
+    Read ``limit`` from spec config, clamped to a sane 1-1000 range.
+
+    Spec config values arrive as strings, so ``limit: 50`` reaches here as
+    ``"50"``.
+
+    :param config: Spec-level config; ``limit`` may be missing or a str.
+    :returns: A valid link cap, or the default on missing/invalid input.
+    """
+    raw = config.get("limit")
+    if raw is None:
+        return _DEFAULT_LIMIT
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_LIMIT
+    return max(1, min(value, 1000))
+
+
+def _map_nimble(url: str, config: dict[str, str]) -> str:
+    """
+    Map a website's URLs via Nimble and format the results.
+
+    :param url: The website URL to map.
+    :param config: Spec-level config; ``api_key`` (required), optional ``limit``.
+    :returns: A numbered list of discovered links, or an error message. Never raises.
+    """
+    api_key = config.get("api_key")
+    if not api_key:
+        return "Error: api_key must be provided in the web_map config in config.yaml."
+    try:
+        resp = httpx.post(
+            _map_url(),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "X-Client-Source": _CLIENT_SOURCE,
+            },
+            json={"url": url, "limit": _resolve_limit(config)},
+            timeout=_MAP_TIMEOUT_S,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        return f"Nimble map error: HTTP {exc.response.status_code}"
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        return f"Nimble map error: {exc}"
+    return _format_map(resp.json())
+
+
+def _format_map(data: dict[str, Any]) -> str:
+    """
+    Format Nimble's ``/v1/map`` response into a numbered link list.
+
+    Nimble returns ``{"links": [{"url", "title"?, "description"?}], "success",
+    "task_id"}``.
+
+    :param data: The parsed JSON response from Nimble.
+    :returns: A numbered list of ``url`` (with title when present), or a short message.
+    """
+    links = data.get("links") or []
+    if not links:
+        return "No links found."
+    formatted: list[str] = []
+    for i, link in enumerate(links):
+        url = link.get("url", "")
+        title = link.get("title") or ""
+        entry = f"{i + 1}. {url}"
+        if title:
+            entry += f"\n   {title}"
+        formatted.append(entry)
+    return "\n".join(formatted)
+
+
+class WebMapTool(Tool):
+    """
+    Website URL-discovery tool backed by Nimble's Map endpoint.
+
+    :param config: Spec-level config, e.g. ``{"api_key": "...", "limit": "50"}``.
+    """
+
+    def __init__(self, config: dict[str, str] | None = None) -> None:
+        """
+        :param config: Spec-level config with ``api_key`` and optional ``limit``.
+        """
+        self._config = config or {}
+
+    @classmethod
+    def name(cls) -> str:
+        """:returns: ``"web_map"``."""
+        return "web_map"
+
+    @classmethod
+    def description(cls) -> str:
+        """:returns: Human-readable description of the tool."""
+        return _DESCRIPTION
+
+    def get_schema(self) -> dict[str, Any]:
+        """
+        Return the OpenAI function schema for web_map.
+
+        :returns: A function tool schema with a required ``url`` parameter.
+        """
+        return {
+            "type": "function",
+            "function": {
+                "name": "web_map",
+                "description": _DESCRIPTION,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "The website URL to map.",
+                        },
+                    },
+                    "required": ["url"],
+                },
+            },
+        }
+
+    def is_async(self, arguments: str | None = None) -> bool:
+        """
+        Run web_map synchronously in the parent's tool loop.
+
+        :param arguments: Ignored — async-ness is a property of this tool.
+        :returns: ``False``.
+        """
+        del arguments
+        return False
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        """
+        Execute a web_map call.
+
+        :param arguments: JSON-encoded dict with a ``url`` key.
+        :param ctx: Tool execution context (unused).
+        :returns: A numbered link list, or an error message.
+        """
+        del ctx
+        parsed: dict[str, Any] = json.loads(arguments)
+        url = parsed.get("url")
+        if not url:
+            return "Error: 'url' parameter is required."
+        return _map_nimble(str(url), self._config)

--- a/tests/e2e/test_web_map_e2e.py
+++ b/tests/e2e/test_web_map_e2e.py
@@ -1,0 +1,164 @@
+"""E2E test: the ``web_map`` builtin (Nimble Map).
+
+A real-LLM agent with the ``web_map`` builtin maps a site, and the runner
+dispatches to Nimble's ``/v1/map`` endpoint (stubbed locally via
+``OMNIGENT_NIMBLE_MAP_URL``, set at import time so the session-scoped
+server/runner subprocesses inherit it — no live Nimble key needed).
+
+Like the repo's other spec-level builtin e2e tests (see
+``tests/e2e/test_file_tools.py``), this **requires a real LLM** and skips under
+the mock LLM.
+
+Usage::
+
+    pytest tests/e2e/test_web_map_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+import uuid
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+import pytest
+
+from tests.e2e.conftest import (
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    send_user_message_to_session,
+)
+
+
+def _reserve_port() -> int:
+    """Reserve a free localhost port for the Map stub."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
+
+
+_STUB_PORT = _reserve_port()
+os.environ["OMNIGENT_NIMBLE_MAP_URL"] = f"http://127.0.0.1:{_STUB_PORT}/v1/map"
+
+_received_requests: list[dict[str, object]] = []
+
+
+class _MapStubHandler(BaseHTTPRequestHandler):
+    """Minimal stand-in for Nimble ``POST /v1/map``."""
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            body = {}
+        _received_requests.append({"headers": dict(self.headers), "body": body})
+
+        payload = json.dumps(
+            {
+                "links": [
+                    {"url": "https://example.com/", "title": "Example Home"},
+                    {"url": "https://example.com/about", "title": "About"},
+                ],
+                "success": True,
+                "task_id": "stub",
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args: object) -> None:  # keep test output quiet
+        del args
+
+
+@pytest.fixture
+def map_stub() -> Iterator[list[dict[str, object]]]:
+    """Run the local Map stub for the duration of the test."""
+    _received_requests.clear()
+    server = HTTPServer(("127.0.0.1", _STUB_PORT), _MapStubHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield _received_requests
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_web_map_happy_path(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    using_mock_llm: bool,
+    map_stub: list[dict[str, object]],
+) -> None:
+    """
+    A real-LLM agent with ``web_map`` maps a site via Nimble Map and completes.
+
+    Verifies agent → web_map → runner dispatch → Nimble Map (stub) → result →
+    completion, and that the request carried the ``X-Client-Source`` header.
+    """
+    if using_mock_llm:
+        pytest.skip(
+            "requires real LLM (spec-level builtin tools don't resolve under the mock LLM)"
+        )
+
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"nimble-map-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model="gpt-4.1-mini",
+        profile="",
+        prompt=(
+            "You discover the pages on a website. When asked to map a site, call "
+            "the web_map tool with that url and report the links you find."
+        ),
+        extra_config={
+            "tools": {
+                "builtins": [
+                    {
+                        "name": "web_map",
+                        "api_key": "test-key",
+                    },
+                ],
+            },
+        },
+    )
+
+    session_id = create_runner_bound_session(
+        http_client, agent_name=agent_name, runner_id=live_runner_id
+    )
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Use web_map to list the pages on https://example.com.",
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=response_id, timeout=180
+    )
+
+    assert body["status"] == "completed", (
+        f"Response status is {body['status']!r}, expected 'completed'. "
+        f"Output: {body.get('output', [])}"
+    )
+
+    assert map_stub, "Nimble Map stub was never called — web_map not dispatched."
+    last = map_stub[-1]
+    headers = last["headers"]
+    assert isinstance(headers, dict)
+    assert headers.get("X-Client-Source") == "omnigent", (
+        f"Expected X-Client-Source 'omnigent', got {headers.get('X-Client-Source')!r}"
+    )
+    request_body = last["body"]
+    assert isinstance(request_body, dict)
+    assert request_body.get("url") == "https://example.com"

--- a/tests/runner/test_web_map_dispatch.py
+++ b/tests/runner/test_web_map_dispatch.py
@@ -1,0 +1,75 @@
+"""Dispatch tests for the ``web_map`` builtin (runner-local Nimble Map).
+
+Lock in that web_map is runner-local (so a non-OpenAI model's call resolves to
+``WebMapTool.invoke`` → Nimble ``/v1/map``) and not advertised to native harnesses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from omnigent.runner.tool_dispatch import (
+    _ALL_LOCAL_TOOLS,
+    _NATIVE_RELAY_BUILTIN_TOOLS,
+    _execute_web_map_tool,
+    _web_map_config_from_spec,
+    should_dispatch_locally,
+)
+
+
+def _spec_with_web_map(config: dict[str, str]) -> SimpleNamespace:
+    """Minimal agent_spec stub: a single ``web_map`` builtin carrying ``config``."""
+    return SimpleNamespace(
+        tools=SimpleNamespace(
+            builtins=[SimpleNamespace(name="web_map", config=config)],
+        ),
+    )
+
+
+def test_web_map_is_runner_local() -> None:
+    """``web_map`` dispatches locally, like ``web_search`` / ``web_fetch``."""
+    assert "web_map" in _ALL_LOCAL_TOOLS
+    assert should_dispatch_locally("web_map") is True
+
+
+def test_web_map_not_relayed_to_native_harnesses() -> None:
+    """Native harnesses use their own tooling; web_map is not relayed."""
+    assert "web_map" not in _NATIVE_RELAY_BUILTIN_TOOLS
+
+
+def test_config_from_spec_reads_web_map_config() -> None:
+    """The config helper returns the ``web_map`` builtin's config dict."""
+    spec = _spec_with_web_map({"api_key": "k", "limit": "10"})
+    assert _web_map_config_from_spec(spec) == {"api_key": "k", "limit": "10"}
+
+
+def test_config_from_spec_empty_when_absent() -> None:
+    """No ``web_map`` entry → empty config."""
+    spec = SimpleNamespace(tools=SimpleNamespace(builtins=[]))
+    assert _web_map_config_from_spec(spec) == {}
+
+
+def test_dispatch_calls_nimble_map() -> None:
+    """The dispatch handler builds WebMapTool from spec config and calls Nimble Map."""
+    spec = _spec_with_web_map({"api_key": "k"})
+    fake = MagicMock()
+    fake.json.return_value = {
+        "links": [{"url": "https://example.com/a"}],
+        "success": True,
+        "task_id": "t",
+    }
+    with patch("omnigent.tools.builtins.web_map.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = asyncio.run(
+            _execute_web_map_tool(
+                {"url": "https://example.com"},
+                agent_spec=spec,
+                conversation_id="c",
+            )
+        )
+
+    assert mock_post.call_count == 1, "dispatch must call Nimble Map"
+    assert "https://example.com/a" in result
+    assert mock_post.call_args.kwargs["headers"]["X-Client-Source"] == "omnigent"

--- a/tests/tools/builtins/test_registry_unified.py
+++ b/tests/tools/builtins/test_registry_unified.py
@@ -115,6 +115,7 @@ def test_builtin_names_size_matches_registry() -> None:
             {
                 # Instantiable
                 "web_search",
+                "web_map",
                 "upload_file",
                 "list_files",
                 "download_file",

--- a/tests/tools/builtins/test_web_map.py
+++ b/tests/tools/builtins/test_web_map.py
@@ -1,0 +1,133 @@
+"""Tests for the ``web_map`` built-in tool (Nimble Map backend)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins import get_builtin_tool
+from omnigent.tools.builtins.web_map import WebMapTool, _format_map, _resolve_limit
+
+
+def test_get_builtin_tool_returns_web_map() -> None:
+    """``get_builtin_tool("web_map")`` returns a WebMapTool."""
+    tool = get_builtin_tool("web_map")
+    assert isinstance(tool, WebMapTool), f"Expected WebMapTool, got {type(tool).__name__}."
+
+
+def test_tool_name_is_web_map() -> None:
+    """Tool name is 'web_map'."""
+    assert WebMapTool.name() == "web_map"
+
+
+def test_schema_requires_url() -> None:
+    """The function schema requires a ``url`` parameter."""
+    schema = WebMapTool().get_schema()
+    assert schema["type"] == "function"
+    assert schema["function"]["name"] == "web_map"
+    assert "url" in schema["function"]["parameters"]["required"]
+
+
+def test_is_sync() -> None:
+    """web_map runs synchronously."""
+    assert WebMapTool().is_async() is False
+
+
+def test_missing_api_key_returns_error(tool_ctx: ToolContext) -> None:
+    """Without api_key the tool returns a clear error, never raises."""
+    tool = WebMapTool(config={})
+    result = tool.invoke(json.dumps({"url": "https://example.com"}), tool_ctx)
+    assert "api_key" in result
+
+
+def test_missing_url_returns_error(tool_ctx: ToolContext) -> None:
+    """Without a url the tool returns a clear error, no HTTP call."""
+    tool = WebMapTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.web_map.httpx.post") as mock_post:
+        result = tool.invoke(json.dumps({}), tool_ctx)
+    assert "url" in result.lower()
+    assert mock_post.call_count == 0
+
+
+def test_map_sends_bearer_client_source_and_body(tool_ctx: ToolContext) -> None:
+    """api_key → Bearer header, X-Client-Source set, body carries url + limit."""
+    fake = MagicMock()
+    fake.json.return_value = {"links": [], "success": True, "task_id": "t"}
+    tool = WebMapTool(config={"api_key": "spec-key", "limit": "10"})
+    with patch("omnigent.tools.builtins.web_map.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        tool.invoke(json.dumps({"url": "https://example.com"}), tool_ctx)
+
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer spec-key", (
+        f"Expected spec config api_key in header, got {headers['Authorization']!r}"
+    )
+    assert headers["X-Client-Source"] == "omnigent", (
+        f"Expected X-Client-Source 'omnigent', got {headers.get('X-Client-Source')!r}"
+    )
+    body = mock_post.call_args.kwargs["json"]
+    assert body["url"] == "https://example.com"
+    # limit comes from config as a str ("10") and must be coerced to int.
+    assert body["limit"] == 10, f"Expected int 10, got {body['limit']!r}"
+
+
+def test_format_links_numbered(tool_ctx: ToolContext) -> None:
+    """Discovered links are formatted as a numbered list with titles when present."""
+    fake = MagicMock()
+    fake.json.return_value = {
+        "links": [
+            {"url": "https://example.com/a", "title": "Page A"},
+            {"url": "https://example.com/b"},
+        ],
+        "success": True,
+        "task_id": "t",
+    }
+    tool = WebMapTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.web_map.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = tool.invoke(json.dumps({"url": "https://example.com"}), tool_ctx)
+
+    assert "1. https://example.com/a" in result
+    assert "Page A" in result
+    assert "2. https://example.com/b" in result
+
+
+def test_no_links_message(tool_ctx: ToolContext) -> None:
+    """An empty link list returns a short message, not a crash."""
+    fake = MagicMock()
+    fake.json.return_value = {"links": [], "success": True, "task_id": "t"}
+    tool = WebMapTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.web_map.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = tool.invoke(json.dumps({"url": "https://example.com"}), tool_ctx)
+    assert "No links" in result
+
+
+def test_http_error_returns_string(tool_ctx: ToolContext) -> None:
+    """An HTTP error is returned as a string, never raised."""
+    fake = MagicMock()
+    fake.status_code = 403
+    tool = WebMapTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.web_map.httpx.post") as mock_post:
+        mock_post.side_effect = httpx.HTTPStatusError("403", request=MagicMock(), response=fake)
+        result = tool.invoke(json.dumps({"url": "https://example.com"}), tool_ctx)
+    assert "Nimble map error" in result
+    assert "403" in result
+
+
+def test_limit_clamped() -> None:
+    """``limit`` is coerced + clamped to 1-1000; junk → default 50."""
+    assert _resolve_limit({}) == 50  # missing → default
+    assert _resolve_limit({"limit": "0"}) == 1  # below min → clamped up
+    assert _resolve_limit({"limit": "5000"}) == 1000  # above max → clamped down
+    assert _resolve_limit({"limit": "abc"}) == 50  # non-numeric → default
+    assert _resolve_limit({"limit": "25"}) == 25
+
+
+def test_format_map_direct() -> None:
+    """``_format_map`` numbers links and indents the title."""
+    out = _format_map({"links": [{"url": "https://x.test", "title": "X"}]})
+    assert out == "1. https://x.test\n   X"


### PR DESCRIPTION
## Related issue

N/A — adds a Nimble-backed `web_map` builtin (site URL discovery), registered the same way as the merged `web_search` provider (#55).

## Summary

- Adds a `web_map` built-in tool: given a site URL, it discovers the site's pages via Nimble's `POST /v1/map` and returns a numbered list of links (with titles where available). Useful for finding pages on a site before fetching them with `web_fetch`.
- Registers as a first-class builtin — a registry entry plus runner-local dispatch — so a non-OpenAI model's `web_map` call resolves to the backend, the same posture as `web_search`.
- Raw `httpx` (no SDK dependency), `api_key` from spec config, results capped (default 50 links), errors returned as strings, and an `X-Client-Source` header identifying the integration.

### ELI5

Point `web_map` at a website and it returns a list of the pages on that site. The agent can then pick a page and read it with `web_fetch`.

### How it's wired

```
web_map(url)  [non-OpenAI model]
  └─ runner dispatch (_ALL_LOCAL_TOOLS → _execute_web_map_tool)
       └─ WebMapTool.invoke ──► Nimble POST /v1/map ──► numbered link list
```

Config:

```yaml
tools:
  builtins:
    - name: web_map
      api_key: ${NIMBLE_API_KEY}
      # optional: limit: 50   # max links (default 50)
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E test added (collection/skip-verified under the mock LLM; not run against a live LLM — see rationale)
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

**Live smoke** (the evidence behind *Manual verification completed*): invoked `web_map` through the runner's tool-dispatch handler (`_execute_web_map_tool` → `WebMapTool.invoke`) — the same path a non-OpenAI model's `web_map` call takes — against `https://example.com` with a real `NIMBLE_API_KEY`. It returned the site's links as a numbered list (HTTP 200 from Nimble's `/v1/map`). Note: `/v1/map` crawls the site and is slow (~120s even for this single-page site), so the backend uses a generous read timeout and returns a clear error string on timeout rather than hanging.

Other commands run:

- `uv run pytest tests/tools/builtins/test_web_map.py tests/runner/test_web_map_dispatch.py` → **17 passed**. Backend unit tests (registry resolution, Bearer + `X-Client-Source` header, request body with url + limit, numbered-link formatting, missing-key/url errors, error-as-string, limit clamping) plus runner-dispatch tests (`web_map` is runner-local and not relayed to native harnesses; the dispatch handler builds the tool from spec config and calls Nimble Map).
- `uv run pytest tests/tools/builtins/test_web_search.py tests/runner/test_web_search_local_dispatch.py` → **49 passed** (regression — the shared dispatch table is unaffected).
- `tests/e2e/test_web_map_e2e.py` — added, following the repo's spec-level-builtin e2e convention (e.g. `tests/e2e/test_file_tools.py`): it drives `web_map` against a local Map stub and is skipped under the mock LLM (which can't resolve spec-level builtins). I verified it collects and skips cleanly under the mock LLM this cycle; I have not run it end-to-end against a live LLM.
- `uv run ruff check` + `uv run ruff format --check` on the changed files, and `uv run pre-commit run --files ...` → all pass.

Files: `omnigent/tools/builtins/web_map.py` (new builtin + backend), `omnigent/tools/builtins/__init__.py` (registry entry), `omnigent/runner/tool_dispatch.py` (runner-local dispatch: `_WEB_MAP_TOOLS`, `_execute_web_map_tool`, dispatch branch), and the three test files.
