### PR TITLE
fix(server): resolve endpoint never wakes a parked harness elicitation

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -4053,6 +4053,15 @@ async def _resolve_elicitation(
                 result=pre_resolved,
             )
             _prune_pre_resolved_harness_elicitations()
+    # Wake a currently-parked long-poll via resolved_elsewhere, not only its
+    # Future: setting the Future alone races the sever/re-park cycle and the
+    # ASK-gated call hangs. Set the event directly; the signal helper's
+    # parked-is-None branch would clobber the verdict-carrying tombstone.
+    if isinstance(elicitation_id, str) and elicitation_id:
+        _parked = _harness_parked_elicitations.get(elicitation_id)
+        if _parked is not None and _harness_elicitation_owners.get(elicitation_id) == session_id:
+            _parked.resolved_elsewhere.set()
+
     # Fan-out for every other subscribed client (other tabs, REPL
     # TUI). Idempotent vs. the runner's own ``wait_for_user_approval``
     # finally / harness hook finally — those also publish for the id.

--- a/tests/server/test_resolve_url_wakes_harness_park.py
+++ b/tests/server/test_resolve_url_wakes_harness_park.py
@@ -1,0 +1,81 @@
+"""The resolve-URL path (UI Approve) must wake a parked harness elicitation via
+its ``resolved_elsewhere`` event, not only its Future.
+
+Before the fix, ``_resolve_elicitation`` set the Future but never signalled
+``_harness_parked_elicitations``, so an ASK-gated tool call whose long-poll had
+severed/re-parked never woke on UI Approve → indefinite hang. Only the
+``/events`` path signalled it. This locks the resolve-URL path in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from omnigent.server.routes import sessions as S
+
+
+@pytest.mark.asyncio
+async def test_resolve_elicitation_signals_parked_harness_elicitation():
+    sid = "conv_resolveurl_test"
+    eid = "elicit_evaluate_deadbeefdeadbeefdeadbeefdeadbeef"
+    parked = S._ParkedHarnessElicitation(
+        session_id=sid,
+        tool_name="mcp_example__apply_change",
+        tool_input={},
+        resolved_elsewhere=asyncio.Event(),
+    )
+    S._harness_parked_elicitations[eid] = parked
+    S._harness_elicitation_owners[eid] = sid
+    try:
+        assert not parked.resolved_elsewhere.is_set()
+        # runner_router=None → the runner forward is skipped; we only assert the
+        # server-side parked-elicitation wake.
+        await S._resolve_elicitation(sid, {"elicitation_id": eid, "action": "accept"}, None)
+        assert parked.resolved_elsewhere.is_set(), (
+            "resolve-URL must signal the parked harness elicitation (resolved_elsewhere), "
+            "otherwise an ASK-gated tool hangs on UI Approve"
+        )
+    finally:
+        S._harness_parked_elicitations.pop(eid, None)
+        S._harness_elicitation_owners.pop(eid, None)
+
+
+@pytest.mark.asyncio
+async def test_not_parked_resolve_keeps_verdict_tombstone():
+    # Regression (#62 review): when nothing is parked (severed long-poll, before
+    # the retry re-parks), resolve-URL must store a pre-resolved tombstone
+    # carrying the ACTUAL verdict, so the re-park returns it. The resolved_elsewhere
+    # wake must NOT clobber it with a verdict-less tombstone.
+    sid = "conv_tombstone"
+    eid = "elicit_evaluate_22222222222222222222222222222222"
+    S._harness_parked_elicitations.pop(eid, None)  # ensure NOT parked
+    S._harness_pre_resolved_elicitations.pop(eid, None)
+    try:
+        await S._resolve_elicitation(sid, {"elicitation_id": eid, "action": "accept"}, None)
+        tomb = S._harness_pre_resolved_elicitations.get(eid)
+        assert tomb is not None, "a not-parked resolve must leave a pre-resolved tombstone"
+        assert tomb.result is not None, "the tombstone must carry the verdict (not clobbered)"
+    finally:
+        S._harness_pre_resolved_elicitations.pop(eid, None)
+
+
+@pytest.mark.asyncio
+async def test_resolve_elicitation_wrong_session_does_not_wake():
+    # Ownership guard: a resolve for a DIFFERENT session must not wake this park.
+    sid = "conv_owner"
+    eid = "elicit_evaluate_11111111111111111111111111111111"
+    parked = S._ParkedHarnessElicitation(
+        session_id=sid, tool_name="t", tool_input={}, resolved_elsewhere=asyncio.Event()
+    )
+    S._harness_parked_elicitations[eid] = parked
+    S._harness_elicitation_owners[eid] = sid
+    try:
+        await S._resolve_elicitation(
+            "conv_other", {"elicitation_id": eid, "action": "accept"}, None
+        )
+        assert not parked.resolved_elsewhere.is_set()
+    finally:
+        S._harness_parked_elicitations.pop(eid, None)
+        S._harness_elicitation_owners.pop(eid, None)


### PR DESCRIPTION
## Related issue

Closes #2141

## Summary

Resolving an elicitation through the resolve endpoint completes the elicitation's Future but never signals `resolved_elsewhere`, so a harness turn parked on that elicitation stays parked until its timeout. Visible symptom: approving an inbox approval card returns 202 and the approved tool call never resumes. Related but distinct from #2055 (between-poll tombstone delivery).

The fix wires the resolve path to the existing `resolved_elsewhere` registry in `omnigent/server/routes/sessions.py`, the same mechanism the terminal resolve path already uses.

## Test Plan

`tests/server/test_resolve_url_wakes_harness_park.py` parks a harness elicitation, resolves it via the endpoint, and asserts the parked wait wakes with the verdict. It fails before the fix:

```
AssertionError: assert False
 +  where False = is_set()
 +    where <asyncio.locks.Event ... [unset]> = _ParkedHarnessElicitation(...).resolved_elsewhere
```

and passes after. Full `tests/server/` suite on the fixed branch: 2104 passed, 3 xfailed.

## Demo

Server-side fix; the user-visible behavior is "inbox Approve does nothing". The regression test red -> green:

![regression test fails before the fix and passes after](https://raw.githubusercontent.com/dosenr/omnigent/assets/pr-2142-demo/2142-demo.png)

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit test added

## Changelog

Fixed inbox approvals not resuming the gated tool call.
