### PR TITLE
fix(host): ride out a transient 404 during a server restart instead of exiting (#2039)

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -15,6 +15,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -425,12 +426,14 @@ HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
 # their runners need; everything unnamed stays behind the allowlist.
 RUNNER_ENV_PASSTHROUGH_ENV_VAR: str = "OMNIGENT_RUNNER_ENV_PASSTHROUGH"
 
-# HTTP statuses on the WebSocket upgrade that are worth retrying. Everything
-# else in the 4xx range is a permanent client error (auth, authorization,
-# wrong/old server) where reconnecting can never succeed — those fail loud.
-# 408 (Request Timeout) and 429 (Too Many Requests) are transient by HTTP
-# semantics, so they stay in the reconnect path.
-_RETRYABLE_UPGRADE_STATUSES: frozenset[int] = frozenset({408, 429})
+# HTTP statuses on the WebSocket upgrade that are ALWAYS worth retrying: they
+# are transient by HTTP semantics no matter the connection history — 408
+# (Request Timeout), 425 (Too Early), and 429 (Too Many Requests). A 404 is
+# handled separately (see :meth:`HostProcess._classify_transient_404`) because
+# it is transient only while the server restarts behind a reverse proxy. Every
+# other 4xx is a permanent client error (auth, authorization, wrong/old server)
+# where reconnecting can never succeed — those fail loud.
+_RETRYABLE_UPGRADE_STATUSES: frozenset[int] = frozenset({408, 425, 429})
 
 # Consecutive login-page redirects tolerated on a host that has NEVER
 # completed a WS upgrade in this process. A single redirect can be a server
@@ -441,6 +444,16 @@ _RETRYABLE_UPGRADE_STATUSES: frozenset[int] = frozenset({408, 429})
 # HAS connected keeps retrying indefinitely, so a deploy restart never
 # kills a live host with running sessions.
 _LOGIN_REDIRECT_FATAL_ATTEMPTS = 3
+
+# Grace window during which a 404 on the tunnel upgrade is retried on a host
+# that has NEVER completed an upgrade in this process. A reverse proxy in front
+# of a restarting server answers 404 for the tunnel route until the backend is
+# back; a host that has already connected rides that out indefinitely (see
+# :meth:`HostProcess._classify_transient_404`), while a never-connected host
+# retries only until this window elapses and then fails loud — so a genuinely
+# wrong server URL, or a server too old to expose the tunnel route, still
+# surfaces instead of looping silently forever. Measured on the monotonic clock.
+_UNCONNECTED_TRANSIENT_404_GRACE_S = 180.0
 
 
 class HostConnectError(Exception):
@@ -617,6 +630,9 @@ class HostProcess:
         self._ever_connected = False
         # Consecutive login-page redirects; reset by a successful upgrade.
         self._login_redirect_streak = 0
+        # Monotonic timestamp of the first 404 in the current never-connected
+        # streak; ``None`` when not mid-streak. Reset by a successful upgrade.
+        self._transient_404_since: float | None = None
         # Live tunnel connection, set by _serve_frames for the watcher
         # tasks (which outlive any single connection) to report on.
         self._ws: websockets.asyncio.client.ClientConnection | None = None
@@ -950,11 +966,15 @@ class HostProcess:
             ``403``.
         :returns: A :class:`HostConnectError` for a permanent 4xx, or
             ``None`` for a transient status (retryable 4xx in
-            :data:`_RETRYABLE_UPGRADE_STATUSES`, or any non-4xx such as a
-            5xx server bounce) that the reconnect loop should retry.
+            :data:`_RETRYABLE_UPGRADE_STATUSES`, a 404 still within the
+            restart grace window per :meth:`_classify_transient_404`, or any
+            non-4xx such as a 5xx server bounce) that the reconnect loop
+            should retry.
         """
         if status in _RETRYABLE_UPGRADE_STATUSES or not (400 <= status < 500):
             return None
+        if status == 404:
+            return self._classify_transient_404()
         if status == 401:
             return HostConnectError(
                 "Authentication failed (HTTP 401): the server rejected the "
@@ -987,6 +1007,42 @@ class HostProcess:
             f"Connection refused (HTTP {status}): the server rejected the host "
             "tunnel request. This is a permanent error; retrying will not help. "
             "Check the server URL and your access."
+        )
+
+    def _classify_transient_404(self) -> HostConnectError | None:
+        """Treat a 404 on the tunnel upgrade as a transient restart blip.
+
+        A reverse proxy in front of the server answers 404 for the tunnel
+        route while the backend container restarts (upgrade, config change,
+        agent re-seed). A host that has already completed an upgrade in this
+        process rides that window out indefinitely, so a routine server bounce
+        never tears down its live runner sessions. A host that has never
+        connected retries only until
+        :data:`_UNCONNECTED_TRANSIENT_404_GRACE_S` elapses and then fails loud,
+        so a genuinely wrong server URL — or a server too old to expose the
+        tunnel route — still surfaces instead of looping silently forever.
+        The first 404 of a streak is always retried, so a one-off blip is
+        absorbed even when the grace window is short.
+
+        :returns: ``None`` while the 404 should be retried, or a
+            :class:`HostConnectError` once a never-connected host has
+            exhausted the grace window.
+        """
+        if self._ever_connected:
+            return None
+        now = time.monotonic()
+        if self._transient_404_since is None:
+            self._transient_404_since = now
+            return None
+        if now - self._transient_404_since < _UNCONNECTED_TRANSIENT_404_GRACE_S:
+            return None
+        waited = int(now - self._transient_404_since)
+        return HostConnectError(
+            f"Connection refused (HTTP 404): the server did not expose the "
+            f"host tunnel route for {waited}s. If the server is mid-restart "
+            "this clears on its own; otherwise the server URL is wrong or the "
+            "server predates the host API (the /v1/hosts tunnel route). Check "
+            "the URL and that the server is up to date, then retry."
         )
 
     async def _handle_launch(
@@ -1671,6 +1727,7 @@ class HostProcess:
         # from here on are server restarts, not an unauthenticated host.
         self._ever_connected = True
         self._login_redirect_streak = 0
+        self._transient_404_since = None
         try:
             await self._serve_frames(ws)
         finally:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -2201,7 +2201,7 @@ async def test_connected_host_retries_login_redirects_indefinitely(
     [
         (401, "HTTP 401"),
         (403, "HTTP 403"),
-        (404, "permanent"),
+        (400, "permanent"),
     ],
 )
 async def test_run_fails_loud_on_permanent_4xx(
@@ -2209,9 +2209,12 @@ async def test_run_fails_loud_on_permanent_4xx(
 ) -> None:
     """A permanent 4xx upgrade rejection fails loud on the first attempt.
 
