### PR TITLE
fix(web): reuse prior file upload on message retry

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2676,6 +2676,42 @@ describe("chatStore — send (file attachments)", () => {
       { type: "input_text", text: "[Attached: /tmp/diagram.png]\n\ndraw this" },
     ]);
   });
+
+  it("reuses a prior upload when re-sending the same File after a failed post", async () => {
+    // send()'s first attempt uploads then fails at the post; the caller retries
+    // with the same File. The upload must not run twice (which would orphan the
+    // first blob) — the second send reuses the cached file_id.
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+    });
+    let uploads = 0;
+    let failPost = true;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_existing/resources/files")) {
+        uploads += 1;
+        return mockResponse({
+          id: "file_dedupe_send",
+          name: "photo.png",
+          metadata: { filename: "photo.png", bytes: 10, created_at: 0 },
+        });
+      }
+      if (url.endsWith("/v1/sessions/conv_existing/events") && init?.method === "POST") {
+        if (failPost) return mockResponse({}, { ok: false, status: 500 });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const file = new File(["fake-bytes"], "photo.png", { type: "image/png" });
+    await useChatStore.getState().send("look at this", "agent_xyz", [file]);
+    expect(uploads).toBe(1);
+
+    // Retry with the SAME File object → cached upload is reused.
+    failPost = false;
+    await useChatStore.getState().send("look at this", "agent_xyz", [file]);
+    expect(uploads).toBe(1);
+  });
 });
 
 describe("chatStore — stop", () => {
@@ -7930,5 +7966,68 @@ describe("chatStore — background cross-session flush", () => {
     // Upload failed → no message posted, and the item is re-queued to retry.
     expect(events).toBe(0);
     expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["with-image"]);
+  });
+
+  it("does not re-upload an attachment when a retry follows a post-phase failure", async () => {
+    // Upload succeeds but the post fails → re-queued on cooldown. The retry
+    // must reuse the already-uploaded file_id, not upload the blob again (which
+    // would orphan the first one server-side).
+    seedConversationsCache([conv("conv_active", "running"), conv("conv_bg", "idle")]);
+    let uploads = 0;
+    let failPost = true;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_bg/resources/files") && init?.method === "POST") {
+        uploads += 1;
+        return mockResponse({
+          id: "file_bg_dedupe",
+          name: "shot.png",
+          metadata: { filename: "shot.png", bytes: 4, created_at: 0 },
+        });
+      }
+      if (/\/v1\/sessions\/conv_bg\/events$/.test(url) && init?.method === "POST") {
+        if (failPost) return mockResponse({}, { ok: false, status: 500 });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const file = new File(["png!"], "shot.png", { type: "image/png" });
+    useChatStore.setState({
+      conversationId: "conv_active",
+      queuedMessages: [
+        { queueId: "q_1", text: "see this", conversationId: "conv_bg", files: [file] },
+      ],
+    });
+
+    // First attempt: upload lands, post fails → re-queued.
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+    await tick();
+    expect(uploads).toBe(1);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["see this"]);
+
+    // Retry (post now succeeds): the upload must NOT run again. Re-init clears
+    // the post-failure cooldown (same query client → seeded cache persists)
+    // without touching the queue or the File→upload cache.
+    failPost = false;
+    initChatStore(client);
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+    await tick();
+    expect(uploads).toBe(1);
+    expect(useChatStore.getState().queuedMessages).toEqual([]);
+    // The message that finally posted carries the original uploaded id.
+    const posted = fetchMock.mock.calls
+      .filter(
+        ([u, init]) =>
+          String(u).endsWith("/v1/sessions/conv_bg/events") &&
+          (init as RequestInit | undefined)?.method === "POST",
+      )
+      .map(([, init]) => JSON.parse((init as RequestInit).body as string).data.content)
+      .at(-1);
+    expect(posted).toContainEqual({
+      type: "input_image",
+      file_id: "file_bg_dedupe",
+      filename: "shot.png",
+    });
   });
 });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -667,6 +667,37 @@ const BACKGROUND_FLUSH_COOLDOWN_MS = 5_000;
 const backgroundFlushInFlight = new Set<string>();
 const backgroundFlushCooldownUntil = new Map<string, number>();
 
