### PR TITLE
feat(harness-bench): observe native Tool calling; scaffold native Policy DENY

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -215,6 +215,7 @@ from omnigent.server.schemas import (
     OutputTextDeltaEvent,
     PaginatedList,
     PermissionObject,
+    PolicyDeniedEvent,
     PolicySummary,
     ReadStatePutRequest,
     ReasoningStartedEvent,
@@ -489,6 +490,29 @@ def _publish_collaboration_mode(session_id: str, mode: str) -> None:
         type="session.collaboration_mode",
         conversation_id=session_id,
         mode=mode,
+    )
+    session_stream.publish(session_id, event.model_dump())
+
+
+def _publish_policy_denied(session_id: str, reason: str, phase: str) -> None:
+    """
+    Publish a native policy-DENY signal on the session stream.
+
+    A native harness's policy DENY is decided synchronously in the
+    ``/policies/evaluate`` hook response, so nothing on the stream otherwise
+    reflects that an action was blocked. This surfaces the decision as a
+    positive event for observers (web UI, capability bench). Fire-and-forget.
+
+    :param session_id: Session/conversation identifier, e.g. ``"conv_abc123"``.
+    :param reason: Deny reason from the deciding policy.
+    :param phase: The policy phase the DENY landed on, e.g. ``"tool_call"``.
+    :returns: None.
+    """
+    event = PolicyDeniedEvent(
+        type="response.policy_denied",
+        conversation_id=session_id,
+        reason=reason,
+        phase=phase,
     )
     session_stream.publish(session_id, event.model_dump())
 
