### PR TITLE
fix(claude-native): mirror launch overrides into settings

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1047,6 +1047,9 @@ def build_hook_settings(
     ap_server_url: str | None = None,
     ap_auth_headers: dict[str, str] | None = None,
     api_key_helper: str | None = None,
+    launch_model: str | None = None,
+    launch_permission_mode: str | None = None,
+    launch_effort: str | None = None,
 ) -> dict[str, Any]:
     """
     Build invocation-local Claude Code hook settings.
@@ -1066,6 +1069,15 @@ def build_hook_settings(
     :param api_key_helper: Optional Claude Code ``apiKeyHelper``
         command from ucode state, e.g. ``"databricks auth token
         --host https://example.databricks.com ..."``.
+    :param launch_model: Effective launch model from ``--model``. Mirrored
+        into the invocation-local settings sidecar so a wrapped Claude Code
+        re-exec that preserves ``--settings`` but rebuilds argv cannot fall
+        back to the user's global default model.
+    :param launch_permission_mode: Effective launch permission mode from
+        ``--permission-mode``. Mirrored into ``permissions.defaultMode``
+        for the same re-exec hardening.
+    :param launch_effort: Effective launch effort from ``--effort``.
+        Mirrored into ``effortLevel`` for restart/re-exec parity.
     :returns: JSON-serializable Claude settings fragment.
     """
     python = python_executable or sys.executable
