### PR TITLE
feat(web): choose a terminal theme in Appearance settings

### DIFF
--- a/tests/e2e_ui/sessions/test_terminal_theme.py
+++ b/tests/e2e_ui/sessions/test_terminal_theme.py
@@ -1,0 +1,155 @@
+"""E2E: the Settings → Appearance terminal-theme picker themes a live terminal
+independently of the app theme, and persists.
+
+The terminal-theme control lives on the Settings page (``pages/SettingsPage.tsx``,
+``TerminalThemeControl``): three radio cards — Match app / Light / Dark — under a
+``role="radiogroup"`` labelled "Terminal theme". Picking a mode writes the choice
+to ``localStorage["omnigent:terminal-theme"]`` (absent = "auto" = follow the app).
+
+Unlike the chrome, the terminal is an xterm.js widget whose colors are a JS
+``ITheme`` object, so the choice can't ride the ``.dark`` class the app theme
+uses. ``TerminalView`` resolves the mode against the app's resolved appearance
+(``resolveTerminalIsDark``) and reflects the result on the mounted terminal as
+``data-terminal-theme`` ("light"/"dark") — the portable DOM signal here, since
+xterm paints to a WebGL canvas (see ``shells/test_new_shell.py`` for why terminal
+pixels aren't asserted). ``auto`` follows the app; ``light``/``dark`` pin the
+terminal regardless of the app theme.
+
+This is exactly the pair the feature exists for: a light terminal under a dark
+app, and a dark terminal under a light app. The shell is user-launched (no LLM
+turn) via the rail's "+ New shell" affordance, mirroring
+``shells/test_new_shell.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+TERMINAL_THEME_KEY = "omnigent:terminal-theme"
+APP_THEME_KEY = "web-theme"
+
+
+def _html_has_dark(page: Page) -> bool:
+    """True when the ``dark`` class is applied to ``<html>`` (next-themes)."""
+    return page.evaluate("() => document.documentElement.classList.contains('dark')")
+
+
+def _stored_terminal_theme(page: Page) -> str | None:
+    """The persisted terminal-theme mode, or None when unset (default "auto")."""
+    return page.evaluate(f"() => window.localStorage.getItem('{TERMINAL_THEME_KEY}')")
+
+
+def _open_appearance(page: Page, base_url: str) -> None:
+    """Navigate to the Settings Appearance section and wait for the control."""
+    page.goto(f"{base_url}/settings/appearance")
+    expect(page.get_by_role("radiogroup", name="Terminal theme")).to_be_visible(timeout=30_000)
+
+
+def _pick_app_theme(page: Page, mode: str) -> None:
+    """Pin the app theme to an explicit mode via its Appearance radio card."""
+    card = page.get_by_test_id(f"theme-{mode}")
+    card.click()
+    expect(card).to_have_attribute("aria-checked", "true")
+
+
+def _pick_terminal_theme(page: Page, mode: str) -> None:
+    """Pick a terminal-theme mode via its Appearance radio card."""
+    card = page.get_by_test_id(f"terminal-theme-{mode}")
+    card.click()
+    expect(card).to_have_attribute("aria-checked", "true")
+
+
+def _open_new_shell(page: Page) -> None:
+    """Open the Shells tab and click "+ New shell" (mirrors test_new_shell)."""
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("Shells")).click()
+    rail.get_by_role("button", name="New shell").click()
+
+
+def _connected_main_terminal(page: Page):
+    """Wait for a freshly opened shell's xterm to mount + connect in the main view."""
+    main_terminal = page.get_by_test_id("main-terminal-view")
+    expect(main_terminal).to_be_visible(timeout=60_000)
+    terminal_view = main_terminal.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=20_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+    return terminal_view
+
+
+def test_light_terminal_under_dark_app(page: Page, terminal_session: tuple[str, str]) -> None:
+    """A "Light" terminal stays light while the app runs Dark.
+
+    Pins the app to Dark and the terminal to Light in Settings, then launches a
+    shell: the mounted terminal resolves to light (``data-terminal-theme=light``)
+    even though ``<html>`` carries the ``dark`` class. This is the "light terminal
+    with a dark theme" case.
+    """
+    base_url, session_id = terminal_session
+
+    _open_appearance(page, base_url)
+    _pick_app_theme(page, "dark")
+    _pick_terminal_theme(page, "light")
+    assert _html_has_dark(page), "app should be dark after picking the Dark theme card"
+    assert _stored_terminal_theme(page) == "light", "terminal theme choice was not persisted"
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+    terminal_view = _connected_main_terminal(page)
+
+    # The terminal is light despite the dark app chrome — the two themes are
+    # independent, which is the whole point of the feature.
+    expect(terminal_view).to_have_attribute("data-terminal-theme", "light")
+    assert _html_has_dark(page), "app theme must stay dark while the terminal is light"
+
+
+def test_dark_terminal_under_light_app(page: Page, terminal_session: tuple[str, str]) -> None:
+    """A "Dark" terminal stays dark while the app runs Light.
+
+    The mirror of the light-on-dark case: pin the app to Light and the terminal to
+    Dark, launch a shell, and confirm the terminal resolves to dark
+    (``data-terminal-theme=dark``) with no ``dark`` class on ``<html>``.
+    """
+    base_url, session_id = terminal_session
+
+    _open_appearance(page, base_url)
+    _pick_app_theme(page, "light")
+    _pick_terminal_theme(page, "dark")
+    assert not _html_has_dark(page), "app should be light after picking the Light theme card"
+    assert _stored_terminal_theme(page) == "dark", "terminal theme choice was not persisted"
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+    terminal_view = _connected_main_terminal(page)
+
+    expect(terminal_view).to_have_attribute("data-terminal-theme", "dark")
+    assert not _html_has_dark(page), "app theme must stay light while the terminal is dark"
+
+
+def test_terminal_theme_control_defaults_and_persists(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """Match-app is the default; a pick persists and survives a reload.
+
+    A fast, shell-free check of the control itself: fresh context selects "Match
+    app" with nothing stored; picking Light persists "light" and re-selects after
+    a full reload (so the choice a terminal reads at mount is durable).
+    """
+    base_url, _session_id = seeded_session
+    _open_appearance(page, base_url)
+
+    # Fresh context → "Match app" (auto) is the selected default, nothing stored.
+    expect(page.get_by_test_id("terminal-theme-auto")).to_have_attribute("aria-checked", "true")
+    assert _stored_terminal_theme(page) is None, "a fresh load should store no terminal theme"
+
+    _pick_terminal_theme(page, "light")
+    assert _stored_terminal_theme(page) == "light"
+
+    page.reload()
+    expect(page.get_by_role("radiogroup", name="Terminal theme")).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id("terminal-theme-light")).to_have_attribute("aria-checked", "true")
+    assert _stored_terminal_theme(page) == "light", "the terminal theme did not survive a reload"

