### PR TITLE
fix(claude-native): clear busy state after in-pane /model switch

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -2839,6 +2839,31 @@ async def _ensure_state_for_transcript(
     return state
 
 
+def _turn_has_assistant_output(items: list[ClaudeTranscriptItem], response_id: str) -> bool:
+    """
+    Whether ``response_id`` has assistant-generated output among ``items``.
+
+    The turn-start ``running`` edge should open a streaming turn only for an id
+    that a later ``Stop``/``StopFailure`` hook will close — i.e. one produced by
+    an actual LLM turn. Assistant text (``message`` with ``role=assistant``) and
+    tool calls (``function_call``) qualify; a ``slash_command`` (``/model``,
+    ``/effort``) or ``terminal_command`` (``!cmd``) item opens an id with no LLM
+    turn behind it, so it must not.
+
+    :param items: Transcript items read this poll.
+    :param response_id: The current turn's response id.
+    :returns: ``True`` when an assistant-output item carries ``response_id``.
+    """
+    for item in items:
+        if item.response_id != response_id:
+            continue
+        if item.item_type == "function_call":
+            return True
+        if item.item_type == "message" and item.data.get("role") == "assistant":
+            return True
+    return False
+
+
 async def _forward_available_items(
     *,
     client: httpx.AsyncClient,
@@ -2902,9 +2927,19 @@ async def _forward_available_items(
     # status post must not abort item forwarding (the items below are the
     # primary payload); the turn-end idle/failed edge still carries the id to
     # close the lifecycle, and the badge is unaffected either way.
+    #
+    # Only open the streaming turn for an id that has ASSISTANT output in this
+    # poll's items. A surfaced CLI built-in (``/model``, ``/effort``) or a
+    # ``!cmd`` becomes a slash_command / terminal_command item that opens its
+    # own response id but runs no LLM turn, so no ``Stop`` hook ever fires to
+    # close it — a ``running`` opened for it would strand the web composer in
+    # its "Stop"/busy state until the next real message. A skill that DOES
+    # trigger an LLM turn shares its id with the assistant text it produces, so
+    # ``running`` still fires — one poll later, when that output appears.
     if (
         current_response_id is not None
         and dedupe.posted_running_response_id != current_response_id
+        and _turn_has_assistant_output(items, current_response_id)
     ):
         try:
             await post_external_session_status(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -1166,11 +1166,14 @@ async def test_forwarder_posts_visible_transcript_items(tmp_path: Path) -> None:
         )
     )
     try:
-        # The turn-start ``running`` status (carrying the turn's response id)
-        # posts first, then the seven transcript items, then the ``Stop`` →
-        # idle status. Collect the running edge + 7 items; the trailing idle is
-        # not asserted here.
-        requests = [await _get_recorded_request(server) for _index in range(8)]
+        # Collect the seven transcript items. This transcript's final turn is a
+        # ``!bash`` command (a ``terminal_command``, no assistant output), so
+        # ``current_response_id`` lands on a turn that runs no LLM turn and thus
+        # gets no id-bearing ``running`` edge (that would strand the web UI busy
+        # with no ``Stop`` hook to close it). The turn-start ``running`` edge is
+        # asserted for a real assistant turn in
+        # ``test_forwarder_emits_turn_start_running_with_response_id``.
+        requests = [await _get_recorded_item_request(server) for _index in range(7)]
     finally:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -1179,26 +1182,9 @@ async def test_forwarder_posts_visible_transcript_items(tmp_path: Path) -> None:
         server.server_close()
         thread.join(timeout=5.0)
 
-    assert [request["path"] for request in requests] == ["/v1/sessions/conv_abc/events"] * 8
-    assert [request["body"]["type"] for request in requests] == [
-        "external_session_status",
-        "external_conversation_item",
-        "external_conversation_item",
-        "external_conversation_item",
-        "external_conversation_item",
-        "external_conversation_item",
-        "external_conversation_item",
-        "external_conversation_item",
-    ]
-    # The leading status is the turn-start ``running`` edge carrying the turn's
-    # response id (what drives the live tool-card spinner on the client).
-    assert requests[0]["body"]["data"]["status"] == "running"
-    assert isinstance(requests[0]["body"]["data"].get("response_id"), str)
-    posted = [
-        request["body"]["data"]
-        for request in requests
-        if request["body"]["type"] == "external_conversation_item"
-    ]
+    assert [request["path"] for request in requests] == ["/v1/sessions/conv_abc/events"] * 7
+    assert [request["body"]["type"] for request in requests] == ["external_conversation_item"] * 7
+    posted = [request["body"]["data"] for request in requests]
     assert [item["item_type"] for item in posted] == [
         "message",
         "function_call",
@@ -1236,11 +1222,6 @@ async def test_forwarder_posts_visible_transcript_items(tmp_path: Path) -> None:
     assert posted[5]["response_id"] == posted[6]["response_id"]
     assert posted[5]["response_id"] != posted[4]["response_id"]
     assert posted[1]["response_id"].startswith("resp_claude_")
-    # The turn-start running edge carries an assistant turn's response id (here
-    # the whole multi-turn transcript flushes in one poll, so it's the last
-    # turn's id). The single-turn id↔function_call match is asserted directly in
-    # test_forwarder_emits_turn_start_running_with_response_id.
-    assert requests[0]["body"]["data"]["response_id"].startswith("resp_claude_")
 
 
 @pytest.mark.asyncio
@@ -6922,3 +6903,120 @@ async def test_forwarder_emits_turn_start_running_with_response_id(tmp_path: Pat
         and body["body"]["data"]["item_type"] == "function_call"
     )
     assert function_call["body"]["data"]["response_id"] == running_rid
+
+
+@pytest.mark.asyncio
+async def test_forwarder_does_not_leave_running_open_for_slash_command_only_turn(
+    tmp_path: Path,
+) -> None:
+    """
+    A ``/model``-only turn must not leave an id-bearing ``running`` dangling.
+
+    Surfaced CLI built-ins (``/model``, ``/effort``, ...) become a
+    ``slash_command`` item that opens its OWN response id but produce no LLM
+    turn — so no ``Stop`` hook ever fires to close it. The forwarder's
+    turn-start edge still publishes ``running`` + that id, which opens a
+    streaming ``activeResponse`` in the web UI. Because the web store
+    suppresses the trailing bare (id-less) PTY ``idle`` while a response is
+    streaming, nothing clears it: the composer's Stop button stays lit and
+    the session looks busy even though the terminal is free.
+
+    The invariant: a poll that forwards only a slash-command item (no
+    assistant output) must either skip the id-bearing ``running`` edge or
+    emit a matching ``idle``/``failed`` carrying the same id, so the turn's
+    lifecycle closes.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "uuid": "prior-assistant",
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Earlier reply."}],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "user",
+                        "uuid": "slash-model",
+                        "message": {
+                            "role": "user",
+                            "content": (
+                                "<command-name>/model</command-name>\n"
+                                "            <command-message>model</command-message>\n"
+                                "            <command-args>opus</command-args>"
+                            ),
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    state = forwarder.TranscriptForwardState(
+        transcript_path=transcript_path,
+        line_cursor=0,
+        byte_offset=0,
+        cursor_fingerprint=forwarder._jsonl_cursor_fingerprint(transcript_path, 0),
+    )
+    retry_tracker = forwarder._PostRetryTracker(
+        max_permanent_attempts=2,
+        base_delay_s=0.0,
+        max_delay_s=0.0,
+    )
+    requests: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        assert isinstance(payload, dict)
+        requests.append(payload)
+        return httpx.Response(202, json={})
+
+    transport = httpx.MockTransport(_handle_request)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        dedupe = forwarder._ForwardDedupeState()
+        await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=state,
+            retry_tracker=retry_tracker,
+            dedupe=dedupe,
+        )
+
+    statuses = [
+        request["data"] for request in requests if request["type"] == "external_session_status"
+    ]
+    running_ids = {
+        status.get("response_id")
+        for status in statuses
+        if status["status"] == "running" and status.get("response_id") is not None
+    }
+    closed_ids = {
+        status.get("response_id") for status in statuses if status["status"] in ("idle", "failed")
+    }
+    # Any id-bearing ``running`` opened for the slash-command-only turn must
+    # be closed within the same poll — otherwise the web UI is stuck busy
+    # until the next real message. (No LLM turn means no later Stop hook.)
+    dangling = running_ids - closed_ids
+    assert not dangling, (
+        "slash-command-only turn left an id-bearing running status open with "
+        f"no matching idle/failed: {dangling}"
+    )
+    # Stronger: the forwarder opens NO id-bearing running for this turn at all
+    # (there is no assistant output to render live, so nothing to stream).
+    assert running_ids == set()
+    # The slash_command item itself still forwards — the switch stays visible
+    # in the web transcript; only the phantom ``running`` edge is suppressed.
+    forwarded = [
+        request["data"] for request in requests if request["type"] == "external_conversation_item"
+    ]
+    assert any(item["item_type"] == "slash_command" for item in forwarded)


### PR DESCRIPTION
## Related issue

N/A

## Summary

Native Claude sessions stayed "busy" in the web UI — the composer's Send button stuck on **Stop** — after an in-pane `/model` switch, even though the terminal was actually idle. It only self-healed on the next real message.

- **Root cause:** A surfaced CLI built-in (`/model`, `/effort`) becomes a `slash_command` transcript item that opens its own `response_id` but runs no LLM turn, so no `Stop` hook ever fires to close it. The forwarder's turn-start edge still published an id-bearing `running` for it, which opened a streaming `activeResponse` in the web store. The store deliberately suppresses the trailing bare (id-less) PTY `idle` while a response is streaming, so nothing cleared the phantom turn — the Stop button stayed lit.
- **Fix:** Gate the turn-start `running` edge on the turn actually having assistant output (a `function_call` or assistant `message`) — the exact turns a later `Stop`/`StopFailure` hook will close. Turns that produce no LLM output (`slash_command`, or `terminal_command` from `!cmd`) no longer strand the UI busy. A skill that *does* trigger an LLM turn shares its id with the assistant text it produces, so `running` still fires — one poll later, when that output appears.
- **Regression origin:** #1499 (Jul 2) added the id-bearing turn-start `running` edge; before it, native `running` was PTY-derived and carried no id, so `/model` never opened a streaming turn.

### ELI5

The web chat shows a spinner/Stop button while Claude is "working." It decides Claude is working when the runner sends a `running` signal tagged with a turn id, and stops when a matching `idle` arrives. Typing `/model` looked like the *start* of a turn (it got a `running`), but since `/model` just flips a setting and never actually asks the model anything, the matching `idle` never came — so the spinner never stopped. Now we only send that `running` signal when there's real model work behind it.

```
Before:  /model  ──► running(id=X)  ──►  … no LLM turn … no Stop hook … no idle(id=X)
                                          └─► web store swallows the bare PTY idle
                                              (a response is "streaming") ──► STUCK on Stop

After:   /model  ──► slash_command item forwarded, but NO running(id=X) opened
                     (turn has no assistant output) ──► composer stays idle ✓

         real turn ──► assistant output ──► running(id=X) ──► Stop hook ──► idle(id=X) ✓
```

## Test Plan

- Added `test_forwarder_does_not_leave_running_open_for_slash_command_only_turn`: forwards a `/model`-only turn and asserts no id-bearing `running` is left dangling (and that the `slash_command` item still forwards). Fails on `main` (dangling `resp_claude_…`), passes with the fix.
- Updated `test_forwarder_posts_visible_transcript_items`: its synthetic transcript ends on a `!bash` turn, which correctly opens no `running` now; retargeted to its actual purpose (item forwarding).
- `python -m pytest tests/test_claude_native_forwarder.py` → **112 passed** (incl. the existing turn-start-running test for real assistant turns).
- Pre-existing failures in `test_claude_native_bridge.py` (MCP-channel) and `tests/runner/test_app_sessions_native.py` (codex_native) were confirmed present on the pristine branch via `git stash` — unrelated to this change.

## Demo

N/A — no visual change; the fix removes a spurious status edge. Behavior: after `/model`, the composer returns to idle instead of showing Stop.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The bug reproduces deterministically at the forwarder layer (no server/PTY timing), so the new unit test drives `_forward_available_items` directly over a `/model`-only transcript. The web-store guard that suppresses the bare PTY `idle` is unchanged — the fix keeps the two sides consistent by not opening a streaming turn that will never be closed.

## Changelog

Native Claude sessions no longer get stuck showing "Stop" after switching models in the terminal with `/model`
