### PR TITLE
fix(web): keep regex lookbehinds off the boot path for Safari < 16.4

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -203,8 +203,44 @@ function emitPwaAssets(): Plugin {
   };
 }
 
+// Safari < 16.4 cannot parse regex lookbehind; these dependency regexes would
+// otherwise throw there, at module scope during boot or on the first rendered
+// markdown message (#1978):
+// - marked probes lookbehind support with `new RegExp("(?<=1)(?<!1)")` inside
+//   try/catch, but rolldown constant-folds the probe to `true`; route the
+//   constructor through `globalThis` so it stays a runtime check.
+// - remend builds its single-tilde repair regex at module scope with no
+//   guard; fall back to a never-matching regex so the repair no-ops.
+// - mdast-util-gfm-autolink-literal's email regex is constructed when a GFM
+//   message renders; fall back to a never-matching regex (plain-text emails
+//   just don't autolink).
+const LOOKBEHIND_REWRITES: [string, string][] = [
+  ['new RegExp("(?<=1)(?<!1)")', 'new globalThis.RegExp("(?<=1)(?<!1)")'],
+  [
+    'new RegExp("(?<=[\\\\p{L}\\\\p{N}_])~(?!~)(?=[\\\\p{L}\\\\p{N}_])","gu")',
+    '(() => { try { return new globalThis.RegExp("(?<=[\\\\p{L}\\\\p{N}_])~(?!~)(?=[\\\\p{L}\\\\p{N}_])", "gu"); } catch { return /(?!)/gu; } })()',
+  ],
+  [
+    "/(?<=^|\\s|\\p{P}|\\p{S})([-.\\w+]+)@([-\\w]+(?:\\.[-\\w]+)+)/gu",
+    '(() => { try { return new globalThis.RegExp("(?<=^|\\\\s|\\\\p{P}|\\\\p{S})([-.\\\\w+]+)@([-\\\\w]+(?:\\\\.[-\\\\w]+)+)", "gu"); } catch { return /(?!)/gu; } })()',
+  ],
+];
+function safariLookbehindWorkarounds(): Plugin {
+  return {
+    name: "safari-lookbehind-workarounds",
+    transform(code) {
+      let out = code;
+      for (const [from, to] of LOOKBEHIND_REWRITES) {
+        out = out.replaceAll(from, to);
+      }
+      if (out === code) return;
+      return { code: out, map: null };
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [emitPwaAssets(), react(), tailwindcss()],
+  plugins: [emitPwaAssets(), safariLookbehindWorkarounds(), react(), tailwindcss()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
@@ -241,6 +277,8 @@ export default defineConfig({
     proxy: proxyConfig,
   },
   build: {
+    // default baseline is Safari 16.4+; iPadOS 15 can't parse dep regex lookbehinds (#1978)
+    target: ["chrome111", "edge111", "firefox114", "safari15", "ios15"],
     outDir: path.resolve(__dirname, "../omnigent/server/static/web-ui"),
     emptyOutDir: true,
   },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -225,10 +225,23 @@ const LOOKBEHIND_REWRITES: [string, string][] = [
     '(() => { try { return new globalThis.RegExp("(?<=^|\\\\s|\\\\p{P}|\\\\p{S})([-.\\\\w+]+)@([-\\\\w]+(?:\\\\.[-\\\\w]+)+)", "gu"); } catch { return /(?!)/gu; } })()',
   ],
 ];
+const LOOKBEHIND_REWRITE_MODULES = [
+  "/node_modules/marked/",
+  "/node_modules/remend/",
+  "/node_modules/mdast-util-gfm-autolink-literal/",
+];
+
+function isLookbehindRewriteModule(id: string): boolean {
+  const normalizedId = id.replaceAll("\\", "/");
+  return LOOKBEHIND_REWRITE_MODULES.some((modulePath) => normalizedId.includes(modulePath));
+}
+
 function safariLookbehindWorkarounds(): Plugin {
   return {
     name: "safari-lookbehind-workarounds",
-    transform(code) {
+    transform(code, id) {
+      if (!isLookbehindRewriteModule(id)) return;
+
       let out = code;
       for (const [from, to] of LOOKBEHIND_REWRITES) {
         out = out.replaceAll(from, to);


### PR DESCRIPTION
## Related issue

Closes #1978

## Summary

Safari older than 16.4 cannot parse regex lookbehind (`(?<=`/`(?<!`), and three dependencies put one on the web UI's startup path, so iPadOS 15 died before first paint with `SyntaxError: Invalid regular expression: invalid group specifier name` and a blank white page:

- [mdast-util-gfm-autolink-literal](https://github.com/syntax-tree/mdast-util-gfm-autolink-literal) (pulled in by [remark-gfm](https://github.com/remarkjs/remark-gfm)) ships its email autolink regex as a lookbehind regex literal. Regex literals are validated when the module is parsed, so the whole entry chunk fails to parse. This is a known limitation upstream ([remarkjs/remark-gfm#69](https://github.com/remarkjs/remark-gfm/issues/69)).
- [marked](https://github.com/markedjs/marked) actually handles old Safari correctly: it probes `new RegExp("(?<=1)(?<!1)")` inside try/catch and falls back to a lookbehind-free pattern. But rolldown constant-folds the probe to `true` at build time, hard-enabling the lookbehind branch, and marked builds its inline rules at module scope. This looks like an unreported rolldown bug (constant-folding `new RegExp(...)` assumes build-machine regex semantics and defeats runtime feature detection).
- [remend](https://github.com/vercel/streamdown) (streamdown's markdown repair library) constructs its single-tilde repair regex at module scope with no guard.

The fix has two parts, both in `web/vite.config.ts`:

1. `build.target` set to the default baseline (`chrome111`, `edge111`, `firefox114`) with the Safari/iOS floor lowered from 16.4 to 15. The bundler then emits regex literals that use lookbehind as runtime `RegExp()` calls at their original in-function sites, so they are constructed lazily instead of failing chunk parse. It does not rewrite the pattern itself; lookbehind cannot be transpiled away.
2. A small transform plugin with three exact-string rewrites: marked's probe goes through `globalThis.RegExp` so rolldown keeps it a runtime check, and the remend and mdast constructions get a try/catch with a never-matching `/(?!)/gu` fallback. On Safari older than 16.4 this degrades single-tilde repair and plain-text email autolinking to no-ops instead of crashing; on every other browser the try succeeds and behavior is byte-for-byte what it is today.

Bundle size cost: +18 KB total (+0.08%), entry chunk +12 KB (+0.27%).

## Test plan

- Reproduced and verified against Playwright WebKit 16.0, the nearest available engine that lacks lookbehind and throws the exact error string from the report:
  - default build: `pageerror: Invalid regular expression: invalid group specifier name`, `#root` stays empty, blank white page.
  - fixed build: zero page errors, the full app shell renders (sidebar, composer, settings). Remaining console noise is only 404s because the static build was served with no backend.
- Modern Chromium 149 renders the fixed build identically to the default build, no page errors, and marked's restored runtime probe returns `true` there, so it keeps its lookbehind path.
- Scanned all 404 built JS chunks with an acorn tokenizer: lookbehind regex literals went from 3 (entry chunk via mdast, plus two lazy monaco-editor chunks) to 0. All three plugin rewrites verified present in the built output.
- `cd web && npm test`: 208 files, 3689 tests pass. `npx oxlint vite.config.ts` clean. `tsc -b` runs as part of `npm run build`.
- Not proven: no real iPadOS 15.8.8 device was available, WebKit 16.0 headless is the closest proxy. Logged-in flows and streamed markdown rendering on old Safari were not exercised end to end (no backend). Tailwind 4 officially supports Safari 16.4+, so minor CSS degradation on iPadOS 15 is possible even though the shell styled correctly in WebKit 16.0.
- Not included: `web/vite.embed.config.ts` (the embeddable island build) has the same exposure and could take the same two changes; left out to keep this reviewable. Happy to follow up if wanted.

## Demo

Before (default build, WebKit 16.0, the closest engine to Safari older than 16.4): the entry chunk fails to parse, nothing renders.

![blank white page on the default build](https://raw.githubusercontent.com/EnesYilmazcode/omnigent/assets/safari-lookbehind-demo/before-white-page.png)

After (this fix, same engine): the app shell renders with zero page errors.

![app shell renders on the fixed build](https://raw.githubusercontent.com/EnesYilmazcode/omnigent/assets/safari-lookbehind-demo/after-fixed.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified against Playwright WebKit 16.0, the nearest available engine without lookbehind support: the default build reproduces the reported blank page and error string, the fixed build renders the app shell with zero page errors. Full vitest suite passes, and an acorn scan over all built chunks confirms zero lookbehind regex literals remain.

## Changelog

Fix blank white page on Safari/iPadOS older than 16.4 caused by regex lookbehinds on the web UI boot path