@@ -16433,6 +16457,13 @@ def create_sessions_router(
             _spawn_native_blocked_notice_forward(
                 session_id, result.reason or "Blocked by policy.", result.deciding_policy
             )
+        # A tool-call DENY is decided synchronously here, so nothing else on the
+        # stream reflects that the native tool was blocked. Publish a positive
+        # signal so observers (web UI, capability bench) see the decision rather
+        # than infer it from the blocked tool's absence. Observational, so it is
+        # not gated on write access.
+        if result.action == PolicyAction.DENY and phase == Phase.TOOL_CALL:
+            _publish_policy_denied(session_id, result.reason or "Blocked by policy.", phase.value)
         return Response(
             content=json.dumps(resp_body),
             media_type="application/json",

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -3269,6 +3269,37 @@ class ElicitationResolvedEvent(_SSEEventBase):
     elicitation_id: str
 
 
+class PolicyDeniedEvent(_SSEEventBase):
+    """
+    Signal that a policy DENY was enforced on a native harness turn.
+
+    A native harness (Claude Code, Codex, ...) routes each tool call and
+    prompt through Omnigent's policy engine via the vendor command-hook
+    (``POST /v1/sessions/{id}/policies/evaluate``). The DENY verdict is
+    returned synchronously to that hook, so unlike the SDK/wrap path there is
+    no stream-visible signal that a native action was blocked — only the
+    *effect* (the blocked tool never runs). This event surfaces the decision
+    itself on the session stream so observers (the web UI, the capability
+    bench) can see a native DENY as a positive signal rather than infer it
+    from an absence.
+
+    Fire-and-forget and observational: it does not gate the turn (the hook
+    response already did that) and carries no correlation id.
+
+    :param type: Always ``"response.policy_denied"``.
+    :param conversation_id: Session/conversation id the DENY applies to,
+        e.g. ``"conv_abc123"``.
+    :param reason: Human-readable deny reason from the deciding policy, e.g.
+        ``"Blocked by policy."``.
+    :param phase: The policy phase the DENY landed on, e.g. ``"tool_call"``.
+    """
+
+    type: Literal["response.policy_denied"]
+    conversation_id: str
+    reason: str = ""
+    phase: str = ""
+
+
 class CreatedEvent(_SSEEventBase):
     """
     Initial event emitted at the start of every streaming response.
@@ -3769,6 +3800,8 @@ ServerStreamEvent = Annotated[
     # ── Transient (SSE-only) — synchronous decision request ────
     | ElicitationRequestEvent
     | ElicitationResolvedEvent
+    # ── Transient (SSE-only) — native policy DENY signal ───────
+    | PolicyDeniedEvent
     # ── Transient (SSE-only) — Responses-API turn lifecycle ────
     | CreatedEvent
     | QueuedEvent

--- a/openapi.json
+++ b/openapi.json
@@ -2148,6 +2148,52 @@
         "title": "PermissionObject",
         "type": "object"
       },
+      "PolicyDeniedEvent": {
+        "description": "Signal that a policy DENY was enforced on a native harness turn.\n\nA native harness (Claude Code, Codex, ...) routes each tool call and\nprompt through Omnigent's policy engine via the vendor command-hook\n(`POST /v1/sessions/{id}/policies/evaluate`). The DENY verdict is\nreturned synchronously to that hook, so unlike the SDK/wrap path there is\nno stream-visible signal that a native action was blocked \u2014 only the\n*effect* (the blocked tool never runs). This event surfaces the decision\nitself on the session stream so observers (the web UI, the capability\nbench) can see a native DENY as a positive signal rather than infer it\nfrom an absence.\n\nFire-and-forget and observational: it does not gate the turn (the hook\nresponse already did that) and carries no correlation id.",
+        "properties": {
+          "conversation_id": {
+            "description": "Session/conversation id the DENY applies to, e.g. `\"conv_abc123\"`.",
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "phase": {
+            "default": "",
+            "description": "The policy phase the DENY landed on, e.g. `\"tool_call\"`.",
+            "title": "Phase",
+            "type": "string"
+          },
+          "reason": {
+            "default": "",
+            "description": "Human-readable deny reason from the deciding policy, e.g. `\"Blocked by policy.\"`.",
+            "title": "Reason",
+            "type": "string"
+          },
+          "sequence_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence Number"
+          },
+          "type": {
+            "const": "response.policy_denied",
+            "description": "Always `\"response.policy_denied\"`.",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "conversation_id"
+        ],
+        "title": "PolicyDeniedEvent",
+        "type": "object"
+      },
       "PolicySummary": {
         "description": "Safe subset of a policy's spec for API exposure.\n\nExposes the policy name, type, and phases so the UI can\ndisplay which guardrails are active on an agent. The full\npolicy body (prompt text, callable path, label conditions)\nis intentionally excluded \u2014 this is a summary for display,\nnot a full spec.",
         "properties": {
@@ -2859,6 +2905,7 @@
             "response.output_file.done": "#/components/schemas/OutputFileDoneEvent",
             "response.output_item.done": "#/components/schemas/OutputItemDoneEvent",
             "response.output_text.delta": "#/components/schemas/OutputTextDeltaEvent",
+            "response.policy_denied": "#/components/schemas/PolicyDeniedEvent",
             "response.queued": "#/components/schemas/QueuedEvent",
             "response.reasoning.started": "#/components/schemas/ReasoningStartedEvent",
             "response.reasoning_summary_text.delta": "#/components/schemas/ReasoningSummaryTextDeltaEvent",
@@ -2986,6 +3033,9 @@
           },
           {
             "$ref": "#/components/schemas/ElicitationResolvedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PolicyDeniedEvent"
           },
           {
             "$ref": "#/components/schemas/CreatedEvent"

--- a/tests/harness_bench/manifest.py
+++ b/tests/harness_bench/manifest.py
@@ -63,6 +63,13 @@ _AUTH_PROSE: dict[AuthModel, str] = {
 # These stay explicitly SUPPORTED for the official (P0) harnesses: every one
 # completes a turn, calls tools, and enforces a policy DENY. They are NOT
 # derived from any capability axis (see the module docstring / seam brief).
+#
+# tool_calling / policy_deny are now live-probed on BOTH transports: SDK
+# harnesses via full-server (server-dispatched builtin + spec-baked deny), and
+# native harnesses via native-tui (observing the vendor's own function_call item
+# + a response.policy_denied stream signal from a session-attached deny). An
+# environment gap (fail-open policy, no tool-provocation mapping) reports
+# SKIPPED, so SUPPORTED here only ever drifts on a genuine capability gap.
 _PROBE_ONLY_DECLARED: dict[str, Verdict] = {
     "basic_turn": Verdict.SUPPORTED,
     "tool_calling": Verdict.SUPPORTED,

--- a/tests/harness_bench/manifest.py
+++ b/tests/harness_bench/manifest.py
@@ -64,12 +64,14 @@ _AUTH_PROSE: dict[AuthModel, str] = {
 # completes a turn, calls tools, and enforces a policy DENY. They are NOT
 # derived from any capability axis (see the module docstring / seam brief).
 #
-# tool_calling / policy_deny are now live-probed on BOTH transports: SDK
-# harnesses via full-server (server-dispatched builtin + spec-baked deny), and
-# native harnesses via native-tui (observing the vendor's own function_call item
-# + a response.policy_denied stream signal from a session-attached deny). An
-# environment gap (fail-open policy, no tool-provocation mapping) reports
-# SKIPPED, so SUPPORTED here only ever drifts on a genuine capability gap.
+# tool_calling is now live-probed on BOTH transports: SDK harnesses via
+# full-server (server-dispatched builtin) and native harnesses via native-tui
+# (observing the vendor's own function_call item). policy_deny is live on
+# full-server (spec-baked deny) and wired on native-tui (a session-attached CEL
+# deny + the response.policy_denied stream signal), though native enforcement is
+# a follow-up. An environment gap (fail-open policy, no tool-provocation mapping,
+# CEL unavailable) reports SKIPPED, so SUPPORTED here only ever drifts on a
+# genuine capability gap.
 _PROBE_ONLY_DECLARED: dict[str, Verdict] = {
     "basic_turn": Verdict.SUPPORTED,
     "tool_calling": Verdict.SUPPORTED,

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -152,14 +152,15 @@ class NativeVendor:
         ``external_session_id`` — that id cannot exist until a turn is posted,
         so waiting for it pre-turn deadlocks. Thread-at-launch vendors
         (claude/codex) leave this ``False`` and are gated normally.
-    :param tool_name: The vendor's own tool the tool/policy probes provoke and
-        gate, as it appears on the wire (``event.data.name`` = the vendor's raw
-        PreToolUse ``tool_name``), e.g. ``"Bash"`` for claude, ``"shell"`` for
-        codex. Empty means the tool/policy probes cannot run for this vendor
-        and SKIP. Not derivable from the capability model, so it is an explicit
-        per-vendor fact (see :data:`_NATIVE_TOOL_PROVOCATION`).
-    :param tool_prompt: A prompt that reliably makes the vendor call
-        :attr:`tool_name`. Empty when :attr:`tool_name` is.
+    :param tool_name: The vendor's own shell/terminal tool, e.g. ``"Bash"`` for
+        claude, ``"shell"`` for codex/kiro, ``"run_shell_command"`` for qwen.
+        Used for documentation and as a non-empty gate: empty means the
+        tool/policy probes cannot run for this vendor and SKIP. The deny gates
+        on the tool_call phase (name-agnostic), so this need not be wire-exact.
+        Not derivable from the capability model, so it is an explicit per-vendor
+        fact (see :data:`_NATIVE_TOOL_PROVOCATION`).
+    :param tool_prompt: A prompt that reliably makes the vendor call its shell
+        tool. Empty when :attr:`tool_name` is.
     """
 
     harness: str
@@ -178,23 +179,33 @@ class NativeVendor:
 # are added only once live-verified to behave this way.
 _LAZY_CHAT_HARNESSES: frozenset[str] = frozenset({"cursor-native"})
 
-# The vendor tool the tool/policy probes provoke + gate, keyed by harness:
-# (tool_name as it appears on the wire, a prompt that provokes it). The
-# tool_name must equal the vendor's raw PreToolUse ``tool_name`` (what surfaces
-# as ``event.data.name`` and what the deny policy targets) — claude runs a shell
-# command as ``Bash``, codex as ``shell``. A harmless ``echo`` keeps the ALLOW
-# turn side-effect-free in the ephemeral workspace. A harness absent here has no
-# tool_name, so its tool/policy probes SKIP (never a false UNSUPPORTED).
+# Per-harness tool provocation for the tool/policy probes:
+# ``harness -> (tool_name, prompt)``. The prompt asks the vendor to run a
+# harmless ``echo`` via its own shell/terminal tool (side-effect-free in the
+# ephemeral workspace); the tool call then surfaces as a ``function_call`` item
+# and (with a deny attached) trips the tool_call-phase policy.
+#
+# ``tool_name`` is the vendor's own tool for a shell command, for documentation
+# and as a non-empty gate — a harness absent here (or with an empty entry) has
+# its tool/policy probes SKIP, never a false UNSUPPORTED. The deny policy gates
+# on the tool_call *phase* alone (name-agnostic; see _attach_tool_deny_policy),
+# so ``tool_name`` no longer has to match the vendor's raw hook name exactly.
+# Names sourced from omnigent/policies/builtins/safety.py::ask_on_os_tools and
+# each vendor's native module.
+_SHELL_PROMPT = "Use your shell/terminal tool to run this exact command: echo omnigent-bench-ok"
 _NATIVE_TOOL_PROVOCATION: dict[str, tuple[str, str]] = {
     "claude-native": (
         "Bash",
         "Use the Bash tool to run this exact command: echo omnigent-bench-ok",
     ),
-    "codex-native": (
-        "shell",
-        "Run this exact shell command using your shell tool: echo omnigent-bench-ok",
-    ),
+    "codex-native": ("shell", _SHELL_PROMPT),
     "pi-native": ("Bash", "Use the Bash tool to run this exact command: echo omnigent-bench-ok"),
+    "kiro-native": ("shell", _SHELL_PROMPT),
+    "qwen-native": ("run_shell_command", _SHELL_PROMPT),
+    "goose-native": ("developer__shell", _SHELL_PROMPT),
+    "hermes-native": ("terminal", _SHELL_PROMPT),
+    "antigravity-native": ("run_command", _SHELL_PROMPT),
+    "kimi-native": ("Bash", "Use the Bash tool to run this exact command: echo omnigent-bench-ok"),
 }
 
 

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -49,6 +49,7 @@ already logged in.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import shutil
 import signal
@@ -109,6 +110,17 @@ _OUTPUT_DONE_EVENT = "response.output_item.done"
 _IN_PROGRESS_EVENT = "response.in_progress"
 _FAILED_EVENT = "response.failed"
 _INTERRUPTED_EVENT = "session.interrupted"
+# Published by the server when a native tool-call policy DENY is enforced (see
+# sessions.py::_publish_policy_denied). The positive signal the deny probe keys
+# on — a native deny is decided in the hook and otherwise leaves no stream trace.
+_POLICY_DENIED_EVENT = "response.policy_denied"
+
+# The registered CEL policy handler + a bench-owned deny reason. The deny probe
+# attaches a session policy that DENYs the provoked tool at the tool_call phase.
+_CEL_POLICY_HANDLER = "omnigent.policies.builtins.cel.cel_policy"
+_NATIVE_DENY_REASON = "bench-native-tool-deny"
+# How long to wait for the tool call / deny signal on a tool turn.
+_TOOL_TURN_TIMEOUT_S = 180.0
 
 # How long to let a turn run after it reports in-progress before firing the
 # interrupt, so the cancel lands mid-turn rather than racing turn setup.
@@ -140,6 +152,14 @@ class NativeVendor:
         ``external_session_id`` — that id cannot exist until a turn is posted,
         so waiting for it pre-turn deadlocks. Thread-at-launch vendors
         (claude/codex) leave this ``False`` and are gated normally.
+    :param tool_name: The vendor's own tool the tool/policy probes provoke and
+        gate, as it appears on the wire (``event.data.name`` = the vendor's raw
+        PreToolUse ``tool_name``), e.g. ``"Bash"`` for claude, ``"shell"`` for
+        codex. Empty means the tool/policy probes cannot run for this vendor
+        and SKIP. Not derivable from the capability model, so it is an explicit
+        per-vendor fact (see :data:`_NATIVE_TOOL_PROVOCATION`).
+    :param tool_prompt: A prompt that reliably makes the vendor call
+        :attr:`tool_name`. Empty when :attr:`tool_name` is.
     """
 
     harness: str
@@ -147,6 +167,8 @@ class NativeVendor:
     terminal_name: str
     own_auth: bool = False
     lazy_chat: bool = False
+    tool_name: str = ""
+    tool_prompt: str = ""
 
 
 # Vendors whose external_session_id is created by the first message, not at TUI
@@ -155,6 +177,25 @@ class NativeVendor:
 # (its forwarder discovers the chat store written on the first message); others
 # are added only once live-verified to behave this way.
 _LAZY_CHAT_HARNESSES: frozenset[str] = frozenset({"cursor-native"})
+
+# The vendor tool the tool/policy probes provoke + gate, keyed by harness:
+# (tool_name as it appears on the wire, a prompt that provokes it). The
+# tool_name must equal the vendor's raw PreToolUse ``tool_name`` (what surfaces
+# as ``event.data.name`` and what the deny policy targets) — claude runs a shell
+# command as ``Bash``, codex as ``shell``. A harmless ``echo`` keeps the ALLOW
+# turn side-effect-free in the ephemeral workspace. A harness absent here has no
+# tool_name, so its tool/policy probes SKIP (never a false UNSUPPORTED).
+_NATIVE_TOOL_PROVOCATION: dict[str, tuple[str, str]] = {
+    "claude-native": (
+        "Bash",
+        "Use the Bash tool to run this exact command: echo omnigent-bench-ok",
+    ),
+    "codex-native": (
+        "shell",
+        "Run this exact shell command using your shell tool: echo omnigent-bench-ok",
+    ),
+    "pi-native": ("Bash", "Use the Bash tool to run this exact command: echo omnigent-bench-ok"),
+}
 
 
 def native_vendor(harness: str) -> NativeVendor | None:
@@ -174,12 +215,15 @@ def native_vendor(harness: str) -> NativeVendor | None:
     # vendor CLI name), which holds for every in-repo native. A community
     # plugin whose registered terminal/agent name diverges would need an
     # override map here, mirroring the manifest's _NATIVE_CLI_BINARY.
+    tool_name, tool_prompt = _NATIVE_TOOL_PROVOCATION.get(harness, ("", ""))
     return NativeVendor(
         harness=harness,
         agent_name=f"{harness}-ui",
         terminal_name=harness.removesuffix("-native"),
         own_auth=caps.auth is not AuthModel.OMNIGENT_CREDENTIAL,
         lazy_chat=harness in _LAZY_CHAT_HARNESSES,
+        tool_name=tool_name,
+        tool_prompt=tool_prompt,
     )
 
 
@@ -205,6 +249,10 @@ class NativeTuiDriver:
         self._session_id: str | None = None
         self._base_url = ""
         self._tmp = Path("/tmp") / f"omni-bench-nt-{uuid.uuid4().hex[:8]}"
+        # Set from the terminal-ensure response when native policy enforcement
+        # is inactive (fail-open: codex too old / hook untrusted). The deny
+        # probe reads this to SKIP rather than report a false UNSUPPORTED.
+        self._policy_hook_disabled_reason: str | None = None
 
     @staticmethod
     def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
@@ -257,15 +305,7 @@ class NativeTuiDriver:
         return await asyncio.to_thread(self._drive_turn, _STREAM_PROMPT, count_deltas=True)
 
     async def run_tool_turn(self, *, deny: bool) -> TurnResult:
-        # Native tool calls are the vendor's own tools (Bash/Read/...), not a
-        # server-dispatched builtin the bench can force, and a native deny
-        # surfaces as a vendor permission decision rather than a
-        # function_call_output. Wiring that observation is the next
-        # increment; today the skeleton reports it unmeasured so the probe
-        # records a capability-neutral skip rather than a false verdict.
-        result = TurnResult()
-        result.error = "native tool/policy observation not yet wired (skeleton)"
-        return result
+        return await asyncio.to_thread(self._drive_tool_turn, deny=deny)
 
     async def run_interrupt_turn(self) -> TurnResult:
         return await asyncio.to_thread(self._drive_interrupt_turn)
@@ -350,6 +390,13 @@ class NativeTuiDriver:
             timeout=90.0,
         )
         ensure.raise_for_status()
+        # The terminal-ensure success body carries a one-shot
+        # ``policy_hook_disabled_reason`` when native tool-call policy
+        # enforcement is inactive (fail-open: codex too old / hook untrusted).
+        # Record it so the deny probe SKIPs rather than reading an unenforced
+        # deny as UNSUPPORTED.
+        with contextlib.suppress(Exception):
+            self._policy_hook_disabled_reason = ensure.json().get("policy_hook_disabled_reason")
         # A lazy-chat vendor (cursor) does not create its external_session_id
         # until the first message lands, so it cannot be gated on here — waiting
         # pre-turn would deadlock. The terminal is ensured; the first probe turn
@@ -532,6 +579,153 @@ class NativeTuiDriver:
             result.timed_out = True
         return result
 
+    def _drive_tool_turn(self, *, deny: bool) -> TurnResult:
+        """Provoke the vendor's own tool, observe the call (and, with *deny*, the block).
+
+        The tool call surfaces as a persisted ``function_call`` item (the vendor
+        bridge mirrors ``tool_use`` into one), so ``result.tool_calls`` is filled
+        by scanning the session items past a pre-turn baseline. With *deny*, a
+        tool_call-phase DENY is attached to the session first (a CEL policy
+        targeting the provoked tool); the block is decided in the vendor hook and
+        surfaces on the stream as ``response.policy_denied`` — the positive signal
+        that sets ``result.tool_call_denied``.
+
+        Returns a capability-neutral SKIP (``error`` set, no verdict fields) when
+        the vendor has no known tool to provoke, or when *deny* is requested but
+        native policy enforcement is inactive (fail-open) — so the probes never
+        read an environment gap as UNSUPPORTED.
+        """
+        assert self._client is not None and self._vendor is not None
+        result = TurnResult()
+        if not self._vendor.tool_name:
+            result.error = f"no tool-provocation mapping for {self._vendor.harness!r}; skipped"
+            return result
+        if deny:
+            if self._policy_hook_disabled_reason:
+                result.error = (
+                    f"native policy enforcement inactive ({self._policy_hook_disabled_reason}); "
+                    "cannot exercise tool-call DENY"
+                )
+                return result
+            attached = self._attach_tool_deny_policy(self._vendor.tool_name)
+            if attached is not None:
+                result.error = attached  # e.g. CEL handler unavailable -> SKIP
+                return result
+
+        events: list[str] = []
+        ready = threading.Event()
+
+        def _read() -> None:
+            assert self._client is not None
+            try:
+                with self._client.stream(
+                    "GET",
+                    f"/v1/sessions/{self._session_id}/stream",
+                    timeout=_TOOL_TURN_TIMEOUT_S,
+                ) as resp:
+                    ready.set()
+                    for line in resp.iter_lines():
+                        if not line.startswith("event:"):
+                            continue
+                        etype = line[len("event:") :].strip()
+                        events.append(etype)
+                        if etype == _POLICY_DENIED_EVENT:
+                            result.tool_call_denied = True
+                        # Stop once output is done/failed/interrupted. On a deny
+                        # the tool never runs, so the turn still ends normally.
+                        if etype in _READER_TERMINAL:
+                            return
+            except httpx.HTTPError as exc:
+                result.error = repr(exc)
+
+        baseline = self._tool_item_count()
+        reader = threading.Thread(target=_read)
+        reader.start()
+        ready.wait(timeout=10.0)  # subscribe before posting so no event is lost
+        self._post_message(self._vendor.tool_prompt)
+        self._poll_new_tool_calls(baseline, result)
+        reader.join(timeout=10.0)
+
+        # Turn end: output finished (or, on a deny, the blocked tool left the
+        # turn to complete without producing the tool item).
+        result.completed = _OUTPUT_DONE_EVENT in events or bool(result.tool_calls)
+        return result
+
+    def _attach_tool_deny_policy(self, tool_name: str) -> str | None:
+        """Attach a session policy that DENYs *tool_name* at the tool_call phase.
+
+        Uses the registered CEL handler via ``POST /v1/sessions/{id}/policies``.
+        Returns ``None`` on success (200/201/409); a skip-reason string when the
+        handler is unavailable (e.g. ``cel_expr_python`` not installed, so the
+        server rejects it as unregistered) — an environment gap, not a
+        capability gap.
+        """
+        assert self._client is not None
+        # Ternary so the expression returns a map (a bare `&&` returns a bool,
+        # which the CEL policy treats as abstain -> ALLOW).
+        expression = (
+            f'event.type == "tool_call" && event.data.name == "{tool_name}" '
+            f'? {{"result": "DENY", "reason": "{_NATIVE_DENY_REASON}"}} '
+            f': {{"result": "ALLOW"}}'
+        )
+        resp = self._client.post(
+            f"/v1/sessions/{self._session_id}/policies",
+            json={
+                "name": "bench_tool_deny",
+                "type": "python",
+                "handler": _CEL_POLICY_HANDLER,
+                "factory_params": {"expression": expression, "reason": _NATIVE_DENY_REASON},
+            },
+            timeout=30.0,
+        )
+        if resp.status_code in (200, 201, 409):  # 409: already attached (reused session)
+            return None
+        return f"could not attach tool-call deny policy (status {resp.status_code}); skipped"
+
+    def _tool_item_count(self) -> int:
+        """Current number of function_call items in the session (pre-turn baseline)."""
+        assert self._client is not None
+        resp = self._client.get(f"/v1/sessions/{self._session_id}/items", params={"order": "asc"})
+        if resp.status_code != 200:
+            return 0
+        return sum(1 for it in resp.json().get("data", []) if _item_type(it) == "function_call")
+
+    def _poll_new_tool_calls(
+        self, baseline: int, result: TurnResult, timeout: float = _TOOL_TURN_TIMEOUT_S
+    ) -> None:
+        """Poll session items for NEW function_call items; append them to *result*.
+
+        Scoped past *baseline* so a reused session's prior tool calls don't
+        re-count. Stops as soon as at least one new call is seen (or on a deny,
+        as soon as the deny signal already landed on the stream).
+        """
+        assert self._client is not None
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            resp = self._client.get(
+                f"/v1/sessions/{self._session_id}/items", params={"order": "asc"}
+            )
+            if resp.status_code == 200:
+                calls = [
+                    it for it in resp.json().get("data", []) if _item_type(it) == "function_call"
+                ]
+                if len(calls) > baseline:
+                    for raw in calls[baseline:]:
+                        data = raw.get("data", raw)
+                        result.tool_calls.append(
+                            {
+                                "call_id": data.get("call_id"),
+                                "name": data.get("name"),
+                                "arguments": data.get("arguments"),
+                            }
+                        )
+                    return
+            # On a deny the tool never runs, so no new function_call item will
+            # appear — stop waiting once the stream already reported the block.
+            if result.tool_call_denied:
+                return
+            time.sleep(_POLL_INTERVAL_S)
+
     def _assistant_item_count(self) -> int:
         """Current number of assistant items in the session (pre-turn baseline)."""
         assert self._client is not None
@@ -641,3 +835,14 @@ def _assistant_text(item: dict[str, Any]) -> str:
         for block in content
         if isinstance(block, dict) and isinstance(block.get("text"), str)
     )
+
+
+def _item_type(item: dict[str, Any]) -> str | None:
+    """The item's type, tolerant of a top-level or nested-``data`` shape.
+
+    A native ``function_call`` item may carry ``type`` at the top level or under
+    ``data`` depending on the items-endpoint serialization, so check both (mirrors
+    full_server_driver._scan_tool_items).
+    """
+    data = item.get("data", item)
+    return item.get("type") or (data.get("type") if isinstance(data, dict) else None)

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -654,6 +654,14 @@ class NativeTuiDriver:
 
         # Turn end: output finished (or, on a deny, the blocked tool left the
         # turn to complete without producing the tool item).
+        #
+        # Live finding: on this transport a deny-turn tool call is NOT gated —
+        # the bench's native terminal-ensure launch does not thread ap_server_url
+        # into build_hook_settings, so the evaluate-policy PreToolUse hook is
+        # silently omitted and no response.policy_denied ever fires. The probe
+        # then SKIPs (tool ran, no deny) rather than reporting a false verdict.
+        # Wiring that hook on the bench launch path is the follow-up that turns
+        # native Policy DENY from `·` into a real verdict.
         result.completed = _OUTPUT_DONE_EVENT in events or bool(result.tool_calls)
         return result
 

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -607,7 +607,7 @@ class NativeTuiDriver:
                     "cannot exercise tool-call DENY"
                 )
                 return result
-            attached = self._attach_tool_deny_policy(self._vendor.tool_name)
+            attached = self._attach_tool_deny_policy()
             if attached is not None:
                 result.error = attached  # e.g. CEL handler unavailable -> SKIP
                 return result
@@ -638,11 +638,17 @@ class NativeTuiDriver:
             except httpx.HTTPError as exc:
                 result.error = repr(exc)
 
+        # Vary the command per turn so a reused session can't treat the deny
+        # turn as already-satisfied by the allow turn's identical request (which
+        # would leave the model with nothing to call, and nothing to deny).
+        token = "deny" if deny else "allow"
+        prompt = self._vendor.tool_prompt.replace("omnigent-bench-ok", f"omnigent-bench-{token}")
+
         baseline = self._tool_item_count()
         reader = threading.Thread(target=_read)
         reader.start()
         ready.wait(timeout=10.0)  # subscribe before posting so no event is lost
-        self._post_message(self._vendor.tool_prompt)
+        self._post_message(prompt)
         self._poll_new_tool_calls(baseline, result)
         reader.join(timeout=10.0)
 
@@ -651,22 +657,30 @@ class NativeTuiDriver:
         result.completed = _OUTPUT_DONE_EVENT in events or bool(result.tool_calls)
         return result
 
-    def _attach_tool_deny_policy(self, tool_name: str) -> str | None:
-        """Attach a session policy that DENYs *tool_name* at the tool_call phase.
+    def _attach_tool_deny_policy(self) -> str | None:
+        """Attach a session policy that DENYs any tool call at the tool_call phase.
 
         Uses the registered CEL handler via ``POST /v1/sessions/{id}/policies``.
+        Denies on the *phase* alone rather than a specific tool name: the wire
+        ``event.data.name`` is the vendor's raw hook ``tool_name``, which varies
+        per vendor and is not always the item name the forwarder mirrors (codex
+        mirrors ``shell`` but its hook may report a different tool_name). Gating
+        on ``event.type == "tool_call"`` blocks whatever tool the model calls,
+        which is exactly what "is a tool-call DENY enforced?" asks. The session
+        is bench-owned, so denying every tool call in it is harmless.
+
         Returns ``None`` on success (200/201/409); a skip-reason string when the
         handler is unavailable (e.g. ``cel_expr_python`` not installed, so the
         server rejects it as unregistered) — an environment gap, not a
         capability gap.
         """
         assert self._client is not None
-        # Ternary so the expression returns a map (a bare `&&` returns a bool,
-        # which the CEL policy treats as abstain -> ALLOW).
+        # Ternary so the expression returns a map (a bare comparison returns a
+        # bool, which the CEL policy treats as abstain -> ALLOW).
         expression = (
-            f'event.type == "tool_call" && event.data.name == "{tool_name}" '
+            'event.type == "tool_call" '
             f'? {{"result": "DENY", "reason": "{_NATIVE_DENY_REASON}"}} '
-            f': {{"result": "ALLOW"}}'
+            ': {"result": "ALLOW"}'
         )
         resp = self._client.post(
             f"/v1/sessions/{self._session_id}/policies",

--- a/tests/harness_bench/probes/policy_deny.py
+++ b/tests/harness_bench/probes/policy_deny.py
@@ -38,45 +38,52 @@ class PolicyDenyProbe(CapabilityProbe):
             "completed": result.completed,
         }
 
+        # A confirmed tool-call DENY is enforcement, whether or not a
+        # ``function_call`` item persisted. On full-server the denied call still
+        # surfaces an item (with a blocked output); on native-tui the deny is
+        # decided at the vendor hook *before* the tool runs, so no item persists
+        # and the only signal is the server's ``response.policy_denied`` event.
+        # Check the deny signal first so the native path is not swallowed by the
+        # "no tool call" guard below.
+        if result.tool_call_denied:
+            if result.completed or result.failed:
+                return ProbeResult(
+                    Verdict.SUPPORTED,
+                    note="tool-call DENY delivered and enforced; turn advanced past the block",
+                    detail=detail,
+                )
+            if result.timed_out:
+                return ProbeResult(
+                    Verdict.UNSUPPORTED,
+                    note="turn stalled after tool-call DENY (blocked call not handled)",
+                    detail=detail,
+                )
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note="tool-call DENY delivered and enforced",
+                detail=detail,
+            )
+
         if not result.tool_calls:
-            # The model never tried the tool, so the tool-call DENY path was
-            # never exercised — cannot conclude anything about enforcement.
+            # No deny signal AND no tool call: the model never tried the tool, so
+            # the tool-call DENY path was never exercised. (On native this also
+            # covers a turn where the vendor simply didn't call the tool.)
             return ProbeResult(
                 Verdict.SKIPPED,
                 note="model never attempted the tool; tool-call DENY path not exercised",
                 detail=detail,
             )
-        if not result.tool_call_denied:
-            # A tool call happened but no PHASE_TOOL_CALL evaluation was
-            # surfaced to deny. Policy evaluation is normally driven by the
-            # server / runner; in this wrap-direct transport some harnesses
-            # (e.g. codex) dispatch the tool without a tool-call evaluation
-            # hook, so we cannot exercise DENY here. That is a transport
-            # limitation, not proof the harness ignores policy — report
-            # SKIPPED and let the full-server transport assert enforcement.
-            return ProbeResult(
-                Verdict.SKIPPED,
-                note=(
-                    "tool call not routed through a tool-call policy evaluation "
-                    "(wrap-direct limitation)"
-                ),
-                detail=detail,
-            )
-        # A DENY landed on the tool-call phase and the turn advanced (to
-        # completion or a clean end) without hanging on the blocked call —
-        # the harness accepted and enforced the tool-call DENY.
-        if result.completed or result.failed:
-            return ProbeResult(
-                Verdict.SUPPORTED,
-                note="tool-call DENY delivered and enforced; blocked call did not stall the turn",
-                detail=detail,
-            )
-        if result.timed_out:
-            return ProbeResult(
-                Verdict.UNSUPPORTED,
-                note="turn stalled after tool-call DENY (blocked call not handled)",
-                detail=detail,
-            )
+        # A tool call happened but no DENY was surfaced. Policy evaluation is
+        # normally driven by the server / runner; in the wrap-direct transport
+        # some harnesses (e.g. codex) dispatch the tool without a tool-call
+        # evaluation hook, so we cannot exercise DENY here. That is a transport
+        # limitation, not proof the harness ignores policy — report SKIPPED and
+        # let the full-server / native transport assert enforcement.
         return ProbeResult(
-            Verdict.UNKNOWN, note="tool-call DENY delivered; outcome inconclusive", detail=detail
+            Verdict.SKIPPED,
+            note=(
+                "tool call not routed through a tool-call policy evaluation "
+                "(wrap-direct limitation)"
+            ),
+            detail=detail,
         )

--- a/tests/harness_bench/test_native_tui_driver.py
+++ b/tests/harness_bench/test_native_tui_driver.py
@@ -1,0 +1,218 @@
+"""Offline tests for the native-tui driver's tool/policy observation.
+
+Network-free: a fake HTTP client feeds the driver canned session items (the
+``function_call`` a native tool call persists as) and a canned SSE stream (the
+``response.policy_denied`` a native tool-call DENY publishes). This exercises
+``_drive_tool_turn`` and its helpers without a server, host daemon, or vendor
+CLI. The live path is covered by the gated ``test_native_tui`` layer.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.native_tui_driver import NativeTuiDriver, native_vendor
+from tests.harness_bench.probes.policy_deny import PolicyDenyProbe
+from tests.harness_bench.probes.tool_calling import ToolCallingProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Verdict
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class _FakeStream:
+    """Context manager yielding canned SSE ``event:`` lines via iter_lines."""
+
+    def __init__(self, event_names: list[str]) -> None:
+        self._lines = [f"event: {name}" for name in event_names]
+
+    def __enter__(self) -> _FakeStream:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        pass
+
+    def iter_lines(self):
+        yield from self._lines
+
+
+class _FakeClient:
+    """A minimal stand-in for the driver's httpx.Client.
+
+    - ``GET .../items`` returns empty on the first call (the pre-turn baseline),
+      then ``items`` (the function_call records the turn produced) — mirroring
+      real timing where the tool item persists only after the turn runs.
+    - ``GET .../stream`` yields ``stream_events`` as SSE ``event:`` lines.
+    - ``POST .../policies`` records the attach and returns ``policy_status``.
+    - other POSTs (the message post) are no-ops.
+    """
+
+    def __init__(
+        self,
+        *,
+        items: list[dict] | None = None,
+        stream_events: list[str] | None = None,
+        policy_status: int = 200,
+    ) -> None:
+        self._items = items or []
+        self._stream_events = stream_events or [
+            "response.output_item.done",
+        ]
+        self._policy_status = policy_status
+        self.attached_policies: list[dict] = []
+        self._items_calls = 0
+
+    def get(self, url: str, params: dict | None = None, timeout: float | None = None):
+        if url.endswith("/items"):
+            # First call is the pre-turn baseline (empty); later calls see the
+            # item the turn produced.
+            self._items_calls += 1
+            data = [] if self._items_calls == 1 else self._items
+            return _FakeResponse(200, {"data": data})
+        return _FakeResponse(200, {})
+
+    def post(self, url: str, json: dict | None = None, timeout: float | None = None):
+        if url.endswith("/policies"):
+            self.attached_policies.append(json or {})
+            return _FakeResponse(self._policy_status, {"name": "bench_tool_deny"})
+        return _FakeResponse(202, {})
+
+    def stream(self, method: str, url: str, timeout: float | None = None):
+        return _FakeStream(self._stream_events)
+
+
+def _driver_with_fake(harness: str, client: _FakeClient) -> NativeTuiDriver:
+    profile = BenchProfile(
+        harness=harness,
+        model="m",
+        env_prefix="HARNESS_X_",
+        marker="X",
+        transport="native-tui",
+    )
+    driver = NativeTuiDriver(profile, databricks_profile="oss")
+    driver._client = client  # type: ignore[assignment]
+    driver._session_id = "conv_test"
+    return driver
+
+
+def _function_call_item(name: str) -> dict:
+    return {"type": "function_call", "data": {"call_id": "c1", "name": name, "arguments": "{}"}}
+
+
+def test_tool_turn_observes_function_call_item() -> None:
+    """deny=False: a new function_call item populates result.tool_calls."""
+    client = _FakeClient(items=[_function_call_item("Bash")])
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_tool_turn(deny=False)
+
+    assert [tc["name"] for tc in result.tool_calls] == ["Bash"]
+    assert result.completed
+    assert not result.tool_call_denied
+    # No deny policy is attached on the allow path.
+    assert client.attached_policies == []
+
+
+def test_tool_turn_deny_attaches_policy_and_observes_denied_event() -> None:
+    """deny=True: attaches a CEL deny and sets tool_call_denied on the stream event."""
+    client = _FakeClient(
+        items=[],  # the blocked tool never runs, so no function_call item persists
+        stream_events=["response.policy_denied", "response.output_item.done"],
+    )
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_tool_turn(deny=True)
+
+    assert result.tool_call_denied
+    # The attached policy targets the provoked tool at the tool_call phase.
+    assert len(client.attached_policies) == 1
+    attached = client.attached_policies[0]
+    assert attached["handler"] == "omnigent.policies.builtins.cel.cel_policy"
+    expr = attached["factory_params"]["expression"]
+    assert 'event.type == "tool_call"' in expr
+    assert 'event.data.name == "Bash"' in expr
+
+
+def test_tool_turn_deny_skips_when_policy_enforcement_inactive() -> None:
+    """Fail-open (policy hook disabled) -> SKIP, never a false UNSUPPORTED."""
+    client = _FakeClient()
+    driver = _driver_with_fake("claude-native", client)
+    driver._policy_hook_disabled_reason = "Codex CLI too old"
+
+    result = driver._drive_tool_turn(deny=True)
+
+    assert result.error and "inactive" in result.error
+    assert not result.tool_call_denied
+    assert not result.tool_calls
+    # No policy is attached when enforcement is known-inactive.
+    assert client.attached_policies == []
+
+
+def test_tool_turn_deny_skips_when_cel_handler_unregistered() -> None:
+    """POST /policies rejecting the CEL handler (env gap) -> SKIP."""
+    client = _FakeClient(policy_status=400)
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_tool_turn(deny=True)
+
+    assert result.error and "deny policy" in result.error
+    assert not result.tool_call_denied
+
+
+def test_tool_turn_skips_vendor_without_tool_mapping() -> None:
+    """A native with no tool-provocation entry (e.g. cursor) SKIPs cleanly."""
+    client = _FakeClient()
+    driver = _driver_with_fake("cursor-native", client)
+    assert native_vendor("cursor-native").tool_name == ""  # precondition
+
+    result = driver._drive_tool_turn(deny=False)
+
+    assert result.error and "no tool-provocation" in result.error
+    assert not result.tool_calls
+
+
+async def test_probes_read_native_tool_result_as_supported() -> None:
+    """The transport-agnostic probes turn the native TurnResults into verdicts."""
+    profile = BenchProfile(
+        harness="claude-native",
+        model="m",
+        env_prefix="HARNESS_X_",
+        marker="X",
+        transport="native-tui",
+    )
+
+    class _Driver:
+        async def run_tool_turn(self, *, deny: bool) -> TurnResult:
+            if deny:
+                return TurnResult(
+                    completed=True, tool_calls=[{"name": "Bash"}], tool_call_denied=True
+                )
+            return TurnResult(completed=True, tool_calls=[{"name": "Bash"}])
+
+    tool_result = await ToolCallingProbe().run(_Driver(), profile)
+    assert tool_result.verdict is Verdict.SUPPORTED
+    deny_result = await PolicyDenyProbe().run(_Driver(), profile)
+    assert deny_result.verdict is Verdict.SUPPORTED
+
+
+def test_format_matches_server_wire_name() -> None:
+    """The driver keys on the exact wire name the server publishes."""
+    from omnigent.server.routes.sessions import _format_sse
+    from tests.harness_bench.native_tui_driver import _POLICY_DENIED_EVENT
+
+    sse = _format_sse(_POLICY_DENIED_EVENT, {"type": _POLICY_DENIED_EVENT})
+    # The reader parses `event: <name>`; assert the driver's key is that name.
+    assert sse.startswith(f"event: {_POLICY_DENIED_EVENT}\n")
+    assert json.loads(sse.split("data: ", 1)[1])["type"] == _POLICY_DENIED_EVENT

--- a/tests/harness_bench/test_native_tui_driver.py
+++ b/tests/harness_bench/test_native_tui_driver.py
@@ -136,13 +136,14 @@ def test_tool_turn_deny_attaches_policy_and_observes_denied_event() -> None:
     result = driver._drive_tool_turn(deny=True)
 
     assert result.tool_call_denied
-    # The attached policy targets the provoked tool at the tool_call phase.
+    # The attached policy denies at the tool_call phase (name-agnostic, so it
+    # blocks whatever tool the vendor calls regardless of its wire name).
     assert len(client.attached_policies) == 1
     attached = client.attached_policies[0]
     assert attached["handler"] == "omnigent.policies.builtins.cel.cel_policy"
     expr = attached["factory_params"]["expression"]
     assert 'event.type == "tool_call"' in expr
-    assert 'event.data.name == "Bash"' in expr
+    assert '"result": "DENY"' in expr
 
 
 def test_tool_turn_deny_skips_when_policy_enforcement_inactive() -> None:

--- a/tests/server/test_stream_events.py
+++ b/tests/server/test_stream_events.py
@@ -24,6 +24,7 @@ import pytest
 from pydantic import TypeAdapter, ValidationError
 
 from omnigent.server.schemas import (
+    PolicyDeniedEvent,
     ServerStreamEvent,
     SessionCreatedEvent,
     SessionModelOptionsEvent,
@@ -392,6 +393,77 @@ def test_session_created_event_is_known() -> None:
     # all_in_the_union) relies on ``is_known_event`` — a missed
     # registration would let the new event slip past the gate.
     assert is_known_event("session.created")
+
+
+def test_policy_denied_event_round_trips_through_union() -> None:
+    """``response.policy_denied`` routes via the discriminator.
+
+    ``_publish_policy_denied`` publishes this on a native tool-call DENY so
+    observers (web UI, capability bench) see the decision. If the variant were
+    missing from the union, the SSE serializer's boundary validation would
+    reject the emit and kill the stream. The wire name must be
+    ``response.policy_denied`` (not ``policy_denied``): the web-UI wire decoder
+    matches the raw ``event:`` name literally.
+    """
+    event = PolicyDeniedEvent(
+        type="response.policy_denied",
+        conversation_id="conv_abc",
+        reason="Blocked by policy.",
+        phase="tool_call",
+    )
+    dumped = event.model_dump()
+    parsed = _ADAPTER.validate_python(dumped)
+    assert isinstance(parsed, PolicyDeniedEvent)
+    assert parsed.conversation_id == "conv_abc"
+    assert parsed.phase == "tool_call"
+    assert parsed.reason == "Blocked by policy."
+    assert is_known_event("response.policy_denied")
+
+
+def test_publish_policy_denied_helper_emits_typed_event() -> None:
+    """``sessions._publish_policy_denied`` publishes a typed, union-valid event.
+
+    Captures the published payload via the live publish hook (the same pattern
+    as the status helper test) and asserts the wire name / fields, plus that
+    the dict round-trips the union adapter — the wire-validation gate.
+    """
+    from omnigent.runtime import session_stream as cs
+    from omnigent.server.routes.sessions import _publish_policy_denied
+
+    captured: list[tuple[str, dict[str, Any]]] = []
+    real_publish = cs.publish
+
+    def capturing_publish(conversation_id: str, event: dict[str, Any]) -> None:
+        captured.append((conversation_id, event))
+
+    cs.publish = capturing_publish  # type: ignore[assignment]
+    try:
+        _publish_policy_denied("conv_abc", "Blocked by policy.", "tool_call")
+    finally:
+        cs.publish = real_publish  # type: ignore[assignment]
+
+    assert len(captured) == 1
+    conv, event = captured[0]
+    assert conv == "conv_abc"
+    assert event["type"] == "response.policy_denied"
+    assert event["conversation_id"] == "conv_abc"
+    assert event["phase"] == "tool_call"
+    assert event["reason"] == "Blocked by policy."
+    parsed = _ADAPTER.validate_python(event)
+    assert isinstance(parsed, PolicyDeniedEvent)
+
+
+def test_policy_denied_format_sse_uses_response_prefixed_wire_name() -> None:
+    """``_format_sse`` emits ``event: response.policy_denied``.
+
+    Locks the exact ``event:`` line the web-UI wire decoder and the bench's
+    native driver key on — a rename to ``policy_denied`` would silently break
+    both (the web UI drops the frame, the driver's key misses).
+    """
+    from omnigent.server.routes.sessions import _format_sse
+
+    sse = _format_sse("response.policy_denied", {"type": "response.policy_denied"})
+    assert sse.startswith("event: response.policy_denied\ndata: {")
 
 
 def test_publish_session_status_helper_uses_waiting_literal() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Native harnesses used to report `·` (SKIPPED) for **Tool calling** and **Policy
DENY**, which we'd documented as a *bench observation gap, not a native
limitation*. This closes the Tool calling gap and builds (but does not yet fully
enforce) the Policy DENY path.

- **Tool calling — live-verified `✓`** on claude-native, codex-native, and
  pi-native (was `·`). The driver provokes the vendor's own tool (a harmless
  `echo` via its shell tool) and observes the `function_call` item the vendor
  bridge mirrors into the session — no forwarder changes. The provocation map
  covers every in-repo native, but two (kiro, qwen) stay `·`: their forwarders
  deliberately mirror only text blocks and skip `tool_use`, so no
  `function_call` ever surfaces — a forwarder enhancement, upstream of the
  bench (see "Known limitations").
- **Policy DENY — machinery built + offline-tested; NOT yet enforced live.**
  A native tool-call DENY is decided synchronously in the vendor PreToolUse
  hook, so nothing on the session stream reflected it. This adds a positive
  signal: a new `response.policy_denied` server event, plus a driver path that
  attaches a `tool_call`-phase CEL deny to the session and watches for it. In
  live runs the deny is not yet enforced — the bench's native launch omits the
  policy hook (see "Known limitations") — so the probe reports a clean SKIP.

Both probes are transport-agnostic and unchanged in intent; the driver just
populates `result.tool_calls` / `result.tool_call_denied` on the native path.
Every environment gap (no tool mapping, unmirrored tool call, fail-open policy,
CEL unavailable) reports SKIPPED, never a false UNSUPPORTED — so the bench
distinguishes "not wired" from "not capable" rather than lying.

## Known limitations (follow-ups)

Both are upstream signal gaps, not bench bugs — the probes SKIP cleanly (no
false verdict, no drift) until the upstream emits the signal.

### 1. Native Policy DENY not enforced (hook not wired on the bench launch)

The full deny path is in place and offline-tested, but a live claude/codex
native tool call is not yet blocked by the session-attached deny. Root cause is
**confirmed** by live instrumentation (since removed):

- The deny policy IS attached to the correct session (`policies=['bench_tool_deny']`
  on the bench's `self._session_id`), and the CEL correctly DENYs a `tool_call`
  event. Session-scoping was ruled out.
- On the deny turn the tool runs anyway (`tool_calls=['Bash']`,
  `tool_call_denied=False`) with **no policy evaluation on the stream at all** —
  my `response.policy_denied` publish never fires because the vendor's
  `evaluate-policy` PreToolUse hook is never invoked.
- Why: `claude_native_bridge.build_hook_settings` registers that hook only
  inside `if ap_server_url:` (bridge.py:1151). The bench's native terminal-ensure
  launch does not thread `ap_server_url` through to it, so the hook is silently
  omitted (no `permission_hook.json` is written) and native tool calls are never
  gated.

So this is an **unwired hook on the bench launch path**, not a harness that
ignores policy. Wiring `ap_server_url` through the bench's provisioning is the
follow-up that flips native Policy DENY from `·` to a real verdict.

### 2. kiro / qwen Tool calling `·` (forwarders skip tool_use)

kiro-native and qwen-native run turns fine but their forwarders deliberately
mirror only text blocks and **skip `tool_use`** (`qwen_native_forwarder.py:21`
says so explicitly; kiro has no `function_call` mirroring). No `function_call`
item ever persists, so the bench can't observe the call. Their provocation-map
entries are grounded and harmless (SKIP-safe), but flipping them to `✓` needs a
forwarder enhancement (mirror `tool_use` -> `function_call`), upstream of the
bench. claude/codex/pi-native mirror tool calls, so they observe fine.

## Test Plan

- Offline: `pytest tests/harness_bench/ tests/server/test_stream_events.py`
  -> 87 passed / 18 skipped; `ruff check` clean. New tests: `PolicyDeniedEvent`
  round-trips the stream-event union, the `_publish_policy_denied` helper emits
  a typed event, `_format_sse` locks the `response.policy_denied` wire name; and
  a network-free native-driver suite (fake client/stream) covering tool-call
  observation, the deny attach + `response.policy_denied` handling, and every
  SKIP path (no tool mapping, fail-open, CEL unregistered).
- Live (gateway `oss`, host with the native CLIs logged in):
  `python -m tests.harness_bench --profile oss --jobs 2`
  -> Tool calling `✓` on claude/codex/pi-native (reproduced across runs); Policy
  DENY SKIP (see above); kiro/qwen Tool calling SKIP (forwarder gap). Note:
  natives are heavy to provision — `--jobs 2` (or sequential) avoids the
  cold-start timeouts a higher `--jobs` causes.

## Demo

```
Harness                 Basic turn  Streaming  Tool calling  Policy DENY  Model override  Interrupt
----------------------  ----------  ---------  ------------  -----------  --------------  ---------
claude-native [native]      ✓           ✓           ✓             ·             ✓             ✓
codex-native [native]       ✓           ✓           ✓             ·             ✓             ✓
pi-native [native]          ✓           ✓           ✓             ·             ✓             ✓
kiro-native [native]        ✓           ✗           ·             ·             ✓             ✓
```

Tool calling is now a real `✓` on the natives whose forwarders mirror tool calls
(claude/codex/pi; was `·`). kiro's `·` is the forwarder gap, Policy DENY's `·`
the unwired hook — both follow-ups above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tool-call observation and the server `response.policy_denied` event are covered
offline (fake client/stream, union round-trip). The end-to-end native turn
(server + host daemon + vendor CLI) can't run in CI — it needs gateway creds
and a logged-in vendor CLI — so Tool calling was verified by hand on a live
`oss` run and Policy DENY's live gap is documented above rather than asserted.

## Changelog

The harness capability bench now observes native harness tool calls (Tool
calling verdict on claude-native / codex-native), and the server publishes a
`response.policy_denied` stream event when a native tool-call policy is enforced.

