### PR TITLE
fix(codex-native): surface MCP startup in the web session and let Stop cancel it

### DIFF
--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -538,6 +538,10 @@ def settle_pending_mcp_startup(bridge_dir: Path) -> tuple[dict[str, dict[str, st
     :returns: ``(map_after, changed)`` — the settled map and whether any
         entry was dropped.
     """
+    # The read→write below is not locked across processes: a runner Stop
+    # can flip an entry to ``cancelled`` in between, and this write drops
+    # it. Cosmetic only — both outcomes end the round, and the Stop path
+    # publishes its cancelled map independently.
     servers = read_mcp_startup(bridge_dir)
     pending = pending_mcp_servers(servers)
     if not pending:

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -19,6 +19,21 @@ CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CODEX_NATIVE_REQUEST_SESSION_
 
 _STATE_FILE = "state.json"
 _STARTUP_ERROR_FILE = "startup_error.json"
+# Per-MCP-server startup state mirrored from Codex's
+# ``mcpServer/startupStatus/updated`` notifications. Written by the
+# forwarder (and by ``wait_for_thread_started`` while it drains startup
+# events), read by the executor's first-turn gate and the runner's
+# Stop handler.
+_MCP_STARTUP_FILE = "mcp_startup.json"
+
+# Startup states mirrored from Codex's ``McpServerStartupState`` enum.
+MCP_STARTUP_STARTING = "starting"
+MCP_STARTUP_READY = "ready"
+MCP_STARTUP_FAILED = "failed"
+MCP_STARTUP_CANCELLED = "cancelled"
+MCP_STARTUP_STATES = frozenset(
+    {MCP_STARTUP_STARTING, MCP_STARTUP_READY, MCP_STARTUP_FAILED, MCP_STARTUP_CANCELLED}
+)
 # Must match ``_CONFIG_FILE`` in ``claude_native_bridge.py`` because
 # ``serve-mcp`` reads this filename for the token.
 _MCP_CONFIG_FILE = "bridge.json"
@@ -341,7 +356,7 @@ def clear_bridge_state(bridge_dir: Path) -> None:
     :param bridge_dir: Native Codex bridge directory.
     :returns: None.
     """
-    for name in (_STATE_FILE, _STARTUP_ERROR_FILE):
+    for name in (_STATE_FILE, _STARTUP_ERROR_FILE, _MCP_STARTUP_FILE):
         try:
             (bridge_dir / name).unlink()
         except FileNotFoundError:
@@ -390,6 +405,162 @@ def read_bridge_startup_error(bridge_dir: Path) -> str | None:
         return None
     message = raw.get("message")
     return message if isinstance(message, str) and message else None
+
+
+def read_mcp_startup(bridge_dir: Path) -> dict[str, dict[str, str | None]]:
+    """
+    Read the recorded per-MCP-server startup state.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :returns: Mapping of server name to its latest startup record, e.g.
+        ``{"safe": {"status": "starting", "error": None}}``. Empty when
+        no state has been recorded or the file is unreadable.
+    """
+    path = bridge_dir / _MCP_STARTUP_FILE
+    if not path.is_file():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    servers = raw.get("servers") if isinstance(raw, dict) else None
+    if not isinstance(servers, dict):
+        return {}
+    parsed: dict[str, dict[str, str | None]] = {}
+    for name, record in servers.items():
+        if not (isinstance(name, str) and name and isinstance(record, dict)):
+            continue
+        status = record.get("status")
+        if status not in MCP_STARTUP_STATES:
+            continue
+        error = record.get("error")
+        parsed[name] = {
+            "status": status,
+            "error": error if isinstance(error, str) and error else None,
+        }
+    return parsed
+
+
+def _write_mcp_startup(bridge_dir: Path, servers: dict[str, dict[str, str | None]]) -> None:
+    """
+    Persist the per-MCP-server startup map atomically (best-effort).
+
+    :param bridge_dir: Native Codex bridge directory.
+    :param servers: Full startup map, e.g.
+        ``{"safe": {"status": "ready", "error": None}}``.
+    :returns: None.
+    """
+    try:
+        bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        path = bridge_dir / _MCP_STARTUP_FILE
+        fd, tmp_name = tempfile.mkstemp(prefix=f"{_MCP_STARTUP_FILE}.", dir=str(bridge_dir))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump({"servers": servers}, handle, sort_keys=True)
+                handle.write("\n")
+            os.replace(tmp_name, path)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+    except OSError:
+        return  # best-effort; surfacing MCP state must never sink startup
+
+
+def update_mcp_server_startup(
+    bridge_dir: Path,
+    name: str,
+    status: str,
+    error: str | None = None,
+) -> dict[str, dict[str, str | None]]:
+    """
+    Record one Codex MCP-server startup update.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :param name: MCP server name, e.g. ``"storage-console"``.
+    :param status: One of :data:`MCP_STARTUP_STATES`.
+    :param error: Failure detail when ``status == "failed"``, e.g.
+        ``"handshaking with MCP server failed"``. ``None`` otherwise.
+    :returns: The full startup map after the update.
+    """
+    servers = read_mcp_startup(bridge_dir)
+    servers[name] = {"status": status, "error": error}
+    _write_mcp_startup(bridge_dir, servers)
+    return servers
+
+
+def pending_mcp_servers(servers: dict[str, dict[str, str | None]]) -> list[str]:
+    """
+    Return the MCP servers still reported as ``starting``.
+
+    :param servers: Startup map from :func:`read_mcp_startup`.
+    :returns: Sorted server names whose latest status is ``starting``.
+    """
+    return sorted(
+        name for name, record in servers.items() if record.get("status") == MCP_STARTUP_STARTING
+    )
+
+
+def cancel_pending_mcp_startup(bridge_dir: Path) -> list[str]:
+    """
+    Mark every still-``starting`` MCP server as ``cancelled``.
+
+    Used by the Stop path so the executor's first-turn gate unblocks
+    immediately, even when Codex's own ``cancelled`` notifications are
+    delayed or lost.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :returns: Sorted names of the servers that were flipped, e.g.
+        ``["storage-console"]``. Empty when nothing was pending.
+    """
+    servers = read_mcp_startup(bridge_dir)
+    pending = pending_mcp_servers(servers)
+    if not pending:
+        return []
+    for name in pending:
+        servers[name] = {"status": MCP_STARTUP_CANCELLED, "error": servers[name].get("error")}
+    _write_mcp_startup(bridge_dir, servers)
+    return pending
+
+
+def settle_pending_mcp_startup(bridge_dir: Path) -> tuple[dict[str, dict[str, str | None]], bool]:
+    """
+    Drop every still-``starting`` MCP server from the recorded map.
+
+    Codex delivers per-server terminal states (ready/failed) only to the
+    connection that owns the thread — never to Omnigent's observer
+    connection — so when a settle signal arrives (the thread went idle
+    after a turn, or the startup window elapsed) the round is known to be
+    over but the per-server outcomes are not. Unresolved entries are
+    removed rather than guessed; locally-known terminal states
+    (``cancelled`` from a Stop) are preserved.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :returns: ``(map_after, changed)`` — the settled map and whether any
+        entry was dropped.
+    """
+    servers = read_mcp_startup(bridge_dir)
+    pending = pending_mcp_servers(servers)
+    if not pending:
+        return servers, False
+    for name in pending:
+        servers.pop(name, None)
+    _write_mcp_startup(bridge_dir, servers)
+    return servers, True
+
+
+def mcp_startup_waiting_detail(servers: dict[str, dict[str, str | None]]) -> str | None:
+    """
+    Describe the MCP servers a startup wait is still blocked on.
+
+    :param servers: Startup map from :func:`read_mcp_startup`.
+    :returns: Text naming the pending servers, e.g.
+        ``"MCP startup still waiting on storage-console"``, or ``None``
+        when nothing is pending.
+    """
+    pending = pending_mcp_servers(servers)
+    if not pending:
+        return None
+    return f"MCP startup still waiting on {', '.join(pending)}"
 
 
 def read_bridge_state(bridge_dir: Path) -> CodexNativeBridgeState | None:

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -39,6 +39,7 @@ from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
     clear_active_turn_id_if_matches,
     codex_home_for_bridge_dir,
+    pending_mcp_servers,
     read_bridge_state,
     read_codex_config_model,
     read_mcp_startup,
@@ -3164,12 +3165,41 @@ def _mcp_startup_settle_timeout_seconds(bridge_dir: Path) -> float:
     servers = config.get("mcp_servers")
     if isinstance(servers, dict):
         for table in servers.values():
-            if not isinstance(table, dict):
+            # Same enabled filter as _expected_mcp_servers_from_config:
+            # codex never boots a disabled server, so its budget must not
+            # stretch the window for a round it is not part of.
+            if not isinstance(table, dict) or table.get("enabled") is False:
                 continue
             timeout = table.get("startup_timeout_sec")
             if isinstance(timeout, (int, float)) and timeout > slowest:
                 slowest = float(timeout)
     return min(slowest + _MCP_STARTUP_SETTLE_GRACE_SECONDS, _MCP_STARTUP_SETTLE_MAX_SECONDS)
+
+
+def _arm_mcp_settle_timer(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+) -> asyncio.Task[None]:
+    """
+    Arm the bounded settle window for an in-flight MCP startup round.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param bridge_dir: Native Codex bridge directory.
+    :returns: The settle-timer task.
+    """
+    timeout = _mcp_startup_settle_timeout_seconds(bridge_dir)
+
+    async def settle_after_window() -> None:
+        """Settle the synthesized round once the startup window elapses."""
+        await _sleep(timeout)
+        await _settle_mcp_startup(
+            client, session_id=session_id, bridge_dir=bridge_dir, reason="startup window elapsed"
+        )
+
+    return asyncio.create_task(settle_after_window(), name="codex-native-mcp-settle")
 
 
 async def _seed_mcp_startup_round(
@@ -3181,19 +3211,27 @@ async def _seed_mcp_startup_round(
     """
     Record the config-declared MCP servers as ``starting`` and post them.
 
-    Runs once per app-server launch: ``clear_bridge_state`` wipes the
+    Seeds once per app-server launch: ``clear_bridge_state`` wipes the
     recorded map before each launch, and an existing map means a
     forwarder reconnect mid-session — reseeding then would flash a false
-    "starting" band for servers that finished booting long ago.
+    "starting" band for servers that finished booting long ago. A
+    reconnect that finds the round still pending does re-arm the settle
+    window, though: the previous forwarder's timer died with it, and
+    without a replacement a missed idle edge would leave the band stuck
+    on "starting" for the rest of the session.
 
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param bridge_dir: Native Codex bridge directory.
-    :returns: The armed settle-timer task, or ``None`` when nothing was
-        seeded.
+    :returns: The armed settle-timer task, or ``None`` when the recorded
+        round has already settled.
     """
-    if read_mcp_startup(bridge_dir):
-        return None
+    existing = read_mcp_startup(bridge_dir)
+    if existing:
+        if not pending_mcp_servers(existing):
+            return None
+        _logger.info("Codex MCP startup round still pending after reconnect; re-arming settle")
+        return _arm_mcp_settle_timer(client, session_id=session_id, bridge_dir=bridge_dir)
     expected = _expected_mcp_servers_from_config(bridge_dir)
     if not expected:
         return None
@@ -3202,16 +3240,7 @@ async def _seed_mcp_startup_round(
         servers = update_mcp_server_startup(bridge_dir, name, MCP_STARTUP_STARTING)
     _logger.info("Codex MCP startup round synthesized: %s", ", ".join(expected))
     await _post_mcp_startup(client, session_id, servers)
-    timeout = _mcp_startup_settle_timeout_seconds(bridge_dir)
-
-    async def settle_after_window() -> None:
-        """Settle the synthesized round once the startup window elapses."""
-        await _sleep(timeout)
-        await _settle_mcp_startup(
-            client, session_id=session_id, bridge_dir=bridge_dir, reason="startup window elapsed"
-        )
-
-    return asyncio.create_task(settle_after_window(), name="codex-native-mcp-settle")
+    return _arm_mcp_settle_timer(client, session_id=session_id, bridge_dir=bridge_dir)
 
 
 async def _settle_mcp_startup(

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -34,12 +34,17 @@ from omnigent.codex_native_app_server import (
 )
 from omnigent.codex_native_bridge import (
     CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
+    MCP_STARTUP_STARTING,
+    MCP_STARTUP_STATES,
     CodexNativeBridgeState,
     clear_active_turn_id_if_matches,
     codex_home_for_bridge_dir,
     read_bridge_state,
     read_codex_config_model,
+    read_mcp_startup,
+    settle_pending_mcp_startup,
     update_active_turn_id,
+    update_mcp_server_startup,
     update_thread_id,
     write_bridge_state,
 )
@@ -112,6 +117,31 @@ _CODEX_ELICITATION_CONNECT_TIMEOUT_SECONDS = 30.0
 _CODEX_ELICITATION_RETRY_INITIAL_BACKOFF_SECONDS = 1.0
 _CODEX_ELICITATION_RETRY_MAX_BACKOFF_SECONDS = 30.0
 _CODEX_MCP_ELICITATION_REQUEST_METHOD = "mcpServer/elicitation/request"
+# Per-server MCP startup progress (issue #2058). Codex runs an MCP
+# startup round when a thread starts, but delivers the per-server
+# ``mcpServer/startupStatus/updated`` edges ONLY to the connection that
+# owns the thread (the TUI) — verified against codex 0.142.5 — so this
+# observer connection cannot passively mirror them. Instead the round is
+# SYNTHESIZED: at forwarder start the config-declared servers are
+# recorded as ``starting`` (true — codex boots them all at thread start)
+# in the bridge dir and posted to Omnigent as ``external_mcp_startup``; the
+# round is settled (unresolved entries dropped) when the thread goes
+# idle after a turn — codex defers turn execution until startup ends, so
+# an idle edge proves the round is over — or when the config-derived
+# startup window elapses. ``cancelled`` states are recorded locally by
+# the Stop path. The notification handler is kept as a zero-cost path
+# for any delivery codex broadens later (it fully supersedes synthesis
+# when edges do arrive).
+_CODEX_MCP_STARTUP_STATUS_METHOD = "mcpServer/startupStatus/updated"
+_CODEX_THREAD_STATUS_CHANGED_METHOD = "thread/status/changed"
+_EXTERNAL_MCP_STARTUP_TYPE = "external_mcp_startup"
+# Codex bounds each MCP server's spawn+handshake by its per-server
+# ``startup_timeout_sec`` (codex default 10s); the round cannot outlive
+# the slowest server's budget. The synthesis settle timer mirrors that
+# bound, with floor/grace/cap keeping a misconfigured value sane.
+_MCP_STARTUP_DEFAULT_TIMEOUT_SECONDS = 10.0
+_MCP_STARTUP_SETTLE_GRACE_SECONDS = 15.0
+_MCP_STARTUP_SETTLE_MAX_SECONDS = 240.0
 _CODEX_TOOL_REQUEST_USER_INPUT_METHOD = "item/tool/requestUserInput"
 _CODEX_COMMAND_EXECUTION_REQUEST_APPROVAL_METHOD = "item/commandExecution/requestApproval"
 _CODEX_FILE_CHANGE_REQUEST_APPROVAL_METHOD = "item/fileChange/requestApproval"
@@ -1601,6 +1631,14 @@ async def supervise_forwarder(
         # outage or restart). Runs before live forwarding begins, so no
         # other writer races the dead-letter files (#1579).
         await _replay_dead_letters_on_startup(ap_client, bridge_dir)
+        # Synthesize the thread's MCP startup round (see the comment on
+        # _CODEX_MCP_STARTUP_STATUS_METHOD): the fresh-launch forwarder
+        # starts right at thread creation, which is when codex boots its
+        # configured MCP servers. Skipped when the bridge already carries
+        # round state (forwarder reconnect mid-session).
+        mcp_settle_timer = await _seed_mcp_startup_round(
+            ap_client, session_id=session_id, bridge_dir=bridge_dir
+        )
         target = _ForwarderTarget(
             session_id=session_id,
             thread_id=thread_id,
@@ -1686,6 +1724,10 @@ async def supervise_forwarder(
                 except Exception:  # noqa: BLE001 - keep the long-lived mirror alive.
                     _logger.warning("Codex forwarder event handling failed", exc_info=True)
         finally:
+            if mcp_settle_timer is not None:
+                mcp_settle_timer.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await mcp_settle_timer
             await target.delta_coalescer.close()
             await target.usage_coalescer.close()
             await target.elicitation_tracker.close()
@@ -2254,6 +2296,39 @@ async def _handle_event(
                 _parent_thread_id_from_started_event(event),
             )
         return
+    if method == _CODEX_MCP_STARTUP_STATUS_METHOD:
+        # MCP startup is bridge-level state, surfaced on the parent
+        # session. The notification's ``threadId`` is nullable; a child
+        # thread's startup (different id) is not mirrored.
+        event_thread_id = _thread_id_from_params(params)
+        if (
+            event_thread_id is None
+            or expected_thread_id is None
+            or event_thread_id == expected_thread_id
+        ):
+            parent_session_id = (
+                forwarder_state.parent_session_id
+                if forwarder_state is not None and forwarder_state.parent_session_id is not None
+                else session_id
+            )
+            await _handle_mcp_startup_status(
+                client,
+                session_id=parent_session_id,
+                bridge_dir=bridge_dir,
+                params=params,
+            )
+        return
+    if _is_thread_idle_status_event(method, params) and _thread_id_from_params(params) in {
+        None,
+        expected_thread_id,
+    }:
+        # A completed turn proves MCP startup settled (codex defers turn
+        # execution until the round ends) — resolve the synthesized round.
+        # Not an exclusive handler: idle status also feeds the subscribe
+        # release below, so fall through.
+        await _settle_mcp_startup(
+            client, session_id=session_id, bridge_dir=bridge_dir, reason="thread went idle"
+        )
     # Resolve routing: parent thread, known child thread, or stale/ignored.
     route_session_id, is_child = _resolve_event_session(
         params, method, expected_thread_id, forwarder_state, fallback_session_id=session_id
@@ -2987,6 +3062,228 @@ def _handle_turn_diff_updated(
         return
     diff = params.get("diff")
     forwarder_state.note_turn_diff(turn_id, diff if isinstance(diff, str) else "")
+
+
+async def _handle_mcp_startup_status(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    params: dict[str, Any],
+) -> None:
+    """
+    Mirror one Codex MCP-server startup update.
+
+    Records the update into the bridge dir (the Stop path and turn-error
+    text read it) and republishes the full per-server map to Omnigent so the
+    web session shows startup progress. In practice codex delivers these
+    edges only to the thread-owning connection (see the comment on
+    :data:`_CODEX_MCP_STARTUP_STATUS_METHOD`); when they do arrive they
+    carry real terminal states and supersede the synthesized round.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param bridge_dir: Native Codex bridge directory.
+    :param params: Codex ``mcpServer/startupStatus/updated`` params, e.g.
+        ``{"name": "safe", "status": "failed", "error": "..."}``.
+    :returns: None.
+    """
+    name = params.get("name")
+    status = params.get("status")
+    if not (isinstance(name, str) and name and status in MCP_STARTUP_STATES):
+        _logger.info("Codex forwarder ignored malformed MCP startup update: %r", params)
+        return
+    error = params.get("error")
+    servers = update_mcp_server_startup(
+        bridge_dir,
+        name,
+        status,
+        error=error if isinstance(error, str) and error else None,
+    )
+    await _post_mcp_startup(client, session_id, servers)
+
+
+def _expected_mcp_servers_from_config(bridge_dir: Path) -> list[str]:
+    """
+    Read the enabled MCP server names from the session's Codex config.
+
+    The per-session ``config.toml`` (private ``CODEX_HOME``) is what the
+    app-server loads, so its ``[mcp_servers.*]`` tables are exactly the
+    servers codex boots at thread start — including the injected
+    ``omnigent`` relay server. Codex-internal servers that are not
+    config-declared (e.g. ``codex_apps``) are not visible here and are
+    simply absent from the synthesized round.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :returns: Sorted enabled server names, e.g. ``["omnigent", "safe"]``.
+        Empty when the config is missing or unparsable.
+    """
+    import tomllib
+
+    config_path = codex_home_for_bridge_dir(bridge_dir) / "config.toml"
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return []
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return []
+    return sorted(
+        name
+        for name, table in servers.items()
+        if isinstance(name, str)
+        and name
+        and isinstance(table, dict)
+        and table.get("enabled") is not False
+    )
+
+
+def _mcp_startup_settle_timeout_seconds(bridge_dir: Path) -> float:
+    """
+    Derive the synthesized round's settle window from the session config.
+
+    Codex bounds each server's spawn+handshake by its per-server
+    ``startup_timeout_sec`` (default
+    :data:`_MCP_STARTUP_DEFAULT_TIMEOUT_SECONDS`), so the round cannot
+    outlive the slowest server's budget; a grace period absorbs spawn
+    overhead and the cap keeps a misconfigured budget from pinning the
+    band for many minutes.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :returns: Settle timeout in seconds, e.g. ``135.0`` for a config whose
+        slowest server declares ``startup_timeout_sec = 120``.
+    """
+    import tomllib
+
+    slowest = _MCP_STARTUP_DEFAULT_TIMEOUT_SECONDS
+    config_path = codex_home_for_bridge_dir(bridge_dir) / "config.toml"
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        config = {}
+    servers = config.get("mcp_servers")
+    if isinstance(servers, dict):
+        for table in servers.values():
+            if not isinstance(table, dict):
+                continue
+            timeout = table.get("startup_timeout_sec")
+            if isinstance(timeout, (int, float)) and timeout > slowest:
+                slowest = float(timeout)
+    return min(slowest + _MCP_STARTUP_SETTLE_GRACE_SECONDS, _MCP_STARTUP_SETTLE_MAX_SECONDS)
+
+
+async def _seed_mcp_startup_round(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+) -> asyncio.Task[None] | None:
+    """
+    Record the config-declared MCP servers as ``starting`` and post them.
+
+    Runs once per app-server launch: ``clear_bridge_state`` wipes the
+    recorded map before each launch, and an existing map means a
+    forwarder reconnect mid-session — reseeding then would flash a false
+    "starting" band for servers that finished booting long ago.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param bridge_dir: Native Codex bridge directory.
+    :returns: The armed settle-timer task, or ``None`` when nothing was
+        seeded.
+    """
+    if read_mcp_startup(bridge_dir):
+        return None
+    expected = _expected_mcp_servers_from_config(bridge_dir)
+    if not expected:
+        return None
+    servers: dict[str, dict[str, str | None]] = {}
+    for name in expected:
+        servers = update_mcp_server_startup(bridge_dir, name, MCP_STARTUP_STARTING)
+    _logger.info("Codex MCP startup round synthesized: %s", ", ".join(expected))
+    await _post_mcp_startup(client, session_id, servers)
+    timeout = _mcp_startup_settle_timeout_seconds(bridge_dir)
+
+    async def settle_after_window() -> None:
+        """Settle the synthesized round once the startup window elapses."""
+        await _sleep(timeout)
+        await _settle_mcp_startup(
+            client, session_id=session_id, bridge_dir=bridge_dir, reason="startup window elapsed"
+        )
+
+    return asyncio.create_task(settle_after_window(), name="codex-native-mcp-settle")
+
+
+async def _settle_mcp_startup(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    reason: str,
+) -> None:
+    """
+    Settle the synthesized MCP startup round, if any of it is unresolved.
+
+    Drops still-``starting`` entries from the bridge map (their real
+    terminal states are only ever delivered to the thread-owning
+    connection) and posts the settled map so the web band clears.
+    Locally-recorded terminal states — ``cancelled`` from a Stop — are
+    preserved. Idempotent: a fully settled map is left untouched.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param bridge_dir: Native Codex bridge directory.
+    :param reason: Settle trigger for logs, e.g. ``"thread went idle"``.
+    :returns: None.
+    """
+    servers, changed = settle_pending_mcp_startup(bridge_dir)
+    if not changed:
+        return
+    _logger.info("Codex MCP startup round settled (%s)", reason)
+    await _post_mcp_startup(client, session_id, servers)
+
+
+def _is_thread_idle_status_event(method: str, params: dict[str, Any]) -> bool:
+    """
+    Return whether an event reports the thread going idle.
+
+    Codex defers turn execution until MCP startup settles, so a thread
+    reaching ``idle`` after a turn proves the startup round is over. This
+    is one of the few notifications codex broadcasts to non-owning
+    connections, making it the natural live settle signal for the
+    synthesized round.
+
+    :param method: Codex method value, e.g. ``"thread/status/changed"``.
+    :param params: Codex notification params.
+    :returns: ``True`` for an idle ``thread/status/changed``.
+    """
+    if method != _CODEX_THREAD_STATUS_CHANGED_METHOD:
+        return False
+    status = params.get("status")
+    return isinstance(status, dict) and status.get("type") == "idle"
+
+
+async def _post_mcp_startup(
+    client: httpx.AsyncClient,
+    session_id: str,
+    servers: dict[str, dict[str, str | None]],
+) -> None:
+    """
+    Post the current per-MCP-server startup map to Omnigent.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param servers: Full startup map, e.g.
+        ``{"safe": {"status": "starting", "error": None}}``.
+    :returns: None.
+    """
+    response = await _post_session_event(
+        client,
+        session_id,
+        event_type=_EXTERNAL_MCP_STARTUP_TYPE,
+        data={"servers": servers},
+    )
+    _log_failed_session_event_post(_EXTERNAL_MCP_STARTUP_TYPE, response)
 
 
 def _is_codex_elicitation_request(event: CodexMessage) -> bool:

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -15,8 +15,11 @@ from omnigent.codex_native_app_server import client_for_transport
 from omnigent.codex_native_bridge import (
     CODEX_NATIVE_BRIDGE_DIR_ENV_VAR,
     CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
+    cancel_pending_mcp_startup,
+    mcp_startup_waiting_detail,
     read_bridge_startup_error,
     read_bridge_state,
+    read_mcp_startup,
     update_active_turn_id,
 )
 from omnigent.inner.executor import (
@@ -115,15 +118,28 @@ class CodexNativeExecutor(Executor):
 
     async def interrupt_session(self, session_key: str) -> bool:
         """
-        Interrupt the active native Codex turn.
+        Interrupt the active native Codex turn and any in-flight MCP startup.
+
+        Stop means "stop everything": the active turn (which codex may be
+        holding back until MCP startup settles) is interrupted with its
+        recorded turn id, and a still-pending MCP startup round is
+        cancelled the way the Codex TUI does — ``turn/interrupt`` with an
+        empty turn id (its ``startup_interrupt``). Either alone also works:
+        no recorded turn cancels just the startup; no pending startup
+        interrupts just the turn.
 
         :param session_key: Adapter session key. Unused because the
             bridge is per conversation.
-        :returns: ``True`` when an interrupt was sent.
+        :returns: ``True`` when an interrupt or a startup cancel was sent.
         """
         del session_key
         state = read_bridge_state(self._bridge_dir)
-        if state is None or state.active_turn_id is None:
+        if state is None:
+            return False
+        # Flip the local map first: the cancelled record is what the web
+        # band and turn-error text read, even if Codex never acknowledges.
+        pending = cancel_pending_mcp_startup(self._bridge_dir)
+        if state.active_turn_id is None and not pending:
             return False
         client = client_for_transport(
             state.socket_path,
@@ -131,13 +147,26 @@ class CodexNativeExecutor(Executor):
         )
         await client.connect()
         try:
-            await client.request(
-                "turn/interrupt",
-                {
-                    "threadId": state.thread_id,
-                    "turnId": state.active_turn_id,
-                },
-            )
+            if pending:
+                # Startup interrupt first and best-effort: the local
+                # cancel above already updated what Omnigent shows, and a
+                # failure here must not block the active-turn interrupt.
+                try:
+                    await client.request(
+                        "turn/interrupt",
+                        {"threadId": state.thread_id, "turnId": ""},
+                    )
+                except Exception:  # noqa: BLE001 - the local cancel above already took effect.
+                    _logger.warning("Codex native MCP startup interrupt failed", exc_info=True)
+                _logger.info("Codex native MCP startup cancelled: %s", ", ".join(pending))
+            if state.active_turn_id is not None:
+                await client.request(
+                    "turn/interrupt",
+                    {
+                        "threadId": state.thread_id,
+                        "turnId": state.active_turn_id,
+                    },
+                )
         finally:
             await client.close()
         return True
@@ -189,6 +218,11 @@ class CodexNativeExecutor(Executor):
                 state = read_bridge_state(self._bridge_dir)
                 if state is not None:
                     break
+
+        # No client-side wait for Codex MCP startup: the app-server accepts
+        # ``turn/start`` mid-startup and defers execution until the round
+        # settles (verified against codex 0.142.5), so sending immediately
+        # is safe. The web UI's MCP-startup band explains the wait.
 
         # Serialized against enqueue_session_message: the
         # turn/start-vs-turn/steer decision, the RPC, and the
@@ -255,6 +289,12 @@ class CodexNativeExecutor(Executor):
                             _logger.info("Codex native started turn: turn_id=%s", turn_id)
                 except Exception as exc:  # noqa: BLE001 - converted into a harness error event.
                     error_msg = f"Codex native executor error: {exc}"
+                    # Name the servers a still-unsettled MCP startup is
+                    # blocked on — the most common cause of an injection
+                    # failure this early in the session's life.
+                    waiting = mcp_startup_waiting_detail(read_mcp_startup(self._bridge_dir))
+                    if waiting:
+                        error_msg = f"{error_msg} ({waiting})"
                 finally:
                     await client.close()
         if error_msg is not None:

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -138,6 +138,9 @@ class CodexNativeExecutor(Executor):
             return False
         # Flip the local map first: the cancelled record is what the web
         # band and turn-error text read, even if Codex never acknowledges.
+        # Unlike the runner's Stop handler, the flipped map is not
+        # published here — the inner process has no server client; web
+        # Stop routes through the runner handler, which does publish.
         pending = cancel_pending_mcp_startup(self._bridge_dir)
         if state.active_turn_id is None and not pending:
             return False

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10821,19 +10821,51 @@ def create_runner_app(
         message). claude-native is unaffected: its badge mirrors Claude Code's
         *own* ``[Request interrupted by user]`` record, which is real.
 
+        Stop also cancels an in-flight MCP startup round (issue #2058): the
+        bridge's still-``starting`` servers are marked ``cancelled``
+        locally (what the web band and turn-error text read, even if Codex
+        never acknowledges) and the app-server is asked to abort startup
+        the way the Codex TUI does — ``turn/interrupt`` with an EMPTY turn
+        id (its ``startup_interrupt``). This runs alongside the active-turn
+        interrupt when both apply, because codex defers a mid-startup
+        turn's execution until the round settles: stopping only the turn
+        would leave the user watching a startup they asked to stop.
+
         :param conv_id: Session/conversation identifier, e.g.
             ``"conv_abc123"``.
-        :returns: 204 when no active turn is recorded or the interrupt lands;
-            503 when Codex rejects the active-turn interrupt.
+        :returns: 204 when nothing needs interrupting or the interrupts
+            land; 503 when Codex rejects the active-turn interrupt.
         """
         from omnigent.codex_native_app_server import client_for_transport
+        from omnigent.codex_native_bridge import (
+            CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
+            bridge_dir_for_bridge_id,
+            cancel_pending_mcp_startup,
+        )
 
         state = await _codex_native_bridge_state_for_session(conv_id, action="interrupt")
         if state is None:
             return Response(status_code=204)
-        if state.active_turn_id is None:
-            _logger.info("Codex-native interrupt skipped for %s: no active turn.", conv_id)
+        labels = await _session_labels_for_runner_spawn(
+            server_client=server_client,
+            session_id=conv_id,
+        )
+        bridge_dir = bridge_dir_for_bridge_id(
+            labels.get(CODEX_NATIVE_BRIDGE_ID_LABEL_KEY) or conv_id
+        )
+        pending_mcp = cancel_pending_mcp_startup(bridge_dir)
+        if state.active_turn_id is None and not pending_mcp:
+            _logger.info(
+                "Codex-native interrupt skipped for %s: no active turn or MCP startup.",
+                conv_id,
+            )
             return Response(status_code=204)
+        if pending_mcp:
+            _logger.info(
+                "Codex-native interrupt for %s cancels MCP startup: %s",
+                conv_id,
+                ", ".join(pending_mcp),
+            )
 
         codex_client = client_for_transport(
             state.socket_path,
@@ -10841,13 +10873,29 @@ def create_runner_app(
         )
         try:
             await codex_client.connect()
-            await codex_client.request(
-                "turn/interrupt",
-                {
-                    "threadId": state.thread_id,
-                    "turnId": state.active_turn_id,
-                },
-            )
+            if pending_mcp:
+                # Startup interrupt first and best-effort: the local
+                # cancel above already updated what Omnigent shows.
+                try:
+                    await codex_client.request(
+                        "turn/interrupt",
+                        {"threadId": state.thread_id, "turnId": ""},
+                    )
+                except Exception:  # noqa: BLE001 - the local cancel already took effect.
+                    _logger.warning(
+                        "Codex-native MCP startup interrupt failed for session=%s thread=%s",
+                        conv_id,
+                        state.thread_id,
+                        exc_info=True,
+                    )
+            if state.active_turn_id is not None:
+                await codex_client.request(
+                    "turn/interrupt",
+                    {
+                        "threadId": state.thread_id,
+                        "turnId": state.active_turn_id,
+                    },
+                )
         except Exception as exc:  # noqa: BLE001 - surface active-turn interrupt failures to caller.
             _logger.warning(
                 "Codex-native turn/interrupt failed for session=%s thread=%s turn=%s",

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10841,6 +10841,7 @@ def create_runner_app(
             CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
             bridge_dir_for_bridge_id,
             cancel_pending_mcp_startup,
+            read_mcp_startup,
         )
 
         state = await _codex_native_bridge_state_for_session(conv_id, action="interrupt")
@@ -10866,6 +10867,23 @@ def create_runner_app(
                 conv_id,
                 ", ".join(pending_mcp),
             )
+            # Publish the flipped map ourselves: the forwarder only reposts
+            # when IT changes the map, and codex's own cancelled edges are
+            # owner-only — without this post the web band and snapshot stay
+            # stuck on "Starting MCP servers" after a Stop.
+            try:
+                await server_client.post(
+                    f"/v1/sessions/{conv_id}/events",
+                    json={
+                        "type": "external_mcp_startup",
+                        "data": {"servers": read_mcp_startup(bridge_dir)},
+                    },
+                    timeout=10.0,
+                )
+            except Exception:  # noqa: BLE001 - the bridge flip already took effect locally.
+                _logger.warning(
+                    "Failed to publish cancelled MCP startup for %s", conv_id, exc_info=True
+                )
 
         codex_client = client_for_transport(
             state.socket_path,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -209,6 +209,7 @@ from omnigent.server.schemas import (
     ErrorDetail,
     ErrorEvent,
     GrantPermissionRequest,
+    McpServerStartup,
     MCPServerSummary,
     ModelUsage,
     OutputItemDoneEvent,
@@ -237,6 +238,7 @@ from omnigent.server.schemas import (
     SessionLabelsResponse,
     SessionList,
     SessionListItem,
+    SessionMcpStartupEvent,
     SessionModelEvent,
     SessionModelOptionsEvent,
     SessionReasoningEffortEvent,
@@ -397,6 +399,17 @@ _EXTERNAL_STATUS_ASSISTANT_SCAN_LIMIT: int = 1000
 _EXTERNAL_COMPACTION_STATUS_TYPE: str = "external_compaction_status"
 _EXTERNAL_COMPACTION_STATUS_VALUES: frozenset[str] = frozenset(
     {"in_progress", "completed", "failed"}
+)
+
+# Per-MCP-server startup progress observed by a native forwarder while
+# its harness boots MCP servers (codex-native today). Republished as a
+# ``session.mcp_startup`` SSE event so the web UI shows which servers
+# are still starting — instead of an apparently hung session — and
+# which failed or were cancelled. Payload:
+# ``{"servers": {"safe": {"status": "starting", "error": null}}}``.
+_EXTERNAL_MCP_STARTUP_TYPE: str = "external_mcp_startup"
+_EXTERNAL_MCP_STARTUP_STATUS_VALUES: frozenset[str] = frozenset(
+    {"starting", "ready", "failed", "cancelled"}
 )
 
 # Usage update from a terminal-backed runtime (claude-native
@@ -817,6 +830,7 @@ _ALLOWED_EVENT_TYPES: frozenset[str] = frozenset(ITEM_TYPE_TO_DATA_CLS.keys()) |
     _EXTERNAL_SESSION_STATUS_TYPE,
     _EXTERNAL_SESSION_USAGE_TYPE,
     _EXTERNAL_COMPACTION_STATUS_TYPE,
+    _EXTERNAL_MCP_STARTUP_TYPE,
     _EXTERNAL_MODEL_CHANGE_TYPE,
     _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE,
     _EXTERNAL_SESSION_TODOS_TYPE,
@@ -1037,6 +1051,13 @@ _session_terminal_pending_cache: dict[str, bool] = {}
 # ManagedLaunchTracker — so a reload after a dead launch still shows
 # why the sandbox never came up.
 _session_sandbox_status_cache: dict[str, SandboxStatus] = {}
+# Per-MCP-server startup state keyed by session id. Written by
+# _publish_mcp_startup as the native forwarder reports harness MCP
+# startup progress; read by _build_session_response to populate the
+# ``mcp_startup`` snapshot field so a client opening (or reloading) the
+# session mid-startup still sees the startup band. Evicted when the
+# forwarder posts an empty/settled map — absent == no startup state.
+_session_mcp_startup_cache: dict[str, dict[str, McpServerStartup]] = {}
 # Per-session runner-skills cache + in-flight fetch. The snapshot fetches
 # these off its critical path (see _fetch_runner_skills) so the continuous
 # poll can't pin the runner's event loop and wedge a turn.
@@ -2543,6 +2564,9 @@ def _build_session_response(
         # once the launch succeeds; a failed launch is retained with
         # its reason. Populated by _publish_sandbox_status.
         sandbox_status=_session_sandbox_status_cache.get(conv.id),
+        # Replay harness MCP-server startup state (codex-native) so a
+        # client opening the session mid-startup sees the startup band.
+        mcp_startup=_session_mcp_startup_cache.get(conv.id),
         # In-flight turn id so a mid-turn reconnect can reopen a streaming
         # ``activeResponse`` (the turn-start ``running`` edge that carried it
         # is not replayed on the SSE stream). Populated for native-terminal
@@ -5677,6 +5701,34 @@ def _publish_sandbox_status(session_id: str, stage: str, error: str | None = Non
         conversation_id=session_id,
         stage=stage,
         error=error,
+    )
+    session_stream.publish(session_id, event.model_dump())
+
+
+def _publish_mcp_startup(session_id: str, servers: dict[str, McpServerStartup]) -> None:
+    """
+    Publish a typed :class:`SessionMcpStartupEvent` to the live stream.
+
+    Fired when a native forwarder reports harness MCP-server startup
+    progress via ``external_mcp_startup``, so the web UI can show
+    per-server startup state while the harness boots instead of an
+    apparently hung session. Also updates the snapshot cache so a client
+    opening the session mid-startup seeds the band from the snapshot's
+    ``mcp_startup`` field; an empty (settled) map evicts the cache entry.
+
+    :param session_id: Session/conversation identifier,
+        e.g. ``"conv_abc123"``.
+    :param servers: Latest per-server startup map, e.g.
+        ``{"safe": McpServerStartup(status="starting", error=None)}``.
+    """
+    if servers:
+        _session_mcp_startup_cache[session_id] = servers
+    else:
+        _session_mcp_startup_cache.pop(session_id, None)
+    event = SessionMcpStartupEvent(
+        type="session.mcp_startup",
+        conversation_id=session_id,
+        servers=servers,
     )
     session_stream.publish(session_id, event.model_dump())
 
@@ -18543,6 +18595,7 @@ def create_sessions_router(
             _EXTERNAL_SESSION_STATUS_TYPE,
             _EXTERNAL_SESSION_USAGE_TYPE,
             _EXTERNAL_COMPACTION_STATUS_TYPE,
+            _EXTERNAL_MCP_STARTUP_TYPE,
             _EXTERNAL_MODEL_CHANGE_TYPE,
             _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE,
             _EXTERNAL_SESSION_TODOS_TYPE,
@@ -19056,6 +19109,40 @@ def create_sessions_router(
                 _publish_compaction_completed(session_id, None)
             else:
                 _publish_compaction_failed(session_id)
+            return {"queued": False}
+        if body.type == _EXTERNAL_MCP_STARTUP_TYPE:
+            # Harness MCP-server startup progress (codex-native forwarder):
+            # republish as a ``session.mcp_startup`` SSE so the web UI shows
+            # per-server startup state while the harness boots. Malformed
+            # entries are rejected at the boundary — a bogus map would only
+            # strand the UI's startup band.
+            raw_servers = body.data.get("servers")
+            if not isinstance(raw_servers, dict):
+                raise OmnigentError(
+                    "external_mcp_startup requires data.servers to be an object "
+                    f"mapping server names to startup records; got {raw_servers!r}",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            mcp_servers: dict[str, McpServerStartup] = {}
+            for server_name, record in raw_servers.items():
+                record_status = record.get("status") if isinstance(record, dict) else None
+                if not (
+                    isinstance(server_name, str)
+                    and server_name
+                    and record_status in _EXTERNAL_MCP_STARTUP_STATUS_VALUES
+                ):
+                    raise OmnigentError(
+                        "external_mcp_startup server records require a status in "
+                        f"{sorted(_EXTERNAL_MCP_STARTUP_STATUS_VALUES)}; got "
+                        f"{server_name!r}: {record!r}",
+                        code=ErrorCode.INVALID_INPUT,
+                    )
+                record_error = record.get("error")
+                mcp_servers[server_name] = McpServerStartup(
+                    status=record_status,
+                    error=record_error if isinstance(record_error, str) and record_error else None,
+                )
+            _publish_mcp_startup(session_id, mcp_servers)
             return {"queued": False}
         if body.type == _EXTERNAL_SESSION_USAGE_TYPE:
             # Persist the harness-reported cumulative usage so the

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -5714,14 +5714,17 @@ def _publish_mcp_startup(session_id: str, servers: dict[str, McpServerStartup]) 
     per-server startup state while the harness boots instead of an
     apparently hung session. Also updates the snapshot cache so a client
     opening the session mid-startup seeds the band from the snapshot's
-    ``mcp_startup`` field; an empty (settled) map evicts the cache entry.
+    ``mcp_startup`` field; a map with nothing left to show — empty, or
+    every server ``ready`` — evicts the cache entry, mirroring the web
+    store's all-ready clear so a reloading client never seeds a band
+    that renders nothing.
 
     :param session_id: Session/conversation identifier,
         e.g. ``"conv_abc123"``.
     :param servers: Latest per-server startup map, e.g.
         ``{"safe": McpServerStartup(status="starting", error=None)}``.
     """
-    if servers:
+    if any(record.status != "ready" for record in servers.values()):
         _session_mcp_startup_cache[session_id] = servers
     else:
         _session_mcp_startup_cache.pop(session_id, None)
@@ -19838,6 +19841,10 @@ def create_sessions_router(
         # failed-launch session would leak one entry for the process
         # lifetime.
         _session_sandbox_status_cache.pop(session_id, None)
+        # Same for MCP startup state: failed/cancelled maps are retained
+        # for reload visibility while the session exists, so a session
+        # whose MCP startup never settled clean would leak its entry.
+        _session_mcp_startup_cache.pop(session_id, None)
         # Drop the deleted session's per-user read-state from every user's
         # caches so they don't accumulate orphan entries for the process
         # lifetime.

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1748,6 +1748,12 @@ class SessionResponse(BaseModel):
     model_options: list[dict[str, Any]] = Field(default_factory=list)
     terminal_pending: bool = False
     sandbox_status: SandboxStatus | None = None
+    # Per-MCP-server startup state for native harness sessions
+    # (codex-native), present while the harness boots its MCP servers or
+    # when servers were cancelled/failed. ``None`` otherwise. Sourced from
+    # ``_session_mcp_startup_cache`` at snapshot build time so a client
+    # opening the session mid-startup sees the startup band.
+    mcp_startup: dict[str, McpServerStartup] | None = None
     active_response_id: str | None = None
 
 
@@ -2586,6 +2592,48 @@ class SessionSandboxStatusEvent(_SSEEventBase):
     conversation_id: str
     stage: SandboxLaunchStage
     error: str | None = None
+
+
+class McpServerStartup(BaseModel):
+    """
+    One MCP server's startup state within a ``session.mcp_startup`` event.
+
+    :param status: Latest startup state reported by the harness, mirroring
+        Codex's ``McpServerStartupState`` enum.
+    :param error: Failure detail when ``status == "failed"``, e.g.
+        ``"handshaking with MCP server failed"``. ``None`` otherwise.
+    """
+
+    status: Literal["starting", "ready", "failed", "cancelled"]
+    error: str | None = None
+
+
+class SessionMcpStartupEvent(_SSEEventBase):
+    """
+    Per-MCP-server startup progress for a native harness session.
+
+    A codex-native session brings up its configured MCP servers when its
+    Codex thread starts; slow or failing servers previously left the web
+    session looking hung with no signal. The native forwarder mirrors
+    Codex's ``mcpServer/startupStatus/updated`` notifications as
+    ``external_mcp_startup`` posts, republished here so the web UI can
+    show which servers are still starting and which failed or were
+    cancelled.
+
+    :param type: Always ``"session.mcp_startup"``.
+    :param conversation_id: Session identifier,
+        e.g. ``"conv_abc123"``.
+    :param servers: Latest per-server startup map, e.g.
+        ``{"safe": {"status": "starting", "error": None}}``.
+
+    Category: **transient** (SSE + snapshot cache). Not persisted; a
+    client connecting mid-startup seeds from the session snapshot's
+    ``mcp_startup`` field and updates live off this event.
+    """
+
+    type: Literal["session.mcp_startup"]
+    conversation_id: str
+    servers: dict[str, McpServerStartup]
 
 
 class SessionSkillsEvent(_SSEEventBase):
@@ -3742,6 +3790,7 @@ ServerStreamEvent = Annotated[
     | SessionTodosEvent
     | SessionTerminalPendingEvent
     | SessionSandboxStatusEvent
+    | SessionMcpStartupEvent
     | SessionSkillsEvent
     | SessionModelOptionsEvent
     | SessionInputConsumedEvent

--- a/openapi.json
+++ b/openapi.json
@@ -1757,6 +1757,39 @@
         "title": "MCPServerSummary",
         "type": "object"
       },
+      "McpServerStartup": {
+        "description": "One MCP server's startup state within a `session.mcp_startup` event.",
+        "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Failure detail when `status == \"failed\"`, e.g. `\"handshaking with MCP server failed\"`. `None` otherwise.",
+            "title": "Error"
+          },
+          "status": {
+            "description": "Latest startup state reported by the harness, mirroring Codex's `McpServerStartupState` enum.",
+            "enum": [
+              "starting",
+              "ready",
+              "failed",
+              "cancelled"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "McpServerStartup",
+        "type": "object"
+      },
       "MessageData": {
         "description": "Data for a message item (user or assistant).\n\n**Parameters**\n\n- `agent` \u2014 Agent name (required for assistant messages, absent for user). Serialized as `\"model\"` in JSON.",
         "properties": {
@@ -2872,6 +2905,7 @@
             "session.heartbeat": "#/components/schemas/SessionHeartbeatEvent",
             "session.input.consumed": "#/components/schemas/SessionInputConsumedEvent",
             "session.interrupted": "#/components/schemas/SessionInterruptedEvent",
+            "session.mcp_startup": "#/components/schemas/SessionMcpStartupEvent",
             "session.model": "#/components/schemas/SessionModelEvent",
             "session.model_options": "#/components/schemas/SessionModelOptionsEvent",
             "session.presence": "#/components/schemas/SessionPresenceEvent",
@@ -2920,6 +2954,9 @@
           },
           {
             "$ref": "#/components/schemas/SessionSandboxStatusEvent"
+          },
+          {
+            "$ref": "#/components/schemas/SessionMcpStartupEvent"
           },
           {
             "$ref": "#/components/schemas/SessionSkillsEvent"
@@ -3866,6 +3903,49 @@
         "title": "SessionListItem",
         "type": "object"
       },
+      "SessionMcpStartupEvent": {
+        "description": "Per-MCP-server startup progress for a native harness session.\n\nA codex-native session brings up its configured MCP servers when its\nCodex thread starts; slow or failing servers previously left the web\nsession looking hung with no signal. The native forwarder mirrors\nCodex's `mcpServer/startupStatus/updated` notifications as\n`external_mcp_startup` posts, republished here so the web UI can\nshow which servers are still starting and which failed or were\ncancelled.",
+        "properties": {
+          "conversation_id": {
+            "description": "Session identifier, e.g. `\"conv_abc123\"`.",
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "sequence_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence Number"
+          },
+          "servers": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/McpServerStartup"
+            },
+            "description": "Latest per-server startup map, e.g. `{\"safe\": {\"status\": \"starting\", \"error\": None}}`. Category: **transient** (SSE + snapshot cache). Not persisted; a client connecting mid-startup seeds from the session snapshot's `mcp_startup` field and updates live off this event.",
+            "title": "Servers",
+            "type": "object"
+          },
+          "type": {
+            "const": "session.mcp_startup",
+            "description": "Always `\"session.mcp_startup\"`.",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "conversation_id",
+          "servers"
+        ],
+        "title": "SessionMcpStartupEvent",
+        "type": "object"
+      },
       "SessionModelEvent": {
         "description": "Active-model update from a terminal-backed integration.\n\nEmitted after an `external_model_change` POST from the\n`omnigent claude` transcript forwarder when the model is\nswitched inside the Claude Code terminal (a `/model` command or\nthe in-TUI picker). Lets the web model picker reflect a TUI-side\nswitch without a reload.",
         "properties": {
@@ -4426,6 +4506,20 @@
             ],
             "description": "The LLM model identifier from the bound agent's spec, e.g. `\"anthropic/claude-sonnet-4-6\"`. `None` when the agent has no explicit `llm:` block or the agent cannot be looked up.",
             "title": "Llm Model"
+          },
+          "mcp_startup": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/McpServerStartup"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mcp Startup"
           },
           "model_options": {
             "description": "Codex app-server `model/list` options for codex-native sessions, including each model's supported reasoning efforts. Empty for non-codex-native sessions or while the bound runner / Codex app-server cannot answer yet.",

--- a/tests/e2e_ui/chat/test_mcp_startup_indicator.py
+++ b/tests/e2e_ui/chat/test_mcp_startup_indicator.py
@@ -1,0 +1,141 @@
+"""MCP startup band lifecycle on the session page.
+
+A codex-native session boots its harness MCP servers when its thread
+starts; the forwarder mirrors that round as ``external_mcp_startup``
+posts and the web chat must show it — an otherwise-idle session used to
+look hung for the whole boot (and forever, when servers failed). These
+tests drive the real per-server maps through the Sessions events route
+(the same path the codex-native forwarder posts to), so they are
+deterministic — no live codex TUI, whose MCP round timing would make the
+assertions flaky. The forwarder-side synthesis/settle bookkeeping is
+covered by the codex_native_forwarder unit tests.
+"""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, expect
+
+_BAND = '[data-testid="mcp-startup-indicator"]'
+
+
+def _publish_mcp_startup(
+    base_url: str,
+    session_id: str,
+    servers: dict[str, dict[str, str | None]],
+) -> None:
+    """Publish a per-server MCP startup map through the events route.
+
+    :param base_url: Base URL of the local e2e server.
+    :param session_id: Session/conversation id.
+    :param servers: Full startup map, e.g.
+        ``{"safe": {"status": "starting", "error": None}}``. An empty map
+        settles the round (band clears, snapshot cache evicts).
+    :returns: None.
+    """
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={"type": "external_mcp_startup", "data": {"servers": servers}},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def test_mcp_startup_band_lifecycle(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Band tracks starting → progress → settled-with-failure → cleared.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server
+        fixture.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    band = page.locator(_BAND)
+
+    # 1. Startup begins BEFORE the page is opened: the snapshot cache must
+    #    seed the band on load — a mid-startup page load (or reload) that
+    #    showed nothing was exactly the "session looks hung" bug.
+    _publish_mcp_startup(
+        base_url,
+        session_id,
+        {
+            "glean": {"status": "starting", "error": None},
+            "jira": {"status": "starting", "error": None},
+            "safe": {"status": "starting", "error": None},
+        },
+    )
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(band).to_contain_text("Starting MCP servers (0/3): glean, jira, safe", timeout=15_000)
+
+    # 2. Live progress: one server settles, the count advances and the
+    #    settled name drops out of the pending list.
+    _publish_mcp_startup(
+        base_url,
+        session_id,
+        {
+            "glean": {"status": "ready", "error": None},
+            "jira": {"status": "starting", "error": None},
+            "safe": {"status": "starting", "error": None},
+        },
+    )
+    expect(band).to_contain_text("Starting MCP servers (1/3): jira, safe", timeout=15_000)
+
+    # 3. The round settles with a failure: the spinner flips to the
+    #    warning naming the server that never came up.
+    _publish_mcp_startup(
+        base_url,
+        session_id,
+        {
+            "glean": {"status": "ready", "error": None},
+            "jira": {"status": "ready", "error": None},
+            "safe": {"status": "failed", "error": "handshaking with MCP server failed"},
+        },
+    )
+    expect(band).to_contain_text("MCP startup incomplete (failed: safe)", timeout=15_000)
+
+    # 4. A settled-empty map clears the band entirely (and evicts the
+    #    snapshot cache): the session reads as a normal idle chat again.
+    _publish_mcp_startup(base_url, session_id, {})
+    expect(band).to_have_count(0, timeout=15_000)
+
+
+def test_mcp_startup_band_shows_cancelled_after_stop(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A Stop-cancelled round renders the cancelled warning, not a spinner.
+
+    The runner's Stop path flips still-``starting`` servers to
+    ``cancelled`` and publishes the flipped map (codex's own cancelled
+    edges are owner-only and never reach the web); this pins the rendering
+    of that published map so a user who stopped a slow MCP boot sees what
+    happened instead of a stuck "Starting…" spinner.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server
+        fixture.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    band = page.locator(_BAND)
+
+    _publish_mcp_startup(
+        base_url,
+        session_id,
+        {"storage-console": {"status": "starting", "error": None}},
+    )
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(band).to_contain_text("Starting MCP server: storage-console", timeout=15_000)
+
+    # What the runner's Stop handler publishes after cancel_pending_mcp_startup.
+    _publish_mcp_startup(
+        base_url,
+        session_id,
+        {"storage-console": {"status": "cancelled", "error": None}},
+    )
+    expect(band).to_contain_text(
+        "MCP startup incomplete (cancelled: storage-console)", timeout=15_000
+    )

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -837,3 +837,214 @@ def test_run_turn_surfaces_recorded_startup_error(
     assert "never started" in error.message
     assert "startup timeout" in error.message
     assert error.message != "Codex native bridge state is missing"
+
+
+# ── MCP startup: no client-side gate + Stop cancel (issue #2058) ────────
+
+
+def _seed_bridge(tmp_path: Path, active_turn_id: str | None = None) -> None:
+    """
+    Write bridge state for the executor under test.
+
+    :param tmp_path: Bridge directory.
+    :param active_turn_id: Active turn id to seed, or ``None``.
+    """
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=active_turn_id,
+        ),
+    )
+
+
+def test_turn_start_is_not_gated_on_pending_mcp_startup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    ``turn/start`` dispatches immediately while MCP servers still boot.
+
+    The Codex app-server accepts a mid-startup ``turn/start`` and defers
+    its execution until the startup round settles (verified against codex
+    0.142.5), so a client-side wait would only add latency — up to its
+    full bound when a server hangs. The bounded ``asyncio.timeout`` fails
+    this test if a gate sneaks back in.
+    """
+    from omnigent.codex_native_bridge import update_mcp_server_startup
+
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    _seed_bridge(tmp_path)
+    update_mcp_server_startup(tmp_path, "storage-console", "starting")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    async def run() -> list[Any]:
+        """
+        Drive one turn under a budget any startup gate would blow.
+
+        :returns: Events yielded by the turn.
+        """
+        events: list[Any] = []
+        async with asyncio.timeout(5.0):
+            async for event in executor.run_turn(
+                [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+                [],
+                "",
+            ):
+                events.append(event)
+        return events
+
+    events = asyncio.run(run())
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert [method for method, _ in _FakeCodexNativeClient.requests] == ["turn/start"]
+
+
+def test_turn_error_names_pending_mcp_servers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A turn failure during MCP startup names the still-pending servers.
+
+    An injection failure this early in the session's life is most often
+    the startup itself; without the suffix the user sees a bare transport
+    error and has no idea codex is still booting MCP servers.
+    """
+    from omnigent.codex_native_bridge import update_mcp_server_startup
+
+    class _FailingTurnClient(_FakeCodexNativeClient):
+        """Fake client whose ``turn/start`` fails like a mid-boot app-server."""
+
+        async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            """
+            Reject ``turn/start``; defer to the base fake otherwise.
+
+            :param method: JSON-RPC method, e.g. ``"turn/start"``.
+            :param params: JSON-RPC params.
+            :returns: Codex-shaped response payload.
+            """
+            if method == "turn/start":
+                raise RuntimeError("app-server hiccup")
+            return await super().request(method, params)
+
+    _FailingTurnClient.requests = []
+    _FailingTurnClient.created = []
+    _FailingTurnClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FailingTurnClient,
+    )
+    _seed_bridge(tmp_path)
+    update_mcp_server_startup(tmp_path, "storage-console", "starting")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "hi")
+
+    assert [type(event) for event in events] == [ExecutorError]
+    assert "MCP startup still waiting on storage-console" in events[0].message
+
+
+def test_interrupt_with_active_turn_and_pending_mcp_stops_both(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Stop during a startup-deferred turn interrupts the turn AND the startup.
+
+    Codex holds a mid-startup turn until the MCP round settles, so
+    stopping only the turn would leave the user watching a startup they
+    asked to stop. The startup interrupt (empty turn id) is sent first and
+    best-effort, then the recorded turn is interrupted.
+    """
+    from omnigent.codex_native_bridge import read_mcp_startup, update_mcp_server_startup
+
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    _seed_bridge(tmp_path, active_turn_id="turn_active")
+    update_mcp_server_startup(tmp_path, "storage-console", "starting")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    interrupted = asyncio.run(executor.interrupt_session("key"))
+
+    assert interrupted is True
+    assert _FakeCodexNativeClient.requests == [
+        ("turn/interrupt", {"threadId": "thread_123", "turnId": ""}),
+        ("turn/interrupt", {"threadId": "thread_123", "turnId": "turn_active"}),
+    ]
+    assert read_mcp_startup(tmp_path)["storage-console"]["status"] == "cancelled"
+
+
+def test_interrupt_with_no_active_turn_cancels_mcp_startup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Stop during MCP startup cancels it instead of no-oping.
+
+    With no active turn id recorded, ``interrupt_session`` used to return
+    ``False`` and the user's Stop did nothing while Codex was wedged on a
+    slow MCP server. It must flip the pending servers to ``cancelled``
+    (unblocking the first-turn gate) and send Codex the TUI's startup
+    interrupt: ``turn/interrupt`` with an empty turn id.
+    """
+    from omnigent.codex_native_bridge import read_mcp_startup, update_mcp_server_startup
+
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    _seed_bridge(tmp_path, active_turn_id=None)
+    update_mcp_server_startup(tmp_path, "storage-console", "starting")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    interrupted = asyncio.run(executor.interrupt_session("key"))
+
+    assert interrupted is True
+    assert _FakeCodexNativeClient.requests == [
+        ("turn/interrupt", {"threadId": "thread_123", "turnId": ""})
+    ]
+    assert read_mcp_startup(tmp_path)["storage-console"]["status"] == "cancelled"
+
+
+def test_interrupt_with_no_active_turn_and_no_pending_mcp_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Stop with nothing running and nothing starting stays a no-op.
+
+    An idle session must not send spurious ``turn/interrupt`` requests to
+    the app-server on every Stop press.
+    """
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    _seed_bridge(tmp_path, active_turn_id=None)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    interrupted = asyncio.run(executor.interrupt_session("key"))
+
+    assert interrupted is False
+    assert _FakeCodexNativeClient.requests == []

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -9811,6 +9811,339 @@ async def test_events_stop_session_on_codex_native_uses_turn_interrupt_without_m
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("event_type", ["interrupt", "stop_session"])
+async def test_events_stop_on_codex_native_cancels_mcp_startup_without_active_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    event_type: str,
+) -> None:
+    """
+    Stop/interrupt with no active turn cancels in-flight MCP startup.
+
+    During codex-native startup no turn id is recorded yet, so Stop used to
+    204 no-op while Codex sat wedged on a slow or failing MCP server
+    (issue #2058). The handler must flip the bridge's pending servers to
+    ``cancelled`` (unblocking the executor's first-turn gate) and send the
+    Codex TUI's startup interrupt — ``turn/interrupt`` with an empty turn
+    id — instead of doing nothing.
+    """
+    from omnigent import codex_native_app_server
+    from omnigent.spec.types import ExecutorSpec
+
+    conv_id = f"conv_codex_native_mcp_{event_type}"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
+    # Abort the session-create auto-terminal path before it reaches
+    # ``clear_bridge_state`` — otherwise the seeded bridge state below is
+    # wiped on hosts where the codex CLI/provider config exist (in CI the
+    # auto-create aborts on its own before the clear).
+    import omnigent.runner.app as runner_app_module
+
+    async def _fail_launch_config(**kwargs: Any) -> None:
+        """Abort codex auto-create before it clears bridge state."""
+        del kwargs
+        raise RuntimeError("launch config disabled in test")
+
+    monkeypatch.setattr(runner_app_module, "_codex_native_launch_config", _fail_launch_config)
+    bridge_dir = codex_native_bridge.bridge_dir_for_bridge_id(conv_id)
+    codex_native_bridge.write_bridge_state(
+        bridge_dir,
+        codex_native_bridge.CodexNativeBridgeState(
+            session_id=conv_id,
+            socket_path="ws://127.0.0.1:43212",
+            thread_id="thread_codex_mcp",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=None,
+        ),
+    )
+    codex_native_bridge.update_mcp_server_startup(bridge_dir, "storage-console", "starting")
+
+    fake_client = _RecordingCodexAppServerClient(
+        transport="ws://127.0.0.1:43212",
+        client_name="omnigent-codex-native-runner",
+    )
+
+    def _fake_client_for_transport(
+        transport: str,
+        *,
+        client_name: str = "omnigent",
+    ) -> _RecordingCodexAppServerClient:
+        """
+        Return the fake Codex app-server client for the startup-cancel path.
+
+        :param transport: App-server transport from bridge state, e.g.
+            ``"ws://127.0.0.1:43212"``.
+        :param client_name: Client name supplied by the runner, e.g.
+            ``"omnigent-codex-native-runner"``.
+        :returns: Fake client that records JSON-RPC calls.
+        """
+        assert transport == fake_client.transport
+        assert client_name == fake_client.client_name
+        return fake_client
+
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "client_for_transport",
+        _fake_client_for_transport,
+    )
+
+    codex_native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "codex-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the codex-native spec for any agent_id."""
+        del agent_id, session_id
+        return codex_native_spec
+
+    server_client = _EventRecordingServerClient()
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=server_client,  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        stop_resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": event_type},
+        )
+
+    assert stop_resp.status_code == 204, (
+        f"codex-native {event_type} must return 204; got {stop_resp.status_code}: {stop_resp.text}"
+    )
+    # The Codex TUI's startup interrupt shape: turn/interrupt with an
+    # EMPTY turn id (its ``startup_interrupt``); a recorded-turn shape
+    # here would be rejected by the app-server mid-startup.
+    assert fake_client.requests == [
+        (
+            "turn/interrupt",
+            {"threadId": "thread_codex_mcp", "turnId": ""},
+        )
+    ], (
+        f"codex-native {event_type} during MCP startup must send the startup "
+        f"interrupt (empty turnId); got {fake_client.requests!r}."
+    )
+    # The local flip is what unblocks the executor's first-turn gate even
+    # if Codex never acknowledges the interrupt.
+    assert codex_native_bridge.read_mcp_startup(bridge_dir) == {
+        "storage-console": {"status": "cancelled", "error": None}
+    }
+
+
+@pytest.mark.asyncio
+async def test_events_interrupt_on_codex_native_with_turn_and_mcp_stops_both(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Stop during a startup-deferred turn interrupts the turn AND the startup.
+
+    Codex accepts ``turn/start`` mid-MCP-startup and defers its execution
+    until the round settles, so a Stop pressed in that window finds an
+    active turn id recorded. Interrupting only the turn would leave the
+    user watching a startup they asked to stop — the handler must also
+    send the startup interrupt (empty turn id, best-effort, first) and
+    flip the bridge's pending servers to ``cancelled``.
+    """
+    from omnigent import codex_native_app_server
+    from omnigent.spec.types import ExecutorSpec
+
+    conv_id = "conv_codex_native_dual_stop"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
+    # Keep the seeded bridge state alive through session create (see the
+    # sister startup-cancel test for why auto-create must abort early).
+    import omnigent.runner.app as runner_app_module
+
+    async def _fail_launch_config(**kwargs: Any) -> None:
+        """Abort codex auto-create before it clears bridge state."""
+        del kwargs
+        raise RuntimeError("launch config disabled in test")
+
+    monkeypatch.setattr(runner_app_module, "_codex_native_launch_config", _fail_launch_config)
+    bridge_dir = codex_native_bridge.bridge_dir_for_bridge_id(conv_id)
+    codex_native_bridge.write_bridge_state(
+        bridge_dir,
+        codex_native_bridge.CodexNativeBridgeState(
+            session_id=conv_id,
+            socket_path="ws://127.0.0.1:43214",
+            thread_id="thread_codex_dual",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id="turn_deferred",
+        ),
+    )
+    codex_native_bridge.update_mcp_server_startup(bridge_dir, "storage-console", "starting")
+
+    fake_client = _RecordingCodexAppServerClient(
+        transport="ws://127.0.0.1:43214",
+        client_name="omnigent-codex-native-runner",
+    )
+
+    def _fake_client_for_transport(
+        transport: str,
+        *,
+        client_name: str = "omnigent",
+    ) -> _RecordingCodexAppServerClient:
+        """
+        Return the fake Codex app-server client for the dual-stop path.
+
+        :param transport: App-server transport from bridge state, e.g.
+            ``"ws://127.0.0.1:43214"``.
+        :param client_name: Client name supplied by the runner, e.g.
+            ``"omnigent-codex-native-runner"``.
+        :returns: Fake client that records JSON-RPC calls.
+        """
+        assert transport == fake_client.transport
+        assert client_name == fake_client.client_name
+        return fake_client
+
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "client_for_transport",
+        _fake_client_for_transport,
+    )
+
+    codex_native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "codex-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the codex-native spec for any agent_id."""
+        del agent_id, session_id
+        return codex_native_spec
+
+    server_client = _EventRecordingServerClient()
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=server_client,  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        int_resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": "interrupt"},
+        )
+
+    assert int_resp.status_code == 204, int_resp.text
+    # Startup interrupt (empty turnId) first — best-effort — then the
+    # recorded turn's interrupt.
+    assert fake_client.requests == [
+        ("turn/interrupt", {"threadId": "thread_codex_dual", "turnId": ""}),
+        ("turn/interrupt", {"threadId": "thread_codex_dual", "turnId": "turn_deferred"}),
+    ], f"dual stop must send startup interrupt then turn interrupt; got {fake_client.requests!r}."
+    assert codex_native_bridge.read_mcp_startup(bridge_dir) == {
+        "storage-console": {"status": "cancelled", "error": None}
+    }
+
+
+@pytest.mark.asyncio
+async def test_events_interrupt_on_codex_native_without_turn_or_mcp_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Stop with no active turn and no pending MCP startup stays a 204 no-op.
+
+    An idle codex-native session must not send spurious ``turn/interrupt``
+    requests to the app-server on every Stop press.
+    """
+    from omnigent import codex_native_app_server
+    from omnigent.spec.types import ExecutorSpec
+
+    conv_id = "conv_codex_native_idle_stop"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
+    # Keep the seeded bridge state alive through session create (see the
+    # sister startup-cancel test for why auto-create must abort early).
+    import omnigent.runner.app as runner_app_module
+
+    async def _fail_launch_config(**kwargs: Any) -> None:
+        """Abort codex auto-create before it clears bridge state."""
+        del kwargs
+        raise RuntimeError("launch config disabled in test")
+
+    monkeypatch.setattr(runner_app_module, "_codex_native_launch_config", _fail_launch_config)
+    bridge_dir = codex_native_bridge.bridge_dir_for_bridge_id(conv_id)
+    codex_native_bridge.write_bridge_state(
+        bridge_dir,
+        codex_native_bridge.CodexNativeBridgeState(
+            session_id=conv_id,
+            socket_path="ws://127.0.0.1:43213",
+            thread_id="thread_codex_idle",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=None,
+        ),
+    )
+
+    def _fail_client_for_transport(
+        transport: str,
+        *,
+        client_name: str = "omnigent",
+    ) -> _RecordingCodexAppServerClient:
+        """Fail the test if the runner opens an app-server connection."""
+        raise AssertionError(
+            f"idle codex-native interrupt must not reach the app-server; "
+            f"attempted connect to {transport!r} as {client_name!r}"
+        )
+
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "client_for_transport",
+        _fail_client_for_transport,
+    )
+
+    codex_native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "codex-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the codex-native spec for any agent_id."""
+        del agent_id, session_id
+        return codex_native_spec
+
+    server_client = _EventRecordingServerClient()
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=server_client,  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        int_resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": "interrupt"},
+        )
+
+    assert int_resp.status_code == 204, int_resp.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event_type", ["interrupt", "stop_session"])
 async def test_events_interrupt_and_stop_on_pi_native_enqueue_bridge_interrupt(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -9010,22 +9010,27 @@ async def test_events_interrupt_on_native_session_503_skips_cleanup_when_inject_
 
 
 class _EventRecordingServerClient(NullServerClient):
-    """Records Omnigent ``external_conversation_item`` POSTs for assertion.
+    """Records Omnigent ``external_*`` event POSTs for assertion.
 
     Subclasses :class:`NullServerClient` so all other runner→AP calls still
-    succeed silently; captures the bodies so a test can assert that NO
-    interrupt marker was persisted.
+    succeed silently; captures ``external_conversation_item`` bodies so a
+    test can assert that NO interrupt marker was persisted, and
+    ``external_mcp_startup`` bodies so Stop tests can assert the cancelled
+    MCP map was published.
     """
 
     def __init__(self) -> None:
         self.posted_items: list[dict[str, Any]] = []
+        self.posted_mcp_startup: list[dict[str, Any]] = []
 
     async def post(self, url: str, **kwargs: Any) -> NullServerClient._Response:
-        """Record ``external_conversation_item`` bodies."""
+        """Record ``external_conversation_item`` / ``external_mcp_startup`` bodies."""
         del url
         body = kwargs.get("json")
         if isinstance(body, dict) and body.get("type") == "external_conversation_item":
             self.posted_items.append(body.get("data") or {})
+        if isinstance(body, dict) and body.get("type") == "external_mcp_startup":
+            self.posted_mcp_startup.append(body.get("data") or {})
         return self._Response()
 
 
@@ -9931,11 +9936,20 @@ async def test_events_stop_on_codex_native_cancels_mcp_startup_without_active_tu
         f"codex-native {event_type} during MCP startup must send the startup "
         f"interrupt (empty turnId); got {fake_client.requests!r}."
     )
-    # The local flip is what unblocks the executor's first-turn gate even
-    # if Codex never acknowledges the interrupt.
+    # The local flip is authoritative even if Codex never acknowledges
+    # the interrupt.
     assert codex_native_bridge.read_mcp_startup(bridge_dir) == {
         "storage-console": {"status": "cancelled", "error": None}
     }
+    # And the flipped map is PUBLISHED: the forwarder only reposts when it
+    # changes the map itself and codex's cancelled edges are owner-only,
+    # so without this post the web band would stay stuck on "starting".
+    assert server_client.posted_mcp_startup == [
+        {"servers": {"storage-console": {"status": "cancelled", "error": None}}}
+    ], (
+        f"codex-native {event_type} must publish the cancelled MCP map; "
+        f"got {server_client.posted_mcp_startup!r}."
+    )
 
 
 @pytest.mark.asyncio
@@ -10051,6 +10065,10 @@ async def test_events_interrupt_on_codex_native_with_turn_and_mcp_stops_both(
     assert codex_native_bridge.read_mcp_startup(bridge_dir) == {
         "storage-console": {"status": "cancelled", "error": None}
     }
+    # The cancelled map is published to the session (band + snapshot update).
+    assert server_client.posted_mcp_startup == [
+        {"servers": {"storage-console": {"status": "cancelled", "error": None}}}
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -5783,6 +5783,96 @@ async def test_post_external_session_todos_rejects_non_list_todos(
     assert "external_session_todos" in resp.text
 
 
+async def test_post_external_mcp_startup_publishes_session_mcp_startup(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``external_mcp_startup`` publishes a ``session.mcp_startup`` SSE event.
+
+    The codex-native forwarder posts the full per-server map on every MCP
+    startup edge so the web UI can show which servers are still starting
+    instead of an apparently hung session (issue #2058). A regression here
+    leaves the session silent while Codex boots slow or failing MCP
+    servers.
+    """
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda sid, ev: published.append((sid, ev)),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    servers = {
+        "safe": {"status": "failed", "error": "handshake failed"},
+        "storage-console": {"status": "starting", "error": None},
+    }
+
+    from omnigent.server.routes import sessions as sessions_module
+
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{session['id']}/events",
+            json={"type": "external_mcp_startup", "data": {"servers": servers}},
+        )
+        assert resp.status_code == 202, resp.text
+        assert resp.json() == {"queued": False}
+
+        # Exactly one session.mcp_startup event, carrying the full map.
+        assert [ev["type"] for _, ev in published] == ["session.mcp_startup"]
+        assert published[0][0] == session["id"]
+        assert published[0][1]["conversation_id"] == session["id"]
+        assert published[0][1]["servers"] == servers
+
+        # The snapshot replays the map so a client opening the session
+        # mid-startup seeds the band without waiting for the next event.
+        snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+        assert snapshot["mcp_startup"] == servers
+
+        # An empty (settled) map evicts the cache — the snapshot goes back
+        # to carrying no startup state instead of a stale settled map.
+        settled = await client.post(
+            f"/v1/sessions/{session['id']}/events",
+            json={"type": "external_mcp_startup", "data": {"servers": {}}},
+        )
+        assert settled.status_code == 202, settled.text
+        snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+        assert snapshot["mcp_startup"] is None
+    finally:
+        sessions_module._session_mcp_startup_cache.pop(session["id"], None)
+
+
+async def test_post_external_mcp_startup_rejects_malformed_servers(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    Malformed ``data.servers`` payloads are rejected with a 400.
+
+    A missing map, or a server record with an unknown status, must fail
+    loud at the route boundary rather than publish a bogus SSE frame the
+    web UI would render as a stuck startup band.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    missing = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_mcp_startup", "data": {}},
+    )
+    assert missing.status_code == 400, missing.text
+    assert "external_mcp_startup" in missing.text
+
+    bad_status = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_mcp_startup",
+            "data": {"servers": {"safe": {"status": "exploded"}}},
+        },
+    )
+    assert bad_status.status_code == 400, bad_status.text
+    assert "external_mcp_startup" in bad_status.text
+
+
 async def test_post_external_conversation_item_auto_assigns_response_id(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -5842,6 +5842,87 @@ async def test_post_external_mcp_startup_publishes_session_mcp_startup(
         sessions_module._session_mcp_startup_cache.pop(session["id"], None)
 
 
+async def test_post_external_mcp_startup_all_ready_evicts_snapshot_cache(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An all-``ready`` map clears the snapshot cache like an empty one.
+
+    The web store clears the startup band once every server settles
+    ready, so a snapshot that kept replaying an all-ready map would make
+    a reloading client suppress its empty state for a band that renders
+    nothing — a blank conversation area.
+    """
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda sid, ev: published.append((sid, ev)),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    from omnigent.server.routes import sessions as sessions_module
+
+    try:
+        starting = {"safe": {"status": "starting", "error": None}}
+        resp = await client.post(
+            f"/v1/sessions/{session['id']}/events",
+            json={"type": "external_mcp_startup", "data": {"servers": starting}},
+        )
+        assert resp.status_code == 202, resp.text
+        snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+        assert snapshot["mcp_startup"] == starting
+
+        all_ready = {"safe": {"status": "ready", "error": None}}
+        resp = await client.post(
+            f"/v1/sessions/{session['id']}/events",
+            json={"type": "external_mcp_startup", "data": {"servers": all_ready}},
+        )
+        assert resp.status_code == 202, resp.text
+        # The live event still carries the map (the store clears on it),
+        # but the snapshot stops replaying it.
+        assert published[-1][1]["servers"] == all_ready
+        snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+        assert snapshot["mcp_startup"] is None
+    finally:
+        sessions_module._session_mcp_startup_cache.pop(session["id"], None)
+
+
+async def test_delete_session_evicts_mcp_startup_cache(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    Deleting a session drops its MCP-startup snapshot-cache entry.
+
+    A round that settles with failed/cancelled servers leaves a
+    non-empty map in the cache (retained for reload visibility); without
+    the DELETE eviction every such session would leak one entry for the
+    process lifetime.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    from omnigent.server.routes import sessions as sessions_module
+
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{session['id']}/events",
+            json={
+                "type": "external_mcp_startup",
+                "data": {"servers": {"safe": {"status": "cancelled", "error": None}}},
+            },
+        )
+        assert resp.status_code == 202, resp.text
+        assert session["id"] in sessions_module._session_mcp_startup_cache
+
+        resp = await client.delete(f"/v1/sessions/{session['id']}")
+        assert resp.status_code == 200, resp.text
+        assert session["id"] not in sessions_module._session_mcp_startup_cache
+    finally:
+        sessions_module._session_mcp_startup_cache.pop(session["id"], None)
+
+
 async def test_post_external_mcp_startup_rejects_malformed_servers(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -8,14 +8,20 @@ import pytest
 
 from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
+    cancel_pending_mcp_startup,
     clear_active_turn_id_if_matches,
     clear_bridge_state,
     codex_home_for_bridge_dir,
+    mcp_startup_waiting_detail,
+    pending_mcp_servers,
     prepare_bridge_dir,
     read_bridge_startup_error,
     read_bridge_state,
     read_codex_config_model,
+    read_mcp_startup,
     read_policy_hook_config,
+    settle_pending_mcp_startup,
+    update_mcp_server_startup,
     write_bridge_startup_error,
     write_bridge_state,
     write_policy_hook_config,
@@ -216,3 +222,105 @@ def test_bridge_startup_error_round_trips_and_is_cleared(bridge_dir: Path) -> No
 
     clear_bridge_state(bridge_dir)
     assert read_bridge_startup_error(bridge_dir) is None
+
+
+def test_mcp_startup_updates_round_trip(bridge_dir: Path) -> None:
+    """
+    Per-server MCP startup updates accumulate and read back (issue #2058).
+
+    The executor's first-turn gate and the runner's Stop handler both key
+    off this map; the ``pending``/``waiting`` views must name exactly the
+    servers whose latest status is ``starting``.
+    """
+    assert read_mcp_startup(bridge_dir) == {}
+    assert pending_mcp_servers({}) == []
+    assert mcp_startup_waiting_detail({}) is None
+
+    update_mcp_server_startup(bridge_dir, "safe", "starting")
+    update_mcp_server_startup(bridge_dir, "storage-console", "starting")
+    servers = update_mcp_server_startup(bridge_dir, "safe", "failed", error="handshake failed")
+
+    assert servers == read_mcp_startup(bridge_dir)
+    assert read_mcp_startup(bridge_dir) == {
+        "safe": {"status": "failed", "error": "handshake failed"},
+        "storage-console": {"status": "starting", "error": None},
+    }
+    # Only still-starting servers are pending; the failed one settled.
+    assert pending_mcp_servers(read_mcp_startup(bridge_dir)) == ["storage-console"]
+    assert (
+        mcp_startup_waiting_detail(read_mcp_startup(bridge_dir))
+        == "MCP startup still waiting on storage-console"
+    )
+
+
+def test_cancel_pending_mcp_startup_flips_only_starting(bridge_dir: Path) -> None:
+    """
+    Stop's local cancel flips ``starting`` servers to ``cancelled`` only.
+
+    Settled servers (ready/failed) must keep their state — rewriting them
+    would misreport what actually happened; a second cancel is a no-op so
+    a repeated Stop doesn't claim it cancelled anything.
+    """
+    update_mcp_server_startup(bridge_dir, "safe", "ready")
+    update_mcp_server_startup(bridge_dir, "testman", "failed", error="boom")
+    update_mcp_server_startup(bridge_dir, "storage-console", "starting")
+
+    assert cancel_pending_mcp_startup(bridge_dir) == ["storage-console"]
+    assert read_mcp_startup(bridge_dir) == {
+        "safe": {"status": "ready", "error": None},
+        "testman": {"status": "failed", "error": "boom"},
+        "storage-console": {"status": "cancelled", "error": None},
+    }
+    # Nothing pending anymore → repeat cancel reports nothing flipped.
+    assert cancel_pending_mcp_startup(bridge_dir) == []
+
+
+def test_settle_pending_mcp_startup_drops_only_starting(bridge_dir: Path) -> None:
+    """
+    Settling drops unresolved ``starting`` entries and keeps terminal ones.
+
+    Codex never delivers per-server outcomes to Omnigent's observer
+    connection, so at settle the unresolved entries are removed rather
+    than guessed; a locally-cancelled server must survive so the web band
+    can keep saying it was cancelled. A second settle is a no-op.
+    """
+    update_mcp_server_startup(bridge_dir, "safe", "starting")
+    update_mcp_server_startup(bridge_dir, "storage-console", "cancelled")
+
+    servers, changed = settle_pending_mcp_startup(bridge_dir)
+
+    assert changed is True
+    assert servers == {"storage-console": {"status": "cancelled", "error": None}}
+    assert read_mcp_startup(bridge_dir) == servers
+    # Fully settled → nothing to drop, nothing rewritten.
+    assert settle_pending_mcp_startup(bridge_dir) == (servers, False)
+
+
+def test_read_mcp_startup_ignores_malformed_entries(bridge_dir: Path) -> None:
+    """
+    Malformed or unknown-status entries are dropped on read.
+
+    A corrupt file must degrade to "no state" rather than crash the
+    executor gate or feed a bogus status into the web UI.
+    """
+    (bridge_dir / "mcp_startup.json").write_text("not json")
+    assert read_mcp_startup(bridge_dir) == {}
+
+    (bridge_dir / "mcp_startup.json").write_text(
+        '{"servers": {"ok": {"status": "ready"}, "bad": {"status": "exploded"},'
+        ' "": {"status": "ready"}}}'
+    )
+    assert read_mcp_startup(bridge_dir) == {"ok": {"status": "ready", "error": None}}
+
+
+def test_clear_bridge_state_removes_mcp_startup(bridge_dir: Path) -> None:
+    """
+    ``clear_bridge_state`` drops the MCP startup map with the other
+    runtime state, so a relaunch never gates its first turn on a prior
+    app-server's startup round.
+    """
+    update_mcp_server_startup(bridge_dir, "safe", "starting")
+
+    clear_bridge_state(bridge_dir)
+
+    assert read_mcp_startup(bridge_dir) == {}

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1840,3 +1840,336 @@ async def test_post_session_event_records_connectivity_failure_for_watchdog(
         assert "No route to host" in detail
     finally:
         health.clear()
+
+
+# ── MCP startup status mirroring (issue #2058) ─────────────────────────
+
+
+def _mcp_startup_event(
+    name: str,
+    status: str,
+    *,
+    error: str | None = None,
+    thread_id: str | None = None,
+) -> dict:
+    """
+    Build a Codex ``mcpServer/startupStatus/updated`` envelope.
+
+    :param name: MCP server name, e.g. ``"safe"``.
+    :param status: Startup state, e.g. ``"starting"``.
+    :param error: Optional failure detail.
+    :param thread_id: Optional ``threadId`` param.
+    :returns: Notification envelope dict.
+    """
+    params: dict = {"name": name, "status": status}
+    if error is not None:
+        params["error"] = error
+    if thread_id is not None:
+        params["threadId"] = thread_id
+    return {"method": "mcpServer/startupStatus/updated", "params": params}
+
+
+@pytest.mark.asyncio
+async def test_mcp_startup_event_records_and_posts(tmp_path: Path) -> None:
+    """
+    An MCP startup notification updates the bridge map and mirrors it to AP.
+
+    The bridge write is what unblocks the executor's first-turn gate; the
+    ``external_mcp_startup`` post is what makes the web session show
+    per-server startup state instead of appearing hung.
+    """
+    client = _RecordingClient()
+
+    await fwd._handle_event(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        bridge_dir=tmp_path,
+        event=_mcp_startup_event("safe", "starting", thread_id="thread_1"),
+        usage_coalescer=fwd._SessionUsageCoalescer(client, "conv_x"),  # type: ignore[arg-type]
+        elicitation_tracker=fwd._CodexElicitationTaskTracker(),
+        expected_thread_id="thread_1",
+    )
+
+    from omnigent.codex_native_bridge import read_mcp_startup
+
+    assert read_mcp_startup(tmp_path) == {"safe": {"status": "starting", "error": None}}
+    assert client.posts == [
+        (
+            "/v1/sessions/conv_x/events",
+            {
+                "type": "external_mcp_startup",
+                "data": {"servers": {"safe": {"status": "starting", "error": None}}},
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mcp_startup_event_carries_failure_error(tmp_path: Path) -> None:
+    """
+    A ``failed`` update retains the error detail through bridge and post.
+
+    The error text is what the web UI (and the executor's timeout text)
+    surface for a server that never came up.
+    """
+    client = _RecordingClient()
+
+    await fwd._handle_event(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        bridge_dir=tmp_path,
+        event=_mcp_startup_event("safe", "failed", error="handshake failed"),
+        usage_coalescer=fwd._SessionUsageCoalescer(client, "conv_x"),  # type: ignore[arg-type]
+        elicitation_tracker=fwd._CodexElicitationTaskTracker(),
+        expected_thread_id="thread_1",
+    )
+
+    from omnigent.codex_native_bridge import read_mcp_startup
+
+    assert read_mcp_startup(tmp_path) == {
+        "safe": {"status": "failed", "error": "handshake failed"}
+    }
+    assert client.posts[0][1]["data"]["servers"]["safe"]["error"] == "handshake failed"
+
+
+@pytest.mark.asyncio
+async def test_mcp_startup_event_for_other_thread_is_ignored(tmp_path: Path) -> None:
+    """
+    An MCP startup update naming a different thread is dropped.
+
+    A child thread's (or stale thread's) startup must not overwrite the
+    parent bridge map or flash the parent session's startup band.
+    """
+    client = _RecordingClient()
+
+    await fwd._handle_event(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        bridge_dir=tmp_path,
+        event=_mcp_startup_event("safe", "starting", thread_id="thread_other"),
+        usage_coalescer=fwd._SessionUsageCoalescer(client, "conv_x"),  # type: ignore[arg-type]
+        elicitation_tracker=fwd._CodexElicitationTaskTracker(),
+        expected_thread_id="thread_1",
+    )
+
+    from omnigent.codex_native_bridge import read_mcp_startup
+
+    assert read_mcp_startup(tmp_path) == {}
+    assert client.posts == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_startup_event_with_unknown_status_is_ignored(tmp_path: Path) -> None:
+    """
+    An unknown status value neither records nor posts.
+
+    Guards against a future Codex enum change feeding a bogus status into
+    the executor gate or the web UI.
+    """
+    client = _RecordingClient()
+
+    await fwd._handle_event(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        bridge_dir=tmp_path,
+        event=_mcp_startup_event("safe", "exploded"),
+        usage_coalescer=fwd._SessionUsageCoalescer(client, "conv_x"),  # type: ignore[arg-type]
+        elicitation_tracker=fwd._CodexElicitationTaskTracker(),
+        expected_thread_id="thread_1",
+    )
+
+    from omnigent.codex_native_bridge import read_mcp_startup
+
+    assert read_mcp_startup(tmp_path) == {}
+    assert client.posts == []
+
+
+def _write_session_config(tmp_path: Path, body: str) -> None:
+    """
+    Write the session's private ``config.toml`` under the bridge dir.
+
+    :param tmp_path: Bridge directory.
+    :param body: Raw TOML body, e.g. ``"[mcp_servers.safe]\ncommand='x'"``.
+    """
+    home = codex_home_for_bridge_dir(tmp_path)
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.toml").write_text(body)
+
+
+@pytest.mark.asyncio
+async def test_seed_mcp_startup_round_posts_config_servers(tmp_path: Path) -> None:
+    """
+    Seeding records the enabled config servers as ``starting`` and posts them.
+
+    Codex delivers per-server startup edges only to the thread-owning
+    connection, so this synthesized round is the only way the web session
+    learns startup is in flight (issue #2058). Disabled servers must be
+    excluded — codex does not boot them, and a permanently-"starting"
+    band entry would never resolve.
+    """
+    from omnigent.codex_native_bridge import read_mcp_startup
+
+    client = _RecordingClient()
+    _write_session_config(
+        tmp_path,
+        '[mcp_servers.safe]\ncommand = "x"\n'
+        '[mcp_servers.off]\ncommand = "y"\nenabled = false\n'
+        '[mcp_servers.omnigent]\ncommand = "z"\n',
+    )
+
+    timer = await fwd._seed_mcp_startup_round(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        bridge_dir=tmp_path,
+    )
+
+    try:
+        assert read_mcp_startup(tmp_path) == {
+            "safe": {"status": "starting", "error": None},
+            "omnigent": {"status": "starting", "error": None},
+        }
+        assert client.posts == [
+            (
+                "/v1/sessions/conv_x/events",
+                {
+                    "type": "external_mcp_startup",
+                    "data": {
+                        "servers": {
+                            "safe": {"status": "starting", "error": None},
+                            "omnigent": {"status": "starting", "error": None},
+                        }
+                    },
+                },
+            )
+        ]
+        assert timer is not None
+    finally:
+        if timer is not None:
+            timer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_seed_mcp_startup_round_skips_when_state_exists(tmp_path: Path) -> None:
+    """
+    A bridge dir that already carries round state is not reseeded.
+
+    ``supervise_forwarder`` restarts on reconnect mid-session; reseeding
+    then would flash a false "starting" band for servers that finished
+    booting long ago. Only ``clear_bridge_state`` (each app-server
+    launch) resets the map.
+    """
+    from omnigent.codex_native_bridge import read_mcp_startup, update_mcp_server_startup
+
+    client = _RecordingClient()
+    _write_session_config(tmp_path, '[mcp_servers.safe]\ncommand = "x"\n')
+    update_mcp_server_startup(tmp_path, "safe", "cancelled")
+
+    timer = await fwd._seed_mcp_startup_round(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        bridge_dir=tmp_path,
+    )
+
+    assert timer is None
+    assert client.posts == []
+    assert read_mcp_startup(tmp_path) == {"safe": {"status": "cancelled", "error": None}}
+
+
+@pytest.mark.asyncio
+async def test_thread_idle_settles_synthesized_round(tmp_path: Path) -> None:
+    """
+    An idle ``thread/status/changed`` resolves the synthesized round.
+
+    Codex defers turn execution until MCP startup settles, so a thread
+    going idle after a turn proves the round ended. Unresolved
+    ``starting`` entries are dropped (their real outcomes are only
+    delivered to the thread owner) while locally-recorded ``cancelled``
+    states survive, and the settled map is posted so the band clears.
+    """
+    from omnigent.codex_native_bridge import read_mcp_startup, update_mcp_server_startup
+
+    client = _RecordingClient()
+    update_mcp_server_startup(tmp_path, "safe", "starting")
+    update_mcp_server_startup(tmp_path, "storage-console", "cancelled")
+
+    await fwd._handle_event(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        bridge_dir=tmp_path,
+        event={
+            "method": "thread/status/changed",
+            "params": {"threadId": "thread_1", "status": {"type": "idle"}},
+        },
+        usage_coalescer=fwd._SessionUsageCoalescer(client, "conv_x"),  # type: ignore[arg-type]
+        elicitation_tracker=fwd._CodexElicitationTaskTracker(),
+        expected_thread_id="thread_1",
+    )
+
+    assert read_mcp_startup(tmp_path) == {
+        "storage-console": {"status": "cancelled", "error": None}
+    }
+    assert client.posts == [
+        (
+            "/v1/sessions/conv_x/events",
+            {
+                "type": "external_mcp_startup",
+                "data": {"servers": {"storage-console": {"status": "cancelled", "error": None}}},
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_thread_active_status_does_not_settle_round(tmp_path: Path) -> None:
+    """
+    An ``active`` status edge must not settle the round.
+
+    Codex flips the thread active the moment a turn is ACCEPTED — which
+    happens mid-startup, before the round ends — so settling there would
+    clear the band exactly when it matters most.
+    """
+    from omnigent.codex_native_bridge import read_mcp_startup, update_mcp_server_startup
+
+    client = _RecordingClient()
+    update_mcp_server_startup(tmp_path, "safe", "starting")
+
+    await fwd._handle_event(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        bridge_dir=tmp_path,
+        event={
+            "method": "thread/status/changed",
+            "params": {"threadId": "thread_1", "status": {"type": "active", "activeFlags": []}},
+        },
+        usage_coalescer=fwd._SessionUsageCoalescer(client, "conv_x"),  # type: ignore[arg-type]
+        elicitation_tracker=fwd._CodexElicitationTaskTracker(),
+        expected_thread_id="thread_1",
+    )
+
+    assert read_mcp_startup(tmp_path) == {"safe": {"status": "starting", "error": None}}
+    assert client.posts == []
+
+
+def test_settle_timeout_tracks_slowest_configured_server(tmp_path: Path) -> None:
+    """
+    The settle window follows the slowest ``startup_timeout_sec`` in config.
+
+    Codex bounds each server's spawn+handshake by that budget, so the
+    round cannot outlive it; a config without budgets falls back to the
+    codex default, and an absurd budget is capped.
+    """
+    _write_session_config(
+        tmp_path,
+        '[mcp_servers.fast]\ncommand = "x"\n'
+        '[mcp_servers.slow]\ncommand = "y"\nstartup_timeout_sec = 120\n',
+    )
+    assert fwd._mcp_startup_settle_timeout_seconds(tmp_path) == 135.0
+
+    _write_session_config(tmp_path, '[mcp_servers.fast]\ncommand = "x"\n')
+    assert fwd._mcp_startup_settle_timeout_seconds(tmp_path) == 25.0
+
+    _write_session_config(
+        tmp_path,
+        '[mcp_servers.slow]\ncommand = "y"\nstartup_timeout_sec = 100000\n',
+    )
+    assert fwd._mcp_startup_settle_timeout_seconds(tmp_path) == 240.0

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -2076,6 +2076,58 @@ async def test_seed_mcp_startup_round_skips_when_state_exists(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_seed_rearms_settle_timer_when_round_still_pending(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A reconnect that finds the round still pending re-arms the settle window.
+
+    The previous forwarder's settle timer dies with its connection; if the
+    reconnect only skipped reseeding, a missed idle edge would leave the
+    band stuck on "starting" for the rest of the session. The re-armed
+    timer must actually resolve the round: once it fires, the pending
+    entries are dropped and the settled map is posted.
+    """
+    from omnigent.codex_native_bridge import read_mcp_startup, update_mcp_server_startup
+
+    client = _RecordingClient()
+    update_mcp_server_startup(tmp_path, "safe", "starting")
+    update_mcp_server_startup(tmp_path, "storage-console", "cancelled")
+
+    async def _no_sleep(_seconds: float) -> None:
+        """Collapse the settle window so the test observes the timer firing."""
+
+    monkeypatch.setattr(fwd, "_sleep", _no_sleep)
+
+    timer = await fwd._seed_mcp_startup_round(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        bridge_dir=tmp_path,
+    )
+
+    # No reseed/repost on reconnect — the recorded map is left intact...
+    assert timer is not None
+    assert client.posts == []
+    assert read_mcp_startup(tmp_path)["safe"]["status"] == "starting"
+
+    # ...but the re-armed timer settles the round when the window elapses.
+    await timer
+    assert read_mcp_startup(tmp_path) == {
+        "storage-console": {"status": "cancelled", "error": None}
+    }
+    assert client.posts == [
+        (
+            "/v1/sessions/conv_x/events",
+            {
+                "type": "external_mcp_startup",
+                "data": {"servers": {"storage-console": {"status": "cancelled", "error": None}}},
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_thread_idle_settles_synthesized_round(tmp_path: Path) -> None:
     """
     An idle ``thread/status/changed`` resolves the synthesized round.
@@ -2173,3 +2225,12 @@ def test_settle_timeout_tracks_slowest_configured_server(tmp_path: Path) -> None
         '[mcp_servers.slow]\ncommand = "y"\nstartup_timeout_sec = 100000\n',
     )
     assert fwd._mcp_startup_settle_timeout_seconds(tmp_path) == 240.0
+
+    # A disabled server's budget must not stretch the window: codex never
+    # boots it, and the seed excludes it from the synthesized round.
+    _write_session_config(
+        tmp_path,
+        '[mcp_servers.fast]\ncommand = "x"\n'
+        '[mcp_servers.off]\ncommand = "y"\nenabled = false\nstartup_timeout_sec = 120\n',
+    )
+    assert fwd._mcp_startup_settle_timeout_seconds(tmp_path) == 25.0

--- a/web/src/lib/blockStream.ts
+++ b/web/src/lib/blockStream.ts
@@ -900,6 +900,7 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
     case "session_todos":
     case "session_terminal_pending":
     case "session_sandbox_status":
+    case "session_mcp_startup":
     case "session_input_consumed":
     case "session_created":
     // Mutates an existing block in the chat-store; see

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -589,6 +589,29 @@ export interface SessionSandboxStatusEvent {
   error: string | null;
 }
 
+/** Startup state of one harness MCP server (Codex's `McpServerStartupState`). */
+export type McpServerStartupState = "starting" | "ready" | "failed" | "cancelled";
+
+/** One MCP server's latest startup record within `session.mcp_startup`. */
+export interface McpServerStartup {
+  status: McpServerStartupState;
+  /** Failure detail when `status === "failed"`; `null` otherwise. */
+  error: string | null;
+}
+
+/**
+ * `session.mcp_startup` — per-MCP-server startup progress for a native
+ * harness session (codex-native today). Emitted while the harness boots
+ * its configured MCP servers, carrying the full latest map each time.
+ * Drives the MCP startup band on the session page so a slow or failing
+ * MCP server reads as live progress instead of a hung session.
+ */
+export interface SessionMcpStartupEvent {
+  type: "session_mcp_startup";
+  conversationId: string;
+  servers: Record<string, McpServerStartup>;
+}
+
 /**
  * `session.input.consumed` — a queued input item was persisted into
  * conversation history. Used to backfill optimistic user-bubble
@@ -844,6 +867,7 @@ export type StreamEvent =
   | SessionTodosEvent
   | SessionTerminalPendingEvent
   | SessionSandboxStatusEvent
+  | SessionMcpStartupEvent
   | SessionInputConsumedEvent
   | SessionInterruptedEvent
   | SessionCreatedEvent

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -101,6 +101,7 @@ describe("createSession", () => {
       codexModelOptions: [],
       terminalPending: false,
       sandboxStatus: null,
+      mcpStartup: null,
       activeResponseId: null,
       workspace: null,
       gitBranch: null,

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -13,6 +13,7 @@
 import type { ConversationItem } from "./conversationItems";
 import { isMessageItem } from "./conversationItems";
 import type { MessageContentBlock } from "./blocks";
+import type { McpServerStartup } from "./events";
 import { authenticatedFetch } from "./identity";
 import type {
   CodexModelOption,
@@ -212,6 +213,7 @@ interface SessionResponseWire {
    * `omnigent.server.schemas.SandboxStatus`.
    */
   sandbox_status?: SandboxStatus | null;
+  mcp_startup?: Record<string, McpServerStartup> | null;
   /**
    * Response id of the turn currently in flight, or absent/null when
    * idle. Lets a client reconnecting mid-turn reopen a streaming
@@ -304,6 +306,7 @@ function sessionFromWire(wire: SessionResponseWire): Session {
     codexModelOptions: wire.model_options ?? [],
     terminalPending: wire.terminal_pending ?? false,
     sandboxStatus: wire.sandbox_status ?? null,
+    mcpStartup: wire.mcp_startup ?? null,
     activeResponseId: wire.active_response_id ?? null,
   };
 }

--- a/web/src/lib/sse.test.ts
+++ b/web/src/lib/sse.test.ts
@@ -113,3 +113,47 @@ describe("parseEvent — session.status (background_task_count)", () => {
     expect(bgCount({ background_task_count: -1 })).toBeUndefined();
   });
 });
+
+describe("parseEvent — session.mcp_startup", () => {
+  it("parses a per-server startup map for the MCP startup band", () => {
+    const ev = parseEvent("session.mcp_startup", {
+      conversation_id: "conv_a",
+      servers: {
+        safe: { status: "failed", error: "handshake failed" },
+        "storage-console": { status: "starting", error: null },
+      },
+    });
+    expect(ev).toEqual({
+      type: "session_mcp_startup",
+      conversationId: "conv_a",
+      servers: {
+        safe: { status: "failed", error: "handshake failed" },
+        "storage-console": { status: "starting", error: null },
+      },
+    });
+  });
+
+  it("skips entries with unknown statuses instead of dropping the frame", () => {
+    // A partial map still updates the band; a bogus status must not reach
+    // the store where it would render an unknown state.
+    const ev = parseEvent("session.mcp_startup", {
+      conversation_id: "conv_a",
+      servers: {
+        ok: { status: "ready" },
+        bad: { status: "exploded" },
+      },
+    });
+    expect(ev).toEqual({
+      type: "session_mcp_startup",
+      conversationId: "conv_a",
+      servers: { ok: { status: "ready", error: null } },
+    });
+  });
+
+  it("rejects frames without a conversation id or servers map", () => {
+    expect(parseEvent("session.mcp_startup", { servers: {} })).toBeNull();
+    expect(
+      parseEvent("session.mcp_startup", { conversation_id: "conv_a", servers: "nope" }),
+    ).toBeNull();
+  });
+});

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -52,6 +52,8 @@ import type {
   SessionAgentChangedEvent,
   SessionTodosEvent,
   SessionSandboxStatusEvent,
+  McpServerStartup,
+  SessionMcpStartupEvent,
   SessionTerminalPendingEvent,
   SessionUsageEvent,
   SlashCommand,
@@ -598,6 +600,37 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
       stage,
       error: typeof data.error === "string" ? data.error : null,
     } satisfies SessionSandboxStatusEvent;
+  }
+  if (eventType === "session.mcp_startup") {
+    const conversationId = data.conversation_id;
+    if (typeof conversationId !== "string" || !conversationId) return null;
+    const rawServers = data.servers;
+    if (!rawServers || typeof rawServers !== "object" || Array.isArray(rawServers)) return null;
+    // Skip malformed entries rather than dropping the frame — a partial
+    // map still updates the startup band; unknown statuses are ignored.
+    const servers: Record<string, McpServerStartup> = {};
+    for (const [name, record] of Object.entries(rawServers as Record<string, unknown>)) {
+      if (!name || !record || typeof record !== "object" || Array.isArray(record)) continue;
+      const status = (record as Record<string, unknown>).status;
+      if (
+        status !== "starting" &&
+        status !== "ready" &&
+        status !== "failed" &&
+        status !== "cancelled"
+      ) {
+        continue;
+      }
+      const error = (record as Record<string, unknown>).error;
+      servers[name] = {
+        status,
+        error: typeof error === "string" && error ? error : null,
+      };
+    }
+    return {
+      type: "session_mcp_startup",
+      conversationId,
+      servers,
+    } satisfies SessionMcpStartupEvent;
   }
   if (eventType === "session.input.consumed") {
     // Nested envelope: `{type, data: {item_id, type, data}}`.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -11,6 +11,7 @@
 // `SessionEventInput`, `SessionStatusEvent.status`).
 
 import type { ConversationItem } from "./conversationItems";
+import type { McpServerStartup } from "./events";
 import type { MessageContentBlock } from "./blocks";
 
 /** Reference to a conversation, as returned on response objects. */
@@ -432,6 +433,14 @@ export interface Session {
    * sees the current stage.
    */
   sandboxStatus?: SandboxStatus | null;
+  /**
+   * Per-MCP-server startup state for native harness sessions
+   * (codex-native). Present while the harness boots its MCP servers or
+   * when servers were cancelled/failed; `null` otherwise. Sourced from
+   * the server's `_session_mcp_startup_cache` at snapshot build time so
+   * a client opening the session mid-startup sees the startup band.
+   */
+  mcpStartup?: Record<string, McpServerStartup> | null;
   /**
    * Response id of the turn currently in flight, or `null`/absent when
    * the session is idle. Sourced from the server's

--- a/web/src/pages/ChatPage.mcpStartup.test.ts
+++ b/web/src/pages/ChatPage.mcpStartup.test.ts
@@ -1,0 +1,32 @@
+// Vitest cases for the MCP startup band's pure line formatters.
+import { describe, expect, it } from "vitest";
+
+import { mcpSettledNames, mcpStartingLine } from "./ChatPage";
+
+describe("mcpStartingLine", () => {
+  it("mirrors the Codex TUI header: caps the name list at three", () => {
+    // A 20-server config must stay one scannable line, not a paragraph.
+    expect(mcpStartingLine(["a", "b", "c", "d", "e"], 20)).toBe(
+      "Starting MCP servers (15/20): a, b, c, …",
+    );
+  });
+
+  it("spells out short lists in full", () => {
+    expect(mcpStartingLine(["glean", "safe"], 3)).toBe("Starting MCP servers (1/3): glean, safe");
+  });
+
+  it("uses the singular header for a single-server round", () => {
+    expect(mcpStartingLine(["safe"], 1)).toBe("Starting MCP server: safe…");
+  });
+});
+
+describe("mcpSettledNames", () => {
+  it("keeps short failure lists verbatim", () => {
+    expect(mcpSettledNames(["safe", "storage-console"])).toBe("safe, storage-console");
+  });
+
+  it("collapses long lists into a count so the band stays scannable", () => {
+    const names = Array.from({ length: 12 }, (_, i) => `s${String(i).padStart(2, "0")}`);
+    expect(mcpSettledNames(names)).toBe("s00, s01, s02, s03, s04, s05, s06, s07, +4 more");
+  });
+});

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1405,6 +1405,11 @@ function MainAgentSurface({
   // the not-yet-host-bound session as stranded.
   const sandboxStatus = useChatStore((s) => s.sandboxStatus);
   const sandboxLaunching = sandboxStatus !== null && sandboxStatus.stage !== "failed";
+  // True while the harness reports MCP-server startup state (codex-native).
+  // Forces the message-flow branch below even with zero bubbles, so a user
+  // staring at a fresh session during a slow MCP boot sees the startup band
+  // instead of a bare "What should we work on?" empty state.
+  const mcpStartupActive = useChatStore((s) => s.mcpStartup !== null);
   // Render the inline terminal whenever the user has opted in via the
   // connection pill. The terminal surface owns its no-terminal state,
   // including stopped/resumable sessions, and the connection indicator
@@ -1619,7 +1624,7 @@ function MainAgentSurface({
               hasMoreHistory={hasMoreHistory}
               loadingMoreHistory={loadingMoreHistory}
             />
-            {bubbles.length === 0 && !showWorkingIndicator ? (
+            {bubbles.length === 0 && !showWorkingIndicator && !mcpStartupActive ? (
               // Cold launch: a centered spinner instead of the "ready to
               // type" empty state (the create-then-send path uses the
               // "row" variant). Two launch shapes land here: a
@@ -1683,6 +1688,12 @@ function MainAgentSurface({
                     Self-gates to null off the spin-up window; rendered only
                     when not already showing Working… so the two never stack. */}
                 {!showWorkingIndicator && <RunnerStartingIndicator variant="row" />}
+                {/* MCP-server startup band (codex-native): renders while the
+                    harness boots its MCP servers and, after startup settles,
+                    when servers failed or were cancelled. Independent of the
+                    Working… shimmer — it is strictly more specific about why
+                    the turn hasn't produced output yet. */}
+                <McpStartupIndicator />
               </>
             )}
           </ConversationContent>
@@ -2600,6 +2611,92 @@ export function RunnerStartingIndicator({ variant }: { variant: "hero" | "row" }
         <span className="flex items-center gap-2 text-muted-foreground text-sm">
           <Loader2Icon className="size-4 shrink-0 animate-spin" aria-hidden />
           {line}
+        </span>
+      </MessageContent>
+    </Message>
+  );
+}
+
+// How many still-starting server names the startup band spells out
+// before collapsing the rest into "…" — mirrors the Codex TUI's own
+// startup header, and keeps a 20-server config to one line.
+const MCP_STARTING_NAMES_SHOWN = 3;
+// Cap for the settled warning's failed/cancelled name lists. Longer
+// than the starting cap because these name servers the user may need
+// to fix; beyond this the count carries the signal.
+const MCP_SETTLED_NAMES_SHOWN = 8;
+
+/**
+ * The startup band's in-flight line, mirroring the Codex TUI's header.
+ *
+ * @param starting Still-starting server names, sorted.
+ * @param total Total servers in the round.
+ * @returns e.g. `"Starting MCP servers (1/20): glean, jira, safe, …"`.
+ */
+export function mcpStartingLine(starting: string[], total: number): string {
+  if (total === 1 && starting.length === 1) {
+    return `Starting MCP server: ${starting[0]}…`;
+  }
+  const shown = starting.slice(0, MCP_STARTING_NAMES_SHOWN);
+  if (starting.length > MCP_STARTING_NAMES_SHOWN) shown.push("…");
+  return `Starting MCP servers (${total - starting.length}/${total}): ${shown.join(", ")}`;
+}
+
+/**
+ * A settled warning's name list, capped so the band stays scannable.
+ *
+ * @param names Failed or cancelled server names, sorted.
+ * @returns e.g. `"a, b, c, d, e, f, g, h, +12 more"`.
+ */
+export function mcpSettledNames(names: string[]): string {
+  if (names.length <= MCP_SETTLED_NAMES_SHOWN) return names.join(", ");
+  const shown = names.slice(0, MCP_SETTLED_NAMES_SHOWN);
+  return `${shown.join(", ")}, +${names.length - MCP_SETTLED_NAMES_SHOWN} more`;
+}
+
+/**
+ * Per-MCP-server startup band for native harness sessions (codex-native).
+ * Codex defers a mid-startup turn's execution until its MCP servers
+ * settle, and the session previously showed nothing during that window.
+ * Renders a spinner naming the still-starting servers; once startup
+ * settles with failures/cancellations, a one-line notice says which
+ * servers never came up. Self-gates to null when the store carries no
+ * startup state (an all-ready map is cleared by the store handler).
+ */
+export function McpStartupIndicator() {
+  const mcpStartup = useChatStore((s) => s.mcpStartup);
+  if (mcpStartup === null) return null;
+  const names = Object.keys(mcpStartup).sort();
+  const starting = names.filter((name) => mcpStartup[name].status === "starting");
+  if (starting.length > 0) {
+    return (
+      <Message
+        from="assistant"
+        data-testid="mcp-startup-indicator"
+        role="status"
+        aria-live="polite"
+      >
+        <MessageContent>
+          <span className="flex items-center gap-2 text-muted-foreground text-sm">
+            <Loader2Icon className="size-4 shrink-0 animate-spin" aria-hidden />
+            {mcpStartingLine(starting, names.length)}
+          </span>
+        </MessageContent>
+      </Message>
+    );
+  }
+  const failed = names.filter((name) => mcpStartup[name].status === "failed");
+  const cancelled = names.filter((name) => mcpStartup[name].status === "cancelled");
+  if (failed.length === 0 && cancelled.length === 0) return null;
+  const parts: string[] = [];
+  if (failed.length > 0) parts.push(`failed: ${mcpSettledNames(failed)}`);
+  if (cancelled.length > 0) parts.push(`cancelled: ${mcpSettledNames(cancelled)}`);
+  return (
+    <Message from="assistant" data-testid="mcp-startup-indicator" role="status">
+      <MessageContent>
+        <span className="flex items-center gap-2 text-muted-foreground text-sm">
+          <AlertTriangleIcon className="size-4 shrink-0" aria-hidden />
+          {`MCP startup incomplete (${parts.join("; ")})`}
         </span>
       </MessageContent>
     </Message>

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -3402,6 +3402,56 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
     });
   });
 
+  describe("session.mcp_startup", () => {
+    it("mirrors an in-flight startup map for the MCP startup band", () => {
+      useChatStore.setState({ mcpStartup: null });
+      handleSessionEvent({
+        type: "session_mcp_startup",
+        conversationId: "conv_abc",
+        servers: {
+          safe: { status: "ready", error: null },
+          "storage-console": { status: "starting", error: null },
+        },
+      });
+      expect(useChatStore.getState().mcpStartup).toEqual({
+        safe: { status: "ready", error: null },
+        "storage-console": { status: "starting", error: null },
+      });
+    });
+
+    it("clears the map once every server settles ready", () => {
+      // An all-ready map means startup completed cleanly — retaining it
+      // would strand the startup band on screen.
+      useChatStore.setState({
+        mcpStartup: { safe: { status: "starting", error: null } },
+      });
+      handleSessionEvent({
+        type: "session_mcp_startup",
+        conversationId: "conv_abc",
+        servers: { safe: { status: "ready", error: null } },
+      });
+      expect(useChatStore.getState().mcpStartup).toBeNull();
+    });
+
+    it("retains failed and cancelled servers after startup settles", () => {
+      // The settled-with-failures map is what lets the page say which
+      // servers never came up (mirrors the Codex TUI's startup warnings).
+      useChatStore.setState({ mcpStartup: null });
+      handleSessionEvent({
+        type: "session_mcp_startup",
+        conversationId: "conv_abc",
+        servers: {
+          safe: { status: "failed", error: "handshake failed" },
+          "storage-console": { status: "cancelled", error: null },
+        },
+      });
+      expect(useChatStore.getState().mcpStartup).toEqual({
+        safe: { status: "failed", error: "handshake failed" },
+        "storage-console": { status: "cancelled", error: null },
+      });
+    });
+  });
+
   describe("session.skills", () => {
     /**
      * Route GET /v1/sessions/{seedId} to a snapshot carrying `skills`;

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -68,7 +68,12 @@ import {
   type SessionItemsPage,
   updateSession,
 } from "@/lib/sessionsApi";
-import type { SessionInputConsumedEvent, SessionViewer, StreamEvent } from "@/lib/events";
+import type {
+  McpServerStartup,
+  SessionInputConsumedEvent,
+  SessionViewer,
+  StreamEvent,
+} from "@/lib/events";
 import { createPresenceIdleTracker } from "@/lib/presenceIdle";
 import { parseEvent, parseSseStream, type SseStreamResult } from "@/lib/sse";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
@@ -512,6 +517,15 @@ export interface ChatState {
    * launch.
    */
   sandboxStatus: SandboxStatus | null;
+  /**
+   * Per-MCP-server startup map for the bound session (codex-native).
+   * Updated by `session.mcp_startup` SSE events while the harness boots
+   * its MCP servers; cleared back to `null` once every server settles
+   * `ready`. Failed/cancelled servers are retained so the page can say
+   * which servers never came up. Always `null` for sessions whose
+   * harness reports no MCP startup.
+   */
+  mcpStartup: Record<string, McpServerStartup> | null;
 
   // Internal mutable bookkeeping. NOT meant to be subscribed to.
   abortController: AbortController | null;
@@ -835,6 +849,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   terminalPending: false,
   viewers: [],
   sandboxStatus: null,
+  mcpStartup: null,
   abortController: null,
   historyGeneration: 0,
 
@@ -1402,6 +1417,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // discipline as ``viewers`` above.
         pendingComposerAttachments: [],
         sandboxStatus: null,
+        mcpStartup: null,
         abortController: null,
         historyGeneration: s.historyGeneration + 1,
       };
@@ -1844,6 +1860,7 @@ function sessionBindingPatch(
   | "codexModelOptions"
   | "terminalPending"
   | "sandboxStatus"
+  | "mcpStartup"
 > {
   const wrapper = session.labels?.["omnigent.wrapper"];
   return {
@@ -1867,6 +1884,7 @@ function sessionBindingPatch(
     codexModelOptions: session.codexModelOptions ?? [],
     terminalPending: session.terminalPending ?? false,
     sandboxStatus: session.sandboxStatus ?? null,
+    mcpStartup: session.mcpStartup ?? null,
   };
 }
 
@@ -3602,6 +3620,16 @@ export function handleSessionEvent(event: StreamEvent): void {
         sandboxStatus: event.stage === "ready" ? null : { stage: event.stage, error: event.error },
       });
       return;
+    case "session_mcp_startup": {
+      // Mirror the harness's per-MCP-server startup map. Cleared once
+      // every server settles `ready` (the band disappears); failures and
+      // cancellations are retained so the page can say which servers
+      // never came up.
+      const records = Object.values(event.servers);
+      const allReady = records.length === 0 || records.every((r) => r.status === "ready");
+      useChatStore.setState({ mcpStartup: allReady ? null : event.servers });
+      return;
+    }
     case "session_usage": {
       // Apply only fields that arrived; a window-only broadcast must
       // not clobber tokensUsed (and vice versa), and a cost-only


### PR DESCRIPTION
## Related issue

Closes #2058

## Summary

- A codex-native session with slow or failing MCP servers used to look hung: Codex runs an MCP startup round when its thread starts and (verified against codex 0.142.5) delivers `mcpServer/startupStatus/updated` only to the thread-owning connection — the TUI — so Omnigent's forwarder could not passively mirror it, and the web session showed nothing.
- The forwarder now **synthesizes the startup round**: at thread start it records the session config's enabled `[mcp_servers.*]` as `starting` in the bridge dir and posts them to the session (`external_mcp_startup` → snapshot-backed `session.mcp_startup` SSE). The round settles when the thread goes idle after a turn (codex defers turn execution until startup ends, so idle proves the round is over) or when the config-derived `startup_timeout_sec` window elapses; real notification edges, when codex does deliver them, supersede the synthesized states with true `ready`/`failed` outcomes.
- The web session renders an **MCP startup band** — `Starting MCP servers (0/18): confluence, databricks-v2, dbra, …` while booting (also in the empty state, where the session previously showed nothing), then `MCP startup incomplete (failed: …)` / `(cancelled: …)` when servers never came up. Seeded from the session snapshot so a mid-startup page load or reload still shows it.
- **Stop now cancels MCP startup** instead of no-oping: the runner and executor flip the bridge's pending servers to `cancelled` and send codex's startup interrupt (`turn/interrupt` with an empty `turnId`, the TUI's own `startup_interrupt`) — alongside the active-turn interrupt when a turn was queued mid-startup, since codex holds that turn until the round ends.
- Turn errors during startup name the pending servers (`… (MCP startup still waiting on storage-console)`).
- No client-side gate before `turn/start`: probing showed the app-server accepts a mid-startup turn immediately and defers its execution until the round settles, so sending right away is safe and a gate would only add latency.

### ELI5

Codex boots its MCP servers when a session starts, and quietly holds your first message until they're all up (or given up on). Omnigent never knew this was happening, so the chat just sat there. Now the chat shows "Starting MCP servers …" while codex boots them, tells you which ones failed or were cancelled, and the Stop button actually aborts a stuck startup.

```mermaid
sequenceDiagram
    participant Web as Web UI
    participant AP as Omnigent server
    participant FWD as Forwarder (runner)
    participant CDX as Codex app-server

    CDX->>FWD: thread/started (broadcast)
    FWD->>FWD: read session config.toml for expected MCP servers
    FWD->>AP: external_mcp_startup (all starting)
    AP->>Web: session.mcp_startup event + snapshot cache
    Note over Web: band shows Starting MCP servers (0/18)
    CDX--)FWD: startupStatus edges (owner-only, upgrade the map when delivered)
    Web->>AP: user message, turn/start accepted and deferred by codex
    alt Stop pressed
        Web->>AP: interrupt
        AP->>CDX: startup interrupt (empty turnId) + active-turn interrupt
        FWD->>AP: map flips to cancelled
    else round ends
        CDX->>FWD: thread status idle (turn ran)
        FWD->>AP: settle map (drop unresolved, keep failed and cancelled)
    end
    Note over Web: band clears or names failed and cancelled servers
```

## Test Plan

- Unit/integration: 111 tests across `tests/test_codex_native_bridge.py`, `tests/test_codex_native_forwarder.py` (round synthesis, idle settle, active-status non-settle, config-derived timeout, notification mirroring), `tests/inner/test_codex_native_executor.py` (no turn gating, dual Stop, error text), runner Stop paths in `tests/runner/test_app_sessions_native.py`, and the full `tests/server/integration/test_sessions_endpoints.py` (177 passed) including the new event route + snapshot cache tests. Web: `vitest` (sse parser, chatStore, band formatters — 272 passed) and `tsc -b`.
- Protocol probing against a bare `codex app-server` (0.142.5) with two raw clients established the behaviors the design relies on: owner-only delivery of startup edges, `thread/started`/`thread/status/changed` broadcast, mid-startup `turn/start` accepted-and-deferred, foreign-client empty-`turnId` interrupt cancelling startup, and `mcpServerStatus/list` blocking + retrying failed servers (which rules it out as a settle probe).
- Live end-to-end on a local server + runner + real codex TUI (`omnigent codex`), with a config containing a 40s-slow server and an instant-fail server on top of a real 18-server config: the band appears in a fresh empty session, a first message sent mid-startup is deferred by codex and answers after the round settles, the settled band names the real failures (`failed: safe, slowpoke_demo`), and Stop mid-startup flips the band to `cancelled` while the codex TUI shows the turn interrupted.

## Demo

Screenshots from the live end-to-end run:

**1. Fresh session during MCP boot — the startup band in the empty state:**

![Starting MCP servers band in a fresh session](https://raw.githubusercontent.com/andrewli81/omnigent/demo-assets-2058/demo/band-starting-capped.png)

**2. First message sent mid-startup (codex defers the turn), band still live:**

![Message sent while MCP servers still starting](https://raw.githubusercontent.com/andrewli81/omnigent/demo-assets-2058/demo/stop-2-message-sent.png)

**3. Stop pressed mid-startup — the band flips to cancelled:**

![Band shows MCP startup incomplete with cancelled servers after Stop](https://raw.githubusercontent.com/andrewli81/omnigent/demo-assets-2058/demo/stop-3-cancelled.png)

**4. Round settled — the deferred turn answered (`PONG`) and the band names the real failures:**

![Settled band naming failed servers next to the completed reply](https://raw.githubusercontent.com/andrewli81/omnigent/demo-assets-2058/demo/settle-3-settled.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the parts automated tests cannot: real codex 0.142.5 protocol behavior (owner-only notification delivery, deferred mid-startup turns, the empty-`turnId` startup interrupt actually cancelling the round) and the full live path server → runner → forwarder → SSE → web band, including Stop. Known limitation, verified live and documented in the code: when codex withholds the per-server edges, the synthesized round cannot know per-server `ready`/`failed` outcomes — unresolved entries are dropped at settle rather than guessed, and a Stop pressed after the real round quietly settled (but before Omnigent can observe that) may briefly label already-ready servers `cancelled`.

## Changelog

codex-native sessions now show MCP server startup progress in the chat, name servers that failed or were cancelled, and Stop can abort a slow MCP startup

---
This pull request and its description were written by Isaac.