+// Remembers each File's successful upload so a retry reuses the server-assigned
+// file_id instead of re-uploading the blob (which would orphan the prior one).
+// Retries re-send the same File objects — background flush re-queues them on a
+// cooldown, and any send whose post fails after an upload succeeded — so keying
+// by File identity dedupes across attempts. Keyed by session too, since a File
+// could be sent to more than one. WeakMap so entries vanish when the File is
+// dropped from the queue/pending state.
+const uploadedFileBlockCache = new WeakMap<File, Map<string, ContentBlock>>();
+
+/**
+ * Upload a file to a session and return its content block, reusing a prior
+ * successful upload of the same File to the same session. Deduping here means
+ * a failed post (or a later file's upload failing) doesn't re-upload files
+ * that already landed when the message is retried.
+ */
+async function uploadFileBlock(sessionId: string, file: File): Promise<ContentBlock> {
+  const cached = uploadedFileBlockCache.get(file)?.get(sessionId);
+  if (cached !== undefined) return cached;
+  const uploaded = await uploadFile(sessionId, file);
+  const block: ContentBlock = file.type.startsWith("image/")
+    ? { type: "input_image", file_id: uploaded.id, filename: uploaded.filename }
+    : { type: "input_file", file_id: uploaded.id, filename: uploaded.filename };
+  let bySession = uploadedFileBlockCache.get(file);
+  if (bySession === undefined) {
+    bySession = new Map<string, ContentBlock>();
+    uploadedFileBlockCache.set(file, bySession);
+  }
+  bySession.set(sessionId, block);
+  return block;
+}
+
 // Must match the @keyframes user-msg-flash duration in index.css.
 const FLASH_DURATION_MS = 800;
 const WORKSPACE_INVALIDATION_DEBOUNCE_MS = 750;
@@ -996,12 +1027,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       void (async () => {
         const fileBlocks: ContentBlock[] = [];
         for (const file of head.files ?? []) {
-          const uploaded = await uploadFile(conversationId, file);
-          fileBlocks.push(
-            file.type.startsWith("image/")
-              ? { type: "input_image", file_id: uploaded.id, filename: uploaded.filename }
-              : { type: "input_file", file_id: uploaded.id, filename: uploaded.filename },
-          );
+          // Reuse a prior successful upload so the cooldown-paced retry doesn't
+          // re-upload files that already landed (orphaning the earlier blobs).
+          fileBlocks.push(await uploadFileBlock(conversationId, file));
         }
         const content: ContentBlock[] = [
           ...fileBlocks,
@@ -1106,25 +1134,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
       postedSessionId = sessionId;
 
       // Upload any attached files and build the real content blocks with
-      // server-assigned file_ids. For images use input_image; for all
-      // other types use input_file. Plain text (if any) appended last.
+      // server-assigned file_ids (input_image for images, input_file
+      // otherwise). Plain text (if any) appended last. uploadFileBlock reuses
+      // a prior successful upload of the same File so a retry after a
+      // post-phase failure doesn't re-upload — and orphan — blobs that landed.
       const fileBlocks: ContentBlock[] = [];
       if (files && files.length > 0) {
         for (const file of files) {
-          const uploaded = await uploadFile(sessionId, file);
-          if (file.type.startsWith("image/")) {
-            fileBlocks.push({
-              type: "input_image",
-              file_id: uploaded.id,
-              filename: uploaded.filename,
-            });
-          } else {
-            fileBlocks.push({
-              type: "input_file",
-              file_id: uploaded.id,
-              filename: uploaded.filename,
-            });
-          }
+          fileBlocks.push(await uploadFileBlock(sessionId, file));
         }
       }
       const serverContent: ContentBlock[] = [


### PR DESCRIPTION
## Related issue

Follow-up to #2065 — addresses the one non-blocking note Polly raised
([duplicate uploads on retry](https://github.com/omnigent-ai/omnigent/pull/2065#issuecomment-4899943491)).

## Summary

- When a message with attachments **retries after a post-phase failure**, the
  retry re-uploaded every `File` from scratch — orphaning the blobs the first
  attempt already stored server-side. This affected two paths:
  - **background flush** — re-queues on a 5s cooldown, so the leak accumulates
    silently on every retry of a persistently-failing idle conversation;
  - **`send()`** — the same pre-existing pattern when the caller retries.
- Fix: a shared **`uploadFileBlock(sessionId, file)`** helper memoizes each
  `File`'s successful upload (`WeakMap<File, Map<sessionId, ContentBlock>>`) and
  returns the cached `input_image`/`input_file` block on a retry instead of
  re-uploading. Both `send()` and `flushBackgroundQueues` now go through it.
- The same `File` object survives a re-queue (background) and is re-passed by
  the caller (`send`), so keying by `File` identity dedupes across attempts.
  Keyed by session too (a `File` could be sent to more than one). `WeakMap` so
  entries release once the `File` is dropped from the queue/pending state.

## Test Plan

- **Unit** (`web`, vitest): 2 new `chatStore` tests —
  - a `send()` retry after a failed post reuses the cached `file_id` (one
    upload, not two);
  - the background-flush retry does the same, and the message that finally posts
    still carries the original uploaded id.
- 323 passing across store + strip + composer suites.
- **Gates**: `npm run type-check`, tests, prettier all pass.

## Demo

N/A — no user-visible change; removes redundant network uploads on retry.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The dedupe-on-retry behavior is covered for both call sites (`send()` and
`flushBackgroundQueues`) by the two new store unit tests, each asserting the
upload runs exactly once across a failed-then-successful attempt.

This pull request and its description were written by Isaac.