-    401/403/other-4xx mean unauthenticated / unauthorized / wrong-or-old
-    server — reconnecting can never succeed, so run() must raise
-    HostConnectError immediately rather than backing off.
+    401/403/other-4xx (e.g. 400) mean unauthenticated / unauthorized /
+    wrong-or-old server — reconnecting can never succeed, so run() must
+    raise HostConnectError immediately rather than backing off. 404 is
+    deliberately excluded: it is transient during a server restart (a
+    reverse proxy answers 404 while the backend is down) and has its own
+    retry-then-fail-loud tests below.
     """
     spy = _ConnectSpy([_invalid_status(status)])
     _patch_connect(monkeypatch, spy)
@@ -2255,13 +2258,15 @@ async def test_auth_rejection_suggests_omnigent_login(
 async def test_non_auth_permanent_4xx_omits_login_hint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A non-auth permanent 4xx (404) does NOT suggest ``omnigent login``.
+    """A non-auth permanent 4xx (400) does NOT suggest ``omnigent login``.
 
     The login remedy is specific to credential/authorization failures;
-    surfacing it on a 404 ("wrong URL / route missing") would misdirect
-    the user. This pins the hint to the 401/403 paths only.
+    surfacing it on a generic permanent 4xx ("wrong URL / bad request")
+    would misdirect the user. This pins the hint to the 401/403 paths
+    only. (404 is no longer permanent; its own fatal message, asserted in
+    the grace-window test below, likewise omits the login hint.)
     """
-    spy = _ConnectSpy([_invalid_status(404)])
+    spy = _ConnectSpy([_invalid_status(400)])
     _patch_connect(monkeypatch, spy)
     host = _host()
 
@@ -2269,20 +2274,20 @@ async def test_non_auth_permanent_4xx_omits_login_hint(
         await host.run()
 
     message = str(excinfo.value)
-    # Confirm we got the actual 404 fatal message (not some unrelated
+    # Confirm we got the actual 400 fatal message (not some unrelated
     # error that happens to lack "login") before asserting the absence.
-    assert "HTTP 404" in message
+    assert "HTTP 400" in message
     assert "omnigent login" not in message
 
 
-@pytest.mark.parametrize("status", [408, 429, 500, 503])
+@pytest.mark.parametrize("status", [408, 425, 429, 500, 503])
 async def test_run_reconnects_on_transient_upgrade_failure(
     monkeypatch: pytest.MonkeyPatch, status: int
 ) -> None:
     """Transient upgrade failures reconnect instead of failing loud.
 
