### PR TITLE
feat: shrink hosts.name from VARCHAR(256) to VARCHAR(64)

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -826,7 +826,8 @@ class SqlHost(Base):
     :param host_id: Stable host identifier from the host's local
         ``~/.omnigent/config.yaml``, e.g. ``"host_a1b2c3d4e5f6..."``.
     :param name: Human-readable name from ``config.yaml``, e.g.
-        ``"corey-laptop"``. Displayed in the Web UI host picker.
+        ``"corey-laptop"``. Displayed in the Web UI host picker. Max 64
+        characters.
     :param owner: User ID from the Databricks auth Bearer token
         presented during the host's WebSocket handshake, e.g.
         ``"corey.zumar@databricks.com"``.
@@ -876,7 +877,7 @@ class SqlHost(Base):
         default=current_workspace_id,
     )
     owner: Mapped[str] = mapped_column(String(256), primary_key=True)
-    name: Mapped[str] = mapped_column(String(256), primary_key=True)
+    name: Mapped[str] = mapped_column(String(64), primary_key=True)
     host_id: Mapped[str] = mapped_column(String(64))
     status: Mapped[str] = mapped_column(String(16))
     created_at: Mapped[int] = mapped_column(Integer)

--- a/omnigent/db/migrations/versions/t1a2b3c4d5e6_hosts_name_varchar64.py
+++ b/omnigent/db/migrations/versions/t1a2b3c4d5e6_hosts_name_varchar64.py
@@ -1,0 +1,67 @@
+"""Shrink hosts.name from VARCHAR(256) to VARCHAR(64).
+
+Revision ID: t1a2b3c4d5e6
+Revises: s1a2b3c4d5e6
+Create Date: 2026-07-07 00:00:00.000000
+
+Host names come from ``~/.omnigent/config.yaml`` and are short identifiers
+like ``"corey-laptop"``. 256 characters is far more than needed; 64 matches
+every other short-identifier column in the schema and keeps the composite
+primary key (workspace_id, owner, name) compact.
+
+No FK constraints reference ``hosts.name`` (all FKs were removed in
+p1a2b3c4d5e6), so no PRAGMA guard is required and no dependent indexes need
+manual rebuilding — the batch rebuild recreates the table DDL from the current
+metadata (String(64)) and the only constraint on ``name`` is its role as a
+composite PK member.
+
+Upgrade path:
+  Batch-rebuild the ``hosts`` table, narrowing ``name`` from VARCHAR(256)
+  to VARCHAR(64). recreate="always" on SQLite (cannot ALTER column types
+  in-place); "auto" on other dialects.
+
+Downgrade path:
+  Batch-rebuild the table, widening ``name`` back to VARCHAR(256).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "t1a2b3c4d5e6"
+down_revision: str | None = "s1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Narrow hosts.name from VARCHAR(256) to VARCHAR(64)."""
+    sqlite = _is_sqlite()
+
+    with op.batch_alter_table("hosts", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.alter_column(
+            "name",
+            existing_type=sa.String(256),
+            type_=sa.String(64),
+            nullable=False,
+        )
+
+
+def downgrade() -> None:
+    """Widen hosts.name back to VARCHAR(256)."""
+    sqlite = _is_sqlite()
+
+    with op.batch_alter_table("hosts", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.alter_column(
+            "name",
+            existing_type=sa.String(64),
+            type_=sa.String(256),
+            nullable=False,
+        )

--- a/tests/db/test_migration_host_name_varchar64.py
+++ b/tests/db/test_migration_host_name_varchar64.py
@@ -1,0 +1,93 @@
+"""Tests for the hosts.name VARCHAR(64) migration (t1a2b3c4d5e6).
+
+Verifies that after upgrade the column is VARCHAR(64) and NOT NULL, and
+that downgrade restores it to VARCHAR(256).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite database with the full migration chain applied (including t1a2b3c4d5e6)."""
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def test_hosts_name_column_is_varchar64(db_engine: Engine) -> None:
+    """After upgrade, hosts.name must be VARCHAR(64) and NOT NULL."""
+    cols = sa.inspect(db_engine).get_columns("hosts")
+    name_cols = [c for c in cols if c["name"] == "name"]
+    assert len(name_cols) == 1, "Expected exactly one 'name' column on hosts"
+    col = name_cols[0]
+    assert not col["nullable"], "hosts.name must be NOT NULL after the migration"
+    col_type = col["type"]
+    assert isinstance(col_type, sa.String), (
+        f"hosts.name must be a String type; got {type(col_type)}"
+    )
+    assert col_type.length == 64, f"hosts.name must be VARCHAR(64); got VARCHAR({col_type.length})"
+
+
+def test_downgrade_restores_varchar256(tmp_path: Path) -> None:
+    """Downgrade to s1a2b3c4d5e6 widens hosts.name back to VARCHAR(256)."""
+    db_path = tmp_path / "downgrade.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+
+    # Insert a host row at head (t1a2b3c4d5e6).
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO hosts "
+                "(workspace_id, owner, name, host_id, status, created_at, updated_at) "
+                "VALUES (0, 'user@example.com', 'my-laptop', 'host_abc123', 'online', "
+                "1700000000, 1700000001)"
+            )
+        )
+        conn.commit()
+
+    # Downgrade one step to s1a2b3c4d5e6.
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, "s1a2b3c4d5e6")
+
+    inspector = sa.inspect(engine)
+    name_col = next(c for c in inspector.get_columns("hosts") if c["name"] == "name")
+    assert not name_col["nullable"], "hosts.name must still be NOT NULL after downgrade"
+    col_type = name_col["type"]
+    assert isinstance(col_type, sa.String), (
+        f"hosts.name must be a String type after downgrade; got {type(col_type)}"
+    )
+    assert col_type.length == 256, (
+        f"hosts.name must be VARCHAR(256) after downgrade; got VARCHAR({col_type.length})"
+    )
+
+    # Existing data should survive the round-trip.
+    with engine.connect() as conn:
+        row = conn.execute(
+            sa.text("SELECT name FROM hosts WHERE owner = 'user@example.com'")
+        ).scalar_one_or_none()
+    assert row == "my-laptop", f"Existing host name should survive downgrade; got {row!r}"
+
+    engine.dispose()
+    clear_engine_cache()


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `SqlHost.name` was `String(256)`; host names are short config-file identifiers (e.g. `"corey-laptop"`) that never approach 256 chars. Narrowing to `String(64)` aligns this column with every other short-identifier column in the schema.
- Adds Alembic migration `t1a2b3c4d5e6` (down_revision `s1a2b3c4d5e6`) that batch-rebuilds the `hosts` table on SQLite and runs an in-place `ALTER COLUMN` on other dialects.
- The `name` column is a composite PK member (`workspace_id`, `owner`, `name`). No FK constraints reference it (all FKs were removed in `p1a2b3c4d5e6`), so no cascade or PRAGMA guard is needed.

## Test Plan

- Ran `uv run omnigent debug db-upgrade sqlite:////Users/tomu.hirata/.omnigent/chat.db` against a real database; confirmed `hosts.name` is now `VARCHAR(64)` via SQLAlchemy inspection.
- `uv run pytest tests/db/test_migration_host_name_varchar64.py -v` — 2 new tests pass (upgrade asserts VARCHAR(64); downgrade asserts VARCHAR(256) and data survives round-trip).
- `uv run pytest tests/db/ tests/stores/ -q` — 607 passed, 3 pre-existing failures unrelated to this change (missing `psycopg` module for PostgreSQL URI tests).
- `pre-commit run --all-files` — all hooks pass.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New migration test covers both upgrade (VARCHAR(64)) and downgrade (VARCHAR(256)) paths including a data round-trip.