### PR TITLE
feat(server): add DELETE /v1/hosts/{host_id} to retire external self-registered hosts (#2038)

### DIFF
--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -402,6 +402,69 @@ def create_hosts_router(
             "runners": [],
         }
 
+    @router.delete("/hosts/{host_id}")
+    async def delete_host(request: Request, host_id: str) -> dict[str, Any]:
+        """Delete a retired external (self-registered) host.
+
+        Removes the host row so a permanently decommissioned machine
+        stops polluting the session-creation host picker (issue #2038).
+        Scoped to **external self-registered** hosts
+        (``sandbox_provider is None``): server-managed sandbox hosts
+        have their own teardown lifecycle and are refused here.
+
+        Session history is preserved, never destroyed: any conversations
+        still bound to this host have their ``host_id`` nulled -- the DB
+        no longer FK-cascades this after the R032 FK removal -- so those
+        sessions survive and stay readable with no host binding. This
+        reuses the same store operation as managed-host teardown
+        (:meth:`HostStore.delete_host`).
+
+        :param request: The incoming request (for auth).
+        :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :returns: ``{"host_id": ..., "deleted": True}`` on success.
+        :raises HTTPException: 404 if the host does not exist, 403 if
+            the caller does not own it, 409 if it is a server-managed
+            host or is currently connected.
+        """
+        # Mirror get_host's authz exactly: require_user 401s an
+        # unauthenticated caller; a 404 hides existence from non-owners,
+        # and an authenticated non-owner gets 403 -- never the delete.
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.owner != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+        # External self-registered hosts only (issue #2038). A managed
+        # sandbox host (sandbox_provider set) is torn down by the
+        # managed-launch lifecycle, not by hand -- deleting its row here
+        # would orphan a live sandbox binding.
+        if host.sandbox_provider is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="cannot delete a server-managed host",
+            )
+        # Refuse while the host is connected. A live host re-registers
+        # via upsert_on_connect on its next heartbeat, so deleting the
+        # row mid-tunnel is self-defeating (it reappears) and races the
+        # connection -- the operator must stop the daemon first. No
+        # force override: force-deleting a live host is never useful.
+        if host_is_live(host):
+            raise HTTPException(
+                status_code=409,
+                detail=("host is currently connected; stop the host daemon before deleting it"),
+            )
+        # SET-NULL "cascade" at the application layer (no DB FK after
+        # R032): delete_host nulls conversations.host_id for sessions
+        # bound to this host -- history is preserved, only the dangling
+        # host binding is cleared -- then removes the row.
+        await asyncio.to_thread(host_store.delete_host, host_id)
+        # Drop any stale in-memory connection on THIS replica (best
+        # effort; the registry is per-replica, like every other host
+        # route's live-connection view).
+        host_registry.deregister(host_id)
+        return {"host_id": host_id, "deleted": True}
+
     @router.post("/hosts/{host_id}/runners")
     async def launch_runner(
         request: Request,

--- a/openapi.json
+++ b/openapi.json
@@ -6191,6 +6191,50 @@
       }
     },
     "/v1/hosts/{host_id}": {
+      "delete": {
+        "description": "Delete a retired external (self-registered) host.\n\nRemoves the host row so a permanently decommissioned machine\nstops polluting the session-creation host picker (issue #2038).\nScoped to **external self-registered** hosts\n(`sandbox_provider is None`): server-managed sandbox hosts\nhave their own teardown lifecycle and are refused here.\n\nSession history is preserved, never destroyed: any conversations\nstill bound to this host have their `host_id` nulled -- the DB\nno longer FK-cascades this after the R032 FK removal -- so those\nsessions survive and stay readable with no host binding. This\nreuses the same store operation as managed-host teardown\n(`HostStore.delete_host`).\n\n**Returns:** `{\"host_id\": ..., \"deleted\": True}` on success.\n\n**Raises**\n\n- `HTTPException` \u2014 404 if the host does not exist, 403 if the caller does not own it, 409 if it is a server-managed host or is currently connected.",
+        "operationId": "delete_host_v1_hosts__host_id__delete",
+        "parameters": [
+          {
+            "description": "Host identifier, e.g. `\"host_a1b2c3d4...\"`.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Delete Host V1 Hosts  Host Id  Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Host",
+        "tags": [
+          "hosts"
+        ]
+      },
       "get": {
         "description": "Get details for a single host.\n\n**Returns:** Host details dict.\n\n**Raises**\n\n- `HTTPException` \u2014 404 if the host does not exist.",
         "operationId": "get_host_v1_hosts__host_id__get",

--- a/tests/server/integration/test_hosts_api.py
+++ b/tests/server/integration/test_hosts_api.py
@@ -1243,3 +1243,140 @@ async def test_runner_exited_invokes_callback_with_runner_and_error(
 
     # The callback got the exact runner id and error string off the frame.
     assert received == [("runner_x", "exited with code 1")]
+
+
+# ── DELETE /v1/hosts/{id} — retire an external self-registered host (#2038) ──
+
+
+async def test_delete_offline_external_host_removes_row(
+    host_api_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    DELETE /v1/hosts/{id} removes an offline external host's row so a
+    retired machine stops polluting the picker.
+
+    If the row survives, the #2038 gap (register is automatic,
+    deregister impossible) is not closed.
+    """
+    app, _reg, host_store, _cs = host_api_app
+    host_store.upsert_on_connect("host_retired", "old-runner", "local")
+    host_store.set_offline("host_retired")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/v1/hosts/host_retired")
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"host_id": "host_retired", "deleted": True}
+        # The row is gone: a follow-up GET 404s and the picker omits it.
+        follow = await client.get("/v1/hosts/host_retired")
+        assert follow.status_code == 404, follow.text
+    assert host_store.get_host("host_retired") is None
+
+
+async def test_delete_host_preserves_bound_session_history(
+    host_api_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Deleting a host nulls ``host_id`` on sessions bound to it but never
+    destroys the session rows themselves (post-R032 there is no DB FK
+    cascade; the route reuses HostStore.delete_host's app-level SET NULL).
+
+    If the conversation vanishes, host deletion is silently shredding
+    history — the exact outcome the design forbids.
+    """
+    app, _reg, host_store, conv_store = host_api_app
+    host_store.upsert_on_connect("host_bound", "bound-runner", "local")
+    host_store.set_offline("host_bound")
+    conv = conv_store.create_conversation(
+        host_id="host_bound",
+        workspace="/tmp/session-workspace",
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/v1/hosts/host_bound")
+    assert resp.status_code == 200, resp.text
+
+    survived = conv_store.get_conversation(conv.id)
+    assert survived is not None, "host delete destroyed a bound session's history"
+    assert survived.host_id is None, (
+        f"bound session should have its host_id nulled after host delete, got {survived.host_id!r}"
+    )
+    assert host_store.get_host("host_bound") is None
+
+
+async def test_delete_host_404_when_absent(
+    host_api_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """DELETE of an unknown host_id returns 404, not a silent success."""
+    app, *_ = host_api_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/v1/hosts/host_does_not_exist")
+    assert resp.status_code == 404, resp.text
+
+
+async def test_delete_connected_host_refused_409(
+    host_api_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    A currently-connected host cannot be deleted: 409, row untouched.
+
+    Deleting a live host's row mid-tunnel is a footgun — it would just
+    reappear on the next upsert_on_connect heartbeat — so the route
+    refuses and tells the operator to stop the daemon first.
+    """
+    app, _reg, host_store, _cs = host_api_app
+    # upsert_on_connect leaves the row online + fresh => host_is_live.
+    host_store.upsert_on_connect("host_live", "live-runner", "local")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/v1/hosts/host_live")
+    assert resp.status_code == 409, resp.text
+    assert host_store.get_host("host_live") is not None, (
+        "a refused delete must leave the connected host's row intact"
+    )
+
+
+async def test_delete_managed_host_refused_409(
+    host_api_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    Server-managed sandbox hosts (``sandbox_provider`` set) are out of
+    scope for this endpoint (#2038 is external self-registered hosts):
+    409, row untouched. Managed hosts are torn down by their own
+    lifecycle; deleting one here would orphan a live sandbox binding.
+    """
+    app, _reg, host_store, _cs = host_api_app
+    host_store.register_managed_host(
+        host_id="host_managed",
+        name="managed-runner",
+        owner="local",
+        token="tok-managed",
+        provider="modal",
+        sandbox_id="sb-123",
+        token_expires_at=time.time_ns() // 1_000_000_000 + 3600,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/v1/hosts/host_managed")
+    assert resp.status_code == 409, resp.text
+    assert host_store.get_host("host_managed") is not None
+
+
+async def test_delete_host_403_wrong_owner(
+    multi_user_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
+) -> None:
+    """
+    DELETE /v1/hosts/{id} returns 403 when the caller doesn't own the
+    host, and the row survives — mirrors get_host's ownership gate so a
+    user can't retire another user's host.
+    """
+    app, _reg, host_store, _cs = multi_user_app
+    host_store.upsert_on_connect("host_alice_del", "alice-laptop", "alice@test.com")
+    host_store.set_offline("host_alice_del")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete(
+            "/v1/hosts/host_alice_del",
+            headers={"x-test-user": "bob@test.com"},
+        )
+    assert resp.status_code == 403, resp.text
+    assert host_store.get_host("host_alice_del") is not None


### PR DESCRIPTION
### Summary

External hosts self-register via the daemon (`POST /hosts` path) and become
rows in `host_store` (postgres), but there was **no API to remove one**:
`server/routes/hosts.py` exposed only GET/POST, and `HostRegistry.deregister()`
only mutates per-replica in-memory state — it never deletes the persisted row.
So a permanently decommissioned machine's row lingered in `host_store` forever
and showed as an offline entry in **every session-creation host picker**, with
no UI or API affordance to remove it. This is issue #2038.

This PR adds `DELETE /v1/hosts/{host_id}`, scoped to **external
self-registered** hosts.

### Design decisions (and why)

**Auth / ownership — mirror the neighbouring `get_host` route.**
`require_user` 401s an unauthenticated caller in multi-user mode; a non-existent
host returns **404** (existence is not leaked to non-owners); an authenticated
caller who is not the owner gets **403 "not your host"**. This is byte-for-byte
the gate `GET /v1/hosts/{host_id}` already applies, so delete authorization is
exactly as strong as read authorization — no new ownership surface.

**Managed vs external — scope to external self-registered (per the issue).**
A server-managed sandbox host is marked by a non-`None` `sandbox_provider` and
is torn down by the managed-launch lifecycle (`register_managed_host` /
`HostStore.delete_host` on sandbox teardown). Deleting its row through this
user-facing route would orphan a live sandbox binding, so a managed host is
**refused with 409**. Only external (`sandbox_provider is None`) hosts —
exactly the ones the issue is about — are deletable here.

**Connected host — refuse (409), no force override.**
Deleting a live host's row mid-tunnel is a footgun: a connected host
**re-registers via `upsert_on_connect` on its next heartbeat**, so a
force-delete of a live host is self-defeating (the row reappears) and races the
tunnel. The route therefore refuses a currently-connected host
(`host_is_live(host)` → 409) and tells the operator to stop the daemon first.
We deliberately did **not** add a `?force=` param: there is no case where
force-deleting a live host is the caller's intent. (This is the inverse of the
neighbouring routes' "409 if host is offline" idiom.)

**FK / cascade for referencing sessions — application-level SET NULL,
preserving history.**
As of #2081 (merged to `main` 2026-07-07, Rule R032) the schema has **no
database-enforced foreign keys** — referential integrity is application-level.
The store already has the right primitive: `HostStore.delete_host` nulls
`conversations.host_id` for any sessions bound to the host and then deletes the
row (it is what managed-host teardown already calls). The route **reuses it**,
so:

- **Session history is preserved, never destroyed** — the conversation rows
  survive; only the dangling host binding is cleared.
- Nulling `host_id` satisfies the table's check constraint
  (`host_id IS NULL OR workspace IS NOT NULL`), which only requires a workspace
  when `host_id` is *set*.
- It is the least-invasive option the post-R032 schema supports and is DRY with
  the existing managed-teardown path — no new deletion logic, no refuse-if-
  referenced friction (which would have blocked retiring a host that has any
  historical sessions, the common case).

**In-memory cleanup.** After the DB delete the route also calls
`host_registry.deregister(host_id)` to drop any stale connection object on the
current replica — best-effort, and per-replica exactly like every other host
route's live-connection view.

### API surface

`DELETE /v1/hosts/{host_id}` → `200 {"host_id": ..., "deleted": true}` on
success; `404` unknown / non-owner, `403` wrong owner, `409` managed or
connected. `openapi.json` is regenerated (`scripts/dump_openapi.py`) and the CI
`--check` mode passes.

### Tests

Added to `tests/server/integration/test_hosts_api.py`, matching the existing
hosts-route test patterns (single-user `host_api_app` fixture; multi-user
`multi_user_app` + `_StubAuthProvider` for the ownership case):

- `test_delete_offline_external_host_removes_row` — happy path: an offline
  external host's row is gone (follow-up GET 404s, `get_host` returns `None`).
- `test_delete_host_preserves_bound_session_history` — the cascade path: a
  conversation bound to the host survives the delete with its `host_id` nulled
  (history is not destroyed).
- `test_delete_host_404_when_absent` — unknown `host_id` → 404.
- `test_delete_connected_host_refused_409` — a live host is refused; row intact.
- `test_delete_managed_host_refused_409` — a `register_managed_host` sandbox
  host is refused; row intact.
- `test_delete_host_403_wrong_owner` — a non-owner is refused; row intact.

### Verification

**Unit / route tests** — green on the fix branch:

```
env -u PYTHONPATH .venv/bin/python -m pytest \
  tests/server/routes/test_hosts_routes.py \
  tests/server/integration/test_hosts_api.py \
  tests/server/integration/test_hosts_management_e2e.py
# 41 passed
ruff check  omnigent/server/routes/hosts.py tests/server/integration/test_hosts_api.py   # clean
ruff format --check  (same two files)                                                    # clean
python scripts/dump_openapi.py --check                                                    # openapi.json up to date
```

> **Scope note (honest):** verification is **route/unit-level and scoped to the
> hosts-route test dirs plus ruff on the two changed source files** — the six
> new tests exercise authz (403), the two 409 refusals, 404, and the
> history-preserving cascade directly. The **whole-repo suite was deliberately
> not run** (it has killed sessions on our runner); the change is contained to
> the hosts route and its tests, and reviewers running CI get the broader
> signal.

**Live server repro — not performed; the fix is straightforwardly
route-level.** Unlike #2039 (which needed a real Traefik + a server bounce to
open a 404 window), #2038 is a missing-CRUD gap fully exercised by the route
tests against a real `HostStore` + `ConversationStore` on SQLite. No dev-server
deploy was required to demonstrate the fix. Our own stale row (retired hm-dev1
`host_c8884…`) will be deleted via this new endpoint once the fix ships — that
is the removal condition tracked in `docs/upstream-issues.md`.
