### PR TITLE
feat(db): add workspace_id to all tables as leading primary-key column

### DIFF
--- a/omnigent/db/__init__.py
+++ b/omnigent/db/__init__.py
@@ -9,6 +9,8 @@ from omnigent.db.db_models import (
     SqlFile,
     SqlSessionPermission,
     SqlUser,
+    current_workspace_id,
+    workspace_scope,
 )
 
 __all__ = [
@@ -20,4 +22,6 @@ __all__ = [
     "SqlFile",
     "SqlSessionPermission",
     "SqlUser",
+    "current_workspace_id",
+    "workspace_scope",
 ]

--- a/omnigent/db/__init__.py
+++ b/omnigent/db/__init__.py
@@ -1,6 +1,7 @@
 """Database package — SQLAlchemy models and Alembic migrations."""
 
 from omnigent.db.db_models import (
+    DEFAULT_WORKSPACE_ID,
     Base,
     SqlAgent,
     SqlConversation,
@@ -11,6 +12,7 @@ from omnigent.db.db_models import (
 )
 
 __all__ = [
+    "DEFAULT_WORKSPACE_ID",
     "Base",
     "SqlAgent",
     "SqlConversation",

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import Iterator
+from contextvars import ContextVar
+
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -25,10 +29,47 @@ class Base(DeclarativeBase):
 
 # Default workspace id stamped on every row and used as the leading
 # member of every composite primary key. 0 is the single-workspace /
-# unassigned sentinel: until a workspace is threaded through the request
-# path, all rows live in workspace 0, so primary-key lookups pass this
-# for the workspace_id component.
+# unassigned sentinel: with no workspace bound to the request, all rows
+# live in workspace 0.
 DEFAULT_WORKSPACE_ID = 0
+
+# Ambient per-request workspace id. Stores are process-wide singletons, so
+# the active workspace can't ride on the store instance — it lives here.
+# OSS leaves this at the default (single-workspace 0); a multi-tenant
+# deployment (e.g. universe) sets it per request from the authenticated
+# context (via ``workspace_scope`` in middleware). Reads and inserts
+# resolve it through ``current_workspace_id()`` so the same store code
+# scopes to the caller's workspace without threading the id through every
+# signature — keeping this file byte-identical across deployments.
+_current_workspace_id: ContextVar[int] = ContextVar(
+    "omnigent_workspace_id", default=DEFAULT_WORKSPACE_ID
+)
+
+
+def current_workspace_id() -> int:
+    """Return the workspace id bound to the active request/context.
+
+    Defaults to :data:`DEFAULT_WORKSPACE_ID` (0) — the single-workspace OSS
+    deployment. Multi-tenant deployments set it per request so every
+    primary-key lookup, filter, and insert scopes to that workspace.
+    """
+    return _current_workspace_id.get()
+
+
+@contextlib.contextmanager
+def workspace_scope(workspace_id: int) -> Iterator[None]:
+    """Bind *workspace_id* for the duration of the ``with`` block.
+
+    Used by multi-tenant request middleware (and tests) to scope all
+    store access to one workspace; resets to the prior value on exit so
+    nested / concurrent contexts don't leak.
+    """
+    token = _current_workspace_id.set(workspace_id)
+    try:
+        yield
+    finally:
+        _current_workspace_id.reset(token)
+
 
 AGENT_KIND_TEMPLATE = "template"
 AGENT_KIND_SESSION = "session"
@@ -65,7 +106,11 @@ class SqlAgent(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
@@ -111,7 +156,11 @@ class SqlFile(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
@@ -155,7 +204,11 @@ class SqlUser(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     id: Mapped[str] = mapped_column(String(128), primary_key=True)
     is_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=false())
@@ -201,7 +254,11 @@ class SqlAccountToken(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     id: Mapped[str] = mapped_column(String(128), primary_key=True)
     kind: Mapped[str] = mapped_column(String(16), nullable=False)
@@ -243,7 +300,11 @@ class SqlSessionPermission(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     user_id: Mapped[str] = mapped_column(
         String(128),
@@ -342,7 +403,11 @@ class SqlConversation(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
@@ -510,7 +575,11 @@ class SqlConversationItem(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     conversation_id: Mapped[str] = mapped_column(
@@ -576,7 +645,11 @@ class SqlConversationLabel(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     conversation_id: Mapped[str] = mapped_column(
         String(64),
@@ -627,7 +700,11 @@ class SqlComment(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     conversation_id: Mapped[str] = mapped_column(String(64))
@@ -691,7 +768,11 @@ class SqlPolicy(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     name: Mapped[str] = mapped_column(String(256))
@@ -789,7 +870,11 @@ class SqlHost(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     owner: Mapped[str] = mapped_column(String(256), primary_key=True)
     name: Mapped[str] = mapped_column(String(256), primary_key=True)
@@ -854,7 +939,11 @@ class SqlUserDailyCost(Base):
 
     # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
     workspace_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
     )
     user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     day_utc: Mapped[str] = mapped_column(String(10), primary_key=True)

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -23,6 +23,13 @@ class Base(DeclarativeBase):
     """Shared declarative base for all omnigent tables."""
 
 
+# Default workspace id stamped on every row and used as the leading
+# member of every composite primary key. 0 is the single-workspace /
+# unassigned sentinel: until a workspace is threaded through the request
+# path, all rows live in workspace 0, so primary-key lookups pass this
+# for the workspace_id component.
+DEFAULT_WORKSPACE_ID = 0
+
 AGENT_KIND_TEMPLATE = "template"
 AGENT_KIND_SESSION = "session"
 
@@ -56,6 +63,10 @@ class SqlAgent(Base):
 
     __tablename__ = "agents"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
     name: Mapped[str] = mapped_column(String(256))
@@ -98,6 +109,10 @@ class SqlFile(Base):
 
     __tablename__ = "files"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
     filename: Mapped[str] = mapped_column(String(512))
@@ -138,6 +153,10 @@ class SqlUser(Base):
 
     __tablename__ = "users"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     id: Mapped[str] = mapped_column(String(128), primary_key=True)
     is_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=false())
     password_hash: Mapped[str | None] = mapped_column(String(256), nullable=True)
@@ -180,6 +199,10 @@ class SqlAccountToken(Base):
 
     __tablename__ = "account_tokens"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     id: Mapped[str] = mapped_column(String(128), primary_key=True)
     kind: Mapped[str] = mapped_column(String(16), nullable=False)
     user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
@@ -218,6 +241,10 @@ class SqlSessionPermission(Base):
 
     __tablename__ = "session_permissions"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     user_id: Mapped[str] = mapped_column(
         String(128),
         primary_key=True,
@@ -313,6 +340,10 @@ class SqlConversation(Base):
 
     __tablename__ = "conversations"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int] = mapped_column(Integer)
@@ -477,6 +508,10 @@ class SqlConversationItem(Base):
 
     __tablename__ = "conversation_items"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     conversation_id: Mapped[str] = mapped_column(
         String(64),
@@ -539,6 +574,10 @@ class SqlConversationLabel(Base):
 
     __tablename__ = "conversation_labels"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     conversation_id: Mapped[str] = mapped_column(
         String(64),
         primary_key=True,
@@ -586,6 +625,10 @@ class SqlComment(Base):
 
     __tablename__ = "comments"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     conversation_id: Mapped[str] = mapped_column(String(64))
     path: Mapped[str] = mapped_column(String(4096))
@@ -646,6 +689,10 @@ class SqlPolicy(Base):
 
     __tablename__ = "policies"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     name: Mapped[str] = mapped_column(String(256))
     # Nullable: NULL for server-wide default policies.
@@ -740,6 +787,10 @@ class SqlHost(Base):
 
     __tablename__ = "hosts"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     owner: Mapped[str] = mapped_column(String(256), primary_key=True)
     name: Mapped[str] = mapped_column(String(256), primary_key=True)
     host_id: Mapped[str] = mapped_column(String(64))
@@ -801,6 +852,10 @@ class SqlUserDailyCost(Base):
 
     __tablename__ = "user_daily_cost"
 
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, nullable=False, server_default="0", default=0
+    )
     user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     day_utc: Mapped[str] = mapped_column(String(10), primary_key=True)
     cost_usd: Mapped[float] = mapped_column(Float, nullable=False)

--- a/omnigent/db/migrations/versions/r1a2b3c4d5e6_add_workspace_id_to_all_tables.py
+++ b/omnigent/db/migrations/versions/r1a2b3c4d5e6_add_workspace_id_to_all_tables.py
@@ -1,0 +1,125 @@
+"""Add workspace_id to every table and fold it into the primary key.
+
+Revision ID: r1a2b3c4d5e6
+Revises: q1a2b3c4d5e6
+Create Date: 2026-07-07 00:00:00.000000
+
+Adds a ``workspace_id`` tenant-partition column to all twelve tables and
+extends each primary key to ``(workspace_id, <existing pk cols>)``.  The
+column is NOT NULL with ``server_default = 0`` so existing rows backfill
+to workspace 0 (the single-workspace / unassigned sentinel) and inserts
+that omit it land in workspace 0.  ``workspace_id`` leads the composite
+key so rows for one workspace stay contiguous for prefix scans.
+
+There are no FK constraints in the schema anymore (see ``p1a2b3c4d5e6``),
+so rebuilding each primary key is a purely local operation per table.
+
+SQLite note: ``batch_alter_table(recreate="always")`` rebuilds the table
+so the primary key can change (SQLite cannot alter a PK in place); the
+new ``create_primary_key`` overrides the reflected single-column PK.  On
+PostgreSQL the existing named PK is dropped explicitly first (a table can
+hold only one primary key) before the wider one is added.  Both paths
+guard the rebuilds with ``PRAGMA foreign_keys`` on SQLite.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import warnings
+from collections.abc import Iterator, Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "r1a2b3c4d5e6"
+down_revision: str | None = "q1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Every table mapped to the primary-key columns it had before this
+# migration. The new primary key is ``["workspace_id", *existing]``.
+_TABLE_PKS: dict[str, list[str]] = {
+    "agents": ["id"],
+    "files": ["id"],
+    "users": ["id"],
+    "account_tokens": ["id"],
+    "session_permissions": ["user_id", "conversation_id"],
+    "conversations": ["id"],
+    "conversation_items": ["id"],
+    "conversation_labels": ["conversation_id", "key"],
+    "comments": ["id"],
+    "policies": ["id"],
+    "hosts": ["owner", "name"],
+    "user_daily_cost": ["user_id", "day_utc"],
+}
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def _existing_pk_name(table: str) -> str | None:
+    """Reflect the current primary-key constraint name (PostgreSQL path)."""
+    return sa.inspect(op.get_bind()).get_pk_constraint(table).get("name")
+
+
+@contextlib.contextmanager
+def _quiet_pk_override() -> Iterator[None]:
+    """
+    Silence the expected SQLite batch-rebuild warning about the reflected
+    single-column PK not matching the wider one we install. The override is
+    intentional here, and this fires once per table on every fresh DB.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*not matching locally specified columns.*",
+            category=sa.exc.SAWarning,
+        )
+        yield
+
+
+def upgrade() -> None:
+    """Add ``workspace_id`` and widen every primary key to include it."""
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    for table, pk_cols in _TABLE_PKS.items():
+        # On PostgreSQL the current PK must be dropped before a wider one
+        # can be added; on SQLite the batch rebuild overrides it in place.
+        old_pk_name = None if sqlite else _existing_pk_name(table)
+        with (
+            _quiet_pk_override(),
+            op.batch_alter_table(table, recreate="always" if sqlite else "auto") as batch_op,
+        ):
+            batch_op.add_column(
+                sa.Column("workspace_id", sa.BigInteger(), nullable=False, server_default="0")
+            )
+            if old_pk_name is not None:
+                batch_op.drop_constraint(old_pk_name, type_="primary")
+            batch_op.create_primary_key(f"pk_{table}", ["workspace_id", *pk_cols])
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def downgrade() -> None:
+    """Restore each original primary key and drop ``workspace_id``."""
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    for table, pk_cols in _TABLE_PKS.items():
+        old_pk_name = None if sqlite else _existing_pk_name(table)
+        with (
+            _quiet_pk_override(),
+            op.batch_alter_table(table, recreate="always" if sqlite else "auto") as batch_op,
+        ):
+            if old_pk_name is not None:
+                batch_op.drop_constraint(old_pk_name, type_="primary")
+            batch_op.drop_column("workspace_id")
+            batch_op.create_primary_key(f"pk_{table}", pk_cols)
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))

--- a/omnigent/server/accounts_store.py
+++ b/omnigent/server/accounts_store.py
@@ -174,7 +174,14 @@ class SqlAlchemyAccountStore:
         :param is_admin: The flag value to set.
         """
         with self._session() as session:
-            session.execute(update(SqlUser).where(SqlUser.id == user_id).values(is_admin=is_admin))
+            session.execute(
+                update(SqlUser)
+                .where(
+                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.id == user_id,
+                )
+                .values(is_admin=is_admin)
+            )
 
     def list_users(self) -> list[Account]:
         """Return all users for the admin members page.
@@ -196,7 +203,13 @@ class SqlAlchemyAccountStore:
         Result is unordered; UI sorts.
         """
         with self._session() as session:
-            rows = session.execute(select(SqlUser)).scalars().all()
+            rows = (
+                session.execute(
+                    select(SqlUser).where(SqlUser.workspace_id == DEFAULT_WORKSPACE_ID)
+                )
+                .scalars()
+                .all()
+            )
             return [_to_account(r) for r in rows if r.id not in _HIDDEN_LIST_USERS]
 
     def delete_user(self, user_id: str) -> bool:
@@ -209,9 +222,17 @@ class SqlAlchemyAccountStore:
         """
         with self._session() as session:
             session.execute(
-                delete(SqlSessionPermission).where(SqlSessionPermission.user_id == user_id)
+                delete(SqlSessionPermission).where(
+                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlSessionPermission.user_id == user_id,
+                )
             )
-            result = session.execute(delete(SqlUser).where(SqlUser.id == user_id))
+            result = session.execute(
+                delete(SqlUser).where(
+                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.id == user_id,
+                )
+            )
             return result.rowcount > 0
 
     def get_password_hash(self, user_id: str) -> str | None:
@@ -235,7 +256,12 @@ class SqlAlchemyAccountStore:
         """
         with self._session() as session:
             session.execute(
-                update(SqlUser).where(SqlUser.id == user_id).values(password_hash=password_hash)
+                update(SqlUser)
+                .where(
+                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.id == user_id,
+                )
+                .values(password_hash=password_hash)
             )
 
     def mark_logged_in(self, user_id: str, when_epoch_seconds: int) -> None:
@@ -247,7 +273,10 @@ class SqlAlchemyAccountStore:
         with self._session() as session:
             session.execute(
                 update(SqlUser)
-                .where(SqlUser.id == user_id)
+                .where(
+                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.id == user_id,
+                )
                 .values(last_login_at=when_epoch_seconds)
             )
 
@@ -317,6 +346,7 @@ class SqlAlchemyAccountStore:
                 update(SqlAccountToken)
                 .where(
                     and_(
+                        SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
                         SqlAccountToken.id == token_id,
                         SqlAccountToken.kind == kind,
                         SqlAccountToken.redeemed_at.is_(None),
@@ -342,7 +372,10 @@ class SqlAlchemyAccountStore:
         """
         with self._session() as session:
             result = session.execute(
-                delete(SqlAccountToken).where(SqlAccountToken.expires_at <= now_epoch_seconds)
+                delete(SqlAccountToken).where(
+                    SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlAccountToken.expires_at <= now_epoch_seconds,
+                )
             )
             return result.rowcount
 
@@ -378,6 +411,7 @@ class SqlAlchemyAccountStore:
                 update(SqlAccountToken)
                 .where(
                     and_(
+                        SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
                         SqlAccountToken.id == token_id,
                         SqlAccountToken.kind == "invite",
                         SqlAccountToken.redeemed_at.is_(None),
@@ -405,6 +439,7 @@ class SqlAlchemyAccountStore:
                 select(
                     exists().where(
                         and_(
+                            SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
                             SqlAccountToken.kind == "invite",
                             SqlAccountToken.user_id == email,
                             SqlAccountToken.redeemed_at.is_not(None),

--- a/omnigent/server/accounts_store.py
+++ b/omnigent/server/accounts_store.py
@@ -34,10 +34,10 @@ from sqlalchemy import and_, delete, exists, select, update
 from sqlalchemy.exc import IntegrityError
 
 from omnigent.db.db_models import (
-    DEFAULT_WORKSPACE_ID,
     SqlAccountToken,
     SqlSessionPermission,
     SqlUser,
+    current_workspace_id,
 )
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
 from omnigent.entities import Account, AccountToken
@@ -120,7 +120,7 @@ class SqlAlchemyAccountStore:
         """
         now = int(time.time())
         with self._session() as session:
-            existing = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
+            existing = session.get(SqlUser, (current_workspace_id(), user_id))
             if existing is not None:
                 raise ValueError(f"user {user_id!r} already exists")
             row = SqlUser(
@@ -143,7 +143,7 @@ class SqlAlchemyAccountStore:
     def get_user(self, user_id: str) -> Account | None:
         """Look up a user by id. Returns ``None`` if missing."""
         with self._session() as session:
-            row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
+            row = session.get(SqlUser, (current_workspace_id(), user_id))
             return _to_account(row) if row is not None else None
 
     def is_admin(self, user_id: str) -> bool:
@@ -156,7 +156,7 @@ class SqlAlchemyAccountStore:
         construction (single source of truth: the column).
         """
         with self._session() as session:
-            row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
+            row = session.get(SqlUser, (current_workspace_id(), user_id))
             return row is not None and row.is_admin
 
     def set_admin(self, user_id: str, is_admin: bool) -> None:
@@ -177,7 +177,7 @@ class SqlAlchemyAccountStore:
             session.execute(
                 update(SqlUser)
                 .where(
-                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.workspace_id == current_workspace_id(),
                     SqlUser.id == user_id,
                 )
                 .values(is_admin=is_admin)
@@ -205,7 +205,7 @@ class SqlAlchemyAccountStore:
         with self._session() as session:
             rows = (
                 session.execute(
-                    select(SqlUser).where(SqlUser.workspace_id == DEFAULT_WORKSPACE_ID)
+                    select(SqlUser).where(SqlUser.workspace_id == current_workspace_id())
                 )
                 .scalars()
                 .all()
@@ -223,13 +223,13 @@ class SqlAlchemyAccountStore:
         with self._session() as session:
             session.execute(
                 delete(SqlSessionPermission).where(
-                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlSessionPermission.workspace_id == current_workspace_id(),
                     SqlSessionPermission.user_id == user_id,
                 )
             )
             result = session.execute(
                 delete(SqlUser).where(
-                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.workspace_id == current_workspace_id(),
                     SqlUser.id == user_id,
                 )
             )
@@ -244,7 +244,7 @@ class SqlAlchemyAccountStore:
         log, return, or store the value elsewhere.
         """
         with self._session() as session:
-            row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
+            row = session.get(SqlUser, (current_workspace_id(), user_id))
             return row.password_hash if row is not None else None
 
     def update_password(self, user_id: str, password_hash: str) -> None:
@@ -258,7 +258,7 @@ class SqlAlchemyAccountStore:
             session.execute(
                 update(SqlUser)
                 .where(
-                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.workspace_id == current_workspace_id(),
                     SqlUser.id == user_id,
                 )
                 .values(password_hash=password_hash)
@@ -274,7 +274,7 @@ class SqlAlchemyAccountStore:
             session.execute(
                 update(SqlUser)
                 .where(
-                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.workspace_id == current_workspace_id(),
                     SqlUser.id == user_id,
                 )
                 .values(last_login_at=when_epoch_seconds)
@@ -346,7 +346,7 @@ class SqlAlchemyAccountStore:
                 update(SqlAccountToken)
                 .where(
                     and_(
-                        SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlAccountToken.workspace_id == current_workspace_id(),
                         SqlAccountToken.id == token_id,
                         SqlAccountToken.kind == kind,
                         SqlAccountToken.redeemed_at.is_(None),
@@ -357,7 +357,7 @@ class SqlAlchemyAccountStore:
             )
             if result.rowcount == 0:
                 return None
-            row = session.get(SqlAccountToken, (DEFAULT_WORKSPACE_ID, token_id))
+            row = session.get(SqlAccountToken, (current_workspace_id(), token_id))
             return _to_account_token(row) if row is not None else None
 
     def purge_expired_tokens(self, now_epoch_seconds: int) -> int:
@@ -373,7 +373,7 @@ class SqlAlchemyAccountStore:
         with self._session() as session:
             result = session.execute(
                 delete(SqlAccountToken).where(
-                    SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlAccountToken.workspace_id == current_workspace_id(),
                     SqlAccountToken.expires_at <= now_epoch_seconds,
                 )
             )
@@ -411,7 +411,7 @@ class SqlAlchemyAccountStore:
                 update(SqlAccountToken)
                 .where(
                     and_(
-                        SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlAccountToken.workspace_id == current_workspace_id(),
                         SqlAccountToken.id == token_id,
                         SqlAccountToken.kind == "invite",
                         SqlAccountToken.redeemed_at.is_(None),
@@ -439,7 +439,7 @@ class SqlAlchemyAccountStore:
                 select(
                     exists().where(
                         and_(
-                            SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
+                            SqlAccountToken.workspace_id == current_workspace_id(),
                             SqlAccountToken.kind == "invite",
                             SqlAccountToken.user_id == email,
                             SqlAccountToken.redeemed_at.is_not(None),

--- a/omnigent/server/accounts_store.py
+++ b/omnigent/server/accounts_store.py
@@ -33,7 +33,12 @@ import time
 from sqlalchemy import and_, delete, exists, select, update
 from sqlalchemy.exc import IntegrityError
 
-from omnigent.db.db_models import SqlAccountToken, SqlSessionPermission, SqlUser
+from omnigent.db.db_models import (
+    DEFAULT_WORKSPACE_ID,
+    SqlAccountToken,
+    SqlSessionPermission,
+    SqlUser,
+)
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
 from omnigent.entities import Account, AccountToken
 from omnigent.server.auth import RESERVED_USER_LOCAL, RESERVED_USER_PUBLIC
@@ -115,7 +120,7 @@ class SqlAlchemyAccountStore:
         """
         now = int(time.time())
         with self._session() as session:
-            existing = session.get(SqlUser, user_id)
+            existing = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
             if existing is not None:
                 raise ValueError(f"user {user_id!r} already exists")
             row = SqlUser(
@@ -138,7 +143,7 @@ class SqlAlchemyAccountStore:
     def get_user(self, user_id: str) -> Account | None:
         """Look up a user by id. Returns ``None`` if missing."""
         with self._session() as session:
-            row = session.get(SqlUser, user_id)
+            row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
             return _to_account(row) if row is not None else None
 
     def is_admin(self, user_id: str) -> bool:
@@ -151,7 +156,7 @@ class SqlAlchemyAccountStore:
         construction (single source of truth: the column).
         """
         with self._session() as session:
-            row = session.get(SqlUser, user_id)
+            row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
             return row is not None and row.is_admin
 
     def set_admin(self, user_id: str, is_admin: bool) -> None:
@@ -218,7 +223,7 @@ class SqlAlchemyAccountStore:
         log, return, or store the value elsewhere.
         """
         with self._session() as session:
-            row = session.get(SqlUser, user_id)
+            row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
             return row.password_hash if row is not None else None
 
     def update_password(self, user_id: str, password_hash: str) -> None:
@@ -322,7 +327,7 @@ class SqlAlchemyAccountStore:
             )
             if result.rowcount == 0:
                 return None
-            row = session.get(SqlAccountToken, token_id)
+            row = session.get(SqlAccountToken, (DEFAULT_WORKSPACE_ID, token_id))
             return _to_account_token(row) if row is not None else None
 
     def purge_expired_tokens(self, now_epoch_seconds: int) -> int:

--- a/omnigent/server/identity_migration.py
+++ b/omnigent/server/identity_migration.py
@@ -101,7 +101,11 @@ def build_domain_mapping(engine: Engine, domain: str) -> dict[str, str]:
     domain = domain.lstrip("@").strip().lower()
     mapping: dict[str, str] = {}
     with Session(engine) as session:
-        ids = session.execute(select(SqlUser.id)).scalars().all()
+        ids = (
+            session.execute(select(SqlUser.id).where(SqlUser.workspace_id == DEFAULT_WORKSPACE_ID))
+            .scalars()
+            .all()
+        )
     for uid in ids:
         if "@" in uid or uid in _RESERVED_USERS:
             continue
@@ -178,7 +182,10 @@ def remap_identities(
             # merges to the higher level instead of violating the PK.
             old_grants = (
                 session.execute(
-                    select(SqlSessionPermission).where(SqlSessionPermission.user_id == old_id)
+                    select(SqlSessionPermission).where(
+                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlSessionPermission.user_id == old_id,
+                    )
                 )
                 .scalars()
                 .all()
@@ -203,7 +210,9 @@ def remap_identities(
                 (SqlPolicy, SqlPolicy.created_by),
             ):
                 result = session.execute(
-                    update(model).where(column == old_id).values(created_by=new_id)
+                    update(model)
+                    .where(model.workspace_id == DEFAULT_WORKSPACE_ID, column == old_id)
+                    .values(created_by=new_id)
                 )
                 report._bump(model.__tablename__, result.rowcount or 0)
 
@@ -211,7 +220,12 @@ def remap_identities(
             for column_name in ("user_id", "created_by"):
                 column = getattr(SqlAccountToken, column_name)
                 result = session.execute(
-                    update(SqlAccountToken).where(column == old_id).values(**{column_name: new_id})
+                    update(SqlAccountToken)
+                    .where(
+                        SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
+                        column == old_id,
+                    )
+                    .values(**{column_name: new_id})
                 )
                 report._bump(SqlAccountToken.__tablename__, result.rowcount or 0)
 
@@ -220,7 +234,14 @@ def remap_identities(
             # per-row. Rare in OSS (hosts are a Databricks-connect
             # feature), but correctness over assumption.
             old_hosts = (
-                session.execute(select(SqlHost).where(SqlHost.owner == old_id)).scalars().all()
+                session.execute(
+                    select(SqlHost).where(
+                        SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlHost.owner == old_id,
+                    )
+                )
+                .scalars()
+                .all()
             )
             for host in old_hosts:
                 clash = session.get(SqlHost, (DEFAULT_WORKSPACE_ID, new_id, host.name))

--- a/omnigent/server/identity_migration.py
+++ b/omnigent/server/identity_migration.py
@@ -40,13 +40,13 @@ from sqlalchemy import Engine, select, update
 from sqlalchemy.orm import Session
 
 from omnigent.db.db_models import (
-    DEFAULT_WORKSPACE_ID,
     SqlAccountToken,
     SqlComment,
     SqlHost,
     SqlPolicy,
     SqlSessionPermission,
     SqlUser,
+    current_workspace_id,
 )
 from omnigent.server.auth import _RESERVED_USERS
 
@@ -102,7 +102,9 @@ def build_domain_mapping(engine: Engine, domain: str) -> dict[str, str]:
     mapping: dict[str, str] = {}
     with Session(engine) as session:
         ids = (
-            session.execute(select(SqlUser.id).where(SqlUser.workspace_id == DEFAULT_WORKSPACE_ID))
+            session.execute(
+                select(SqlUser.id).where(SqlUser.workspace_id == current_workspace_id())
+            )
             .scalars()
             .all()
         )
@@ -152,12 +154,12 @@ def remap_identities(
             if old_id == new_id:
                 continue
 
-            old_user = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, old_id))
+            old_user = session.get(SqlUser, (current_workspace_id(), old_id))
             if old_user is None:
                 report.skipped_missing.append(old_id)
                 continue
 
-            new_user = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, new_id))
+            new_user = session.get(SqlUser, (current_workspace_id(), new_id))
             if new_user is not None:
                 if not force:
                     report.refused.append(f"{old_id} -> {new_id}")
@@ -183,7 +185,7 @@ def remap_identities(
             old_grants = (
                 session.execute(
                     select(SqlSessionPermission).where(
-                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlSessionPermission.workspace_id == current_workspace_id(),
                         SqlSessionPermission.user_id == old_id,
                     )
                 )
@@ -192,7 +194,7 @@ def remap_identities(
             )
             for grant in old_grants:
                 existing = session.get(
-                    SqlSessionPermission, (DEFAULT_WORKSPACE_ID, new_id, grant.conversation_id)
+                    SqlSessionPermission, (current_workspace_id(), new_id, grant.conversation_id)
                 )
                 if existing is not None:
                     if grant.level > existing.level:
@@ -211,7 +213,7 @@ def remap_identities(
             ):
                 result = session.execute(
                     update(model)
-                    .where(model.workspace_id == DEFAULT_WORKSPACE_ID, column == old_id)
+                    .where(model.workspace_id == current_workspace_id(), column == old_id)
                     .values(created_by=new_id)
                 )
                 report._bump(model.__tablename__, result.rowcount or 0)
@@ -222,7 +224,7 @@ def remap_identities(
                 result = session.execute(
                     update(SqlAccountToken)
                     .where(
-                        SqlAccountToken.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlAccountToken.workspace_id == current_workspace_id(),
                         column == old_id,
                     )
                     .values(**{column_name: new_id})
@@ -236,7 +238,7 @@ def remap_identities(
             old_hosts = (
                 session.execute(
                     select(SqlHost).where(
-                        SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlHost.workspace_id == current_workspace_id(),
                         SqlHost.owner == old_id,
                     )
                 )
@@ -244,7 +246,7 @@ def remap_identities(
                 .all()
             )
             for host in old_hosts:
-                clash = session.get(SqlHost, (DEFAULT_WORKSPACE_ID, new_id, host.name))
+                clash = session.get(SqlHost, (current_workspace_id(), new_id, host.name))
                 if clash is not None:
                     session.delete(host)  # new owner already has this host name
                 else:

--- a/omnigent/server/identity_migration.py
+++ b/omnigent/server/identity_migration.py
@@ -40,6 +40,7 @@ from sqlalchemy import Engine, select, update
 from sqlalchemy.orm import Session
 
 from omnigent.db.db_models import (
+    DEFAULT_WORKSPACE_ID,
     SqlAccountToken,
     SqlComment,
     SqlHost,
@@ -147,12 +148,12 @@ def remap_identities(
             if old_id == new_id:
                 continue
 
-            old_user = session.get(SqlUser, old_id)
+            old_user = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, old_id))
             if old_user is None:
                 report.skipped_missing.append(old_id)
                 continue
 
-            new_user = session.get(SqlUser, new_id)
+            new_user = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, new_id))
             if new_user is not None:
                 if not force:
                     report.refused.append(f"{old_id} -> {new_id}")
@@ -183,7 +184,9 @@ def remap_identities(
                 .all()
             )
             for grant in old_grants:
-                existing = session.get(SqlSessionPermission, (new_id, grant.conversation_id))
+                existing = session.get(
+                    SqlSessionPermission, (DEFAULT_WORKSPACE_ID, new_id, grant.conversation_id)
+                )
                 if existing is not None:
                     if grant.level > existing.level:
                         existing.level = grant.level
@@ -220,7 +223,7 @@ def remap_identities(
                 session.execute(select(SqlHost).where(SqlHost.owner == old_id)).scalars().all()
             )
             for host in old_hosts:
-                clash = session.get(SqlHost, (new_id, host.name))
+                clash = session.get(SqlHost, (DEFAULT_WORKSPACE_ID, new_id, host.name))
                 if clash is not None:
                     session.delete(host)  # new owner already has this host name
                 else:

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -92,7 +92,12 @@ class SqlAlchemyAgentStore(AgentStore):
             session_id: str | None = None
             if row.kind == AGENT_KIND_SESSION:
                 session_id = session.execute(
-                    select(SqlConversation.id).where(SqlConversation.agent_id == agent_id).limit(1)
+                    select(SqlConversation.id)
+                    .where(
+                        SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversation.agent_id == agent_id,
+                    )
+                    .limit(1)
                 ).scalar_one_or_none()
             return sql_agent_to_entity(row, session_id=session_id)
 
@@ -110,6 +115,7 @@ class SqlAlchemyAgentStore(AgentStore):
         with self._session() as session:
             row = session.execute(
                 select(SqlAgent).where(
+                    SqlAgent.workspace_id == DEFAULT_WORKSPACE_ID,
                     SqlAgent.name == name,
                     SqlAgent.kind == AGENT_KIND_TEMPLATE,
                 )
@@ -142,11 +148,12 @@ class SqlAlchemyAgentStore(AgentStore):
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
             is_template = SqlAgent.kind == AGENT_KIND_TEMPLATE
-            stmt = select(SqlAgent).where(is_template)
+            in_workspace = SqlAgent.workspace_id == DEFAULT_WORKSPACE_ID
+            stmt = select(SqlAgent).where(in_workspace, is_template)
             if after:
                 sub = (
                     select(SqlAgent.created_at)
-                    .where(SqlAgent.id == after, is_template)
+                    .where(in_workspace, SqlAgent.id == after, is_template)
                     .scalar_subquery()
                 )
                 ts_cmp = SqlAgent.created_at < sub if is_desc else SqlAgent.created_at > sub
@@ -155,7 +162,7 @@ class SqlAlchemyAgentStore(AgentStore):
             if before:
                 sub = (
                     select(SqlAgent.created_at)
-                    .where(SqlAgent.id == before, is_template)
+                    .where(in_workspace, SqlAgent.id == before, is_template)
                     .scalar_subquery()
                 )
                 ts_cmp = SqlAgent.created_at > sub if is_desc else SqlAgent.created_at < sub
@@ -192,7 +199,10 @@ class SqlAlchemyAgentStore(AgentStore):
             return {}
         with self._session() as session:
             rows = session.execute(
-                select(SqlAgent.id, SqlAgent.name).where(SqlAgent.id.in_(agent_ids))
+                select(SqlAgent.id, SqlAgent.name).where(
+                    SqlAgent.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlAgent.id.in_(agent_ids),
+                )
             ).all()
             return {row.id: row.name for row in rows}
 
@@ -222,7 +232,12 @@ class SqlAlchemyAgentStore(AgentStore):
             session_id: str | None = None
             if row.kind == AGENT_KIND_SESSION:
                 session_id = session.execute(
-                    select(SqlConversation.id).where(SqlConversation.agent_id == agent_id).limit(1)
+                    select(SqlConversation.id)
+                    .where(
+                        SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversation.agent_id == agent_id,
+                    )
+                    .limit(1)
                 ).scalar_one_or_none()
             return sql_agent_to_entity(row, session_id=session_id)
 

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -8,9 +8,9 @@ from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
     AGENT_KIND_SESSION,
     AGENT_KIND_TEMPLATE,
-    DEFAULT_WORKSPACE_ID,
     SqlAgent,
     SqlConversation,
+    current_workspace_id,
 )
 from omnigent.db.utils import (
     get_or_create_engine,
@@ -84,7 +84,7 @@ class SqlAlchemyAgentStore(AgentStore):
         :returns: The :class:`Agent` if found, otherwise ``None``.
         """
         with self._session() as session:
-            row = session.get(SqlAgent, (DEFAULT_WORKSPACE_ID, agent_id))
+            row = session.get(SqlAgent, (current_workspace_id(), agent_id))
             if row is None:
                 return None
             # For session-scoped agents, derive the owning conversation id
@@ -94,7 +94,7 @@ class SqlAlchemyAgentStore(AgentStore):
                 session_id = session.execute(
                     select(SqlConversation.id)
                     .where(
-                        SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversation.workspace_id == current_workspace_id(),
                         SqlConversation.agent_id == agent_id,
                     )
                     .limit(1)
@@ -115,7 +115,7 @@ class SqlAlchemyAgentStore(AgentStore):
         with self._session() as session:
             row = session.execute(
                 select(SqlAgent).where(
-                    SqlAgent.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlAgent.workspace_id == current_workspace_id(),
                     SqlAgent.name == name,
                     SqlAgent.kind == AGENT_KIND_TEMPLATE,
                 )
@@ -148,7 +148,7 @@ class SqlAlchemyAgentStore(AgentStore):
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
             is_template = SqlAgent.kind == AGENT_KIND_TEMPLATE
-            in_workspace = SqlAgent.workspace_id == DEFAULT_WORKSPACE_ID
+            in_workspace = SqlAgent.workspace_id == current_workspace_id()
             stmt = select(SqlAgent).where(in_workspace, is_template)
             if after:
                 sub = (
@@ -200,7 +200,7 @@ class SqlAlchemyAgentStore(AgentStore):
         with self._session() as session:
             rows = session.execute(
                 select(SqlAgent.id, SqlAgent.name).where(
-                    SqlAgent.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlAgent.workspace_id == current_workspace_id(),
                     SqlAgent.id.in_(agent_ids),
                 )
             ).all()
@@ -223,7 +223,7 @@ class SqlAlchemyAgentStore(AgentStore):
             found.
         """
         with self._session() as session:
-            row = session.get(SqlAgent, (DEFAULT_WORKSPACE_ID, agent_id))
+            row = session.get(SqlAgent, (current_workspace_id(), agent_id))
             if not row:
                 return None
             row.bundle_location = bundle_location
@@ -234,7 +234,7 @@ class SqlAlchemyAgentStore(AgentStore):
                 session_id = session.execute(
                     select(SqlConversation.id)
                     .where(
-                        SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversation.workspace_id == current_workspace_id(),
                         SqlConversation.agent_id == agent_id,
                     )
                     .limit(1)
@@ -251,7 +251,7 @@ class SqlAlchemyAgentStore(AgentStore):
             it did not exist.
         """
         with self._session() as session:
-            row = session.get(SqlAgent, (DEFAULT_WORKSPACE_ID, agent_id))
+            row = session.get(SqlAgent, (current_workspace_id(), agent_id))
             if not row:
                 return False
             session.delete(row)

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -8,6 +8,7 @@ from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
     AGENT_KIND_SESSION,
     AGENT_KIND_TEMPLATE,
+    DEFAULT_WORKSPACE_ID,
     SqlAgent,
     SqlConversation,
 )
@@ -83,7 +84,7 @@ class SqlAlchemyAgentStore(AgentStore):
         :returns: The :class:`Agent` if found, otherwise ``None``.
         """
         with self._session() as session:
-            row = session.get(SqlAgent, agent_id)
+            row = session.get(SqlAgent, (DEFAULT_WORKSPACE_ID, agent_id))
             if row is None:
                 return None
             # For session-scoped agents, derive the owning conversation id
@@ -212,7 +213,7 @@ class SqlAlchemyAgentStore(AgentStore):
             found.
         """
         with self._session() as session:
-            row = session.get(SqlAgent, agent_id)
+            row = session.get(SqlAgent, (DEFAULT_WORKSPACE_ID, agent_id))
             if not row:
                 return None
             row.bundle_location = bundle_location
@@ -235,7 +236,7 @@ class SqlAlchemyAgentStore(AgentStore):
             it did not exist.
         """
         with self._session() as session:
-            row = session.get(SqlAgent, agent_id)
+            row = session.get(SqlAgent, (DEFAULT_WORKSPACE_ID, agent_id))
             if not row:
                 return False
             session.delete(row)

--- a/omnigent/stores/comment_store/sqlalchemy_store.py
+++ b/omnigent/stores/comment_store/sqlalchemy_store.py
@@ -102,7 +102,10 @@ class SqlAlchemyCommentStore(CommentStore):
         path: str | None = None,
     ) -> list[Comment]:
         """Return comments for a conversation. See base class for contract."""
-        stmt = select(SqlComment).where(SqlComment.conversation_id == conversation_id)
+        stmt = select(SqlComment).where(
+            SqlComment.workspace_id == DEFAULT_WORKSPACE_ID,
+            SqlComment.conversation_id == conversation_id,
+        )
         if path is not None:
             stmt = stmt.where(SqlComment.path == path)
         stmt = stmt.order_by(SqlComment.created_at)
@@ -153,7 +156,10 @@ class SqlAlchemyCommentStore(CommentStore):
                 func.count(SqlComment.id),
                 func.max(SqlComment.updated_at),
             )
-            .where(SqlComment.conversation_id.in_(conversation_ids))
+            .where(
+                SqlComment.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlComment.conversation_id.in_(conversation_ids),
+            )
             .group_by(SqlComment.conversation_id)
         )
         with self._session() as session:
@@ -164,6 +170,9 @@ class SqlAlchemyCommentStore(CommentStore):
 
     def remove_conversation(self, conversation_id: str) -> None:
         """Delete all comments for a conversation. See base class for contract."""
-        stmt = delete(SqlComment).where(SqlComment.conversation_id == conversation_id)
+        stmt = delete(SqlComment).where(
+            SqlComment.workspace_id == DEFAULT_WORKSPACE_ID,
+            SqlComment.conversation_id == conversation_id,
+        )
         with self._session() as session:
             session.execute(stmt)

--- a/omnigent/stores/comment_store/sqlalchemy_store.py
+++ b/omnigent/stores/comment_store/sqlalchemy_store.py
@@ -6,7 +6,7 @@ import uuid
 
 from sqlalchemy import delete, func, select
 
-from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, SqlComment
+from omnigent.db.db_models import SqlComment, current_workspace_id
 from omnigent.db.utils import (
     get_or_create_engine,
     make_managed_session_maker,
@@ -58,7 +58,7 @@ class SqlAlchemyCommentStore(CommentStore):
     def get(self, comment_id: str, conversation_id: str) -> Comment | None:
         """Fetch a single comment by id, scoped to a conversation. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlComment, (DEFAULT_WORKSPACE_ID, comment_id))
+            row = session.get(SqlComment, (current_workspace_id(), comment_id))
             if row is None or row.conversation_id != conversation_id:
                 return None
             return _to_entity(row)
@@ -103,7 +103,7 @@ class SqlAlchemyCommentStore(CommentStore):
     ) -> list[Comment]:
         """Return comments for a conversation. See base class for contract."""
         stmt = select(SqlComment).where(
-            SqlComment.workspace_id == DEFAULT_WORKSPACE_ID,
+            SqlComment.workspace_id == current_workspace_id(),
             SqlComment.conversation_id == conversation_id,
         )
         if path is not None:
@@ -123,7 +123,7 @@ class SqlAlchemyCommentStore(CommentStore):
     ) -> Comment | None:
         """Update a comment's fields, scoped to a conversation. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlComment, (DEFAULT_WORKSPACE_ID, comment_id))
+            row = session.get(SqlComment, (current_workspace_id(), comment_id))
             if row is None or row.conversation_id != conversation_id:
                 return None
             if status is not None:
@@ -137,7 +137,7 @@ class SqlAlchemyCommentStore(CommentStore):
     def delete(self, comment_id: str, conversation_id: str) -> Comment | None:
         """Delete a single comment by id, scoped to a conversation. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlComment, (DEFAULT_WORKSPACE_ID, comment_id))
+            row = session.get(SqlComment, (current_workspace_id(), comment_id))
             if row is None or row.conversation_id != conversation_id:
                 return None
             entity = _to_entity(row)
@@ -157,7 +157,7 @@ class SqlAlchemyCommentStore(CommentStore):
                 func.max(SqlComment.updated_at),
             )
             .where(
-                SqlComment.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlComment.workspace_id == current_workspace_id(),
                 SqlComment.conversation_id.in_(conversation_ids),
             )
             .group_by(SqlComment.conversation_id)
@@ -171,7 +171,7 @@ class SqlAlchemyCommentStore(CommentStore):
     def remove_conversation(self, conversation_id: str) -> None:
         """Delete all comments for a conversation. See base class for contract."""
         stmt = delete(SqlComment).where(
-            SqlComment.workspace_id == DEFAULT_WORKSPACE_ID,
+            SqlComment.workspace_id == current_workspace_id(),
             SqlComment.conversation_id == conversation_id,
         )
         with self._session() as session:

--- a/omnigent/stores/comment_store/sqlalchemy_store.py
+++ b/omnigent/stores/comment_store/sqlalchemy_store.py
@@ -6,7 +6,7 @@ import uuid
 
 from sqlalchemy import delete, func, select
 
-from omnigent.db.db_models import SqlComment
+from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, SqlComment
 from omnigent.db.utils import (
     get_or_create_engine,
     make_managed_session_maker,
@@ -58,7 +58,7 @@ class SqlAlchemyCommentStore(CommentStore):
     def get(self, comment_id: str, conversation_id: str) -> Comment | None:
         """Fetch a single comment by id, scoped to a conversation. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlComment, comment_id)
+            row = session.get(SqlComment, (DEFAULT_WORKSPACE_ID, comment_id))
             if row is None or row.conversation_id != conversation_id:
                 return None
             return _to_entity(row)
@@ -120,7 +120,7 @@ class SqlAlchemyCommentStore(CommentStore):
     ) -> Comment | None:
         """Update a comment's fields, scoped to a conversation. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlComment, comment_id)
+            row = session.get(SqlComment, (DEFAULT_WORKSPACE_ID, comment_id))
             if row is None or row.conversation_id != conversation_id:
                 return None
             if status is not None:
@@ -134,7 +134,7 @@ class SqlAlchemyCommentStore(CommentStore):
     def delete(self, comment_id: str, conversation_id: str) -> Comment | None:
         """Delete a single comment by id, scoped to a conversation. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlComment, comment_id)
+            row = session.get(SqlComment, (DEFAULT_WORKSPACE_ID, comment_id))
             if row is None or row.conversation_id != conversation_id:
                 return None
             entity = _to_entity(row)

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -368,6 +368,7 @@ def _fetch_labels(
     """
     rows = session.execute(
         select(SqlConversationLabel.key, SqlConversationLabel.value).where(
+            SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
             SqlConversationLabel.conversation_id == conversation_id,
         )
     ).all()
@@ -400,7 +401,10 @@ def _fetch_labels_bulk(
             SqlConversationLabel.conversation_id,
             SqlConversationLabel.key,
             SqlConversationLabel.value,
-        ).where(SqlConversationLabel.conversation_id.in_(conversation_ids))
+        ).where(
+            SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+            SqlConversationLabel.conversation_id.in_(conversation_ids),
+        )
     ).all()
     out: dict[str, dict[str, str]] = {}
     for conv_id, key, value in rows:
@@ -450,6 +454,7 @@ def _ranked_latest_message_item_ids(conversation_ids: list[str]) -> Subquery:
             .label("row_num"),
         )
         .where(
+            SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
             SqlConversationItem.conversation_id.in_(conversation_ids),
             SqlConversationItem.type == "message",
         )
@@ -538,7 +543,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         if self._supports_for_update:
             stmt = (
                 select(SqlConversation.id)
-                .where(SqlConversation.id == conversation_id)
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id == conversation_id,
+                )
                 .with_for_update()
             )
             session.execute(stmt)
@@ -733,7 +741,8 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             rows = session.execute(
                 select(SqlConversation.id, SqlConversation.runner_id).where(
-                    SqlConversation.id.in_(unique_ids)
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id.in_(unique_ids),
                 )
             ).all()
         return {row.id: row.runner_id for row in rows}
@@ -764,7 +773,10 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversation.id,
                     SqlConversation.runner_id,
                     SqlConversation.host_id,
-                ).where(SqlConversation.id.in_(unique_ids))
+                ).where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id.in_(unique_ids),
+                )
             ).all()
             # One pass over the fork-source connectivity marker, which
             # signals on presence (its value is the source id).
@@ -774,6 +786,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversationLabel.key,
                     SqlConversationLabel.value,
                 ).where(
+                    SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
                     SqlConversationLabel.conversation_id.in_(unique_ids),
                     SqlConversationLabel.key.in_([FORK_SOURCE_LABEL_KEY]),
                 )
@@ -808,7 +821,12 @@ class SqlAlchemyConversationStore(ConversationStore):
         unique_ids = list(set(conversation_ids))
         with self._session() as session:
             rows = list(
-                session.execute(select(SqlConversation).where(SqlConversation.id.in_(unique_ids)))
+                session.execute(
+                    select(SqlConversation).where(
+                        SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversation.id.in_(unique_ids),
+                    )
+                )
                 .scalars()
                 .all()
             )
@@ -847,6 +865,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             rows = session.execute(
                 select(SqlConversation.parent_conversation_id, SqlConversation.id)
+                .where(SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID)
                 .where(SqlConversation.kind == "sub_agent")
                 .where(SqlConversation.parent_conversation_id.in_(unique_ids))
                 .order_by(
@@ -912,7 +931,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             session.execute(
                 update(SqlConversation)
-                .where(SqlConversation.id == conversation_id)
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id == conversation_id,
+                )
                 .values(session_state=json.dumps(state))
             )
 
@@ -939,7 +961,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             session.execute(
                 update(SqlConversation)
-                .where(SqlConversation.id == conversation_id)
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id == conversation_id,
+                )
                 .values(session_usage=json.dumps(usage))
             )
 
@@ -975,7 +1000,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         from omnigent.stores.conversation_store import apply_session_usage_delta
 
         with self._session_immediate() as session:
-            q = select(SqlConversation).where(SqlConversation.id == conversation_id)
+            q = select(SqlConversation).where(
+                SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlConversation.id == conversation_id,
+            )
             if self._supports_for_update:
                 q = q.with_for_update()
             row = session.scalars(q).first()
@@ -985,7 +1013,10 @@ class SqlAlchemyConversationStore(ConversationStore):
             apply_session_usage_delta(current, delta)
             session.execute(
                 update(SqlConversation)
-                .where(SqlConversation.id == conversation_id)
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id == conversation_id,
+                )
                 .values(session_usage=json.dumps(current))
             )
             return current
@@ -1213,6 +1244,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             return session.execute(
                 select(SqlSessionPermission.user_id)
+                .where(SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID)
                 .where(SqlSessionPermission.conversation_id == conversation_id)
                 .where(SqlSessionPermission.user_id != RESERVED_USER_PUBLIC)
                 .order_by(SqlSessionPermission.level.desc())
@@ -1266,14 +1298,16 @@ class SqlAlchemyConversationStore(ConversationStore):
                 if conversation_id is not None:
                     stmt = text(
                         "SELECT ci.id FROM conversation_items ci "
-                        "WHERE ci.conversation_id = :cid "
+                        "WHERE ci.workspace_id = 0 "
+                        "AND ci.conversation_id = :cid "
                         "AND ci.data::text ILIKE :query "
                         "ORDER BY ci.created_at DESC LIMIT :limit"
                     )
                 else:
                     stmt = text(
                         "SELECT ci.id FROM conversation_items ci "
-                        "WHERE ci.data::text ILIKE :query "
+                        "WHERE ci.workspace_id = 0 "
+                        "AND ci.data::text ILIKE :query "
                         "ORDER BY ci.created_at DESC LIMIT :limit"
                     )
                 query = like_pattern
@@ -1285,7 +1319,10 @@ class SqlAlchemyConversationStore(ConversationStore):
                 return []
             rows = (
                 session.execute(
-                    select(SqlConversationItem).where(SqlConversationItem.id.in_(item_ids))
+                    select(SqlConversationItem).where(
+                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.id.in_(item_ids),
+                    )
                 )
                 .scalars()
                 .all()
@@ -1326,14 +1363,18 @@ class SqlAlchemyConversationStore(ConversationStore):
             is_asc = order == "asc"
             sort_fn = asc if is_asc else desc
             stmt = select(SqlConversationItem).where(
-                SqlConversationItem.conversation_id == conversation_id
+                SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlConversationItem.conversation_id == conversation_id,
             )
             if type is not None:
                 stmt = stmt.where(SqlConversationItem.type == type)
             if after:
                 sub = (
                     select(SqlConversationItem.position)
-                    .where(SqlConversationItem.id == after)
+                    .where(
+                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.id == after,
+                    )
                     .scalar_subquery()
                 )
                 # "after" = further in sort direction
@@ -1345,7 +1386,10 @@ class SqlAlchemyConversationStore(ConversationStore):
             if before:
                 sub = (
                     select(SqlConversationItem.position)
-                    .where(SqlConversationItem.id == before)
+                    .where(
+                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.id == before,
+                    )
                     .scalar_subquery()
                 )
                 # "before" = opposite of sort direction
@@ -1399,7 +1443,10 @@ class SqlAlchemyConversationStore(ConversationStore):
                 session.execute(
                     select(SqlConversationItem)
                     .join(ranked, SqlConversationItem.id == ranked.c.item_id)
-                    .where(ranked.c.row_num <= per_conversation_limit)
+                    .where(
+                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        ranked.c.row_num <= per_conversation_limit,
+                    )
                     .order_by(
                         SqlConversationItem.conversation_id,
                         desc(SqlConversationItem.position),
@@ -1464,7 +1511,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                 next_pos = (
                     session.execute(
                         select(func.coalesce(func.max(SqlConversationItem.position), -1)).where(
-                            SqlConversationItem.conversation_id == conversation_id
+                            SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                            SqlConversationItem.conversation_id == conversation_id,
                         )
                     ).scalar_one()
                     + 1
@@ -1547,6 +1595,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversation.id == SqlConversationLabel.conversation_id,
                 )
                 .where(
+                    SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
                     SqlConversationLabel.key == PROJECT_LABEL_KEY,
                     SqlConversation.archived.is_(False),
                 )
@@ -1555,7 +1605,8 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
             if accessible_by is not None:
                 accessible_ids = select(SqlSessionPermission.conversation_id).where(
-                    SqlSessionPermission.user_id == accessible_by
+                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlSessionPermission.user_id == accessible_by,
                 )
                 stmt = stmt.where(SqlConversationLabel.conversation_id.in_(accessible_ids))
             return [row[0] for row in session.execute(stmt).all()]
@@ -1576,6 +1627,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             session.execute(
                 delete(SqlConversationLabel).where(
+                    SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
                     SqlConversationLabel.conversation_id == conversation_id,
                     SqlConversationLabel.key == key,
                 )
@@ -1655,7 +1707,9 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
-            stmt = select(SqlConversation)
+            stmt = select(SqlConversation).where(
+                SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID
+            )
             # Filter by kind when specified (None = no filter).
             if kind is not None:
                 stmt = stmt.where(SqlConversation.kind == kind)
@@ -1673,7 +1727,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                 stmt = stmt.where(SqlConversation.archived.is_(False))
             if agent_name is not None:
                 stmt = stmt.join(SqlAgent, SqlAgent.id == SqlConversation.agent_id).where(
-                    SqlAgent.name == agent_name
+                    SqlAgent.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlAgent.name == agent_name,
                 )
             if agent_id is not None:
                 # Filter by the agent_id column on conversations directly
@@ -1683,7 +1738,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                 stmt = stmt.where(SqlConversation.agent_id == agent_id)
             if accessible_by is not None:
                 accessible_ids = select(SqlSessionPermission.conversation_id).where(
-                    SqlSessionPermission.user_id == accessible_by
+                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlSessionPermission.user_id == accessible_by,
                 )
                 stmt = stmt.where(SqlConversation.id.in_(accessible_ids))
             if search_query:
@@ -1691,7 +1747,10 @@ class SqlAlchemyConversationStore(ConversationStore):
                 title_match = func.lower(SqlConversation.title).like(pattern)
                 content_match = SqlConversation.id.in_(
                     select(SqlConversationItem.conversation_id)
-                    .where(func.lower(SqlConversationItem.search_text).like(pattern))
+                    .where(
+                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        func.lower(SqlConversationItem.search_text).like(pattern),
+                    )
                     .distinct()
                 )
                 stmt = stmt.where(or_(title_match, content_match))
@@ -1701,7 +1760,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     stmt = stmt.where(
                         SqlConversation.id.not_in(
                             select(SqlConversationLabel.conversation_id).where(
-                                SqlConversationLabel.key == PROJECT_LABEL_KEY
+                                SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+                                SqlConversationLabel.key == PROJECT_LABEL_KEY,
                             )
                         )
                     )
@@ -1710,6 +1770,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     stmt = stmt.where(
                         SqlConversation.id.in_(
                             select(SqlConversationLabel.conversation_id).where(
+                                SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
                                 SqlConversationLabel.key == PROJECT_LABEL_KEY,
                                 SqlConversationLabel.value == project,
                             )
@@ -1806,7 +1867,14 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``before`` cursors.
         :returns: The statement with the cursor WHERE clause applied.
         """
-        sub = select(sort_col).where(SqlConversation.id == cursor_id).scalar_subquery()
+        sub = (
+            select(sort_col)
+            .where(
+                SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlConversation.id == cursor_id,
+            )
+            .scalar_subquery()
+        )
         # When tiebreaker_col is SqlConversation.id (non-SQLite), its value for
         # the cursor row is cursor_id itself — no extra subquery needed.
         # For SQLite rowid (a literal_column), we must query the DB.
@@ -1814,7 +1882,12 @@ class SqlAlchemyConversationStore(ConversationStore):
             tiebreaker_val: Any = cursor_id
         else:
             tiebreaker_val = (
-                select(tiebreaker_col).where(SqlConversation.id == cursor_id).scalar_subquery()
+                select(tiebreaker_col)
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id == cursor_id,
+                )
+                .scalar_subquery()
             )
         # "after" (forward=True) = further in sort direction;
         # "before" (forward=False) = opposite of sort direction.
@@ -1941,7 +2014,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             stmt = (
                 update(SqlConversation)
-                .where(SqlConversation.id == conversation_id)
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id == conversation_id,
+                )
                 .where(SqlConversation.runner_id.is_(None))
                 .values(runner_id=runner_id)
             )
@@ -2034,7 +2110,14 @@ class SqlAlchemyConversationStore(ConversationStore):
         :returns: List of :class:`Conversation` entities.
         """
         with self._session() as session:
-            rows = session.query(SqlConversation).filter(SqlConversation.host_id == host_id).all()
+            rows = (
+                session.query(SqlConversation)
+                .filter(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.host_id == host_id,
+                )
+                .all()
+            )
             return [_to_conversation(row) for row in rows]
 
     def list_conversations_by_runner_id(
@@ -2050,7 +2133,12 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         with self._session() as session:
             rows = (
-                session.query(SqlConversation).filter(SqlConversation.runner_id == runner_id).all()
+                session.query(SqlConversation)
+                .filter(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.runner_id == runner_id,
+                )
+                .all()
             )
             return [_to_conversation(row) for row in rows]
 
@@ -2438,6 +2526,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             if up_to_response_id is not None:
                 cutoff_position = session.execute(
                     select(func.max(SqlConversationItem.position)).where(
+                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
                         SqlConversationItem.conversation_id == source_conversation_id,
                         SqlConversationItem.response_id == up_to_response_id,
                     )
@@ -2449,7 +2538,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     )
                 last_position = session.execute(
                     select(func.max(SqlConversationItem.position)).where(
-                        SqlConversationItem.conversation_id == source_conversation_id
+                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.conversation_id == source_conversation_id,
                     )
                 ).scalar_one()
                 truncated = cutoff_position < last_position
@@ -2458,7 +2548,10 @@ class SqlAlchemyConversationStore(ConversationStore):
             # the original chronological order.
             items_query = (
                 select(SqlConversationItem)
-                .where(SqlConversationItem.conversation_id == source_conversation_id)
+                .where(
+                    SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversationItem.conversation_id == source_conversation_id,
+                )
                 .order_by(SqlConversationItem.position.asc())
             )
             if cutoff_position is not None:
@@ -2679,6 +2772,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             if present_drop:
                 session.execute(
                     delete(SqlConversationLabel).where(
+                        SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
                         SqlConversationLabel.conversation_id == conversation_id,
                         SqlConversationLabel.key.in_(present_drop),
                     )
@@ -2718,12 +2812,16 @@ class SqlAlchemyConversationStore(ConversationStore):
             # clean up the full subtree in one pass.
             cte = (
                 select(SqlConversation.id)
-                .where(SqlConversation.id == conversation_id)
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id == conversation_id,
+                )
                 .cte(name="subtree", recursive=True)
             )
             cte = cte.union_all(
                 select(SqlConversation.id).where(
-                    SqlConversation.parent_conversation_id == cte.c.id
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.parent_conversation_id == cte.c.id,
                 )
             )
             subtree_ids_rows = session.execute(select(cte.c.id)).fetchall()
@@ -2736,19 +2834,32 @@ class SqlAlchemyConversationStore(ConversationStore):
 
             session.execute(
                 delete(SqlConversationItem).where(
-                    SqlConversationItem.conversation_id.in_(subtree_ids)
+                    SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversationItem.conversation_id.in_(subtree_ids),
                 )
             )
             session.execute(
                 delete(SqlConversationLabel).where(
-                    SqlConversationLabel.conversation_id.in_(subtree_ids)
+                    SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversationLabel.conversation_id.in_(subtree_ids),
                 )
             )
-            session.execute(delete(SqlComment).where(SqlComment.conversation_id.in_(subtree_ids)))
-            session.execute(delete(SqlPolicy).where(SqlPolicy.session_id.in_(subtree_ids)))
+            session.execute(
+                delete(SqlComment).where(
+                    SqlComment.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlComment.conversation_id.in_(subtree_ids),
+                )
+            )
+            session.execute(
+                delete(SqlPolicy).where(
+                    SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlPolicy.session_id.in_(subtree_ids),
+                )
+            )
             session.execute(
                 delete(SqlSessionPermission).where(
-                    SqlSessionPermission.conversation_id.in_(subtree_ids)
+                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlSessionPermission.conversation_id.in_(subtree_ids),
                 )
             )
 
@@ -2756,6 +2867,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             # ordering constraints are satisfied.
             session.execute(
                 delete(SqlConversation).where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
                     SqlConversation.id.in_(subtree_ids),
                     SqlConversation.id != conversation_id,
                 )

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -26,7 +26,6 @@ from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY
 from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
     AGENT_KIND_SESSION,
-    DEFAULT_WORKSPACE_ID,
     LABEL_VALUE_MAX_LEN,
     SqlAgent,
     SqlComment,
@@ -36,6 +35,7 @@ from omnigent.db.db_models import (
     SqlPolicy,
     SqlSessionPermission,
     SqlUserDailyCost,
+    current_workspace_id,
 )
 from omnigent.db.utils import (
     _supports_fts5,
@@ -293,7 +293,7 @@ def _upsert_labels(
     for row in rows:
         existing = session.get(
             SqlConversationLabel,
-            (DEFAULT_WORKSPACE_ID, row["conversation_id"], row["key"]),
+            (current_workspace_id(), row["conversation_id"], row["key"]),
         )
         if existing is None:
             session.add(SqlConversationLabel(**row))
@@ -368,7 +368,7 @@ def _fetch_labels(
     """
     rows = session.execute(
         select(SqlConversationLabel.key, SqlConversationLabel.value).where(
-            SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+            SqlConversationLabel.workspace_id == current_workspace_id(),
             SqlConversationLabel.conversation_id == conversation_id,
         )
     ).all()
@@ -402,7 +402,7 @@ def _fetch_labels_bulk(
             SqlConversationLabel.key,
             SqlConversationLabel.value,
         ).where(
-            SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+            SqlConversationLabel.workspace_id == current_workspace_id(),
             SqlConversationLabel.conversation_id.in_(conversation_ids),
         )
     ).all()
@@ -454,7 +454,7 @@ def _ranked_latest_message_item_ids(conversation_ids: list[str]) -> Subquery:
             .label("row_num"),
         )
         .where(
-            SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+            SqlConversationItem.workspace_id == current_workspace_id(),
             SqlConversationItem.conversation_id.in_(conversation_ids),
             SqlConversationItem.type == "message",
         )
@@ -544,7 +544,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             stmt = (
                 select(SqlConversation.id)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id == conversation_id,
                 )
                 .with_for_update()
@@ -645,7 +645,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     root_id: str = new_id
                 else:
                     parent_row = session.get(
-                        SqlConversation, (DEFAULT_WORKSPACE_ID, parent_conversation_id)
+                        SqlConversation, (current_workspace_id(), parent_conversation_id)
                     )
                     if parent_row is None:
                         raise ConversationNotFoundError(
@@ -723,7 +723,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``None``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 return None
             return _to_conversation(row, _fetch_labels(session, conversation_id))
@@ -741,7 +741,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             rows = session.execute(
                 select(SqlConversation.id, SqlConversation.runner_id).where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id.in_(unique_ids),
                 )
             ).all()
@@ -774,7 +774,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversation.runner_id,
                     SqlConversation.host_id,
                 ).where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id.in_(unique_ids),
                 )
             ).all()
@@ -786,7 +786,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversationLabel.key,
                     SqlConversationLabel.value,
                 ).where(
-                    SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversationLabel.workspace_id == current_workspace_id(),
                     SqlConversationLabel.conversation_id.in_(unique_ids),
                     SqlConversationLabel.key.in_([FORK_SOURCE_LABEL_KEY]),
                 )
@@ -823,7 +823,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             rows = list(
                 session.execute(
                     select(SqlConversation).where(
-                        SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversation.workspace_id == current_workspace_id(),
                         SqlConversation.id.in_(unique_ids),
                     )
                 )
@@ -865,7 +865,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             rows = session.execute(
                 select(SqlConversation.parent_conversation_id, SqlConversation.id)
-                .where(SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID)
+                .where(SqlConversation.workspace_id == current_workspace_id())
                 .where(SqlConversation.kind == "sub_agent")
                 .where(SqlConversation.parent_conversation_id.in_(unique_ids))
                 .order_by(
@@ -932,7 +932,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             session.execute(
                 update(SqlConversation)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id == conversation_id,
                 )
                 .values(session_state=json.dumps(state))
@@ -962,7 +962,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             session.execute(
                 update(SqlConversation)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id == conversation_id,
                 )
                 .values(session_usage=json.dumps(usage))
@@ -1001,7 +1001,7 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         with self._session_immediate() as session:
             q = select(SqlConversation).where(
-                SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlConversation.workspace_id == current_workspace_id(),
                 SqlConversation.id == conversation_id,
             )
             if self._supports_for_update:
@@ -1014,7 +1014,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             session.execute(
                 update(SqlConversation)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id == conversation_id,
                 )
                 .values(session_usage=json.dumps(current))
@@ -1049,7 +1049,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             # Generic dialect fallback — SELECT-then-INSERT/UPDATE in one
             # transaction (race-safe under SERIALIZABLE / SQLite's
             # single-writer semantics).
-            existing = session.get(SqlUserDailyCost, (DEFAULT_WORKSPACE_ID, user_id, day_utc))
+            existing = session.get(SqlUserDailyCost, (current_workspace_id(), user_id, day_utc))
             if existing is None:
                 session.add(
                     SqlUserDailyCost(
@@ -1127,7 +1127,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             exists for ``(user_id, day_utc)``.
         """
         with self._session() as session:
-            row = session.get(SqlUserDailyCost, (DEFAULT_WORKSPACE_ID, user_id, day_utc))
+            row = session.get(SqlUserDailyCost, (current_workspace_id(), user_id, day_utc))
             return float(row.cost_usd) if row is not None else 0.0
 
     def get_daily_cost_state(self, user_id: str, day_utc: str) -> dict[str, float]:
@@ -1145,7 +1145,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             both ``0.0`` when no row exists for ``(user_id, day_utc)``.
         """
         with self._session() as session:
-            row = session.get(SqlUserDailyCost, (DEFAULT_WORKSPACE_ID, user_id, day_utc))
+            row = session.get(SqlUserDailyCost, (current_workspace_id(), user_id, day_utc))
             if row is None:
                 return {"cost_usd": 0.0, "ask_approved_usd": 0.0}
             return {
@@ -1205,7 +1205,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 session.execute(stmt)
                 return
             # Generic dialect fallback — SELECT-then-INSERT/UPDATE.
-            existing = session.get(SqlUserDailyCost, (DEFAULT_WORKSPACE_ID, user_id, day_utc))
+            existing = session.get(SqlUserDailyCost, (current_workspace_id(), user_id, day_utc))
             if existing is None:
                 session.add(
                     SqlUserDailyCost(
@@ -1244,7 +1244,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             return session.execute(
                 select(SqlSessionPermission.user_id)
-                .where(SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID)
+                .where(SqlSessionPermission.workspace_id == current_workspace_id())
                 .where(SqlSessionPermission.conversation_id == conversation_id)
                 .where(SqlSessionPermission.user_id != RESERVED_USER_PUBLIC)
                 .order_by(SqlSessionPermission.level.desc())
@@ -1298,7 +1298,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 if conversation_id is not None:
                     stmt = text(
                         "SELECT ci.id FROM conversation_items ci "
-                        "WHERE ci.workspace_id = 0 "
+                        "WHERE ci.workspace_id = :ws "
                         "AND ci.conversation_id = :cid "
                         "AND ci.data::text ILIKE :query "
                         "ORDER BY ci.created_at DESC LIMIT :limit"
@@ -1306,12 +1306,16 @@ class SqlAlchemyConversationStore(ConversationStore):
                 else:
                     stmt = text(
                         "SELECT ci.id FROM conversation_items ci "
-                        "WHERE ci.workspace_id = 0 "
+                        "WHERE ci.workspace_id = :ws "
                         "AND ci.data::text ILIKE :query "
                         "ORDER BY ci.created_at DESC LIMIT :limit"
                     )
                 query = like_pattern
-            params: dict[str, str | int] = {"query": query, "limit": limit}
+            params: dict[str, str | int] = {
+                "query": query,
+                "limit": limit,
+                "ws": current_workspace_id(),
+            }
             if conversation_id is not None:
                 params["cid"] = conversation_id
             item_ids = [row[0] for row in session.execute(stmt, params).fetchall()]
@@ -1320,7 +1324,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             rows = (
                 session.execute(
                     select(SqlConversationItem).where(
-                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.workspace_id == current_workspace_id(),
                         SqlConversationItem.id.in_(item_ids),
                     )
                 )
@@ -1363,7 +1367,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             is_asc = order == "asc"
             sort_fn = asc if is_asc else desc
             stmt = select(SqlConversationItem).where(
-                SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlConversationItem.workspace_id == current_workspace_id(),
                 SqlConversationItem.conversation_id == conversation_id,
             )
             if type is not None:
@@ -1372,7 +1376,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 sub = (
                     select(SqlConversationItem.position)
                     .where(
-                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.workspace_id == current_workspace_id(),
                         SqlConversationItem.id == after,
                     )
                     .scalar_subquery()
@@ -1387,7 +1391,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 sub = (
                     select(SqlConversationItem.position)
                     .where(
-                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.workspace_id == current_workspace_id(),
                         SqlConversationItem.id == before,
                     )
                     .scalar_subquery()
@@ -1444,7 +1448,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     select(SqlConversationItem)
                     .join(ranked, SqlConversationItem.id == ranked.c.item_id)
                     .where(
-                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.workspace_id == current_workspace_id(),
                         ranked.c.row_num <= per_conversation_limit,
                     )
                     .order_by(
@@ -1488,7 +1492,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             self._lock_conversation(session, conversation_id)
 
             # Bump updated_at on the conversation.
-            conv_row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            conv_row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if conv_row is not None:
                 conv_row.updated_at = now
 
@@ -1511,7 +1515,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 next_pos = (
                     session.execute(
                         select(func.coalesce(func.max(SqlConversationItem.position), -1)).where(
-                            SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                            SqlConversationItem.workspace_id == current_workspace_id(),
                             SqlConversationItem.conversation_id == conversation_id,
                         )
                     ).scalar_one()
@@ -1595,8 +1599,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversation.id == SqlConversationLabel.conversation_id,
                 )
                 .where(
-                    SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversationLabel.workspace_id == current_workspace_id(),
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversationLabel.key == PROJECT_LABEL_KEY,
                     SqlConversation.archived.is_(False),
                 )
@@ -1605,7 +1609,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
             if accessible_by is not None:
                 accessible_ids = select(SqlSessionPermission.conversation_id).where(
-                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlSessionPermission.workspace_id == current_workspace_id(),
                     SqlSessionPermission.user_id == accessible_by,
                 )
                 stmt = stmt.where(SqlConversationLabel.conversation_id.in_(accessible_ids))
@@ -1627,7 +1631,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             session.execute(
                 delete(SqlConversationLabel).where(
-                    SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversationLabel.workspace_id == current_workspace_id(),
                     SqlConversationLabel.conversation_id == conversation_id,
                     SqlConversationLabel.key == key,
                 )
@@ -1708,7 +1712,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
             stmt = select(SqlConversation).where(
-                SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID
+                SqlConversation.workspace_id == current_workspace_id()
             )
             # Filter by kind when specified (None = no filter).
             if kind is not None:
@@ -1727,7 +1731,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 stmt = stmt.where(SqlConversation.archived.is_(False))
             if agent_name is not None:
                 stmt = stmt.join(SqlAgent, SqlAgent.id == SqlConversation.agent_id).where(
-                    SqlAgent.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlAgent.workspace_id == current_workspace_id(),
                     SqlAgent.name == agent_name,
                 )
             if agent_id is not None:
@@ -1738,7 +1742,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 stmt = stmt.where(SqlConversation.agent_id == agent_id)
             if accessible_by is not None:
                 accessible_ids = select(SqlSessionPermission.conversation_id).where(
-                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlSessionPermission.workspace_id == current_workspace_id(),
                     SqlSessionPermission.user_id == accessible_by,
                 )
                 stmt = stmt.where(SqlConversation.id.in_(accessible_ids))
@@ -1748,7 +1752,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 content_match = SqlConversation.id.in_(
                     select(SqlConversationItem.conversation_id)
                     .where(
-                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.workspace_id == current_workspace_id(),
                         func.lower(SqlConversationItem.search_text).like(pattern),
                     )
                     .distinct()
@@ -1760,7 +1764,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     stmt = stmt.where(
                         SqlConversation.id.not_in(
                             select(SqlConversationLabel.conversation_id).where(
-                                SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+                                SqlConversationLabel.workspace_id == current_workspace_id(),
                                 SqlConversationLabel.key == PROJECT_LABEL_KEY,
                             )
                         )
@@ -1770,7 +1774,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     stmt = stmt.where(
                         SqlConversation.id.in_(
                             select(SqlConversationLabel.conversation_id).where(
-                                SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+                                SqlConversationLabel.workspace_id == current_workspace_id(),
                                 SqlConversationLabel.key == PROJECT_LABEL_KEY,
                                 SqlConversationLabel.value == project,
                             )
@@ -1870,7 +1874,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         sub = (
             select(sort_col)
             .where(
-                SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlConversation.workspace_id == current_workspace_id(),
                 SqlConversation.id == cursor_id,
             )
             .scalar_subquery()
@@ -1884,7 +1888,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             tiebreaker_val = (
                 select(tiebreaker_col)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id == cursor_id,
                 )
                 .scalar_subquery()
@@ -1950,7 +1954,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             if the conversation does not exist.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if not row:
                 return None
             changed = False
@@ -2015,7 +2019,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             stmt = (
                 update(SqlConversation)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id == conversation_id,
                 )
                 .where(SqlConversation.runner_id.is_(None))
@@ -2041,7 +2045,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             exists for ``conversation_id``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -2061,7 +2065,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             exists for ``conversation_id``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -2086,7 +2090,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             exists for ``conversation_id``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -2113,7 +2117,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             rows = (
                 session.query(SqlConversation)
                 .filter(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.host_id == host_id,
                 )
                 .all()
@@ -2135,7 +2139,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             rows = (
                 session.query(SqlConversation)
                 .filter(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.runner_id == runner_id,
                 )
                 .all()
@@ -2183,7 +2187,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             and the caller did not supply one).
         """
         with self._session() as session:
-            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -2220,7 +2224,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``external_session_id``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -2312,7 +2316,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             root_conversation_id: str | None = None
             if parent_conversation_id is not None:
                 parent_row = session.get(
-                    SqlConversation, (DEFAULT_WORKSPACE_ID, parent_conversation_id)
+                    SqlConversation, (current_workspace_id(), parent_conversation_id)
                 )
                 if parent_row is None:
                     raise ConversationNotFoundError(
@@ -2463,7 +2467,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         now = now_epoch()
         with self._session() as session:
-            source = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, source_conversation_id))
+            source = session.get(SqlConversation, (current_workspace_id(), source_conversation_id))
             if source is None:
                 raise LookupError(f"conversation not found: {source_conversation_id!r}")
 
@@ -2526,7 +2530,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             if up_to_response_id is not None:
                 cutoff_position = session.execute(
                     select(func.max(SqlConversationItem.position)).where(
-                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.workspace_id == current_workspace_id(),
                         SqlConversationItem.conversation_id == source_conversation_id,
                         SqlConversationItem.response_id == up_to_response_id,
                     )
@@ -2538,7 +2542,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     )
                 last_position = session.execute(
                     select(func.max(SqlConversationItem.position)).where(
-                        SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationItem.workspace_id == current_workspace_id(),
                         SqlConversationItem.conversation_id == source_conversation_id,
                     )
                 ).scalar_one()
@@ -2549,7 +2553,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             items_query = (
                 select(SqlConversationItem)
                 .where(
-                    SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversationItem.workspace_id == current_workspace_id(),
                     SqlConversationItem.conversation_id == source_conversation_id,
                 )
                 .order_by(SqlConversationItem.position.asc())
@@ -2706,7 +2710,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         now = now_epoch()
         with self._session() as session:
-            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 raise LookupError(f"conversation not found: {conversation_id!r}")
 
@@ -2719,7 +2723,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             row.agent_id = None
             session.flush()
             if old_agent_id is not None:
-                old_agent = session.get(SqlAgent, (DEFAULT_WORKSPACE_ID, old_agent_id))
+                old_agent = session.get(SqlAgent, (current_workspace_id(), old_agent_id))
                 if old_agent is not None and old_agent.kind == AGENT_KIND_SESSION:
                     session.delete(old_agent)
                     session.flush()
@@ -2772,7 +2776,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             if present_drop:
                 session.execute(
                     delete(SqlConversationLabel).where(
-                        SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlConversationLabel.workspace_id == current_workspace_id(),
                         SqlConversationLabel.conversation_id == conversation_id,
                         SqlConversationLabel.key.in_(present_drop),
                     )
@@ -2804,7 +2808,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``False`` otherwise.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if not row:
                 return False
 
@@ -2813,14 +2817,14 @@ class SqlAlchemyConversationStore(ConversationStore):
             cte = (
                 select(SqlConversation.id)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id == conversation_id,
                 )
                 .cte(name="subtree", recursive=True)
             )
             cte = cte.union_all(
                 select(SqlConversation.id).where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.parent_conversation_id == cte.c.id,
                 )
             )
@@ -2834,31 +2838,31 @@ class SqlAlchemyConversationStore(ConversationStore):
 
             session.execute(
                 delete(SqlConversationItem).where(
-                    SqlConversationItem.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversationItem.workspace_id == current_workspace_id(),
                     SqlConversationItem.conversation_id.in_(subtree_ids),
                 )
             )
             session.execute(
                 delete(SqlConversationLabel).where(
-                    SqlConversationLabel.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversationLabel.workspace_id == current_workspace_id(),
                     SqlConversationLabel.conversation_id.in_(subtree_ids),
                 )
             )
             session.execute(
                 delete(SqlComment).where(
-                    SqlComment.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlComment.workspace_id == current_workspace_id(),
                     SqlComment.conversation_id.in_(subtree_ids),
                 )
             )
             session.execute(
                 delete(SqlPolicy).where(
-                    SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlPolicy.workspace_id == current_workspace_id(),
                     SqlPolicy.session_id.in_(subtree_ids),
                 )
             )
             session.execute(
                 delete(SqlSessionPermission).where(
-                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlSessionPermission.workspace_id == current_workspace_id(),
                     SqlSessionPermission.conversation_id.in_(subtree_ids),
                 )
             )
@@ -2867,7 +2871,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             # ordering constraints are satisfied.
             session.execute(
                 delete(SqlConversation).where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id.in_(subtree_ids),
                     SqlConversation.id != conversation_id,
                 )

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -26,6 +26,7 @@ from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY
 from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
     AGENT_KIND_SESSION,
+    DEFAULT_WORKSPACE_ID,
     LABEL_VALUE_MAX_LEN,
     SqlAgent,
     SqlComment,
@@ -292,7 +293,7 @@ def _upsert_labels(
     for row in rows:
         existing = session.get(
             SqlConversationLabel,
-            (row["conversation_id"], row["key"]),
+            (DEFAULT_WORKSPACE_ID, row["conversation_id"], row["key"]),
         )
         if existing is None:
             session.add(SqlConversationLabel(**row))
@@ -339,7 +340,7 @@ def _dialect_upsert_labels(
 
         stmt = pg_insert(SqlConversationLabel).values(rows)
     stmt = stmt.on_conflict_do_update(
-        index_elements=["conversation_id", "key"],
+        index_elements=["workspace_id", "conversation_id", "key"],
         set_={
             "value": stmt.excluded.value,
             "updated_at": stmt.excluded.updated_at,
@@ -635,7 +636,9 @@ class SqlAlchemyConversationStore(ConversationStore):
                     # it lands.
                     root_id: str = new_id
                 else:
-                    parent_row = session.get(SqlConversation, parent_conversation_id)
+                    parent_row = session.get(
+                        SqlConversation, (DEFAULT_WORKSPACE_ID, parent_conversation_id)
+                    )
                     if parent_row is None:
                         raise ConversationNotFoundError(
                             f"parent conversation {parent_conversation_id!r} does not exist"
@@ -712,7 +715,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``None``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, conversation_id)
+            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if row is None:
                 return None
             return _to_conversation(row, _fetch_labels(session, conversation_id))
@@ -1015,7 +1018,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             # Generic dialect fallback — SELECT-then-INSERT/UPDATE in one
             # transaction (race-safe under SERIALIZABLE / SQLite's
             # single-writer semantics).
-            existing = session.get(SqlUserDailyCost, (user_id, day_utc))
+            existing = session.get(SqlUserDailyCost, (DEFAULT_WORKSPACE_ID, user_id, day_utc))
             if existing is None:
                 session.add(
                     SqlUserDailyCost(
@@ -1074,7 +1077,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             stmt = pg_insert(SqlUserDailyCost)
         stmt = stmt.values(user_id=user_id, day_utc=day_utc, cost_usd=delta_usd, updated_at=now)
         stmt = stmt.on_conflict_do_update(
-            index_elements=["user_id", "day_utc"],
+            index_elements=["workspace_id", "user_id", "day_utc"],
             set_={
                 "cost_usd": SqlUserDailyCost.cost_usd + stmt.excluded.cost_usd,
                 "updated_at": stmt.excluded.updated_at,
@@ -1093,7 +1096,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             exists for ``(user_id, day_utc)``.
         """
         with self._session() as session:
-            row = session.get(SqlUserDailyCost, (user_id, day_utc))
+            row = session.get(SqlUserDailyCost, (DEFAULT_WORKSPACE_ID, user_id, day_utc))
             return float(row.cost_usd) if row is not None else 0.0
 
     def get_daily_cost_state(self, user_id: str, day_utc: str) -> dict[str, float]:
@@ -1111,7 +1114,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             both ``0.0`` when no row exists for ``(user_id, day_utc)``.
         """
         with self._session() as session:
-            row = session.get(SqlUserDailyCost, (user_id, day_utc))
+            row = session.get(SqlUserDailyCost, (DEFAULT_WORKSPACE_ID, user_id, day_utc))
             if row is None:
                 return {"cost_usd": 0.0, "ask_approved_usd": 0.0}
             return {
@@ -1162,7 +1165,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 # On conflict touch only the approval (+ stamp) — never
                 # the accumulated cost.
                 stmt = stmt.on_conflict_do_update(
-                    index_elements=["user_id", "day_utc"],
+                    index_elements=["workspace_id", "user_id", "day_utc"],
                     set_={
                         "ask_approved_usd": stmt.excluded.ask_approved_usd,
                         "updated_at": stmt.excluded.updated_at,
@@ -1171,7 +1174,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 session.execute(stmt)
                 return
             # Generic dialect fallback — SELECT-then-INSERT/UPDATE.
-            existing = session.get(SqlUserDailyCost, (user_id, day_utc))
+            existing = session.get(SqlUserDailyCost, (DEFAULT_WORKSPACE_ID, user_id, day_utc))
             if existing is None:
                 session.add(
                     SqlUserDailyCost(
@@ -1438,7 +1441,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             self._lock_conversation(session, conversation_id)
 
             # Bump updated_at on the conversation.
-            conv_row = session.get(SqlConversation, conversation_id)
+            conv_row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if conv_row is not None:
                 conv_row.updated_at = now
 
@@ -1874,7 +1877,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             if the conversation does not exist.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, conversation_id)
+            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if not row:
                 return None
             changed = False
@@ -1962,7 +1965,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             exists for ``conversation_id``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, conversation_id)
+            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -1982,7 +1985,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             exists for ``conversation_id``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, conversation_id)
+            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -2007,7 +2010,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             exists for ``conversation_id``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, conversation_id)
+            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -2092,7 +2095,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             and the caller did not supply one).
         """
         with self._session() as session:
-            row = session.get(SqlConversation, conversation_id)
+            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -2129,7 +2132,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``external_session_id``.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, conversation_id)
+            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if row is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
@@ -2220,7 +2223,9 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._session() as session:
             root_conversation_id: str | None = None
             if parent_conversation_id is not None:
-                parent_row = session.get(SqlConversation, parent_conversation_id)
+                parent_row = session.get(
+                    SqlConversation, (DEFAULT_WORKSPACE_ID, parent_conversation_id)
+                )
                 if parent_row is None:
                     raise ConversationNotFoundError(
                         f"parent conversation {parent_conversation_id!r} does not exist"
@@ -2370,7 +2375,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         now = now_epoch()
         with self._session() as session:
-            source = session.get(SqlConversation, source_conversation_id)
+            source = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, source_conversation_id))
             if source is None:
                 raise LookupError(f"conversation not found: {source_conversation_id!r}")
 
@@ -2608,7 +2613,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         now = now_epoch()
         with self._session() as session:
-            row = session.get(SqlConversation, conversation_id)
+            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if row is None:
                 raise LookupError(f"conversation not found: {conversation_id!r}")
 
@@ -2621,7 +2626,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             row.agent_id = None
             session.flush()
             if old_agent_id is not None:
-                old_agent = session.get(SqlAgent, old_agent_id)
+                old_agent = session.get(SqlAgent, (DEFAULT_WORKSPACE_ID, old_agent_id))
                 if old_agent is not None and old_agent.kind == AGENT_KIND_SESSION:
                     session.delete(old_agent)
                     session.flush()
@@ -2705,7 +2710,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``False`` otherwise.
         """
         with self._session() as session:
-            row = session.get(SqlConversation, conversation_id)
+            row = session.get(SqlConversation, (DEFAULT_WORKSPACE_ID, conversation_id))
             if not row:
                 return False
 

--- a/omnigent/stores/file_store/sqlalchemy_store.py
+++ b/omnigent/stores/file_store/sqlalchemy_store.py
@@ -129,7 +129,7 @@ class SqlAlchemyFileStore(FileStore):
         with self._session() as session:
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
-            stmt = select(SqlFile)
+            stmt = select(SqlFile).where(SqlFile.workspace_id == DEFAULT_WORKSPACE_ID)
             if session_id is not None:
                 if include_unscoped:
                     stmt = stmt.where(
@@ -138,12 +138,26 @@ class SqlAlchemyFileStore(FileStore):
                 else:
                     stmt = stmt.where(SqlFile.session_id == session_id)
             if after:
-                sub = select(SqlFile.created_at).where(SqlFile.id == after).scalar_subquery()
+                sub = (
+                    select(SqlFile.created_at)
+                    .where(
+                        SqlFile.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlFile.id == after,
+                    )
+                    .scalar_subquery()
+                )
                 ts_cmp = SqlFile.created_at < sub if is_desc else SqlFile.created_at > sub
                 id_cmp = SqlFile.id < after if is_desc else SqlFile.id > after
                 stmt = stmt.where(or_(ts_cmp, and_(SqlFile.created_at == sub, id_cmp)))
             if before:
-                sub = select(SqlFile.created_at).where(SqlFile.id == before).scalar_subquery()
+                sub = (
+                    select(SqlFile.created_at)
+                    .where(
+                        SqlFile.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlFile.id == before,
+                    )
+                    .scalar_subquery()
+                )
                 ts_cmp = SqlFile.created_at > sub if is_desc else SqlFile.created_at < sub
                 id_cmp = SqlFile.id > before if is_desc else SqlFile.id < before
                 stmt = stmt.where(or_(ts_cmp, and_(SqlFile.created_at == sub, id_cmp)))
@@ -196,6 +210,7 @@ class SqlAlchemyFileStore(FileStore):
         """
         with self._session() as session:
             stmt = select(SqlFile).where(
+                SqlFile.workspace_id == DEFAULT_WORKSPACE_ID,
                 SqlFile.session_id == session_id,
             )
             rows = list(session.execute(stmt).scalars().all())

--- a/omnigent/stores/file_store/sqlalchemy_store.py
+++ b/omnigent/stores/file_store/sqlalchemy_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from sqlalchemy import and_, asc, desc, or_, select
 
-from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, SqlFile
+from omnigent.db.db_models import SqlFile, current_workspace_id
 from omnigent.db.utils import (
     generate_file_id,
     get_or_create_engine,
@@ -97,7 +97,7 @@ class SqlAlchemyFileStore(FileStore):
             ``None``.
         """
         with self._session() as session:
-            row = session.get(SqlFile, (DEFAULT_WORKSPACE_ID, file_id))
+            row = session.get(SqlFile, (current_workspace_id(), file_id))
             if row is None:
                 return None
             if session_id is not None and row.session_id != session_id:
@@ -129,7 +129,7 @@ class SqlAlchemyFileStore(FileStore):
         with self._session() as session:
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
-            stmt = select(SqlFile).where(SqlFile.workspace_id == DEFAULT_WORKSPACE_ID)
+            stmt = select(SqlFile).where(SqlFile.workspace_id == current_workspace_id())
             if session_id is not None:
                 if include_unscoped:
                     stmt = stmt.where(
@@ -141,7 +141,7 @@ class SqlAlchemyFileStore(FileStore):
                 sub = (
                     select(SqlFile.created_at)
                     .where(
-                        SqlFile.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlFile.workspace_id == current_workspace_id(),
                         SqlFile.id == after,
                     )
                     .scalar_subquery()
@@ -153,7 +153,7 @@ class SqlAlchemyFileStore(FileStore):
                 sub = (
                     select(SqlFile.created_at)
                     .where(
-                        SqlFile.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlFile.workspace_id == current_workspace_id(),
                         SqlFile.id == before,
                     )
                     .scalar_subquery()
@@ -193,7 +193,7 @@ class SqlAlchemyFileStore(FileStore):
         :returns: ``True`` if deleted, ``False`` otherwise.
         """
         with self._session() as session:
-            row = session.get(SqlFile, (DEFAULT_WORKSPACE_ID, file_id))
+            row = session.get(SqlFile, (current_workspace_id(), file_id))
             if not row:
                 return False
             if session_id is not None and row.session_id != session_id:
@@ -210,7 +210,7 @@ class SqlAlchemyFileStore(FileStore):
         """
         with self._session() as session:
             stmt = select(SqlFile).where(
-                SqlFile.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlFile.workspace_id == current_workspace_id(),
                 SqlFile.session_id == session_id,
             )
             rows = list(session.execute(stmt).scalars().all())

--- a/omnigent/stores/file_store/sqlalchemy_store.py
+++ b/omnigent/stores/file_store/sqlalchemy_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from sqlalchemy import and_, asc, desc, or_, select
 
-from omnigent.db.db_models import SqlFile
+from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, SqlFile
 from omnigent.db.utils import (
     generate_file_id,
     get_or_create_engine,
@@ -97,7 +97,7 @@ class SqlAlchemyFileStore(FileStore):
             ``None``.
         """
         with self._session() as session:
-            row = session.get(SqlFile, file_id)
+            row = session.get(SqlFile, (DEFAULT_WORKSPACE_ID, file_id))
             if row is None:
                 return None
             if session_id is not None and row.session_id != session_id:
@@ -179,7 +179,7 @@ class SqlAlchemyFileStore(FileStore):
         :returns: ``True`` if deleted, ``False`` otherwise.
         """
         with self._session() as session:
-            row = session.get(SqlFile, file_id)
+            row = session.get(SqlFile, (DEFAULT_WORKSPACE_ID, file_id))
             if not row:
                 return False
             if session_id is not None and row.session_id != session_id:

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -309,13 +309,19 @@ class HostStore:
         old_host_id = row.host_id
         bound_ids = list(
             session.execute(
-                select(SqlConversation.id).where(SqlConversation.host_id == old_host_id)
+                select(SqlConversation.id).where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.host_id == old_host_id,
+                )
             ).scalars()
         )
         if bound_ids:
             session.execute(
                 update(SqlConversation)
-                .where(SqlConversation.host_id == old_host_id)
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.host_id == old_host_id,
+                )
                 .values(host_id=None)
             )
             session.flush()
@@ -324,7 +330,10 @@ class HostStore:
         if bound_ids:
             session.execute(
                 update(SqlConversation)
-                .where(SqlConversation.id.in_(bound_ids))
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.id.in_(bound_ids),
+                )
                 .values(host_id=new_host_id)
             )
             session.flush()
@@ -364,7 +373,9 @@ class HostStore:
             *host_id* (caller falls through to a normal insert).
         """
         existing = session.execute(
-            select(SqlHost).where(SqlHost.host_id == host_id)
+            select(SqlHost).where(
+                SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+            )
         ).scalar_one_or_none()
         if existing is None:
             return None
@@ -372,7 +383,10 @@ class HostStore:
         now = now_epoch()
         session.execute(
             update(SqlHost)
-            .where(SqlHost.host_id == host_id)
+            .where(
+                SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlHost.host_id == host_id,
+            )
             .values(
                 owner=owner,
                 name=name,
@@ -405,7 +419,9 @@ class HostStore:
         """
         with self._session() as session:
             row = session.execute(
-                select(SqlHost).where(SqlHost.host_id == host_id)
+                select(SqlHost).where(
+                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+                )
             ).scalar_one_or_none()
             if row is not None:
                 row.status = "offline"
@@ -431,7 +447,12 @@ class HostStore:
         # pure overhead. A missing host simply matches no rows (a no-op).
         with self._session() as session:
             session.execute(
-                update(SqlHost).where(SqlHost.host_id == host_id).values(updated_at=now_epoch())
+                update(SqlHost)
+                .where(
+                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.host_id == host_id,
+                )
+                .values(updated_at=now_epoch())
             )
 
     def is_online(self, host_id: str) -> bool:
@@ -478,7 +499,8 @@ class HostStore:
         with self._session() as session:
             rows = session.execute(
                 select(SqlHost.host_id, SqlHost.status, SqlHost.updated_at).where(
-                    SqlHost.host_id.in_(unique_ids)
+                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.host_id.in_(unique_ids),
                 )
             ).all()
         return {
@@ -501,7 +523,10 @@ class HostStore:
         with self._session() as session:
             rows = (
                 session.query(SqlHost)
-                .filter(SqlHost.owner == owner)
+                .filter(
+                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.owner == owner,
+                )
                 .order_by(SqlHost.updated_at.desc())
                 .all()
             )
@@ -517,7 +542,9 @@ class HostStore:
         """
         with self._session() as session:
             row = session.execute(
-                select(SqlHost).where(SqlHost.host_id == host_id)
+                select(SqlHost).where(
+                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+                )
             ).scalar_one_or_none()
             if row is None:
                 return None
@@ -574,7 +601,9 @@ class HostStore:
         token_hash = hash_host_launch_token(token)
         with self._session() as session:
             existing = session.execute(
-                select(SqlHost).where(SqlHost.host_id == host_id)
+                select(SqlHost).where(
+                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+                )
             ).scalar_one_or_none()
             if existing is not None:
                 if existing.owner != owner:
@@ -627,7 +656,10 @@ class HostStore:
         """
         with self._session() as session:
             row = session.execute(
-                select(SqlHost).where(SqlHost.token_hash == hash_host_launch_token(token))
+                select(SqlHost).where(
+                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.token_hash == hash_host_launch_token(token),
+                )
             ).scalar_one_or_none()
             # token_expires_at is written together with token_hash, so a
             # matched row always carries it; the None arm is mypy
@@ -652,10 +684,18 @@ class HostStore:
         with self._session() as session:
             session.execute(
                 update(SqlConversation)
-                .where(SqlConversation.host_id == host_id)
+                .where(
+                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.host_id == host_id,
+                )
                 .values(host_id=None)
             )
-            session.execute(sql_delete(SqlHost).where(SqlHost.host_id == host_id))
+            session.execute(
+                sql_delete(SqlHost).where(
+                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.host_id == host_id,
+                )
+            )
 
     def revoke_launch_token(self, host_id: str) -> None:
         """
@@ -672,7 +712,9 @@ class HostStore:
         """
         with self._session() as session:
             row = session.execute(
-                select(SqlHost).where(SqlHost.host_id == host_id)
+                select(SqlHost).where(
+                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+                )
             ).scalar_one_or_none()
             if row is None:
                 return

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -20,7 +20,7 @@ from sqlalchemy import Engine, select, update
 from sqlalchemy import delete as sql_delete
 from sqlalchemy.orm import Session
 
-from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, SqlConversation, SqlHost
+from omnigent.db.db_models import SqlConversation, SqlHost, current_workspace_id
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker, now_epoch
 
 # A host is considered live only if its row was touched (connect or
@@ -234,7 +234,7 @@ class HostStore:
             json.dumps(configured_harnesses) if configured_harnesses is not None else None
         )
         with self._session() as session:
-            row = session.get(SqlHost, (DEFAULT_WORKSPACE_ID, owner, name))
+            row = session.get(SqlHost, (current_workspace_id(), owner, name))
             if row is None and allow_host_id_reown:
                 reowned = self._reown_host_id(
                     session,
@@ -310,7 +310,7 @@ class HostStore:
         bound_ids = list(
             session.execute(
                 select(SqlConversation.id).where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.host_id == old_host_id,
                 )
             ).scalars()
@@ -319,7 +319,7 @@ class HostStore:
             session.execute(
                 update(SqlConversation)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.host_id == old_host_id,
                 )
                 .values(host_id=None)
@@ -331,7 +331,7 @@ class HostStore:
             session.execute(
                 update(SqlConversation)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.id.in_(bound_ids),
                 )
                 .values(host_id=new_host_id)
@@ -374,7 +374,7 @@ class HostStore:
         """
         existing = session.execute(
             select(SqlHost).where(
-                SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+                SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
             )
         ).scalar_one_or_none()
         if existing is None:
@@ -384,7 +384,7 @@ class HostStore:
         session.execute(
             update(SqlHost)
             .where(
-                SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                SqlHost.workspace_id == current_workspace_id(),
                 SqlHost.host_id == host_id,
             )
             .values(
@@ -420,7 +420,7 @@ class HostStore:
         with self._session() as session:
             row = session.execute(
                 select(SqlHost).where(
-                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+                    SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
                 )
             ).scalar_one_or_none()
             if row is not None:
@@ -449,7 +449,7 @@ class HostStore:
             session.execute(
                 update(SqlHost)
                 .where(
-                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.host_id == host_id,
                 )
                 .values(updated_at=now_epoch())
@@ -499,7 +499,7 @@ class HostStore:
         with self._session() as session:
             rows = session.execute(
                 select(SqlHost.host_id, SqlHost.status, SqlHost.updated_at).where(
-                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.host_id.in_(unique_ids),
                 )
             ).all()
@@ -524,7 +524,7 @@ class HostStore:
             rows = (
                 session.query(SqlHost)
                 .filter(
-                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.owner == owner,
                 )
                 .order_by(SqlHost.updated_at.desc())
@@ -543,7 +543,7 @@ class HostStore:
         with self._session() as session:
             row = session.execute(
                 select(SqlHost).where(
-                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+                    SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
                 )
             ).scalar_one_or_none()
             if row is None:
@@ -602,7 +602,7 @@ class HostStore:
         with self._session() as session:
             existing = session.execute(
                 select(SqlHost).where(
-                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+                    SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
                 )
             ).scalar_one_or_none()
             if existing is not None:
@@ -657,7 +657,7 @@ class HostStore:
         with self._session() as session:
             row = session.execute(
                 select(SqlHost).where(
-                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.token_hash == hash_host_launch_token(token),
                 )
             ).scalar_one_or_none()
@@ -685,14 +685,14 @@ class HostStore:
             session.execute(
                 update(SqlConversation)
                 .where(
-                    SqlConversation.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversation.host_id == host_id,
                 )
                 .values(host_id=None)
             )
             session.execute(
                 sql_delete(SqlHost).where(
-                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.host_id == host_id,
                 )
             )
@@ -713,7 +713,7 @@ class HostStore:
         with self._session() as session:
             row = session.execute(
                 select(SqlHost).where(
-                    SqlHost.workspace_id == DEFAULT_WORKSPACE_ID, SqlHost.host_id == host_id
+                    SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
                 )
             ).scalar_one_or_none()
             if row is None:

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -20,7 +20,7 @@ from sqlalchemy import Engine, select, update
 from sqlalchemy import delete as sql_delete
 from sqlalchemy.orm import Session
 
-from omnigent.db.db_models import SqlConversation, SqlHost
+from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, SqlConversation, SqlHost
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker, now_epoch
 
 # A host is considered live only if its row was touched (connect or
@@ -234,7 +234,7 @@ class HostStore:
             json.dumps(configured_harnesses) if configured_harnesses is not None else None
         )
         with self._session() as session:
-            row = session.get(SqlHost, (owner, name))
+            row = session.get(SqlHost, (DEFAULT_WORKSPACE_ID, owner, name))
             if row is None and allow_host_id_reown:
                 reowned = self._reown_host_id(
                     session,

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -116,6 +116,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         with self._session() as session:
             result = session.execute(
                 delete(SqlSessionPermission).where(
+                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
                     SqlSessionPermission.user_id == user_id,
                     SqlSessionPermission.conversation_id == conversation_id,
                 )
@@ -158,6 +159,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
             rows = (
                 session.execute(
                     select(SqlSessionPermission).where(
+                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
                         SqlSessionPermission.user_id == from_user_id,
                     )
                 )
@@ -181,6 +183,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 session.execute(
                     update(SqlSessionPermission)
                     .where(
+                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
                         SqlSessionPermission.user_id == from_user_id,
                         SqlSessionPermission.conversation_id == conversation_id,
                     )
@@ -195,6 +198,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
             rows = (
                 session.execute(
                     select(SqlSessionPermission).where(
+                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
                         SqlSessionPermission.conversation_id == conversation_id,
                     )
                 )
@@ -214,7 +218,8 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 _to_entity(r)
                 for r in session.execute(
                     select(SqlSessionPermission).where(
-                        SqlSessionPermission.conversation_id.in_(conversation_ids)
+                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlSessionPermission.conversation_id.in_(conversation_ids),
                     )
                 )
                 .scalars()
@@ -231,6 +236,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
             rows = (
                 session.execute(
                     select(SqlSessionPermission).where(
+                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
                         SqlSessionPermission.user_id == user_id,
                     )
                 )
@@ -261,7 +267,13 @@ class SqlAlchemyPermissionStore(PermissionStore):
     def list_users(self) -> list[Account]:
         """List every real user row. See base class for contract."""
         with self._session() as session:
-            rows = session.execute(select(SqlUser)).scalars().all()
+            rows = (
+                session.execute(
+                    select(SqlUser).where(SqlUser.workspace_id == DEFAULT_WORKSPACE_ID)
+                )
+                .scalars()
+                .all()
+            )
             return [_to_account(r) for r in rows if r.id not in _HIDDEN_LIST_USERS]
 
     def is_admin(self, user_id: str) -> bool:
@@ -273,7 +285,14 @@ class SqlAlchemyPermissionStore(PermissionStore):
     def set_admin(self, user_id: str, is_admin: bool) -> None:
         """Set the admin flag on an existing user. See base class for contract."""
         with self._session() as session:
-            session.execute(update(SqlUser).where(SqlUser.id == user_id).values(is_admin=is_admin))
+            session.execute(
+                update(SqlUser)
+                .where(
+                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.id == user_id,
+                )
+                .values(is_admin=is_admin)
+            )
 
     def check_access(
         self,
@@ -352,6 +371,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
             return session.execute(
                 select(
                     exists().where(
+                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
                         SqlSessionPermission.conversation_id == conversation_id,
                     )
                 )

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -6,7 +6,7 @@ from sqlalchemy import delete, exists, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, SqlSessionPermission, SqlUser
+from omnigent.db.db_models import SqlSessionPermission, SqlUser, current_workspace_id
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
 from omnigent.entities import Account, ResolvedAccess, SessionPermission
 from omnigent.server.auth import (
@@ -116,7 +116,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         with self._session() as session:
             result = session.execute(
                 delete(SqlSessionPermission).where(
-                    SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlSessionPermission.workspace_id == current_workspace_id(),
                     SqlSessionPermission.user_id == user_id,
                     SqlSessionPermission.conversation_id == conversation_id,
                 )
@@ -127,7 +127,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         """Look up a single grant. See base class for contract."""
         with self._session() as session:
             row = session.get(
-                SqlSessionPermission, (DEFAULT_WORKSPACE_ID, user_id, conversation_id)
+                SqlSessionPermission, (current_workspace_id(), user_id, conversation_id)
             )
             return _to_entity(row) if row is not None else None
 
@@ -153,13 +153,13 @@ class SqlAlchemyPermissionStore(PermissionStore):
         with self._session() as session:
             # FK target: ensure the destination users.id row exists. Don't
             # downgrade an existing admin flag; only create it if missing.
-            if session.get(SqlUser, (DEFAULT_WORKSPACE_ID, to_user_id)) is None:
+            if session.get(SqlUser, (current_workspace_id(), to_user_id)) is None:
                 session.add(SqlUser(id=to_user_id, is_admin=False))
                 session.flush()
             rows = (
                 session.execute(
                     select(SqlSessionPermission).where(
-                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlSessionPermission.workspace_id == current_workspace_id(),
                         SqlSessionPermission.user_id == from_user_id,
                     )
                 )
@@ -171,7 +171,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 if (
                     session.get(
                         SqlSessionPermission,
-                        (DEFAULT_WORKSPACE_ID, to_user_id, conversation_id),
+                        (current_workspace_id(), to_user_id, conversation_id),
                     )
                     is not None
                 ):
@@ -183,7 +183,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 session.execute(
                     update(SqlSessionPermission)
                     .where(
-                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlSessionPermission.workspace_id == current_workspace_id(),
                         SqlSessionPermission.user_id == from_user_id,
                         SqlSessionPermission.conversation_id == conversation_id,
                     )
@@ -198,7 +198,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
             rows = (
                 session.execute(
                     select(SqlSessionPermission).where(
-                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlSessionPermission.workspace_id == current_workspace_id(),
                         SqlSessionPermission.conversation_id == conversation_id,
                     )
                 )
@@ -218,7 +218,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 _to_entity(r)
                 for r in session.execute(
                     select(SqlSessionPermission).where(
-                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlSessionPermission.workspace_id == current_workspace_id(),
                         SqlSessionPermission.conversation_id.in_(conversation_ids),
                     )
                 )
@@ -236,7 +236,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
             rows = (
                 session.execute(
                     select(SqlSessionPermission).where(
-                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlSessionPermission.workspace_id == current_workspace_id(),
                         SqlSessionPermission.user_id == user_id,
                     )
                 )
@@ -269,7 +269,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         with self._session() as session:
             rows = (
                 session.execute(
-                    select(SqlUser).where(SqlUser.workspace_id == DEFAULT_WORKSPACE_ID)
+                    select(SqlUser).where(SqlUser.workspace_id == current_workspace_id())
                 )
                 .scalars()
                 .all()
@@ -279,7 +279,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
     def is_admin(self, user_id: str) -> bool:
         """Check the admin flag. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
+            row = session.get(SqlUser, (current_workspace_id(), user_id))
             return row is not None and row.is_admin
 
     def set_admin(self, user_id: str, is_admin: bool) -> None:
@@ -288,7 +288,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
             session.execute(
                 update(SqlUser)
                 .where(
-                    SqlUser.workspace_id == DEFAULT_WORKSPACE_ID,
+                    SqlUser.workspace_id == current_workspace_id(),
                     SqlUser.id == user_id,
                 )
                 .values(is_admin=is_admin)
@@ -351,13 +351,13 @@ class SqlAlchemyPermissionStore(PermissionStore):
         # calling is_admin + check_access + get_permission_level separately
         # did — see the GET /v1/sessions/{id} snapshot path).
         with self._session() as session:
-            user_row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
+            user_row = session.get(SqlUser, (current_workspace_id(), user_id))
             user_grant = session.get(
-                SqlSessionPermission, (DEFAULT_WORKSPACE_ID, user_id, conversation_id)
+                SqlSessionPermission, (current_workspace_id(), user_id, conversation_id)
             )
             public_grant = session.get(
                 SqlSessionPermission,
-                (DEFAULT_WORKSPACE_ID, RESERVED_USER_PUBLIC, conversation_id),
+                (current_workspace_id(), RESERVED_USER_PUBLIC, conversation_id),
             )
             return ResolvedAccess(
                 is_admin=user_row is not None and user_row.is_admin,
@@ -371,7 +371,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
             return session.execute(
                 select(
                     exists().where(
-                        SqlSessionPermission.workspace_id == DEFAULT_WORKSPACE_ID,
+                        SqlSessionPermission.workspace_id == current_workspace_id(),
                         SqlSessionPermission.conversation_id == conversation_id,
                     )
                 )

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -6,7 +6,7 @@ from sqlalchemy import delete, exists, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-from omnigent.db.db_models import SqlSessionPermission, SqlUser
+from omnigent.db.db_models import DEFAULT_WORKSPACE_ID, SqlSessionPermission, SqlUser
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
 from omnigent.entities import Account, ResolvedAccess, SessionPermission
 from omnigent.server.auth import (
@@ -90,7 +90,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                     sqlite_insert(SqlSessionPermission)
                     .values(**values)
                     .on_conflict_do_update(
-                        index_elements=["user_id", "conversation_id"],
+                        index_elements=["workspace_id", "user_id", "conversation_id"],
                         set_={"level": level},
                     )
                 )
@@ -99,7 +99,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                     pg_insert(SqlSessionPermission)
                     .values(**values)
                     .on_conflict_do_update(
-                        index_elements=["user_id", "conversation_id"],
+                        index_elements=["workspace_id", "user_id", "conversation_id"],
                         set_={"level": level},
                     )
                 )
@@ -125,7 +125,9 @@ class SqlAlchemyPermissionStore(PermissionStore):
     def get(self, user_id: str, conversation_id: str) -> SessionPermission | None:
         """Look up a single grant. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlSessionPermission, (user_id, conversation_id))
+            row = session.get(
+                SqlSessionPermission, (DEFAULT_WORKSPACE_ID, user_id, conversation_id)
+            )
             return _to_entity(row) if row is not None else None
 
     def reassign_user_grants(self, from_user_id: str, to_user_id: str) -> int:
@@ -150,7 +152,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         with self._session() as session:
             # FK target: ensure the destination users.id row exists. Don't
             # downgrade an existing admin flag; only create it if missing.
-            if session.get(SqlUser, to_user_id) is None:
+            if session.get(SqlUser, (DEFAULT_WORKSPACE_ID, to_user_id)) is None:
                 session.add(SqlUser(id=to_user_id, is_admin=False))
                 session.flush()
             rows = (
@@ -164,7 +166,13 @@ class SqlAlchemyPermissionStore(PermissionStore):
             )
             for row in rows:
                 conversation_id = row.conversation_id
-                if session.get(SqlSessionPermission, (to_user_id, conversation_id)) is not None:
+                if (
+                    session.get(
+                        SqlSessionPermission,
+                        (DEFAULT_WORKSPACE_ID, to_user_id, conversation_id),
+                    )
+                    is not None
+                ):
                     # Destination already has access — drop the duplicate.
                     session.delete(row)
                     continue
@@ -240,13 +248,13 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 stmt = (
                     sqlite_insert(SqlUser)
                     .values(**values)
-                    .on_conflict_do_nothing(index_elements=["id"])
+                    .on_conflict_do_nothing(index_elements=["workspace_id", "id"])
                 )
             else:
                 stmt = (
                     pg_insert(SqlUser)
                     .values(**values)
-                    .on_conflict_do_nothing(index_elements=["id"])
+                    .on_conflict_do_nothing(index_elements=["workspace_id", "id"])
                 )
             session.execute(stmt)
 
@@ -259,7 +267,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
     def is_admin(self, user_id: str) -> bool:
         """Check the admin flag. See base class for contract."""
         with self._session() as session:
-            row = session.get(SqlUser, user_id)
+            row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
             return row is not None and row.is_admin
 
     def set_admin(self, user_id: str, is_admin: bool) -> None:
@@ -324,10 +332,13 @@ class SqlAlchemyPermissionStore(PermissionStore):
         # calling is_admin + check_access + get_permission_level separately
         # did — see the GET /v1/sessions/{id} snapshot path).
         with self._session() as session:
-            user_row = session.get(SqlUser, user_id)
-            user_grant = session.get(SqlSessionPermission, (user_id, conversation_id))
+            user_row = session.get(SqlUser, (DEFAULT_WORKSPACE_ID, user_id))
+            user_grant = session.get(
+                SqlSessionPermission, (DEFAULT_WORKSPACE_ID, user_id, conversation_id)
+            )
             public_grant = session.get(
-                SqlSessionPermission, (RESERVED_USER_PUBLIC, conversation_id)
+                SqlSessionPermission,
+                (DEFAULT_WORKSPACE_ID, RESERVED_USER_PUBLIC, conversation_id),
             )
             return ResolvedAccess(
                 is_admin=user_row is not None and user_row.is_admin,

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -114,6 +114,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         with self._session() as session:
             stmt = (
                 select(SqlPolicy)
+                .where(SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID)
                 .where(SqlPolicy.session_id == session_id)
                 .order_by(asc(SqlPolicy.created_at), asc(SqlPolicy.id))
             )
@@ -203,6 +204,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
             existing = (
                 session.execute(
                     select(SqlPolicy)
+                    .where(SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID)
                     .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
                     .where(SqlPolicy.name == name)
                 )
@@ -232,6 +234,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         with self._session() as session:
             stmt = (
                 select(SqlPolicy)
+                .where(SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID)
                 .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
                 .order_by(asc(SqlPolicy.created_at), asc(SqlPolicy.id))
             )
@@ -262,6 +265,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
                 conflict = (
                     session.execute(
                         select(SqlPolicy)
+                        .where(SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID)
                         .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
                         .where(SqlPolicy.name == name)
                         .where(SqlPolicy.id != policy_id)

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -9,10 +9,10 @@ from sqlalchemy import asc, select
 from sqlalchemy.exc import IntegrityError
 
 from omnigent.db.db_models import (
-    DEFAULT_WORKSPACE_ID,
     POLICY_SCOPE_DEFAULT,
     POLICY_SCOPE_SESSION,
     SqlPolicy,
+    current_workspace_id,
 )
 from omnigent.db.utils import (
     get_or_create_engine,
@@ -104,7 +104,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
     def get(self, policy_id: str, session_id: str) -> Policy | None:
         """Return the policy if it belongs to the given session."""
         with self._session() as session:
-            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
+            row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.session_id != session_id:
                 return None
             return _to_entity(row)
@@ -114,7 +114,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         with self._session() as session:
             stmt = (
                 select(SqlPolicy)
-                .where(SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID)
+                .where(SqlPolicy.workspace_id == current_workspace_id())
                 .where(SqlPolicy.session_id == session_id)
                 .order_by(asc(SqlPolicy.created_at), asc(SqlPolicy.id))
             )
@@ -135,7 +135,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         wrong session.
         """
         with self._session() as session:
-            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
+            row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.session_id != session_id:
                 return None
             changed = False
@@ -156,7 +156,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
     def delete(self, policy_id: str, session_id: str) -> bool:
         """Delete a policy. Idempotent: returns ``False`` if not found."""
         with self._session() as session:
-            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
+            row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.session_id != session_id:
                 return False
             session.delete(row)
@@ -204,7 +204,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
             existing = (
                 session.execute(
                     select(SqlPolicy)
-                    .where(SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID)
+                    .where(SqlPolicy.workspace_id == current_workspace_id())
                     .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
                     .where(SqlPolicy.name == name)
                 )
@@ -224,7 +224,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
     def get_default(self, policy_id: str) -> Policy | None:
         """Return a default policy by ID (``scope = 'default'``)."""
         with self._session() as session:
-            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
+            row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.scope != POLICY_SCOPE_DEFAULT:
                 return None
             return _to_entity(row)
@@ -234,7 +234,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         with self._session() as session:
             stmt = (
                 select(SqlPolicy)
-                .where(SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID)
+                .where(SqlPolicy.workspace_id == current_workspace_id())
                 .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
                 .order_by(asc(SqlPolicy.created_at), asc(SqlPolicy.id))
             )
@@ -254,7 +254,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         if not found or not a default policy.
         """
         with self._session() as session:
-            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
+            row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.scope != POLICY_SCOPE_DEFAULT:
                 return None
             changed = False
@@ -265,7 +265,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
                 conflict = (
                     session.execute(
                         select(SqlPolicy)
-                        .where(SqlPolicy.workspace_id == DEFAULT_WORKSPACE_ID)
+                        .where(SqlPolicy.workspace_id == current_workspace_id())
                         .where(SqlPolicy.scope == POLICY_SCOPE_DEFAULT)
                         .where(SqlPolicy.name == name)
                         .where(SqlPolicy.id != policy_id)
@@ -295,7 +295,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
     def delete_default(self, policy_id: str) -> bool:
         """Delete a default policy. Idempotent."""
         with self._session() as session:
-            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
+            row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.scope != POLICY_SCOPE_DEFAULT:
                 return False
             session.delete(row)

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -8,7 +8,12 @@ from typing import Any
 from sqlalchemy import asc, select
 from sqlalchemy.exc import IntegrityError
 
-from omnigent.db.db_models import POLICY_SCOPE_DEFAULT, POLICY_SCOPE_SESSION, SqlPolicy
+from omnigent.db.db_models import (
+    DEFAULT_WORKSPACE_ID,
+    POLICY_SCOPE_DEFAULT,
+    POLICY_SCOPE_SESSION,
+    SqlPolicy,
+)
 from omnigent.db.utils import (
     get_or_create_engine,
     make_managed_session_maker,
@@ -99,7 +104,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
     def get(self, policy_id: str, session_id: str) -> Policy | None:
         """Return the policy if it belongs to the given session."""
         with self._session() as session:
-            row = session.get(SqlPolicy, policy_id)
+            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
             if row is None or row.session_id != session_id:
                 return None
             return _to_entity(row)
@@ -129,7 +134,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         wrong session.
         """
         with self._session() as session:
-            row = session.get(SqlPolicy, policy_id)
+            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
             if row is None or row.session_id != session_id:
                 return None
             changed = False
@@ -150,7 +155,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
     def delete(self, policy_id: str, session_id: str) -> bool:
         """Delete a policy. Idempotent: returns ``False`` if not found."""
         with self._session() as session:
-            row = session.get(SqlPolicy, policy_id)
+            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
             if row is None or row.session_id != session_id:
                 return False
             session.delete(row)
@@ -217,7 +222,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
     def get_default(self, policy_id: str) -> Policy | None:
         """Return a default policy by ID (``scope = 'default'``)."""
         with self._session() as session:
-            row = session.get(SqlPolicy, policy_id)
+            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
             if row is None or row.scope != POLICY_SCOPE_DEFAULT:
                 return None
             return _to_entity(row)
@@ -246,7 +251,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         if not found or not a default policy.
         """
         with self._session() as session:
-            row = session.get(SqlPolicy, policy_id)
+            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
             if row is None or row.scope != POLICY_SCOPE_DEFAULT:
                 return None
             changed = False
@@ -286,7 +291,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
     def delete_default(self, policy_id: str) -> bool:
         """Delete a default policy. Idempotent."""
         with self._session() as session:
-            row = session.get(SqlPolicy, policy_id)
+            row = session.get(SqlPolicy, (DEFAULT_WORKSPACE_ID, policy_id))
             if row is None or row.scope != POLICY_SCOPE_DEFAULT:
                 return False
             session.delete(row)

--- a/tests/db/test_converters.py
+++ b/tests/db/test_converters.py
@@ -160,7 +160,7 @@ class TestSqlAgentToEntity:
             session.add(row)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, "ag_dbrt")
+            loaded = session.get(SqlAgent, (0, "ag_dbrt"))
             assert loaded is not None
             result = sql_agent_to_entity(loaded)
 
@@ -189,7 +189,7 @@ class TestSqlAgentToEntity:
             session.add(row)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, "ag_defver")
+            loaded = session.get(SqlAgent, (0, "ag_defver"))
             assert loaded is not None
             entity = sql_agent_to_entity(loaded)
             assert entity.version == 1

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -101,7 +101,7 @@ class TestSqlAgent:
             session.add(agent)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, "ag_test1")
+            loaded = session.get(SqlAgent, (0, "ag_test1"))
             assert loaded is not None
             assert loaded.name == "test-agent"
             assert loaded.version == 1
@@ -120,7 +120,7 @@ class TestSqlAgent:
             session.add(agent)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, "ag_test1")
+            loaded = session.get(SqlAgent, (0, "ag_test1"))
             assert loaded is not None
             assert loaded.description == "A test agent"
             assert loaded.updated_at is not None
@@ -135,7 +135,7 @@ class TestSqlAgent:
             session.add(agent)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, "ag_test1")
+            loaded = session.get(SqlAgent, (0, "ag_test1"))
             assert loaded is not None
             assert loaded.kind == "session"
 
@@ -171,7 +171,7 @@ class TestSqlFile:
             session.add(f)
 
         with managed() as session:
-            loaded = session.get(SqlFile, "file_test1")
+            loaded = session.get(SqlFile, (0, "file_test1"))
             assert loaded is not None
             assert loaded.filename == "report.pdf"
             assert loaded.bytes == 12345
@@ -191,7 +191,7 @@ class TestSqlFile:
             session.add(f)
 
         with managed() as session:
-            loaded = session.get(SqlFile, "file_test2")
+            loaded = session.get(SqlFile, (0, "file_test2"))
             assert loaded is not None
             assert loaded.content_type is None
 
@@ -209,7 +209,7 @@ class TestSqlUser:
             session.add(user)
 
         with managed() as session:
-            loaded = session.get(SqlUser, "alice@example.com")
+            loaded = session.get(SqlUser, (0, "alice@example.com"))
             assert loaded is not None
             assert loaded.is_admin is False
             assert loaded.password_hash is None
@@ -229,7 +229,7 @@ class TestSqlUser:
             session.add(user)
 
         with managed() as session:
-            loaded = session.get(SqlUser, "admin@example.com")
+            loaded = session.get(SqlUser, (0, "admin@example.com"))
             assert loaded is not None
             assert loaded.is_admin is True
             assert loaded.password_hash == "$argon2id$hash"
@@ -267,7 +267,7 @@ class TestSqlAccountToken:
             session.add(token)
 
         with managed() as session:
-            loaded = session.get(SqlAccountToken, "tok_invite_abc")
+            loaded = session.get(SqlAccountToken, (0, "tok_invite_abc"))
             assert loaded is not None
             assert loaded.kind == "invite"
             assert loaded.user_id is None
@@ -290,7 +290,7 @@ class TestSqlAccountToken:
             session.add(token)
 
         with managed() as session:
-            loaded = session.get(SqlAccountToken, "tok_magic_xyz")
+            loaded = session.get(SqlAccountToken, (0, "tok_magic_xyz"))
             assert loaded is not None
             assert loaded.kind == "magic"
             assert loaded.user_id == "alice@example.com"
@@ -324,7 +324,7 @@ class TestSqlConversation:
             session.add(conv)
 
         with managed() as session:
-            loaded = session.get(SqlConversation, "conv_test1")
+            loaded = session.get(SqlConversation, (0, "conv_test1"))
             assert loaded is not None
             assert loaded.title == "Hello World"
             assert loaded.kind == "default"
@@ -339,7 +339,7 @@ class TestSqlConversation:
             session.add(conv)
 
         with managed() as session:
-            loaded = session.get(SqlConversation, "conv_test1")
+            loaded = session.get(SqlConversation, (0, "conv_test1"))
             assert loaded is not None
             assert loaded.runner_id is None
             assert loaded.host_id is None
@@ -378,7 +378,7 @@ class TestSqlConversation:
             session.add(child)
 
         with managed() as session:
-            loaded = session.get(SqlConversation, "conv_child")
+            loaded = session.get(SqlConversation, (0, "conv_child"))
             assert loaded is not None
             assert loaded.kind == "sub_agent"
             assert loaded.parent_conversation_id == "conv_parent"
@@ -406,13 +406,13 @@ class TestSqlConversation:
             session.add(child)
 
         with managed() as session:
-            p = session.get(SqlConversation, "conv_parent2")
+            p = session.get(SqlConversation, (0, "conv_parent2"))
             assert p is not None
             session.delete(p)
 
         # Without FK cascade the child is NOT automatically deleted.
         with managed() as session:
-            assert session.get(SqlConversation, "conv_child2") is not None
+            assert session.get(SqlConversation, (0, "conv_child2")) is not None
 
 
 # ── SqlConversationItem ───────────────────────────────
@@ -430,7 +430,7 @@ class TestSqlConversationItem:
             session.add(item)
 
         with managed() as session:
-            loaded = session.get(SqlConversationItem, "msg_test1")
+            loaded = session.get(SqlConversationItem, (0, "msg_test1"))
             assert loaded is not None
             assert loaded.conversation_id == "conv_test1"
             assert loaded.type == "message"
@@ -469,13 +469,13 @@ class TestSqlConversationItem:
             session.add(item)
 
         with managed() as session:
-            c = session.get(SqlConversation, "conv_del")
+            c = session.get(SqlConversation, (0, "conv_del"))
             assert c is not None
             session.delete(c)
 
         # Without FK cascade the item is NOT automatically deleted.
         with managed() as session:
-            assert session.get(SqlConversationItem, "msg_del") is not None
+            assert session.get(SqlConversationItem, (0, "msg_del")) is not None
 
     def test_multiple_items_ordered_by_position(self, db_uri: str) -> None:
         engine = get_or_create_engine(db_uri)
@@ -571,7 +571,7 @@ class TestSqlSessionPermission:
             session.add(perm)
 
         with managed() as session:
-            loaded = session.get(SqlSessionPermission, ("alice@example.com", "conv_test1"))
+            loaded = session.get(SqlSessionPermission, (0, "alice@example.com", "conv_test1"))
             assert loaded is not None
             assert loaded.level == 2
 
@@ -621,7 +621,7 @@ class TestSqlComment:
             session.add(comment)
 
         with managed() as session:
-            loaded = session.get(SqlComment, "cmt_test1")
+            loaded = session.get(SqlComment, (0, "cmt_test1"))
             assert loaded is not None
             assert loaded.path == "src/App.tsx"
             assert loaded.body == "Looks good!"
@@ -651,7 +651,7 @@ class TestSqlComment:
             session.add(comment)
 
         with managed() as session:
-            loaded = session.get(SqlComment, "cmt_test2")
+            loaded = session.get(SqlComment, (0, "cmt_test2"))
             assert loaded is not None
             assert loaded.anchor_content is None
             assert loaded.created_by is None
@@ -678,7 +678,7 @@ class TestSqlPolicy:
             session.add(policy)
 
         with managed() as session:
-            loaded = session.get(SqlPolicy, "pol_test1")
+            loaded = session.get(SqlPolicy, (0, "pol_test1"))
             assert loaded is not None
             assert loaded.name == "cost-guard"
             assert loaded.type == "python"
@@ -737,7 +737,7 @@ class TestSqlHost:
             session.add(host)
 
         with managed() as session:
-            loaded = session.get(SqlHost, ("corey@example.com", "corey-laptop"))
+            loaded = session.get(SqlHost, (0, "corey@example.com", "corey-laptop"))
             assert loaded is not None
             assert loaded.host_id == "host_abc123"
             assert loaded.status == "online"
@@ -807,7 +807,7 @@ class TestSqlUserDailyCost:
             session.add(row)
 
         with managed() as session:
-            loaded = session.get(SqlUserDailyCost, ("alice@example.com", "2026-06-16"))
+            loaded = session.get(SqlUserDailyCost, (0, "alice@example.com", "2026-06-16"))
             assert loaded is not None
             assert loaded.cost_usd == pytest.approx(1.23)
             assert loaded.ask_approved_usd == pytest.approx(0.0)

--- a/tests/db/test_migration_workspace_id.py
+++ b/tests/db/test_migration_workspace_id.py
@@ -1,0 +1,119 @@
+"""Tests for the workspace_id migration (r1a2b3c4d5e6)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.db_models import DEFAULT_WORKSPACE_ID
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+# Every table and the primary key it had BEFORE the migration. After the
+# migration each key is ``["workspace_id", *original]``.
+_ORIGINAL_PKS: dict[str, list[str]] = {
+    "agents": ["id"],
+    "files": ["id"],
+    "users": ["id"],
+    "account_tokens": ["id"],
+    "session_permissions": ["user_id", "conversation_id"],
+    "conversations": ["id"],
+    "conversation_items": ["id"],
+    "conversation_labels": ["conversation_id", "key"],
+    "comments": ["id"],
+    "policies": ["id"],
+    "hosts": ["owner", "name"],
+    "user_daily_cost": ["user_id", "day_utc"],
+}
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite database with the full migration chain applied."""
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+@pytest.mark.parametrize("table", sorted(_ORIGINAL_PKS))
+def test_workspace_id_column_exists_and_is_not_nullable(db_engine: Engine, table: str) -> None:
+    """Every table gains a NOT NULL ``workspace_id`` column."""
+    columns = {c["name"]: c for c in sa.inspect(db_engine).get_columns(table)}
+    assert "workspace_id" in columns, f"{table}.workspace_id must exist after migration"
+    assert not columns["workspace_id"]["nullable"], f"{table}.workspace_id must be NOT NULL"
+
+
+@pytest.mark.parametrize("table", sorted(_ORIGINAL_PKS))
+def test_workspace_id_leads_the_primary_key(db_engine: Engine, table: str) -> None:
+    """The primary key becomes ``(workspace_id, *original)`` on every table."""
+    pk = sa.inspect(db_engine).get_pk_constraint(table)["constrained_columns"]
+    assert pk == ["workspace_id", *_ORIGINAL_PKS[table]]
+
+
+def test_existing_rows_and_omitted_inserts_default_to_zero(db_engine: Engine) -> None:
+    """server_default backfills existing rows and fills omitted inserts with 0."""
+    with db_engine.begin() as conn:
+        # Insert without specifying workspace_id — the DB server_default applies.
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents"
+                " (id, created_at, name, bundle_location, version, kind)"
+                " VALUES ('ag_ws', 1, 'n', 'loc', 1, 'template')"
+            )
+        )
+        workspace_id = conn.execute(
+            sa.text("SELECT workspace_id FROM agents WHERE id = 'ag_ws'")
+        ).scalar_one()
+    assert workspace_id == DEFAULT_WORKSPACE_ID
+
+
+def test_agent_round_trip_via_store(db_engine: Engine) -> None:
+    """A store insert/read cycle still works once workspace_id is in the PK."""
+    from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+
+    store = SqlAlchemyAgentStore(str(db_engine.url))
+    created = store.create(
+        agent_id="ag_rt",
+        name="round-trip",
+        bundle_location="loc",
+    )
+    fetched = store.get(created.id)
+    assert fetched is not None
+    assert fetched.id == "ag_rt"
+
+
+def test_downgrade_removes_workspace_id_and_restores_pk(tmp_path: Path) -> None:
+    """Downgrade drops workspace_id and restores each original primary key."""
+    db_path = tmp_path / "downgrade.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+
+    # Start at head (includes r1a2b3c4d5e6).
+    assert "workspace_id" in {c["name"] for c in sa.inspect(engine).get_columns("agents")}
+
+    # Downgrade one step to the prior head.
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, "q1a2b3c4d5e6")
+
+    inspector = sa.inspect(engine)
+    for table, original_pk in _ORIGINAL_PKS.items():
+        columns = {c["name"] for c in inspector.get_columns(table)}
+        assert "workspace_id" not in columns, f"{table}.workspace_id must be dropped by downgrade"
+        assert inspector.get_pk_constraint(table)["constrained_columns"] == original_pk
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/db/test_utils_extended.py
+++ b/tests/db/test_utils_extended.py
@@ -113,7 +113,7 @@ class TestManagedSessionMaker:
 
         # Data should be visible in a new session
         with managed() as session:
-            loaded = session.get(SqlUser, "commit_test")
+            loaded = session.get(SqlUser, (0, "commit_test"))
             assert loaded is not None
 
     def test_auto_rollback_on_exception(self, db_uri: str) -> None:
@@ -127,7 +127,7 @@ class TestManagedSessionMaker:
 
         # Data should NOT be visible
         with managed() as session:
-            loaded = session.get(SqlUser, "rollback_test")
+            loaded = session.get(SqlUser, (0, "rollback_test"))
             assert loaded is None
 
     def test_sqlite_foreign_keys_enabled(self, db_uri: str) -> None:
@@ -147,7 +147,7 @@ class TestManagedSessionMaker:
             session.add(SqlUser(id="immediate_test", is_admin=False))
 
         with managed() as session:
-            loaded = session.get(SqlUser, "immediate_test")
+            loaded = session.get(SqlUser, (0, "immediate_test"))
             assert loaded is not None
 
 

--- a/tests/db/test_workspace_scope.py
+++ b/tests/db/test_workspace_scope.py
@@ -1,0 +1,63 @@
+"""Tests for the ``current_workspace_id`` / ``workspace_scope`` seam.
+
+The stores hardcode no workspace id: reads, filters, and inserts resolve it
+through ``current_workspace_id()`` (a ContextVar). OSS leaves it at the
+default (0); a multi-tenant deployment binds a real id per request via
+``workspace_scope``. These tests pin that behaviour so the seam stays the
+single place a workspace id is injected.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from omnigent.db.db_models import (
+    DEFAULT_WORKSPACE_ID,
+    current_workspace_id,
+    workspace_scope,
+)
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+
+
+def test_default_workspace_is_zero() -> None:
+    """With nothing bound, the resolver yields the OSS default (0)."""
+    assert current_workspace_id() == DEFAULT_WORKSPACE_ID == 0
+
+
+def test_workspace_scope_sets_and_resets() -> None:
+    """``workspace_scope`` binds inside the block and restores on exit."""
+    assert current_workspace_id() == 0
+    with workspace_scope(42):
+        assert current_workspace_id() == 42
+        with workspace_scope(7):
+            assert current_workspace_id() == 7
+        assert current_workspace_id() == 42
+    assert current_workspace_id() == 0
+
+
+def test_insert_stamps_scoped_workspace(db_uri: str) -> None:
+    """An ORM insert stamps ``workspace_id`` from the active context."""
+    store = SqlAlchemyAgentStore(db_uri)
+    store.create(agent_id="ag_ws0", name="n0", bundle_location="loc")
+    with workspace_scope(42):
+        store.create(agent_id="ag_ws42", name="n42", bundle_location="loc")
+
+    engine = sa.create_engine(db_uri)
+    with engine.connect() as conn:
+        stored = dict(conn.exec_driver_sql("SELECT id, workspace_id FROM agents").fetchall())
+    engine.dispose()
+    assert stored == {"ag_ws0": 0, "ag_ws42": 42}
+
+
+def test_reads_are_isolated_per_workspace(db_uri: str) -> None:
+    """A row created in one workspace is invisible from another."""
+    store = SqlAlchemyAgentStore(db_uri)
+    store.create(agent_id="ag_default", name="d", bundle_location="loc")
+    with workspace_scope(42):
+        store.create(agent_id="ag_tenant", name="t", bundle_location="loc")
+        # In workspace 42: sees its own row, not workspace 0's.
+        assert store.get("ag_tenant") is not None
+        assert store.get("ag_default") is None
+    # Back in the default workspace: the reverse.
+    assert store.get("ag_default") is not None
+    assert store.get("ag_tenant") is None

--- a/tests/server/test_accounts.py
+++ b/tests/server/test_accounts.py
@@ -1485,7 +1485,7 @@ def test_admin_list_excludes_legacy_local_and_public_sentinels(
     session_maker = make_managed_session_maker(engine)
     with session_maker() as session:
         for sentinel in ("local", "__public__"):
-            if session.get(SqlUser, sentinel) is None:
+            if session.get(SqlUser, (0, sentinel)) is None:
                 session.add(SqlUser(id=sentinel, is_admin=False))
         session.commit()
 

--- a/tests/server/test_identity_migration.py
+++ b/tests/server/test_identity_migration.py
@@ -156,9 +156,9 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
     remap_identities(engine, {"alice": "alice@example.com"}, dry_run=False)
 
     with Session(engine) as s:
-        assert s.get(SqlComment, "cmt_1").created_by == "alice@example.com"
-        assert s.get(SqlPolicy, "pol_1").created_by == "alice@example.com"
-        assert s.get(SqlAccountToken, "tok_1").created_by == "alice@example.com"
+        assert s.get(SqlComment, (0, "cmt_1")).created_by == "alice@example.com"
+        assert s.get(SqlPolicy, (0, "pol_1")).created_by == "alice@example.com"
+        assert s.get(SqlAccountToken, (0, "tok_1")).created_by == "alice@example.com"
         host_owners = s.execute(select(SqlHost.owner)).scalars().all()
         assert host_owners == ["alice@example.com"]
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4122,7 +4122,7 @@ def _stored_next_position(
     from omnigent.db.db_models import SqlConversation
 
     with conversation_store._session() as session:
-        row = session.get(SqlConversation, conversation_id)
+        row = session.get(SqlConversation, (0, conversation_id))
         assert row is not None
         return row.next_position
 
@@ -4192,7 +4192,7 @@ def test_append_reads_counter_not_max_scan(
     conversation_store.append(conv.id, [_user_message("a"), _user_message("b")])
     # Real max position is 1; jump the counter ahead to 100.
     with conversation_store._session() as session:
-        session.get(SqlConversation, conv.id).next_position = 100
+        session.get(SqlConversation, (0, conv.id)).next_position = 100
 
     conversation_store.append(conv.id, [_user_message("c")])
 
@@ -4218,7 +4218,7 @@ def test_append_falls_back_to_scan_when_counter_null(
         conversation_store.append(conv.id, [_user_message(f"pre{i}") for i in range(preexisting)])
     # Simulate a pre-counter row: clear the maintained counter.
     with conversation_store._session() as session:
-        session.get(SqlConversation, conv.id).next_position = None
+        session.get(SqlConversation, (0, conv.id)).next_position = None
     assert _stored_next_position(conversation_store, conv.id) is None
 
     conversation_store.append(conv.id, [_user_message("new")])


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds a `workspace_id` tenant column to all twelve database tables, folds it into
each primary key as the **leading** column, and routes every data-access path
through a single workspace-resolution seam so the code is multi-tenant-ready
while staying a no-op for single-workspace OSS. Three commits:

**1. Schema — `workspace_id` on every table, leading the PK.**
`workspace_id` (`BigInteger`, `NOT NULL`, `server_default 0`) is added as the
first PK member on `agents`, `files`, `users`, `account_tokens`,
`session_permissions`, `conversations`, `conversation_items`,
`conversation_labels`, `comments`, `policies`, `hosts`, `user_daily_cost`.
Migration `r1a2b3c4d5e6` backfills existing rows to 0 and rebuilds each PK to
`(workspace_id, <existing pk cols>)` — SQLite-safe batch recreate, explicit PK
drop on PostgreSQL, fully reversible.

**2. Scope every query to the workspace.**
With `workspace_id` leading the PK, a `WHERE id = ?` could no longer seek the
index. Every store/server query — selects, updates, deletes, subqueries, joins,
the legacy `Query.filter` paths, and the raw-SQL search fallback — now
constrains `workspace_id`, so primary-key lookups seek the composite PK again
and every access path is workspace-scoped.

**3. Resolve the workspace id through a context seam, not a constant.**
Adds `current_workspace_id()` (a `ContextVar` defaulting to
`DEFAULT_WORKSPACE_ID`) and a `workspace_scope()` context manager. Reads/filters
call the resolver instead of a hardcoded constant, and the `workspace_id`
column's insert default is the callable (ORM inserts stamp the active
workspace). OSS leaves the ContextVar at 0 → unchanged behaviour. A multi-tenant
deployment binds a real id per request via `workspace_scope` in middleware — an
**additive** change that modifies none of these files, so the code stays
identical across deployments and syncs cleanly.

Not included (deferred to a multi-tenant deployment): making the *secondary*
indexes `workspace_id`-leading. It only affects selectivity once many
workspaces share a DB; a no-op for single-workspace OSS.

## Test Plan

- `tests/db/test_migration_workspace_id.py` — column present + NOT NULL and
  `workspace_id` leads the PK on all 12 tables; default-0 backfill; store
  round-trip; downgrade restores each original PK.
- `tests/db/test_workspace_scope.py` — resolver default (0), `workspace_scope`
  set/reset, insert stamping, and cross-workspace read isolation.
- Updated the existing db / store / server unit tests for the composite key.
- `pre-commit` (ruff format + check + secret-scan) clean; **746 passed** across
  `tests/stores`, `tests/db`, `tests/server/test_accounts.py`,
  `test_identity_migration.py`, `test_permissions.py`. The only failures are the
  pre-existing `tests/db/test_utils.py` cases needing the `psycopg` driver (not
  installed locally) — confirmed identical with these changes stashed, so
  unrelated.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behaviour is unchanged (all rows are workspace 0 in OSS). The new migration and
workspace-scope tests plus the updated store/db/server unit tests cover the
schema change, the composite-key access paths, and the resolver seam.

This pull request and its description were written by Isaac.
