### PR TITLE
fix: harden polly test count reconciliation

### DIFF
--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -22,6 +22,8 @@ prompt: |
     contract.
   - Make the change, then drive it to green: run the relevant tests, lint, and
     typecheck for the code you touched.
+  - When you report test results, include the exact command and file set. If
+    you mention counts, distinguish collected test cases from test functions.
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`

--- a/examples/polly/agents/codex/config.yaml
+++ b/examples/polly/agents/codex/config.yaml
@@ -22,6 +22,8 @@ prompt: |
     contract.
   - Make the change, then drive it to green: run the relevant tests, lint, and
     typecheck for the code you touched.
+  - When you report test results, include the exact command and file set. If
+    you mention counts, distinguish collected test cases from test functions.
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`

--- a/examples/polly/agents/cursor/config.yaml
+++ b/examples/polly/agents/cursor/config.yaml
@@ -32,6 +32,8 @@ prompt: |
     contract.
   - Make the change, then drive it to green: run the relevant tests, lint, and
     typecheck for the code you touched.
+  - When you report test results, include the exact command and file set. If
+    you mention counts, distinguish collected test cases from test functions.
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`

--- a/examples/polly/agents/hermes/config.yaml
+++ b/examples/polly/agents/hermes/config.yaml
@@ -22,6 +22,8 @@ prompt: |
     contract.
   - Make the change, then drive it to green: run the relevant tests, lint, and
     typecheck for the code you touched.
+  - When you report test results, include the exact command and file set. If
+    you mention counts, distinguish collected test cases from test functions.
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`

--- a/examples/polly/agents/opencode/config.yaml
+++ b/examples/polly/agents/opencode/config.yaml
@@ -23,6 +23,8 @@ prompt: |
     contract.
   - Make the change, then drive it to green: run the relevant tests, lint, and
     typecheck for the code you touched.
