### PR TITLE
feat(web): keymap registry + hotkey refactor (PR 1/3)

### DIFF
--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -18,6 +18,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { getShortcutGroups, matchesCommand, modKeyLabel } from "@/lib/keymap";
 import { isNativeShell } from "@/lib/nativeBridge";
 
 // Custom event the dialog listens for, so non-adjacent surfaces (e.g. the
@@ -30,101 +31,8 @@ export function openKeyboardShortcuts(): void {
   window.dispatchEvent(new Event(KEYBOARD_SHORTCUTS_EVENT));
 }
 
-// Platform-aware modifier glyphs. macOS shows ⌘/⌥; elsewhere Ctrl/Alt — the
-// same split the underlying handlers use (`metaKey || ctrlKey`).
-const IS_MAC =
-  typeof navigator !== "undefined" &&
-  /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || "");
-
 /** Modifier label shown in menu hints (⌘ on macOS, Ctrl elsewhere). */
-export const MOD_KEY = IS_MAC ? "⌘" : "Ctrl";
-
-// Glyphs match the in-app tooltips (e.g. UserMessageNav's "⌘⌥↑").
-const ENTER = "↵";
-const SHIFT = "⇧";
-const ALT = IS_MAC ? "⌥" : "Alt";
-const UP = "↑";
-const DOWN = "↓";
-
-interface Shortcut {
-  label: string;
-  /** Keys rendered left→right as chips. A chord (held together) or, for the
-   *  arrow-pairs, the two interchangeable keys for that action. */
-  keys: string[];
-}
-
-interface ShortcutGroup {
-  title: string;
-  /** Optional qualifier shown next to the group title. */
-  note?: string;
-  items: Shortcut[];
-}
-
-// ONLY shortcuts that exist today (see file header). Keep in sync with the
-// composer's `handleKeyDown` and the global hotkey hooks.
-const SHORTCUT_GROUPS: ShortcutGroup[] = [
-  {
-    title: "General",
-    items: [
-      { label: "Open command palette", keys: [MOD_KEY, "K"] },
-      { label: "Show keyboard shortcuts", keys: [MOD_KEY, "/"] },
-    ],
-  },
-  {
-    title: "In chats",
-    items: [
-      { label: "Send message", keys: [ENTER] },
-      { label: "New line in message", keys: [SHIFT, ENTER] },
-      { label: "Recall previous prompt", keys: [UP] },
-      { label: "Recall next prompt", keys: [DOWN] },
-      { label: "Accept approval prompt", keys: [MOD_KEY, ENTER] },
-      { label: "Stop response", keys: ["Esc"] },
-    ],
-  },
-  {
-    title: "Navigation",
-    items: [
-      { label: "Previous session", keys: [MOD_KEY, UP] },
-      { label: "Next session", keys: [MOD_KEY, DOWN] },
-    ],
-  },
-  {
-    title: "View",
-    items: [
-      { label: "Toggle conversations sidebar", keys: [MOD_KEY, ALT, "["] },
-      { label: "Toggle workspace sidebar", keys: [MOD_KEY, ALT, "]"] },
-    ],
-  },
-  {
-    title: "Slash commands",
-    note: "while the suggestions menu is open",
-    items: [
-      { label: "Navigate suggestions", keys: [UP, DOWN] },
-      { label: "Apply highlighted command", keys: ["Tab"] },
-      { label: "Dismiss menu", keys: ["Esc"] },
-    ],
-  },
-];
-
-// Numeric pinned-session jump. The chord is platform-aware (see
-// usePinnedSessionHotkeys): plain Cmd/Ctrl+digit in the Electron shell, but
-// Cmd/Ctrl+Alt+digit in a browser tab, where plain Cmd+digit is reserved for
-// native tab-switching. Shown in both, with the matching glyphs.
-function pinnedSessionShortcut(native: boolean): Shortcut {
-  return {
-    label: "Jump to pinned session (1–10)",
-    keys: native ? [MOD_KEY, "1…0"] : [MOD_KEY, ALT, "1…0"],
-  };
-}
-
-/** Shortcut groups for the current runtime — the pinned-jump chord differs by shell. */
-function shortcutGroupsFor(native: boolean): ShortcutGroup[] {
-  return SHORTCUT_GROUPS.map((group) =>
-    group.title === "Navigation"
-      ? { ...group, items: [...group.items, pinnedSessionShortcut(native)] }
-      : group,
-  );
-}
+export const MOD_KEY = modKeyLabel();
 
 function Kbd({ children }: { children: ReactNode }) {
   return (
@@ -140,8 +48,7 @@ function Kbd({ children }: { children: ReactNode }) {
  * Settings page, which embeds it directly instead of behind a trigger.
  */
 export function KeyboardShortcutsList() {
-  // Feature-based, stable per session; computed at render so tests can vary it.
-  const groups = shortcutGroupsFor(isNativeShell());
+  const groups = getShortcutGroups(isNativeShell());
   return (
     <>
       {groups.map((group) => (
@@ -178,9 +85,7 @@ export function KeyboardShortcutsDialog() {
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      // ⌘/Ctrl + / toggles the panel. Plain `/` is the composer's slash-menu
-      // trigger, so require the modifier and no Shift/Alt to avoid clashing.
-      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key === "/") {
+      if (matchesCommand("show-keyboard-shortcuts", e)) {
         e.preventDefault();
         setOpen((prev) => !prev);
       }

--- a/web/src/hooks/useApproveHotkey.ts
+++ b/web/src/hooks/useApproveHotkey.ts
@@ -16,14 +16,13 @@
 import { useEffect } from "react";
 
 import type { ElicitationBlock } from "@/lib/blocks";
+import { matchesCommand } from "@/lib/keymap";
 import { useChatStore } from "@/store/chatStore";
 
 export function useApproveHotkey(): void {
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
-      // Cmd/Ctrl, not Alt/Shift (mirrors the session-switch hotkey's guard).
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-      if (e.key !== "Enter") return;
+      if (!matchesCommand("accept-approval", e)) return;
 
       const { blocks, submitApproval } = useChatStore.getState();
       // Newest-first: accept the most recent still-pending prompt that takes a

--- a/web/src/hooks/useCommandPaletteHotkey.ts
+++ b/web/src/hooks/useCommandPaletteHotkey.ts
@@ -13,17 +13,14 @@
 
 import { useEffect, useRef } from "react";
 
+import { matchesCommand } from "@/lib/keymap";
+
 /** Selector for surfaces that own ⌘K and must keep it (terminals, code editor). */
 const HOTKEY_OWNING_SURFACES = ".xterm, .monaco-editor";
 
 /** True when the event is the command-palette chord: Cmd/Ctrl+K, no Alt/Shift. */
 export function isCommandPaletteHotkey(e: globalThis.KeyboardEvent): boolean {
-  if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return false;
-  // AltGr reports as Ctrl+Alt on some layouts; the altKey check above already
-  // rejects it, but guard explicitly so intl typing never triggers the palette.
-  if (e.getModifierState("AltGraph")) return false;
-  // Match the letter, not a physical code — ⌘ doesn't remap "k" across layouts.
-  return e.key === "k" || e.key === "K";
+  return matchesCommand("command-palette", e);
 }
 
 /** Does focus sit inside a surface that owns ⌘K (xterm / Monaco)? */

--- a/web/src/hooks/useMentionBrowser.test.tsx
+++ b/web/src/hooks/useMentionBrowser.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MentionState } from "@/lib/composerMentions";
+import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
+import { useMentionBrowser } from "./useMentionBrowser";
+
+function makeKeyEvent(
+  key: string,
+  mods: Partial<{
+    metaKey: boolean;
+    ctrlKey: boolean;
+    altKey: boolean;
+    shiftKey: boolean;
+  }> = {},
+): React.KeyboardEvent<HTMLTextAreaElement> {
+  const preventDefault = vi.fn();
+  return {
+    key,
+    code: key.startsWith("Arrow") ? key : "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...mods,
+    preventDefault,
+  } as unknown as React.KeyboardEvent<HTMLTextAreaElement>;
+}
+
+function setup(entries: WorkspaceFile[]) {
+  const mention: MentionState = { query: "src", start: 0, end: 4 };
+  const setMention = vi.fn();
+  const setText = vi.fn();
+  const textareaRef = { current: document.createElement("textarea") };
+
+  const { result, rerender } = renderHook(
+    (props: { entries: WorkspaceFile[] }) =>
+      useMentionBrowser({
+        mention,
+        setMention,
+        mentionEntries: props.entries,
+        text: "@src",
+        setText,
+        textareaRef,
+      }),
+    { initialProps: { entries } },
+  );
+
+  return { result, rerender, setMention };
+}
+
+describe("useMentionBrowser handleKeyDown", () => {
+  const entries: WorkspaceFile[] = [
+    { type: "file", path: "a.ts", name: "a.ts", bytes: 1, modified_at: 0 },
+    { type: "file", path: "b.ts", name: "b.ts", bytes: 1, modified_at: 0 },
+  ];
+
+  it("Cmd+ArrowDown navigates the menu and consumes the event", () => {
+    const { result } = setup(entries);
+    const e = makeKeyEvent("ArrowDown", { metaKey: true });
+
+    let consumed = false;
+    act(() => {
+      consumed = result.current.handleKeyDown(e);
+    });
+
+    expect(consumed).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(result.current.mentionIndex).toBe(1);
+  });
+
+  it("Ctrl+ArrowUp wraps to the last row with modifiers held", () => {
+    const { result } = setup(entries);
+    const e = makeKeyEvent("ArrowUp", { ctrlKey: true });
+
+    let consumed = false;
+    act(() => {
+      consumed = result.current.handleKeyDown(e);
+    });
+
+    expect(consumed).toBe(true);
+    expect(result.current.mentionIndex).toBe(1);
+  });
+
+  it("Ctrl+Tab applies the highlighted row", () => {
+    const { result } = setup(entries);
+    const e = makeKeyEvent("Tab", { ctrlKey: true });
+
+    let consumed = false;
+    act(() => {
+      consumed = result.current.handleKeyDown(e);
+    });
+
+    expect(consumed).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+  });
+
+  it("does nothing when the menu is closed", () => {
+    const { result, rerender } = setup(entries);
+    rerender({ entries: [] });
+
+    const e = makeKeyEvent("ArrowDown", { metaKey: true });
+    expect(result.current.handleKeyDown(e)).toBe(false);
+  });
+});

--- a/web/src/hooks/useMentionBrowser.ts
+++ b/web/src/hooks/useMentionBrowser.ts
@@ -1,6 +1,7 @@
 import { type KeyboardEvent, type RefObject, useRef, useState } from "react";
 
 import { type MentionItem, type MentionState } from "@/lib/composerMentions";
+import { matchesCommand } from "@/lib/keymap";
 import { composerAttachmentKey } from "@/store/chatStore";
 import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 
@@ -124,12 +125,12 @@ export function useMentionBrowser(params: MentionBrowserParams): MentionBrowser 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): boolean => {
     if (!mentionOpen) return false;
     const active = mentionIndex >= 0 ? mentionEntries[mentionIndex] : undefined;
-    if (e.key === "ArrowDown") {
+    if (matchesCommand("mention-navigate-down", e)) {
       e.preventDefault();
       setMentionIndex((i) => (i + 1) % mentionEntries.length);
       return true;
     }
-    if (e.key === "ArrowUp") {
+    if (matchesCommand("mention-navigate-up", e)) {
       e.preventDefault();
       setMentionIndex((i) => (i <= 0 ? mentionEntries.length - 1 : i - 1));
       return true;
@@ -142,12 +143,12 @@ export function useMentionBrowser(params: MentionBrowserParams): MentionBrowser 
       else attachMention(active.path, false);
       return true;
     }
-    if (e.key === "Tab" && active) {
+    if (active && matchesCommand("mention-apply", e)) {
       e.preventDefault();
       attachMention(active.path, active.type === "directory");
       return true;
     }
-    if (e.key === "Escape") {
+    if (matchesCommand("mention-dismiss", e)) {
       e.preventDefault();
       dismiss();
       return true;

--- a/web/src/hooks/usePinnedSessionHotkeys.ts
+++ b/web/src/hooks/usePinnedSessionHotkeys.ts
@@ -12,27 +12,13 @@
 
 import { useEffect, useRef } from "react";
 import { useNavigate } from "@/lib/routing";
-import { isNativeShell } from "@/lib/nativeBridge";
+import {
+  PINNED_HOTKEY_CODES,
+  PINNED_HOTKEY_DIGITS,
+  pinnedSessionIndexFromEvent,
+} from "@/lib/keymap";
 
-/** Index → the digit key that selects it (native path; matched against e.key).
- *  Single source of truth shared with the shortcuts dialog so binding and label
- *  can't drift. */
-export const PINNED_HOTKEY_DIGITS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"] as const;
-
-/** Index → the physical key code (browser path; matched against e.code, since
- *  Alt rewrites e.key on macOS). Same order as {@link PINNED_HOTKEY_DIGITS}. */
-export const PINNED_HOTKEY_CODES = [
-  "Digit1",
-  "Digit2",
-  "Digit3",
-  "Digit4",
-  "Digit5",
-  "Digit6",
-  "Digit7",
-  "Digit8",
-  "Digit9",
-  "Digit0",
-] as const;
+export { PINNED_HOTKEY_CODES, PINNED_HOTKEY_DIGITS };
 
 /**
  * @param orderedPinnedIds Pinned conversation ids in sidebar render order
@@ -50,25 +36,7 @@ export function usePinnedSessionHotkeys(
 
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
-      // Cmd/Ctrl required; Shift left to other bindings.
-      if (e.shiftKey || !(e.metaKey || e.ctrlKey)) return;
-
-      let index: number;
-      if (isNativeShell()) {
-        // Desktop owns plain Cmd/Ctrl+digit (Alt+chord is the message hotkey).
-        if (e.altKey) return;
-        index = PINNED_HOTKEY_DIGITS.indexOf(e.key as (typeof PINNED_HOTKEY_DIGITS)[number]);
-      } else {
-        // Browser: plain Cmd/Ctrl+digit is the native tab-switch, so own the
-        // Cmd/Ctrl+Alt+digit chord instead. Alt rewrites e.key → match e.code.
-        if (!e.altKey) return;
-        // AltGr reports as Ctrl+Alt on Windows/Linux intl layouts — typing
-        // AltGr+digit must compose the character, not yank the user to a
-        // pinned session. Same guard (and same feature-detect, so synthetic
-        // events without the method don't throw) as useSidebarToggleHotkeys.
-        if (typeof e.getModifierState === "function" && e.getModifierState("AltGraph")) return;
-        index = PINNED_HOTKEY_CODES.indexOf(e.code as (typeof PINNED_HOTKEY_CODES)[number]);
-      }
+      const index = pinnedSessionIndexFromEvent(e);
       if (index === -1) return;
 
       const { orderedPinnedIds: ids, activeId: active } = latest.current;

--- a/web/src/hooks/useSessionSwitchHotkey.ts
+++ b/web/src/hooks/useSessionSwitchHotkey.ts
@@ -5,6 +5,7 @@
 
 import { useEffect, useRef } from "react";
 import { useNavigate } from "@/lib/routing";
+import { matchesCommand } from "@/lib/keymap";
 
 /**
  * @param orderedIds Conversation ids in sidebar render order, visible sections
@@ -23,15 +24,15 @@ export function useSessionSwitchHotkey(
 
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
-      // Cmd/Ctrl, not Alt (Alt+arrow is the message hotkey); Shift left to selection.
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+      const isUp = matchesCommand("previous-session", e);
+      const isDown = matchesCommand("next-session", e);
+      if (!isUp && !isDown) return;
 
       const { orderedIds: ids, activeId: active } = latest.current;
       if (ids.length === 0) return;
 
       e.preventDefault(); // also suppresses the native caret-to-start/end in fields
-      const dir = e.key === "ArrowDown" ? 1 : -1;
+      const dir = isDown ? 1 : -1;
       const current = active ? ids.indexOf(active) : -1;
       // Off-list: ↓ enters at the top, ↑ at the bottom. Otherwise step + wrap.
       const next =

--- a/web/src/hooks/useSidebarToggleHotkeys.ts
+++ b/web/src/hooks/useSidebarToggleHotkeys.ts
@@ -12,6 +12,8 @@
 
 import { useEffect, useRef } from "react";
 
+import { matchesCommand } from "@/lib/keymap";
+
 export interface SidebarToggleHandlers {
   /** Flip the left (Conversations) sidebar. Bound to ⌘/Ctrl + ⌥/Alt + [. */
   onToggleLeft: () => void;
@@ -27,25 +29,13 @@ export function useSidebarToggleHotkeys(handlers: SidebarToggleHandlers): void {
 
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
-      // Require Cmd/Ctrl AND Alt (the ⌘⌥ message-nav chord) and additionally
-      // reject Shift, so ⌘⌥⇧ combos stay free for future bindings.
-      if (!(e.metaKey || e.ctrlKey) || !e.altKey || e.shiftKey) return;
-      // AltGr often reports as Ctrl+Alt; ignore it so intl-layout typing doesn't
-      // accidentally toggle sidebars while focused in an editor/composer. Guard
-      // the call: not every environment implements getModifierState, and an
-      // unguarded call there would throw and break the whole keydown handler.
-      if (typeof e.getModifierState === "function" && e.getModifierState("AltGraph")) return;
       // Ignore auto-repeat: holding the chord would flap the panel open/closed.
       if (e.repeat) return;
-      // Match the physical key, not the character: ⌥ turns "[" / "]" into "“" /
-      // "‘" on macOS, but e.code is stable across layouts and modifiers.
-      // Claim the chord: preventDefault drops any default action and
-      // stopPropagation keeps it from reaching other keydown listeners.
-      if (e.code === "BracketLeft") {
+      if (matchesCommand("toggle-conversations-sidebar", e)) {
         e.preventDefault();
         e.stopPropagation();
         latest.current.onToggleLeft();
-      } else if (e.code === "BracketRight") {
+      } else if (matchesCommand("toggle-workspace-sidebar", e)) {
         e.preventDefault();
         e.stopPropagation();
         latest.current.onToggleRight();

--- a/web/src/lib/keymap/index.ts
+++ b/web/src/lib/keymap/index.ts
@@ -1,0 +1,41 @@
+export type {
+  KeyBinding,
+  KeymapCommand,
+  KeymapCommandId,
+  KeymapDisplayContext,
+  KeymapGroupId,
+  KeymapKeyEvent,
+  KeymapScope,
+  KeymapShortcutGroup,
+  ModifierRequirement,
+  PlatformKeyBinding,
+} from "./types";
+
+export { altKeyLabel, defaultDisplayContext, isMacPlatform, modKeyLabel } from "./platform";
+
+export {
+  KEYMAP_COMMAND_IDS,
+  KEYMAP_COMMANDS,
+  getKeymapCommand,
+  getShortcutGroups,
+  PINNED_HOTKEY_CODES,
+  PINNED_HOTKEY_DIGITS,
+  resolveCommandDefaultBinding,
+} from "./registry";
+
+export {
+  clearKeymapOverrides,
+  getEffectiveBinding,
+  isCommandOverridden,
+  isPlatformBinding,
+  readKeymapOverrides,
+  writeKeymapOverride,
+  type KeymapOverrides,
+} from "./preferences";
+
+export {
+  matchesBinding,
+  matchesCommand,
+  pinnedSessionIndexFromEvent,
+  resolveDefaultBinding,
+} from "./matcher";

--- a/web/src/lib/keymap/matcher.test.ts
+++ b/web/src/lib/keymap/matcher.test.ts
@@ -62,6 +62,37 @@ describe("matchesBinding", () => {
     ).toBe(false);
     altGraph.mockRestore();
   });
+
+  it("rejects AltGraph for command palette even without alt required", () => {
+    const binding = getEffectiveBinding("command-palette");
+    const altGraph = vi
+      .spyOn(KeyboardEvent.prototype, "getModifierState")
+      .mockImplementation((keyArg) => keyArg === "AltGraph");
+    expect(matchesBinding(keydown({ key: "k", ctrlKey: true }), binding)).toBe(false);
+    altGraph.mockRestore();
+  });
+});
+
+describe("mention-menu bindings", () => {
+  it("match modified arrow keys (modifier-agnostic)", () => {
+    expect(matchesCommand("mention-navigate-down", keydown({ key: "ArrowDown" }))).toBe(true);
+    expect(
+      matchesCommand("mention-navigate-down", keydown({ key: "ArrowDown", metaKey: true })),
+    ).toBe(true);
+    expect(
+      matchesCommand(
+        "mention-navigate-up",
+        keydown({ key: "ArrowUp", ctrlKey: true, altKey: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("still forbids modifiers for slash-menu defaults", () => {
+    expect(matchesCommand("slash-navigate-down", keydown({ key: "ArrowDown" }))).toBe(true);
+    expect(
+      matchesCommand("slash-navigate-down", keydown({ key: "ArrowDown", metaKey: true })),
+    ).toBe(false);
+  });
 });
 
 describe("matchesCommand", () => {

--- a/web/src/lib/keymap/matcher.test.ts
+++ b/web/src/lib/keymap/matcher.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearKeymapOverrides,
+  getEffectiveBinding,
+  KEYMAP_COMMANDS,
+  matchesBinding,
+  matchesCommand,
+  pinnedSessionIndexFromEvent,
+  readKeymapOverrides,
+  writeKeymapOverride,
+} from "./index";
+
+const isNativeShell = vi.fn(() => true);
+vi.mock("@/lib/nativeBridge", () => ({
+  isNativeShell: () => isNativeShell(),
+}));
+
+afterEach(() => {
+  clearKeymapOverrides();
+  isNativeShell.mockReturnValue(true);
+});
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
+describe("matchesBinding", () => {
+  it("matches Cmd/Ctrl+K for the command palette default", () => {
+    const binding = KEYMAP_COMMANDS["command-palette"].defaultBinding;
+    expect(matchesBinding(keydown({ key: "k", metaKey: true }), binding as never)).toBe(true);
+    expect(matchesBinding(keydown({ key: "k", ctrlKey: true }), binding as never)).toBe(true);
+    expect(matchesBinding(keydown({ key: "K", metaKey: true }), binding as never)).toBe(true);
+  });
+
+  it("rejects modifier variants that the binding forbids", () => {
+    const binding = KEYMAP_COMMANDS["command-palette"].defaultBinding;
+    expect(
+      matchesBinding(keydown({ key: "k", metaKey: true, altKey: true }), binding as never),
+    ).toBe(false);
+    expect(
+      matchesBinding(keydown({ key: "k", metaKey: true, shiftKey: true }), binding as never),
+    ).toBe(false);
+    expect(matchesBinding(keydown({ key: "k" }), binding as never)).toBe(false);
+  });
+
+  it("matches physical bracket codes for sidebar toggles", () => {
+    const left = getEffectiveBinding("toggle-conversations-sidebar");
+    expect(
+      matchesBinding(keydown({ code: "BracketLeft", ctrlKey: true, altKey: true }), left),
+    ).toBe(true);
+    expect(matchesBinding(keydown({ code: "BracketLeft", ctrlKey: true }), left)).toBe(false);
+  });
+
+  it("ignores AltGraph when rejectAltGraph is set", () => {
+    const binding = getEffectiveBinding("toggle-conversations-sidebar");
+    const altGraph = vi
+      .spyOn(KeyboardEvent.prototype, "getModifierState")
+      .mockImplementation((keyArg) => keyArg === "AltGraph");
+    expect(
+      matchesBinding(keydown({ code: "BracketLeft", ctrlKey: true, altKey: true }), binding),
+    ).toBe(false);
+    altGraph.mockRestore();
+  });
+});
+
+describe("matchesCommand", () => {
+  it("resolves accept-approval from the registry", () => {
+    expect(matchesCommand("accept-approval", keydown({ key: "Enter", metaKey: true }))).toBe(true);
+    expect(matchesCommand("accept-approval", keydown({ key: "Enter" }))).toBe(false);
+  });
+
+  it("applies a stored override", () => {
+    writeKeymapOverride("accept-approval", {
+      mod: "required",
+      alt: "forbidden",
+      shift: "forbidden",
+      key: "a",
+    });
+    expect(matchesCommand("accept-approval", keydown({ key: "a", metaKey: true }))).toBe(true);
+    expect(matchesCommand("accept-approval", keydown({ key: "Enter", metaKey: true }))).toBe(false);
+    expect(readKeymapOverrides()["accept-approval"]?.key).toBe("a");
+  });
+});
+
+describe("pinnedSessionIndexFromEvent", () => {
+  it("maps native Cmd+digit to index", () => {
+    isNativeShell.mockReturnValue(true);
+    expect(pinnedSessionIndexFromEvent(keydown({ key: "1", metaKey: true }))).toBe(0);
+    expect(pinnedSessionIndexFromEvent(keydown({ key: "0", metaKey: true }))).toBe(9);
+  });
+
+  it("maps browser Cmd+Alt+Digit to index via code", () => {
+    isNativeShell.mockReturnValue(false);
+    expect(
+      pinnedSessionIndexFromEvent(
+        keydown({ key: "¡", metaKey: true, altKey: true, code: "Digit1" }),
+      ),
+    ).toBe(0);
+    expect(pinnedSessionIndexFromEvent(keydown({ key: "1", metaKey: true, code: "Digit1" }))).toBe(
+      -1,
+    );
+  });
+});

--- a/web/src/lib/keymap/matcher.ts
+++ b/web/src/lib/keymap/matcher.ts
@@ -38,6 +38,8 @@ function matchesKeyField(e: KeymapKeyEvent, binding: KeyBinding): boolean {
     binding.codes !== undefined;
   if (!hasKeyConstraint) return false;
 
+  // OR semantics: any one populated key field may match. No current command
+  // combines fields; overrides that do would match more broadly than expected.
   if (binding.key !== undefined && letterMatches(e.key, binding.key)) return true;
   if (binding.code !== undefined && e.code === binding.code) return true;
   if (binding.keys?.some((k) => letterMatches(e.key, k))) return true;
@@ -56,7 +58,6 @@ export function matchesBinding(e: KeymapKeyEvent, binding: KeyBinding): boolean 
 
   if (
     binding.rejectAltGraph &&
-    binding.alt === "required" &&
     typeof e.getModifierState === "function" &&
     e.getModifierState("AltGraph")
   ) {

--- a/web/src/lib/keymap/matcher.ts
+++ b/web/src/lib/keymap/matcher.ts
@@ -1,0 +1,123 @@
+// Normalize keyboard events and test them against registry bindings.
+
+import type {
+  KeyBinding,
+  KeymapCommandId,
+  KeymapKeyEvent,
+  ModifierRequirement,
+  PlatformKeyBinding,
+} from "./types";
+import { getEffectiveBinding } from "./preferences";
+import { isNativeShell } from "@/lib/nativeBridge";
+
+function hasPrimaryMod(e: KeymapKeyEvent): boolean {
+  return e.metaKey || e.ctrlKey;
+}
+
+function satisfiesModifier(
+  requirement: ModifierRequirement | undefined,
+  present: boolean,
+): boolean {
+  if (requirement === undefined || requirement === "any") return true;
+  if (requirement === "required") return present;
+  return !present;
+}
+
+function letterMatches(eventKey: string, bindingKey: string): boolean {
+  if (bindingKey.length === 1 && /[a-zA-Z]/.test(bindingKey)) {
+    return eventKey.toLowerCase() === bindingKey.toLowerCase();
+  }
+  return eventKey === bindingKey;
+}
+
+function matchesKeyField(e: KeymapKeyEvent, binding: KeyBinding): boolean {
+  const hasKeyConstraint =
+    binding.key !== undefined ||
+    binding.code !== undefined ||
+    binding.keys !== undefined ||
+    binding.codes !== undefined;
+  if (!hasKeyConstraint) return false;
+
+  if (binding.key !== undefined && letterMatches(e.key, binding.key)) return true;
+  if (binding.code !== undefined && e.code === binding.code) return true;
+  if (binding.keys?.some((k) => letterMatches(e.key, k))) return true;
+  if (binding.codes?.some((c) => e.code === c)) return true;
+  return false;
+}
+
+/**
+ * Test a keyboard event against a single binding. Does not consult user
+ * overrides — pass the effective binding from {@link getEffectiveBinding}.
+ */
+export function matchesBinding(e: KeymapKeyEvent, binding: KeyBinding): boolean {
+  if (!satisfiesModifier(binding.mod, hasPrimaryMod(e))) return false;
+  if (!satisfiesModifier(binding.alt, e.altKey)) return false;
+  if (!satisfiesModifier(binding.shift, e.shiftKey)) return false;
+
+  if (
+    binding.rejectAltGraph &&
+    binding.alt === "required" &&
+    typeof e.getModifierState === "function" &&
+    e.getModifierState("AltGraph")
+  ) {
+    return false;
+  }
+
+  return matchesKeyField(e, binding);
+}
+
+function resolvePlatformBinding(
+  binding: KeyBinding | PlatformKeyBinding,
+  native: boolean,
+): KeyBinding {
+  if ("native" in binding) return native ? binding.native : binding.browser;
+  return binding;
+}
+
+/**
+ * Test whether `e` matches the effective binding for `commandId` (defaults
+ * merged with user overrides from localStorage).
+ */
+export function matchesCommand(commandId: KeymapCommandId, e: KeymapKeyEvent): boolean {
+  const binding = getEffectiveBinding(commandId, isNativeShell());
+  return matchesBinding(e, binding);
+}
+
+/** Resolve the platform-appropriate default before overrides. */
+export function resolveDefaultBinding(
+  binding: KeyBinding | PlatformKeyBinding,
+  native: boolean = isNativeShell(),
+): KeyBinding {
+  return resolvePlatformBinding(binding, native);
+}
+
+/**
+ * For pinned-session jump: return the 0-based index when the chord matches,
+ * otherwise -1. Digit order is 1–9 then 0 (browser tab style).
+ */
+export function pinnedSessionIndexFromEvent(e: KeymapKeyEvent): number {
+  const binding = getEffectiveBinding("jump-pinned-session", isNativeShell());
+  if (!matchesBinding(e, binding)) return -1;
+
+  const digits = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"] as const;
+  const codes = [
+    "Digit1",
+    "Digit2",
+    "Digit3",
+    "Digit4",
+    "Digit5",
+    "Digit6",
+    "Digit7",
+    "Digit8",
+    "Digit9",
+    "Digit0",
+  ] as const;
+
+  if (binding.keys) {
+    return binding.keys.indexOf(e.key as (typeof digits)[number]);
+  }
+  if (binding.codes) {
+    return binding.codes.indexOf(e.code as (typeof codes)[number]);
+  }
+  return -1;
+}

--- a/web/src/lib/keymap/platform.ts
+++ b/web/src/lib/keymap/platform.ts
@@ -1,0 +1,30 @@
+// Platform-aware modifier labels and display glyphs for shortcut lists.
+
+import type { KeymapDisplayContext } from "./types";
+
+/** True on macOS / iOS — matches the handlers' `metaKey || ctrlKey` split. */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || "");
+}
+
+/** Modifier label shown in menu hints (⌘ on macOS, Ctrl elsewhere). */
+export function modKeyLabel(): string {
+  return isMacPlatform() ? "⌘" : "Ctrl";
+}
+
+export function altKeyLabel(): string {
+  return isMacPlatform() ? "⌥" : "Alt";
+}
+
+export function defaultDisplayContext(isNativeShell: boolean): KeymapDisplayContext {
+  return {
+    modKey: modKeyLabel(),
+    altKey: altKeyLabel(),
+    shiftKey: "⇧",
+    enterKey: "↵",
+    upKey: "↑",
+    downKey: "↓",
+    isNativeShell,
+  };
+}

--- a/web/src/lib/keymap/preferences.test.ts
+++ b/web/src/lib/keymap/preferences.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { clearKeymapOverrides, readKeymapOverrides, writeKeymapOverride } from "./preferences";
+
+const STORAGE_KEY = "omnigent:keymap";
+
+afterEach(() => {
+  clearKeymapOverrides();
+  localStorage.clear();
+});
+
+describe("keymap preferences", () => {
+  it("ignores inherited object keys in stored JSON", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ toString: { key: "x" }, "accept-approval": { key: "Enter" } }),
+    );
+    const overrides = readKeymapOverrides();
+    expect(Object.hasOwn(overrides, "toString")).toBe(false);
+    expect(overrides["accept-approval"]?.key).toBe("Enter");
+  });
+
+  it("reuses the cached override map across reads until a write", () => {
+    writeKeymapOverride("accept-approval", { key: "a", mod: "required" });
+    const first = readKeymapOverrides();
+    const second = readKeymapOverrides();
+    expect(second).toBe(first);
+    writeKeymapOverride("accept-approval", null);
+    const afterClear = readKeymapOverrides();
+    expect(afterClear).not.toBe(first);
+  });
+});

--- a/web/src/lib/keymap/preferences.ts
+++ b/web/src/lib/keymap/preferences.ts
@@ -1,8 +1,9 @@
 // Persisted user overrides for keyboard shortcuts (`omnigent:keymap`).
 //
-// Overrides are a partial map of command id → binding, merged over the
-// registry defaults at read time. PR 1 stores the shape only; the settings
-// editor (PR 2) writes here.
+// Overrides are a partial map of command id → binding. At read time each
+// stored binding fully *replaces* the registry default (no field-level merge).
+// Platform-paired defaults (e.g. jump-pinned-session) collapse to a single
+// override binding — the PR 2 editor must account for that when remapping.
 
 import type { KeyBinding, KeymapCommandId, PlatformKeyBinding } from "./types";
 import { KEYMAP_COMMANDS, resolveCommandDefaultBinding } from "./registry";
@@ -10,6 +11,14 @@ import { KEYMAP_COMMANDS, resolveCommandDefaultBinding } from "./registry";
 const STORAGE_KEY = "omnigent:keymap";
 
 export type KeymapOverrides = Partial<Record<KeymapCommandId, KeyBinding>>;
+
+let cachedOverrides: KeymapOverrides | null = null;
+let cachedRaw: string | null | undefined;
+
+function invalidateOverrideCache(): void {
+  cachedOverrides = null;
+  cachedRaw = undefined;
+}
 
 function isModifierRequirement(value: unknown): value is KeyBinding["mod"] {
   return value === "required" || value === "forbidden" || value === "any";
@@ -69,17 +78,31 @@ function readRawOverrides(): KeymapOverrides {
   if (typeof window === "undefined") return {};
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
+    if (raw === cachedRaw && cachedOverrides !== null) {
+      return cachedOverrides;
+    }
+    if (!raw) {
+      cachedRaw = raw;
+      cachedOverrides = {};
+      return cachedOverrides;
+    }
     const parsed: unknown = JSON.parse(raw);
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      cachedRaw = raw;
+      cachedOverrides = {};
+      return cachedOverrides;
+    }
     const out: KeymapOverrides = {};
     for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
-      if (!(id in KEYMAP_COMMANDS)) continue;
+      if (!Object.hasOwn(KEYMAP_COMMANDS, id)) continue;
       const binding = coerceBinding(value);
       if (binding) out[id as KeymapCommandId] = binding;
     }
+    cachedRaw = raw;
+    cachedOverrides = out;
     return out;
   } catch {
+    invalidateOverrideCache();
     return {};
   }
 }
@@ -105,9 +128,11 @@ export function writeKeymapOverride(id: KeymapCommandId, binding: KeyBinding | n
     }
     if (Object.keys(next).length === 0) {
       window.localStorage.removeItem(STORAGE_KEY);
+      invalidateOverrideCache();
       return;
     }
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    invalidateOverrideCache();
   } catch {
     // Quota / access errors shouldn't break the app.
   }
@@ -118,6 +143,7 @@ export function clearKeymapOverrides(): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.removeItem(STORAGE_KEY);
+    invalidateOverrideCache();
   } catch {
     // ignore
   }

--- a/web/src/lib/keymap/preferences.ts
+++ b/web/src/lib/keymap/preferences.ts
@@ -1,0 +1,149 @@
+// Persisted user overrides for keyboard shortcuts (`omnigent:keymap`).
+//
+// Overrides are a partial map of command id → binding, merged over the
+// registry defaults at read time. PR 1 stores the shape only; the settings
+// editor (PR 2) writes here.
+
+import type { KeyBinding, KeymapCommandId, PlatformKeyBinding } from "./types";
+import { KEYMAP_COMMANDS, resolveCommandDefaultBinding } from "./registry";
+
+const STORAGE_KEY = "omnigent:keymap";
+
+export type KeymapOverrides = Partial<Record<KeymapCommandId, KeyBinding>>;
+
+function isModifierRequirement(value: unknown): value is KeyBinding["mod"] {
+  return value === "required" || value === "forbidden" || value === "any";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/** Coerce one stored binding; returns null when the shape can't be salvaged. */
+function coerceBinding(value: unknown): KeyBinding | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const binding: KeyBinding = {};
+
+  if (raw.mod !== undefined) {
+    if (!isModifierRequirement(raw.mod)) return null;
+    binding.mod = raw.mod;
+  }
+  if (raw.alt !== undefined) {
+    if (!isModifierRequirement(raw.alt)) return null;
+    binding.alt = raw.alt;
+  }
+  if (raw.shift !== undefined) {
+    if (!isModifierRequirement(raw.shift)) return null;
+    binding.shift = raw.shift;
+  }
+  if (raw.key !== undefined) {
+    if (typeof raw.key !== "string" || !raw.key) return null;
+    binding.key = raw.key;
+  }
+  if (raw.code !== undefined) {
+    if (typeof raw.code !== "string" || !raw.code) return null;
+    binding.code = raw.code;
+  }
+  if (raw.keys !== undefined) {
+    if (!isStringArray(raw.keys) || raw.keys.length === 0) return null;
+    binding.keys = raw.keys;
+  }
+  if (raw.codes !== undefined) {
+    if (!isStringArray(raw.codes) || raw.codes.length === 0) return null;
+    binding.codes = raw.codes;
+  }
+  if (raw.rejectAltGraph === true) binding.rejectAltGraph = true;
+
+  const hasKey =
+    binding.key !== undefined ||
+    binding.code !== undefined ||
+    binding.keys !== undefined ||
+    binding.codes !== undefined;
+  if (!hasKey) return null;
+
+  return binding;
+}
+
+function readRawOverrides(): KeymapOverrides {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const out: KeymapOverrides = {};
+    for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!(id in KEYMAP_COMMANDS)) continue;
+      const binding = coerceBinding(value);
+      if (binding) out[id as KeymapCommandId] = binding;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read persisted overrides. Never throws — corrupt storage yields an empty map.
+ */
+export function readKeymapOverrides(): KeymapOverrides {
+  return readRawOverrides();
+}
+
+/**
+ * Persist one override. Pass `null` to clear that command's override.
+ */
+export function writeKeymapOverride(id: KeymapCommandId, binding: KeyBinding | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    const next = { ...readRawOverrides() };
+    if (binding === null) {
+      delete next[id];
+    } else {
+      next[id] = binding;
+    }
+    if (Object.keys(next).length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Quota / access errors shouldn't break the app.
+  }
+}
+
+/** Remove every stored override. */
+export function clearKeymapOverrides(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Default binding for `id`, optionally merged with a user override.
+ *
+ * @param native When true, pick the native-shell variant for platform-paired
+ *   defaults (jump-to-pinned). Defaults to {@link isNativeShell}.
+ */
+export function getEffectiveBinding(id: KeymapCommandId, native?: boolean): KeyBinding {
+  const command = KEYMAP_COMMANDS[id];
+  const defaultBinding = resolveCommandDefaultBinding(command.defaultBinding, native);
+  const override = readRawOverrides()[id];
+  return override ?? defaultBinding;
+}
+
+/** True when a user override is stored for the command. */
+export function isCommandOverridden(id: KeymapCommandId): boolean {
+  return readRawOverrides()[id] !== undefined;
+}
+
+/** Export for tests and the future editor. */
+export function isPlatformBinding(
+  binding: KeyBinding | PlatformKeyBinding,
+): binding is PlatformKeyBinding {
+  return "native" in binding;
+}

--- a/web/src/lib/keymap/registry.test.ts
+++ b/web/src/lib/keymap/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { KeyBinding } from "./types";
 import {
   getShortcutGroups,
   KEYMAP_COMMANDS,
@@ -69,5 +70,12 @@ describe("getShortcutGroups", () => {
     const pinned = nav?.items.find((i) => i.label.includes("pinned session"));
     expect(pinned?.keys).not.toContain("Alt");
     expect(pinned?.keys).toContain("1…0");
+  });
+
+  it("uses modifier-agnostic bindings for the mention menu", () => {
+    const up = KEYMAP_COMMANDS["mention-navigate-up"].defaultBinding as KeyBinding;
+    const slashUp = KEYMAP_COMMANDS["slash-navigate-up"].defaultBinding as KeyBinding;
+    expect(up.mod).toBeUndefined();
+    expect(slashUp.mod).toBe("forbidden");
   });
 });

--- a/web/src/lib/keymap/registry.test.ts
+++ b/web/src/lib/keymap/registry.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getShortcutGroups,
+  KEYMAP_COMMANDS,
+  KEYMAP_COMMAND_IDS,
+  PINNED_HOTKEY_CODES,
+  PINNED_HOTKEY_DIGITS,
+  resolveCommandDefaultBinding,
+} from "./index";
+
+describe("KEYMAP_COMMANDS registry", () => {
+  it("defines a command for every id", () => {
+    for (const id of KEYMAP_COMMAND_IDS) {
+      expect(KEYMAP_COMMANDS[id].id).toBe(id);
+    }
+  });
+
+  it("exposes ten pinned-session digits in tab order", () => {
+    expect(PINNED_HOTKEY_DIGITS).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]);
+    expect(PINNED_HOTKEY_CODES).toHaveLength(10);
+  });
+
+  it("uses plain Cmd+digit in the native shell", () => {
+    const binding = resolveCommandDefaultBinding(
+      KEYMAP_COMMANDS["jump-pinned-session"].defaultBinding,
+      true,
+    );
+    expect(binding.keys).toEqual(PINNED_HOTKEY_DIGITS);
+    expect(binding.alt).toBe("forbidden");
+  });
+
+  it("uses Cmd+Alt+Digit codes in the browser", () => {
+    const binding = resolveCommandDefaultBinding(
+      KEYMAP_COMMANDS["jump-pinned-session"].defaultBinding,
+      false,
+    );
+    expect(binding.codes).toEqual(PINNED_HOTKEY_CODES);
+    expect(binding.alt).toBe("required");
+    expect(binding.rejectAltGraph).toBe(true);
+  });
+});
+
+describe("getShortcutGroups", () => {
+  it("lists one row per shipped shortcut group", () => {
+    const groups = getShortcutGroups(false);
+    expect(groups.map((g) => g.title)).toEqual([
+      "General",
+      "In chats",
+      "Navigation",
+      "View",
+      "Slash commands",
+    ]);
+    expect(groups[0]?.items.map((i) => i.label)).toEqual([
+      "Open command palette",
+      "Show keyboard shortcuts",
+    ]);
+    expect(groups[4]?.note).toContain("suggestions menu");
+  });
+
+  it("shows Alt in the browser pinned-session chord", () => {
+    const nav = getShortcutGroups(false).find((g) => g.title === "Navigation");
+    const pinned = nav?.items.find((i) => i.label.includes("pinned session"));
+    expect(pinned?.keys).toContain("Alt");
+  });
+
+  it("omits Alt from the native pinned-session chord", () => {
+    const nav = getShortcutGroups(true).find((g) => g.title === "Navigation");
+    const pinned = nav?.items.find((i) => i.label.includes("pinned session"));
+    expect(pinned?.keys).not.toContain("Alt");
+    expect(pinned?.keys).toContain("1…0");
+  });
+});

--- a/web/src/lib/keymap/registry.ts
+++ b/web/src/lib/keymap/registry.ts
@@ -34,6 +34,14 @@ const SLASH_NAV_DOWN: KeyBinding = { mod: "forbidden", alt: "forbidden", key: "A
 const SLASH_APPLY: KeyBinding = { mod: "forbidden", alt: "forbidden", key: "Tab" };
 const SLASH_DISMISS: KeyBinding = { mod: "forbidden", alt: "forbidden", key: "Escape" };
 
+// Mention menu: match key identity regardless of held modifiers (pre-registry
+// behavior). While the menu is open these keys must still consume modified
+// chords so global hotkeys (e.g. Cmd+Arrow session switch) do not fire through.
+const MENTION_NAV_UP: KeyBinding = { key: "ArrowUp" };
+const MENTION_NAV_DOWN: KeyBinding = { key: "ArrowDown" };
+const MENTION_APPLY: KeyBinding = { key: "Tab" };
+const MENTION_DISMISS: KeyBinding = { key: "Escape" };
+
 const GROUP_TITLES: Record<KeymapGroupId, string> = {
   general: "General",
   "in-chats": "In chats",
@@ -53,7 +61,13 @@ export const KEYMAP_COMMANDS: Record<KeymapCommandId, KeymapCommand> = {
     label: "Open command palette",
     group: "general",
     scope: "global",
-    defaultBinding: { mod: "required", alt: "forbidden", shift: "forbidden", key: "k" },
+    defaultBinding: {
+      mod: "required",
+      alt: "forbidden",
+      shift: "forbidden",
+      key: "k",
+      rejectAltGraph: true,
+    },
     displayKeys: (ctx) => [ctx.modKey, "K"],
   },
   "show-keyboard-shortcuts": {
@@ -231,7 +245,7 @@ export const KEYMAP_COMMANDS: Record<KeymapCommandId, KeymapCommand> = {
     label: "Navigate suggestions",
     group: "slash-commands",
     scope: "mention-menu",
-    defaultBinding: SLASH_NAV_UP,
+    defaultBinding: MENTION_NAV_UP,
     displayKeys: () => [],
   },
   "mention-navigate-down": {
@@ -239,7 +253,7 @@ export const KEYMAP_COMMANDS: Record<KeymapCommandId, KeymapCommand> = {
     label: "Navigate suggestions",
     group: "slash-commands",
     scope: "mention-menu",
-    defaultBinding: SLASH_NAV_DOWN,
+    defaultBinding: MENTION_NAV_DOWN,
     displayKeys: () => [],
   },
   "mention-apply": {
@@ -247,7 +261,7 @@ export const KEYMAP_COMMANDS: Record<KeymapCommandId, KeymapCommand> = {
     label: "Apply highlighted command",
     group: "slash-commands",
     scope: "mention-menu",
-    defaultBinding: SLASH_APPLY,
+    defaultBinding: MENTION_APPLY,
     displayKeys: () => [],
   },
   "mention-dismiss": {
@@ -255,7 +269,7 @@ export const KEYMAP_COMMANDS: Record<KeymapCommandId, KeymapCommand> = {
     label: "Dismiss menu",
     group: "slash-commands",
     scope: "mention-menu",
-    defaultBinding: SLASH_DISMISS,
+    defaultBinding: MENTION_DISMISS,
     displayKeys: () => [],
   },
 };

--- a/web/src/lib/keymap/registry.ts
+++ b/web/src/lib/keymap/registry.ts
@@ -1,0 +1,336 @@
+// Canonical registry of named keyboard commands — single source for defaults,
+// shortcut-list display, and handler matching.
+
+import type {
+  KeyBinding,
+  KeymapCommand,
+  KeymapCommandId,
+  KeymapDisplayContext,
+  KeymapGroupId,
+  KeymapShortcutGroup,
+  PlatformKeyBinding,
+} from "./types";
+import { defaultDisplayContext } from "./platform";
+
+/** Index → digit key (native path; matched against `e.key`). */
+export const PINNED_HOTKEY_DIGITS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"] as const;
+
+/** Index → physical key code (browser path; matched against `e.code`). */
+export const PINNED_HOTKEY_CODES = [
+  "Digit1",
+  "Digit2",
+  "Digit3",
+  "Digit4",
+  "Digit5",
+  "Digit6",
+  "Digit7",
+  "Digit8",
+  "Digit9",
+  "Digit0",
+] as const;
+
+const SLASH_NAV_UP: KeyBinding = { mod: "forbidden", alt: "forbidden", key: "ArrowUp" };
+const SLASH_NAV_DOWN: KeyBinding = { mod: "forbidden", alt: "forbidden", key: "ArrowDown" };
+const SLASH_APPLY: KeyBinding = { mod: "forbidden", alt: "forbidden", key: "Tab" };
+const SLASH_DISMISS: KeyBinding = { mod: "forbidden", alt: "forbidden", key: "Escape" };
+
+const GROUP_TITLES: Record<KeymapGroupId, string> = {
+  general: "General",
+  "in-chats": "In chats",
+  navigation: "Navigation",
+  view: "View",
+  "slash-commands": "Slash commands",
+};
+
+const GROUP_NOTES: Partial<Record<KeymapGroupId, string>> = {
+  "slash-commands": "while the suggestions menu is open",
+};
+
+/** Every command that ships today (mirrors KeyboardShortcutsDialog + mention menu). */
+export const KEYMAP_COMMANDS: Record<KeymapCommandId, KeymapCommand> = {
+  "command-palette": {
+    id: "command-palette",
+    label: "Open command palette",
+    group: "general",
+    scope: "global",
+    defaultBinding: { mod: "required", alt: "forbidden", shift: "forbidden", key: "k" },
+    displayKeys: (ctx) => [ctx.modKey, "K"],
+  },
+  "show-keyboard-shortcuts": {
+    id: "show-keyboard-shortcuts",
+    label: "Show keyboard shortcuts",
+    group: "general",
+    scope: "global",
+    defaultBinding: { mod: "required", alt: "forbidden", shift: "forbidden", key: "/" },
+    displayKeys: (ctx) => [ctx.modKey, "/"],
+  },
+  "send-message": {
+    id: "send-message",
+    label: "Send message",
+    group: "in-chats",
+    scope: "composer",
+    defaultBinding: { mod: "forbidden", alt: "forbidden", shift: "forbidden", key: "Enter" },
+    displayKeys: (ctx) => [ctx.enterKey],
+  },
+  "new-line-in-message": {
+    id: "new-line-in-message",
+    label: "New line in message",
+    group: "in-chats",
+    scope: "composer",
+    defaultBinding: { mod: "forbidden", alt: "forbidden", shift: "required", key: "Enter" },
+    displayKeys: (ctx) => [ctx.shiftKey, ctx.enterKey],
+  },
+  "recall-previous-prompt": {
+    id: "recall-previous-prompt",
+    label: "Recall previous prompt",
+    group: "in-chats",
+    scope: "composer",
+    defaultBinding: { mod: "forbidden", alt: "forbidden", key: "ArrowUp" },
+    displayKeys: (ctx) => [ctx.upKey],
+  },
+  "recall-next-prompt": {
+    id: "recall-next-prompt",
+    label: "Recall next prompt",
+    group: "in-chats",
+    scope: "composer",
+    defaultBinding: { mod: "forbidden", alt: "forbidden", key: "ArrowDown" },
+    displayKeys: (ctx) => [ctx.downKey],
+  },
+  "accept-approval": {
+    id: "accept-approval",
+    label: "Accept approval prompt",
+    group: "in-chats",
+    scope: "global",
+    defaultBinding: {
+      mod: "required",
+      alt: "forbidden",
+      shift: "forbidden",
+      key: "Enter",
+    },
+    displayKeys: (ctx) => [ctx.modKey, ctx.enterKey],
+  },
+  "stop-response": {
+    id: "stop-response",
+    label: "Stop response",
+    group: "in-chats",
+    scope: "composer",
+    defaultBinding: { mod: "forbidden", alt: "forbidden", key: "Escape" },
+    displayKeys: () => ["Esc"],
+  },
+  "previous-session": {
+    id: "previous-session",
+    label: "Previous session",
+    group: "navigation",
+    scope: "global",
+    defaultBinding: {
+      mod: "required",
+      alt: "forbidden",
+      shift: "forbidden",
+      key: "ArrowUp",
+    },
+    displayKeys: (ctx) => [ctx.modKey, ctx.upKey],
+  },
+  "next-session": {
+    id: "next-session",
+    label: "Next session",
+    group: "navigation",
+    scope: "global",
+    defaultBinding: {
+      mod: "required",
+      alt: "forbidden",
+      shift: "forbidden",
+      key: "ArrowDown",
+    },
+    displayKeys: (ctx) => [ctx.modKey, ctx.downKey],
+  },
+  "jump-pinned-session": {
+    id: "jump-pinned-session",
+    label: "Jump to pinned session (1–10)",
+    group: "navigation",
+    scope: "global",
+    defaultBinding: {
+      native: {
+        mod: "required",
+        alt: "forbidden",
+        shift: "forbidden",
+        keys: PINNED_HOTKEY_DIGITS,
+      },
+      browser: {
+        mod: "required",
+        alt: "required",
+        shift: "forbidden",
+        codes: PINNED_HOTKEY_CODES,
+        rejectAltGraph: true,
+      },
+    },
+    displayKeys: (ctx) =>
+      ctx.isNativeShell ? [ctx.modKey, "1…0"] : [ctx.modKey, ctx.altKey, "1…0"],
+  },
+  "toggle-conversations-sidebar": {
+    id: "toggle-conversations-sidebar",
+    label: "Toggle conversations sidebar",
+    group: "view",
+    scope: "global",
+    defaultBinding: {
+      mod: "required",
+      alt: "required",
+      shift: "forbidden",
+      code: "BracketLeft",
+      rejectAltGraph: true,
+    },
+    displayKeys: (ctx) => [ctx.modKey, ctx.altKey, "["],
+  },
+  "toggle-workspace-sidebar": {
+    id: "toggle-workspace-sidebar",
+    label: "Toggle workspace sidebar",
+    group: "view",
+    scope: "global",
+    defaultBinding: {
+      mod: "required",
+      alt: "required",
+      shift: "forbidden",
+      code: "BracketRight",
+      rejectAltGraph: true,
+    },
+    displayKeys: (ctx) => [ctx.modKey, ctx.altKey, "]"],
+  },
+  "slash-navigate-up": {
+    id: "slash-navigate-up",
+    label: "Navigate suggestions",
+    group: "slash-commands",
+    scope: "slash-menu",
+    defaultBinding: SLASH_NAV_UP,
+    displayKeys: (ctx) => [ctx.upKey, ctx.downKey],
+  },
+  "slash-navigate-down": {
+    id: "slash-navigate-down",
+    label: "Navigate suggestions",
+    group: "slash-commands",
+    scope: "slash-menu",
+    defaultBinding: SLASH_NAV_DOWN,
+    displayKeys: () => [],
+  },
+  "slash-apply-command": {
+    id: "slash-apply-command",
+    label: "Apply highlighted command",
+    group: "slash-commands",
+    scope: "slash-menu",
+    defaultBinding: SLASH_APPLY,
+    displayKeys: () => ["Tab"],
+  },
+  "slash-dismiss-menu": {
+    id: "slash-dismiss-menu",
+    label: "Dismiss menu",
+    group: "slash-commands",
+    scope: "slash-menu",
+    defaultBinding: SLASH_DISMISS,
+    displayKeys: () => ["Esc"],
+  },
+  "mention-navigate-up": {
+    id: "mention-navigate-up",
+    label: "Navigate suggestions",
+    group: "slash-commands",
+    scope: "mention-menu",
+    defaultBinding: SLASH_NAV_UP,
+    displayKeys: () => [],
+  },
+  "mention-navigate-down": {
+    id: "mention-navigate-down",
+    label: "Navigate suggestions",
+    group: "slash-commands",
+    scope: "mention-menu",
+    defaultBinding: SLASH_NAV_DOWN,
+    displayKeys: () => [],
+  },
+  "mention-apply": {
+    id: "mention-apply",
+    label: "Apply highlighted command",
+    group: "slash-commands",
+    scope: "mention-menu",
+    defaultBinding: SLASH_APPLY,
+    displayKeys: () => [],
+  },
+  "mention-dismiss": {
+    id: "mention-dismiss",
+    label: "Dismiss menu",
+    group: "slash-commands",
+    scope: "mention-menu",
+    defaultBinding: SLASH_DISMISS,
+    displayKeys: () => [],
+  },
+};
+
+const GROUP_ORDER: KeymapGroupId[] = [
+  "general",
+  "in-chats",
+  "navigation",
+  "view",
+  "slash-commands",
+];
+
+/** Commands shown in the shortcuts list, in group order (one row per label). */
+const DISPLAY_COMMAND_IDS: KeymapCommandId[] = [
+  "command-palette",
+  "show-keyboard-shortcuts",
+  "send-message",
+  "new-line-in-message",
+  "recall-previous-prompt",
+  "recall-next-prompt",
+  "accept-approval",
+  "stop-response",
+  "previous-session",
+  "next-session",
+  "jump-pinned-session",
+  "toggle-conversations-sidebar",
+  "toggle-workspace-sidebar",
+  "slash-navigate-up",
+  "slash-apply-command",
+  "slash-dismiss-menu",
+];
+
+function resolveDisplayKeys(command: KeymapCommand, ctx: KeymapDisplayContext): readonly string[] {
+  const keys =
+    typeof command.displayKeys === "function" ? command.displayKeys(ctx) : command.displayKeys;
+  return keys.length > 0 ? keys : [];
+}
+
+export function resolveCommandDefaultBinding(
+  binding: KeyBinding | PlatformKeyBinding,
+  native?: boolean,
+): KeyBinding {
+  if ("native" in binding) {
+    const isNative = native ?? false;
+    return isNative ? binding.native : binding.browser;
+  }
+  return binding;
+}
+
+/** Shortcut groups for the reference list / settings panel. */
+export function getShortcutGroups(isNative: boolean): KeymapShortcutGroup[] {
+  const ctx = defaultDisplayContext(isNative);
+  const byGroup = new Map<KeymapGroupId, KeymapShortcutGroup>();
+
+  for (const groupId of GROUP_ORDER) {
+    byGroup.set(groupId, {
+      title: GROUP_TITLES[groupId],
+      note: GROUP_NOTES[groupId],
+      items: [],
+    });
+  }
+
+  for (const id of DISPLAY_COMMAND_IDS) {
+    const command = KEYMAP_COMMANDS[id];
+    const keys = resolveDisplayKeys(command, ctx);
+    if (keys.length === 0) continue;
+    const group = byGroup.get(command.group)!;
+    group.items.push({ label: command.label, keys });
+  }
+
+  return GROUP_ORDER.map((id) => byGroup.get(id)!);
+}
+
+export function getKeymapCommand(id: KeymapCommandId): KeymapCommand {
+  return KEYMAP_COMMANDS[id];
+}
+
+export const KEYMAP_COMMAND_IDS = Object.keys(KEYMAP_COMMANDS) as KeymapCommandId[];

--- a/web/src/lib/keymap/types.ts
+++ b/web/src/lib/keymap/types.ts
@@ -21,7 +21,7 @@ export interface KeyBinding {
   code?: string;
   keys?: readonly string[];
   codes?: readonly string[];
-  /** When alt is required, ignore AltGr (Ctrl+Alt on intl layouts). */
+  /** When set, reject AltGr even if alt is not required (intl layout guard). */
   rejectAltGraph?: boolean;
 }
 

--- a/web/src/lib/keymap/types.ts
+++ b/web/src/lib/keymap/types.ts
@@ -1,0 +1,96 @@
+// Typed keymap model: named commands, physical bindings, and UI scopes.
+
+/** Where a command is meant to fire — used for grouping and future conflict rules. */
+export type KeymapScope = "global" | "composer" | "slash-menu" | "mention-menu" | "code-viewer";
+
+export type KeymapGroupId = "general" | "in-chats" | "navigation" | "view" | "slash-commands";
+
+/** Whether a modifier must be held, must not be held, or is unconstrained. */
+export type ModifierRequirement = "required" | "forbidden" | "any";
+
+/**
+ * A single chord or key press. Match `key` against `e.key` and `code` against
+ * `e.code`; `keys` / `codes` match any listed value. The primary platform
+ * modifier (⌘ on macOS, Ctrl elsewhere) is `mod` and matches `metaKey || ctrlKey`.
+ */
+export interface KeyBinding {
+  mod?: ModifierRequirement;
+  alt?: ModifierRequirement;
+  shift?: ModifierRequirement;
+  key?: string;
+  code?: string;
+  keys?: readonly string[];
+  codes?: readonly string[];
+  /** When alt is required, ignore AltGr (Ctrl+Alt on intl layouts). */
+  rejectAltGraph?: boolean;
+}
+
+/** Platform-specific default for commands whose chord differs by shell. */
+export interface PlatformKeyBinding {
+  native: KeyBinding;
+  browser: KeyBinding;
+}
+
+/** Minimal key-event shape for matching (DOM or React synthetic events). */
+export interface KeymapKeyEvent {
+  key: string;
+  code: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  getModifierState?(key: string): boolean;
+}
+
+export type KeymapCommandId =
+  | "command-palette"
+  | "show-keyboard-shortcuts"
+  | "send-message"
+  | "new-line-in-message"
+  | "recall-previous-prompt"
+  | "recall-next-prompt"
+  | "accept-approval"
+  | "stop-response"
+  | "previous-session"
+  | "next-session"
+  | "jump-pinned-session"
+  | "toggle-conversations-sidebar"
+  | "toggle-workspace-sidebar"
+  | "slash-navigate-up"
+  | "slash-navigate-down"
+  | "slash-apply-command"
+  | "slash-dismiss-menu"
+  | "mention-navigate-up"
+  | "mention-navigate-down"
+  | "mention-apply"
+  | "mention-dismiss";
+
+export interface KeymapCommand {
+  id: KeymapCommandId;
+  label: string;
+  group: KeymapGroupId;
+  scope: KeymapScope;
+  /** Default chord(s). Platform pair when the shell changes the binding. */
+  defaultBinding: KeyBinding | PlatformKeyBinding;
+  /**
+   * Keys rendered left→right in shortcut lists. A function receives display
+   * context (platform shell, modifier glyphs).
+   */
+  displayKeys: readonly string[] | ((ctx: KeymapDisplayContext) => readonly string[]);
+}
+
+export interface KeymapDisplayContext {
+  modKey: string;
+  altKey: string;
+  shiftKey: string;
+  enterKey: string;
+  upKey: string;
+  downKey: string;
+  isNativeShell: boolean;
+}
+
+export interface KeymapShortcutGroup {
+  title: string;
+  note?: string;
+  items: Array<{ label: string; keys: readonly string[] }>;
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

This is **PR 1 of 3** toward user-remappable keyboard shortcuts.

- Add `web/src/lib/keymap/` with a typed command registry (every shortcut currently listed in `KeyboardShortcutsDialog`), a key-event matcher (normalized modifiers + platform Cmd/Ctrl), and a `omnigent:keymap` localStorage pref module for future overrides.
- Refactor global hotkey hooks (`useApproveHotkey`, `useCommandPaletteHotkey`, `useSidebarToggleHotkeys`, `usePinnedSessionHotkeys`, `useSessionSwitchHotkey`), mention-menu navigation in `useMentionBrowser`, and the shortcuts dialog opener to resolve bindings from the registry.
- Drive `KeyboardShortcutsDialog` / `KeyboardShortcutsList` from the registry so the reference list cannot drift from live handlers.

**No user-visible behavior change** in this PR — defaults reproduce today's chords exactly.

## Test Plan

- [x] `cd web && npm run type-check`
- [x] `cd web && npx vitest run src/lib/keymap src/hooks/use*Hotkey*.test.tsx src/components/KeyboardShortcutsDialog.test.tsx`
- [x] `cd web && npm run build`
- [x] Prettier + oxlint on changed files
- [x] `uv run pre-commit run --files <changed web files>`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the matcher (modifier normalization, bracket codes, AltGr guard, override merge) and registry defaults (pinned-session platform split, shortcut-group display). Existing hook and dialog tests were run unchanged and pass.