### PR TITLE
fix(hermes): don't ring the parent-waking idle edge before the final assistant message is mirrored

### DIFF
--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -598,7 +598,9 @@ def _assistant_row_has_tool_calls(tool_calls: object) -> bool:
     return isinstance(calls, list) and len(calls) > 0
 
 
-def _count_completed_turns(db_path: Path, hermes_session_id: str) -> int:
+def _count_completed_turns(
+    db_path: Path, hermes_session_id: str, max_id: int | None = None
+) -> int:
     """Count completed turns for *hermes_session_id* (0 on unreadable/empty).
 
     A completed turn is an ``assistant`` row with no ``tool_calls`` — the agentic
@@ -607,16 +609,22 @@ def _count_completed_turns(db_path: Path, hermes_session_id: str) -> int:
     (sets ``active = 0``) rather than deleting rows, so ignoring it keeps the
     count monotonic and append-only — the dedup baseline can then only grow, never
     drop below the posted-count and falsely re-arm an idle post for an old turn.
+
+    With *max_id*, only rows at or below that id are counted. The idle check
+    passes the mirror's high-water mark here so a terminal row that lands while
+    a batch is still being POSTed cannot be counted — and ring the parent-waking
+    idle edge — before the row itself has been mirrored.
     """
     con = _connect_ro(db_path)
     if con is None:
         return 0
+    query = "SELECT tool_calls FROM messages WHERE session_id = ? AND role = 'assistant'"
+    params: tuple[object, ...] = (hermes_session_id,)
+    if max_id is not None:
+        query += " AND id <= ?"
+        params = (hermes_session_id, max_id)
     try:
-        rows = con.execute(
-            "SELECT tool_calls FROM messages "
-            "WHERE session_id = ? AND role = 'assistant' ORDER BY id",
-            (hermes_session_id,),
-        ).fetchall()
+        rows = con.execute(query + " ORDER BY id", params).fetchall()
     except sqlite3.Error as exc:
         _warn_sqlite_once("turn-end count", exc)
         return 0
