### PR TITLE
perf(web): cache-first session switch hydration

### DIFF
--- a/web/src/hooks/SessionPrefetchSchedulerContext.tsx
+++ b/web/src/hooks/SessionPrefetchSchedulerContext.tsx
@@ -1,0 +1,25 @@
+import { type ReactNode, createContext, useContext, useMemo } from "react";
+import { createSessionPrefetchScheduler } from "@/lib/sessionPrefetchScheduler";
+import type { SessionPrefetchScheduler } from "@/lib/sessionPrefetchScheduler";
+
+const SessionPrefetchSchedulerContext = createContext<SessionPrefetchScheduler | null>(null);
+
+/** One shared hover-prefetch scheduler for all session rows in the sidebar. */
+export function SessionPrefetchSchedulerProvider({ children }: { children: ReactNode }) {
+  const scheduler = useMemo(() => createSessionPrefetchScheduler(), []);
+  return (
+    <SessionPrefetchSchedulerContext.Provider value={scheduler}>
+      {children}
+    </SessionPrefetchSchedulerContext.Provider>
+  );
+}
+
+export function useSessionPrefetchScheduler(): SessionPrefetchScheduler {
+  const scheduler = useContext(SessionPrefetchSchedulerContext);
+  if (scheduler === null) {
+    throw new Error(
+      "useSessionPrefetchScheduler must be used within SessionPrefetchSchedulerProvider",
+    );
+  }
+  return scheduler;
+}

--- a/web/src/lib/sessionPrefetchScheduler.test.ts
+++ b/web/src/lib/sessionPrefetchScheduler.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { QueryClient } from "@tanstack/react-query";
+import {
+  SESSION_HOVER_PREFETCH_DELAY_MS,
+  createSessionPrefetchScheduler,
+} from "./sessionPrefetchScheduler";
+
+describe("createSessionPrefetchScheduler", () => {
+  const queryClient = {} as QueryClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("prefetches only the last row when skimming several targets", () => {
+    const prefetch = vi.fn();
+    const scheduler = createSessionPrefetchScheduler({ delayMs: 100, prefetch });
+
+    scheduler.scheduleHover(queryClient, "conv_a");
+    vi.advanceTimersByTime(50);
+    scheduler.scheduleHover(queryClient, "conv_b");
+    vi.advanceTimersByTime(50);
+    scheduler.scheduleHover(queryClient, "conv_c");
+    vi.advanceTimersByTime(100);
+
+    expect(prefetch).toHaveBeenCalledOnce();
+    expect(prefetch).toHaveBeenCalledWith(queryClient, "conv_c");
+  });
+
+  it("cancelHover drops a pending schedule", () => {
+    const prefetch = vi.fn();
+    const scheduler = createSessionPrefetchScheduler({ prefetch });
+
+    scheduler.scheduleHover(queryClient, "conv_a");
+    scheduler.cancelHover();
+    vi.advanceTimersByTime(SESSION_HOVER_PREFETCH_DELAY_MS);
+
+    expect(prefetch).not.toHaveBeenCalled();
+  });
+
+  it("prefetchNow runs immediately and cancels a pending hover", () => {
+    const prefetch = vi.fn();
+    const scheduler = createSessionPrefetchScheduler({ prefetch });
+
+    scheduler.scheduleHover(queryClient, "conv_a");
+    scheduler.prefetchNow(queryClient, "conv_b");
+    vi.advanceTimersByTime(SESSION_HOVER_PREFETCH_DELAY_MS);
+
+    expect(prefetch).toHaveBeenCalledOnce();
+    expect(prefetch).toHaveBeenCalledWith(queryClient, "conv_b");
+  });
+});

--- a/web/src/lib/sessionPrefetchScheduler.ts
+++ b/web/src/lib/sessionPrefetchScheduler.ts
@@ -1,0 +1,56 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { prefetchSessionForSwitch } from "./sessionsApi";
+
+export const SESSION_HOVER_PREFETCH_DELAY_MS = 100;
+
+export type SessionPrefetchFn = (queryClient: QueryClient, sessionId: string) => void;
+
+/**
+ * Debounced hover prefetch for session rows. One instance should be shared
+ * across all rows so skimming N rows schedules at most one prefetch (the last).
+ */
+export interface SessionPrefetchScheduler {
+  /** Debounced hover prefetch; each call replaces the pending target. */
+  scheduleHover: (queryClient: QueryClient, sessionId: string) => void;
+  /** Drop a pending hover without prefetching. */
+  cancelHover: () => void;
+  /** Immediate prefetch (e.g. keyboard focus); cancels any pending hover. */
+  prefetchNow: (queryClient: QueryClient, sessionId: string) => void;
+}
+
+/**
+ * Create a scheduler with closed-over timer state (no module-level mutable vars).
+ *
+ * :param options.delayMs: hover debounce, default {@link SESSION_HOVER_PREFETCH_DELAY_MS}.
+ * :param options.prefetch: prefetch implementation, default {@link prefetchSessionForSwitch}.
+ */
+export function createSessionPrefetchScheduler(
+  options: {
+    delayMs?: number;
+    prefetch?: SessionPrefetchFn;
+  } = {},
+): SessionPrefetchScheduler {
+  const delayMs = options.delayMs ?? SESSION_HOVER_PREFETCH_DELAY_MS;
+  const prefetch = options.prefetch ?? prefetchSessionForSwitch;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const cancelHover = (): void => {
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+  };
+
+  return {
+    scheduleHover(queryClient, sessionId) {
+      cancelHover();
+      timer = setTimeout(() => {
+        timer = null;
+        prefetch(queryClient, sessionId);
+      }, delayMs);
+    },
+    cancelHover,
+    prefetchNow(queryClient, sessionId) {
+      cancelHover();
+      prefetch(queryClient, sessionId);
+    },
+  };
+}

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -7,19 +7,24 @@
 // useful client-side error trail.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
 import {
   approve,
   bindOnlyOnlineRunner,
   createSession,
+  extendInitialHistoryWindow,
+  fetchInitialHistoryFirstPage,
   fetchInitialHistoryWindow,
   fetchSessionItemsPage,
   forkSession,
   getSession,
   getSessionSlim,
+  initialHistoryQueryKey,
   interrupt,
   listRunners,
   openSessionStream,
   postEvent,
+  prefetchSessionForSwitch,
   SESSION_HISTORY_PAGE_SIZE,
   stopSession,
   updateSession,
@@ -924,6 +929,72 @@ describe("fetchInitialHistoryWindow", () => {
   });
 });
 