@@ -1251,6 +1263,12 @@ def build_hook_settings(
         # prompts, since both fire UserPromptSubmit.
         hooks["UserPromptSubmit"].append({"hooks": [evaluate_policy_hook]})
     settings: dict[str, Any] = {"hooks": hooks}
+    if launch_model:
+        settings["model"] = launch_model
+    if launch_permission_mode:
+        settings["permissions"] = {"defaultMode": launch_permission_mode}
+    if launch_effort and launch_effort in CLAUDE_EFFORTS:
+        settings["effortLevel"] = launch_effort
     if api_key_helper:
         settings["apiKeyHelper"] = api_key_helper
     # Override Claude Code's statusLine so we receive its stdin (the
@@ -1347,6 +1365,9 @@ def augment_claude_args(
         ap_server_url=ap_server_url,
         ap_auth_headers=ap_auth_headers,
         api_key_helper=api_key_helper,
+        launch_model=_arg_value(claude_args, "--model"),
+        launch_permission_mode=_arg_value(claude_args, "--permission-mode"),
+        launch_effort=_arg_value(claude_args, "--effort"),
     )
     args = _merge_disallowed_tools(list(claude_args), _OMNIGENT_DISALLOWED_TOOLS)
     args.extend(
@@ -1365,6 +1386,32 @@ def augment_claude_args(
         )
     )
     return args
+
+
+def _arg_value(args: tuple[str, ...], flag: str) -> str | None:
+    """Return the effective CLI flag value from ``args``.
+
+    Supports both ``--flag value`` and ``--flag=value`` spellings. When a
+    flag appears more than once, the last valid occurrence wins, matching the
+    usual CLI precedence for repeated long options.
+
+    :param args: Claude CLI args, e.g. ``("--model", "sonnet")``.
+    :param flag: Long flag to read, e.g. ``"--model"``.
+    :returns: The flag value, or ``None`` when absent/empty.
+    """
+    joined_prefix = f"{flag}="
+    value: str | None = None
+    for idx, arg in enumerate(args):
+        if arg.startswith(joined_prefix):
+            candidate = arg[len(joined_prefix) :]
+            if candidate:
+                value = candidate
+            continue
+        if arg == flag and idx + 1 < len(args):
+            candidate = args[idx + 1]
+            if candidate and not candidate.startswith("--"):
+                value = candidate
+    return value
 
 
 def _merge_disallowed_tools(args: list[str], extra: tuple[str, ...]) -> list[str]:

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2016,6 +2016,74 @@ def test_augment_claude_args_injects_mcp_and_hooks(tmp_path: Path) -> None:
     assert "--disallowedTools" not in args
 
 
+def test_augment_claude_args_mirrors_launch_overrides_into_settings(
+    tmp_path: Path,
+) -> None:
+    """
+    Launch-time overrides are duplicated into the ``--settings`` sidecar.
+
+    Claude Code has had restart/re-exec paths that preserve ``--settings``
+    while rebuilding argv without ``--model`` / ``--effort`` /
+    ``--permission-mode``. Mirroring the same effective values into the
+    sidecar prevents a restarted wrapped CLI from falling back to the user's
+    global ``~/.claude/settings.json`` and diverging from the Omnigent
+    session pill.
+    """
+    args = augment_claude_args(
+        ("--model", "claude-fable-5", "--permission-mode", "auto", "--effort", "xhigh"),
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+    )
+
+    settings = json.loads(args[args.index("--settings") + 1])
+    assert settings["model"] == "claude-fable-5"
+    assert settings["permissions"] == {"defaultMode": "auto"}
+    assert settings["effortLevel"] == "xhigh"
+
+
+def test_augment_claude_args_mirrors_joined_model_arg_into_settings(
+    tmp_path: Path,
+) -> None:
+    """The ``--model=<id>`` spelling is mirrored just like ``--model <id>``."""
+    args = augment_claude_args(
+        ("--model=claude-sonnet-5",),
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+    )
+
+    settings = json.loads(args[args.index("--settings") + 1])
+    assert settings["model"] == "claude-sonnet-5"
+    assert "permissions" not in settings
+    assert "effortLevel" not in settings
+
+
+def test_augment_claude_args_uses_last_repeated_launch_override(
+    tmp_path: Path,
+) -> None:
+    """Repeated launch override flags mirror the same last-value-wins semantics."""
+    args = augment_claude_args(
+        (
+            "--model",
+            "claude-old",
+            "--model=claude-new",
+            "--permission-mode",
+            "default",
+            "--permission-mode",
+            "auto",
+            "--effort=low",
+            "--effort",
+            "high",
+        ),
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+    )
+
+    settings = json.loads(args[args.index("--settings") + 1])
+    assert settings["model"] == "claude-new"
+    assert settings["permissions"] == {"defaultMode": "auto"}
+    assert settings["effortLevel"] == "high"
+
+
 def test_augment_claude_args_merges_user_disallowed_tools(tmp_path: Path) -> None:
     """
     A user-supplied ``--disallowedTools`` passes through unchanged.


### PR DESCRIPTION
## Related issue

Refs #2062

## Summary

- Mirror claude-native launch overrides into the invocation-local `--settings` sidecar: `model`, `permissions.defaultMode`, and `effortLevel`.
- Keep the existing CLI flags in place for initial launch, but make restarts/re-execs that preserve `--settings` keep the same effective defaults instead of falling back to the user's global Claude Code settings.
- Add regression coverage for `--model <id>`, `--model=<id>`, and repeated launch override flags using last-value-wins semantics.

## Test Plan

```bash
uv run ruff check omnigent/claude_native_bridge.py tests/test_claude_native_bridge.py
uv run ruff format --check omnigent/claude_native_bridge.py tests/test_claude_native_bridge.py
uv run pytest tests/test_claude_native_bridge.py::test_augment_claude_args_mirrors_launch_overrides_into_settings \
  tests/test_claude_native_bridge.py::test_augment_claude_args_mirrors_joined_model_arg_into_settings \
  tests/test_claude_native_bridge.py::test_augment_claude_args_uses_last_repeated_launch_override \
  tests/test_claude_native_bridge.py::test_augment_claude_args_injects_mcp_and_hooks \
  tests/runner/test_app_claude_native_launch_args.py -q
uv run pytest tests/test_claude_native_bridge.py tests/runner/test_app_claude_native_launch_args.py -q
uv run pre-commit run --all-files
```

## Demo

This is backend/launch-argument hardening rather than a UI change. The terminal snapshot below shows the launch path mirroring model, permission mode, and effort overrides into the invocation-local Claude Code `--settings` sidecar:

![PR #2116 terminal demo](https://gist.githubusercontent.com/roian6/dbe8e8a5433386a6b65738deeec78464/raw/ab33b0ab24ec41550ee4e10840ace2665d511dc4/pr2116_demo_terminal.svg)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover the launch-argument to `--settings` sidecar mapping, including separate-value flags, joined `--model=<id>` flags, and repeated override flags. I did not manually reproduce the historical Claude Code 2.1.170 fullscreen re-exec behavior; this is a targeted hardening patch for the preserved-sidecar path described in #2062.

## Changelog

Keep claude-native model, permission mode, and effort overrides stable across wrapped Claude Code restarts that preserve the settings sidecar.
