### PR TITLE
feat(auth): optional trusted-proxy proof for header mode

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -476,6 +476,21 @@ forwarding, anyone can impersonate anyone by sending the header themselves.
 Getting this wrong exposes every user's sessions, conversation history, tool
 output, and files to every other caller.
 
+For defense in depth, header mode can also require a trusted-proxy proof
+header before it accepts the identity header:
+
+```dotenv
+OMNIGENT_AUTH_PROVIDER=header
+OMNIGENT_AUTH_PROXY_PROOF_VALUE=<shared-secret>
+# Optional; defaults to X-Omnigent-Proxy-Proof
+OMNIGENT_AUTH_PROXY_PROOF_HEADER=X-Omnigent-Proxy-Proof
+```
+
+When `OMNIGENT_AUTH_PROXY_PROOF_VALUE` is unset, header mode behaves as
+before. When it is set, requests that carry the identity header are rejected
+unless the configured proof header has the exact configured value. The proxy
+must strip any client-supplied proof header before injecting its own.
+
 **For almost everyone, use built-in `accounts` (the default in these
 deploys) or `oidc`**; both authenticate users at the server with no proxy to
 get right. Only choose `header` when you already operate a proxy you trust

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -227,6 +227,8 @@ trusts whatever value reaches it.
 | `OMNIGENT_AUTH_PROVIDER` | unset | Escape hatch to pin a mode explicitly: `header` / `accounts` / `oidc`. Overrides the `AUTH_ENABLED` auto-selection. |
 | `OMNIGENT_AUTH_HEADER` | `X-Forwarded-Email` | Header-mode only: name of the trusted identity header. Set for proxies that use another name, e.g. `Cf-Access-Authenticated-User-Email` (Cloudflare Access). |
 | `OMNIGENT_AUTH_HEADER_STRIP_PREFIX` | unset (strip nothing) | Header-mode only: prefix removed from the identity header value. Set to `accounts.google.com:` for Google IAP's `X-Goog-Authenticated-User-Email`. |
+| `OMNIGENT_AUTH_PROXY_PROOF_VALUE` | unset | Header-mode only: optional proof value required before the server trusts the identity header. Unset preserves existing behavior. |
+| `OMNIGENT_AUTH_PROXY_PROOF_HEADER` | `X-Omnigent-Proxy-Proof` | Header-mode only: proof header name used when `OMNIGENT_AUTH_PROXY_PROOF_VALUE` is set. The proxy must strip client-supplied copies before injecting its own. |
 | `OMNIGENT_OIDC_*` | unset | OIDC config — required in oidc mode (issuer set, or `AUTH_PROVIDER=oidc`). See `.env.example`. |
 | `PYPI_INDEX_URL` | `https://pypi.org/simple` | Build-time PyPI index — override only behind a corporate proxy. |
 

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -27,6 +27,7 @@ and closed over by route factories — no per-request import cost.
 
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 import time
@@ -72,6 +73,16 @@ _DEFAULT_AUTH_HEADER = "X-Forwarded-Email"
 # email used everywhere else. Unset (the default) strips nothing. See
 # :func:`resolve_auth_header_strip_prefix`.
 _AUTH_HEADER_STRIP_PREFIX_ENV = "OMNIGENT_AUTH_HEADER_STRIP_PREFIX"
+
+# Optional proof header required before a header-auth identity is trusted.
+# When OMNIGENT_AUTH_PROXY_PROOF_VALUE is unset, header auth behaves exactly
+# as before. When set, any request that carries the configured identity header
+# must also carry this proof header with the exact configured value. This lets
+# a deployed server validate that X-Forwarded-Email came through a trusted
+# local proxy/injector instead of relying solely on a host firewall.
+_AUTH_PROXY_PROOF_HEADER_ENV = "OMNIGENT_AUTH_PROXY_PROOF_HEADER"
+_DEFAULT_AUTH_PROXY_PROOF_HEADER = "X-Omnigent-Proxy-Proof"
+_AUTH_PROXY_PROOF_VALUE_ENV = "OMNIGENT_AUTH_PROXY_PROOF_VALUE"
 
 LEVEL_READ = 1
 LEVEL_EDIT = 2
