### PR TITLE
Add syntax theme picker for Shiki and Monaco

### DIFF
--- a/web/src/components/ai-elements/code-block.test.tsx
+++ b/web/src/components/ai-elements/code-block.test.tsx
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeCodeThemeDark, writeCodeThemeLight } from "@/lib/codeThemePreferences";
+
+const createHighlighterMock = vi.fn(async ({ themes }: { themes: string[] }) => ({
+  getLoadedLanguages: () => ["typescript"],
+  codeToTokens: vi.fn(() => ({
+    bg: "#111111",
+    fg: "#eeeeee",
+    tokens: [[{ color: "#fff", content: "x" }]],
+  })),
+  themes,
+}));
+
+vi.mock("shiki", () => ({
+  createHighlighter: (options: { themes: string[] }) => createHighlighterMock(options),
+}));
+
+describe("highlightCode theme selection", () => {
+  afterEach(() => {
+    vi.resetModules();
+    createHighlighterMock.mockClear();
+    localStorage.clear();
+  });
+
+  it("loads the selected light and dark themes into the highlighter", async () => {
+    writeCodeThemeLight("solarized-light");
+    writeCodeThemeDark("nord");
+
+    const { highlightCode } = await import("@/components/ai-elements/code-block");
+
+    await new Promise<void>((resolve) => {
+      highlightCode("const x = 1", "typescript", () => resolve());
+    });
+
+    expect(createHighlighterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        themes: ["solarized-light", "nord"],
+      }),
+    );
+  });
+});

--- a/web/src/components/ai-elements/code-block.tsx
+++ b/web/src/components/ai-elements/code-block.tsx
@@ -22,6 +22,12 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  readCodeThemeDark,
+  readCodeThemeLight,
+  subscribeCodeThemes,
+  useCodeThemeRevision,
+} from "@/lib/codeThemePreferences";
 import type { BundledLanguage, BundledTheme, HighlighterGeneric, ThemedToken } from "shiki";
 import { createHighlighter } from "shiki";
 
@@ -138,25 +144,35 @@ const subscribers = new Map<string, Set<(result: TokenizedCode) => void>>();
 const getTokensCacheKey = (code: string, language: BundledLanguage) => {
   const start = code.slice(0, 100);
   const end = code.length > 100 ? code.slice(-100) : "";
-  return `${language}:${code.length}:${start}:${end}`;
+  const light = readCodeThemeLight();
+  const dark = readCodeThemeDark();
+  return `${language}:${light}:${dark}:${code.length}:${start}:${end}`;
 };
 
 const getHighlighter = (
   language: BundledLanguage,
 ): Promise<HighlighterGeneric<BundledLanguage, BundledTheme>> => {
-  const cached = highlighterCache.get(language);
+  const light = readCodeThemeLight();
+  const dark = readCodeThemeDark();
+  const cacheKey = `${language}:${light}:${dark}`;
+  const cached = highlighterCache.get(cacheKey);
   if (cached) {
     return cached;
   }
 
   const highlighterPromise = createHighlighter({
     langs: [language],
-    themes: ["github-light", "github-dark"],
+    themes: [light, dark],
   });
 
-  highlighterCache.set(language, highlighterPromise);
+  highlighterCache.set(cacheKey, highlighterPromise);
   return highlighterPromise;
 };
