### PR TITLE
fix(host): non-editable install so Landlock-sandboxed imports work

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -328,11 +328,13 @@ RUN set -eu; \
     fi; \
     echo "agy ${AGY_VERSION} pinned (sha256 verified)"
 
-# Preserve /build/ — the venv's editable install .pth files reference
-# /build/omnigent and /build/sdks/* by absolute path. Copying these to
-# /app/ would break the import paths silently.
+# Copy the venv and source tree. The editable install's .pth files reference
+# /build/omnigent and /build/sdks/* -- both denied by the k8s Landlock LSM
+# policy. Re-install without -e so the package bytes land in the venv's
+# site-packages and imports no longer require /build at runtime.
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /build /build
+RUN pip install --no-cache-dir /build
 
 # Sandbox launchers exec commands through `bash -lc`, and Debian's
 # /etc/profile unconditionally resets PATH for login shells — the ENV


### PR DESCRIPTION
## Related issue

Closes #2034

## Summary

The builder stage installs omnigent as an editable package (-e), leaving .pth files in /opt/venv that reference /build/omnigent and /build/sdks/* by absolute path. The k8s Landlock LSM policy denies both paths, so the sandbox process cannot import the package at runtime. Fix: after the COPY steps in the host target, re-install from /build without -e so the package bytes land in /opt/venv/lib/pythonX.X/site-packages and /build is not accessed at import time.

## Test Plan

Manual verification -- the non-editable install bakes package bytes directly into /opt/venv/lib/pythonX.X/site-packages, removing the .pth dependency on /build that the Landlock policy denies.

## Demo

N/A (non-visual change)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

The non-editable install ensures the package is fully baked into the venv's site-packages, removing the .pth dependency on /build that the Landlock policy denies. Landlock policy enforcement requires a k8s environment to verify end-to-end.