@@ -151,6 +162,32 @@ def resolve_auth_header_strip_prefix() -> str:
     :returns: The prefix to strip, or ``""`` to strip nothing.
     """
     return os.environ.get(_AUTH_HEADER_STRIP_PREFIX_ENV, "").strip()
+
+
+def resolve_auth_proxy_proof_header() -> str:
+    """Resolve the trusted-proxy proof header name for header-auth mode.
+
+    Reads ``OMNIGENT_AUTH_PROXY_PROOF_HEADER`` and falls back to
+    ``X-Omnigent-Proxy-Proof`` when unset or empty. Only consulted when
+    ``OMNIGENT_AUTH_PROXY_PROOF_VALUE`` is set.
+
+    :returns: The proof header name.
+    """
+    raw = os.environ.get(_AUTH_PROXY_PROOF_HEADER_ENV, "").strip()
+    return raw or _DEFAULT_AUTH_PROXY_PROOF_HEADER
+
+
+def resolve_auth_proxy_proof_value() -> str:
+    """Resolve the trusted-proxy proof value for header-auth mode.
+
+    Unset or whitespace-only values disable proof enforcement, preserving
+    existing header-auth deployments. A non-empty value makes header-auth
+    reject identity headers unless the request carries the configured proof
+    header with the exact value.
+
+    :returns: The configured proof value, or ``""`` when disabled.
+    """
+    return os.environ.get(_AUTH_PROXY_PROOF_VALUE_ENV, "").strip()
 
 
 _auth_enabled_deprecation_warned = False
@@ -305,6 +342,12 @@ class UnifiedAuthProvider(AuthProvider):
         back to ``""`` (strip nothing; see
         :func:`resolve_auth_header_strip_prefix`). Only consulted in
         header mode. Tests pass an explicit prefix.
+    :param header_proxy_proof_header: Proof header name used when
+        ``header_proxy_proof_value`` is configured. ``None`` resolves
+        from ``OMNIGENT_AUTH_PROXY_PROOF_HEADER``.
+    :param header_proxy_proof_value: Optional trusted-proxy proof value.
+        ``None`` resolves from ``OMNIGENT_AUTH_PROXY_PROOF_VALUE``.
+        Empty means proof enforcement is disabled.
     """
 
     def __init__(
@@ -315,6 +358,8 @@ class UnifiedAuthProvider(AuthProvider):
         local_single_user: bool | None = None,
         header_name: str | None = None,
         header_strip_prefix: str | None = None,
+        header_proxy_proof_header: str | None = None,
+        header_proxy_proof_value: str | None = None,
     ) -> None:
         self._source = source
         self._oidc_config = oidc_config
@@ -327,6 +372,16 @@ class UnifiedAuthProvider(AuthProvider):
             header_strip_prefix
             if header_strip_prefix is not None
             else resolve_auth_header_strip_prefix()
+        )
+        self._header_proxy_proof_header = (
+            header_proxy_proof_header
+            if header_proxy_proof_header is not None
+            else resolve_auth_proxy_proof_header()
+        )
+        self._header_proxy_proof_value = (
+            header_proxy_proof_value
+            if header_proxy_proof_value is not None
+            else resolve_auth_proxy_proof_value()
         )
         self._cookie_cache: dict[str, tuple[str, float]] = {}
 
