### PR TITLE
feat(db): store enum-like columns as SMALLINT int codes

### DIFF
--- a/omnigent/db/converters.py
+++ b/omnigent/db/converters.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from omnigent.db.db_models import AGENT_KIND_TEMPLATE, SqlAgent
+from omnigent.db.db_models import SqlAgent
+from omnigent.db.enum_codecs import AGENT_KIND
 from omnigent.entities import Agent
 
 
@@ -15,7 +16,7 @@ def sql_agent_to_entity(row: SqlAgent, session_id: str | None = None) -> Agent:
         session-scoped; ``None`` for template agents. Callers that know
         the owning conversation id (e.g. the conversation store) pass it
         directly; the agent store leaves it ``None`` for templates (where
-        ``row.kind == AGENT_KIND_TEMPLATE``).
+        ``row.kind`` is the "template" code).
     :returns: An :class:`Agent` dataclass instance.
     """
     return Agent(
@@ -26,5 +27,5 @@ def sql_agent_to_entity(row: SqlAgent, session_id: str | None = None) -> Agent:
         version=row.version,
         description=row.description,
         updated_at=row.updated_at,
-        session_id=None if row.kind == AGENT_KIND_TEMPLATE else session_id,
+        session_id=None if row.kind == AGENT_KIND["template"] else session_id,
     )

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Float,
     Index,
     Integer,
+    SmallInteger,
     String,
     Text,
     UniqueConstraint,
@@ -117,21 +118,25 @@ class SqlAgent(Base):
     name: Mapped[str] = mapped_column(String(256))
     bundle_location: Mapped[str] = mapped_column(String(512))
     version: Mapped[int] = mapped_column(Integer, default=1)
-    kind: Mapped[str] = mapped_column(String(16))
+    # Enum stored as a stable int code (see omnigent.db.enum_codecs
+    # AGENT_KIND: template=1, session=2). The store converts to/from the
+    # string name at the row↔entity boundary.
+    kind: Mapped[int] = mapped_column(SmallInteger)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     __table_args__ = (
+        CheckConstraint("kind IN (1, 2)", name="ck_agents_kind"),
         Index("ix_agents_created_at", "created_at"),
-        # Template agents have unique names; session-scoped agents (kind='session')
+        # Template agents have unique names; session-scoped agents (kind=2)
         # may reuse the same name across conversations. The partial index enforces
-        # uniqueness only within the template set.
+        # uniqueness only within the template set. kind = 1 is the "template" code.
         Index(
             "ix_agents_template_name",
             "name",
             unique=True,
-            sqlite_where=text("kind = 'template'"),
-            postgresql_where=text("kind = 'template'"),
+            sqlite_where=text("kind = 1"),
+            postgresql_where=text("kind = 1"),
         ),
     )
 
@@ -261,7 +266,10 @@ class SqlAccountToken(Base):
         default=current_workspace_id,
     )
     id: Mapped[str] = mapped_column(String(128), primary_key=True)
-    kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    # Enum stored as a stable int code (see omnigent.db.enum_codecs
+    # ACCOUNT_TOKEN_KIND: invite=1, magic=2). The store converts to/from
+    # the string name at the row↔entity boundary.
+    kind: Mapped[int] = mapped_column(SmallInteger, nullable=False)
     user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
     created_at: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -270,7 +278,7 @@ class SqlAccountToken(Base):
     invited_is_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=false())
 
     __table_args__ = (
-        CheckConstraint("kind IN ('invite', 'magic')", name="ck_account_tokens_kind"),
+        CheckConstraint("kind IN (1, 2)", name="ck_account_tokens_kind"),
         Index("ix_account_tokens_expires_at", "expires_at"),
     )
 
@@ -412,7 +420,10 @@ class SqlConversation(Base):
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int] = mapped_column(Integer)
     title: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
-    kind: Mapped[str] = mapped_column(String(32), default="default")
+    # Enum stored as a stable int code (see omnigent.db.enum_codecs
+    # CONVERSATION_KIND: default=1, sub_agent=2). The store converts to/from
+    # the string name at the row↔entity boundary.
+    kind: Mapped[int] = mapped_column(SmallInteger, default=1)
     parent_conversation_id: Mapped[str | None] = mapped_column(
         String(64),
         nullable=True,
@@ -500,7 +511,7 @@ class SqlConversation(Base):
     )
 
     __table_args__ = (
-        CheckConstraint("kind IN ('default', 'sub_agent')", name="ck_conversations_kind"),
+        CheckConstraint("kind IN (1, 2)", name="ck_conversations_kind"),
         CheckConstraint(
             "host_id IS NULL OR workspace IS NOT NULL",
             name="ck_conversations_workspace_required_for_host",
@@ -530,13 +541,14 @@ class SqlConversation(Base):
         ),
         # Partial composite index for child-session listing
         # (list_conversations(kind="sub_agent", parent_conversation_id=...)).
+        # kind = 2 is the "sub_agent" code (enum_codecs.CONVERSATION_KIND).
         Index(
             "idx_conversations_parent",
             "parent_conversation_id",
             text("created_at DESC"),
             text("id DESC"),
-            sqlite_where=text("kind = 'sub_agent'"),
-            postgresql_where=text("kind = 'sub_agent'"),
+            sqlite_where=text("kind = 2"),
+            postgresql_where=text("kind = 2"),
         ),
     )
 
@@ -586,9 +598,15 @@ class SqlConversationItem(Base):
     )
     response_id: Mapped[str] = mapped_column(String(64))
     created_at: Mapped[int] = mapped_column(Integer)
-    status: Mapped[str] = mapped_column(String(32), default="completed")
+    # Enum stored as a stable int code (see omnigent.db.enum_codecs
+    # ITEM_STATUS: completed=1). Only "completed" is written today, but the
+    # CHECK admits the wider OpenAI-style status vocabulary reserved there.
+    status: Mapped[int] = mapped_column(SmallInteger, default=1)
     position: Mapped[int] = mapped_column(Integer)
-    type: Mapped[str] = mapped_column(String(32))
+    # Enum stored as a stable int code (see omnigent.db.enum_codecs
+    # ITEM_TYPE). The store converts to/from the string name at the
+    # row↔entity boundary.
+    type: Mapped[int] = mapped_column(SmallInteger)
     data: Mapped[str] = mapped_column(Text)
     search_text: Mapped[str] = mapped_column(Text)
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
@@ -601,6 +619,11 @@ class SqlConversationItem(Base):
             unique=True,
         ),
         Index("ix_conversation_items_response_id", "response_id"),
+        CheckConstraint(
+            "type IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)",
+            name="ck_conversation_items_type",
+        ),
+        CheckConstraint("status IN (1, 2, 3, 4)", name="ck_conversation_items_status"),
     )
 
 
@@ -711,13 +734,16 @@ class SqlComment(Base):
     start_index: Mapped[int] = mapped_column(Integer)
     end_index: Mapped[int] = mapped_column(Integer)
     body: Mapped[str] = mapped_column(Text)
-    status: Mapped[str] = mapped_column(String(32))
+    # Enum stored as a stable int code (see omnigent.db.enum_codecs
+    # COMMENT_STATUS: draft=1, addressed=2).
+    status: Mapped[int] = mapped_column(SmallInteger)
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int] = mapped_column(BigInteger)
     anchor_content: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     __table_args__ = (
+        CheckConstraint("status IN (1, 2)", name="ck_comments_status"),
         Index("ix_comments_conversation_id", "conversation_id"),
         Index("ix_comments_created_at", "created_at"),
     )
@@ -782,7 +808,9 @@ class SqlPolicy(Base):
     )
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    type: Mapped[str] = mapped_column(String(16))
+    # Handler discriminator stored as a stable int code (see
+    # omnigent.db.enum_codecs POLICY_TYPE: python=1, url=2).
+    type: Mapped[int] = mapped_column(SmallInteger)
     # Dotted import path (type="python") or HTTPS URL
     # (type="url") for the policy handler.
     handler: Mapped[str] = mapped_column(Text)
@@ -794,23 +822,27 @@ class SqlPolicy(Base):
     enabled: Mapped[bool] = mapped_column(Boolean, server_default=true())
     # "default" for server-wide policies; "session" for per-conversation
     # copies. Mirrors the agents.kind pattern so queries filter by column
-    # value rather than session_id IS NULL.
-    scope: Mapped[str] = mapped_column(String(16))
+    # value rather than session_id IS NULL. Enum stored as a stable int
+    # code (see omnigent.db.enum_codecs POLICY_SCOPE: default=1, session=2).
+    scope: Mapped[int] = mapped_column(SmallInteger)
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     __table_args__ = (
+        CheckConstraint("type IN (1, 2)", name="ck_policies_type"),
+        CheckConstraint("scope IN (1, 2)", name="ck_policies_scope"),
         Index("ix_policies_created_at", "created_at"),
         Index("ix_policies_session_id", "session_id"),
         UniqueConstraint("session_id", "name", name="uq_policies_session_id_name"),
         # Default policies must have unique names; session-scoped policies
         # may reuse the same name across conversations. Mirrors
-        # ix_agents_template_name scoping to the 'default' set.
+        # ix_agents_template_name scoping to the 'default' set. scope = 1 is
+        # the "default" code.
         Index(
             "ix_policies_default_name",
             "name",
             unique=True,
-            sqlite_where=text("scope = 'default'"),
-            postgresql_where=text("scope = 'default'"),
+            sqlite_where=text("scope = 1"),
+            postgresql_where=text("scope = 1"),
         ),
     )
 
@@ -879,7 +911,9 @@ class SqlHost(Base):
     owner: Mapped[str] = mapped_column(String(256), primary_key=True)
     name: Mapped[str] = mapped_column(String(64), primary_key=True)
     host_id: Mapped[str] = mapped_column(String(64))
-    status: Mapped[str] = mapped_column(String(16))
+    # Enum stored as a stable int code (see omnigent.db.enum_codecs
+    # HOST_STATUS: online=1, offline=2).
+    status: Mapped[int] = mapped_column(SmallInteger)
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int] = mapped_column(Integer)
     token_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
@@ -890,7 +924,7 @@ class SqlHost(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "status IN ('online', 'offline')",
+            "status IN (1, 2)",
             name="ck_hosts_status",
         ),
         UniqueConstraint("host_id", name="uq_hosts_host_id"),

--- a/omnigent/db/enum_codecs.py
+++ b/omnigent/db/enum_codecs.py
@@ -1,0 +1,249 @@
+"""Name↔int codecs for enum-like columns stored as ``SMALLINT``.
+
+Several low-cardinality closed-set columns (``conversations.kind``,
+``conversation_items.type``/``status``, ``comments.status``,
+``account_tokens.kind``, ``policies.type``, ``policies.scope``,
+``hosts.status``, ``agents.kind``) are stored as integer codes rather
+than their string names — smaller rows and a tighter ``CHECK`` than a
+free ``VARCHAR``. The string names remain the
+contract for entities, the HTTP API, the web client, and the SDKs; the
+integer form never leaves the store row↔entity boundary. These codecs are
+the single place that translates between the two.
+
+Codes are STABLE and append-only: never renumber or reuse a shipped code,
+and leave gaps rather than reordering, so old rows keep their meaning.
+This mirrors :data:`omnigent.server.auth.LEVEL_READ` and friends, the
+existing int-coded ``session_permissions.level``.
+"""
+
+from __future__ import annotations
+
+from omnigent.entities.conversation import ITEM_TYPE_TO_DATA_CLS
+
+# ── Code tables (name → stable int code) ───────────────
+
+CONVERSATION_KIND: dict[str, int] = {
+    "default": 1,
+    "sub_agent": 2,
+}
+
+# Item type codes. The key set is kept in lock-step with
+# ITEM_TYPE_TO_DATA_CLS (the app-layer source of truth) by
+# _assert_item_type_codes_cover_data_classes below, so a newly added item
+# type cannot ship without a code. Codes are append-only.
+ITEM_TYPE: dict[str, int] = {
+    "message": 1,
+    "function_call": 2,
+    "function_call_output": 3,
+    "reasoning": 4,
+    "error": 5,
+    "compaction": 6,
+    "native_tool": 7,
+    "resource_event": 8,
+    "routing_decision": 9,
+    "slash_command": 10,
+    "terminal_command": 11,
+}
+
+# Item status codes. Only "completed" is written today (items are final on
+# append), but the field is semantically an OpenAI-style status that may
+# widen, so codes for the rest of that vocabulary are reserved up front and
+# the column CHECK admits all of them.
+ITEM_STATUS: dict[str, int] = {
+    "completed": 1,
+    "in_progress": 2,
+    "incomplete": 3,
+    "failed": 4,
+}
+
+COMMENT_STATUS: dict[str, int] = {
+    "draft": 1,
+    "addressed": 2,
+}
+
+ACCOUNT_TOKEN_KIND: dict[str, int] = {
+    "invite": 1,
+    "magic": 2,
+}
+
+POLICY_TYPE: dict[str, int] = {
+    "python": 1,
+    "url": 2,
+}
+
+HOST_STATUS: dict[str, int] = {
+    "online": 1,
+    "offline": 2,
+}
+
+AGENT_KIND: dict[str, int] = {
+    "template": 1,
+    "session": 2,
+}
+
+POLICY_SCOPE: dict[str, int] = {
+    "default": 1,
+    "session": 2,
+}
+
+
+def _assert_item_type_codes_cover_data_classes() -> None:
+    """
+    Guard that :data:`ITEM_TYPE` matches the app's item-type registry.
+
+    Raised at import time (and asserted by a unit test) so a new item type
+    added to ``ITEM_TYPE_TO_DATA_CLS`` without a corresponding code fails
+    loudly instead of silently breaking persistence.
+
+    :raises RuntimeError: If the two key sets diverge.
+    """
+    missing = set(ITEM_TYPE_TO_DATA_CLS) - set(ITEM_TYPE)
+    extra = set(ITEM_TYPE) - set(ITEM_TYPE_TO_DATA_CLS)
+    if missing or extra:
+        raise RuntimeError(
+            "ITEM_TYPE codes are out of sync with ITEM_TYPE_TO_DATA_CLS "
+            f"(missing codes for {sorted(missing)}, "
+            f"unknown types {sorted(extra)})."
+        )
+
+
+_assert_item_type_codes_cover_data_classes()
+
+
+# ── Encode / decode ────────────────────────────────────
+
+
+def _invert(table: dict[str, int]) -> dict[int, str]:
+    """Return the code→name inverse of a name→code table."""
+    return {code: name for name, code in table.items()}
+
+
+_CODE_TO_NAME: dict[int, dict[int, str]] = {}
+
+
+def _encode(table: dict[str, int], name: str, *, field: str) -> int:
+    """
+    Map an enum *name* to its stable integer code.
+
+    :param table: The name→code table for the field.
+    :param name: The string enum name, e.g. ``"sub_agent"``.
+    :param field: Field label used in the error message, e.g.
+        ``"conversations.kind"``.
+    :returns: The integer code.
+    :raises ValueError: If *name* is not a known value for the field.
+    """
+    try:
+        return table[name]
+    except KeyError:
+        raise ValueError(f"unknown {field} value: {name!r}") from None
+
+
+def _decode(table: dict[str, int], code: int, *, field: str) -> str:
+    """
+    Map an integer *code* back to its enum name.
+
+    :param table: The name→code table for the field.
+    :param code: The stored integer code.
+    :param field: Field label used in the error message, e.g.
+        ``"conversations.kind"``.
+    :returns: The string enum name.
+    :raises ValueError: If *code* is not a known code for the field.
+    """
+    inverse = _CODE_TO_NAME.get(id(table))
+    if inverse is None:
+        inverse = _invert(table)
+        _CODE_TO_NAME[id(table)] = inverse
+    try:
+        return inverse[code]
+    except KeyError:
+        raise ValueError(f"unknown {field} code: {code!r}") from None
+
+
+def encode_conversation_kind(name: str) -> int:
+    """Encode a ``conversations.kind`` name to its int code."""
+    return _encode(CONVERSATION_KIND, name, field="conversations.kind")
+
+
+def decode_conversation_kind(code: int) -> str:
+    """Decode a ``conversations.kind`` int code to its name."""
+    return _decode(CONVERSATION_KIND, code, field="conversations.kind")
+
+
+def encode_item_type(name: str) -> int:
+    """Encode a ``conversation_items.type`` name to its int code."""
+    return _encode(ITEM_TYPE, name, field="conversation_items.type")
+
+
+def decode_item_type(code: int) -> str:
+    """Decode a ``conversation_items.type`` int code to its name."""
+    return _decode(ITEM_TYPE, code, field="conversation_items.type")
+
+
+def encode_item_status(name: str) -> int:
+    """Encode a ``conversation_items.status`` name to its int code."""
+    return _encode(ITEM_STATUS, name, field="conversation_items.status")
+
+
+def decode_item_status(code: int) -> str:
+    """Decode a ``conversation_items.status`` int code to its name."""
+    return _decode(ITEM_STATUS, code, field="conversation_items.status")
+
+
+def encode_comment_status(name: str) -> int:
+    """Encode a ``comments.status`` name to its int code."""
+    return _encode(COMMENT_STATUS, name, field="comments.status")
+
+
+def decode_comment_status(code: int) -> str:
+    """Decode a ``comments.status`` int code to its name."""
+    return _decode(COMMENT_STATUS, code, field="comments.status")
+
+
+def encode_account_token_kind(name: str) -> int:
+    """Encode an ``account_tokens.kind`` name to its int code."""
+    return _encode(ACCOUNT_TOKEN_KIND, name, field="account_tokens.kind")
+
+
+def decode_account_token_kind(code: int) -> str:
+    """Decode an ``account_tokens.kind`` int code to its name."""
+    return _decode(ACCOUNT_TOKEN_KIND, code, field="account_tokens.kind")
+
+
+def encode_policy_type(name: str) -> int:
+    """Encode a ``policies.type`` name to its int code."""
+    return _encode(POLICY_TYPE, name, field="policies.type")
+
+
+def decode_policy_type(code: int) -> str:
+    """Decode a ``policies.type`` int code to its name."""
+    return _decode(POLICY_TYPE, code, field="policies.type")
+
+
+def encode_host_status(name: str) -> int:
+    """Encode a ``hosts.status`` name to its int code."""
+    return _encode(HOST_STATUS, name, field="hosts.status")
+
+
+def decode_host_status(code: int) -> str:
+    """Decode a ``hosts.status`` int code to its name."""
+    return _decode(HOST_STATUS, code, field="hosts.status")
+
+
+def encode_agent_kind(name: str) -> int:
+    """Encode an ``agents.kind`` name to its int code."""
+    return _encode(AGENT_KIND, name, field="agents.kind")
+
+
+def decode_agent_kind(code: int) -> str:
+    """Decode an ``agents.kind`` int code to its name."""
+    return _decode(AGENT_KIND, code, field="agents.kind")
+
+
+def encode_policy_scope(name: str) -> int:
+    """Encode a ``policies.scope`` name to its int code."""
+    return _encode(POLICY_SCOPE, name, field="policies.scope")
+
+
+def decode_policy_scope(code: int) -> str:
+    """Decode a ``policies.scope`` int code to its name."""
+    return _decode(POLICY_SCOPE, code, field="policies.scope")

--- a/omnigent/db/migrations/versions/u1a2b3c4d5e6_enums_varchar_to_smallint.py
+++ b/omnigent/db/migrations/versions/u1a2b3c4d5e6_enums_varchar_to_smallint.py
@@ -1,0 +1,370 @@
+"""Convert enum-like varchar columns to SMALLINT int codes.
+
+Revision ID: u1a2b3c4d5e6
+Revises: t1a2b3c4d5e6
+Create Date: 2026-07-07
+
+Several low-cardinality closed-set columns were stored as ``VARCHAR``
+guarded by string ``CHECK`` constraints. This migration converts them to
+compact ``SMALLINT`` integer codes (client-side name↔int conversion lives
+in ``omnigent.db.enum_codecs``), matching the existing int-coded
+``session_permissions.level``. The string names remain the contract above
+the store layer, so only the stored representation changes.
+
+Columns converted (name → code):
+
+- ``conversations.kind``          default=1, sub_agent=2
+- ``conversation_items.type``     message=1 … terminal_command=11
+- ``conversation_items.status``   completed=1 (in_progress=2, incomplete=3,
+                                   failed=4 reserved)
+- ``comments.status``             draft=1, addressed=2
+- ``account_tokens.kind``         invite=1, magic=2
+- ``policies.type``               python=1, url=2
+- ``hosts.status``                online=1, offline=2
+
+Each column is converted with the add-int-column → backfill-with-``CASE`` →
+drop-old-column → rename pattern (portable across SQLite and PostgreSQL),
+swapping the string ``CHECK`` for an integer one. ``render_as_batch`` (see
+migrations/env.py) rebuilds the SQLite table so the constraint swap lands.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "u1a2b3c4d5e6"
+down_revision: str | None = "t1a2b3c4d5e6"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+# Name → int code, mirroring omnigent.db.enum_codecs. Duplicated here on
+# purpose: a migration must be pinned to the codes as they were when it was
+# written, independent of later edits to the codec module.
+_CONVERSATION_KIND = {"default": 1, "sub_agent": 2}
+_ITEM_TYPE = {
+    "message": 1,
+    "function_call": 2,
+    "function_call_output": 3,
+    "reasoning": 4,
+    "error": 5,
+    "compaction": 6,
+    "native_tool": 7,
+    "resource_event": 8,
+    "routing_decision": 9,
+    "slash_command": 10,
+    "terminal_command": 11,
+}
+_ITEM_STATUS = {"completed": 1, "in_progress": 2, "incomplete": 3, "failed": 4}
+_COMMENT_STATUS = {"draft": 1, "addressed": 2}
+_ACCOUNT_TOKEN_KIND = {"invite": 1, "magic": 2}
+_POLICY_TYPE = {"python": 1, "url": 2}
+_POLICY_SCOPE = {"default": 1, "session": 2}
+_HOST_STATUS = {"online": 1, "offline": 2}
+_AGENT_KIND = {"template": 1, "session": 2}
+
+
+def _case_sql(column: str, mapping: dict[str, int]) -> str:
+    """Build a ``CASE`` expression mapping string names to int codes."""
+    whens = " ".join(f"WHEN '{name}' THEN {code}" for name, code in mapping.items())
+    return f"CASE {column} {whens} END"
+
+
+def _case_sql_reverse(column: str, mapping: dict[str, int]) -> str:
+    """Build a ``CASE`` expression mapping int codes back to string names."""
+    whens = " ".join(f"WHEN {code} THEN '{name}'" for name, code in mapping.items())
+    return f"CASE {column} {whens} END"
+
+
+def _int_check(mapping: dict[str, int]) -> str:
+    """Build an ``IN (...)`` predicate over the mapping's int codes."""
+    codes = ", ".join(str(c) for c in sorted(mapping.values()))
+    return f"{{col}} IN ({codes})"
+
+
+def _string_check(mapping: dict[str, int]) -> str:
+    """Build an ``IN (...)`` predicate over the mapping's string names."""
+    names = ", ".join(f"'{n}'" for n in mapping)
+    return f"{{col}} IN ({names})"
+
+
+def _swap_to_int(
+    table: str,
+    column: str,
+    mapping: dict[str, int],
+    *,
+    check_name: str | None,
+    nullable: bool,
+) -> None:
+    """
+    Replace a string enum *column* with an int-coded ``SmallInteger``.
+
+    Adds ``<column>_int``, backfills it from the string values via ``CASE``,
+    then drops the old column, renames the new one into place, and (re)creates
+    the integer ``CHECK``. ``check_name`` drops a pre-existing string ``CHECK``
+    of that name inside the batch rebuild; pass ``None`` when the column has no
+    ``CHECK`` today.
+    """
+    tmp = f"{column}_int"
+    op.add_column(table, sa.Column(tmp, sa.SmallInteger(), nullable=True))
+    op.execute(f"UPDATE {table} SET {tmp} = {_case_sql(column, mapping)}")
+    recreate = "always" if _is_sqlite() else "auto"
+    with op.batch_alter_table(table, recreate=recreate) as batch_op:
+        if check_name is not None:
+            batch_op.drop_constraint(check_name, type_="check")
+        batch_op.drop_column(column)
+        batch_op.alter_column(tmp, new_column_name=column, nullable=nullable)
+        batch_op.create_check_constraint(
+            check_name or f"ck_{table}_{column}",
+            _int_check(mapping).format(col=column),
+        )
+
+
+def _swap_to_string(
+    table: str,
+    column: str,
+    mapping: dict[str, int],
+    *,
+    check_name: str | None,
+    nullable: bool,
+    length: int,
+) -> None:
+    """Inverse of :func:`_swap_to_int` — restore the string enum column."""
+    tmp = f"{column}_str"
+    op.add_column(table, sa.Column(tmp, sa.String(length=length), nullable=True))
+    op.execute(f"UPDATE {table} SET {tmp} = {_case_sql_reverse(column, mapping)}")
+    recreate = "always" if _is_sqlite() else "auto"
+    with op.batch_alter_table(table, recreate=recreate) as batch_op:
+        batch_op.drop_constraint(check_name or f"ck_{table}_{column}", type_="check")
+        batch_op.drop_column(column)
+        batch_op.alter_column(tmp, new_column_name=column, nullable=nullable)
+        if check_name is not None:
+            batch_op.create_check_constraint(check_name, _string_check(mapping).format(col=column))
+
+
+def _recreate_conversations_indexes(*, kind_is_int: bool) -> None:
+    """
+    Recreate the ``conversations`` indexes dropped for the ``kind`` swap.
+
+    The two partial indexes and the plain ``kind`` index are dropped before
+    the batch rebuild (SQLite batch mode can't copy a partial-index predicate
+    across a column swap) and recreated here. ``kind_is_int`` selects the
+    predicate literal for ``idx_conversations_parent`` — ``kind = 2`` after the
+    upgrade, ``kind = 'sub_agent'`` after a downgrade.
+    """
+    op.create_index("ix_conversations_kind", "conversations", ["kind"])
+    op.create_index(
+        "ix_conversations_parent_title_unique",
+        "conversations",
+        ["parent_conversation_id", "title"],
+        unique=True,
+        sqlite_where=sa.text("parent_conversation_id IS NOT NULL"),
+        postgresql_where=sa.text("parent_conversation_id IS NOT NULL"),
+    )
+    sub_agent = "2" if kind_is_int else "'sub_agent'"
+    op.create_index(
+        "idx_conversations_parent",
+        "conversations",
+        ["parent_conversation_id", sa.text("created_at DESC"), sa.text("id DESC")],
+        unique=False,
+        sqlite_where=sa.text(f"kind = {sub_agent}"),
+        postgresql_where=sa.text(f"kind = {sub_agent}"),
+    )
+
+
+def _drop_conversations_kind_indexes() -> None:
+    """Drop the ``conversations`` indexes that block the ``kind`` batch swap."""
+    op.drop_index("idx_conversations_parent", table_name="conversations")
+    op.drop_index("ix_conversations_parent_title_unique", table_name="conversations")
+    op.drop_index("ix_conversations_kind", table_name="conversations")
+
+
+def _drop_agents_kind_index() -> None:
+    """Drop the partial index whose predicate references ``agents.kind``."""
+    op.drop_index("ix_agents_template_name", table_name="agents")
+
+
+def _recreate_agents_kind_index(*, kind_is_int: bool) -> None:
+    """Recreate ``ix_agents_template_name`` (partial on the template kind)."""
+    template = "1" if kind_is_int else "'template'"
+    op.create_index(
+        "ix_agents_template_name",
+        "agents",
+        ["name"],
+        unique=True,
+        sqlite_where=sa.text(f"kind = {template}"),
+        postgresql_where=sa.text(f"kind = {template}"),
+    )
+
+
+def _drop_policies_scope_index() -> None:
+    """Drop the partial index whose predicate references ``policies.scope``."""
+    op.drop_index("ix_policies_default_name", table_name="policies")
+
+
+def _recreate_policies_scope_index(*, scope_is_int: bool) -> None:
+    """Recreate ``ix_policies_default_name`` (partial on the default scope)."""
+    default = "1" if scope_is_int else "'default'"
+    op.create_index(
+        "ix_policies_default_name",
+        "policies",
+        ["name"],
+        unique=True,
+        sqlite_where=sa.text(f"scope = {default}"),
+        postgresql_where=sa.text(f"scope = {default}"),
+    )
+
+
+def upgrade() -> None:
+    """Convert every enum-like varchar column to a SMALLINT int code."""
+    sqlite = _is_sqlite()
+    # SQLite runs migrations with foreign_keys ON; a batch table-rebuild then
+    # cascade-deletes child rows through the ON DELETE CASCADE FKs that point at
+    # the rebuilt table. Disable enforcement for the rebuilds (SQLite-only), and
+    # restore it after. Matches the p1/o1 migrations' guard.
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    # conversations has two partial indexes and a plain index on kind; SQLite
+    # batch mode can't copy a partial-index predicate across a column swap, so
+    # drop all three, swap the column, then recreate them (idx_conversations_
+    # parent's predicate now compares the int code).
+    _drop_conversations_kind_indexes()
+    _swap_to_int(
+        "conversations",
+        "kind",
+        _CONVERSATION_KIND,
+        check_name="ck_conversations_kind",
+        nullable=False,
+    )
+    _recreate_conversations_indexes(kind_is_int=True)
+
+    _swap_to_int(
+        "conversation_items",
+        "type",
+        _ITEM_TYPE,
+        check_name=None,
+        nullable=False,
+    )
+    _swap_to_int(
+        "conversation_items",
+        "status",
+        _ITEM_STATUS,
+        check_name=None,
+        nullable=False,
+    )
+    _swap_to_int(
+        "comments",
+        "status",
+        _COMMENT_STATUS,
+        check_name=None,
+        nullable=False,
+    )
+    _swap_to_int(
+        "account_tokens",
+        "kind",
+        _ACCOUNT_TOKEN_KIND,
+        check_name="ck_account_tokens_kind",
+        nullable=False,
+    )
+    # policies has a partial index (ix_policies_default_name) whose predicate
+    # references scope; drop it around both policy-column swaps so the batch
+    # rebuild doesn't copy a stale predicate, then recreate against the code.
+    _drop_policies_scope_index()
+    _swap_to_int(
+        "policies",
+        "type",
+        _POLICY_TYPE,
+        check_name=None,
+        nullable=False,
+    )
+    _swap_to_int(
+        "policies",
+        "scope",
+        _POLICY_SCOPE,
+        check_name=None,
+        nullable=False,
+    )
+    _recreate_policies_scope_index(scope_is_int=True)
+    _swap_to_int(
+        "hosts",
+        "status",
+        _HOST_STATUS,
+        check_name="ck_hosts_status",
+        nullable=False,
+    )
+    # agents has a partial index (ix_agents_template_name) whose predicate
+    # references kind; drop it around the swap and recreate against the code.
+    _drop_agents_kind_index()
+    _swap_to_int(
+        "agents",
+        "kind",
+        _AGENT_KIND,
+        check_name=None,
+        nullable=False,
+    )
+    _recreate_agents_kind_index(kind_is_int=True)
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def downgrade() -> None:
+    """Restore the original string enum columns and their CHECKs."""
+    sqlite = _is_sqlite()
+    # Same FK guard as upgrade(): the batch rebuilds below would otherwise
+    # cascade-delete child rows through ON DELETE CASCADE FKs on SQLite.
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    _drop_conversations_kind_indexes()
+    _swap_to_string(
+        "conversations",
+        "kind",
+        _CONVERSATION_KIND,
+        check_name="ck_conversations_kind",
+        nullable=False,
+        length=32,
+    )
+    _recreate_conversations_indexes(kind_is_int=False)
+
+    _swap_to_string(
+        "conversation_items", "type", _ITEM_TYPE, check_name=None, nullable=False, length=32
+    )
+    _swap_to_string(
+        "conversation_items",
+        "status",
+        _ITEM_STATUS,
+        check_name=None,
+        nullable=False,
+        length=32,
+    )
+    _swap_to_string(
+        "comments", "status", _COMMENT_STATUS, check_name=None, nullable=False, length=32
+    )
+    _swap_to_string(
+        "account_tokens",
+        "kind",
+        _ACCOUNT_TOKEN_KIND,
+        check_name="ck_account_tokens_kind",
+        nullable=False,
+        length=16,
+    )
+    _drop_policies_scope_index()
+    _swap_to_string("policies", "type", _POLICY_TYPE, check_name=None, nullable=False, length=16)
+    _swap_to_string("policies", "scope", _POLICY_SCOPE, check_name=None, nullable=False, length=16)
+    _recreate_policies_scope_index(scope_is_int=False)
+    _swap_to_string(
+        "hosts", "status", _HOST_STATUS, check_name="ck_hosts_status", nullable=False, length=16
+    )
+    _drop_agents_kind_index()
+    _swap_to_string("agents", "kind", _AGENT_KIND, check_name=None, nullable=False, length=16)
+    _recreate_agents_kind_index(kind_is_int=False)
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))

