### PR TITLE
Recover claude-native boot timeouts

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -189,10 +189,15 @@ def is_claude_prompt_ready_timeout(exc: BaseException) -> bool:
     :param exc: Exception raised by :func:`inject_user_message`.
     :returns: ``True`` for the prompt-readiness timeout class/message.
     """
-    return isinstance(exc, ClaudePromptReadyTimeout) or (
-        isinstance(exc, RuntimeError)
-        and _CLAUDE_PROMPT_READY_TIMEOUT_PREFIX in str(exc)
-        and "input prompt never rendered" in str(exc)
+    if isinstance(exc, ClaudePromptReadyTimeout):
+        return True
+    # Compatibility for stale bridge/runtime pairs that still raise a
+    # plain RuntimeError with the historic prompt-timeout message.
+    if type(exc) is not RuntimeError:
+        return False
+    message = str(exc)
+    return message.startswith(_CLAUDE_PROMPT_READY_TIMEOUT_PREFIX) and (
+        "input prompt never rendered" in message
     )
 
 

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -167,8 +167,33 @@ _DRAFT_NEEDLE_MAX_CHARS = 24
 # surfaces in the web UI error banner instead of only in the terminal.
 _TERMINAL_FAILURE_TAIL_LINES = 12
 _TERMINAL_FAILURE_TAIL_CHARS = 800
+_CLAUDE_PROMPT_READY_TIMEOUT_PREFIX = "Claude Code terminal did not become ready"
 
 ToolExecutor = Callable[[str, dict[str, Any]], Awaitable[Any]]
+
+
+class ClaudePromptReadyTimeout(RuntimeError):
+    """Claude Code never rendered its input prompt after tmux launch."""
+
+
+def is_claude_prompt_ready_timeout(exc: BaseException) -> bool:
+    """
+    Return whether *exc* is the Claude Code prompt readiness timeout.
+
+    The recovery path must stay narrow: only a launched tmux pane whose
+    Claude input prompt never rendered is safe to tear down and cold
+    relaunch automatically. Other ``RuntimeError`` paths (tmux target
+    missing, send-keys failure, submit verification failure) keep their
+    existing behavior.
+
+    :param exc: Exception raised by :func:`inject_user_message`.
+    :returns: ``True`` for the prompt-readiness timeout class/message.
+    """
+    return isinstance(exc, ClaudePromptReadyTimeout) or (
+        isinstance(exc, RuntimeError)
+        and _CLAUDE_PROMPT_READY_TIMEOUT_PREFIX in str(exc)
+        and "input prompt never rendered" in str(exc)
+    )
 
 
 def _absolute_syntactic_path(path: Path) -> Path:
@@ -3006,7 +3031,7 @@ def _wait_for_claude_prompt_ready(
     # error banner this raises into, instead of only a generic timeout
     # the user has to open the terminal to diagnose.
     pane = _capture_pane(socket_path, tmux_target)
-    raise RuntimeError(
+    raise ClaudePromptReadyTimeout(
         f"Claude Code terminal did not become ready within {timeout_s}s "
         "(input prompt never rendered). The message was not delivered."
         + _format_terminal_failure_tail(pane)

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -5,16 +5,23 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import urllib.parse
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
+import httpx
+
 from omnigent.claude_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
     REQUEST_SESSION_ID_ENV_VAR,
+    ClaudePromptReadyTimeout,
     inject_user_message,
+    is_claude_prompt_ready_timeout,
     read_active_session_id,
+    read_permission_hook_config,
 )
+from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.inner.executor import (
     Executor,
     ExecutorConfig,
@@ -27,6 +34,10 @@ from omnigent.inner.executor import (
 from omnigent.inner.native_attachments import materialize_attachment
 
 _logger = logging.getLogger(__name__)
+_CLAUDE_TERMINAL_NAME = "claude"
+_CLAUDE_TERMINAL_SESSION_KEY = "main"
+_CLAUDE_TERMINAL_RECOVERY_TIMEOUT_S = 30.0
+_CLAUDE_BOOT_RECOVERY_ERROR_CODE = "timeout"
 
 
 class ClaudeNativeExecutor(Executor):
@@ -142,15 +153,183 @@ class ClaudeNativeExecutor(Executor):
         try:
             with telemetry.span("claude_native.inject"):
                 async with self._inject_lock:
-                    await asyncio.to_thread(
-                        inject_user_message,
+                    await _inject_user_message_with_boot_recovery(
                         self._bridge_dir,
                         content=text,
+                        request_session_id=self._request_session_id,
                     )
         except RuntimeError as exc:
-            yield ExecutorError(message=str(exc))
+            yield ExecutorError(
+                message=str(exc),
+                retryable=is_claude_prompt_ready_timeout(exc),
+                code=(
+                    _CLAUDE_BOOT_RECOVERY_ERROR_CODE
+                    if is_claude_prompt_ready_timeout(exc)
+                    else None
+                ),
+            )
             return
         yield TurnComplete(response=None)
+
+
+async def _inject_user_message_with_boot_recovery(
+    bridge_dir: Path,
+    *,
+    content: str,
+    request_session_id: str | None,
+) -> None:
+    """
+    Inject a message, recovering once from Claude Code boot timeouts.
+
+    A readiness timeout means tmux exists but Claude Code's input
+    prompt never mounted. The pane is not reusable, so close it through
+    the resource API, ask the runner to cold-resume the native terminal,
+    then deliver the same pending message once more. No other injection
+    failure is retried.
+
+    :param bridge_dir: Native bridge directory.
+    :param content: User text to deliver to Claude Code.
+    :param request_session_id: Session id from harness spawn env.
+    :returns: None on successful injection.
+    :raises RuntimeError: Original non-readiness failures, or a
+        readiness timeout after the single recovery attempt.
+    """
+    try:
+        await asyncio.to_thread(inject_user_message, bridge_dir, content=content)
+        return
+    except RuntimeError as exc:
+        if not is_claude_prompt_ready_timeout(exc):
+            raise
+        first_error = str(exc)
+
+    session_id = _recovery_session_id(bridge_dir, request_session_id)
+    _logger.warning(
+        "Claude Code prompt readiness timed out for session %s; closing terminal "
+        "and relaunching once before retrying injection.",
+        session_id,
+    )
+    await _close_claude_terminal_for_recovery(bridge_dir, session_id)
+    await _ensure_claude_terminal_for_recovery(bridge_dir, session_id)
+
+    try:
+        await asyncio.to_thread(inject_user_message, bridge_dir, content=content)
+        return
+    except RuntimeError as exc:
+        if not is_claude_prompt_ready_timeout(exc):
+            raise
+        await _close_claude_terminal_for_recovery(bridge_dir, session_id)
+        raise ClaudeNativeBootRecoveryError(
+            "Claude Code terminal did not become ready after one automatic "
+            "relaunch. The crashed pane was closed; retry this message to "
+            f"cold-resume the session. First startup error: {first_error} "
+            f"Retry startup error: {exc}"
+        ) from exc
+
+
+class ClaudeNativeBootRecoveryError(ClaudePromptReadyTimeout):
+    """Claude prompt readiness failed again after the single recovery retry."""
+
+
+def _recovery_session_id(bridge_dir: Path, request_session_id: str | None) -> str:
+    """
+    Resolve the Omnigent session id used for terminal recovery.
+
+    :param bridge_dir: Native bridge directory.
+    :param request_session_id: Harness spawn session id, when present.
+    :returns: Active Omnigent session id.
+    :raises RuntimeError: If no session id can be resolved.
+    """
+    if request_session_id:
+        return request_session_id
+    active_session_id = read_active_session_id(bridge_dir)
+    if active_session_id:
+        return active_session_id
+    raise RuntimeError("Claude native boot recovery cannot resolve the active session id.")
+
+
+def _recovery_server_config(bridge_dir: Path) -> tuple[str, dict[str, str]]:
+    """
+    Read server URL and headers from the bridge permission-hook config.
+
+    :param bridge_dir: Native bridge directory.
+    :returns: ``(base_url, headers)`` for Omnigent server requests.
+    :raises RuntimeError: If the bridge lacks server routing metadata.
+    """
+    config = read_permission_hook_config(bridge_dir)
+    raw_base_url = config.get("ap_server_url")
+    if not isinstance(raw_base_url, str) or not raw_base_url.strip():
+        raise RuntimeError(
+            "Claude native boot recovery cannot relaunch the terminal because "
+            "the bridge is missing Omnigent server routing metadata."
+        )
+    raw_headers = config.get("ap_auth_headers")
+    headers = (
+        {str(key): str(value) for key, value in raw_headers.items()}
+        if isinstance(raw_headers, dict)
+        else {}
+    )
+    return raw_base_url.rstrip("/"), headers
+
+
+async def _close_claude_terminal_for_recovery(bridge_dir: Path, session_id: str) -> None:
+    """
+    Close the claude/main terminal through the existing resource API.
+
+    :param bridge_dir: Native bridge directory.
+    :param session_id: Omnigent session id.
+    :returns: None.
+    :raises RuntimeError: If the server rejects the close.
+    """
+    base_url, headers = _recovery_server_config(bridge_dir)
+    terminal_id = terminal_resource_id(_CLAUDE_TERMINAL_NAME, _CLAUDE_TERMINAL_SESSION_KEY)
+    quoted_session_id = urllib.parse.quote(session_id, safe="")
+    quoted_terminal_id = urllib.parse.quote(terminal_id, safe="")
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=_CLAUDE_TERMINAL_RECOVERY_TIMEOUT_S,
+    ) as client:
+        response = await client.delete(
+            f"/v1/sessions/{quoted_session_id}/resources/terminals/{quoted_terminal_id}"
+        )
+    if response.status_code in (200, 404):
+        return
+    raise RuntimeError(
+        "Claude native boot recovery failed to close the crashed terminal "
+        f"(HTTP {response.status_code})."
+    )
+
+
+async def _ensure_claude_terminal_for_recovery(bridge_dir: Path, session_id: str) -> None:
+    """
+    Relaunch claude/main through the existing native ensure API.
+
+    :param bridge_dir: Native bridge directory.
+    :param session_id: Omnigent session id.
+    :returns: None when the runner accepted the relaunch.
+    :raises RuntimeError: If the server rejects the relaunch.
+    """
+    base_url, headers = _recovery_server_config(bridge_dir)
+    quoted_session_id = urllib.parse.quote(session_id, safe="")
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=_CLAUDE_TERMINAL_RECOVERY_TIMEOUT_S,
+    ) as client:
+        response = await client.post(
+            f"/v1/sessions/{quoted_session_id}/resources/terminals",
+            json={
+                "terminal": _CLAUDE_TERMINAL_NAME,
+                "session_key": _CLAUDE_TERMINAL_SESSION_KEY,
+                "ensure_native_terminal": True,
+            },
+        )
+    if response.status_code < 400:
+        return
+    raise RuntimeError(
+        "Claude native boot recovery failed to relaunch the terminal "
+        f"(HTTP {response.status_code})."
+    )
 
 
 def _bridge_dir_from_env() -> Path:

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -32,6 +32,10 @@ from omnigent.inner.executor import (
     TurnComplete,
 )
 from omnigent.inner.native_attachments import materialize_attachment
+from omnigent.native_policy_hook import (
+    _is_login_redirect_or_unauthorized,
+    policy_hook_reauth,
+)
 
 _logger = logging.getLogger(__name__)
 _CLAUDE_TERMINAL_NAME = "claude"
@@ -227,9 +231,12 @@ async def _inject_user_message_with_boot_recovery(
             f"Retry injection error: {exc}"
         ) from exc
     except RuntimeError as exc:
+        # Any retry-injection failure (readiness timeout, tmux target
+        # missing, submit verification) leaves the freshly-ensured pane
+        # behind; close it so a later native ensure cannot reuse it.
+        await _best_effort_close_claude_terminal_for_recovery(bridge_dir, session_id)
         if not is_claude_prompt_ready_timeout(exc):
             raise
-        await _best_effort_close_claude_terminal_for_recovery(bridge_dir, session_id)
         raise ClaudeNativeBootRecoveryError(
             "Claude Code terminal did not become ready after one automatic "
             "relaunch. The crashed pane was closed; retry this message to "
@@ -277,7 +284,9 @@ def _recovery_session_id(bridge_dir: Path, request_session_id: str | None) -> st
     active_session_id = read_active_session_id(bridge_dir)
     if active_session_id:
         return active_session_id
-    raise RuntimeError("Claude native boot recovery cannot resolve the active session id.")
+    raise ClaudeNativeBootRecoveryError(
+        "Claude native boot recovery cannot resolve the active session id."
+    )
 
 
 def _recovery_server_config(bridge_dir: Path) -> tuple[str, dict[str, str]]:
@@ -291,7 +300,7 @@ def _recovery_server_config(bridge_dir: Path) -> tuple[str, dict[str, str]]:
     config = read_permission_hook_config(bridge_dir)
     raw_base_url = config.get("ap_server_url")
     if not isinstance(raw_base_url, str) or not raw_base_url.strip():
-        raise RuntimeError(
+        raise ClaudeNativeBootRecoveryError(
             "Claude native boot recovery cannot relaunch the terminal because "
             "the bridge is missing Omnigent server routing metadata."
         )
@@ -321,6 +330,45 @@ def _recovery_http_client(base_url: str, headers: dict[str, str]) -> httpx.Async
     )
 
 
+async def _recovery_request(
+    bridge_dir: Path,
+    method: str,
+    path: str,
+    *,
+    json_body: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """
+    Send a recovery request, re-minting the bearer once on an auth lapse.
+
+    The bridge's ``ap_auth_headers`` are snapshotted at launch and expire
+    with the ~1h Databricks OAuth lifetime, so a long-idle session's
+    close/ensure calls can arrive with a dead bearer. On a 401 or an
+    OAuth-login redirect the token is re-minted through the same factory
+    the permission hook uses (``policy_hook_reauth``) and the request is
+    retried once, keeping routing headers so the retry still lands.
+
+    :param bridge_dir: Native bridge directory.
+    :param method: HTTP method, e.g. ``"DELETE"`` or ``"POST"``.
+    :param path: Server request path.
+    :param json_body: Optional JSON payload for the request.
+    :returns: The server response, after at most one re-auth retry.
+    :raises httpx.HTTPError: If the request transport fails.
+    """
+    base_url, headers = _recovery_server_config(bridge_dir)
+    reauth = policy_hook_reauth(base_url, headers)
+    reauthed = False
+    while True:
+        async with _recovery_http_client(base_url, headers) as client:
+            response = await client.request(method, path, json=json_body)
+        if not reauthed and _is_login_redirect_or_unauthorized(response):
+            refreshed = await asyncio.to_thread(reauth)
+            if refreshed:
+                headers = refreshed
+                reauthed = True
+                continue
+        return response
+
+
 async def _close_claude_terminal_for_recovery(bridge_dir: Path, session_id: str) -> None:
     """
     Close the claude/main terminal through the existing resource API.