@@ -501,6 +556,8 @@ class UnifiedAuthProvider(AuthProvider):
         """
         email = request.headers.get(self._header_name)
         if email:
+            if not self._check_header_proxy_proof(request):
+                return None
             if self._header_strip_prefix:
                 email = email.removeprefix(self._header_strip_prefix)
             if not email or email in _RESERVED_USERS:
@@ -509,6 +566,23 @@ class UnifiedAuthProvider(AuthProvider):
         if self._local_single_user:
             return RESERVED_USER_LOCAL
         return None
+
+    def _check_header_proxy_proof(self, request: HTTPConnection) -> bool:
+        """Return whether the request satisfies the optional proxy proof.
+
+        The proof is disabled unless ``_header_proxy_proof_value`` is
+        non-empty. When enabled, compare the request's configured proof
+        header using constant-time comparison before trusting the identity
+        header.
+
+        :param request: The incoming HTTP request or WebSocket.
+        :returns: ``True`` when proof is disabled or valid.
+        """
+        expected = self._header_proxy_proof_value
+        if not expected:
+            return True
+        actual = request.headers.get(self._header_proxy_proof_header, "")
+        return hmac.compare_digest(actual, expected)
 
 
 def create_auth_provider() -> AuthProvider:

--- a/tests/server/test_oidc.py
+++ b/tests/server/test_oidc.py
@@ -19,6 +19,8 @@ from omnigent.server.auth import (
     create_auth_provider,
     resolve_auth_header,
     resolve_auth_header_strip_prefix,
+    resolve_auth_proxy_proof_header,
+    resolve_auth_proxy_proof_value,
 )
 from omnigent.server.oidc import (
     OIDCConfig,
@@ -211,6 +213,85 @@ def test_header_source_returns_email_from_header() -> None:
     assert provider.get_user_id(request) == "alice@example.com"
 
 
+def test_header_source_proxy_proof_unset_keeps_existing_behavior() -> None:
+    """Header-auth remains backwards-compatible when no proof is configured."""
+    provider = UnifiedAuthProvider(
+        source="header",
+        header_proxy_proof_value="",
+    )
+    request = _mock_request(headers={"X-Forwarded-Email": "alice@example.com"})
+    assert provider.get_user_id(request) == "alice@example.com"
+
+
+def test_header_source_requires_proxy_proof_when_configured() -> None:
+    """Configured proof makes a spoofed identity header fail closed."""
+    provider = UnifiedAuthProvider(
+        source="header",
+        header_proxy_proof_value="secret-proof",
+        local_single_user=False,
+    )
+    request = _mock_request(headers={"X-Forwarded-Email": "attacker@example.com"})
+    assert provider.get_user_id(request) is None
+
+
+def test_header_source_accepts_matching_proxy_proof() -> None:
+    """A trusted proxy can authenticate by sending identity plus proof."""
+    provider = UnifiedAuthProvider(
+        source="header",
+        header_proxy_proof_value="secret-proof",
+    )
+    request = _mock_request(
+        headers={
+            "X-Forwarded-Email": "alice@example.com",
+            "X-Omnigent-Proxy-Proof": "secret-proof",
+        }
+    )
+    assert provider.get_user_id(request) == "alice@example.com"
+
+
+def test_header_source_rejects_wrong_proxy_proof() -> None:
+    """Proof comparison must be exact; wrong proof is unauthenticated."""
+    provider = UnifiedAuthProvider(
+        source="header",
+        header_proxy_proof_value="secret-proof",
+        local_single_user=False,
+    )
+    request = _mock_request(
+        headers={
+            "X-Forwarded-Email": "attacker@example.com",
+            "X-Omnigent-Proxy-Proof": "wrong-proof",
+        }
+    )
+    assert provider.get_user_id(request) is None
+
+
+def test_header_source_custom_proxy_proof_header_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deploys can rename the proof header while keeping exact proof semantics."""
+    monkeypatch.setenv("OMNIGENT_AUTH_PROXY_PROOF_HEADER", "X-Ergon-Proxy-Proof")
+    monkeypatch.setenv("OMNIGENT_AUTH_PROXY_PROOF_VALUE", "secret-proof")
+    provider = UnifiedAuthProvider(source="header")
+    request = _mock_request(
+        headers={
+            "X-Forwarded-Email": "alice@example.com",
+            "X-Ergon-Proxy-Proof": "secret-proof",
+        }
+    )
+    assert provider.get_user_id(request) == "alice@example.com"
+
+
+def test_header_source_proxy_proof_does_not_block_local_fallback() -> None:
+    """The proof gates proxy identity headers, not local single-user mode."""
+    provider = UnifiedAuthProvider(
+        source="header",
+        local_single_user=True,
+        header_proxy_proof_value="secret-proof",
+    )
+    request = _mock_request()
+    assert provider.get_user_id(request) == RESERVED_USER_LOCAL
+
+
 def test_header_source_rejects_missing_header(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -359,6 +440,20 @@ def test_resolve_auth_header_defaults_to_x_forwarded_email(
     assert resolve_auth_header() == "X-Forwarded-Email"
     monkeypatch.setenv("OMNIGENT_AUTH_HEADER", "   ")
     assert resolve_auth_header() == "X-Forwarded-Email"
+
+
+def test_resolve_auth_proxy_proof_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Proof is disabled by default but the default header name is stable."""
+    monkeypatch.delenv("OMNIGENT_AUTH_PROXY_PROOF_HEADER", raising=False)
+    monkeypatch.delenv("OMNIGENT_AUTH_PROXY_PROOF_VALUE", raising=False)
+    assert resolve_auth_proxy_proof_header() == "X-Omnigent-Proxy-Proof"
+    assert resolve_auth_proxy_proof_value() == ""
+    monkeypatch.setenv("OMNIGENT_AUTH_PROXY_PROOF_HEADER", "   ")
+    monkeypatch.setenv("OMNIGENT_AUTH_PROXY_PROOF_VALUE", "   ")
+    assert resolve_auth_proxy_proof_header() == "X-Omnigent-Proxy-Proof"
+    assert resolve_auth_proxy_proof_value() == ""
 
 
 # ── UnifiedAuthProvider (header source: Google IAP prefix strip) ──


### PR DESCRIPTION
## Related issue

Closes #2144

## Summary

Header mode trusts the identity header entirely; the only safeguard is the deploy-docs warning that the proxy must strip inbound copies. This adds an opt-in proof: when `OMNIGENT_AUTH_PROXY_PROOF_VALUE` is set, a request carrying the identity header must also carry the proof header (`X-Omnigent-Proxy-Proof` by default, name configurable via `OMNIGENT_AUTH_PROXY_PROOF_HEADER`) with that exact value, compared constant-time (`hmac.compare_digest`), fail-closed. Unset leaves header mode exactly as it is.

The check runs in `UnifiedAuthProvider._check_header` before the identity is trusted; resolver functions and constructor parameters follow the existing `OMNIGENT_AUTH_HEADER` / `OMNIGENT_AUTH_HEADER_STRIP_PREFIX` pattern. Env-var rows added to both deploy READMEs.

## Test Plan

8 new cases in `tests/server/test_oidc.py`: proof disabled preserves behavior; valid proof accepted; missing/wrong proof rejected (fail-closed); custom header name; whitespace-only value disables; single-user local fallback unaffected. Full `test_oidc.py`: 57 passed on current main with the patch.

## Demo

![proof required: identity header alone 401, with proof header 200](https://raw.githubusercontent.com/dosenr/omnigent/assets/pr-2142-demo/2145-demo.png)

## Type of change

- [x] New feature

## Test coverage

- [x] Unit tests added

## Changelog

Header mode can require a trusted-proxy proof header before accepting the identity header.
