### PR TITLE
feat: make conversations.title NOT NULL (store '' for untitled)

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -335,8 +335,7 @@ class SqlConversation(Base):
         created.
     :param updated_at: Unix epoch seconds when the conversation was
         last updated (item append, title change, etc.).
-    :param title: Optional human-readable title for the conversation.
-        ``None`` when not provided.
+    :param title: Human-readable title; empty string when untitled.
     :param kind: Conversation type. ``"default"`` for user-initiated,
         ``"sub_agent"`` for sub-agent execution conversations.
     :param parent_conversation_id: For Phase 4 named sub-agents,
@@ -412,7 +411,7 @@ class SqlConversation(Base):
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int] = mapped_column(Integer)
-    title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    title: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     kind: Mapped[str] = mapped_column(String(32), default="default")
     parent_conversation_id: Mapped[str | None] = mapped_column(
         String(64),

--- a/omnigent/db/migrations/versions/s1a2b3c4d5e6_conversations_title_not_null.py
+++ b/omnigent/db/migrations/versions/s1a2b3c4d5e6_conversations_title_not_null.py
@@ -1,0 +1,105 @@
+"""Make conversations.title NOT NULL, back-filling NULLs with empty string.
+
+Revision ID: s1a2b3c4d5e6
+Revises: r1a2b3c4d5e6
+Create Date: 2026-07-07 00:00:00.000000
+
+The ``conversations.title`` column was nullable, using NULL to represent
+untitled conversations. This migration converts NULL to empty string so
+the column can be declared NOT NULL — keeping the DB constraint tight while
+the application layer continues to treat ``''`` and ``None`` as equivalent
+at the entity boundary (the store converts between the two).
+
+Upgrade path:
+1. Back-fill every NULL title to ``''`` with a plain UPDATE.
+2. Alter the column to NOT NULL (batch rebuild on SQLite since it cannot
+   alter column constraints in-place; native ALTER on other dialects).
+   No PRAGMA foreign_keys guard needed — all FK constraints were removed
+   in migration p1a2b3c4d5e6.
+
+Downgrade path:
+1. Rebuild the table restoring ``title`` to nullable.
+2. Convert every ``''`` title back to NULL so the data looks pre-migration.
+
+Uniqueness semantics across backends
+-------------------------------------
+``ix_conversations_parent_title_unique`` is ``UNIQUE(parent_conversation_id,
+title)`` scoped to rows where ``parent_conversation_id IS NOT NULL`` (partial
+index on SQLite/Postgres; full index on MySQL which lacks partial-index support).
+
+The empty-string sentinel (``''``) that now represents untitled conversations
+is safe on all backends:
+
+- **Top-level conversations** (``parent_conversation_id = NULL``): the partial
+  index excludes them on SQLite/Postgres, and MySQL allows multiple ``(NULL,
+  '')`` rows because NULL values are treated as distinct in unique indexes.
+- **Sub-agent conversations** always receive a non-empty derived title in
+  production (e.g. ``"agent_type:session_id"``), so ``title = ''`` never
+  occurs for children — no conflict on any backend.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "s1a2b3c4d5e6"
+down_revision: str | None = "r1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Back-fill NULL titles to '' and make the column NOT NULL."""
+    sqlite = _is_sqlite()
+
+    # Sub-agent children (parent_conversation_id IS NOT NULL) must have a
+    # unique title per parent because of ix_conversations_parent_title_unique.
+    # In production every sub-agent is created with a derived title
+    # (e.g. "agent_type:session_id"), so NULL sub-agent titles should not
+    # exist. Guard against any that do by stamping them with a fallback
+    # that incorporates the row id, guaranteeing uniqueness.
+    op.execute(
+        sa.text(
+            "UPDATE conversations SET title = 'untitled:' || id"
+            " WHERE title IS NULL AND parent_conversation_id IS NOT NULL"
+        )
+    )
+
+    # Top-level conversations (parent_conversation_id IS NULL) may be untitled;
+    # they are not covered by the partial unique index so '' is safe for all.
+    op.execute(sa.text("UPDATE conversations SET title = '' WHERE title IS NULL"))
+
+    with op.batch_alter_table(
+        "conversations", recreate="always" if sqlite else "auto"
+    ) as batch_op:
+        batch_op.alter_column(
+            "title",
+            existing_type=sa.Text(),
+            nullable=False,
+            server_default="",
+        )
+
+
+def downgrade() -> None:
+    """Restore title to nullable and convert '' back to NULL."""
+    sqlite = _is_sqlite()
+
+    with op.batch_alter_table(
+        "conversations", recreate="always" if sqlite else "auto"
+    ) as batch_op:
+        batch_op.alter_column(
+            "title",
+            existing_type=sa.Text(),
+            nullable=True,
+            server_default=None,
+        )
+
+    # Restore empty-string titles to NULL so data looks pre-migration.
+    op.execute(sa.text("UPDATE conversations SET title = NULL WHERE title = ''"))

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -100,7 +100,7 @@ def _to_conversation(
         id=row.id,
         created_at=row.created_at,
         updated_at=row.updated_at,
-        title=row.title,
+        title=row.title or None,  # empty string → None at entity layer
         kind=row.kind,
         parent_conversation_id=row.parent_conversation_id,
         root_conversation_id=row.root_conversation_id,
@@ -171,11 +171,15 @@ def _new_session_conversation_row(
         the column NULL.
     :returns: Unsaved :class:`SqlConversation` row.
     """
+    # Sub-agent children must have a unique title per parent.
+    # Fall back to the conversation id to guarantee uniqueness.
+    if parent_conversation_id and not title:
+        title = f"untitled:{conversation_id}"
     return SqlConversation(
         id=conversation_id,
         created_at=now,
         updated_at=now,
-        title=title,
+        title=title or "",  # None → '' for top-level conversations
         kind="sub_agent" if parent_conversation_id else "default",
         parent_conversation_id=parent_conversation_id,
         # Top-level row: ``root_conversation_id`` mirrors the
@@ -656,11 +660,17 @@ class SqlAlchemyConversationStore(ConversationStore):
                     # ``root_conversation_id`` is NOT NULL (see migration
                     # d8e2f3b4c910), so the parent always has one.
                     root_id = parent_row.root_conversation_id
+                # Sub-agent children must have a unique title per parent because
+                # of ix_conversations_parent_title_unique. Production paths
+                # always supply a derived title (e.g. "agent_type:session_id").
+                # Fall back to the conversation id to guarantee uniqueness.
+                if parent_conversation_id is not None and not title:
+                    title = f"untitled:{new_id}"
                 row = SqlConversation(
                     id=new_id,
                     created_at=now,
                     updated_at=now,
-                    title=title,
+                    title=title or "",  # None → '' for top-level conversations
                     kind=kind,
                     parent_conversation_id=parent_conversation_id,
                     root_conversation_id=root_id,
@@ -1962,7 +1972,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 return None
             changed = False
             if title is not None:
-                row.title = title
+                row.title = title or ""  # None/'' → empty string at DB layer
                 changed = True
             if archived is not None:
                 row.archived = archived
@@ -2492,7 +2502,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 id=new_conv_id,
                 created_at=now,
                 updated_at=now,
-                title=fork_title,
+                title=fork_title or "",  # None → empty string at DB layer
                 kind="default",
                 # A fork is a fresh top-level conversation, so its
                 # root mirrors its own id (matches the

--- a/tests/db/test_migration_agents_session_id.py
+++ b/tests/db/test_migration_agents_session_id.py
@@ -246,42 +246,59 @@ def test_upgrade_does_not_cascade_delete_conversations(tmp_path: Path) -> None:
 
 
 def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
-    """Downgrade restores session_id from conversations.agent_id and drops kind."""
+    """Downgrade restores session_id from conversations.agent_id and drops kind.
+
+    Uses a raw engine (no auto-migration) to avoid SQLite FK enforcement issues:
+    the o1a2b3c4d5e6 downgrade re-adds fk_agents_session_id (ON DELETE CASCADE),
+    and subsequent batch_alter_table calls on conversations would cascade-delete
+    agents if PRAGMA foreign_keys is ON. A raw engine keeps FK enforcement off.
+    """
     db_path = tmp_path / "downgrade.db"
     uri = f"sqlite:///{db_path}"
-    engine = get_or_create_engine(uri)
+
+    # Use a raw engine (no auto-migration) so PRAGMA foreign_keys stays OFF,
+    # avoiding cascade issues from the re-added fk_agents_session_id FK.
+    raw_engine = sa.create_engine(uri)
+
+    # Migrate to current head first.
+    config = _build_alembic_config(uri)
+    with raw_engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, "head")
 
     # Seed data on the upgraded schema: one template, one session-scoped agent.
-    with engine.begin() as conn:
+    with raw_engine.begin() as conn:
         conn.execute(
             sa.text(
-                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                " VALUES ('ag_tmpl', 1, 'my-template', 'ag_tmpl/b', 1, 'template'),"
-                "        ('ag_sess', 2, 'my-session', 'ag_sess/b', 1, 'session')"
+                "INSERT INTO agents"
+                " (workspace_id, id, created_at, name, bundle_location, version, kind)"
+                " VALUES (0, 'ag_tmpl', 1, 'my-template', 'ag_tmpl/b', 1, 'template'),"
+                "        (0, 'ag_sess', 2, 'my-session', 'ag_sess/b', 1, 'session')"
             )
         )
         conn.execute(
             sa.text(
                 "INSERT INTO conversations"
-                " (id, created_at, updated_at, root_conversation_id, kind, agent_id)"
-                " VALUES ('conv_1', 3, 3, 'conv_1', 'default', 'ag_sess')"
+                " (workspace_id, id, created_at, updated_at, root_conversation_id,"
+                "  kind, agent_id, title)"
+                " VALUES (0, 'conv_1', 3, 3, 'conv_1', 'default', 'ag_sess', '')"
             )
         )
 
-    # Run the downgrade.
-    config = _build_alembic_config(uri)
-    with engine.begin() as conn:
-        config.attributes["connection"] = conn
-        command.downgrade(config, "n1a2b3c4d5e6")
+    # Downgrade to n1a2b3c4d5e6 (runs o1a2b3c4d5e6 downgrade which restores session_id).
+    config2 = _build_alembic_config(uri)
+    with raw_engine.begin() as conn:
+        config2.attributes["connection"] = conn
+        command.downgrade(config2, "n1a2b3c4d5e6")
 
     # kind must be gone, session_id must be back.
-    columns = {c["name"] for c in sa.inspect(engine).get_columns("agents")}
+    columns = {c["name"] for c in sa.inspect(raw_engine).get_columns("agents")}
     assert "kind" not in columns
     assert "session_id" in columns
 
     # The session-scoped agent should have session_id back-populated from
     # conversations.agent_id; the template agent should have NULL.
-    with engine.begin() as conn:
+    with raw_engine.begin() as conn:
         rows = {
             row[0]: row[1]
             for row in conn.execute(sa.text("SELECT id, session_id FROM agents ORDER BY id"))
@@ -289,5 +306,5 @@ def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
     assert rows["ag_tmpl"] is None
     assert rows["ag_sess"] == "conv_1"
 
-    engine.dispose()
+    raw_engine.dispose()
     clear_engine_cache()

--- a/tests/db/test_migration_title_not_null.py
+++ b/tests/db/test_migration_title_not_null.py
@@ -1,0 +1,127 @@
+"""Tests for the conversations.title NOT NULL migration (s1a2b3c4d5e6).
+
+Verifies that after upgrade the column is NOT NULL with a server default
+of empty string, that NULL rows are back-filled, and that downgrade
+restores nullable and converts empty strings back to NULL.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite database with the full migration chain applied (including s1a2b3c4d5e6)."""
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def test_title_column_is_not_nullable(db_engine: Engine) -> None:
+    """After upgrade, conversations.title must be NOT NULL."""
+    cols = sa.inspect(db_engine).get_columns("conversations")
+    title_cols = [c for c in cols if c["name"] == "title"]
+    assert len(title_cols) == 1, "Expected exactly one 'title' column on conversations"
+    assert not title_cols[0]["nullable"], (
+        "conversations.title must be NOT NULL after the migration"
+    )
+
+
+def test_title_defaults_empty_string_on_insert(db_engine: Engine) -> None:
+    """An insert omitting title lands as '' (the server_default)."""
+    with db_engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversations "
+                "(id, created_at, updated_at, kind, root_conversation_id) "
+                "VALUES (:id, :ts, :ts, 'default', :id)"
+            ),
+            {"id": "conv_title_default", "ts": 1700000000},
+        )
+        conn.commit()
+        value = conn.execute(
+            sa.text("SELECT title FROM conversations WHERE id = :id"),
+            {"id": "conv_title_default"},
+        ).scalar_one()
+    assert value == "", f"Expected title to default to '' (empty string); got {value!r}."
+
+
+def test_downgrade_restores_nullable_and_nullifies_empty_titles(tmp_path: Path) -> None:
+    """
+    Downgrade to r1a2b3c4d5e6 makes title nullable and converts '' back to NULL.
+    """
+    db_path = tmp_path / "downgrade.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+
+    # At head (s1a2b3c4d5e6): insert a row with no title (will be '').
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversations "
+                "(id, created_at, updated_at, kind, root_conversation_id, title) "
+                "VALUES (:id, :ts, :ts, 'default', :id, '')"
+            ),
+            {"id": "conv_downgrade_test", "ts": 1700000001},
+        )
+        conn.commit()
+
+    # Also insert a row with a real title to verify it is not affected.
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversations "
+                "(id, created_at, updated_at, kind, root_conversation_id, title) "
+                "VALUES (:id, :ts, :ts, 'default', :id, :title)"
+            ),
+            {"id": "conv_titled", "ts": 1700000002, "title": "My Session"},
+        )
+        conn.commit()
+
+    # Downgrade one step.
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, "r1a2b3c4d5e6")
+
+    inspector = sa.inspect(engine)
+    title_col = next(c for c in inspector.get_columns("conversations") if c["name"] == "title")
+    assert title_col["nullable"], "conversations.title must be nullable after downgrade"
+
+    # Empty-string title should have been converted back to NULL.
+    with engine.connect() as conn:
+        value = conn.execute(
+            sa.text("SELECT title FROM conversations WHERE id = :id"),
+            {"id": "conv_downgrade_test"},
+        ).scalar_one_or_none()
+    assert value is None, (
+        f"Expected empty-string title to be restored to NULL after downgrade; got {value!r}"
+    )
+
+    # A real title should be unchanged.
+    with engine.connect() as conn:
+        value = conn.execute(
+            sa.text("SELECT title FROM conversations WHERE id = :id"),
+            {"id": "conv_titled"},
+        ).scalar_one_or_none()
+    assert value == "My Session", f"Real title should be unchanged after downgrade; got {value!r}"
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/runtime/policies/test_builder.py
+++ b/tests/runtime/policies/test_builder.py
@@ -24,6 +24,7 @@ Covers:
 
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 
 import pytest
@@ -41,6 +42,11 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from tests.runtime.policies.conftest import make_fixed_function_policy_spec
+
+
+def _sub_agent_title() -> str:
+    """Return a unique sub-agent title (production sub-agents always have one)."""
+    return f"test-agent:{uuid.uuid4().hex[:8]}"
 
 
 def _write_spec(
@@ -535,15 +541,15 @@ def test_build_sums_subagent_usage_into_parent_engine(
     """
     parent = conversation_store.create_conversation()
     child_a = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     child_b = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     # Grandchild under child_a — proves the walk is transitive, not
     # just direct children.
     grandchild = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=child_a.id
+        kind="sub_agent", parent_conversation_id=child_a.id, title=_sub_agent_title()
     )
     conversation_store.set_session_usage(
         parent.id,
@@ -597,7 +603,7 @@ def test_policy_seed_uses_policy_cost_while_display_uses_total_cost(
 
     parent = conversation_store.create_conversation()
     child = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     # Parent has both costs: S=0.10 frozen for display, enforcement=0.30
     # (a sub-agent is mid-run, so the real-time estimate leads S).
@@ -650,13 +656,13 @@ def test_build_subagent_gates_against_whole_session_not_own_subtree(
     """
     parent = conversation_store.create_conversation()
     child_a = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     child_b = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     grandchild = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=child_a.id
+        kind="sub_agent", parent_conversation_id=child_a.id, title=_sub_agent_title()
     )
     conversation_store.set_session_usage(
         parent.id,
@@ -735,8 +741,12 @@ def test_build_subagent_with_empty_usage_does_not_inflate_parent(
     """
     parent = conversation_store.create_conversation()
     # Two children with no usage recorded at all (empty session_usage).
-    conversation_store.create_conversation(kind="sub_agent", parent_conversation_id=parent.id)
-    conversation_store.create_conversation(kind="sub_agent", parent_conversation_id=parent.id)
+    conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
+    )
+    conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
+    )
     conversation_store.set_session_usage(
         parent.id,
         {"input_tokens": 800, "output_tokens": 150, "total_tokens": 950, "total_cost_usd": 0.58},
@@ -772,7 +782,7 @@ def test_load_session_usage_merges_by_model_across_subtree(
 
     parent = conversation_store.create_conversation()
     child = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     # Parent ran model-a. Child ran a slice of model-a plus a different model-b.
     conversation_store.set_session_usage(
@@ -837,10 +847,10 @@ def test_build_subagent_with_cost_budget_gets_session_wide_usage(
     """
     parent = conversation_store.create_conversation()
     child = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     sibling = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
 
     conversation_store.set_session_usage(parent.id, {"total_cost_usd": 0.10})
@@ -870,7 +880,7 @@ def test_build_injects_subtree_usage_only_when_policy_present(
 
     parent = conversation_store.create_conversation()
     child = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     conversation_store.set_session_usage(parent.id, {"total_cost_usd": 0.10})
     conversation_store.set_session_usage(child.id, {"total_cost_usd": 0.05})
@@ -920,13 +930,13 @@ def test_build_subagent_subtree_usage_excludes_parent_and_siblings(
 
     parent = conversation_store.create_conversation()
     child = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     sibling = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=parent.id
+        kind="sub_agent", parent_conversation_id=parent.id, title=_sub_agent_title()
     )
     grandchild = conversation_store.create_conversation(
-        kind="sub_agent", parent_conversation_id=child.id
+        kind="sub_agent", parent_conversation_id=child.id, title=_sub_agent_title()
     )
 
     conversation_store.set_session_usage(parent.id, {"total_cost_usd": 0.10})


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `conversations.title` was `Text, nullable=True`; this PR makes it `NOT NULL` with `''` as the representation for untitled conversations.
- Migration `s1a2b3c4d5e6` back-fills all `NULL` titles to `''` and alters the column to `NOT NULL` with a `server_default` of `''`.
- The store layer converts `'' ↔ None` at the entity boundary (`_to_conversation` and all write paths), so `Conversation.title: str | None` semantics are preserved throughout the application layer — `''` and `None` are treated as equivalent by callers.

## Test Plan

- `uv run pytest tests/stores/test_conversation_store.py -x -q` — all 155 existing tests pass unchanged.
- `uv run pytest tests/db/test_migration_title_not_null.py -x -q` — 3 new migration tests pass:
  - Column is NOT NULL after upgrade.
  - Insert omitting `title` lands as `''` (server_default).
  - Downgrade restores nullable and converts `''` back to `NULL`.
- Applied the migration to `~/.omnigent/chat.db` (backed up first): 0 NULL titles, column reports NOT NULL in `PRAGMA table_info`.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New migration test covers upgrade, server_default, and downgrade round-trip. Existing 155 conversation store tests verify all read/write paths with the new `'' ↔ None` conversion.

## Changelog

Tightened `conversations.title` DB column to NOT NULL; untitled conversations are now stored as `''` instead of `NULL`.