--- a/omnigent/server/accounts_store.py
+++ b/omnigent/server/accounts_store.py
@@ -39,6 +39,7 @@ from omnigent.db.db_models import (
     SqlUser,
     current_workspace_id,
 )
+from omnigent.db.enum_codecs import decode_account_token_kind, encode_account_token_kind
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
 from omnigent.entities import Account, AccountToken
 from omnigent.server.auth import RESERVED_USER_LOCAL, RESERVED_USER_PUBLIC
@@ -66,7 +67,7 @@ def _to_account_token(row: SqlAccountToken) -> AccountToken:
     """Convert a :class:`SqlAccountToken` row to a domain entity."""
     return AccountToken(
         id=row.id,
-        kind=row.kind,
+        kind=decode_account_token_kind(row.kind),
         user_id=row.user_id,
         created_by=row.created_by,
         created_at=row.created_at,
@@ -314,7 +315,7 @@ class SqlAlchemyAccountStore:
         with self._session() as session:
             row = SqlAccountToken(
                 id=token_id,
-                kind=kind,
+                kind=encode_account_token_kind(kind),
                 user_id=user_id,
                 created_by=created_by,
                 created_at=created_at,
@@ -348,7 +349,7 @@ class SqlAlchemyAccountStore:
                     and_(
                         SqlAccountToken.workspace_id == current_workspace_id(),
                         SqlAccountToken.id == token_id,
-                        SqlAccountToken.kind == kind,
+                        SqlAccountToken.kind == encode_account_token_kind(kind),
                         SqlAccountToken.redeemed_at.is_(None),
                         SqlAccountToken.expires_at > now_epoch_seconds,
                     )
@@ -413,7 +414,7 @@ class SqlAlchemyAccountStore:
                     and_(
                         SqlAccountToken.workspace_id == current_workspace_id(),
                         SqlAccountToken.id == token_id,
-                        SqlAccountToken.kind == "invite",
+                        SqlAccountToken.kind == encode_account_token_kind("invite"),
                         SqlAccountToken.redeemed_at.is_(None),
                         SqlAccountToken.expires_at > now_epoch_seconds,
                     )
@@ -440,7 +441,7 @@ class SqlAlchemyAccountStore:
                     exists().where(
                         and_(
                             SqlAccountToken.workspace_id == current_workspace_id(),
-                            SqlAccountToken.kind == "invite",
+                            SqlAccountToken.kind == encode_account_token_kind("invite"),
                             SqlAccountToken.user_id == email,
                             SqlAccountToken.redeemed_at.is_not(None),
                         )

--- a/omnigent/server/routes/comments.py
+++ b/omnigent/server/routes/comments.py
@@ -13,6 +13,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, model_validator
 
+from omnigent.db.enum_codecs import COMMENT_STATUS
 from omnigent.entities import Comment
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.auth import LEVEL_EDIT, LEVEL_READ, AuthProvider
@@ -292,6 +293,18 @@ def create_comments_router(
             # update_comment tool) may perform.
             if body.body is not None:
                 await _require_comment_author(user_id, comment_id, session_id)
+        # Validate the status only after existence/ownership checks, so a
+        # request targeting a comment the caller can't see still returns 404
+        # (not a 400 that would leak the comment's existence). The check keeps
+        # an unknown status out of the store, where the enum codec would raise
+        # into an opaque 500; the column is a closed enum (draft/addressed).
+        if body.status is not None and body.status not in COMMENT_STATUS:
+            if store.get(comment_id, session_id) is None:
+                raise OmnigentError("Comment not found", code=ErrorCode.NOT_FOUND)
+            raise OmnigentError(
+                f"invalid status {body.status!r}; must be one of {sorted(COMMENT_STATUS)}",
+                code=ErrorCode.INVALID_INPUT,
+            )
         comment = store.update_comment(comment_id, session_id, status=body.status, body=body.body)
         if comment is None:
             raise OmnigentError("Comment not found", code=ErrorCode.NOT_FOUND)

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -6,12 +6,11 @@ from sqlalchemy import and_, asc, desc, or_, select
 
 from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
-    AGENT_KIND_SESSION,
-    AGENT_KIND_TEMPLATE,
     SqlAgent,
     SqlConversation,
     current_workspace_id,
 )
+from omnigent.db.enum_codecs import encode_agent_kind
 from omnigent.db.utils import (
     get_or_create_engine,
     make_managed_session_maker,
@@ -68,7 +67,7 @@ class SqlAlchemyAgentStore(AgentStore):
             name=name,
             bundle_location=bundle_location,
             version=1,
-            kind=AGENT_KIND_TEMPLATE,
+            kind=encode_agent_kind("template"),
             description=description,
         )
         with self._session() as session:
@@ -90,7 +89,7 @@ class SqlAlchemyAgentStore(AgentStore):
             # For session-scoped agents, derive the owning conversation id
             # from the forward pointer so callers can use agent.session_id.
             session_id: str | None = None
-            if row.kind == AGENT_KIND_SESSION:
+            if row.kind == encode_agent_kind("session"):
                 session_id = session.execute(
                     select(SqlConversation.id)
                     .where(
@@ -117,7 +116,7 @@ class SqlAlchemyAgentStore(AgentStore):
                 select(SqlAgent).where(
                     SqlAgent.workspace_id == current_workspace_id(),
                     SqlAgent.name == name,
-                    SqlAgent.kind == AGENT_KIND_TEMPLATE,
+                    SqlAgent.kind == encode_agent_kind("template"),
                 )
             ).scalar_one_or_none()
             return sql_agent_to_entity(row) if row else None
@@ -147,7 +146,7 @@ class SqlAlchemyAgentStore(AgentStore):
         with self._session() as session:
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
-            is_template = SqlAgent.kind == AGENT_KIND_TEMPLATE
+            is_template = SqlAgent.kind == encode_agent_kind("template")
             in_workspace = SqlAgent.workspace_id == current_workspace_id()
             stmt = select(SqlAgent).where(in_workspace, is_template)
             if after:
@@ -230,7 +229,7 @@ class SqlAlchemyAgentStore(AgentStore):
             row.version = row.version + 1
             row.updated_at = now_epoch()
             session_id: str | None = None
-            if row.kind == AGENT_KIND_SESSION:
+            if row.kind == encode_agent_kind("session"):
                 session_id = session.execute(
                     select(SqlConversation.id)
                     .where(

--- a/omnigent/stores/comment_store/sqlalchemy_store.py
+++ b/omnigent/stores/comment_store/sqlalchemy_store.py
@@ -7,6 +7,7 @@ import uuid
 from sqlalchemy import delete, func, select
 
 from omnigent.db.db_models import SqlComment, current_workspace_id
+from omnigent.db.enum_codecs import decode_comment_status, encode_comment_status
 from omnigent.db.utils import (
     get_or_create_engine,
     make_managed_session_maker,
@@ -29,7 +30,7 @@ def _to_entity(row: SqlComment) -> Comment:
         start_index=row.start_index,
         end_index=row.end_index,
         body=row.body,
-        status=row.status,
+        status=decode_comment_status(row.status),
         created_at=row.created_at,
         updated_at=row.updated_at,
         anchor_content=row.anchor_content,
@@ -86,7 +87,7 @@ class SqlAlchemyCommentStore(CommentStore):
             start_index=start_index,
             end_index=end_index,
             body=body,
-            status="draft",
+            status=encode_comment_status("draft"),
             created_at=created_us // 1_000_000,
             updated_at=created_us,
             anchor_content=anchor_content,
@@ -127,7 +128,7 @@ class SqlAlchemyCommentStore(CommentStore):
             if row is None or row.conversation_id != conversation_id:
                 return None
             if status is not None:
-                row.status = status
+                row.status = encode_comment_status(status)
             if body is not None:
                 row.body = body
             if status is not None or body is not None:

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -25,7 +25,6 @@ from sqlalchemy.sql.selectable import Subquery
 from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY
 from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
-    AGENT_KIND_SESSION,
     LABEL_VALUE_MAX_LEN,
     SqlAgent,
     SqlComment,
@@ -36,6 +35,15 @@ from omnigent.db.db_models import (
     SqlSessionPermission,
     SqlUserDailyCost,
     current_workspace_id,
+)
+from omnigent.db.enum_codecs import (
+    decode_conversation_kind,
+    decode_item_status,
+    decode_item_type,
+    encode_agent_kind,
+    encode_conversation_kind,
+    encode_item_status,
+    encode_item_type,
 )
 from omnigent.db.utils import (
     _supports_fts5,
@@ -101,7 +109,7 @@ def _to_conversation(
         created_at=row.created_at,
         updated_at=row.updated_at,
         title=row.title or None,  # empty string → None at entity layer
-        kind=row.kind,
+        kind=decode_conversation_kind(row.kind),
         parent_conversation_id=row.parent_conversation_id,
         root_conversation_id=row.root_conversation_id,
         agent_id=row.agent_id,
@@ -180,7 +188,7 @@ def _new_session_conversation_row(
         created_at=now,
         updated_at=now,
         title=title or "",  # None → '' for top-level conversations
-        kind="sub_agent" if parent_conversation_id else "default",
+        kind=encode_conversation_kind("sub_agent" if parent_conversation_id else "default"),
         parent_conversation_id=parent_conversation_id,
         # Top-level row: ``root_conversation_id`` mirrors the
         # primary key so tree-scoped lookups treat it as its own
@@ -220,7 +228,7 @@ def _new_session_agent_row(
         name=agent_name,
         bundle_location=agent_bundle_location,
         version=1,
-        kind=AGENT_KIND_SESSION,
+        kind=encode_agent_kind("session"),
         description=agent_description,
     )
 
@@ -427,13 +435,14 @@ def _to_item(row: SqlConversationItem) -> ConversationItem:
     :param row: The SQLAlchemy ORM row to convert.
     :returns: A :class:`ConversationItem` Pydantic model.
     """
+    item_type = decode_item_type(row.type)
     return ConversationItem(
         id=row.id,
-        type=row.type,
-        status=row.status,
+        type=item_type,
+        status=decode_item_status(row.status),
         response_id=row.response_id,
         created_at=row.created_at,
-        data=parse_item_data(row.type, json.loads(row.data)),
+        data=parse_item_data(item_type, json.loads(row.data)),
         created_by=row.created_by,
     )
 
@@ -460,7 +469,7 @@ def _ranked_latest_message_item_ids(conversation_ids: list[str]) -> Subquery:
         .where(
             SqlConversationItem.workspace_id == current_workspace_id(),
             SqlConversationItem.conversation_id.in_(conversation_ids),
-            SqlConversationItem.type == "message",
+            SqlConversationItem.type == encode_item_type("message"),
         )
         .subquery()
     )
@@ -671,7 +680,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     created_at=now,
                     updated_at=now,
                     title=title or "",  # None → '' for top-level conversations
-                    kind=kind,
+                    kind=encode_conversation_kind(kind),
                     parent_conversation_id=parent_conversation_id,
                     root_conversation_id=root_id,
                     agent_id=agent_id,
@@ -876,7 +885,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             rows = session.execute(
                 select(SqlConversation.parent_conversation_id, SqlConversation.id)
                 .where(SqlConversation.workspace_id == current_workspace_id())
-                .where(SqlConversation.kind == "sub_agent")
+                .where(SqlConversation.kind == encode_conversation_kind("sub_agent"))
                 .where(SqlConversation.parent_conversation_id.in_(unique_ids))
                 .order_by(
                     SqlConversation.parent_conversation_id,
@@ -1381,7 +1390,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 SqlConversationItem.conversation_id == conversation_id,
             )
             if type is not None:
-                stmt = stmt.where(SqlConversationItem.type == type)
+                stmt = stmt.where(SqlConversationItem.type == encode_item_type(type))
             if after:
                 sub = (
                     select(SqlConversationItem.position)
@@ -1548,9 +1557,9 @@ class SqlAlchemyConversationStore(ConversationStore):
                     conversation_id=conversation_id,
                     response_id=item.response_id,
                     created_at=now,
-                    status="completed",  # items are final on append
+                    status=encode_item_status("completed"),  # items are final on append
                     position=position,
-                    type=item.type,
+                    type=encode_item_type(item.type),
                     data=data,
                     search_text=search,
                     created_by=item.created_by,
@@ -1560,8 +1569,11 @@ class SqlAlchemyConversationStore(ConversationStore):
                 persisted.append(
                     ConversationItem(
                         id=row.id,
-                        type=row.type,
-                        status=row.status,
+                        # The row stores int codes; the entity carries the
+                        # string names. item.type is the source string and
+                        # the status was just written as "completed".
+                        type=item.type,
+                        status="completed",
                         response_id=row.response_id,
                         created_at=row.created_at,
                         data=item.data,
@@ -1727,7 +1739,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
             # Filter by kind when specified (None = no filter).
             if kind is not None:
-                stmt = stmt.where(SqlConversation.kind == kind)
+                stmt = stmt.where(SqlConversation.kind == encode_conversation_kind(kind))
             if parent_conversation_id is not None:
                 stmt = stmt.where(
                     SqlConversation.parent_conversation_id == parent_conversation_id,
@@ -2503,7 +2515,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 created_at=now,
                 updated_at=now,
                 title=fork_title or "",  # None → empty string at DB layer
-                kind="default",
+                kind=encode_conversation_kind("default"),
                 # A fork is a fresh top-level conversation, so its
                 # root mirrors its own id (matches the
                 # ``_new_session_conversation_row`` invariant).
@@ -2576,7 +2588,9 @@ class SqlAlchemyConversationStore(ConversationStore):
             source_items = session.execute(items_query).scalars().all()
 
             for pos, src_item in enumerate(source_items):
-                new_item_id = generate_item_id(src_item.type)
+                # src_item.type/status are int codes copied verbatim to the new
+                # row; only generate_item_id needs the decoded string type.
+                new_item_id = generate_item_id(decode_item_type(src_item.type))
                 new_item = SqlConversationItem(
                     id=new_item_id,
                     conversation_id=new_conv.id,
@@ -2737,7 +2751,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             session.flush()
             if old_agent_id is not None:
                 old_agent = session.get(SqlAgent, (current_workspace_id(), old_agent_id))
-                if old_agent is not None and old_agent.kind == AGENT_KIND_SESSION:
+                if old_agent is not None and old_agent.kind == encode_agent_kind("session"):
                     session.delete(old_agent)
                     session.flush()
 

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -21,6 +21,7 @@ from sqlalchemy import delete as sql_delete
 from sqlalchemy.orm import Session
 
 from omnigent.db.db_models import SqlConversation, SqlHost, current_workspace_id
+from omnigent.db.enum_codecs import decode_host_status, encode_host_status
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker, now_epoch
 
 # A host is considered live only if its row was touched (connect or
@@ -137,7 +138,7 @@ def _row_to_host(row: SqlHost) -> Host:
         host_id=row.host_id,
         name=row.name,
         owner=row.owner,
-        status=row.status,
+        status=decode_host_status(row.status),
         created_at=row.created_at,
         updated_at=row.updated_at,
         sandbox_provider=row.sandbox_provider,
@@ -268,7 +269,7 @@ class HostStore:
                     # itself (ordering matters for the FK), so we only touch
                     # status/timestamp here.
                     self._rotate_host_id(session, row, host_id)
-                row.status = "online"
+                row.status = encode_host_status("online")
                 row.updated_at = now
                 row.configured_harnesses = harnesses_json
             else:
@@ -276,7 +277,7 @@ class HostStore:
                     owner=owner,
                     name=name,
                     host_id=host_id,
-                    status="online",
+                    status=encode_host_status("online"),
                     created_at=now,
                     updated_at=now,
                     configured_harnesses=harnesses_json,
@@ -390,7 +391,7 @@ class HostStore:
             .values(
                 owner=owner,
                 name=name,
-                status="online",
+                status=encode_host_status("online"),
                 updated_at=now,
                 configured_harnesses=configured_harnesses_json,
             )
@@ -424,7 +425,7 @@ class HostStore:
                 )
             ).scalar_one_or_none()
             if row is not None:
-                row.status = "offline"
+                row.status = encode_host_status("offline")
                 row.updated_at = now_epoch()
 
     def heartbeat(self, host_id: str) -> None:
@@ -503,10 +504,11 @@ class HostStore:
                     SqlHost.host_id.in_(unique_ids),
                 )
             ).all()
+        online_code = encode_host_status("online")
         return {
             row.host_id
             for row in rows
-            if row.status == "online" and row.updated_at >= ref - HOST_LIVENESS_TTL_S
+            if row.status == online_code and row.updated_at >= ref - HOST_LIVENESS_TTL_S
         }
 
     def list_hosts(self, owner: str) -> list[Host]:
@@ -627,7 +629,7 @@ class HostStore:
                 owner=owner,
                 name=name,
                 host_id=host_id,
-                status="offline",
+                status=encode_host_status("offline"),
                 created_at=now,
                 updated_at=now,
                 token_hash=token_hash,

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -9,10 +9,14 @@ from sqlalchemy import asc, select
 from sqlalchemy.exc import IntegrityError
 
 from omnigent.db.db_models import (
-    POLICY_SCOPE_DEFAULT,
-    POLICY_SCOPE_SESSION,
     SqlPolicy,
     current_workspace_id,
+)
+from omnigent.db.enum_codecs import (
+    decode_policy_scope,
+    decode_policy_type,
+    encode_policy_scope,
+    encode_policy_type,
 )
 from omnigent.db.utils import (
     get_or_create_engine,
@@ -34,9 +38,9 @@ def _to_entity(row: SqlPolicy) -> Policy:
         id=row.id,
         name=row.name,
         session_id=row.session_id,
-        scope=row.scope,
+        scope=decode_policy_scope(row.scope),
         created_at=row.created_at,
-        type=row.type,
+        type=decode_policy_type(row.type),
         handler=row.handler,
         factory_params=json.loads(row.factory_params) if row.factory_params else None,
         enabled=bool(row.enabled),
@@ -88,10 +92,10 @@ class SqlAlchemyPolicyStore(PolicyStore):
             id=policy_id,
             name=name,
             session_id=session_id,
-            scope=POLICY_SCOPE_SESSION,
+            scope=encode_policy_scope("session"),
             created_at=now_epoch(),
             updated_at=None,
-            type=type,
+            type=encode_policy_type(type),
             handler=handler,
             factory_params=json.dumps(factory_params) if factory_params else None,
             enabled=enabled,
@@ -188,10 +192,10 @@ class SqlAlchemyPolicyStore(PolicyStore):
             id=policy_id,
             name=name,
             session_id=None,
-            scope=POLICY_SCOPE_DEFAULT,
+            scope=encode_policy_scope("default"),
             created_at=now_epoch(),
             updated_at=None,
-            type=type,
+            type=encode_policy_type(type),
             handler=handler,
             factory_params=json.dumps(factory_params) if factory_params else None,
             enabled=enabled,
@@ -205,7 +209,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
                 session.execute(
                     select(SqlPolicy)
                     .where(SqlPolicy.workspace_id == current_workspace_id())
-                    .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
+                    .where(SqlPolicy.scope == encode_policy_scope("default"))
                     .where(SqlPolicy.name == name)
                 )
                 .scalars()
@@ -225,7 +229,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         """Return a default policy by ID (``scope = 'default'``)."""
         with self._session() as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
-            if row is None or row.scope != POLICY_SCOPE_DEFAULT:
+            if row is None or row.scope != encode_policy_scope("default"):
                 return None
             return _to_entity(row)
 
@@ -235,7 +239,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
             stmt = (
                 select(SqlPolicy)
                 .where(SqlPolicy.workspace_id == current_workspace_id())
-                .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
+                .where(SqlPolicy.scope == encode_policy_scope("default"))
                 .order_by(asc(SqlPolicy.created_at), asc(SqlPolicy.id))
             )
             rows = session.execute(stmt).scalars().all()
@@ -255,7 +259,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         """
         with self._session() as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
-            if row is None or row.scope != POLICY_SCOPE_DEFAULT:
+            if row is None or row.scope != encode_policy_scope("default"):
                 return None
             changed = False
             if name is not None and row.name != name:
@@ -266,7 +270,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
                     session.execute(
                         select(SqlPolicy)
                         .where(SqlPolicy.workspace_id == current_workspace_id())
-                        .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
+                        .where(SqlPolicy.scope == encode_policy_scope("default"))
                         .where(SqlPolicy.name == name)
                         .where(SqlPolicy.id != policy_id)
                     )
@@ -296,7 +300,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         """Delete a default policy. Idempotent."""
         with self._session() as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
-            if row is None or row.scope != POLICY_SCOPE_DEFAULT:
+            if row is None or row.scope != encode_policy_scope("default"):
                 return False
             session.delete(row)
             return True

--- a/tests/db/test_converters.py
+++ b/tests/db/test_converters.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 import time
 
 from omnigent.db.converters import sql_agent_to_entity
-from omnigent.db.db_models import AGENT_KIND_SESSION, AGENT_KIND_TEMPLATE, SqlAgent
+from omnigent.db.db_models import SqlAgent
+from omnigent.db.enum_codecs import encode_agent_kind
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
 from omnigent.entities import Agent
+
+AGENT_KIND_TEMPLATE = encode_agent_kind("template")
+AGENT_KIND_SESSION = encode_agent_kind("session")
 
 
 def _now() -> int:

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -26,6 +26,17 @@ from omnigent.db.db_models import (
     SqlUser,
     SqlUserDailyCost,
 )
+from omnigent.db.enum_codecs import (
+    encode_account_token_kind,
+    encode_agent_kind,
+    encode_comment_status,
+    encode_conversation_kind,
+    encode_host_status,
+    encode_item_status,
+    encode_item_type,
+    encode_policy_scope,
+    encode_policy_type,
+)
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
 
 # ── helpers ───────────────────────────────────────────
@@ -46,7 +57,7 @@ def _make_agent(
         name=name,
         bundle_location="ag_test1/abc123",
         version=1,
-        kind=kind,
+        kind=encode_agent_kind(kind),
     )
 
 
@@ -62,7 +73,7 @@ def _make_conversation(
         id=id,
         created_at=_now(),
         updated_at=_now(),
-        kind=kind,
+        kind=encode_conversation_kind(kind),
         agent_id=agent_id,
         parent_conversation_id=parent_conversation_id,
         root_conversation_id=root_conversation_id or id,
@@ -80,9 +91,9 @@ def _make_item(
         conversation_id=conversation_id,
         response_id="resp_test1",
         created_at=_now(),
-        status="completed",
+        status=encode_item_status("completed"),
         position=position,
-        type="message",
+        type=encode_item_type("message"),
         data='{"content": [{"type": "text", "text": "hello"}]}',
         search_text="hello",
     )
@@ -107,7 +118,7 @@ class TestSqlAgent:
             assert loaded.version == 1
             assert loaded.description is None
             assert loaded.updated_at is None
-            assert loaded.kind == "template"
+            assert loaded.kind == encode_agent_kind("template")
 
     def test_nullable_columns(self, db_uri: str) -> None:
         engine = get_or_create_engine(db_uri)
@@ -137,7 +148,7 @@ class TestSqlAgent:
         with managed() as session:
             loaded = session.get(SqlAgent, (0, "ag_test1"))
             assert loaded is not None
-            assert loaded.kind == "session"
+            assert loaded.kind == encode_agent_kind("session")
 
     def test_multiple_session_agents_allowed(self, db_uri: str) -> None:
         """Multiple session-scoped agents are permitted (no unique constraint on kind)."""
@@ -257,7 +268,7 @@ class TestSqlAccountToken:
         now = _now()
         token = SqlAccountToken(
             id="tok_invite_abc",
-            kind="invite",
+            kind=encode_account_token_kind("invite"),
             created_at=now,
             expires_at=now + 3600,
             created_by="admin@example.com",
@@ -269,7 +280,7 @@ class TestSqlAccountToken:
         with managed() as session:
             loaded = session.get(SqlAccountToken, (0, "tok_invite_abc"))
             assert loaded is not None
-            assert loaded.kind == "invite"
+            assert loaded.kind == encode_account_token_kind("invite")
             assert loaded.user_id is None
             assert loaded.redeemed_at is None
             assert loaded.invited_is_admin is True
@@ -281,7 +292,7 @@ class TestSqlAccountToken:
         now = _now()
         token = SqlAccountToken(
             id="tok_magic_xyz",
-            kind="magic",
+            kind=encode_account_token_kind("magic"),
             user_id="alice@example.com",
             created_at=now,
             expires_at=now + 300,
@@ -292,7 +303,7 @@ class TestSqlAccountToken:
         with managed() as session:
             loaded = session.get(SqlAccountToken, (0, "tok_magic_xyz"))
             assert loaded is not None
-            assert loaded.kind == "magic"
+            assert loaded.kind == encode_account_token_kind("magic")
             assert loaded.user_id == "alice@example.com"
 
     def test_check_constraint_rejects_invalid_kind(self, db_uri: str) -> None:
@@ -300,9 +311,10 @@ class TestSqlAccountToken:
         managed = make_managed_session_maker(engine)
 
         now = _now()
+        # An out-of-range int code must be rejected by ck_account_tokens_kind.
         token = SqlAccountToken(
             id="tok_bad",
-            kind="invalid",
+            kind=99,
             created_at=now,
             expires_at=now + 3600,
         )
@@ -327,7 +339,7 @@ class TestSqlConversation:
             loaded = session.get(SqlConversation, (0, "conv_test1"))
             assert loaded is not None
             assert loaded.title == "Hello World"
-            assert loaded.kind == "default"
+            assert loaded.kind == encode_conversation_kind("default")
             assert loaded.archived is False
 
     def test_defaults(self, db_uri: str) -> None:
@@ -356,7 +368,8 @@ class TestSqlConversation:
         managed = make_managed_session_maker(engine)
 
         conv = _make_conversation()
-        conv.kind = "invalid_kind"
+        # An out-of-range int code must be rejected by ck_conversations_kind.
+        conv.kind = 99
         with pytest.raises(IntegrityError):
             with managed() as session:
                 session.add(conv)
@@ -380,7 +393,7 @@ class TestSqlConversation:
         with managed() as session:
             loaded = session.get(SqlConversation, (0, "conv_child"))
             assert loaded is not None
-            assert loaded.kind == "sub_agent"
+            assert loaded.kind == encode_conversation_kind("sub_agent")
             assert loaded.parent_conversation_id == "conv_parent"
             assert loaded.root_conversation_id == "conv_parent"
 
@@ -433,9 +446,9 @@ class TestSqlConversationItem:
             loaded = session.get(SqlConversationItem, (0, "msg_test1"))
             assert loaded is not None
             assert loaded.conversation_id == "conv_test1"
-            assert loaded.type == "message"
+            assert loaded.type == encode_item_type("message")
             assert loaded.position == 0
-            assert loaded.status == "completed"
+            assert loaded.status == encode_item_status("completed")
             assert loaded.created_by is None
 
     def test_unique_position_per_conversation(self, db_uri: str) -> None:
@@ -609,7 +622,7 @@ class TestSqlComment:
             start_index=10,
             end_index=20,
             body="Looks good!",
-            status="draft",
+            status=encode_comment_status("draft"),
             created_at=now,
             updated_at=now * 1_000_000,
             anchor_content="selected text",
@@ -625,7 +638,7 @@ class TestSqlComment:
             assert loaded is not None
             assert loaded.path == "src/App.tsx"
             assert loaded.body == "Looks good!"
-            assert loaded.status == "draft"
+            assert loaded.status == encode_comment_status("draft")
             assert loaded.anchor_content == "selected text"
             assert loaded.created_by == "alice@example.com"
 
@@ -641,7 +654,7 @@ class TestSqlComment:
             start_index=0,
             end_index=5,
             body="Legacy comment",
-            status="addressed",
+            status=encode_comment_status("addressed"),
             created_at=now,
             updated_at=now * 1_000_000,
         )
@@ -668,9 +681,9 @@ class TestSqlPolicy:
         policy = SqlPolicy(
             id="pol_test1",
             name="cost-guard",
-            scope="default",
+            scope=encode_policy_scope("default"),
             created_at=_now(),
-            type="python",
+            type=encode_policy_type("python"),
             handler="omnigent.policies.cost_guard:handler",
             enabled=True,
         )
@@ -681,7 +694,7 @@ class TestSqlPolicy:
             loaded = session.get(SqlPolicy, (0, "pol_test1"))
             assert loaded is not None
             assert loaded.name == "cost-guard"
-            assert loaded.type == "python"
+            assert loaded.type == encode_policy_type("python")
             assert loaded.enabled is True
             assert loaded.session_id is None
 
@@ -695,18 +708,18 @@ class TestSqlPolicy:
             id="pol_1",
             name="guard",
             session_id="conv_test1",
-            scope="session",
+            scope=encode_policy_scope("session"),
             created_at=_now(),
-            type="python",
+            type=encode_policy_type("python"),
             handler="mod:fn",
         )
         p2 = SqlPolicy(
             id="pol_2",
             name="guard",
             session_id="conv_test1",
-            scope="session",
+            scope=encode_policy_scope("session"),
             created_at=_now(),
-            type="python",
+            type=encode_policy_type("python"),
             handler="mod:fn2",
         )
         with pytest.raises(IntegrityError):
@@ -729,7 +742,7 @@ class TestSqlHost:
             owner="corey@example.com",
             name="corey-laptop",
             host_id="host_abc123",
-            status="online",
+            status=encode_host_status("online"),
             created_at=now,
             updated_at=now,
         )
@@ -740,7 +753,7 @@ class TestSqlHost:
             loaded = session.get(SqlHost, (0, "corey@example.com", "corey-laptop"))
             assert loaded is not None
             assert loaded.host_id == "host_abc123"
-            assert loaded.status == "online"
+            assert loaded.status == encode_host_status("online")
             assert loaded.token_hash is None
             assert loaded.sandbox_provider is None
 
@@ -749,11 +762,12 @@ class TestSqlHost:
         managed = make_managed_session_maker(engine)
 
         now = _now()
+        # An out-of-range int code must be rejected by ck_hosts_status.
         host = SqlHost(
             owner="owner",
             name="host",
             host_id="host_bad",
-            status="unknown",
+            status=99,
             created_at=now,
             updated_at=now,
         )
@@ -770,7 +784,7 @@ class TestSqlHost:
             owner="a@x.com",
             name="h1",
             host_id="host_dup",
-            status="online",
+            status=encode_host_status("online"),
             created_at=now,
             updated_at=now,
         )
@@ -778,7 +792,7 @@ class TestSqlHost:
             owner="b@x.com",
             name="h2",
             host_id="host_dup",
-            status="offline",
+            status=encode_host_status("offline"),
             created_at=now,
             updated_at=now,
         )

--- a/tests/db/test_enum_codecs.py
+++ b/tests/db/test_enum_codecs.py
@@ -1,0 +1,99 @@
+"""Tests for the enum name↔int codecs.
+
+These codecs are the single translation point between the string enum
+names (the contract above the store layer) and the ``SMALLINT`` codes
+persisted in the DB. A regression here would silently corrupt stored
+enum values, so we assert round-trips, stability of the shipped codes,
+fail-loud behaviour on unknown values, and — critically — that the item
+type codes stay in lock-step with the app's item-type registry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.db import enum_codecs as ec
+from omnigent.entities.conversation import ITEM_TYPE_TO_DATA_CLS
+
+# Each entry: (name→code table, encode fn, decode fn).
+_CODECS = [
+    (ec.CONVERSATION_KIND, ec.encode_conversation_kind, ec.decode_conversation_kind),
+    (ec.ITEM_TYPE, ec.encode_item_type, ec.decode_item_type),
+    (ec.ITEM_STATUS, ec.encode_item_status, ec.decode_item_status),
+    (ec.COMMENT_STATUS, ec.encode_comment_status, ec.decode_comment_status),
+    (ec.ACCOUNT_TOKEN_KIND, ec.encode_account_token_kind, ec.decode_account_token_kind),
+    (ec.POLICY_TYPE, ec.encode_policy_type, ec.decode_policy_type),
+    (ec.POLICY_SCOPE, ec.encode_policy_scope, ec.decode_policy_scope),
+    (ec.HOST_STATUS, ec.encode_host_status, ec.decode_host_status),
+    (ec.AGENT_KIND, ec.encode_agent_kind, ec.decode_agent_kind),
+]
+
+
+@pytest.mark.parametrize("table, encode, decode", _CODECS)
+def test_round_trip_every_value(table, encode, decode) -> None:
+    """Every name encodes to its code and decodes back unchanged."""
+    for name, code in table.items():
+        assert encode(name) == code
+        assert decode(code) == name
+
+
+@pytest.mark.parametrize("table, encode, decode", _CODECS)
+def test_codes_are_unique(table, encode, decode) -> None:
+    """Codes within a table are distinct (no two names share a code)."""
+    assert len(set(table.values())) == len(table)
+
+
+@pytest.mark.parametrize("table, encode, decode", _CODECS)
+def test_unknown_name_raises(table, encode, decode) -> None:
+    """Encoding an unknown name fails loud rather than persisting garbage."""
+    with pytest.raises(ValueError):
+        encode("definitely-not-a-real-value")
+
+
+@pytest.mark.parametrize("table, encode, decode", _CODECS)
+def test_unknown_code_raises(table, encode, decode) -> None:
+    """Decoding an unknown code fails loud rather than returning None."""
+    with pytest.raises(ValueError):
+        decode(9999)
+
+
+def test_item_type_codes_cover_data_classes() -> None:
+    """
+    ``ITEM_TYPE`` must cover exactly the app's item-type registry.
+
+    A new item type added to ``ITEM_TYPE_TO_DATA_CLS`` without a code here
+    would fail to persist; a stale code would mask a removed type. Keeping
+    the key sets identical is the guard.
+    """
+    assert set(ec.ITEM_TYPE) == set(ITEM_TYPE_TO_DATA_CLS)
+
+
+def test_shipped_codes_are_stable() -> None:
+    """
+    Pin the shipped codes so a reorder/renumber is caught in review.
+
+    Codes are persisted on disk; changing one silently reinterprets every
+    existing row. This test is the tripwire — update it only alongside a
+    migration that rewrites the affected column.
+    """
+    assert ec.CONVERSATION_KIND == {"default": 1, "sub_agent": 2}
+    assert ec.ITEM_TYPE == {
+        "message": 1,
+        "function_call": 2,
+        "function_call_output": 3,
+        "reasoning": 4,
+        "error": 5,
+        "compaction": 6,
+        "native_tool": 7,
+        "resource_event": 8,
+        "routing_decision": 9,
+        "slash_command": 10,
+        "terminal_command": 11,
+    }
+    assert ec.ITEM_STATUS == {"completed": 1, "in_progress": 2, "incomplete": 3, "failed": 4}
+    assert ec.COMMENT_STATUS == {"draft": 1, "addressed": 2}
+    assert ec.ACCOUNT_TOKEN_KIND == {"invite": 1, "magic": 2}
+    assert ec.POLICY_TYPE == {"python": 1, "url": 2}
+    assert ec.POLICY_SCOPE == {"default": 1, "session": 2}
+    assert ec.HOST_STATUS == {"online": 1, "offline": 2}
+    assert ec.AGENT_KIND == {"template": 1, "session": 2}

--- a/tests/db/test_migration_agents_session_id.py
+++ b/tests/db/test_migration_agents_session_id.py
@@ -67,15 +67,16 @@ def test_template_agent_kind_stored_and_read(db_engine: Engine) -> None:
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
+                # kind=1 → 'template'
                 "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES (:id, :ts, :name, :loc, 1, 'template')"
+                " VALUES (:id, :ts, :name, :loc, 1, 1)"
             ),
             {"id": "ag_tmpl", "ts": 1700000001, "name": "my-template", "loc": "ag_tmpl/bundle"},
         )
         kind = conn.execute(
             sa.text("SELECT kind FROM agents WHERE id = :id"), {"id": "ag_tmpl"}
         ).scalar_one()
-    assert kind == "template"
+    assert kind == 1
 
 
 def test_session_agent_kind_stored_and_read(db_engine: Engine) -> None:
@@ -83,15 +84,16 @@ def test_session_agent_kind_stored_and_read(db_engine: Engine) -> None:
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
+                # kind=2 → 'session'
                 "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES (:id, :ts, :name, :loc, 1, 'session')"
+                " VALUES (:id, :ts, :name, :loc, 1, 2)"
             ),
             {"id": "ag_sess", "ts": 1700000001, "name": "my-session", "loc": "ag_sess/bundle"},
         )
         kind = conn.execute(
             sa.text("SELECT kind FROM agents WHERE id = :id"), {"id": "ag_sess"}
         ).scalar_one()
-    assert kind == "session"
+    assert kind == 2
 
 
 def test_agents_session_id_fk_accepts_existing_session(db_engine: Engine) -> None:
@@ -99,8 +101,9 @@ def test_agents_session_id_fk_accepts_existing_session(db_engine: Engine) -> Non
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
+                # kind=2 → 'session'
                 "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES (:id, :ts, :name, :loc, 1, 'session')"
+                " VALUES (:id, :ts, :name, :loc, 1, 2)"
             ),
             {"id": "ag_bound", "ts": 1700000001, "name": "bound-agent", "loc": "ag_bound/bundle"},
         )
@@ -108,7 +111,7 @@ def test_agents_session_id_fk_accepts_existing_session(db_engine: Engine) -> Non
             sa.text(
                 "INSERT INTO conversations"
                 " (id, created_at, updated_at, root_conversation_id, kind, agent_id)"
-                " VALUES (:id, :ts, :ts, :id, 'default', :agent_id)"
+                " VALUES (:id, :ts, :ts, :id, 1, :agent_id)"
             ),
             {"id": "conv_bound", "ts": 1700000002, "agent_id": "ag_bound"},
         )
@@ -130,7 +133,7 @@ def test_agents_session_id_fk_rejects_missing_session(db_engine: Engine) -> None
             sa.text(
                 "INSERT INTO conversations"
                 " (id, created_at, updated_at, root_conversation_id, kind, agent_id)"
-                " VALUES (:id, :ts, :ts, :id, 'default', :agent_id)"
+                " VALUES (:id, :ts, :ts, :id, 1, :agent_id)"
             ),
             {"id": "conv_missing", "ts": 1700000002, "agent_id": "ag_nonexistent"},
         )
@@ -148,8 +151,8 @@ def test_agents_template_name_unique_index_rejects_duplicate_template(
             conn.execute(
                 sa.text(
                     "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                    " VALUES (:id1, :ts, 'dup-template', :loc1, 1, 'template'),"
-                    "        (:id2, :ts, 'dup-template', :loc2, 1, 'template')"
+                    " VALUES (:id1, :ts, 'dup-template', :loc1, 1, 1),"
+                    "        (:id2, :ts, 'dup-template', :loc2, 1, 1)"
                 ),
                 {
                     "id1": "ag_dup1",
@@ -169,8 +172,8 @@ def test_agents_session_id_allows_duplicate_names_for_distinct_sessions(
         conn.execute(
             sa.text(
                 "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES (:id1, :ts, 'shared-name', :loc1, 1, 'session'),"
-                "        (:id2, :ts, 'shared-name', :loc2, 1, 'session')"
+                " VALUES (:id1, :ts, 'shared-name', :loc1, 1, 2),"
+                "        (:id2, :ts, 'shared-name', :loc2, 1, 2)"
             ),
             {
                 "id1": "ag_s1",
@@ -218,6 +221,8 @@ def test_upgrade_does_not_cascade_delete_conversations(tmp_path: Path) -> None:
         )
         conn.execute(
             sa.text(
+                # Seeded at n1 and upgraded only to o1 — both precede the enum→
+                # SMALLINT migration (q1), so conversations.kind is still a string.
                 "INSERT INTO conversations"
                 " (id, created_at, updated_at, root_conversation_id, kind, agent_id)"
                 " VALUES ('conv_1', 3, 3, 'conv_1', 'default', 'ag_sess')"
@@ -267,13 +272,15 @@ def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
         command.upgrade(config, "head")
 
     # Seed data on the upgraded schema: one template, one session-scoped agent.
+    # This runs against the full chain (head), where agents.kind and
+    # conversations.kind are int codes (1 = "template"/"default", 2 = "session").
     with raw_engine.begin() as conn:
         conn.execute(
             sa.text(
                 "INSERT INTO agents"
                 " (workspace_id, id, created_at, name, bundle_location, version, kind)"
-                " VALUES (0, 'ag_tmpl', 1, 'my-template', 'ag_tmpl/b', 1, 'template'),"
-                "        (0, 'ag_sess', 2, 'my-session', 'ag_sess/b', 1, 'session')"
+                " VALUES (0, 'ag_tmpl', 1, 'my-template', 'ag_tmpl/b', 1, 1),"
+                "        (0, 'ag_sess', 2, 'my-session', 'ag_sess/b', 1, 2)"
             )
         )
         conn.execute(
@@ -281,7 +288,7 @@ def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
                 "INSERT INTO conversations"
                 " (workspace_id, id, created_at, updated_at, root_conversation_id,"
                 "  kind, agent_id, title)"
-                " VALUES (0, 'conv_1', 3, 3, 'conv_1', 'default', 'ag_sess', '')"
+                " VALUES (0, 'conv_1', 3, 3, 'conv_1', 1, 'ag_sess', '')"
             )
         )
 

--- a/tests/db/test_migration_archived.py
+++ b/tests/db/test_migration_archived.py
@@ -74,7 +74,7 @@ def test_archived_defaults_false_on_insert(db_engine: Engine) -> None:
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, root_conversation_id) "
-                "VALUES (:id, :ts, :ts, 'default', :id)"
+                "VALUES (:id, :ts, :ts, 1, :id)"
             ),
             {"id": "conv_arch_default", "ts": 1700000000},
         )

--- a/tests/db/test_migration_enums_to_smallint.py
+++ b/tests/db/test_migration_enums_to_smallint.py
@@ -1,0 +1,189 @@
+"""Tests for the enums-varchar→SMALLINT migration (``u1a2b3c4d5e6``).
+
+Seeds a database at the prior revision with legacy string enum values,
+upgrades through the migration, and asserts each column is now an int
+code with the values correctly backfilled and the ``CHECK`` constraints
+rejecting out-of-range codes. Also asserts the downgrade restores the
+original strings, since the migration ships a reversible ``downgrade``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import _build_alembic_config, clear_engine_cache
+
+_PRIOR = "t1a2b3c4d5e6"
+_THIS = "u1a2b3c4d5e6"
+
+
+def _seed_legacy_rows(engine: Engine) -> None:
+    """Insert one row per table using the pre-migration string values."""
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversations (id, created_at, updated_at, kind, "
+                "root_conversation_id) VALUES "
+                "('c1', 1, 1, 'default', 'c1'), ('c2', 1, 1, 'sub_agent', 'c2')"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversation_items (id, conversation_id, response_id, "
+                "created_at, status, position, type, data, search_text) VALUES "
+                "('i1', 'c1', 'r1', 1, 'completed', 0, 'message', '{}', '')"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO comments (id, conversation_id, path, start_index, "
+                "end_index, body, status, created_at, updated_at) VALUES "
+                "('cm1', 'c1', 'f', 0, 1, 'b', 'draft', 1, 1), "
+                "('cm2', 'c1', 'f', 0, 1, 'b', 'addressed', 1, 1)"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO account_tokens (id, kind, created_at, expires_at, "
+                "invited_is_admin) VALUES ('t1', 'invite', 1, 2, 0), ('t2', 'magic', 1, 2, 0)"
+            )
+        )
+        conn.execute(
+            sa.text(
+                # policies.scope holds legacy string values here (default/session);
+                # the migration converts both type and scope to int codes.
+                "INSERT INTO policies "
+                "(id, name, created_at, type, handler, enabled, scope) VALUES "
+                "('p1', 'n1', 1, 'python', 'h', 1, 'default'), "
+                "('p2', 'n2', 1, 'url', 'http', 1, 'session')"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO hosts (owner, name, host_id, status, created_at, updated_at) "
+                "VALUES ('o', 'h1', 'hid1', 'online', 1, 1), ('o', 'h2', 'hid2', 'offline', 1, 1)"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind) VALUES "
+                "('a1', 1, 'tmpl', 'a1/b', 1, 'template'), "
+                "('a2', 1, 'sess', 'a2/b', 1, 'session')"
+            )
+        )
+
+
+@pytest.fixture
+def seeded_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Engine at the prior revision, seeded with legacy string rows."""
+    uri = f"sqlite:///{tmp_path / 'test.db'}"
+    engine = sa.create_engine(uri)
+    cfg = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        cfg.attributes["connection"] = conn
+        from alembic import command
+
+        command.upgrade(cfg, _PRIOR)
+    _seed_legacy_rows(engine)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+        clear_engine_cache()
+
+
+def _upgrade(engine: Engine, target: str) -> None:
+    from alembic import command
+
+    cfg = _build_alembic_config(str(engine.url))
+    with engine.begin() as conn:
+        cfg.attributes["connection"] = conn
+        command.upgrade(cfg, target)
+    # Drop pooled connections so a subsequent sa.inspect()/SELECT reflects the
+    # post-migration schema rather than a cached pre-migration reflection.
+    engine.dispose()
+
+
+def _downgrade(engine: Engine, target: str) -> None:
+    from alembic import command
+
+    cfg = _build_alembic_config(str(engine.url))
+    with engine.begin() as conn:
+        cfg.attributes["connection"] = conn
+        command.downgrade(cfg, target)
+    engine.dispose()
+
+
+def test_columns_become_smallint(seeded_engine: Engine) -> None:
+    """After the migration every enum column is a SMALLINT."""
+    _upgrade(seeded_engine, _THIS)
+    insp = sa.inspect(seeded_engine)
+    for table, column in [
+        ("conversations", "kind"),
+        ("conversation_items", "type"),
+        ("conversation_items", "status"),
+        ("comments", "status"),
+        ("account_tokens", "kind"),
+        ("policies", "type"),
+        ("policies", "scope"),
+        ("hosts", "status"),
+        ("agents", "kind"),
+    ]:
+        col = next(c for c in insp.get_columns(table) if c["name"] == column)
+        assert isinstance(col["type"], sa.SmallInteger), f"{table}.{column} is {col['type']}"
+        assert not col["nullable"], f"{table}.{column} should stay NOT NULL"
+
+
+def test_values_backfilled_to_codes(seeded_engine: Engine) -> None:
+    """Legacy string values map to their stable int codes."""
+    _upgrade(seeded_engine, _THIS)
+    with seeded_engine.connect() as conn:
+        rows = dict(conn.execute(sa.text("SELECT id, kind FROM conversations")).all())
+        assert rows == {"c1": 1, "c2": 2}
+        item = conn.execute(sa.text("SELECT type, status FROM conversation_items")).one()
+        assert tuple(item) == (1, 1)
+        comments = dict(conn.execute(sa.text("SELECT id, status FROM comments")).all())
+        assert comments == {"cm1": 1, "cm2": 2}
+        tokens = dict(conn.execute(sa.text("SELECT id, kind FROM account_tokens")).all())
+        assert tokens == {"t1": 1, "t2": 2}
+        policies = dict(conn.execute(sa.text("SELECT id, type FROM policies")).all())
+        assert policies == {"p1": 1, "p2": 2}
+        scopes = dict(conn.execute(sa.text("SELECT id, scope FROM policies")).all())
+        assert scopes == {"p1": 1, "p2": 2}
+        hosts = dict(conn.execute(sa.text("SELECT name, status FROM hosts")).all())
+        assert hosts == {"h1": 1, "h2": 2}
+        agents = dict(conn.execute(sa.text("SELECT id, kind FROM agents")).all())
+        assert agents == {"a1": 1, "a2": 2}
+
+
+def test_check_rejects_out_of_range_code(seeded_engine: Engine) -> None:
+    """The swapped-in int CHECK rejects a code outside the enum."""
+    _upgrade(seeded_engine, _THIS)
+    with seeded_engine.connect() as conn:
+        conn.execute(sa.text("PRAGMA foreign_keys=ON"))
+        with pytest.raises(sa.exc.IntegrityError):
+            conn.execute(
+                sa.text(
+                    "INSERT INTO conversations (id, created_at, updated_at, kind, "
+                    "root_conversation_id) VALUES ('bad', 1, 1, 99, 'bad')"
+                )
+            )
+            conn.commit()
+
+
+def test_downgrade_restores_strings(seeded_engine: Engine) -> None:
+    """The reversible downgrade maps int codes back to the original strings."""
+    _upgrade(seeded_engine, _THIS)
+    _downgrade(seeded_engine, _PRIOR)
+    with seeded_engine.connect() as conn:
+        rows = dict(conn.execute(sa.text("SELECT id, kind FROM conversations")).all())
+        assert rows == {"c1": "default", "c2": "sub_agent"}
+        hosts = dict(conn.execute(sa.text("SELECT name, status FROM hosts")).all())
+        assert hosts == {"h1": "online", "h2": "offline"}
+        comments = dict(conn.execute(sa.text("SELECT id, status FROM comments")).all())
+        assert comments == {"cm1": "draft", "cm2": "addressed"}

--- a/tests/db/test_migration_host_name_varchar64.py
+++ b/tests/db/test_migration_host_name_varchar64.py
@@ -59,13 +59,14 @@ def test_downgrade_restores_varchar256(tmp_path: Path) -> None:
             sa.text(
                 "INSERT INTO hosts "
                 "(workspace_id, owner, name, host_id, status, created_at, updated_at) "
-                "VALUES (0, 'user@example.com', 'my-laptop', 'host_abc123', 'online', "
+                "VALUES (0, 'user@example.com', 'my-laptop', 'host_abc123', 1, "
                 "1700000000, 1700000001)"
             )
         )
         conn.commit()
 
-    # Downgrade one step to s1a2b3c4d5e6.
+    # Downgrade to s1a2b3c4d5e6 (below the enums→SMALLINT migration that now
+    # sits above t1, which converts hosts.status back to a string on the way).
     config = _build_alembic_config(uri)
     with engine.begin() as conn:
         config.attributes["connection"] = conn

--- a/tests/db/test_migration_policy_scope.py
+++ b/tests/db/test_migration_policy_scope.py
@@ -48,22 +48,25 @@ def test_backfill_sets_session_scope_for_session_policies(db_engine: Engine) -> 
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
+                # kind/type run at head, where they are int codes
+                # (1 = "default"/"python" per enum_codecs).
                 "INSERT INTO conversations"
                 " (id, created_at, updated_at, root_conversation_id, kind)"
-                " VALUES ('conv_sc1', 1, 1, 'conv_sc1', 'default')"
+                " VALUES ('conv_sc1', 1, 1, 'conv_sc1', 1)"
             )
         )
         conn.execute(
             sa.text(
+                # scope runs at head, where it is an int code (2 = "session").
                 "INSERT INTO policies"
                 " (id, name, session_id, scope, created_at, type, handler, enabled)"
-                " VALUES ('pol_sc1', 'sess_pol', 'conv_sc1', 'session', 1, 'python', 'mod.f', 1)"
+                " VALUES ('pol_sc1', 'sess_pol', 'conv_sc1', 2, 1, 1, 'mod.f', 1)"
             )
         )
         scope = conn.execute(
             sa.text("SELECT scope FROM policies WHERE id = 'pol_sc1'")
         ).scalar_one()
-    assert scope == "session"
+    assert scope == 2
 
 
 def test_backfill_sets_default_scope_for_default_policies(db_engine: Engine) -> None:
@@ -71,15 +74,16 @@ def test_backfill_sets_default_scope_for_default_policies(db_engine: Engine) -> 
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
+                # scope runs at head, where it is an int code (1 = "default").
                 "INSERT INTO policies"
                 " (id, name, session_id, scope, created_at, type, handler, enabled)"
-                " VALUES ('pol_def1', 'def_pol', NULL, 'default', 1, 'python', 'mod.f', 1)"
+                " VALUES ('pol_def1', 'def_pol', NULL, 1, 1, 1, 'mod.f', 1)"
             )
         )
         scope = conn.execute(
             sa.text("SELECT scope FROM policies WHERE id = 'pol_def1'")
         ).scalar_one()
-    assert scope == "default"
+    assert scope == 1
 
 
 def test_scope_round_trip_via_store(db_engine: Engine) -> None:
@@ -147,10 +151,11 @@ def test_downgrade_removes_scope_column(tmp_path: Path) -> None:
     uri = f"sqlite:///{db_path}"
     engine = get_or_create_engine(uri)
 
-    # Start at head (includes q1a2b3c4d5e6).
+    # Start at head (includes the scope migration q1a2b3c4d5e6).
     assert "scope" in {c["name"] for c in sa.inspect(engine).get_columns("policies")}
 
-    # Downgrade one step.
+    # Downgrade below the scope migration (through the later enums→SMALLINT
+    # migration that now sits above it).
     config = _build_alembic_config(uri)
     with engine.begin() as conn:
         config.attributes["connection"] = conn

--- a/tests/db/test_migration_runner_id.py
+++ b/tests/db/test_migration_runner_id.py
@@ -72,7 +72,7 @@ def test_runner_id_round_trip_null_and_value(db_engine: Engine) -> None:
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, root_conversation_id, kind) "
-                "VALUES (:id, :ts, :ts, :id, 'default')"
+                "VALUES (:id, :ts, :ts, :id, 1)"
             ),
             {"id": "conv_null_test", "ts": 1700000000},
         )
@@ -87,7 +87,7 @@ def test_runner_id_round_trip_null_and_value(db_engine: Engine) -> None:
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, root_conversation_id, kind, runner_id) "
-                "VALUES (:id, :ts, :ts, :id, 'default', :rid)"
+                "VALUES (:id, :ts, :ts, :id, 1, :rid)"
             ),
             {"id": "conv_value_test", "ts": 1700000000, "rid": "runner-uuid-abc"},
         )

--- a/tests/db/test_migration_terminal_launch_args.py
+++ b/tests/db/test_migration_terminal_launch_args.py
@@ -86,7 +86,7 @@ def test_terminal_launch_args_round_trip_null_and_json(db_engine: Engine) -> Non
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, root_conversation_id) "
-                "VALUES (:id, :ts, :ts, 'default', :id)"
+                "VALUES (:id, :ts, :ts, 1, :id)"
             ),
             {"id": "conv_tla_null", "ts": 1700000000},
         )
@@ -104,7 +104,7 @@ def test_terminal_launch_args_round_trip_null_and_json(db_engine: Engine) -> Non
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, terminal_launch_args, "
                 "root_conversation_id) "
-                "VALUES (:id, :ts, :ts, 'default', :tla, :id)"
+                "VALUES (:id, :ts, :ts, 1, :tla, :id)"
             ),
             {
                 "id": "conv_tla_value",

--- a/tests/db/test_migration_title_not_null.py
+++ b/tests/db/test_migration_title_not_null.py
@@ -51,7 +51,7 @@ def test_title_defaults_empty_string_on_insert(db_engine: Engine) -> None:
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, root_conversation_id) "
-                "VALUES (:id, :ts, :ts, 'default', :id)"
+                "VALUES (:id, :ts, :ts, 1, :id)"
             ),
             {"id": "conv_title_default", "ts": 1700000000},
         )
@@ -71,13 +71,14 @@ def test_downgrade_restores_nullable_and_nullifies_empty_titles(tmp_path: Path) 
     uri = f"sqlite:///{db_path}"
     engine = get_or_create_engine(uri)
 
-    # At head (s1a2b3c4d5e6): insert a row with no title (will be '').
+    # At head: insert a row with no title (will be ''). kind=1 is the
+    # "default" int code (conversations.kind is a SMALLINT at head).
     with engine.connect() as conn:
         conn.execute(
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, root_conversation_id, title) "
-                "VALUES (:id, :ts, :ts, 'default', :id, '')"
+                "VALUES (:id, :ts, :ts, 1, :id, '')"
             ),
             {"id": "conv_downgrade_test", "ts": 1700000001},
         )
@@ -89,13 +90,14 @@ def test_downgrade_restores_nullable_and_nullifies_empty_titles(tmp_path: Path) 
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, root_conversation_id, title) "
-                "VALUES (:id, :ts, :ts, 'default', :id, :title)"
+                "VALUES (:id, :ts, :ts, 1, :id, :title)"
             ),
             {"id": "conv_titled", "ts": 1700000002, "title": "My Session"},
         )
         conn.commit()
 
-    # Downgrade one step.
+    # Downgrade to r1a2b3c4d5e6 (below the title migration; passes back through
+    # the enums→SMALLINT downgrade that restores kind to a string).
     config = _build_alembic_config(uri)
     with engine.begin() as conn:
         config.attributes["connection"] = conn

--- a/tests/db/test_migration_workspace.py
+++ b/tests/db/test_migration_workspace.py
@@ -88,7 +88,7 @@ def test_workspace_round_trip_null_and_value(db_engine: Engine) -> None:
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, root_conversation_id) "
-                "VALUES (:id, :ts, :ts, 'default', :id)"
+                "VALUES (:id, :ts, :ts, 1, :id)"
             ),
             {"id": "conv_ws_null", "ts": 1700000000},
         )
@@ -103,7 +103,7 @@ def test_workspace_round_trip_null_and_value(db_engine: Engine) -> None:
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, workspace, root_conversation_id) "
-                "VALUES (:id, :ts, :ts, 'default', :ws, :id)"
+                "VALUES (:id, :ts, :ts, 1, :ws, :id)"
             ),
             {
                 "id": "conv_ws_cli",
@@ -140,7 +140,7 @@ def test_check_constraint_blocks_host_id_without_workspace(
                 sa.text(
                     "INSERT INTO conversations "
                     "(id, created_at, updated_at, kind, host_id, root_conversation_id) "
-                    "VALUES (:id, :ts, :ts, 'default', :hid, :id)"
+                    "VALUES (:id, :ts, :ts, 1, :hid, :id)"
                 ),
                 {
                     "id": "conv_ws_host_no_ws",
@@ -174,7 +174,7 @@ def test_check_constraint_allows_host_id_with_workspace(
             sa.text(
                 "INSERT INTO hosts "
                 "(owner, name, host_id, status, created_at, updated_at) "
-                "VALUES (:o, :n, :hid, 'online', :ts, :ts)"
+                "VALUES (:o, :n, :hid, 1, :ts, :ts)"
             ),
             {"o": "alice@test.com", "n": "laptop", "hid": "host_abc", "ts": 1700000000},
         )
@@ -182,7 +182,7 @@ def test_check_constraint_allows_host_id_with_workspace(
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, host_id, workspace, root_conversation_id) "
-                "VALUES (:id, :ts, :ts, 'default', :hid, :ws, :id)"
+                "VALUES (:id, :ts, :ts, 1, :hid, :ws, :id)"
             ),
             {
                 "id": "conv_ws_host_ok",
@@ -226,7 +226,7 @@ def test_host_id_fk_sets_null_when_host_deleted(db_engine: Engine) -> None:
             sa.text(
                 "INSERT INTO hosts "
                 "(owner, name, host_id, status, created_at, updated_at) "
-                "VALUES (:o, :n, :hid, 'online', :ts, :ts)"
+                "VALUES (:o, :n, :hid, 1, :ts, :ts)"
             ),
             {"o": "alice@test.com", "n": "laptop", "hid": "host_del", "ts": 1700000000},
         )
@@ -234,7 +234,7 @@ def test_host_id_fk_sets_null_when_host_deleted(db_engine: Engine) -> None:
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, host_id, workspace, root_conversation_id) "
-                "VALUES (:id, :ts, :ts, 'default', :hid, :ws, :id)"
+                "VALUES (:id, :ts, :ts, 1, :hid, :ws, :id)"
             ),
             {"id": "conv_fk", "ts": 1700000000, "hid": "host_del", "ws": "/ws/foo"},
         )
@@ -273,7 +273,7 @@ def test_check_constraint_allows_cli_session_workspace_no_host(
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, kind, workspace, root_conversation_id) "
-                "VALUES (:id, :ts, :ts, 'default', :ws, :id)"
+                "VALUES (:id, :ts, :ts, 1, :ws, :id)"
             ),
             {
                 "id": "conv_cli_ws_only",

--- a/tests/db/test_migration_workspace_id.py
+++ b/tests/db/test_migration_workspace_id.py
@@ -70,7 +70,7 @@ def test_existing_rows_and_omitted_inserts_default_to_zero(db_engine: Engine) ->
             sa.text(
                 "INSERT INTO agents"
                 " (id, created_at, name, bundle_location, version, kind)"
-                " VALUES ('ag_ws', 1, 'n', 'loc', 1, 'template')"
+                " VALUES ('ag_ws', 1, 'n', 'loc', 1, 1)"  # kind=1 → 'template'
             )
         )
         workspace_id = conn.execute(

--- a/tests/e2e/omnigent/test_run_omnigent_resumption.py
+++ b/tests/e2e/omnigent/test_run_omnigent_resumption.py
@@ -578,10 +578,11 @@ def test_run_omnigent_session_id_pins_the_specific_conversation(
 
     # Capture convA's id BEFORE planting B so we get the
     # right one — "newest" walks forward as more
-    # conversations are added.
+    # conversations are added. kind = 1 is the "default" enum code (the
+    # column is a SMALLINT; see omnigent.db.enum_codecs.CONVERSATION_KIND).
     with sqlite3.connect(str(persistent_db)) as conn:
         rows = conn.execute(
-            "SELECT id FROM conversations WHERE kind = 'default' ORDER BY updated_at DESC, id DESC"
+            "SELECT id FROM conversations WHERE kind = 1 ORDER BY updated_at DESC, id DESC"
         ).fetchall()
     assert len(rows) == 1, (
         f"Expected exactly 1 conversation after plant A; got {len(rows)}. "
@@ -621,9 +622,10 @@ def test_run_omnigent_session_id_pins_the_specific_conversation(
     )
     assert nonce_b in plant_b.stdout.lower()
 
+    # kind = 1 is the "default" enum code (SMALLINT column).
     with sqlite3.connect(str(persistent_db)) as conn:
         rows = conn.execute(
-            "SELECT id FROM conversations WHERE kind = 'default' ORDER BY updated_at DESC, id DESC"
+            "SELECT id FROM conversations WHERE kind = 1 ORDER BY updated_at DESC, id DESC"
         ).fetchall()
     assert len(rows) == 2, (
         f"Expected exactly 2 conversations after plant B; got {len(rows)}. "

--- a/tests/e2e/test_comments_e2e.py
+++ b/tests/e2e/test_comments_e2e.py
@@ -391,18 +391,18 @@ def test_comments_update_body_and_status(http_client: httpx.Client) -> None:
         f"Status changed unexpectedly: expected 'draft', got {updated['status']!r}"
     )
 
-    # Update status to resolved.
+    # Update status to addressed.
     resolve_resp = http_client.patch(
         f"/v1/sessions/{session_id}/comments/{comment_id}",
-        json={"status": "resolved"},
+        json={"status": "addressed"},
         headers={"X-Forwarded-Email": _OWNER_EMAIL},
     )
     resolve_resp.raise_for_status()
     resolved = resolve_resp.json()
 
     # The status must reflect the PATCH; body must be unchanged.
-    assert resolved["status"] == "resolved", (
-        f"Status not updated to 'resolved': got {resolved['status']!r}"
+    assert resolved["status"] == "addressed", (
+        f"Status not updated to 'addressed': got {resolved['status']!r}"
     )
     assert resolved["body"] == "Revised text", (
         "Body regressed after status update — PATCH should only touch "

--- a/tests/server/integration/test_comments_routes.py
+++ b/tests/server/integration/test_comments_routes.py
@@ -557,6 +557,39 @@ async def test_comment_api_serializes_updated_at(
     assert patched["created_at"] == 1_000
 
 
+async def test_patch_rejects_unknown_status_with_400(
+    auth_client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """An out-of-domain status is a 400, not a 500.
+
+    ``comments.status`` is a closed enum (draft/addressed). A PATCH with an
+    unknown value must be rejected at the route with a clean validation
+    error rather than reaching the store, where the enum codec raises and
+    would otherwise surface as an opaque 500.
+    """
+    alice = "alice@example.com"
+    session_id = _seed_session_with_grants(db_uri, {alice: LEVEL_EDIT})
+    created = await _add_comment(
+        auth_client,
+        session_id,
+        user=alice,
+        path="src/app.py",
+        body="fix me",
+        start_index=0,
+        end_index=6,
+    )
+
+    resp = await auth_client.patch(
+        f"/v1/sessions/{session_id}/comments/{created['id']}",
+        json={"status": "resolved"},  # not a real comment status
+        headers={"X-Forwarded-Email": alice},
+    )
+    assert resp.status_code == 400, (
+        f"Unknown status must be a 400, got {resp.status_code}: {resp.text}"
+    )
+
+
 # ── Author-only edit/delete (one editor may not rewrite another's comment) ─────
 
 

--- a/tests/server/test_identity_migration.py
+++ b/tests/server/test_identity_migration.py
@@ -25,6 +25,13 @@ from omnigent.db.db_models import (
     SqlHost,
     SqlPolicy,
 )
+from omnigent.db.enum_codecs import (
+    encode_account_token_kind,
+    encode_comment_status,
+    encode_host_status,
+    encode_policy_scope,
+    encode_policy_type,
+)
 from omnigent.db.utils import get_or_create_engine
 from omnigent.server.accounts_store import SqlAlchemyAccountStore
 from omnigent.server.identity_migration import build_domain_mapping, remap_identities
@@ -112,7 +119,7 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
                 start_index=0,
                 end_index=1,
                 body="hi",
-                status="draft",
+                status=encode_comment_status("draft"),
                 created_at=1,
                 # created_at scaled to epoch-µs, matching the store's invariant.
                 updated_at=1_000_000,
@@ -124,9 +131,9 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
                 id="pol_1",
                 name="p",
                 session_id=None,
-                scope="default",
+                scope=encode_policy_scope("default"),
                 created_at=1,
-                type="python",
+                type=encode_policy_type("python"),
                 handler="x.y",
                 created_by="alice",
             )
@@ -134,7 +141,7 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
         s.add(
             SqlAccountToken(
                 id="tok_1",
-                kind="invite",
+                kind=encode_account_token_kind("invite"),
                 user_id=None,
                 created_by="alice",
                 created_at=1,
@@ -146,7 +153,7 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
                 owner="alice",
                 name="laptop",
                 host_id="h1",
-                status="offline",
+                status=encode_host_status("offline"),
                 created_at=1,
                 updated_at=1,
             )

--- a/tests/stores/test_agent_store.py
+++ b/tests/stores/test_agent_store.py
@@ -46,7 +46,7 @@ def test_get_by_name_and_list_hide_session_scoped_agents(
             sa.text(
                 "INSERT INTO conversations "
                 "(id, created_at, updated_at, root_conversation_id, kind) "
-                "VALUES (:id, :ts, :ts, :id, 'default')",
+                "VALUES (:id, :ts, :ts, :id, 1)",
             ),
             {"id": "conv_agent_store_session", "ts": 1700000000},
         )
@@ -54,7 +54,7 @@ def test_get_by_name_and_list_hide_session_scoped_agents(
             sa.text(
                 "INSERT INTO agents "
                 "(id, created_at, name, bundle_location, version, kind) "
-                "VALUES (:id, :ts, :name, :loc, 1, 'session')",
+                "VALUES (:id, :ts, :name, :loc, 1, 2)",  # kind=2 → 'session'
             ),
             {
                 "id": "ag_agent_store_session",

--- a/tests/stores/test_comment_store.py
+++ b/tests/stores/test_comment_store.py
@@ -368,12 +368,12 @@ def test_update_comment_status(store: SqlAlchemyCommentStore) -> None:
         end_index=8,
     )
 
-    updated = store.update_comment(comment.id, "conv_upd", status="resolved")
+    updated = store.update_comment(comment.id, "conv_upd", status="addressed")
 
     assert updated is not None, "update_comment must return the updated Comment"
     # Status must be the new value.
-    assert updated.status == "resolved", (
-        f"Expected status 'resolved', got {updated.status!r}. "
+    assert updated.status == "addressed", (
+        f"Expected status 'addressed', got {updated.status!r}. "
         "update_comment is not persisting the status change."
     )
     # Body must be unchanged.
@@ -414,16 +414,16 @@ def test_update_comment_both_fields(store: SqlAlchemyCommentStore) -> None:
         end_index=6,
     )
 
-    updated = store.update_comment(comment.id, "conv_upd_both", status="sent", body="After")
+    updated = store.update_comment(comment.id, "conv_upd_both", status="addressed", body="After")
 
     assert updated is not None
-    assert updated.status == "sent"
+    assert updated.status == "addressed"
     assert updated.body == "After"
 
 
 def test_update_comment_returns_none_for_missing(store: SqlAlchemyCommentStore) -> None:
     """``update_comment`` returns ``None`` when the comment id does not exist."""
-    result = store.update_comment("nonexistent-uuid-xyz", "conv_5c6d7e", status="resolved")
+    result = store.update_comment("nonexistent-uuid-xyz", "conv_5c6d7e", status="addressed")
 
     # Must return None, not raise, for an unknown id.
     assert result is None, f"Expected None for an unknown comment id, got {result!r}"
@@ -444,7 +444,7 @@ def test_update_comment_wrong_conversation_is_noop(store: SqlAlchemyCommentStore
         end_index=8,
     )
 
-    result = store.update_comment(comment.id, "conv_4d5e6f", status="resolved")
+    result = store.update_comment(comment.id, "conv_4d5e6f", status="addressed")
     assert result is None, (
         f"Expected None updating a comment owned by another conversation, got {result!r}. "
         "update_comment must scope by conversation_id."


### PR DESCRIPTION
## Related issue

N/A

## Summary

Store the low-cardinality, closed-set enum columns as `SMALLINT` integer codes instead of `VARCHAR` guarded by string `CHECK` constraints — matching the existing int-coded `session_permissions.level`.

- New `omnigent/db/enum_codecs.py` owns the stable name↔int tables and is the **single** translation point. Conversion happens only at the store row↔entity boundary, so entities, the HTTP API, the web client, and the SDKs keep seeing the **string names** unchanged (there is no OpenAPI→client codegen, so keeping strings at the boundary avoids hand-syncing every consumer).
- Columns converted: `conversations.kind`, `conversation_items.type` & `.status`, `comments.status`, `account_tokens.kind`, `policies.type`, `hosts.status`. `hosts.sandbox_provider` is intentionally left a string (open-ended provider registry).
- Backfill migration `o1a2b3c4d5e6` converts existing rows in place via `CASE`, swaps each string `CHECK` for an integer one, and is reversible + portable across SQLite and PostgreSQL. The `conversations` partial indexes are dropped/recreated around the swap because SQLite batch mode can't copy a partial-index predicate across a column rename.

Scope note: this is the OSS SQLAlchemy backend only. The managed (e-store) deployment serializes each entity into a single protobuf blob, so its enum-as-int change is a proto edit (`estore/namespaces/mas/latest.proto`) gated by e-store's version-history rules — tracked as a separate follow-up.

## Test Plan

Run with the `dev` + `databricks` extras so the Postgres engine tests have `psycopg`:

```
uv run --extra dev --extra databricks python -m pytest tests/db tests/stores
# 595 passed
```

- `tests/db/test_enum_codecs.py` (new): round-trips every value, code-stability tripwire, unknown-value/-code raise, and a guard that `ITEM_TYPE` stays in sync with `ITEM_TYPE_TO_DATA_CLS`.
- `tests/db/test_migration_enums_to_smallint.py` (new): seeds a DB at the prior revision with legacy **string** rows, upgrades through the migration, and asserts columns are `SMALLINT`, values are backfilled to the right codes, the int `CHECK` rejects out-of-range codes, and the downgrade restores the original strings.
- Existing `tests/db` + `tests/stores` pass unchanged in behavior (updated only where a test asserted the raw stored representation).
- Server integration suites (child sessions, comments, fork, policy CRUD, accounts/invites, hosts management) pass — confirming the string contract end-to-end.
- Manual end-to-end: created a session + sub-agent + message item + comment + policy on a fresh migrated DB; the entity/API layer returns `"default"`/`"sub_agent"`/`"message"`/`"addressed"`/`"python"` while the raw SQLite columns hold `1`/`2`/… — ints on disk, strings at the boundary.

## Demo

N/A — no user-visible/UI change (storage-layer only; API responses are byte-for-byte identical).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added codec unit tests and up/down migration tests (SQLite). Verified on PostgreSQL via the `databricks` extra (`psycopg`) that the `CASE` backfill and integer `CHECK` apply on both dialects. Manually drove a full create-session → sub-agent → append-item → comment → policy flow on a freshly-migrated DB and confirmed the API still emits the enum strings while the columns store int codes.
