### PR TITLE
Restore-terminal-pane-for-Glitchy-Codex-sessions

### DIFF
--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -224,6 +224,7 @@ function TerminalFirstViewProbe() {
       data-testid="view-probe"
       data-is-terminal-first={ctx.isTerminalFirst ? "true" : "false"}
       data-is-claude-native={ctx.isClaudeNative ? "true" : "false"}
+      data-is-native-wrapper={ctx.isNativeWrapper ? "true" : "false"}
       data-view={ctx.view}
       data-terminals-available={ctx.terminalsAvailable ? "true" : "false"}
       data-terminal-starting-up={ctx.terminalStartingUp ? "true" : "false"}
@@ -345,6 +346,7 @@ function mockConversations(
     id: string;
     permission_level: number | null;
     labels?: Record<string, string>;
+    agent_name?: string | null;
     host_id?: string | null;
     runner_id?: string | null;
   }>,
@@ -361,6 +363,7 @@ function mockConversations(
             updated_at: 0,
             labels: c.labels ?? {},
             permission_level: c.permission_level,
+            agent_name: c.agent_name ?? null,
             host_id: c.host_id ?? null,
             runner_id: c.runner_id ?? null,
           })),
@@ -546,6 +549,51 @@ describe("TerminalFirstContext", () => {
     const regularProbe = screen.getByTestId("view-probe");
     expect(regularProbe).toHaveAttribute("data-is-terminal-first", "false");
     expect(regularProbe).toHaveAttribute("data-is-claude-native", "false");
+  });
+
+  it.each(["glitchy-codex", "polly-codex"])(
+    "flags %s sessions terminal-first without a UI label",
+    (agentName) => {
+      // These custom Codex agents are not created by the direct `omnigent codex`
+      // wrapper, so their rows may lack `omnigent.ui: terminal` even though the
+      // runner owns a Codex terminal resource. The shell should still expose the
+      // existing Chat/Terminal surface, without treating them as native wrappers.
+      mockConversations([
+        {
+          id: "conv_codex_agent",
+          permission_level: null,
+          labels: {},
+          agent_name: agentName,
+        },
+      ]);
+      useTerminalsMock.mockReturnValue({
+        terminals: [{ id: "terminal_codex_main", name: "codex", session: "main", running: true }],
+        isLoading: false,
+        error: null,
+      });
+
+      renderShell("/c/conv_codex_agent");
+      const probe = screen.getByTestId("view-probe");
+      expect(probe).toHaveAttribute("data-is-terminal-first", "true");
+      expect(probe).toHaveAttribute("data-is-native-wrapper", "false");
+      expect(probe).toHaveAttribute("data-terminals-available", "true");
+      expect(screen.queryByTestId("terminals-panel")).toBeNull();
+    },
+  );
+
+  it("keeps ordinary Polly sessions chat-first without a UI label", () => {
+    mockConversations([
+      {
+        id: "conv_polly",
+        permission_level: null,
+        labels: {},
+        agent_name: "polly",
+      },
+    ]);
+
+    renderShell("/c/conv_polly");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-is-terminal-first", "false");
   });
 
   it("flags a child (sub-agent) session terminal-first from the snapshot when the sidebar omits it", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -77,6 +77,14 @@ import { InlineTerminalsSection } from "./InlineTerminalsSection";
 import { WorkspacePanel } from "./WorkspacePanel";
 import type { RightRailTab } from "./railTabs";
 
+const CODEX_ACTIVITY_PANE_AGENT_NAMES = new Set(["glitchy-codex", "polly-codex"]);
+
+function isCodexActivityPaneAgentName(name: string | null | undefined): boolean {
+  return CODEX_ACTIVITY_PANE_AGENT_NAMES.has(
+    name?.trim().toLowerCase().replace(/[\s_]+/g, "-") ?? "",
+  );
+}
+
 /**
  * Top-level layout. The sidebar and right panels are responsive:
  *
@@ -314,7 +322,12 @@ export function AppShell() {
   // this merge an added claude-native agent loses its terminal-first
   // toggle. Snapshot wins on conflict; spreading undefined is a no-op.
   const sessionLabels = { ...activeConv?.labels, ...activeSession?.labels };
-  const terminalFirst = sessionLabels["omnigent.ui"] === "terminal";
+  const activeAgentName = activeSession?.agentName ?? activeConv?.agent_name ?? null;
+  const agentNameImpliesTerminalFirst =
+    (activeConv != null || (activeSession != null && activeSession.parentSessionId == null)) &&
+    isCodexActivityPaneAgentName(activeAgentName);
+  const terminalFirst =
+    sessionLabels["omnigent.ui"] === "terminal" || agentNameImpliesTerminalFirst;
   const isClaudeNative = sessionLabels["omnigent.wrapper"] === "claude-code-native-ui";
   // Native-CLI wrapper of either family. Keys harness behavior gates
   // (composer slash commands, `/model`); terminal-first SDK sessions
@@ -844,8 +857,8 @@ export function AppShell() {
         return next;
       });
     },
-    [setSearchParams],
-  ); // eslint-disable-line react-hooks/exhaustive-deps
+    [clearFileViewerUrl, setSearchParams],
+  );
 
   // Switch the workspace rail's tab. The side effect (closing any open
   // file + its comments + URL) lives here, not in WorkspacePanel, so the


### PR DESCRIPTION
## What changed
- Treat top-level `glitchy-codex` and `polly-codex` sessions as terminal-presentational when they lack `omnigent.ui: terminal`, reusing the existing Chat/Terminal inline terminal surface.
- Keep native-wrapper behavior separate so these custom agents do not inherit native wrapper slash-command/model gating.
- Add AppShell coverage for Glitchy/Polly Codex sessions and ordinary Polly.
- Fix the touched-file hook dependency so the focused lint check is green.

## Verification
- `npx vitest run src/shell/AppShell.test.tsx --reporter=json --outputFile=E:/omnigent-vault/.codex-tmp/appshell-vitest.json` (79 passed)
- `npm --prefix web run type-check`
- `npx oxlint src/shell/AppShell.tsx src/shell/AppShell.test.tsx`
- `git diff --cached --check`

## Notes
- No live Omnigent server was restarted or mutated.
