### PR TITLE
feat(web): select an existing git worktree when starting a session

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -36,6 +36,8 @@ from omnigent.host.frames import (
     HostListDirEntry,
     HostListDirFrame,
     HostListDirResultFrame,
+    HostListWorktreesFrame,
+    HostListWorktreesResultFrame,
     HostRemoveWorktreeFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
@@ -49,6 +51,7 @@ from omnigent.host.frames import (
 from omnigent.host.git_worktree import (
     WorktreeError,
     create_worktree,
+    list_worktrees,
     remove_worktree,
 )
 from omnigent.host.identity import HostIdentity, load_or_create_host_identity
@@ -1522,6 +1525,47 @@ class HostProcess:
             status="ok",
         )
 
+    async def _handle_list_worktrees(
+        self,
+        frame: HostListWorktreesFrame,
+    ) -> HostListWorktreesResultFrame:
+        """Handle a ``host.list_worktrees`` request from the server.
+
+        Runs the blocking git work in a worker thread so the tunnel
+        loop keeps servicing pings.
+
+        :param frame: The list-worktrees request frame.
+        :returns: Result frame with the worktrees on success, or
+            ``status: "failed"`` with an error message.
+        """
+        try:
+            # Pause the orphan reaper while git runs — see
+            # _handle_create_worktree above and _reap_orphans_once.
+            with self._host_subprocess_op():
+                worktrees = await asyncio.to_thread(
+                    list_worktrees,
+                    repo_path=frame.repo_path,
+                )
+        except WorktreeError as exc:
+            return HostListWorktreesResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=exc.message,
+            )
+        return HostListWorktreesResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            worktrees=[
+                {
+                    "path": wt.path,
+                    "branch": wt.branch,
+                    "is_main": wt.is_main,
+                    "detached": wt.detached,
+                }
+                for wt in worktrees
+            ],
+        )
+
     async def run(self) -> None:
         """Run the host process with reconnection.
 
@@ -1858,6 +1902,8 @@ class HostProcess:
             await ws.send(encode_host_frame(await self._handle_create_worktree(frame)))
         elif isinstance(frame, HostRemoveWorktreeFrame):
             await ws.send(encode_host_frame(await self._handle_remove_worktree(frame)))
+        elif isinstance(frame, HostListWorktreesFrame):
+            await ws.send(encode_host_frame(await self._handle_list_worktrees(frame)))
 
 
 def run_host_process(

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -51,6 +51,8 @@ class HostFrameKind(str, Enum):
     CREATE_WORKTREE_RESULT = "host.create_worktree_result"
     REMOVE_WORKTREE = "host.remove_worktree"
     REMOVE_WORKTREE_RESULT = "host.remove_worktree_result"
+    LIST_WORKTREES = "host.list_worktrees"
+    LIST_WORKTREES_RESULT = "host.list_worktrees_result"
     CREATE_DIR = "host.create_dir"
     CREATE_DIR_RESULT = "host.create_dir_result"
 
@@ -431,6 +433,44 @@ class HostRemoveWorktreeResultFrame:
 
 
 @dataclass
+class HostListWorktreesFrame:
+    """Server → host: list the git worktrees of a repository.
+
+    Backs ``GET /v1/hosts/{id}/worktrees``, used by the Web UI's
+    new-session worktree picker to show worktrees a session can start
+    in directly. Read-only; the host derives the main work tree from
+    ``repo_path`` (so a linked worktree resolves the same list).
+
+    :param request_id: Correlates the result, e.g. ``"req_wt_ls_1"``.
+    :param repo_path: Absolute path inside the repo (the picked dir or
+        a subdir), e.g. ``"/Users/alice/myrepo"``.
+    """
+
+    request_id: str
+    repo_path: str
+
+
+@dataclass
+class HostListWorktreesResultFrame:
+    """Host → server: outcome of a list-worktrees request.
+
+    :param request_id: Correlates to the
+        :class:`HostListWorktreesFrame`, e.g. ``"req_wt_ls_1"``.
+    :param status: ``"ok"`` or ``"failed"``.
+    :param worktrees: One dict per worktree with keys ``path`` (str),
+        ``branch`` (str | None), ``is_main`` (bool), ``detached``
+        (bool), main first. ``None`` on failure.
+    :param error: Error message when ``status`` is ``"failed"``, e.g.
+        ``"not a git repository"``. ``None`` on success.
+    """
+
+    request_id: str
+    status: str
+    worktrees: list[dict[str, Any]] | None = None
+    error: str | None = None
+
+
+@dataclass
 class HostCreateDirFrame:
     """Server → host: create a new directory on the host.
 
@@ -489,6 +529,8 @@ HostFrame = (
     | HostCreateWorktreeResultFrame
     | HostRemoveWorktreeFrame
     | HostRemoveWorktreeResultFrame
+    | HostListWorktreesFrame
+    | HostListWorktreesResultFrame
     | HostCreateDirFrame
     | HostCreateDirResultFrame
 )
@@ -676,6 +718,24 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "error": frame.error,
             }
         )
