### PR TITLE
feat(db): checksum-based unique indexes for agent and policy names

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 from collections.abc import Iterator
 from contextvars import ContextVar
 
@@ -20,7 +21,25 @@ from sqlalchemy import (
     text,
     true,
 )
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, validates
+
+
+def name_checksum(value: str) -> str:
+    """
+    SHA-256 hex digest of a name, used as the indexed key for
+    columns that would otherwise carry a unique index on raw
+    variable-length text.
+
+    The full 64-char digest is stored (no truncation) so the
+    checksum alone is a reliable unique key — collisions are
+    cryptographically negligible. The input is hashed verbatim
+    (no case-folding or trimming) to preserve the byte-for-byte
+    exact-match semantics of the original text index.
+
+    :param value: The name to hash, e.g. an agent or policy name.
+    :returns: 64-character lowercase hex SHA-256 digest.
+    """
+    return hashlib.sha256(value.encode()).hexdigest()
 
 
 class Base(DeclarativeBase):
@@ -115,11 +134,21 @@ class SqlAgent(Base):
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
     name: Mapped[str] = mapped_column(String(256))
+    # SHA-256 of ``name``, kept in sync by the ``@validates`` hook
+    # below. The template-name unique index is on this checksum
+    # rather than the raw name.
+    name_cksum: Mapped[str] = mapped_column(String(64))
     bundle_location: Mapped[str] = mapped_column(String(512))
     version: Mapped[int] = mapped_column(Integer, default=1)
     kind: Mapped[str] = mapped_column(String(16))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    @validates("name")
