### PR TITLE
fix(web): stop offering OpenAI Agents SDK in the agent harness picker

### DIFF
--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -619,7 +619,9 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "codex": "Codex",
         "copilot": "Copilot",
         "cursor": "Cursor",
-        "openai-agents": "OpenAI Agents SDK",
+        # openai-agents is intentionally omitted from the picker catalog: it
+        # stays a valid harness for YAML specs (and the credential-free
+        # integration mock LLM), but is no longer offered as a UI pick.
         "pi": "Pi",
     },
     capabilities=_BUILTIN_CAPABILITIES,

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1005,8 +1005,9 @@ async def _drive_select_harness(base_url: str, session_id: str) -> None:
             # Polly auto-selects (ranked ahead of Debby); its brain-harness
             # override radios live in the picker's per-entry config submenu.
             await _open_entry_config(page, "ag_polly_e2e")
-            # All four brain harnesses render as radio rows, in registry order.
-            for harness in ("claude-sdk", "openai-agents", "codex", "pi"):
+            # The built-in brain harnesses render as radio rows, in registry
+            # order (openai-agents is intentionally not offered in the picker).
+            for harness in ("claude-sdk", "codex", "pi"):
                 await expect(
                     page.get_by_test_id(f"new-chat-landing-harness-{harness}")
                 ).to_be_visible()

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -13,12 +13,13 @@ import { authenticatedFetch } from "@/lib/identity";
  * are canonical server harness ids, values are picker labels. Native
  * terminal wrappers (claude-native / codex-native) are deliberately
  * absent: an agent whose declared harness isn't in this map gets no
- * harness options or pill suffix at all.
+ * harness options or pill suffix at all. ``openai-agents`` is likewise
+ * omitted — it stays a valid harness for YAML specs (the server
+ * ``harness_labels`` catalog drops it too), but is not offered as a pick.
  */
 export const BRAIN_HARNESS_LABELS: Record<string, string> = {
   // Insertion order IS the fly-out's menu order.
   "claude-sdk": "Claude SDK",
-  "openai-agents": "OpenAI Agents SDK",
   codex: "Codex",
   cursor: "Cursor",
   pi: "Pi",

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -33,7 +33,6 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
-    "openai-agents": "OpenAI Agents SDK",
     codex: "Codex",
     cursor: "Cursor",
     pi: "Pi",

--- a/web/src/pages/ChatPage.mention.test.tsx
+++ b/web/src/pages/ChatPage.mention.test.tsx
@@ -66,7 +66,6 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
-    "openai-agents": "OpenAI Agents SDK",
     codex: "Codex",
     cursor: "Cursor",
     pi: "Pi",

--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -41,7 +41,6 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
-    "openai-agents": "OpenAI Agents SDK",
     codex: "Codex",
     cursor: "Cursor",
     pi: "Pi",

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -83,7 +83,6 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
-    "openai-agents": "OpenAI Agents SDK",
     codex: "Codex",
     cursor: "Cursor",
     pi: "Pi",

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -71,7 +71,6 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
-    "openai-agents": "OpenAI Agents SDK",
     codex: "Codex",
     cursor: "Cursor",
     pi: "Pi",


### PR DESCRIPTION
## What

Removes **OpenAI Agents SDK** (`openai-agents`) as a selectable brain harness in the UI pickers (composer / new-chat / create-agent) that appear for bundle YAML agents — polly, debby, and other custom agents.

## Why

`openai-agents` is a footgun as a per-session brain for custom agents: an unpinned model is treated as a Databricks model and silently falls back to the Databricks gateway (the same reason `examples/debby/agents/gpt` already documents choosing `codex` over it). It shouldn't be offered as a pick.

## How

Picker labels come from `useBrainHarnessLabels()`, which merges two sources — the server harness catalog (`GET /v1/harnesses`) and a static `BRAIN_HARNESS_LABELS` fallback. The web merge only **adds** server rows (never removes), so `openai-agents` had to be dropped from **both**:

- `omnigent/harness_plugins.py` — remove its `harness_labels` entry (drops it from the `/v1/harnesses` catalog).
- `web/src/lib/agentLabels.ts` — remove it from the static `BRAIN_HARNESS_LABELS` seed.

`openai-agents` stays a **fully valid harness** — `valid_harnesses`, `harness_modules`, `capabilities`, aliases, and model-env keys are untouched. It remains usable in YAML specs and remains the credential-free mock harness the integration/e2e suites and the required `Integration (openai-agents)` CI check depend on. Only the UI picker option is removed.

## Tests

- Updated the `test_start_session` e2e_ui picker assertion (dropped `openai-agents` from the expected radio rows).
- Scrubbed the `openai-agents` seed from 5 web unit-test `useBrainHarnessLabels` mocks so the doubles match the real picker set.

This pull request and its description were written by Isaac.