@@ -330,15 +378,15 @@ async def _close_claude_terminal_for_recovery(bridge_dir: Path, session_id: str)
     :returns: None.
     :raises RuntimeError: If the server rejects the close.
     """
-    base_url, headers = _recovery_server_config(bridge_dir)
     terminal_id = terminal_resource_id(_CLAUDE_TERMINAL_NAME, _CLAUDE_TERMINAL_SESSION_KEY)
     quoted_session_id = urllib.parse.quote(session_id, safe="")
     quoted_terminal_id = urllib.parse.quote(terminal_id, safe="")
     try:
-        async with _recovery_http_client(base_url, headers) as client:
-            response = await client.delete(
-                f"/v1/sessions/{quoted_session_id}/resources/terminals/{quoted_terminal_id}"
-            )
+        response = await _recovery_request(
+            bridge_dir,
+            "DELETE",
+            f"/v1/sessions/{quoted_session_id}/resources/terminals/{quoted_terminal_id}",
+        )
     except httpx.HTTPError as exc:
         raise ClaudeNativeBootRecoveryError(
             "Claude native boot recovery could not close the crashed terminal "
@@ -361,18 +409,18 @@ async def _ensure_claude_terminal_for_recovery(bridge_dir: Path, session_id: str
     :returns: None when the runner accepted the relaunch.
     :raises RuntimeError: If the server rejects the relaunch.
     """
