### PR TITLE
feat: add nimble_agent builtin backed by Nimble Web Search Agent

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -254,6 +254,11 @@ _WEB_FETCH_TOOLS = frozenset({"web_fetch"})
 # web_search known-failure.
 _WEB_SEARCH_TOOLS = frozenset({"web_search"})
 
+# Priority 5f.1d: nimble_agent — Nimble Web Search Agent (WSA) → structured JSON.
+# Runner-local so a non-OpenAI model's nimble_agent call resolves to
+# NimbleAgentTool.invoke (POST /v1/agent), the same posture as web_search.
+_NIMBLE_AGENT_TOOLS = frozenset({"nimble_agent"})
+
 # Priority 5f.2: sys_list_models — runner-local because provider resolution
 # reads the runner host's config/credentials, same as the spawn paths.
 _LIST_MODELS_TOOLS = frozenset({"sys_list_models"})
@@ -461,6 +466,7 @@ _ALL_LOCAL_TOOLS = (
     | _SESSION_QUERY_TOOLS
     | _WEB_FETCH_TOOLS
     | _WEB_SEARCH_TOOLS
+    | _NIMBLE_AGENT_TOOLS
     | _TIMER_TOOLS
     | _TASK_LIFECYCLE_TOOLS
     | _SKILL_TOOLS
@@ -2307,6 +2313,64 @@ async def _execute_web_search_tool(
     return await asyncio.to_thread(tool.invoke, json.dumps(args), ctx)
 
 
+def _nimble_agent_config_from_spec(agent_spec: Any | None) -> dict[str, str]:
+    """
+    Return the ``nimble_agent`` builtin's config dict from the parent spec.
+
+    Mirrors :func:`_web_search_config_from_spec`: scans ``spec.tools.builtins``
+    for the entry named ``"nimble_agent"`` and returns its ``config`` (credentials
+    + optional ``agent`` template). Empty dict when the builtin is a bare string
+    or absent.
+
+    :param agent_spec: Parent agent's spec, or ``None``.
+    :returns: The nimble_agent config dict, e.g.
+        ``{"api_key": "...", "agent": "google_search"}``.
+    """
+    if agent_spec is None:
+        return {}
+    tools = getattr(agent_spec, "tools", None)
+    builtins = getattr(tools, "builtins", None) or []
+    for entry in builtins:
+        if getattr(entry, "name", None) == "nimble_agent":
+            return getattr(entry, "config", None) or {}
+    return {}
+
+
+async def _execute_nimble_agent_tool(
+    args: dict[str, Any],
+    *,
+    agent_spec: Any | None,
+    conversation_id: str | None = None,
+    task_id: str | None = None,
+    agent_id: str | None = None,
+) -> str:
+    """
+    Dispatch a ``nimble_agent`` tool call to Nimble's Web Search Agent endpoint.
+
+    Builds ``NimbleAgentTool`` from the spec's ``nimble_agent`` builtin config and
+    runs its synchronous ``invoke`` off the event loop (the backend makes a
+    blocking HTTP call), mirroring :func:`_execute_web_search_tool`.
+
+    :param args: Parsed LLM arguments — ``query`` (required).
+    :param agent_spec: Parent agent's spec; carries the nimble_agent config.
+    :param conversation_id: Parent session id, threaded into the context.
+    :param task_id: Calling task id, threaded into the context.
+    :param agent_id: Calling agent id, threaded into the context.
+    :returns: The structured JSON, or an error string.
+    """
+    from omnigent.tools.base import ToolContext
+    from omnigent.tools.builtins.nimble_agent import NimbleAgentTool
+
+    config = _nimble_agent_config_from_spec(agent_spec)
+    tool = NimbleAgentTool(config=config)
+    ctx = ToolContext(
+        task_id=task_id or "nimble_agent",
+        agent_id=agent_id or "nimble_agent",
+        conversation_id=conversation_id,
+    )
+    return await asyncio.to_thread(tool.invoke, json.dumps(args), ctx)
+
+
 def _has_subagent(
     sub_agent_name: str,
     agent_spec: Any | None,
@@ -4123,6 +4187,14 @@ async def execute_tool(
             )
         elif tool_name in _WEB_SEARCH_TOOLS:
             output = await _execute_web_search_tool(
+                args,
+                agent_spec=agent_spec,
+                conversation_id=conversation_id,
+                task_id=task_id,
+                agent_id=agent_id,
+            )
+        elif tool_name in _NIMBLE_AGENT_TOOLS:
+            output = await _execute_nimble_agent_tool(
                 args,
                 agent_spec=agent_spec,
                 conversation_id=conversation_id,

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -44,6 +44,7 @@ from omnigent.tools.builtins.load_skill import (
     format_skill_meta_text,
     list_skill_resources,
 )
+from omnigent.tools.builtins.nimble_agent import NimbleAgentTool
 from omnigent.tools.builtins.read_skill_file import (
     ReadSkillFileTool,
 )
@@ -68,6 +69,7 @@ __all__ = [
     "INSTANTIABLE_BUILTINS",
     "ListCommentsTool",
     "LoadSkillTool",
+    "NimbleAgentTool",
     "ReadSkillFileTool",
     "SysAdviseModelsTool",
     "SysAgentDownloadTool",
@@ -185,6 +187,7 @@ def _create_export_agent(config: dict[str, str]) -> Tool:
 _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     # User-enablable tools (factory present).
     "web_search": lambda config: WebSearchTool(config=config),
+    "nimble_agent": lambda config: NimbleAgentTool(config=config),
     "upload_file": _create_upload_file,
     "list_files": _create_list_files,
     "download_file": _create_download_file,

--- a/omnigent/tools/builtins/nimble_agent.py
+++ b/omnigent/tools/builtins/nimble_agent.py
@@ -1,0 +1,197 @@
+"""Built-in tool: nimble_agent — Nimble Web Search Agent (WSA) → structured JSON.
+
+Runs a Nimble Web Search Agent (``POST /v1/agent``) and returns the agent's
+structured, parsed results (e.g. Google SERP entities) as JSON in one call. The
+WSA template is selected via the ``agent`` config value (default
+``google_search``); the LLM supplies the ``query``.
+
+Configured in the agent spec::
+
+    tools:
+      builtins:
+        - name: nimble_agent
+          api_key: ${NIMBLE_API_KEY}
+          # optional:
+          # agent: google_search   # the Nimble WSA template (default)
+
+See https://docs.nimbleway.com/api-reference/agent
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+# Any: Nimble's JSON response is a heterogeneous dict with string keys and
+# mixed value types (str, dict, list, None).
+from typing import Any
+
+import httpx
+
+from omnigent.tools.base import Tool, ToolContext
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_NIMBLE_AGENT_URL = "https://sdk.nimbleway.com/v1/agent"
+
+# Identifies this integration to Nimble via the ``X-Client-Source`` header that
+# Nimble's own SDKs send (same convention as the web_search / web_fetch / web_map backends).
+_CLIENT_SOURCE = "omnigent"
+
+# Default Nimble WSA template. ``google_search`` returns structured Google SERP entities.
+_DEFAULT_AGENT = "google_search"
+
+# WSA runs a browser task; allow a generous read timeout.
+_AGENT_TIMEOUT_S = 90.0
+
+# Cap the returned JSON so a large SERP cannot blow the model context.
+_MAX_CONTENT_CHARS = 50_000
+
+_DESCRIPTION = (
+    "Run a Nimble Web Search Agent to get structured, parsed results (e.g. Google "
+    "SERP entities — organic results, ads, related searches) for a query in one "
+    "call. Returns structured JSON, unlike web_search which returns a text list."
+)
+
+
+def _agent_url() -> str:
+    """Resolve the Nimble Agent URL; ``OMNIGENT_NIMBLE_AGENT_URL`` overrides for tests."""
+    return os.environ.get("OMNIGENT_NIMBLE_AGENT_URL", _DEFAULT_NIMBLE_AGENT_URL)
+
+
+def _run_agent_nimble(query: str, config: dict[str, str]) -> str:
+    """
+    Run a Nimble Web Search Agent for a query and return its structured results.
+
+    :param query: The search query.
+    :param config: Spec-level config; ``api_key`` (required), optional ``agent``
+        (the WSA template, default ``google_search``).
+    :returns: Structured JSON (the agent's parsed entities), or an error message.
+        Never raises.
+    """
+    api_key = config.get("api_key")
+    if not api_key:
+        return "Error: api_key must be provided in the nimble_agent config in config.yaml."
+    agent = config.get("agent") or _DEFAULT_AGENT
+    try:
+        resp = httpx.post(
+            _agent_url(),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "X-Client-Source": _CLIENT_SOURCE,
+            },
+            json={"agent": agent, "params": {"query": query}},
+            timeout=_AGENT_TIMEOUT_S,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        return f"Nimble agent error: HTTP {exc.response.status_code}"
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        return f"Nimble agent error: {exc}"
+    return _format_agent(resp.json())
+
+
+def _truncate(text: str) -> str:
+    """Cap text to keep the model context bounded."""
+    if len(text) > _MAX_CONTENT_CHARS:
+        return text[:_MAX_CONTENT_CHARS] + "\n\n[truncated]"
+    return text
+
+
+def _format_agent(data: dict[str, Any]) -> str:
+    """
+    Format Nimble's ``/v1/agent`` response into structured JSON text for the LLM.
+
+    Nimble returns ``{"data": {"parsing": {"entities": {...}}, "markdown"?,
+    "html"?}, "status", "task_id", ...}``. Prefer the parsed ``entities`` as JSON;
+    fall back to ``markdown`` / ``html``.
+
+    :param data: The parsed JSON response from Nimble.
+    :returns: Structured JSON (entities) or text, truncated; or a status message.
+    """
+    inner = data.get("data") or {}
+    parsing = inner.get("parsing")
+    if isinstance(parsing, dict):
+        entities = parsing.get("entities")
+        if entities:
+            return _truncate(json.dumps(entities, ensure_ascii=False))
+    body = inner.get("markdown") or inner.get("html") or ""
+    if body.strip():
+        return _truncate(body)
+    status = data.get("status", "unknown")
+    return f"No structured data returned by the Nimble agent (status: {status})."
+
+
+class NimbleAgentTool(Tool):
+    """
+    Nimble Web Search Agent tool: WSA → structured JSON.
+
+    :param config: Spec-level config, e.g. ``{"api_key": "...", "agent": "google_search"}``.
+    """
+
+    def __init__(self, config: dict[str, str] | None = None) -> None:
+        """
+        :param config: Spec-level config with ``api_key`` and optional ``agent``.
+        """
+        self._config = config or {}
+
+    @classmethod
+    def name(cls) -> str:
+        """:returns: ``"nimble_agent"``."""
+        return "nimble_agent"
+
+    @classmethod
+    def description(cls) -> str:
+        """:returns: Human-readable description of the tool."""
+        return _DESCRIPTION
+
+    def get_schema(self) -> dict[str, Any]:
+        """
+        Return the OpenAI function schema for nimble_agent.
+
+        :returns: A function tool schema with a required ``query`` parameter.
+        """
+        return {
+            "type": "function",
+            "function": {
+                "name": "nimble_agent",
+                "description": _DESCRIPTION,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The search query.",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+        }
+
+    def is_async(self, arguments: str | None = None) -> bool:
+        """
+        Run nimble_agent synchronously in the parent's tool loop.
+
+        :param arguments: Ignored — async-ness is a property of this tool.
+        :returns: ``False``.
+        """
+        del arguments
+        return False
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        """
+        Execute a nimble_agent call.
+
+        :param arguments: JSON-encoded dict with a ``query`` key.
+        :param ctx: Tool execution context (unused).
+        :returns: Structured JSON, or an error message.
+        """
+        del ctx
+        parsed: dict[str, Any] = json.loads(arguments)
+        query = parsed.get("query")
+        if not query:
+            return "Error: 'query' parameter is required."
+        return _run_agent_nimble(str(query), self._config)

--- a/tests/e2e/test_nimble_agent_e2e.py
+++ b/tests/e2e/test_nimble_agent_e2e.py
@@ -1,0 +1,170 @@
+"""E2E test: the ``nimble_agent`` builtin (Nimble WSA → structured JSON).
+
+A real-LLM agent with the ``nimble_agent`` builtin runs a Web Search Agent, and
+the runner dispatches to Nimble's ``/v1/agent`` endpoint (stubbed locally via
+``OMNIGENT_NIMBLE_AGENT_URL``, set at import time so the session-scoped
+server/runner subprocesses inherit it — no live Nimble key needed).
+
+Like the repo's other spec-level builtin e2e tests (see
+``tests/e2e/test_file_tools.py``), this **requires a real LLM** and skips under
+the mock LLM.
+
+Usage::
+
+    pytest tests/e2e/test_nimble_agent_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+import uuid
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+import pytest
+
+from tests.e2e.conftest import (
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    send_user_message_to_session,
+)
+
+
+def _reserve_port() -> int:
+    """Reserve a free localhost port for the WSA stub."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
+
+
+_STUB_PORT = _reserve_port()
+os.environ["OMNIGENT_NIMBLE_AGENT_URL"] = f"http://127.0.0.1:{_STUB_PORT}/v1/agent"
+
+_received_requests: list[dict[str, object]] = []
+
+
+class _AgentStubHandler(BaseHTTPRequestHandler):
+    """Minimal stand-in for Nimble ``POST /v1/agent``."""
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            body = {}
+        _received_requests.append({"headers": dict(self.headers), "body": body})
+
+        payload = json.dumps(
+            {
+                "data": {
+                    "parsing": {
+                        "entities": {
+                            "OrganicResult": [
+                                {"title": "Nimble", "url": "https://nimbleway.com", "position": 1}
+                            ]
+                        }
+                    }
+                },
+                "status": "success",
+                "task_id": "stub",
+                "url": "https://www.google.com/search",
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args: object) -> None:  # keep test output quiet
+        del args
+
+
+@pytest.fixture
+def agent_stub() -> Iterator[list[dict[str, object]]]:
+    """Run the local WSA stub for the duration of the test."""
+    _received_requests.clear()
+    server = HTTPServer(("127.0.0.1", _STUB_PORT), _AgentStubHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield _received_requests
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_nimble_agent_happy_path(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    using_mock_llm: bool,
+    agent_stub: list[dict[str, object]],
+) -> None:
+    """
+    A real-LLM agent with ``nimble_agent`` runs a WSA query and completes.
+
+    Verifies agent → nimble_agent → runner dispatch → Nimble WSA (stub) → result
+    → completion, and that the request carried the ``X-Client-Source`` header.
+    """
+    if using_mock_llm:
+        pytest.skip(
+            "requires real LLM (spec-level builtin tools don't resolve under the mock LLM)"
+        )
+
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"nimble-agent-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model="gpt-4.1-mini",
+        profile="",
+        prompt=(
+            "You get structured search results. When asked to search, call the "
+            "nimble_agent tool with the query and report the results."
+        ),
+        extra_config={
+            "tools": {
+                "builtins": [
+                    {
+                        "name": "nimble_agent",
+                        "api_key": "test-key",
+                    },
+                ],
+            },
+        },
+    )
+
+    session_id = create_runner_bound_session(
+        http_client, agent_name=agent_name, runner_id=live_runner_id
+    )
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Use nimble_agent to search for 'nimbleway' and report the top result.",
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=response_id, timeout=180
+    )
+
+    assert body["status"] == "completed", (
+        f"Response status is {body['status']!r}, expected 'completed'. "
+        f"Output: {body.get('output', [])}"
+    )
+
+    assert agent_stub, "Nimble WSA stub was never called — nimble_agent not dispatched."
+    last = agent_stub[-1]
+    headers = last["headers"]
+    assert isinstance(headers, dict)
+    assert headers.get("X-Client-Source") == "omnigent", (
+        f"Expected X-Client-Source 'omnigent', got {headers.get('X-Client-Source')!r}"
+    )
+    request_body = last["body"]
+    assert isinstance(request_body, dict)
+    assert request_body.get("agent") == "google_search"

--- a/tests/runner/test_nimble_agent_dispatch.py
+++ b/tests/runner/test_nimble_agent_dispatch.py
@@ -1,0 +1,75 @@
+"""Dispatch tests for the ``nimble_agent`` builtin (runner-local Nimble WSA).
+
+Lock in that nimble_agent is runner-local (so a non-OpenAI model's call resolves
+to ``NimbleAgentTool.invoke`` → Nimble ``/v1/agent``) and not relayed to native
+harnesses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from omnigent.runner.tool_dispatch import (
+    _ALL_LOCAL_TOOLS,
+    _NATIVE_RELAY_BUILTIN_TOOLS,
+    _execute_nimble_agent_tool,
+    _nimble_agent_config_from_spec,
+    should_dispatch_locally,
+)
+
+
+def _spec_with_nimble_agent(config: dict[str, str]) -> SimpleNamespace:
+    """Minimal agent_spec stub: a single ``nimble_agent`` builtin carrying ``config``."""
+    return SimpleNamespace(
+        tools=SimpleNamespace(
+            builtins=[SimpleNamespace(name="nimble_agent", config=config)],
+        ),
+    )
+
+
+def test_nimble_agent_is_runner_local() -> None:
+    """``nimble_agent`` dispatches locally, like ``web_search``."""
+    assert "nimble_agent" in _ALL_LOCAL_TOOLS
+    assert should_dispatch_locally("nimble_agent") is True
+
+
+def test_nimble_agent_not_relayed_to_native_harnesses() -> None:
+    """Native harnesses use their own tooling; nimble_agent is not relayed."""
+    assert "nimble_agent" not in _NATIVE_RELAY_BUILTIN_TOOLS
+
+
+def test_config_from_spec_reads_config() -> None:
+    """The config helper returns the ``nimble_agent`` builtin's config dict."""
+    spec = _spec_with_nimble_agent({"api_key": "k", "agent": "google_search"})
+    assert _nimble_agent_config_from_spec(spec) == {"api_key": "k", "agent": "google_search"}
+
+
+def test_config_from_spec_empty_when_absent() -> None:
+    """No ``nimble_agent`` entry → empty config."""
+    spec = SimpleNamespace(tools=SimpleNamespace(builtins=[]))
+    assert _nimble_agent_config_from_spec(spec) == {}
+
+
+def test_dispatch_calls_nimble_agent() -> None:
+    """The dispatch handler builds NimbleAgentTool from spec config and calls Nimble WSA."""
+    spec = _spec_with_nimble_agent({"api_key": "k"})
+    fake = MagicMock()
+    fake.json.return_value = {
+        "data": {"parsing": {"entities": {"OrganicResult": []}}},
+        "status": "success",
+    }
+    with patch("omnigent.tools.builtins.nimble_agent.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = asyncio.run(
+            _execute_nimble_agent_tool(
+                {"query": "x"},
+                agent_spec=spec,
+                conversation_id="c",
+            )
+        )
+
+    assert mock_post.call_count == 1, "dispatch must call Nimble WSA"
+    assert "OrganicResult" in result
+    assert mock_post.call_args.kwargs["headers"]["X-Client-Source"] == "omnigent"

--- a/tests/tools/builtins/test_nimble_agent.py
+++ b/tests/tools/builtins/test_nimble_agent.py
@@ -1,0 +1,142 @@
+"""Tests for the ``nimble_agent`` built-in tool (Nimble WSA backend)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins import get_builtin_tool
+from omnigent.tools.builtins.nimble_agent import NimbleAgentTool, _format_agent
+
+
+def test_get_builtin_tool_returns_nimble_agent() -> None:
+    """``get_builtin_tool("nimble_agent")`` returns a NimbleAgentTool."""
+    tool = get_builtin_tool("nimble_agent")
+    assert isinstance(tool, NimbleAgentTool), (
+        f"Expected NimbleAgentTool, got {type(tool).__name__}."
+    )
+
+
+def test_tool_name() -> None:
+    """Tool name is 'nimble_agent'."""
+    assert NimbleAgentTool.name() == "nimble_agent"
+
+
+def test_schema_requires_query() -> None:
+    """The function schema requires a ``query`` parameter."""
+    schema = NimbleAgentTool().get_schema()
+    assert schema["type"] == "function"
+    assert schema["function"]["name"] == "nimble_agent"
+    assert "query" in schema["function"]["parameters"]["required"]
+
+
+def test_is_sync() -> None:
+    """nimble_agent runs synchronously."""
+    assert NimbleAgentTool().is_async() is False
+
+
+def test_missing_api_key_returns_error(tool_ctx: ToolContext) -> None:
+    """Without api_key the tool returns a clear error, never raises."""
+    tool = NimbleAgentTool(config={})
+    result = tool.invoke(json.dumps({"query": "x"}), tool_ctx)
+    assert "api_key" in result
+
+
+def test_missing_query_returns_error(tool_ctx: ToolContext) -> None:
+    """Without a query the tool returns a clear error, no HTTP call."""
+    tool = NimbleAgentTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.nimble_agent.httpx.post") as mock_post:
+        result = tool.invoke(json.dumps({}), tool_ctx)
+    assert "query" in result.lower()
+    assert mock_post.call_count == 0
+
+
+def test_sends_bearer_client_source_agent_and_params(tool_ctx: ToolContext) -> None:
+    """api_key → Bearer, X-Client-Source set, body carries agent + params{query}."""
+    fake = MagicMock()
+    fake.json.return_value = {"data": {"parsing": {"entities": {}}}, "status": "success"}
+    tool = NimbleAgentTool(config={"api_key": "spec-key", "agent": "google_search"})
+    with patch("omnigent.tools.builtins.nimble_agent.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        tool.invoke(json.dumps({"query": "nimbleway"}), tool_ctx)
+
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer spec-key", (
+        f"Expected spec config api_key in header, got {headers['Authorization']!r}"
+    )
+    assert headers["X-Client-Source"] == "omnigent", (
+        f"Expected X-Client-Source 'omnigent', got {headers.get('X-Client-Source')!r}"
+    )
+    body = mock_post.call_args.kwargs["json"]
+    assert body["agent"] == "google_search"
+    assert body["params"] == {"query": "nimbleway"}
+
+
+def test_default_agent_is_google_search(tool_ctx: ToolContext) -> None:
+    """When no ``agent`` is configured, the default WSA template is used."""
+    fake = MagicMock()
+    fake.json.return_value = {"data": {"parsing": {"entities": {}}}, "status": "success"}
+    tool = NimbleAgentTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.nimble_agent.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        tool.invoke(json.dumps({"query": "x"}), tool_ctx)
+    assert mock_post.call_args.kwargs["json"]["agent"] == "google_search"
+
+
+def test_returns_structured_entities_json(tool_ctx: ToolContext) -> None:
+    """The parsed ``entities`` are returned as structured JSON."""
+    entities = {"OrganicResult": [{"title": "Nimble", "url": "https://nimbleway.com"}]}
+    fake = MagicMock()
+    fake.json.return_value = {"data": {"parsing": {"entities": entities}}, "status": "success"}
+    tool = NimbleAgentTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.nimble_agent.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = tool.invoke(json.dumps({"query": "nimble"}), tool_ctx)
+
+    assert "OrganicResult" in result
+    assert "https://nimbleway.com" in result
+    assert json.loads(result) == entities, "Result must be valid JSON of the entities."
+
+
+def test_markdown_fallback_when_no_entities(tool_ctx: ToolContext) -> None:
+    """When there are no parsed entities, markdown is used as the fallback."""
+    fake = MagicMock()
+    fake.json.return_value = {"data": {"parsing": None, "markdown": "# md"}, "status": "success"}
+    tool = NimbleAgentTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.nimble_agent.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = tool.invoke(json.dumps({"query": "x"}), tool_ctx)
+    assert "# md" in result
+
+
+def test_no_data_returns_status_message(tool_ctx: ToolContext) -> None:
+    """An empty response returns a short status message."""
+    fake = MagicMock()
+    fake.json.return_value = {"data": {}, "status": "blocked"}
+    tool = NimbleAgentTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.nimble_agent.httpx.post") as mock_post:
+        mock_post.return_value = fake
+        result = tool.invoke(json.dumps({"query": "x"}), tool_ctx)
+    assert "No structured data" in result
+    assert "blocked" in result
+
+
+def test_http_error_returns_string(tool_ctx: ToolContext) -> None:
+    """An HTTP error is returned as a string, never raised."""
+    fake = MagicMock()
+    fake.status_code = 500
+    tool = NimbleAgentTool(config={"api_key": "k"})
+    with patch("omnigent.tools.builtins.nimble_agent.httpx.post") as mock_post:
+        mock_post.side_effect = httpx.HTTPStatusError("500", request=MagicMock(), response=fake)
+        result = tool.invoke(json.dumps({"query": "x"}), tool_ctx)
+    assert "Nimble agent error" in result
+    assert "500" in result
+
+
+def test_format_agent_direct() -> None:
+    """``_format_agent`` returns the entities as JSON text."""
+    out = _format_agent({"data": {"parsing": {"entities": {"a": 1}}}, "status": "success"})
+    assert json.loads(out) == {"a": 1}

--- a/tests/tools/builtins/test_registry_unified.py
+++ b/tests/tools/builtins/test_registry_unified.py
@@ -115,6 +115,7 @@ def test_builtin_names_size_matches_registry() -> None:
             {
                 # Instantiable
                 "web_search",
+                "nimble_agent",
                 "upload_file",
                 "list_files",
                 "download_file",


### PR DESCRIPTION
## Related issue

N/A — adds a Nimble-backed `nimble_agent` builtin (Web Search Agent → structured JSON), registered the same way as the merged `web_search` provider (#55).

## Summary

- Adds a `nimble_agent` built-in tool: it runs a Nimble Web Search Agent (`POST /v1/agent`) and returns the agent's structured, parsed results (e.g. Google SERP entities — organic results, ads, related searches) as JSON in one call.
- The WSA template is selected via the `agent` config value (default `google_search`); the LLM supplies the `query`. Complements `web_search` (which returns a text list) by returning structured JSON.
- Registers as a first-class builtin — a registry entry plus runner-local dispatch — so a non-OpenAI model's `nimble_agent` call resolves to the backend, the same posture as `web_search`.
- Raw `httpx` (no SDK dependency), `api_key` from spec config, output capped, errors returned as strings, and an `X-Client-Source` header identifying the integration.

### ELI5

Ask `nimble_agent` a query and it runs a Nimble Web Search Agent that returns clean, structured results (as JSON) instead of a plain text list — handy when the model needs to parse specific fields (titles, URLs, positions).

### How it's wired

```
nimble_agent(query)  [non-OpenAI model]
  └─ runner dispatch (_ALL_LOCAL_TOOLS → _execute_nimble_agent_tool)
       └─ NimbleAgentTool.invoke ──► Nimble POST /v1/agent {agent, params:{query}} ──► structured JSON
```

Config:

```yaml
tools:
  builtins:
    - name: nimble_agent
      api_key: ${NIMBLE_API_KEY}
      # optional: agent: google_search   # the Nimble WSA template (default)
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E test added (collection/skip-verified under the mock LLM; not run against a live LLM — see rationale)
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

**Live smoke** (the evidence behind *Manual verification completed*): invoked `nimble_agent` through the runner's tool-dispatch handler (`_execute_nimble_agent_tool` → `NimbleAgentTool.invoke`) — the same path a non-OpenAI model's `nimble_agent` call takes — with a real `NIMBLE_API_KEY` and query "nimbleway". It returned ~9.5 KB of structured Google SERP entities as JSON (HTTP 200 from Nimble's `/v1/agent`, ~7s). The WSA occasionally returns a transient 500 ("please try again"); the backend surfaces that as a clear error string so the model can retry.

Other commands run:

- `uv run pytest tests/tools/builtins/test_nimble_agent.py tests/runner/test_nimble_agent_dispatch.py` → **18 passed**. Backend unit tests (registry resolution, Bearer + `X-Client-Source` header, request body with `agent` + `params.query`, default agent, entities-as-JSON / markdown fallback, missing-key/query errors, error-as-string) plus runner-dispatch tests (`nimble_agent` is runner-local and not relayed to native harnesses; the dispatch handler builds the tool from spec config and calls Nimble WSA).
- `uv run pytest tests/tools/builtins/test_web_search.py tests/runner/test_web_search_local_dispatch.py` → **49 passed** (regression — the shared dispatch table is unaffected).
- `tests/e2e/test_nimble_agent_e2e.py` — added, following the repo's spec-level-builtin e2e convention (e.g. `tests/e2e/test_file_tools.py`): it drives `nimble_agent` against a local WSA stub and is skipped under the mock LLM (which can't resolve spec-level builtins). I verified it collects and skips cleanly under the mock LLM this cycle; I have not run it end-to-end against a live LLM.
- `uv run ruff check` + `uv run ruff format --check` on the changed files, and `uv run pre-commit run --files ...` → all pass.

Files: `omnigent/tools/builtins/nimble_agent.py` (new builtin + backend), `omnigent/tools/builtins/__init__.py` (registry entry), `omnigent/runner/tool_dispatch.py` (runner-local dispatch: `_NIMBLE_AGENT_TOOLS`, `_execute_nimble_agent_tool`, dispatch branch), and the three test files.
