### PR TITLE
feat(os_env): let declared sandbox path grants extend file-tool reach (#2070)

### DIFF
--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -948,7 +948,7 @@ def _handle_helper_request(
             return {"error": "path must be a non-empty string"}
         path = _resolve_path(cwd, raw_path)
         try:
-            _assert_within_cwd(cwd, path)
+            _assert_within_reach(cwd, sandbox, path, need_write=False)
             _assert_read_allowed(sandbox, path)
         except PermissionError as exc:
             return {"error": str(exc)}
@@ -969,7 +969,7 @@ def _handle_helper_request(
             return {"error": "path must be a non-empty string"}
         path = _resolve_path(cwd, raw_path)
         try:
-            _assert_within_cwd(cwd, path)
+            _assert_within_reach(cwd, sandbox, path, need_write=True)
             _assert_write_allowed(sandbox, path)
         except PermissionError as exc:
             return {"error": str(exc)}
@@ -990,7 +990,7 @@ def _handle_helper_request(
             return {"error": "path must be a non-empty string"}
         path = _resolve_path(cwd, raw_path)
         try:
-            _assert_within_cwd(cwd, path)
+            _assert_within_reach(cwd, sandbox, path, need_write=True)
             _assert_read_allowed(sandbox, path)
             _assert_write_allowed(sandbox, path)
         except PermissionError as exc:
@@ -1059,6 +1059,82 @@ def _assert_within_cwd(cwd: Path, resolved: Path) -> None:
             f"Access to '{resolved}' is blocked: path is outside "
             f"the environment root '{resolved_cwd}'"
         ) from exc
+
+
+def _assert_within_reach(
+    cwd: Path,
+    policy: SandboxPolicy,
+    resolved: Path,
+    *,
+    need_write: bool,
+) -> None:
+    """Confine a file-tool op to *cwd*, extended by declared sandbox grants.
+
+    Replaces the historical cwd-only guard at the read / write / edit sites.
+    *resolved* is already canonicalised by :func:`_resolve_path` (symlinks
+    followed, ``..`` collapsed) and every grant root is canonicalised at
+    resolve time, so a symlink or ``..`` chain whose real target leaves both
+    *cwd* and every grant is rejected -- the confinement boundary cannot be
+    escaped by traversal.
+
+    Precedence and grant semantics:
+
+    - A path inside *cwd* is always permitted here (the active-sandbox
+      allow-list narrowing in :func:`_assert_read_allowed` /
+      :func:`_assert_write_allowed` still runs afterwards, unchanged).
+    - A path OUTSIDE *cwd* is permitted only when an explicitly declared
+      grant of the right kind covers it. These reuse the SAME grant shapes the
+      active backends already populate -- ``read_paths`` / ``write_paths`` are
+      directory roots (containment match against ``read_roots`` /
+      ``write_roots``) and ``write_files`` is the single-file grant (exact
+      resolved-path match); no new grant vocabulary is introduced. A **write**
+      grant (``write_paths`` / ``write_files``) admits both reads and writes of
+      that subtree (a writable path is readable); a **read** grant
+      (``read_paths``) admits reads only -- so a read grant never confers
+      write. Read grants are directory roots; a single readable file is
+      expressed by rooting a ``read_paths`` entry at that file (an exact-path
+      match still succeeds, but there is no ``read_files`` shape).
+    - With NO grants declared, ``write_roots`` / ``write_files`` are empty and
+      ``read_roots`` is ``None``: nothing outside *cwd* is permitted, byte for
+      byte the previous cwd-confinement behaviour. This default-unchanged
+      property is the security invariant.
+
+    The target is resolved ONCE (by :func:`_resolve_path`) before comparison,
+    so this guard shares the prior cwd-guard's TOCTOU posture: a symlink
+    swapped between this check and the later open could redirect the op. That
+    is unchanged by this diff -- for an ACTIVE sandbox the backend's OS-level
+    mount mask stays the hard boundary, and under ``type: none`` the file tools
+    were never a containment boundary anyway (the co-resident ``sys_os_shell``
+    is unconfined). Widening reach to declared grants does not alter that
+    posture.
+
+    :param cwd: The environment root (resolved inside).
+    :param policy: Resolved sandbox policy carrying the declared grants.
+    :param resolved: Fully-resolved target path (post ``_resolve_path``).
+    :param need_write: ``True`` for write / edit ops (only write grants admit
+        an out-of-cwd path); ``False`` for read ops (read OR write grants
+        admit).
+    :raises PermissionError: If *resolved* is outside *cwd* and no grant of
+        the required kind covers it.
+    """
+    resolved_cwd = cwd.resolve()
+    if _is_within(resolved, resolved_cwd):
+        return
+    # Write grants (directories + single files) admit both reads and writes.
+    if any(_is_within(resolved, root) for root in policy.write_roots):
+        return
+    if any(resolved == grant for grant in policy.write_files):
+        return
+    # Read grants admit reads only.
+    if not need_write and policy.read_roots is not None:
+        if any(_is_within(resolved, root) for root in policy.read_roots):
+            return
+    kind = "write" if need_write else "read"
+    raise PermissionError(
+        f"Access to '{resolved}' is blocked: path is outside the "
+        f"environment root '{resolved_cwd}' and no sandbox {kind} grant "
+        f"covers it"
+    )
 
 
 def _assert_read_allowed(policy: SandboxPolicy, path: Path) -> None:

--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -368,21 +368,66 @@ def register_backend(backend: SandboxBackend) -> None:
     _BACKENDS[backend.type_name] = backend
 
 
+def _resolve_grant_root(cwd: Path, root: str) -> Path:
+    """Resolve a spec-supplied path grant against *cwd*.
+
+    Expands ``~`` but intentionally NOT ``$VAR`` -- env-var expansion at
+    resolve time is a grant-widening lever when an attacker can shape the
+    parent environment (mirrors the hardening in
+    :func:`omnigent.inner.bwrap_sandbox._resolve_root`). Relative entries
+    resolve against *cwd*; the result is absolute and symlink-normalised
+    (``strict=False`` -- a granted path need not exist yet). Callers compare
+    already-resolved target paths against these roots, so traversal via
+    symlinks or ``..`` cannot escape a grant.
+
+    :param cwd: The environment's working directory; relative grants resolve
+        against it.
+    :param root: The raw path string from the spec, e.g. ``"~/code"`` or
+        ``"../sibling"``.
+    :returns: An absolute, normalised :class:`Path`.
+    """
+    if "$" in root:
+        logger.warning(
+            "sandbox: grant path %r contains '$', which is NOT expanded "
+            "against the parent environment (security hardening -- env-var "
+            "expansion was a grant-widening lever). Use a literal path or ~.",
+            root,
+        )
+    expanded = os.path.expanduser(root)
+    path = Path(expanded)
+    if not path.is_absolute():
+        path = cwd / path
+    return path.resolve(strict=False)
+
+
 def resolve_sandbox(spec: OSEnvSpec, cwd: Path) -> SandboxPolicy:
     sandbox_spec = spec.sandbox or _default_sandbox_for_platform()
     if sandbox_spec.type == "none":
-        if (
-            sandbox_spec.read_paths is not None
-            or sandbox_spec.write_paths is not None
-            or sandbox_spec.allow_network is False
-        ):
-            raise ValueError("sandbox type 'none' cannot restrict reads, writes, or network")
+        # ``sandbox.type: none`` runs the helper UNSANDBOXED, so path grants
+        # cannot *restrict* the (unconfined) shell -- a network restriction is
+        # still meaningless here and rejected. But ``read_paths`` /
+        # ``write_paths`` / ``write_files`` ARE honoured as explicit
+        # FILE-TOOL reach grants: they are the opt-in that lets
+        # ``sys_os_read`` / ``sys_os_write`` / ``sys_os_edit`` reach declared
+        # paths OUTSIDE the workspace root (enforced by ``_assert_within_reach``
+        # in ``os_env.py``). With none declared, ``read_roots``/``write_roots``
+        # stay empty and the file tools remain confined to cwd exactly as
+        # before -- the default is byte-for-byte unchanged.
+        if sandbox_spec.allow_network is False:
+            raise ValueError("sandbox type 'none' cannot restrict network")
+        read_roots = (
+            [_resolve_grant_root(cwd, root) for root in sandbox_spec.read_paths]
+            if sandbox_spec.read_paths is not None
+            else None
+        )
+        write_roots = [_resolve_grant_root(cwd, root) for root in (sandbox_spec.write_paths or [])]
+        write_files = [_resolve_grant_root(cwd, root) for root in (sandbox_spec.write_files or [])]
         return SandboxPolicy(
             backend_type="none",
             active=False,
-            read_roots=None,
-            write_roots=[],
-            write_files=[],
+            read_roots=read_roots,
+            write_roots=write_roots,
+            write_files=write_files,
             allow_network=True,
         )
     return _get_backend(sandbox_spec.type).resolve(spec, cwd)

--- a/tests/inner/test_os_env_grant_reach.py
+++ b/tests/inner/test_os_env_grant_reach.py
@@ -1,0 +1,388 @@
+"""File-tool reach grants (#2070).
+
+The runner-local file tools (``sys_os_read`` / ``sys_os_write`` /
+``sys_os_edit``) are confined to the session workspace by
+``_assert_within_reach``. These tests pin the security contract of the grant
+extension:
+
+- **Default unchanged:** with NO path grants declared, nothing outside cwd is
+  reachable -- byte-for-byte the historical cwd-only confinement.
+- A **read** grant admits reads only; it never confers write.
+- A **write** grant (directory or single file) admits writes AND reads of that
+  subtree (a writable path is readable), so ``edit`` works there.
+- Symlink / ``..`` traversal cannot escape a grant into ungranted paths (the
+  target is resolved before it is compared to the grant roots).
+- Grants may be declared relative to cwd, and may target a single file.
+- ``resolve_sandbox`` under ``sandbox.type: none`` carries these grants onto
+  the (still-inactive) policy, and still rejects a network restriction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.os_env import _handle_helper_request
+from omnigent.inner.sandbox import SandboxPolicy, resolve_sandbox
+
+
+def _grant_policy(
+    *,
+    read_roots: list[Path] | None = None,
+    write_roots: tuple[Path, ...] | list[Path] = (),
+    write_files: tuple[Path, ...] | list[Path] = (),
+) -> SandboxPolicy:
+    """Build an inactive (``type: none``) policy carrying resolved grants.
+
+    Grant roots are canonicalised here exactly as ``resolve_sandbox`` does at
+    resolve time, so ``_assert_within_reach``'s resolved-vs-resolved compare
+    matches production.
+    """
+    return SandboxPolicy(
+        backend_type="none",
+        active=False,
+        read_roots=(
+            [p.resolve(strict=False) for p in read_roots] if read_roots is not None else None
+        ),
+        write_roots=[p.resolve(strict=False) for p in write_roots],
+        write_files=[p.resolve(strict=False) for p in write_files],
+        allow_network=True,
+    )
+
+
+def _req(op: str, path: Path, cwd: Path, policy: SandboxPolicy, **extra: object) -> dict:
+    return _handle_helper_request(
+        request={"op": op, "path": str(path), **extra},
+        cwd=cwd,
+        shell_path="/bin/sh",
+        sandbox=policy,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default-unchanged: no grants => cwd-only, exactly as before.
+# ---------------------------------------------------------------------------
+
+
+def test_no_grants_blocks_outside_path_for_every_op(tmp_path: Path) -> None:
+    """With no grants declared, an absolute out-of-cwd path is blocked."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "f.txt"
+    target.write_text("data")
+
+    policy = _grant_policy()  # no grants at all
+
+    read_res = _req("read", target, workspace, policy)
+    assert "error" in read_res
+    assert "outside the environment root" in read_res["error"]
+
+    write_res = _req("write", target, workspace, policy, content="pwn")
+    assert "error" in write_res
+    assert "outside the environment root" in write_res["error"]
+
+    edit_res = _req("edit", target, workspace, policy, oldText="data", newText="pwn")
+    assert "error" in edit_res
+    assert "outside the environment root" in edit_res["error"]
+
+    # Nothing was written through the blocked ops.
+    assert target.read_text() == "data"
+
+
+# ---------------------------------------------------------------------------
+# Read grant admits reads only -- never write.
+# ---------------------------------------------------------------------------
+
+
+def test_read_grant_permits_read_but_denies_write_and_edit(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    grant = tmp_path / "ro"
+    grant.mkdir()
+    target = grant / "f.txt"
+    target.write_text("hello")
+
+    policy = _grant_policy(read_roots=[grant])
+
+    read_res = _req("read", target, workspace, policy)
+    assert "error" not in read_res
+    assert read_res["content"] == "hello"
+
+    write_res = _req("write", target, workspace, policy, content="x")
+    assert "error" in write_res
+    assert "no sandbox write grant" in write_res["error"]
+
+    edit_res = _req("edit", target, workspace, policy, oldText="hello", newText="x")
+    assert "error" in edit_res
+    assert "no sandbox write grant" in edit_res["error"]
+
+    # The read-only grant really was read-only.
+    assert target.read_text() == "hello"
+
+
+def test_read_paths_are_directory_roots(tmp_path: Path) -> None:
+    """``read_paths`` entries are directory ROOTS: everything under the root is
+    readable, siblings outside it are not. (There is no ``read_files`` shape --
+    a single readable file is expressed by rooting a ``read_paths`` entry at
+    that file, where an exact-path match still succeeds; see the next test.)"""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    grant = tmp_path / "ro"
+    grant.mkdir()
+    child = grant / "nested" / "f.txt"
+    child.parent.mkdir()
+    child.write_text("deep")
+    sibling = tmp_path / "other.txt"
+    sibling.write_text("no")
+
+    policy = _grant_policy(read_roots=[grant])
+
+    ok = _req("read", child, workspace, policy)
+    assert ok.get("content") == "deep"
+
+    blocked = _req("read", sibling, workspace, policy)
+    assert "error" in blocked
+    assert "no sandbox read grant" in blocked["error"]
+
+
+def test_read_paths_entry_rooted_at_a_file_matches_only_that_file(tmp_path: Path) -> None:
+    """A ``read_paths`` entry that resolves to a single file matches that exact
+    file only (containment against a file root reduces to equality)."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    granted = tmp_path / "single.txt"
+    granted.write_text("hi")
+    sibling = tmp_path / "other.txt"
+    sibling.write_text("no")
+
+    policy = _grant_policy(read_roots=[granted])
+
+    ok = _req("read", granted, workspace, policy)
+    assert ok.get("content") == "hi"
+
+    blocked = _req("read", sibling, workspace, policy)
+    assert "error" in blocked
+    assert "no sandbox read grant" in blocked["error"]
+
+
+# ---------------------------------------------------------------------------
+# Write grant admits write + edit + read of the subtree.
+# ---------------------------------------------------------------------------
+
+
+def test_write_grant_permits_write_edit_and_read(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    grant = tmp_path / "rw"
+    grant.mkdir()
+    target = grant / "f.txt"
+    target.write_text("hello")
+
+    policy = _grant_policy(write_roots=[grant])
+
+    # Writable implies readable.
+    read_res = _req("read", target, workspace, policy)
+    assert read_res.get("content") == "hello"
+
+    write_res = _req("write", target, workspace, policy, content="new")
+    assert "error" not in write_res
+    assert target.read_text() == "new"
+
+    target.write_text("hello")
+    edit_res = _req("edit", target, workspace, policy, oldText="hello", newText="bye")
+    assert "error" not in edit_res
+    assert target.read_text() == "bye"
+
+
+def test_write_files_grant_is_file_scoped(tmp_path: Path) -> None:
+    """A single-file write grant covers exactly that file, not its siblings."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    granted = cfg / "a.json"
+    granted.write_text("{}")
+    sibling = cfg / "b.json"
+    sibling.write_text("{}")
+
+    policy = _grant_policy(write_files=[granted])
+
+    write_res = _req("write", granted, workspace, policy, content='{"ok":1}')
+    assert "error" not in write_res
+    assert granted.read_text() == '{"ok":1}'
+
+    # The granted file is also readable (write implies read).
+    read_res = _req("read", granted, workspace, policy)
+    assert "error" not in read_res
+
+    # The sibling in the same directory is NOT granted -- blocked for both.
+    blocked_write = _req("write", sibling, workspace, policy, content="pwn")
+    assert "error" in blocked_write
+    assert "no sandbox write grant" in blocked_write["error"]
+    blocked_read = _req("read", sibling, workspace, policy)
+    assert "error" in blocked_read
+    assert "no sandbox read grant" in blocked_read["error"]
+    assert sibling.read_text() == "{}"
+
+
+# ---------------------------------------------------------------------------
+# Traversal cannot escape a grant (resolve before compare).
+# ---------------------------------------------------------------------------
+
+
+def test_symlink_inside_grant_cannot_escape_grant(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    grant = tmp_path / "rw"
+    grant.mkdir()
+    secret_dir = tmp_path / "secret"
+    secret_dir.mkdir()
+    secret = secret_dir / "s.txt"
+    secret.write_text("top")
+
+    # A symlink that lives inside the grant but points OUTSIDE it.
+    link = grant / "escape.txt"
+    link.symlink_to(secret)
+
+    policy = _grant_policy(write_roots=[grant])
+
+    read_res = _req("read", link, workspace, policy)
+    assert "error" in read_res
+    assert "outside the environment root" in read_res["error"]
+
+    write_res = _req("write", link, workspace, policy, content="pwn")
+    assert "error" in write_res
+    assert "outside the environment root" in write_res["error"]
+    assert secret.read_text() == "top"
+
+
+def test_dotdot_traversal_from_grant_cannot_escape(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    grant = tmp_path / "rw"
+    grant.mkdir()
+    sibling_dir = tmp_path / "sibling"
+    sibling_dir.mkdir()
+    sibling = sibling_dir / "s.txt"
+    sibling.write_text("safe")
+
+    policy = _grant_policy(write_roots=[grant])
+
+    # grant/../sibling/s.txt resolves to an ungranted path.
+    traversal = grant / ".." / "sibling" / "s.txt"
+    res = _req("write", traversal, workspace, policy, content="pwn")
+    assert "error" in res
+    assert "outside the environment root" in res["error"]
+    assert sibling.read_text() == "safe"
+
+
+# ---------------------------------------------------------------------------
+# resolve_sandbox(type=none) grant plumbing.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_sandbox_none_default_declares_no_grants(tmp_path: Path) -> None:
+    """No grants declared => policy carries no reach extension (default)."""
+    cwd = tmp_path.resolve()
+    spec = OSEnvSpec(type="caller_process", cwd=str(cwd), sandbox=OSEnvSandboxSpec(type="none"))
+    policy = resolve_sandbox(spec, cwd)
+    assert policy.active is False
+    assert policy.read_roots is None
+    assert policy.write_roots == []
+    assert policy.write_files == []
+
+
+def test_resolve_sandbox_none_populates_grants_relative_to_cwd(tmp_path: Path) -> None:
+    cwd = (tmp_path / "ws").resolve()
+    cwd.mkdir()
+    spec = OSEnvSpec(
+        type="caller_process",
+        cwd=str(cwd),
+        sandbox=OSEnvSandboxSpec(
+            type="none",
+            read_paths=["../sibling"],
+            write_paths=["../sibling/out"],
+            write_files=["../sibling/f.json"],
+        ),
+    )
+    policy = resolve_sandbox(spec, cwd)
+    assert policy.active is False
+    assert policy.read_roots == [(cwd / ".." / "sibling").resolve()]
+    assert policy.write_roots == [(cwd / ".." / "sibling" / "out").resolve()]
+    assert policy.write_files == [(cwd / ".." / "sibling" / "f.json").resolve()]
+
+
+def test_resolve_sandbox_none_still_rejects_network_restriction(tmp_path: Path) -> None:
+    spec = OSEnvSpec(
+        type="caller_process",
+        cwd=str(tmp_path),
+        sandbox=OSEnvSandboxSpec(type="none", allow_network=False),
+    )
+    with pytest.raises(ValueError, match="cannot restrict network"):
+        resolve_sandbox(spec, tmp_path.resolve())
+
+
+def test_declared_write_grant_enables_edit_outside_cwd_end_to_end(tmp_path: Path) -> None:
+    """The #2070 scenario: a declared write grant lets ``edit`` reach a sibling
+    checkout that would otherwise be blocked as outside the workspace root."""
+    cwd = (tmp_path / "repo").resolve()
+    cwd.mkdir()
+    sibling = (tmp_path / "sibling").resolve()
+    sibling.mkdir()
+    target = sibling / "file.txt"
+    target.write_text("alpha")
+
+    spec = OSEnvSpec(
+        type="caller_process",
+        cwd=str(cwd),
+        sandbox=OSEnvSandboxSpec(type="none", write_paths=["../sibling"]),
+    )
+    policy = resolve_sandbox(spec, cwd)
+
+    res = _handle_helper_request(
+        request={"op": "edit", "path": str(target), "oldText": "alpha", "newText": "beta"},
+        cwd=cwd,
+        shell_path="/bin/sh",
+        sandbox=policy,
+    )
+    assert "error" not in res
+    assert target.read_text() == "beta"
+
+    # A DIFFERENT sibling that was never granted stays blocked.
+    ungranted = (tmp_path / "other").resolve()
+    ungranted.mkdir()
+    other = ungranted / "x.txt"
+    other.write_text("keep")
+    blocked = _handle_helper_request(
+        request={"op": "write", "path": str(other), "content": "pwn"},
+        cwd=cwd,
+        shell_path="/bin/sh",
+        sandbox=policy,
+    )
+    assert "error" in blocked
+    assert "outside the environment root" in blocked["error"]
+    assert other.read_text() == "keep"
+
+
+def test_inactive_policy_with_grants_survives_jsonable_round_trip(tmp_path: Path) -> None:
+    """An inactive (``type: none``) policy now carries non-empty grants; the
+    helper subprocess reconstructs the policy from JSON, so the grants must
+    round-trip intact (else the reach guard would silently see no grants in the
+    helper)."""
+    read_root = (tmp_path / "ro").resolve()
+    write_root = (tmp_path / "rw").resolve()
+    write_file = (tmp_path / "rw" / "f.json").resolve()
+    policy = _grant_policy(
+        read_roots=[read_root], write_roots=[write_root], write_files=[write_file]
+    )
+
+    rebuilt = SandboxPolicy.from_jsonable(policy.to_jsonable())
+
+    assert rebuilt.active is False
+    assert rebuilt.read_roots == [read_root]
+    assert rebuilt.write_roots == [write_root]
+    assert rebuilt.write_files == [write_file]


### PR DESCRIPTION
### Summary

The runner-local file tools (`sys_os_read` / `sys_os_write` / `sys_os_edit`)
are hard-confined to the session workspace. `_assert_within_cwd` runs **before**
the sandbox grant checks at every operation site
(`inner/os_env.py` read/write/edit), **unconditionally** — even under
`sandbox.type: none`. So `os_env.sandbox.read_paths` / `write_paths` can only
ever *narrow* access **within** the workspace; they can never extend it. A
multi-repo agent whose `cwd` is one checkout cannot `sys_os_edit` a sibling
checkout or a per-task git worktree.

Where that agent also has `sys_os_shell` with `sandbox.type: none` (a common
self-hosted runner setup), the confinement adds **no containment** — the
unconfined shell sits right next to the confined file tools — so agents route
every out-of-root edit through `python3 - <<'PY' …` shell heredocs to recover
the exact-string-replace semantics the blocked `sys_os_edit` would have
provided. Net effect: more tokens, more quoting failure modes, harder-to-audit
transcripts, and zero added security. This is issue #2070.

### What changes

Make the **existing** declared-grant vocabulary
(`read_paths` / `write_paths` / `write_files`) extend the file tools' reach —
no new grant shapes are introduced:

- **`_assert_within_reach` replaces the cwd-only guard** at the read / write /
  edit sites. A path inside `cwd` is permitted (the active-sandbox allow-list
  narrowing in `_assert_read_allowed` / `_assert_write_allowed` still runs
  afterwards — unchanged). A path **outside** `cwd` is permitted **only** when a
  declared grant of the right kind covers it:
  - a **write** grant (`write_paths` / `write_files`) admits both reads and
    writes of that subtree — a writable path is readable, so `edit` works there;
  - a **read** grant (`read_paths`) admits **reads only** — a read grant never
    confers write.
  These reuse the same shapes the active backends already populate:
  `read_paths` / `write_paths` are **directory roots** (containment match),
  `write_files` is the **single-file grant** (exact resolved-path match). There
  is no `read_files` shape; a single readable file is expressed by rooting a
  `read_paths` entry at that file.
- **`resolve_sandbox` under `sandbox.type: none`** now carries
  `read_paths` / `write_paths` / `write_files` onto the (still-inactive) policy
  as file-tool reach grants. With an inactive sandbox they cannot *restrict* the
  unconfined shell — so they act purely as the opt-in that widens the file
  tools to match what the shell can already touch. A **network** restriction
  (`allow_network: false`) under `type: none` is **still rejected** (unchanged);
  only the read/write path grants are reinterpreted.

### Security invariant (headline)

**With no path grants declared, behaviour is byte-for-byte unchanged.**
`write_roots` / `write_files` are empty and `read_roots` is `None`, so nothing
outside `cwd` is reachable — exactly the previous cwd-confinement. This is
proven by an explicit default-unchanged test. Other confinement properties:

- **Traversal cannot escape a grant.** The target is canonicalised by
  `_resolve_path` (symlinks followed, `..` collapsed) and every grant root is
  canonicalised at resolve time, so the resolved-vs-resolved compare rejects a
  symlink or `..` chain whose real target leaves both `cwd` and every grant.
- **Read never confers write.** The write-op reach set excludes `read_paths`.
- **Env-var expansion is intentionally not applied** to grant strings
  (`$VAR` is a grant-widening lever when an attacker can shape the parent env),
  mirroring the existing `bwrap` / `seatbelt` `_resolve_root` hardening; a `$`
  in a grant is warned about.
- **`_assert_within_cwd`** is retained as the pure cwd-only primitive (still
  unit-tested); `_assert_within_reach` builds the grant-aware boundary on the
  same `_is_within` primitive.

### Tests

New `tests/inner/test_os_env_grant_reach.py` (13 tests) drives the real
`_handle_helper_request` and `resolve_sandbox` paths:

- **default unchanged** — no grants ⇒ an out-of-cwd path is blocked for read,
  write, and edit;
- **read grant** permits read but denies write **and** edit;
- **`read_paths` are directory roots** — a nested child under the root is
  readable, a sibling outside it is not;
- **a file-rooted `read_paths` entry** matches only that exact file;
- **write grant** permits write, edit, and read of the subtree;
- **`write_files` grant** is file-scoped — the exact file is writable/readable,
  a sibling in the same dir is not;
- **symlink inside a grant** pointing outside it is blocked (resolve-before-
  compare);
- **`..` traversal from a grant** into an ungranted sibling is blocked;
- **`resolve_sandbox(type=none)`** default declares no grants; populates
  `read_roots` / `write_roots` / `write_files` from the spec (relative-to-cwd
  resolution); and still rejects `allow_network: false`;
- **inactive-policy-with-grants `to_jsonable` → `from_jsonable` round-trip** —
  the helper subprocess reconstructs the policy from JSON, so the newly
  non-empty grants on an inactive policy must survive the trip;
- **end-to-end** — a declared `write_paths` grant enables an `edit` of a sibling
  directory, while a different, ungranted sibling stays blocked.

### Verification

**Unit tests** — green on the fix branch, scoped to the changed surface:

```
env -u PYTHONPATH .venv/bin/python -m pytest \
  tests/inner/test_os_env.py tests/inner/test_os_env_grant_reach.py \
  tests/inner/test_sandbox.py tests/inner/test_bwrap_sandbox.py \
  tests/inner/test_seatbelt_sandbox.py \
  tests/runner/test_runner_filesystem_hardening.py tests/sandbox/
# 145 passed, 11 skipped (platform-specific bwrap/seatbelt)

env -u PYTHONPATH .venv/bin/python -m pytest \
  tests/policies/builtins/test_enforce_sandbox.py \
  tests/runner/test_enforce_sandbox_gate.py tests/spec
# 534 passed

env -u PYTHONPATH .venv/bin/ruff check  omnigent/inner/os_env.py omnigent/inner/sandbox.py tests/inner/test_os_env_grant_reach.py   # clean
env -u PYTHONPATH .venv/bin/ruff format --check <same three files>          # clean
```

> **Scope note (honest):** verification is **unit-test-level**, scoped to the
> sandbox / os_env / enforce-sandbox / spec test dirs plus the new test module,
> and `ruff` on the three changed files. The **whole-repo suite was
> deliberately not run** (it has previously killed sessions on this runner);
> the change is contained to the file-tool confinement and the `type: none`
> policy resolver, and no unrelated code was touched. Reviewers running CI get
> the broader signal.

**Live-server repro — not performed; stated plainly.** The behaviour under test
is a pure runner-side confinement decision with no server round-trip, so a live
dev-server repro adds little here (unlike #2039's proxy-404 race). Our
dev-server verification is serialized by the ops session afterwards; this draft
does not claim it.

### TOCTOU note (deliberate scope boundary)

`_assert_within_reach` resolves the target once and compares, sharing the prior
cwd-guard's TOCTOU posture: a symlink swapped between the check and the later
open could redirect the op. This is **unchanged** by this PR. For an **active**
sandbox the backend's OS-level mount mask remains the hard boundary; under
`type: none` the file tools were never a containment boundary anyway (the
co-resident `sys_os_shell` is unconfined). Widening reach to declared grants
does not alter that posture. A fd-relative / `O_NOFOLLOW` hardening of the file
ops themselves would be a separate, orthogonal change.
