### PR TITLE
feat(web): generate a worktree branch name from the new-session composer

### DIFF
--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1205,6 +1205,36 @@ describe("NewChatLandingScreen", () => {
     expect(screen.queryByTestId("new-chat-landing-worktree-option")).toBeNull();
   });
 
+  it("generates a unique worktree branch name and sends it on create", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
+    // Clicking the generate button fills a "worktree-<hex>" name.
+    fireEvent.mouseDown(screen.getByTestId("new-chat-landing-branch-generate"));
+    const branchInput = screen.getByTestId("new-chat-landing-branch-input") as HTMLInputElement;
+    expect(branchInput.value).toMatch(/^worktree-[0-9a-f]{8}$/);
+
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "spin up a scratch worktree" },
+    });
+    fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = authenticatedFetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      git?: { branch_name: string };
+    };
+    // The generated name rides through as a new-worktree create.
+    expect(body.git?.branch_name).toMatch(/^worktree-[0-9a-f]{8}$/);
+  });
+
   it("shows no conflict banner when no live session shares the directory", async () => {
     // Default setup: no other directory sessions → nothing to warn about.
     renderLanding();

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -25,6 +25,7 @@ import {
   PaperclipIcon,
   PlusIcon,
   SearchIcon,
+  ShuffleIcon,
   TagIcon,
   TriangleAlertIcon,
   XIcon,
@@ -2241,6 +2242,14 @@ export function NewChatLandingScreen() {
       (w) => (w.branch ?? "").toLowerCase().includes(q) || w.path.toLowerCase().includes(q),
     );
   }, [linkedWorktrees, branchName]);
+  // Fill the branch field with a unique auto-generated name so the user can
+  // spin up a throwaway worktree without inventing one. crypto.randomUUID is
+  // available in every browser the app targets; the short prefix keeps the
+  // dir/branch readable (worktree-1a2b3c4d).
+  const generateBranchName = useCallback(() => {
+    const suffix = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+    setBranchName(`worktree-${suffix}`);
+  }, []);
 
   // Sandbox repo inputs are valid when blank (empty workspace), or when
   // the URL passes the shape check; a branch without a URL is dangling.
@@ -3410,9 +3419,28 @@ export function NewChatLandingScreen() {
                           autoCapitalize="off"
                           spellCheck={false}
                           name="omnigent-worktree-branch"
-                          className="rounded-md border border-input bg-background px-3 py-2 text-xs outline-none transition-colors focus-visible:border-ring"
+                          // pr-9 leaves room for the generate button overlaid at
+                          // the right edge.
+                          className="rounded-md border border-input bg-background py-2 pr-9 pl-3 text-xs outline-none transition-colors focus-visible:border-ring"
                           data-testid="new-chat-landing-branch-input"
                         />
+                        {/* Fill a unique branch name for a throwaway worktree.
+                          onMouseDown so it fires before the input's blur closes
+                          the combobox and preventDefault keeps focus on the
+                          input. */}
+                        <button
+                          type="button"
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            generateBranchName();
+                          }}
+                          title="Generate a unique branch name"
+                          aria-label="Generate a unique branch name"
+                          className="absolute top-0 right-0 flex h-9 w-9 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                          data-testid="new-chat-landing-branch-generate"
+                        >
+                          <ShuffleIcon className="size-4" />
+                        </button>
                         {branchInputFocused && filteredWorktrees.length > 0 && (
                           <div
                             // Floats over the popover as a combobox popup, so it


### PR DESCRIPTION
## Related issue

Follow-up to #1919 / #2088 (select an existing git worktree).

## Summary

Adds a **Generate a name** affordance to the new-session **Git worktree branch** field: a sparkle button inside the branch input fills a unique `worktree-<hex>` name (`crypto.randomUUID`), so users can spin up a throwaway worktree without inventing a branch name.

_(A base-branch default is being discussed separately and is intentionally not part of this PR.)_

## Test Plan

- `NewChatDialog` component test: the generate button fills a `worktree-<hex>` name and it rides through to `POST /v1/sessions` as `git.branch_name`.
- Full web suite (`npm test`, 3684 passing) + `npm run build` + `tsc -b` + prettier/oxlint — all green.

## Demo

_UI change — screen recording of the generate button to be attached._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: clicked the generate button in the running web UI and confirmed it fills `worktree-<hex>`. Pure frontend change, covered by a component test.

## Changelog

Generate a unique worktree branch name from the new-session composer.

This pull request and its description were written by Isaac.