-    base_url, headers = _recovery_server_config(bridge_dir)
     quoted_session_id = urllib.parse.quote(session_id, safe="")
     try:
-        async with _recovery_http_client(base_url, headers) as client:
-            response = await client.post(
-                f"/v1/sessions/{quoted_session_id}/resources/terminals",
-                json={
-                    "terminal": _CLAUDE_TERMINAL_NAME,
-                    "session_key": _CLAUDE_TERMINAL_SESSION_KEY,
-                    "ensure_native_terminal": True,
-                },
-            )
+        response = await _recovery_request(
+            bridge_dir,
+            "POST",
+            f"/v1/sessions/{quoted_session_id}/resources/terminals",
+            json_body={
+                "terminal": _CLAUDE_TERMINAL_NAME,
+                "session_key": _CLAUDE_TERMINAL_SESSION_KEY,
+                "ensure_native_terminal": True,
+            },
+        )
     except httpx.HTTPError as exc:
         raise ClaudeNativeBootRecoveryError(
             "Claude native boot recovery could not relaunch the terminal "

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -209,15 +209,27 @@ async def _inject_user_message_with_boot_recovery(
         session_id,
     )
     await _close_claude_terminal_for_recovery(bridge_dir, session_id)
-    await _ensure_claude_terminal_for_recovery(bridge_dir, session_id)
+    try:
+        await _ensure_claude_terminal_for_recovery(bridge_dir, session_id)
+    except ClaudeNativeBootRecoveryError:
+        await _best_effort_close_claude_terminal_for_recovery(bridge_dir, session_id)
+        raise
 
     try:
         await asyncio.to_thread(inject_user_message, bridge_dir, content=content)
         return
+    except httpx.HTTPError as exc:
+        await _best_effort_close_claude_terminal_for_recovery(bridge_dir, session_id)
+        raise ClaudeNativeBootRecoveryError(
+            "Claude native boot recovery relaunched the terminal, but retry injection "
+            f"failed with a transient HTTP error. The retry pane was closed; retry this "
+            f"message to cold-resume the session. First startup error: {first_error} "
+            f"Retry injection error: {exc}"
+        ) from exc
     except RuntimeError as exc:
         if not is_claude_prompt_ready_timeout(exc):
             raise
-        await _close_claude_terminal_for_recovery(bridge_dir, session_id)
+        await _best_effort_close_claude_terminal_for_recovery(bridge_dir, session_id)
         raise ClaudeNativeBootRecoveryError(
             "Claude Code terminal did not become ready after one automatic "
             "relaunch. The crashed pane was closed; retry this message to "
@@ -228,6 +240,27 @@ async def _inject_user_message_with_boot_recovery(
 
 class ClaudeNativeBootRecoveryError(ClaudePromptReadyTimeout):
     """Claude prompt readiness failed again after the single recovery retry."""
+
+
+async def _best_effort_close_claude_terminal_for_recovery(
+    bridge_dir: Path,
+    session_id: str,
+) -> None:
+    """
+    Close a possibly-created retry pane without masking the real failure.
+
+    :param bridge_dir: Native bridge directory.
+    :param session_id: Omnigent session id.
+    :returns: None.
+    """
+    try:
+        await _close_claude_terminal_for_recovery(bridge_dir, session_id)
+    except ClaudeNativeBootRecoveryError:
+        _logger.warning(
+            "Claude native boot recovery could not confirm cleanup for session %s",
+            session_id,
+            exc_info=True,
+        )
 
 
 def _recovery_session_id(bridge_dir: Path, request_session_id: str | None) -> str:
@@ -268,7 +301,24 @@ def _recovery_server_config(bridge_dir: Path) -> tuple[str, dict[str, str]]:
         if isinstance(raw_headers, dict)
         else {}
     )
+    # Replays the runner-minted owner bearer plus routing headers; the
+    # server terminal routes enforce the normal session LEVEL_EDIT ACL.
     return raw_base_url.rstrip("/"), headers
+
+
+def _recovery_http_client(base_url: str, headers: dict[str, str]) -> httpx.AsyncClient:
+    """
+    Build the HTTP client used for terminal recovery calls.
+
+    :param base_url: Omnigent server base URL.
+    :param headers: Auth/routing headers read from the bridge config.
+    :returns: Configured async HTTP client.
+    """
+    return httpx.AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        timeout=_CLAUDE_TERMINAL_RECOVERY_TIMEOUT_S,
+    )
 
 
 async def _close_claude_terminal_for_recovery(bridge_dir: Path, session_id: str) -> None:
@@ -284,17 +334,19 @@ async def _close_claude_terminal_for_recovery(bridge_dir: Path, session_id: str)
     terminal_id = terminal_resource_id(_CLAUDE_TERMINAL_NAME, _CLAUDE_TERMINAL_SESSION_KEY)
     quoted_session_id = urllib.parse.quote(session_id, safe="")
     quoted_terminal_id = urllib.parse.quote(terminal_id, safe="")
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=_CLAUDE_TERMINAL_RECOVERY_TIMEOUT_S,
-    ) as client:
-        response = await client.delete(
-            f"/v1/sessions/{quoted_session_id}/resources/terminals/{quoted_terminal_id}"
-        )
+    try:
+        async with _recovery_http_client(base_url, headers) as client:
+            response = await client.delete(
+                f"/v1/sessions/{quoted_session_id}/resources/terminals/{quoted_terminal_id}"
+            )
+    except httpx.HTTPError as exc:
+        raise ClaudeNativeBootRecoveryError(
+            "Claude native boot recovery could not close the crashed terminal "
+            f"because the Omnigent server request failed: {exc}"
+        ) from exc
     if response.status_code in (200, 404):
         return
