### PR TITLE
feat(web): add selectable color themes with a palette picker

### DIFF
--- a/tests/e2e_ui/sessions/test_color_theme.py
+++ b/tests/e2e_ui/sessions/test_color_theme.py
@@ -1,0 +1,119 @@
+"""E2E: the Settings → Appearance color-palette picker skins the app and persists.
+
+Alongside the light/dark **mode** cards, ``AppearanceSection``
+(``pages/SettingsPage.tsx``) renders a second ``role="radiogroup"`` labelled
+"Color palette" — one card per palette (Omnigent, Nord, Monokai, Solarized,
+Dracula). Selecting one calls ``applyThemePalette`` (``lib/themePalette.ts``),
+which sets ``data-theme`` on ``<html>`` and persists the id to
+``localStorage["omnigent:ui-theme-palette"]``. The default "Omnigent" palette
+carries no override, so choosing it removes the attribute and clears the key.
+
+The palette axis is orthogonal to the light/dark class next-themes toggles, so
+``data-theme`` and the ``dark`` class coexist on ``<html>``. On reload the saved
+palette is re-applied before first paint (``main.tsx``), so the skin survives a
+refresh with no flash.
+
+No LLM turn is involved.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Locator, Page, expect
+
+
+def _data_theme(page: Page) -> str | None:
+    """The palette applied to ``<html>`` via ``data-theme``, or None when unset."""
+    return page.evaluate("() => document.documentElement.getAttribute('data-theme')")
+
+
+def _stored_palette(page: Page) -> str | None:
+    """The persisted palette preference (raw JSON), or None when unset (default)."""
+    return page.evaluate("() => window.localStorage.getItem('omnigent:ui-theme-palette')")
+
+
+def _html_has_dark(page: Page) -> bool:
+    """True when the ``dark`` mode class is applied to ``<html>`` (next-themes)."""
+    return page.evaluate("() => document.documentElement.classList.contains('dark')")
+
+
+def _theme_radiogroup(page: Page) -> Locator:
+    """The app-theme (mode) radiogroup, matched exactly so it can't also resolve
+    the "Terminal theme" radiogroup (its name contains "Theme" and its cards
+    reuse the Light/Dark labels)."""
+    return page.get_by_role("radiogroup", name="Theme", exact=True)
+
+
+def _open_appearance(page: Page, base_url: str) -> None:
+    """Navigate to the Settings Appearance section and wait for the palette group."""
+    page.goto(f"{base_url}/settings/appearance")
+    expect(page.get_by_role("radiogroup", name="Color palette")).to_be_visible(timeout=30_000)
+
+
+def test_color_palette_applies_persists_and_resets(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """Selecting a palette skins ``<html>`` + persists; the default clears it.
+
+    Fresh load is the default "Omnigent" (its card checked, nothing stored, no
+    ``data-theme``). Picking GitHub sets ``data-theme="github"`` and persists it —
+    and survives a reload (re-applied at boot). Returning to Omnigent removes the
+    attribute and clears the stored key.
+    """
+    base_url, _session_id = seeded_session
+    _open_appearance(page, base_url)
+
+    # Fresh context → default "Omnigent" palette: card checked, no override, no
+    # persisted preference.
+    expect(page.get_by_role("radio", name="Omnigent")).to_have_attribute("aria-checked", "true")
+    assert _data_theme(page) is None, "expected no data-theme override on a fresh load"
+    assert _stored_palette(page) is None, "expected no persisted palette on a fresh load"
+
+    # → GitHub: the data-theme attribute lands on <html> and the choice persists.
+    github = page.get_by_role("radio", name="GitHub")
+    github.click()
+    expect(github).to_have_attribute("aria-checked", "true")
+    assert _data_theme(page) == "github", "data-theme=github not set after selecting GitHub"
+    assert _stored_palette(page) == '"github"'
+
+    # Reload: the saved palette is re-applied before first paint (main.tsx), so
+    # <html> still carries data-theme=github and the card stays selected.
+    page.reload()
+    expect(page.get_by_role("radiogroup", name="Color palette")).to_be_visible(timeout=30_000)
+    assert _data_theme(page) == "github", "saved palette not re-applied after reload"
+    expect(page.get_by_role("radio", name="GitHub")).to_have_attribute("aria-checked", "true")
+
+    # → back to Omnigent (the default): the override is removed and the stored
+    # key cleared, since the default reverts to the base brand tokens.
+    omnigent = page.get_by_role("radio", name="Omnigent")
+    omnigent.click()
+    expect(omnigent).to_have_attribute("aria-checked", "true")
+    assert _data_theme(page) is None, "<html> kept data-theme after returning to Omnigent"
+    assert _stored_palette(page) is None, "the palette key was not cleared for the default"
+
+
+def test_color_palette_composes_with_dark_mode(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """The palette (``data-theme``) and light/dark mode (``dark`` class) coexist.
+
+    They are independent axes, so a palette + Dark mode leaves <html> carrying
+    both the ``data-theme`` attribute and the ``dark`` class at once.
+    """
+    # Pin a light OS so Dark is an explicit, observable change.
+    page.emulate_media(color_scheme="light")
+
+    base_url, _session_id = seeded_session
+    _open_appearance(page, base_url)
+
+    # Pick a palette, then Dark mode; the two controls are independent.
+    catppuccin = page.get_by_role("radio", name="Catppuccin")
+    catppuccin.click()
+    expect(catppuccin).to_have_attribute("aria-checked", "true")
+
+    dark = _theme_radiogroup(page).get_by_role("radio", name="Dark")
+    dark.click()
+    expect(dark).to_have_attribute("aria-checked", "true")
+
+    # Both axes are live on <html> simultaneously.
+    assert _data_theme(page) == "catppuccin", "palette override lost when switching to Dark"
+    assert _html_has_dark(page), "dark class missing — the palette should compose with dark mode"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -747,14 +747,15 @@
   .xterm {
     font-family: var(--font-mono);
   }
-  /* Text selection — brand pink highlight. Light: gentle wash + dark pink
-   * text. Dark: solid brand pink background + white text. */
+  /* Text selection tracks the palette's brand accent so it stays cohesive
+   * across themes (pink on Omni, blue on GitHub, coral on Claude, …). Light:
+   * gentle accent wash + accent-colored text. Dark: solid accent + white. */
   ::selection {
-    background: color-mix(in srgb, #f22286 20%, transparent);
-    color: #f22286;
+    background: color-mix(in srgb, var(--brand-accent) 22%, transparent);
+    color: var(--brand-accent);
   }
   .dark ::selection {
-    background: #f22286;
+    background: var(--brand-accent);
     color: #ffffff;
   }
 }
@@ -1446,4 +1447,327 @@
 /* Cursor when hovering over a resizable column border */
 .tiptap-md-content .resize-cursor {
   cursor: col-resize;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * COLOR PALETTES
+ *
+ * A palette is a second appearance axis, orthogonal to light/dark mode. It is
+ * selected in Appearance settings and applied as `data-theme` on <html> (see
+ * lib/themePalette.ts), re-pointing the same color tokens the whole app already
+ * reads. The default "omni" palette has NO block here — it falls through to the
+ * base `:root` / `.dark` brand tokens above.
+ *
+ * Each palette defines a light block and a dark block:
+ *   - Light: `:root:not(.dark)[data-theme="X"]` — only when the mode class is
+ *     absent, so the light values never leak into dark.
+ *   - Dark:  `.dark[data-theme="X"]` — outspecifies the base `.dark`.
+ * Tokens left unset (status hues, charts, destructive) inherit the base so the
+ * semantic palette stays consistent everywhere. The `.app-shell` canvas
+ * gradient is overridden per palette + mode.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── GitHub — clean neutrals, signal blue, green primary ──────────────────── */
+:root:not(.dark)[data-theme="github"] {
+  --background: #f6f8fa;
+  --foreground: #1f2328;
+  --card: #ffffff;
+  --card-solid: #ffffff;
+  --card-foreground: #1f2328;
+  --tray: #ffffff;
+  --popover: #ffffff;
+  --popover-foreground: #1f2328;
+  --primary: #1f883d;
+  --primary-foreground: #ffffff;
+  --secondary: #eaeef2;
+  --secondary-foreground: #1f2328;
+  --muted: #eaeef2;
+  --muted-foreground: #59636e;
+  --code-bg: #eff1f3;
+  --accent: #ddf4ff;
+  --accent-foreground: #0550ae;
+  --border: #d1d9e0;
+  --border-strong: #afb8c1;
+  --button-border: #d1d9e0;
+  --input: #d1d9e0;
+  --ring: #0969da;
+  --brand-accent: #0969da;
+  --sidebar: #f6f8fa;
+  --sidebar-foreground: #1f2328;
+  --sidebar-primary: #0969da;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #ddf4ff;
+  --sidebar-accent-foreground: #0550ae;
+  --sidebar-border: #d1d9e0;
+  --sidebar-ring: #0969da;
+}
+.dark[data-theme="github"] {
+  --background: #0d1117;
+  --foreground: #e6edf3;
+  --card: rgba(22, 27, 34, 0.72);
+  --card-solid: #161b22;
+  --card-foreground: #e6edf3;
+  --tray: rgba(22, 27, 34, 0.72);
+  --popover: rgba(22, 27, 34, 0.9);
+  --popover-foreground: #e6edf3;
+  --primary: #238636;
+  --primary-foreground: #ffffff;
+  --secondary: #21262d;
+  --secondary-foreground: #e6edf3;
+  --muted: #21262d;
+  --muted-foreground: #8b949e;
+  --code-bg: #1c2128;
+  --accent: #121d2f;
+  --accent-foreground: #58a6ff;
+  --border: #30363d;
+  --border-strong: #444c56;
+  --button-border: #30363d;
+  --input: #30363d;
+  --ring: #58a6ff;
+  --brand-accent: #58a6ff;
+  --sidebar: rgba(13, 17, 23, 0.75);
+  --sidebar-foreground: #e6edf3;
+  --sidebar-primary: #58a6ff;
+  --sidebar-primary-foreground: #0d1117;
+  --sidebar-accent: #121d2f;
+  --sidebar-accent-foreground: #58a6ff;
+  --sidebar-border: #30363d;
+  --sidebar-ring: #58a6ff;
+}
+:root:not(.dark)[data-theme="github"] .app-shell {
+  background: linear-gradient(180deg, #fbfcfd 0%, #f6f8fa 100%);
+}
+.dark[data-theme="github"] .app-shell {
+  background: linear-gradient(160deg, #0d1117 0%, #0a0e14 100%);
+}
+
+/* ── Catppuccin — soft pastels (Latte light / Mocha dark) ─────────────────── */
+:root:not(.dark)[data-theme="catppuccin"] {
+  --background: #eff1f5;
+  --foreground: #4c4f69;
+  --card: #ffffff;
+  --card-solid: #ffffff;
+  --card-foreground: #4c4f69;
+  --tray: #ffffff;
+  --popover: #ffffff;
+  --popover-foreground: #4c4f69;
+  --primary: #8839ef;
+  --primary-foreground: #ffffff;
+  --secondary: #e6e9ef;
+  --secondary-foreground: #4c4f69;
+  --muted: #e6e9ef;
+  --muted-foreground: #6c6f85;
+  --code-bg: #e6e9ef;
+  --accent: #ccd0da;
+  --accent-foreground: #8839ef;
+  --border: #ccd0da;
+  --border-strong: #acb0be;
+  --button-border: #ccd0da;
+  --input: #ccd0da;
+  --ring: #8839ef;
+  --brand-accent: #ea76cb;
+  --sidebar: #e6e9ef;
+  --sidebar-foreground: #4c4f69;
+  --sidebar-primary: #8839ef;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #ccd0da;
+  --sidebar-accent-foreground: #8839ef;
+  --sidebar-border: #ccd0da;
+  --sidebar-ring: #8839ef;
+}
+.dark[data-theme="catppuccin"] {
+  --background: #1e1e2e;
+  --foreground: #cdd6f4;
+  --card: rgba(49, 50, 68, 0.6);
+  --card-solid: #282938;
+  --card-foreground: #cdd6f4;
+  --tray: rgba(49, 50, 68, 0.6);
+  --popover: rgba(24, 24, 37, 0.92);
+  --popover-foreground: #cdd6f4;
+  --primary: #cba6f7;
+  --primary-foreground: #1e1e2e;
+  --secondary: #313244;
+  --secondary-foreground: #cdd6f4;
+  --muted: #313244;
+  --muted-foreground: #a6adc8;
+  --code-bg: #181825;
+  --accent: #45475a;
+  --accent-foreground: #cba6f7;
+  --border: #45475a;
+  --border-strong: #585b70;
+  --button-border: #45475a;
+  --input: #45475a;
+  --ring: #cba6f7;
+  --brand-accent: #cba6f7;
+  --sidebar: rgba(24, 24, 37, 0.8);
+  --sidebar-foreground: #cdd6f4;
+  --sidebar-primary: #cba6f7;
+  --sidebar-primary-foreground: #1e1e2e;
+  --sidebar-accent: #45475a;
+  --sidebar-accent-foreground: #cba6f7;
+  --sidebar-border: #45475a;
+  --sidebar-ring: #cba6f7;
+}
+:root:not(.dark)[data-theme="catppuccin"] .app-shell {
+  background: linear-gradient(160deg, #f2f3f7 0%, #eff1f5 60%, #e9ecf2 100%);
+}
+.dark[data-theme="catppuccin"] .app-shell {
+  background:
+    radial-gradient(ellipse at 20% 30%, rgba(203, 166, 247, 0.12) 0%, transparent 55%),
+    radial-gradient(ellipse at 80% 20%, rgba(245, 194, 231, 0.08) 0%, transparent 45%),
+    linear-gradient(160deg, #232336 0%, #1e1e2e 60%, #181825 100%);
+}
+
+/* ── Gruvbox — warm retro earth tones ─────────────────────────────────────── */
+:root:not(.dark)[data-theme="gruvbox"] {
+  --background: #fbf1c7;
+  --foreground: #3c3836;
+  --card: #fffdf2;
+  --card-solid: #fffdf2;
+  --card-foreground: #3c3836;
+  --tray: #fffdf2;
+  --popover: #fffdf2;
+  --popover-foreground: #3c3836;
+  --primary: #d65d0e;
+  --primary-foreground: #ffffff;
+  --secondary: #ebdbb2;
+  --secondary-foreground: #3c3836;
+  --muted: #ebdbb2;
+  --muted-foreground: #7c6f64;
+  --code-bg: #ebdbb2;
+  --accent: #f2e5bc;
+  --accent-foreground: #af3a03;
+  --border: #e6d5a8;
+  --border-strong: #bdae93;
+  --button-border: #e6d5a8;
+  --input: #e6d5a8;
+  --ring: #d65d0e;
+  --brand-accent: #d65d0e;
+  --sidebar: #f4e8bc;
+  --sidebar-foreground: #3c3836;
+  --sidebar-primary: #d65d0e;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f2e5bc;
+  --sidebar-accent-foreground: #af3a03;
+  --sidebar-border: #e6d5a8;
+  --sidebar-ring: #d65d0e;
+}
+.dark[data-theme="gruvbox"] {
+  --background: #282828;
+  --foreground: #ebdbb2;
+  --card: rgba(60, 56, 54, 0.6);
+  --card-solid: #32302f;
+  --card-foreground: #ebdbb2;
+  --tray: rgba(60, 56, 54, 0.6);
+  --popover: rgba(29, 32, 33, 0.92);
+  --popover-foreground: #ebdbb2;
+  --primary: #fe8019;
+  --primary-foreground: #282828;
+  --secondary: #3c3836;
+  --secondary-foreground: #ebdbb2;
+  --muted: #3c3836;
+  --muted-foreground: #a89984;
+  --code-bg: #1d2021;
+  --accent: #504945;
+  --accent-foreground: #fe8019;
+  --border: #504945;
+  --border-strong: #665c54;
+  --button-border: #504945;
+  --input: #504945;
+  --ring: #fe8019;
+  --brand-accent: #fe8019;
+  --sidebar: rgba(29, 32, 33, 0.8);
+  --sidebar-foreground: #ebdbb2;
+  --sidebar-primary: #fe8019;
+  --sidebar-primary-foreground: #282828;
+  --sidebar-accent: #504945;
+  --sidebar-accent-foreground: #fe8019;
+  --sidebar-border: #504945;
+  --sidebar-ring: #fe8019;
+}
+:root:not(.dark)[data-theme="gruvbox"] .app-shell {
+  background: linear-gradient(160deg, #fbf3cd 0%, #fbf1c7 55%, #f7ecbb 100%);
+}
+.dark[data-theme="gruvbox"] .app-shell {
+  background:
+    radial-gradient(ellipse at 20% 30%, rgba(254, 128, 25, 0.1) 0%, transparent 55%),
+    radial-gradient(ellipse at 80% 20%, rgba(250, 189, 47, 0.07) 0%, transparent 45%),
+    linear-gradient(160deg, #32302f 0%, #282828 60%, #1d2021 100%);
+}
+
+/* ── Dracula — moody purple, pink pop (dark-first classic) ─────────────────── */
+:root:not(.dark)[data-theme="dracula"] {
+  --background: #f7f5fd;
+  --foreground: #1e1a2b;
+  --card: #ffffff;
+  --card-solid: #ffffff;
+  --card-foreground: #1e1a2b;
+  --tray: #ffffff;
+  --popover: #ffffff;
+  --popover-foreground: #1e1a2b;
+  --primary: #7c3aed;
+  --primary-foreground: #ffffff;
+  --secondary: #efeaf9;
+  --secondary-foreground: #1e1a2b;
+  --muted: #efeaf9;
+  --muted-foreground: #6b6786;
+  --code-bg: #efeaf9;
+  --accent: #f3e8ff;
+  --accent-foreground: #6b21a8;
+  --border: #e6e0f2;
+  --border-strong: #b6abd6;
+  --button-border: #e6e0f2;
+  --input: #e6e0f2;
+  --ring: #7c3aed;
+  --brand-accent: #d6409f;
+  --sidebar: #f3f0fa;
+  --sidebar-foreground: #1e1a2b;
+  --sidebar-primary: #7c3aed;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f3e8ff;
+  --sidebar-accent-foreground: #6b21a8;
+  --sidebar-border: #e6e0f2;
+  --sidebar-ring: #7c3aed;
+}
+.dark[data-theme="dracula"] {
+  --background: #282a36;
+  --foreground: #f8f8f2;
+  --card: rgba(68, 71, 90, 0.5);
+  --card-solid: #343746;
+  --card-foreground: #f8f8f2;
+  --tray: rgba(68, 71, 90, 0.5);
+  --popover: rgba(33, 34, 44, 0.92);
+  --popover-foreground: #f8f8f2;
+  --primary: #bd93f9;
+  --primary-foreground: #282a36;
+  --secondary: #343746;
+  --secondary-foreground: #f8f8f2;
+  --muted: #3b3d4d;
+  --muted-foreground: #b3b8d4;
+  --code-bg: #21222c;
+  --accent: #3b304f;
+  --accent-foreground: #ff79c6;
+  --border: #44475a;
+  --border-strong: #5a5d75;
+  --button-border: #44475a;
+  --input: #44475a;
+  --ring: #bd93f9;
+  --brand-accent: #ff79c6;
+  --sidebar: rgba(33, 34, 44, 0.8);
+  --sidebar-foreground: #f8f8f2;
+  --sidebar-primary: #bd93f9;
+  --sidebar-primary-foreground: #282a36;
+  --sidebar-accent: #3b304f;
+  --sidebar-accent-foreground: #ff79c6;
+  --sidebar-border: #44475a;
+  --sidebar-ring: #bd93f9;
+}
+:root:not(.dark)[data-theme="dracula"] .app-shell {
+  background: linear-gradient(160deg, #faf8ff 0%, #f5f1fd 50%, #f3eefb 100%);
+}
+.dark[data-theme="dracula"] .app-shell {
+  background:
+    radial-gradient(ellipse at 20% 40%, rgba(189, 147, 249, 0.14) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 20%, rgba(255, 121, 198, 0.1) 0%, transparent 45%),
+    linear-gradient(160deg, #2a2c3a 0%, #282a36 55%, #21222c 100%);
 }

--- a/web/src/lib/themePalette.test.ts
+++ b/web/src/lib/themePalette.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyThemePalette,
+  DEFAULT_PALETTE,
+  isThemePalette,
+  PALETTES,
+  readThemePalette,
+  themePalettes,
+  writeThemePalette,
+} from "./themePalette";
+
+const STORAGE_KEY = "omnigent:ui-theme-palette";
+
+afterEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+describe("themePalette", () => {
+  it("returns the default palette when nothing is stored", () => {
+    expect(readThemePalette()).toBe(DEFAULT_PALETTE);
+    expect(DEFAULT_PALETTE).toBe("omni");
+  });
+
+  it("round-trips a valid palette", () => {
+    writeThemePalette("github");
+    expect(readThemePalette()).toBe("github");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify("github"));
+  });
+
+  it("clears the key when the default is written (nothing to persist)", () => {
+    writeThemePalette("dracula");
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    writeThemePalette(DEFAULT_PALETTE);
+    // Storing the default just reverts to base tokens, so drop the key.
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(readThemePalette()).toBe(DEFAULT_PALETTE);
+  });
+
+  it("falls back to the default on an unknown stored id", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify("not-a-theme"));
+    expect(readThemePalette()).toBe(DEFAULT_PALETTE);
+  });
+
+  it("falls back to the default on malformed JSON", () => {
+    // Corrupt localStorage should not break app boot.
+    localStorage.setItem(STORAGE_KEY, "}{not json");
+    expect(readThemePalette()).toBe(DEFAULT_PALETTE);
+  });
+
+  it("guards known vs unknown palette ids", () => {
+    expect(isThemePalette("github")).toBe(true);
+    expect(isThemePalette("omni")).toBe(true);
+    expect(isThemePalette("nope")).toBe(false);
+    expect(isThemePalette(undefined)).toBe(false);
+    expect(isThemePalette(42)).toBe(false);
+  });
+
+  it("sets data-theme on the document root for a non-default palette", () => {
+    applyThemePalette("catppuccin");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("catppuccin");
+  });
+
+  it("removes data-theme for the default palette so the base tokens take over", () => {
+    applyThemePalette("github");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("github");
+    applyThemePalette(DEFAULT_PALETTE);
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+
+  it("exposes swatch metadata for every selectable palette, default first", () => {
+    // The picker renders one card per palette, so the metadata list and the id
+    // union must stay in lockstep.
+    expect(PALETTES.map((p) => p.id)).toEqual([...themePalettes]);
+    expect(PALETTES[0].id).toBe(DEFAULT_PALETTE);
+    for (const palette of PALETTES) {
+      expect(palette.label.length).toBeGreaterThan(0);
+      expect(palette.light.bg).toMatch(/^#|rgb/);
+      expect(palette.dark.bg).toMatch(/^#|rgb/);
+    }
+  });
+});

--- a/web/src/lib/themePalette.ts
+++ b/web/src/lib/themePalette.ts
@@ -1,0 +1,194 @@
+// Persisted, app-global color-palette preference.
+//
+// The web UI has two independent appearance axes:
+//
+//   1. MODE  — light / dark / system, owned by next-themes (toggles the
+//      `.dark` class on <html>; see components/theme/ThemeProvider.tsx).
+//   2. PALETTE — the color scheme (Omni pink, GitHub, Vercel, …), owned here.
+//
+// A palette is applied as a `data-theme` attribute on <html>, so it composes
+// with the mode class: `:root:not(.dark)[data-theme="github"]` is GitHub-light
+// and `.dark[data-theme="github"]` is GitHub-dark (see the palette blocks in
+// index.css). The default "omni" palette carries no CSS overrides — it falls
+// through to the base `:root` / `.dark` tokens — so selecting it just restores
+// the brand look. Everything is expressed through the existing CSS custom
+// properties (--background, --primary, --sidebar, …), so a palette re-skins the
+// whole app without any component knowing a theme changed.
+//
+// Mirrors lib/uiFontPreferences.ts: a read/write pair backed by localStorage
+// plus a single `apply*` function that owns the DOM side-effect, called at boot
+// (main.tsx) before first paint and on every change (Appearance settings).
+
+const STORAGE_KEY = "omnigent:ui-theme-palette";
+
+/** Selectable color palettes. The first entry is the default (brand) look. */
+export const themePalettes = ["omni", "dracula", "github", "catppuccin", "gruvbox"] as const;
+
+export type ThemePalette = (typeof themePalettes)[number];
+
+/** Default palette: the Omni brand tokens already defined in `:root` / `.dark`. */
+export const DEFAULT_PALETTE: ThemePalette = "omni";
+
+/** A few representative colors used to render a palette's preview swatch. */
+export interface PaletteSwatch {
+  /** Page canvas (behind the cards). */
+  bg: string;
+  /** Card / panel surface floating on the canvas. */
+  card: string;
+  /** Primary action / brand accent for this palette. */
+  accent: string;
+  /** Card border / divider. */
+  border: string;
+  /** Body text on the card. */
+  text: string;
+}
+
+export interface PaletteMeta {
+  id: ThemePalette;
+  /** Display name shown under the swatch. */
+  label: string;
+  /** One-line description of the palette's character. */
+  blurb: string;
+  /** Swatch colors for the light rendering of this palette. */
+  light: PaletteSwatch;
+  /** Swatch colors for the dark rendering of this palette. */
+  dark: PaletteSwatch;
+}
+
+// Swatch colors are a hand-picked summary of each palette's CSS block — enough
+// to render a faithful mini-preview without parsing the stylesheet. Keep these
+// in sync with the matching `[data-theme]` block in index.css.
+export const PALETTES: readonly PaletteMeta[] = [
+  {
+    id: "omni",
+    label: "Omnigent",
+    blurb: "The signature pink brand look.",
+    light: {
+      bg: "#fdf7fb",
+      card: "#ffffff",
+      accent: "#df3c85",
+      border: "#e8ecf0",
+      text: "#11171c",
+    },
+    dark: { bg: "#160e24", card: "#28223a", accent: "#df3c85", border: "#2a2440", text: "#f4f5f7" },
+  },
+  {
+    id: "dracula",
+    label: "Dracula",
+    blurb: "Moody purple with a pink pop.",
+    light: {
+      bg: "#f7f5fd",
+      card: "#ffffff",
+      accent: "#7c3aed",
+      border: "#e6e0f2",
+      text: "#1e1a2b",
+    },
+    dark: { bg: "#282a36", card: "#343746", accent: "#bd93f9", border: "#44475a", text: "#f8f8f2" },
+  },
+  {
+    id: "github",
+    label: "GitHub",
+    blurb: "Clean neutrals with a signal blue.",
+    light: {
+      bg: "#f6f8fa",
+      card: "#ffffff",
+      accent: "#0969da",
+      border: "#d1d9e0",
+      text: "#1f2328",
+    },
+    dark: { bg: "#0d1117", card: "#161b22", accent: "#58a6ff", border: "#30363d", text: "#e6edf3" },
+  },
+  {
+    id: "catppuccin",
+    label: "Catppuccin",
+    blurb: "Soft pastels — Latte & Mocha.",
+    light: {
+      bg: "#eff1f5",
+      card: "#ffffff",
+      accent: "#8839ef",
+      border: "#ccd0da",
+      text: "#4c4f69",
+    },
+    dark: { bg: "#1e1e2e", card: "#313244", accent: "#cba6f7", border: "#45475a", text: "#cdd6f4" },
+  },
+  {
+    id: "gruvbox",
+    label: "Gruvbox",
+    blurb: "Warm retro earth tones.",
+    light: {
+      bg: "#fbf1c7",
+      card: "#fffdf2",
+      accent: "#d65d0e",
+      border: "#e6d5a8",
+      text: "#3c3836",
+    },
+    dark: { bg: "#282828", card: "#3c3836", accent: "#fe8019", border: "#504945", text: "#ebdbb2" },
+  },
+] as const;
+
+/**
+ * Return whether a string is a supported palette id.
+ *
+ * localStorage can hold any stale or hand-edited value, so this type guard
+ * lets call sites reject unknown ids before handing them to the UI or the DOM.
+ *
+ * @param value Palette string to validate, e.g. `"github"`.
+ * @returns Whether the value is a supported palette id.
+ */
+export function isThemePalette(value: unknown): value is ThemePalette {
+  return typeof value === "string" && (themePalettes as readonly string[]).includes(value);
+}
+
+/**
+ * Read the persisted palette.
+ *
+ * Returns the default when nothing is stored, on a server render (no `window`),
+ * or when the stored value is missing/malformed — never throws, so a corrupt
+ * entry can't break app boot.
+ */
+export function readThemePalette(): ThemePalette {
+  if (typeof window === "undefined") return DEFAULT_PALETTE;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_PALETTE;
+    const parsed: unknown = JSON.parse(raw);
+    return isThemePalette(parsed) ? parsed : DEFAULT_PALETTE;
+  } catch {
+    return DEFAULT_PALETTE;
+  }
+}
+
+/**
+ * Persist the palette. An unknown id clears the preference (reverting to the
+ * default) rather than storing garbage. Swallows quota/access errors so a
+ * failed write can't break the app.
+ */
+export function writeThemePalette(palette: ThemePalette): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (!isThemePalette(palette) || palette === DEFAULT_PALETTE) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(palette));
+  } catch {
+    // localStorage quota or access errors shouldn't break the app.
+  }
+}
+
+/**
+ * Apply the palette to the DOM by setting `data-theme` on the document root.
+ * The `[data-theme]` blocks in index.css re-point the color tokens; the default
+ * "omni" palette has no block, so it removes the attribute and the base
+ * `:root` / `.dark` tokens take over. This is the single source of the DOM
+ * side-effect and composes with next-themes' `.dark` class untouched.
+ */
+export function applyThemePalette(palette: ThemePalette): void {
+  if (typeof document === "undefined") return;
+  const next = isThemePalette(palette) ? palette : DEFAULT_PALETTE;
+  if (next === DEFAULT_PALETTE) {
+    document.documentElement.removeAttribute("data-theme");
+    return;
+  }
+  document.documentElement.setAttribute("data-theme", next);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -21,6 +21,7 @@ import {
   readUiFontFamily,
   readUiFontSizePx,
 } from "./lib/uiFontPreferences";
+import { applyThemePalette, readThemePalette } from "./lib/themePalette";
 import { initChatStore } from "./store/chatStore";
 import "./index.css";
 
@@ -58,6 +59,10 @@ initNativeInsets();
 // Apply the saved UI font size and family before first paint so there's no flash.
 applyUiFontScale(readUiFontSizePx());
 applyUiFontFamily(readUiFontFamily());
+
+// Apply the saved color palette (data-theme on <html>) before first paint too,
+// so the app renders in the chosen theme rather than flashing the brand default.
+applyThemePalette(readThemePalette());
 
 // Probe /v1/info BEFORE the first render so the route table knows
 // whether to mount accounts routes. The probe is unauthed and the

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -101,6 +101,9 @@ afterEach(() => {
   // don't leak persisted state or the --ui-font-scale variable into each other.
   localStorage.clear();
   document.documentElement.style.removeProperty("--ui-font-scale");
+  // The palette picker sets data-theme on <html>; clear it so a palette
+  // selected in one test doesn't leak into the next.
+  document.documentElement.removeAttribute("data-theme");
 });
 
 describe("SettingsPage", () => {
@@ -141,6 +144,23 @@ describe("SettingsPage", () => {
     renderPage("/settings/appearance");
     expect(screen.getByTestId("terminal-theme-light")).toHaveAttribute("aria-checked", "true");
     expect(screen.getByTestId("terminal-theme-auto")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("renders the color palette picker, defaults to Omnigent, and applies a palette on click", () => {
+    localStorage.clear();
+    renderPage("/settings/appearance");
+
+    // The palette picker is its own radiogroup, distinct from the mode cards.
+    expect(screen.getByRole("radiogroup", { name: "Color palette" })).toBeInTheDocument();
+    // Nothing stored → the default (Omnigent) palette is selected and no
+    // data-theme override is applied to the document.
+    expect(screen.getByTestId("palette-omni")).toHaveAttribute("aria-checked", "true");
+
+    // Choosing a palette selects it, applies it live to <html>, and persists it.
+    fireEvent.click(screen.getByTestId("palette-github"));
+    expect(screen.getByTestId("palette-github")).toHaveAttribute("aria-checked", "true");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("github");
+    expect(localStorage.getItem("omnigent:ui-theme-palette")).toBe(JSON.stringify("github"));
   });
 
   it("shows the default UI font size and steps it up, persisting the choice", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -33,6 +33,7 @@ import {
   UserCogIcon,
 } from "lucide-react";
 import {
+  CheckIcon,
   LaptopMinimalIcon,
   MinusIcon,
   MonitorIcon,
@@ -65,7 +66,11 @@ import {
 import { conversationDisplayLabel } from "@/shell/sidebarNav";
 import { absoluteTime } from "@/lib/relativeTime";
 import { useSettingsRoute } from "@/shell/settingsNav";
-import { type ThemeMode, normalizeThemeMode } from "@/components/theme/themeMode";
+import {
+  normalizeResolvedTheme,
+  normalizeThemeMode,
+  type ThemeMode,
+} from "@/components/theme/themeMode";
 import {
   applyUiFontFamily,
   applyUiFontScale,
@@ -95,6 +100,14 @@ import {
   writeTerminalThemeMode,
   type TerminalThemeMode,
 } from "@/lib/terminalThemePreferences";
+import {
+  applyThemePalette,
+  PALETTES,
+  type PaletteSwatch,
+  readThemePalette,
+  type ThemePalette,
+  writeThemePalette,
+} from "@/lib/themePalette";
 import { useIsEmbedded } from "@/lib/embedded";
 import { type CliStatus, getCliStatus, isElectronShell, resetCliPath } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
@@ -218,6 +231,104 @@ function TerminalThemeControl() {
   );
 }
 
+/**
+ * Color-theme (palette) picker — the second appearance axis, shown under the
+ * same "Theme" heading as the mode cards. Renders a swatch grid of the
+ * available palettes (see lib/themePalette.ts); selecting one applies it live
+ * to <html> via `data-theme`, persists it, and composes with the light/dark
+ * mode picker above.
+ */
+function ColorThemeControl() {
+  // Render each swatch in the currently-resolved mode so the previews match
+  // what the app looks like right now.
+  const { resolvedTheme } = useTheme();
+  const isDark = normalizeResolvedTheme(resolvedTheme) === "dark";
+  const [palette, setPalette] = useState<ThemePalette>(() => readThemePalette());
+
+  const choose = useCallback((next: ThemePalette) => {
+    setPalette(next);
+    writeThemePalette(next);
+    applyThemePalette(next);
+  }, []);
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Color palette"
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
+    >
+      {PALETTES.map((p) => {
+        const selected = palette === p.id;
+        return (
+          <button
+            key={p.id}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            title={p.blurb}
+            data-testid={`palette-${p.id}`}
+            onClick={() => choose(p.id)}
+            className={cn(
+              "flex flex-col gap-2 rounded-xl border-2 p-2 text-left transition-colors hover:bg-muted",
+              selected ? "border-primary" : "border-border",
+            )}
+          >
+            <PaletteSwatchPreview swatch={isDark ? p.dark : p.light} />
+            <span className="flex items-center justify-between gap-1 px-0.5 text-sm font-medium">
+              {p.label}
+              {selected && <CheckIcon className="size-3.5 text-primary" />}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Miniature "app window" preview for a palette: a canvas with a small sidebar
+ * and content card, a few text lines, and an accent chip — built purely from
+ * the swatch colors so each palette reads at a glance.
+ */
+function PaletteSwatchPreview({ swatch }: { swatch: PaletteSwatch }) {
+  return (
+    <div
+      aria-hidden
+      className="flex h-16 w-full gap-1.5 overflow-hidden rounded-lg p-1.5"
+      style={{ backgroundColor: swatch.bg, border: `1px solid ${swatch.border}` }}
+    >
+      <div
+        className="flex w-1/3 flex-col gap-1 rounded-md p-1"
+        style={{ backgroundColor: swatch.card, border: `1px solid ${swatch.border}` }}
+      >
+        <div className="size-1.5 rounded-full" style={{ backgroundColor: swatch.accent }} />
+        <div
+          className="h-1 w-4/5 rounded-full"
+          style={{ backgroundColor: swatch.text, opacity: 0.35 }}
+        />
+        <div
+          className="h-1 w-3/5 rounded-full"
+          style={{ backgroundColor: swatch.text, opacity: 0.25 }}
+        />
+      </div>
+      <div
+        className="flex flex-1 flex-col gap-1 rounded-md p-1.5"
+        style={{ backgroundColor: swatch.card, border: `1px solid ${swatch.border}` }}
+      >
+        <div
+          className="h-1 w-3/4 rounded-full"
+          style={{ backgroundColor: swatch.text, opacity: 0.5 }}
+        />
+        <div
+          className="h-1 w-1/2 rounded-full"
+          style={{ backgroundColor: swatch.text, opacity: 0.3 }}
+        />
+        <div className="mt-auto h-2.5 w-2/5 rounded" style={{ backgroundColor: swatch.accent }} />
+      </div>
+    </div>
+  );
+}
+
 function AppearanceSection() {
   // Embedded: the host owns the theme (embed.tsx forces light), so the
   // selector would be a no-op — match ThemeModeMenu and hide it.
@@ -228,37 +339,41 @@ function AppearanceSection() {
   return (
     <Section title="Appearance" description="Choose how Omnigent looks on this device.">
       <div className="flex flex-col gap-8">
-        <div className="flex flex-col gap-3">
+        {/* One "Theme" group: appearance mode (System / Light / Dark) on top,
+            then the color palette swatches. Both are hidden when embedded — the
+            host owns theming there. */}
+        <div className="flex flex-col gap-4">
           <span className="text-sm font-medium">Theme</span>
-          {/* Embedded: the host owns the theme (embed.tsx forces light), so the
-              selector would be a no-op — match ThemeModeMenu and hide it. */}
           {isEmbedded ? (
             <p className="text-sm text-muted-foreground">
               Theme is controlled by the host application.
             </p>
           ) : (
-            <div className="grid grid-cols-3 gap-3" role="radiogroup" aria-label="Theme">
-              {themeCards.map(({ mode: cardMode, label, icon: Icon }) => {
-                const selected = mode === cardMode;
-                return (
-                  <button
-                    key={cardMode}
-                    type="button"
-                    role="radio"
-                    aria-checked={selected}
-                    data-testid={`theme-${cardMode}`}
-                    onClick={() => setTheme(cardMode)}
-                    className={cn(
-                      "flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors hover:bg-muted",
-                      selected ? "border-primary bg-primary/5" : "border-border",
-                    )}
-                  >
-                    <Icon className="size-6 text-muted-foreground" />
-                    <span className="text-sm font-medium">{label}</span>
-                  </button>
-                );
-              })}
-            </div>
+            <>
+              <div className="grid grid-cols-3 gap-3" role="radiogroup" aria-label="Theme">
+                {themeCards.map(({ mode: cardMode, label, icon: Icon }) => {
+                  const selected = mode === cardMode;
+                  return (
+                    <button
+                      key={cardMode}
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      data-testid={`theme-${cardMode}`}
+                      onClick={() => setTheme(cardMode)}
+                      className={cn(
+                        "flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors hover:bg-muted",
+                        selected ? "border-primary bg-primary/5" : "border-border",
+                      )}
+                    >
+                      <Icon className="size-6 text-muted-foreground" />
+                      <span className="text-sm font-medium">{label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+              <ColorThemeControl />
+            </>
           )}
         </div>
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds a **color-palette** picker to Appearance settings — a second theming axis, independent of light/dark mode (à la Codex's theme picker). Ships the Omnigent brand palette (default) plus four popular palettes, each with full light + dark variants:

- **Omnigent** — the signature pink brand look (default; unchanged for existing users)
- **Dracula** — moody purple with a pink pop
- **GitHub** — clean neutrals with a signal blue
- **Catppuccin** — soft pastels (Latte in light, Mocha in dark)
- **Gruvbox** — warm retro earth tones

A palette re-points the existing CSS custom properties (`--background`, `--primary`, `--sidebar`, …) under a `data-theme` attribute on `<html>`, so it composes with next-themes' `.dark` class and re-skins the whole app **without any component change**. The selection persists in `localStorage` and is applied before first paint (no flash). Text selection now follows the palette accent instead of a hardcoded pink.

Both controls live under one **Theme** group in Appearance: System / Light / Dark on top, the palette swatches below.

ELI5: light/dark is *how bright* the app is; the color theme is *which colors* it uses — and you can mix any color theme with System / Light / Dark.

```
data-theme (palette)       ×      .dark class (mode)     ->   resolved CSS tokens
 omnigent | dracula | github | ...        light | dark
```

## Test Plan

- `npm run type-check` — clean
- `npm run lint` (oxlint) — no new issues
- `npm test` (Vitest): `themePalette.test.ts` + palette-picker assertions in `SettingsPage.test.tsx` — 27 passing
- `npm run build` — production bundle + LightningCSS minification succeed; compiled CSS carries exactly the four `[data-theme]` blocks
- New Playwright e2e (`tests/e2e_ui/sessions/test_color_theme.py`): applies a palette (`data-theme` on `<html>`), persists + re-applies on reload, resets to the default, and composes with dark mode
- Ran a local server + Vite dev server and clicked through all palettes in light and dark

## Demo

Appearance → **Theme**: the System / Light / Dark row sits on top, with the color-theme swatches (each a mini app-window preview) below. Selecting a swatch re-skins the whole app instantly.

_Screenshot/recording to be attached by author._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

- Vitest covers the palette module (read/write/apply, default fallback, `data-theme` toggling) and the settings picker (default selection, applying + persisting on click).
- `tests/e2e_ui/sessions/test_color_theme.py` (Playwright) mirrors the existing `test_theme_toggle.py` harness and exercises the palette picker end-to-end. It was not run on the local dev box (Playwright/browsers aren't installed there); CI's e2e_ui job runs it.
- Manually verified all palettes across light/dark in a live local stack.

## Changelog

Pick a color theme (Omnigent, Dracula, GitHub, Catppuccin, or Gruvbox) in Appearance settings, independent of light/dark mode.