### PR TITLE
feat(polly): LiteLLM Gateway configuration and smart-router skill rewrite

### DIFF
--- a/examples/gateway/README.md
+++ b/examples/gateway/README.md
@@ -1,0 +1,140 @@
+# Omnigent LiteLLM Gateway Configuration
+
+This directory contains a [LiteLLM Proxy](https://litellm.vercel.app/) configuration
+that exposes a unified OpenAI-compatible API endpoint to all Omnigent agents.
+Agents reference models through `gateway/<name>` aliases; the Gateway handles
+provider routing, key management, fallbacks, and rate-limit handling.
+
+## Quick Start
+
+### 1. Install LiteLLM
+
+```bash
+pip install 'litellm[proxy]'
+```
+
+Or, if you use the project's package manager:
+
+```bash
+uv pip install 'litellm[proxy]'
+```
+
+### 2. Set environment variables
+
+All API keys are read from the environment — never hardcoded in the config.
+Create a `.env` file (or export directly in your shell):
+
+```bash
+# Google AI Studio (Gemini)
+export GEMINI_API_KEY="your-gemini-api-key"
+
+# OpenRouter (free tier + Claude)
+export OPENROUTER_API_KEY="your-openrouter-api-key"
+
+# DeepSeek
+export DEEPSEEK_API_KEY="your-deepseek-api-key"
+
+# MiniMax
+export MINIMAX_API_KEY="your-minimax-api-key"
+
+# Zhipu AI (GLM-5)
+export ZHIPU_API_KEY="your-zhipu-api-key"
+```
+
+A template is available at `examples/polly/.env.example`.
+
+### 3. Start the proxy
+
+```bash
+litellm --config litellm-config.yaml --port 4000
+```
+
+The proxy listens on `http://0.0.0.0:4000` by default (configurable with `--port`).
+
+### 4. Verify it works
+
+```bash
+curl http://localhost:4000/v1/models
+```
+
+You should see the six `gateway/<name>` aliases listed.
+
+Test a completion:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gateway/gemini-35-flash",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+## Integration with Omnigent / Polly
+
+### Option A: Global `llm:` block in `~/.hermes/config.yaml`
+
+```yaml
+llm:
+  provider: openai  # LiteLLM exposes an OpenAI-compatible API
+  model: gateway/deepseek-v4-flash   # default brain model
+  api_base: http://localhost:4000/v1
+  api_key: "not-needed"              # LiteLLM uses its own env-var keys
+```
+
+Now every Omnigent agent uses the Gateway by default.
+
+### Option B: Agent-scoped override
+
+In a Polly agent config (`examples/polly/agents/<name>/config.yaml`), pass
+`args.model: gateway/<alias>` when dispatching, or set a default model for
+that agent.
+
+### Option C: Credential registration
+
+If Omnigent's credential system is enabled (`omnigent credential add`),
+register the Gateway as an OpenAI-compatible provider:
+
+```bash
+omnigent credential add \
+  --provider openai \
+  --api-base http://localhost:4000/v1 \
+  --api-key placeholder \
+  --label gateway
+```
+
+## Enabling Intelligent Routing
+
+Set the environment variable that tells Omnigent to use the `sys_advise_models`
+tool for smart model selection:
+
+```bash
+export OMNIGENT_SMART_ROUTING=1
+```
+
+When this is set, Polly and other orchestrators will call `sys_advise_models`
+before every fan-out to get the optimal model per task. The LiteLLM Gateway
+handles the actual fallback and retry logic at the proxy layer.
+
+## Model Aliases
+
+| Gateway Alias                   | Backend Provider | Model                         | Cost Tier |
+|---------------------------------|------------------|-------------------------------|-----------|
+| `gateway/openrouter-free`       | OpenRouter       | `openrouter/free`             | Free      |
+| `gateway/gemini-35-flash`       | Google AI Studio | Gemini 3.5 Flash              | Low       |
+| `gateway/deepseek-v4-flash`     | DeepSeek         | DeepSeek V4 Flash             | Low       |
+| `gateway/minimax-m3`            | MiniMax          | MiniMax-M3 (Hailuo)           | Mid       |
+| `gateway/claude-sonnet-4-6`     | OpenRouter       | Claude Sonnet 4-6             | High      |
+| `gateway/glm-5`                 | Zhipu AI         | GLM-5                         | Mid       |
+
+## Fallback Chain
+
+The LiteLLM Gateway is configured with automatic fallbacks:
+
+- **Free exhaustion**: `gateway/openrouter-free` → `gateway/gemini-35-flash` → `gateway/deepseek-v4-flash`
+- **Gemini rate-limit**: `gateway/gemini-35-flash` → `gateway/deepseek-v4-flash` → `gateway/minimax-m3`
+- **DeepSeek overload**: `gateway/deepseek-v4-flash` → `gateway/minimax-m3` → `gateway/claude-sonnet-4-6`
+- **Sonnet unavailable**: `gateway/claude-sonnet-4-6` → `gateway/minimax-m3` → `gateway/deepseek-v4-flash`
+- **GLM-5 unavailable**: `gateway/glm-5` → `gateway/deepseek-v4-flash` → `gateway/gemini-35-flash`
+
+All fallback is transparent to the calling agent — no 429 handling needed in Polly.

--- a/examples/gateway/litellm-config.yaml
+++ b/examples/gateway/litellm-config.yaml
@@ -1,0 +1,112 @@
+# LiteLLM Proxy Configuration — Omnigent Polly Gateway
+#
+# This file defines model aliases that the smart-router skill and other
+# Omnigent agents reference via the ``gateway/<name>`` convention.
+# All API keys are read from environment variables — never hardcoded.
+#
+# Usage:
+#   litellm --config litellm-config.yaml
+#
+# See README.md for environment setup and Omnigent integration.
+
+model_list:
+  # ── Google Gemini 3.5 Flash ──────────────────────────────────────────
+  # Fast, cheap, good at structured output and vision.
+  - model_name: gateway/gemini-35-flash
+    litellm_params:
+      model: gemini/gemini-3.5-flash-latest
+      api_key: "os.environ/GEMINI_API_KEY"
+
+  # ── OpenRouter Free Tier ─────────────────────────────────────────────
+  # Best-effort free model endpoint. Rate-limited; fallback handled below.
+  - model_name: gateway/openrouter-free
+    litellm_params:
+      model: openrouter/openrouter/free
+      api_key: "os.environ/OPENROUTER_API_KEY"
+
+  # ── DeepSeek V4 Flash ─────────────────────────────────────────────────
+  # Primary coding / implementation model — fast, strong at multi-file edits.
+  - model_name: gateway/deepseek-v4-flash
+    litellm_params:
+      model: deepseek/deepseek-v4-flash
+      api_key: "os.environ/DEEPSEEK_API_KEY"
+
+  # ── MiniMax-M3 ────────────────────────────────────────────────────────
+  # Mid-tier implementation / review — good balance of quality and speed.
+  - model_name: gateway/minimax-m3
+    litellm_params:
+      model: openai/Hailuo-M3-0825-1122
+      api_base: https://api.minimax.chat/v1
+      api_key: "os.environ/MINIMAX_API_KEY"
+
+  # ── Claude Sonnet 4-6 (via OpenRouter) ────────────────────────────────
+  # Strongest reasoning / code review model. Used for critical-path
+  # architecture review and hard implementation work.
+  - model_name: gateway/claude-sonnet-4-6
+    litellm_params:
+      model: openrouter/anthropic/claude-sonnet-4-6
+      api_key: "os.environ/OPENROUTER_API_KEY"
+
+  # ── GLM-5 (for Kiro rapid prototyping) ────────────────────────────────
+  # Zhipu AI's latest. Used by the kiro agent for fast prototypes.
+  - model_name: gateway/glm-5
+    litellm_params:
+      model: openai/glm-5
+      api_base: https://open.bigmodel.cn/api/paas/v4
+      api_key: "os.environ/ZHIPU_API_KEY"
+
+
+# ── Router Settings ─────────────────────────────────────────────────────
+router_settings:
+  # Strategy: "latency-based-routing" picks the fastest responding model;
+  # "usage-based-routing" distributes load; omit for simple round-robin.
+  routing_strategy: latency-based-routing
+
+  # Per-request timeout and retry
+  num_retries: 3
+  request_timeout: 30
+
+  # ── Fallback chain ────────────────────────────────────────────────────
+  # When a model exhausts its quota, returns a 429, or times out, LiteLLM
+  # automatically downgrades through the chain. Order: free → low-cost →
+  # mid-cost → premium.
+  fallbacks:
+    # OpenRouter free → Gemini 3.5 Flash → DeepSeek V4 Flash
+    - model_name: gateway/openrouter-free
+      fallback_models:
+        - gateway/gemini-35-flash
+        - gateway/deepseek-v4-flash
+
+    # Gemini 3.5 Flash → DeepSeek V4 Flash → MiniMax-M3
+    - model_name: gateway/gemini-35-flash
+      fallback_models:
+        - gateway/deepseek-v4-flash
+        - gateway/minimax-m3
+
+    # DeepSeek V4 Flash → MiniMax-M3 → Claude Sonnet 4-6 (paid fallback)
+    - model_name: gateway/deepseek-v4-flash
+      fallback_models:
+        - gateway/minimax-m3
+        - gateway/claude-sonnet-4-6
+
+    # MiniMax-M3 → DeepSeek V4 Flash → Claude Sonnet 4-6
+    - model_name: gateway/minimax-m3
+      fallback_models:
+        - gateway/deepseek-v4-flash
+        - gateway/claude-sonnet-4-6
+
+    # Claude Sonnet 4-6 → MiniMax-M3 (expensive → cheaper)
+    - model_name: gateway/claude-sonnet-4-6
+      fallback_models:
+        - gateway/minimax-m3
+        - gateway/deepseek-v4-flash
+
+    # GLM-5 → DeepSeek V4 Flash → Gemini 3.5 Flash
+    - model_name: gateway/glm-5
+      fallback_models:
+        - gateway/deepseek-v4-flash
+        - gateway/gemini-35-flash
+
+  # Cooldown: if a model fails N times in a window, pause it temporarily
+  cooldown_time: 30  # seconds
+  allowed_fails: 5   # before cooldown kicks in

--- a/examples/polly/.env.example
+++ b/examples/polly/.env.example
@@ -1,0 +1,42 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Polly + LiteLLM Gateway — Environment Variables
+# ─────────────────────────────────────────────────────────────────────────────
+# Copy this file to `.env` in your project root or export the values directly.
+#   cp examples/polly/.env.example .env
+# Then: source .env   (or use dotenv/auto-export)
+#
+# Required: at least one API key for the models you plan to use.
+# The Gateway uses these keys at startup — they are never hardcoded in config.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── LiteLLM Gateway ──────────────────────────────────────────────────────────
+# Set to 1 to enable the sys_advise_models tool for smart routing.
+OMNIGENT_SMART_ROUTING=1
+
+# LiteLLM proxy address (only needed if connecting from outside)
+# LITELLM_BASE_URL=http://localhost:4000
+
+# ── Google AI Studio / Gemini ────────────────────────────────────────────────
+# Required for: gateway/gemini-35-flash
+GEMINI_API_KEY=
+
+# ── OpenRouter ───────────────────────────────────────────────────────────────
+# Required for: gateway/openrouter-free, gateway/claude-sonnet-4-6
+OPENROUTER_API_KEY=
+
+# ── DeepSeek ─────────────────────────────────────────────────────────────────
+# Required for: gateway/deepseek-v4-flash
+DEEPSEEK_API_KEY=
+
+# ── MiniMax ──────────────────────────────────────────────────────────────────
+# Required for: gateway/minimax-m3
+MINIMAX_API_KEY=
+
+# ── Zhipu AI (GLM) ───────────────────────────────────────────────────────────
+# Required for: gateway/glm-5
+ZHIPU_API_KEY=
+
+# ── Optional: sub-agent CLI authentication ───────────────────────────────────
+# Each coding agent may need its own credentials beyond the Gateway.
+# ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-proj-...

--- a/examples/polly/agents/antigravity/config.yaml
+++ b/examples/polly/agents/antigravity/config.yaml
@@ -1,0 +1,62 @@
+spec_version: 1
+name: antigravity
+description: Antigravity coding sub-agent — Gemini-native multi-model harness.
+
+executor:
+  type: omnigent
+  config:
+    harness: antigravity-native
+    # Headless workers can't answer ApprovalCards. ``auto`` auto-approves
+    # without prompting and is allowed under managed settings.
+    permission_mode: auto
+
+prompt: |
+  You are Antigravity, a coding sub-agent dispatched by the polly
+  orchestrator for a single scoped task in a dedicated git worktree. Your task
+  prompt names its purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one
+  thing; don't refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the orchestrator to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/polly/agents/kiro/config.yaml
+++ b/examples/polly/agents/kiro/config.yaml
@@ -1,0 +1,62 @@
+spec_version: 1
+name: kiro
+description: Kiro coding sub-agent — GLM-5 rapid-prototyping harness.
+
+executor:
+  type: omnigent
+  config:
+    harness: kiro-native
+    # Headless workers can't answer ApprovalCards. ``auto`` auto-approves
+    # without prompting and is allowed under managed settings.
+    permission_mode: auto
+
+prompt: |
+  You are Kiro, a coding sub-agent dispatched by the polly
+  orchestrator for a single scoped task in a dedicated git worktree. Your task
+  prompt names its purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one
+  thing; don't refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the orchestrator to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -2,7 +2,7 @@ spec_version: 1
 name: polly
 description: >-
   A coding orchestrator that breaks your goal into pieces and hands them
-  to a team of Claude Code, Codex, OpenCode, Cursor, Hermes, and Pi sub-agents
+  to a team of Claude Code, Codex, OpenCode, Cursor, Hermes, Pi, Antigravity, and Kiro sub-agents
   to build. Polly
   writes no code itself — it plans and splits up the work, delegates all
   of it (investigation / implementation / review), then has a separate
@@ -18,7 +18,7 @@ spawn: true
 
 # Orchestrator "brain": Claude Agent SDK. polly writes no code itself — it
 # delegates ALL coding work (investigation, implementation, review) to the
-# claude_code / codex / opencode / cursor / hermes / pi sub-agents, doing only non-code authoring (docs /
+# claude_code / codex / opencode / cursor / hermes / pi / antigravity / kiro sub-agents, doing only non-code authoring (docs /
 # Markdown / text edits, skills) itself. No model/profile is pinned, so the
 # brain runs on whatever Claude provider is configured as the default
 # (`omnigent setup --no-internal-beta`) — an Anthropic API key, a Claude
@@ -51,8 +51,8 @@ prompt: |
   a "docs" task starts requiring code changes or real code investigation, STOP
   and delegate that part.
 
-  You have exactly SIX sub-agents. `claude_code`, `codex`, `opencode`, `cursor`,
-  and `hermes` are real CLI coding harnesses that run in their own terminal —
+  You have exactly EIGHT sub-agents. `claude_code`, `codex`, `opencode`, `cursor`,
+  `hermes`, `antigravity`, and `kiro` are real CLI coding harnesses that run in their own terminal —
   the human can open any of them in the UI's Subagents panel and watch or TAKE
   OVER. `pi` runs headless (no terminal to open):
   - `claude_code` — Claude Code (`claude-native` harness).
@@ -60,6 +60,8 @@ prompt: |
   - `opencode` — OpenCode (`opencode-native` harness).
   - `cursor` — Cursor (`cursor-native` harness).
   - `hermes` — Hermes Agent (`hermes-native` harness).
+  - `antigravity` — Antigravity (`antigravity-native` harness), Gemini-native multi-model.
+  - `kiro` — Kiro (`kiro-native` harness), GLM-5 / rapid prototyping.
   - `pi` — Pi (`pi` harness), the REVIEW / EXPLORE specialist for read-mostly
     work, and the only worker that can run ANY gateway model.
 
@@ -68,9 +70,10 @@ prompt: |
 
   Roster preflight (FIRST turn, before any dispatch). Each worker needs its own
   CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `opencode` for
-  `opencode`, `cursor-agent` for `cursor`, `hermes` for `hermes`, `pi` for `pi`.
+  `opencode`, `cursor-agent` for `cursor`, `hermes` for `hermes`, `pi` for `pi`,
+  `agy` for `antigravity`, `kiro-cli` for `kiro`.
   Before delegating anything, run exactly ONE
-  `sys_os_shell("command -v claude codex opencode cursor-agent hermes pi || true")`. A worker is AVAILABLE
+  `sys_os_shell("command -v claude codex opencode cursor-agent hermes pi agy kiro-cli || true")`. A worker is AVAILABLE
   only if its binary resolved in that output; record the available set and route
   work ONLY to available workers for the entire run. Do this in the same first
   turn you start planning (the preflight `sys_os_shell` call counts as acting —
@@ -146,17 +149,18 @@ prompt: |
   edit (no code) you make yourself per the rule above. If the human says
   "launch agents",
   "use claude code", "use codex", "use opencode", "use cursor", "use hermes",
-  or "use pi", that is a literal instruction to dispatch them. `claude_code`,
-  `codex`, `opencode`, `cursor`, and `hermes` are the primary implementers —
+  "use antigravity", "use kiro", or "use pi", that is a literal instruction to dispatch them. `claude_code`,
+  `codex`, `opencode`, `cursor`, `hermes`, `antigravity`, and `kiro` are the primary implementers —
   pick per task: `claude_code` for multi-file / refactor / test-writing work,
-  `codex` for narrow, well-scoped changes, and `opencode` / `cursor` / `hermes`
+  `codex` for narrow, well-scoped changes, `antigravity` for frontend / UI / design,
+  `kiro` for rapid prototypes, and `opencode` / `cursor` / `hermes`
   when another implement/review vendor is wanted. Route `review` / `explore` /
   `search` tasks to `pi` (or a different-vendor implementer) when a third
   perspective or a specific model is wanted.
 
   Cross-vendor verification is the point: review is ALWAYS done by a DIFFERENT
   vendor than the implementer — e.g. `claude_code`'s PR is reviewed by any of
-  `codex` / `opencode` / `cursor` / `hermes` / `pi`, and vice versa. Give the
+  `codex` / `opencode` / `cursor` / `hermes` / `antigravity` / `kiro` / `pi`, and vice versa. Give the
   reviewer ONLY the diff +
   contract; never point it at the implementer's worktree. Only the implementer
   ever opens a PR (the reviewer just reports), so a reviewer's stray edits
@@ -184,7 +188,7 @@ prompt: |
   terminal via `sys_terminal_launch` (it accepts a `cwd` override so you can run
   it inside a per-task worktree). NEVER use this terminal to launch coding
   agents / sub-agents — all delegation goes through `sys_session_send` to
-  `claude_code` / `codex` / `opencode` / `cursor` / `hermes` / `pi`.
+  `claude_code` / `codex` / `opencode` / `cursor` / `hermes` / `antigravity` / `kiro` / `pi`.
 
   For external context and deterministic status, use the `gh` CLI (via
   `sys_os_shell`) for github.com. Reach for such tools sparingly — only to
@@ -288,7 +292,7 @@ terminals:
 
 tools:
   # Coding sub-agents — see agents/<name>/. claude_code, codex, opencode,
-  # cursor, and hermes are real CLI coding harnesses; pi is a headless
+  # cursor, hermes, antigravity, and kiro are real CLI coding harnesses; pi is a headless
   # multi-model worker. Each implements, reviews (cross-vendor), and explores.
   agents:
     - claude_code
@@ -296,6 +300,8 @@ tools:
     - opencode
     - cursor
     - hermes
+    - antigravity
+    - kiro
     - pi
 
 # Mechanism-layer enforcement — runner-side tool gate, no server change.

--- a/examples/polly/skills/cross-review/SKILL.md
+++ b/examples/polly/skills/cross-review/SKILL.md
@@ -17,10 +17,11 @@ anyone needs to read through.
    don't involve the reviewer yet.
 3. Dispatch a DIFFERENT-vendor sub-agent as reviewer: pick any AVAILABLE worker
    whose vendor differs from the implementer's — `claude_code`, `codex`,
-   `opencode`, `cursor`, `hermes`, or `pi` (e.g. Claude built it → any of
-   `codex` / `opencode` / `cursor` / `hermes` / `pi`, and so on). Use a
-   task-based title such as `review-auth-refactor`, never the raw vendor name:
-   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"pi", title="review-<task_slug>",
+   `opencode`, `cursor`, `hermes`, `antigravity`, `kiro`, or `pi` (e.g. Claude
+   built it → any of `codex` / `opencode` / `cursor` / `hermes` / `antigravity` /
+   `kiro` / `pi`, and so on). Use a task-based title such as `review-auth-refactor`,
+   never the raw vendor name:
+   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"antigravity"|"kiro"|"pi", title="review-<task_slug>",
    args={purpose: "review", input: "<the diff> + <the acceptance contract>.
    Review ONLY against the contract. Report blocking / non-blocking /
    suggestions. Do not edit code."})`. Give it the diff as text — do NOT point
@@ -55,8 +56,8 @@ anyone needs to read through.
   human at the plan gate.
 - Give the reviewer ONLY the diff + contract — never the implementer's
   transcript or worktree. The cross-vendor independence is the whole point.
-- Review is a coding sub-agent (`claude_code`/`codex`/`opencode`/`cursor`/`hermes`/`pi`) dispatched with
-  `purpose: "review"` — a DIFFERENT vendor from the one that built the diff. It
+- Review is a coding sub-agent (`claude_code`/`codex`/`opencode`/`cursor`/`hermes`/`antigravity`/`kiro`/`pi`)
+  dispatched with `purpose: "review"` — a DIFFERENT vendor from the one that built the diff. It
   reports issues and never edits; only the implementer opens a PR, so a stray
   reviewer edit never reaches the deliverable.
 - Non-blocking issues / suggestions go in the registry as follow-ups; they

--- a/examples/polly/skills/fanout/SKILL.md
+++ b/examples/polly/skills/fanout/SKILL.md
@@ -14,7 +14,7 @@ dependency).
    Record the worktree path + branch in the registry
    (`.polly/registry.json`).
 2. Dispatch one implementation sub-agent per task, scoped to its worktree:
-   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes", title="<task_slug>",
+   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"antigravity"|"kiro", title="<task_slug>",
    args={purpose: "implement", input: "<task + acceptance contract +
    worktree path>"})`. Use a short task-based title such as `auth-refactor` or
    `fix-sse-error`, never the raw vendor name. State the scope and that it must
@@ -43,8 +43,9 @@ dependency).
 ## Notes
 - Respect the per-turn dispatch cap (enforced by policy). More tasks than the
   cap → dispatch in waves (let the running batch finish before dispatching more).
-- The human can open any sub-agent in the UI's Subagents panel and read its
-  conversation while it runs.
+- The human can open any terminal-based sub-agent (`claude_code`, `codex`,
+  `opencode`, `cursor`, `hermes`, `antigravity`, `kiro`) in the UI's Subagents
+  panel and read its conversation while it runs.
 - If a running worker is wrong, runaway, superseded, or no longer useful, call
   `sys_cancel_task` with `task_id` set to the recorded `conversation_id` before
   dispatching a replacement. `claude_code` is hard-stopped; `codex` cancellation

--- a/examples/polly/skills/investigate/SKILL.md
+++ b/examples/polly/skills/investigate/SKILL.md
@@ -12,13 +12,14 @@ repository-specific technical question.
 ## Procedure
 1. Decompose the question into one or more bounded investigation tasks. Prefer
    two independent lenses for ambiguous or high-stakes questions.
-2. Dispatch each task to `claude_code`, `codex`, `opencode`, `cursor`, `hermes`, or `pi`:
-   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"pi",
+2. Dispatch each task to `claude_code`, `codex`, `opencode`, `cursor`, `hermes`, `antigravity`, `kiro`, or `pi`:
+   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"cursor"|"hermes"|"antigravity"|"kiro"|"pi",
    title="explore-<task_slug>", args={purpose: "explore", input: "<question +
    exact scope + evidence requested>"})`. Use a task-based title such as
    `explore-ci-flake`, never the raw vendor name. Use `purpose: "search"` only
    when the task is primarily external/document search. Prefer `pi` when a
-   third lens or a non-Claude/GPT model is wanted. Any worker takes an optional
+   third lens or a non-Claude/GPT model is wanted; prefer `antigravity` or `kiro`
+   when a Gemini or GLM-5 lens is useful. Any worker takes an optional
    `args.model` (`sys_list_models` shows what each worker can run; an invalid
    model/worker combination fails loud at dispatch, and `model` only applies on
    the dispatch that CREATES the session — a send that continues an existing

--- a/examples/polly/skills/smart-router/SKILL.md
+++ b/examples/polly/skills/smart-router/SKILL.md
@@ -1,27 +1,101 @@
 ---
 name: smart-router
-description: Pick the right polly sub-agent and model override for a task based on task type and harness constraints.
+description: >-
+  Static decision table mapping task types to the best-fit sub-agent and
+  LiteLLM Gateway model alias. Model selection deferred to sys_advise_models
+  at runtime; Gateway handles fallback/retry.
 ---
 
-# smart-router — task-to-agent/model routing
+# Smart Router — 任务到最优 agent+model 的静态决策手册
 
-Polly invokes this skill when it needs to route a task to a sub-agent and an
-explicit `args.model` is useful. The skill is documentation-only; the actual
-routing decision lives in polly's prompt, but this file is the canonical
-reference for the mapping.
+本 skill **不决定最终 model**，只决定"任务类型 → 候选 agent + 候选 model alias"。
+具体 model 选择由 `sys_advise_models`（当 `OMNIGENT_SMART_ROUTING=1` 时可用）在每次
+fan-out 前给出建议；Gateway 层自动处理 429、超时、quota 耗尽等降级。
 
-## Routing rules
+## 路由表
 
-- Frontend / UI / design tasks → `antigravity` with `args.model: gemini-3.5-flash`
-- Code review / architecture → `claude_code` with `args.model: claude-sonnet-4-6`
-- Core implementation → `claude_code` with `args.model: claude-opus-4-6`
-- Light exploration / search → `pi` with `args.model: MiniMax-M3`
-- Mid-tier implementation → `opencode` (DeepSeek default; no override needed)
-- Rapid prototype → `kiro` with `args.model: GLM-5`
+| 任务类型 | 候选 Agent | 首选模型 alias | 成本优先级 |
+|---|---|---|---|
+| 前端/UI/设计 | `antigravity` | `gateway/gemini-35-flash` | 免费 > 低价 |
+| 多文件长文本实现 | `pi` / `opencode` | `gateway/minimax-m3` / `gateway/deepseek-v4-flash` | 低价 > 中价 |
+| 代码审查/架构 | `claude_code` / `pi` | `gateway/claude-sonnet-4-6` / `gateway/deepseek-v4-flash` | 中价 > 高价 |
+| 轻量修复/单测 | `codex` / `opencode` | `gateway/deepseek-v4-flash` / `gateway/gemini-35-flash` | 免费 > 低价 |
+| 快速原型 | `kiro` | `gateway/glm-5` | 中价 |
+| 探索/搜索 | `pi` | `gateway/openrouter-free` / `gateway/gemini-35-flash` | 免费 > 低价 |
 
-## Important harness constraints
+## 核心原则
 
-- Antigravity is **Gemini-native**. `model_override.py` rejects non-Gemini models
-  for the `antigravity-native` harness, so never route Claude models to
-  `antigravity`.
-- Kiro is its own family and accepts `GLM-5`.
+### 1. 每次 fan-out 前必须先调用 `sys_advise_models`
+
+当 `OMNIGENT_SMART_ROUTING=1` 时，`sys_advise_models` 工具会在你的工具列表中。
+在调用 `sys_session_send` 之前，传入你即将 dispatch 的全部任务，用每个返回的
+`model` 作为 `args.model`。例如：
+
+```
+sys_advise_models([
+  {task_id: "fix-header", agent: "opencode",  model_hint: "gateway/deepseek-v4-flash"},
+  {task_id: "review-header", agent: "pi",     model_hint: "gateway/claude-sonnet-4-6"},
+])
+```
+
+### 2. 成本优先级
+
+```
+免费 → 低价 → 中价 → 高价
+```
+
+- **免费**: `gateway/openrouter-free`（OpenRouter free tier）
+- **低价**: `gateway/gemini-35-flash`、`gateway/deepseek-v4-flash`
+- **中价**: `gateway/minimax-m3`、`gateway/glm-5`
+- **高价**: `gateway/claude-sonnet-4-6`
+
+尽可能从左侧选择，等免费/低价配额耗尽后自动升至右侧。
+
+### 3. Fallback 由 Gateway 层自动处理
+
+Polly **不自己处理 429/rate-limit/timeout**。LiteLLM Gateway 配置了完整的
+fallback 链：
+
+- 免费耗尽 → Gemini → DeepSeek
+- Gemini 限速 → DeepSeek → MiniMax
+- DeepSeek 过载 → MiniMax → Claude Sonnet
+- 高价不可用 → 降到中价/低价
+- Gateway 还有 cooldown 机制（连续 5 次失败后暂停 30 秒）
+
+如果 dispatch 返回 model 错误，**不要重试**——检查 `sys_list_models` 确认
+Gateway 上该 alias 是否在线，然后重新调用 `sys_advise_models` 获取建议。
+
+### 4. Agent 与模型兼容性
+
+- `antigravity` 使用 Gemini-native harness，只能运行 Gemini 系列模型
+  （`gateway/gemini-35-flash`）。
+- `kiro` 使用 Kiro-native harness，只能运行 GLM 系列（`gateway/glm-5`）。
+- `pi` 是通用 agent，可以运行任意 Gateway model alias。
+- `claude_code`、`codex`、`opencode` 等 CLI harness 有自身的内置模型，
+  `args.model` 仅在他们支持 model 覆盖时可生效——通过 `sys_list_models`
+  查看每个 agent 实际支持的模型列表。
+
+## 工作流示意
+
+```
+                         ┌──────────────────┐
+                         │  Polly 分解任务    │
+                         └────────┬─────────┘
+                                  │
+                                  ▼
+                    ┌──────────────────────────┐
+                    │ sys_advise_models(tasks)  │ ← OMNIGENT_SMART_ROUTING=1
+                    └──────────┬───────────────┘
+                               │ returns [{agent, model, cost_tier}]
+                               ▼
+                    ┌──────────────────────────┐
+                    │ sys_session_send(agent,  │
+                    │   args.model=...)        │ ← 使用 Gateway alias
+                    └──────────┬───────────────┘
+                               │
+                    ┌──────────▼──────────┐
+                    │ LiteLLM Gateway      │ ← 自动 fallback / retry / cooldown
+                    │ (http://localhost    │
+                    │   :4000/v1)          │
+                    └──────────────────────┘
+```

--- a/examples/polly/skills/smart-router/SKILL.md
+++ b/examples/polly/skills/smart-router/SKILL.md
@@ -32,9 +32,17 @@ fan-out 前给出建议；Gateway 层自动处理 429、超时、quota 耗尽等
 `model` 作为 `args.model`。例如：
 
 ```
-sys_advise_models([
-  {task_id: "fix-header", agent: "opencode",  model_hint: "gateway/deepseek-v4-flash"},
-  {task_id: "review-header", agent: "pi",     model_hint: "gateway/claude-sonnet-4-6"},
+sys_advise_models(tasks=[
+  {
+    title: "fix-header",
+    agents: [{agent: "opencode", models: ["gateway/deepseek-v4-flash"]}],
+    task: "Fix the header rendering bug in the login page."
+  },
+  {
+    title: "review-header",
+    agents: [{agent: "pi", models: ["gateway/claude-sonnet-4-6"]}],
+    task: "Review the header fix for correctness and style."
+  }
 ])
 ```
 

--- a/examples/polly/skills/smart-router/SKILL.md
+++ b/examples/polly/skills/smart-router/SKILL.md
@@ -12,7 +12,7 @@ reference for the mapping.
 
 ## Routing rules
 
-- Frontend / UI / design tasks → `antigravity` with `args.model: gemini-flash-3.5`
+- Frontend / UI / design tasks → `antigravity` with `args.model: gemini-3.5-flash`
 - Code review / architecture → `claude_code` with `args.model: claude-sonnet-4-6`
 - Core implementation → `claude_code` with `args.model: claude-opus-4-6`
 - Light exploration / search → `pi` with `args.model: MiniMax-M3`

--- a/examples/polly/skills/smart-router/SKILL.md
+++ b/examples/polly/skills/smart-router/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: smart-router
+description: Pick the right polly sub-agent and model override for a task based on task type and harness constraints.
+---
+
+# smart-router — task-to-agent/model routing
+
+Polly invokes this skill when it needs to route a task to a sub-agent and an
+explicit `args.model` is useful. The skill is documentation-only; the actual
+routing decision lives in polly's prompt, but this file is the canonical
+reference for the mapping.
+
+## Routing rules
+
+- Frontend / UI / design tasks → `antigravity` with `args.model: gemini-flash-3.5`
+- Code review / architecture → `claude_code` with `args.model: claude-sonnet-4-6`
+- Core implementation → `claude_code` with `args.model: claude-opus-4-6`
+- Light exploration / search → `pi` with `args.model: MiniMax-M3`
+- Mid-tier implementation → `opencode` (DeepSeek default; no override needed)
+- Rapid prototype → `kiro` with `args.model: GLM-5`
+
+## Important harness constraints
+
+- Antigravity is **Gemini-native**. `model_override.py` rejects non-Gemini models
+  for the `antigravity-native` harness, so never route Claude models to
+  `antigravity`.
+- Kiro is its own family and accepts `GLM-5`.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds `examples/gateway/litellm-config.yaml` with six `gateway/<name>` model aliases (Gemini 3.5 Flash, OpenRouter free tier, DeepSeek V4 Flash, MiniMax-M3, Claude Sonnet 4-6, GLM-5), all backed by environment variables and connected through automatic fallback chains.
- Adds `examples/gateway/README.md` with installation, startup, verification, and Omnigent/Polly integration instructions.
- Adds `examples/polly/.env.example` documenting every API key and `OMNIGENT_SMART_ROUTING` needed by the Gateway.
- Rewrites `examples/polly/skills/smart-router/SKILL.md` to route tasks through Gateway aliases and defer final model selection to `sys_advise_models` at runtime.

This branch builds on the Antigravity/Kiro sub-agent work already in PR #2155; once that PR merges, this diff will collapse to only the Gateway-related commit.

## Test Plan

1. YAML syntax check on `examples/gateway/litellm-config.yaml` using PyYAML (`yaml.safe_load`).
2. Verified every `gateway/<name>` alias referenced in `smart-router/SKILL.md` exists in `litellm-config.yaml`.
3. Verified every `os.environ/XXX` API-key reference in `litellm-config.yaml` is documented in both `README.md` and `examples/polly/.env.example`.
4. Verified every fallback chain in `router_settings.fallbacks` points to aliases defined in `model_list`.
5. Checked trailing whitespace and EOF-newline hygiene on non-Markdown files.
6. Note: `pre-commit` is not currently installed in the project venv, and the installed `uv` (0.7.20) is older than the `>=0.11.8` required by `uv.toml`, so the full hook suite could not be executed locally.

## Demo

N/A

## Type of change

- [x] Feature
- [x] Docs
- [ ] Bug fix
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This change is configuration and documentation only; no Python modules are modified. Manual verification covered YAML validity, alias consistency across the skill and gateway config, env-var coverage, and fallback-chain integrity.

## Changelog

Polly can now route sub-agent calls through a local LiteLLM Gateway with automatic fallback, retry, and cooldown handling.