### PR TITLE
fix(host): forward DATABRICKS_AUTH_STORAGE to spawned runners

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -282,6 +282,15 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # executor.profile propagated into the daemon's env).
         "DATABRICKS_CONFIG_PROFILE",
         "DATABRICKS_CONFIG_FILE",
+        # DATABRICKS_AUTH_STORAGE selects the token-storage backend ("secure"
+        # OS keychain vs "plaintext" JSON cache) — also a non-secret selector.
+        # Without it a runner falls back to the ~/.databrickscfg [__settings__]
+        # auth_storage default and can resolve a DIFFERENT token store than the
+        # host/daemon (which inherits it via the daemon env's DATABRICKS_ prefix
+        # in cli.py). That mismatch makes the runner read an empty/stale store
+        # and fail to mint a token — the runner tunnel is rejected with HTTP 401
+        # even though the host authenticated fine.
+        "DATABRICKS_AUTH_STORAGE",
         # Runtime config/data-dir selection. These are filesystem PATHS, not
         # secrets, so they're safe to propagate to the host owner's own
         # daemon/runner subprocesses. They MUST propagate so the whole local

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1224,6 +1224,7 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "LC_CTYPE": "UTF-8",
         "DATABRICKS_CONFIG_PROFILE": "ambient",
         "DATABRICKS_CONFIG_FILE": "/tmp/databrickscfg",
+        "DATABRICKS_AUTH_STORAGE": "plaintext",
         "ANTHROPIC_API_KEY": "sk-harness",
         "IS_SANDBOX": "1",
         "DATABRICKS_TOKEN": "dapi-secret",
@@ -1252,6 +1253,10 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     # the ambient value reaches the runner unmodified (no flag override).
     assert env["DATABRICKS_CONFIG_PROFILE"] == "ambient"
     assert env["DATABRICKS_CONFIG_FILE"] == "/tmp/databrickscfg"
+    # The token-storage backend selector forwards too — without it the runner
+    # falls back to the ~/.databrickscfg default and can read a different token
+    # store than the host/daemon, failing to mint a token (runner tunnel 401).
+    assert env["DATABRICKS_AUTH_STORAGE"] == "plaintext"
     # Harness credentials forward — they exist FOR the runner's
     # harnesses (laptop: exported keys; managed sandbox: the
     # deployment's injected provider secrets).


### PR DESCRIPTION
## Related issue

Closes #2129

## Summary

- `_RUNNER_ENV_ALLOWLIST` in `omnigent/host/connect.py` forwards the Databricks config *selectors* `DATABRICKS_CONFIG_PROFILE` / `DATABRICKS_CONFIG_FILE` to spawned runners, but **not `DATABRICKS_AUTH_STORAGE`** (the token-storage backend selector: `secure` OS keychain vs `plaintext` JSON cache).
- The host **daemon** *does* inherit it — `omnigent/cli.py` builds the daemon env with `daemon_env_prefixes = (*_RUNNER_ENV_ALLOWLIST_PREFIXES, "DATABRICKS_")`. So on a machine that selects its token store via the env var (e.g. `DATABRICKS_AUTH_STORAGE=plaintext` while `~/.databrickscfg [__settings__] auth_storage = secure`), the **host authenticates fine** but every spawned **runner** falls back to the cfg default, reads a different/stale token store, can't mint a token, and the runner tunnel is rejected with **HTTP 401** — `runner tunnel rejected by server (HTTP 401)`, runner exits 1, UI shows "runner didn't come online in time." Host `host status` still shows `host=online`, which makes it confusing to diagnose.
- **Fix:** add `DATABRICKS_AUTH_STORAGE` to `_RUNNER_ENV_ALLOWLIST`, alongside the existing config selectors it sits with. It's a non-secret backend selector, matching that block's stated rationale. Deliberately **not** switching the runner to the daemon's blanket `DATABRICKS_` prefix — that would forward bearer secrets (`DATABRICKS_TOKEN`, `DATABRICKS_CLIENT_SECRET`, …) into (possibly hosted) runners, which is why the runner uses an explicit allowlist.

## Behavior

- **Before:** host connects (`host=online`) but every runner dies with `runner tunnel rejected by server (HTTP 401)` — it can't read the same Databricks token store the host used.
- **After:** runner inherits `DATABRICKS_AUTH_STORAGE`, resolves the same token store as the host, authenticates, and comes online.

## Test Plan

- Extended `tests/host/test_connect.py::test_build_runner_env_allowlists_host_env_and_strips_secrets` to seed `DATABRICKS_AUTH_STORAGE` in the host env and assert it reaches the runner env.
- ⚠️ I was unable to run the suite locally: the repo's `uv.toml` uses `exclude-newer = "P7D"` (requires `uv >= 0.11.8`) and my environment has uv 0.9.0; bypassing config with `--no-config` loses the package index and my network can't reach public PyPI. The change is a single allowlist entry mirrored by the added assertion, so I'm relying on CI to validate — happy to iterate if CI flags anything.

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added an assertion to the existing runner-env allowlist test (`test_build_runner_env_allowlists_host_env_and_strips_secrets`). Full suite not run locally due to a uv version / package-network constraint (see Test Plan); CI covers it.

## Changelog

Host-spawned runners now inherit `DATABRICKS_AUTH_STORAGE`, so a runner authenticates against the same Databricks token store as the host (fixes a runner tunnel 401 when the store is selected via env var rather than `~/.databrickscfg`).

---

This pull request and its description were written by Isaac.