-    Retryable 4xx (408/429) and any 5xx are transient (server bounce,
-    rate limit) and must stay on the reconnect path. A clean
+    Retryable 4xx (408/425/429) and any 5xx are transient (server
+    bounce, rate limit) and must stay on the reconnect path. A clean
     ``CancelledError`` on the second attempt ends the loop so the test
     terminates; with backoff zeroed the retry is immediate.
     """
@@ -2299,6 +2304,128 @@ async def test_run_reconnects_on_transient_upgrade_failure(
 
     # 2 = transient attempt + cancel attempt → it genuinely reconnected.
     assert spy.call_count == 2
+
+
+async def test_connected_host_rides_out_404_restart_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host that already connected retries 404s indefinitely.
+
+    This is the #2039 fix. A reverse proxy in front of the server answers
+    404 for the tunnel route while the backend container restarts (deploy,
+    config change, nightly backup window). A host that has already
+    completed an upgrade is watching a routine restart — killing it would
+    drop its live runners — so it must ride the 404 window out past the
+    never-connected grace window and reconnect when the backend returns.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    # Tiny grace so a *never-connected* host would fail fast — proving the
+    # indefinite retry here is due to _ever_connected, not a long window.
+    monkeypatch.setattr("omnigent.host.connect._UNCONNECTED_TRANSIENT_404_GRACE_S", 0.0)
+    not_found = _invalid_status(404)
+    # Accepted upgrade first (None), then a burst of 404s (the restart
+    # window), then another accepted upgrade, then a cancel to end.
+    spy = _ConnectSpy([None, not_found, not_found, not_found, None, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    # Returns normally: if the post-connect 404s were misclassified as
+    # fatal this would raise HostConnectError after the first 404 (the
+    # zeroed grace window) instead of reconnecting.
+    await host.run()
+
+    # 6 = accepted connect + 3 ridden-out 404s + reconnect + ending
+    # cancel. Fewer means the host died mid-restart (the #2039 bug).
+    assert spy.call_count == 6
+
+
+async def test_fresh_host_retries_404_within_grace_then_connects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A never-connected host absorbs a transient 404 during startup.
+
+    A host booting while the server is mid-restart may hit a 404 before it
+    ever connects. Within the grace window it must retry rather than fail
+    loud, so a host that starts a few seconds ahead of its server still
+    comes up on its own.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    not_found = _invalid_status(404)
+    # Two 404s inside the (default, generous) grace window, then an
+    # accepted upgrade, then a cancel to end the loop.
+    spy = _ConnectSpy([not_found, not_found, None, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    # Returns normally: the 404s were retried and the accepted upgrade
+    # brought the host up. A raise here would mean a startup-race 404
+    # killed a host that would have connected a beat later.
+    await host.run()
+
+    # 4 = two retried 404s + accepted connect + ending cancel.
+    assert spy.call_count == 4
+
+
+async def test_fresh_host_fails_loud_after_404_grace_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A never-connected host stops retrying 404 once the grace elapses.
+
+    A 404 that never clears on a host that has never connected is a
+    genuinely wrong server URL, or a server too old to expose the tunnel
+    route — not a restart blip. Once the grace window elapses the host
+    must fail loud (→ exit 1 with the cause printed) instead of looping
+    silently forever. The first 404 of the streak is always retried, so a
+    one-off blip is still absorbed even with the window zeroed.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._UNCONNECTED_TRANSIENT_404_GRACE_S", 0.0)
+    # A single queued 404 repeats forever — the streak only ends because
+    # the host gives up after the grace window.
+    spy = _ConnectSpy([_invalid_status(404)])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with pytest.raises(HostConnectError) as excinfo:
+        await host.run()
+
+    message = str(excinfo.value)
+    # The fatal message names the 404 cause and the tunnel route, and —
+    # unlike 401/403 — does NOT suggest `omnigent login` (a 404 is not an
+    # auth failure).
+    assert "HTTP 404" in message
+    assert "host tunnel route" in message
+    assert "omnigent login" not in message
+    # 2 = first 404 always retried + second 404 past the zeroed grace →
+    # fatal. 1 would mean the one-off-blip tolerance regressed; more (or
+    # no raise) would mean the fail-loud threshold is broken.
+    assert spy.call_count == 2
+
+
+async def test_ownership_conflict_409_fails_loud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 409 ownership conflict stays fatal on the first attempt.
+
+    409 means this machine is already registered to a different account
+    (#864/#865): reconnecting can never succeed, so run() must raise
+    HostConnectError immediately with the ownership-conflict remedy rather
+    than retrying. This pins that the 404 change did not disturb the
+    neighbouring 409 handling.
+    """
+    spy = _ConnectSpy([_invalid_status(409)])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with pytest.raises(HostConnectError) as excinfo:
+        await host.run()
+
+    message = str(excinfo.value)
+    assert "HTTP 409" in message
+    assert "already" in message
+    # Exactly one attempt — no silent reconnect/backoff on an ownership
+    # conflict.
+    assert spy.call_count == 1
 
 
 def test_run_host_process_exits_nonzero_on_fatal(


### PR DESCRIPTION
### Summary

`HostProcess`'s 4xx classifier in `omnigent/host/connect.py` treated **any**
non-special-cased 4xx on the tunnel upgrade as a permanent client error:
`HostConnectError` → the reconnect loop re-raises → `run_host_process` exits 1.
But a **404 is routinely transient** when the server sits behind a reverse
proxy — while the server container restarts (upgrade, config change, agent
re-seed bounce) the proxy briefly answers 404 for the tunnel route. A host
that reconnects inside that window read the 404 as "permanent — retrying will
not help" and exited, and because runner subprocesses live in the daemon's
process group / systemd cgroup, **every live runner session on that host was
killed** as collateral. This is issue #2039.

### What changes

Treat a 404 on the tunnel upgrade as transient, with a bound so a genuinely
wrong URL still surfaces:

- **A host that has already completed an upgrade in this process**
  (`_ever_connected`) rides out 404s **indefinitely** — a routine server
  bounce is exactly the lifecycle event the host daemon should absorb, so it
  reconnects when the backend returns instead of dropping its live runners.
- **A host that has never connected** retries 404s only until a grace window
  (`_UNCONNECTED_TRANSIENT_404_GRACE_S`, 180s) elapses, then **fails loud** —
  so a genuinely wrong server URL, or a server too old to expose the tunnel
  route (`/v1/hosts`), still surfaces with a clear message instead of looping
  silently forever. The **first 404 of a streak is always retried**, so a
  one-off startup-race blip is absorbed even with a short window.
- Additionally, **425 (Too Early)** joins 408/429 in
  `_RETRYABLE_UPGRADE_STATUSES` — transient by HTTP semantics regardless of
  connection history.

**401 / 403 / 409 and every other 4xx stay fatal on the first attempt**, so
auth failures, authorization failures, and ownership conflicts
(#864/#865) are unchanged. The 404 fatal message (when the never-connected
grace window is exhausted) names the tunnel route and, unlike 401/403,
deliberately omits the `omnigent login` hint (a 404 is not an auth failure).

This matches the behaviour the issue asks for: "a 404/502/503 during connect
should be retried with backoff for at least a grace window before being
declared permanent." (5xx and the retryable 4xx set were already on the
reconnect path; this PR closes the 404 gap that was doing the damage.)

