### PR TITLE
feat(sandbox): let node_selector override the k8s runner arch default (arm64 support)

### DIFF
--- a/deploy/kubernetes/overlays/sandbox-runners/README.md
+++ b/deploy/kubernetes/overlays/sandbox-runners/README.md
@@ -130,9 +130,9 @@ writing nothing to disk — use HTTPS repository URLs. Details by provider match
 | `namespace` | Runner-Pod namespace (defaults to `omnigent-sandboxes`). |
 | `secret_name` | Harness-creds Secret projected into every Pod via `envFrom`. |
 | `service_account` | ServiceAccount the runner Pods run as (powerless). |
-| `image` | Optional runner image override (defaults to the official amd64 host image). |
+| `image` | Optional runner image override (defaults to the official multi-arch amd64/arm64 host image). |
 | `env` | Optional list of SERVER env-var names to inject as literal Pod env (prefer `secret_name` for credentials). |
-| `node_selector` | Optional extra node labels, merged with the mandatory `kubernetes.io/arch: amd64`. |
+| `node_selector` | Optional extra node labels, merged with a default `kubernetes.io/arch: amd64` — set that key to `arm64` to schedule runners on arm64 nodes. (arm64 note: the CEL policy module is unavailable there — `cel-expr-python` ships no aarch64 wheel — and degrades gracefully.) |
 | `resources` | Optional `requests` / `limits` (`cpu` / `memory`) override. |
 | `in_cluster` | Optional cluster-config source: `true` (in-cluster SA only), `false` (kubeconfig only), omit (try in-cluster, then kubeconfig). |
 | `kubeconfig` | Optional kubeconfig path for the out-of-cluster fallback (env: `OMNIGENT_KUBERNETES_KUBECONFIG`). |

--- a/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
+++ b/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
@@ -28,9 +28,9 @@ data:
         # ServiceAccount the runner Pods run as (deliberately powerless).
         service_account: omnigent-runner
         # ── all optional below ──
-        # image: ghcr.io/your-org/omnigent-host:latest  # default: official amd64 host image
+        # image: ghcr.io/your-org/omnigent-host:latest  # default: official multi-arch (amd64/arm64) host image
         # env: [PROXY_URL]           # SERVER env vars injected as literal Pod env (prefer secret_name for creds)
-        # node_selector:             # extra node labels, merged with the mandatory kubernetes.io/arch: amd64
+        # node_selector:             # extra node labels; default kubernetes.io/arch: amd64, override to arm64 to run there
         #   disktype: ssd
         # resources:                 # runner Pod sizing (defaults: 0.5-2 cpu / 1-4Gi)
         #   requests: {cpu: "500m", memory: "1Gi"}

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -81,7 +81,7 @@ _logger = logging.getLogger(__name__)
 HOST_IMAGE_ENV_VAR: str = "OMNIGENT_KUBERNETES_HOST_IMAGE"
 """Environment variable overriding
 :data:`~omnigent.onboarding.sandboxes.base.DEFAULT_HOST_IMAGE` for Kubernetes
-sandbox Pods (amd64-only)."""
+sandbox Pods (published multi-arch: amd64 + arm64)."""
 
 NAMESPACE_ENV_VAR: str = "OMNIGENT_KUBERNETES_NAMESPACE"
 """Environment variable naming the namespace sandbox Pods are created in.
