### PR TITLE
feat(sandbox): allow wildcard host egress rules

### DIFF
--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -193,9 +193,25 @@ not pass secrets through the environment unless the tool genuinely needs them.
 
 You usually don't need to choose a `sandbox.type` — omit it and Omnigent picks
 the platform default (`linux_bwrap` on Linux, `darwin_seatbelt` on macOS), so the
-same YAML works across platforms. For the full set of sandbox options, how to
-share one policy across `sys_os_*` and terminals, and how to set up network
-egress rules, see the `sandbox:` examples below and the sandbox source under `omnigent/inner/`.
+same YAML works across platforms.
+
+Use `egress_rules` for proxy-enforced HTTP(S) allowlists. Rules use
+`METHODS host/path`, where methods can be comma-separated verbs or `*`, hosts
+can be exact names, `*.domain` wildcard subdomains, or `*`, and paths are globs:
+
+```yaml
+os_env:
+  sandbox:
+    type: linux_bwrap
+    egress_rules:
+      - "GET api.github.com/repos/myorg/**"
+      - "* *.pypi.org/**"
+      - "* *"  # allow all methods/hosts/paths; trusted agents only
+```
+
+For the full set of sandbox options, how to share one policy across `sys_os_*`
+and terminals, and more egress examples, see the `sandbox:` examples below and
+the sandbox source under `omnigent/inner/`.
 
 ## Tools
 

--- a/omnigent/inner/egress/rules.py
+++ b/omnigent/inner/egress/rules.py
@@ -8,9 +8,11 @@ Examples::
     "GET,POST api.github.com/repos/myorg/**"  # Multiple methods
     "* pypi.org/**"                           # Any method
     "GET *.github.com/**"                     # Wildcard subdomain
+    "* *"                                     # Any method, host, and path
+    "* */**"                                  # Explicit any-host/any-path
 
 - **Methods**: comma-separated HTTP verbs, or ``*`` for any.
-- **Host**: exact match, or ``*.domain`` for wildcard subdomains.
+- **Host**: exact match, ``*.domain`` for wildcard subdomains, or ``*`` for any host.
 - **Path**: glob — ``*`` matches one segment, ``**`` matches any depth.
 - Default deny: requests not matching any rule are blocked.
 """
@@ -72,7 +74,8 @@ class EgressRule:
     :param methods: Allowed HTTP methods as upper-case strings, or
         ``{"*"}`` for any method.
     :param host_pattern: Host match pattern, e.g. ``"api.github.com"``
-        or ``"*.github.com"`` for wildcard subdomains.
+        or ``"*.github.com"`` for wildcard subdomains,
+        or ``"*"`` for any host.
     :param path_pattern: Path glob, e.g. ``"/repos/myorg/**"``.
     """
 
@@ -110,6 +113,8 @@ class EgressRule:
             return False
         host = host.lower()
         pattern = self.host_pattern.lower()
+        if pattern == "*":
+            return True
         if pattern.startswith("*."):
             suffix = pattern[1:]  # e.g. ".github.com"
             return host.endswith(suffix) or host == pattern[2:]

--- a/tests/inner/egress/test_rules.py
+++ b/tests/inner/egress/test_rules.py
@@ -51,6 +51,19 @@ from omnigent.inner.egress.rules import (
             "api.example.com",
             "/v1/items/*",
         ),