### Tests

Added to `tests/host/test_connect.py`:

- `test_connected_host_rides_out_404_restart_window` — the #2039 case: a host
  that already connected retries a 404 burst indefinitely (grace window zeroed
  to prove the indefinite retry is due to `_ever_connected`, not a long
  window) and reconnects.
- `test_fresh_host_retries_404_within_grace_then_connects` — a never-connected
  host absorbs transient 404s inside the grace window and comes up.
- `test_fresh_host_fails_loud_after_404_grace_window` — a never-connected host
  stops retrying once the grace elapses and raises with the 404 cause + tunnel
  route, no `omnigent login` hint.
- `test_ownership_conflict_409_fails_loud` — pins that the 404 change did not
  disturb neighbouring 409 handling.

The existing permanent-4xx tests (`test_run_fails_loud_on_permanent_4xx`,
`test_non_auth_permanent_4xx_omits_login_hint`) move their representative
"other 4xx" case off 404 onto 400, since 404 is no longer permanent. The
transient-reconnect parametrize gains 425.

### Verification

**Unit tests** — the full host suite is green on the fix branch:

```
env -u PYTHONPATH .venv/bin/python -m pytest tests/host/
# 216 passed
ruff check  omnigent/host/connect.py tests/host/test_connect.py   # clean
ruff format --check omnigent/host/connect.py tests/host/test_connect.py  # clean
```

> **Scope note (honest):** verification for this PR is **unit-test-level and
> scoped to `tests/host/` plus ruff on the two changed files** — the two new
> host-tunnel tests exercise the connected-rides-out, fresh-within-grace, and
> fresh-past-grace paths directly. The **whole-repo suite was deliberately not
> run** in the session that finalized this branch. The behaviour under test is
> fully contained in the host tunnel 4xx classifier, and no non-host code was
> touched, but reviewers running CI will get the broader signal.

**Live server repro — not performed; blocked, stated plainly.** Our SOP for
reproducing #2039 against a real prod-shape server requires (a) the fix image
deployed to our dev server and (b) **bouncing the server container to open the
404 window**. From our runner host we have **no self-service path to bounce the
nas1 container** (no SSH/docker access; the bounce needs Bobby or a homelab
redeploy). So the before/after live repro described in the issue was **not run
in this session** — we are not claiming it. The unit tests above reproduce the
exact classification bug (a post-connect 404 that previously raised
`HostConnectError`) and its fix at the unit boundary.
