### PR TITLE
feat(terminals): native "+ New shell" honors $SHELL and offers installed shells

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -273,12 +273,21 @@ os_env:
   sandbox:
     type: none
 
-# Generic shell terminal for long-running processes (dev servers, watchers, log
+# Generic shell terminals for long-running processes (dev servers, watchers, log
 # tails) and ad-hoc shell when sys_os_shell's blocking model doesn't fit. NOT
 # for launching coding agents / sub-agents — those go through sys_session_send.
+# bash and zsh are both offered; the "+ New shell" affordance picks between them.
 terminals:
   shell:
     command: bash
+    allow_cwd_override: true
+    os_env:
+      type: caller_process
+      cwd: .
+      sandbox:
+        type: none
+  zsh:
+    command: zsh
     allow_cwd_override: true
     os_env:
       type: caller_process

--- a/omnigent/_platform.py
+++ b/omnigent/_platform.py
@@ -91,6 +91,66 @@ def default_shell_argv(command: str) -> list[str]:
     return [sh, "-c", command]
 
 
+#: Interactive shells we honor from ``$SHELL`` for a user terminal. Anything
+#: outside this set (or a ``$SHELL`` that doesn't resolve on PATH) falls back to
+#: bash for a predictable pane.
+_KNOWN_INTERACTIVE_SHELLS = frozenset({"bash", "zsh", "fish", "sh", "dash", "ksh", "tcsh"})
+
+#: Mainstream interactive shells we proactively offer as launch choices (the
+#: "New shell" picker), in display order. The user's ``$SHELL`` is always
+#: offered first regardless (see :func:`installed_interactive_shells`); this is
+#: the set of well-known alternatives we surface beyond it.
+_OFFERED_INTERACTIVE_SHELLS = ("bash", "zsh", "fish")
+
+
+def default_interactive_shell() -> str:
+    """
+    Basename of the user's login shell for an interactive terminal.
+
+    Reads ``$SHELL`` and keeps its basename when it names a known shell that
+    resolves on PATH; otherwise falls back to ``"bash"``. Returns a basename
+    (not the absolute ``$SHELL`` path) so it stays PATH-resolvable when the
+    terminal launches under a runner on a different host than the one that read
+    the env.
+
+    :returns: A shell basename such as ``"zsh"``, ``"fish"``, or ``"bash"``.
+    """
+    if IS_WINDOWS:
+        # Native tmux/PTY terminals are unsupported on Windows anyway.
+        return "bash"
+    import shutil
+
+    name = os.path.basename(os.environ.get("SHELL", "")).strip()
+    if name in _KNOWN_INTERACTIVE_SHELLS and shutil.which(name):
+        return name
+    return "bash"
+
+
+def installed_interactive_shells() -> list[str]:
+    """
+    Ordered, deduped shell basenames to offer for a new interactive terminal.
+
+    The user's login shell (:func:`default_interactive_shell`) comes first — so
+    the "New shell" affordance can treat entry ``[0]`` as the click default —
+    followed by any mainstream alternatives (bash/zsh/fish) that resolve on
+    PATH. Always non-empty (the default is always present, and bash is the
+    ultimate fallback).
+
+    :returns: Basenames such as ``["zsh", "bash", "fish"]`` — the default first.
+    """
+    ordered = [default_interactive_shell()]
+    if IS_WINDOWS:
+        # Native tmux/PTY terminals are unsupported on Windows anyway; the lone
+        # bash default from above is all we can meaningfully offer.
+        return ordered
+    import shutil
+
+    for name in _OFFERED_INTERACTIVE_SHELLS:
+        if name not in ordered and shutil.which(name):
+            ordered.append(name)
+    return ordered
+
+
 def stable_user_id() -> str:
     """
     A stable, filesystem-safe token identifying the current OS user.

--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -124,6 +124,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -313,18 +314,9 @@ def _materialize_antigravity_agent_spec(tmpdir: Path) -> Path:
         # the ``sys_terminal_*`` family to the wrapped agy (the relay's gate is
         # a non-empty ``terminals:`` block on this spec). This also feeds the
         # web-UI new-terminal affordance (``server/routes/sessions.py``), so it
-        # is not inert even independent of the relay.
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # is not inert even independent of the relay. Its command follows the
+        # user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -89,6 +89,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -1785,20 +1786,10 @@ def _materialize_claude_agent_spec(tmpdir: Path) -> Path:
         # Declare a default shell terminal so the relay advertises the
         # ``sys_terminal_*`` family to the wrapped Claude Code (the
         # relay's gate is a non-empty ``terminals:`` block on this
-        # spec). Caller process / no sandbox matches the ``os_env``
-        # stance above — the native CLI already runs unsandboxed on
-        # the user's workspace.
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # spec). Its command follows the user's ``$SHELL`` (zsh/fish/bash);
+        # caller process / no sandbox matches the ``os_env`` stance above —
+        # the native CLI already runs unsandboxed on the user's workspace.
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False))
     return yaml_path

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -66,6 +66,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -526,21 +527,11 @@ def _materialize_codex_agent_spec(
         },
         # Declare a default shell terminal so the relay advertises the
         # ``sys_terminal_*`` family to the wrapped codex (the relay's
-        # gate is a non-empty ``terminals:`` block on this spec).
-        # Caller process / no sandbox matches the ``os_env`` stance
-        # above — the native CLI already runs unsandboxed on the
-        # user's workspace.
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # gate is a non-empty ``terminals:`` block on this spec). Its
+        # command follows the user's ``$SHELL`` (zsh/fish/bash); caller
+        # process / no sandbox matches the ``os_env`` stance above — the
+        # native CLI already runs unsandboxed on the user's workspace.
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -41,6 +41,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -334,17 +335,9 @@ def _materialize_cursor_agent_spec(tmpdir: Path) -> Path:
             "cwd": ".",
             "sandbox": {"type": "none"},
         },
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # Default shell terminal for the web-UI "+ New shell" affordance;
+        # its command follows the user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/omnigent/goose_native.py
+++ b/omnigent/goose_native.py
@@ -43,6 +43,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -206,17 +207,9 @@ def _materialize_goose_agent_spec(tmpdir: Path) -> Path:
             "cwd": ".",
             "sandbox": {"type": "none"},
         },
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # Default shell terminal for the web-UI "+ New shell" affordance;
+        # its command follows the user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/omnigent/hermes_native.py
+++ b/omnigent/hermes_native.py
@@ -42,6 +42,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -204,17 +205,9 @@ def _materialize_hermes_agent_spec(tmpdir: Path) -> Path:
             "cwd": ".",
             "sandbox": {"type": "none"},
         },
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # Default shell terminal for the web-UI "+ New shell" affordance;
+        # its command follows the user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -40,6 +40,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -209,17 +210,9 @@ def _materialize_kimi_agent_spec(tmpdir: Path) -> Path:
             "cwd": ".",
             "sandbox": {"type": "none"},
         },
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # Default shell terminal for the web-UI "+ New shell" affordance;
+        # its command follows the user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -28,6 +28,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -230,17 +231,9 @@ def _materialize_kiro_agent_spec(tmpdir: Path, *, model: str | None = None) -> P
             "cwd": ".",
             "sandbox": {"type": "none"},
         },
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # Default shell terminal for the web-UI "+ New shell" affordance;
+        # its command follows the user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/omnigent/native_coding_agents.py
+++ b/omnigent/native_coding_agents.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from omnigent._platform import installed_interactive_shells
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_plugins import (
     NativeCodingAgent,
@@ -60,3 +63,33 @@ def native_coding_agent_for_wrapper_label(wrapper: str | None) -> NativeCodingAg
 def native_coding_agent_for_terminal_name(name: str | None) -> NativeCodingAgent | None:
     """Return the native coding-agent metadata for *name*, if any."""
     return _BY_TERMINAL_NAME.get(name or "")
+
+
+def native_shell_terminal_spec() -> dict[str, Any]:
+    """The user-shell terminals every native wrapper declares.
+
+    Native sessions expose the web UI's "+ New shell" affordance, which lets a
+    user open an interactive shell. We declare one terminal per installed shell
+    (:func:`omnigent._platform.installed_interactive_shells`), keyed and
+    commanded by the shell basename (``zsh``/``bash``/``fish``), with the user's
+    ``$SHELL`` first so the UI can treat it as the click default and offer the
+    rest behind a picker. ``caller_process`` / no sandbox matches the native
+    CLI's own unsandboxed stance on the user's workspace. The block is always
+    non-empty, which is also what gates the MCP relay's ``sys_terminal_*``
+    advertisement.
+
+    :returns: A ``terminals:`` mapping, e.g. ``{"zsh": {...}, "bash": {...}}``,
+        with the user's login shell first.
+    """
+    return {
+        shell: {
+            "command": shell,
+            "allow_cwd_override": True,
+            "os_env": {
+                "type": "caller_process",
+                "cwd": ".",
+                "sandbox": {"type": "none"},
+            },
+        }
+        for shell in installed_interactive_shells()
+    }

--- a/omnigent/opencode_native.py
+++ b/omnigent/opencode_native.py
@@ -44,6 +44,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -100,18 +101,9 @@ def _materialize_opencode_agent_spec(
         },
         # Declare a default shell terminal so the relay advertises the
         # ``sys_terminal_*`` family to the wrapped opencode (the relay's gate
-        # is a non-empty ``terminals:`` block on this spec).
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # is a non-empty ``terminals:`` block on this spec). Its command
+        # follows the user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -28,6 +28,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -185,17 +186,9 @@ def _materialize_pi_agent_spec(tmpdir: Path) -> Path:
             "cwd": ".",
             "sandbox": {"type": "none"},
         },
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # Default shell terminal for the web-UI "+ New shell" affordance;
+        # its command follows the user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/omnigent/qwen_native.py
+++ b/omnigent/qwen_native.py
@@ -43,6 +43,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
 )
@@ -204,17 +205,9 @@ def _materialize_qwen_agent_spec(tmpdir: Path) -> Path:
             "cwd": ".",
             "sandbox": {"type": "none"},
         },
-        "terminals": {
-            "shell": {
-                "command": "bash",
-                "allow_cwd_override": True,
-                "os_env": {
-                    "type": "caller_process",
-                    "cwd": ".",
-                    "sandbox": {"type": "none"},
-                },
-            },
-        },
+        # Default shell terminal for the web-UI "+ New shell" affordance;
+        # its command follows the user's ``$SHELL`` (zsh/fish/bash).
+        "terminals": native_shell_terminal_spec(),
     }
     yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return yaml_path

--- a/tests/inner/test_proc_and_platform.py
+++ b/tests/inner/test_proc_and_platform.py
@@ -44,6 +44,79 @@ def test_default_shell_argv_runs_an_echo() -> None:
     assert "omnigent-shell-ok" in out.stdout
 
 
+@pytest.mark.posix_only
+def test_default_interactive_shell_honors_known_shell_on_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``$SHELL`` naming a known shell that resolves on PATH is kept.
+
+    Returns the basename (not the ``$SHELL`` path) so it stays resolvable
+    when the terminal launches under a runner on a different host.
+    """
+    # Patch shutil.which on the shared module so the function's local
+    # ``import shutil`` sees the fake; make every known shell "installed".
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    for shell_path, expected in (
+        ("/bin/zsh", "zsh"),
+        ("/usr/local/bin/fish", "fish"),
+        ("/bin/bash", "bash"),
+    ):
+        monkeypatch.setenv("SHELL", shell_path)
+        assert _platform.default_interactive_shell() == expected
+
+
+@pytest.mark.posix_only
+def test_default_interactive_shell_falls_back_to_bash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset / unknown / not-on-PATH ``$SHELL`` all fall back to bash."""
+    # Unset $SHELL → bash (known shells resolve on PATH here).
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("SHELL", raising=False)
+    assert _platform.default_interactive_shell() == "bash"
+    # An unknown shell name is never honored, even if on PATH.
+    monkeypatch.setenv("SHELL", "/opt/weird/nushell")
+    assert _platform.default_interactive_shell() == "bash"
+    # A known shell that does not resolve on PATH also falls back.
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    assert _platform.default_interactive_shell() == "bash"
+
+
+@pytest.mark.posix_only
+def test_installed_interactive_shells_lists_default_first_then_alternatives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default ($SHELL) leads; installed alternatives follow, deduped."""
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    # zsh is the default → first; bash/fish follow in offer order; no dupes.
+    assert _platform.installed_interactive_shells() == ["zsh", "bash", "fish"]
+
+
+@pytest.mark.posix_only
+def test_installed_interactive_shells_skips_uninstalled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Alternatives that don't resolve on PATH are omitted."""
+    # Only bash and zsh installed; fish absent.
+    monkeypatch.setattr(
+        "shutil.which", lambda name: f"/usr/bin/{name}" if name in {"bash", "zsh"} else None
+    )
+    monkeypatch.setenv("SHELL", "/bin/bash")
+    assert _platform.installed_interactive_shells() == ["bash", "zsh"]
+
+
+@pytest.mark.posix_only
+def test_installed_interactive_shells_always_nonempty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With nothing resolvable the bash fallback is still offered alone."""
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.delenv("SHELL", raising=False)
+    assert _platform.installed_interactive_shells() == ["bash"]
+
+
 def test_stable_user_id_is_stable_and_path_safe() -> None:
     uid = _platform.stable_user_id()
     assert uid == _platform.stable_user_id()

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -546,7 +546,9 @@ def test_attach_url_encodes_path_components() -> None:
     )
 
 
-def test_materialized_session_spec_is_valid_terminal_metadata(tmp_path: Path) -> None:
+def test_materialized_session_spec_is_valid_terminal_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """
     The generated bundled agent spec validates for Omnigent session creation.
 
