### PR TITLE
fix(claude-sdk): evict the cached client when a turn is cancelled

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1223,6 +1223,9 @@ class ClaudeSDKExecutor(Executor):
         self._clients: dict[str, _ClaudeClientState] = {}
         # Session keys whose Claude harness process crashed and must not be reused.
         self._crashed_sessions: dict[str, str] = {}
+        # Force-close tasks for clients evicted on turn cancellation, kept
+        # referenced so they are not GC'd mid-close.
+        self._cancel_close_tasks: set[asyncio.Task[None]] = set()
 
         # Prefer system-installed claude over the SDK's bundled CLI.
         # The bundled CLI may be older and send beta flags that the
@@ -1469,6 +1472,16 @@ class ClaudeSDKExecutor(Executor):
         # call _force_close_client to flip transport._closed before
         # the loop tears down.
         await self._force_close_client(state.client)
+
+    def _evict_client_on_cancel(self, session_key: str) -> None:
+        state = self._clients.pop(session_key, None)
+        if state is None:
+            return
+        # Close in the background: an await here runs under an in-flight
+        # cancellation and could itself be cancelled, leaking the CLI process.
+        task = asyncio.create_task(self._force_close_client(state.client))
+        self._cancel_close_tasks.add(task)
+        task.add_done_callback(self._cancel_close_tasks.discard)
 
     async def close(self) -> None:
         session_keys = list(self._clients)
@@ -2495,6 +2508,13 @@ class ClaudeSDKExecutor(Executor):
                 if aclose is not None:
                     await aclose()
 
+        except asyncio.CancelledError:
+            # CancelledError is a BaseException, so a watchdog-cancelled turn
+            # skips the boundary below. Evict the wedged client (no crash
+            # mark) so the next turn rebuilds a fresh one and replays history
+            # instead of reusing it and re-tripping the watchdog (#2109).
+            self._evict_client_on_cancel(session_key)
+            raise
         except Exception as exc:  # noqa: BLE001 — top-level executor error boundary; records crash and surfaces to caller
             self._crashed_sessions[session_key] = str(exc)
             await self._close_live_client(session_key)

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -1792,6 +1792,84 @@ class TestStreamEventStreaming(unittest.TestCase):
 
         _run(_t())
 
+    def test_cancelled_turn_evicts_wedged_client(self):
+        """A cancelled turn evicts the cached client so resume can recover (#2109).
+
+        ``asyncio.CancelledError`` is a ``BaseException``, so the idle-watchdog
+        cancel bypasses run_turn's ``except Exception`` boundary and the
+        wedged client used to stay cached.
+        """
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        created = []
+        wedge_reached = asyncio.Event()
+
+        class _ResultMessage:
+            def __init__(self, session_id, result):
+                self.session_id = session_id
+                self.result = result
+
+        class _FakeSDK:
+            AssistantMessage = type("AssistantMessage", (), {})
+            UserMessage = type("UserMessage", (), {})
+            SystemMessage = type("SystemMessage", (), {})
+            ResultMessage = _ResultMessage
+            StreamEvent = type("StreamEvent", (), {})
+            ClaudeAgentOptions = type(
+                "ClaudeAgentOptions",
+                (),
+                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+            )
+
+            class ClaudeSDKClient:
+                def __init__(self, options):
+                    self.options = options
+                    self.index = len(created)
+                    created.append(self)
+
+                async def connect(self):
+                    return None
+
+                async def query(self, prompt, session_id="default"):
+                    return None
+
+                async def receive_response(self):
+                    if self.index == 0:
+                        # First client wedges like a stuck tool: no events.
+                        wedge_reached.set()
+                        await asyncio.Event().wait()
+                    yield _ResultMessage("claude-session-a", "recovered")
+
+                async def disconnect(self):
+                    return None
+
+        async def _t():
+            executor = ClaudeSDKExecutor()
+            messages = [{"role": "user", "content": "hello", "session_id": "session-a"}]
+            with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=_FakeSDK):
+
+                async def _consume():
+                    return [e async for e in executor.run_turn(messages, [], "")]
+
+                turn = asyncio.ensure_future(_consume())
+                await asyncio.wait_for(wedge_reached.wait(), timeout=5)
+                turn.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await turn
+
+                # Evicted without a crash mark so the next turn rebuilds
+                # a fresh client.
+                self.assertEqual(executor._clients, {})
+                self.assertNotIn("session-a", executor._crashed_sessions)
+
+                events = [e async for e in executor.run_turn(messages, [], "")]
+
+            self.assertEqual(len(created), 2)
+            self.assertIsInstance(events[-1], TurnComplete)
+            self.assertEqual(events[-1].response, "recovered")
+
+        _run(_t())
+
     def test_close_session_disconnects_live_client(self):
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor, _ClaudeClientState
 


### PR DESCRIPTION
## Related issue

Closes #2109

## Summary

On the `claude-sdk` harness the per-turn idle watchdog ([`_guarded_run_turn` in `_scaffold.py`](https://github.com/omnigent-ai/omnigent/blob/main/omnigent/runtime/harnesses/_scaffold.py)) cancels a wedged turn with `asyncio.CancelledError`. That is a `BaseException`, so it bypasses `run_turn`'s `except Exception` cleanup boundary in [`claude_sdk_executor.py`](https://github.com/omnigent-ai/omnigent/blob/main/omnigent/inner/claude_sdk_executor.py), and the wedged `ClaudeSDKClient` stays cached in `_clients`. Every later resume reuses the stuck client, emits no events, and re-trips the 240s watchdog, so the session is unrecoverable until the host daemon restarts.

This change adds an `except asyncio.CancelledError` handler at the same boundary; it pops the client from `_clients` synchronously, force-closes it in a background task (awaiting a graceful close under an in-flight cancellation could itself be cancelled and leak the CLI process), and re-raises. The session is not marked crashed, so the next turn rebuilds a fresh client and replays full history through the existing text-prefix path (`_build_prompt(resume_session=False)`). No context is lost.

```text
watchdog cancel -> CancelledError in run_turn -> evict + background force-close -> next turn builds a fresh client
```

## Test Plan

- Added `test_cancelled_turn_evicts_wedged_client`: cancels a mid-turn consuming task on a client that emits nothing, asserts the CancelledError propagates, the wedged client is evicted with no crash mark, and the next turn completes on a fresh client.
- Fail-without-fix proof: on unmodified `main` the test fails with the wedged client still cached (`AssertionError: {'session-a': _ClaudeClientState(...)} != {}`).
- `pytest tests/inner/test_claude_sdk_executor.py`: 104 passed.
- Scripted watchdog repro: `asyncio.timeout` around `run_turn` (the same cancellation mechanism `_guarded_run_turn` uses) with a first client that wedges. Before the fix all three turns re-trip the watchdog on the same cached client; after the fix turn 1 trips and evicts, and turns 2 and 3 complete on a fresh client.
- `ruff check` and `ruff format --check` pass on the changed files.

A live end-to-end repro against a real Claude session (wedged tool call under a lowered `HARNESS_TURN_TIMEOUT_S`) was not run; no valid Claude CLI credentials were available in the test environment. The cancellation delivery path is covered by the watchdog-style repro above.

## Demo

N/A: backend session-lifecycle fix with no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test covers eviction, the absent crash mark, CancelledError re-raise, and the fresh-client rebuild on the next turn. The scripted watchdog repro confirmed the recovery loop end to end at the executor level; a live Claude session was not exercised.

## Changelog

Evict the cached claude-sdk client when a turn is cancelled so the session recovers on the next turn
