### PR TITLE
[Bug] Project folders in the sidebar have no right-click context menu and no rename action

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -14336,6 +14336,7 @@ def create_sessions_router(
     )
     async def list_session_projects(
         request: Request,
+        include_archived: bool = False,
     ) -> list[str]:
         """
         Return all project names for the authenticated user, ordered
@@ -14344,12 +14345,17 @@ def create_sessions_router(
         Projects are implicit: they exist while at least one session
         has a ``conversation_labels`` row with ``key="omni_project"``.
 
+        :param include_archived: When ``True``, also list projects whose
+            sessions are all archived (hidden from the sidebar). Rename
+            validation uses this so it can't merge into an archived-only
+            project the sidebar never shows.
         :returns: List of project names.
         """
         user_id = _require_user(request, auth_provider)
         return await asyncio.to_thread(
             conversation_store.list_projects,
             accessible_by=user_id,
+            include_archived=include_archived,
         )
 
     # ── PUT /sessions/{session_id}/read-state ─────────────────────

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -737,6 +737,7 @@ class ConversationStore(ABC):
     def list_projects(
         self,
         accessible_by: str | None = None,
+        include_archived: bool = False,
     ) -> list[str]:
         """
         Return all distinct sidebar "project" names, ordered ascending.
@@ -753,6 +754,9 @@ class ConversationStore(ABC):
             sessions the user has a permission row for (mirrors the
             ``list_conversations`` ACL filter). ``None`` returns
             projects across all sessions.
+        :param include_archived: When ``True``, also return projects
+            whose members are all archived (absent from the sidebar), so
+            rename validation can detect a collision the sidebar can't show.
         :returns: List of project names ordered alphabetically.
         """
         ...

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1579,6 +1579,7 @@ class SqlAlchemyConversationStore(ConversationStore):
     def list_projects(
         self,
         accessible_by: str | None = None,
+        include_archived: bool = False,
     ) -> list[str]:
         """
         Return all distinct project names, ordered alphabetically.
@@ -1597,11 +1598,16 @@ class SqlAlchemyConversationStore(ConversationStore):
         :param accessible_by: When set, restrict to sessions that
             ``accessible_by`` has a permission row for (mirrors the
             ``list_conversations`` ACL filter).
+        :param include_archived: When ``True``, also count projects whose
+            members are all archived (they never appear in the sidebar). Used
+            by rename validation so a rename can't silently merge into an
+            archived-only project that the sidebar can't show.
         :returns: List of project names ordered ascending.
         """
         with self._session() as session:
             # Join to the conversation so archived sessions don't keep an
-            # otherwise-empty project alive in the sidebar.
+            # otherwise-empty project alive in the sidebar (unless the caller
+            # opts in with ``include_archived``).
             stmt = (
                 select(SqlConversationLabel.value)
                 .join(
@@ -1612,11 +1618,12 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversationLabel.workspace_id == current_workspace_id(),
                     SqlConversation.workspace_id == current_workspace_id(),
                     SqlConversationLabel.key == PROJECT_LABEL_KEY,
-                    SqlConversation.archived.is_(False),
                 )
                 .distinct()
                 .order_by(SqlConversationLabel.value)
             )