+    def _sync_name_cksum(self, _key: str, value: str) -> str:
+        """Derive ``name_cksum`` on every ``name`` assignment."""
+        self.name_cksum = name_checksum(value)
+        return value
 
     __table_args__ = (
         Index("ix_agents_created_at", "created_at"),
@@ -127,8 +156,8 @@ class SqlAgent(Base):
         # may reuse the same name across conversations. The partial index enforces
         # uniqueness only within the template set.
         Index(
-            "ix_agents_template_name",
-            "name",
+            "ix_agents_template_name_cksum",
+            "name_cksum",
             unique=True,
             sqlite_where=text("kind = 'template'"),
             postgresql_where=text("kind = 'template'"),
@@ -776,6 +805,10 @@ class SqlPolicy(Base):
     )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     name: Mapped[str] = mapped_column(String(256))
+    # SHA-256 of ``name``, kept in sync by the ``@validates`` hook
+    # below. The per-session name uniqueness constraint is on this
+    # checksum rather than the raw name.
+    name_cksum: Mapped[str] = mapped_column(String(64))
     # Nullable: NULL for server-wide default policies.
     session_id: Mapped[str | None] = mapped_column(
         String(64),
@@ -799,16 +832,22 @@ class SqlPolicy(Base):
     scope: Mapped[str] = mapped_column(String(16))
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
+    @validates("name")
+    def _sync_name_cksum(self, _key: str, value: str) -> str:
+        """Derive ``name_cksum`` on every ``name`` assignment."""
+        self.name_cksum = name_checksum(value)
+        return value
+
     __table_args__ = (
         Index("ix_policies_created_at", "created_at"),
         Index("ix_policies_session_id", "session_id"),
-        UniqueConstraint("session_id", "name", name="uq_policies_session_id_name"),
+        UniqueConstraint("session_id", "name_cksum", name="uq_policies_session_id_name_cksum"),
         # Default policies must have unique names; session-scoped policies
-        # may reuse the same name across conversations. Mirrors
-        # ix_agents_template_name scoping to the 'default' set.
+        # may reuse the same name across conversations. Checksum-indexed
+        # (rather than the raw ``name``) so no unique index carries text.
         Index(
-            "ix_policies_default_name",
-            "name",
+            "ix_policies_default_name_cksum",
+            "name_cksum",
             unique=True,
             sqlite_where=text("scope = 'default'"),
             postgresql_where=text("scope = 'default'"),

--- a/omnigent/db/migrations/versions/s1a2b3c4d5e6_add_name_cksum_to_agents_and_policies.py
+++ b/omnigent/db/migrations/versions/s1a2b3c4d5e6_add_name_cksum_to_agents_and_policies.py
@@ -1,0 +1,200 @@
+"""add name_cksum to agents and policies
+
+Revision ID: s1a2b3c4d5e6
+Revises: r1a2b3c4d5e6
+Create Date: 2026-07-08 00:00:00.000000
+
+Replaces the text-based unique indexes on ``agents.name`` and
+``policies.name`` with checksum-based ones so no unique index carries
+raw variable-length text.
+
+- Adds ``agents.name_cksum`` and ``policies.name_cksum`` (SHA-256 hex
+  of the name).
+- Backfills both from the existing names in Python — SQLite and
+  Cloudflare D1 have no ``sha256()``/``md5()`` SQL function, so the
+  digest is computed in the migration and written via parameterized
+  ``UPDATE``s. The digest here is inlined (not imported from the app)
+  so the backfill stays frozen if the app-side helper ever changes;
+  both must produce an identical value.
+- Swaps the agents template-name index off ``name`` (``ix_agents_template_name``,
+  partial unique where ``kind = 'template'``) onto ``name_cksum``
+  (``ix_agents_template_name_cksum``, same predicate).
+- Swaps both policy name indexes onto ``name_cksum``:
+  ``uq_policies_session_id_name`` -> ``uq_policies_session_id_name_cksum``
+  on ``(session_id, name_cksum)``, and the default-name partial unique
+  ``ix_policies_default_name`` (where ``scope = 'default'``) ->
+  ``ix_policies_default_name_cksum``.
+
+The name uniqueness scope is unchanged: the preceding ``workspace_id``
+migration widened every primary key to ``(workspace_id, id)`` but left
+these unique indexes global, so the checksum indexes mirror that exactly
+(no ``workspace_id`` column in the index).
+
+The checksum columns are backfilled while nullable, then flipped to
+NOT NULL. No new uniqueness violation is possible: the pre-existing
+name indexes already forbade the duplicates that would collide on the
+checksum.
+
+SQLite note: ``batch_alter_table`` rebuilds the table. Earlier
+migrations in a combined downgrade walk restore the
+``conversations.agent_id`` CASCADE FK, so FK enforcement is disabled
+around the batch ops here — matching the convention of the adjacent
+migrations — to avoid cascade-deleting bound conversations during a
+rebuild.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "s1a2b3c4d5e6"
+down_revision: str | None = "r1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    """Whether the bound dialect is SQLite (incl. Cloudflare D1)."""
+    return op.get_bind().dialect.name in ("sqlite", "cloudflare_d1")
+
+
+def _backfill_name_cksum(table: str) -> None:
+    """
+    Populate ``{table}.name_cksum`` from ``{table}.name`` in Python.
+
+    :param table: ``"agents"`` or ``"policies"``.
+    """
+    bind = op.get_bind()
+    rows = bind.execute(sa.text(f"SELECT id, name FROM {table}")).mappings().all()
+    for row in rows:
+        bind.execute(
+            sa.text(f"UPDATE {table} SET name_cksum = :cksum WHERE id = :id"),
+            {
+                "cksum": hashlib.sha256(row["name"].encode()).hexdigest(),
+                "id": row["id"],
+            },
+        )
+    remaining = bind.execute(
+        sa.text(f"SELECT COUNT(*) FROM {table} WHERE name_cksum IS NULL")
+    ).scalar()
+    if remaining and remaining > 0:
+        raise RuntimeError(f"{table}.name_cksum backfill incomplete: {remaining} rows still NULL")
+
+
+def upgrade() -> None:
+    # On SQLite, batch_alter_table drops and recreates the table. The
+    # conversations.agent_id -> agents ON DELETE CASCADE FK (restored by
+    # earlier downgrades in a combined walk) would fire during the rebuild
+    # and wipe bound conversations, so FK enforcement is disabled around
+    # the batch ops — matching the convention of the adjacent migrations.
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    # Add the checksum columns nullable so existing rows can be
+    # backfilled before the NOT NULL constraint is enforced.
+    with op.batch_alter_table("agents") as batch_op:
+        batch_op.add_column(sa.Column("name_cksum", sa.String(length=64), nullable=True))
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.add_column(sa.Column("name_cksum", sa.String(length=64), nullable=True))
+
+    _backfill_name_cksum("agents")
+    _backfill_name_cksum("policies")
+
+    # agents: enforce NOT NULL, then swap the partial unique index off
+    # ``name`` and onto ``name_cksum`` (same ``kind = 'template'``
+    # predicate). Index ops run on the bare op (SQLite executes
+    # CREATE/DROP INDEX natively); only the NOT NULL flip needs batch mode.
+    op.drop_index("ix_agents_template_name", table_name="agents")
+    with op.batch_alter_table("agents") as batch_op:
+        batch_op.alter_column(
+            "name_cksum",
+            existing_type=sa.String(length=64),
+            nullable=False,
+        )
+    op.create_index(
+        "ix_agents_template_name_cksum",
+        "agents",
+        ["name_cksum"],
+        unique=True,
+        sqlite_where=sa.text("kind = 'template'"),
+        postgresql_where=sa.text("kind = 'template'"),
+    )
+
+    # policies: enforce NOT NULL, then swap both name indexes onto
+    # ``name_cksum`` — the composite session-uniqueness constraint and
+    # the default-name partial unique index. The default-name index runs
+    # on the bare op; the composite-constraint swap and NOT NULL flip
+    # need batch mode.
+    op.drop_index("ix_policies_default_name", table_name="policies")
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.alter_column(
+            "name_cksum",
+            existing_type=sa.String(length=64),
+            nullable=False,
+        )
+        batch_op.drop_constraint("uq_policies_session_id_name", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_policies_session_id_name_cksum",
+            ["session_id", "name_cksum"],
+        )
+    op.create_index(
+        "ix_policies_default_name_cksum",
+        "policies",
+        ["name_cksum"],
+        unique=True,
+        sqlite_where=sa.text("scope = 'default'"),
+        postgresql_where=sa.text("scope = 'default'"),
+    )
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def downgrade() -> None:
+    # See upgrade(): disable FK enforcement around the SQLite batch
+    # rebuilds so the conversations.agent_id CASCADE doesn't delete bound
+    # conversations when this runs as part of a combined downgrade walk.
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    # policies: restore the name-based default index and composite
+    # constraint, and drop the checksum column.
+    op.drop_index("ix_policies_default_name_cksum", table_name="policies")
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.drop_constraint("uq_policies_session_id_name_cksum", type_="unique")
+        batch_op.drop_column("name_cksum")
+        batch_op.create_unique_constraint(
+            "uq_policies_session_id_name",
+            ["session_id", "name"],
+        )
+    op.create_index(
+        "ix_policies_default_name",
+        "policies",
+        ["name"],
+        unique=True,
+        sqlite_where=sa.text("scope = 'default'"),
+        postgresql_where=sa.text("scope = 'default'"),
+    )
+
+    # agents: drop the checksum index and column, then recreate the
+    # original partial unique index on ``name`` (kind = 'template').
+    op.drop_index("ix_agents_template_name_cksum", table_name="agents")
+    with op.batch_alter_table("agents") as batch_op:
+        batch_op.drop_column("name_cksum")
+    op.create_index(
+        "ix_agents_template_name",
+        "agents",
+        ["name"],
+        unique=True,
+        sqlite_where=sa.text("kind = 'template'"),
+        postgresql_where=sa.text("kind = 'template'"),
+    )
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -11,6 +11,7 @@ from omnigent.db.db_models import (
     SqlAgent,
     SqlConversation,
     current_workspace_id,
+    name_checksum,
 )
 from omnigent.db.utils import (
     get_or_create_engine,
@@ -113,9 +114,13 @@ class SqlAlchemyAgentStore(AgentStore):
         :returns: The :class:`Agent` if found, otherwise ``None``.
         """
         with self._session() as session:
+            # Filter on the checksum so the query uses the
+            # ``ix_agents_template_name_cksum`` unique index; the raw
+            # ``name`` predicate guards against a hash collision.
             row = session.execute(
                 select(SqlAgent).where(
                     SqlAgent.workspace_id == current_workspace_id(),
+                    SqlAgent.name_cksum == name_checksum(name),
                     SqlAgent.name == name,
                     SqlAgent.kind == AGENT_KIND_TEMPLATE,
                 )

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -36,6 +36,7 @@ from omnigent.db.db_models import (
     SqlSessionPermission,
     SqlUserDailyCost,
     current_workspace_id,
+    name_checksum,
 )
 from omnigent.db.utils import (
     _supports_fts5,
@@ -1731,8 +1732,11 @@ class SqlAlchemyConversationStore(ConversationStore):
             if not include_archived:
                 stmt = stmt.where(SqlConversation.archived.is_(False))
             if agent_name is not None:
+                # Match on the checksum (backed by the template-name
+                # unique index) with the raw name as a collision guard.
                 stmt = stmt.join(SqlAgent, SqlAgent.id == SqlConversation.agent_id).where(
                     SqlAgent.workspace_id == current_workspace_id(),
+                    SqlAgent.name_cksum == name_checksum(agent_name),
                     SqlAgent.name == agent_name,
                 )
             if agent_id is not None:

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -13,6 +13,7 @@ from omnigent.db.db_models import (
     POLICY_SCOPE_SESSION,
     SqlPolicy,
     current_workspace_id,
+    name_checksum,
 )
 from omnigent.db.utils import (
     get_or_create_engine,
@@ -206,6 +207,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
                     select(SqlPolicy)
                     .where(SqlPolicy.workspace_id == current_workspace_id())
                     .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
+                    .where(SqlPolicy.name_cksum == name_checksum(name))
                     .where(SqlPolicy.name == name)
                 )
                 .scalars()
@@ -260,13 +262,14 @@ class SqlAlchemyPolicyStore(PolicyStore):
             changed = False
             if name is not None and row.name != name:
                 # Explicit uniqueness check for the application layer;
-                # the partial index ix_policies_default_name is the
+                # the partial index ix_policies_default_name_cksum is the
                 # DB-layer guard, but checking here gives a cleaner error.
                 conflict = (
                     session.execute(
                         select(SqlPolicy)
                         .where(SqlPolicy.workspace_id == current_workspace_id())
                         .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
+                        .where(SqlPolicy.name_cksum == name_checksum(name))
                         .where(SqlPolicy.name == name)
                         .where(SqlPolicy.id != policy_id)
                     )

--- a/tests/db/test_migration_agents_session_id.py
+++ b/tests/db/test_migration_agents_session_id.py
@@ -11,6 +11,7 @@ from alembic import command
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 
+from omnigent.db.db_models import name_checksum
 from omnigent.db.utils import (
     _build_alembic_config,
     clear_engine_cache,
@@ -56,10 +57,11 @@ def test_ix_conversations_agent_id_added(db_engine: Engine) -> None:
 
 
 def test_agents_name_unique_index_exists(db_engine: Engine) -> None:
-    """ix_agents_template_name unique index must still exist."""
+    """The template-name unique index is on name_cksum at head."""
     indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("agents")}
-    assert "ix_agents_template_name" in indexes
-    assert indexes["ix_agents_template_name"]["unique"]
+    assert "ix_agents_template_name" not in indexes
+    assert "ix_agents_template_name_cksum" in indexes
+    assert indexes["ix_agents_template_name_cksum"]["unique"]
 
 
 def test_template_agent_kind_stored_and_read(db_engine: Engine) -> None:
@@ -67,10 +69,17 @@ def test_template_agent_kind_stored_and_read(db_engine: Engine) -> None:
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
-                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES (:id, :ts, :name, :loc, 1, 'template')"
+                "INSERT INTO agents"
+                " (id, created_at, name, name_cksum, bundle_location, version, kind)"
+                " VALUES (:id, :ts, :name, :cksum, :loc, 1, 'template')"
             ),
-            {"id": "ag_tmpl", "ts": 1700000001, "name": "my-template", "loc": "ag_tmpl/bundle"},
+            {
+                "id": "ag_tmpl",
+                "ts": 1700000001,
+                "name": "my-template",
+                "cksum": name_checksum("my-template"),
+                "loc": "ag_tmpl/bundle",
+            },
         )
         kind = conn.execute(
             sa.text("SELECT kind FROM agents WHERE id = :id"), {"id": "ag_tmpl"}
@@ -83,10 +92,17 @@ def test_session_agent_kind_stored_and_read(db_engine: Engine) -> None:
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
-                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES (:id, :ts, :name, :loc, 1, 'session')"
+                "INSERT INTO agents"
+                " (id, created_at, name, name_cksum, bundle_location, version, kind)"
+                " VALUES (:id, :ts, :name, :cksum, :loc, 1, 'session')"
             ),
-            {"id": "ag_sess", "ts": 1700000001, "name": "my-session", "loc": "ag_sess/bundle"},
+            {
+                "id": "ag_sess",
+                "ts": 1700000001,
+                "name": "my-session",
+                "cksum": name_checksum("my-session"),
+                "loc": "ag_sess/bundle",
+            },
         )
         kind = conn.execute(
             sa.text("SELECT kind FROM agents WHERE id = :id"), {"id": "ag_sess"}
@@ -99,10 +115,17 @@ def test_agents_session_id_fk_accepts_existing_session(db_engine: Engine) -> Non
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
-                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES (:id, :ts, :name, :loc, 1, 'session')"
+                "INSERT INTO agents"
+                " (id, created_at, name, name_cksum, bundle_location, version, kind)"
+                " VALUES (:id, :ts, :name, :cksum, :loc, 1, 'session')"
             ),
-            {"id": "ag_bound", "ts": 1700000001, "name": "bound-agent", "loc": "ag_bound/bundle"},
+            {
+                "id": "ag_bound",
+                "ts": 1700000001,
+                "name": "bound-agent",
+                "cksum": name_checksum("bound-agent"),
+                "loc": "ag_bound/bundle",
+            },
         )
         conn.execute(
             sa.text(
@@ -147,14 +170,16 @@ def test_agents_template_name_unique_index_rejects_duplicate_template(
         with db_engine.begin() as conn:
             conn.execute(
                 sa.text(
-                    "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                    " VALUES (:id1, :ts, 'dup-template', :loc1, 1, 'template'),"
-                    "        (:id2, :ts, 'dup-template', :loc2, 1, 'template')"
+                    "INSERT INTO agents"
+                    " (id, created_at, name, name_cksum, bundle_location, version, kind)"
+                    " VALUES (:id1, :ts, 'dup-template', :cksum, :loc1, 1, 'template'),"
+                    "        (:id2, :ts, 'dup-template', :cksum, :loc2, 1, 'template')"
                 ),
                 {
                     "id1": "ag_dup1",
                     "id2": "ag_dup2",
                     "ts": 1700000001,
+                    "cksum": name_checksum("dup-template"),
                     "loc1": "ag_dup1/bundle",
                     "loc2": "ag_dup2/bundle",
                 },
@@ -168,14 +193,16 @@ def test_agents_session_id_allows_duplicate_names_for_distinct_sessions(
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
-                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES (:id1, :ts, 'shared-name', :loc1, 1, 'session'),"
-                "        (:id2, :ts, 'shared-name', :loc2, 1, 'session')"
+                "INSERT INTO agents"
+                " (id, created_at, name, name_cksum, bundle_location, version, kind)"
+                " VALUES (:id1, :ts, 'shared-name', :cksum, :loc1, 1, 'session'),"
+                "        (:id2, :ts, 'shared-name', :cksum, :loc2, 1, 'session')"
             ),
             {
                 "id1": "ag_s1",
                 "id2": "ag_s2",
                 "ts": 1700000001,
+                "cksum": name_checksum("shared-name"),
                 "loc1": "ag_s1/bundle",
                 "loc2": "ag_s2/bundle",
             },
@@ -255,10 +282,15 @@ def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
     with engine.begin() as conn:
         conn.execute(
             sa.text(
-                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES ('ag_tmpl', 1, 'my-template', 'ag_tmpl/b', 1, 'template'),"
-                "        ('ag_sess', 2, 'my-session', 'ag_sess/b', 1, 'session')"
-            )
+                "INSERT INTO agents"
+                " (id, created_at, name, name_cksum, bundle_location, version, kind)"
+                " VALUES ('ag_tmpl', 1, 'my-template', :tmpl_cksum, 'ag_tmpl/b', 1, 'template'),"
+                "        ('ag_sess', 2, 'my-session', :sess_cksum, 'ag_sess/b', 1, 'session')"
+            ),
+            {
+                "tmpl_cksum": name_checksum("my-template"),
+                "sess_cksum": name_checksum("my-session"),
+            },
         )
         conn.execute(
             sa.text(

--- a/tests/db/test_migration_name_cksum.py
+++ b/tests/db/test_migration_name_cksum.py
@@ -1,0 +1,297 @@
+"""Tests for the ``name_cksum`` migration on agents and policies."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+
+from omnigent.db.db_models import name_checksum
+from omnigent.db.utils import _build_alembic_config
+
+# The revision immediately before name_cksum was introduced, and the
+# name_cksum migration itself.
+_PRE_REVISION = "r1a2b3c4d5e6"
+_CKSUM_REVISION = "s1a2b3c4d5e6"
+
+
+def _new_engine(uri: str) -> sa.Engine:
+    """
+    Create a raw migration-test engine without auto-upgrading to head.
+
+    :param uri: SQLAlchemy database URI.
+    :returns: SQLAlchemy engine with SQLite foreign keys enabled.
+    """
+    engine = sa.create_engine(uri)
+    with engine.connect() as conn:
+        conn.execute(sa.text("PRAGMA foreign_keys=ON"))
+    return engine
+
+
+def _upgrade(engine: sa.Engine, uri: str, revision: str) -> None:
+    """Run Alembic upgrade to *revision* on a raw engine."""
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, revision)
+
+
+def _downgrade(engine: sa.Engine, uri: str, revision: str) -> None:
+    """Run Alembic downgrade to *revision* on a raw engine."""
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, revision)
+
+
+def _insert_agent(
+    conn: sa.Connection,
+    *,
+    agent_id: str,
+    name: str,
+    kind: str = "template",
+    name_cksum: str | None = None,
+) -> None:
+    """Insert an ``agents`` row, optionally supplying ``name_cksum``."""
+    if name_cksum is None:
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind) "
+                "VALUES (:id, :ts, :name, :loc, 1, :kind)"
+            ),
+            {
+                "id": agent_id,
+                "ts": 1700000000,
+                "name": name,
+                "loc": f"{agent_id}/bundle",
+                "kind": kind,
+            },
+        )
+    else:
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents "
+                "(id, created_at, name, name_cksum, bundle_location, version, kind) "
+                "VALUES (:id, :ts, :name, :cksum, :loc, 1, :kind)"
+            ),
+            {
+                "id": agent_id,
+                "ts": 1700000000,
+                "name": name,
+                "cksum": name_cksum,
+                "loc": f"{agent_id}/bundle",
+                "kind": kind,
+            },
+        )
+
+
+def _insert_policy(
+    conn: sa.Connection,
+    *,
+    policy_id: str,
+    name: str,
+    session_id: str | None = None,
+    name_cksum: str | None = None,
+) -> None:
+    """Insert a ``policies`` row, optionally supplying ``name_cksum``.
+
+    ``scope`` is derived from ``session_id`` (NULL -> ``default``).
+    """
+    scope = "session" if session_id is not None else "default"
+    if name_cksum is None:
+        conn.execute(
+            sa.text(
+                "INSERT INTO policies (id, name, session_id, scope, created_at, type, handler) "
+                "VALUES (:id, :name, :session_id, :scope, :ts, 'python', 'pkg.handler')"
+            ),
+            {
+                "id": policy_id,
+                "name": name,
+                "session_id": session_id,
+                "scope": scope,
+                "ts": 1700000000,
+            },
+        )
+    else:
+        conn.execute(
+            sa.text(
+                "INSERT INTO policies "
+                "(id, name, name_cksum, session_id, scope, created_at, type, handler) "
+                "VALUES (:id, :name, :cksum, :session_id, :scope, :ts, 'python', 'pkg.handler')"
+            ),
+            {
+                "id": policy_id,
+                "name": name,
+                "cksum": name_cksum,
+                "session_id": session_id,
+                "scope": scope,
+                "ts": 1700000000,
+            },
+        )
+
+
+def test_name_cksum_backfill_populates_agents_and_policies(tmp_path: Path) -> None:
+    """Upgrade backfills name_cksum = sha256(name) for every existing row."""
+    uri = f"sqlite:///{tmp_path / 'backfill.db'}"
+    engine = _new_engine(uri)
+    try:
+        _upgrade(engine, uri, _PRE_REVISION)
+        with engine.begin() as conn:
+            _insert_agent(conn, agent_id="ag_a", name="code-assistant")
+            _insert_agent(conn, agent_id="ag_b", name="researcher")
+            # A default policy (session_id IS NULL) plus a session-scoped one.
+            _insert_policy(conn, policy_id="pol_default", name="baseline")
+            _insert_policy(conn, policy_id="pol_scoped", name="baseline", session_id="conv_p")
+
+        _upgrade(engine, uri, _CKSUM_REVISION)
+
+        with engine.connect() as conn:
+            agents = {
+                str(r["name"]): str(r["name_cksum"])
+                for r in conn.execute(sa.text("SELECT name, name_cksum FROM agents")).mappings()
+            }
+            policies = {
+                str(r["id"]): (str(r["name"]), str(r["name_cksum"]))
+                for r in conn.execute(
+                    sa.text("SELECT id, name, name_cksum FROM policies")
+                ).mappings()
+            }
+        assert agents == {
+            "code-assistant": name_checksum("code-assistant"),
+            "researcher": name_checksum("researcher"),
+        }
+        # The migration's inlined digest must match the app-side helper.
+        assert agents["researcher"] == hashlib.sha256(b"researcher").hexdigest()
+        for _pid, (name, cksum) in policies.items():
+            assert cksum == name_checksum(name)
+    finally:
+        engine.dispose()
+
+
+def test_name_cksum_indexes_are_swapped(tmp_path: Path) -> None:
+    """The unique indexes move from the name columns to the cksum columns."""
+    uri = f"sqlite:///{tmp_path / 'indexes.db'}"
+    engine = _new_engine(uri)
+    try:
+        _upgrade(engine, uri, _CKSUM_REVISION)
+        inspector = sa.inspect(engine)
+
+        agent_indexes = {idx["name"]: idx for idx in inspector.get_indexes("agents")}
+        assert "ix_agents_template_name" not in agent_indexes
+        assert "ix_agents_template_name_cksum" in agent_indexes
+        assert bool(agent_indexes["ix_agents_template_name_cksum"]["unique"]) is True
+        assert agent_indexes["ix_agents_template_name_cksum"]["column_names"] == ["name_cksum"]
+
+        policy_uniques = {uc["name"]: uc for uc in inspector.get_unique_constraints("policies")}
+        assert "uq_policies_session_id_name" not in policy_uniques
+        assert "uq_policies_session_id_name_cksum" in policy_uniques
+        assert policy_uniques["uq_policies_session_id_name_cksum"]["column_names"] == [
+            "session_id",
+            "name_cksum",
+        ]
+
+        policy_indexes = {idx["name"]: idx for idx in inspector.get_indexes("policies")}
+        assert "ix_policies_default_name" not in policy_indexes
+        assert "ix_policies_default_name_cksum" in policy_indexes
+        assert bool(policy_indexes["ix_policies_default_name_cksum"]["unique"]) is True
+        assert policy_indexes["ix_policies_default_name_cksum"]["column_names"] == ["name_cksum"]
+    finally:
+        engine.dispose()
+
+
+def test_template_name_cksum_rejects_duplicate(tmp_path: Path) -> None:
+    """Two template agents (kind='template') can't share a name."""
+    uri = f"sqlite:///{tmp_path / 'dup-agent.db'}"
+    engine = _new_engine(uri)
+    try:
+        _upgrade(engine, uri, _CKSUM_REVISION)
+        cksum = name_checksum("dup-name")
+        with pytest.raises(sa.exc.IntegrityError):
+            with engine.begin() as conn:
+                _insert_agent(conn, agent_id="ag_1", name="dup-name", name_cksum=cksum)
+                _insert_agent(conn, agent_id="ag_2", name="dup-name", name_cksum=cksum)
+    finally:
+        engine.dispose()
+
+
+def test_session_kind_agents_may_reuse_name(tmp_path: Path) -> None:
+    """Session-scoped agents (kind='session') are not covered by the template index."""
+    uri = f"sqlite:///{tmp_path / 'reuse-agent.db'}"
+    engine = _new_engine(uri)
+    try:
+        _upgrade(engine, uri, _CKSUM_REVISION)
+        cksum = name_checksum("shared")
+        with engine.begin() as conn:
+            _insert_agent(conn, agent_id="ag_s1", name="shared", kind="session", name_cksum=cksum)
+            _insert_agent(conn, agent_id="ag_s2", name="shared", kind="session", name_cksum=cksum)
+        with engine.connect() as conn:
+            count = conn.execute(
+                sa.text("SELECT COUNT(*) FROM agents WHERE name = 'shared'")
+            ).scalar()
+        assert count == 2
+    finally:
+        engine.dispose()
+
+
+def test_policy_name_cksum_uniqueness_per_session(tmp_path: Path) -> None:
+    """Two policies in one session can't share a name (via the cksum key)."""
+    uri = f"sqlite:///{tmp_path / 'dup-policy.db'}"
+    engine = _new_engine(uri)
+    try:
+        _upgrade(engine, uri, _CKSUM_REVISION)
+        cksum = name_checksum("guardrail")
+        with pytest.raises(sa.exc.IntegrityError):
+            with engine.begin() as conn:
+                _insert_policy(
+                    conn,
+                    policy_id="pol_1",
+                    name="guardrail",
+                    session_id="conv_dup",
+                    name_cksum=cksum,
+                )
+                _insert_policy(
+                    conn,
+                    policy_id="pol_2",
+                    name="guardrail",
+                    session_id="conv_dup",
+                    name_cksum=cksum,
+                )
+    finally:
+        engine.dispose()
+
+
+def test_name_cksum_downgrade_round_trips(tmp_path: Path) -> None:
+    """Downgrade drops the cksum columns and restores the name indexes."""
+    uri = f"sqlite:///{tmp_path / 'downgrade.db'}"
+    engine = _new_engine(uri)
+    try:
+        _upgrade(engine, uri, _PRE_REVISION)
+        with engine.begin() as conn:
+            _insert_agent(conn, agent_id="ag_d", name="code-assistant")
+            _insert_policy(conn, policy_id="pol_d", name="baseline")
+        _upgrade(engine, uri, _CKSUM_REVISION)
+
+        _downgrade(engine, uri, _PRE_REVISION)
+
+        inspector = sa.inspect(engine)
+        agent_cols = {c["name"] for c in inspector.get_columns("agents")}
+        policy_cols = {c["name"] for c in inspector.get_columns("policies")}
+        assert "name_cksum" not in agent_cols
+        assert "name_cksum" not in policy_cols
+
+        agent_indexes = {idx["name"] for idx in inspector.get_indexes("agents")}
+        assert "ix_agents_template_name" in agent_indexes
+        assert "ix_agents_template_name_cksum" not in agent_indexes
+
+        policy_uniques = {uc["name"] for uc in inspector.get_unique_constraints("policies")}
+        assert "uq_policies_session_id_name" in policy_uniques
+        assert "uq_policies_session_id_name_cksum" not in policy_uniques
+
+        policy_indexes = {idx["name"] for idx in inspector.get_indexes("policies")}
+        assert "ix_policies_default_name" in policy_indexes
+        assert "ix_policies_default_name_cksum" not in policy_indexes
+    finally:
+        engine.dispose()

--- a/tests/db/test_migration_policy_scope.py
+++ b/tests/db/test_migration_policy_scope.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 from alembic import command
 from sqlalchemy.engine import Engine
 
+from omnigent.db.db_models import name_checksum
 from omnigent.db.utils import (
     _build_alembic_config,
     clear_engine_cache,
@@ -37,10 +38,13 @@ def test_scope_column_exists_and_is_not_nullable(db_engine: Engine) -> None:
 
 
 def test_ix_policies_default_name_index_exists(db_engine: Engine) -> None:
-    """ix_policies_default_name unique index is present after the migration."""
+    """The default-name unique index is on name_cksum at head."""
     indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("policies")}
-    assert "ix_policies_default_name" in indexes
-    assert indexes["ix_policies_default_name"]["unique"]
+    # The name_cksum migration (r1a2b3c4d5e6) swaps this partial unique
+    # index off the raw name onto the checksum column.
+    assert "ix_policies_default_name" not in indexes
+    assert "ix_policies_default_name_cksum" in indexes
+    assert indexes["ix_policies_default_name_cksum"]["unique"]
 
 
 def test_backfill_sets_session_scope_for_session_policies(db_engine: Engine) -> None:
@@ -56,9 +60,11 @@ def test_backfill_sets_session_scope_for_session_policies(db_engine: Engine) -> 
         conn.execute(
             sa.text(
                 "INSERT INTO policies"
-                " (id, name, session_id, scope, created_at, type, handler, enabled)"
-                " VALUES ('pol_sc1', 'sess_pol', 'conv_sc1', 'session', 1, 'python', 'mod.f', 1)"
-            )
+                " (id, name, name_cksum, session_id, scope, created_at, type, handler, enabled)"
+                " VALUES ('pol_sc1', 'sess_pol', :cksum, 'conv_sc1', 'session', 1,"
+                " 'python', 'mod.f', 1)"
+            ),
+            {"cksum": name_checksum("sess_pol")},
         )
         scope = conn.execute(
             sa.text("SELECT scope FROM policies WHERE id = 'pol_sc1'")
@@ -72,9 +78,11 @@ def test_backfill_sets_default_scope_for_default_policies(db_engine: Engine) -> 
         conn.execute(
             sa.text(
                 "INSERT INTO policies"
-                " (id, name, session_id, scope, created_at, type, handler, enabled)"
-                " VALUES ('pol_def1', 'def_pol', NULL, 'default', 1, 'python', 'mod.f', 1)"
-            )
+                " (id, name, name_cksum, session_id, scope, created_at, type, handler, enabled)"
+                " VALUES ('pol_def1', 'def_pol', :cksum, NULL, 'default', 1,"
+                " 'python', 'mod.f', 1)"
+            ),
+            {"cksum": name_checksum("def_pol")},
         )
         scope = conn.execute(
             sa.text("SELECT scope FROM policies WHERE id = 'pol_def1'")

--- a/tests/db/test_migration_workspace_id.py
+++ b/tests/db/test_migration_workspace_id.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from alembic import command
 from sqlalchemy.engine import Engine
 
-from omnigent.db.db_models import DEFAULT_WORKSPACE_ID
+from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, name_checksum
 from omnigent.db.utils import (
     _build_alembic_config,
     clear_engine_cache,
@@ -69,9 +69,10 @@ def test_existing_rows_and_omitted_inserts_default_to_zero(db_engine: Engine) ->
         conn.execute(
             sa.text(
                 "INSERT INTO agents"
-                " (id, created_at, name, bundle_location, version, kind)"
-                " VALUES ('ag_ws', 1, 'n', 'loc', 1, 'template')"
-            )
+                " (id, created_at, name, name_cksum, bundle_location, version, kind)"
+                " VALUES ('ag_ws', 1, 'n', :cksum, 'loc', 1, 'template')"
+            ),
+            {"cksum": name_checksum("n")},
         )
         workspace_id = conn.execute(
             sa.text("SELECT workspace_id FROM agents WHERE id = 'ag_ws'")

--- a/tests/stores/test_agent_store.py
+++ b/tests/stores/test_agent_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlalchemy as sa
 
+from omnigent.db.db_models import name_checksum
 from omnigent.db.utils import get_or_create_engine
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 
@@ -53,13 +54,14 @@ def test_get_by_name_and_list_hide_session_scoped_agents(
         conn.execute(
             sa.text(
                 "INSERT INTO agents "
-                "(id, created_at, name, bundle_location, version, kind) "
-                "VALUES (:id, :ts, :name, :loc, 1, 'session')",
+                "(id, created_at, name, name_cksum, bundle_location, version, kind) "
+                "VALUES (:id, :ts, :name, :cksum, :loc, 1, 'session')",
             ),
             {
                 "id": "ag_agent_store_session",
                 "ts": 1700000001,
                 "name": "session-only-agent",
+                "cksum": name_checksum("session-only-agent"),
                 "loc": "ag_agent_store_session/bundle",
             },
         )


### PR DESCRIPTION
## Related issue

N/A

## Summary

Replaces the text-based unique indexes on `agents.name` and `policies.name` with checksum-based ones, so no unique index carries raw variable-length text.

- Adds `name_cksum` (`String(64)`, full SHA-256 hex) to `agents` and `policies`, kept in sync by a SQLAlchemy `@validates("name")` hook so every ORM write populates it (no write path can silently skip it).
- Moves **all three** name unique indexes onto the checksum, each keeping its exact predicate/scope:
  - `ix_agents_template_name` → `ix_agents_template_name_cksum` (partial, `kind = 'template'`)
  - `uq_policies_session_id_name` → `uq_policies_session_id_name_cksum` on `(session_id, name_cksum)`
  - `ix_policies_default_name` → `ix_policies_default_name_cksum` (partial, `scope = 'default'`)
- Exact-match lookups (`agent_store.get_by_name`, the two default-policy name checks, the conversation-store `agent_name` join filter) now filter on `name_cksum == name_checksum(name)` so the new index serves the read, with the raw `name ==` retained as a collision guard.
- Backfill is computed in **Python** (`hashlib`), not SQL — SQLite and Cloudflare D1 have no `sha256()`/`md5()` function. The migration inlines the digest so it stays frozen if the app-side helper ever changes.

Uniqueness scope is unchanged. The recently-landed `workspace_id` migration (#2138) widened every primary key to `(workspace_id, id)` but left these name indexes **global** (not workspace-scoped), so the checksum indexes mirror that exactly — no `workspace_id` in the index. The store lookups still combine the existing `workspace_id == current_workspace_id()` filter with the new checksum predicate.

Scope note: `conversations.title` (the third column in the original ask) is intentionally **not** included. Its only SQL query is a `LIKE` substring search a checksum can't serve, it's a dual-role display label + parsed sub-agent key, and there's a runtime `IntegrityError` string-match on the index name — it needs separate, more delicate handling and will be a follow-up.

### ELI5

A unique index over a text column stores the whole string as the key. Instead we store a fixed-size fingerprint (SHA-256) of the name and make *that* unique. Two names are "the same" iff their fingerprints match, so uniqueness and exact lookups still work — the index just never holds raw text.

```
write:  name="researcher" --(@validates)--> name_cksum=sha256("researcher")
                                                    │
                                          UNIQUE index lives here
read:   get_by_name("researcher")
          WHERE workspace_id = current_workspace_id()   ← workspace scope (unchanged)
            AND name_cksum   = sha256("researcher")     ← index-backed
            AND name         = "researcher"             ← collision guard
```

## Test Plan

- New `tests/db/test_migration_name_cksum.py`: backfill correctness (`name_cksum == sha256(name)` for agents + policies, incl. a default and a session-scoped policy), swap of all three indexes via reflection, template-name uniqueness rejection, session-kind reuse allowed, per-session policy-name uniqueness, and a full upgrade→downgrade round-trip.
- Updated `test_migration_agents_session_id.py`, `test_migration_policy_scope.py`, `test_migration_workspace_id.py`, and `test_agent_store.py` where raw-SQL inserts (which bypass the ORM `@validates` hook) must now supply `name_cksum`.
- `pytest` across the DB migration suite (name_cksum, workspace_id, policy_scope, agents_session_id, sqlite-safe chain guard), `tests/db/test_workspace_scope.py`, the agent/policy store suites, `test_default_policy_routes.py`, and the model/converter tests — **all pass** (361 in the broad run), including the full-chain upgrade→downgrade→upgrade round-trip. Direct-construction and route CRUD tests pass unchanged, confirming the `@validates` hook auto-populates the column.
- Fresh-DB smoke test: full chain (incl. `workspace_id`) runs to head; PK is `(workspace_id, id)`; all three name indexes are on `name_cksum`; duplicate template + default names rejected via the cksum indexes; `get_by_name` resolves through the cksum path.
- `pre-commit run --files ...` clean.

## Demo

N/A — schema/backend change, no UI surface.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was a fresh-DB smoke test through the store API (create two same-named template agents → second rejected by the cksum unique index; create two same-named default policies → second rejected; `get_by_name` resolves via the checksum path; PK widened to `(workspace_id, id)`). Automated coverage is the new migration test plus the existing store/route/model suites, which exercise the rewritten lookups and the `@validates` hook end-to-end.