+
+subscribeCodeThemes(() => {
+  highlighterCache.clear();
+  tokensCache.clear();
+});
 
 // Create raw tokens for immediate display while highlighting loads
 const createRawTokens = (code: string): TokenizedCode => ({
@@ -207,8 +223,8 @@ export const highlightCode = (
       const result = highlighter.codeToTokens(code, {
         lang: langToUse,
         themes: {
-          dark: "github-dark",
-          light: "github-light",
+          dark: readCodeThemeDark(),
+          light: readCodeThemeLight(),
         },
       });
 
@@ -364,22 +380,28 @@ export const CodeBlockContent = ({
   language: BundledLanguage;
   showLineNumbers?: boolean;
 }) => {
+  const themeRevision = useCodeThemeRevision();
+
   // Memoized raw tokens for immediate display
   const rawTokens = useMemo(() => createRawTokens(code), [code]);
 
   // Synchronous cache lookup — avoids setState in effect for cached results
-  const syncTokens = useMemo(
-    () => highlightCode(code, language) ?? rawTokens,
-    [code, language, rawTokens],
-  );
+  const syncTokens = useMemo(() => {
+    void themeRevision;
+    return highlightCode(code, language) ?? rawTokens;
+  }, [code, language, rawTokens, themeRevision]);
 
   // Async highlighting result (populated after shiki loads)
   const [asyncTokens, setAsyncTokens] = useState<TokenizedCode | null>(null);
-  const asyncKeyRef = useRef({ code, language });
+  const asyncKeyRef = useRef({ code, language, themeRevision });
 
   // Invalidate stale async tokens synchronously during render
-  if (asyncKeyRef.current.code !== code || asyncKeyRef.current.language !== language) {
-    asyncKeyRef.current = { code, language };
+  if (
+    asyncKeyRef.current.code !== code ||
+    asyncKeyRef.current.language !== language ||
+    asyncKeyRef.current.themeRevision !== themeRevision
+  ) {
+    asyncKeyRef.current = { code, language, themeRevision };
     setAsyncTokens(null);
   }
 
@@ -395,7 +417,7 @@ export const CodeBlockContent = ({
     return () => {
       cancelled = true;
     };
-  }, [code, language]);
+  }, [code, language, themeRevision]);
 
   const tokenized = asyncTokens ?? syncTokens;
 

--- a/web/src/lib/codeThemePreferences.test.ts
+++ b/web/src/lib/codeThemePreferences.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CODE_THEME_DARK_DEFAULT,
+  CODE_THEME_LIGHT_DEFAULT,
+  readCodeThemeDark,
+  readCodeThemeLight,
+  subscribeCodeThemes,
+  writeCodeThemeDark,
+  writeCodeThemeLight,
+} from "./codeThemePreferences";
+
+const STORAGE_KEY_LIGHT = "omnigent:code-theme-light";
+const STORAGE_KEY_DARK = "omnigent:code-theme-dark";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("codeThemePreferences", () => {
+  it("returns defaults when nothing is stored", () => {
+    expect(readCodeThemeLight()).toBe(CODE_THEME_LIGHT_DEFAULT);
+    expect(readCodeThemeDark()).toBe(CODE_THEME_DARK_DEFAULT);
+  });
+
+  it("round-trips valid theme ids", () => {
+    writeCodeThemeLight("nord");
+    writeCodeThemeDark("dracula");
+    expect(readCodeThemeLight()).toBe("nord");
+    expect(readCodeThemeDark()).toBe("dracula");
+    expect(localStorage.getItem(STORAGE_KEY_LIGHT)).toBe(JSON.stringify("nord"));
+    expect(localStorage.getItem(STORAGE_KEY_DARK)).toBe(JSON.stringify("dracula"));
+  });
+
+  it("falls back to defaults for unknown or malformed values", () => {
+    localStorage.setItem(STORAGE_KEY_LIGHT, JSON.stringify("not-a-theme"));
+    localStorage.setItem(STORAGE_KEY_DARK, "}{bad json");
+    expect(readCodeThemeLight()).toBe(CODE_THEME_LIGHT_DEFAULT);
+    expect(readCodeThemeDark()).toBe(CODE_THEME_DARK_DEFAULT);
+  });
+
+  it("clamps invalid writes to the default for that slot", () => {
+    writeCodeThemeLight("bogus" as "nord");
+    writeCodeThemeDark("bogus" as "nord");
+    expect(readCodeThemeLight()).toBe(CODE_THEME_LIGHT_DEFAULT);
+    expect(readCodeThemeDark()).toBe(CODE_THEME_DARK_DEFAULT);
+  });
+
+  it("notifies subscribers when either theme changes", () => {
+    const listener = vi.fn();
+    const unsub = subscribeCodeThemes(listener);
+    writeCodeThemeLight("monokai");
+    expect(listener).toHaveBeenCalledTimes(1);
+    writeCodeThemeDark("one-dark-pro");
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsub();
+    writeCodeThemeLight("solarized-light");
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/lib/codeThemePreferences.ts
+++ b/web/src/lib/codeThemePreferences.ts
@@ -1,0 +1,139 @@
+// Persisted syntax-highlighting theme preferences for Shiki and Monaco.
+//
+// Independent from the app's light/dark UI mode: the user picks a light theme
+// and a dark theme from the Shiki bundled set, and the active one follows the
+// resolved palette. Subscribers are notified on change so open code viewers
+// re-highlight and Monaco editors call setTheme without a reload.
+
+import { useEffect, useState } from "react";
+import type { BundledTheme } from "shiki";
+
+const STORAGE_KEY_LIGHT = "omnigent:code-theme-light";
+const STORAGE_KEY_DARK = "omnigent:code-theme-dark";
+
+export const CODE_THEME_LIGHT_DEFAULT = "github-light" satisfies BundledTheme;
+export const CODE_THEME_DARK_DEFAULT = "github-dark" satisfies BundledTheme;
+
+/** Curated Shiki bundled theme ids exposed in Settings → Appearance. */
+export const CODE_THEME_ALLOWLIST = [
+  "github-light",
+  "github-dark",
+  "one-dark-pro",
+  "dracula",
+  "nord",
+  "monokai",
+  "solarized-light",
+  "solarized-dark",
+  "catppuccin-latte",
+  "catppuccin-mocha",
+] as const satisfies readonly BundledTheme[];
+
+export type CodeThemeId = (typeof CODE_THEME_ALLOWLIST)[number];
+
+const allowlistSet = new Set<string>(CODE_THEME_ALLOWLIST);
+
+/** Editor / read-only viewer background per theme (Shiki `bg` defaults). */
+export const CODE_THEME_BACKGROUNDS: Record<CodeThemeId, string> = {
+  "github-light": "#ffffff",
+  "github-dark": "#0d1117",
+  "one-dark-pro": "#282c34",
+  dracula: "#282a36",
+  nord: "#2e3440",
+  monokai: "#272822",
+  "solarized-light": "#fdf6e3",
+  "solarized-dark": "#002b36",
+  "catppuccin-latte": "#eff1f5",
+  "catppuccin-mocha": "#1e1e2e",
+};
+
+const CODE_THEME_LABELS: Record<CodeThemeId, string> = {
+  "github-light": "GitHub Light",
+  "github-dark": "GitHub Dark",
+  "one-dark-pro": "One Dark Pro",
+  dracula: "Dracula",
+  nord: "Nord",
+  monokai: "Monokai",
+  "solarized-light": "Solarized Light",
+  "solarized-dark": "Solarized Dark",
+  "catppuccin-latte": "Catppuccin Latte",
+  "catppuccin-mocha": "Catppuccin Mocha",
+};
+
+/** Human-readable label for a theme id in the Settings dropdown. */
+export function codeThemeLabel(id: CodeThemeId): string {
+  return CODE_THEME_LABELS[id];
+}
+
+function isAllowedTheme(value: unknown): value is CodeThemeId {
+  return typeof value === "string" && allowlistSet.has(value);
+}
+
+function readStoredTheme(key: string, fallback: CodeThemeId): CodeThemeId {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    const parsed: unknown = JSON.parse(raw);
+    return isAllowedTheme(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeStoredTheme(key: string, id: CodeThemeId): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(id));
+  } catch {
+    // localStorage quota or access errors shouldn't break the app.
+  }
+}
+
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Subscribe to light/dark syntax theme changes. Returns an unsubscribe fn. */
+export function subscribeCodeThemes(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Bump when either syntax theme changes — for React components. */
+export function useCodeThemeRevision(): number {
+  const [revision, setRevision] = useState(0);
+  useEffect(() => subscribeCodeThemes(() => setRevision((r) => r + 1)), []);
+  return revision;
+}
+
+export function readCodeThemeLight(): CodeThemeId {
+  return readStoredTheme(STORAGE_KEY_LIGHT, CODE_THEME_LIGHT_DEFAULT);
+}
+
+export function readCodeThemeDark(): CodeThemeId {
+  return readStoredTheme(STORAGE_KEY_DARK, CODE_THEME_DARK_DEFAULT);
+}
+
+export function writeCodeThemeLight(id: CodeThemeId): void {
+  const normalized = isAllowedTheme(id) ? id : CODE_THEME_LIGHT_DEFAULT;
+  writeStoredTheme(STORAGE_KEY_LIGHT, normalized);
+  emit();
+}
+
+export function writeCodeThemeDark(id: CodeThemeId): void {
+  const normalized = isAllowedTheme(id) ? id : CODE_THEME_DARK_DEFAULT;
+  writeStoredTheme(STORAGE_KEY_DARK, normalized);
+  emit();
+}
+
+/** Background color for the active syntax theme given a resolved UI palette. */
+export function codeThemeBackgroundForMode(resolved: "light" | "dark"): string {
+  const id = resolved === "dark" ? readCodeThemeDark() : readCodeThemeLight();
+  return CODE_THEME_BACKGROUNDS[id];
+}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -167,6 +167,14 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("ui-font-family-reset")).not.toBeDisabled();
   });
 
+  it("persists a chosen dark syntax theme from the Appearance dropdown", async () => {
+    localStorage.clear();
+    renderPage("/settings/appearance");
+    fireEvent.click(screen.getByTestId("code-theme-dark"));
+    fireEvent.click(await screen.findByRole("option", { name: "Dracula" }));
+    expect(localStorage.getItem("omnigent:code-theme-dark")).toBe(JSON.stringify("dracula"));
+  });
+
   it("reset restores the system default font family", () => {
     localStorage.setItem("omnigent:ui-font-family", JSON.stringify("Georgia"));
     renderPage("/settings/appearance");

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -38,6 +38,13 @@ import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -72,6 +79,15 @@ import {
   writeUiFontFamily,
   writeUiFontSizePx,
 } from "@/lib/uiFontPreferences";
+import {
+  CODE_THEME_ALLOWLIST,
+  type CodeThemeId,
+  codeThemeLabel,
+  readCodeThemeDark,
+  readCodeThemeLight,
+  writeCodeThemeDark,
+  writeCodeThemeLight,
+} from "@/lib/codeThemePreferences";
 import { useIsEmbedded } from "@/lib/embedded";
 import { type CliStatus, getCliStatus, isElectronShell, resetCliPath } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
@@ -123,6 +139,82 @@ export function SettingsPage() {
       {section === "archived" && <ArchivedSection />}
       {section === "cli" && isElectronShell() && <LocalCliSection />}
     </PageScroll>
+  );
+}
+
+/**
+ * Syntax-highlighting theme pickers for Shiki read-only blocks and Monaco.
+ * Light and dark choices are independent from the UI palette: the active syntax
+ * theme follows whichever mode is resolved.
+ */
+function SyntaxThemeControls() {
+  const [lightTheme, setLightTheme] = useState<CodeThemeId>(() => readCodeThemeLight());
+  const [darkTheme, setDarkTheme] = useState<CodeThemeId>(() => readCodeThemeDark());
+
+  const onLightChange = useCallback((value: string) => {
+    const next = value as CodeThemeId;
+    setLightTheme(next);
+    writeCodeThemeLight(next);
+  }, []);
+
+  const onDarkChange = useCallback((value: string) => {
+    const next = value as CodeThemeId;
+    setDarkTheme(next);
+    writeCodeThemeDark(next);
+  }, []);
+
+  return (
+    <>
+      <SyntaxThemeRow
+        label="Light syntax theme"
+        description="Colors for code blocks and editors when the UI is in light mode."
+        testId="code-theme-light"
+        value={lightTheme}
+        onChange={onLightChange}
+      />
+      <SyntaxThemeRow
+        label="Dark syntax theme"
+        description="Colors for code blocks and editors when the UI is in dark mode."
+        testId="code-theme-dark"
+        value={darkTheme}
+        onChange={onDarkChange}
+      />
+    </>
+  );
+}
+
+function SyntaxThemeRow({
+  label,
+  description,
+  testId,
+  value,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  testId: string;
+  value: CodeThemeId;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="text-sm font-medium">{label}</span>
+        <span className="text-sm text-muted-foreground">{description}</span>
+      </div>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="h-9 w-56 shrink-0" data-testid={testId}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {CODE_THEME_ALLOWLIST.map((id) => (
+            <SelectItem key={id} value={id}>
+              {codeThemeLabel(id)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
   );
 }
 
@@ -198,6 +290,8 @@ function AppearanceSection() {
         <UiFontSizeControl />
 
         <UiFontFamilyControl />
+
+        <SyntaxThemeControls />
       </div>
     </Section>
   );

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -29,6 +29,9 @@ import {
   SearchIcon,
   XIcon,
 } from "lucide-react";
+import { useTheme } from "next-themes";
+import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import { codeThemeBackgroundForMode, useCodeThemeRevision } from "@/lib/codeThemePreferences";
 import { useChatStore } from "@/store/chatStore";
 import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
 import type { BundledLanguage, ThemedToken } from "shiki";
@@ -277,6 +280,12 @@ export function CodeViewer({
   pendingBodyRef,
 }: CodeViewerProps) {
   const canEdit = useCanEdit(conversationId);
+  const { resolvedTheme } = useTheme();
+  const themeRevision = useCodeThemeRevision();
+  const codeBackground = useMemo(() => {
+    void themeRevision;
+    return codeThemeBackgroundForMode(normalizeResolvedTheme(resolvedTheme));
+  }, [resolvedTheme, themeRevision]);
 
   const [tokenLines, setTokenLines] = useState<ThemedToken[][] | null>(null);
 
@@ -348,7 +357,7 @@ export function CodeViewer({
     return () => {
       cancelled = true;
     };
-  }, [content, lang, viewMode, showMonaco]);
+  }, [content, lang, viewMode, showMonaco, themeRevision]);
 
   // Scroll to the line containing the active selection when it changes
   // (e.g. user clicked a comment in the panel).
@@ -723,8 +732,11 @@ export function CodeViewer({
         </div>
       )}
 
-      {/* GitHub Light/Dark backgrounds match the shiki themes used by highlightCode */}
-      <div ref={codeContainerRef} className="font-mono text-xs bg-white dark:bg-[#0d1117]">
+      <div
+        ref={codeContainerRef}
+        className="font-mono text-xs"
+        style={{ backgroundColor: codeBackground }}
+      >
         {rawLines.map((rawLine, idx) => {
           const lineNum = idx + 1;
           const isMatchLine =

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -20,6 +20,7 @@ import { Editor, type EditorProps, type OnChange, type OnMount } from "@monaco-e
 import { useTheme } from "next-themes";
 import { AlertTriangleIcon, MessageSquareOffIcon } from "lucide-react";
 import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import { useCodeThemeRevision } from "@/lib/codeThemePreferences";
 import type { Comment } from "@/hooks/useComments";
 import { useCanEdit } from "@/hooks/usePermissions";
 import { detectLang, type ActiveSelection, type SaveStatus } from "./codeViewerHelpers";
@@ -31,6 +32,7 @@ import { useEditorAutoSave } from "./useEditorAutoSave";
 import {
   ensureLanguage,
   ensureMonacoReady,
+  monaco,
   monacoLanguageId,
   resolvedThemeToMonaco,
 } from "./monacoSetup";
@@ -196,9 +198,13 @@ function MonacoCodeEditorInner({
 }: InnerProps) {
   const lang = detectLang(path);
   const { resolvedTheme } = useTheme();
-  const monacoTheme = resolvedThemeToMonaco(normalizeResolvedTheme(resolvedTheme));
+  const themeRevision = useCodeThemeRevision();
+  const monacoTheme = useMemo(() => {
+    void themeRevision;
+    return resolvedThemeToMonaco(normalizeResolvedTheme(resolvedTheme));
+  }, [resolvedTheme, themeRevision]);
 
-  // Gate rendering until Shiki has registered the github themes + this file's
+  // Gate rendering until Shiki has registered the selected themes + this file's
   // grammar, so the editor never flashes Monaco's default 'vs' theme.
   const [ready, setReady] = useState(false);
   const [loadError, setLoadError] = useState(false);
@@ -222,6 +228,11 @@ function MonacoCodeEditorInner({
       cancelled = true;
     };
   }, [lang]);
+
+  useEffect(() => {
+    if (!ready) return;
+    monaco.editor.setTheme(monacoTheme);
+  }, [monacoTheme, ready]);
 
   const editorInstanceRef = useRef<CodeEditorInstance | null>(null);
   // True once the editor instance exists; gates the comment-layer wiring.

--- a/web/src/shell/MonacoDiffViewer.tsx
+++ b/web/src/shell/MonacoDiffViewer.tsx
@@ -10,12 +10,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DiffEditor, type DiffEditorProps, type DiffOnMount } from "@monaco-editor/react";
 import { useTheme } from "next-themes";
 import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import { useCodeThemeRevision } from "@/lib/codeThemePreferences";
 import type { Comment } from "@/hooks/useComments";
 import { useCanEdit } from "@/hooks/usePermissions";
 import { detectLang, type ActiveSelection } from "./codeViewerHelpers";
 import {
   ensureLanguage,
   ensureMonacoReady,
+  monaco,
   monacoLanguageId,
   resolvedThemeToMonaco,
 } from "./monacoSetup";
@@ -65,9 +67,13 @@ export function MonacoDiffViewer({
   const canEdit = useCanEdit(conversationId);
   const lang = detectLang(path);
   const { resolvedTheme } = useTheme();
-  const monacoTheme = resolvedThemeToMonaco(normalizeResolvedTheme(resolvedTheme));
+  const themeRevision = useCodeThemeRevision();
+  const monacoTheme = useMemo(() => {
+    void themeRevision;
+    return resolvedThemeToMonaco(normalizeResolvedTheme(resolvedTheme));
+  }, [resolvedTheme, themeRevision]);
 
-  // Gate rendering until Shiki has registered the github themes + this file's
+  // Gate rendering until Shiki has registered the selected themes + this file's
   // grammar (so the diff never flashes Monaco's default 'vs' theme); surface an
   // error rather than an unhandled rejection + permanent spinner on failure.
   const [ready, setReady] = useState(false);
@@ -90,6 +96,11 @@ export function MonacoDiffViewer({
       cancelled = true;
     };
   }, [lang]);
+
+  useEffect(() => {
+    if (!ready) return;
+    monaco.editor.setTheme(monacoTheme);
+  }, [monacoTheme, ready]);
 
   // The modified-side code editor, obtained from the diff editor on mount.
   const modifiedEditorRef = useRef<CodeEditorInstance | null>(null);

--- a/web/src/shell/monacoSetup.ts
+++ b/web/src/shell/monacoSetup.ts
@@ -6,10 +6,11 @@
 //      network-restricted deployments, so @monaco-editor/react's default
 //      CDN AMD loader would fail; loader.config({ monaco }) points it at the
 //      bundled ESM instance instead.
-//   2. Drive tokenization and theming from Shiki (github-light/github-dark)
-//      via @shikijs/monaco so editor colors match the read-only Shiki views
-//      and chat code blocks. Monaco's own Monarch tokenizers and language
-//      services are left unused.
+//   2. Drive tokenization and theming from Shiki via @shikijs/monaco so editor
+//      colors match the read-only Shiki views and chat code blocks. The active
+//      light/dark syntax themes come from codeThemePreferences (user-chosen,
+//      independent of the UI palette). Monaco's own Monarch tokenizers and
+//      language services are left unused.
 //
 // Importing this module is the trigger that sets MonacoEnvironment and points
 // @monaco-editor/react at the bundled instance. It lives behind the lazy
@@ -33,10 +34,13 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 // missing worker). This keeps grammars out while still giving real editor UX.
 import "monaco-editor/esm/vs/editor/edcore.main.js";
 import type { ResolvedThemeMode } from "@/components/theme/themeMode";
+import {
+  readCodeThemeDark,
+  readCodeThemeLight,
+  subscribeCodeThemes,
+} from "@/lib/codeThemePreferences";
 
-// Shiki theme ids registered into Monaco; identical to the read-only viewer.
-const LIGHT_THEME = "github-light";
-const DARK_THEME = "github-dark";
+let registeredThemes: { light: string; dark: string } | null = null;
 
 // Monaco reads this global to construct its workers. The global is declared by
 // monaco's own types (editor.api.d.ts), so no augmentation is needed. Set once
@@ -76,22 +80,20 @@ export { monaco };
 export type MonacoModule = typeof monaco;
 
 /**
- * Create the Shiki highlighter (github light + dark) once and register its
- * themes with Monaco. Idempotent — repeated calls return the same promise, so
- * every editor instance shares one highlighter.
+ * Create the Shiki highlighter (selected light + dark themes) once and register
+ * its themes with Monaco. Idempotent — repeated calls return the same promise,
+ * so every editor instance shares one highlighter.
  *
  * @returns The shared Shiki highlighter instance, ready to tokenize.
  */
 export function ensureMonacoReady(): Promise<ShikiHighlighter> {
   if (!readyPromise) {
     readyPromise = createHighlighter({
-      themes: [LIGHT_THEME, DARK_THEME],
+      themes: [readCodeThemeLight(), readCodeThemeDark()],
       langs: [],
     })
-      .then((hl) => {
-        // Registers the github themes under their ids so the editor's `theme`
-        // option and monaco.editor.setTheme resolve them.
-        shikiToMonaco(hl, monaco);
+      .then(async (hl) => {
+        await syncMonacoThemes(hl);
         return hl;
       })
       .catch((err: unknown) => {
@@ -101,6 +103,29 @@ export function ensureMonacoReady(): Promise<ShikiHighlighter> {
       });
   }
   return readyPromise;
+}
+
+async function syncMonacoThemes(hl: ShikiHighlighter): Promise<void> {
+  const light = readCodeThemeLight();
+  const dark = readCodeThemeDark();
+  if (registeredThemes?.light === light && registeredThemes?.dark === dark) {
+    return;
+  }
+  await Promise.all([hl.loadTheme(light), hl.loadTheme(dark)]);
+  shikiToMonaco(hl, monaco);
+  registeredThemes = { light, dark };
+  monaco.editor.setTheme(resolvedThemeToMonaco(resolveDocumentTheme()));
+}
+
+function resolveDocumentTheme(): ResolvedThemeMode {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+if (typeof window !== "undefined") {
+  subscribeCodeThemes(() => {
+    void ensureMonacoReady().then((hl) => syncMonacoThemes(hl));
+  });
 }
 
 /**
@@ -150,5 +175,5 @@ export function monacoLanguageId(lang: BundledLanguage | "text"): string {
  * @returns The registered Monaco theme id, e.g. `"github-dark"`.
  */
 export function resolvedThemeToMonaco(resolved: ResolvedThemeMode): string {
-  return resolved === "dark" ? DARK_THEME : LIGHT_THEME;
+  return resolved === "dark" ? readCodeThemeDark() : readCodeThemeLight();
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add persisted light/dark **syntax highlight** theme preferences (`codeThemePreferences.ts`), separate from the UI light/dark mode picker.
- Wire Shiki read-only highlighting (`code-block.tsx`, `CodeViewer`) and Monaco editor/diff (`monacoSetup.ts`) to load the user's chosen themes and refresh live when the selection changes.
- Add **Light syntax theme** / **Dark syntax theme** dropdowns to Settings → Appearance, matching the font control row layout.

**Follow-up (out of scope for v1):** a full UI color-theme engine or accent-color customization — this PR only covers code/syntax highlighting.

## Test Plan

- [x] `npm run type-check` (web/)
- [x] `npm run test -- src/lib/codeThemePreferences.test.ts src/pages/SettingsPage.test.tsx src/components/ai-elements/code-block.test.tsx`
- [x] `npm run build` (web/)
- [x] Prettier + oxlint on changed files
- [ ] Manual: open Settings → Appearance, change dark syntax theme → confirm an open Monaco editor and a markdown code block re-color live
- [ ] Manual: reload and confirm the choice persists; flip UI light/dark mode and confirm the corresponding syntax theme is used

## Demo

N/A (manual screen recording recommended before merge — see Test Plan checkboxes above)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover preference persistence/validation/subscribe, Settings dropdown persistence, and that `highlightCode` loads the selected Shiki theme pair. Live Monaco + markdown re-highlight behavior is left for manual verification (see Test Plan).

## Changelog

Choose separate light and dark syntax-highlight themes for code blocks and editors in Settings → Appearance.