### PR TITLE
feat(web): approval card renders gated tool calls as labeled arguments

### DIFF
--- a/tests/e2e_ui/approvals/test_approval_card_args_render.py
+++ b/tests/e2e_ui/approvals/test_approval_card_args_render.py
@@ -1,0 +1,64 @@
+"""E2E: a policy-ASK card renders the gated call as labeled arguments.
+
+A tool-call preview that parses as ``{name, arguments}`` now renders as a
+labeled argument block (``data-testid="approval-args"``) with the raw JSON
+demoted to a collapsed "Raw call" details element, instead of a raw JSON
+dump (``web/src/components/blocks/ApprovalCard.tsx``). When the arguments
+carry the optional ``approval_context`` convention, that text is promoted
+to prose above the block — covered unit-side in ``ApprovalCard.test.tsx``;
+this test drives the browser-rendered path on the standard gated-push
+fixture, whose ``sys_os_shell`` call already produces the parseable shape.
+
+Same ``approval_session`` fixture and marks as ``test_approval_card.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+_APPROVAL_CARD = '[data-testid="approval-card"]'
+_ARGS_BLOCK = '[data-testid="approval-args"]'
+
+# The agent must boot, take a turn, and emit the gated tool call before the
+# card appears — cold-start can be slow, so allow well past the streaming
+# default but under the test's 600s ceiling.
+_AGENT_TURN_TIMEOUT_MS = 120_000
+
+
+@pytest.mark.nightly
+@pytest.mark.timeout(600)
+def test_approval_card_renders_labeled_args(
+    page: Page,
+    approval_session: tuple[str, str],
+) -> None:
+    """Gated tool call → labeled argument block + collapsed raw call."""
+    base_url, session_id = approval_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("Run the command now.")
+    page.get_by_role("button", name="Send", exact=True).click()
+
+    card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
+    expect(card).to_be_visible(timeout=_AGENT_TURN_TIMEOUT_MS)
+
+    # The gated call renders as labeled arguments: the shell command
+    # appears as a labeled value, not inside a raw JSON dump.
+    args_block = card.locator(_ARGS_BLOCK)
+    expect(args_block).to_be_visible()
+    expect(args_block.get_by_text("command")).to_be_visible()
+    expect(args_block.get_by_text("git push origin main")).to_be_visible()
+
+    # The verbatim preview stays reachable behind the collapsed details.
+    raw_toggle = card.get_by_text("Raw call")
+    expect(raw_toggle).to_be_visible()
+    raw_toggle.click()
+    expect(card.locator("details pre")).to_be_visible()
+
+    # The card still resolves normally through the labeled render.
+    card.get_by_role("button", name="Approve").click()
+    responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
+    expect(responded).to_be_visible(timeout=30_000)

--- a/tests/e2e_ui/approvals/test_approval_card_args_render.py
+++ b/tests/e2e_ui/approvals/test_approval_card_args_render.py
@@ -1,16 +1,4 @@
-"""E2E: a policy-ASK card renders the gated call as labeled arguments.
-
-A tool-call preview that parses as ``{name, arguments}`` now renders as a
-labeled argument block (``data-testid="approval-args"``) with the raw JSON
-demoted to a collapsed "Raw call" details element, instead of a raw JSON
-dump (``web/src/components/blocks/ApprovalCard.tsx``). When the arguments
-carry the optional ``approval_context`` convention, that text is promoted
-to prose above the block — covered unit-side in ``ApprovalCard.test.tsx``;
-this test drives the browser-rendered path on the standard gated-push
-fixture, whose ``sys_os_shell`` call already produces the parseable shape.
-
-Same ``approval_session`` fixture and marks as ``test_approval_card.py``.
-"""
+"""Browser coverage for labeled arguments in a policy approval card."""
 
 from __future__ import annotations
 
@@ -21,9 +9,7 @@ _COMPOSER = "Ask the agent anything…"
 _APPROVAL_CARD = '[data-testid="approval-card"]'
 _ARGS_BLOCK = '[data-testid="approval-args"]'
 
-# The agent must boot, take a turn, and emit the gated tool call before the
-# card appears — cold-start can be slow, so allow well past the streaming
-# default but under the test's 600s ceiling.
+# Allow for the agent cold start before the gated tool call appears.
 _AGENT_TURN_TIMEOUT_MS = 120_000
 
 
@@ -33,7 +19,7 @@ def test_approval_card_renders_labeled_args(
     page: Page,
     approval_session: tuple[str, str],
 ) -> None:
-    """Gated tool call → labeled argument block + collapsed raw call."""
+    """Render labeled arguments while retaining the raw call details."""
     base_url, session_id = approval_session
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -45,20 +31,16 @@ def test_approval_card_renders_labeled_args(
     card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
     expect(card).to_be_visible(timeout=_AGENT_TURN_TIMEOUT_MS)
 
-    # The gated call renders as labeled arguments: the shell command
-    # appears as a labeled value, not inside a raw JSON dump.
     args_block = card.locator(_ARGS_BLOCK)
     expect(args_block).to_be_visible()
     expect(args_block.get_by_text("command")).to_be_visible()
     expect(args_block.get_by_text("git push origin main")).to_be_visible()
 
-    # The verbatim preview stays reachable behind the collapsed details.
     raw_toggle = card.get_by_text("Raw call")
     expect(raw_toggle).to_be_visible()
     raw_toggle.click()
     expect(card.locator("details pre")).to_be_visible()
 
-    # The card still resolves normally through the labeled render.
     card.get_by_role("button", name="Approve").click()
     responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
     expect(responded).to_be_visible(timeout=30_000)

--- a/web/src/components/blocks/ApprovalCard.test.tsx
+++ b/web/src/components/blocks/ApprovalCard.test.tsx
@@ -7,6 +7,167 @@ afterEach(() => {
   cleanup();
 });
 
+describe("ApprovalCard — approval_context prose", () => {
+  const preview = JSON.stringify({
+    name: "mcp_omnigent_atlassian_server__transitionJiraIssue",
+    arguments: {
+      issueIdOrKey: "AM-4773",
+      transition: { id: "71", name: "resp area approval" },
+      approval_context: "Routine termination; precedent AM-4772. Recommend approve.",
+    },
+  });
+
+  it("lifts approval_context out of the JSON and renders it as prose", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_ctx"
+        message="Jira workflow transition — Robert must approve."
+        phase="tool_call"
+        policyName="jira_approval_gate"
+        contentPreview={preview}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    // The justification renders as prose…
+    expect(screen.getByTestId("approval-context").textContent).toBe(
+      "Routine termination; precedent AM-4772. Recommend approve.",
+    );
+    // …the remaining arguments render as a labeled block (keys as
+    // labels, no approval_context row, no raw JSON braces)…
+    const argsBlock = screen.getByTestId("approval-args");
+    expect(argsBlock.textContent).toContain("issueIdOrKey");
+    expect(argsBlock.textContent).toContain("AM-4773");
+    expect(argsBlock.textContent).not.toContain("approval_context");
+    // …and the verbatim preview survives in the collapsed raw block.
+    const details = document.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(details!.textContent).toContain("Raw call");
+  });
+
+  it("renders a labeled argument block for any parseable tool call (no approval_context)", () => {
+    // The generic path: every policy-gated tool gets the labeled render,
+    // not just ones opting into the approval_context convention.
+    render(
+      <ApprovalCard
+        elicitationId="elic_generic"
+        message="M365 send requires approval."
+        phase="tool_call"
+        policyName="m365_send_gate"
+        contentPreview={JSON.stringify({
+          name: "mcp_omnigent_mso__mail_send_commit",
+          arguments: {
+            to: "someone@example.com",
+            subject: "Quarterly report",
+            body: "A".repeat(150),
+          },
+        })}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.queryByTestId("approval-context")).toBeNull();
+    const argsBlock = screen.getByTestId("approval-args");
+    expect(argsBlock.textContent).toContain("subject");
+    expect(argsBlock.textContent).toContain("Quarterly report");
+    // Long string values (message bodies) render pre-wrapped.
+    expect(argsBlock.querySelector("pre")).not.toBeNull();
+    // Tool name is shown as the block caption.
+    expect(screen.getByText("mcp_omnigent_mso__mail_send_commit")).toBeDefined();
+  });
+
+  it("falls back to the raw preview when the JSON is truncated mid-token", () => {
+    // The server caps content_preview at 1024 chars, so a long
+    // approval_context can arrive cut off. The parse fails and the
+    // card must render exactly as before this feature.
+    const truncated = preview.slice(0, 80);
+    render(
+      <ApprovalCard
+        elicitationId="elic_cut"
+        message="Jira workflow transition — Robert must approve."
+        phase="tool_call"
+        policyName="jira_approval_gate"
+        contentPreview={truncated}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.queryByTestId("approval-context")).toBeNull();
+    expect(screen.queryByTestId("approval-args")).toBeNull();
+    expect(document.querySelector("details")).toBeNull();
+    expect(document.querySelector("pre")).not.toBeNull();
+  });
+
+  it("renders the bare-arguments policy-ASK shape as labeled args", () => {
+    // The runner policy gate previews the raw arguments object with no
+    // {name, arguments} envelope.
+    render(
+      <ApprovalCard
+        elicitationId="elic_bare"
+        message="blast_radius: command is recoverable but outward."
+        phase="tool_call"
+        policyName="blast_radius"
+        contentPreview={JSON.stringify({ command: "git push origin main" })}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    const argsBlock = screen.getByTestId("approval-args");
+    expect(argsBlock.textContent).toContain("command");
+    expect(argsBlock.textContent).toContain("git push origin main");
+  });
+
+  it("renders the ToolName({...}) permission-hook shape with the tool caption", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_hook"
+        message="Claude wants to use **WebFetch**"
+        phase="tool_call"
+        policyName="claude_sdk_permission"
+        contentPreview={'WebFetch({"url": "https://example.com", "prompt": "summarize"})'}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.getByText("WebFetch")).toBeDefined();
+    const argsBlock = screen.getByTestId("approval-args");
+    expect(argsBlock.textContent).toContain("url");
+    expect(argsBlock.textContent).toContain("https://example.com");
+  });
+
+  it("ignores non-string or empty approval_context", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_empty"
+        message="Approve?"
+        phase="tool_call"
+        policyName="jira_approval_gate"
+        contentPreview={JSON.stringify({
+          name: "tool",
+          arguments: { approval_context: "   " },
+        })}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.queryByTestId("approval-context")).toBeNull();
+    // The empty-context field is dropped from the labeled block too.
+    expect(screen.queryByTestId("approval-args")).toBeNull();
+  });
+});
+
 describe("ApprovalCard — binary approve/reject", () => {
   it("renders Approve and Reject buttons when requestedSchema has no enum", () => {
     // Policy-ASK and PermissionRequest cards arrive with an empty

--- a/web/src/components/blocks/ApprovalCard.test.tsx
+++ b/web/src/components/blocks/ApprovalCard.test.tsx
@@ -7,13 +7,13 @@ afterEach(() => {
   cleanup();
 });
 
-describe("ApprovalCard — approval_context prose", () => {
+describe("ApprovalCard approval_context prose", () => {
   const preview = JSON.stringify({
-    name: "mcp_omnigent_atlassian_server__transitionJiraIssue",
+    name: "project_issue_transition",
     arguments: {
-      issueIdOrKey: "AM-4773",
-      transition: { id: "71", name: "resp area approval" },
-      approval_context: "Routine termination; precedent AM-4772. Recommend approve.",
+      issueId: "ISSUE-123",
+      transition: { id: "71", name: "ready for review" },
+      approval_context: "The requested transition requires approval.",
     },
   });
 
@@ -21,7 +21,7 @@ describe("ApprovalCard — approval_context prose", () => {
     render(
       <ApprovalCard
         elicitationId="elic_ctx"
-        message="Jira workflow transition — Robert must approve."
+        message="Issue transition requires approval."
         phase="tool_call"
         policyName="jira_approval_gate"
         contentPreview={preview}
@@ -31,17 +31,13 @@ describe("ApprovalCard — approval_context prose", () => {
       />,
     );
 
-    // The justification renders as prose…
     expect(screen.getByTestId("approval-context").textContent).toBe(
-      "Routine termination; precedent AM-4772. Recommend approve.",
+      "The requested transition requires approval.",
     );
-    // …the remaining arguments render as a labeled block (keys as
-    // labels, no approval_context row, no raw JSON braces)…
     const argsBlock = screen.getByTestId("approval-args");
-    expect(argsBlock.textContent).toContain("issueIdOrKey");
-    expect(argsBlock.textContent).toContain("AM-4773");
+    expect(argsBlock.textContent).toContain("issueId");
+    expect(argsBlock.textContent).toContain("ISSUE-123");
     expect(argsBlock.textContent).not.toContain("approval_context");
-    // …and the verbatim preview survives in the collapsed raw block.
     const details = document.querySelector("details");
     expect(details).not.toBeNull();
     expect(details!.textContent).toContain("Raw call");
@@ -88,7 +84,7 @@ describe("ApprovalCard — approval_context prose", () => {
     render(
       <ApprovalCard
         elicitationId="elic_cut"
-        message="Jira workflow transition — Robert must approve."
+        message="Issue transition requires approval."
         phase="tool_call"
         policyName="jira_approval_gate"
         contentPreview={truncated}
@@ -105,8 +101,6 @@ describe("ApprovalCard — approval_context prose", () => {
   });
 
   it("renders the bare-arguments policy-ASK shape as labeled args", () => {
-    // The runner policy gate previews the raw arguments object with no
-    // {name, arguments} envelope.
     render(
       <ApprovalCard
         elicitationId="elic_bare"
@@ -123,6 +117,74 @@ describe("ApprovalCard — approval_context prose", () => {
     const argsBlock = screen.getByTestId("approval-args");
     expect(argsBlock.textContent).toContain("command");
     expect(argsBlock.textContent).toContain("git push origin main");
+  });
+
+  it("keeps siblings when a bare payload contains an arguments field", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_bare_arguments"
+        message="Deployment requires approval."
+        phase="tool_call"
+        policyName="deployment_gate"
+        contentPreview={JSON.stringify({
+          command: "deploy",
+          arguments: { force: true },
+          environment: "test",
+        })}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    const argsBlock = screen.getByTestId("approval-args");
+    expect(argsBlock.textContent).toContain("command");
+    expect(argsBlock.textContent).toContain("environment");
+    expect(argsBlock.textContent).toContain("arguments");
+  });
+
+  it("unwraps an exact name-and-arguments envelope", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_envelope"
+        message="Command requires approval."
+        phase="tool_call"
+        policyName="shell_gate"
+        contentPreview={JSON.stringify({
+          name: "Bash",
+          arguments: { command: "rm -rf ./build" },
+        })}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.getByText("Bash")).toBeDefined();
+    expect(screen.getByTestId("approval-args").textContent).toContain("rm -rf ./build");
+  });
+
+  it("keeps a non-string approval_context visible", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_object_context"
+        message="Approve?"
+        phase="tool_call"
+        policyName="approval_gate"
+        contentPreview={JSON.stringify({
+          issueId: "ISSUE-123",
+          approval_context: { reason: "routine" },
+        })}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.queryByTestId("approval-context")).toBeNull();
+    const argsBlock = screen.getByTestId("approval-args");
+    expect(argsBlock.textContent).toContain("approval_context");
+    expect(argsBlock.textContent).toContain("routine");
   });
 
   it("renders the ToolName({...}) permission-hook shape with the tool caption", () => {

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -75,31 +75,11 @@ function extractOptionLabels(schema: Record<string, unknown>): string[] {
   return enumValues.filter((v): v is string => typeof v === "string" && v.length > 0);
 }
 
-/**
- * Parse a policy-ASK tool-call preview into a renderable structure —
- * the generic path for EVERY policy-gated tool (Jira transitions, M365
- * sends, future consumers), with no tool-name branching:
- *
- * - ``context`` — the platform ``approval_context`` convention: a tool
- *   may accept an optional ``approval_context`` string argument that an
- *   agent fills with its human-facing summary/recommendation. When
- *   present it is promoted to prose at the top of the card and omitted
- *   from the argument block.
- * - ``args`` — the remaining call arguments, rendered as a labeled
- *   field block (see ``ToolArgEntries``) instead of a raw JSON dump.
- * - ``name`` — the gated tool's name (shown as the block caption).
- *
- * Handles the three producer shapes ``previewFormat.ts`` documents:
- * the ``{name, arguments}`` envelope, the bare arguments object the
- * runner policy gate emits, and the ``ToolName({...})`` permission-hook
- * form. Returns ``null`` for anything unparseable — including previews
- * cut mid-token by the server-side 1024-char ``content_preview`` cap —
- * and the card then falls back to the raw-preview render unchanged.
- */
+/** Parse a tool-call preview without hiding fields from malformed or bare payloads. */
 function parseToolCallPreview(
   raw: string,
 ): { name: string | null; context: string | null; args: Record<string, unknown> } | null {
-  // Shape 2: ``ToolName({...})`` — the native permission-hook preview.
+  // Shape 2: ``ToolName({...})``, used by native permission hooks.
   let name: string | null = null;
   let jsonText = raw;
   const hookMatch = raw.trim().match(/^([A-Za-z0-9_.:-]+)\((\{[\s\S]*\})\)$/);
@@ -115,34 +95,31 @@ function parseToolCallPreview(
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
   const record = parsed as Record<string, unknown>;
-  // Shape 1: the ``{name, arguments}`` envelope (MCP-style tool call).
-  // Shape 3: a bare arguments object (the runner policy-ASK preview).
+  // Only the exact MCP shape is an envelope. A bare policy payload may
+  // legitimately contain an object-valued `arguments` field.
   let args: Record<string, unknown>;
-  if (
-    record.arguments &&
+  const isEnvelope =
+    !hookMatch &&
+    typeof record.name === "string" &&
+    record.name !== "" &&
+    !!record.arguments &&
     typeof record.arguments === "object" &&
-    !Array.isArray(record.arguments)
-  ) {
+    !Array.isArray(record.arguments) &&
+    Object.keys(record).every((key) => key === "name" || key === "arguments");
+  if (isEnvelope) {
     args = { ...(record.arguments as Record<string, unknown>) };
-    if (typeof record.name === "string" && record.name) name = record.name;
+    name = record.name as string;
   } else {
     args = { ...record };
   }
   if (Object.keys(args).length === 0) return null;
   const rawContext = args.approval_context;
   const context = typeof rawContext === "string" && rawContext.trim() ? rawContext.trim() : null;
-  delete args.approval_context;
+  if (typeof rawContext === "string") delete args.approval_context;
   return { name, context, args };
 }
 
-/**
- * Labeled, type-aware render of a gated tool call's arguments —
- * derived from the argument values themselves (schema-agnostic; if the
- * card ever gains access to the tool's input JSON Schema, titles and
- * descriptions slot in here). Scalars render inline; long or multiline
- * strings (message bodies, justifications) render pre-wrapped;
- * objects/arrays render as compact pretty JSON.
- */
+/** Render tool arguments as labeled, type-aware fields. */
 function ToolArgEntries({ args }: { args: Record<string, unknown> }) {
   const entries = Object.entries(args);
   if (entries.length === 0) return null;

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -32,6 +32,7 @@
 //      on `POST /v1/sessions/{id}/elicitations/{eid}/resolve`,
 //   3. rolls back to "pending" on network error.
 
+import type { ReactNode } from "react";
 import {
   CheckIcon,
   ClipboardListIcon,
@@ -72,6 +73,112 @@ function extractOptionLabels(schema: Record<string, unknown>): string[] {
   const enumValues = (answer as Record<string, unknown>).enum;
   if (!Array.isArray(enumValues)) return [];
   return enumValues.filter((v): v is string => typeof v === "string" && v.length > 0);
+}
+
+/**
+ * Parse a policy-ASK tool-call preview into a renderable structure —
+ * the generic path for EVERY policy-gated tool (Jira transitions, M365
+ * sends, future consumers), with no tool-name branching:
+ *
+ * - ``context`` — the platform ``approval_context`` convention: a tool
+ *   may accept an optional ``approval_context`` string argument that an
+ *   agent fills with its human-facing summary/recommendation. When
+ *   present it is promoted to prose at the top of the card and omitted
+ *   from the argument block.
+ * - ``args`` — the remaining call arguments, rendered as a labeled
+ *   field block (see ``ToolArgEntries``) instead of a raw JSON dump.
+ * - ``name`` — the gated tool's name (shown as the block caption).
+ *
+ * Handles the three producer shapes ``previewFormat.ts`` documents:
+ * the ``{name, arguments}`` envelope, the bare arguments object the
+ * runner policy gate emits, and the ``ToolName({...})`` permission-hook
+ * form. Returns ``null`` for anything unparseable — including previews
+ * cut mid-token by the server-side 1024-char ``content_preview`` cap —
+ * and the card then falls back to the raw-preview render unchanged.
+ */
+function parseToolCallPreview(
+  raw: string,
+): { name: string | null; context: string | null; args: Record<string, unknown> } | null {
+  // Shape 2: ``ToolName({...})`` — the native permission-hook preview.
+  let name: string | null = null;
+  let jsonText = raw;
+  const hookMatch = raw.trim().match(/^([A-Za-z0-9_.:-]+)\((\{[\s\S]*\})\)$/);
+  if (hookMatch) {
+    name = hookMatch[1];
+    jsonText = hookMatch[2];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const record = parsed as Record<string, unknown>;
+  // Shape 1: the ``{name, arguments}`` envelope (MCP-style tool call).
+  // Shape 3: a bare arguments object (the runner policy-ASK preview).
+  let args: Record<string, unknown>;
+  if (
+    record.arguments &&
+    typeof record.arguments === "object" &&
+    !Array.isArray(record.arguments)
+  ) {
+    args = { ...(record.arguments as Record<string, unknown>) };
+    if (typeof record.name === "string" && record.name) name = record.name;
+  } else {
+    args = { ...record };
+  }
+  if (Object.keys(args).length === 0) return null;
+  const rawContext = args.approval_context;
+  const context = typeof rawContext === "string" && rawContext.trim() ? rawContext.trim() : null;
+  delete args.approval_context;
+  return { name, context, args };
+}
+
+/**
+ * Labeled, type-aware render of a gated tool call's arguments —
+ * derived from the argument values themselves (schema-agnostic; if the
+ * card ever gains access to the tool's input JSON Schema, titles and
+ * descriptions slot in here). Scalars render inline; long or multiline
+ * strings (message bodies, justifications) render pre-wrapped;
+ * objects/arrays render as compact pretty JSON.
+ */
+function ToolArgEntries({ args }: { args: Record<string, unknown> }) {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return null;
+  return (
+    <dl className="flex flex-col gap-1" data-testid="approval-args">
+      {entries.map(([key, value]) => {
+        let rendered: ReactNode;
+        if (typeof value === "string") {
+          rendered =
+            value.length > 100 || value.includes("\n") ? (
+              <pre className="max-h-40 overflow-y-auto rounded bg-muted px-2 py-1 font-mono text-xs whitespace-pre-wrap break-words">
+                {value}
+              </pre>
+            ) : (
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">{value}</code>
+            );
+        } else if (value === null || typeof value === "number" || typeof value === "boolean") {
+          rendered = (
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">{String(value)}</code>
+          );
+        } else {
+          rendered = (
+            <pre className="max-h-40 overflow-y-auto rounded bg-muted px-2 py-1 font-mono text-xs whitespace-pre-wrap break-words">
+              {JSON.stringify(value, null, 2)}
+            </pre>
+          );
+        }
+        return (
+          <div key={key} className="flex flex-col gap-0.5">
+            <dt className="text-muted-foreground text-xs">{key}</dt>
+            <dd className="m-0">{rendered}</dd>
+          </div>
+        );
+      })}
+    </dl>
+  );
 }
 
 /**
@@ -254,13 +361,21 @@ export function ApprovalCard({
           ? "Cursor has questions"
           : "Claude has questions";
 
+  // Generic tool-call render for policy-ASK cards: labeled argument
+  // block + promoted approval_context prose (platform convention), with
+  // the raw preview demoted to a collapsed details block. Falls back to
+  // the raw preview when the preview isn't a parseable tool call.
+  const toolCall =
+    isAskUserQuestion || isExitPlanMode || isMultiChoice || isCodexCommandApproval
+      ? null
+      : parseToolCallPreview(contentPreview);
   // Hide the raw JSON preview for AskUserQuestion (the form already
   // renders the questions + options structurally) and for option-
   // button mode (the buttons render the choices). Codex command
   // approvals get a dedicated command render below, so showing the
   // transport JSON would expose unrelated ids and duplicate details.
   const formattedPreview =
-    isAskUserQuestion || isExitPlanMode || isMultiChoice || isCodexCommandApproval
+    isAskUserQuestion || isExitPlanMode || isMultiChoice || isCodexCommandApproval || toolCall
       ? ""
       : formatPreview(contentPreview);
   const execPolicyAmendment =
@@ -517,6 +632,27 @@ export function ApprovalCard({
         ) : (
           <>
             <span>{message}</span>
+            {toolCall?.context && (
+              <span className="text-foreground whitespace-pre-wrap" data-testid="approval-context">
+                {toolCall.context}
+              </span>
+            )}
+            {toolCall && (
+              <>
+                {toolCall.name && (
+                  <span className="text-muted-foreground font-mono text-xs">{toolCall.name}</span>
+                )}
+                <ToolArgEntries args={toolCall.args} />
+                <details>
+                  <summary className="cursor-pointer text-xs text-muted-foreground select-none">
+                    Raw call
+                  </summary>
+                  <pre className="mt-1 max-h-64 overflow-y-auto rounded bg-muted px-2 py-1 font-mono text-xs whitespace-pre-wrap break-words">
+                    {formatPreview(contentPreview)}
+                  </pre>
+                </details>
+              </>
+            )}
             {formattedPreview && (
               <pre className="max-h-64 overflow-y-auto rounded bg-muted px-2 py-1 font-mono text-xs whitespace-pre-wrap break-words">
                 {formattedPreview}


### PR DESCRIPTION
## Related issue

Closes omnigent-ai/omnigent#2148

## Summary

Approval cards currently show policy-gated tool calls as raw JSON. This change renders parseable previews as labeled, type-aware arguments and promotes an optional string `approval_context` to prose.

Only an exact `{name, arguments}` object is treated as an envelope. Bare payloads keep all sibling fields, malformed non-string context remains visible, and unparseable or truncated previews retain the existing raw display. Structured card modes are unchanged.

ELI5: instead of showing a tool request as a JSON blob, the card labels each input and keeps the original request available for inspection.

```text
tool preview
  -> exact envelope, bare arguments, or permission-hook form
  -> context prose + labeled arguments
  -> collapsed raw call
```

## Test Plan

* `npm test -- --run src/components/blocks/ApprovalCard.test.tsx` (`45 passed`)
* `npm run type-check`
* `oxlint src/components/blocks/ApprovalCard.tsx src/components/blocks/ApprovalCard.test.tsx`
* `prettier --check src/components/blocks/ApprovalCard.tsx src/components/blocks/ApprovalCard.test.tsx`

Focused cases cover all three preview shapes, exact-envelope detection, a bare payload containing its own `arguments` field, non-string context preservation, and truncated-preview fallback.

## Demo

Dark and light examples covering context prose, a generic long-body call, and the unchanged truncated fallback:

![dark](https://uploads.linear.app/95e60749-d218-42b7-ad62-15f7e7a0d321/13f50644-3b91-49e3-b114-21abb0a7f717/ba762fa8-edce-419d-8d1f-cc18885a071b?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzk1ZTYwNzQ5LWQyMTgtNDJiNy1hZDYyLTE1ZjdlN2EwZDMyMS8xM2Y1MDY0NC0zYjkxLTQ5ZTMtYjExNC0yMWFiYjBhN2Y3MTcvYmE3NjJmYTgtZWRjZS00MTlkLThkMWYtY2MxODg4NWEwNzFiIiwiaWF0IjoxNzg0NjI0NDE1LCJleHAiOjE4MTYxOTQ5NzV9.n787ZebW3RmkG0AIdCXIVRx2zIv48UuW97ThQ_JpZPY)

![light](https://raw.githubusercontent.com/dosenr/omnigent/assets/pr-2142-demo/approval-card-preview-light.png)

## Type of change

- [ ] Bug fix
- [X] Feature
- [X] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [X] E2E tests added / updated
- [X] Manual verification completed
- [X] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The component tests cover parser and rendering behavior. The added Playwright case covers the standard gated-tool approval flow. The screenshots were captured from the original visual implementation; this correction changes parsing and fixtures, not layout.

## Changelog

Approval cards render gated tool calls as labeled arguments, with optional approval context shown as prose.