+            if not include_archived:
+                stmt = stmt.where(SqlConversation.archived.is_(False))
             if accessible_by is not None:
                 accessible_ids = select(SqlSessionPermission.conversation_id).where(
                     SqlSessionPermission.workspace_id == current_workspace_id(),

--- a/openapi.json
+++ b/openapi.json
@@ -7330,6 +7330,19 @@
       "get": {
         "description": "Return all project names for the authenticated user, ordered\nalphabetically.\n\nProjects are implicit: they exist while at least one session\nhas a `conversation_labels` row with `key=\"omni_project\"`.\n\n**Returns:** List of project names.",
         "operationId": "list_session_projects_v1_sessions_projects_get",
+        "parameters": [
+          {
+            "description": "When `True`, also list projects whose sessions are all archived (hidden from the sidebar). Rename validation uses this so it can't merge into an archived-only project the sidebar never shows.",
+            "in": "query",
+            "name": "include_archived",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Archived",
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -7338,6 +7351,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "List Session Projects",

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -163,6 +163,31 @@ async def test_list_projects_returns_names_sorted(
     assert resp.json() == ["Customer X", "Sprint 42"]
 
 
+async def test_list_projects_include_archived(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """``?include_archived=true`` also lists projects whose sessions are all
+    archived (hidden from the sidebar) so rename validation can detect a
+    collision against a project the default view omits."""
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    active = conv_store.create_conversation()
+    archived = conv_store.create_conversation()
+    conv_store.set_labels(active.id, {"omni_project": "Active"})
+    conv_store.set_labels(archived.id, {"omni_project": "Archived"})
+    conv_store.update_conversation(archived.id, archived=True)
+
+    # Default view hides the all-archived project…
+    resp = await client.get("/v1/sessions/projects")
+    assert resp.status_code == 200
+    assert resp.json() == ["Active"]
+
+    # …but the opt-in surfaces it.
+    resp = await client.get("/v1/sessions/projects?include_archived=true")
+    assert resp.status_code == 200
+    assert resp.json() == ["Active", "Archived"]
+
+
 # ── GET /v1/sessions?project= (filter) ───────────────────────────────
 
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4387,6 +4387,29 @@ def test_list_projects_excludes_all_archived_projects(
     assert conversation_store.list_projects() == ["Gone", "Mixed"]
 
 
+def test_list_projects_include_archived_keeps_all_archived_projects(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``include_archived=True`` also returns projects whose every member is
+    archived (hidden from the sidebar). Rename validation relies on this so it
+    can't silently merge into a project the sidebar can't show."""
+    solo = conversation_store.create_conversation()
+    mix_archived = conversation_store.create_conversation()
+    mix_active = conversation_store.create_conversation()
+
+    conversation_store.set_labels(solo.id, {"omni_project": "Gone"})
+    conversation_store.set_labels(mix_archived.id, {"omni_project": "Mixed"})
+    conversation_store.set_labels(mix_active.id, {"omni_project": "Mixed"})
+
+    conversation_store.update_conversation(solo.id, archived=True)
+    conversation_store.update_conversation(mix_archived.id, archived=True)
+
+    # Sidebar view drops the all-archived "Gone"; the archived-inclusive view
+    # keeps it so a rename onto "Gone" is still detected as a collision.
+    assert conversation_store.list_projects() == ["Mixed"]
+    assert conversation_store.list_projects(include_archived=True) == ["Gone", "Mixed"]
+
+
 def test_list_projects_scoped_by_accessible_by(
     conversation_store: SqlAlchemyConversationStore,
     db_uri: str,

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -17,6 +17,8 @@ import {
   useBulkStopSessions,
   useConversations,
   useDeleteProject,
+  useRenameProject,
+  ProjectNameTakenError,
   useProjects,
   useProjectSessions,
   useMoveToProject,
@@ -792,6 +794,103 @@ describe("useMoveToProject", () => {
     // section, projects so the sidebar list updates.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
+  });
+});
+
+describe("useRenameProject", () => {
+  it("blocks the rename via an archived-inclusive, case-insensitive pre-flight when the target is taken", async () => {
+    // `useProjects` (the dialog's fast check) omits archived-only projects, so
+    // the hook asks the server for the archived-inclusive name list and compares
+    // case-insensitively. Here only an archived-only "beta" exists — renaming to
+    // "Beta" must still be blocked (a case variant of a name the sidebar can't
+    // even show), relabelling nothing.
+    fetchMock.mockResolvedValueOnce(mockResponse(["Alpha", "beta"]));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useRenameProject(), { wrapper });
+
+    result.current.mutate({ from: "Alpha", to: "Beta" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(ProjectNameTakenError);
+    expect((result.current.error as ProjectNameTakenError).projectName).toBe("Beta");
+    // Pre-flight hits the archived-inclusive project-name list…
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/sessions/projects?include_archived=true");
+    // …and nothing else runs: no enumeration of the source, no PATCH.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows re-casing a project onto itself (case-insensitive self-collision is excluded)", async () => {
+    // Renaming "Work" → "work" is a re-case of the *same* project, not a merge,
+    // so the case-insensitive guard must exclude the source name and proceed.
+    fetchMock.mockResolvedValueOnce(mockResponse(["Work"]));
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        data: [{ id: "conv_w", object: "conversation", title: "W", created_at: 0, updated_at: 1 }],
+        first_id: "conv_w",
+        last_id: "conv_w",
+        has_more: false,
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        id: "conv_w",
+        object: "conversation",
+        title: "W",
+        created_at: 0,
+        updated_at: 2,
+        labels: { omni_project: "work" },
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useRenameProject(), { wrapper });
+
+    result.current.mutate({ from: "Work", to: "work" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [patchUrl, patchInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(patchUrl).toBe("/v1/sessions/conv_w");
+    expect(JSON.parse(patchInit.body as string)).toEqual({ labels: { omni_project: "work" } });
+  });
+
+  it("relabels every session to the new name when the target is free", async () => {
+    // 1) pre-flight: archived-inclusive names — "Beta" is not among them → free.
+    fetchMock.mockResolvedValueOnce(mockResponse(["Alpha", "Gamma"]));
+    // 2) enumerate "Alpha" members (archived included).
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        data: [{ id: "conv_a", object: "conversation", title: "A", created_at: 0, updated_at: 1 }],
+        first_id: "conv_a",
+        last_id: "conv_a",
+        has_more: false,
+      }),
+    );
+    // 3) PATCH that session onto "Beta".
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        id: "conv_a",
+        object: "conversation",
+        title: "A",
+        created_at: 0,
+        updated_at: 2,
+        labels: { omni_project: "Beta" },
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useRenameProject(), { wrapper });
+
+    result.current.mutate({ from: "Alpha", to: "Beta" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [patchUrl, patchInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    expect(patchUrl).toBe("/v1/sessions/conv_a");
+    expect(patchInit.method).toBe("PATCH");
+    expect(JSON.parse(patchInit.body as string)).toEqual({ labels: { omni_project: "Beta" } });
   });
 });
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -661,15 +661,24 @@ export function usePinnedConversationBackfill(
  */
 export const PROJECT_LABEL_KEY = "omni_project";
 
+/**
+ * Fetch all project names from `GET /v1/sessions/projects`. Pass
+ * `includeArchived` to also list projects whose sessions are all archived
+ * (hidden from the sidebar) — used by rename validation so it can't merge into
+ * a project the sidebar can't show.
+ */
+export async function fetchProjectNames(includeArchived = false): Promise<string[]> {
+  const query = includeArchived ? "?include_archived=true" : "";
+  const res = await authenticatedFetch(`/v1/sessions/projects${query}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as string[];
+}
+
 /** Fetch all project names from `GET /v1/sessions/projects`. */
 export function useProjects() {
   return useQuery<string[]>({
     queryKey: ["projects"],
-    queryFn: async () => {
-      const res = await authenticatedFetch("/v1/sessions/projects");
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-      return (await res.json()) as string[];
-    },
+    queryFn: () => fetchProjectNames(),
     staleTime: 30_000,
   });
 }
@@ -832,6 +841,72 @@ export function useDeleteProject() {
     onSettled: () => {
       // Refresh regardless of partial failure so the sidebar reflects whatever
       // was actually archived.
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      void queryClient.invalidateQueries({ queryKey: ["projects"] });
+      void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
+    },
+  });
+}
+
+/**
+ * Rename a whole project by re-labelling every session filed under `from` to
+ * `to`. The project is implicit (its identity IS the shared `omni_project`
+ * label), so a rename is a bulk relabel — no dedicated project entity to patch.
+ * Archived members are included so a rename doesn't silently split the project
+ * (unarchiving would otherwise restore them under the old name). Throws
+ * `{ failed, succeeded, total }` if any session couldn't be relabelled (e.g. a
+ * shared session the user can't modify), leaving those under the old name.
+ *
+ * The dialog does a synchronous collision check against the sidebar's project
+ * list for instant feedback, but that list is archived-exclusive; this hook adds
+ * an authoritative server-side pre-flight over the archived-inclusive project
+ * list (case-insensitively, excluding the source name) so a rename can't merge
+ * into any existing project — including one whose sessions are all archived and
+ * so never appears in the sidebar. Throws `ProjectNameTakenError` when taken.
+ */
+export class ProjectNameTakenError extends Error {
+  readonly projectName: string;
+  constructor(projectName: string) {
+    super(`A project named "${projectName}" already exists.`);
+    this.name = "ProjectNameTakenError";
+    this.projectName = projectName;
+  }
+}
+
+export function useRenameProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ from, to }: { from: string; to: string }) => {
+      // Authoritative collision guard. The dialog's fast-path check omits
+      // projects whose sessions are all archived, so ask the server for the
+      // archived-inclusive list and compare case-insensitively (excluding the
+      // source name so re-casing a project — "Work" → "work" — is allowed).
+      const existing = await fetchProjectNames(true);
+      const target = to.toLowerCase();
+      if (existing.some((name) => name !== from && name.toLowerCase() === target)) {
+        throw new ProjectNameTakenError(to);
+      }
+      const ids = await fetchAllProjectSessionIds(from);
+      const results = await Promise.allSettled(ids.map((id) => moveConversationToProject(id, to)));
+      const succeeded: string[] = [];
+      const failed: string[] = [];
+      for (let i = 0; i < results.length; i++) {
+        if (results[i].status === "fulfilled") {
+          succeeded.push(ids[i]);
+          markConversationSeen(
+            ids[i],
+            (results[i] as PromiseFulfilledResult<Conversation>).value.updated_at,
+          );
+        } else {
+          failed.push(ids[i]);
+        }
+      }
+      if (failed.length > 0) throw { failed, succeeded, total: ids.length };
+      return { succeeded, failed };
+    },
+    onSettled: () => {
+      // Refresh regardless of partial failure so the sidebar reflects whatever
+      // was actually relabelled.
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
       void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });

--- a/web/src/shell/Sidebar.bulkActionLayout.test.tsx
+++ b/web/src/shell/Sidebar.bulkActionLayout.test.tsx
@@ -48,6 +48,8 @@ vi.mock("@/hooks/useConversations", () => ({
   }),
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false }),
+  ProjectNameTakenError: class ProjectNameTakenError extends Error {},
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.projectMenu.test.tsx
+++ b/web/src/shell/Sidebar.projectMenu.test.tsx
@@ -1,0 +1,281 @@
+// Tests for the project-folder action menu: the kebab and the folder header's
+// right-click context menu both expose "Rename project" and "Delete project"
+// (parity with a conversation row's context menu), and Rename re-labels the
+// project while refusing to merge onto an existing project name. See
+// ProjectFolder / ProjectMenuItems / ProjectFolderDialogs in Sidebar.tsx.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+// Controllable rename mutation, declared via vi.hoisted so the (hoisted)
+// vi.mock factory can reference it. Tests assert on mutate/reset.
+const mocks = vi.hoisted(() => ({
+  rename: {
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null as Error | null,
+  },
+  del: {
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+  },
+  // Real class so the dialog's `error instanceof ProjectNameTakenError` check
+  // works and tests can construct the async-collision error.
+  ProjectNameTakenError: class ProjectNameTakenError extends Error {},
+}));
+
+// Two projects so "Beta" is a live duplicate for the collision test.
+const PROJECT_NAMES = ["Alpha", "Beta"];
+
+vi.mock("@/hooks/useConversations", () => ({
+  useConversations: vi.fn(),
+  useConnectedConversations: () => [],
+  useStopAndDeleteConversation: () => ({ mutate: vi.fn(), reset: vi.fn() }),
+  usePinnedConversationBackfill: () => [],
+  useRenameConversation: () => ({ mutate: vi.fn() }),
+  useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useStopSession: () => ({ mutate: vi.fn() }),
+  useProjects: () => ({ data: PROJECT_NAMES }),
+  useProjectSessions: () => ({
+    data: undefined,
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+  useMoveToProject: () => ({ mutate: vi.fn() }),
+  useDeleteProject: () => mocks.del,
+  useRenameProject: () => mocks.rename,
+  ProjectNameTakenError: mocks.ProjectNameTakenError,
+  fetchProjectSessionIds: () => Promise.resolve([]),
+  PROJECT_LABEL_KEY: "omni_project",
+}));
+
+vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+
+import { type Conversation, useConversations } from "@/hooks/useConversations";
+import { Sidebar } from "./Sidebar";
+
+const useConvMock = vi.mocked(useConversations);
+
+// One session filed under "Alpha" so the folder has a member; the folder
+// header (and its kebab) renders regardless, but this keeps it realistic.
+const CONV: Conversation = {
+  id: "conv_1",
+  object: "conversation",
+  title: "Alpha Session",
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_000,
+  labels: { omni_project: "Alpha" },
+  permission_level: null,
+  status: "idle",
+  git_branch: null,
+};
+
+function mockConversations(conversations: Conversation[]) {
+  const dataResult = {
+    data: {
+      pages: [
+        {
+          data: conversations,
+          first_id: conversations[0]?.id ?? null,
+          last_id: conversations.at(-1)?.id ?? null,
+          has_more: false,
+        },
+      ],
+      pageParams: [undefined],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  } as unknown as ReturnType<typeof useConversations>;
+  useConvMock.mockImplementation(() => dataResult);
+}
+
+function renderSidebar() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Sidebar open={true} onClose={vi.fn()} />
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** Open the "Alpha" folder's kebab dropdown (Radix opens on pointerdown). */
+function openAlphaKebab() {
+  fireEvent.pointerDown(screen.getByRole("button", { name: "Project actions for Alpha" }), {
+    button: 0,
+  });
+}
+
+beforeEach(() => {
+  mocks.rename.mutate.mockReset();
+  mocks.rename.reset.mockReset();
+  mocks.rename.isPending = false;
+  mocks.rename.isError = false;
+  mocks.rename.error = null;
+  mocks.del.mutate.mockReset();
+  mockConversations([CONV]);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("project folder kebab menu", () => {
+  it("offers Rename project and opens the rename dialog", () => {
+    renderSidebar();
+    openAlphaKebab();
+
+    fireEvent.click(screen.getByTestId("rename-project"));
+
+    const dialog = screen.getByRole("dialog");
+    // "Rename project" is both the title and the confirm button's label, so
+    // target the heading specifically.
+    expect(within(dialog).getByRole("heading", { name: "Rename project" })).toBeInTheDocument();
+    // The field is pre-seeded with the current project name.
+    expect(within(dialog).getByTestId("rename-project-input")).toHaveValue("Alpha");
+  });
+
+  it("still offers Delete project (unchanged behavior)", () => {
+    renderSidebar();
+    openAlphaKebab();
+    expect(screen.getByTestId("delete-project")).toBeInTheDocument();
+  });
+});
+
+describe("project folder right-click (context menu) parity", () => {
+  it("right-clicking the folder header opens a menu with Rename + Delete", () => {
+    renderSidebar();
+
+    // Right-click the folder header (its title). ContextMenuTrigger wraps the
+    // header, so the native contextmenu event opens the same actions menu.
+    fireEvent.contextMenu(screen.getByText("Alpha"));
+
+    // Both project actions are present in the context menu.
+    expect(screen.getByTestId("rename-project")).toBeInTheDocument();
+    expect(screen.getByTestId("delete-project")).toBeInTheDocument();
+  });
+
+  it("Rename from the context menu opens the rename dialog", () => {
+    renderSidebar();
+    fireEvent.contextMenu(screen.getByText("Alpha"));
+
+    fireEvent.click(screen.getByTestId("rename-project"));
+    expect(
+      within(screen.getByRole("dialog")).getByRole("heading", { name: "Rename project" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("rename project — submit + validation", () => {
+  it("fires renameProject.mutate with the new name and closes the dialog", () => {
+    renderSidebar();
+    openAlphaKebab();
+    fireEvent.click(screen.getByTestId("rename-project"));
+
+    fireEvent.change(screen.getByTestId("rename-project-input"), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByTestId("rename-project-confirm"));
+
+    expect(mocks.rename.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.rename.mutate).toHaveBeenCalledWith(
+      { from: "Alpha", to: "Renamed" },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    // Fire the captured onSuccess (mutate is a stub) to drive the close.
+    const onSuccess = mocks.rename.mutate.mock.calls[0][1].onSuccess as () => void;
+    act(() => onSuccess());
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("trims whitespace before submitting", () => {
+    renderSidebar();
+    openAlphaKebab();
+    fireEvent.click(screen.getByTestId("rename-project"));
+
+    fireEvent.change(screen.getByTestId("rename-project-input"), {
+      target: { value: "  Trimmed  " },
+    });
+    fireEvent.click(screen.getByTestId("rename-project-confirm"));
+
+    expect(mocks.rename.mutate).toHaveBeenCalledWith(
+      { from: "Alpha", to: "Trimmed" },
+      expect.anything(),
+    );
+  });
+
+  it("blocks renaming onto an existing project name — no mutation, shows an error", () => {
+    renderSidebar();
+    openAlphaKebab();
+    fireEvent.click(screen.getByTestId("rename-project"));
+
+    // "Beta" already exists → collision.
+    fireEvent.change(screen.getByTestId("rename-project-input"), {
+      target: { value: "Beta" },
+    });
+
+    const confirm = screen.getByTestId("rename-project-confirm");
+    expect(confirm).toBeDisabled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i);
+
+    // Clicking the disabled confirm must not fire the mutation.
+    fireEvent.click(confirm);
+    expect(mocks.rename.mutate).not.toHaveBeenCalled();
+  });
+
+  it('blocks a case-insensitive duplicate ("beta" collides with "Beta")', () => {
+    renderSidebar();
+    openAlphaKebab();
+    fireEvent.click(screen.getByTestId("rename-project"));
+
+    fireEvent.change(screen.getByTestId("rename-project-input"), {
+      target: { value: "beta" },
+    });
+    expect(screen.getByTestId("rename-project-confirm")).toBeDisabled();
+    expect(mocks.rename.mutate).not.toHaveBeenCalled();
+  });
+
+  it("disables confirm when the name is unchanged", () => {
+    renderSidebar();
+    openAlphaKebab();
+    fireEvent.click(screen.getByTestId("rename-project"));
+
+    // Field is pre-seeded with "Alpha" (unchanged) → confirm disabled.
+    expect(screen.getByTestId("rename-project-confirm")).toBeDisabled();
+  });
+
+  it("surfaces the collision error when the rename's server pre-flight rejects an archived-only name", () => {
+    // The sync check only sees non-archived projects (`useProjects`), so an
+    // archived-only name passes it and the hook's authoritative pre-flight
+    // throws ProjectNameTakenError. The dialog must show the collision message,
+    // not the generic partial-failure one.
+    mocks.rename.isError = true;
+    mocks.rename.error = new mocks.ProjectNameTakenError("Gamma");
+
+    renderSidebar();
+    openAlphaKebab();
+    fireEvent.click(screen.getByTestId("rename-project"));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i);
+    expect(screen.getByRole("alert")).not.toHaveTextContent(/couldn't be renamed/i);
+  });
+});

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -88,6 +88,8 @@ vi.mock("@/hooks/useConversations", () => ({
   },
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false }),
+  ProjectNameTakenError: class ProjectNameTakenError extends Error {},
   fetchProjectSessionIds: vi.fn(() => Promise.resolve([] as string[])),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.subagentHighlight.test.tsx
+++ b/web/src/shell/Sidebar.subagentHighlight.test.tsx
@@ -37,6 +37,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useProjectSessions: () => ({ data: undefined, isLoading: false, isError: false, error: null }),
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false }),
+  ProjectNameTakenError: class ProjectNameTakenError extends Error {},
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -85,6 +85,8 @@ vi.mock("@/hooks/useConversations", () => ({
   },
   useMoveToProject: () => ({ mutate: moveToProjectSpy }),
   useDeleteProject: () => ({ mutate: deleteProjectSpy, isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false }),
+  ProjectNameTakenError: class ProjectNameTakenError extends Error {},
   fetchProjectSessionIds: fetchProjectSessionIdsMock,
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -61,6 +61,7 @@ import {
 } from "@dnd-kit/core";
 import { Link, useLocation, useNavigate, useParams } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -99,6 +100,8 @@ import {
   useConversations,
   useMoveToProject,
   useDeleteProject,
+  useRenameProject,
+  ProjectNameTakenError,
   fetchProjectSessionIds,
   PROJECT_LABEL_KEY,
   usePinnedConversationBackfill,
@@ -776,6 +779,14 @@ function ProjectFolder({
     data: { type: "project", name },
   });
 
+  // The project's Rename/Delete dialogs are shared by two triggers — the header
+  // kebab and the header's right-click menu — so their open state lives here,
+  // above both, rather than inside either menu.
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const openRename = useCallback(() => setRenameOpen(true), []);
+  const openDelete = useCallback(() => setDeleteOpen(true), []);
+
   return (
     <div
       ref={setNodeRef}
@@ -808,7 +819,23 @@ function ProjectFolder({
         onProjectAssigned={onProjectAssigned}
         emptyMessage={loadingFirstPage ? undefined : "No chats"}
         indentRows
-        headerAction={<ProjectFolderActions projectName={name} onNavigate={onRowClick} />}
+        headerAction={
+          <ProjectFolderActions
+            projectName={name}
+            onNavigate={onRowClick}
+            onRename={openRename}
+            onDelete={openDelete}
+          />
+        }
+        headerMenu={
+          <ContextMenuContent className="min-w-40 [&_[role=menuitem]]:text-xs">
+            <ProjectMenuItems
+              components={contextBundle}
+              onRename={openRename}
+              onDelete={openDelete}
+            />
+          </ContextMenuContent>
+        }
         footer={
           loadingFirstPage ? (
             <p className="px-2 py-1 pl-7 text-muted-foreground text-xs">Loading…</p>
@@ -822,6 +849,13 @@ function ProjectFolder({
             />
           )
         }
+      />
+      <ProjectFolderDialogs
+        projectName={name}
+        renameOpen={renameOpen}
+        onRenameOpenChange={setRenameOpen}
+        deleteOpen={deleteOpen}
+        onDeleteOpenChange={setDeleteOpen}
       />
     </div>
   );
@@ -1740,6 +1774,7 @@ function ConversationSection({
   emptyMessage,
   indentRows,
   headerAction,
+  headerMenu,
   footer,
   onProjectAssigned,
 }: {
@@ -1765,6 +1800,11 @@ function ConversationSection({
   /** Optional control overlaid at the header's right edge (e.g. a project's
       kebab). Hover/focus-revealed on desktop, always shown on mobile. */
   headerAction?: ReactNode;
+  /** Optional right-click menu for the header. When set, the header is wrapped
+      in a {@link ContextMenu} so right-clicking it opens the same actions as
+      the `headerAction` kebab (parity with a conversation row's context menu).
+      Pass the {@link ContextMenuContent} element; the trigger is wired here. */
+  headerMenu?: ReactNode;
   /** Optional content rendered after the rows inside the expanded body (e.g. a
       project folder's own infinite-scroll sentinel / loading row). */
   footer?: ReactNode;
@@ -1774,28 +1814,41 @@ function ConversationSection({
 }) {
   // An untitled section is always open — there's no header to collapse it.
   const isCollapsed = title != null && collapsed;
-  return (
-    <section className="group/section relative">
-      {title && (
-        // Header + its hover-revealed kebab share a `group/header` scope so the
-        // kebab keys off hovering the header alone — NOT the whole section,
-        // which would also reveal it when hovering a child row.
-        <div className="group/header relative">
-          <SectionHeader
-            title={title}
-            icon={icon}
-            marker={marker}
-            hasAction={headerAction != null}
-            collapsed={isCollapsed}
-            onToggleCollapsed={onToggleCollapsed}
-          />
-          {headerAction && (
-            <div className="absolute top-0.5 right-1 flex items-center transition-opacity md:opacity-0 md:group-focus-within/header:opacity-100 md:group-hover/header:opacity-100 md:group-has-[[data-state=open]]/header:opacity-100">
-              {headerAction}
-            </div>
-          )}
+  // Header + its hover-revealed kebab share a `group/header` scope so the kebab
+  // keys off hovering the header alone — NOT the whole section, which would
+  // also reveal it when hovering a child row.
+  const headerBlock = title ? (
+    <div className="group/header relative">
+      <SectionHeader
+        title={title}
+        icon={icon}
+        marker={marker}
+        hasAction={headerAction != null}
+        collapsed={isCollapsed}
+        onToggleCollapsed={onToggleCollapsed}
+      />
+      {headerAction && (
+        <div className="absolute top-0.5 right-1 flex items-center transition-opacity md:opacity-0 md:group-focus-within/header:opacity-100 md:group-hover/header:opacity-100 md:group-has-[[data-state=open]]/header:opacity-100">
+          {headerAction}
         </div>
       )}
+    </div>
+  ) : null;
+  return (
+    <section className="group/section relative">
+      {/* Right-click the header to open the same actions as the kebab.
+          ContextMenuTrigger preventDefaults the native contextmenu event and
+          asChild merges its handler onto the header div, so left-click still
+          toggles collapse. */}
+      {headerBlock &&
+        (headerMenu ? (
+          <ContextMenu>
+            <ContextMenuTrigger asChild>{headerBlock}</ContextMenuTrigger>
+            {headerMenu}
+          </ContextMenu>
+        ) : (
+          headerBlock
+        ))}
       {!isCollapsed && (
         <>
           {conversations.length === 0 && emptyMessage ? (
@@ -2876,20 +2929,26 @@ function ArchivingRow({ label }: { label: string }) {
  * The hover-revealed controls on a project-folder header: a kebab menu and a
  * pencil that starts a new session pre-filed under this project. The pencil
  * links to the landing composer with `?project=<name>` so its project chip
- * lands already selected.
+ * lands already selected. The kebab and the header's right-click menu both open
+ * the same Rename/Delete dialogs — their open state lives in {@link ProjectFolder}
+ * (above both triggers) and is opened here via `onRename` / `onDelete`.
  */
 function ProjectFolderActions({
   projectName,
   onNavigate,
+  onRename,
+  onDelete,
 }: {
   projectName: string;
   /** Plain-left-click nav handler — closes the mobile overlay so the
       pre-filed new-session page isn't left hidden behind the sidebar. */
   onNavigate: (e: MouseEvent<HTMLAnchorElement>) => void;
+  onRename: () => void;
+  onDelete: () => void;
 }) {
   return (
     <div className="flex items-center">
-      <ProjectFolderMenu projectName={projectName} />
+      <ProjectFolderMenu projectName={projectName} onRename={onRename} onDelete={onDelete} />
       <Button
         asChild
         type="button"
@@ -2917,44 +2976,186 @@ function ProjectFolderActions({
 // ── ProjectFolderMenu ─────────────────────────────────────────────────────────
 
 /**
- * The kebab on a project-folder header. Currently just "Delete project", which
- * removes every session filed under the project (the implicit project then
- * disappears). Confirmation is required since it deletes sessions, not just the
- * grouping.
+ * The project-folder action-menu body — "Rename project" and "Delete project" —
+ * authored once and rendered under both the kebab {@link DropdownMenu} and the
+ * header's right-click {@link ContextMenu} via the {@link MenuComponents} bundle,
+ * so the two menus stay identical (same pattern as {@link ConversationMenuItems}).
  */
-function ProjectFolderMenu({ projectName }: { projectName: string }) {
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
+function ProjectMenuItems({
+  components: C,
+  onRename,
+  onDelete,
+}: {
+  components: MenuComponents;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <>
+      <C.Item data-testid="rename-project" onSelect={onRename}>
+        <PencilIcon className="size-3.5" />
+        Rename project
+      </C.Item>
+      <C.Item data-testid="delete-project" variant="destructive" onSelect={onDelete}>
+        <Trash2Icon className="size-3.5" />
+        Delete project
+      </C.Item>
+    </>
+  );
+}
+
+/**
+ * The kebab on a project-folder header. Opens the shared Rename/Delete dialogs
+ * (owned by {@link ProjectFolder}); the folder header's right-click menu offers
+ * the same two actions.
+ */
+function ProjectFolderMenu({
+  projectName,
+  onRename,
+  onDelete,
+}: {
+  projectName: string;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={`Project actions for ${projectName}`}
+          data-testid="project-actions"
+          // Sits on the folder header; keep its click off the collapse toggle.
+          onClick={(e) => e.stopPropagation()}
+        >
+          <MoreHorizontalIcon className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-40 [&_[role=menuitem]]:text-xs">
+        <ProjectMenuItems components={dropdownBundle} onRename={onRename} onDelete={onDelete} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// ── ProjectFolderDialogs ──────────────────────────────────────────────────────
+
+/**
+ * The Rename- and Delete-project confirmation dialogs for one folder, shared by
+ * the header kebab and the header's right-click menu (both toggle the `*Open`
+ * state passed in). Delete archives every session under the project; Rename
+ * re-labels them to a new name. Rename is blocked when the new name is empty,
+ * unchanged, or collides (case-insensitively) with another existing project —
+ * merging two projects by name is never implicit.
+ */
+function ProjectFolderDialogs({
+  projectName,
+  renameOpen,
+  onRenameOpenChange,
+  deleteOpen,
+  onDeleteOpenChange,
+}: {
+  projectName: string;
+  renameOpen: boolean;
+  onRenameOpenChange: (open: boolean) => void;
+  deleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+}) {
   const deleteProject = useDeleteProject();
+  const renameProject = useRenameProject();
+  const { data: projects = [] } = useProjects();
+  const { reset: resetRename } = renameProject;
+
+  const [newName, setNewName] = useState(projectName);
+  // Reseed the field to the current name each time the dialog opens (and reset
+  // any prior error) so a reopened dialog never shows a stale edit.
+  useEffect(() => {
+    if (renameOpen) {
+      setNewName(projectName);
+      resetRename();
+    }
+  }, [renameOpen, projectName, resetRename]);
+
+  const trimmed = newName.trim();
+  const unchanged = trimmed === projectName;
+  const collides = projects.some(
+    (p) => p !== projectName && p.toLowerCase() === trimmed.toLowerCase(),
+  );
+  const invalid = trimmed.length === 0 || unchanged || collides;
+
+  const submitRename = () => {
+    if (invalid || renameProject.isPending) return;
+    renameProject.mutate(
+      { from: projectName, to: trimmed },
+      { onSuccess: () => onRenameOpenChange(false) },
+    );
+  };
 
   return (
     <>
-      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label={`Project actions for ${projectName}`}
-            data-testid="project-actions"
-            // Sits on the folder header; keep its click off the collapse toggle.
-            onClick={(e) => e.stopPropagation()}
+      <Dialog open={renameOpen} onOpenChange={onRenameOpenChange}>
+        <DialogContent onClick={(e) => e.stopPropagation()}>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              submitRename();
+            }}
           >
-            <MoreHorizontalIcon className="size-3.5" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="min-w-40 [&_[role=menuitem]]:text-xs">
-          <DropdownMenuItem
-            data-testid="delete-project"
-            variant="destructive"
-            onSelect={() => setDeleteOpen(true)}
-          >
-            <Trash2Icon className="size-3.5" />
-            Delete project
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+            <DialogHeader>
+              <DialogTitle>Rename project</DialogTitle>
+              <DialogDescription>
+                Renames the project{" "}
+                <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em] break-all">
+                  {projectName}
+                </span>{" "}
+                and re-files <span className="font-medium">all of its sessions</span> under the new
+                name.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="py-4">
+              {/* biome-ignore lint/a11y/noAutofocus: focus the field so the user can type immediately */}
+              <Input
+                autoFocus
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                aria-label="New project name"
+                aria-invalid={invalid}
+                data-testid="rename-project-input"
+                placeholder="Project name"
+              />
+              {collides || renameProject.error instanceof ProjectNameTakenError ? (
+                <p className="mt-2 text-sm text-destructive" role="alert">
+                  A project named <span className="font-medium">{trimmed}</span> already exists.
+                </p>
+              ) : renameProject.isError ? (
+                <p className="mt-2 text-sm text-destructive" role="alert">
+                  Some sessions couldn't be renamed (you may not own them); the rest were renamed.
+                </p>
+              ) : null}
+            </div>
+            <DialogFooter className="border-t-0 bg-transparent">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => onRenameOpenChange(false)}
+                disabled={renameProject.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={invalid || renameProject.isPending}
+                data-testid="rename-project-confirm"
+              >
+                {renameProject.isPending ? "Renaming…" : "Rename project"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={deleteOpen} onOpenChange={onDeleteOpenChange}>
         <DialogContent onClick={(e) => e.stopPropagation()}>
           <DialogHeader>
             <DialogTitle>Delete project?</DialogTitle>
@@ -2976,7 +3177,7 @@ function ProjectFolderMenu({ projectName }: { projectName: string }) {
             <Button
               type="button"
               variant="ghost"
-              onClick={() => setDeleteOpen(false)}
+              onClick={() => onDeleteOpenChange(false)}
               disabled={deleteProject.isPending}
             >
               Cancel
@@ -2987,10 +3188,7 @@ function ProjectFolderMenu({ projectName }: { projectName: string }) {
               disabled={deleteProject.isPending}
               onClick={() => {
                 deleteProject.mutate(projectName, {
-                  onSuccess: () => {
-                    setDeleteOpen(false);
-                    setMenuOpen(false);
-                  },
+                  onSuccess: () => onDeleteOpenChange(false),
                 });
               }}
             >


### PR DESCRIPTION
Closes #2122

## Related issue

Closes #2122

## Summary

Project folders in the sidebar had a kebab (⋯) menu but no right-click menu and
no way to rename a project. This adds both:

- **Right-click parity** — right-clicking a project folder header now opens the
  same actions menu as the kebab button (a shared items component drives both a
  `DropdownMenu` and a `ContextMenu`).
- **Rename project** — a new action opens a dialog that re-files every session in
  the project onto the new name. Projects are implicit (membership is the
  reserved `omni_project` label, with no project entity), so renaming is a bulk
  relabel of that label across the project's sessions.
- **Collision guard** — renaming onto an existing project name is blocked in two
  layers. The dialog does a synchronous, case-insensitive check against the
  sidebar's project list for instant feedback (confirm stays disabled for an
  empty, unchanged, or colliding name). That list omits projects whose sessions
  are all archived, so the rename hook adds an authoritative pre-flight over the
  **archived-inclusive** project list and compares case-insensitively (excluding
  the source name, so re-casing your own project — `Work` → `work` — is allowed).
  This needs one small, opt-in backend change: `GET /sessions/projects` (and the
  `list_projects` store method behind it) gains an `include_archived` flag that
  defaults to `false`, so the sidebar's list is unchanged and only rename
  validation asks for the archived-inclusive view. The result: a rename can never
  silently merge into an existing project — including a case variant of an
  archived-only name that never appears in the sidebar.

## Test Plan

- `npm run test` (vitest) — full suite green. New `Sidebar.projectMenu.test.tsx`
  covers: kebab + right-click both expose Rename/Delete, Rename opens the dialog
  from either trigger, submit fires the mutation with `{ from, to }` and closes on
  success, whitespace is trimmed, and duplicate names (exact + case-insensitive)
  and unchanged names disable confirm and never mutate. `useConversations.test.ts`
  covers the hook's authoritative pre-flight over the archived-inclusive name
  list: a taken target (including a case variant of an archived-only project)
  throws `ProjectNameTakenError` and relabels nothing; re-casing a project onto
  itself is allowed; and a free target relabels every member onto the new name.
- Backend (`pytest`): `test_list_projects_include_archived_keeps_all_archived_projects`
  (store) and `test_list_projects_include_archived` (route) assert the new opt-in
  surfaces all-archived projects while the default view still hides them.
- `openapi.json` regenerated via `scripts/dump_openapi.py` for the new
  `include_archived` query param; `tests/server/test_openapi_drift.py` passes (no
  drift).
- `npm run type-check` (`tsc -b`) and `oxlint` on the changed files — clean.
- Manual verification in a browser against the real `Sidebar`: confirmed the
  right-click menu, the rename dialog, the case-insensitive duplicate error, and
  the folder relabeling live after a successful rename (see Demo).

## Demo

<!-- Attach the 6 screenshots from the local run (drag-and-drop below): -->
1. Baseline sidebar with `Personal` / `Work` project folders.
<img width="1200" height="897" alt="01-sidebar-baseline" src="https://github.com/user-attachments/assets/c09ae876-d0e1-4668-9cb9-4672aea0695f" />

2. Right-clicking the `Work` folder → context menu with **Rename project** +
   **Delete project** (parity with the kebab).
<img width="1200" height="897" alt="02-rightclick-context-menu" src="https://github.com/user-attachments/assets/a547292b-f9ee-40eb-a254-2885f815564a" />

3. Rename dialog, pre-seeded with the current name.
<img width="1200" height="897" alt="03-rename-dialog" src="https://github.com/user-attachments/assets/f200719c-6960-433c-bae8-8ead0ac95c23" />

4. Case-insensitive duplicate blocked: "A project named Personal already exists."
   with the confirm button disabled.
<img width="1200" height="897" alt="05-duplicate-validation" src="https://github.com/user-attachments/assets/4731cd21-e1f5-4ee3-9bd8-da04da479a05" />

5. A valid new name (`Clients`) entered.
<img width="1200" height="897" alt="06-valid-new-name" src="https://github.com/user-attachments/assets/6d497507-4818-407f-b87e-3b090c37ef27" />

6. After confirm — the folder is relabeled `Work` → `Clients`.
<img width="1200" height="897" alt="07-renamed-result" src="https://github.com/user-attachments/assets/3002f180-5f7e-47d3-93a6-d600d8fd263c" />


## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Manual verification covered the full flow in a browser (right-click menu, rename
dialog, duplicate-name validation, and live folder relabeling). The new component
test asserts the trigger parity, the mutation call shape, and every validation
branch; the mutation's bulk-relabel + query-invalidation reuse the same paths as
the existing `useDeleteProject` flow.

**Known limitations (v1):**

- *Partial failure:* the relabel uses `Promise.allSettled`, mirroring the existing
  delete flow. If some sessions can't be relabeled (e.g. a shared session you
  don't own), the dialog surfaces "Some sessions couldn't be renamed… the rest
  were renamed" and the unmovable sessions stay under the old name — nothing is
  lost or corrupted. Because the new name now exists as a project, retrying the
  same target is blocked by the collision guard; the user would finish the move
  under a different name. A "resume rename" affordance is out of scope.
- *Concurrent creation (TOCTOU):* the collision pre-flight and the relabel are
  two separate requests, so a project created between them isn't seen by the
  guard. This window is inherent to the implicit-label model — projects are just
  a shared `omni_project` label with no uniqueness constraint, so *every* existing
  project operation (create, move-to-project, delete) shares it, and closing it
  would require making projects first-class entities. In practice the rename is
  driven by a single user from one client, so the two requests are effectively
  serialized; the worst case is two same-named projects, which the model already
  permits and which no data is lost to.

## Changelog

Right-click a project folder to rename it, re-filing all its sessions under the new name


---
This contribution was developed with AI assistance via [terminalhire](https://terminalhire.com). The author has reviewed the change and takes responsibility for its content.