### PR TITLE
fix(web): keep queued messages FIFO when status flickers idle

### DIFF
--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -42,7 +42,8 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
 }));
 import type { ElicitationBlock } from "@/lib/blocks";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { Composer } from "./ChatPage";
+import { Composer, shouldQueueSend } from "./ChatPage";
+import type { QueuedMessage } from "@/store/chatStore";
 import { SlashCommandMenu } from "@/components/SlashCommandMenu";
 
 // These tests pin the slash-command suggestions menu UX in the composer:
@@ -1220,5 +1221,39 @@ describe("Composer — queued-message flush gating", () => {
     await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1));
     expect(sendSpy.mock.calls[0]!.slice(0, 2)).toEqual(["held", "agent_xyz"]);
     expect(useChatStore.getState().queuedMessages).toHaveLength(0);
+  });
+});
+
+describe("shouldQueueSend", () => {
+  const q = (conversationId: string): QueuedMessage => ({
+    queueId: `q_${conversationId}`,
+    text: "queued",
+    conversationId,
+  });
+
+  it("sends directly (no queue) for a brand-new chat with no conversation", () => {
+    // A new chat must POST so the session gets created — never queue.
+    expect(shouldQueueSend(null, "streaming", "running", [])).toBe(false);
+  });
+
+  it("queues while the session is busy (streaming or running/waiting)", () => {
+    expect(shouldQueueSend("conv_a", "streaming", "idle", [])).toBe(true);
+    expect(shouldQueueSend("conv_a", "idle", "running", [])).toBe(true);
+    expect(shouldQueueSend("conv_a", "idle", "waiting", [])).toBe(true);
+  });
+
+  it("sends directly when idle and nothing is queued for this conversation", () => {
+    expect(shouldQueueSend("conv_a", "idle", "idle", [])).toBe(false);
+  });
+
+  it("queues when idle but this conversation already has a queued message", () => {
+    // The ordering fix: a momentary idle flicker (cursor-native) must not let a
+    // later send take the direct path and overtake the still-queued earlier one.
+    expect(shouldQueueSend("conv_a", "idle", "idle", [q("conv_a")])).toBe(true);
+  });
+
+  it("ignores queued messages belonging to a different conversation", () => {
+    // Another conversation's queue must not force THIS idle one onto the queue.
+    expect(shouldQueueSend("conv_a", "idle", "idle", [q("conv_b")])).toBe(false);
   });
 });

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1232,7 +1232,6 @@ describe("shouldQueueSend", () => {
   });
 
   it("sends directly (no queue) for a brand-new chat with no conversation", () => {
-    // A new chat must POST so the session gets created — never queue.
     expect(shouldQueueSend(null, "streaming", "running", [])).toBe(false);
   });
 