@@ -487,8 +487,8 @@ def build_pod_manifest(
       (runAsNonRoot as the image's ``sandbox`` user :data:`_RUN_AS_UID`, drop ALL
       caps, ``seccompProfile: RuntimeDefault``, no privilege escalation). The
       root filesystem stays writable (the host writes ``/tmp`` + ``~/.omnigent``).
-    - ``kubernetes.io/arch: amd64`` is always enforced (the host image is
-      amd64-only) and CANNOT be overridden by *node_selector*.
+    - ``kubernetes.io/arch: amd64`` is the default; a *node_selector* entry for
+      that key overrides it (e.g. ``arm64`` — the host image is multi-arch).
 
     :param pod_name: DNS-label-safe Pod name (see :func:`_new_pod_name`).
     :param namespace: Namespace the Pod is created in.
@@ -504,7 +504,8 @@ def build_pod_manifest(
     :param env_literals: Literal name → value env entries (the resolved
         server-env passthrough). Secrets ride *harness_secret*, not this map.
     :param node_selector: Extra node selector labels, or ``None``. Merged with
-        the mandatory amd64 constraint, which always wins.
+        a default ``kubernetes.io/arch: amd64``; an operator-supplied
+        ``kubernetes.io/arch`` entry overrides the default.
     :param workspace: Absolute workspace root created by the init container.
     :param clone_dir: Directory the clone lands in, or ``None`` for no clone.
     :param repo_url: Repository clone URL, or ``None`` for an empty workspace.
@@ -562,9 +563,10 @@ def build_pod_manifest(
         "restartPolicy": "Never",
         "automountServiceAccountToken": False,
         "serviceAccountName": service_account,
-        # arch spread LAST so the amd64 invariant always wins — an operator
-        # "kubernetes.io/arch" key cannot drop it (the host image is amd64-only).
-        "nodeSelector": {**(node_selector or {}), "kubernetes.io/arch": "amd64"},
+        # amd64 default first so existing deployments keep their placement; an
+        # operator "kubernetes.io/arch" entry overrides it (e.g. arm64 nodes —
+        # the host image is published multi-arch).
+        "nodeSelector": {"kubernetes.io/arch": "amd64", **(node_selector or {})},
         "securityContext": {
             "runAsNonRoot": True,
             "runAsUser": _RUN_AS_UID,
@@ -776,8 +778,9 @@ class KubernetesSandboxLauncher(SandboxLauncher):
             literal env. ``None`` resolves :data:`SANDBOX_ENV_PASSTHROUGH_ENV_VAR`.
         :param secret_name: Kubernetes Secret to project via ``envFrom``.
             ``None`` resolves :data:`SANDBOX_SECRET_ENV_VAR` then no Secret.
-        :param node_selector: Extra node selector labels merged with the
-            mandatory ``kubernetes.io/arch: amd64`` constraint.
+        :param node_selector: Extra node selector labels merged with a default
+            ``kubernetes.io/arch: amd64``; a ``kubernetes.io/arch`` entry here
+            overrides the default (e.g. ``arm64``).
         :param service_account: ServiceAccount Pods run as. ``None`` resolves
             :data:`SERVICE_ACCOUNT_ENV_VAR` then :data:`_DEFAULT_SERVICE_ACCOUNT`.
         :param kubeconfig: Kubeconfig path for the out-of-cluster fallback.

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1656,8 +1656,9 @@ def _kubernetes_launcher_factory(
     :param secret_name: Pre-created Secret projected into every Pod via
         ``envFrom`` (harness credentials), or ``None``.
     :param service_account: ServiceAccount the Pods run as, or ``None``.
-    :param node_selector: Extra node selector labels merged with the mandatory
-        amd64 constraint, or ``None``.
+    :param node_selector: Extra node selector labels merged with a default
+        ``kubernetes.io/arch: amd64`` (an entry for that key overrides it),
+        or ``None``.
     :param kubeconfig: Explicit kubeconfig path for the out-of-cluster fallback,
         or ``None``.
     :param in_cluster: Force the cluster-config source, or ``None`` to try

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -133,13 +133,19 @@ def test_build_pod_manifest_omits_envfrom_without_harness_secret() -> None:
     assert "envFrom" not in manifest["spec"]["containers"][0]
 
 
-def test_build_pod_manifest_amd64_invariant_cannot_be_overridden() -> None:
-    """A node_selector cannot drop the mandatory amd64 constraint."""
+def test_build_pod_manifest_defaults_to_amd64_node_selector() -> None:
+    """No node_selector → Pods keep the amd64 default placement."""
+    manifest = build_pod_manifest(**{**_MANIFEST_KW, "node_selector": None})
+    assert manifest["spec"]["nodeSelector"] == {"kubernetes.io/arch": "amd64"}
+
+
+def test_build_pod_manifest_node_selector_can_override_arch() -> None:
+    """An operator kubernetes.io/arch entry overrides the amd64 default."""
     manifest = build_pod_manifest(
         **{**_MANIFEST_KW, "node_selector": {"disktype": "ssd", "kubernetes.io/arch": "arm64"}}
     )
     selector = manifest["spec"]["nodeSelector"]
-    assert selector["kubernetes.io/arch"] == "amd64"
+    assert selector["kubernetes.io/arch"] == "arm64"
     assert selector["disktype"] == "ssd"
 
 


### PR DESCRIPTION
## Related issue

N/A — follow-up to the multi-arch image publish and the kubernetes sandbox provider (no dedicated open issue).

## Summary

- The `kubernetes` sandbox launcher force-merges `kubernetes.io/arch: amd64` **last** into every runner Pod's `nodeSelector`, so an operator-supplied arch entry could never win. That invariant guarded a premise that's now stale: the official host image publishes as a multi-arch manifest list (linux/amd64 + linux/arm64), so runner Pods can run natively on arm64 nodes (e.g. arm64 k3s / Raspberry Pi nodes in a homelab cluster).
- This flips the merge order in `build_pod_manifest`: `kubernetes.io/arch: amd64` stays as the **default** (zero behavior change for every existing deployment that doesn't set the key), but an explicit `sandbox.kubernetes.node_selector: {kubernetes.io/arch: arm64}` now takes effect. No new config surface — `node_selector` already exists, is validated, and flows end-to-end.
- Docs updated to match (launcher docstrings, sandbox-runners overlay README + sample config), including a note that the CEL policy module degrades gracefully on arm64 (`cel-expr-python` ships no aarch64 wheel).

ELI5: the Pod spec used to say "amd64 nodes only, no exceptions" because the runner image only existed for amd64. The image now ships for both amd64 and arm64, so "no exceptions" just blocks arm64 clusters — this keeps amd64 as the default answer but lets the operator overrule it.

Scheduling across *both* arches simultaneously (`nodeAffinity` with `In: [amd64, arm64]`) is an explicit non-goal here; a flat `nodeSelector` can't express it and nothing asks for it yet.

## Test Plan

- `uv run pytest tests/onboarding/sandboxes/test_kubernetes.py tests/server/test_managed_hosts.py` — 128 passed.
- Replaced the amd64-invariant unit test with two tests: `node_selector=None` still yields exactly `{"kubernetes.io/arch": "amd64"}` (locks in backward compat), and an operator `kubernetes.io/arch: arm64` + extra label overrides the default while unrelated labels merge through.
- `pre-commit run` on the changed files — clean.

## Demo

No UI — the change is Pod-manifest generation, so here is the behavior itself: real `build_pod_manifest` output from this repo, main vs this branch, for an operator config of `sandbox.kubernetes.node_selector: {kubernetes.io/arch: arm64, storage: fast}`:

```text
BEFORE (main)              spec.nodeSelector = {'kubernetes.io/arch': 'amd64', 'storage': 'fast'}
                           └─ the arm64 override is silently clobbered back to amd64

AFTER (this branch)        spec.nodeSelector = {'kubernetes.io/arch': 'arm64', 'storage': 'fast'}
                           └─ the operator's arch wins; unrelated labels merge through

AFTER, no node_selector    spec.nodeSelector = {'kubernetes.io/arch': 'amd64'}
                           └─ default unchanged — zero behavior change for existing deployments
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The manifest builder is a pure function and the unit tests assert the exact `nodeSelector` produced for both the default and override paths; config parsing/validation of `node_selector` is already covered by `tests/server/test_managed_hosts.py` and is unchanged.

## Changelog

Kubernetes sandbox runner Pods can now schedule on arm64 nodes: set `sandbox.kubernetes.node_selector: {kubernetes.io/arch: arm64}` (amd64 remains the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

