### PR TITLE
fix(web): let intelligent routing pick the model for claude sessions

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -4962,6 +4962,7 @@ describe("chatStore — bindStream sticky-pref handoff", () => {
     labels?: Record<string, string>;
     reasoning_effort?: string | null;
     model_override?: string | null;
+    cost_control_mode_override?: "on" | "off" | null;
     parent_session_id?: string | null;
     model_options?: Array<Record<string, unknown>>;
   }
@@ -4981,6 +4982,7 @@ describe("chatStore — bindStream sticky-pref handoff", () => {
           labels: overrides.labels ?? {},
           reasoning_effort: overrides.reasoning_effort ?? null,
           model_override: overrides.model_override ?? null,
+          cost_control_mode_override: overrides.cost_control_mode_override ?? null,
           parent_session_id: overrides.parent_session_id ?? null,
           model_options: overrides.model_options ?? [],
         });
@@ -5025,6 +5027,28 @@ describe("chatStore — bindStream sticky-pref handoff", () => {
     const state = useChatStore.getState();
     expect(state.selectedModel).toBe("claude-opus-4-7");
     expect(state.selectedEffort).toBe("high");
+  });
+
+  it("does NOT apply a sticky model to a routing-enabled session", async () => {
+    // Intelligent routing owns model selection: the bind-time sticky handoff
+    // must NOT silently re-pin the last-used model, or the server's
+    // `model_override is None` routing guard would skip and the judge would
+    // never run. (This is the claude-native repro: new chat + routing on.)
+    seedSession("conv_routing", []);
+    withSnapshot("conv_routing", {
+      labels: { "omnigent.wrapper": "claude-code-native-ui" },
+      cost_control_mode_override: "on",
+      model_override: null,
+    });
+
+    useChatStore.setState({ selectedModel: "claude-opus-4-7" });
+    await useChatStore.getState().switchTo("conv_routing");
+
+    // No model_override PATCH fired (contrast the handoff test above).
+    const patches = patchCallsFor("conv_routing");
+    expect(patches.some((p) => "model_override" in p)).toBe(false);
+    // …and the session is not mislabeled as pinned to the sticky model.
+    expect(useChatStore.getState().sessionModelOverride).toBeNull();
   });
 
   it("PATCHes sticky model and effort onto a codex-native session with no overrides", async () => {
@@ -7032,6 +7056,56 @@ describe("chatStore — setCostControlMode", () => {
     expect(body).toEqual({ cost_control_mode_override: "on" });
     // Settled state is the server echo, proving the canonical refresh ran.
     expect(useChatStore.getState().costControlModeOverride).toBe("on");
+  });
+
+  it("clears the pinned model when routing is turned on (mutual exclusion)", async () => {
+    // A session pinned to a model (e.g. Opus from the picker) must drop that
+    // pin when routing is enabled — otherwise `model_override` wins and the
+    // judge never runs. The clear rides in the SAME PATCH as the toggle.
+    seedSession("conv_cc_model", []);
+    await useChatStore.getState().switchTo("conv_cc_model");
+    useChatStore.setState({ sessionModelOverride: "claude-opus-4-7" });
+
+    // The optimistic clear is visible before the PATCH resolves.
+    const settled = useChatStore.getState().setCostControlMode("on");
+    expect(useChatStore.getState().sessionModelOverride).toBeNull();
+    await settled;
+
+    const patchCall = fetchMock.mock.calls.find(([u, init]) => {
+      const url = typeof u === "string" ? u : (u as URL | Request).toString();
+      return (
+        url === "/v1/sessions/conv_cc_model" &&
+        (init as RequestInit | undefined)?.method === "PATCH"
+      );
+    });
+    expect(patchCall).toBeDefined();
+    // One PATCH carries BOTH the toggle and the model clear ("default" alias).
+    expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({
+      cost_control_mode_override: "on",
+      model_override: "default",
+    });
+  });
+
+  it("does NOT clear the model when routing is turned on but nothing is pinned", async () => {
+    // A model-less session (e.g. SDK) must not emit a spurious model clear —
+    // that would fire a redundant model_change and a bogus "changed to none".
+    seedSession("conv_cc_nomodel", []);
+    await useChatStore.getState().switchTo("conv_cc_nomodel");
+    expect(useChatStore.getState().sessionModelOverride).toBeNull();
+
+    await useChatStore.getState().setCostControlMode("on");
+
+    const patchCall = fetchMock.mock.calls.find(([u, init]) => {
+      const url = typeof u === "string" ? u : (u as URL | Request).toString();
+      return (
+        url === "/v1/sessions/conv_cc_nomodel" &&
+        (init as RequestInit | undefined)?.method === "PATCH"
+      );
+    });
+    expect(patchCall).toBeDefined();
+    expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({
+      cost_control_mode_override: "on",
+    });
   });
 
   it("sends an explicit null on clear and settles back to unset", async () => {

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1398,17 +1398,38 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const { conversationId } = get();
     if (!conversationId) return;
     const previous = get().costControlModeOverride;
+    // Routing and a pinned model are mutually exclusive: the server's routing
+    // guard skips whenever model_override is set, so turning routing ON must
+    // also clear this session's pinned model (in the SAME PATCH) — otherwise
+    // the old pick (e.g. Opus from the new-chat picker) would win and the judge
+    // would never run. Mirrors the new-chat dialog's mutual exclusion. Only
+    // clear when a model is actually pinned, so toggling routing on a
+    // model-less (e.g. SDK) session doesn't emit a spurious model-cleared change.
+    const previousModel = get().sessionModelOverride;
+    const clearModel = mode === "on" && previousModel != null;
     // Optimistic flip so the pill responds instantly; the PATCH
     // response (or the rollback below) is the settled truth.
-    set({ costControlModeOverride: mode });
+    set({
+      costControlModeOverride: mode,
+      ...(clearModel ? { sessionModelOverride: null } : {}),
+    });
     try {
-      const session = await updateSession(conversationId, { costControlModeOverride: mode });
+      const session = await updateSession(conversationId, {
+        costControlModeOverride: mode,
+        ...(clearModel ? { modelOverride: null } : {}),
+      });
       if (get().conversationId !== conversationId) return;
-      set({ costControlModeOverride: session.costControlModeOverride ?? null });
+      set({
+        costControlModeOverride: session.costControlModeOverride ?? null,
+        ...(clearModel ? { sessionModelOverride: session.modelOverride ?? null } : {}),
+      });
     } catch (err) {
-      // Roll back so the pill doesn't claim a state the server never persisted.
+      // Roll back so neither control claims a state the server never persisted.
       if (get().conversationId === conversationId) {
-        set({ costControlModeOverride: previous });
+        set({
+          costControlModeOverride: previous,
+          ...(clearModel ? { sessionModelOverride: previousModel } : {}),
+        });
       }
       throw err;
     }
@@ -1866,8 +1887,16 @@ async function bindStream(
     // pick for non-native sessions), this is the session truth the `/model`
     // readout shows, so a non-applied sticky pick is never mislabeled as
     // an active "(override)".
+    // Intelligent routing owns model selection: never carry a sticky model
+    // onto a routing-enabled session. Leaving model_override null is what lets
+    // the server-side judge pick on the first turn; a silent sticky PATCH here
+    // would re-pin the session (e.g. to the last-used Opus) and trip the
+    // server's ``model_override is None`` routing guard. effectiveSessionOverride
+    // then resolves to null too, so the /model readout doesn't mislabel it.
+    const routingOn = session.costControlModeOverride === "on";
     const willApplyStickyModel =
       !isSubAgentSession &&
+      !routingOn &&
       nativeModelFamily !== null &&
       session.modelOverride == null &&
       compatibleStickyModel != null;


### PR DESCRIPTION
## Related issue

N/A

## Summary

Intelligent routing (`databricks.mas.omnigent.intelligentRouting`) worked for
codex sessions but not claude ones: claude sessions stayed pinned to Opus
instead of being handed to the routing judge. The server contract is already
correct — it only routes when `model_override is None` — so the bug was purely
client-side: two spots in the chat store re-pinned a `model_override`, which
trips that guard and suppresses routing.

- **`bindStream` sticky handoff** — skip the sticky-model PATCH when the session
  has routing enabled (`costControlModeOverride === "on"`). A routing-enabled
  session is no longer silently re-pinned to the last-used model, so
  `model_override` stays `null` and the judge picks on the first turn.
- **`setCostControlMode`** — when routing is turned on and a model is pinned,
  clear `modelOverride` in the *same* PATCH (mirrors the new-chat dialog's
  mutual exclusion). The clear is skipped for model-less sessions (e.g. SDK) so
  no spurious `model_change` fires.

ELI5: routing and a manually-pinned model are mutually exclusive. The UI was
quietly re-pinning claude sessions to a model right when it shouldn't, so the
router never got a chance to choose. This stops the re-pinning and clears any
stale pin the moment routing is switched on.

## Test Plan

- `npm --prefix web exec -- vitest run src/store/chatStore.test.ts` → **241/241
  pass**, including 3 new tests: the claude-native routing repro, the same-PATCH
  model clear, and the no-spurious-clear (model-less) case.
- `npm --prefix web run type-check` (`tsc -b`) → clean.
- `oxlint` on both files → only pre-existing warnings, none on the new lines;
  `prettier --check` → clean.

## Demo

N/A — non-visual state-management fix (no layout/pixel change). The observable
effect (routing now runs for claude sessions) is exercised by the new unit
tests above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests in `web/src/store/chatStore.test.ts` cover both fixed code paths
(bind-time sticky handoff and the routing toggle) plus the model-less guard.

## Changelog

Intelligent routing now correctly routes claude sessions instead of leaving them
pinned to a single model.