+        (
+            "* */**",
+            frozenset({"*"}),
+            "*",
+            "/**",
+        ),
+        # Wildcard host with no path defaults to /**
+        (
+            "* *",
+            frozenset({"*"}),
+            "*",
+            "/**",
+        ),
     ],
 )
 def test_parse_rule_valid(
@@ -91,15 +104,11 @@ def test_parse_rule_invalid(rule_str: str, expected_fragment: str) -> None:
 
 
 def test_parse_rules_list() -> None:
-    rules = parse_rules(
-        [
-            "GET api.github.com/repos/**",
-            "* pypi.org/**",
-        ]
-    )
-    assert len(rules) == 2
+    rules = parse_rules(["GET api.github.com/repos/**", "* pypi.org/**", "* */**"])
+    assert len(rules) == 3
     assert rules[0].host_pattern == "api.github.com"
     assert rules[1].host_pattern == "pypi.org"
+    assert rules[2].host_pattern == "*"
 
 
 def test_parse_rules_fails_on_first_invalid() -> None:
@@ -124,6 +133,19 @@ def test_matches_exact_host_and_path() -> None:
     assert rule.matches("GET", "github.com", "/repos/myorg/repo1") is False
     # Denied: wrong path prefix
     assert rule.matches("GET", "api.github.com", "/users/myorg") is False
+
+
+def test_matches_wildcard_host_and_wildcard_path() -> None:
+    rule = parse_rule("* */**")
+    assert rule.matches("GET", "api.example.com", path="/") is True
+    assert rule.matches("GET", "api.example.com", path="/v1") is True
+    assert rule.matches("GET", "api.example.com", path="/v1/item123") is True
+
+
+def test_matches_wildcard_host_and_exact_path() -> None:
+    rule = parse_rule("* */v1/item123")
+    assert rule.matches("GET", "api.example.com", path="/v1/item123") is True
+    assert rule.matches("GET", "api.example.com", path="/v1") is False
 
 
 def test_matches_wildcard_subdomain() -> None:
@@ -188,6 +210,14 @@ def test_check_host_fast_reject() -> None:
     assert check_host(rules, "evil.com") is False
 
 
+@pytest.mark.parametrize(
+    "rule_str,legitimate_host",
+    [
+        ("* *.allowed.com/**", "api.allowed.com"),
+        ("* */**", "api.allowed.com"),
+        ("* *", "api.allowed.com"),
+    ],
+)
 @pytest.mark.parametrize(
     "smuggled_host,why",
     [
@@ -268,7 +298,9 @@ def test_check_host_fast_reject() -> None:
         pytest.param("", "empty host", id="empty"),
     ],
 )
-def test_unsafe_host_never_matches_any_rule(smuggled_host: str, why: str) -> None:
+def test_unsafe_host_never_matches_any_rule(
+    rule_str: str, legitimate_host: str, smuggled_host: str, why: str
+) -> None:
     """A host carrying any byte outside the DNS grammar ``[A-Za-z0-9.-]``
     must not match any rule, even one whose wildcard would otherwise
     apply under ``str.endswith`` semantics.
@@ -279,9 +311,9 @@ def test_unsafe_host_never_matches_any_rule(smuggled_host: str, why: str) -> Non
     guard so any future caller of ``check_host`` / ``check_request``
     that bypasses the entry points still fails closed.
     """
-    rules = parse_rules(["* *.allowed.com/**"])
+    rules = parse_rules([rule_str])
     # Sanity: the legitimate host matches.
-    assert check_host(rules, "api.allowed.com") is True
+    assert check_host(rules, legitimate_host) is True
     # The unsafe host must NOT match, regardless of suffix.
     assert check_host(rules, smuggled_host) is False, (
         f"{why}: {smuggled_host!r} should be rejected by the rule layer"

--- a/tests/resources/examples/agent_with_os_env_bwrap.yaml
+++ b/tests/resources/examples/agent_with_os_env_bwrap.yaml
@@ -193,7 +193,7 @@ os_env:
     #
     # Rule DSL: ``METHODS host/path/pattern``
     # - Methods: comma-separated HTTP verbs, or ``*`` for any.
-    # - Host: exact match, or ``*.domain`` for wildcard subdomains.
+    # - Host: exact match, ``*.domain`` for wildcard subdomains, or ``*`` for any host.
     # - Path: glob — ``*`` matches one segment, ``**`` any depth.
     # - Default deny: requests not matching any rule get HTTP 403.
     #
@@ -207,6 +207,7 @@ os_env:
     #   - "GET api.github.com/repos/myorg/**"
     #   - "GET,POST pypi.org/**"
     #   - "* *.amazonaws.com/**"
+    #   - "* *"  # allow all methods/hosts/paths; trusted agents only
     egress_rules:
       - "GET httpbin.org/get"
       - "GET httpbin.org/status/*"

--- a/tests/resources/examples/agent_with_os_env_seatbelt.yaml
+++ b/tests/resources/examples/agent_with_os_env_seatbelt.yaml
@@ -180,6 +180,7 @@ os_env:
     #   - "GET api.github.com/repos/myorg/**"
     #   - "GET,POST pypi.org/**"
     #   - "* *.amazonaws.com/**"
+    #   - "* *"  # allow all methods/hosts/paths; trusted agents only
     egress_rules:
       - "GET httpbin.org/get"
       - "GET httpbin.org/status/*"


### PR DESCRIPTION
## Related issue

N/A

## Summary

This PR introduces a permissive host wildcard pattern to the `egress_rules` DSL so trusted agents can allow broad HTTP(S) egress through the MITM proxy while still using `credential_proxy`.

`credential_proxy` requires `egress_rules` to be configured because the egress proxy is responsible for swapping synthetic credential placeholders for real credentials and preventing placeholder leaks. Previously, there was no effective allow-all host rule, so users had to restrict egress to specific hosts even when the agent was otherwise trusted for broad HTTP(S) access.

This PR allows rules such as `"* *"` and `"* */**"` to match any DNS-safe host, method, and path. Existing host canonicalization remains in place, so permissive wildcard rules still reject unsafe or smuggled host strings.

- Allow `egress_rules` to use `*` as a host wildcard, enabling permissive rules such as `"* *"` and `"* */**"`.
- Preserve existing unsafe-host canonicalization so wildcard rules still reject smuggled or non-DNS-safe host strings.
- Update egress rule tests and docs/examples to cover the new wildcard host syntax.

## Test Plan

- `uv run pytest tests/inner/egress/test_rules.py`
- Manually verified the wildcard egress rule behavior locally with a custom agent.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered using the new wildcard egress rule syntax in a local custom-agent setup. Unit coverage exercises parsing, matching, and unsafe-host rejection for wildcard host rules.

## Changelog

Allow `egress_rules` to use wildcard host rules such as `"* *"` and `"* */**"` for trusted agents.