@@ -554,6 +556,10 @@ def test_materialized_session_spec_is_valid_terminal_metadata(tmp_path: Path) ->
     normal session row; Claude itself is launched as a terminal
     resource after creation, not through this executor block.
     """
+    # Pin the host shells so the declared terminals are deterministic
+    # ($SHELL=bash → the default/first terminal is ``bash``).
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setenv("SHELL", "/bin/bash")
     path = claude_native._materialize_claude_agent_spec(tmp_path)
 
     raw = yaml.safe_load(path.read_text())
@@ -581,13 +587,12 @@ def test_materialized_session_spec_is_valid_terminal_metadata(tmp_path: Path) ->
     # sys_session_create/send/close from the native CLI.
     assert raw["spawn"] is True
     assert spec.spawn is True
-    # The native wrapper declares a default shell terminal so the
-    # relay advertises the sys_terminal_* family to the wrapped
-    # Claude Code (the relay gate is a non-empty ``terminals:``
-    # block on this spec); a dropped block silently removes the
-    # terminal tools from the native CLI.
+    # The native wrapper declares one terminal per installed shell so the
+    # relay advertises the sys_terminal_* family to the wrapped Claude Code
+    # (the relay gate is a non-empty ``terminals:`` block on this spec); a
+    # dropped block silently removes the terminal tools from the native CLI.
     assert spec.terminals is not None
-    assert spec.terminals["shell"].command == "bash"
+    assert spec.terminals["bash"].command == "bash"
 
 
 def test_remote_run_preflights_local_claude_binary(

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -635,12 +635,18 @@ def _elicitation_tracker() -> codex_native_forwarder._CodexElicitationTaskTracke
     return codex_native_forwarder._CodexElicitationTaskTracker()
 
 
-def test_materialize_codex_agent_spec_uses_codex_native_harness(tmp_path: Path) -> None:
+def test_materialize_codex_agent_spec_uses_codex_native_harness(
+    tmp_path: Path, monkeypatch
+) -> None:
     """
     The generated wrapper spec is self-contained and selects the
     isolated ``codex-native`` harness rather than the existing
     non-TUI ``codex`` harness.
     """
+    # Pin the host shells so the declared terminals are deterministic
+    # ($SHELL=bash → the default/first terminal is ``bash``).
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setenv("SHELL", "/bin/bash")
     spec_path = codex_native._materialize_codex_agent_spec(
         tmp_path,
         model="gpt-test",
@@ -682,13 +688,12 @@ def test_materialized_codex_agent_spec_loads_as_valid_omnigent_yaml(
     # via ToolManager, so a dropped flag silently removes
     # sys_session_create/send/close from the native CLI.
     assert spec.spawn is True
-    # The native wrapper declares a default shell terminal so the
-    # relay advertises the sys_terminal_* family to the wrapped
-    # codex (the relay gate is a non-empty ``terminals:`` block on
-    # this spec); a dropped block silently removes the terminal
-    # tools from the native CLI.
+    # The native wrapper declares one terminal per installed shell so the
+    # relay advertises the sys_terminal_* family to the wrapped codex (the
+    # relay gate is a non-empty ``terminals:`` block on this spec); a
+    # dropped block silently removes the terminal tools from the native CLI.
     assert spec.terminals is not None
-    assert spec.terminals["shell"].command == "bash"
+    assert spec.terminals["bash"].command == "bash"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_hermes_native.py
+++ b/tests/test_hermes_native.py
@@ -95,15 +95,22 @@ def test_create_app_builds() -> None:
 # --- CLI orchestration helpers (no server/daemon needed) ----------------------
 
 
-def test_materialize_agent_spec_is_terminal_first_hermes_native(tmp_path) -> None:
+def test_materialize_agent_spec_is_terminal_first_hermes_native(tmp_path, monkeypatch) -> None:
     import yaml
 
+    # Pin the host shells so the declared terminals are deterministic: zsh is
+    # $SHELL (default, first), bash/fish resolve on PATH.
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
     spec_path = hn._materialize_hermes_agent_spec(tmp_path)
     raw = yaml.safe_load(spec_path.read_text())
     assert raw["name"] == "hermes-native-ui"
     assert raw["executor"] == {"harness": "hermes-native"}
     assert raw["spawn"] is True
-    assert "shell" in raw["terminals"]
+    # One terminal per installed shell, $SHELL first — a non-empty block also
+    # gates the MCP relay's sys_terminal_* advertisement.
+    assert list(raw["terminals"]) == ["zsh", "bash", "fish"]
+    assert raw["terminals"]["zsh"]["command"] == "zsh"
 
 
 def test_configured_hermes_command_default_and_override() -> None:

--- a/tests/test_native_coding_agents.py
+++ b/tests/test_native_coding_agents.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from omnigent._wrapper_labels import (
     KIRO_NATIVE_WRAPPER_VALUE,
     PI_NATIVE_WRAPPER_VALUE,
@@ -13,6 +15,7 @@ from omnigent.harness_plugins import KIRO_NATIVE_CODING_AGENT, PI_NATIVE_CODING_
 from omnigent.native_coding_agents import (
     native_coding_agent_for_harness,
     native_coding_agent_for_wrapper_label,
+    native_shell_terminal_spec,
     public_agent_name,
 )
 
@@ -106,3 +109,40 @@ def test_public_agent_name_passes_through_regular_names() -> None:
     assert public_agent_name("nessie") == "nessie"
     assert public_agent_name("") == ""
     assert public_agent_name(None) is None
+
+
+@pytest.mark.posix_only
+def test_native_shell_terminal_spec_offers_installed_shells_default_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One terminal per installed shell, keyed by name, ``$SHELL`` first.
+
+    Every native wrapper declares this so "+ New shell" opens the user's login
+    shell by default while still offering the other installed shells. Each entry
+    is keyed and commanded by its basename and is an unsandboxed caller-process
+    shell with cwd override allowed.
+    """
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setenv("SHELL", "/usr/local/bin/fish")
+    spec = native_shell_terminal_spec()
+    # $SHELL (fish) leads, then the remaining offered shells in order.
+    assert list(spec) == ["fish", "bash", "zsh"]
+    for name, entry in spec.items():
+        assert entry["command"] == name
+        assert entry["allow_cwd_override"] is True
+        assert entry["os_env"] == {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {"type": "none"},
+        }
+
+
+def test_native_shell_terminal_spec_falls_back_to_bash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no shells installed the spec still offers a single bash terminal."""
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.delenv("SHELL", raising=False)
+    spec = native_shell_terminal_spec()
+    assert list(spec) == ["bash"]
+    assert spec["bash"]["command"] == "bash"

--- a/tests/test_opencode_native.py
+++ b/tests/test_opencode_native.py
@@ -49,11 +49,17 @@ class _FakeClient:
 # ── _materialize_opencode_agent_spec ────────────────────────────────────────
 
 
-def test_materialize_spec_defaults_no_model(tmp_path: Path) -> None:
+def test_materialize_spec_defaults_no_model(tmp_path: Path, monkeypatch) -> None:
+    # Pin the host shells so the declared terminals are deterministic.
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
     spec = yaml.safe_load(_materialize_opencode_agent_spec(tmp_path).read_text())
     assert spec["executor"] == {"harness": "opencode-native"}
     assert spec["spawn"] is True
-    assert "shell" in spec["terminals"]
+    # One terminal per installed shell, $SHELL first — a non-empty block gates
+    # the relay's sys_terminal_* advertisement.
+    assert list(spec["terminals"]) == ["zsh", "bash", "fish"]
+    assert spec["terminals"]["zsh"]["command"] == "zsh"
 
 
 def test_materialize_spec_pins_model(tmp_path: Path) -> None:

--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -51,9 +51,11 @@ export interface Agent {
   /** Guardrails policies declared on the agent. Empty when none configured. */
   policies?: PolicySummary[];
   /** Terminal names declared in the spec's `terminals:` block, in
-   * declaration order (e.g. ["shell"]). Gates the "new terminal"
-   * affordance: empty means the agent has no terminal access and the
-   * UI must not offer creation. Only populated by `useSessionAgent`. */
+   * declaration order (e.g. ["shell"], or ["zsh", "bash"] for a native
+   * session offering the host's installed shells, default first). Gates
+   * the "new terminal" affordance: empty means the agent has no terminal
+   * access and the UI must not offer creation. Only populated by
+   * `useSessionAgent`. */
   terminals?: string[];
 }
 

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -298,7 +298,8 @@ export async function fetchTerminals(conversationId: string): Promise<TerminalIn
  * :param conversationId: Session/conversation identifier,
  *     e.g. ``"conv_abc123"``.
  * :param terminal: Declared terminal name from the agent spec,
- *     e.g. ``"shell"``.
+ *     e.g. ``"shell"`` (or a shell basename like ``"zsh"`` for a native
+ *     session offering the host's installed shells).
  * :returns: The created terminal mapped to :class:`TerminalInfo`.
  * :raises Error: When the server rejects the create (e.g. the agent
  *     has no terminal access) or the launch fails.

--- a/web/src/shell/NewTerminalButton.test.tsx
+++ b/web/src/shell/NewTerminalButton.test.tsx
@@ -10,6 +10,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NewTerminalButton } from "./NewTerminalButton";
+import type { TerminalFirstContextValue } from "./TerminalFirstContext";
+import { TerminalFirstContextProvider } from "./TerminalFirstContext";
 
 function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
   return {
@@ -27,13 +29,34 @@ function agentWire(terminals: string[]): Record<string, unknown> {
   return { id: "ag_1", object: "agent", name: "test-agent", terminals };
 }
 
-function renderButton(onCreated?: (key: string) => void, variant?: "icon" | "row") {
+/** Minimal TerminalFirst context; only `isNativeWrapper` matters here. */
+function terminalFirstCtx(isNativeWrapper: boolean): TerminalFirstContextValue {
+  return {
+    isClaudeNative: false,
+    isNativeWrapper,
+    isTerminalFirst: isNativeWrapper,
+    isShellView: false,
+    view: "chat",
+    terminalViewKey: null,
+    setView: () => {},
+    terminalsAvailable: true,
+    terminalStartingUp: false,
+  } as TerminalFirstContextValue;
+}
+
+function renderButton(
+  onCreated?: (key: string) => void,
+  variant?: "icon" | "row",
+  isNativeWrapper = false,
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <NewTerminalButton conversationId="conv_abc" onCreated={onCreated} variant={variant} />
+      <TerminalFirstContextProvider value={terminalFirstCtx(isNativeWrapper)}>
+        <NewTerminalButton conversationId="conv_abc" onCreated={onCreated} variant={variant} />
+      </TerminalFirstContextProvider>
     </QueryClientProvider>,
   );
 }
@@ -123,5 +146,98 @@ describe("NewTerminalButton access gate", () => {
     // Same create + focus contract as the icon variant — a divergence
     // means the variants forked behavior, not just presentation.
     await waitFor(() => expect(onCreated).toHaveBeenCalledWith("terminal:terminal_shell_u-x2"));
+  });
+});
+
+/**
+ * Wire a fetch mock that answers the agent query with the given declared
+ * terminals and echoes any create POST back as a terminal resource whose
+ * ``terminal_name`` is the launched name.
+ */
+function mockAgentAndCreate(terminals: string[]): void {
+  fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+    if (init?.method === "POST") {
+      const name = JSON.parse(init.body as string).terminal as string;
+      return mockResponse({
+        id: `terminal_${name}_u-xx`,
+        object: "session.resource",
+        type: "terminal",
+        session_id: "conv_abc",
+        name: `${name}:u-xx`,
+        metadata: { terminal_name: name, session_key: "u-xx", running: true },
+      });
+    }
+    return mockResponse(agentWire(terminals));
+  });
+}
+
+/** The POST body's ``terminal`` field for the single create call made so far. */
+function launchedTerminal(): string {
+  const postCall = fetchMock.mock.calls.find(
+    (call) => (call[1] as RequestInit | undefined)?.method === "POST",
+  ) as [string, RequestInit];
+  return JSON.parse(postCall[1].body as string).terminal;
+}
+
+describe("NewTerminalButton native shell picker", () => {
+  it("split button launches the default shell (declared[0]) on primary click", async () => {
+    // Native wrapper declares the host's installed shells, $SHELL first.
+    mockAgentAndCreate(["zsh", "bash", "fish"]);
+    const onCreated = vi.fn();
+
+    renderButton(onCreated, "icon", true);
+
+    // Primary segment is the "New shell" button; the caret is separate.
+    const primary = await screen.findByRole("button", { name: /^new shell$/i });
+    fireEvent.click(primary);
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith("terminal:terminal_zsh_u-xx"));
+    // The default ($SHELL, first) launches directly — no menu interaction.
+    expect(launchedTerminal()).toBe("zsh");
+  });
+
+  it("caret opens a picker that can launch a non-default shell", async () => {
+    mockAgentAndCreate(["zsh", "bash", "fish"]);
+    const onCreated = vi.fn();
+
+    renderButton(onCreated, "icon", true);
+
+    // Open the picker via the caret, then choose fish (not the default).
+    // Radix menus open on pointerdown, not click.
+    const caret = await screen.findByRole("button", { name: /choose shell/i });
+    fireEvent.pointerDown(caret, { button: 0 });
+    const fishItem = await screen.findByRole("menuitem", { name: /^fish$/ });
+    // While the menu is open: the default entry is labeled as such; the
+    // others are bare names. (Radix unmounts the menu on select, so this
+    // must be checked before clicking.)
+    expect(screen.queryByRole("menuitem", { name: /zsh \(default\)/i })).not.toBeNull();
+    fireEvent.click(fishItem);
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith("terminal:terminal_fish_u-xx"));
+    expect(launchedTerminal()).toBe("fish");
+  });
+
+  it("SDK agent with multiple terminals keeps a plain dropdown (no default click)", async () => {
+    // Not a native wrapper: distinct-purpose terminals, no privileged default.
+    mockAgentAndCreate(["worker", "shell"]);
+    const onCreated = vi.fn();
+
+    renderButton(onCreated, "icon", false);
+
+    // The whole control is the dropdown trigger — opening it (Radix opens on
+    // pointerdown) reveals the menu rather than launching anything, and there
+    // is no separate caret.
+    expect(screen.queryByRole("button", { name: /choose shell/i })).toBeNull();
+    const trigger = await screen.findByRole("button", { name: /new shell/i });
+    fireEvent.pointerDown(trigger, { button: 0 });
+    // No launch happened from opening the menu.
+    expect(
+      fetchMock.mock.calls.some((c) => (c[1] as RequestInit | undefined)?.method === "POST"),
+    ).toBe(false);
+    // Picking the first entry launches it verbatim, unlabeled.
+    const workerItem = await screen.findByRole("menuitem", { name: /^worker$/ });
+    fireEvent.click(workerItem);
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith("terminal:terminal_worker_u-xx"));
+    expect(launchedTerminal()).toBe("worker");
   });
 });

--- a/web/src/shell/NewTerminalButton.tsx
+++ b/web/src/shell/NewTerminalButton.tsx
@@ -10,10 +10,17 @@
 // never sees the button, and a user-created terminal is always one
 // the agent can list/read/close.
 //
-// One declared name creates directly on click; multiple names open a
-// dropdown to pick which declared terminal to launch.
+// Behavior by declared-terminal shape:
+//   - One declared name → creates it directly on click.
+//   - Native-wrapper session with several names → these are the host's
+//     installed shells (zsh/bash/fish), declared with `$SHELL` first
+//     (see `native_shell_terminal_spec`). Renders a SPLIT button:
+//     clicking the primary opens the default (`declared[0]`, the user's
+//     `$SHELL`), and a caret opens a picker of all installed shells.
+//   - SDK agent with several names → distinct-purpose terminals with no
+//     "default", so a plain dropdown to pick which one to launch.
 
-import { PlusIcon } from "lucide-react";
+import { ChevronDownIcon, PlusIcon } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -23,6 +30,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useSessionAgent } from "@/hooks/useAgents";
 import { terminalTabKey, useCreateTerminal } from "@/hooks/useTerminals";
+import { useTerminalFirst } from "./TerminalFirstContext";
 
 interface NewTerminalButtonProps {
   conversationId: string;
@@ -50,6 +58,11 @@ export function NewTerminalButton({
 }: NewTerminalButtonProps) {
   const { data: agent } = useSessionAgent(conversationId);
   const create = useCreateTerminal(conversationId);
+  // Native-wrapper sessions declare the host's installed shells as their
+  // terminals (default `$SHELL` first); SDK agents declare distinct-purpose
+  // terminals with no default. Only the native case gets the split-button
+  // shell picker — see the file header.
+  const isNativeWrapper = useTerminalFirst()?.isNativeWrapper ?? false;
   const declared = agent?.terminals ?? [];
   // The iff gate, UI side: no declared terminals → no affordance.
   if (declared.length === 0) return null;
@@ -60,9 +73,18 @@ export function NewTerminalButton({
     });
   };
 
+  const isShellPicker = isNativeWrapper && declared.length > 1;
+
   // Single declared name: create directly on click. Multiple: the
-  // DropdownMenuTrigger wrapper below owns the click instead.
-  const onTriggerClick = declared.length === 1 ? () => launch(declared[0]) : undefined;
+  // DropdownMenuTrigger wrapper below owns the click instead — except the
+  // native shell-picker split button, whose primary segment launches the
+  // default shell directly (`declared[0]`) and whose caret owns the dropdown.
+  const onTriggerClick =
+    declared.length === 1
+      ? () => launch(declared[0])
+      : isShellPicker
+        ? () => launch(declared[0])
+        : undefined;
   const trigger =
     variant === "row" ? (
       <button
@@ -107,16 +129,55 @@ export function NewTerminalButton({
 
   if (declared.length === 1) return withTooltip(trigger);
 
+  // Dropdown listing every declared terminal. In the shell-picker case the
+  // first entry is the `$SHELL` default, so it is labeled as such.
+  const menu = (
+    <DropdownMenuContent align={variant === "row" ? "start" : "end"}>
+      {declared.map((name, i) => (
+        <DropdownMenuItem key={name} onSelect={() => launch(name)}>
+          {isShellPicker && i === 0 ? `${name} (default)` : name}
+        </DropdownMenuItem>
+      ))}
+    </DropdownMenuContent>
+  );
+
+  // SDK agent with multiple distinct-purpose terminals: the whole control is
+  // the dropdown trigger (no privileged default to click).
+  if (!isShellPicker) {
+    return (
+      <DropdownMenu>
+        {withTooltip(<DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>)}
+        {menu}
+      </DropdownMenu>
+    );
+  }
+
+  // Native shell picker: split button. `trigger` (primary) launches the
+  // default shell; the adjacent caret opens the installed-shell picker.
+  const caret = (
+    <DropdownMenuTrigger asChild>
+      <button
+        type="button"
+        aria-label="Choose shell"
+        disabled={create.isPending}
+        className={
+          variant === "row"
+            ? "flex shrink-0 items-center px-2 py-1.5 text-muted-foreground hover:bg-accent/60 hover:text-foreground disabled:cursor-default disabled:opacity-50"
+            : "cursor-pointer rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-default disabled:opacity-50"
+        }
+      >
+        <ChevronDownIcon className="size-3.5" />
+      </button>
+    </DropdownMenuTrigger>
+  );
+
   return (
     <DropdownMenu>
-      {withTooltip(<DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>)}
-      <DropdownMenuContent align={variant === "row" ? "start" : "end"}>
-        {declared.map((name) => (
-          <DropdownMenuItem key={name} onSelect={() => launch(name)}>
-            {name}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
+      <div className={variant === "row" ? "flex w-full items-center" : "flex items-center"}>
+        {withTooltip(trigger)}
+        {caret}
+      </div>
+      {menu}
     </DropdownMenu>
   );
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Native-harness sessions (`omnigent claude`/`codex`/`pi`/etc.) previously always opened bash for "+ New shell"; they now open the user's login shell.
- `omnigent/_platform.py`: add `default_interactive_shell()` (basename of `$SHELL` when it names a known shell on PATH, else bash) and `installed_interactive_shells()` (that default first, then any of bash/zsh/fish on PATH; always non-empty).
- `omnigent/native_coding_agents.py`: `native_shell_terminal_spec()` now declares one unsandboxed caller-process terminal per installed shell, keyed and commanded by the shell basename, `$SHELL` first. The 11 native wrappers call this shared helper instead of a hardcoded `{"shell": {"command": "bash"}}` block.
- `web/src/shell/NewTerminalButton.tsx`: branch on `useTerminalFirst().isNativeWrapper` — native sessions with multiple shells get a split button (primary click launches the `$SHELL` default; a caret opens a picker of installed shells, default labeled). SDK agents with multiple distinct-purpose terminals keep the existing plain dropdown unchanged.
- `examples/polly/config.yaml`: add a `zsh` terminal alongside the existing bash `shell` for the builtin polly agent.

## Test Plan

- `uv run pytest tests/inner/test_proc_and_platform.py tests/test_native_coding_agents.py` — new unit tests for shell detection and the multi-shell spec.
- `uv run pytest -k "native and (materialize or terminal or agent_spec)"` — 296 passed, including the runner create-session-terminal flow; updated 4 native wrapper tests that asserted the old single-`shell` shape.
- `npx vitest run src/shell/NewTerminalButton.test.tsx` (+ related shell suites) — split-button default launch, caret pick of a non-default shell, and SDK dropdown-unchanged cases.
- ruff check/format, prettier, oxlint, and tsc clean on all touched files.
- Verified polly's YAML parses through `_parse_terminals` with both `shell` (bash) and `zsh` terminals.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Shell detection, the native multi-shell spec, and the frontend split-button behavior are covered by new/updated unit tests (pytest + vitest). Manually verified that `default_interactive_shell()`/`installed_interactive_shells()` resolve the host's shells, all 11 native wrappers import cycle-free, and polly's edited YAML parses through Omnigent's real terminal parser. The live end-to-end (clicking "+ New shell" in a running native session and confirming the shell that opens) was not exercised here as it needs an interactive session.