+  - When you report test results, include the exact command and file set. If
+    you mention counts, distinguish collected test cases from test functions.
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`

--- a/examples/polly/agents/pi/config.yaml
+++ b/examples/polly/agents/pi/config.yaml
@@ -21,6 +21,8 @@ prompt: |
     contract.
   - Make the change, then drive it to green: run the relevant tests, lint, and
     typecheck for the code you touched.
+  - When you report test results, include the exact command and file set. If
+    you mention counts, distinguish collected test cases from test functions.
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -178,6 +178,16 @@ prompt: |
   write or edit source code or tests, run a deep code investigation for your own
   answer, or merge a PR — those go to sub-agents.
 
+  Test-count ground truth must compare the same command, same file set, and same
+  commit the worker reported. For pytest, collected CASES are the count: use
+  `python -m pytest --collect-only -q <same files>` when reconciling a reported
+  total, and never use `grep -c 'def test_'` as a correctness oracle. A single
+  test function can expand into many collected cases via parametrized tests, and
+  a one-file function count cannot be compared to a multi-file gate. Do not record
+  `miscount`, `over-report`, or `fabrication` in `.polly/registry.json` or a
+  handoff unless you have re-collected the same gate at the same commit and the
+  numbers still disagree.
+
   For long-running processes that can't block a single tool call (a local dev
   server on localhost:PORT, file watchers, tailing logs) or ad-hoc shell where
   `sys_os_shell`'s one-shot blocking model doesn't fit, launch the `shell`

--- a/examples/polly/skills/cross-review/SKILL.md
+++ b/examples/polly/skills/cross-review/SKILL.md
@@ -15,6 +15,11 @@ anyone needs to read through.
 2. Run the deterministic gates first — tests / lint / typecheck via
    `sys_os_shell`. If red, re-dispatch the implementer to drive it green first;
    don't involve the reviewer yet.
+   If a pytest result's count must be recorded or reconciled, collect ground
+   truth with `python -m pytest --collect-only -q <same files>` against the
+   exact file set/command/commit the implementer reported. Never use
+   `grep -c 'def test_'` as a pytest count: it counts functions, not collected
+   cases, and misses parametrized case expansion.
 3. Dispatch a DIFFERENT-vendor sub-agent as reviewer: pick any AVAILABLE worker
    whose vendor differs from the implementer's — `claude_code`, `codex`,
    `opencode`, `cursor`, `hermes`, or `pi` (e.g. Claude built it → any of

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -208,6 +208,43 @@ def test_orchestrator_keeps_timer_tool_but_forbids_worker_polling(
     assert "not for polling workers that already auto-wake you" in compact
 
 
+def test_polly_test_count_ground_truth_guidance() -> None:
+    """
+    Polly prevents pytest count reconciliation from using source-function counts.
+
+    Regression guard for #949: a prior orchestration handoff compared a worker's
+    multi-file pytest total against ``grep -c 'def test_'`` from a single file,
+    which misses parametrized case expansion and falsely labels accurate reports
+    as over-counts. The contract must be present at the orchestrator layer, the
+    cross-review workflow, while workers supply enough exact test context for
+    Polly to verify the same gate.
+    """
+    config = (_POLLY_BUNDLE / "config.yaml").read_text(encoding="utf-8")
+    cross_review = (_POLLY_BUNDLE / "skills" / "cross-review" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    config_compact = " ".join(config.split())
+    cross_review_compact = " ".join(cross_review.split())
+    for text in (config_compact, cross_review_compact):
+        assert "python -m pytest --collect-only -q <same files>" in text
+        assert "grep -c 'def test_'" in text
+        assert "collected cases" in text
+        assert "parametrized" in text
+
+    assert "same command, same file set, and same commit" in config_compact
+    assert "miscount`, `over-report`, or `fabrication`" in config_compact
+    assert "exact file set/command/commit" in cross_review_compact
+
+    for name in ("claude_code", "codex", "opencode", "cursor", "hermes", "pi"):
+        worker = (_POLLY_BUNDLE / "agents" / name / "config.yaml").read_text(encoding="utf-8")
+        worker_compact = " ".join(worker.split())
+        assert "When you report test results, include the exact command and file set" in (
+            worker_compact
+        ), name
+        assert "distinguish collected test cases from test functions" in worker_compact, name
+
+
 def test_orchestrator_forbids_premature_idle_after_announcing_intent() -> None:
     """
     The base prompt forbids ending a turn after only announcing intent.


### PR DESCRIPTION
## Related issue

Closes #949

## Summary

- Teach Polly to reconcile pytest test counts against the same command, same file set, and same commit the worker reported.
- Centralize the full `pytest --collect-only` guidance in Polly/cross-review, while workers report exact test commands/file sets and distinguish collected cases from test functions.
- Add a Polly regression test that prevents the guidance from disappearing across the orchestrator prompt, cross-review skill, and worker prompts.

## Test Plan

Passed targeted validation:

- In the working checkout:
  - `wsl --cd /mnt/c/Users/ptran/Downloads/Projects/omnigent bash -lc ".venv/bin/python -m pytest -q tests/e2e/omnigent/test_example_polly.py::test_polly_test_count_ground_truth_guidance"`
  - `wsl --cd /mnt/c/Users/ptran/Downloads/Projects/omnigent bash -lc ".venv/bin/python -m pytest -q tests/e2e/omnigent/test_example_polly.py"`
  - `wsl --cd /mnt/c/Users/ptran/Downloads/Projects/omnigent bash -lc ".venv/bin/python -m ruff check tests/e2e/omnigent/test_example_polly.py"`
  - `wsl --cd /mnt/c/Users/ptran/Downloads/Projects/omnigent bash -lc ".venv/bin/python -m ruff format --check tests/e2e/omnigent/test_example_polly.py"`

- In a fresh WSL-native clone at `/tmp/omnigent-native-check`:
  - `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev python -m pytest -q tests/e2e/omnigent/test_example_polly.py`
  - `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev python -m ruff check tests/e2e/omnigent/test_example_polly.py`
  - `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev python -m ruff format --check tests/e2e/omnigent/test_example_polly.py`
  - `git diff --check FETCH_HEAD..HEAD`

Manual reproduction of the issue shape:

- Source `def test_` counts:
  - `tests/inner/test_ui.py`: `7`
  - `tests/inner/test_ui.py` + `tests/entities/test_conversation.py`: `12`
- Pytest collected cases for the same gates:
  - `tests/inner/test_ui.py`: `10`
  - two-file gate: `27`

Broader checks attempted but not green in this local environment:

- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev pytest`
  - Collected `14,528` tests, but failed in unrelated suites and eventually timed out in server/integration tests. No failure was in the touched Polly files.
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev python -m ruff check .`
  - Failed on unrelated `web/src/shell/__fixtures__/*.ipynb` notebook fixture issues.
- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev python -m ruff format --check .`
  - Failed on the same unrelated notebook fixture area. The touched Python test file is formatted.
- `OMNIGENT_SKIP_WEB_UI=true uv run pre-commit run --all-files`
  - Failed in web/Prettier-related hooks. The WSL environment has Node `v18.19.1`, while `CONTRIBUTING.md` requires Node 22+ for web tooling.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a focused Polly example/spec regression test and ran the full Polly example/spec test file in both the working checkout and a fresh WSL-native clone. Also manually reproduced the pytest count mismatch that caused #949: source `def test_` counts undercount parametrized and multi-file pytest gates.

Full repo checks were attempted from the WSL-native clone but are not reported as passing because they failed on unrelated suites / web fixture tooling outside this Polly prompt/test change.

## Changelog

Polly now verifies pytest test-count discrepancies against collected cases before recording miscount/fabrication claims.