### PR TITLE
feat(web): drag-to-reorder queued messages

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3672,6 +3672,7 @@ export function Composer({
   const maybeFlushQueuedHead = useChatStore((s) => s.maybeFlushQueuedHead);
   const dequeueMessage = useChatStore((s) => s.dequeueMessage);
   const steerMessage = useChatStore((s) => s.steerMessage);
+  const reorderQueuedMessage = useChatStore((s) => s.reorderQueuedMessage);
   // Drain the queue whenever idle with a waiting head — level-triggered so a
   // message queued right after the turn ended (or after an SSE reconnect that
   // carries no fresh idle transition) still sends instead of stranding. Hold
@@ -4399,6 +4400,7 @@ export function Composer({
           textareaRef.current?.focus();
         }}
         onSteer={(queueId) => steerMessage(queueId)}
+        onReorder={reorderQueuedMessage}
         widthClassName={CHAT_COLUMN_WIDTH}
       />
       {/* Sub-agent context tray — peeks above the card; reserves its own

--- a/web/src/pages/QueuedMessagesStrip.test.tsx
+++ b/web/src/pages/QueuedMessagesStrip.test.tsx
@@ -91,4 +91,22 @@ describe("QueuedMessagesStrip", () => {
     expect(onSteer).toHaveBeenCalledTimes(1);
     expect(onSteer).toHaveBeenCalledWith("q_2");
   });
+
+  it("shows a drag handle per row only when onReorder is provided", () => {
+    const { rerender } = render(
+      <QueuedMessagesStrip messages={[msg("q_1", "first")]} onDelete={vi.fn()} onEdit={vi.fn()} />,
+    );
+    // No reorder handler → no grip (the row shows the clock icon instead).
+    expect(screen.queryByRole("button", { name: "Reorder queued message" })).toBeNull();
+
+    rerender(
+      <QueuedMessagesStrip
+        messages={[msg("q_1", "first"), msg("q_2", "second")]}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        onReorder={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByRole("button", { name: "Reorder queued message" })).toHaveLength(2);
+  });
 });

--- a/web/src/pages/QueuedMessagesStrip.tsx
+++ b/web/src/pages/QueuedMessagesStrip.tsx
@@ -1,4 +1,21 @@
-import { ClockIcon, CornerDownRightIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import {
+  DndContext,
+  type DragEndEvent,
+  MouseSensor,
+  pointerWithin,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  ClockIcon,
+  CornerDownRightIcon,
+  GripVerticalIcon,
+  PencilIcon,
+  Trash2Icon,
+} from "lucide-react";
 
 import type { QueuedMessage } from "@/store/chatStore";
 import { cn } from "@/lib/utils";
@@ -16,8 +33,99 @@ interface QueuedMessagesStripProps {
    * in which case no steer button is shown.
    */
   onSteer?: (queueId: string) => void;
+  /**
+   * Move `queueId` so it sits before `beforeQueueId` (or to the end when null).
+   * Drives drag-to-reorder; omit to render a non-reorderable strip.
+   */
+  onReorder?: (queueId: string, beforeQueueId: string | null) => void;
   /** Column-width class so the strip lines up with the composer card. */
   widthClassName?: string;
+}
+
+/** A single queued-message row, draggable by its grip when reordering is on. */
+function QueuedRow({
+  message,
+  onDelete,
+  onEdit,
+  onSteer,
+  reorderable,
+}: {
+  message: QueuedMessage;
+  onDelete: (queueId: string) => void;
+  onEdit: (queueId: string) => void;
+  onSteer?: (queueId: string) => void;
+  reorderable: boolean;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setDragRef,
+    isDragging,
+  } = useDraggable({
+    id: message.queueId,
+    disabled: !reorderable,
+  });
+  // The whole row is the drop target so dropping anywhere on it reorders.
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: message.queueId,
+    disabled: !reorderable,
+  });
+
+  return (
+    <div
+      ref={setDropRef}
+      className={cn(
+        "flex items-center gap-1.5 text-xs text-muted-foreground",
+        isDragging && "opacity-40",
+        isOver && "rounded bg-foreground/5",
+      )}
+    >
+      {reorderable ? (
+        <button
+          type="button"
+          ref={setDragRef}
+          aria-label="Reorder queued message"
+          className="shrink-0 cursor-grab touch-none rounded p-0.5 text-muted-foreground/50 transition hover:text-foreground focus-visible:text-foreground active:cursor-grabbing"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVerticalIcon className="size-3.5" aria-hidden="true" />
+        </button>
+      ) : (
+        <ClockIcon className="size-3.5 shrink-0" aria-hidden="true" />
+      )}
+      <span className="min-w-0 flex-1 truncate">{message.text}</span>
+      {/* Always visible (not hover-gated) so the actions are discoverable;
+          they brighten on hover/focus. */}
+      {onSteer ? (
+        <button
+          type="button"
+          aria-label="Send queued message now"
+          className="flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-muted-foreground/60 transition hover:text-foreground focus-visible:text-foreground"
+          onClick={() => onSteer(message.queueId)}
+        >
+          <CornerDownRightIcon className="size-3.5" aria-hidden="true" />
+          Steer
+        </button>
+      ) : null}
+      <button
+        type="button"
+        aria-label="Edit queued message"
+        className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition hover:text-foreground focus-visible:text-foreground"
+        onClick={() => onEdit(message.queueId)}
+      >
+        <PencilIcon className="size-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        aria-label="Remove queued message"
+        className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition hover:text-foreground focus-visible:text-foreground"
+        onClick={() => onDelete(message.queueId)}
+      >
+        <Trash2Icon className="size-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  );
 }
 
 /**
@@ -26,16 +134,50 @@ interface QueuedMessagesStripProps {
  * `SubagentComposerTray`. Renders nothing when the queue is empty.
  *
  * Each row can be steered (sent now), edited (pulled back into the composer),
- * or deleted; reorder lands in a later change.
+ * deleted, or — when `onReorder` is provided — dragged by its grip to reorder
+ * the queue (drains FIFO, so order is the send order).
  */
 export function QueuedMessagesStrip({
   messages,
   onDelete,
   onEdit,
   onSteer,
+  onReorder,
   widthClassName,
 }: QueuedMessagesStripProps) {
+  // Pointer-only sensors with a small activation distance, matching the
+  // sidebar's DnD, so a click on the grip still reaches the row's buttons.
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 8 } }),
+  );
+
   if (messages.length === 0) return null;
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (onReorder === undefined || over === null || active.id === over.id) return;
+    const from = messages.findIndex((m) => m.queueId === active.id);
+    const to = messages.findIndex((m) => m.queueId === over.id);
+    if (from === -1 || to === -1) return;
+    // Dragging down past the target lands after it (before the next row, or the
+    // end); dragging up lands before it. Mirrors dnd-kit sortable's semantics
+    // and lets a drag reach the very end of the list.
+    const beforeQueueId = from < to ? (messages[to + 1]?.queueId ?? null) : messages[to]!.queueId;
+    onReorder(String(active.id), beforeQueueId);
+  };
+
+  const rows = messages.map((message) => (
+    <QueuedRow
+      key={message.queueId}
+      message={message}
+      onDelete={onDelete}
+      onEdit={onEdit}
+      onSteer={onSteer}
+      reorderable={onReorder !== undefined}
+    />
+  ));
+
   return (
     <div
       data-testid="composer-queued-strip"
@@ -47,44 +189,17 @@ export function QueuedMessagesStrip({
       {/* Cap the list height and scroll when the queue is long, so a big
           backlog never pushes the composer off-screen. ~5 rows tall. */}
       <div className="flex max-h-32 flex-col gap-1 overflow-y-auto">
-        {messages.map((message) => (
-          <div
-            key={message.queueId}
-            className="flex items-center gap-1.5 text-xs text-muted-foreground"
+        {onReorder === undefined ? (
+          rows
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={pointerWithin}
+            onDragEnd={handleDragEnd}
           >
-            <ClockIcon className="size-3.5 shrink-0" aria-hidden="true" />
-            <span className="min-w-0 flex-1 truncate">{message.text}</span>
-            {/* Always visible (not hover-gated) so the actions are
-                discoverable; they brighten on hover/focus. */}
-            {onSteer ? (
-              <button
-                type="button"
-                aria-label="Send queued message now"
-                className="flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-muted-foreground/60 transition hover:text-foreground focus-visible:text-foreground"
-                onClick={() => onSteer(message.queueId)}
-              >
-                <CornerDownRightIcon className="size-3.5" aria-hidden="true" />
-                Steer
-              </button>
-            ) : null}
-            <button
-              type="button"
-              aria-label="Edit queued message"
-              className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition hover:text-foreground focus-visible:text-foreground"
-              onClick={() => onEdit(message.queueId)}
-            >
-              <PencilIcon className="size-3.5" aria-hidden="true" />
-            </button>
-            <button
-              type="button"
-              aria-label="Remove queued message"
-              className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition hover:text-foreground focus-visible:text-foreground"
-              onClick={() => onDelete(message.queueId)}
-            >
-              <Trash2Icon className="size-3.5" aria-hidden="true" />
-            </button>
-          </div>
-        ))}
+            {rows}
+          </DndContext>
+        )}
       </div>
     </div>
   );

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7533,6 +7533,89 @@ describe("chatStore — client-side message queue", () => {
     expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual(["first", "third"]);
   });
 
+  it("reorderQueuedMessage moves a message before another within its conversation", () => {
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      queuedMessages: [
+        { queueId: "q_1", text: "first", conversationId: "conv_abc" },
+        { queueId: "q_2", text: "second", conversationId: "conv_abc" },
+        { queueId: "q_3", text: "third", conversationId: "conv_abc" },
+      ],
+    });
+
+    // Move the last message ahead of the first.
+    useChatStore.getState().reorderQueuedMessage("q_3", "q_1");
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual([
+      "third",
+      "first",
+      "second",
+    ]);
+
+    // beforeQueueId=null moves it to the end.
+    useChatStore.getState().reorderQueuedMessage("third", "q_missing"); // (no such row)
+    useChatStore.getState().reorderQueuedMessage("q_3", null);
+    expect(useChatStore.getState().queuedMessages.map((m) => m.text)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("reorderQueuedMessage no-ops for a missing id or a self move", () => {
+    const initial = [
+      { queueId: "q_1", text: "first", conversationId: "conv_abc" },
+      { queueId: "q_2", text: "second", conversationId: "conv_abc" },
+    ];
+    useChatStore.setState({ conversationId: "conv_abc", queuedMessages: initial });
+
+    useChatStore.getState().reorderQueuedMessage("q_missing", "q_1");
+    useChatStore.getState().reorderQueuedMessage("q_1", "q_1"); // before itself
+    // Reference identity preserved — no state churn on a no-op.
+    expect(useChatStore.getState().queuedMessages).toBe(initial);
+  });
+
+  it("reorderQueuedMessage only touches its own conversation's slots (interleaved queue)", () => {
+    // The flat queue interleaves conversations; reordering conv_abc must leave
+    // conv_other's entries at their absolute positions.
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      queuedMessages: [
+        { queueId: "a1", text: "a-first", conversationId: "conv_abc" },
+        { queueId: "o1", text: "other-1", conversationId: "conv_other" },
+        { queueId: "a2", text: "a-second", conversationId: "conv_abc" },
+        { queueId: "o2", text: "other-2", conversationId: "conv_other" },
+        { queueId: "a3", text: "a-third", conversationId: "conv_abc" },
+      ],
+    });
+
+    // Move a-third to the front of conv_abc's run.
+    useChatStore.getState().reorderQueuedMessage("a3", "a1");
+
+    // conv_abc reordered (a3, a1, a2); conv_other's o1/o2 keep their slots
+    // (indices 1 and 3), so the flat array interleaves as below.
+    expect(useChatStore.getState().queuedMessages.map((m) => m.queueId)).toEqual([
+      "a3",
+      "o1",
+      "a1",
+      "o2",
+      "a2",
+    ]);
+  });
+
+  it("reorderQueuedMessage won't move a message across conversations", () => {
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      queuedMessages: [
+        { queueId: "a1", text: "a-first", conversationId: "conv_abc" },
+        { queueId: "o1", text: "other-1", conversationId: "conv_other" },
+      ],
+    });
+
+    // Target belongs to a different conversation → no-op.
+    useChatStore.getState().reorderQueuedMessage("a1", "o1");
+    expect(useChatStore.getState().queuedMessages.map((m) => m.queueId)).toEqual(["a1", "o1"]);
+  });
+
   it("steerMessage sends the chosen message now and removes it from the queue", () => {
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     useChatStore.setState({

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -537,6 +537,15 @@ export interface ChatState {
   /** Remove a queued message by id (the strip's per-row delete). */
   dequeueMessage: (queueId: string) => void;
   /**
+   * Reorder a queued message within its own conversation (the strip's
+   * drag-to-reorder). Moves `queueId` so it sits before `beforeQueueId`, or to
+   * the end of its conversation's run when `beforeQueueId` is null. Only
+   * reorders among the same conversation's messages — the flat `queuedMessages`
+   * array interleaves conversations, so other conversations' entries keep their
+   * absolute positions. No-op if the id isn't queued or the move is a no-op.
+   */
+  reorderQueuedMessage: (queueId: string, beforeQueueId: string | null) => void;
+  /**
    * Send a queued message NOW instead of waiting for the idle flush (the
    * strip's per-row steer). Removes it from the queue and POSTs it: on an
    * SDK harness the server live-injects it into the running turn; the
@@ -920,6 +929,35 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set((s) => ({
       queuedMessages: s.queuedMessages.filter((m) => m.queueId !== queueId),
     }));
+  },
+
+  reorderQueuedMessage: (queueId, beforeQueueId) => {
+    set((s) => {
+      const moved = s.queuedMessages.find((m) => m.queueId === queueId);
+      if (moved === undefined || queueId === beforeQueueId) return {};
+      const conversationId = moved.conversationId;
+
+      // Reorder only within this conversation's messages, in their current
+      // relative order, then drop `moved` before its target (or at the end).
+      const own = s.queuedMessages.filter((m) => m.conversationId === conversationId);
+      const without = own.filter((m) => m.queueId !== queueId);
+      const at =
+        beforeQueueId === null
+          ? without.length
+          : without.findIndex((m) => m.queueId === beforeQueueId);
+      if (at === -1) return {}; // target isn't in this conversation — no-op
+      const reordered = [...without.slice(0, at), moved, ...without.slice(at)];
+      if (reordered.every((m, i) => m.queueId === own[i]?.queueId)) return {}; // unchanged
+
+      // Refill this conversation's slots (their absolute positions in the flat
+      // array) with the reordered run; other conversations' entries stay put.
+      let next = 0;
+      return {
+        queuedMessages: s.queuedMessages.map((m) =>
+          m.conversationId === conversationId ? reordered[next++]! : m,
+        ),
+      };
+    });
   },
 
   steerMessage: (queueId) => {


### PR DESCRIPTION
## Related issue

N/A — the optional reorder item from the queued-messages roadmap (follows
#2029 / #2065 / #2075).

## Summary

- Queued messages could be steered, edited, or deleted, but not **reordered** —
  the queue drained strictly in enqueue order. This adds drag-to-reorder so a
  user can change the order their held follow-ups will send in.
- Each strip row gains a **grip handle** (shown only when reordering is wired
  up); dragging it reorders via `@dnd-kit/core` primitives — the same pointer
  sensors the sidebar uses (5px mouse activation distance, 250ms touch delay),
  so a click on the grip still reaches the row's steer/edit/delete buttons. A
  dedicated handle rather than a whole-row drag keeps those buttons clickable.
- New **`reorderQueuedMessage(queueId, beforeQueueId)`** store action performs
  the move. `queuedMessages` is a single flat array that interleaves
  conversations, so the action reorders **only within the dragged message's own
  conversation** and refills that conversation's absolute slots — other
  conversations' entries keep their positions. No-ops on a missing id, a
  self-move, or a cross-conversation target.

## Test Plan

- **Unit** (`web`, vitest):
  - store `reorderQueuedMessage` — move before another / to the end, no-op
    identity preservation on a missing id or self-move, interleaved-queue slot
    preservation (other conversations stay put), cross-conversation guard;
  - `QueuedMessagesStrip` — the grip handle renders per row only when
    `onReorder` is provided (clock icon otherwise).
- 328 passing across store + strip + composer suites; web build passes.
- **Gates**: `npm run type-check`, tests, prettier, build all pass.

## Demo

<!-- TODO: attach a clip — queue a few messages, drag one by its grip to reorder, watch them send in the new order -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The reorder logic (including the interleaved-conversation slot invariant) is
covered by store unit tests; the drag affordance's presence/absence is covered
by strip render tests. The drag gesture itself (pointer events through
`@dnd-kit`) is left to manual verification — jsdom can't faithfully simulate the
sensor pipeline, and the reorder math it feeds is unit-tested directly via
`onReorder`/`reorderQueuedMessage`.

This pull request and its description were written by Isaac.