@@ -1247,13 +1246,12 @@ describe("shouldQueueSend", () => {
   });
 
   it("queues when idle but this conversation already has a queued message", () => {
-    // The ordering fix: a momentary idle flicker (cursor-native) must not let a
-    // later send take the direct path and overtake the still-queued earlier one.
+    // The ordering fix: an idle flicker must not let a later send overtake the
+    // still-queued earlier one.
     expect(shouldQueueSend("conv_a", "idle", "idle", [q("conv_a")])).toBe(true);
   });
 
   it("ignores queued messages belonging to a different conversation", () => {
-    // Another conversation's queue must not force THIS idle one onto the queue.
     expect(shouldQueueSend("conv_a", "idle", "idle", [q("conv_b")])).toBe(false);
   });
 });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -977,10 +977,21 @@ export function ChatPage() {
     // FIFO when the session next goes idle. Only queue for an already-bound
     // conversation; a brand-new chat (no conversationId) always sends so the
     // session gets created.
+    //
+    // Also queue when this conversation ALREADY has queued messages, even if it
+    // momentarily reads idle: the direct-send path and the queue drain aren't
+    // ordered against each other, so a later message that slips through here
+    // while an earlier one waits in the queue would jump ahead of it. This
+    // surfaces on harnesses whose status flickers idle between quick turns
+    // (e.g. cursor-native), scrambling the delivered order; funnelling every
+    // send for a queued conversation through the single FIFO queue preserves it.
     const chat = useChatStore.getState();
     const isBusy =
       chat.status === "streaming" || ["running", "waiting"].includes(chat.sessionStatus);
-    if (isBusy && chat.conversationId !== null) {
+    const hasQueued =
+      chat.conversationId !== null &&
+      chat.queuedMessages.some((m) => m.conversationId === chat.conversationId);
+    if ((isBusy || hasQueued) && chat.conversationId !== null) {
       chat.enqueueMessage(text, files);
       return;
     }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -469,24 +469,12 @@ export function shouldShowAuthorBadge(
 }
 
 /**
- * Whether a submitted message should be held in the client-side queue rather
- * than POSTed immediately via `send()`.
+ * Whether a submitted message should be queued rather than POSTed now.
  *
- * Queue when the session is busy (the normal type-ahead case) OR when this
- * conversation already has a queued message — even if the session momentarily
- * reads idle. The direct-send and queue-drain paths aren't ordered against each
- * other, so a later message taking the direct path while an earlier one waits
- * in the queue would overtake it; this surfaces on harnesses whose status
- * flickers idle between quick turns (cursor-native), scrambling delivery order.
- * Funnelling every send through the single FIFO queue once anything is queued
- * preserves it. A brand-new chat (no `conversationId`) always sends so the
- * session gets created.
- *
- * @param conversationId The bound conversation id, or `null` for a new chat.
- * @param status The local send lifecycle state.
- * @param sessionStatus The server-derived session status.
- * @param queuedMessages The client-side queue across all conversations.
- * @returns `true` to enqueue, `false` to send now.
+ * Queue when busy, or when this conversation already has a queued message even
+ * if it reads idle: the direct-send and queue-drain paths aren't ordered, so a
+ * later direct send could overtake a still-queued earlier one when status
+ * flickers idle mid-queue (cursor-native). A new chat always sends.
  */
 export function shouldQueueSend(
   conversationId: string | null,
@@ -1006,12 +994,8 @@ export function ChatPage() {
       setReconnectDialogOpen(true);
       return;
     }
-    // Hold the message in the client-side queue (shown in the strip above the
-    // composer) instead of POSTing now when the session is busy — or when this
-    // conversation already has a queued message, so a later send can't overtake
-    // an earlier queued one. See shouldQueueSend for the full rationale. The
-    // queue drains FIFO via maybeFlushQueuedHead (which enqueueMessage triggers
-    // immediately when the session is genuinely idle, so nothing stalls).
+    // Queue instead of POSTing now (see shouldQueueSend). enqueueMessage flushes
+    // FIFO immediately when genuinely idle, so nothing stalls.
     const chat = useChatStore.getState();
     if (
       shouldQueueSend(chat.conversationId, chat.status, chat.sessionStatus, chat.queuedMessages)

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -108,6 +108,7 @@ import {
   consumePendingInitialPrompt,
   type PendingInitialPrompt,
   type PendingUserMessage,
+  type QueuedMessage,
   useChatStore,
 } from "@/store/chatStore";
 import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
@@ -465,6 +466,39 @@ export function shouldShowAuthorBadge(
   isSessionShared: boolean,
 ): boolean {
   return isSessionShared && author !== undefined && author !== viewerId;
+}
+
+/**
+ * Whether a submitted message should be held in the client-side queue rather
+ * than POSTed immediately via `send()`.
+ *
+ * Queue when the session is busy (the normal type-ahead case) OR when this
+ * conversation already has a queued message — even if the session momentarily
+ * reads idle. The direct-send and queue-drain paths aren't ordered against each
+ * other, so a later message taking the direct path while an earlier one waits
+ * in the queue would overtake it; this surfaces on harnesses whose status
+ * flickers idle between quick turns (cursor-native), scrambling delivery order.
+ * Funnelling every send through the single FIFO queue once anything is queued
+ * preserves it. A brand-new chat (no `conversationId`) always sends so the
+ * session gets created.
+ *
+ * @param conversationId The bound conversation id, or `null` for a new chat.
+ * @param status The local send lifecycle state.
+ * @param sessionStatus The server-derived session status.
+ * @param queuedMessages The client-side queue across all conversations.
+ * @returns `true` to enqueue, `false` to send now.
+ */
+export function shouldQueueSend(
+  conversationId: string | null,
+  status: "idle" | "streaming",
+  sessionStatus: SessionStatus,
+  queuedMessages: QueuedMessage[],
+): boolean {
+  if (conversationId === null) return false;
+  const isBusy =
+    status === "streaming" || sessionStatus === "running" || sessionStatus === "waiting";
+  const hasQueued = queuedMessages.some((m) => m.conversationId === conversationId);
+  return isBusy || hasQueued;
 }
 
 // Author labels render only in a shared session; ChatPage provides the
@@ -972,26 +1006,16 @@ export function ChatPage() {
       setReconnectDialogOpen(true);
       return;
     }
-    // Busy → hold the message in the client-side queue (shown in the strip
-    // above the composer) instead of POSTing now. The queue head is flushed
-    // FIFO when the session next goes idle. Only queue for an already-bound
-    // conversation; a brand-new chat (no conversationId) always sends so the
-    // session gets created.
-    //
-    // Also queue when this conversation ALREADY has queued messages, even if it
-    // momentarily reads idle: the direct-send path and the queue drain aren't
-    // ordered against each other, so a later message that slips through here
-    // while an earlier one waits in the queue would jump ahead of it. This
-    // surfaces on harnesses whose status flickers idle between quick turns
-    // (e.g. cursor-native), scrambling the delivered order; funnelling every
-    // send for a queued conversation through the single FIFO queue preserves it.
+    // Hold the message in the client-side queue (shown in the strip above the
+    // composer) instead of POSTing now when the session is busy — or when this
+    // conversation already has a queued message, so a later send can't overtake
+    // an earlier queued one. See shouldQueueSend for the full rationale. The
+    // queue drains FIFO via maybeFlushQueuedHead (which enqueueMessage triggers
+    // immediately when the session is genuinely idle, so nothing stalls).
     const chat = useChatStore.getState();
-    const isBusy =
-      chat.status === "streaming" || ["running", "waiting"].includes(chat.sessionStatus);
-    const hasQueued =
-      chat.conversationId !== null &&
-      chat.queuedMessages.some((m) => m.conversationId === chat.conversationId);
-    if ((isBusy || hasQueued) && chat.conversationId !== null) {
+    if (
+      shouldQueueSend(chat.conversationId, chat.status, chat.sessionStatus, chat.queuedMessages)
+    ) {
       chat.enqueueMessage(text, files);
       return;
     }


### PR DESCRIPTION
## Related issue

N/A — bug found via manual testing on cursor-native.

## Summary

- A follow-up sent while an earlier one still waited in the client-side queue
  could **jump ahead of it**, so the agent received messages out of order.
- `handleSend` had two unordered delivery paths: enqueue (drained one-per-idle by
  `maybeFlushQueuedHead`) vs. direct `send()` (taken whenever the session reads
  idle). They aren't ordered against each other.
- On a harness whose `sessionStatus` **flickers idle between quick turns**
  (cursor-native — its turns are instant and its status signal is thin), a later
  message hit the idle window and took the **direct** path mid-queue, overtaking
  the still-queued earlier one.
- **Verified in a runner log**: `history_msgs` grew 1→10 with the runner
  appending each message FIFO *as it arrived* — the reorder happened client-side,
  before the runner. Delivered order `Hello, testing, 2, I'm, qeueuing, …` vs.
  typed `Hello, I'm, testing, queuing, …`.

Fix: once a conversation has anything queued, **every** subsequent send enqueues
(single FIFO path) even if the status momentarily reads idle. `enqueueMessage`
already flushes immediately when genuinely idle, so nothing stalls.

## Test Plan

- **Unit**: existing store + strip + composer suites pass (331); the `enqueue →
  immediate-flush-when-idle` path (which keeps this from stalling) is covered by
  the existing `chatStore` queue tests.
- **Manual**: reproduced on cursor-native (fast type-ahead scrambled the order);
  with the fix every send funnels through the FIFO queue.
- The gesture is timing-dependent (needs a status flicker mid-queue), so it isn't
  faked in an e2e route-mock; the FIFO invariant it relies on
  (`maybeFlushQueuedHead` flushes the conversation head) is unit-tested.
- **Gates**: type-check, prettier pass.

## Demo

N/A — ordering fix; no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification on cursor-native (the harness whose idle-flicker exposes the
race) plus runner-log confirmation that delivery is FIFO once messages funnel
through the single queue. The reordering trigger is timing-dependent and not
reliably reproducible in a mocked e2e; the FIFO drain invariant it depends on is
covered by existing `chatStore` unit tests.

This pull request and its description were written by Isaac.