+    if isinstance(frame, HostListWorktreesFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.LIST_WORKTREES.value,
+                "request_id": frame.request_id,
+                "repo_path": frame.repo_path,
+            }
+        )
+    if isinstance(frame, HostListWorktreesResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.LIST_WORKTREES_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "worktrees": frame.worktrees,
+                "error": frame.error,
+            }
+        )
     if isinstance(frame, HostCreateDirFrame):
         return _encode_payload(
             {
@@ -782,6 +842,10 @@ def _decode_known_host_frame(
             return _decode_remove_worktree(msg)
         case HostFrameKind.REMOVE_WORKTREE_RESULT:
             return _decode_remove_worktree_result(msg)
+        case HostFrameKind.LIST_WORKTREES:
+            return _decode_list_worktrees(msg)
+        case HostFrameKind.LIST_WORKTREES_RESULT:
+            return _decode_list_worktrees_result(msg)
         case HostFrameKind.CREATE_DIR:
             return _decode_create_dir(msg)
         case HostFrameKind.CREATE_DIR_RESULT:
@@ -1028,6 +1092,41 @@ def _decode_remove_worktree_result(
     return HostRemoveWorktreeResultFrame(
         request_id=_required_str(msg, "request_id"),
         status=_required_str(msg, "status"),
+        error=_optional_nullable_str(msg, "error"),
+    )
+
+
+def _decode_list_worktrees(msg: dict[str, Any]) -> HostListWorktreesFrame:
+    """Decode a host.list_worktrees request frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.list_worktrees frame.
+    """
+    return HostListWorktreesFrame(
+        request_id=_required_str(msg, "request_id"),
+        repo_path=_required_str(msg, "repo_path"),
+    )
+
+
+def _decode_list_worktrees_result(
+    msg: dict[str, Any],
+) -> HostListWorktreesResultFrame:
+    """Decode a host.list_worktrees_result frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.list_worktrees_result frame.
+    """
+    raw = msg.get("worktrees")
+    if raw is not None:
+        if not isinstance(raw, list):
+            raise ValueError("frame field must be a list or null: 'worktrees'")
+        for entry in raw:
+            if not isinstance(entry, dict):
+                raise ValueError("each entry in 'worktrees' must be a JSON object")
+    return HostListWorktreesResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        worktrees=raw,
         error=_optional_nullable_str(msg, "error"),
     )
 

--- a/omnigent/host/git_worktree.py
+++ b/omnigent/host/git_worktree.py
@@ -171,6 +171,80 @@ def _main_work_tree(repo_path: str) -> str:
     raise WorktreeError(f"could not resolve main work tree for {repo_path}")
 
 
+@dataclass
+class WorktreeInfo:
+    """One entry from ``git worktree list``.
+
+    :param path: Absolute worktree directory, e.g.
+        ``"/Users/alice/myrepo-worktrees/feature-login"``.
+    :param branch: Checked-out branch without the ``refs/heads/``
+        prefix, e.g. ``"feature/login"``. ``None`` when the worktree
+        is in detached-HEAD state.
+    :param is_main: ``True`` for the repository's main work tree (the
+        first ``git worktree list`` record), ``False`` for linked
+        worktrees.
+    :param detached: ``True`` when the worktree has a detached HEAD
+        (no branch checked out).
+    """
+
+    path: str
+    branch: str | None
+    is_main: bool
+    detached: bool
+
+
+def list_worktrees(*, repo_path: str) -> list[WorktreeInfo]:
+    """List the git worktrees of the repository containing ``repo_path``.
+
+    Resolves the main work tree first (so a linked worktree resolves the
+    same list as the main checkout), then parses
+    ``git worktree list --porcelain``. The first record is always the
+    main work tree; the rest are linked worktrees.
+
+    :param repo_path: Absolute path inside a git repository — the
+        directory the user picked, e.g. ``"/Users/alice/myrepo"``.
+    :returns: One :class:`WorktreeInfo` per worktree, main first.
+    :raises WorktreeError: If ``repo_path`` is not a directory or not
+        inside a git work tree, or if ``git worktree list`` fails.
+    """
+    repo_root = _main_work_tree(repo_path)
+    result = _run_git(["worktree", "list", "--porcelain"], cwd=repo_root)
+    if result.returncode != 0:
+        raise _git_error("git worktree list failed", result)
+
+    worktrees: list[WorktreeInfo] = []
+    path: str | None = None
+    branch: str | None = None
+    detached = False
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            path = line[len("worktree ") :].strip()
+            branch = None
+            detached = False
+        elif line.startswith("branch "):
+            ref = line[len("branch ") :].strip()
+            branch = ref[len("refs/heads/") :] if ref.startswith("refs/heads/") else ref
+        elif line == "detached":
+            detached = True
+        elif line == "" and path is not None:
+            # Blank line terminates a record.
+            worktrees.append(
+                WorktreeInfo(
+                    path=path,
+                    branch=branch,
+                    is_main=not worktrees,
+                    detached=detached,
+                )
+            )
+            path = None
+    # The porcelain output may omit a trailing blank line for the last record.
+    if path is not None:
+        worktrees.append(
+            WorktreeInfo(path=path, branch=branch, is_main=not worktrees, detached=detached)
+        )
+    return worktrees
+
+
 def _local_branch_exists(repo_root: str, branch_name: str) -> bool:
     """Return whether a local branch already exists in the repo.
 

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -212,6 +212,9 @@ class HostConnection:
     pending_remove_worktrees: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
+    pending_list_worktrees: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
     pending_create_dirs: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )

--- a/omnigent/server/routes/_host_worktree.py
+++ b/omnigent/server/routes/_host_worktree.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 from omnigent.host.frames import (
     HostCreateWorktreeFrame,
+    HostListWorktreesFrame,
     HostRemoveWorktreeFrame,
     encode_host_frame,
 )
@@ -228,3 +229,49 @@ async def remove_worktree_on_host(
         raise WorktreeProxyError(
             f"worktree removal failed: {result.get('error') or 'host reported no detail'}"
         )
+
+
+async def list_worktrees_on_host(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    repo_path: str,
+) -> list[dict[str, object]]:
+    """
+    Send a ``host.list_worktrees`` frame and await the result.
+
+    :param host_registry: Server-side registry; used to enqueue the
+        outbound frame on the host's send queue.
+    :param host_conn: Live host connection to list worktrees on.
+    :param repo_path: Absolute path inside the source repo on the
+        host — the canonical picked directory, e.g.
+        ``"/Users/alice/myrepo"``.
+    :returns: One dict per worktree with keys ``path``, ``branch``,
+        ``is_main``, ``detached`` (main first).
+    :raises WorktreeHostUnavailableError: If the host connection drops
+        or doesn't respond within :data:`_WORKTREE_TIMEOUT_S`.
+    :raises WorktreeProxyError: If the host reports a listing failure.
+    """
+    request_id = secrets.token_hex(8)
+    frame = encode_host_frame(
+        HostListWorktreesFrame(
+            request_id=request_id,
+            repo_path=repo_path,
+        )
+    )
+    result = await _await_host_worktree_result(
+        host_registry=host_registry,
+        host_conn=host_conn,
+        pending=host_conn.pending_list_worktrees,
+        request_id=request_id,
+        frame=frame,
+        op="worktree listing",
+    )
+    if result.get("status") != "ok":
+        raise WorktreeProxyError(
+            f"worktree listing failed: {result.get('error') or 'host reported no detail'}"
+        )
+    worktrees = result.get("worktrees")
+    if not isinstance(worktrees, list):
+        raise WorktreeProxyError("host returned an incomplete worktree list")
+    return worktrees

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -31,6 +31,7 @@ from omnigent.host.frames import (
     HostHelloFrame,
     HostLaunchRunnerResultFrame,
     HostListDirResultFrame,
+    HostListWorktreesResultFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
     HostStatResultFrame,
@@ -525,6 +526,18 @@ async def _receive_loop(
                 remove_wt_future.set_result(
                     {
                         "status": frame.status,
+                        "error": frame.error,
+                    }
+                )
+            continue
+
+        if isinstance(frame, HostListWorktreesResultFrame):
+            list_wt_future = conn.pending_list_worktrees.pop(frame.request_id, None)
+            if list_wt_future is not None and not list_wt_future.done():
+                list_wt_future.set_result(
+                    {
+                        "status": frame.status,
+                        "worktrees": frame.worktrees,
                         "error": frame.error,
                     }
                 )

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -917,4 +917,69 @@ def create_hosts_router(
             "path": result.get("path"),
         }
 
+    @router.get("/hosts/{host_id}/worktrees")
+    async def list_host_worktrees(
+        request: Request,
+        host_id: str,
+        path: str = Query(...),
+    ) -> dict[str, Any]:
+        """
+        List the git worktrees of a repository on a host.
+
+        Used by the Web UI's new-session worktree picker to show the
+        worktrees a session can start in directly. Owner-scoped exactly
+        like the filesystem browse endpoints; NOT scoped to a session.
+        A path that is not a git repository is reported as 400 so the
+        picker can quietly fall back to "no worktrees".
+
+        :param request: FastAPI request (for auth).
+        :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :param path: Absolute path inside the repo on the host to list
+            worktrees for, e.g. ``"/Users/alice/myrepo"``.
+        :returns: ``{"object": "list", "data": [{path, branch,
+            is_main, detached}, ...]}`` (main first).
+        :raises HTTPException: 404 if host not found, 403 if not owned
+            by caller, 409 if host is offline/unresponsive, 400 on path
+            validation or a non-git path.
+        """
+        from omnigent.server.routes._host_worktree import (
+            WorktreeHostUnavailableError,
+            WorktreeProxyError,
+            list_worktrees_on_host,
+        )
+
+        # require_user: unauthenticated callers 401 instead of slipping
+        # past the owner check below as None.
+        user_id = require_user(request, auth_provider)
+
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.owner != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+
+        if not path.strip():
+            raise HTTPException(status_code=400, detail="path must not be empty")
+        if "\x00" in path:
+            raise HTTPException(status_code=400, detail="path must not contain NUL bytes")
+
+        conn = host_registry.get(host.host_id)
+        if conn is None:
+            raise HTTPException(status_code=409, detail="host is offline")
+
+        try:
+            worktrees = await list_worktrees_on_host(
+                host_registry=host_registry,
+                host_conn=conn,
+                repo_path=path,
+            )
+        except WorktreeHostUnavailableError as exc:
+            raise HTTPException(status_code=409, detail=exc.message) from exc
+        except WorktreeProxyError as exc:
+            # Not a git repo / git failure — user-correctable; the picker
+            # treats this as "no worktrees here".
+            raise HTTPException(status_code=400, detail=exc.message) from exc
+
+        return {"object": "list", "data": worktrees}
+
     return router

--- a/openapi.json
+++ b/openapi.json
@@ -6544,6 +6544,62 @@
         ]
       }
     },
+    "/v1/hosts/{host_id}/worktrees": {
+      "get": {
+        "description": "List the git worktrees of a repository on a host.\n\nUsed by the Web UI's new-session worktree picker to show the\nworktrees a session can start in directly. Owner-scoped exactly\nlike the filesystem browse endpoints; NOT scoped to a session.\nA path that is not a git repository is reported as 400 so the\npicker can quietly fall back to \"no worktrees\".\n\n**Returns:** `{\"object\": \"list\", \"data\": [{path, branch, is_main, detached}, ...]}` (main first).\n\n**Raises**\n\n- `HTTPException` \u2014 404 if host not found, 403 if not owned by caller, 409 if host is offline/unresponsive, 400 on path validation or a non-git path.",
+        "operationId": "list_host_worktrees_v1_hosts__host_id__worktrees_get",
+        "parameters": [
+          {
+            "description": "Host identifier, e.g. `\"host_a1b2c3d4...\"`.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Absolute path inside the repo on the host to list worktrees for, e.g. `\"/Users/alice/myrepo\"`.",
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "title": "Path",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Host Worktrees V1 Hosts  Host Id  Worktrees Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Host Worktrees",
+        "tags": [
+          "hosts"
+        ]
+      }
+    },
     "/v1/info": {
       "get": {
         "description": "Runtime capabilities probe for the SPA + CLI.\n\nReturned at app boot by the frontend (and by `omnigent login` when it needs to choose between flows). Drives\nconditional route registration and chrome on the SPA side\n\u2014 when `accounts_enabled` is false, the SPA never\nregisters `/login`, `/register`, `/members` and\nnever renders the AccountMenu, so the bundle behaves\nidentically to a pre-PR-2008 build for header / OIDC\ndeploys (in particular, the internal hosted product that\nsyncs from this repo).\n\nAuthentication: this endpoint is intentionally UNAUTHED\nso the SPA can probe it before holding a session cookie.\nIt exposes no sensitive state \u2014 only the active auth\nsource, the login URL, whether first-run admin setup is\nstill pending (`needs_setup`), coarse capability\nbooleans (`databricks_features`,\n`managed_sandboxes_enabled`), the short sandbox\nprovider name (`sandbox_provider`) the web UI labels the\nnew-session sandbox option with, and the installed\n`server_version` (already public via `/api/version`).",

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -66,6 +66,9 @@ _SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
 # ``…/filesystem/home/e2e/projects``; it never matches the bare
 # ``/v1/hosts`` list (no ``/filesystem`` segment).
 _FILESYSTEM_RE = re.compile(r"/v1/hosts/[^/]+/filesystem")
+# The worktree-list endpoint the branch combobox queries for the picked repo.
+# Distinct ``/worktrees`` segment, so it never collides with ``/filesystem``.
+_WORKTREES_RE = re.compile(r"/v1/hosts/[^/]+/worktrees")
 
 
 def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
@@ -1727,6 +1730,101 @@ async def _drive_add_worktree(base_url: str, session_id: str) -> None:
             assert body["host_id"] == _HOST_ID, body
             assert body["workspace"] == "/work/repo", body
             assert body.get("git") == {"branch_name": "feature/login", "base_branch": "main"}, body
+        finally:
+            await browser.close()
+
+
+def test_start_session_select_existing_worktree(seeded_session: tuple[str, str]) -> None:
+    """Picking an existing worktree starts in its directory with no git opts.
+
+    The branch chip's input doubles as a combobox: focusing it lists the
+    repo's existing worktrees (``GET /v1/hosts/{id}/worktrees``). Selecting
+    one must (a) point the workspace at that worktree's directory and
+    (b) send NO ``git`` spec on ``POST /v1/sessions`` — the session starts
+    directly in the existing worktree rather than creating a new one.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_select_existing_worktree(base_url, session_id))
+
+
+async def _drive_select_existing_worktree(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+
+            async def handle_worktrees(route: Route) -> None:
+                # The main tree (is_main) plus one linked worktree. The picker
+                # hides the main tree, so only "feature/x" is offered.
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps(
+                        {
+                            "object": "list",
+                            "data": [
+                                {
+                                    "path": "/work/repo",
+                                    "branch": "main",
+                                    "is_main": True,
+                                    "detached": False,
+                                },
+                                {
+                                    "path": "/work/repo-worktrees/feature-x",
+                                    "branch": "feature/x",
+                                    "is_main": False,
+                                    "detached": False,
+                                },
+                            ],
+                        }
+                    ),
+                )
+
+            # Registered after the common routes so it wins for its URL.
+            await page.route(_WORKTREES_RE, handle_worktrees)
+
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open the worktree chip; focusing the branch combobox reveals the
+            # repo's existing (linked) worktrees. The main tree is filtered out,
+            # so only the one linked worktree is offered.
+            await page.get_by_test_id("new-chat-landing-branch-chip").click()
+            await page.get_by_test_id("new-chat-landing-branch-input").focus()
+            option = page.get_by_test_id("new-chat-landing-worktree-option")
+            await expect(option).to_have_count(1)
+            await expect(option).to_contain_text("feature/x")
+            await option.click()
+
+            # The warning confirms the session will start in the existing
+            # worktree (rather than creating a new one).
+            await expect(
+                page.get_by_test_id("new-chat-landing-existing-worktree-warning")
+            ).to_be_visible()
+
+            await page.get_by_test_id("new-chat-landing-input").fill("work in the worktree")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["host_id"] == _HOST_ID, body
+            # Workspace is the worktree dir; NO git spec is sent (starting in an
+            # existing worktree creates nothing).
+            assert body["workspace"] == "/work/repo-worktrees/feature-x", body
+            assert body.get("git") is None, body
         finally:
             await browser.close()
 

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -18,6 +18,8 @@ from omnigent.host.frames import (
     HostListDirEntry,
     HostListDirFrame,
     HostListDirResultFrame,
+    HostListWorktreesFrame,
+    HostListWorktreesResultFrame,
     HostRemoveWorktreeFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
@@ -835,6 +837,70 @@ def test_remove_worktree_result_frame_round_trip() -> None:
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostRemoveWorktreeResultFrame)
     assert decoded == original
+
+
+# ── host.list_worktrees frames ──────────────────────────
+
+
+def test_list_worktrees_frame_round_trip() -> None:
+    """Verify HostListWorktreesFrame survives encode → decode.
+
+    A garbled repo_path would list the wrong repository's worktrees.
+    """
+    original = HostListWorktreesFrame(
+        request_id="req_wt_ls_1",
+        repo_path="/Users/alice/myrepo",
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostListWorktreesFrame)
+    assert decoded == original
+
+
+def test_list_worktrees_result_frame_round_trip() -> None:
+    """Verify HostListWorktreesResultFrame survives encode → decode.
+
+    The worktree dicts feed the picker; a dropped or reshaped field
+    would break branch prefill / start-in-worktree selection.
+    """
+    original = HostListWorktreesResultFrame(
+        request_id="req_wt_ls_1",
+        status="ok",
+        worktrees=[
+            {"path": "/Users/alice/myrepo", "branch": "main", "is_main": True, "detached": False},
+            {
+                "path": "/Users/alice/myrepo-worktrees/feature-login",
+                "branch": "feature/login",
+                "is_main": False,
+                "detached": False,
+            },
+        ],
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostListWorktreesResultFrame)
+    assert decoded == original
+
+
+def test_list_worktrees_result_frame_failure_round_trip() -> None:
+    """Verify a failed list-worktrees result carries its error and null list."""
+    original = HostListWorktreesResultFrame(
+        request_id="req_wt_ls_1",
+        status="failed",
+        error="not a git repository",
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostListWorktreesResultFrame)
+    assert decoded.worktrees is None
+    assert decoded.error == "not a git repository"
+
+
+def test_list_worktrees_result_frame_rejects_non_list() -> None:
+    """A non-list ``worktrees`` field is rejected, not coerced."""
+    bad = (
+        '{"kind": "host.list_worktrees_result", "request_id": "r", '
+        '"status": "ok", "worktrees": "nope"}'
+    )
+    with pytest.raises(ValueError, match="worktrees"):
+        decode_host_frame(bad)
 
 
 # ── host.create_dir frames ──────────────────────────────

--- a/tests/host/test_git_worktree.py
+++ b/tests/host/test_git_worktree.py
@@ -18,6 +18,7 @@ from omnigent.host.git_worktree import (
     CreatedWorktree,
     WorktreeError,
     create_worktree,
+    list_worktrees,
     remove_worktree,
     validate_branch_name,
 )
@@ -313,6 +314,60 @@ def test_remove_worktree_missing_path_fails(git_repo: Path) -> None:
             delete_branch=False,
         )
     assert "does not exist" in exc.value.message
+
+
+def test_list_worktrees_returns_main_first(git_repo: Path) -> None:
+    """With no linked worktrees, only the main tree is listed."""
+    result = list_worktrees(repo_path=str(git_repo))
+    assert len(result) == 1
+    main = result[0]
+    assert main.path == str(git_repo)
+    assert main.branch == "main"
+    assert main.is_main is True
+    assert main.detached is False
+
+
+def test_list_worktrees_includes_linked(git_repo: Path) -> None:
+    """A created worktree shows up with its branch and is not flagged main."""
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/login")
+    result = list_worktrees(repo_path=str(git_repo))
+    # Main first, then the linked worktree.
+    assert result[0].is_main is True
+    linked = next(w for w in result if not w.is_main)
+    assert linked.path == created.worktree_path
+    assert linked.branch == "feature/login"
+    assert linked.detached is False
+
+
+def test_list_worktrees_from_linked_resolves_same_list(git_repo: Path) -> None:
+    """Listing from inside a linked worktree resolves the main repo's full list."""
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/a")
+    # Query from the linked worktree — should still see BOTH worktrees.
+    result = list_worktrees(repo_path=created.worktree_path)
+    paths = {w.path for w in result}
+    assert str(git_repo) in paths
+    assert created.worktree_path in paths
+
+
+def test_list_worktrees_reports_detached_head(git_repo: Path) -> None:
+    """A detached-HEAD worktree lists with ``branch=None`` and ``detached=True``."""
+    head = _rev_parse(git_repo)
+    wt = git_repo.parent / "myrepo-worktrees" / "detached"
+    wt.parent.mkdir(parents=True, exist_ok=True)
+    # Add a worktree checked out at a bare commit → detached HEAD.
+    _git(git_repo, "worktree", "add", "--detach", str(wt), head)
+    result = list_worktrees(repo_path=str(git_repo))
+    detached = next(w for w in result if w.path == str(wt))
+    assert detached.branch is None
+    assert detached.detached is True
+
+
+def test_list_worktrees_non_git_path_fails(tmp_path: Path) -> None:
+    """A non-git directory fails loud (the route maps this to 'no worktrees')."""
+    plain = (tmp_path / "plain").resolve()
+    plain.mkdir()
+    with pytest.raises(WorktreeError):
+        list_worktrees(repo_path=str(plain))
 
 
 @pytest.mark.parametrize(

--- a/tests/server/integration/test_hosts_worktrees.py
+++ b/tests/server/integration/test_hosts_worktrees.py
@@ -1,0 +1,239 @@
+"""
+Integration tests for ``GET /v1/hosts/{id}/worktrees``.
+
+Wires up a real host tunnel + REST router pair, drives a fake host
+that auto-replies to ``host.list_worktrees`` frames, and exercises
+the endpoint's contract end-to-end. Backs the Web UI's new-session
+worktree picker (branch prefill / start-in-existing-worktree).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from asgiref.testing import ApplicationCommunicator
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from omnigent.host.frames import (
+    HostHelloFrame,
+    HostListWorktreesFrame,
+    HostListWorktreesResultFrame,
+    decode_host_frame,
+    encode_host_frame,
+)
+from omnigent.server.host_registry import HostRegistry
+from omnigent.server.routes.host_tunnel import create_host_tunnel_router
+from omnigent.server.routes.hosts import create_hosts_router
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.host_store import HostStore
+
+# Same liveness-race flake mitigation as test_hosts_filesystem: the
+# mock-WS host can be deregistered under parallel CI load, yielding a
+# spurious 409. Tests are sub-second; retry masks the race.
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.flaky(reruns=2, reruns_delay=1),
+]
+
+_HOST_ID = "host_wt_test"
+_HOST_NAME = "wt-test-laptop"
+
+
+def _websocket_scope(path: str) -> dict[str, object]:
+    """Build a minimal ASGI WebSocket scope.
+
+    :param path: WebSocket path, e.g. ``"/v1/hosts/X/tunnel"``.
+    :returns: ASGI scope dict.
+    """
+    return {
+        "type": "websocket",
+        "asgi": {"version": "3.0"},
+        "scheme": "ws",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("testserver", 80),
+        "subprotocols": [],
+    }
+
+
+def _hello_text(name: str = _HOST_NAME) -> str:
+    """Encode a hello frame for tests.
+
+    :param name: Host name reported in the hello frame.
+    :returns: JSON-encoded hello frame.
+    """
+    return encode_host_frame(
+        HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name=name)
+    )
+
+
+@pytest.fixture()
+def wt_app(
+    db_uri: str,
+) -> tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore]:
+    """
+    App with host tunnel + REST routes for worktree-list tests.
+
+    :param db_uri: SQLite URI fixture.
+    :returns: (app, registry, host_store, conv_store).
+    """
+    registry = HostRegistry()
+    host_store = HostStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    app = FastAPI()
+    app.include_router(create_host_tunnel_router(registry, host_store), prefix="/v1")
+    app.include_router(
+        create_hosts_router(registry, host_store, conv_store),
+        prefix="/v1",
+    )
+    return app, registry, host_store, conv_store
+
+
+@pytest.fixture()
+async def wt_setup(
+    wt_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> AsyncIterator[
+    tuple[FastAPI, HostRegistry, ApplicationCommunicator, dict[str, dict[str, Any]]]
+]:
+    """
+    Connect a mock host and auto-reply to list_worktrees frames.
+
+    Tests register fake replies in ``replies`` (repo_path → reply
+    dict) before calling the REST endpoint. The auto-replier decodes
+    outbound frames and resolves the matching pending future — the
+    same wiring host_tunnel.py does in production.
+
+    :param wt_app: The fixture above.
+    :returns: Async iterator yielding the wired-up state.
+    """
+    app, registry, _hs, _cs = wt_app
+    path = f"/v1/hosts/{_HOST_ID}/tunnel"
+    comm = ApplicationCommunicator(app, _websocket_scope(path))
+    await comm.send_input({"type": "websocket.connect"})
+    accepted = await comm.receive_output(timeout=1.0)
+    assert accepted["type"] == "websocket.accept"
+    await comm.send_input({"type": "websocket.receive", "text": _hello_text()})
+    while registry.get(_HOST_ID) is None:
+        await asyncio.sleep(0.01)
+
+    replies: dict[str, dict[str, Any]] = {}
+    stop_drain = asyncio.Event()
+
+    async def _drain() -> None:
+        """Drain outbound WS frames and feed back the configured reply."""
+        while not stop_drain.is_set():
+            try:
+                output = await comm.receive_output(timeout=0.5)
+            except asyncio.TimeoutError:
+                continue
+            if output.get("type") != "websocket.send":
+                continue
+            text = output.get("text")
+            if not isinstance(text, str):
+                continue
+            frame = decode_host_frame(text)
+            if not isinstance(frame, HostListWorktreesFrame):
+                continue
+            reply = replies.get(frame.repo_path)
+            if reply is None:
+                reply_frame = HostListWorktreesResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error="not a git repository",
+                )
+            else:
+                reply_frame = HostListWorktreesResultFrame(
+                    request_id=frame.request_id,
+                    status=reply.get("status", "ok"),
+                    worktrees=reply.get("worktrees"),
+                    error=reply.get("error"),
+                )
+            await comm.send_input(
+                {"type": "websocket.receive", "text": encode_host_frame(reply_frame)}
+            )
+
+    drain_task = asyncio.create_task(_drain())
+    try:
+        yield app, registry, comm, replies
+    finally:
+        stop_drain.set()
+        try:
+            await asyncio.wait_for(drain_task, timeout=1.0)
+        except asyncio.TimeoutError:
+            drain_task.cancel()
+
+
+async def test_list_worktrees_returns_data(
+    wt_setup: tuple[FastAPI, HostRegistry, ApplicationCommunicator, dict[str, dict[str, Any]]],
+) -> None:
+    """The endpoint returns ``{"object": "list", "data": [...]}`` from the host."""
+    app, _reg, _comm, replies = wt_setup
+    replies["/Users/corey/repo"] = {
+        "worktrees": [
+            {"path": "/Users/corey/repo", "branch": "main", "is_main": True, "detached": False},
+            {
+                "path": "/Users/corey/repo-worktrees/feature-x",
+                "branch": "feature/x",
+                "is_main": False,
+                "detached": False,
+            },
+        ],
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            f"/v1/hosts/{_HOST_ID}/worktrees",
+            params={"path": "/Users/corey/repo"},
+        )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["object"] == "list"
+    branches = [w["branch"] for w in payload["data"]]
+    assert branches == ["main", "feature/x"]
+    assert payload["data"][1]["is_main"] is False
+
+
+async def test_list_worktrees_non_git_path_400(
+    wt_setup: tuple[FastAPI, HostRegistry, ApplicationCommunicator, dict[str, dict[str, Any]]],
+) -> None:
+    """A non-git path (host reports failed) maps to 400 so the picker shows nothing."""
+    app, _reg, _comm, _replies = wt_setup
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # No reply registered → the drain replies "failed: not a git repository".
+        resp = await client.get(
+            f"/v1/hosts/{_HOST_ID}/worktrees",
+            params={"path": "/tmp/not-a-repo"},
+        )
+    assert resp.status_code == 400, resp.text
+
+
+async def test_list_worktrees_missing_path_param_422(
+    wt_setup: tuple[FastAPI, HostRegistry, ApplicationCommunicator, dict[str, dict[str, Any]]],
+) -> None:
+    """The ``path`` query param is required."""
+    app, _reg, _comm, _replies = wt_setup
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/v1/hosts/{_HOST_ID}/worktrees")
+    assert resp.status_code == 422, resp.text
+
+
+async def test_list_worktrees_unknown_host_404(
+    wt_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """An unknown host id yields 404 (existence is gated before the offline check)."""
+    app, _reg, _hs, _cs = wt_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            f"/v1/hosts/{_HOST_ID}/worktrees",
+            params={"path": "/Users/corey/repo"},
+        )
+    # No host record was created (no tunnel connected) → 404, not 409.
+    assert resp.status_code == 404, resp.text

--- a/web/src/hooks/useHostWorktrees.ts
+++ b/web/src/hooks/useHostWorktrees.ts
@@ -1,0 +1,84 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { authenticatedFetch } from "@/lib/identity";
+
+/**
+ * One worktree of a repository, as returned by
+ * ``GET /v1/hosts/{id}/worktrees``. Mirrors the host's
+ * ``git worktree list`` output.
+ */
+export interface HostWorktree {
+  /**
+   * Absolute worktree directory on the host, e.g.
+   * ``"/Users/alice/myrepo-worktrees/feature-login"``.
+   */
+  path: string;
+  /**
+   * Checked-out branch without the ``refs/heads/`` prefix, e.g.
+   * ``"feature/login"``. ``null`` when the worktree is in
+   * detached-HEAD state.
+   */
+  branch: string | null;
+  /**
+   * ``true`` for the repository's main work tree. The picker hides
+   * it — starting "in the main repo" is just picking the directory.
+   */
+  is_main: boolean;
+  /** ``true`` when the worktree has a detached HEAD (no branch). */
+  detached: boolean;
+}
+
+interface HostWorktreesResponse {
+  object: string;
+  data: HostWorktree[];
+}
+
+/**
+ * Fetch the git worktrees of a repository on a host.
+ *
+ * A 400 response means the path is not a git repository (or git
+ * failed) — the picker treats that as "no worktrees here", so we
+ * resolve to an empty list rather than throwing. Other non-OK
+ * responses throw so React Query surfaces the error.
+ *
+ * @param hostId Host identifier, e.g. ``"host_a1b2..."``.
+ * @param repoPath Absolute path inside the repo to list worktrees for.
+ * @returns The repository's worktrees (main first), or ``[]`` when the
+ *   path is not a git repository.
+ */
+async function fetchHostWorktrees(hostId: string, repoPath: string): Promise<HostWorktree[]> {
+  const params = new URLSearchParams({ path: repoPath });
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/worktrees?${params.toString()}`,
+  );
+  if (res.status === 400) {
+    // Not a git repository — no worktrees to offer.
+    return [];
+  }
+  if (!res.ok) {
+    throw new Error(`host worktrees fetch failed: HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as HostWorktreesResponse;
+  return body.data;
+}
+
+/**
+ * React Query hook: list the git worktrees of a repository on a host.
+ *
+ * Lazy — only fires when both ``hostId`` and ``repoPath`` are set.
+ * Cached per (host, repoPath). A non-git path resolves to an empty
+ * list (see {@link fetchHostWorktrees}).
+ *
+ * @param hostId Host id, e.g. ``"host_a1b2..."``. ``null`` disables.
+ * @param repoPath Absolute repo path. ``null`` disables.
+ * @returns React Query result with ``data: HostWorktree[]``.
+ */
+export function useHostWorktrees(hostId: string | null, repoPath: string | null) {
+  return useQuery({
+    queryKey: ["host-worktrees", hostId, repoPath],
+    queryFn: () => fetchHostWorktrees(hostId as string, repoPath as string),
+    enabled: hostId !== null && repoPath !== null && repoPath !== "",
+    staleTime: 5_000,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -58,6 +58,9 @@ vi.mock("@/hooks/useHostFilesystem", () => ({
   // an idle mutation keeps it inert for these tests.
   useCreateHostDirectory: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
+vi.mock("@/hooks/useHostWorktrees", () => ({
+  useHostWorktrees: () => ({ data: undefined }),
+}));
 // No other sessions in scope — keep the conflict hooks inert so they don't
 // issue their own /health fetch or surface a warning. The warning is covered
 // in NewChatDialog.test.tsx.

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1087,9 +1087,7 @@ describe("NewChatLandingScreen", () => {
     fireEvent.mouseDown(options[0]);
 
     // Selecting a worktree auto-closes the popover.
-    await waitFor(() =>
-      expect(screen.queryByTestId("new-chat-landing-branch-input")).toBeNull(),
-    );
+    await waitFor(() => expect(screen.queryByTestId("new-chat-landing-branch-input")).toBeNull());
 
     // Reopen the chip: the warning shows and the branch field is prefilled with
     // the selected worktree's branch.
@@ -1137,9 +1135,7 @@ describe("NewChatLandingScreen", () => {
     fireEvent.focus(screen.getByTestId("new-chat-landing-branch-input"));
     fireEvent.mouseDown(screen.getByTestId("new-chat-landing-worktree-option"));
     // Selection auto-closes the popover — reopen to edit the prefilled branch.
-    await waitFor(() =>
-      expect(screen.queryByTestId("new-chat-landing-branch-input")).toBeNull(),
-    );
+    await waitFor(() => expect(screen.queryByTestId("new-chat-landing-branch-input")).toBeNull());
     fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
     await screen.findByTestId("new-chat-landing-existing-worktree-warning");
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -17,6 +17,7 @@ import {
   matchSkillInvocation,
   normalizeWorkspacePath,
   sessionsSharingDirectory,
+  worktreePathTail,
   NewChatLandingScreen,
   resetLandingDraft,
 } from "./NewChatDialog";
@@ -26,6 +27,7 @@ import { authenticatedFetch } from "@/lib/identity";
 import { useHosts, type Host } from "@/hooks/useHosts";
 import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFilesystem";
+import { useHostWorktrees } from "@/hooks/useHostWorktrees";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import type { Conversation } from "@/hooks/useConversations";
@@ -47,6 +49,9 @@ vi.mock("@/hooks/useHostFilesystem", () => ({
   // an idle mutation keeps it inert for these tests.
   useCreateHostDirectory: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
+// Mocked so it doesn't hit authenticatedFetch (which would pollute the
+// call list the create-flow assertions index into positionally).
+vi.mock("@/hooks/useHostWorktrees", () => ({ useHostWorktrees: vi.fn() }));
 vi.mock("@/hooks/useDirectorySessions", () => ({
   useDirectorySessions: vi.fn(),
 }));
@@ -86,6 +91,7 @@ const authenticatedFetchMock = vi.mocked(authenticatedFetch);
 const useHostsMock = vi.mocked(useHosts);
 const useAvailableAgentsMock = vi.mocked(useAvailableAgents);
 const useHostFilesystemMock = vi.mocked(useHostFilesystem);
+const useHostWorktreesMock = vi.mocked(useHostWorktrees);
 const useDirectorySessionsMock = vi.mocked(useDirectorySessions);
 const useRunnerHealthMock = vi.mocked(useRunnerHealthRegistration);
 const setPendingInitialPromptMock = vi.mocked(setPendingInitialPrompt);
@@ -349,6 +355,18 @@ describe("sandbox repository helpers", () => {
   ])("deriveRepoName(%j) === %j", (url, expected) => {
     expect(deriveRepoName(url)).toBe(expected);
   });
+
+  it.each<[string, string]>([
+    // Deep path → leading ellipsis + last two segments (the disambiguating tail).
+    ["/Users/me/myrepo-worktrees/feature-x", "…/myrepo-worktrees/feature-x"],
+    // Two-or-fewer segments → returned unchanged (nothing useful to trim).
+    ["/Users", "/Users"],
+    ["/a/b", "/a/b"],
+    // Trailing slash doesn't create an empty tail segment.
+    ["/Users/me/myrepo-worktrees/feature-x/", "…/myrepo-worktrees/feature-x"],
+  ])("worktreePathTail(%j) === %j", (path, expected) => {
+    expect(worktreePathTail(path)).toBe(expected);
+  });
 });
 
 // deriveHomeDir resolves the working-directory default for a first-ever
@@ -560,6 +578,7 @@ function setupLandingMocks() {
   useHostsMock.mockReset();
   useAvailableAgentsMock.mockReset();
   useHostFilesystemMock.mockReset();
+  useHostWorktreesMock.mockReset();
   useDirectorySessionsMock.mockReset();
   useRunnerHealthMock.mockReset();
   setOmnigentHostConfig({});
@@ -578,6 +597,9 @@ function setupLandingMocks() {
     error: null,
     isPlaceholderData: false,
   } as unknown as ReturnType<typeof useHostFilesystem>);
+  useHostWorktreesMock.mockReturnValue({
+    data: undefined,
+  } as unknown as ReturnType<typeof useHostWorktrees>);
   mockHosts([host("online")]);
   mockAgents([
     {
@@ -1030,6 +1052,161 @@ describe("NewChatLandingScreen", () => {
     });
     fireEvent.click(screen.getByTestId("new-chat-landing-workspace-chip"));
     expect(screen.queryByTestId("workspace-picker-conflict")).toBeNull();
+  });
+
+  it("lists existing worktrees and starts directly in a selected one (no git opts)", async () => {
+    // The seeded repo has one linked worktree; the main tree is filtered out.
+    useHostWorktreesMock.mockReturnValue({
+      data: [
+        { path: "/Users/corey/repo", branch: "main", is_main: true, detached: false },
+        {
+          path: "/Users/corey/repo-worktrees/feature-x",
+          branch: "feature/x",
+          is_main: false,
+          detached: false,
+        },
+      ],
+    } as unknown as ReturnType<typeof useHostWorktrees>);
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+
+    // Open the worktree popover, focus the branch combobox to reveal the
+    // existing-worktree dropdown, and select the one linked worktree.
+    fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
+    fireEvent.focus(screen.getByTestId("new-chat-landing-branch-input"));
+    const options = screen.getAllByTestId("new-chat-landing-worktree-option");
+    expect(options).toHaveLength(1); // main tree excluded
+    expect(options[0].textContent).toContain("feature/x");
+    // onMouseDown (fires before the input's blur) drives selection.
+    fireEvent.mouseDown(options[0]);
+
+    // Selecting a worktree auto-closes the popover.
+    await waitFor(() =>
+      expect(screen.queryByTestId("new-chat-landing-branch-input")).toBeNull(),
+    );
+
+    // Reopen the chip: the warning shows and the branch field is prefilled with
+    // the selected worktree's branch.
+    fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
+    await screen.findByTestId("new-chat-landing-existing-worktree-warning");
+    expect((screen.getByTestId("new-chat-landing-branch-input") as HTMLInputElement).value).toBe(
+      "feature/x",
+    );
+
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "work in the worktree" },
+    });
+    fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = authenticatedFetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
+    // Workspace is bound straight to the worktree dir; NO git opts are sent
+    // (starting in an existing worktree creates nothing).
+    expect(body.workspace).toBe("/Users/corey/repo-worktrees/feature-x");
+    expect(body.git).toBeUndefined();
+  });
+
+  it("creates a new worktree when the prefilled branch name is edited", async () => {
+    useHostWorktreesMock.mockReturnValue({
+      data: [
+        {
+          path: "/Users/corey/repo-worktrees/feature-x",
+          branch: "feature/x",
+          is_main: false,
+          detached: false,
+        },
+      ],
+    } as unknown as ReturnType<typeof useHostWorktrees>);
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
+    fireEvent.focus(screen.getByTestId("new-chat-landing-branch-input"));
+    fireEvent.mouseDown(screen.getByTestId("new-chat-landing-worktree-option"));
+    // Selection auto-closes the popover — reopen to edit the prefilled branch.
+    await waitFor(() =>
+      expect(screen.queryByTestId("new-chat-landing-branch-input")).toBeNull(),
+    );
+    fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
+    await screen.findByTestId("new-chat-landing-existing-worktree-warning");
+
+    // Edit the branch away from the prefill: now it's a NEW worktree request.
+    fireEvent.change(screen.getByTestId("new-chat-landing-branch-input"), {
+      target: { value: "feature/y" },
+    });
+    // Warning gone once the name diverges from the existing worktree's branch.
+    expect(screen.queryByTestId("new-chat-landing-existing-worktree-warning")).toBeNull();
+
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "branch off" },
+    });
+    fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = authenticatedFetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      git?: { branch_name: string };
+    };
+    // A new worktree for the edited branch name is requested.
+    expect(body.git?.branch_name).toBe("feature/y");
+  });
+
+  it("filters the worktree dropdown as you type in the branch combobox", async () => {
+    useHostWorktreesMock.mockReturnValue({
+      data: [
+        {
+          path: "/Users/corey/repo-worktrees/feature-x",
+          branch: "feature/x",
+          is_main: false,
+          detached: false,
+        },
+        {
+          path: "/Users/corey/repo-worktrees/bugfix-login",
+          branch: "bugfix/login",
+          is_main: false,
+          detached: false,
+        },
+      ],
+    } as unknown as ReturnType<typeof useHostWorktrees>);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
+    // Radix autofocuses the branch combobox on open, so the dropdown of both
+    // worktrees shows immediately (a focus event keeps it open in jsdom too).
+    fireEvent.focus(screen.getByTestId("new-chat-landing-branch-input"));
+    expect(screen.getAllByTestId("new-chat-landing-worktree-option")).toHaveLength(2);
+
+    // Typing in the branch field narrows to matching branch/path substrings.
+    fireEvent.change(screen.getByTestId("new-chat-landing-branch-input"), {
+      target: { value: "bugfix" },
+    });
+    const options = screen.getAllByTestId("new-chat-landing-worktree-option");
+    expect(options).toHaveLength(1);
+    expect(options[0].textContent).toContain("bugfix/login");
+
+    // A name matching nothing hides the dropdown entirely — that name becomes
+    // a NEW worktree on submit rather than selecting an existing one.
+    fireEvent.change(screen.getByTestId("new-chat-landing-branch-input"), {
+      target: { value: "brand-new-branch" },
+    });
+    expect(screen.queryByTestId("new-chat-landing-worktree-dropdown")).toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-worktree-option")).toBeNull();
   });
 
   it("shows no conflict banner when no live session shares the directory", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -87,6 +87,7 @@ import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFilesystem";
+import { useHostWorktrees } from "@/hooks/useHostWorktrees";
 import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSwitcher";
 import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 import type { Conversation } from "@/hooks/useConversations";
@@ -385,6 +386,22 @@ export function normalizeWorkspacePath(path: string): string | null {
   const stripped = trimmed.replace(/\/+$/, "");
   // All-slashes input (e.g. "///") collapses to the root.
   return stripped === "" ? "/" : stripped;
+}
+
+/**
+ * Shorten an absolute path to its last two segments with a leading
+ * ellipsis, so worktree rows show the disambiguating tail (e.g.
+ * ``"…/myrepo-worktrees/feature-x"``) instead of a shared prefix that
+ * truncates to the same string for every entry.
+ *
+ * @param path Absolute path, e.g. ``"/Users/me/myrepo-worktrees/feature-x"``.
+ * @returns The tail, prefixed with ``"…/"`` when segments were dropped;
+ *   the original path when it already has two or fewer segments.
+ */
+export function worktreePathTail(path: string): string {
+  const segments = path.replace(/\/+$/, "").split("/").filter(Boolean);
+  if (segments.length <= 2) return path;
+  return `…/${segments.slice(-2).join("/")}`;
 }
 
 /**
@@ -1669,6 +1686,7 @@ type LandingDraft = {
   workspace: string;
   branchName: string;
   baseBranch: string;
+  prefilledBranch: string;
   permissionMode: string;
   approvalMode: string;
   bypassSandbox: boolean;
@@ -1836,6 +1854,13 @@ export function NewChatLandingScreen() {
   const [workspace, setWorkspace] = useState<string>(() => landingDraft?.workspace ?? "");
   const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
   const [baseBranch, setBaseBranch] = useState<string>(() => landingDraft?.baseBranch ?? "");
+  // Branch prefilled from the existing worktree the current workspace points
+  // at. When `branchName` still equals this, the session starts directly in
+  // that worktree (no git opts). Editing the field away from it means the user
+  // wants a *new* worktree off that name.
+  const [prefilledBranch, setPrefilledBranch] = useState<string>(
+    () => landingDraft?.prefilledBranch ?? "",
+  );
   // Project to file the new session under (an implicit collection stored as a
   // conversation_labels row). Empty = unfiled. Applied right after create.
   // Pre-filled from a `?project=` query param so the sidebar's per-project
@@ -1907,6 +1932,8 @@ export function NewChatLandingScreen() {
   }, []);
   // Controls the working-directory popover so picking a directory closes it.
   const [workspacePopoverOpen, setWorkspacePopoverOpen] = useState(false);
+  // Controlled so selecting an existing worktree can close the popover.
+  const [worktreePopoverOpen, setWorktreePopoverOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   // "Connect a host" instructions modal, opened from the host dropdown.
@@ -1929,6 +1956,7 @@ export function NewChatLandingScreen() {
     workspace,
     branchName,
     baseBranch,
+    prefilledBranch,
     permissionMode,
     approvalMode,
     bypassSandbox,
@@ -2153,6 +2181,67 @@ export function NewChatLandingScreen() {
     return counts;
   }, [conflictCandidates, runnerHealth]);
 
+  // Existing git worktrees of the picked directory's repo, for the
+  // worktree picker. Skipped for sandbox sessions (server-managed) and
+  // when no directory is picked. A non-git path resolves to [].
+  const worktreesEnabled = !sandboxSelected && selectedHostId !== null && workspaceTrimmed !== "";
+  const { data: hostWorktrees } = useHostWorktrees(
+    worktreesEnabled ? selectedHostId : null,
+    worktreesEnabled ? workspaceTrimmed : null,
+  );
+  // Linked worktrees (exclude the main work tree — "starting in the main
+  // repo" is just picking that directory, not selecting a worktree).
+  const linkedWorktrees = useMemo(
+    () => (hostWorktrees ?? []).filter((w) => !w.is_main),
+    [hostWorktrees],
+  );
+  // The worktree the picked directory currently points at, if any. Set when
+  // the user navigated the picker straight into a worktree folder, or clicked
+  // one in the list below.
+  const activeWorktree = useMemo(() => {
+    const target = normalizeWorkspacePath(workspaceTrimmed);
+    if (target === null) return null;
+    return linkedWorktrees.find((w) => normalizeWorkspacePath(w.path) === target) ?? null;
+  }, [linkedWorktrees, workspaceTrimmed]);
+  // When the workspace lands on an existing worktree, prefill the branch
+  // field with its branch and remember it as the prefill. Leaving the
+  // worktree clears the prefill (but not a name the user typed themselves).
+  useEffect(() => {
+    const branch = activeWorktree?.branch ?? "";
+    if (branch !== "") {
+      setPrefilledBranch(branch);
+      setBranchName(branch);
+    } else {
+      setPrefilledBranch((prev) => {
+        // Only clear the field if it still holds the previous prefill —
+        // don't wipe a branch name the user typed for a new worktree.
+        setBranchName((cur) => (cur === prev ? "" : cur));
+        return "";
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeWorktree?.path]);
+  // True when the session should start directly in the existing worktree:
+  // the workspace is a worktree and the branch field still holds its
+  // prefilled branch (the user hasn't edited it to request a new worktree).
+  const startInExistingWorktree =
+    activeWorktree !== null && prefilledBranch !== "" && branchName.trim() === prefilledBranch;
+  // A new, isolated worktree is created only when a branch is named and the
+  // workspace isn't already sitting on that existing worktree.
+  const shouldCreateWorktree = branchName.trim() !== "" && !startInExistingWorktree;
+  // The branch input doubles as a combobox: focusing it reveals existing
+  // worktrees, and what the user types filters them (match on branch or path
+  // substring, case-insensitive). Typing a name that matches none = a new
+  // worktree; picking a match = start in that existing worktree.
+  const [branchInputFocused, setBranchInputFocused] = useState(false);
+  const filteredWorktrees = useMemo(() => {
+    const q = branchName.trim().toLowerCase();
+    if (q === "") return linkedWorktrees;
+    return linkedWorktrees.filter(
+      (w) => (w.branch ?? "").toLowerCase().includes(q) || w.path.toLowerCase().includes(q),
+    );
+  }, [linkedWorktrees, branchName]);
+
   // Sandbox repo inputs are valid when blank (empty workspace), or when
   // the URL passes the shape check; a branch without a URL is dangling.
   const sandboxRepoValid =
@@ -2333,6 +2422,8 @@ export function NewChatLandingScreen() {
     : sandboxSelected
       ? sandboxLabel
       : (selectedHost?.name ?? (onlineHosts.length === 0 ? "No hosts" : "Select host"));
+  // The chip shows just the branch (the "(existing)" distinction lives in the
+  // popover's warning; appending it here only gets clipped by the chip's cap).
   const worktreeLabel = branchName.trim() || "No worktree";
   // Sandbox repository chip label: repo name (server's clone-dir rule)
   // plus the pinned branch, e.g. "repo#main"; placeholder when unset.
@@ -2428,6 +2519,11 @@ export function NewChatLandingScreen() {
     setCreateError(null);
     try {
       const trimmedBranch = branchName.trim();
+      // `shouldCreateWorktree` (component scope): true only when a branch is
+      // named and the workspace isn't already an existing worktree. Starting
+      // in an existing worktree sends no git opts — the workspace is bound
+      // straight to that dir, which also sidesteps the "branch already
+      // exists" guard.
       const agent = agentList.find((a) => a.id === effectiveAgentId);
       const nativeLabels = nativeWrapperLabelsForAgent(agent);
       const agentSupportsPermissionMode = nativeAgentHasCapability(agent, "permissionMode");
@@ -2452,7 +2548,7 @@ export function NewChatLandingScreen() {
         // Launch the runner on the selected host. The multipart create
         // only stores DB rows — launchRunner binds + starts the runner.
         if (!sandboxSelected && selectedHostId && workspaceTrimmed) {
-          const gitOpts = trimmedBranch
+          const gitOpts = shouldCreateWorktree
             ? { branchName: trimmedBranch, baseBranch: baseBranch.trim() || undefined }
             : undefined;
           await launchRunner(selectedHostId, data.id, workspaceTrimmed, gitOpts);
@@ -2474,7 +2570,7 @@ export function NewChatLandingScreen() {
               : {
                   host_id: selectedHostId,
                   workspace: workspaceTrimmed,
-                  git: trimmedBranch
+                  git: shouldCreateWorktree
                     ? { branch_name: trimmedBranch, base_branch: baseBranch.trim() || undefined }
                     : undefined,
                 }),
@@ -3229,11 +3325,12 @@ export function NewChatLandingScreen() {
                         }
                         onNavigate={setWorkspace}
                         // Warn when browsing into a directory other live agents
-                        // occupy. Suppressed once a git branch is named — that
-                        // starts an isolated worktree, so there's no shared-dir
-                        // conflict regardless of the picked directory.
+                        // occupy. Suppressed only when a NEW isolated worktree
+                        // will be created (no shared-dir conflict then). When
+                        // starting directly in an existing worktree the branch
+                        // is prefilled but the dir IS shared, so keep warning.
                         occupancyForPath={
-                          branchName.trim() === ""
+                          !shouldCreateWorktree
                             ? (abs) => occupancyByDir.get(normalizeWorkspacePath(abs) ?? "") ?? 0
                             : undefined
                         }
@@ -3248,7 +3345,7 @@ export function NewChatLandingScreen() {
               {/* Git worktree chip — hidden for sandbox sessions (worktree
                 creation requires a caller-supplied host_id). */}
               {!sandboxSelected && (
-                <Popover>
+                <Popover open={worktreePopoverOpen} onOpenChange={setWorktreePopoverOpen}>
                   <PopoverTrigger asChild>
                     <button
                       type="button"
@@ -3264,7 +3361,14 @@ export function NewChatLandingScreen() {
                       <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
                     </button>
                   </PopoverTrigger>
-                  <PopoverContent align="start" className="w-[min(20rem,calc(100vw-2rem))] p-3">
+                  <PopoverContent
+                    align="start"
+                    collisionPadding={16}
+                    // No overflow clip here — the worktree dropdown floats as an
+                    // absolute overlay (below) and must be able to escape the
+                    // popover's padding box.
+                    className="w-[min(20rem,calc(100vw-2rem))] p-3"
+                  >
                     <div className="flex flex-col gap-2">
                       <label
                         htmlFor="landing-branch-name"
@@ -3272,30 +3376,119 @@ export function NewChatLandingScreen() {
                       >
                         Git worktree branch (optional)
                       </label>
-                      <input
-                        id="landing-branch-name"
-                        type="text"
-                        value={branchName}
-                        onChange={(e) => setBranchName(e.target.value)}
-                        placeholder="feature/my-branch"
-                        className="rounded-md border border-input bg-background px-3 py-2 text-xs outline-none transition-colors focus-visible:border-ring"
-                        data-testid="new-chat-landing-branch-input"
-                      />
-                      {branchName.trim() !== "" && (
+                      {/* Help text sits above the field. The warning for a picked
+                        existing worktree stays below the input (contextual to the
+                        selection). */}
+                      <p className="text-xs text-muted-foreground">
+                        New branch name, or pick an existing worktree. Leave blank to start directly
+                        in the working directory.
+                      </p>
+                      {/* The branch field is a combobox: focusing it reveals the
+                        repo's existing worktrees, and typing filters them.
+                        Picking one starts in that worktree; a name matching none
+                        creates a new worktree. */}
+                      <div className="relative flex flex-col">
+                        <input
+                          id="landing-branch-name"
+                          type="text"
+                          value={branchName}
+                          onChange={(e) => setBranchName(e.target.value)}
+                          onFocus={() => setBranchInputFocused(true)}
+                          // Delay so a click on a dropdown option registers
+                          // before the list unmounts on blur.
+                          onBlur={() => setTimeout(() => setBranchInputFocused(false), 120)}
+                          placeholder="feature/my-branch"
+                          role="combobox"
+                          aria-expanded={branchInputFocused && filteredWorktrees.length > 0}
+                          aria-autocomplete="list"
+                          // Suppress the browser's native autofill dropdown so it
+                          // doesn't overlay our worktree combobox. `off` alone is
+                          // ignored by some browsers, so also disable spellcheck /
+                          // autocorrect and give it an unrecognized name.
+                          autoComplete="off"
+                          autoCorrect="off"
+                          autoCapitalize="off"
+                          spellCheck={false}
+                          name="omnigent-worktree-branch"
+                          className="rounded-md border border-input bg-background px-3 py-2 text-xs outline-none transition-colors focus-visible:border-ring"
+                          data-testid="new-chat-landing-branch-input"
+                        />
+                        {branchInputFocused && filteredWorktrees.length > 0 && (
+                          <div
+                            // Floats over the popover as a combobox popup, so it
+                            // doesn't stretch the box. Bounded height + internal
+                            // scroll keep it from running off the viewport.
+                            className="absolute top-full right-0 left-0 z-20 mt-1 flex max-h-40 flex-col overflow-y-auto rounded-md border border-input bg-popover p-1 shadow-md"
+                            data-testid="new-chat-landing-worktree-dropdown"
+                          >
+                            <span className="px-2 pt-1 pb-0.5 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
+                              Existing worktrees
+                            </span>
+                            <ul className="flex flex-col gap-0.5">
+                            {filteredWorktrees.map((w) => {
+                              const selected =
+                                normalizeWorkspacePath(w.path) ===
+                                normalizeWorkspacePath(workspaceTrimmed);
+                              return (
+                                <li key={w.path}>
+                                  <button
+                                    type="button"
+                                    // onMouseDown (not onClick): fires before the
+                                    // input's blur, so the selection lands even
+                                    // though blur is about to hide the list.
+                                    onMouseDown={(e) => {
+                                      e.preventDefault();
+                                      setWorkspace(w.path);
+                                      setBranchInputFocused(false);
+                                      setWorktreePopoverOpen(false);
+                                    }}
+                                    className={`flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1 text-left text-xs transition-colors hover:bg-accent ${
+                                      selected ? "bg-accent" : ""
+                                    }`}
+                                    data-testid="new-chat-landing-worktree-option"
+                                  >
+                                    <span className="font-medium text-foreground">
+                                      {w.branch ?? "(detached)"}
+                                    </span>
+                                    {/* Tail-truncated so the disambiguating
+                                      folder shows, not a shared prefix; full
+                                      path on hover. */}
+                                    <span
+                                      className="w-full truncate text-muted-foreground"
+                                      title={w.path}
+                                    >
+                                      {worktreePathTail(w.path)}
+                                    </span>
+                                  </button>
+                                </li>
+                              );
+                            })}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                      {/* Base branch only matters when creating a NEW worktree
+                        — hidden once the workspace points at an existing one
+                        (no worktree is created, so there's nothing to base). */}
+                      {branchName.trim() !== "" && !startInExistingWorktree && (
                         <input
                           type="text"
                           value={baseBranch}
                           onChange={(e) => setBaseBranch(e.target.value)}
-                          placeholder="Base branch (defaults to current branch)"
+                          placeholder="Base branch (defaults to current)"
                           aria-label="Base branch"
                           className="rounded-md border border-input bg-background px-3 py-2 text-xs outline-none transition-colors focus-visible:border-ring"
                           data-testid="new-chat-landing-base-branch-input"
                         />
                       )}
-                      <p className="text-xs text-muted-foreground">
-                        Creates an isolated git worktree for a new branch. Leave blank to start
-                        directly in the working directory.
-                      </p>
+                      {startInExistingWorktree && (
+                        <p
+                          className="text-xs text-amber-600 dark:text-amber-500"
+                          data-testid="new-chat-landing-existing-worktree-warning"
+                        >
+                          Starts in existing worktree, edit the name to create a new one.
+                        </p>
+                      )}
                     </div>
                   </PopoverContent>
                 </Popover>

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3425,44 +3425,44 @@ export function NewChatLandingScreen() {
                               Existing worktrees
                             </span>
                             <ul className="flex flex-col gap-0.5">
-                            {filteredWorktrees.map((w) => {
-                              const selected =
-                                normalizeWorkspacePath(w.path) ===
-                                normalizeWorkspacePath(workspaceTrimmed);
-                              return (
-                                <li key={w.path}>
-                                  <button
-                                    type="button"
-                                    // onMouseDown (not onClick): fires before the
-                                    // input's blur, so the selection lands even
-                                    // though blur is about to hide the list.
-                                    onMouseDown={(e) => {
-                                      e.preventDefault();
-                                      setWorkspace(w.path);
-                                      setBranchInputFocused(false);
-                                      setWorktreePopoverOpen(false);
-                                    }}
-                                    className={`flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1 text-left text-xs transition-colors hover:bg-accent ${
-                                      selected ? "bg-accent" : ""
-                                    }`}
-                                    data-testid="new-chat-landing-worktree-option"
-                                  >
-                                    <span className="font-medium text-foreground">
-                                      {w.branch ?? "(detached)"}
-                                    </span>
-                                    {/* Tail-truncated so the disambiguating
+                              {filteredWorktrees.map((w) => {
+                                const selected =
+                                  normalizeWorkspacePath(w.path) ===
+                                  normalizeWorkspacePath(workspaceTrimmed);
+                                return (
+                                  <li key={w.path}>
+                                    <button
+                                      type="button"
+                                      // onMouseDown (not onClick): fires before the
+                                      // input's blur, so the selection lands even
+                                      // though blur is about to hide the list.
+                                      onMouseDown={(e) => {
+                                        e.preventDefault();
+                                        setWorkspace(w.path);
+                                        setBranchInputFocused(false);
+                                        setWorktreePopoverOpen(false);
+                                      }}
+                                      className={`flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1 text-left text-xs transition-colors hover:bg-accent ${
+                                        selected ? "bg-accent" : ""
+                                      }`}
+                                      data-testid="new-chat-landing-worktree-option"
+                                    >
+                                      <span className="font-medium text-foreground">
+                                        {w.branch ?? "(detached)"}
+                                      </span>
+                                      {/* Tail-truncated so the disambiguating
                                       folder shows, not a shared prefix; full
                                       path on hover. */}
-                                    <span
-                                      className="w-full truncate text-muted-foreground"
-                                      title={w.path}
-                                    >
-                                      {worktreePathTail(w.path)}
-                                    </span>
-                                  </button>
-                                </li>
-                              );
-                            })}
+                                      <span
+                                        className="w-full truncate text-muted-foreground"
+                                        title={w.path}
+                                      >
+                                        {worktreePathTail(w.path)}
+                                      </span>
+                                    </button>
+                                  </li>
+                                );
+                              })}
                             </ul>
                           </div>
                         )}


### PR DESCRIPTION
## Related issue

Closes #1919

## Summary

- The new-session worktree field only ever *created* a new worktree off a branch name; picking a directory that was already an existing worktree errored ("branch already exists"). This adds first-class support for **starting a session directly in an existing worktree**.
- The **branch input is now a combobox**: focusing it lists the repo's existing worktrees, typing filters them, picking one starts the session in that worktree (sends **no git opts**, so it sidesteps the branch-already-exists guard), and a name matching none creates a new worktree as before. A concise amber warning flags when the session will start in an existing worktree.
- Backend adds a read-only `list_worktrees` host git op, the matching `list_worktrees` tunnel frame pair, a server proxy, and `GET /hosts/{id}/worktrees` (owner-scoped; a non-git path → 400 → empty list in the picker) — mirroring the existing create/remove worktree plumbing.

Follow-up (out of scope): showing the branch in the sidebar for existing-worktree sessions requires decoupling display from the `git_branch` ownership/cleanup semantics, so it's deferred.

## Test Plan

- `omnigent/host/git_worktree.py`: unit tests for `list_worktrees` against a real temp repo (main-only, linked worktree, listing from inside a linked worktree, detached HEAD, non-git path).
- `omnigent/host/frames.py`: encode/decode round-trip tests for the new frame pair, including the null-list failure case and non-list rejection.
- `omnigent/server/routes/hosts.py`: integration tests for the new endpoint (returns data, non-git → 400, missing `path` param → 422, unknown host → 404) via a mock host tunnel.
- Web: `NewChatDialog` component tests — combobox lists/filters worktrees, selecting one prefills the branch + starts in it (no git opts) + auto-closes the popover, editing the prefilled name creates a new worktree, and `worktreePathTail` unit tests.
- Ran the full web suite (`npm test`, 3671 passing), `npm run build`, `tsc -b`, `ruff format`/`ruff check`, and `oxlint` — all green.

## Demo

_UI change — screen recordings/screenshots of the worktree combobox to be attached._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: exercised the worktree combobox in the running web UI — focus reveals existing worktrees, typing filters, selecting starts in the worktree and auto-closes the popover, editing the name switches to creating a new worktree. The endpoint's live path (real host tunnel + `git worktree list`) is covered by the integration test's mock tunnel rather than an e2e runner (the e2e-ui runner has no workspace).

## Changelog

Start a new session directly in an existing git worktree by picking it from the worktree field.

This pull request and its description were written by Isaac.