+describe("fetchInitialHistoryFirstPage", () => {
+  it("fetches a single page for fast first paint", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        object: "list",
+        data: [{ id: "msg_2" }, { id: "msg_1" }],
+        first_id: "msg_2",
+        last_id: "msg_1",
+        has_more: true,
+      }),
+    );
+
+    const page = await fetchInitialHistoryFirstPage("conv_fast");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(page.items.map((i) => i.id)).toEqual(["msg_1", "msg_2"]);
+    expect(page.hasMore).toBe(true);
+  });
+});
+
+describe("extendInitialHistoryWindow", () => {
+  function userWire(id: string) {
+    return {
+      id,
+      response_id: `resp_${id}`,
+      type: "message",
+      role: "user",
+      status: "completed",
+      content: [{ type: "input_text", text: id }],
+    };
+  }
+  function asstWire(id: string) {
+    return {
+      id,
+      response_id: `resp_${id}`,
+      type: "message",
+      role: "assistant",
+      status: "completed",
+      model: "agent_xyz",
+      content: [{ type: "output_text", text: id }],
+    };
+  }
+
+  it("extends a one-user first page to include previous user prompt", async () => {
+    const seed = {
+      items: [userWire("u_last"), ...Array.from({ length: 19 }, (_, i) => asstWire(`a${i}`))],
+      hasMore: true,
+    };
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        object: "list",
+        data: [asstWire("a_prev"), userWire("u_prev")],
+        first_id: "a_prev",
+        last_id: "u_prev",
+        has_more: true,
+      }),
+    );
+
+    const page = await extendInitialHistoryWindow("conv_ext", seed);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(page.items[0]!.id).toBe("u_prev");
+    expect(page.items.some((i) => i.id === "u_last")).toBe(true);
+  });
+});
+
 describe("postEvent", () => {
   it("POSTs the event body verbatim and returns {queued, itemId}", async () => {
     fetchMock.mockResolvedValueOnce(mockJsonResponse({ queued: true, item_id: "ci_123" }));
@@ -1037,5 +1108,24 @@ describe("approve", () => {
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/v1/sessions/conv_abc/elicitations/elic_xyz/resolve");
     expect(JSON.parse(init.body as string)).toEqual({ action: "decline" });
+  });
+});
+
+describe("prefetchSessionForSwitch", () => {
+  it("prefetches the session snapshot and initial history window", () => {
+    const queryClient = new QueryClient();
+    const prefetchSpy = vi.spyOn(queryClient, "prefetchQuery");
+
+    prefetchSessionForSwitch(queryClient, "conv_prefetch");
+
+    expect(prefetchSpy).toHaveBeenCalledTimes(2);
+    expect(prefetchSpy.mock.calls[0]![0]).toMatchObject({
+      queryKey: ["session", "conv_prefetch"],
+    });
+    expect(prefetchSpy.mock.calls[1]![0]).toMatchObject({
+      queryKey: initialHistoryQueryKey("conv_prefetch"),
+    });
+    const historyQuery = prefetchSpy.mock.calls[1]![0] as { queryFn?: () => unknown };
+    expect(historyQuery.queryFn).toBeDefined();
   });
 });

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -10,6 +10,7 @@
 // helpers below convert at the boundary so callers never see raw
 // wire fields.
 
+import type { QueryClient } from "@tanstack/react-query";
 import type { ConversationItem } from "./conversationItems";
 import { isMessageItem } from "./conversationItems";
 import type { MessageContentBlock } from "./blocks";
@@ -823,6 +824,47 @@ function isUserPrompt(item: ConversationItem): boolean {
   return isMessageItem(item) && item.role === "user" && !item.is_meta;
 }
 
+function initialHistoryBoundaryReached(items: ConversationItem[], hasMore: boolean): boolean {
+  if (!hasMore) return true;
+  const userCount = items.filter(isUserPrompt).length;
+  return items.length >= SESSION_HISTORY_PAGE_SIZE && userCount >= 2;
+}
+
+/**
+ * Fetch exactly one newest history page for fast first paint on switch.
+ */
+export function fetchInitialHistoryFirstPage(sessionId: string): Promise<SessionItemsPage> {
+  return fetchSessionItemsPage(sessionId);
+}
+
+/**
+ * Continue paging older history until the previous-user boundary is reached.
+ *
+ * Starts from a first page (typically already rendered) so callers can paint
+ * immediately and expand the initial window asynchronously.
+ */
+export async function extendInitialHistoryWindow(
+  sessionId: string,
+  seedPage: SessionItemsPage,
+): Promise<SessionItemsPage> {
+  let items = [...seedPage.items];
+  let hasMore = seedPage.hasMore;
+  if (initialHistoryBoundaryReached(items, hasMore)) return { items, hasMore };
+
+  for (let pages = 1; pages < MAX_INITIAL_PAGES; pages++) {
+    const cursor = items[0]?.id;
+    if (!cursor) break;
+    // Cursor pagination is stateful; each request depends on the prior page.
+    // eslint-disable-next-line no-await-in-loop
+    const page = await fetchSessionItemsPage(sessionId, { olderThan: cursor });
+    items = [...page.items, ...items]; // prepend the older page
+    hasMore = page.hasMore;
+    if (initialHistoryBoundaryReached(items, hasMore)) break;
+  }
+
+  return { items, hasMore };
+}
+
 /**
  * Hydrate the initial conversation window: at least
  * `SESSION_HISTORY_PAGE_SIZE` items, but extended further back when
@@ -845,22 +887,8 @@ function isUserPrompt(item: ConversationItem): boolean {
  * so callers feed `oldestItemId` / `hasMoreHistory` from it unchanged.
  */
 export async function fetchInitialHistoryWindow(sessionId: string): Promise<SessionItemsPage> {
-  let items: ConversationItem[] = [];
-  let hasMore = true;
-  for (let pages = 0; pages < MAX_INITIAL_PAGES; pages++) {
-    const cursor = items[0]?.id;
-    const page = await fetchSessionItemsPage(sessionId, cursor ? { olderThan: cursor } : {});
-    items = [...page.items, ...items]; // prepend the older page
-    hasMore = page.hasMore;
-    if (!hasMore) break; // reached the start of the conversation
-    const userCount = items.filter(isUserPrompt).length;
-    if (items.length >= SESSION_HISTORY_PAGE_SIZE && userCount >= 2) break;
-    if (!items[0]?.id) break; // no cursor to page further; avoid a spin
-  }
-  // If the cap stopped us before the previous user prompt (a pathological
-  // single turn spanning >MAX_INITIAL_PAGES pages), `hasMore` stays true so
-  // the rest remains reachable via scroll-up — same fallback as the default.
-  return { items, hasMore };
+  const firstPage = await fetchInitialHistoryFirstPage(sessionId);
+  return extendInitialHistoryWindow(sessionId, firstPage);
 }
 
 /**
@@ -995,4 +1023,32 @@ export async function approve(
   return postEventResponseFromWire(
     await readJsonOrThrow<{ queued: boolean; item_id?: string }>(res),
   );
+}
+
+/** React Query key for the initial history window prefetched on sidebar hover. */
+export function initialHistoryQueryKey(sessionId: string): readonly [string, string, string] {
+  return ["session", sessionId, "initialHistory"];
+}
+
+/**
+ * Warm the session snapshot and initial history cache before a sidebar click.
+ * TanStack dedupes in-flight prefetches with `bindStream`'s fetches.
+ */
+export function prefetchSessionForSwitch(queryClient: QueryClient, sessionId: string): void {
+  const snapshotState = queryClient.getQueryState(["session", sessionId]);
+  if (snapshotState?.fetchStatus !== "fetching") {
+    void queryClient.prefetchQuery({
+      queryKey: ["session", sessionId],
+      queryFn: () => getSessionSlim(sessionId, { refreshState: true }),
+      staleTime: 30_000,
+    });
+  }
+  const historyState = queryClient.getQueryState(initialHistoryQueryKey(sessionId));
+  if (historyState?.fetchStatus !== "fetching") {
+    void queryClient.prefetchQuery({
+      queryKey: initialHistoryQueryKey(sessionId),
+      queryFn: () => fetchInitialHistoryFirstPage(sessionId),
+      staleTime: 60_000,
+    });
+  }
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5043,14 +5043,14 @@ export function computeShowsWorking(
  *
  * The prompt is the optional first message the landing composer hands off via
  * the shared chatStore. It is sent exactly once per conversation, and only once
- * the session is ready: hydrated (snapshot loaded / stream bound) and an
- * agent resolved.
+ * the session is ready: history hydrated / stream bound and an agent resolved.
  *
  * We intentionally do NOT gate on runner liveness. The stream-bind gate
  * (``loadingConversation``) is load-bearing — the session stream is
- * live-tail with no replay buffer, so POSTing before ``bindStream``
- * connects would lose the turn's events ("no response"). But the runner
- * itself need not be online yet: the server's ``POST /events`` handler
+ * live-tail with no replay buffer, so POSTing before the stream pump
+ * starts would lose the turn's events ("no response"). The gate clears
+ * once history hydrates (snapshot metadata may still be in flight). The
+ * runner itself need not be online yet: the server's ``POST /events`` handler
  * holds the request open while a host-bound runner is spinning up (a 3s
  * connect grace, then a relaunch + 30s wait — see ``post_event`` in
  * ``sessions.py``), and only 503s if no runner ever comes online. So the
@@ -5072,7 +5072,7 @@ export function computeShowsWorking(
  *   ChatPage) does not block.
  * @param params.conversationId Active session id from the URL, or
  *   ``null``/``undefined`` on the new-chat landing, e.g. ``"conv_abc"``.
- * @param params.loadingConversation ``true`` while the snapshot hydrates.
+ * @param params.loadingConversation ``true`` while history hydrates.
  * @param params.agentId Resolved agent id, or ``null`` before agents
  *   load, e.g. ``"ag_abc123"``.
  * @returns ``true`` only when every gate passes.

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -60,6 +60,7 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useNavigate, useParams } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
 import {
@@ -131,6 +132,7 @@ import {
 } from "@/hooks/useUnseenConversations";
 import { cn } from "@/lib/utils";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { prefetchSessionForSwitch } from "@/lib/sessionsApi";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
@@ -154,6 +156,8 @@ import {
   sortByUpdatedAtDesc,
   togglePinnedConversationId,
 } from "./sidebarNav";
+
+const PREFETCH_DELAY = 100;
 
 // Positioning shared by both occupants of a row's trailing time-marker slot
 // (the session-state badge or the relative timestamp). On desktop the slot
@@ -2391,6 +2395,27 @@ function ConversationRow({
   // project flyout's HoverCard and leave it lingering over the chat. Gate the
   // flyout off below the `md` breakpoint (see `projectFlyoutName`).
   const isMobile = useIsMobileViewport();
+  const queryClient = useQueryClient();
+  const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prefetchSession = useCallback(() => {
+    if (isActive || selectionMode) return;
+    prefetchSessionForSwitch(queryClient, conversation.id);
+  }, [conversation.id, isActive, queryClient, selectionMode]);
+  const schedulePrefetch = useCallback(() => {
+    if (prefetchTimerRef.current !== null) clearTimeout(prefetchTimerRef.current);
+    prefetchTimerRef.current = setTimeout(() => {
+      prefetchTimerRef.current = null;
+      prefetchSession();
+    }, PREFETCH_DELAY);
+  }, [prefetchSession]);
+  useEffect(
+    () => () => {
+      if (prefetchTimerRef.current !== null) {
+        clearTimeout(prefetchTimerRef.current);
+      }
+    },
+    [],
+  );
   // Track the *live* active conversation id. Delete is fire-and-forget,
   // so the user can navigate to another conversation before the mutation
   // resolves — the onSuccess redirect must key off where they are now,
@@ -2702,6 +2727,8 @@ function ConversationRow({
         }
         onClick(e);
       }}
+      onPointerEnter={schedulePrefetch}
+      onFocus={prefetchSession}
       onDoubleClick={(e) => {
         if (selectionMode) return;
         if (!canEdit) return;

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -132,7 +132,10 @@ import {
 } from "@/hooks/useUnseenConversations";
 import { cn } from "@/lib/utils";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
-import { prefetchSessionForSwitch } from "@/lib/sessionsApi";
+import {
+  SessionPrefetchSchedulerProvider,
+  useSessionPrefetchScheduler,
+} from "@/hooks/SessionPrefetchSchedulerContext";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
@@ -156,8 +159,6 @@ import {
   sortByUpdatedAtDesc,
   togglePinnedConversationId,
 } from "./sidebarNav";
-
-const PREFETCH_DELAY = 100;
 
 // Positioning shared by both occupants of a row's trailing time-marker slot
 // (the session-state badge or the relative timestamp). On desktop the slot
@@ -402,274 +403,279 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
   const effectiveOpen = open || dragging;
 
   return (
-    <aside
-      aria-label="Conversations"
-      className={cn(
-        // Base: bg + flex column. No transition — expand/collapse snaps
-        // instantly (animating the width also lagged drag-to-resize).
-        // conversations-sidebar only matters under the macOS Electron
-        // shell, where it pushes the card below the traffic lights
-        // (see the [data-electron-mac] rules in index.css).
-        "conversations-sidebar flex flex-col bg-card md:select-none",
-        // Mobile (default): fixed full-screen overlay, slide via
-        // translate-x. Stays edge-to-edge — the floating-card
-        // treatment below is desktop-only.
-        // bg-card-solid (opaque): the overlay sits on top of the chat, and
-        // WebKit drops the glass rule's backdrop-filter once a Radix popper
-        // opens (and never repaints it), letting the chat bleed through the
-        // 60%-alpha glass --card. Desktop keeps the translucent bg-card —
-        // there the sidebar pushes content aside, so nothing sits behind it.
-        "max-md:bg-card-solid",
-        "fixed inset-0 z-50",
-        // Mobile only: animate the slide so the iOS edge-swipe settles
-        // smoothly on release. Suppressed inline while a drag is live (the
-        // overlay must track the finger 1:1). Scoped to transform so it can't
-        // re-introduce the width-animation lag the base comment warns about,
-        // and gated to mobile so the desktop floating card is unaffected.
-        "max-md:transition-transform max-md:duration-200 max-md:ease-out",
-        effectiveOpen ? "translate-x-0" : "-translate-x-full",
-        // Desktop: a floating card. Detached from the window edges by a
-        // margin, rounded, and lifted off the bg-sidebar canvas with a
-        // full border + shadow. Width (the user-resizable variable) animates
-        // →0 to push main; when closed the margin/border collapse too so
-        // nothing lingers.
-        "md:relative md:inset-auto md:translate-x-0 md:overflow-hidden",
-        open
-          ? "md:m-2 md:w-[var(--sidebar-width)] md:rounded-xl md:border md:border-border md:shadow-lg"
-          : "md:m-0 md:w-0 md:border-0",
-      )}
-      style={
-        {
-          "--sidebar-width": `${sidebarWidth}px`,
-          // Track the finger: map the 0→1 open fraction to translateX
-          // -100%→0% and kill the transition so it follows the drag exactly.
-          ...(dragging
-            ? { transform: `translateX(${(dragProgress - 1) * 100}%)`, transition: "none" }
-            : null),
-        } as CSSProperties
-      }
-      // Hide from the accessibility tree when closed so screen readers
-      // don't see the empty-state contents while focus is elsewhere.
-      aria-hidden={!effectiveOpen}
-      data-collapsed={!effectiveOpen || undefined}
-      // Match the keyboard-focus story: when closed, the sidebar's
-      // children shouldn't receive tabs.
-      inert={!effectiveOpen}
-    >
-      {/* Right-edge resize handle (desktop only), mirroring the right rail's
+    <SessionPrefetchSchedulerProvider>
+      <aside
+        aria-label="Conversations"
+        className={cn(
+          // Base: bg + flex column. No transition — expand/collapse snaps
+          // instantly (animating the width also lagged drag-to-resize).
+          // conversations-sidebar only matters under the macOS Electron
+          // shell, where it pushes the card below the traffic lights
+          // (see the [data-electron-mac] rules in index.css).
+          "conversations-sidebar flex flex-col bg-card md:select-none",
+          // Mobile (default): fixed full-screen overlay, slide via
+          // translate-x. Stays edge-to-edge — the floating-card
+          // treatment below is desktop-only.
+          // bg-card-solid (opaque): the overlay sits on top of the chat, and
+          // WebKit drops the glass rule's backdrop-filter once a Radix popper
+          // opens (and never repaints it), letting the chat bleed through the
+          // 60%-alpha glass --card. Desktop keeps the translucent bg-card —
+          // there the sidebar pushes content aside, so nothing sits behind it.
+          "max-md:bg-card-solid",
+          "fixed inset-0 z-50",
+          // Mobile only: animate the slide so the iOS edge-swipe settles
+          // smoothly on release. Suppressed inline while a drag is live (the
+          // overlay must track the finger 1:1). Scoped to transform so it can't
+          // re-introduce the width-animation lag the base comment warns about,
+          // and gated to mobile so the desktop floating card is unaffected.
+          "max-md:transition-transform max-md:duration-200 max-md:ease-out",
+          effectiveOpen ? "translate-x-0" : "-translate-x-full",
+          // Desktop: a floating card. Detached from the window edges by a
+          // margin, rounded, and lifted off the bg-sidebar canvas with a
+          // full border + shadow. Width (the user-resizable variable) animates
+          // →0 to push main; when closed the margin/border collapse too so
+          // nothing lingers.
+          "md:relative md:inset-auto md:translate-x-0 md:overflow-hidden",
+          open
+            ? "md:m-2 md:w-[var(--sidebar-width)] md:rounded-xl md:border md:border-border md:shadow-lg"
+            : "md:m-0 md:w-0 md:border-0",
+        )}
+        style={
+          {
+            "--sidebar-width": `${sidebarWidth}px`,
+            // Track the finger: map the 0→1 open fraction to translateX
+            // -100%→0% and kill the transition so it follows the drag exactly.
+            ...(dragging
+              ? { transform: `translateX(${(dragProgress - 1) * 100}%)`, transition: "none" }
+              : null),
+          } as CSSProperties
+        }
+        // Hide from the accessibility tree when closed so screen readers
+        // don't see the empty-state contents while focus is elsewhere.
+        aria-hidden={!effectiveOpen}
+        data-collapsed={!effectiveOpen || undefined}
+        // Match the keyboard-focus story: when closed, the sidebar's
+        // children shouldn't receive tabs.
+        inert={!effectiveOpen}
+      >
+        {/* Right-edge resize handle (desktop only), mirroring the right rail's
           left-edge handle. Hidden on mobile, where the sidebar is a
           full-screen overlay with no resize affordance; the parent's ``inert``
           when closed also keeps it from being draggable while collapsed. */}
-      <div
-        {...resizeHandleProps}
-        className="absolute inset-y-0 right-0 z-10 hidden w-1 cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50 md:block"
-      />
-      {inSettings ? (
-        <SettingsSidebarBody onNavClick={onNavClick} onClose={onClose} />
-      ) : (
-        <>
-          <div className="flex items-center justify-between px-4 pt-3">
-            {/* Brand mark doubles as the "home" affordance: clicking it
+        <div
+          {...resizeHandleProps}
+          className="absolute inset-y-0 right-0 z-10 hidden w-1 cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50 md:block"
+        />
+        {inSettings ? (
+          <SettingsSidebarBody onNavClick={onNavClick} onClose={onClose} />
+        ) : (
+          <>
+            <div className="flex items-center justify-between px-4 pt-3">
+              {/* Brand mark doubles as the "home" affordance: clicking it
             returns to `/`, the new-session composer. Without this there
             is no way back to the landing composer once you're inside a
             session. Reuses onNavClick so a plain primary click closes
             the sidebar on mobile (where it's a full-screen overlay) but
             modifier/middle clicks still open `/` in a new tab. */}
-            <Link
-              to="/"
-              onClick={onNavClick}
-              className="rounded-sm text-[15px] font-semibold tracking-tight text-foreground transition-colors hover:text-foreground/70"
-            >
-              Omnigent
-            </Link>
-            <div className="flex items-center gap-1">
-              {/* Inbox lives at the top next to the collapse toggle. Rendered
-              as a Link so cmd/middle-click opens it in a new tab; onNavClick
-              still closes the sidebar on a plain mobile tap. */}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    asChild
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Inbox"
-                    className={cn("relative rounded-full", isInboxPage && "bg-muted")}
-                    data-testid="inbox-button"
-                  >
-                    <Link to="/inbox" onClick={onNavClick}>
-                      <InboxIcon className="size-4" />
-                      {inboxCount > 0 && (
-                        <span
-                          aria-label={
-                            inboxCount === 1
-                              ? "1 inbox item waiting"
-                              : `${inboxCount} inbox items waiting`
-                          }
-                          className="-top-0.5 -right-0.5 absolute inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-warning/15 px-1 text-[10px] font-medium text-warning tabular-nums"
-                        >
-                          {inboxCount}
-                        </span>
-                      )}
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Inbox</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Close sidebar"
-                    onClick={onClose}
-                    className="rounded-full"
-                  >
-                    {/* panel-right-open while the sidebar IS open — this button
-                    only renders in the open state (ChatHeader's PanelLeftIcon
-                    covers the collapsed state). */}
-                    <PanelRightOpenIcon className="size-4" />
-                  </Button>
-                </TooltipTrigger>
-                {/* Bottom placement keeps the tooltip clear of the macOS
-                Electron shell's traffic lights at the window's top edge. */}
-                <TooltipContent side="bottom">Collapse sidebar</TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
-
-          <div className="px-3 py-3">
-            {/* "New session" routes to the home composer ("/"), which now owns
-            session creation end-to-end (host/workspace/worktree chips +
-            send). Rendered as a Link so cmd/middle-click opens it in a new
-            tab; onNavClick still closes the sidebar on a plain mobile tap. */}
-            <Button
-              asChild
-              className={cn(
-                // px-2 + gap-1 puts the icon on the sidebar's left (red) column
-                // and the label on the label (blue) column — matching section
-                // headers and project folders.
-                "w-full justify-start gap-1 px-2 text-sm",
-                isNewChatPage && "bg-muted font-semibold",
-              )}
-              variant="ghost"
-              data-testid="new-chat-button"
-            >
-              {/* New session always creates a session the viewer owns, which
-              lands under "My sessions" — so snap the tab back there on click
-              (the button stays visible on both tabs). */}
               <Link
                 to="/"
-                onClick={(e) => {
-                  setActiveTab("mine");
-                  onNavClick(e);
-                }}
+                onClick={onNavClick}
+                className="rounded-sm text-[15px] font-semibold tracking-tight text-foreground transition-colors hover:text-foreground/70"
               >
-                <SquarePenIcon className="size-4 text-foreground" />
-                New session
+                Omnigent
               </Link>
-            </Button>
-            {selectionMode ? (
-              <BulkActionBar
-                selectedIds={selectedIds}
-                allConversations={loadedRows}
-                visibleCount={visibleConversationCount}
-                onSelectAll={() => selectAll(getVisibleConversationsRef.current())}
-                onDeselectAll={deselectAll}
-                onClear={deselectAll}
-                onExit={exitSelectionMode}
-              />
-            ) : (
-              <div className="relative mt-3 flex items-center gap-1.5">
-                {/* "Search" opens the command palette (⌘K), which searches both
-                    session titles and chat content. It replaces the old inline
-                    filter box — the palette is the single search surface now.
-                    The `group` scope reveals the ⌘K badge on hover/focus. */}
-                <button
-                  type="button"
-                  onClick={() => onOpenSearch?.()}
-                  aria-label="Search"
-                  data-testid="sidebar-search-button"
-                  className="group relative flex min-h-8 flex-1 items-center rounded-full border border-input pr-2 pl-7 text-left text-sm text-muted-foreground transition hover:bg-muted focus-visible:outline-1"
-                >
-                  <SearchIcon className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2 size-3.5" />
-                  <span className="flex-1 truncate">Search</span>
-                  {/* ⌘K hint — hidden until the button is hovered / focused,
-                      mirroring the sidebar's other hover-revealed affordances. */}
-                  <kbd className="ml-2 hidden shrink-0 items-center rounded-md border border-border bg-muted px-1.5 py-0.5 font-sans text-[10px] font-medium text-muted-foreground transition-opacity group-hover:inline-flex group-focus-visible:inline-flex">
-                    {MOD_KEY}K
-                  </kbd>
-                </button>
+              <div className="flex items-center gap-1">
+                {/* Inbox lives at the top next to the collapse toggle. Rendered
+              as a Link so cmd/middle-click opens it in a new tab; onNavClick
+              still closes the sidebar on a plain mobile tap. */}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      asChild
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Inbox"
+                      className={cn("relative rounded-full", isInboxPage && "bg-muted")}
+                      data-testid="inbox-button"
+                    >
+                      <Link to="/inbox" onClick={onNavClick}>
+                        <InboxIcon className="size-4" />
+                        {inboxCount > 0 && (
+                          <span
+                            aria-label={
+                              inboxCount === 1
+                                ? "1 inbox item waiting"
+                                : `${inboxCount} inbox items waiting`
+                            }
+                            className="-top-0.5 -right-0.5 absolute inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-warning/15 px-1 text-[10px] font-medium text-warning tabular-nums"
+                          >
+                            {inboxCount}
+                          </span>
+                        )}
+                      </Link>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Inbox</TooltipContent>
+                </Tooltip>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
                       type="button"
                       variant="ghost"
-                      size="icon-sm"
-                      aria-label="Select sessions"
-                      data-testid="toggle-selection-mode"
-                      className="shrink-0 rounded-full"
-                      onClick={() => setSelectionMode(true)}
+                      size="icon"
+                      aria-label="Close sidebar"
+                      onClick={onClose}
+                      className="rounded-full"
                     >
-                      <ListChecksIcon className="size-3.5" />
+                      {/* panel-right-open while the sidebar IS open — this button
+                    only renders in the open state (ChatHeader's PanelLeftIcon
+                    covers the collapsed state). */}
+                      <PanelRightOpenIcon className="size-4" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">Select sessions</TooltipContent>
+                  {/* Bottom placement keeps the tooltip clear of the macOS
+                Electron shell's traffic lights at the window's top edge. */}
+                  <TooltipContent side="bottom">Collapse sidebar</TooltipContent>
                 </Tooltip>
               </div>
-            )}
-          </div>
+            </div>
 
-          {/* Session-scope tabs: split the viewer's own sessions ("My
+            <div className="px-3 py-3">
+              {/* "New session" routes to the home composer ("/"), which now owns
+            session creation end-to-end (host/workspace/worktree chips +
+            send). Rendered as a Link so cmd/middle-click opens it in a new
+            tab; onNavClick still closes the sidebar on a plain mobile tap. */}
+              <Button
+                asChild
+                className={cn(
+                  // px-2 + gap-1 puts the icon on the sidebar's left (red) column
+                  // and the label on the label (blue) column — matching section
+                  // headers and project folders.
+                  "w-full justify-start gap-1 px-2 text-sm",
+                  isNewChatPage && "bg-muted font-semibold",
+                )}
+                variant="ghost"
+                data-testid="new-chat-button"
+              >
+                {/* New session always creates a session the viewer owns, which
+              lands under "My sessions" — so snap the tab back there on click
+              (the button stays visible on both tabs). */}
+                <Link
+                  to="/"
+                  onClick={(e) => {
+                    setActiveTab("mine");
+                    onNavClick(e);
+                  }}
+                >
+                  <SquarePenIcon className="size-4 text-foreground" />
+                  New session
+                </Link>
+              </Button>
+              {selectionMode ? (
+                <BulkActionBar
+                  selectedIds={selectedIds}
+                  allConversations={loadedRows}
+                  visibleCount={visibleConversationCount}
+                  onSelectAll={() => selectAll(getVisibleConversationsRef.current())}
+                  onDeselectAll={deselectAll}
+                  onClear={deselectAll}
+                  onExit={exitSelectionMode}
+                />
+              ) : (
+                <div className="relative mt-3 flex items-center gap-1.5">
+                  {/* "Search" opens the command palette (⌘K), which searches both
+                    session titles and chat content. It replaces the old inline
+                    filter box — the palette is the single search surface now.
+                    The `group` scope reveals the ⌘K badge on hover/focus. */}
+                  <button
+                    type="button"
+                    onClick={() => onOpenSearch?.()}
+                    aria-label="Search"
+                    data-testid="sidebar-search-button"
+                    className="group relative flex min-h-8 flex-1 items-center rounded-full border border-input pr-2 pl-7 text-left text-sm text-muted-foreground transition hover:bg-muted focus-visible:outline-1"
+                  >
+                    <SearchIcon className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2 size-3.5" />
+                    <span className="flex-1 truncate">Search</span>
+                    {/* ⌘K hint — hidden until the button is hovered / focused,
+                      mirroring the sidebar's other hover-revealed affordances. */}
+                    <kbd className="ml-2 hidden shrink-0 items-center rounded-md border border-border bg-muted px-1.5 py-0.5 font-sans text-[10px] font-medium text-muted-foreground transition-opacity group-hover:inline-flex group-focus-visible:inline-flex">
+                      {MOD_KEY}K
+                    </kbd>
+                  </button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label="Select sessions"
+                        data-testid="toggle-selection-mode"
+                        className="shrink-0 rounded-full"
+                        onClick={() => setSelectionMode(true)}
+                      >
+                        <ListChecksIcon className="size-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Select sessions</TooltipContent>
+                  </Tooltip>
+                </div>
+              )}
+            </div>
+
+            {/* Session-scope tabs: split the viewer's own sessions ("My
           sessions") from ones shared with them ("Shared with me"). Sits above
           the scrolling list (non-scrolling) so it stays put while the list
           scrolls. Hidden during selection mode, where the bulk-action bar owns
           this strip. */}
-          {multiUser && !selectionMode && (
-            <div className="px-3 pb-2">
-              <Tabs
-                value={activeTab}
-                onValueChange={(v) => setActiveTab(v as SidebarTab)}
-                className="w-full"
-              >
-                <TabsList className="w-full">
-                  <TabsTrigger value="mine" data-testid="sidebar-tab-mine" className="min-w-0">
-                    <span className="min-w-0 truncate">My sessions</span>
-                  </TabsTrigger>
-                  <TabsTrigger value="shared" data-testid="sidebar-tab-shared" className="min-w-0">
-                    <span className="min-w-0 truncate">Shared with me</span>
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
-            </div>
-          )}
+            {multiUser && !selectionMode && (
+              <div className="px-3 pb-2">
+                <Tabs
+                  value={activeTab}
+                  onValueChange={(v) => setActiveTab(v as SidebarTab)}
+                  className="w-full"
+                >
+                  <TabsList className="w-full">
+                    <TabsTrigger value="mine" data-testid="sidebar-tab-mine" className="min-w-0">
+                      <span className="min-w-0 truncate">My sessions</span>
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="shared"
+                      data-testid="sidebar-tab-shared"
+                      className="min-w-0"
+                    >
+                      <span className="min-w-0 truncate">Shared with me</span>
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
+              </div>
+            )}
 
-          {/* Mobile: extra bottom padding so the last session scrolls clear of
+            {/* Mobile: extra bottom padding so the last session scrolls clear of
           the floating Settings icon (which is absolutely positioned, out of
           flow, over the bottom-left corner). */}
-          <nav
-            ref={scrollContainerRef}
-            className="relative flex-1 overflow-y-auto px-3 pb-3 max-md:pb-16 [scrollbar-gutter:stable]"
-          >
-            <ConversationList
-              conversationsQuery={conversationsQuery}
-              scrollContainerRef={scrollContainerRef}
-              onRowClick={onNavClick}
-              searchQuery=""
-              activeTab={multiUser ? activeTab : "mine"}
-              pinnedConversationIds={pinnedConversationIds}
-              onPinnedConversationIdsChange={setPinnedConversationIds}
-              onTogglePinned={togglePinnedConversation}
-              selectionMode={selectionMode}
-              selectedIds={selectedIds}
-              onToggleSelected={toggleSelected}
-              getVisibleIdsRef={getVisibleIdsRef}
-              getVisibleConversationsRef={getVisibleConversationsRef}
-              onVisibleCountChange={setVisibleConversationCount}
-            />
-          </nav>
+            <nav
+              ref={scrollContainerRef}
+              className="relative flex-1 overflow-y-auto px-3 pb-3 max-md:pb-16 [scrollbar-gutter:stable]"
+            >
+              <ConversationList
+                conversationsQuery={conversationsQuery}
+                scrollContainerRef={scrollContainerRef}
+                onRowClick={onNavClick}
+                searchQuery=""
+                activeTab={multiUser ? activeTab : "mine"}
+                pinnedConversationIds={pinnedConversationIds}
+                onPinnedConversationIdsChange={setPinnedConversationIds}
+                onTogglePinned={togglePinnedConversation}
+                selectionMode={selectionMode}
+                selectedIds={selectedIds}
+                onToggleSelected={toggleSelected}
+                getVisibleIdsRef={getVisibleIdsRef}
+                getVisibleConversationsRef={getVisibleConversationsRef}
+                onVisibleCountChange={setVisibleConversationCount}
+              />
+            </nav>
 
-          {/* Settings entry. Always present (every deploy): the full settings
+            {/* Settings entry. Always present (every deploy): the full settings
           surface — appearance, keyboard shortcuts, archived chats, and the
           account/sign-out controls when accounts auth is on — lives behind
           this on the /settings page.
@@ -679,37 +685,38 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
           Mobile: pulled OUT of flow (absolute, bottom-left) so it floats over
           the conversation list as a compact icon instead of stealing a row's
           height from the scroll area. */}
-          <div className="md:shrink-0 md:px-3 md:pb-3 max-md:absolute max-md:bottom-3 max-md:left-3 max-md:z-10">
-            <Button
-              asChild
-              variant="ghost"
-              className={cn(
-                "gap-2 text-sm",
-                // Desktop: full-width row with label, matching New session /
-                // Inbox. Mobile: a small round icon-only button with its own
-                // surface (border + solid bg + shadow) so it reads as a
-                // floating control over the scrolling list beneath it.
-                "md:w-full md:justify-start",
-                "max-md:size-9 max-md:justify-center max-md:rounded-full max-md:border max-md:border-border max-md:bg-card-solid max-md:p-0 max-md:shadow-sm",
-              )}
-              data-testid="settings-button"
-            >
-              {/* No onNavClick here: on mobile the sidebar is a full-screen
+            <div className="md:shrink-0 md:px-3 md:pb-3 max-md:absolute max-md:bottom-3 max-md:left-3 max-md:z-10">
+              <Button
+                asChild
+                variant="ghost"
+                className={cn(
+                  "gap-2 text-sm",
+                  // Desktop: full-width row with label, matching New session /
+                  // Inbox. Mobile: a small round icon-only button with its own
+                  // surface (border + solid bg + shadow) so it reads as a
+                  // floating control over the scrolling list beneath it.
+                  "md:w-full md:justify-start",
+                  "max-md:size-9 max-md:justify-center max-md:rounded-full max-md:border max-md:border-border max-md:bg-card-solid max-md:p-0 max-md:shadow-sm",
+                )}
+                data-testid="settings-button"
+              >
+                {/* No onNavClick here: on mobile the sidebar is a full-screen
               overlay, and entering settings swaps it to the section list
               (SettingsSidebarBody). Closing the overlay would skip that list
               and drop straight onto the default section's content — instead we
               keep it open so mobile lands on the section list, then tapping a
               section (which DOES use onNavClick) closes it to show content. */}
-              <Link to="/settings" aria-label="Settings">
-                <SettingsIcon className="size-4 text-muted-foreground" />
-                {/* Label is desktop-only; the icon stands alone on mobile. */}
-                <span className="max-md:hidden">Settings</span>
-              </Link>
-            </Button>
-          </div>
-        </>
-      )}
-    </aside>
+                <Link to="/settings" aria-label="Settings">
+                  <SettingsIcon className="size-4 text-muted-foreground" />
+                  {/* Label is desktop-only; the icon stands alone on mobile. */}
+                  <span className="max-md:hidden">Settings</span>
+                </Link>
+              </Button>
+            </div>
+          </>
+        )}
+      </aside>
+    </SessionPrefetchSchedulerProvider>
   );
 }
 
@@ -2396,26 +2403,15 @@ function ConversationRow({
   // flyout off below the `md` breakpoint (see `projectFlyoutName`).
   const isMobile = useIsMobileViewport();
   const queryClient = useQueryClient();
-  const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sessionPrefetch = useSessionPrefetchScheduler();
   const prefetchSession = useCallback(() => {
     if (isActive || selectionMode) return;
-    prefetchSessionForSwitch(queryClient, conversation.id);
-  }, [conversation.id, isActive, queryClient, selectionMode]);
+    sessionPrefetch.prefetchNow(queryClient, conversation.id);
+  }, [conversation.id, isActive, queryClient, selectionMode, sessionPrefetch]);
   const schedulePrefetch = useCallback(() => {
-    if (prefetchTimerRef.current !== null) clearTimeout(prefetchTimerRef.current);
-    prefetchTimerRef.current = setTimeout(() => {
-      prefetchTimerRef.current = null;
-      prefetchSession();
-    }, PREFETCH_DELAY);
-  }, [prefetchSession]);
-  useEffect(
-    () => () => {
-      if (prefetchTimerRef.current !== null) {
-        clearTimeout(prefetchTimerRef.current);
-      }
-    },
-    [],
-  );
+    if (isActive || selectionMode) return;
+    sessionPrefetch.scheduleHover(queryClient, conversation.id);
+  }, [conversation.id, isActive, queryClient, selectionMode, sessionPrefetch]);
   // Track the *live* active conversation id. Delete is fire-and-forget,
   // so the user can navigate to another conversation before the mutation
   // resolves — the onSuccess redirect must key off where they are now,

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -29,7 +29,7 @@ import type {
 import type { ConversationItem } from "@/lib/conversationItems";
 import { itemsToBlocks } from "@/lib/itemsToBlocks";
 import { buildBubbles } from "@/lib/renderItems";
-import { SESSION_HISTORY_PAGE_SIZE } from "@/lib/sessionsApi";
+import { initialHistoryQueryKey, SESSION_HISTORY_PAGE_SIZE } from "@/lib/sessionsApi";
 import { getCurrentAuthorId } from "@/lib/identity";
 import type {
   SessionCreatedEvent,
@@ -447,6 +447,119 @@ describe("chatStore — switchTo", () => {
     expect(user.content).toEqual([{ type: "input_text", text: "hello" }]);
     expect(state.loadingConversation).toBe(false);
     expect(state.conversationLoadError).toBeNull();
+  });
+
+  it("paints history before the session snapshot resolves", async () => {
+    const items: ConversationItem[] = [
+      userMessage("resp_1", "hello"),
+      assistantMessage("resp_1", "hi there"),
+    ];
+    seedSession("conv_slow_snap", items);
+    let releaseSnapshot: (() => void) | null = null;
+    const snapshotReady = new Promise<void>((resolve) => {
+      releaseSnapshot = () => resolve();
+    });
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const path = url.split("?")[0]!;
+      if (path === "/v1/sessions/conv_slow_snap" && (init?.method ?? "GET") === "GET") {
+        return snapshotReady.then(() => defaultFetchHandler(input, init));
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const switchPromise = useChatStore.getState().switchTo("conv_slow_snap");
+    await tick();
+    const mid = useChatStore.getState();
+    expect(mid.loadingConversation).toBe(false);
+    expect(mid.blocks).toHaveLength(2);
+    expect(mid.boundAgentId).toBeNull();
+
+    releaseSnapshot!();
+    await switchPromise;
+
+    const final = useChatStore.getState();
+    expect(final.boundAgentId).toBe("agent_xyz");
+    expect(final.blocks).toHaveLength(2);
+  });
+
+  it("uses prefetched initial-history cache on switch without re-fetching items", async () => {
+    const items: ConversationItem[] = [
+      userMessage("resp_1", "hello"),
+      assistantMessage("resp_1", "hi there"),
+    ];
+    seedSession("conv_cached", items);
+    client.setQueryData(initialHistoryQueryKey("conv_cached"), { items, hasMore: false });
+    let releaseItemsFetch: (() => void) | null = null;
+    const itemsReady = new Promise<void>((resolve) => {
+      releaseItemsFetch = () => resolve();
+    });
+    let itemsCalls = 0;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.startsWith("/v1/sessions/conv_cached/items")) {
+        itemsCalls += 1;
+        return itemsReady.then(() => defaultFetchHandler(input, init));
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const switchPromise = useChatStore.getState().switchTo("conv_cached");
+    await tick();
+
+    expect(itemsCalls).toBe(1);
+    const mid = useChatStore.getState();
+    expect(mid.loadingConversation).toBe(false);
+    expect(mid.blocks).toHaveLength(2);
+
+    releaseItemsFetch!();
+    await switchPromise;
+  });
+
+  it("renders first history page, then prepends older boundary pages in background", async () => {
+    const firstPageTail = Array.from({ length: 19 }, (_, i) =>
+      assistantMessage(`resp_t${i}`, `t${i}`),
+    );
+    const firstPage: ConversationItem[] = [
+      ...firstPageTail,
+      userMessage("resp_last", "latest prompt"),
+    ];
+    const fullItems: ConversationItem[] = [
+      userMessage("resp_prev", "previous prompt"),
+      assistantMessage("resp_prev", "previous assistant"),
+      ...firstPage,
+    ];
+    seedSession("conv_bg_hist", fullItems);
+    let releaseSecondPage: (() => void) | null = null;
+    const secondPageReady = new Promise<void>((resolve) => {
+      releaseSecondPage = () => resolve();
+    });
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/v1/sessions/conv_bg_hist/items") && url.includes("after=")) {
+        return secondPageReady.then(() => defaultFetchHandler(input, init));
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const switchPromise = useChatStore.getState().switchTo("conv_bg_hist");
+    await tick();
+
+    const mid = useChatStore.getState();
+    expect(mid.loadingConversation).toBe(false);
+    expect(
+      mid.blocks.some((b) => b.type === "user_message" && b.ctx.responseId === "resp_prev"),
+    ).toBe(false);
+
+    releaseSecondPage!();
+    await switchPromise;
+    await tick();
+    await tick();
+
+    const final = useChatStore.getState();
+    expect(
+      final.blocks.some((b) => b.type === "user_message" && b.ctx.responseId === "resp_prev"),
+    ).toBe(true);
   });
 
   it("hydrates pendingUserMessages from the snapshot's pending_inputs (native rebind)", async () => {

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -61,9 +61,12 @@ import {
   approve as approveElicitation,
   bindOnlyOnlineRunner,
   createSession,
+  extendInitialHistoryWindow,
+  fetchInitialHistoryFirstPage,
   getSessionSlim,
   fetchInitialHistoryWindow,
   fetchSessionItemsPage,
+  initialHistoryQueryKey,
   interrupt as interruptSession,
   openSessionStream,
   postEvent,
@@ -2251,6 +2254,192 @@ async function refreshSessionBinding(id: string): Promise<void> {
 }
 
 /**
+ * Merge hydrated history blocks into live pump blocks, deduping by item id.
+ */
+function mergeHistoryIntoBlocks(state: ChatState, snapshotBlocks: AnyBlock[]): AnyBlock[] {
+  const seenItemIds = new Set(
+    state.blocks.map((b) => b.ctx.itemId).filter((iid): iid is string => Boolean(iid)),
+  );
+  const unique = snapshotBlocks.filter((b) => !b.ctx.itemId || !seenItemIds.has(b.ctx.itemId));
+  return [...unique, ...state.blocks];
+}
+
+/** Fire-and-forget sticky effort/model writes for native sessions on cold bind. */
+function runStickyPrefHandoff(session: Session, id: string, get: Getter): void {
+  const nativeModelFamily = nativeModelFamilyForSession(session);
+  const isSubAgentSession = session.parentSessionId != null;
+  const canApplyEffort = supportsEffortControl(session);
+  const stickyEffort = get().selectedEffort;
+  const stickyModel = get().selectedModel;
+  const compatibleStickyModel =
+    nativeModelFamily !== null && stickyModel != null
+      ? isNativeModelCompatible(nativeModelFamily, stickyModel, session)
+        ? stickyModel
+        : null
+      : stickyModel;
+  // Intelligent routing owns first-turn model selection on routing-enabled sessions.
+  // Do not auto-apply sticky model overrides in that mode.
+  const routingOn = session.costControlModeOverride === "on";
+  const willApplyStickyModel =
+    !isSubAgentSession &&
+    !routingOn &&
+    nativeModelFamily !== null &&
+    session.modelOverride == null &&
+    compatibleStickyModel != null;
+  if (
+    !isSubAgentSession &&
+    canApplyEffort &&
+    session.reasoningEffort == null &&
+    stickyEffort != null
+  ) {
+    updateSession(id, { reasoningEffort: stickyEffort }).catch((err: unknown) => {
+      console.warn(`Failed to apply sticky effort=${stickyEffort} to session ${id}:`, err);
+    });
+  }
+  if (willApplyStickyModel) {
+    updateSession(id, { modelOverride: compatibleStickyModel, silent: true }).catch(
+      (err: unknown) => {
+        console.warn(
+          `Failed to apply sticky model=${compatibleStickyModel} to session ${id}:`,
+          err,
+        );
+      },
+    );
+  }
+}
+
+function stickySelectionFromSession(
+  session: Session,
+  get: Getter,
+): {
+  effectiveEffort: ChatState["selectedEffort"];
+  effectiveModel: ChatState["selectedModel"];
+  effectiveSessionOverride: ChatState["sessionModelOverride"];
+} {
+  const nativeModelFamily = nativeModelFamilyForSession(session);
+  const canApplyEffort = supportsEffortControl(session);
+  const stickyEffort = get().selectedEffort;
+  const stickyModel = get().selectedModel;
+  const effectiveEffort = canApplyEffort
+    ? (session.reasoningEffort ?? stickyEffort ?? null)
+    : stickyEffort;
+  const compatibleStickyModel =
+    nativeModelFamily !== null && stickyModel != null
+      ? isNativeModelCompatible(nativeModelFamily, stickyModel, session)
+        ? stickyModel
+        : null
+      : stickyModel;
+  const effectiveModel =
+    nativeModelFamily !== null ? (session.modelOverride ?? compatibleStickyModel) : stickyModel;
+  const isSubAgentSession = session.parentSessionId != null;
+  const routingOn = session.costControlModeOverride === "on";
+  const willApplyStickyModel =
+    !isSubAgentSession &&
+    !routingOn &&
+    nativeModelFamily !== null &&
+    session.modelOverride == null &&
+    compatibleStickyModel != null;
+  const effectiveSessionOverride =
+    session.modelOverride ?? (willApplyStickyModel ? compatibleStickyModel : null);
+  return { effectiveEffort, effectiveModel, effectiveSessionOverride };
+}
+
+/**
+ * Apply snapshot-only hydration after history has painted: binding metadata,
+ * pending inputs, elicitations, and session status fields.
+ */
+function snapshotHydrationPatch(
+  session: Session,
+  state: ChatState,
+  id: string,
+  hydratePending: boolean,
+  selections: ReturnType<typeof stickySelectionFromSession>,
+): Partial<ChatState> {
+  const bindingPatch = sessionBindingPatch(session);
+  const pendingElicitationBlocks = pendingElicitationBlocksFromSnapshot(session);
+  const seenElicitationIds = new Set(
+    state.blocks
+      .filter((b): b is typeof b & { type: "elicitation" } => b.type === "elicitation")
+      .map((b) => b.elicitationId),
+  );
+  const uniquePendingElicitations = pendingElicitationBlocks.filter(
+    (b) => b.type !== "elicitation" || !seenElicitationIds.has(b.elicitationId),
+  );
+  const allBlocks = [...state.blocks, ...uniquePendingElicitations];
+  const hasErrorBlock = allBlocks.some((b) => b.type === "error");
+  const toPending = (p: PendingInput): PendingUserMessage => ({
+    tempId: p.pendingId,
+    content: p.content,
+    ...(p.createdBy !== undefined ? { author: p.createdBy } : {}),
+  });
+  let candidatePending: PendingUserMessage[];
+  if (!hydratePending) {
+    candidatePending = state.pendingUserMessages;
+  } else {
+    const serverPending = (session.pendingInputs ?? []).map(toPending);
+    const unmatchedServer = serverPending.map((p) => contentKeyOf(p.content));
+    const unknownToServer = state.pendingUserMessages.filter((p) => {
+      const i = unmatchedServer.indexOf(contentKeyOf(p.content));
+      if (i === -1) return true;
+      unmatchedServer.splice(i, 1);
+      return false;
+    });
+    candidatePending = [...serverPending, ...unknownToServer];
+  }
+  const dedupePending = hydratePending && candidatePending.length > 0;
+  const committedUserTexts = dedupePending ? committedUserTextsOf(allBlocks) : [];
+  const stashBaseline = state.pendingByConversation[id]?.committedTexts ?? [];
+  const countEndsWith = (texts: string[], suffix: string): number =>
+    texts.reduce((n, c) => (c.endsWith(suffix) ? n + 1 : n), 0);
+  const snapshotPending: PendingUserMessage[] = dedupePending
+    ? candidatePending.filter((p) => {
+        const text = messageContentText(p.content);
+        if (text === "") return true;
+        const baseline = p.tempId.startsWith("pend_") ? countEndsWith(stashBaseline, text) : 0;
+        return countEndsWith(committedUserTexts, text) <= baseline;
+      })
+    : candidatePending;
+  const prunedStash = hydratePending
+    ? (() => {
+        const own = snapshotPending.filter((p) => p.tempId.startsWith("pend_"));
+        const next = { ...state.pendingByConversation };
+        if (own.length > 0) next[id] = { messages: own, committedTexts: committedUserTexts };
+        else delete next[id];
+        return next;
+      })()
+    : state.pendingByConversation;
+  const syntheticError: ErrorBlock | null =
+    session.status === "failed" && session.lastTaskError != null && !hasErrorBlock
+      ? {
+          type: "error",
+          ctx: { agent: null, depth: 0, turn: 0, timestamp: 0, responseId: "", itemId: null },
+          message: session.lastTaskError.message,
+          source: "",
+          code: session.lastTaskError.code,
+        }
+      : null;
+  return {
+    ...bindingPatch,
+    blocks: syntheticError !== null ? [...allBlocks, syntheticError] : allBlocks,
+    pendingUserMessages: snapshotPending,
+    pendingByConversation: prunedStash,
+    sessionStatus: session.status,
+    backgroundTaskCount: session.backgroundTaskCount ?? 0,
+    selectedEffort: selections.effectiveEffort,
+    selectedModel: selections.effectiveModel,
+    sessionModelOverride: selections.effectiveSessionOverride,
+    tokensUsed: session.lastTotalTokens ?? null,
+    sessionCostUsd: session.totalCostUsd ?? null,
+    sessionUsageByModel: session.usageByModel ?? null,
+    todos: (session.todos ?? []) as Array<{
+      content: string;
+      status: "pending" | "in_progress" | "completed";
+      activeForm: string;
+    }>,
+  };
+}
+
+/**
  * Start the session SSE stream, kick off the pump in the background
  * once the stream connects, then fetch metadata plus the most recent
  * page of item history and merge it into state.blocks.
@@ -2263,6 +2452,10 @@ async function refreshSessionBinding(id: string): Promise<void> {
  * elicitations must still replay on refresh while the stream is
  * connecting. Dedupe by item id on merge so stream-delivered
  * persisted items don't double-render alongside hydrated ones.
+ *
+ * History hydrates first so messages paint without waiting on the
+ * slower session snapshot (runner-backed refresh_state round-trips).
+ * Snapshot metadata follows in a second pass.
  */
 async function bindStream(
   id: string,
@@ -2291,277 +2484,134 @@ async function bindStream(
     });
   }
 
-  // Snapshot the session metadata and hydrate the most recent page of
-  // item history. The pump may have already pushed blocks by the time
-  // this resolves — dedupe by item id.
-  // Always refetch the snapshot on bind. A cached session snapshot can
-  // be stale after the agent commits new items while the user is viewing
-  // another conversation; reusing it drops messages until a page refresh.
-  // History is windowed to max(one page, back-to-previous-user-message)
-  // so opening a long transcript stays fast while still showing the last
-  // full turn and its preceding prompt; `loadMoreHistory` pages older on
-  // scroll-up. See `fetchInitialHistoryWindow`.
+  // Hydrate history first so messages paint without waiting on the slower
+  // session snapshot (runner-backed refresh_state round-trips). Snapshot
+  // metadata follows in a second pass. If hover prefetch already warmed
+  // React Query, consume cached history/snapshot immediately.
   // `retry: false` because the most common failure here is "invalid conv
   // id in URL" (not transient).
   if (queryClient === null) {
     throw new Error("chatStore.bindStream: queryClient not initialized");
   }
-  try {
-    const [session, page] = await Promise.all([
-      queryClient.fetchQuery({
-        queryKey: ["session", id],
-        queryFn: () => getSessionSlim(id, { refreshState: true }),
-        staleTime: 0,
-        retry: false,
-      }),
-      fetchInitialHistoryWindow(id),
-    ]);
-    if (get().conversationId !== id) return;
-    const items = page.items;
-
-    // Sticky-pref handoff for CLI-created sessions with no override.
-    const nativeModelFamily = nativeModelFamilyForSession(session);
-    // Binding-derived fields (isNativeTerminalSession, bound agent,
-    // model/skills metadata) — shared with the session.agent_changed
-    // refresh path; see sessionBindingPatch.
-    const bindingPatch = sessionBindingPatch(session);
-    // Sub-agents inherit orchestrator choices.
-    const isSubAgentSession = session.parentSessionId != null;
-    const canApplyEffort = supportsEffortControl(session);
-    const stickyEffort = get().selectedEffort;
-    const stickyModel = get().selectedModel;
-    // Apply sticky effort only where the Web UI control is meaningful.
-    const effectiveEffort = canApplyEffort
-      ? (session.reasoningEffort ?? stickyEffort ?? null)
-      : stickyEffort;
-    // Non-native: don't auto-apply the model, but keep the sticky pick so
-    // navigating back to a native session restores it.
-    const compatibleStickyModel =
-      nativeModelFamily !== null && stickyModel != null
-        ? isNativeModelCompatible(nativeModelFamily, stickyModel, session)
-          ? stickyModel
-          : null
-        : stickyModel;
-    const effectiveModel =
-      nativeModelFamily !== null ? (session.modelOverride ?? compatibleStickyModel) : stickyModel;
-    // The session's REAL effective override: the server's stored value,
-    // plus the sticky model the native handoff is about to apply. Unlike
-    // `effectiveModel`/`selectedModel` (which hold the unapplied sticky
-    // pick for non-native sessions), this is the session truth the `/model`
-    // readout shows, so a non-applied sticky pick is never mislabeled as
-    // an active "(override)".
-    // Intelligent routing owns model selection: never carry a sticky model
-    // onto a routing-enabled session. Leaving model_override null is what lets
-    // the server-side judge pick on the first turn; a silent sticky PATCH here
-    // would re-pin the session (e.g. to the last-used Opus) and trip the
-    // server's ``model_override is None`` routing guard. effectiveSessionOverride
-    // then resolves to null too, so the /model readout doesn't mislabel it.
-    const routingOn = session.costControlModeOverride === "on";
-    const willApplyStickyModel =
-      !isSubAgentSession &&
-      !routingOn &&
-      nativeModelFamily !== null &&
-      session.modelOverride == null &&
-      compatibleStickyModel != null;
-    const effectiveSessionOverride =
-      session.modelOverride ?? (willApplyStickyModel ? compatibleStickyModel : null);
-    if (
-      !isSubAgentSession &&
-      canApplyEffort &&
-      session.reasoningEffort == null &&
-      stickyEffort != null
-    ) {
-      updateSession(id, { reasoningEffort: stickyEffort }).catch((err: unknown) => {
-        console.warn(`Failed to apply sticky effort=${stickyEffort} to session ${id}:`, err);
-      });
-    }
-    if (willApplyStickyModel) {
-      updateSession(id, { modelOverride: compatibleStickyModel, silent: true }).catch(
-        (err: unknown) => {
-          console.warn(
-            `Failed to apply sticky model=${compatibleStickyModel} to session ${id}:`,
-            err,
-          );
-        },
-      );
-    }
-
-    const snapshotBlocks = itemsToBlocks(items);
-    // Replay outstanding elicitation prompts from the snapshot.
-    // The live SSE stream has no buffer, so a prompt that fired
-    // before this chat was opened wouldn't render otherwise.
-    const pendingElicitationBlocks = pendingElicitationBlocksFromSnapshot(session);
-    const oldestItemId = items[0]?.id ?? null;
+  const applyHistoryWindow = (page: SessionItemsPage, incrementGeneration: boolean): boolean => {
+    if (get().conversationId !== id) return false;
+    const snapshotBlocks = itemsToBlocks(page.items);
+    const oldestItemId = page.items[0]?.id ?? null;
     set((state) => {
-      const seenItemIds = new Set(
-        state.blocks.map((b) => b.ctx.itemId).filter((iid): iid is string => Boolean(iid)),
-      );
-      const unique = snapshotBlocks.filter((b) => !b.ctx.itemId || !seenItemIds.has(b.ctx.itemId));
-      // Dedupe against any elicitation blocks already produced by
-      // the live pump (the snapshot may race ahead of or behind
-      // the SSE event — match by elicitationId).
-      const seenElicitationIds = new Set(
-        state.blocks
-          .filter((b): b is typeof b & { type: "elicitation" } => b.type === "elicitation")
-          .map((b) => b.elicitationId),
-      );
-      const uniquePendingElicitations = pendingElicitationBlocks.filter(
-        (b) => b.type !== "elicitation" || !seenElicitationIds.has(b.elicitationId),
-      );
-      // Synthesize a visible error block when the session failed and no error
-      // block was already produced by itemsToBlocks. The `response.error` SSE
-      // event is transient (published to the in-memory session stream which
-      // has no replay), so clients that connect after the task has already
-      // failed never receive it. `last_task_error` on the snapshot is the
-      // durable equivalent — use it to ensure the failure reason is always
-      // visible on historical load.
-      // Pending elicitations land after the historical blocks (and any
-      // live blocks the pump already inserted) so the ApprovalCard
-      // appears at the bottom of the chat — same position the live
-      // stream would have given it.
-      const allBlocks = [...unique, ...state.blocks, ...uniquePendingElicitations];
-      const hasErrorBlock = allBlocks.some((b) => b.type === "error");
-      // Decide the optimistic user bubbles to render after this bind, and
-      // (on cold load) keep the per-conversation stash consistent.
-      //
-      // Rebind (``hydratePending=false``): the live ``pendingUserMessages``
-      // are authoritative — keep them untouched. Deduping/merging here would
-      // flink the live bubble; they clear via the consumed FIFO path.
-      //
-      // Cold load (``hydratePending=true``): the server's ``pending_inputs``
-      // is the source of truth for queued-but-unpersisted messages — replay
-      // ALL of it (the viewer's own and collaborators' alike). The only
-      // client-side additions are the bubbles ``switchTo`` restored from
-      // the stash: own sends whose POST hadn't settled at navigate-away,
-      // which the server can't replay because it hasn't been told about
-      // them yet. A restored bubble the server turns out to know
-      // after all (its record landed while the POST response was still in
-      // transit) is dropped in favor of its content-identical
-      // ``pending_inputs`` twin: the server entry carries the durable
-      // pending id, so the eventual consumed event clears it precisely —
-      // keeping both would double-render and strand one of them.
-      const toPending = (p: PendingInput): PendingUserMessage => ({
-        tempId: p.pendingId,
-        content: p.content,
-        ...(p.createdBy !== undefined ? { author: p.createdBy } : {}),
-      });
-      let candidatePending: PendingUserMessage[];
-      if (!hydratePending) {
-        candidatePending = state.pendingUserMessages;
-      } else {
-        const serverPending = (session.pendingInputs ?? []).map(toPending);
-        // One-to-one consumption so two identical queued sends still match
-        // pairwise. Content (not text) equality so image-only messages
-        // correlate too.
-        const unmatchedServer = serverPending.map((p) => contentKeyOf(p.content));
-        const unknownToServer = state.pendingUserMessages.filter((p) => {
-          const i = unmatchedServer.indexOf(contentKeyOf(p.content));
-          if (i === -1) return true;
-          unmatchedServer.splice(i, 1);
-          return false;
-        });
-        // pending_inputs is FIFO-ordered and sends are serialized through
-        // the send chain, so server-known entries precede in-flight ones.
-        candidatePending = [...serverPending, ...unknownToServer];
-      }
-      // Dedupe on a COLD LOAD only: drop any candidate whose message already
-      // committed — a snapshot-replayed ghost the server never drained, or a
-      // restored stash bubble whose message persisted while the user was
-      // away. Without this the bubble double-renders beside the committed
-      // item. Native has no id to correlate the POST with the mirrored item,
-      // so dedupe by text; the transcript prepends markers/blockquotes,
-      // leaving the POSTed text at the end, so match with endsWith.
-      // Image-only entries (no text) are kept.
-      //
-      // Baseline-aware so an optimistic bubble whose text coincides with an
-      // OLDER message already in history isn't wrongly dropped: a stashed own
-      // bubble (``pend_`` id) is deduped only against committed copies that
-      // are NEW since it was stashed — i.e. the snapshot now has MORE copies
-      // of that text than the stash's committedTexts baseline. Foreign /
-      // server-replayed entries (server ids) have no baseline (it stays 0),
-      // so they dedupe against all committed copies as before. Without this,
-      // re-sending text that already appears in a resumed/disconnected
-      // session's history makes the new bubble vanish until it commits (the
-      // "disappears then reappears" report).
-      const dedupePending = hydratePending && candidatePending.length > 0;
-      const committedUserTexts = dedupePending ? committedUserTextsOf(allBlocks) : [];
-      const stashBaseline = state.pendingByConversation[id]?.committedTexts ?? [];
-      const countEndsWith = (texts: string[], suffix: string): number =>
-        texts.reduce((n, c) => (c.endsWith(suffix) ? n + 1 : n), 0);
-      const snapshotPending: PendingUserMessage[] = dedupePending
-        ? candidatePending.filter((p) => {
-            const text = messageContentText(p.content);
-            if (text === "") return true;
-            const baseline = p.tempId.startsWith("pend_") ? countEndsWith(stashBaseline, text) : 0;
-            return countEndsWith(committedUserTexts, text) <= baseline;
-          })
-        : candidatePending;
-      // Keep the stash consistent with what survived dedupe on cold load: a
-      // restored bubble whose message committed while away is now dropped, so
-      // prune it from the stash too (else it lingers until the next
-      // switch-away). Only this client's own bubbles (``pend_`` ids) belong
-      // in the stash — foreign entries are re-served by pending_inputs. Reset
-      // the baseline to the now-current committed texts so a subsequent
-      // navigate-away/back compares against history as it stands after this
-      // bind.
-      const prunedStash = hydratePending
-        ? (() => {
-            const own = snapshotPending.filter((p) => p.tempId.startsWith("pend_"));
-            const next = { ...state.pendingByConversation };
-            if (own.length > 0) next[id] = { messages: own, committedTexts: committedUserTexts };
-            else delete next[id];
-            return next;
-          })()
-        : state.pendingByConversation;
-      const syntheticError: ErrorBlock | null =
-        session.status === "failed" && session.lastTaskError != null && !hasErrorBlock
-          ? {
-              type: "error",
-              ctx: { agent: null, depth: 0, turn: 0, timestamp: 0, responseId: "", itemId: null },
-              message: session.lastTaskError.message,
-              source: "",
-              code: session.lastTaskError.code,
-            }
-          : null;
+      const merged = mergeHistoryIntoBlocks(state, snapshotBlocks);
       return {
-        ...bindingPatch,
-        blocks: syntheticError !== null ? [...allBlocks, syntheticError] : allBlocks,
-        pendingUserMessages: snapshotPending,
-        pendingByConversation: prunedStash,
+        blocks: merged,
         loadingConversation: false,
         hasMoreHistory: page.hasMore,
         oldestItemId,
-        // The window cursor was reset: void any in-flight loadMoreHistory.
-        historyGeneration: state.historyGeneration + 1,
-        // The voided page's stale early-return skips its own flag clear.
+        historyGeneration: incrementGeneration
+          ? state.historyGeneration + 1
+          : state.historyGeneration,
         loadingMoreHistory: false,
-        sessionStatus: session.status,
-        // Re-show "N background tasks still running" after a reload/navigate-back: the
-        // live SSE edge that set this is long gone, so the count rides in on
-        // the snapshot (server keeps it sticky past the trailing PTY `idle`).
-        backgroundTaskCount: session.backgroundTaskCount ?? 0,
-        selectedEffort: effectiveEffort,
-        selectedModel: effectiveModel,
-        // Session truth for the `/model` readout — overrides the snapshot
-        // value spread via `...bindingPatch` so the claude-native sticky
-        // handoff (fired above, silent) shows immediately.
-        sessionModelOverride: effectiveSessionOverride,
-        tokensUsed: session.lastTotalTokens ?? null,
-        sessionCostUsd: session.totalCostUsd ?? null,
-        sessionUsageByModel: session.usageByModel ?? null,
-        todos: (session.todos ?? []) as Array<{
-          content: string;
-          status: "pending" | "in_progress" | "completed";
-          activeForm: string;
-        }>,
       };
     });
+    return true;
+  };
+  const applySessionSnapshot = (session: Session): boolean => {
+    if (get().conversationId !== id) return false;
+    runStickyPrefHandoff(session, id, get);
+    const selections = stickySelectionFromSession(session, get);
+    set((state) => snapshotHydrationPatch(session, state, id, hydratePending, selections));
+    return true;
+  };
+
+  let firstPage: SessionItemsPage | null = null;
+  const cachedHistory = queryClient.getQueryData<SessionItemsPage>(initialHistoryQueryKey(id));
+  if (cachedHistory) {
+    firstPage = cachedHistory;
+    applyHistoryWindow(cachedHistory, true);
+  }
+  if (hydratePending) {
+    try {
+      const freshFirstPage = await queryClient.fetchQuery({
+        queryKey: initialHistoryQueryKey(id),
+        queryFn: () => fetchInitialHistoryFirstPage(id),
+        staleTime: 0,
+        retry: false,
+      });
+      firstPage = freshFirstPage;
+      if (!applyHistoryWindow(freshFirstPage, true)) return;
+    } catch (err) {
+      if (get().conversationId !== id) return;
+      set({
+        loadingConversation: false,
+        conversationLoadError: err instanceof Error ? err : new Error(String(err)),
+      });
+      return;
+    }
+  } else if (!firstPage) {
+    try {
+      const fetchedFirstPage = await queryClient.fetchQuery({
+        queryKey: initialHistoryQueryKey(id),
+        queryFn: () => fetchInitialHistoryFirstPage(id),
+        staleTime: 60_000,
+        retry: false,
+      });
+      firstPage = fetchedFirstPage;
+      if (!applyHistoryWindow(fetchedFirstPage, true)) return;
+    } catch (err) {
+      if (get().conversationId !== id) return;
+      set({
+        loadingConversation: false,
+        conversationLoadError: err instanceof Error ? err : new Error(String(err)),
+      });
+      return;
+    }
+  }
+  if (!firstPage) return;
+
+  if (hydratePending) {
+    try {
+      const expanded = await extendInitialHistoryWindow(id, firstPage);
+      queryClient.setQueryData(initialHistoryQueryKey(id), expanded);
+      if (
+        expanded.items.length !== firstPage.items.length ||
+        expanded.hasMore !== firstPage.hasMore
+      ) {
+        applyHistoryWindow(expanded, true);
+      }
+    } catch (err) {
+      if (get().conversationId !== id) return;
+      console.warn(`bindStream: history expansion failed for ${id}:`, err);
+    }
+  } else {
+    void (async () => {
+      try {
+        const expanded = await extendInitialHistoryWindow(id, firstPage);
+        queryClient.setQueryData(initialHistoryQueryKey(id), expanded);
+        if (
+          expanded.items.length === firstPage.items.length &&
+          expanded.hasMore === firstPage.hasMore
+        ) {
+          return;
+        }
+        applyHistoryWindow(expanded, true);
+      } catch (err) {
+        if (get().conversationId !== id) return;
+        console.warn(`bindStream: background history expansion failed for ${id}:`, err);
+      }
+    })();
+  }
+
+  const cachedSession = queryClient.getQueryData<Session>(["session", id]);
+  if (cachedSession) applySessionSnapshot(cachedSession);
+
+  try {
+    const session = await queryClient.fetchQuery({
+      queryKey: ["session", id],
+      queryFn: () => getSessionSlim(id, { refreshState: true }),
+      staleTime: 0,
+      retry: false,
+    });
+    applySessionSnapshot(session);
   } catch (err) {
     if (get().conversationId !== id) return;
-    set({
-      loadingConversation: false,
-      conversationLoadError: err instanceof Error ? err : new Error(String(err)),
-    });
+    console.warn(`bindStream: snapshot hydration failed for ${id}:`, err);
   }
 }
 


### PR DESCRIPTION
## Related issue

Related to #2079 (session-switch load flow & latency investigation).

## Summary

This rebuilds `ui-perf-improv` on top of current `main` to make sidebar prefetch materially affect perceived switch latency.

- **Cache-first switch path**: `bindStream` consumes prefetched React Query data first (`["session", id]` and `initialHistoryQueryKey(id)`) so transcript paint does not wait for avoidable refetch completion.
- **First-page-first history hydrate**: switch paints from the first `/items` page, then extends to the previous-user boundary asynchronously (or synchronously on hydrate-pending paths that require strict consistency).
- **Background continuation**: deeper initial-history paging continues after first paint and merges safely with live stream blocks.
- **Sidebar prefetch tuning**: keep hover/focus prewarming and tighten trigger timing to improve hover→click cache hit rate.
- **Safety preserved**: stream-first ordering, conversation-id guards, and pending-message reconciliation semantics remain intact.

## Test Plan

- [x] `cd web && npm run type-check`
- [x] `cd web && npx vitest run src/lib/sessionsApi.test.ts`
- [x] `cd web && npx vitest run src/store/chatStore.test.ts`
- [x] Manual sanity on local dev server: switch between cached and uncached sessions and confirm first paint occurs before non-critical follow-up fetches complete

## Perf test

Simulated playwright test scenario: hover 350ms + reaction 180ms before click
Tested against real API on https://omnigents-3272836215725701.aws.databricksapps.com/

What you experience | main (before) | branch (after) | Change
-- | -- | -- | --
Loading spinner disappears | 1558 ms | 954 ms | 39% faster
Chat transcript area appears | 1562 ms | 958 ms | 39% faster
First message bubble visible | 1564 ms | 1000 ms | 36% faster
History loaded from server | 1319 ms | 917 ms | 30% faster

## Demo

https://github.com/user-attachments/assets/d48736b2-dfc7-4846-bd21-5b4ced11acf3

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

- Added unit coverage for first-page fetch + boundary extension helpers in `sessionsApi`.
- Added store coverage for cache-first switch behavior and first-page-then-continue merge flow.
- Existing store regression suite remains green to guard pending-input reconciliation and rapid-switch correctness.

## Changelog

Conversation switching now uses prefetched cache and first-page-first hydration so users see transcript content sooner, while deeper history/session refresh work continues asynchronously.