### PR TITLE
feat(web): add code font size + family setting for editor and terminal

### DIFF
--- a/tests/e2e_ui/comments/test_non_markdown_comments.py
+++ b/tests/e2e_ui/comments/test_non_markdown_comments.py
@@ -46,13 +46,15 @@ _PY_FILE_PATH = "comment_target.py"
 # word-select is unambiguous and the stored offset is deterministic.
 _ANCHOR_WORD = "uniqueanchortoken"
 
-# Python source — the anchor word lives in a trailing comment so it sits on its
-# own token and double-clicking selects the whole identifier.
+# Python source. The anchor word sits alone in a short leading comment so it is
+# its own token (double-click selects the whole identifier) AND stays within the
+# visible viewport at any code-font size — a trailing comment on a long line
+# scrolls off-screen at the larger default sizes, leaving the double-click
+# word-select nothing to land on.
 _PY_CONTENT = f"""\
 def greet(name):
-    message = "hello " + name  # {_ANCHOR_WORD}
-    print(message)
-    return message
+    # {_ANCHOR_WORD}
+    return "hello " + name
 """
 
 

--- a/tests/e2e_ui/sessions/test_code_font.py
+++ b/tests/e2e_ui/sessions/test_code_font.py
@@ -67,7 +67,9 @@ def _stored_size(page: Page) -> str | None:
 def _open_appearance(page: Page, base_url: str) -> None:
     """Navigate to the Settings Appearance section and wait for the code control."""
     page.goto(f"{base_url}/settings/appearance")
-    expect(page.get_by_role("group", name="Code font size")).to_be_visible(timeout=30_000)
+    expect(page.get_by_role("group", name="Code font size", exact=True)).to_be_visible(
+        timeout=30_000
+    )
 
 
 def _open_monaco(page: Page, base_url: str, session_id: str) -> Locator:

--- a/tests/e2e_ui/sessions/test_code_font.py
+++ b/tests/e2e_ui/sessions/test_code_font.py
@@ -1,10 +1,11 @@
 """E2E: the Settings → Appearance *code* font size drives Monaco and persists.
 
 The code-font controls live on the Settings page (``pages/SettingsPage.tsx``,
-``UiCodeFontSizeControl`` / ``UiCodeFontFamilyControl``) under a "Code font"
-subheading: a segmented pill (``−`` / value / ``+``) under a ``role="group"``
-labelled "Code font size", plus a free-text family input. Stepping the size
-writes the px choice to ``localStorage["omnigent:code-font-size"]``.
+``UiCodeFontSizeControl`` / ``UiCodeFontFamilyControl``) as two rows labelled
+"Code font size" and "Code font family": a segmented pill (``−`` / value /
+``+``) under a ``role="group"`` labelled "Code font size", plus a free-text
+family input. Stepping the size writes the px choice to
+``localStorage["omnigent:code-font-size"]``.
 
 Unlike the chrome font (which rides the ``--ui-font-scale`` CSS variable), the
 code editor (Monaco) and terminal (xterm) are fixed-pixel widgets: they read a

--- a/tests/e2e_ui/sessions/test_code_font.py
+++ b/tests/e2e_ui/sessions/test_code_font.py
@@ -1,0 +1,166 @@
+"""E2E: the Settings → Appearance *code* font size drives Monaco and persists.
+
+The code-font controls live on the Settings page (``pages/SettingsPage.tsx``,
+``UiCodeFontSizeControl`` / ``UiCodeFontFamilyControl``) under a "Code font"
+subheading: a segmented pill (``−`` / value / ``+``) under a ``role="group"``
+labelled "Code font size", plus a free-text family input. Stepping the size
+writes the px choice to ``localStorage["omnigent:code-font-size"]``.
+
+Unlike the chrome font (which rides the ``--ui-font-scale`` CSS variable), the
+code editor (Monaco) and terminal (xterm) are fixed-pixel widgets: they read a
+concrete ``fontSize`` at construction and are updated imperatively via the
+in-module pub/sub in ``lib/codeFontPreferences.ts``. Monaco applies the size as
+an inline ``font-size`` on its ``.view-lines`` element, so opening a non-markdown
+file and reading that computed size is the portable signal that the preference
+reached a real, mounted editor. The default is 13px; the range is 10–24px, so
+the ``−`` / ``+`` buttons disable at the bounds.
+
+No LLM turn is involved — the file is seeded via the filesystem PUT endpoint and
+the size is a pure client-side preference.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+STORAGE_KEY = "omnigent:code-font-size"
+
+# The seeded file lands in ``<cwd>/<session_id>/`` (the agent spec uses
+# ``os_env.cwd: .``); mirror test_file_autosave.py's per-session cleanup.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_PY_PATH = "code_font_module.py"
+_PY_CONTENT = 'def greet(name):\n    return "hello " + name\n'
+
+
+def _seed_file(base_url: str, session_id: str, path: str, content: str) -> None:
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem/{path}",
+        json={"content": content, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+@pytest.fixture
+def seeded_python(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    base_url, session_id = seeded_session
+    _seed_file(base_url, session_id, _PY_PATH, _PY_CONTENT)
+    try:
+        yield (base_url, session_id)
+    finally:
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+def _stored_size(page: Page) -> str | None:
+    """The persisted code-font size preference, or None when unset (default 13)."""
+    return page.evaluate(f"() => window.localStorage.getItem('{STORAGE_KEY}')")
+
+
+def _open_appearance(page: Page, base_url: str) -> None:
+    """Navigate to the Settings Appearance section and wait for the code control."""
+    page.goto(f"{base_url}/settings/appearance")
+    expect(page.get_by_role("group", name="Code font size")).to_be_visible(timeout=30_000)
+
+
+def _open_monaco(page: Page, base_url: str, session_id: str) -> Locator:
+    """Open the seeded Python file in Monaco and return the file-viewer locator."""
+    page.goto(f"{base_url}/c/{session_id}?file={_PY_PATH}")
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible(timeout=30_000)
+    # Non-markdown files render in Monaco (lazy-loaded); wait until it has laid
+    # out the file so the inline font-size is present on .view-lines.
+    expect(file_viewer.locator(".monaco-editor")).to_be_visible(timeout=20_000)
+    expect(file_viewer.locator(".view-lines")).to_contain_text("greet", timeout=10_000)
+    return file_viewer
+
+
+def _monaco_font_size(file_viewer: Locator) -> str:
+    """The computed ``font-size`` Monaco applied to its ``.view-lines`` element."""
+    return file_viewer.locator(".view-lines").first.evaluate("el => getComputedStyle(el).fontSize")
+
+
+def test_code_font_size_defaults_apply_to_monaco(
+    page: Page, seeded_python: tuple[str, str]
+) -> None:
+    """A fresh context opens Monaco at the 13px code-font default, nothing stored."""
+    base_url, session_id = seeded_python
+
+    file_viewer = _open_monaco(page, base_url, session_id)
+
+    # No stored preference → 13px default reaches the mounted editor.
+    assert _stored_size(page) is None, "expected no persisted code-font size on a fresh load"
+    assert _monaco_font_size(file_viewer) == "13px", "Monaco did not open at the code-font default"
+
+
+def test_code_font_size_step_applies_to_monaco_and_persists(
+    page: Page, seeded_python: tuple[str, str]
+) -> None:
+    """Stepping the size in Settings re-fonts a Monaco editor and survives reload.
+
+    Steps the code-font size up in Settings, then opens the file: the mounted
+    Monaco editor reads the new size at construction and renders its
+    ``.view-lines`` at that px. A reload restores it (persisted + re-applied), so
+    the editor never flashes back to the default.
+    """
+    base_url, session_id = seeded_python
+
+    _open_appearance(page, base_url)
+    value = page.get_by_test_id("code-font-size-input")
+    increase = page.get_by_test_id("code-font-size-inc")
+
+    # Fresh context → default 13px, nothing stored.
+    expect(value).to_have_value("13")
+    assert _stored_size(page) is None
+
+    # → 15px: two steps up. The value and storage move together.
+    increase.click()
+    increase.click()
+    expect(value).to_have_value("15")
+    assert _stored_size(page) == "15"
+
+    # The editor picks up the stepped size (read at construction).
+    file_viewer = _open_monaco(page, base_url, session_id)
+    assert _monaco_font_size(file_viewer) == "15px", "Monaco did not reflect the stepped size"
+
+    # The choice survives a full reload.
+    page.reload()
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer.locator(".view-lines")).to_contain_text("greet", timeout=30_000)
+    assert _monaco_font_size(file_viewer) == "15px", "size was not restored after reload"
+
+
+def test_code_font_size_steppers_clamp_at_bounds(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """The ``−`` / ``+`` buttons disable at the 10px min and 24px max."""
+    base_url, _session_id = seeded_session
+
+    # Seed the max before the app boots so the "+" button renders disabled.
+    page.goto(base_url)
+    page.evaluate(f"() => window.localStorage.setItem('{STORAGE_KEY}', '24')")
+    _open_appearance(page, base_url)
+
+    value = page.get_by_test_id("code-font-size-input")
+    decrease = page.get_by_test_id("code-font-size-dec")
+    increase = page.get_by_test_id("code-font-size-inc")
+
+    # At the 24px max, only "+" is disabled.
+    expect(value).to_have_value("24")
+    expect(increase).to_be_disabled()
+    expect(decrease).to_be_enabled()
+
+    # Hold "−" down to the 10px min; there it flips to "−" disabled, "+" enabled.
+    for _ in range(16):
+        if decrease.is_disabled():
+            break
+        decrease.click()
+    expect(value).to_have_value("10")
+    expect(decrease).to_be_disabled()
+    expect(increase).to_be_enabled()

--- a/tests/e2e_ui/sessions/test_ui_font_family.py
+++ b/tests/e2e_ui/sessions/test_ui_font_family.py
@@ -39,7 +39,7 @@ def _stored_family(page: Page) -> str | None:
 def _open_appearance(page: Page, base_url: str) -> None:
     """Navigate to the Settings Appearance section and wait for the control."""
     page.goto(f"{base_url}/settings/appearance")
-    expect(page.get_by_role("group", name="Font family")).to_be_visible(timeout=30_000)
+    expect(page.get_by_role("group", name="Font family", exact=True)).to_be_visible(timeout=30_000)
 
 
 def test_ui_font_family_applies_and_persists(page: Page, seeded_session: tuple[str, str]) -> None:
@@ -70,7 +70,7 @@ def test_ui_font_family_applies_and_persists(page: Page, seeded_session: tuple[s
 
     # The choice survives a full reload (persisted + re-applied before paint).
     page.reload()
-    expect(page.get_by_role("group", name="Font family")).to_be_visible(timeout=30_000)
+    expect(page.get_by_role("group", name="Font family", exact=True)).to_be_visible(timeout=30_000)
     expect(page.get_by_test_id("ui-font-family-input")).to_have_value("Georgia")
     assert _ui_font_family(page).startswith("Georgia"), "family was not restored after reload"
 

--- a/tests/e2e_ui/sessions/test_ui_font_size.py
+++ b/tests/e2e_ui/sessions/test_ui_font_size.py
@@ -38,7 +38,7 @@ def _stored_size(page: Page) -> str | None:
 def _open_appearance(page: Page, base_url: str) -> None:
     """Navigate to the Settings Appearance section and wait for the control."""
     page.goto(f"{base_url}/settings/appearance")
-    expect(page.get_by_role("group", name="Font size")).to_be_visible(timeout=30_000)
+    expect(page.get_by_role("group", name="Font size", exact=True)).to_be_visible(timeout=30_000)
 
 
 def test_ui_font_size_scales_and_persists(page: Page, seeded_session: tuple[str, str]) -> None:
@@ -69,7 +69,7 @@ def test_ui_font_size_scales_and_persists(page: Page, seeded_session: tuple[str,
 
     # The choice survives a full reload (persisted + re-applied before paint).
     page.reload()
-    expect(page.get_by_role("group", name="Font size")).to_be_visible(timeout=30_000)
+    expect(page.get_by_role("group", name="Font size", exact=True)).to_be_visible(timeout=30_000)
     expect(page.get_by_test_id("ui-font-size-input")).to_have_value("18")
     assert _ui_font_scale(page) == "1.125", "scale was not restored after reload"
 

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -401,6 +401,29 @@ describe("TerminalSession", () => {
     session.dispose();
   });
 
+  it("setFont re-fonts the terminal in place without reconnecting", () => {
+    // WHY: a code-font change (Settings → Appearance) must re-font the LIVE
+    // terminal — mutating options in place like setTheme, never tearing down
+    // the WebSocket (xterm is a fixed-pixel widget that can't follow a CSS
+    // variable). The new size lands on the terminal and a custom family is
+    // applied with the mono fallback appended so an uninstalled name degrades
+    // to mono, not a serif.
+    const { socket, session } = makeSession();
+    socket.open();
+    const before = socket;
+
+    session.setFont(18, "Fira Code");
+
+    // The socket is untouched (no reconnect) ...
+    expect(socket).toBe(before);
+    expect(socket.closed).toBe(false);
+    // ... and the new size/family reached the terminal instance.
+    const { term } = session as unknown as { term: Terminal };
+    expect(term.options.fontSize).toBe(18);
+    expect(term.options.fontFamily).toContain("Fira Code");
+    session.dispose();
+  });
+
   it("dispose is idempotent and tears down observer + socket once", () => {
     // WHY: the view disposes explicitly on every re-dial and a future React
     // upgrade would call the ref cleanup again — a second dispose must be a

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -401,26 +401,32 @@ describe("TerminalSession", () => {
     session.dispose();
   });
 
-  it("setFont re-fonts the terminal in place without reconnecting", () => {
+  it("setFont re-fonts + refits in place, tolerating a down socket, no reconnect", () => {
     // WHY: a code-font change (Settings → Appearance) must re-font the LIVE
-    // terminal — mutating options in place like setTheme, never tearing down
-    // the WebSocket (xterm is a fixed-pixel widget that can't follow a CSS
-    // variable). The new size lands on the terminal and a custom family is
-    // applied with the mono fallback appended so an uninstalled name degrades
-    // to mono, not a serif.
+    // terminal — mutating options in place like setTheme, never tearing down the
+    // WebSocket (xterm is a fixed-pixel widget that can't follow a CSS variable).
     const { socket, session } = makeSession();
+    const { term } = session as unknown as { term: Terminal };
+
+    // Socket-down (pre-open): setFont still applies the size and must not throw
+    // or send — sendResize no-ops until the WS opens, and the reconnect re-fits.
+    session.setFont(16, "");
+    expect(term.options.fontSize).toBe(16);
+    expect(socket.sent).toHaveLength(0);
+
+    // Once open, setFont refits the grid (sendResize) so the new glyph cell size
+    // reflows cols×rows, and applies a custom family with the mono fallback
+    // appended (an uninstalled name degrades to mono, not a serif).
     socket.open();
     const before = socket;
-
+    const sendResize = vi.spyOn(session as unknown as { sendResize: () => void }, "sendResize");
     session.setFont(18, "Fira Code");
-
-    // The socket is untouched (no reconnect) ...
-    expect(socket).toBe(before);
-    expect(socket.closed).toBe(false);
-    // ... and the new size/family reached the terminal instance.
-    const { term } = session as unknown as { term: Terminal };
+    expect(sendResize).toHaveBeenCalledTimes(1);
     expect(term.options.fontSize).toBe(18);
     expect(term.options.fontFamily).toContain("Fira Code");
+    // Same socket instance, still open — a re-font never reconnects.
+    expect(socket).toBe(before);
+    expect(socket.closed).toBe(false);
     session.dispose();
   });
 

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -14,6 +14,11 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
+import {
+  CODE_FONT_FAMILY_FALLBACK,
+  codeFontFamilyForEditor,
+  readCodeFont,
+} from "@/lib/codeFontPreferences";
 
 // Card background colors derived from the app's CSS palette.
 // Light: --card: oklch(1.000 0 0) = pure white.
@@ -336,13 +341,14 @@ export class TerminalSession {
     onInput?: TerminalInputListener,
     nativeSelection = false,
   ) {
+    // Read the user's code-font preference (Settings → Appearance) at
+    // construction; a mid-session change is applied live via setFont(). The
+    // xterm.js defaults (15px, no theme) feel out of place inside the app
+    // chrome, so an unset family falls back to the shared mono stack.
+    const { sizePx, family } = readCodeFont();
     this.term = new Terminal({
-      // Match the system mono stack at the configured base size. The
-      // xterm.js defaults (15px, no theme) feel out of place inside the
-      // app chrome.
-      fontFamily:
-        "'Geist Mono Variable', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
-      fontSize: 13,
+      fontFamily: codeFontFamilyForEditor(family) ?? CODE_FONT_FAMILY_FALLBACK,
+      fontSize: sizePx,
       scrollback: 20000,
       cursorBlink: true,
       theme: terminalTheme(isDark),
@@ -496,6 +502,21 @@ export class TerminalSession {
    */
   setTheme(isDark: boolean): void {
     this.term.options.theme = terminalTheme(isDark);
+  }
+
+  /**
+   * Update the terminal's code font (size + family) without reconnecting —
+   * mirrors {@link setTheme}, mutating options in place. A new glyph size
+   * changes the character-cell dimensions, so this re-fits the grid to the
+   * container and pushes the resulting cols×rows to tmux via {@link sendResize}
+   * (which no-ops the send while the socket is down; the reconnect re-fits on
+   * open). An empty family falls back to the shared mono stack. Safe to call at
+   * any point after construction.
+   */
+  setFont(sizePx: number, family: string): void {
+    this.term.options.fontFamily = codeFontFamilyForEditor(family) ?? CODE_FONT_FAMILY_FALLBACK;
+    this.term.options.fontSize = sizePx;
+    this.sendResize();
   }
 
   /**

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -14,11 +14,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import {
-  CODE_FONT_FAMILY_FALLBACK,
-  codeFontFamilyForEditor,
-  readCodeFont,
-} from "@/lib/codeFontPreferences";
+import { codeFontFamilyForEditor, readCodeFont } from "@/lib/codeFontPreferences";
 
 // Card background colors derived from the app's CSS palette.
 // Light: --card: oklch(1.000 0 0) = pure white.
@@ -347,7 +343,7 @@ export class TerminalSession {
     // chrome, so an unset family falls back to the shared mono stack.
     const { sizePx, family } = readCodeFont();
     this.term = new Terminal({
-      fontFamily: codeFontFamilyForEditor(family) ?? CODE_FONT_FAMILY_FALLBACK,
+      fontFamily: codeFontFamilyForEditor(family),
       fontSize: sizePx,
       scrollback: 20000,
       cursorBlink: true,
@@ -514,7 +510,7 @@ export class TerminalSession {
    * any point after construction.
    */
   setFont(sizePx: number, family: string): void {
-    this.term.options.fontFamily = codeFontFamilyForEditor(family) ?? CODE_FONT_FAMILY_FALLBACK;
+    this.term.options.fontFamily = codeFontFamilyForEditor(family);
     this.term.options.fontSize = sizePx;
     this.sendResize();
   }

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { resolveWebSocketUrl } from "@/lib/host";
+import { subscribeCodeFont } from "@/lib/codeFontPreferences";
 import {
   type ConnectionState,
   type TerminalActivityListener,
@@ -213,6 +214,18 @@ export function TerminalView({
   useEffect(() => {
     sessionRef.current?.setTheme(isDark);
   }, [isDark]);
+
+  // Push code-font changes (Settings → Appearance) into the live session the
+  // same way — xterm is a fixed-pixel widget, so it can't follow a CSS variable
+  // like the chrome font and must be told imperatively. The subscription
+  // outlives individual re-dials (sessionRef is swapped in place), and a fresh
+  // session reads the current pref at construction, so a change made while
+  // disconnected still lands on reconnect.
+  useEffect(() => {
+    return subscribeCodeFont((font) => {
+      sessionRef.current?.setFont(font.sizePx, font.family);
+    });
+  }, []);
 
   // Auto-reconnect on transport-level drops (background-tab freezes,
   // server restarts — see isUnexpectedTerminalClose). Deliberate

--- a/web/src/lib/codeFontPreferences.test.ts
+++ b/web/src/lib/codeFontPreferences.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CODE_FONT_FAMILY_DEFAULT,
+  CODE_FONT_FAMILY_FALLBACK,
+  CODE_FONT_SIZE_DEFAULT,
+  CODE_FONT_SIZE_MAX,
+  CODE_FONT_SIZE_MIN,
+  codeFontFamilyForEditor,
+  readCodeFont,
+  readCodeFontFamily,
+  readCodeFontSizePx,
+  subscribeCodeFont,
+  writeCodeFontFamily,
+  writeCodeFontSizePx,
+} from "./codeFontPreferences";
+
+const SIZE_STORAGE_KEY = "omnigent:code-font-size";
+const FAMILY_STORAGE_KEY = "omnigent:code-font-family";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("codeFontPreferences — size", () => {
+  it("returns the default when nothing is stored", () => {
+    expect(readCodeFontSizePx()).toBe(CODE_FONT_SIZE_DEFAULT);
+  });
+
+  it("round-trips a valid size", () => {
+    writeCodeFontSizePx(18);
+    expect(readCodeFontSizePx()).toBe(18);
+  });
+
+  it("clamps a stored value above the range", () => {
+    localStorage.setItem(SIZE_STORAGE_KEY, JSON.stringify(99));
+    expect(readCodeFontSizePx()).toBe(CODE_FONT_SIZE_MAX);
+  });
+
+  it("clamps a stored value below the range", () => {
+    localStorage.setItem(SIZE_STORAGE_KEY, JSON.stringify(2));
+    expect(readCodeFontSizePx()).toBe(CODE_FONT_SIZE_MIN);
+  });
+
+  it("clamps out-of-range values on write", () => {
+    writeCodeFontSizePx(40);
+    expect(readCodeFontSizePx()).toBe(CODE_FONT_SIZE_MAX);
+    writeCodeFontSizePx(1);
+    expect(readCodeFontSizePx()).toBe(CODE_FONT_SIZE_MIN);
+  });
+
+  it("falls back to the default on malformed JSON", () => {
+    // Corrupt localStorage should not break app boot.
+    localStorage.setItem(SIZE_STORAGE_KEY, "}{not json");
+    expect(readCodeFontSizePx()).toBe(CODE_FONT_SIZE_DEFAULT);
+  });
+
+  it("falls back to the default on a non-numeric value", () => {
+    localStorage.setItem(SIZE_STORAGE_KEY, JSON.stringify("large"));
+    expect(readCodeFontSizePx()).toBe(CODE_FONT_SIZE_DEFAULT);
+  });
+});
+
+describe("codeFontPreferences — family", () => {
+  it("returns the empty default when nothing is stored", () => {
+    expect(readCodeFontFamily()).toBe(CODE_FONT_FAMILY_DEFAULT);
+    expect(readCodeFontFamily()).toBe("");
+  });
+
+  it("round-trips a valid family name", () => {
+    writeCodeFontFamily("Fira Code");
+    expect(readCodeFontFamily()).toBe("Fira Code");
+    expect(localStorage.getItem(FAMILY_STORAGE_KEY)).toBe(JSON.stringify("Fira Code"));
+  });
+
+  it("preserves spaces, commas and quotes in a font stack", () => {
+    // A multi-family stack must survive normalization intact (the guard only
+    // strips declaration-breaking chars, not the punctuation stacks rely on).
+    writeCodeFontFamily('"JetBrains Mono", monospace');
+    expect(readCodeFontFamily()).toBe('"JetBrains Mono", monospace');
+  });
+
+  it("trims surrounding whitespace", () => {
+    writeCodeFontFamily("  Menlo  ");
+    expect(readCodeFontFamily()).toBe("Menlo");
+  });
+
+  it("clears the preference when written empty or whitespace-only", () => {
+    writeCodeFontFamily("Fira Code");
+    expect(localStorage.getItem(FAMILY_STORAGE_KEY)).not.toBeNull();
+    writeCodeFontFamily("   ");
+    // Empty input removes the key rather than storing a blank string.
+    expect(localStorage.getItem(FAMILY_STORAGE_KEY)).toBeNull();
+    expect(readCodeFontFamily()).toBe("");
+  });
+
+  it("strips characters that could break the CSS declaration", () => {
+    // `;{}` and control chars can't be allowed to escape the value we hand the
+    // widget; everything else about the name (here the leading font) is kept.
+    writeCodeFontFamily("Menlo;}body{");
+    expect(readCodeFontFamily()).toBe("Menlobody");
+  });
+
+  it("falls back to the default on a value longer than the cap", () => {
+    writeCodeFontFamily("x".repeat(200));
+    expect(readCodeFontFamily()).toBe(CODE_FONT_FAMILY_DEFAULT);
+    expect(localStorage.getItem(FAMILY_STORAGE_KEY)).toBeNull();
+  });
+
+  it("falls back to the default on malformed JSON", () => {
+    // Corrupt localStorage should not break app boot.
+    localStorage.setItem(FAMILY_STORAGE_KEY, "}{not json");
+    expect(readCodeFontFamily()).toBe(CODE_FONT_FAMILY_DEFAULT);
+  });
+
+  it("falls back to the default on a non-string value", () => {
+    localStorage.setItem(FAMILY_STORAGE_KEY, JSON.stringify(42));
+    expect(readCodeFontFamily()).toBe(CODE_FONT_FAMILY_DEFAULT);
+  });
+});
+
+describe("codeFontFamilyForEditor", () => {
+  it("appends the mono fallback stack to a custom family", () => {
+    // A custom name leads, with the app mono stack appended so an
+    // uninstalled/partial name degrades to mono, not the widget default.
+    expect(codeFontFamilyForEditor("Fira Code")).toBe(`Fira Code, ${CODE_FONT_FAMILY_FALLBACK}`);
+  });
+
+  it("returns undefined for an empty family (widget keeps its own default)", () => {
+    // Monaco keeps its built-in mono when handed undefined; the terminal
+    // coalesces to CODE_FONT_FAMILY_FALLBACK at the call site.
+    expect(codeFontFamilyForEditor("")).toBeUndefined();
+    expect(codeFontFamilyForEditor("   ")).toBeUndefined();
+  });
+
+  it("strips declaration-breaking chars before appending the fallback", () => {
+    expect(codeFontFamilyForEditor("Menlo;}")).toBe(`Menlo, ${CODE_FONT_FAMILY_FALLBACK}`);
+  });
+});
+
+describe("codeFontPreferences — pub/sub", () => {
+  it("notifies subscribers with the new font when the size is written", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeCodeFont(cb);
+
+    writeCodeFontSizePx(20);
+    // The callback receives the freshly persisted font so a mounted editor can
+    // re-apply it live without re-reading storage itself.
+    expect(cb).toHaveBeenCalledWith({ sizePx: 20, family: "" });
+
+    unsubscribe();
+  });
+
+  it("notifies subscribers with the new font when the family is written", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeCodeFont(cb);
+
+    writeCodeFontFamily("Fira Code");
+    expect(cb).toHaveBeenCalledWith({ sizePx: CODE_FONT_SIZE_DEFAULT, family: "Fira Code" });
+
+    unsubscribe();
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeCodeFont(cb);
+    unsubscribe();
+
+    writeCodeFontSizePx(18);
+    // A disposed editor's listener must not keep firing, or a stale closure
+    // would touch a torn-down instance.
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("reflects the clamped value in the emitted font", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeCodeFont(cb);
+
+    writeCodeFontSizePx(999);
+    // Subscribers see the same clamped value that was persisted, so the live
+    // widget and a later reload agree.
+    expect(cb).toHaveBeenCalledWith({ sizePx: CODE_FONT_SIZE_MAX, family: "" });
+
+    unsubscribe();
+  });
+});
+
+describe("readCodeFont", () => {
+  it("reads size and family together", () => {
+    writeCodeFontSizePx(15);
+    writeCodeFontFamily("Menlo");
+    expect(readCodeFont()).toEqual({ sizePx: 15, family: "Menlo" });
+  });
+});

--- a/web/src/lib/codeFontPreferences.test.ts
+++ b/web/src/lib/codeFontPreferences.test.ts
@@ -125,11 +125,11 @@ describe("codeFontFamilyForEditor", () => {
     expect(codeFontFamilyForEditor("Fira Code")).toBe(`Fira Code, ${CODE_FONT_FAMILY_FALLBACK}`);
   });
 
-  it("returns undefined for an empty family (widget keeps its own default)", () => {
-    // Monaco keeps its built-in mono when handed undefined; the terminal
-    // coalesces to CODE_FONT_FAMILY_FALLBACK at the call site.
-    expect(codeFontFamilyForEditor("")).toBeUndefined();
-    expect(codeFontFamilyForEditor("   ")).toBeUndefined();
+  it("resolves an empty family to the shared mono stack (uniform default)", () => {
+    // Both Monaco and the terminal get the same mono stack when no custom family
+    // is set, so their defaults match rather than each using its own built-in.
+    expect(codeFontFamilyForEditor("")).toBe(CODE_FONT_FAMILY_FALLBACK);
+    expect(codeFontFamilyForEditor("   ")).toBe(CODE_FONT_FAMILY_FALLBACK);
   });
 
   it("strips declaration-breaking chars before appending the fallback", () => {
@@ -180,6 +180,38 @@ describe("codeFontPreferences — pub/sub", () => {
     // widget and a later reload agree.
     expect(cb).toHaveBeenCalledWith({ sizePx: CODE_FONT_SIZE_MAX, family: "" });
 
+    unsubscribe();
+  });
+
+  it("emits the intended size even when the storage write throws", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeCodeFont(cb);
+    // Storage disabled/quota-exceeded: the persist fails, but a mounted editor
+    // must still re-font to the chosen size now instead of the stale value.
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    try {
+      writeCodeFontSizePx(19);
+      expect(cb).toHaveBeenCalledWith({ sizePx: 19, family: "" });
+    } finally {
+      setItem.mockRestore();
+    }
+    unsubscribe();
+  });
+
+  it("emits the intended family even when the storage write throws", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeCodeFont(cb);
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    try {
+      writeCodeFontFamily("Fira Code");
+      expect(cb).toHaveBeenCalledWith({ sizePx: CODE_FONT_SIZE_DEFAULT, family: "Fira Code" });
+    } finally {
+      setItem.mockRestore();
+    }
     unsubscribe();
   });
 });

--- a/web/src/lib/codeFontPreferences.ts
+++ b/web/src/lib/codeFontPreferences.ts
@@ -1,0 +1,191 @@
+// Persisted, app-global preferences for the CODE font — the size and family of
+// the code editor (Monaco) and the terminal (xterm), kept separate from the
+// chrome/UI font (see lib/uiFontPreferences.ts).
+//
+// The chrome font rides a CSS custom property (`--ui-font-*`) because the whole
+// rem-based UI reflows off the root font-size. Monaco and xterm can't: they're
+// fixed-pixel canvas/DOM widgets that read an absolute px size + family once, at
+// construction, and only re-measure when told to. So instead of a CSS variable
+// this module exposes a tiny in-module pub/sub — `subscribeCodeFont` — that the
+// write helpers fire after persisting. An already-mounted editor or terminal
+// subscribes on mount and re-applies the new size/family imperatively
+// (editor.updateOptions / term.options + refit) so a Settings change lands live
+// without a reload or reconnect.
+
+const SIZE_STORAGE_KEY = "omnigent:code-font-size";
+const FAMILY_STORAGE_KEY = "omnigent:code-font-family";
+
+// Code widgets read smaller than the chrome by convention, and a monospaced
+// grid tolerates a wider useful range than body text — hence bounds distinct
+// from the UI font's 12–20.
+export const CODE_FONT_SIZE_DEFAULT = 13;
+export const CODE_FONT_SIZE_MIN = 10;
+export const CODE_FONT_SIZE_MAX = 24;
+export const CODE_FONT_SIZE_STEP = 1;
+
+/** Empty string = "editor default": no override, falls back to the mono stack. */
+export const CODE_FONT_FAMILY_DEFAULT = "";
+
+/** Longest family name we'll accept — a guard against a corrupt/oversized entry. */
+const CODE_FONT_FAMILY_MAX_LENGTH = 100;
+
+/**
+ * The monospaced stack a code widget falls back to when no custom family is
+ * set. Matches the app's default terminal/editor look (Geist Mono, then the
+ * platform mono fonts) rather than a browser's generic monospace.
+ */
+export const CODE_FONT_FAMILY_FALLBACK =
+  "'Geist Mono Variable', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace";
+
+/** Clamp an arbitrary number into the supported px range. */
+export function clampCodeFontSizePx(px: number): number {
+  return Math.min(CODE_FONT_SIZE_MAX, Math.max(CODE_FONT_SIZE_MIN, Math.round(px)));
+}
+
+function isValidPx(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * Read the persisted code font size in px.
+ *
+ * Returns the default when nothing is stored, on a server render (no `window`),
+ * or when the stored value is missing/malformed — never throws, so a corrupt
+ * entry can't break app boot. A stored value outside the range is clamped.
+ */
+export function readCodeFontSizePx(): number {
+  if (typeof window === "undefined") return CODE_FONT_SIZE_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(SIZE_STORAGE_KEY);
+    if (!raw) return CODE_FONT_SIZE_DEFAULT;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidPx(parsed)) return CODE_FONT_SIZE_DEFAULT;
+    return clampCodeFontSizePx(parsed);
+  } catch {
+    return CODE_FONT_SIZE_DEFAULT;
+  }
+}
+
+/**
+ * Persist the code font size (px), clamped to the supported range, then notify
+ * subscribers so mounted editors/terminals re-apply it live. Swallows
+ * quota/access errors so a failed write can't break the app.
+ */
+export function writeCodeFontSizePx(px: number): void {
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(SIZE_STORAGE_KEY, JSON.stringify(clampCodeFontSizePx(px)));
+    } catch {
+      // localStorage quota or access errors shouldn't break the app.
+    }
+  }
+  emit();
+}
+
+/**
+ * Normalize a raw family name into a value safe to persist and to hand a code
+ * widget: trimmed, with characters that could terminate/inject a CSS
+ * declaration (`;{}` and control chars) stripped. Over-long input collapses to
+ * the default. Returns "" for anything that isn't a usable family, so callers
+ * treat empty as "editor default".
+ */
+function normalizeCodeFontFamily(value: unknown): string {
+  if (typeof value !== "string") return CODE_FONT_FAMILY_DEFAULT;
+  // eslint-disable-next-line no-control-regex -- intentionally stripping control chars
+  const cleaned = value.replace(/[;{}\x00-\x1f\x7f]/g, "").trim();
+  if (!cleaned || cleaned.length > CODE_FONT_FAMILY_MAX_LENGTH) {
+    return CODE_FONT_FAMILY_DEFAULT;
+  }
+  return cleaned;
+}
+
+/**
+ * Read the persisted code font family.
+ *
+ * Returns "" (editor default) when nothing is stored, on a server render (no
+ * `window`), or when the stored value is missing/malformed — never throws, so a
+ * corrupt entry can't break app boot.
+ */
+export function readCodeFontFamily(): string {
+  if (typeof window === "undefined") return CODE_FONT_FAMILY_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(FAMILY_STORAGE_KEY);
+    if (!raw) return CODE_FONT_FAMILY_DEFAULT;
+    const parsed: unknown = JSON.parse(raw);
+    return normalizeCodeFontFamily(parsed);
+  } catch {
+    return CODE_FONT_FAMILY_DEFAULT;
+  }
+}
+
+/**
+ * Persist the code font family, then notify subscribers so mounted
+ * editors/terminals re-apply it live. An empty (or all-stripped) name clears
+ * the preference — reverting to the editor default — rather than storing a
+ * blank. Swallows quota/access errors so a failed write can't break the app.
+ */
+export function writeCodeFontFamily(name: string): void {
+  if (typeof window !== "undefined") {
+    try {
+      const normalized = normalizeCodeFontFamily(name);
+      if (normalized) {
+        window.localStorage.setItem(FAMILY_STORAGE_KEY, JSON.stringify(normalized));
+      } else {
+        window.localStorage.removeItem(FAMILY_STORAGE_KEY);
+      }
+    } catch {
+      // localStorage quota or access errors shouldn't break the app.
+    }
+  }
+  emit();
+}
+
+/**
+ * Resolve a persisted family into the `fontFamily` value handed to a code
+ * widget: a custom name gets the mono fallback stack appended (so an
+ * uninstalled/partial name degrades to the app mono, not the widget's own
+ * default or a serif), and an empty name returns `undefined` so the widget
+ * keeps its own default. Terminals, whose native default isn't the app mono,
+ * coalesce this with {@link CODE_FONT_FAMILY_FALLBACK}.
+ */
+export function codeFontFamilyForEditor(family: string): string | undefined {
+  const normalized = normalizeCodeFontFamily(family);
+  return normalized ? `${normalized}, ${CODE_FONT_FAMILY_FALLBACK}` : undefined;
+}
+
+/** The current code font size + family, read together for widget construction. */
+export interface CodeFont {
+  /** Font size in px, already clamped to the supported range. */
+  sizePx: number;
+  /** Custom family, or "" for the editor/terminal default. */
+  family: string;
+}
+
+/** Read both code font preferences at once. Handy on editor/terminal mount. */
+export function readCodeFont(): CodeFont {
+  return { sizePx: readCodeFontSizePx(), family: readCodeFontFamily() };
+}
+
+type CodeFontListener = (font: CodeFont) => void;
+
+const listeners = new Set<CodeFontListener>();
+
+/**
+ * Subscribe to code font changes. The callback fires with the current
+ * {@link CodeFont} whenever the size or family is written (e.g. from Settings),
+ * letting an already-mounted editor or terminal re-apply the change live —
+ * these fixed-pixel widgets can't ride a CSS variable the way the chrome font
+ * does. Returns an unsubscribe function.
+ */
+export function subscribeCodeFont(listener: CodeFontListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Notify subscribers of the current persisted code font. Called after a write. */
+function emit(): void {
+  const font = readCodeFont();
+  for (const listener of listeners) listener(font);
+}

--- a/web/src/lib/codeFontPreferences.ts
+++ b/web/src/lib/codeFontPreferences.ts
@@ -72,14 +72,18 @@ export function readCodeFontSizePx(): number {
  * quota/access errors so a failed write can't break the app.
  */
 export function writeCodeFontSizePx(px: number): void {
+  const sizePx = clampCodeFontSizePx(px);
   if (typeof window !== "undefined") {
     try {
-      window.localStorage.setItem(SIZE_STORAGE_KEY, JSON.stringify(clampCodeFontSizePx(px)));
+      window.localStorage.setItem(SIZE_STORAGE_KEY, JSON.stringify(sizePx));
     } catch {
       // localStorage quota or access errors shouldn't break the app.
     }
   }
-  emit();
+  // Broadcast the intended value, not a storage re-read: if the write above
+  // failed (quota/denied), mounted editors/terminals must still re-font to the
+  // new size now rather than snapping back to the stale/default stored value.
+  emit({ sizePx, family: readCodeFontFamily() });
 }
 
 /**
@@ -125,11 +129,11 @@ export function readCodeFontFamily(): string {
  * blank. Swallows quota/access errors so a failed write can't break the app.
  */
 export function writeCodeFontFamily(name: string): void {
+  const family = normalizeCodeFontFamily(name);
   if (typeof window !== "undefined") {
     try {
-      const normalized = normalizeCodeFontFamily(name);
-      if (normalized) {
-        window.localStorage.setItem(FAMILY_STORAGE_KEY, JSON.stringify(normalized));
+      if (family) {
+        window.localStorage.setItem(FAMILY_STORAGE_KEY, JSON.stringify(family));
       } else {
         window.localStorage.removeItem(FAMILY_STORAGE_KEY);
       }
@@ -137,20 +141,22 @@ export function writeCodeFontFamily(name: string): void {
       // localStorage quota or access errors shouldn't break the app.
     }
   }
-  emit();
+  // Broadcast the intended value, not a storage re-read: a failed write must
+  // still live-apply the new family to mounted editors/terminals.
+  emit({ sizePx: readCodeFontSizePx(), family });
 }
 
 /**
  * Resolve a persisted family into the `fontFamily` value handed to a code
- * widget: a custom name gets the mono fallback stack appended (so an
- * uninstalled/partial name degrades to the app mono, not the widget's own
- * default or a serif), and an empty name returns `undefined` so the widget
- * keeps its own default. Terminals, whose native default isn't the app mono,
- * coalesce this with {@link CODE_FONT_FAMILY_FALLBACK}.
+ * widget. A custom name gets the mono fallback stack appended (so an
+ * uninstalled/partial name degrades to the app mono, not a serif); an empty
+ * name resolves to the fallback stack itself. Both Monaco and the terminal use
+ * this directly, so with no custom family they share one default look — the app
+ * mono stack — rather than each falling back to its own built-in default.
  */
-export function codeFontFamilyForEditor(family: string): string | undefined {
+export function codeFontFamilyForEditor(family: string): string {
   const normalized = normalizeCodeFontFamily(family);
-  return normalized ? `${normalized}, ${CODE_FONT_FAMILY_FALLBACK}` : undefined;
+  return normalized ? `${normalized}, ${CODE_FONT_FAMILY_FALLBACK}` : CODE_FONT_FAMILY_FALLBACK;
 }
 
 /** The current code font size + family, read together for widget construction. */
@@ -184,8 +190,7 @@ export function subscribeCodeFont(listener: CodeFontListener): () => void {
   };
 }
 
-/** Notify subscribers of the current persisted code font. Called after a write. */
-function emit(): void {
-  const font = readCodeFont();
+/** Notify subscribers of the given code font. Called after every write. */
+function emit(font: CodeFont): void {
   for (const listener of listeners) listener(font);
 }

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -227,6 +227,91 @@ describe("SettingsPage", () => {
     expect(localStorage.getItem("omnigent:ui-font-size")).toBe("15");
   });
 
+  it("shows the default code font size and steps it up, persisting the choice", () => {
+    localStorage.clear();
+    renderPage("/settings/appearance");
+    const input = screen.getByTestId("code-font-size-input") as HTMLInputElement;
+    // No stored preference → 13px default (code widgets read a touch smaller
+    // than the 16px chrome default).
+    expect(input.value).toBe("13");
+
+    fireEvent.click(screen.getByTestId("code-font-size-inc"));
+    expect(input.value).toBe("14");
+    // Persisted under the code-font key (distinct from the chrome font's) so it
+    // survives a refresh. There's no --ui-font-scale here — the pref reaches the
+    // editor/terminal imperatively, not via a CSS variable.
+    expect(localStorage.getItem("omnigent:code-font-size")).toBe("14");
+  });
+
+  it("disables the code font steppers at the min and max bounds", () => {
+    localStorage.setItem("omnigent:code-font-size", "24");
+    renderPage("/settings/appearance");
+    // At the 24px max, only the increase button is disabled.
+    expect(screen.getByTestId("code-font-size-inc")).toBeDisabled();
+    expect(screen.getByTestId("code-font-size-dec")).not.toBeDisabled();
+
+    cleanup();
+    localStorage.setItem("omnigent:code-font-size", "10");
+    renderPage("/settings/appearance");
+    // At the 10px min, only the decrease button is disabled.
+    expect(screen.getByTestId("code-font-size-dec")).toBeDisabled();
+    expect(screen.getByTestId("code-font-size-inc")).not.toBeDisabled();
+  });
+
+  it("lets you clear and retype the code font size, clamping below-min on blur", () => {
+    localStorage.setItem("omnigent:code-font-size", "13");
+    renderPage("/settings/appearance");
+    const input = screen.getByTestId("code-font-size-input") as HTMLInputElement;
+    expect(input.value).toBe("13");
+
+    // Backspacing to "1" is below the 10px min: the box SHOWS "1" (free editing)
+    // without snapping or persisting the transient value.
+    fireEvent.change(input, { target: { value: "1" } });
+    expect(input.value).toBe("1");
+    expect(localStorage.getItem("omnigent:code-font-size")).toBe("13");
+
+    // Finishing to a valid size applies + persists it.
+    fireEvent.change(input, { target: { value: "20" } });
+    expect(input.value).toBe("20");
+    expect(localStorage.getItem("omnigent:code-font-size")).toBe("20");
+
+    // A still-out-of-range draft clamps to the minimum on blur.
+    fireEvent.change(input, { target: { value: "2" } });
+    fireEvent.blur(input);
+    expect(input.value).toBe("10");
+    expect(localStorage.getItem("omnigent:code-font-size")).toBe("10");
+  });
+
+  it("shows the empty code font family default and applies + persists a typed name", () => {
+    localStorage.clear();
+    renderPage("/settings/appearance");
+    const input = screen.getByTestId("code-font-family-input") as HTMLInputElement;
+    // No stored preference → empty input, editor-default placeholder.
+    expect(input.value).toBe("");
+    expect(input.placeholder).toBe("Editor default");
+    // Reset has nothing to do at the default.
+    expect(screen.getByTestId("code-font-family-reset")).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "Fira Code" } });
+    expect(input.value).toBe("Fira Code");
+    // The choice is persisted under the code-font family key so it survives a refresh.
+    expect(localStorage.getItem("omnigent:code-font-family")).toBe(JSON.stringify("Fira Code"));
+    expect(screen.getByTestId("code-font-family-reset")).not.toBeDisabled();
+  });
+
+  it("reset restores the default code font family", () => {
+    localStorage.setItem("omnigent:code-font-family", JSON.stringify("JetBrains Mono"));
+    renderPage("/settings/appearance");
+    const input = screen.getByTestId("code-font-family-input") as HTMLInputElement;
+    // The control reflects the stored preference on mount.
+    expect(input.value).toBe("JetBrains Mono");
+
+    fireEvent.click(screen.getByTestId("code-font-family-reset"));
+    // Reset clears the field and the stored key.
+    expect(input.value).toBe("");
+    expect(localStorage.getItem("omnigent:code-font-family")).toBeNull();
+  });
+
   it("defaults bare /settings to Account when a login session exists, else Appearance", async () => {
     // Login session (accounts OR OIDC) → Account leads, so /settings lands on it.
     renderPage("/settings");

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -210,13 +210,13 @@ function AppearanceSection() {
 
         <UiFontFamilyControl />
 
-        {/* Code font — the fixed-pixel editor + terminal, grouped under their own
-            subheading so it's clear these don't scale the surrounding chrome. */}
-        <div className="flex flex-col gap-6">
-          <span className="text-sm font-medium">Code font</span>
-          <UiCodeFontSizeControl />
-          <UiCodeFontFamilyControl />
-        </div>
+        {/* Code font (Monaco + xterm) sits as its own two rows — labelled in full
+            ("Code font size" / "Code font family") rather than under a shared
+            heading — so each control reads unambiguously next to the UI-font rows
+            above and it's clear these don't scale the surrounding chrome. */}
+        <UiCodeFontSizeControl />
+
+        <UiCodeFontFamilyControl />
       </div>
     </Section>
   );
@@ -437,7 +437,7 @@ function UiCodeFontSizeControl() {
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
       <div className="flex flex-col">
-        <span className="text-sm font-medium">Font size</span>
+        <span className="text-sm font-medium">Code font size</span>
         <span className="text-sm text-muted-foreground">
           Size of code in the editor and terminal.
         </span>
@@ -510,7 +510,7 @@ function UiCodeFontFamilyControl() {
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
       <div className="flex min-w-0 flex-1 flex-col">
-        <span className="text-sm font-medium">Font family</span>
+        <span className="text-sm font-medium">Code font family</span>
         <span className="text-sm text-muted-foreground">
           Font for the code editor and terminal. Leave blank for the default.
         </span>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -72,6 +72,17 @@ import {
   writeUiFontFamily,
   writeUiFontSizePx,
 } from "@/lib/uiFontPreferences";
+import {
+  clampCodeFontSizePx,
+  CODE_FONT_FAMILY_DEFAULT,
+  CODE_FONT_SIZE_MAX,
+  CODE_FONT_SIZE_MIN,
+  CODE_FONT_SIZE_STEP,
+  readCodeFontFamily,
+  readCodeFontSizePx,
+  writeCodeFontFamily,
+  writeCodeFontSizePx,
+} from "@/lib/codeFontPreferences";
 import { useIsEmbedded } from "@/lib/embedded";
 import { type CliStatus, getCliStatus, isElectronShell, resetCliPath } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
@@ -198,6 +209,14 @@ function AppearanceSection() {
         <UiFontSizeControl />
 
         <UiFontFamilyControl />
+
+        {/* Code font — the fixed-pixel editor + terminal, grouped under their own
+            subheading so it's clear these don't scale the surrounding chrome. */}
+        <div className="flex flex-col gap-6">
+          <span className="text-sm font-medium">Code font</span>
+          <UiCodeFontSizeControl />
+          <UiCodeFontFamilyControl />
+        </div>
       </div>
     </Section>
   );
@@ -358,6 +377,164 @@ function UiFontFamilyControl() {
           aria-label="UI font family"
           data-testid="ui-font-family-input"
           placeholder="System default"
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          className="h-9 w-56"
+          value={family}
+          onChange={(e) => update(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Code font size stepper. Sizes the code editor (Monaco) and terminal (xterm)
+ * — fixed-pixel widgets that can't ride the chrome's --ui-font-scale variable,
+ * so writing the pref emits to already-mounted editors/terminals (see
+ * lib/codeFontPreferences.ts). Same free-editing draft/commit + blur-clamp
+ * behavior as UiFontSizeControl; only the bounds and storage differ.
+ */
+function UiCodeFontSizeControl() {
+  // `px` is the committed value; `draft` is the raw text in the box, kept
+  // separate so a transient out-of-range/empty mid-edit state isn't clamped or
+  // persisted on every keystroke. We only commit while typing when the draft is
+  // already a valid in-range size; blur/Enter clamps and re-syncs the text.
+  const [px, setPx] = useState(() => readCodeFontSizePx());
+  const [draft, setDraft] = useState(() => String(px));
+
+  const commit = useCallback((next: number) => {
+    const clamped = clampCodeFontSizePx(next);
+    setPx(clamped);
+    setDraft(String(clamped));
+    writeCodeFontSizePx(clamped);
+  }, []);
+
+  const onDraftChange = useCallback((text: string) => {
+    setDraft(text);
+    // Apply live only once the field holds a valid, in-range whole number;
+    // leave partial/out-of-range/empty drafts untouched until blur.
+    if (/^\d+$/.test(text)) {
+      const value = Number(text);
+      if (value >= CODE_FONT_SIZE_MIN && value <= CODE_FONT_SIZE_MAX) {
+        setPx(value);
+        writeCodeFontSizePx(value);
+      }
+    }
+  }, []);
+
+  // Clamp and re-sync the text to the committed value. An empty or invalid
+  // draft reverts to the last committed size rather than a bogus one.
+  const commitDraft = useCallback(() => {
+    const value = Number(draft);
+    commit(Number.isFinite(value) && draft.trim() !== "" ? value : px);
+  }, [commit, draft, px]);
+
+  const atMin = px <= CODE_FONT_SIZE_MIN;
+  const atMax = px >= CODE_FONT_SIZE_MAX;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+      <div className="flex flex-col">
+        <span className="text-sm font-medium">Font size</span>
+        <span className="text-sm text-muted-foreground">
+          Size of code in the editor and terminal.
+        </span>
+      </div>
+      {/* One cohesive pill: [ −  | value px |  + ] — same shell as the UI
+          font-size control. */}
+      <div
+        role="group"
+        aria-label="Code font size"
+        className={cn(
+          "inline-flex h-9 items-stretch overflow-hidden rounded-lg border border-input bg-background transition-colors dark:bg-input/30",
+          "focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50",
+        )}
+      >
+        <StepperButton
+          label="Decrease code font size"
+          testId="code-font-size-dec"
+          disabled={atMin}
+          onClick={() => commit(px - CODE_FONT_SIZE_STEP)}
+        >
+          <MinusIcon className="size-4" />
+        </StepperButton>
+        <div className="flex items-center border-x border-input px-2 tabular-nums">
+          <input
+            type="number"
+            inputMode="numeric"
+            min={CODE_FONT_SIZE_MIN}
+            max={CODE_FONT_SIZE_MAX}
+            step={CODE_FONT_SIZE_STEP}
+            aria-label="Code font size in pixels"
+            data-testid="code-font-size-input"
+            className="w-8 bg-transparent text-center text-sm font-medium tabular-nums outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            value={draft}
+            onChange={(e) => onDraftChange(e.target.value)}
+            onBlur={commitDraft}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.currentTarget.blur();
+            }}
+          />
+        </div>
+        <StepperButton
+          label="Increase code font size"
+          testId="code-font-size-inc"
+          disabled={atMax}
+          onClick={() => commit(px + CODE_FONT_SIZE_STEP)}
+        >
+          <PlusIcon className="size-4" />
+        </StepperButton>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Code font family picker. Free-text (Cursor-style): type any monospace font
+ * installed on this device; blank means the editor/terminal default (the shared
+ * mono stack). Applies live and persists on every change via the code-font
+ * pub/sub (see lib/codeFontPreferences.ts). Mirrors UiFontFamilyControl.
+ */
+function UiCodeFontFamilyControl() {
+  const [family, setFamily] = useState(() => readCodeFontFamily());
+
+  const update = useCallback((next: string) => {
+    setFamily(next);
+    writeCodeFontFamily(next);
+  }, []);
+
+  const isDefault = family.trim() === CODE_FONT_FAMILY_DEFAULT;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="text-sm font-medium">Font family</span>
+        <span className="text-sm text-muted-foreground">
+          Font for the code editor and terminal. Leave blank for the default.
+        </span>
+      </div>
+      {/* Reset sits left of the input so the input's right edge lines up flush
+          with the size stepper above. `invisible` (not removed) at the default
+          keeps the row from shifting. */}
+      <div role="group" aria-label="Code font family" className="flex shrink-0 items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-testid="code-font-family-reset"
+          disabled={isDefault}
+          className={cn("h-9", isDefault && "invisible")}
+          onClick={() => update(CODE_FONT_FAMILY_DEFAULT)}
+        >
+          Reset
+        </Button>
+        <Input
+          type="text"
+          aria-label="Code font family"
+          data-testid="code-font-family-input"
+          placeholder="Editor default"
           spellCheck={false}
           autoCapitalize="off"
           autoCorrect="off"

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -20,6 +20,12 @@ import { Editor, type EditorProps, type OnChange, type OnMount } from "@monaco-e
 import { useTheme } from "next-themes";
 import { AlertTriangleIcon, MessageSquareOffIcon } from "lucide-react";
 import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import {
+  codeFontFamilyForEditor,
+  readCodeFontFamily,
+  readCodeFontSizePx,
+  subscribeCodeFont,
+} from "@/lib/codeFontPreferences";
 import type { Comment } from "@/hooks/useComments";
 import { useCanEdit } from "@/hooks/usePermissions";
 import { detectLang, type ActiveSelection, type SaveStatus } from "./codeViewerHelpers";
@@ -392,7 +398,11 @@ function MonacoCodeEditorInner({
       readOnly: !canEdit,
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
-      fontSize: 12,
+      // Code-font preference (Settings → Appearance), read at creation; live
+      // changes arrive via updateOptions in the effect below. An unset family
+      // is undefined, so Monaco keeps its built-in mono default.
+      fontSize: readCodeFontSizePx(),
+      fontFamily: codeFontFamilyForEditor(readCodeFontFamily()),
       automaticLayout: true,
       renderLineHighlight: canEdit ? "line" : "none",
       // Read-only buffers still allow selection + copy; just hide the caret.
@@ -400,6 +410,19 @@ function MonacoCodeEditorInner({
     }),
     [canEdit],
   );
+
+  // Apply live code-font changes to the mounted editor. Monaco is a fixed-pixel
+  // widget with no CSS-variable path like the chrome font, so the new
+  // size/family must be pushed imperatively; the options memo seeds the initial
+  // value at creation.
+  useEffect(() => {
+    return subscribeCodeFont((font) => {
+      editorInstanceRef.current?.updateOptions({
+        fontSize: font.sizePx,
+        fontFamily: codeFontFamilyForEditor(font.family),
+      });
+    });
+  }, []);
 
   return (
     <div className="flex h-full flex-col">

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -400,7 +400,8 @@ function MonacoCodeEditorInner({
       scrollBeyondLastLine: false,
       // Code-font preference (Settings → Appearance), read at creation; live
       // changes arrive via updateOptions in the effect below. An unset family
-      // is undefined, so Monaco keeps its built-in mono default.
+      // resolves to the shared mono stack, so the editor matches the terminal
+      // rather than falling back to Monaco's own platform default.
       fontSize: readCodeFontSizePx(),
       fontFamily: codeFontFamilyForEditor(readCodeFontFamily()),
       automaticLayout: true,

--- a/web/src/shell/MonacoDiffViewer.test.tsx
+++ b/web/src/shell/MonacoDiffViewer.test.tsx
@@ -51,6 +51,7 @@ vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }))
 vi.mock("@/hooks/usePermissions", () => ({ useCanEdit: vi.fn(() => true) }));
 
 import { MonacoDiffViewer } from "./MonacoDiffViewer";
+import { codeFontFamilyForEditor, writeCodeFontSizePx } from "@/lib/codeFontPreferences";
 
 function renderDiff(props: {
   before: string | null;
@@ -80,6 +81,9 @@ beforeEach(() => {
 });
 afterEach(() => {
   cleanup();
+  // writeCodeFontSizePx (live-apply test) persists to localStorage; clear it so
+  // other suites start from the code-font default.
+  localStorage.clear();
 });
 
 describe("MonacoDiffViewer", () => {
@@ -139,5 +143,34 @@ describe("MonacoDiffViewer", () => {
     expect(h.commentOptions?.mounted).toBe(true);
     // CRLF "after" → model EOL set to CRLF (1) so comment offsets stay aligned.
     expect(setEOL).toHaveBeenCalledWith(1);
+  });
+
+  it("re-fonts the mounted diff editor when the code-font preference changes", async () => {
+    const updateOptions = vi.fn();
+    const fakeModified = { getModel: () => ({ setEOL: vi.fn() }) };
+    const fakeDiff = { getModifiedEditor: () => fakeModified, updateOptions };
+    renderDiff({ before: "a", after: "b", layout: "split" });
+    await waitFor(() => expect(h.onMount).not.toBeNull());
+
+    // Mount wires diffEditorRef → our fake diff editor.
+    act(() => {
+      h.onMount?.(
+        fakeDiff as unknown as Parameters<DiffOnMount>[0],
+        {
+          editor: { EndOfLineSequence: { LF: 0, CRLF: 1 } },
+        } as unknown as Parameters<DiffOnMount>[1],
+      );
+    });
+
+    // A Settings change emits through the code-font pub/sub; the mounted diff
+    // editor re-fonts in place via updateOptions (both panes) — the imperative
+    // path a fixed-pixel Monaco widget needs, vs the chrome font's CSS variable.
+    act(() => {
+      writeCodeFontSizePx(20);
+    });
+    expect(updateOptions).toHaveBeenCalledWith({
+      fontSize: 20,
+      fontFamily: codeFontFamilyForEditor(""),
+    });
   });
 });

--- a/web/src/shell/MonacoDiffViewer.tsx
+++ b/web/src/shell/MonacoDiffViewer.tsx
@@ -10,6 +10,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DiffEditor, type DiffEditorProps, type DiffOnMount } from "@monaco-editor/react";
 import { useTheme } from "next-themes";
 import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import {
+  codeFontFamilyForEditor,
+  readCodeFontFamily,
+  readCodeFontSizePx,
+  subscribeCodeFont,
+} from "@/lib/codeFontPreferences";
 import type { Comment } from "@/hooks/useComments";
 import { useCanEdit } from "@/hooks/usePermissions";
 import { detectLang, type ActiveSelection } from "./codeViewerHelpers";
@@ -93,10 +99,14 @@ export function MonacoDiffViewer({
 
   // The modified-side code editor, obtained from the diff editor on mount.
   const modifiedEditorRef = useRef<CodeEditorInstance | null>(null);
+  // The diff editor itself — its updateOptions propagates the code font to both
+  // panes (per-pane updateOptions would only re-font one side).
+  const diffEditorRef = useRef<Parameters<DiffOnMount>[0] | null>(null);
   const [mounted, setMounted] = useState(false);
 
   const handleMount: DiffOnMount = useCallback(
     (diffEditor, monaco) => {
+      diffEditorRef.current = diffEditor;
       const modified = diffEditor.getModifiedEditor();
       modifiedEditorRef.current = modified;
       // Align the modified model's offsets with the raw "after" char offsets that
@@ -116,9 +126,23 @@ export function MonacoDiffViewer({
   useEffect(
     () => () => {
       modifiedEditorRef.current = null;
+      diffEditorRef.current = null;
     },
     [],
   );
+
+  // Apply live code-font changes to both diff panes. Monaco is a fixed-pixel
+  // widget with no CSS-variable path like the chrome font, so the new
+  // size/family must be pushed imperatively; the options memo seeds the initial
+  // value at creation.
+  useEffect(() => {
+    return subscribeCodeFont((font) => {
+      diffEditorRef.current?.updateOptions({
+        fontSize: font.sizePx,
+        fontFamily: codeFontFamilyForEditor(font.family),
+      });
+    });
+  }, []);
 
   // Comments anchor into the current ("after") content == the saved file, so
   // they're always offset-valid here; gate only on edit permission.
@@ -145,7 +169,11 @@ export function MonacoDiffViewer({
       // responsive default in place rather than forcing split at any width.
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
-      fontSize: 12,
+      // Code-font preference (Settings → Appearance), read at creation; live
+      // changes arrive via updateOptions in the effect above. An unset family
+      // is undefined, so Monaco keeps its built-in mono default.
+      fontSize: readCodeFontSizePx(),
+      fontFamily: codeFontFamilyForEditor(readCodeFontFamily()),
       automaticLayout: true,
       renderOverviewRuler: false,
       ignoreTrimWhitespace: hideWhitespace,

--- a/web/src/shell/MonacoDiffViewer.tsx
+++ b/web/src/shell/MonacoDiffViewer.tsx
@@ -171,7 +171,8 @@ export function MonacoDiffViewer({
       scrollBeyondLastLine: false,
       // Code-font preference (Settings → Appearance), read at creation; live
       // changes arrive via updateOptions in the effect above. An unset family
-      // is undefined, so Monaco keeps its built-in mono default.
+      // resolves to the shared mono stack, so the diff matches the terminal
+      // rather than falling back to Monaco's own platform default.
       fontSize: readCodeFontSizePx(),
       fontFamily: codeFontFamilyForEditor(readCodeFontFamily()),
       automaticLayout: true,


### PR DESCRIPTION
## Related issue

N/A — deliberate follow-up to the merged UI-font work (#2040 size, #2047 family), which scoped the chrome/UI font only and explicitly deferred the *code* font.

## Summary

- Adds a **Code font size** stepper + free-text **Code font family** input to Settings → Appearance (their own rows, below the UI-font controls) that drive the Monaco code editor and the xterm terminal, independent of the chrome/UI font.
- New `web/src/lib/codeFontPreferences.ts` mirrors the UI-font read/clamp/write/normalize pattern (keys `omnigent:code-font-size` / `omnigent:code-font-family`; size default 13, range 10–24; family `""` = editor default, with the same `;{}`/control-char sanitization).
- **Why imperative wiring instead of a CSS variable:** the chrome font rides `--ui-font-scale` / `--ui-font-family` because the rem-based UI reflows off the root `font-size`. Monaco and xterm are fixed-pixel widgets — they read an absolute size + family once at construction and only re-measure when told to. So the module exposes an in-module pub/sub (`subscribeCodeFont`); the write helpers **emit the intended value** after persisting (so a failed persist still live-applies), and already-mounted widgets re-apply live: Monaco via `editor.updateOptions({ fontSize, fontFamily })` (the diff viewer updates the diff editor so both panes re-font), and xterm via a new `setFont()` that mutates `term.options.*` and refits — modeled on `setTheme()`, so no reconnect.
- **Scope:** the pref reaches only Monaco (editor + diff) and xterm. Other `--font-mono` surfaces (chat code blocks, notebook preview, CLI command blocks) are intentionally unaffected — consistent with the "editor and terminal" framing.

## Behavior changes (editor defaults unified with the terminal)

With **no custom code font set**, the editor now matches the terminal rather than using Monaco's own defaults:
- **Family:** Monaco uses the shared app mono stack (Geist Mono → platform mono), same as the terminal — previously Monaco's built-in default. A custom family applies to both, with that stack appended as a fallback so an uninstalled name degrades to mono, not serif.
- **Size:** Monaco's default is now 13px (the shared code-font default), up from a hardcoded 12px.

## Test Plan

Run from `web/`:
- `npm run type-check` — clean
- `npm exec -- vitest run` — **3725 passed**, 0 unexpected failures
- `npm run build` — succeeds
- `npm exec -- prettier --check` (changed files) + `npm run lint` — clean for changed files
- pinned `ruff format --check` + `ruff check` on the new e2e test — clean

Coverage of the code-font path:
- **Module** (`codeFontPreferences.test.ts`): read/clamp/normalize; the pub/sub (emit on write, unsubscribe); the uniform empty-family fallback; and **emit-on-write-failure** — subscribers still receive the intended value when `localStorage` throws.
- **Live-apply on a mounted editor** (`MonacoDiffViewer.test.tsx`): after mount, writing the pref calls `updateOptions({ fontSize, fontFamily })` on the diff editor — the imperative re-font path.
- **Terminal** (`TerminalSession.test.ts`): `setFont` re-fonts in place, triggers the refit (`sendResize`), tolerates a down socket, and never reconnects.
- **Settings** (`SettingsPage.test.tsx`): draft/commit, blur-clamp, reset, persistence under the code-font keys.
- **E2E** (`tests/e2e_ui/sessions/test_code_font.py`, modeled on `test_ui_font_size.py`): stepping the size persists to `localStorage`; a seeded file opened in Monaco renders `.view-lines` at the chosen size (13px default and after stepping); steppers clamp at 10/24.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Live re-fonting of an already-mounted widget is now covered by component/unit tests (the `MonacoDiffViewer` `updateOptions` test and the `TerminalSession.setFont` refit/socket-down test) plus the module pub/sub tests; the e2e covers construction + reload persistence + bounds. Also exercised on a local `omnigent server` + `host` + Vite dev instance — the Settings controls render and behave (size/family/reset), and the layout was confirmed.

## Changelog

Set the code editor and terminal font size and family from Settings → Appearance