@@ -940,13 +948,16 @@ async def forward_hermes_store_to_session(
                         # status never does). A completed turn is an assistant row
                         # with no tool_calls (the agentic loop's terminal step);
                         # posted only AFTER its messages are mirrored above so the
-                        # parent sees the content before the completion. Deduped
+                        # parent sees the content before the completion — the
+                        # count is bounded by the mirrored high-water mark, so a
+                        # terminal row landing while this poll's batch was being
+                        # POSTed waits for the next poll to mirror it. Deduped
                         # against a persisted posted-count so a supervisor restart
                         # never re-wakes the parent for a turn it already reported.
                         # Best-effort: a failed post raises into the outer handler
                         # and leaves the count unadvanced, so the next poll retries.
                         completed_turns = await asyncio.to_thread(
-                            _count_completed_turns, db, hermes_session_id
+                            _count_completed_turns, db, hermes_session_id, last_id
                         )
                         if completed_turns > await asyncio.to_thread(
                             hermes_native_status.read_posted_count, bridge_dir

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -833,6 +833,18 @@ def test_count_completed_turns_counts_regardless_of_active(tmp_path: Path) -> No
     assert f._count_completed_turns(db, "s1") == 2
 
 
+def test_count_completed_turns_respects_max_id(tmp_path: Path) -> None:
+    """Terminal rows above the mirrored high-water mark are not counted yet."""
+    db = tmp_path / "state.db"
+    # Rows: 1=user, 2=assistant(final), 3=user, 4=assistant(final).
+    _seed_turns(db, cwd=str(tmp_path), started_at=1000.0, session_id="s1", n_turns=2)
+    assert f._count_completed_turns(db, "s1", max_id=1) == 0
+    assert f._count_completed_turns(db, "s1", max_id=2) == 1
+    assert f._count_completed_turns(db, "s1", max_id=3) == 1
+    assert f._count_completed_turns(db, "s1", max_id=4) == 2
+    assert f._count_completed_turns(db, "s1") == 2
+
+
 def test_hermes_status_posted_count_roundtrip_and_clear(tmp_path: Path) -> None:
     bridge = tmp_path / "b"
     assert hstatus.read_posted_count(bridge) == 0
@@ -978,3 +990,89 @@ async def test_forward_loop_idle_dedupes_and_posts_per_new_turn(tmp_path, monkey
     # one-per-poll across the six iterations.
     assert statuses == ["idle", "idle"]
     assert hstatus.read_posted_count(bridge_dir) == 2
+
+
+async def test_forward_loop_idle_waits_for_mid_delivery_final_message(
+    tmp_path, monkeypatch
+) -> None:
+    """A final assistant row landing while a poll's batch is still being
+    delivered must not ring idle until that row is itself mirrored — the idle
+    edge wakes the parent orchestrator, which then reads the transcript, so the
+    completion signal may never overtake the content it announces."""
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    con = sqlite3.connect(db)
+    con.executescript(_SCHEMA)
+    con.execute(
+        "INSERT INTO sessions(id, source, cwd, started_at) VALUES (?,?,?,?)",
+        ("s1", "cli", workspace, 1000.0),
+    )
+    tc = json.dumps([{"id": "c1", "call_id": "c1", "function": {"name": "f", "arguments": "{}"}}])
+    con.executemany(
+        "INSERT INTO messages"
+        "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+        " VALUES (?,?,?,?,?,?,?)",
+        [
+            ("s1", "user", "go", None, None, None, 1),
+            ("s1", "assistant", "", None, tc, None, 1),  # mid-turn tool-call step
+            ("s1", "tool", "result", "c1", None, "f", 1),
+        ],
+    )
+    con.commit()
+    con.close()
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    # One ordered log for both channels so the content/signal order is provable.
+    events: list[tuple[str, object]] = []
+    landed = {"done": False}
+
+    async def _post_item(_client, *, session_id, item):
+        events.append(("item", item.msg_id))
+        if not landed["done"]:
+            # The turn's final assistant row lands while this batch is still
+            # being POSTed — after the mirror's read, before the idle check.
+            landed["done"] = True
+            con = sqlite3.connect(db)
+            con.execute(
+                "INSERT INTO messages"
+                "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+                " VALUES (?,?,?,?,?,?,?)",
+                ("s1", "assistant", "final answer", None, None, None, 1),
+            )
+            con.commit()
+            con.close()
+
+    async def _record_status(_client, *, session_id, status):
+        events.append(("status", status))
+
+    monkeypatch.setattr(f, "_post_conversation_item", _post_item)
+    monkeypatch.setattr(f, "_post_external_session_status", _record_status)
+
+    iteration = {"n": 0}
+
+    async def _sleep(_s):
+        iteration["n"] += 1
+        if iteration["n"] >= 3:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(f.asyncio, "sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_hermes_store_to_session(
+            base_url="http://x",
+            headers={},
+            session_id="conv_idle",
+            bridge_dir=bridge_dir,
+            agent_name="hermes-native-ui",
+            workspace=workspace,
+            launch_epoch_s=1000.0,
+            db_path=db,
+        )
+
+    assert ("status", "idle") in events
+    assert ("item", 4) in events  # the final answer row was mirrored
+    # The invariant under test: content first, completion signal second.
+    assert events.index(("item", 4)) < events.index(("status", "idle"))
+    assert events.count(("status", "idle")) == 1
+    assert hstatus.read_posted_count(bridge_dir) == 1


### PR DESCRIPTION
## Related issue

Closes #2160

## Summary

- A final assistant row landing while a poll's batch was still being POSTed was picked up by the end-of-iteration completed-turn count, ringing the parent-waking `external_session_status: idle` edge **before the row itself was mirrored** — a sub-agent orchestrator woke to a transcript missing the final answer.
- Fix: `_count_completed_turns` now takes the mirror's high-water mark (`last_id`) and counts only rows `id <= last_id`, so the completion signal can never overtake the content it announces. The row lands one poll later (0.4s) and idle rings right after it is mirrored.
- The comment at the idle post already promised this ordering ("posted only AFTER its messages are mirrored above"); the count read just wasn't taken from the same snapshot as the mirror read.

ELI5: the courier loads a batch of letters, and while he's out delivering, the final letter drops into the mailbox. He then re-checks the mailbox to decide whether to ring the "all done" bell — and rings it for a letter he hasn't delivered yet. Now he only counts letters up to the last one actually delivered.

```
before:  read batch ──POST──POST──POST──> fresh count (sees new row) ──> idle 🔔 ──(next poll)──> final row mirrored
after:   read batch ──POST──POST──POST──> count ≤ last_id (0)        ──(next poll)──> final row mirrored ──> idle 🔔
```

## Test Plan

- New regression test `test_forward_loop_idle_waits_for_mid_delivery_final_message`: seeds a mid-turn store (user / tool-call step / tool result), and the item-POST stub inserts the terminal assistant row **during delivery** — making the race deterministic, no sleeps. Both channels record into one ordered log; the test asserts the final row's mirror precedes the idle edge.
- Red on main: `[('item',1), ('item',2), ('item',3), ('status','idle'), ('item',4)]` — idle overtakes the final message.
- Green with the fix, and the idle still fires exactly once (dedup and restart-safety tests unchanged).
- New unit test `test_count_completed_turns_respects_max_id` pins the bound at every watermark position.
- `pytest tests/test_hermes_native_forwarder.py`: 32 passed.

## Demo

Red→green regression-test comparison — on `main` the parent-waking `idle` edge lands **before** the final assistant message in the ordered event log; with the fix the content is mirrored first:

![red/green: idle edge vs final message ordering](https://raw.githubusercontent.com/tomsen-ai/omnigent/demo-assets/2161-hermes-idle-red-green.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test reproduces the race deterministically (terminal row injected from inside the POST stub), so the ordering invariant is pinned by CI rather than by timing.

## Changelog

Sub-agent hermes sessions no longer wake their parent orchestrator before the turn's final answer is mirrored into the transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)

