### PR TITLE
feat(web): show and manage the branch when starting in an existing worktree

### DIFF
--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -22,7 +22,7 @@ import secrets
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel
 
 from omnigent.db.utils import now_epoch
 from omnigent.entities import Conversation
@@ -215,38 +215,20 @@ class LaunchRunnerRequest(BaseModel):
         ``"/Users/corey/projects/frontend"``. When ``git`` is set,
         this is interpreted as the source repository directory and
         the runner starts in the created worktree instead.
-    :param git: Optional git worktree options. When set, the server
-        creates a worktree for a new branch off ``workspace`` on the
-        host and binds the runner to it (the fork-resume path; mirrors
-        ``POST /v1/sessions``). ``None`` binds ``workspace`` directly.
-        ``host_id`` is always present (it is in the path), so no
-        host requirement check is needed here.
-    :param workspace_branch: Branch of a pre-existing worktree the
-        runner is bound to (``workspace`` is that worktree). No
-        worktree is created; the branch is persisted as the session's
-        ``git_branch`` for display and opt-in cleanup. Mutually
-        exclusive with ``git``.
+    :param git: Optional git worktree options. In create mode the
+        server creates a worktree for a new branch off ``workspace`` on
+        the host and binds the runner to it (the fork-resume path;
+        mirrors ``POST /v1/sessions``). In bind mode
+        (``existing_worktree=True``) ``workspace`` already IS a
+        worktree — no worktree is created; ``branch_name`` is recorded
+        as the session's ``git_branch`` for display and opt-in cleanup.
+        ``None`` binds ``workspace`` directly. ``host_id`` is always
+        present (it is in the path), so no host check is needed here.
     """
 
     session_id: str
     workspace: str
     git: SessionGitOptions | None = None
-    workspace_branch: str | None = None
-
-    @model_validator(mode="after")
-    def _check_workspace_branch(self) -> LaunchRunnerRequest:
-        """Reject ``workspace_branch`` combined with ``git`` (422).
-
-        ``git`` creates a worktree and sets its own branch;
-        ``workspace_branch`` records an existing worktree's branch
-        without creating one. Both at once is contradictory.
-
-        :returns: The validated instance.
-        :raises ValueError: If both are set.
-        """
-        if self.workspace_branch is not None and self.git is not None:
-            raise ValueError("workspace_branch cannot be combined with git")
-        return self
 
 
 async def _resolve_agent_spec_cwd(
@@ -504,8 +486,26 @@ def create_hosts_router(
         # lost CAS or a failed launch can roll it back, leaving no orphan
         # worktree on the host.
         git_branch: str | None = None
-        worktree = None  # CreatedWorktree | None — set when body.git is used
-        if body.git is not None:
+        # CreatedWorktree | None — set ONLY when Omnigent creates a worktree
+        # (create mode). Left None in bind mode so the rollback below never
+        # force-removes the user's pre-existing worktree.
+        worktree = None
+        if body.git is not None and body.git.existing_worktree:
+            # Binding to a pre-existing worktree: no worktree is created, but
+            # record its branch so the sidebar shows it and the opt-in delete
+            # flow can offer to remove it. The host never runs git for this
+            # path, so the server validates the name.
+            from omnigent.host.git_worktree import (
+                WorktreeError,
+                validate_branch_name,
+            )
+
+            try:
+                validate_branch_name(body.git.branch_name)
+            except WorktreeError as exc:
+                raise HTTPException(status_code=400, detail=exc.message) from exc
+            git_branch = body.git.branch_name
+        elif body.git is not None:
             from omnigent.host.git_worktree import (
                 WorktreeError,
                 validate_branch_name,
@@ -537,21 +537,6 @@ def create_hosts_router(
                 raise HTTPException(status_code=400, detail=exc.message) from exc
             workspace = worktree.worktree_path
             git_branch = worktree.branch
-        elif body.workspace_branch is not None:
-            # Binding to a pre-existing worktree: no worktree is created, but
-            # record its branch so the sidebar shows it and the opt-in delete
-            # flow can offer to remove it. The host never runs git for this
-            # path, so the server validates the name.
-            from omnigent.host.git_worktree import (
-                WorktreeError,
-                validate_branch_name,
-            )
-
-            try:
-                validate_branch_name(body.workspace_branch)
-            except WorktreeError as exc:
-                raise HTTPException(status_code=400, detail=exc.message) from exc
-            git_branch = body.workspace_branch
 
         async def _rollback_worktree() -> None:
             """

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -490,53 +490,48 @@ def create_hosts_router(
         # (create mode). Left None in bind mode so the rollback below never
         # force-removes the user's pre-existing worktree.
         worktree = None
-        if body.git is not None and body.git.existing_worktree:
-            # Binding to a pre-existing worktree: no worktree is created, but
-            # record its branch so the sidebar shows it and the opt-in delete
-            # flow can offer to remove it. The host never runs git for this
-            # path, so the server validates the name.
+        if body.git is not None:
             from omnigent.host.git_worktree import (
                 WorktreeError,
                 validate_branch_name,
             )
 
+            # Shared by both modes — the host never runs git in bind mode, so
+            # the server is the only gate on the name there.
             try:
                 validate_branch_name(body.git.branch_name)
             except WorktreeError as exc:
                 raise HTTPException(status_code=400, detail=exc.message) from exc
-            git_branch = body.git.branch_name
-        elif body.git is not None:
-            from omnigent.host.git_worktree import (
-                WorktreeError,
-                validate_branch_name,
-            )
-            from omnigent.server.routes._host_worktree import (
-                WorktreeHostUnavailableError,
-                WorktreeProxyError,
-                create_worktree_on_host,
-            )
 
-            try:
-                validate_branch_name(body.git.branch_name)
-            except WorktreeError as exc:
-                raise HTTPException(status_code=400, detail=exc.message) from exc
-            try:
-                worktree = await create_worktree_on_host(
-                    host_registry=host_registry,
-                    host_conn=conn,
-                    repo_path=workspace,
-                    branch_name=body.git.branch_name,
-                    base_branch=body.git.base_branch,
+            if body.git.existing_worktree:
+                # Binding to a pre-existing worktree: no worktree is created,
+                # but record its branch so the sidebar shows it and the opt-in
+                # delete flow can offer to remove it.
+                git_branch = body.git.branch_name
+            else:
+                from omnigent.server.routes._host_worktree import (
+                    WorktreeHostUnavailableError,
+                    WorktreeProxyError,
+                    create_worktree_on_host,
                 )
-            except WorktreeHostUnavailableError as exc:
-                # Host offline / unresponsive — infra, not user input.
-                raise HTTPException(status_code=409, detail=exc.message) from exc
-            except WorktreeProxyError as exc:
-                # Host-reported git failure (dup branch, bad base, not a
-                # repo) — user-correctable input.
-                raise HTTPException(status_code=400, detail=exc.message) from exc
-            workspace = worktree.worktree_path
-            git_branch = worktree.branch
+
+                try:
+                    worktree = await create_worktree_on_host(
+                        host_registry=host_registry,
+                        host_conn=conn,
+                        repo_path=workspace,
+                        branch_name=body.git.branch_name,
+                        base_branch=body.git.base_branch,
+                    )
+                except WorktreeHostUnavailableError as exc:
+                    # Host offline / unresponsive — infra, not user input.
+                    raise HTTPException(status_code=409, detail=exc.message) from exc
+                except WorktreeProxyError as exc:
+                    # Host-reported git failure (dup branch, bad base, not a
+                    # repo) — user-correctable input.
+                    raise HTTPException(status_code=400, detail=exc.message) from exc
+                workspace = worktree.worktree_path
+                git_branch = worktree.branch
 
         async def _rollback_worktree() -> None:
             """

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -22,7 +22,7 @@ import secrets
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from omnigent.db.utils import now_epoch
 from omnigent.entities import Conversation
@@ -221,11 +221,32 @@ class LaunchRunnerRequest(BaseModel):
         ``POST /v1/sessions``). ``None`` binds ``workspace`` directly.
         ``host_id`` is always present (it is in the path), so no
         host requirement check is needed here.
+    :param workspace_branch: Branch of a pre-existing worktree the
+        runner is bound to (``workspace`` is that worktree). No
+        worktree is created; the branch is persisted as the session's
+        ``git_branch`` for display and opt-in cleanup. Mutually
+        exclusive with ``git``.
     """
 
     session_id: str
     workspace: str
     git: SessionGitOptions | None = None
+    workspace_branch: str | None = None
+
+    @model_validator(mode="after")
+    def _check_workspace_branch(self) -> LaunchRunnerRequest:
+        """Reject ``workspace_branch`` combined with ``git`` (422).
+
+        ``git`` creates a worktree and sets its own branch;
+        ``workspace_branch`` records an existing worktree's branch
+        without creating one. Both at once is contradictory.
+
+        :returns: The validated instance.
+        :raises ValueError: If both are set.
+        """
+        if self.workspace_branch is not None and self.git is not None:
+            raise ValueError("workspace_branch cannot be combined with git")
+        return self
 
 
 async def _resolve_agent_spec_cwd(
@@ -516,6 +537,21 @@ def create_hosts_router(
                 raise HTTPException(status_code=400, detail=exc.message) from exc
             workspace = worktree.worktree_path
             git_branch = worktree.branch
+        elif body.workspace_branch is not None:
+            # Binding to a pre-existing worktree: no worktree is created, but
+            # record its branch so the sidebar shows it and the opt-in delete
+            # flow can offer to remove it. The host never runs git for this
+            # path, so the server validates the name.
+            from omnigent.host.git_worktree import (
+                WorktreeError,
+                validate_branch_name,
+            )
+
+            try:
+                validate_branch_name(body.workspace_branch)
+            except WorktreeError as exc:
+                raise HTTPException(status_code=400, detail=exc.message) from exc
+            git_branch = body.workspace_branch
 
         async def _rollback_worktree() -> None:
             """

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12247,28 +12247,29 @@ async def _create_session_from_existing_agent(
     # existing_worktree must never be force-removed on failure — it is
     # the user's, not an Omnigent orphan.
     created_worktree_path: str | None = None
-    if body.git is not None and body.git.existing_worktree:
-        # Starting in a pre-existing worktree: no worktree is created, but
-        # record its branch so the sidebar shows it and the opt-in delete
-        # flow can offer to remove it. Validate the name (the host never
-        # runs git for this path, so the server is the only gate).
-        from omnigent.host.git_worktree import WorktreeError, validate_branch_name
+    if body.git is not None:
+        if body.git.existing_worktree:
+            # Starting in a pre-existing worktree: no worktree is created, but
+            # record its branch so the sidebar shows it and the opt-in delete
+            # flow can offer to remove it. Validate the name (the host never
+            # runs git for this path, so the server is the only gate).
+            from omnigent.host.git_worktree import WorktreeError, validate_branch_name
 
-        try:
-            validate_branch_name(body.git.branch_name)
-        except WorktreeError as exc:
-            raise OmnigentError(exc.message, code=ErrorCode.INVALID_INPUT) from exc
-        git_branch = body.git.branch_name
-    elif body.git is not None:
-        created_worktree = await _create_session_worktree(
-            host_id=body.host_id,
-            source_repo=canonical_workspace,
-            git=body.git,
-            request=request,
-        )
-        canonical_workspace = created_worktree.worktree_path
-        git_branch = created_worktree.branch
-        created_worktree_path = created_worktree.worktree_path
+            try:
+                validate_branch_name(body.git.branch_name)
+            except WorktreeError as exc:
+                raise OmnigentError(exc.message, code=ErrorCode.INVALID_INPUT) from exc
+            git_branch = body.git.branch_name
+        else:
+            created_worktree = await _create_session_worktree(
+                host_id=body.host_id,
+                source_repo=canonical_workspace,
+                git=body.git,
+                request=request,
+            )
+            canonical_workspace = created_worktree.worktree_path
+            git_branch = created_worktree.branch
+            created_worktree_path = created_worktree.worktree_path
 
     # Native-terminal pass-through args.
     #

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12236,15 +12236,30 @@ async def _create_session_from_existing_agent(
             request=request,
         )
 
-    # Git worktree creation (optional): the worktree becomes the
-    # stored workspace and its branch is recorded.
+    # Git worktree options (optional). Two modes on body.git:
+    #  - create (default): make a worktree; it becomes the stored
+    #    workspace and its branch is recorded.
+    #  - bind (existing_worktree): workspace already IS the worktree;
+    #    record its branch only, create nothing.
     git_branch: str | None = None
-    # Set to the created worktree path ONLY when Omnigent creates one
-    # (body.git). Gates create-rollback: an existing worktree bound via
-    # workspace_branch must never be force-removed on failure — it is the
-    # user's, not an Omnigent orphan.
+    # Set to the created worktree path ONLY when Omnigent creates one.
+    # Gates create-rollback: an existing worktree bound via
+    # existing_worktree must never be force-removed on failure — it is
+    # the user's, not an Omnigent orphan.
     created_worktree_path: str | None = None
-    if body.git is not None:
+    if body.git is not None and body.git.existing_worktree:
+        # Starting in a pre-existing worktree: no worktree is created, but
+        # record its branch so the sidebar shows it and the opt-in delete
+        # flow can offer to remove it. Validate the name (the host never
+        # runs git for this path, so the server is the only gate).
+        from omnigent.host.git_worktree import WorktreeError, validate_branch_name
+
+        try:
+            validate_branch_name(body.git.branch_name)
+        except WorktreeError as exc:
+            raise OmnigentError(exc.message, code=ErrorCode.INVALID_INPUT) from exc
+        git_branch = body.git.branch_name
+    elif body.git is not None:
         created_worktree = await _create_session_worktree(
             host_id=body.host_id,
             source_repo=canonical_workspace,
@@ -12254,18 +12269,6 @@ async def _create_session_from_existing_agent(
         canonical_workspace = created_worktree.worktree_path
         git_branch = created_worktree.branch
         created_worktree_path = created_worktree.worktree_path
-    elif body.workspace_branch is not None:
-        # Starting in a pre-existing worktree: no worktree is created, but
-        # record its branch so the sidebar shows it and the opt-in delete
-        # flow can offer to remove it. Validate the name (the host never
-        # runs git for this path, so the server is the only gate).
-        from omnigent.host.git_worktree import WorktreeError, validate_branch_name
-
-        try:
-            validate_branch_name(body.workspace_branch)
-        except WorktreeError as exc:
-            raise OmnigentError(exc.message, code=ErrorCode.INVALID_INPUT) from exc
-        git_branch = body.workspace_branch
 
     # Native-terminal pass-through args.
     #

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12248,6 +12248,18 @@ async def _create_session_from_existing_agent(
         )
         canonical_workspace = created_worktree.worktree_path
         git_branch = created_worktree.branch
+    elif body.workspace_branch is not None:
+        # Starting in a pre-existing worktree: no worktree is created, but
+        # record its branch so the sidebar shows it and the opt-in delete
+        # flow can offer to remove it. Validate the name (the host never
+        # runs git for this path, so the server is the only gate).
+        from omnigent.host.git_worktree import WorktreeError, validate_branch_name
+
+        try:
+            validate_branch_name(body.workspace_branch)
+        except WorktreeError as exc:
+            raise OmnigentError(exc.message, code=ErrorCode.INVALID_INPUT) from exc
+        git_branch = body.workspace_branch
 
     # Native-terminal pass-through args.
     #

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12239,6 +12239,11 @@ async def _create_session_from_existing_agent(
     # Git worktree creation (optional): the worktree becomes the
     # stored workspace and its branch is recorded.
     git_branch: str | None = None
+    # Set to the created worktree path ONLY when Omnigent creates one
+    # (body.git). Gates create-rollback: an existing worktree bound via
+    # workspace_branch must never be force-removed on failure — it is the
+    # user's, not an Omnigent orphan.
+    created_worktree_path: str | None = None
     if body.git is not None:
         created_worktree = await _create_session_worktree(
             host_id=body.host_id,
@@ -12248,6 +12253,7 @@ async def _create_session_from_existing_agent(
         )
         canonical_workspace = created_worktree.worktree_path
         git_branch = created_worktree.branch
+        created_worktree_path = created_worktree.worktree_path
     elif body.workspace_branch is not None:
         # Starting in a pre-existing worktree: no worktree is created, but
         # record its branch so the sidebar shows it and the opt-in delete
@@ -12322,12 +12328,18 @@ async def _create_session_from_existing_agent(
         # Broad catch is intentional: ANY create_conversation failure
         # (integrity error, name clash, ...) must trigger orphan-worktree
         # cleanup before the error propagates. We re-raise unchanged
-        # below, so nothing is swallowed. git_branch is set only on
-        # worktree success.
-        if git_branch is not None and canonical_workspace is not None and body.host_id is not None:
+        # below, so nothing is swallowed. Gate on created_worktree_path,
+        # NOT git_branch: only a worktree Omnigent created here may be
+        # force-removed. An existing worktree bound via workspace_branch
+        # also sets git_branch but is the user's — never destroy it.
+        if (
+            created_worktree_path is not None
+            and body.host_id is not None
+            and git_branch is not None
+        ):
             await _remove_session_worktree_best_effort(
                 host_id=body.host_id,
-                worktree_path=canonical_workspace,
+                worktree_path=created_worktree_path,
                 branch=git_branch,
                 delete_branch=True,
                 request=request,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1091,23 +1091,50 @@ class SessionGitOptions(BaseModel):
     """
     Git worktree options for ``POST /v1/sessions``.
 
-    When present, the server creates a git worktree on the host for a
-    new branch and starts the runner in that worktree instead of the
-    picked directory. Requires ``host_id`` to be set (and therefore
-    ``workspace``, which is interpreted as the source repository
-    directory). See designs/SESSION_GIT_WORKTREE.md.
+    Requires ``host_id`` to be set (and therefore ``workspace``, which
+    is interpreted as the source repository directory). Two modes,
+    selected by ``existing_worktree``:
 
-    :param branch_name: Name of the new branch to create and check
-        out in the worktree, e.g. ``"feature/login"``. Validated
-        against git ref-format rules; invalid names fail with
-        ``invalid_input``.
+    - **create** (default): the server creates a git worktree on the
+      host for a new branch and starts the runner in that worktree
+      instead of the picked directory.
+    - **bind** (``existing_worktree=True``): ``workspace`` already IS a
+      pre-existing worktree; no worktree is created. ``branch_name`` is
+      recorded as the session's ``git_branch`` for display and opt-in
+      cleanup, and ``base_branch`` must not be set.
+
+    See designs/SESSION_GIT_WORKTREE.md.
+
+    :param branch_name: In create mode, the new branch to create and
+        check out, e.g. ``"feature/login"``. In bind mode, the branch
+        already checked out in the existing worktree. Validated against
+        git ref-format rules; invalid names fail with ``invalid_input``.
     :param base_branch: Optional base ref to branch from, e.g.
         ``"main"`` or ``"origin/main"``. ``None`` branches from the
-        source repository's current ``HEAD``.
+        source repository's current ``HEAD``. Create mode only —
+        invalid with ``existing_worktree``.
+    :param existing_worktree: When ``True``, bind to the pre-existing
+        worktree at ``workspace`` instead of creating one (see above).
     """
 
     branch_name: str
     base_branch: str | None = None
+    existing_worktree: bool = False
+
+    @model_validator(mode="after")
+    def _check_existing_worktree(self) -> SessionGitOptions:
+        """Reject ``base_branch`` in bind mode (422).
+
+        ``base_branch`` selects the ref a *new* branch forks from; it is
+        meaningless when binding to a worktree that already exists.
+
+        :returns: The validated instance.
+        :raises ValueError: If ``base_branch`` is set with
+            ``existing_worktree``.
+        """
+        if self.existing_worktree and self.base_branch is not None:
+            raise ValueError("base_branch cannot be set when existing_worktree is true")
+        return self
 
 
 class SessionCreateRequest(BaseModel):
@@ -1233,7 +1260,6 @@ class SessionCreateRequest(BaseModel):
     host_id: str | None = None
     workspace: str | None = None
     git: SessionGitOptions | None = None
-    workspace_branch: str | None = None
     terminal_launch_args: list[str] | None = None
     model_override: str | None = None
     reasoning_effort: str | None = None
@@ -1255,29 +1281,6 @@ class SessionCreateRequest(BaseModel):
         """
         if self.git is not None and self.host_id is None:
             raise ValueError("git worktree creation requires host_id")
-        return self
-
-    @model_validator(mode="after")
-    def _check_workspace_branch(self) -> SessionCreateRequest:
-        """
-        Validate ``workspace_branch`` and its exclusivity with ``git``.
-
-        ``workspace_branch`` records the branch of a pre-existing
-        worktree the caller started the session in (no worktree is
-        created), so it is persisted as the session's ``git_branch``
-        for display and opt-in cleanup. It is meaningless without a
-        host, and mutually exclusive with ``git`` (which *creates* a
-        worktree and sets its own branch). Failing here returns 422.
-
-        :returns: The validated instance.
-        :raises ValueError: If ``workspace_branch`` is combined with
-            ``git``, or set without ``host_id``.
-        """
-        if self.workspace_branch is not None:
-            if self.git is not None:
-                raise ValueError("workspace_branch cannot be combined with git")
-            if self.host_id is None:
-                raise ValueError("workspace_branch requires host_id")
         return self
 
     @model_validator(mode="after")

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1233,6 +1233,7 @@ class SessionCreateRequest(BaseModel):
     host_id: str | None = None
     workspace: str | None = None
     git: SessionGitOptions | None = None
+    workspace_branch: str | None = None
     terminal_launch_args: list[str] | None = None
     model_override: str | None = None
     reasoning_effort: str | None = None
@@ -1254,6 +1255,29 @@ class SessionCreateRequest(BaseModel):
         """
         if self.git is not None and self.host_id is None:
             raise ValueError("git worktree creation requires host_id")
+        return self
+
+    @model_validator(mode="after")
+    def _check_workspace_branch(self) -> SessionCreateRequest:
+        """
+        Validate ``workspace_branch`` and its exclusivity with ``git``.
+
+        ``workspace_branch`` records the branch of a pre-existing
+        worktree the caller started the session in (no worktree is
+        created), so it is persisted as the session's ``git_branch``
+        for display and opt-in cleanup. It is meaningless without a
+        host, and mutually exclusive with ``git`` (which *creates* a
+        worktree and sets its own branch). Failing here returns 422.
+
+        :returns: The validated instance.
+        :raises ValueError: If ``workspace_branch`` is combined with
+            ``git``, or set without ``host_id``.
+        """
+        if self.workspace_branch is not None:
+            if self.git is not None:
+                raise ValueError("workspace_branch cannot be combined with git")
+            if self.host_id is None:
+                raise ValueError("workspace_branch requires host_id")
         return self
 
     @model_validator(mode="after")

--- a/openapi.json
+++ b/openapi.json
@@ -1672,7 +1672,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional git worktree options. When set, the server creates a worktree for a new branch off `workspace` on the host and binds the runner to it (the fork-resume path; mirrors `POST /v1/sessions`). `None` binds `workspace` directly. `host_id` is always present (it is in the path), so no host requirement check is needed here."
+            "description": "Optional git worktree options. In create mode the server creates a worktree for a new branch off `workspace` on the host and binds the runner to it (the fork-resume path; mirrors `POST /v1/sessions`). In bind mode (`existing_worktree=True`) `workspace` already IS a worktree \u2014 no worktree is created; `branch_name` is recorded as the session's `git_branch` for display and opt-in cleanup. `None` binds `workspace` directly. `host_id` is always present (it is in the path), so no host check is needed here."
           },
           "session_id": {
             "description": "Session to bind the new runner to, e.g. `\"conv_abc123\"`.",
@@ -1683,18 +1683,6 @@
             "description": "Absolute path on the host machine to use as the runner's working directory, e.g. `\"/Users/corey/projects/frontend\"`. When `git` is set, this is interpreted as the source repository directory and the runner starts in the created worktree instead.",
             "title": "Workspace",
             "type": "string"
-          },
-          "workspace_branch": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Branch of a pre-existing worktree the runner is bound to (`workspace` is that worktree). No worktree is created; the branch is persisted as the session's `git_branch` for display and opt-in cleanup. Mutually exclusive with `git`.",
-            "title": "Workspace Branch"
           }
         },
         "required": [
@@ -3348,7 +3336,7 @@
         "type": "object"
       },
       "SessionGitOptions": {
-        "description": "Git worktree options for `POST /v1/sessions`.\n\nWhen present, the server creates a git worktree on the host for a\nnew branch and starts the runner in that worktree instead of the\npicked directory. Requires `host_id` to be set (and therefore\n`workspace`, which is interpreted as the source repository\ndirectory). See designs/SESSION_GIT_WORKTREE.md.",
+        "description": "Git worktree options for `POST /v1/sessions`.\n\nRequires `host_id` to be set (and therefore `workspace`, which\nis interpreted as the source repository directory). Two modes,\nselected by `existing_worktree`:\n\n- **create** (default): the server creates a git worktree on the\n  host for a new branch and starts the runner in that worktree\n  instead of the picked directory.\n- **bind** (`existing_worktree=True`): `workspace` already IS a\n  pre-existing worktree; no worktree is created. `branch_name` is\n  recorded as the session's `git_branch` for display and opt-in\n  cleanup, and `base_branch` must not be set.\n\nSee designs/SESSION_GIT_WORKTREE.md.",
         "properties": {
           "base_branch": {
             "anyOf": [
@@ -3359,13 +3347,19 @@
                 "type": "null"
               }
             ],
-            "description": "Optional base ref to branch from, e.g. `\"main\"` or `\"origin/main\"`. `None` branches from the source repository's current `HEAD`.",
+            "description": "Optional base ref to branch from, e.g. `\"main\"` or `\"origin/main\"`. `None` branches from the source repository's current `HEAD`. Create mode only \u2014 invalid with `existing_worktree`.",
             "title": "Base Branch"
           },
           "branch_name": {
-            "description": "Name of the new branch to create and check out in the worktree, e.g. `\"feature/login\"`. Validated against git ref-format rules; invalid names fail with `invalid_input`.",
+            "description": "In create mode, the new branch to create and check out, e.g. `\"feature/login\"`. In bind mode, the branch already checked out in the existing worktree. Validated against git ref-format rules; invalid names fail with `invalid_input`.",
             "title": "Branch Name",
             "type": "string"
+          },
+          "existing_worktree": {
+            "default": false,
+            "description": "When `True`, bind to the pre-existing worktree at `workspace` instead of creating one (see above).",
+            "title": "Existing Worktree",
+            "type": "boolean"
           }
         },
         "required": [

--- a/openapi.json
+++ b/openapi.json
@@ -1683,6 +1683,18 @@
             "description": "Absolute path on the host machine to use as the runner's working directory, e.g. `\"/Users/corey/projects/frontend\"`. When `git` is set, this is interpreted as the source repository directory and the runner starts in the created worktree instead.",
             "title": "Workspace",
             "type": "string"
+          },
+          "workspace_branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Branch of a pre-existing worktree the runner is bound to (`workspace` is that worktree). No worktree is created; the branch is persisted as the session's `git_branch` for display and opt-in cleanup. Mutually exclusive with `git`.",
+            "title": "Workspace Branch"
           }
         },
         "required": [

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1735,15 +1735,15 @@ async def _drive_add_worktree(base_url: str, session_id: str) -> None:
 
 
 def test_start_session_select_existing_worktree(seeded_session: tuple[str, str]) -> None:
-    """Picking an existing worktree starts in its directory with no git opts.
+    """Picking an existing worktree starts in its directory in git bind mode.
 
     The branch chip's input doubles as a combobox: focusing it lists the
     repo's existing worktrees (``GET /v1/hosts/{id}/worktrees``). Selecting
-    one must (a) point the workspace at that worktree's directory,
-    (b) send NO ``git`` spec on ``POST /v1/sessions`` — the session starts
-    directly in the existing worktree rather than creating a new one — and
-    (c) send the worktree's branch as ``workspace_branch`` so the sidebar
-    shows it and the delete flow can offer to remove it.
+    one must (a) point the workspace at that worktree's directory and
+    (b) send the ``git`` spec in bind mode on ``POST /v1/sessions`` —
+    ``existing_worktree: true`` with the worktree's branch as
+    ``branch_name`` — so no worktree is created but the sidebar shows the
+    branch and the delete flow can offer to remove it.
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_select_existing_worktree(base_url, session_id))
@@ -1823,13 +1823,13 @@ async def _drive_select_existing_worktree(base_url: str, session_id: str) -> Non
             await _wait_until(lambda: len(create_bodies) == 1)
             body = create_bodies[0]
             assert body["host_id"] == _HOST_ID, body
-            # Workspace is the worktree dir; NO git spec is sent (starting in an
-            # existing worktree creates nothing). The worktree's branch rides
-            # along as workspace_branch so the sidebar shows it and the delete
-            # flow can offer to remove it.
+            # Workspace is the worktree dir; the git spec is in bind mode
+            # (existing_worktree) so no worktree is created, and the worktree's
+            # branch rides along as branch_name so the sidebar shows it and the
+            # delete flow can offer to remove it.
             assert body["workspace"] == "/work/repo-worktrees/feature-x", body
-            assert body.get("git") is None, body
-            assert body["workspace_branch"] == "feature/x", body
+            assert body["git"]["existing_worktree"] is True, body
+            assert body["git"]["branch_name"] == "feature/x", body
         finally:
             await browser.close()
 

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1739,9 +1739,11 @@ def test_start_session_select_existing_worktree(seeded_session: tuple[str, str])
 
     The branch chip's input doubles as a combobox: focusing it lists the
     repo's existing worktrees (``GET /v1/hosts/{id}/worktrees``). Selecting
-    one must (a) point the workspace at that worktree's directory and
+    one must (a) point the workspace at that worktree's directory,
     (b) send NO ``git`` spec on ``POST /v1/sessions`` — the session starts
-    directly in the existing worktree rather than creating a new one.
+    directly in the existing worktree rather than creating a new one — and
+    (c) send the worktree's branch as ``workspace_branch`` so the sidebar
+    shows it and the delete flow can offer to remove it.
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_select_existing_worktree(base_url, session_id))
@@ -1822,9 +1824,12 @@ async def _drive_select_existing_worktree(base_url: str, session_id: str) -> Non
             body = create_bodies[0]
             assert body["host_id"] == _HOST_ID, body
             # Workspace is the worktree dir; NO git spec is sent (starting in an
-            # existing worktree creates nothing).
+            # existing worktree creates nothing). The worktree's branch rides
+            # along as workspace_branch so the sidebar shows it and the delete
+            # flow can offer to remove it.
             assert body["workspace"] == "/work/repo-worktrees/feature-x", body
             assert body.get("git") is None, body
+            assert body["workspace_branch"] == "feature/x", body
         finally:
             await browser.close()
 

--- a/tests/server/integration/test_host_runner_launch_worktree.py
+++ b/tests/server/integration/test_host_runner_launch_worktree.py
@@ -245,24 +245,20 @@ async def _launch(
     client: httpx.AsyncClient,
     session_id: str,
     *,
-    git: dict[str, str] | None = None,
-    workspace_branch: str | None = None,
+    git: dict[str, object] | None = None,
 ) -> httpx.Response:
     """POST the dedicated per-session bind+launch endpoint.
 
     :param client: The test HTTP client.
     :param session_id: Existing session to bind.
-    :param git: Optional ``git`` block, e.g.
-        ``{"branch_name": "feature/x"}``.
-    :param workspace_branch: Optional pre-existing worktree branch to
-        record without creating a worktree.
+    :param git: Optional ``git`` block. Create mode, e.g.
+        ``{"branch_name": "feature/x"}``; bind mode, e.g.
+        ``{"branch_name": "feature/x", "existing_worktree": True}``.
     :returns: The raw HTTP response.
     """
     body: dict[str, object] = {"session_id": session_id, "workspace": _SOURCE_REPO}
     if git is not None:
         body["git"] = git
-    if workspace_branch is not None:
-        body["workspace_branch"] = workspace_branch
     return await client.post(f"/v1/hosts/{_HOST_ID}/runners", json=body)
 
 
@@ -334,22 +330,26 @@ async def test_launch_runner_without_git_binds_source_dir_no_worktree(
     assert conv.host_id == _HOST_ID
 
 
-async def test_launch_runner_with_workspace_branch_persists_without_creating(
+async def test_launch_runner_with_existing_worktree_persists_without_creating(
     register_host: RegisterHost,
     client: httpx.AsyncClient,
     db_uri: str,
 ) -> None:
-    """``workspace_branch`` binds the existing worktree dir and records its
-    branch without creating a worktree (the existing-worktree resume path).
+    """``git.existing_worktree`` binds the existing worktree dir and records
+    its branch without creating a worktree (the existing-worktree resume path).
 
     The workspace is already a worktree, so no ``host.create_worktree``
-    frame is sent; the supplied branch is persisted as ``git_branch`` so
-    the sidebar shows it and the opt-in delete flow can offer to remove it.
+    frame is sent; ``branch_name`` is persisted as ``git_branch`` so the
+    sidebar shows it and the opt-in delete flow can offer to remove it.
     """
     cap = register_host()
     session_id = await _bare_session(client, "existing-wt-agent")
 
-    resp = await _launch(client, session_id, workspace_branch="feature/existing")
+    resp = await _launch(
+        client,
+        session_id,
+        git={"branch_name": "feature/existing", "existing_worktree": True},
+    )
     assert resp.status_code == 200, resp.text
 
     assert cap.create == [], "no worktree should be created for an existing worktree"

--- a/tests/server/integration/test_host_runner_launch_worktree.py
+++ b/tests/server/integration/test_host_runner_launch_worktree.py
@@ -246,6 +246,7 @@ async def _launch(
     session_id: str,
     *,
     git: dict[str, str] | None = None,
+    workspace_branch: str | None = None,
 ) -> httpx.Response:
     """POST the dedicated per-session bind+launch endpoint.
 
@@ -253,11 +254,15 @@ async def _launch(
     :param session_id: Existing session to bind.
     :param git: Optional ``git`` block, e.g.
         ``{"branch_name": "feature/x"}``.
+    :param workspace_branch: Optional pre-existing worktree branch to
+        record without creating a worktree.
     :returns: The raw HTTP response.
     """
     body: dict[str, object] = {"session_id": session_id, "workspace": _SOURCE_REPO}
     if git is not None:
         body["git"] = git
+    if workspace_branch is not None:
+        body["workspace_branch"] = workspace_branch
     return await client.post(f"/v1/hosts/{_HOST_ID}/runners", json=body)
 
 
@@ -326,6 +331,32 @@ async def test_launch_runner_without_git_binds_source_dir_no_worktree(
     assert conv is not None
     assert conv.workspace == _SOURCE_REPO
     assert conv.git_branch is None
+    assert conv.host_id == _HOST_ID
+
+
+async def test_launch_runner_with_workspace_branch_persists_without_creating(
+    register_host: RegisterHost,
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """``workspace_branch`` binds the existing worktree dir and records its
+    branch without creating a worktree (the existing-worktree resume path).
+
+    The workspace is already a worktree, so no ``host.create_worktree``
+    frame is sent; the supplied branch is persisted as ``git_branch`` so
+    the sidebar shows it and the opt-in delete flow can offer to remove it.
+    """
+    cap = register_host()
+    session_id = await _bare_session(client, "existing-wt-agent")
+
+    resp = await _launch(client, session_id, workspace_branch="feature/existing")
+    assert resp.status_code == 200, resp.text
+
+    assert cap.create == [], "no worktree should be created for an existing worktree"
+    conv = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
+    assert conv is not None
+    assert conv.workspace == _SOURCE_REPO
+    assert conv.git_branch == "feature/existing"
     assert conv.host_id == _HOST_ID
 
 

--- a/tests/server/integration/test_session_worktree_create.py
+++ b/tests/server/integration/test_session_worktree_create.py
@@ -278,16 +278,16 @@ async def test_create_with_invalid_base_branch_fails_400(
     assert "base branch does not exist" in body["error"]["message"]
 
 
-async def test_create_with_workspace_branch_persists_without_creating(
+async def test_create_with_existing_worktree_persists_without_creating(
     register_worktree_host: RegisterHost,
     client: httpx.AsyncClient,
 ) -> None:
     """Starting in an existing worktree persists its branch, creates nothing.
 
-    ``workspace_branch`` binds the session straight to a pre-existing
-    worktree directory: no create-worktree frame is sent to the host,
-    and the supplied branch is persisted as ``git_branch`` so the
-    sidebar shows it and the opt-in delete flow can offer to remove it.
+    ``git.existing_worktree`` binds the session straight to a
+    pre-existing worktree directory: no create-worktree frame is sent
+    to the host, and ``branch_name`` is persisted as ``git_branch`` so
+    the sidebar shows it and the opt-in delete flow can offer to remove it.
     """
     cap = register_worktree_host()
     agent = await create_test_agent(client, name="wt-existing-agent")
@@ -298,7 +298,7 @@ async def test_create_with_workspace_branch_persists_without_creating(
             "agent_id": agent["id"],
             "host_id": _HOST_ID,
             "workspace": _SOURCE_REPO,
-            "workspace_branch": "feature/existing",
+            "git": {"branch_name": "feature/existing", "existing_worktree": True},
         },
     )
     assert resp.status_code == 201, resp.text
@@ -313,11 +313,11 @@ async def test_create_with_workspace_branch_persists_without_creating(
     assert body["workspace"] == _SOURCE_REPO
 
 
-async def test_create_with_invalid_workspace_branch_fails_400(
+async def test_create_with_invalid_existing_worktree_branch_fails_400(
     register_worktree_host: RegisterHost,
     client: httpx.AsyncClient,
 ) -> None:
-    """An invalid ``workspace_branch`` name fails the create with 400.
+    """An invalid bind-mode ``branch_name`` fails the create with 400.
 
     The host never runs git for this path, so the server is the only
     gate on the name; a malformed branch is user-correctable input and
@@ -332,7 +332,7 @@ async def test_create_with_invalid_workspace_branch_fails_400(
             "agent_id": agent["id"],
             "host_id": _HOST_ID,
             "workspace": _SOURCE_REPO,
-            "workspace_branch": "bad..branch",
+            "git": {"branch_name": "bad..branch", "existing_worktree": True},
         },
     )
 
@@ -350,8 +350,8 @@ async def test_create_failure_never_removes_existing_worktree(
 ) -> None:
     """A create_conversation failure must NOT destroy the user's worktree.
 
-    Regression: the ``workspace_branch`` path binds a *pre-existing*
-    worktree and sets ``git_branch`` without Omnigent creating one. The
+    Regression: the ``existing_worktree`` bind path sets ``git_branch``
+    for a *pre-existing* worktree without Omnigent creating one. The
     create-rollback (``git worktree remove --force`` + ``git branch -D``)
     is gated on Omnigent having created a worktree, NOT on ``git_branch``
     being set — otherwise a persistence failure would force-remove the
@@ -365,11 +365,11 @@ async def test_create_failure_never_removes_existing_worktree(
     cap = register_worktree_host()
     agent = await create_test_agent(client, name="wt-no-destroy-agent")
 
-    # Force the persistence step to fail after the workspace_branch path
-    # has already set git_branch — the exact window the rollback guards.
-    # Patch the class method (the store is a thin, stateless db_uri wrapper,
-    # and the route uses its own instance) so the failure hits regardless
-    # of which instance the router closed over.
+    # Force the persistence step to fail after the bind path has already
+    # set git_branch — the exact window the rollback guards. Patch the class
+    # method (the store is a thin, stateless db_uri wrapper, and the route
+    # uses its own instance) so the failure hits regardless of which
+    # instance the router closed over.
     def _boom(*args: Any, **kwargs: Any) -> Any:
         raise RuntimeError("simulated create_conversation failure")
 
@@ -385,7 +385,7 @@ async def test_create_failure_never_removes_existing_worktree(
                 "agent_id": agent["id"],
                 "host_id": _HOST_ID,
                 "workspace": _SOURCE_REPO,
-                "workspace_branch": "feature/existing",
+                "git": {"branch_name": "feature/existing", "existing_worktree": True},
             },
         )
 

--- a/tests/server/integration/test_session_worktree_create.py
+++ b/tests/server/integration/test_session_worktree_create.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
@@ -23,6 +24,7 @@ from fastapi import FastAPI
 from omnigent.host.frames import (
     HostCreateWorktreeFrame,
     HostHelloFrame,
+    HostRemoveWorktreeFrame,
     HostStatFrame,
     decode_host_frame,
 )
@@ -47,9 +49,23 @@ class _FakeWebSocket:
         """
 
 
+@dataclass
+class _HostCapture:
+    """
+    Frames a fake host received during one ``POST /v1/sessions`` create.
+
+    :param create: ``host.create_worktree`` frames received.
+    :param remove: ``host.remove_worktree`` frames received (a non-empty
+        list proves the create-rollback path fired).
+    """
+
+    create: list[HostCreateWorktreeFrame] = field(default_factory=list)
+    remove: list[HostRemoveWorktreeFrame] = field(default_factory=list)
+
+
 # Factory yielded by the ``register_worktree_host`` fixture:
-# register(*, create_status=, create_error=) -> captured create frames.
-RegisterHost = Callable[..., list[HostCreateWorktreeFrame]]
+# register(*, create_status=, create_error=) -> _HostCapture.
+RegisterHost = Callable[..., _HostCapture]
 
 
 @pytest_asyncio.fixture()
@@ -70,14 +86,13 @@ async def register_worktree_host(
     :returns: Async iterator yielding a ``register`` factory. Its
         kwargs: ``create_status`` (``"ok"`` returns a worktree path,
         ``"failed"`` simulates a host git failure such as a bad base
-        ref) and ``create_error`` (the failure message). Returns the
-        list that accumulates the create-worktree frames.
+        ref) and ``create_error`` (the failure message). Returns a
+        ``_HostCapture`` whose ``.create`` / ``.remove`` lists accumulate
+        the create- and remove-worktree frames the host received.
     """
     conns: list[HostConnection] = []
 
-    def _register(
-        *, create_status: str = "ok", create_error: str | None = None
-    ) -> list[HostCreateWorktreeFrame]:
+    def _register(*, create_status: str = "ok", create_error: str | None = None) -> _HostCapture:
         HostStore(db_uri).upsert_on_connect(_HOST_ID, "wt-host", RESERVED_USER_LOCAL)
         conn = app.state.host_registry.register(
             host_id=_HOST_ID,
@@ -85,10 +100,10 @@ async def register_worktree_host(
             hello=HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name="wt-host"),
             owner=RESERVED_USER_LOCAL,
         )
-        captured: list[HostCreateWorktreeFrame] = []
+        cap = _HostCapture()
 
         async def _drain() -> None:
-            """Answer stat + create-worktree frames; capture the latter."""
+            """Answer stat + create/remove-worktree frames; capture them."""
             while True:
                 frame_text = await conn.outbound_queue.get()
                 if frame_text is None:
@@ -107,7 +122,7 @@ async def register_worktree_host(
                             }
                         )
                 elif isinstance(frame, HostCreateWorktreeFrame):
-                    captured.append(frame)
+                    cap.create.append(frame)
                     fut = conn.pending_create_worktrees.pop(frame.request_id, None)
                     if fut is not None and not fut.done():
                         if create_status == "ok":
@@ -129,10 +144,15 @@ async def register_worktree_host(
                                     "error": create_error,
                                 }
                             )
+                elif isinstance(frame, HostRemoveWorktreeFrame):
+                    cap.remove.append(frame)
+                    fut = conn.pending_remove_worktrees.pop(frame.request_id, None)
+                    if fut is not None and not fut.done():
+                        fut.set_result({"status": "ok", "error": None})
 
         conn._drain_task_for_test = asyncio.create_task(_drain())  # type: ignore[attr-defined]
         conns.append(conn)
-        return captured
+        return cap
 
     yield _register
 
@@ -182,7 +202,7 @@ async def test_create_passes_branch_and_base_branch_to_host(
     frame. If base_branch were dropped on the route, the captured
     frame's base_branch would be ``None`` and this fails.
     """
-    captured = register_worktree_host()
+    cap = register_worktree_host()
     agent = await create_test_agent(client, name="wt-create-agent")
 
     resp = await _create_git_session(
@@ -192,8 +212,8 @@ async def test_create_passes_branch_and_base_branch_to_host(
 
     # The host received exactly one create-worktree frame carrying both
     # the new branch and the requested base ref.
-    assert len(captured) == 1, f"expected one create_worktree frame, got {len(captured)}"
-    frame = captured[0]
+    assert len(cap.create) == 1, f"expected one create_worktree frame, got {len(cap.create)}"
+    frame = cap.create[0]
     assert frame.repo_path == _SOURCE_REPO
     assert frame.branch_name == "feature/login"
     assert frame.base_branch == "main"
@@ -215,15 +235,15 @@ async def test_create_without_base_branch_sends_none(
     threads through, an omitted one stays ``None`` so the host branches
     from the source repo's current HEAD.
     """
-    captured = register_worktree_host()
+    cap = register_worktree_host()
     agent = await create_test_agent(client, name="wt-create-agent-2")
 
     resp = await _create_git_session(client, agent["id"], {"branch_name": "wip"})
     assert resp.status_code == 201, resp.text
 
-    assert len(captured) == 1
-    assert captured[0].branch_name == "wip"
-    assert captured[0].base_branch is None
+    assert len(cap.create) == 1
+    assert cap.create[0].branch_name == "wip"
+    assert cap.create[0].base_branch is None
 
 
 async def test_create_with_invalid_base_branch_fails_400(
@@ -269,7 +289,7 @@ async def test_create_with_workspace_branch_persists_without_creating(
     and the supplied branch is persisted as ``git_branch`` so the
     sidebar shows it and the opt-in delete flow can offer to remove it.
     """
-    captured = register_worktree_host()
+    cap = register_worktree_host()
     agent = await create_test_agent(client, name="wt-existing-agent")
 
     resp = await client.post(
@@ -284,7 +304,7 @@ async def test_create_with_workspace_branch_persists_without_creating(
     assert resp.status_code == 201, resp.text
 
     # No worktree was created — the host received no create frame.
-    assert len(captured) == 0, f"expected no create_worktree frame, got {len(captured)}"
+    assert len(cap.create) == 0, f"expected no create_worktree frame, got {len(cap.create)}"
 
     # The existing worktree's branch is persisted; the workspace is the
     # supplied directory verbatim (no worktree-path rewrite).
@@ -321,3 +341,92 @@ async def test_create_with_invalid_workspace_branch_fails_400(
     assert body["error"]["code"] == "invalid_input"
     # The failed create returned an error, not a session.
     assert "id" not in body
+
+
+async def test_create_failure_never_removes_existing_worktree(
+    register_worktree_host: RegisterHost,
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A create_conversation failure must NOT destroy the user's worktree.
+
+    Regression: the ``workspace_branch`` path binds a *pre-existing*
+    worktree and sets ``git_branch`` without Omnigent creating one. The
+    create-rollback (``git worktree remove --force`` + ``git branch -D``)
+    is gated on Omnigent having created a worktree, NOT on ``git_branch``
+    being set — otherwise a persistence failure would force-remove the
+    user's own worktree and delete their branch. Assert no remove frame
+    is sent when ``create_conversation`` raises on this path.
+    """
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    cap = register_worktree_host()
+    agent = await create_test_agent(client, name="wt-no-destroy-agent")
+
+    # Force the persistence step to fail after the workspace_branch path
+    # has already set git_branch — the exact window the rollback guards.
+    # Patch the class method (the store is a thin, stateless db_uri wrapper,
+    # and the route uses its own instance) so the failure hits regardless
+    # of which instance the router closed over.
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated create_conversation failure")
+
+    monkeypatch.setattr(SqlAlchemyConversationStore, "create_conversation", _boom)
+
+    # The in-process ASGI transport re-raises unhandled server errors, so
+    # the simulated failure surfaces here rather than as a 500 response.
+    # Either way the create failed; what matters is the side effect below.
+    with pytest.raises(RuntimeError, match="simulated create_conversation failure"):
+        await client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent["id"],
+                "host_id": _HOST_ID,
+                "workspace": _SOURCE_REPO,
+                "workspace_branch": "feature/existing",
+            },
+        )
+
+    # Critically, the user's worktree is left untouched: the create-rollback
+    # did NOT fire, so no remove_worktree frame reached the host.
+    assert cap.remove == [], (
+        f"create-rollback force-removed the user's existing worktree: {cap.remove}"
+    )
+
+
+async def test_create_failure_rolls_back_omnigent_created_worktree(
+    register_worktree_host: RegisterHost,
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A create_conversation failure DOES clean up an Omnigent-made worktree.
+
+    The counterpart to the data-loss guard: when Omnigent creates the
+    worktree (the ``git`` path) and persistence then fails, the orphan
+    worktree it just made must be force-removed. Proves the narrowed
+    rollback guard (gated on Omnigent having created a worktree) still
+    fires for the case it is meant to clean up.
+    """
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    cap = register_worktree_host()
+    agent = await create_test_agent(client, name="wt-rollback-agent")
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated create_conversation failure")
+
+    monkeypatch.setattr(SqlAlchemyConversationStore, "create_conversation", _boom)
+
+    with pytest.raises(RuntimeError, match="simulated create_conversation failure"):
+        await _create_git_session(client, agent["id"], {"branch_name": "feature/orphan"})
+
+    # Omnigent created the worktree, so the rollback force-removed it: one
+    # remove frame for the worktree it just made, deleting the branch too.
+    assert len(cap.create) == 1, cap.create
+    assert len(cap.remove) == 1, f"expected a create-rollback remove frame, got {cap.remove}"
+    assert cap.remove[0].branch == "feature/orphan"
+    assert cap.remove[0].delete_branch is True

--- a/tests/server/integration/test_session_worktree_create.py
+++ b/tests/server/integration/test_session_worktree_create.py
@@ -256,5 +256,68 @@ async def test_create_with_invalid_base_branch_fails_400(
     assert body["error"]["code"] == "invalid_input"
     # The host's reason is surfaced verbatim so the UI can show it.
     assert "base branch does not exist" in body["error"]["message"]
+
+
+async def test_create_with_workspace_branch_persists_without_creating(
+    register_worktree_host: RegisterHost,
+    client: httpx.AsyncClient,
+) -> None:
+    """Starting in an existing worktree persists its branch, creates nothing.
+
+    ``workspace_branch`` binds the session straight to a pre-existing
+    worktree directory: no create-worktree frame is sent to the host,
+    and the supplied branch is persisted as ``git_branch`` so the
+    sidebar shows it and the opt-in delete flow can offer to remove it.
+    """
+    captured = register_worktree_host()
+    agent = await create_test_agent(client, name="wt-existing-agent")
+
+    resp = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "host_id": _HOST_ID,
+            "workspace": _SOURCE_REPO,
+            "workspace_branch": "feature/existing",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+    # No worktree was created — the host received no create frame.
+    assert len(captured) == 0, f"expected no create_worktree frame, got {len(captured)}"
+
+    # The existing worktree's branch is persisted; the workspace is the
+    # supplied directory verbatim (no worktree-path rewrite).
+    body = resp.json()
+    assert body["git_branch"] == "feature/existing"
+    assert body["workspace"] == _SOURCE_REPO
+
+
+async def test_create_with_invalid_workspace_branch_fails_400(
+    register_worktree_host: RegisterHost,
+    client: httpx.AsyncClient,
+) -> None:
+    """An invalid ``workspace_branch`` name fails the create with 400.
+
+    The host never runs git for this path, so the server is the only
+    gate on the name; a malformed branch is user-correctable input and
+    maps to INVALID_INPUT (400), not 500.
+    """
+    register_worktree_host()
+    agent = await create_test_agent(client, name="wt-existing-bad-agent")
+
+    resp = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "host_id": _HOST_ID,
+            "workspace": _SOURCE_REPO,
+            "workspace_branch": "bad..branch",
+        },
+    )
+
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_input"
     # The failed create returned an error, not a session.
     assert "id" not in body

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -610,54 +610,50 @@ def test_session_create_git_with_host_id_ok() -> None:
     assert req.git.branch_name == "feature/x"
 
 
-def test_session_create_workspace_branch_requires_host_id() -> None:
-    """``workspace_branch`` without ``host_id`` is rejected (422).
+def test_session_git_existing_worktree_still_requires_host_id() -> None:
+    """``git`` in bind mode without ``host_id`` is rejected (422).
 
-    The branch is persisted as the session's ``git_branch``, which is
-    only meaningful for a host-bound session. Failing in the model
-    keeps the error at the boundary instead of deeper in the flow.
-    """
-    from omnigent.server.schemas import SessionCreateRequest
-
-    with pytest.raises(ValidationError, match="workspace_branch requires host_id"):
-        SessionCreateRequest(
-            agent_id="ag_x",
-            workspace="/repo/worktrees/feature-x",
-            workspace_branch="feature/x",
-        )
-
-
-def test_session_create_workspace_branch_rejects_git() -> None:
-    """``workspace_branch`` + ``git`` is contradictory and rejected (422).
-
-    ``git`` *creates* a worktree and sets its own branch;
-    ``workspace_branch`` records an *existing* worktree's branch
-    without creating one. Both at once is a caller bug.
+    ``existing_worktree`` records the branch as the session's
+    ``git_branch``, which is only meaningful for a host-bound session —
+    so the ``git`` → ``host_id`` requirement applies to bind mode too.
     """
     from omnigent.server.schemas import SessionCreateRequest, SessionGitOptions
 
-    with pytest.raises(ValidationError, match="workspace_branch cannot be combined with git"):
+    with pytest.raises(ValidationError, match="git worktree creation requires host_id"):
         SessionCreateRequest(
             agent_id="ag_x",
-            host_id="host_abc",
             workspace="/repo/worktrees/feature-x",
-            git=SessionGitOptions(branch_name="feature/x"),
-            workspace_branch="feature/x",
+            git=SessionGitOptions(branch_name="feature/x", existing_worktree=True),
         )
 
 
-def test_session_create_workspace_branch_with_host_id_ok() -> None:
-    """``workspace_branch`` with ``host_id`` and no ``git`` validates cleanly."""
-    from omnigent.server.schemas import SessionCreateRequest
+def test_session_git_existing_worktree_rejects_base_branch() -> None:
+    """Bind mode + ``base_branch`` is contradictory and rejected (422).
+
+    ``base_branch`` selects the ref a *new* branch forks from; it is
+    meaningless when binding to a worktree that already exists.
+    """
+    from omnigent.server.schemas import SessionGitOptions
+
+    with pytest.raises(
+        ValidationError, match="base_branch cannot be set when existing_worktree is true"
+    ):
+        SessionGitOptions(branch_name="feature/x", base_branch="main", existing_worktree=True)
+
+
+def test_session_git_existing_worktree_with_host_id_ok() -> None:
+    """Bind mode with ``host_id`` and no ``base_branch`` validates cleanly."""
+    from omnigent.server.schemas import SessionCreateRequest, SessionGitOptions
 
     req = SessionCreateRequest(
         agent_id="ag_x",
         host_id="host_abc",
         workspace="/repo/worktrees/feature-x",
-        workspace_branch="feature/x",
+        git=SessionGitOptions(branch_name="feature/x", existing_worktree=True),
     )
-    assert req.workspace_branch == "feature/x"
-    assert req.git is None
+    assert req.git is not None
+    assert req.git.existing_worktree is True
+    assert req.git.branch_name == "feature/x"
 
 
 def test_session_create_host_type_defaults_external() -> None:

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -610,6 +610,56 @@ def test_session_create_git_with_host_id_ok() -> None:
     assert req.git.branch_name == "feature/x"
 
 
+def test_session_create_workspace_branch_requires_host_id() -> None:
+    """``workspace_branch`` without ``host_id`` is rejected (422).
+
+    The branch is persisted as the session's ``git_branch``, which is
+    only meaningful for a host-bound session. Failing in the model
+    keeps the error at the boundary instead of deeper in the flow.
+    """
+    from omnigent.server.schemas import SessionCreateRequest
+
+    with pytest.raises(ValidationError, match="workspace_branch requires host_id"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            workspace="/repo/worktrees/feature-x",
+            workspace_branch="feature/x",
+        )
+
+
+def test_session_create_workspace_branch_rejects_git() -> None:
+    """``workspace_branch`` + ``git`` is contradictory and rejected (422).
+
+    ``git`` *creates* a worktree and sets its own branch;
+    ``workspace_branch`` records an *existing* worktree's branch
+    without creating one. Both at once is a caller bug.
+    """
+    from omnigent.server.schemas import SessionCreateRequest, SessionGitOptions
+
+    with pytest.raises(ValidationError, match="workspace_branch cannot be combined with git"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            host_id="host_abc",
+            workspace="/repo/worktrees/feature-x",
+            git=SessionGitOptions(branch_name="feature/x"),
+            workspace_branch="feature/x",
+        )
+
+
+def test_session_create_workspace_branch_with_host_id_ok() -> None:
+    """``workspace_branch`` with ``host_id`` and no ``git`` validates cleanly."""
+    from omnigent.server.schemas import SessionCreateRequest
+
+    req = SessionCreateRequest(
+        agent_id="ag_x",
+        host_id="host_abc",
+        workspace="/repo/worktrees/feature-x",
+        workspace_branch="feature/x",
+    )
+    assert req.workspace_branch == "feature/x"
+    assert req.git is None
+
+
 def test_session_create_host_type_defaults_external() -> None:
     """
     ``host_type`` defaults to ``"external"`` — the pre-existing

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -584,26 +584,25 @@ export async function launchRunner(
   hostId: string,
   sessionId: string,
   workspace: string,
-  git?: { branchName: string; baseBranch?: string },
-  workspaceBranch?: string,
+  git?: { branchName: string; baseBranch?: string; existingWorktree?: boolean },
 ): Promise<{ runnerId: string }> {
   const body: {
     session_id: string;
     workspace: string;
-    git?: { branch_name: string; base_branch?: string };
-    workspace_branch?: string;
+    git?: { branch_name: string; base_branch?: string; existing_worktree?: boolean };
   } = { session_id: sessionId, workspace };
   if (git !== undefined) {
+    // `existing_worktree` binds a pre-existing worktree (no worktree is
+    // created; the branch is recorded for the sidebar + delete flow), so it
+    // never carries a base_branch.
     body.git = {
       branch_name: git.branchName,
-      ...(git.baseBranch !== undefined ? { base_branch: git.baseBranch } : {}),
+      ...(git.existingWorktree
+        ? { existing_worktree: true }
+        : git.baseBranch !== undefined
+          ? { base_branch: git.baseBranch }
+          : {}),
     };
-  }
-  // Binding to a pre-existing worktree: record its branch so the sidebar
-  // shows it and the delete flow can offer to remove it. Mutually exclusive
-  // with `git` (which creates a new worktree).
-  if (workspaceBranch !== undefined && git === undefined) {
-    body.workspace_branch = workspaceBranch;
   }
   const res = await authenticatedFetch(`/v1/hosts/${encodeURIComponent(hostId)}/runners`, {
     method: "POST",

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -585,17 +585,25 @@ export async function launchRunner(
   sessionId: string,
   workspace: string,
   git?: { branchName: string; baseBranch?: string },
+  workspaceBranch?: string,
 ): Promise<{ runnerId: string }> {
   const body: {
     session_id: string;
     workspace: string;
     git?: { branch_name: string; base_branch?: string };
+    workspace_branch?: string;
   } = { session_id: sessionId, workspace };
   if (git !== undefined) {
     body.git = {
       branch_name: git.branchName,
       ...(git.baseBranch !== undefined ? { base_branch: git.baseBranch } : {}),
     };
+  }
+  // Binding to a pre-existing worktree: record its branch so the sidebar
+  // shows it and the delete flow can offer to remove it. Mutually exclusive
+  // with `git` (which creates a new worktree).
+  if (workspaceBranch !== undefined && git === undefined) {
+    body.workspace_branch = workspaceBranch;
   }
   const res = await authenticatedFetch(`/v1/hosts/${encodeURIComponent(hostId)}/runners`, {
     method: "POST",

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1054,7 +1054,7 @@ describe("NewChatLandingScreen", () => {
     expect(screen.queryByTestId("workspace-picker-conflict")).toBeNull();
   });
 
-  it("lists existing worktrees and starts directly in a selected one (workspace_branch, no git opts)", async () => {
+  it("lists existing worktrees and starts directly in a selected one (git bind mode)", async () => {
     // The seeded repo has one linked worktree; the main tree is filtered out.
     useHostWorktreesMock.mockReturnValue({
       data: [
@@ -1104,14 +1104,18 @@ describe("NewChatLandingScreen", () => {
 
     await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
     const [, init] = authenticatedFetchMock.mock.calls[0];
-    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
-    // Workspace is bound straight to the worktree dir; NO git opts are sent
-    // (starting in an existing worktree creates nothing). The worktree's
-    // branch rides along as `workspace_branch` so the sidebar shows it and
-    // the delete flow can offer to remove it.
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      workspace?: string;
+      git?: { branch_name: string; existing_worktree?: boolean; base_branch?: string };
+    };
+    // Workspace is bound straight to the worktree dir. The git block is in
+    // bind mode (`existing_worktree`): no worktree is created, but the
+    // worktree's branch rides along as `branch_name` so the sidebar shows it
+    // and the delete flow can offer to remove it. No base_branch on a bind.
     expect(body.workspace).toBe("/Users/corey/repo-worktrees/feature-x");
-    expect(body.git).toBeUndefined();
-    expect(body.workspace_branch).toBe("feature/x");
+    expect(body.git?.existing_worktree).toBe(true);
+    expect(body.git?.branch_name).toBe("feature/x");
+    expect(body.git?.base_branch).toBeUndefined();
   });
 
   it("creates a new worktree when the prefilled branch name is edited", async () => {
@@ -1157,13 +1161,12 @@ describe("NewChatLandingScreen", () => {
     await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
     const [, init] = authenticatedFetchMock.mock.calls[0];
     const body = JSON.parse((init as RequestInit).body as string) as {
-      git?: { branch_name: string };
-      workspace_branch?: string;
+      git?: { branch_name: string; existing_worktree?: boolean };
     };
     // A new worktree for the edited branch name is requested — this is a
-    // create, not a bind to an existing worktree, so no `workspace_branch`.
+    // create, not a bind, so `existing_worktree` is not set.
     expect(body.git?.branch_name).toBe("feature/y");
-    expect(body.workspace_branch).toBeUndefined();
+    expect(body.git?.existing_worktree).toBeUndefined();
   });
 
   it("filters the worktree dropdown as you type in the branch combobox", async () => {

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1054,7 +1054,7 @@ describe("NewChatLandingScreen", () => {
     expect(screen.queryByTestId("workspace-picker-conflict")).toBeNull();
   });
 
-  it("lists existing worktrees and starts directly in a selected one (no git opts)", async () => {
+  it("lists existing worktrees and starts directly in a selected one (workspace_branch, no git opts)", async () => {
     // The seeded repo has one linked worktree; the main tree is filtered out.
     useHostWorktreesMock.mockReturnValue({
       data: [
@@ -1106,9 +1106,12 @@ describe("NewChatLandingScreen", () => {
     const [, init] = authenticatedFetchMock.mock.calls[0];
     const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
     // Workspace is bound straight to the worktree dir; NO git opts are sent
-    // (starting in an existing worktree creates nothing).
+    // (starting in an existing worktree creates nothing). The worktree's
+    // branch rides along as `workspace_branch` so the sidebar shows it and
+    // the delete flow can offer to remove it.
     expect(body.workspace).toBe("/Users/corey/repo-worktrees/feature-x");
     expect(body.git).toBeUndefined();
+    expect(body.workspace_branch).toBe("feature/x");
   });
 
   it("creates a new worktree when the prefilled branch name is edited", async () => {
@@ -1155,9 +1158,12 @@ describe("NewChatLandingScreen", () => {
     const [, init] = authenticatedFetchMock.mock.calls[0];
     const body = JSON.parse((init as RequestInit).body as string) as {
       git?: { branch_name: string };
+      workspace_branch?: string;
     };
-    // A new worktree for the edited branch name is requested.
+    // A new worktree for the edited branch name is requested — this is a
+    // create, not a bind to an existing worktree, so no `workspace_branch`.
     expect(body.git?.branch_name).toBe("feature/y");
+    expect(body.workspace_branch).toBeUndefined();
   });
 
   it("filters the worktree dropdown as you type in the branch combobox", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2557,13 +2557,15 @@ export function NewChatLandingScreen() {
         // Launch the runner on the selected host. The multipart create
         // only stores DB rows — launchRunner binds + starts the runner.
         if (!sandboxSelected && selectedHostId && workspaceTrimmed) {
+          // Create a new worktree, bind an existing one (records the branch
+          // for the sidebar + delete flow without creating anything), or
+          // neither — mirrored on the `git` block.
           const gitOpts = shouldCreateWorktree
             ? { branchName: trimmedBranch, baseBranch: baseBranch.trim() || undefined }
-            : undefined;
-          // Starting in an existing worktree: bind its branch for the sidebar
-          // + delete flow without creating a worktree.
-          const workspaceBranch = startInExistingWorktree ? trimmedBranch : undefined;
-          await launchRunner(selectedHostId, data.id, workspaceTrimmed, gitOpts, workspaceBranch);
+            : startInExistingWorktree
+              ? { branchName: trimmedBranch, existingWorktree: true }
+              : undefined;
+          await launchRunner(selectedHostId, data.id, workspaceTrimmed, gitOpts);
         }
         // Clear pending agent after successful creation.
         setPendingAgent(null);
@@ -2582,12 +2584,14 @@ export function NewChatLandingScreen() {
               : {
                   host_id: selectedHostId,
                   workspace: workspaceTrimmed,
+                  // Create a new worktree, or bind an existing one
+                  // (`existing_worktree` records the branch for the sidebar +
+                  // delete flow without creating anything), or neither.
                   git: shouldCreateWorktree
                     ? { branch_name: trimmedBranch, base_branch: baseBranch.trim() || undefined }
-                    : undefined,
-                  // Starting in an existing worktree: record its branch so the
-                  // sidebar shows it and the delete flow can offer to remove it.
-                  workspace_branch: startInExistingWorktree ? trimmedBranch : undefined,
+                    : startInExistingWorktree
+                      ? { branch_name: trimmedBranch, existing_worktree: true }
+                      : undefined,
                 }),
             // Native terminal agents open terminal-first: `omnigent.ui:
             // terminal` tells the UI to render the terminal wrapper, and

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2560,7 +2560,10 @@ export function NewChatLandingScreen() {
           const gitOpts = shouldCreateWorktree
             ? { branchName: trimmedBranch, baseBranch: baseBranch.trim() || undefined }
             : undefined;
-          await launchRunner(selectedHostId, data.id, workspaceTrimmed, gitOpts);
+          // Starting in an existing worktree: bind its branch for the sidebar
+          // + delete flow without creating a worktree.
+          const workspaceBranch = startInExistingWorktree ? trimmedBranch : undefined;
+          await launchRunner(selectedHostId, data.id, workspaceTrimmed, gitOpts, workspaceBranch);
         }
         // Clear pending agent after successful creation.
         setPendingAgent(null);
@@ -2582,6 +2585,9 @@ export function NewChatLandingScreen() {
                   git: shouldCreateWorktree
                     ? { branch_name: trimmedBranch, base_branch: baseBranch.trim() || undefined }
                     : undefined,
+                  // Starting in an existing worktree: record its branch so the
+                  // sidebar shows it and the delete flow can offer to remove it.
+                  workspace_branch: startInExistingWorktree ? trimmedBranch : undefined,
                 }),
             // Native terminal agents open terminal-first: `omnigent.ui:
             // terminal` tells the UI to render the terminal wrapper, and


### PR DESCRIPTION
## Related issue

N/A — follow-up to the existing-worktree selection landed in #2088 (issue #1919).

## Summary

Starting a session directly in a pre-existing git worktree previously bound the workspace with **no branch recorded**, so:
- the sidebar showed no branch subtitle for that session, and
- the opt-in "Delete local branch" flow was unavailable — even though it's the same worktree Omnigent would offer to clean up had it created it.

This threads the existing worktree's branch through a new `workspace_branch` field on both create paths (`POST /v1/sessions` and `POST /v1/hosts/{id}/runners`). It persists as the session's `git_branch` **without creating a worktree**, so the sidebar shows the branch and the existing delete dialog (gated on `git_branch != null`) can remove the worktree + branch — the same flow as an Omnigent-created worktree.

`workspace_branch` is mutually exclusive with `git` (which *creates* a worktree) and requires a host; the server validates the branch name since the host runs no git on this path.

## Test Plan

- `cd web && npm test` (3688 passed) + `npm run build` ✓
- `python -m pytest tests/server/test_schemas.py tests/server/integration/test_session_worktree_create.py tests/server/integration/test_host_runner_launch_worktree.py` — 85 passed ✓
- openapi drift test passes (`openapi.json` regenerated for the new field) ✓
- ruff format + check, prettier: clean ✓

New tests:
- **Schema (3):** `workspace_branch` requires host_id, rejects combination with `git`, and validates cleanly with host_id + no git.
- **Session-create integration (2):** existing worktree persists `git_branch` and sends no create-worktree frame; an invalid branch name fails 400.
- **Launch-runner integration (1):** `workspace_branch` binds the dir and records the branch with no worktree creation.
- Updated the 2 existing NewChatDialog worktree tests to assert `workspace_branch` is sent (existing) / omitted (new-worktree edit).

## Demo

Starting in an existing worktree now shows the branch under the session name in the sidebar, and the delete dialog offers "Delete local branch" — identical to an Omnigent-created worktree. _(Sidebar/delete-dialog rendering is unchanged code, gated on `git_branch`; this PR only makes the field populated for existing-worktree sessions.)_

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated unit + integration coverage added on both create paths and the schema validators. The sidebar subtitle and delete dialog are existing code paths already gated on `git_branch != null` (covered by prior worktree tests); this PR only populates that field for existing-worktree sessions.

## Changelog

Sessions started in an existing git worktree now show the branch in the sidebar and can delete the worktree + branch from the session delete dialog.

This pull request and its description were written by Isaac.