--- a/tests/e2e_ui/sessions/test_theme_toggle.py
+++ b/tests/e2e_ui/sessions/test_theme_toggle.py
@@ -19,7 +19,7 @@ No LLM turn is involved.
 
 from __future__ import annotations
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 
 def _html_has_dark(page: Page) -> bool:
@@ -32,10 +32,17 @@ def _stored_theme(page: Page) -> str | None:
     return page.evaluate("() => window.localStorage.getItem('web-theme')")
 
 
+def _theme_radiogroup(page: Page) -> Locator:
+    """The app-theme radiogroup, matched exactly so it can't also resolve the
+    Appearance page's "Terminal theme" radiogroup, whose name contains "Theme"
+    and whose cards reuse the Light/Dark labels."""
+    return page.get_by_role("radiogroup", name="Theme", exact=True)
+
+
 def _open_appearance(page: Page, base_url: str) -> None:
     """Navigate to the Settings Appearance section and wait for the cards."""
     page.goto(f"{base_url}/settings/appearance")
-    expect(page.get_by_role("radiogroup", name="Theme")).to_be_visible(timeout=30_000)
+    expect(_theme_radiogroup(page)).to_be_visible(timeout=30_000)
 
 
 def test_theme_toggle_cycles_and_persists(page: Page, seeded_session: tuple[str, str]) -> None:
@@ -54,12 +61,14 @@ def test_theme_toggle_cycles_and_persists(page: Page, seeded_session: tuple[str,
 
     # Fresh context → no stored preference → default "system" is selected, and
     # on a light OS that renders without the dark class.
-    expect(page.get_by_role("radio", name="System")).to_have_attribute("aria-checked", "true")
+    expect(_theme_radiogroup(page).get_by_role("radio", name="System")).to_have_attribute(
+        "aria-checked", "true"
+    )
     assert _stored_theme(page) is None, "expected no persisted theme on a fresh load"
     assert not _html_has_dark(page), "system on a light OS should not apply the dark class"
 
     # → Dark: the dark class lands and the choice persists.
-    dark = page.get_by_role("radio", name="Dark")
+    dark = _theme_radiogroup(page).get_by_role("radio", name="Dark")
     dark.click()
     expect(dark).to_have_attribute("aria-checked", "true")
     assert _html_has_dark(page), "<html> did not gain the dark class after selecting Dark"
@@ -67,7 +76,7 @@ def test_theme_toggle_cycles_and_persists(page: Page, seeded_session: tuple[str,
 
     # → System: the dark class clears (system resolves to light) and "system"
     # persists.
-    system = page.get_by_role("radio", name="System")
+    system = _theme_radiogroup(page).get_by_role("radio", name="System")
     system.click()
     expect(system).to_have_attribute("aria-checked", "true")
     assert not _html_has_dark(page), "<html> kept the dark class after returning to System"
@@ -88,12 +97,14 @@ def test_theme_toggle_reaches_explicit_light_on_dark_os(
     _open_appearance(page, base_url)
 
     # Fresh "system" on a dark OS renders dark; System is the checked card.
-    expect(page.get_by_role("radio", name="System")).to_have_attribute("aria-checked", "true")
+    expect(_theme_radiogroup(page).get_by_role("radio", name="System")).to_have_attribute(
+        "aria-checked", "true"
+    )
     assert _html_has_dark(page), "system on a dark OS should apply the dark class"
     assert _stored_theme(page) is None, "expected no persisted theme on a fresh load"
 
     # → Light: the dark class clears and "light" persists.
-    light = page.get_by_role("radio", name="Light")
+    light = _theme_radiogroup(page).get_by_role("radio", name="Light")
     light.click()
     expect(light).to_have_attribute("aria-checked", "true")
     assert not _html_has_dark(page), "<html> kept the dark class after selecting Light"
@@ -101,7 +112,7 @@ def test_theme_toggle_reaches_explicit_light_on_dark_os(
 
     # → System: the dark class returns (system resolves to dark) and "system"
     # persists.
-    system = page.get_by_role("radio", name="System")
+    system = _theme_radiogroup(page).get_by_role("radio", name="System")
     system.click()
     expect(system).to_have_attribute("aria-checked", "true")
     assert _html_has_dark(page), "<html> did not regain the dark class after returning to System"

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -15,6 +15,12 @@ import { Button } from "@/components/ui/button";
 import { resolveWebSocketUrl } from "@/lib/host";
 import { subscribeCodeFont } from "@/lib/codeFontPreferences";
 import {
+  readTerminalThemeMode,
+  resolveTerminalIsDark,
+  subscribeTerminalTheme,
+  type TerminalThemeMode,
+} from "@/lib/terminalThemePreferences";
+import {
   type ConnectionState,
   type TerminalActivityListener,
   type TerminalInputListener,
@@ -107,7 +113,15 @@ export function TerminalView({
   // (reset the budget) from "re-dial died straight away" (burn it).
   const connectedAtRef = useRef<number | null>(null);
   const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === "dark";
+  // Terminal theme is independent of the app theme: "auto" follows the app's
+  // resolved appearance, while "light"/"dark" pin the terminal. Reading the
+  // pref as state (seeded at mount, updated via the pub/sub) lets a Settings
+  // change re-theme a live terminal through the existing setTheme effect below.
+  const [terminalMode, setTerminalMode] = useState<TerminalThemeMode>(() =>
+    readTerminalThemeMode(),
+  );
+  useEffect(() => subscribeTerminalTheme(setTerminalMode), []);
+  const isDark = resolveTerminalIsDark(terminalMode, resolvedTheme === "dark");
   // Stable ref so the theme-update effect can reach the live session
   // without adding isDark to the attachSession deps (which would
   // reconnect the WebSocket on every theme change).
@@ -291,6 +305,7 @@ export function TerminalView({
       data-testid="terminal-view"
       data-state={state.kind}
       data-terminal-id={terminalId}
+      data-terminal-theme={isDark ? "dark" : "light"}
       className="relative flex min-h-0 flex-1 flex-col"
     >
       {/* `p-1` lives on the wrapper, not the xterm mount node: FitAddon

--- a/web/src/lib/terminalThemePreferences.test.ts
+++ b/web/src/lib/terminalThemePreferences.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  normalizeTerminalThemeMode,
+  readTerminalThemeMode,
+  resolveTerminalIsDark,
+  subscribeTerminalTheme,
+  TERMINAL_THEME_DEFAULT,
+  writeTerminalThemeMode,
+} from "./terminalThemePreferences";
+
+const STORAGE_KEY = "omnigent:terminal-theme";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("terminalThemePreferences — read/write", () => {
+  it("returns auto when nothing is stored", () => {
+    expect(readTerminalThemeMode()).toBe(TERMINAL_THEME_DEFAULT);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("stores raw light and dark strings", () => {
+    writeTerminalThemeMode("light");
+    expect(readTerminalThemeMode()).toBe("light");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+
+    writeTerminalThemeMode("dark");
+    expect(readTerminalThemeMode()).toBe("dark");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+  });
+
+  it("removes the key when written auto", () => {
+    writeTerminalThemeMode("dark");
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    writeTerminalThemeMode("auto");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(readTerminalThemeMode()).toBe("auto");
+  });
+});
+
+describe("normalizeTerminalThemeMode", () => {
+  it("passes through valid modes", () => {
+    expect(normalizeTerminalThemeMode("auto")).toBe("auto");
+    expect(normalizeTerminalThemeMode("light")).toBe("light");
+    expect(normalizeTerminalThemeMode("dark")).toBe("dark");
+  });
+
+  it("maps unknown, null, and garbage to auto", () => {
+    expect(normalizeTerminalThemeMode("system")).toBe("auto");
+    expect(normalizeTerminalThemeMode("bogus")).toBe("auto");
+    expect(normalizeTerminalThemeMode(null)).toBe("auto");
+    expect(normalizeTerminalThemeMode(undefined)).toBe("auto");
+  });
+});
+
+describe("resolveTerminalIsDark", () => {
+  it("follows the app when mode is auto", () => {
+    expect(resolveTerminalIsDark("auto", true)).toBe(true);
+    expect(resolveTerminalIsDark("auto", false)).toBe(false);
+  });
+
+  it("pins light regardless of app theme", () => {
+    expect(resolveTerminalIsDark("light", true)).toBe(false);
+    expect(resolveTerminalIsDark("light", false)).toBe(false);
+  });
+
+  it("pins dark regardless of app theme", () => {
+    expect(resolveTerminalIsDark("dark", true)).toBe(true);
+    expect(resolveTerminalIsDark("dark", false)).toBe(true);
+  });
+});
+
+describe("terminalThemePreferences — pub/sub", () => {
+  it("notifies subscribers with the written mode", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeTerminalTheme(cb);
+
+    writeTerminalThemeMode("dark");
+    expect(cb).toHaveBeenCalledWith("dark");
+
+    unsubscribe();
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeTerminalTheme(cb);
+    unsubscribe();
+
+    writeTerminalThemeMode("light");
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/terminalThemePreferences.ts
+++ b/web/src/lib/terminalThemePreferences.ts
@@ -1,0 +1,111 @@
+// Persisted preference for the terminal's light/dark palette — independent of
+// the app chrome theme. The terminal is an xterm.js `ITheme` JS object applied
+// imperatively (unlike the chrome theme, which rides the `.dark` class + CSS
+// vars), so a mid-session change is pushed to mounted terminals via a pub/sub;
+// `auto` follows the app's resolved theme while `light`/`dark` pin it.
+
+const STORAGE_KEY = "omnigent:terminal-theme";
+
+export const terminalThemeModes = ["auto", "light", "dark"] as const;
+export type TerminalThemeMode = (typeof terminalThemeModes)[number];
+export const TERMINAL_THEME_DEFAULT: TerminalThemeMode = "auto";
+
+/** Return whether a string is one of the selectable terminal theme modes. */
+export function isTerminalThemeMode(value: string | null | undefined): value is TerminalThemeMode {
+  return value === "auto" || value === "light" || value === "dark";
+}
+
+/**
+ * Normalize a stored terminal theme string to the default auto mode.
+ *
+ * Unknown values can only come from localStorage drift or manual edits.
+ * Falling back to `auto` matches the documented default and preserves
+ * backwards-compatible "follow the app" behavior.
+ */
+export function normalizeTerminalThemeMode(value: string | null | undefined): TerminalThemeMode {
+  return isTerminalThemeMode(value) ? value : TERMINAL_THEME_DEFAULT;
+}
+
+/**
+ * Read the persisted terminal theme mode.
+ *
+ * Returns "auto" when nothing is stored, on a server render (no `window`),
+ * or when the stored value is missing/unknown — never throws, so a corrupt
+ * entry can't break app boot.
+ */
+export function readTerminalThemeMode(): TerminalThemeMode {
+  if (typeof window === "undefined") return TERMINAL_THEME_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return TERMINAL_THEME_DEFAULT;
+    return normalizeTerminalThemeMode(raw);
+  } catch {
+    return TERMINAL_THEME_DEFAULT;
+  }
+}
+
+/**
+ * Persist the terminal theme mode, then notify subscribers so mounted
+ * terminals re-apply it live. "auto" clears the key (the default). Swallows
+ * quota/access errors so a failed write can't break the app.
+ */
+export function writeTerminalThemeMode(mode: TerminalThemeMode): void {
+  const normalized = normalizeTerminalThemeMode(mode);
+  if (typeof window !== "undefined") {
+    try {
+      if (normalized === TERMINAL_THEME_DEFAULT) {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(STORAGE_KEY, normalized);
+      }
+    } catch {
+      // localStorage quota or access errors shouldn't break the app.
+    }
+  }
+  // Broadcast the intended value, not a storage re-read: if the write above
+  // failed (quota/denied), mounted terminals must still re-theme now rather
+  // than snapping back to the stale/default stored value.
+  emit(normalized);
+}
+
+/**
+ * Resolve whether the terminal should render dark given the user's mode and
+ * the app's current resolved appearance.
+ */
+export function resolveTerminalIsDark(mode: TerminalThemeMode, appIsDark: boolean): boolean {
+  switch (mode) {
+    case "auto":
+      return appIsDark;
+    case "light":
+      return false;
+    case "dark":
+      return true;
+    default: {
+      const _exhaustive: never = mode;
+      return _exhaustive;
+    }
+  }
+}
+
+type TerminalThemeListener = (mode: TerminalThemeMode) => void;
+
+const listeners = new Set<TerminalThemeListener>();
+
+/**
+ * Subscribe to terminal theme changes. The callback fires with the current
+ * {@link TerminalThemeMode} whenever it is written (e.g. from Settings),
+ * letting an already-mounted terminal re-apply the palette live — xterm's
+ * `ITheme` can't ride a CSS variable the way the chrome theme does. Returns
+ * an unsubscribe function.
+ */
+export function subscribeTerminalTheme(listener: TerminalThemeListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Notify subscribers of the given terminal theme mode. Called after every write. */
+function emit(mode: TerminalThemeMode): void {
+  for (const listener of listeners) listener(mode);
+}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -113,6 +113,36 @@ describe("SettingsPage", () => {
     expect(mocks.setTheme).toHaveBeenCalledWith("dark");
   });
 
+  it("renders the Terminal theme radiogroup with auto selected by default", () => {
+    renderPage("/settings/appearance");
+    expect(screen.getByRole("radiogroup", { name: "Terminal theme" })).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-theme-auto")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("terminal-theme-light")).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByTestId("terminal-theme-dark")).toHaveAttribute("aria-checked", "false");
+    expect(localStorage.getItem("omnigent:terminal-theme")).toBeNull();
+  });
+
+  it("persists dark and light terminal theme choices on card click", () => {
+    renderPage("/settings/appearance");
+
+    fireEvent.click(screen.getByTestId("terminal-theme-dark"));
+    expect(localStorage.getItem("omnigent:terminal-theme")).toBe("dark");
+    expect(screen.getByTestId("terminal-theme-dark")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("terminal-theme-auto")).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(screen.getByTestId("terminal-theme-light"));
+    expect(localStorage.getItem("omnigent:terminal-theme")).toBe("light");
+    expect(screen.getByTestId("terminal-theme-light")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("terminal-theme-dark")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("reflects a stored light terminal theme on mount", () => {
+    localStorage.setItem("omnigent:terminal-theme", "light");
+    renderPage("/settings/appearance");
+    expect(screen.getByTestId("terminal-theme-light")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("terminal-theme-auto")).toHaveAttribute("aria-checked", "false");
+  });
+
   it("shows the default UI font size and steps it up, persisting the choice", () => {
     localStorage.clear();
     renderPage("/settings/appearance");

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -32,7 +32,14 @@ import {
   Trash2Icon,
   UserCogIcon,
 } from "lucide-react";
-import { LaptopMinimalIcon, MinusIcon, MoonIcon, PlusIcon, SunIcon } from "lucide-react";
+import {
+  LaptopMinimalIcon,
+  MinusIcon,
+  MonitorIcon,
+  MoonIcon,
+  PlusIcon,
+  SunIcon,
+} from "lucide-react";
 import { useTheme } from "next-themes";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
@@ -83,6 +90,11 @@ import {
   writeCodeFontFamily,
   writeCodeFontSizePx,
 } from "@/lib/codeFontPreferences";
+import {
+  readTerminalThemeMode,
+  writeTerminalThemeMode,
+  type TerminalThemeMode,
+} from "@/lib/terminalThemePreferences";
 import { useIsEmbedded } from "@/lib/embedded";
 import { type CliStatus, getCliStatus, isElectronShell, resetCliPath } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
@@ -162,6 +174,50 @@ const themeCards: { mode: ThemeMode; label: string; icon: typeof SunIcon }[] = [
   { mode: "dark", label: "Dark", icon: MoonIcon },
 ];
 
+const terminalThemeCards: { mode: TerminalThemeMode; label: string; icon: typeof SunIcon }[] = [
+  { mode: "auto", label: "Match app", icon: MonitorIcon },
+  { mode: "light", label: "Light", icon: SunIcon },
+  { mode: "dark", label: "Dark", icon: MoonIcon },
+];
+
+function TerminalThemeControl() {
+  const [mode, setMode] = useState(() => readTerminalThemeMode());
+
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-sm font-medium">Terminal theme</span>
+      <span className="text-sm text-muted-foreground">
+        Use a light or dark terminal, or match the app.
+      </span>
+      <div className="grid grid-cols-3 gap-3" role="radiogroup" aria-label="Terminal theme">
+        {terminalThemeCards.map(({ mode: cardMode, label, icon: Icon }) => {
+          const selected = mode === cardMode;
+          return (
+            <button
+              key={cardMode}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              data-testid={`terminal-theme-${cardMode}`}
+              onClick={() => {
+                setMode(cardMode);
+                writeTerminalThemeMode(cardMode);
+              }}
+              className={cn(
+                "flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors hover:bg-muted",
+                selected ? "border-primary bg-primary/5" : "border-border",
+              )}
+            >
+              <Icon className="size-6 text-muted-foreground" />
+              <span className="text-sm font-medium">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function AppearanceSection() {
   // Embedded: the host owns the theme (embed.tsx forces light), so the
   // selector would be a no-op — match ThemeModeMenu and hide it.
@@ -205,6 +261,8 @@ function AppearanceSection() {
             </div>
           )}
         </div>
+
+        <TerminalThemeControl />
 
         <UiFontSizeControl />
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds a **Terminal theme** control to Settings, Appearance (Match app / Light / Dark) so the terminal's light/dark palette can be chosen independently of the app chrome theme.
- "Match app" is the default and keeps today's behavior, where the terminal follows the app's resolved theme. "Light" and "Dark" pin the terminal regardless of the app theme, so you can run a light terminal under a dark app, or a dark terminal under a light app.
- Mirrors the existing `codeFontPreferences` feature. A small `terminalThemePreferences` module (localStorage plus an in-module pub/sub) re-themes already-mounted xterm terminals live through the existing `TerminalSession.setTheme` path, with no WebSocket reconnect.

## Test Plan

- `cd web && npx vitest run src/lib/terminalThemePreferences.test.ts src/pages/SettingsPage.test.tsx` passes (35 tests): resolver truth table, read/write/normalize, pub/sub, and the Settings control render + persistence.
- `cd web && npm run build` (tsc -b + vite) is clean, so type-check passes.
- `uv run pytest tests/e2e_ui/sessions/test_terminal_theme.py --ui-skip-build` passes (3 tests). It drives the real Appearance control and a live shell, asserting `data-terminal-theme` independence in both directions plus the match-app default and reload persistence.
- `uv run pre-commit run --files <changed files>` passes all hooks.

## Demo

Settings, Appearance gains a **Terminal theme** picker under the app Theme cards. With the app in Dark, choosing **Light** renders the terminal light while the chrome stays dark. With the app in Light, choosing **Dark** renders the terminal dark. Both directions are asserted end to end in `tests/e2e_ui/sessions/test_terminal_theme.py` against a live xterm shell. Screenshots of the picker and both light-on-dark / dark-on-light terminals were captured locally and shared with the reviewer.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Ran the e2e suite live (spawned server, runner, and a real zsh shell in xterm) and confirmed the terminal renders light under a dark app and dark under a light app, and that the choice survives a reload. Unit and component tests cover the resolver, persistence, the pub/sub, and the Settings control.

## Changelog

Choose a terminal theme (light or dark) independent of the app theme in Settings, Appearance
