### PR TITLE
fix(claude-native): attach observed capture, not a post-timeout one, to readiness error

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2991,25 +2991,47 @@ def _wait_for_claude_prompt_ready(
     :param timeout_s: Seconds to wait for the prompt, e.g. ``30.0``.
     :returns: None.
     :raises RuntimeError: If the prompt never renders within
-        *timeout_s* (Claude failed to boot). The message carries the
-        tail of the captured pane (see :func:`_format_terminal_failure_tail`)
-        so Claude Code's own startup output surfaces in the caller's error.
+        *timeout_s* (Claude failed to boot). The message carries a poll
+        count, how many of those polls saw an empty capture, and the tail
+        of the last non-empty capture the loop actually observed (see
+        :func:`_format_terminal_failure_tail`) so the true failure mode —
+        a startup crash, a torn/empty capture under a mid-turn repaint, or
+        a box that never appeared — is diagnosable from the error alone.
     """
     deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if _claude_prompt_rendered(_capture_pane(socket_path, tmux_target)):
+    polls = 0
+    empty_polls = 0
+    # Keep the last non-empty capture the loop actually saw, not a fresh
+    # capture taken after the deadline. A post-timeout re-capture can show
+    # a different (often healthier-looking) frame than any decision the
+    # loop made — e.g. the input box repainting just as the turn settles —
+    # which misrepresents why the gate failed. Attaching what was observed
+    # while it mattered keeps the error honest.
+    last_nonempty = ""
+    # Poll at least once even at timeout_s=0: a single readiness check is
+    # still meaningful, and it guarantees a capture to attach on failure.
+    while True:
+        pane = _capture_pane(socket_path, tmux_target)
+        polls += 1
+        if pane.strip():
+            last_nonempty = pane
+        else:
+            empty_polls += 1
+        if _claude_prompt_rendered(pane):
             return
+        if time.monotonic() >= deadline:
+            break
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-    # Timed out: Claude Code never rendered its input prompt. Capture the
-    # pane one last time and attach its tail so the real cause — often a
-    # startup crash like a ``JSON Parse error`` — surfaces in the web UI
-    # error banner this raises into, instead of only a generic timeout
-    # the user has to open the terminal to diagnose.
-    pane = _capture_pane(socket_path, tmux_target)
+    # Timed out. The poll/empty-capture counts separate the failure modes:
+    # mostly-empty captures point at a torn read under a busy repaint (the
+    # session is alive but capture-pane came back blank); non-empty captures
+    # with no box point at Claude never rendering the prompt (a boot crash,
+    # e.g. a ``JSON Parse error``, whose text the tail then surfaces).
     raise RuntimeError(
         f"Claude Code terminal did not become ready within {timeout_s}s "
-        "(input prompt never rendered). The message was not delivered."
-        + _format_terminal_failure_tail(pane)
+        f"(input prompt never rendered in {polls} polls, "
+        f"{empty_polls} empty captures). The message was not delivered."
+        + _format_terminal_failure_tail(last_nonempty)
     )
 
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -5320,6 +5320,84 @@ def test_wait_for_claude_prompt_ready_surfaces_terminal_output_on_timeout(
     assert "JSON Parse error: Unrecognized token '<'" in message
 
 
+def test_wait_for_claude_prompt_ready_reports_empty_capture_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A timeout where every capture came back empty says so in the error.
+
+    An empty ``capture-pane`` (a torn read under a busy mid-turn repaint,
+    not a boot crash) leaves no tail to attach. Without the poll/empty
+    counts the error is indistinguishable from "Claude never rendered a
+    prompt", which is what sent triage down the wrong path. The counts make
+    the two failure modes tell themselves apart.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._capture_pane",
+        lambda socket_path, tmux_target: "",
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        claude_native_bridge._wait_for_claude_prompt_ready(
+            "/tmp/example/tmux.sock",
+            "claude:0.0",
+            timeout_s=0.0,
+        )
+    message = str(excinfo.value)
+    assert "did not become ready" in message
+    # One poll happened (do-while), and it was empty.
+    assert "1 polls, 1 empty captures" in message
+    # No pane text to surface when every capture was empty.
+    assert "Last terminal output:" not in message
+
+
+def test_wait_for_claude_prompt_ready_tail_is_observed_not_recaptured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The attached tail is a capture the loop saw, not a post-timeout one.
+
+    The bug this guards: attaching a fresh capture taken *after* the
+    deadline can show a healthier frame (e.g. the input box repainting as
+    the turn settles) than any decision the loop actually made, so the
+    error misrepresents why the gate failed. The tail must come from a
+    capture observed while the loop was still deciding. A box-less capture
+    followed by a box-present one that arrives only after the deadline
+    proves the point: the box-present frame must NOT leak into the error.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    observed = "  ✱ Working…\n  ⏵⏵ auto mode on (shift+tab to cycle)\n"
+    # A frame that would satisfy the readiness check, but only ever returned
+    # after the deadline has passed — mimicking the box repainting late.
+    late_ready = "────────────────\n❯ \n────────────────\n  Opus 4.8\n"
+    calls = {"n": 0}
+
+    def fake_capture(socket_path: str, tmux_target: str) -> str:
+        calls["n"] += 1
+        # First (and only, at timeout_s=0) in-loop capture: no box.
+        # Any later capture would be the box-present frame — which the
+        # rewritten gate must never fetch, since it does not re-capture.
+        return observed if calls["n"] == 1 else late_ready
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._capture_pane", fake_capture)
+    with pytest.raises(RuntimeError) as excinfo:
+        claude_native_bridge._wait_for_claude_prompt_ready(
+            "/tmp/example/tmux.sock",
+            "claude:0.0",
+            timeout_s=0.0,
+        )
+    message = str(excinfo.value)
+    # The tail reflects what the loop observed, and the late box-present
+    # frame never appears — proving no post-deadline re-capture happened.
+    assert "auto mode on" in message
+    assert "❯" not in message
+    assert calls["n"] == 1
+
+
 # ── _hook_record_from_jsonl_record: background_task_count ────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `_wait_for_claude_prompt_ready` raised its "terminal did not become ready" error with the tail of a **fresh** capture taken *after* the 30s deadline. That frame is a different moment than any of the ~200 poll decisions the loop actually made — it can show a healthy, box-present composer while the real failure was 30s of box-absent (or empty) captures. The mismatch makes the error actively misleading: triaging one such failure sent us chasing footer-height, prompt-glyph, and box-rule theories that the attached frame contradicted.
- Attach the **last non-empty capture the loop observed** instead, and report the poll count and empty-capture count in the message. Those counts separate the two failure modes that previously looked identical: mostly-empty captures point at a torn read under a busy mid-turn repaint (session alive, `capture-pane` came back blank), while non-empty captures with no box point at Claude never rendering the prompt (a boot crash whose text the tail then surfaces).
- Poll loop is now do-while so `timeout_s=0` still checks once and always yields a capture to attach on failure.
- Observability-only: this does not change when the gate passes or fails, so it does not by itself stop a dropped message — it makes the next occurrence self-diagnosing instead of requiring reconstruction.

## Test Plan

- `pytest tests/test_claude_native_bridge.py -k wait_for_claude_prompt_ready` — 3 passed (the pre-existing crash-tail test plus the two added below).
- Full file: 152 passed; the 3 failing tests are pre-existing MCP channel-server tests unrelated to this change (verified by reproducing them on the stashed clean tree).
- `pre-commit run --files omnigent/claude_native_bridge.py tests/test_claude_native_bridge.py` — clean (ruff-format normalized one line).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two regression tests added: one asserts the empty-capture count appears in the error and no bogus "Last terminal output" tail is attached when every capture was empty; the other proves the tail comes from an in-loop capture and that a box-present frame arriving only after the deadline never leaks into the error (i.e. no post-deadline re-capture happens). Manually verified the live behavior earlier in the investigation by driving real `claude` 2.1.203 under the production 80x24 tmux geometry (idle, a 6-subagent fan-out, pane shrunk to 8 rows, all permission modes) to establish which frames the detector sees.