-    raise RuntimeError(
+    raise ClaudeNativeBootRecoveryError(
         "Claude native boot recovery failed to close the crashed terminal "
         f"(HTTP {response.status_code})."
     )
@@ -311,22 +363,24 @@ async def _ensure_claude_terminal_for_recovery(bridge_dir: Path, session_id: str
     """
     base_url, headers = _recovery_server_config(bridge_dir)
     quoted_session_id = urllib.parse.quote(session_id, safe="")
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=_CLAUDE_TERMINAL_RECOVERY_TIMEOUT_S,
-    ) as client:
-        response = await client.post(
-            f"/v1/sessions/{quoted_session_id}/resources/terminals",
-            json={
-                "terminal": _CLAUDE_TERMINAL_NAME,
-                "session_key": _CLAUDE_TERMINAL_SESSION_KEY,
-                "ensure_native_terminal": True,
-            },
-        )
+    try:
+        async with _recovery_http_client(base_url, headers) as client:
+            response = await client.post(
+                f"/v1/sessions/{quoted_session_id}/resources/terminals",
+                json={
+                    "terminal": _CLAUDE_TERMINAL_NAME,
+                    "session_key": _CLAUDE_TERMINAL_SESSION_KEY,
+                    "ensure_native_terminal": True,
+                },
+            )
+    except httpx.HTTPError as exc:
+        raise ClaudeNativeBootRecoveryError(
+            "Claude native boot recovery could not relaunch the terminal "
+            f"because the Omnigent server request failed: {exc}"
+        ) from exc
     if response.status_code < 400:
         return
-    raise RuntimeError(
+    raise ClaudeNativeBootRecoveryError(
         "Claude native boot recovery failed to relaunch the terminal "
         f"(HTTP {response.status_code})."
     )

--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -254,10 +254,14 @@ class ExecutorError(ExecutorEvent):
         failures (auth, SDK crash, protocol violation) that would recur.
         Consumed by the omnigent workflow to pick between
         :class:`RetryableLLMError` and :class:`PermanentLLMError`.
+    :param code: Optional semantic error code for retryable failures,
+        e.g. ``"timeout"`` or ``"connection_error"``. When omitted,
+        adapters use their safest generic retryable code.
     """
 
     message: str
     retryable: bool = False
+    code: str | None = None
 
 
 def _close_stream_quietly(stream: Iterator[ProviderStreamItem]) -> None:

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -108,6 +108,15 @@ _OBSERVED_TOOL_CALL_STATUS = "in_progress"
 #    ToolCallComplete — the dispatch's PATCH handler emits the
 #    paired output. Keeps the dedup story symmetric.
 _MCP_TOOL_NAME_PREFIX = "mcp__"
+_DEFAULT_RETRYABLE_EXECUTOR_ERROR_CODE = "server_error"
+
+
+class _RetryableExecutorError(RuntimeError):
+    """Runtime wrapper preserving ``ExecutorError.retryable`` semantics."""
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code or _DEFAULT_RETRYABLE_EXECUTOR_ERROR_CODE
 
 
 def _strip_mcp_tool_prefix(name: str) -> str:
@@ -457,7 +466,10 @@ class ExecutorAdapter(HarnessApp):
                                 error=event.message,
                             )
                             agent_span = None
-                        raise RuntimeError(f"inner executor error: {event.message}")
+                        error_message = f"inner executor error: {event.message}"
+                        if event.retryable:
+                            raise _RetryableExecutorError(error_message, code=event.code)
+                        raise RuntimeError(error_message)
         except ElicitationDeclinedError:
             # Fallback for executors that propagate the exception directly
             # (non-SDK / non-spawned-task paths). SDK-based executors use
@@ -1091,6 +1103,8 @@ class ExecutorAdapter(HarnessApp):
             # Project-internal structured errors already carry a
             # semantic code (e.g. ``RetryableLLMError(code="timeout")``).
             return ErrorDetail(code=exception.code, message=str(exception))
+        if isinstance(exception, _RetryableExecutorError):
+            return ErrorDetail(code=exception.code, message=str(exception))
 
         code = classify_inner_exception(exception)
         if code is not None:
@@ -1341,6 +1355,8 @@ def classify_inner_exception(exception: BaseException) -> str | None:
         ``"rate_limit_exceeded"``), or ``None`` when no
         classifier matched.
     """
+    if isinstance(exception, _RetryableExecutorError):
+        return exception.code
     for classifier in (
         _classify_openai_exception,
         _classify_anthropic_exception,

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -1055,16 +1055,11 @@ class ExecutorAdapter(HarnessApp):
         error code.
 
         Default :meth:`HarnessApp._build_error_detail` uses
-        ``type(exception).__name__`` as the code, which never
-        matches AP's retryable allowlist
-        (:data:`omnigent.runtime.harnesses._client_executor._RETRYABLE_HARNESS_ERROR_CODES`).
-        Result before this override: a known transient failure
-        like ``anthropic.RateLimitError`` would surface as
-        ``code="RateLimitError"``, AP's allowlist wouldn't match,
-        retry-classification would call it permanent, and the
-        workflow would never retry. This method closes that gap
-        for the harnesses the adapter wraps (claude-sdk, plus the
-        codex / openai-agents-sdk / pi wraps once they land).
+        ``type(exception).__name__`` as the code. This method preserves
+        structured retryable executor codes and translates known SDK
+        exceptions to semantic codes such as ``"timeout"`` or
+        ``"connection_error"`` so callers do not have to understand
+        provider-specific exception class names.
 
         Translation precedence:
 
@@ -1074,8 +1069,7 @@ class ExecutorAdapter(HarnessApp):
            project's own classification, so use it verbatim.
         2. OpenAI SDK exceptions — surfaced by the inner OpenAI
            Agents SDK / Open Responses SDK executors used by the
-           codex / openai-agents wraps. Maps onto the AP
-           allowlist's semantic codes
+           codex / openai-agents wraps. Maps onto semantic codes
            (``"rate_limit_exceeded"``, ``"server_error"``,
            ``"timeout"``, ``"connection_error"``).
         3. ``claude_agent_sdk`` exceptions — the Claude Code CLI
@@ -1092,9 +1086,8 @@ class ExecutorAdapter(HarnessApp):
 
         :param exception: The exception :meth:`run_turn` raised.
         :returns: An :class:`ErrorDetail` whose ``code`` matches
-            the Omnigent allowlist for known retryable failures, and is
-            still informative (provider exception class) for the
-            rest.
+            the Omnigent contract for known retryable failures, and is
+            still informative (provider exception class) for the rest.
         """
         from omnigent.errors import OmnigentError
         from omnigent.server.schemas import ErrorDetail
@@ -1111,8 +1104,7 @@ class ExecutorAdapter(HarnessApp):
             return ErrorDetail(code=code, message=str(exception))
 
         # Unknown exception type — preserve the class name so
-        # operators can still grep for it in logs, even though
-        # AP's retry allowlist won't match.
+        # operators can still grep for it in logs.
         return super()._build_error_detail(exception)
 
     async def on_shutdown(self) -> None:

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -822,24 +822,19 @@ class HarnessApp:
 
         Default implementation: uses the exception class name as
         the error code (e.g. ``"RuntimeError"``, ``"ValueError"``)
