### PR TITLE
feat(web): split sidebar sessions into My sessions / Shared with me tabs

### DIFF
--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -48,6 +48,10 @@ vi.mock("@/hooks/useConversations", () => ({
 vi.mock("./AgentTypeFilter", () => ({ AgentTypeFilter: () => null }));
 vi.mock("./ReportIssueButton", () => ({ ReportIssueButton: () => null }));
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+// Force a multi-user (non-local) server so the "Shared with me" tab renders —
+// jsdom's default loopback origin would otherwise read as single-user and hide
+// the tabs the shared-session row actions rely on.
+vi.mock("@/lib/serverOrigin", () => ({ isCurrentServerLocal: () => false }));
 
 import { type Conversation, useConversations } from "@/hooks/useConversations";
 import { __resetReadStateForTests, seedReadState } from "@/hooks/useUnseenConversations";
@@ -238,9 +242,13 @@ describe("double-click to rename", () => {
 
   it("does not enter rename on double-click for a viewer-only row", () => {
     // permission_level 1 is below the edit threshold (>= 2), so the kebab's
-    // Rename item is disabled and double-click must be inert too.
+    // Rename item is disabled and double-click must be inert too. A viewer-only
+    // (non-owner) session lives on the "Shared with me" tab, so switch to it
+    // before reaching for the row.
     mockConversations([{ ...CONV, permission_level: 1 }]);
     renderSidebar();
+    // Radix Tabs triggers activate on mousedown (primary button), not click.
+    fireEvent.mouseDown(screen.getByTestId("sidebar-tab-shared"), { button: 0 });
 
     fireEvent.dblClick(screen.getByRole("link", { name: /My Session/ }));
 

--- a/web/src/shell/Sidebar.stop.test.tsx
+++ b/web/src/shell/Sidebar.stop.test.tsx
@@ -49,6 +49,10 @@ vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({
 }));
 
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+// Force a multi-user (non-local) server so the "Shared with me" tab renders —
+// jsdom's default loopback origin would otherwise read as single-user and hide
+// the tabs the shared-session row actions rely on.
+vi.mock("@/lib/serverOrigin", () => ({ isCurrentServerLocal: () => false }));
 
 import { type Conversation, useConversations } from "@/hooks/useConversations";
 import { Sidebar } from "./Sidebar";
@@ -184,8 +188,12 @@ describe("sidebar Stop session item", () => {
 
   it("is disabled for non-owners even on a stoppable session", () => {
     // Owner-gated server-side; a shared viewer (level 1) sees it disabled.
+    // A non-owner session lives on the "Shared with me" tab, so switch there
+    // before opening its kebab.
     mockConversations([{ ...HOST_SPAWNED, permission_level: 1 }]);
     renderSidebar();
+    // Radix Tabs triggers activate on mousedown (primary button), not click.
+    fireEvent.mouseDown(screen.getByTestId("sidebar-tab-shared"), { button: 0 });
     openKebab();
     const item = screen.getByTestId("stop-conversation");
     expect(item).toHaveAttribute("data-disabled");

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -423,22 +423,6 @@ describe("Sidebar tabs", () => {
     expect(screen.queryByText("conv_shared")).toBeNull();
   });
 
-  it("does not render project folders on the Shared with me tab", () => {
-    projectsMock.push("Alpha");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Alpha" } }),
-      conv("conv_shared", "Claude Code", { permission_level: 2 }),
-    ]);
-    renderSidebar();
-    // My sessions tab carries the Projects group.
-    expect(screen.getByText("Projects")).toBeInTheDocument();
-
-    // Shared tab is a flat list — projects are a "My sessions"-only tool.
-    showSharedTab();
-    expect(screen.queryByText("Projects")).toBeNull();
-    expect(screen.getByText("conv_shared")).toBeInTheDocument();
-  });
-
   it("hides the tabs on a single-user (local) server and shows only owned sessions", () => {
     // A loopback-only server can't share sessions with anyone, so the tab
     // split is meaningless — collapse to the plain owned-session list.
@@ -455,9 +439,11 @@ describe("Sidebar tabs", () => {
     expect(screen.queryByText("conv_shared")).toBeNull();
   });
 
-  it("keeps a pinned shared session on the Shared tab only, not under Pinned", () => {
-    // Pinning is a My-sessions-only tool: a pinned shared session must not leak
-    // into the owned tab's Pinned section (which would show it in two places).
+  it("gives a pinned shared session a Pinned section on the Shared tab, not My sessions", () => {
+    // Pins are ownership-agnostic (localStorage), so both tabs reuse the same
+    // Pinned section — scoped to that tab's conversations. A pinned shared
+    // session floats to Pinned on the Shared tab and never leaks onto My
+    // sessions (which shows only owned sessions).
     mockConversations([
       conv("conv_mine", "Claude Code"),
       conv("conv_shared", "Claude Code", { permission_level: 2 }),
@@ -465,35 +451,35 @@ describe("Sidebar tabs", () => {
     localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_shared"]));
     renderSidebar();
 
-    // My sessions tab: no Pinned section leaking the shared row in.
+    // My sessions tab: owned session is unpinned (no Pinned section), and the
+    // pinned shared row doesn't appear here at all.
     expect(screen.queryByText("Pinned")).toBeNull();
     expect(screen.getByText("conv_mine")).toBeInTheDocument();
     expect(screen.queryByText("conv_shared")).toBeNull();
 
-    // The shared session lives only on the Shared tab.
+    // Shared tab: the shared session shows under its own Pinned section.
     showSharedTab();
-    expect(screen.getByText("conv_shared")).toBeInTheDocument();
+    const pinnedSection = screen.getByText("Pinned").closest("section")!;
+    expect(within(pinnedSection).getByText("conv_shared")).toBeInTheDocument();
   });
 
-  it("keeps a project-filed shared session on the Shared tab only, not under Projects", () => {
-    // Filing into a project is a My-sessions-only tool: an editable shared
-    // session filed into a project must not render under a project folder.
+  it("does not render project folders on the Shared tab (projects are owner-only)", () => {
+    // Filing into a project is owner-only, so the Shared tab shows no Projects
+    // group; a shared session that carries a project label just lands in the
+    // flat Sessions list there.
     projectsMock.push("Alpha");
     mockConversations([
-      conv("conv_mine", "Claude Code"),
-      conv("conv_shared", "Claude Code", {
-        permission_level: 2,
-        labels: { omni_project: "Alpha" },
-      }),
+      conv("conv_mine", "Claude Code", { labels: { omni_project: "Alpha" } }),
+      conv("conv_shared", "Claude Code", { permission_level: 2 }),
     ]);
     renderSidebar();
 
-    // My sessions tab: the Alpha folder renders but doesn't hold the shared row.
-    expect(screen.getByText("Alpha")).toBeInTheDocument();
-    expect(screen.queryByText("conv_shared")).toBeNull();
+    // My sessions tab carries the Projects group.
+    expect(screen.getByText("Projects")).toBeInTheDocument();
 
-    // The shared session lives only on the Shared tab.
+    // Shared tab: no Projects group; the shared session shows in Sessions.
     showSharedTab();
+    expect(screen.queryByText("Projects")).toBeNull();
     expect(screen.getByText("conv_shared")).toBeInTheDocument();
   });
 

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -454,6 +454,97 @@ describe("Sidebar tabs", () => {
     expect(screen.getByText("conv_mine")).toBeInTheDocument();
     expect(screen.queryByText("conv_shared")).toBeNull();
   });
+
+  it("keeps a pinned shared session on the Shared tab only, not under Pinned", () => {
+    // Pinning is a My-sessions-only tool: a pinned shared session must not leak
+    // into the owned tab's Pinned section (which would show it in two places).
+    mockConversations([
+      conv("conv_mine", "Claude Code"),
+      conv("conv_shared", "Claude Code", { permission_level: 2 }),
+    ]);
+    localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_shared"]));
+    renderSidebar();
+
+    // My sessions tab: no Pinned section leaking the shared row in.
+    expect(screen.queryByText("Pinned")).toBeNull();
+    expect(screen.getByText("conv_mine")).toBeInTheDocument();
+    expect(screen.queryByText("conv_shared")).toBeNull();
+
+    // The shared session lives only on the Shared tab.
+    showSharedTab();
+    expect(screen.getByText("conv_shared")).toBeInTheDocument();
+  });
+
+  it("keeps a project-filed shared session on the Shared tab only, not under Projects", () => {
+    // Filing into a project is a My-sessions-only tool: an editable shared
+    // session filed into a project must not render under a project folder.
+    projectsMock.push("Alpha");
+    mockConversations([
+      conv("conv_mine", "Claude Code"),
+      conv("conv_shared", "Claude Code", {
+        permission_level: 2,
+        labels: { omni_project: "Alpha" },
+      }),
+    ]);
+    renderSidebar();
+
+    // My sessions tab: the Alpha folder renders but doesn't hold the shared row.
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("conv_shared")).toBeNull();
+
+    // The shared session lives only on the Shared tab.
+    showSharedTab();
+    expect(screen.getByText("conv_shared")).toBeInTheDocument();
+  });
+
+  it("keeps paginating when the shared tab is empty on the loaded page but more exist", () => {
+    // The list is one paginated stream (owned + shared mixed, updated_at desc),
+    // so page 1 can be all-owned while shared sessions live on a later page.
+    // The Shared tab must keep its pagination sentinel mounted rather than
+    // stranding the user on a false "empty" state.
+    let observerCallback: IntersectionObserverCallback | undefined;
+    class TestObserver {
+      constructor(cb: IntersectionObserverCallback) {
+        observerCallback = cb;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+      takeRecords = () => [];
+      root = null;
+      rootMargin = "";
+      thresholds = [];
+    }
+    vi.stubGlobal("IntersectionObserver", TestObserver);
+
+    const fetchNextPage = vi.fn();
+    const rows = [conv("conv_mine", "Claude Code")]; // owned only on this page
+    useConvMock.mockImplementation(
+      () =>
+        ({
+          data: {
+            pages: [{ data: rows, first_id: rows[0]!.id, last_id: rows[0]!.id, has_more: true }],
+            pageParams: [undefined],
+          },
+          isLoading: false,
+          isError: false,
+          error: null,
+          fetchNextPage,
+          hasNextPage: true,
+          isFetchingNextPage: false,
+        }) as unknown as ReturnType<typeof useConversations>,
+    );
+    renderSidebar();
+
+    showSharedTab();
+    // False-empty on the loaded window, but the sentinel is still mounted.
+    expect(screen.getByText("No sessions shared with you")).toBeInTheDocument();
+    observerCallback?.(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
 });
 
 // Section headers double as collapse toggles, persisted to localStorage so

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -92,6 +92,17 @@ vi.mock("@/hooks/useConversations", () => ({
 // test scoped to the conversation list + funnel.
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
 
+// The "Shared with me" tab only renders on a multi-user (non-local) server.
+// jsdom's default origin is loopback, which would read as single-user and hide
+// the tabs; force multi-user so the tab-based tests exercise the split. The
+// single-user case (tabs hidden) is covered explicitly below.
+const isServerLocalMock = vi.hoisted(() => vi.fn(() => false));
+vi.mock("@/lib/serverOrigin", () => ({
+  isCurrentServerLocal: isServerLocalMock,
+  isLocalServerOrigin: (origin: string) =>
+    ["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"].includes(new URL(origin).hostname),
+}));
+
 import { useConversations } from "@/hooks/useConversations";
 import { Sidebar } from "./Sidebar";
 
@@ -159,6 +170,13 @@ function renderSidebar(open = true, initialEntry = "/", onOpenSearch?: () => voi
   );
 }
 
+// "Shared with me" sessions live on their own sidebar tab now; click it to
+// reveal the flat shared list (the default tab is "My sessions").
+function showSharedTab() {
+  // Radix Tabs triggers activate on mousedown (primary button), not click.
+  fireEvent.mouseDown(screen.getByTestId("sidebar-tab-shared"), { button: 0 });
+}
+
 beforeEach(() => {
   useConvMock.mockReset();
   localStorage.clear();
@@ -168,6 +186,8 @@ beforeEach(() => {
   fetchProjectSessionIdsMock.mockReset();
   fetchProjectSessionIdsMock.mockResolvedValue([]);
   projectSessionsMock.current = {};
+  // Default to a multi-user server so the tab-based tests see the tabs.
+  isServerLocalMock.mockReturnValue(false);
 });
 afterEach(cleanup);
 
@@ -337,12 +357,12 @@ describe("Sidebar session list", () => {
   });
 });
 
-// Sidebar grouping: Pinned / Sessions / Shared with me are distinguished by
-// muted micro-headers + whitespace only (the pink divider rules are gone).
-// "Shared with me" = sessions where the caller's permission_level says
-// non-owner (< 4); null/4+ are the viewer's own sessions.
+// Sidebar grouping: the viewer's own sessions ("My sessions" tab) keep the
+// Pinned / Projects / Sessions structure; sessions shared with the viewer live
+// on a separate "Shared with me" tab. "Shared" = sessions where the caller's
+// permission_level says non-owner (< 4); null/4+ are the viewer's own.
 describe("Sidebar sections", () => {
-  it("splits owned and shared sessions under Sessions / Shared with me", () => {
+  it("splits owned and shared sessions across the My sessions / Shared with me tabs", () => {
     mockConversations([
       conv("conv_mine_legacy", "Claude Code"), // permission_level null = owner
       conv("conv_mine_acl", "Claude Code", { permission_level: 4 }),
@@ -350,28 +370,89 @@ describe("Sidebar sections", () => {
     ]);
     renderSidebar();
 
-    // Both headers render because both groups are non-empty.
-    const recentHeader = screen.getByText("Sessions");
-    const sharedHeader = screen.getByText("Shared with me");
-    // Each row lands in the right <section>: a mis-split would either leak
-    // a shared session into Sessions (viewer thinks they own it) or hide an
-    // owned one under Shared with me.
-    const recentSection = recentHeader.closest("section")!;
-    const sharedSection = sharedHeader.closest("section")!;
+    // Default ("My sessions") tab: owned sessions under Sessions, no shared one
+    // leaking in (which would make the viewer think they own it).
+    const recentSection = screen.getByText("Sessions").closest("section")!;
     expect(within(recentSection).getByText("conv_mine_legacy")).toBeInTheDocument();
     expect(within(recentSection).getByText("conv_mine_acl")).toBeInTheDocument();
-    expect(within(recentSection).queryByText("conv_shared")).toBeNull();
-    expect(within(sharedSection).getByText("conv_shared")).toBeInTheDocument();
+    expect(screen.queryByText("conv_shared")).toBeNull();
+
+    // Shared tab: only the shared session, and the owned ones are hidden.
+    showSharedTab();
+    expect(screen.getByText("conv_shared")).toBeInTheDocument();
+    expect(screen.queryByText("conv_mine_legacy")).toBeNull();
+    expect(screen.queryByText("conv_mine_acl")).toBeNull();
   });
 
   it("titles the baseline list Sessions even with no sibling group", () => {
     mockConversations([conv("conv_only_mine", "Claude Code")]);
     renderSidebar();
     // "Sessions" always renders so the list is labeled (and collapsible)
-    // from the first session; empty sibling groups stay hidden.
+    // from the first session; the project group stays hidden when empty.
     expect(screen.getByText("conv_only_mine")).toBeInTheDocument();
     expect(screen.getByText("Sessions")).toBeInTheDocument();
-    expect(screen.queryByText("Shared with me")).toBeNull();
+    // With no shared sessions, the Shared tab shows its empty state rather
+    // than any session rows.
+    showSharedTab();
+    expect(screen.getByText("No sessions shared with you")).toBeInTheDocument();
+    expect(screen.queryByText("conv_only_mine")).toBeNull();
+  });
+});
+
+// The sidebar splits sessions across two tabs: "My sessions" (owned, with the
+// full Pinned / Projects / Chats structure) and "Shared with me" (a flat list).
+describe("Sidebar tabs", () => {
+  it("keeps New session visible on both tabs and snaps back to My sessions when used", () => {
+    mockConversations([
+      conv("conv_mine", "Claude Code"),
+      conv("conv_shared", "Claude Code", { permission_level: 2 }),
+    ]);
+    renderSidebar();
+    expect(screen.getByTestId("new-chat-button")).toBeInTheDocument();
+
+    // New session always creates a session the viewer owns, so it stays
+    // reachable on the Shared tab too (not hidden).
+    showSharedTab();
+    expect(screen.getByTestId("new-chat-button")).toBeInTheDocument();
+    expect(screen.getByText("conv_shared")).toBeInTheDocument();
+
+    // Using it flips back to "My sessions": the shared row hides and the owned
+    // one returns.
+    fireEvent.click(screen.getByTestId("new-chat-button"));
+    expect(screen.getByText("conv_mine")).toBeInTheDocument();
+    expect(screen.queryByText("conv_shared")).toBeNull();
+  });
+
+  it("does not render project folders on the Shared with me tab", () => {
+    projectsMock.push("Alpha");
+    mockConversations([
+      conv("conv_filed", "Claude Code", { labels: { omni_project: "Alpha" } }),
+      conv("conv_shared", "Claude Code", { permission_level: 2 }),
+    ]);
+    renderSidebar();
+    // My sessions tab carries the Projects group.
+    expect(screen.getByText("Projects")).toBeInTheDocument();
+
+    // Shared tab is a flat list — projects are a "My sessions"-only tool.
+    showSharedTab();
+    expect(screen.queryByText("Projects")).toBeNull();
+    expect(screen.getByText("conv_shared")).toBeInTheDocument();
+  });
+
+  it("hides the tabs on a single-user (local) server and shows only owned sessions", () => {
+    // A loopback-only server can't share sessions with anyone, so the tab
+    // split is meaningless — collapse to the plain owned-session list.
+    isServerLocalMock.mockReturnValue(true);
+    mockConversations([
+      conv("conv_mine", "Claude Code"),
+      conv("conv_shared", "Claude Code", { permission_level: 2 }),
+    ]);
+    renderSidebar();
+    expect(screen.queryByTestId("sidebar-tab-mine")).toBeNull();
+    expect(screen.queryByTestId("sidebar-tab-shared")).toBeNull();
+    // Falls back to the owned list; the shared row never appears.
+    expect(screen.getByText("conv_mine")).toBeInTheDocument();
+    expect(screen.queryByText("conv_shared")).toBeNull();
   });
 });
 
@@ -379,29 +460,25 @@ describe("Sidebar sections", () => {
 // the preference survives reloads (same contract as pins).
 describe("Sidebar collapsible sections", () => {
   it("collapses a section on header click and persists across remount", () => {
-    mockConversations([
-      conv("conv_mine", "Claude Code"),
-      conv("conv_shared", "Claude Code", { permission_level: 2 }),
-    ]);
+    mockConversations([conv("conv_mine", "Claude Code"), conv("conv_mine_two", "Claude Code")]);
     renderSidebar();
 
-    // Collapse hides the section's rows but keeps the header (and the
-    // other section untouched) — a vanished header would strand the user
-    // with no way to expand again.
-    fireEvent.click(screen.getByRole("button", { name: "Shared with me" }));
-    expect(screen.queryByText("conv_shared")).toBeNull();
-    expect(screen.getByRole("button", { name: "Shared with me" })).toBeInTheDocument();
-    expect(screen.getByText("conv_mine")).toBeInTheDocument();
+    // Collapse hides the section's rows but keeps the header — a vanished
+    // header would strand the user with no way to expand again.
+    fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
+    expect(screen.queryByText("conv_mine")).toBeNull();
+    expect(screen.queryByText("conv_mine_two")).toBeNull();
+    expect(screen.getByRole("button", { name: "Sessions" })).toBeInTheDocument();
 
     // Fresh mount re-reads localStorage: still collapsed. If this fails,
     // the toggle wrote state only to memory and reloads lose it.
     cleanup();
     renderSidebar();
-    expect(screen.queryByText("conv_shared")).toBeNull();
+    expect(screen.queryByText("conv_mine")).toBeNull();
 
     // Expanding brings the rows back.
-    fireEvent.click(screen.getByRole("button", { name: "Shared with me" }));
-    expect(screen.getByText("conv_shared")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
+    expect(screen.getByText("conv_mine")).toBeInTheDocument();
   });
 });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -953,13 +953,20 @@ function ConversationList({
   const sections = useMemo(() => {
     const allWithBackfill = [...allConversations, ...pinnedBackfill];
     const notArchived = allWithBackfill.filter((c) => c.archived !== true);
+    // Pinning and projects are "My sessions"-only organizational tools, so they
+    // draw from owned sessions alone. Otherwise a shared session the viewer can
+    // pin (localStorage is ownership-agnostic) or file into a project (editable
+    // shared session) would render under Pinned / a project folder on My
+    // sessions AND on the Shared tab. Building both from owned-only keeps the
+    // non-owned sessions on the Shared tab exclusively.
+    const ownedNotArchived = notArchived.filter(isOwnedByViewer);
 
     // Pinned takes precedence over Project: pinning a session moves it OUT of
     // its project into the flat global Pinned section (no nested pins). Ordered
     // strictly by when they were pinned (newest pin at the bottom), not by
     // `updated_at`, so a pinned session doesn't jump when it gets a new message.
     const pinned = orderByPinnedSequence(
-      notArchived.filter((c) => pinnedSet.has(c.id)),
+      ownedNotArchived.filter((c) => pinnedSet.has(c.id)),
       pinnedConversationIds,
     );
     const pinnedIdSet = new Set(pinned.map((c) => c.id));
@@ -970,7 +977,7 @@ function ConversationList({
     const filedIds = new Set<string>();
     const projectGroups: { name: string; conversations: Conversation[] }[] = projectNames.map(
       (name) => {
-        const inProject = notArchived.filter(
+        const inProject = ownedNotArchived.filter(
           (c) => c.labels?.[PROJECT_LABEL_KEY] === name && !pinnedIdSet.has(c.id),
         );
         inProject.forEach((c) => filedIds.add(c.id));
@@ -1379,7 +1386,22 @@ function ConversationList({
           <UngroupDropZone />
         )}
         {totalVisible === 0 ? (
-          <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
+          <>
+            <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
+            {/* The list is one paginated stream ordered by updated_at across
+              owned + shared sessions, so the current tab can be empty on the
+              loaded window while its sessions live on a later page. Keep the
+              sentinel mounted so pagination continues instead of stranding the
+              user on a false "empty" state. */}
+            {hasMorePages && (
+              <InfiniteScrollSentinel
+                hasMore={hasMorePages}
+                isFetching={isFetchingNextPage}
+                fetchMore={fetchNextPage}
+                scrollRoot={scrollContainerRef}
+              />
+            )}
+          </>
         ) : showShared ? (
           <>
             {/* Shared tab: a flat, headerless list of sessions others shared

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -953,63 +953,59 @@ function ConversationList({
   const sections = useMemo(() => {
     const allWithBackfill = [...allConversations, ...pinnedBackfill];
     const notArchived = allWithBackfill.filter((c) => c.archived !== true);
-    // Pinning and projects are "My sessions"-only organizational tools, so they
-    // draw from owned sessions alone. Otherwise a shared session the viewer can
-    // pin (localStorage is ownership-agnostic) or file into a project (editable
-    // shared session) would render under Pinned / a project folder on My
-    // sessions AND on the Shared tab. Building both from owned-only keeps the
-    // non-owned sessions on the Shared tab exclusively.
-    const ownedNotArchived = notArchived.filter(isOwnedByViewer);
+    // Each tab shows a disjoint slice — "mine" is the sessions the viewer owns,
+    // "shared" is the ones others shared with them. The Pinned / Projects /
+    // Sessions structure is then built from that slice, so both tabs reuse the
+    // same section layout with different conversations.
+    const tabScoped =
+      activeTab === "shared"
+        ? notArchived.filter((c) => !isOwnedByViewer(c))
+        : notArchived.filter(isOwnedByViewer);
 
     // Pinned takes precedence over Project: pinning a session moves it OUT of
     // its project into the flat global Pinned section (no nested pins). Ordered
     // strictly by when they were pinned (newest pin at the bottom), not by
     // `updated_at`, so a pinned session doesn't jump when it gets a new message.
+    // Pins are localStorage and ownership-agnostic, so a pinned shared session
+    // floats to Pinned on the Shared tab just like an owned one on My sessions.
     const pinned = orderByPinnedSequence(
-      ownedNotArchived.filter((c) => pinnedSet.has(c.id)),
+      tabScoped.filter((c) => pinnedSet.has(c.id)),
       pinnedConversationIds,
     );
     const pinnedIdSet = new Set(pinned.map((c) => c.id));
 
-    // Projects: each folder holds its non-pinned, non-archived sessions. A
-    // pinned member is excluded here (it lives under Pinned instead), so
-    // pinning a project's last session leaves the folder showing "No chats".
+    // Projects are a "My sessions"-only tool (filing into a project is
+    // owner-only), so the Shared tab renders no folders. On "mine" each folder
+    // holds its non-pinned, non-archived sessions; a pinned member is excluded
+    // (it lives under Pinned), so pinning a project's last session leaves the
+    // folder showing "No chats".
     const filedIds = new Set<string>();
-    const projectGroups: { name: string; conversations: Conversation[] }[] = projectNames.map(
-      (name) => {
-        const inProject = ownedNotArchived.filter(
-          (c) => c.labels?.[PROJECT_LABEL_KEY] === name && !pinnedIdSet.has(c.id),
-        );
-        inProject.forEach((c) => filedIds.add(c.id));
-        return { name, conversations: sortByUpdatedAtDesc(inProject, activeOverride) };
-      },
-    );
+    const projectGroups: { name: string; conversations: Conversation[] }[] =
+      activeTab === "shared"
+        ? []
+        : projectNames.map((name) => {
+            const inProject = tabScoped.filter(
+              (c) => c.labels?.[PROJECT_LABEL_KEY] === name && !pinnedIdSet.has(c.id),
+            );
+            inProject.forEach((c) => filedIds.add(c.id));
+            return { name, conversations: sortByUpdatedAtDesc(inProject, activeOverride) };
+          });
     // NOTE: empty projects are intentionally NOT filtered out. A project comes
     // from the server project list (useProjects), so it can have zero *loaded*
     // conversations — either genuinely empty or because its chats live on an
     // unloaded page. We render it as a folder with a "No chats" placeholder
     // rather than hiding it (matches the target sidebar layout).
 
-    // Chats / Shared: the remainder — not archived, not pinned, and not in any
-    // project.
-    const rest = allConversations.filter(
-      (c) => c.archived !== true && !pinnedIdSet.has(c.id) && !filedIds.has(c.id),
-    );
-    const sessions = sortByUpdatedAtDesc(rest.filter(isOwnedByViewer), activeOverride);
-    // The "Shared with me" tab is a flat list of every non-archived session the
-    // viewer doesn't own — deliberately independent of pinning and projects
-    // (those are "My sessions"-only organizational tools). Computed from
-    // `notArchived`, not `rest`, so a shared session never drops off this tab
-    // just because it was pinned or filed into a project on the other one.
-    const shared = sortByUpdatedAtDesc(
-      notArchived.filter((c) => !isOwnedByViewer(c)),
+    // Sessions: the remainder of the tab's slice — not pinned, not filed.
+    const sessions = sortByUpdatedAtDesc(
+      tabScoped.filter((c) => !pinnedIdSet.has(c.id) && !filedIds.has(c.id)),
       activeOverride,
     );
     const archived = sortByUpdatedAtDesc(
       allWithBackfill.filter((c) => c.archived === true),
       activeOverride,
     );
-    return { pinned, sessions, shared, archived, projectGroups };
+    return { pinned, sessions, archived, projectGroups };
   }, [
     allConversations,
     pinnedBackfill,
@@ -1017,6 +1013,7 @@ function ConversationList({
     pinnedConversationIds,
     activeOverride,
     projectNames,
+    activeTab,
   ]);
 
   // Collapsed section titles — persisted like pins so the preference
@@ -1261,35 +1258,22 @@ function ConversationList({
     const projectsCollapsed = effectiveCollapsedSections.includes("Projects");
     const projectVisible = (name: string, list: readonly Conversation[]) =>
       !projectsCollapsed && expandedProjects.includes(name) ? list : [];
-    // Keyboard nav follows the visible tab: "shared" lists only the flat
-    // shared sessions, "mine" the Pinned / Projects / Chats structure. The
-    // shared tab always renders expanded (no in-list header to collapse), so
-    // don't consult the collapsed set — a stale persisted "Shared with me"
-    // collapse (from the old inline section) must not empty this list.
-    if (activeTab === "shared") {
-      return sections.shared.map((c) => c.id);
-    }
+    // `sections` is already scoped to the active tab, so the same Pinned /
+    // Projects / Sessions walk covers both tabs (Projects is empty on shared).
     return [
       ...visible("Pinned", sections.pinned),
       ...sections.projectGroups.flatMap((g) => projectVisible(g.name, g.conversations)),
       ...visible("Chats", sections.sessions),
     ].map((c) => c.id);
-  }, [sections, effectiveCollapsedSections, expandedProjects, activeTab]);
+  }, [sections, effectiveCollapsedSections, expandedProjects]);
   // Getter that builds the shift-select visible order on demand (at click
   // time). Reading projectRenderedIdsRef lazily — rather than snapshotting it
   // during render — guarantees the project segment is always fresh even when a
   // ProjectFolder re-renders independently (async query resolve, session
-  // re-sort) without triggering a parent re-render. Tab-aware like
-  // orderedConversationIds: the "shared" tab ranges over the flat shared list,
-  // "mine" over Pinned / Projects / Chats.
+  // re-sort) without triggering a parent re-render.
   getVisibleIdsRef.current = () => {
     const vis = (title: string, list: readonly Conversation[]) =>
       effectiveCollapsedSections.includes(title) ? [] : list.map((c) => c.id);
-    // Shared tab renders expanded regardless of the collapsed set (see above),
-    // so range-select over the full list.
-    if (activeTab === "shared") {
-      return sections.shared.map((c) => c.id);
-    }
     const projCollapsed = effectiveCollapsedSections.includes("Projects");
     return [
       ...vis("Pinned", sections.pinned),
@@ -1353,14 +1337,13 @@ function ConversationList({
   // don't count toward the sidebar's empty-state threshold. Each project
   // counts itself (not just its loaded chats) so an empty project still
   // renders its "Projects" header + "No chats" folder rather than the global
-  // empty-state message. The count is per-tab: "shared" sees only the flat
-  // shared list, "mine" the Pinned / Projects / Chats structure.
-  const totalVisible = showShared
-    ? sections.shared.length
-    : sections.pinned.length +
-      sections.sessions.length +
-      sections.projectGroups.length +
-      sections.projectGroups.reduce((sum, g) => sum + g.conversations.length, 0);
+  // empty-state message. `sections` is tab-scoped, so this counts the active
+  // tab only (Projects is empty on the Shared tab).
+  const totalVisible =
+    sections.pinned.length +
+    sections.sessions.length +
+    sections.projectGroups.length +
+    sections.projectGroups.reduce((sum, g) => sum + g.conversations.length, 0);
 
   // Section structure comes from the muted micro-headers + whitespace
   // alone (Linear-style) — no icons or counts in the headers, no divider
@@ -1401,32 +1384,6 @@ function ConversationList({
                 scrollRoot={scrollContainerRef}
               />
             )}
-          </>
-        ) : showShared ? (
-          <>
-            {/* Shared tab: a flat, headerless list of sessions others shared
-              with the viewer. The "Shared with me" label lives in the tab, so
-              there's no in-list section header; projects and pinning are
-              "My sessions"-only and don't render here. */}
-            <ConversationSection
-              conversations={sections.shared}
-              pinnedConversationIds={pinnedConversationIds}
-              collapsed={false}
-              onToggleCollapsed={() => {}}
-              onRowClick={onRowClick}
-              onTogglePinned={onTogglePinned}
-              selectionMode={selectionMode}
-              selectedIds={selectedIds}
-              onToggleSelected={onToggleSelected}
-            />
-            {/* Shared sessions live on the same paginated list as owned ones,
-              so keep loading more pages while this tab is open. */}
-            <InfiniteScrollSentinel
-              hasMore={hasMorePages}
-              isFetching={isFetchingNextPage}
-              fetchMore={fetchNextPage}
-              scrollRoot={scrollContainerRef}
-            />
           </>
         ) : (
           <>
@@ -1560,8 +1517,9 @@ function ConversationList({
                 />
               </ChatsDropZone>
             )}
-            {/* "Shared with me" sessions now live on their own sidebar tab
-              (see the showShared branch above), not inline under My sessions. */}
+            {/* Both tabs render this same Pinned / Projects / Sessions tree;
+              `sections` is scoped to the active tab's conversations (owned vs.
+              shared), and Projects is empty on the Shared tab. */}
             {/* Archived sessions are no longer listed here — they live on the
               Settings page ("Archived chats"), reachable from the footer. */}
             {/* Infinite-scroll sentinel for the global list. Pagination extends
@@ -2121,7 +2079,9 @@ function ConversationMenuItems({
           Mark as unread
         </C.Item>
       )}
-      {canEdit && (
+      {/* Projects are a My-sessions-only tool, so filing is owner-only — a
+          shared session (even editable) shows no project affordance. */}
+      {canEdit && isOwner && (
         <C.Sub>
           <C.SubTrigger data-testid="move-to-project" className="whitespace-nowrap">
             <FolderInputIcon className="size-3.5" />

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -107,6 +107,7 @@ import {
   useStopSession,
 } from "@/hooks/useConversations";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { showToast } from "@/components/ui/toast";
 import { PermissionsModal } from "@/components/PermissionsModal";
 import { SessionStateBadge } from "@/components/SessionStateBadge";
@@ -129,6 +130,7 @@ import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
 import { absoluteTime, relativeTime } from "@/lib/relativeTime";
 import { MOD_KEY } from "@/components/KeyboardShortcutsDialog";
+import { isCurrentServerLocal } from "@/lib/serverOrigin";
 import { SettingsSidebarBody, useSettingsRoute, useTrackSettingsReturn } from "./settingsNav";
 import {
   type ActiveChatOverride,
@@ -158,6 +160,14 @@ const TIME_MARKER_SLOT_CLASS =
 // gentler gray in light mode (a gentler glow in dark mode) and reads as "active
 // area" without the heavy fill. Pair with `transition-colors` so it eases in.
 const DROP_TARGET_HIGHLIGHT = "bg-primary/5";
+
+/**
+ * Which session tab the sidebar is showing. ``"mine"`` is the viewer's own
+ * sessions (the Pinned / Projects / Chats structure); ``"shared"`` is the flat
+ * list of sessions others have shared with the viewer. The split mirrors
+ * :func:`isOwnedByViewer`.
+ */
+type SidebarTab = "mine" | "shared";
 
 interface SidebarProps {
   open: boolean;
@@ -252,6 +262,16 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
   const [pinnedConversationIds, setPinnedConversationIds] = useState(readPinnedConversationIds);
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Which session tab is shown. "mine" (default) keeps the full Pinned /
+  // Projects / Chats structure; "shared" is a flat list of sessions others
+  // shared with the viewer.
+  const [activeTab, setActiveTab] = useState<SidebarTab>("mine");
+  // The "Shared with me" tab only makes sense when sessions can be shared with
+  // other people at all — i.e. a multi-user server. A loopback-only local
+  // server has just the one user (mirrors the disabled Share affordance; see
+  // `isCurrentServerLocal` and AppShell's `shareDisabled`), so hide the tabs
+  // and always show the viewer's own sessions there.
+  const multiUser = !isCurrentServerLocal();
 
   const lastSelectedIdRef = useRef<string | null>(null);
   const getVisibleIdsRef = useRef<() => string[]>(() => []);
@@ -518,7 +538,16 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
               variant="ghost"
               data-testid="new-chat-button"
             >
-              <Link to="/" onClick={onNavClick}>
+              {/* New session always creates a session the viewer owns, which
+              lands under "My sessions" — so snap the tab back there on click
+              (the button stays visible on both tabs). */}
+              <Link
+                to="/"
+                onClick={(e) => {
+                  setActiveTab("mine");
+                  onNavClick(e);
+                }}
+              >
                 <SquarePenIcon className="size-4 text-foreground" />
                 New session
               </Link>
@@ -577,6 +606,30 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
             )}
           </div>
 
+          {/* Session-scope tabs: split the viewer's own sessions ("My
+          sessions") from ones shared with them ("Shared with me"). Sits above
+          the scrolling list (non-scrolling) so it stays put while the list
+          scrolls. Hidden during selection mode, where the bulk-action bar owns
+          this strip. */}
+          {multiUser && !selectionMode && (
+            <div className="px-3 pb-2">
+              <Tabs
+                value={activeTab}
+                onValueChange={(v) => setActiveTab(v as SidebarTab)}
+                className="w-full"
+              >
+                <TabsList className="w-full">
+                  <TabsTrigger value="mine" data-testid="sidebar-tab-mine">
+                    My sessions
+                  </TabsTrigger>
+                  <TabsTrigger value="shared" data-testid="sidebar-tab-shared">
+                    Shared with me
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </div>
+          )}
+
           {/* Mobile: extra bottom padding so the last session scrolls clear of
           the floating Settings icon (which is absolutely positioned, out of
           flow, over the bottom-left corner). */}
@@ -589,6 +642,7 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
               scrollContainerRef={scrollContainerRef}
               onRowClick={onNavClick}
               searchQuery=""
+              activeTab={multiUser ? activeTab : "mine"}
               pinnedConversationIds={pinnedConversationIds}
               onPinnedConversationIdsChange={setPinnedConversationIds}
               onTogglePinned={togglePinnedConversation}
@@ -833,6 +887,7 @@ interface ConversationListProps {
   scrollContainerRef: RefObject<HTMLElement | null>;
   onRowClick: (e: MouseEvent<HTMLAnchorElement>) => void;
   searchQuery: string;
+  activeTab: SidebarTab;
   pinnedConversationIds: string[];
   onPinnedConversationIdsChange: (ids: string[]) => void;
   onTogglePinned: (conversationId: string) => void;
@@ -852,6 +907,7 @@ function ConversationList({
   scrollContainerRef,
   onRowClick,
   searchQuery,
+  activeTab,
   pinnedConversationIds,
   onPinnedConversationIdsChange,
   onTogglePinned,
@@ -933,8 +989,13 @@ function ConversationList({
       (c) => c.archived !== true && !pinnedIdSet.has(c.id) && !filedIds.has(c.id),
     );
     const sessions = sortByUpdatedAtDesc(rest.filter(isOwnedByViewer), activeOverride);
+    // The "Shared with me" tab is a flat list of every non-archived session the
+    // viewer doesn't own — deliberately independent of pinning and projects
+    // (those are "My sessions"-only organizational tools). Computed from
+    // `notArchived`, not `rest`, so a shared session never drops off this tab
+    // just because it was pinned or filed into a project on the other one.
     const shared = sortByUpdatedAtDesc(
-      rest.filter((c) => !isOwnedByViewer(c)),
+      notArchived.filter((c) => !isOwnedByViewer(c)),
       activeOverride,
     );
     const archived = sortByUpdatedAtDesc(
@@ -1193,21 +1254,35 @@ function ConversationList({
     const projectsCollapsed = effectiveCollapsedSections.includes("Projects");
     const projectVisible = (name: string, list: readonly Conversation[]) =>
       !projectsCollapsed && expandedProjects.includes(name) ? list : [];
+    // Keyboard nav follows the visible tab: "shared" lists only the flat
+    // shared sessions, "mine" the Pinned / Projects / Chats structure. The
+    // shared tab always renders expanded (no in-list header to collapse), so
+    // don't consult the collapsed set — a stale persisted "Shared with me"
+    // collapse (from the old inline section) must not empty this list.
+    if (activeTab === "shared") {
+      return sections.shared.map((c) => c.id);
+    }
     return [
       ...visible("Pinned", sections.pinned),
       ...sections.projectGroups.flatMap((g) => projectVisible(g.name, g.conversations)),
       ...visible("Chats", sections.sessions),
-      ...visible("Shared with me", sections.shared),
     ].map((c) => c.id);
-  }, [sections, effectiveCollapsedSections, expandedProjects]);
+  }, [sections, effectiveCollapsedSections, expandedProjects, activeTab]);
   // Getter that builds the shift-select visible order on demand (at click
   // time). Reading projectRenderedIdsRef lazily — rather than snapshotting it
   // during render — guarantees the project segment is always fresh even when a
   // ProjectFolder re-renders independently (async query resolve, session
-  // re-sort) without triggering a parent re-render.
+  // re-sort) without triggering a parent re-render. Tab-aware like
+  // orderedConversationIds: the "shared" tab ranges over the flat shared list,
+  // "mine" over Pinned / Projects / Chats.
   getVisibleIdsRef.current = () => {
     const vis = (title: string, list: readonly Conversation[]) =>
       effectiveCollapsedSections.includes(title) ? [] : list.map((c) => c.id);
+    // Shared tab renders expanded regardless of the collapsed set (see above),
+    // so range-select over the full list.
+    if (activeTab === "shared") {
+      return sections.shared.map((c) => c.id);
+    }
     const projCollapsed = effectiveCollapsedSections.includes("Projects");
     return [
       ...vis("Pinned", sections.pinned),
@@ -1215,7 +1290,6 @@ function ConversationList({
         ? []
         : sections.projectGroups.flatMap((g) => projectRenderedIdsRef.current.get(g.name) ?? [])),
       ...vis("Chats", sections.sessions),
-      ...vis("Shared with me", sections.shared),
     ];
   };
   useSessionSwitchHotkey(orderedConversationIds, activeId);
@@ -1261,19 +1335,25 @@ function ConversationList({
       </p>
     );
   }
-  const emptyMessage = searchQuery ? "No matching conversations" : "No active sessions";
+  const showShared = activeTab === "shared";
+  const emptyMessage = searchQuery
+    ? "No matching conversations"
+    : showShared
+      ? "No sessions shared with you"
+      : "No active sessions";
 
   // Archived sessions are surfaced on the Settings page, not here, so they
   // don't count toward the sidebar's empty-state threshold. Each project
   // counts itself (not just its loaded chats) so an empty project still
   // renders its "Projects" header + "No chats" folder rather than the global
-  // empty-state message.
-  const totalVisible =
-    sections.pinned.length +
-    sections.sessions.length +
-    sections.shared.length +
-    sections.projectGroups.length +
-    sections.projectGroups.reduce((sum, g) => sum + g.conversations.length, 0);
+  // empty-state message. The count is per-tab: "shared" sees only the flat
+  // shared list, "mine" the Pinned / Projects / Chats structure.
+  const totalVisible = showShared
+    ? sections.shared.length
+    : sections.pinned.length +
+      sections.sessions.length +
+      sections.projectGroups.length +
+      sections.projectGroups.reduce((sum, g) => sum + g.conversations.length, 0);
 
   // Section structure comes from the muted micro-headers + whitespace
   // alone (Linear-style) — no icons or counts in the headers, no divider
@@ -1295,9 +1375,37 @@ function ConversationList({
             ungroup target (wrapped below). This top strip is only a FALLBACK
             for when there are no ungrouped chats yet, so the Chats section
             isn't rendered and there'd otherwise be nowhere to drop. */}
-        {activeDrag?.project != null && sections.sessions.length === 0 && <UngroupDropZone />}
+        {!showShared && activeDrag?.project != null && sections.sessions.length === 0 && (
+          <UngroupDropZone />
+        )}
         {totalVisible === 0 ? (
           <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
+        ) : showShared ? (
+          <>
+            {/* Shared tab: a flat, headerless list of sessions others shared
+              with the viewer. The "Shared with me" label lives in the tab, so
+              there's no in-list section header; projects and pinning are
+              "My sessions"-only and don't render here. */}
+            <ConversationSection
+              conversations={sections.shared}
+              pinnedConversationIds={pinnedConversationIds}
+              collapsed={false}
+              onToggleCollapsed={() => {}}
+              onRowClick={onRowClick}
+              onTogglePinned={onTogglePinned}
+              selectionMode={selectionMode}
+              selectedIds={selectedIds}
+              onToggleSelected={onToggleSelected}
+            />
+            {/* Shared sessions live on the same paginated list as owned ones,
+              so keep loading more pages while this tab is open. */}
+            <InfiniteScrollSentinel
+              hasMore={hasMorePages}
+              isFetching={isFetchingNextPage}
+              fetchMore={fetchNextPage}
+              scrollRoot={scrollContainerRef}
+            />
+          </>
         ) : (
           <>
             {sections.pinned.length > 0 && (
@@ -1430,21 +1538,8 @@ function ConversationList({
                 />
               </ChatsDropZone>
             )}
-            {sections.shared.length > 0 && (
-              <ConversationSection
-                title="Shared with me"
-                conversations={sections.shared}
-                pinnedConversationIds={pinnedConversationIds}
-                collapsed={effectiveCollapsedSections.includes("Shared with me")}
-                onToggleCollapsed={() => effectiveToggleSectionCollapsed("Shared with me")}
-                onRowClick={onRowClick}
-                onTogglePinned={onTogglePinned}
-                selectionMode={selectionMode}
-                selectedIds={selectedIds}
-                onToggleSelected={onToggleSelected}
-                onProjectAssigned={expandProject}
-              />
-            )}
+            {/* "Shared with me" sessions now live on their own sidebar tab
+              (see the showShared branch above), not inline under My sessions. */}
             {/* Archived sessions are no longer listed here — they live on the
               Settings page ("Archived chats"), reachable from the footer. */}
             {/* Infinite-scroll sentinel for the global list. Pagination extends


### PR DESCRIPTION
## Related issue

N/A

## Summary

Splits the web sidebar's session list into two tabs — **My sessions** and **Shared with me** — instead of stacking sessions-shared-with-you in an inline collapsible section under the owned list.

- **My sessions** keeps the existing Pinned / Projects / Sessions structure. **Shared with me** is a flat, headerless list of every non-archived session the viewer doesn't own, with its own infinite scroll. "New session" snaps back to My sessions.
- Pinning and project folders are **My-sessions-only** tools — both are built from owned-only sessions, so a shared session that's pinned or filed into a project renders only on the Shared tab (each session lives in exactly one place).
- The shared list is computed from `notArchived` (not `rest`), so a shared session isn't dropped by the owned tab's pin/file filtering.
- **The tab strip only renders on a multi-user server** — gated on `!isCurrentServerLocal()`, the same predicate `AppShell` uses to disable the Share affordance (`serverOrigin.ts`: "Sharing a session from a loopback-only server produces links nobody else can open"). A loopback-only local server has a single user and can't share sessions, so the split is meaningless there and the list falls back to the owned sessions.
- Keyboard nav and shift-select are tab-aware; on the shared tab they ignore the collapsed set (the list always renders expanded), so a **stale persisted "Shared with me" collapse** from the old inline section can't silently empty them.
- Pagination is one stream (owned + shared mixed, `updated_at desc`); the sentinel stays mounted even when the current tab is empty on the loaded window but more pages exist, so a tab whose sessions live on a later page keeps loading instead of showing a false "empty" state.

## Test Plan

- `cd web && npm test` — full suite green.
- `cd web && npm run build` — `tsc -b && vite build` clean.
- `npx tsc --noEmit` — clean.
- Sidebar unit tests (63 across the 3 Sidebar suites), including:
  - owned/shared split across the two tabs,
  - projects/pinning are My-sessions-only (incl. pinned-shared and filed-shared regression tests),
  - New session snapping back to My sessions,
  - **tabs hidden on a single-user (local) server**, falling back to the owned list,
  - empty tab keeps paginating when more pages exist.

## Demo

https://github.com/user-attachments/assets/ee0cf213-3c07-46c1-84d7-10515597de43

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: unit-level via the Sidebar suites (mocking `@/lib/serverOrigin` to toggle multi-user vs local). The `multiUser` gate, per-tab keyboard-nav/shift-select ordering, owned-only pin/project construction, and empty-tab pagination are exercised by the tests. The e2e-ui runner has no workspace so the tab UI isn't covered there.

## Changelog

Sessions shared with you now live in a dedicated "Shared with me" sidebar tab (multi-user servers only)

This pull request and its description were written by Isaac.