-        and ``str(exception)`` as the message. AP's retryable-error
-        allowlist at
-        :data:`omnigent.runtime.harnesses._client_executor._RETRYABLE_HARNESS_ERROR_CODES`
-        uses semantic names (``"rate_limit_exceeded"``,
-        ``"timeout"``, etc.), so the default mapping makes every
-        failure non-retryable — safe but coarse.
+        and ``str(exception)`` as the message. Semantic names
+        (``"rate_limit_exceeded"``, ``"timeout"``, etc.) are more
+        useful to downstream callers than raw exception class names;
+        the default mapping is safe but coarse.
 
         Per-harness subclasses (e.g.
         :class:`omnigent.runtime.harnesses._executor_adapter.ExecutorAdapter`)
         override this to translate SDK-specific exception types
-        onto the semantic allowlist so the retry-classification
-        promise from §Error envelopes / step 5j actually fires
-        for known retryable failures.
+        onto semantic error codes for known retryable failures.
 
         :param exception: The exception :meth:`run_turn` raised.
         :returns: An :class:`ErrorDetail` whose ``code`` field
-            ideally matches one of the contract-recognized codes
-            so AP-side retry decisions can act on it.
+            uses a contract-recognized code when one is known.
         """
         from omnigent.server.schemas import ErrorDetail
 

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import pytest
 
-from omnigent.claude_native_bridge import REQUEST_SESSION_ID_ENV_VAR
+from omnigent.claude_native_bridge import REQUEST_SESSION_ID_ENV_VAR, ClaudePromptReadyTimeout
 from omnigent.inner import claude_native_executor
 from omnigent.inner.claude_native_executor import ClaudeNativeExecutor
 from omnigent.inner.executor import ExecutorError, TurnComplete
@@ -89,6 +89,152 @@ async def test_run_turn_injects_user_message_without_streaming_transcript(
     assert events == [TurnComplete(response=None)]
     assert not (bridge_dir / "transcript_forwarder.json").exists()
     assert not (bridge_dir / "transcript_forwarder.pause.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_run_turn_recovers_prompt_timeout_and_retries_message(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A Claude Code boot timeout is closed, relaunched, and retried once.
+
+    The first injection sees tmux but never sees Claude's input prompt,
+    which is the startup crash class this recovery handles. The executor
+    must close the poisoned terminal, use the native ensure path to
+    relaunch, then deliver the same pending message exactly once on the
+    retry.
+    """
+    monkeypatch.setenv(REQUEST_SESSION_ID_ENV_VAR, "conv_boot")
+    bridge_dir = tmp_path / "bridge"
+    ops: list[str] = []
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path,
+        *,
+        content: str,
+        timeout_s: float = 30.0,
+    ) -> None:
+        del bridge_dir_arg, timeout_s
+        ops.append(f"inject:{content}")
+        if ops == ["inject:recover me"]:
+            raise ClaudePromptReadyTimeout(
+                "Claude Code terminal did not become ready within 0.1s "
+                "(input prompt never rendered). The message was not delivered."
+            )
+
+    async def fake_close(bridge_dir_arg: Path, session_id: str) -> None:
+        del bridge_dir_arg
+        ops.append(f"close:{session_id}")
+
+    async def fake_ensure(bridge_dir_arg: Path, session_id: str) -> None:
+        del bridge_dir_arg
+        ops.append(f"ensure:{session_id}")
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fake_inject_user_message)
+    monkeypatch.setattr(
+        claude_native_executor,
+        "_close_claude_terminal_for_recovery",
+        fake_close,
+    )
+    monkeypatch.setattr(
+        claude_native_executor,
+        "_ensure_claude_terminal_for_recovery",
+        fake_ensure,
+    )
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "recover me"}],
+            tools=[],
+            system_prompt="ignored",
+        )
+    ]
+
+    assert events == [TurnComplete(response=None)]
+    assert ops == [
+        "inject:recover me",
+        "close:conv_boot",
+        "ensure:conv_boot",
+        "inject:recover me",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_turn_double_prompt_timeout_is_retryable_and_closes_retry_pane(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    If the recovery launch also times out, the retry pane is closed.
+
+    The executor must not loop or emit multiple failures. It returns one
+    retryable error so the session can be resumed by a later message, and
+    it closes the second crashed pane so the next native ensure cannot
+    reuse it.
+    """
+    monkeypatch.setenv(REQUEST_SESSION_ID_ENV_VAR, "conv_retry_fails")
+    bridge_dir = tmp_path / "bridge"
+    ops: list[str] = []
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path,
+        *,
+        content: str,
+        timeout_s: float = 30.0,
+    ) -> None:
+        del bridge_dir_arg, timeout_s
+        ops.append(f"inject:{content}")
+        raise ClaudePromptReadyTimeout(
+            "Claude Code terminal did not become ready within 0.1s "
+            "(input prompt never rendered). The message was not delivered."
+        )
+
+    async def fake_close(bridge_dir_arg: Path, session_id: str) -> None:
+        del bridge_dir_arg
+        ops.append(f"close:{session_id}")
+
+    async def fake_ensure(bridge_dir_arg: Path, session_id: str) -> None:
+        del bridge_dir_arg
+        ops.append(f"ensure:{session_id}")
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fake_inject_user_message)
+    monkeypatch.setattr(
+        claude_native_executor,
+        "_close_claude_terminal_for_recovery",
+        fake_close,
+    )
+    monkeypatch.setattr(
+        claude_native_executor,
+        "_ensure_claude_terminal_for_recovery",
+        fake_ensure,
+    )
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "still recover"}],
+            tools=[],
+            system_prompt="ignored",
+        )
+    ]
+
+    assert len(events) == 1
+    error = events[0]
+    assert isinstance(error, ExecutorError)
+    assert error.retryable is True
+    assert error.code == "timeout"
+    assert "one automatic relaunch" in error.message
+    assert ops == [
+        "inject:still recover",
+        "close:conv_retry_fails",
+        "ensure:conv_retry_fails",
+        "inject:still recover",
+        "close:conv_retry_fails",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -4,13 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import threading
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 
-from omnigent.claude_native_bridge import REQUEST_SESSION_ID_ENV_VAR, ClaudePromptReadyTimeout
+from omnigent.claude_native_bridge import (
+    REQUEST_SESSION_ID_ENV_VAR,
+    ClaudePromptReadyTimeout,
+    build_hook_settings,
+)
 from omnigent.inner import claude_native_executor
 from omnigent.inner.claude_native_executor import ClaudeNativeExecutor
 from omnigent.inner.executor import ExecutorError, TurnComplete
@@ -234,6 +240,185 @@ async def test_run_turn_double_prompt_timeout_is_retryable_and_closes_retry_pane
         "ensure:conv_retry_fails",
         "inject:still recover",
         "close:conv_retry_fails",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("close_status", [200, 404])
+async def test_boot_recovery_uses_terminal_resource_api_and_auth_headers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    close_status: int,
+) -> None:
+    """
+    Recovery tears down before ensure through the real HTTP request path.
+
+    The permission-hook config carries the same owner bearer and routing
+    headers that satisfy the server terminal routes' LEVEL_EDIT checks.
+    Recovery must replay them unchanged for both the normal close case
+    and the already-gone 404 close case.
+    """
+    root = tmp_path / "root"
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", root)
+    bridge_dir = root / "bridge"
+    build_hook_settings(
+        bridge_dir,
+        ap_server_url="http://ap",
+        ap_auth_headers={
+            "Authorization": "Bearer owner-token",
+            "X-Databricks-Org-Id": "123",
+        },
+    )
+    ops: list[str] = []
+    requests: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path,
+        *,
+        content: str,
+        timeout_s: float = 30.0,
+    ) -> None:
+        del bridge_dir_arg, timeout_s
+        ops.append(f"inject:{content}")
+        if len(ops) == 1:
+            raise ClaudePromptReadyTimeout(
+                "Claude Code terminal did not become ready within 0.1s "
+                "(input prompt never rendered). The message was not delivered."
+            )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer owner-token"
+        assert request.headers["x-databricks-org-id"] == "123"
+        body = json.loads(request.content.decode("utf-8")) if request.content else None
+        requests.append((request.method, request.url.path, body))
+        if request.method == "DELETE":
+            return httpx.Response(close_status, json={"id": "terminal_claude_main"})
+        if request.method == "POST":
+            return httpx.Response(200, json={"id": "terminal_claude_main"})
+        return httpx.Response(500)
+
+    transport = httpx.MockTransport(handler)
+
+    def recovery_http_client(base_url: str, headers: dict[str, str]) -> httpx.AsyncClient:
+        assert base_url == "http://ap"
+        assert headers == {
+            "Authorization": "Bearer owner-token",
+            "X-Databricks-Org-Id": "123",
+        }
+        return httpx.AsyncClient(
+            base_url=base_url,
+            headers=headers,
+            transport=transport,
+            timeout=30.0,
+        )
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fake_inject_user_message)
+    monkeypatch.setattr(claude_native_executor, "_recovery_http_client", recovery_http_client)
+
+    await claude_native_executor._inject_user_message_with_boot_recovery(
+        bridge_dir,
+        content="recover over http",
+        request_session_id="conv_boot",
+    )
+
+    assert ops == ["inject:recover over http", "inject:recover over http"]
+    assert requests == [
+        (
+            "DELETE",
+            "/v1/sessions/conv_boot/resources/terminals/terminal_claude_main",
+            None,
+        ),
+        (
+            "POST",
+            "/v1/sessions/conv_boot/resources/terminals",
+            {
+                "terminal": "claude",
+                "session_key": "main",
+                "ensure_native_terminal": True,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ensure_failure", ["timeout", "status"])
+async def test_boot_recovery_http_failure_is_retryable_and_cleans_up_retry_pane(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    ensure_failure: str,
+) -> None:
+    """
+    Recovery HTTP failures become one retryable executor error.
+
+    A timeout or non-2xx ensure may have partially created a retry
+    pane, so the executor closes claude/main again before surfacing the
+    retryable outcome.
+    """
+    monkeypatch.setenv(REQUEST_SESSION_ID_ENV_VAR, "conv_http_fail")
+    root = tmp_path / "root"
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", root)
+    bridge_dir = root / "bridge"
+    build_hook_settings(
+        bridge_dir,
+        ap_server_url="http://ap",
+        ap_auth_headers={"Authorization": "Bearer owner-token"},
+    )
+    requests: list[tuple[str, str]] = []
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path,
+        *,
+        content: str,
+        timeout_s: float = 30.0,
+    ) -> None:
+        del bridge_dir_arg, content, timeout_s
+        raise ClaudePromptReadyTimeout(
+            "Claude Code terminal did not become ready within 0.1s "
+            "(input prompt never rendered). The message was not delivered."
+        )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path))
+        if request.method == "DELETE":
+            return httpx.Response(200, json={"id": "terminal_claude_main"})
+        if ensure_failure == "timeout":
+            raise httpx.TimeoutException("ensure timed out", request=request)
+        return httpx.Response(503, json={"error": {"message": "busy"}})
+
+    transport = httpx.MockTransport(handler)
+
+    def recovery_http_client(base_url: str, headers: dict[str, str]) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=base_url,
+            headers=headers,
+            transport=transport,
+            timeout=30.0,
+        )
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fake_inject_user_message)
+    monkeypatch.setattr(claude_native_executor, "_recovery_http_client", recovery_http_client)
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "recover me"}],
+            tools=[],
+            system_prompt="ignored",
+        )
+    ]
+
+    assert len(events) == 1
+    error = events[0]
+    assert isinstance(error, ExecutorError)
+    assert error.retryable is True
+    assert error.code == "timeout"
+    assert requests == [
+        ("DELETE", "/v1/sessions/conv_http_fail/resources/terminals/terminal_claude_main"),
+        ("POST", "/v1/sessions/conv_http_fail/resources/terminals"),
+        ("DELETE", "/v1/sessions/conv_http_fail/resources/terminals/terminal_claude_main"),
     ]
 
 

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -423,6 +423,195 @@ async def test_boot_recovery_http_failure_is_retryable_and_cleans_up_retry_pane(
 
 
 @pytest.mark.asyncio
+async def test_boot_recovery_closes_retry_pane_on_non_readiness_retry_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A non-readiness retry failure still closes the freshly-ensured pane.
+
+    When the post-recovery injection fails with a different RuntimeError
+    (tmux target missing, submit verification), the original error must
+    propagate — but the retry pane must be closed first, or the next
+    native ensure could reuse the dead pane.
+    """
+    monkeypatch.setenv(REQUEST_SESSION_ID_ENV_VAR, "conv_sibling_err")
+    bridge_dir = tmp_path / "bridge"
+    ops: list[str] = []
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path,
+        *,
+        content: str,
+        timeout_s: float = 30.0,
+    ) -> None:
+        del bridge_dir_arg, timeout_s
+        ops.append(f"inject:{content}")
+        if len(ops) == 1:
+            raise ClaudePromptReadyTimeout(
+                "Claude Code terminal did not become ready within 0.1s "
+                "(input prompt never rendered). The message was not delivered."
+            )
+        raise RuntimeError("tmux send-keys target claude:main is not advertised yet")
+
+    async def fake_close(bridge_dir_arg: Path, session_id: str) -> None:
+        del bridge_dir_arg
+        ops.append(f"close:{session_id}")
+
+    async def fake_ensure(bridge_dir_arg: Path, session_id: str) -> None:
+        del bridge_dir_arg
+        ops.append(f"ensure:{session_id}")
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fake_inject_user_message)
+    monkeypatch.setattr(
+        claude_native_executor,
+        "_close_claude_terminal_for_recovery",
+        fake_close,
+    )
+    monkeypatch.setattr(
+        claude_native_executor,
+        "_ensure_claude_terminal_for_recovery",
+        fake_ensure,
+    )
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "sibling failure"}],
+            tools=[],
+            system_prompt="ignored",
+        )
+    ]
+
+    assert len(events) == 1
+    error = events[0]
+    assert isinstance(error, ExecutorError)
+    assert error.retryable is False
+    assert "not advertised yet" in error.message
+    assert ops == [
+        "inject:sibling failure",
+        "close:conv_sibling_err",
+        "ensure:conv_sibling_err",
+        "inject:sibling failure",
+        "close:conv_sibling_err",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing", ["session_id", "server_config"])
+async def test_boot_recovery_config_failures_stay_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    missing: str,
+) -> None:
+    """
+    Recovery pre-flight config failures surface as retryable errors.
+
+    An unresolvable session id or missing server routing metadata means
+    recovery could not run — the underlying boot timeout is still the
+    transient failure, so the executor must not downgrade it to a
+    permanent (non-retryable) error.
+    """
+    if missing == "session_id":
+        monkeypatch.delenv(REQUEST_SESSION_ID_ENV_VAR, raising=False)
+        monkeypatch.setattr(claude_native_executor, "read_active_session_id", lambda _: None)
+    else:
+        monkeypatch.setenv(REQUEST_SESSION_ID_ENV_VAR, "conv_cfg")
+        monkeypatch.setattr(claude_native_executor, "read_permission_hook_config", lambda _: {})
+    bridge_dir = tmp_path / "bridge"
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path,
+        *,
+        content: str,
+        timeout_s: float = 30.0,
+    ) -> None:
+        del bridge_dir_arg, content, timeout_s
+        raise ClaudePromptReadyTimeout(
+            "Claude Code terminal did not become ready within 0.1s "
+            "(input prompt never rendered). The message was not delivered."
+        )
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", fake_inject_user_message)
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "recover me"}],
+            tools=[],
+            system_prompt="ignored",
+        )
+    ]
+
+    assert len(events) == 1
+    error = events[0]
+    assert isinstance(error, ExecutorError)
+    assert error.retryable is True
+    assert error.code == "timeout"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lapse_signal", ["401", "oidc_redirect"])
+async def test_boot_recovery_reauths_once_on_lapsed_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    lapse_signal: str,
+) -> None:
+    """
+    Recovery re-mints the bearer once when the snapshotted token lapsed.
+
+    The bridge's auth headers are snapshotted at launch; a long-idle
+    session's recovery close can hit a 401 or an OAuth-login redirect.
+    The request must retry exactly once with the freshly minted bearer.
+    """
+    root = tmp_path / "root"
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", root)
+    bridge_dir = root / "bridge"
+    build_hook_settings(
+        bridge_dir,
+        ap_server_url="http://ap",
+        ap_auth_headers={
+            "Authorization": "Bearer stale-token",
+            "X-Databricks-Org-Id": "123",
+        },
+    )
+    seen_auth: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_auth.append(request.headers["authorization"])
+        if request.headers["authorization"] == "Bearer stale-token":
+            if lapse_signal == "401":
+                return httpx.Response(401)
+            return httpx.Response(302, headers={"location": "http://ap/oidc/login"})
+        assert request.headers["x-databricks-org-id"] == "123"
+        return httpx.Response(200, json={"id": "terminal_claude_main"})
+
+    transport = httpx.MockTransport(handler)
+
+    def recovery_http_client(base_url: str, headers: dict[str, str]) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=base_url,
+            headers=headers,
+            transport=transport,
+            timeout=30.0,
+        )
+
+    def fake_policy_hook_reauth(base_url: str, headers: dict[str, str]) -> Any:
+        assert base_url == "http://ap"
+        return lambda: {**headers, "Authorization": "Bearer fresh-token"}
+
+    monkeypatch.setattr(claude_native_executor, "_recovery_http_client", recovery_http_client)
+    monkeypatch.setattr(claude_native_executor, "policy_hook_reauth", fake_policy_hook_reauth)
+
+    await claude_native_executor._close_claude_terminal_for_recovery(bridge_dir, "conv_auth")
+
+    assert seen_auth == ["Bearer stale-token", "Bearer fresh-token"]
+
+
+@pytest.mark.asyncio
 async def test_run_turn_does_not_advertise_active_omnigent_tools(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/runtime/harnesses/_test_executor_adapter_harness.py
+++ b/tests/runtime/harnesses/_test_executor_adapter_harness.py
@@ -149,6 +149,19 @@ def _build_error() -> Executor:
     return executor
 
 
+def _build_retryable_error() -> Executor:
+    """
+    MockExecutor scripted with a retryable :class:`ExecutorError`.
+
+    :returns: A configured :class:`MockExecutor` instance.
+    """
+    executor = MockExecutor()
+    executor._turns.append(
+        [ExecutorError(message="transient boot timeout", retryable=True, code="timeout")]
+    )
+    return executor
+
+
 def _build_cancelled() -> Executor:
     """
     MockExecutor scripted with a provider-side :class:`TurnCancelled`.
@@ -180,6 +193,7 @@ _SCRIPTS: dict[str, Callable[[], Executor]] = {
     "text_only": _build_text_only,
     "tool_call": _build_tool_call,
     "error": _build_error,
+    "retryable_error": _build_retryable_error,
     "cancelled": _build_cancelled,
     "capture_messages": _build_capture_messages,
 }

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -155,6 +155,12 @@ def use_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
+def use_retryable_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MockExecutor that yields a retryable ExecutorError."""
+    monkeypatch.setenv("MOCK_EXECUTOR_SCRIPT", "retryable_error")
+
+
+@pytest.fixture
 def use_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
     """MockExecutor that yields a provider-side TurnCancelled."""
     monkeypatch.setenv("MOCK_EXECUTOR_SCRIPT", "cancelled")
@@ -401,6 +407,33 @@ async def test_executor_error_terminates_with_response_failed(
     # via the RuntimeError wrap in the adapter; the scaffold
     # builds an ErrorDetail with the exception's str().
     assert "mock error" in error_detail["message"]
+
+
+async def test_retryable_executor_error_preserves_semantic_code(
+    use_retryable_error: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    ``ExecutorError.retryable`` survives the adapter boundary.
+
+    A retryable inner error must not be demoted to a plain
+    ``RuntimeError`` code, otherwise AP's retry classifier treats a
+    recoverable harness failure as permanent.
+    """
+    conv_id = "conv_retryable_err"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    events: list[_ParsedSSEEvent] = []
+    async with client.stream(
+        "POST", f"/v1/sessions/{conv_id}/events", json=_start_turn_body()
+    ) as response:
+        async for event in _stream_iter(response):
+            events.append(event)
+
+    assert events[-1].event == "response.failed"
+    error_detail = events[-1].data["response"]["error"]
+    assert error_detail is not None
+    assert error_detail["code"] == "timeout"
+    assert "transient boot timeout" in error_detail["message"]
 
 
 async def test_turn_cancelled_terminates_with_response_cancelled(

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -417,8 +417,7 @@ async def test_retryable_executor_error_preserves_semantic_code(
     ``ExecutorError.retryable`` survives the adapter boundary.
 
     A retryable inner error must not be demoted to a plain
-    ``RuntimeError`` code, otherwise AP's retry classifier treats a
-    recoverable harness failure as permanent.
+    ``RuntimeError`` code in the emitted ``response.failed`` detail.
     """
     conv_id = "conv_retryable_err"
     client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
@@ -474,10 +473,9 @@ def test_build_error_detail_uses_omnigent_error_code() -> None:
 
     What breaks if this fails: a ``RetryableLLMError(code="timeout")``
     raised by the inner executor would surface as
-    ``code="RetryableLLMError"``, AP's allowlist wouldn't
-    match, and the workflow's retry policy would treat the
-    timeout as permanent. The whole point of step 5j is the
-    structured ``code + retryable`` flowing through.
+    ``code="RetryableLLMError"`` instead of the semantic timeout code.
+    The whole point of the adapter override is the structured
+    ``code + retryable`` flowing through.
     """
     from omnigent.llms.errors import LLMErrorDetail, RetryableLLMError
     from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
@@ -491,10 +489,9 @@ def test_build_error_detail_uses_omnigent_error_code() -> None:
     )
     detail = adapter._build_error_detail(error)
 
-    # Code preserved verbatim — the Omnigent allowlist matches this and
-    # marks the failure retryable. Class-name fallback (which the
-    # base HarnessApp implementation would have used) gives
-    # ``"RetryableLLMError"`` instead, which Omnigent would NOT match.
+    # Code preserved verbatim. Class-name fallback (which the base
+    # HarnessApp implementation would have used) gives
+    # ``"RetryableLLMError"`` instead.
     assert detail.code == "rate_limit_exceeded"
     assert "rate-limited by gateway" in detail.message
     # Sanity: the base class fallback would NOT have produced this
@@ -544,7 +541,7 @@ def test_classify_openai_exception_maps_known_types() -> None:
         body=None,
     )
 
-    # Each known type maps onto AP's allowlist verbatim.
+    # Each known type maps onto a semantic error code verbatim.
     assert _classify_openai_exception(rate) == "rate_limit_exceeded"
     assert _classify_openai_exception(timeout) == "timeout"
     assert _classify_openai_exception(connect) == "connection_error"
@@ -712,9 +709,7 @@ def test_classify_anthropic_exception_maps_known_types(
     which can still surface raw :class:`anthropic.RateLimitError`
     upward when the SDK's framing layer fails. Without this
     classifier, those would render as ``[llm] RateLimitError``
-    and AP's retry allowlist (which uses semantic codes, not
-    class names) wouldn't match — silent demotion of retryable
-    failures to permanent.
+    instead of a semantic rate-limit code.
     """
     import sys
     import types

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2632,6 +2632,34 @@ def test_inject_user_message_raises_when_prompt_never_renders(
     assert send_keys == [], "no keystrokes should be sent when the prompt never renders"
 
 
+def test_claude_prompt_ready_timeout_classifier_is_precise() -> None:
+    """
+    Only the prompt-readiness boot timeout is eligible for recovery.
+
+    Other bridge ``RuntimeError`` paths must not trigger pane teardown
+    and relaunch, because they can represent unrelated tmux or submit
+    failures.
+    """
+    assert claude_native_bridge.is_claude_prompt_ready_timeout(
+        claude_native_bridge.ClaudePromptReadyTimeout("prompt never rendered")
+    )
+    assert claude_native_bridge.is_claude_prompt_ready_timeout(
+        RuntimeError(
+            "Claude Code terminal did not become ready within 30.0s "
+            "(input prompt never rendered). The message was not delivered."
+        )
+    )
+    assert not claude_native_bridge.is_claude_prompt_ready_timeout(
+        RuntimeError("Claude terminal tmux target is not advertised yet.")
+    )
+    assert not claude_native_bridge.is_claude_prompt_ready_timeout(
+        RuntimeError(
+            "Claude Code did not accept the submitted message within 10.0s "
+            "(the draft is still in the input box). The message was not delivered."
+        )
+    )
+
+
 def test_inject_user_message_ignores_prompt_glyph_in_scrollback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Root cause: a precise claude-native prompt readiness timeout (`Claude Code terminal did not become ready... input prompt never rendered`) was converted from bridge `RuntimeError` -> non-retryable `ExecutorError` -> dropped retryability in the harness adapter -> `response.failed` -> sticky failed session labels. At the same time, the crashed tmux pane stayed alive/attached, so `resource_registry.get_terminal_resource` treated it as healthy and later ensures reused the dead pane instead of cold-resuming.
- Fix layer: bridge/executor/adapter. The bridge is the smallest place to classify this exact timeout, the executor already owns message delivery and can call the existing terminal close + native ensure APIs, and the adapter is where retryability was being lost. This avoids broad runner/app.py changes while still guaranteeing pane teardown, one cold relaunch, and retryable failure semantics.
- Behavior change: on the first prompt-readiness timeout, close `claude/main`, ensure a fresh claude-native terminal with resume args, and redeliver the pending message exactly once. If close/ensure/retry-inject hits a transport error or non-2xx ensure/close response, surface a retryable boot-recovery timeout; if the retry pane may have been created, close it before returning. If the retry also prompt-times-out, close that pane and surface a retryable timeout so a later user message can cold-resume.
- Auth: recovery reuses the runner-written `ap_auth_headers` from `permission_hook.json` (owner bearer plus routing headers). Those are the same headers the server validates through `_validate_session(..., LEVEL_EDIT)` on terminal create/delete.

ELI5: if Claude Code crashes before showing its input box, omnigent now throws away that broken terminal, starts one clean replacement, and tries the same message once more. If the replacement or recovery HTTP call fails, omnigent leaves the session recoverable instead of stuck behind a dead terminal.

```mermaid
flowchart TD
    A[Deliver claude-native message] --> B{Prompt ready?}
    B -->|yes| C[Continue normal stream]
    B -->|first timeout| D[Close crashed claude/main]
    D --> E[Ensure fresh claude/main with resume]
    E --> F[Redeliver same message once]
    E -->|HTTP/status failure| H[Best-effort close]
    F --> G{Prompt ready?}
    G -->|yes| C
    G -->|timeout or HTTP failure| H
    H --> I[Return retryable timeout]
```

## Test Plan

- `env TMPDIR=/tmp uv run --frozen --extra dev pytest tests/test_claude_native_bridge.py tests/inner/test_claude_native_executor.py tests/runtime/harnesses/test_executor_adapter.py -q` → `212 passed`
- `env TMPDIR=/tmp uv run --frozen --extra dev pytest tests/test_claude_native_bridge.py tests/inner/test_claude_native_executor.py tests/runtime/harnesses/test_executor_adapter.py tests/runner/test_runner_dispatch.py::test_runner_publishes_terminal_failed_when_harness_stream_fails tests/runner/test_app_sessions_native.py::test_auto_create_claude_terminal_recreate_cancels_prior_forwarder -q` → `216 passed`
- `uv run --frozen --extra dev ruff check omnigent/claude_native_bridge.py omnigent/inner/claude_native_executor.py omnigent/inner/executor.py omnigent/runtime/harnesses/_executor_adapter.py omnigent/runtime/harnesses/_scaffold.py tests/test_claude_native_bridge.py tests/inner/test_claude_native_executor.py tests/runtime/harnesses/_test_executor_adapter_harness.py tests/runtime/harnesses/test_executor_adapter.py` → passed
- `uv run --frozen --extra dev ruff format --check omnigent/claude_native_bridge.py omnigent/inner/claude_native_executor.py omnigent/inner/executor.py omnigent/runtime/harnesses/_executor_adapter.py omnigent/runtime/harnesses/_scaffold.py tests/test_claude_native_bridge.py tests/inner/test_claude_native_executor.py tests/runtime/harnesses/_test_executor_adapter_harness.py tests/runtime/harnesses/test_executor_adapter.py` → passed
- `uv run --frozen --extra dev pre-commit run --all-files` → all hooks passed

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage includes the bridge timeout classifier, executor success-after-one-retry behavior, executor both-attempts-fail cleanup/retryable behavior, recovery DELETE/POST method/path/body/header assertions via `httpx.MockTransport`, 200/404 close handling, timeout/non-2xx recovery failures returning retryable errors, adapter retryable propagation, and the requested runner/app-session anchor tests.

## Changelog

Claude-native sessions recover from transient Claude Code startup crashes instead of getting stuck on a dead terminal.
