### PR TITLE
fix(host): show session id in runner launch log

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1100,9 +1100,11 @@ class HostProcess:
         # Print the exact runner log file (not just the dir): a foreground
         # host's own terminal shows lifecycle lines, but the runner's real
         # output — the agent turn, tracebacks — lands only in this file.
+        session_line = f"\n    session: {frame.session_id}" if frame.session_id else ""
         print(
             f"  ↑ Runner started: {runner_id} (pid={proc.pid})\n"
-            f"    log: {_display_log_path(log_path)}",
+            f"    log: {_display_log_path(log_path)}"
+            f"{session_line}",
             flush=True,
         )
         return HostLaunchRunnerResultFrame(

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -100,6 +100,9 @@ class HostLaunchRunnerFrame:
     :param workspace: Absolute path on the host machine to use
         as the runner's working directory, e.g.
         ``"/Users/corey/projects/frontend"``.
+    :param session_id: Conversation/session ID the runner is being
+        launched for, e.g. ``"conv_abc123"``. ``None`` means an older
+        server did not include it.
     :param harness: Canonical harness the session will run, e.g.
         ``"claude-sdk"``. The host checks it is configured before
         spawning and refuses with
@@ -111,6 +114,7 @@ class HostLaunchRunnerFrame:
     request_id: str
     binding_token: str
     workspace: str
+    session_id: str | None = None
     harness: str | None = None
 
 
@@ -588,6 +592,7 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "request_id": frame.request_id,
                 "binding_token": frame.binding_token,
                 "workspace": frame.workspace,
+                "session_id": frame.session_id,
                 "harness": frame.harness,
             }
         )
@@ -878,6 +883,7 @@ def _decode_launch_runner(msg: dict[str, Any]) -> HostLaunchRunnerFrame:
         request_id=_required_str(msg, "request_id"),
         binding_token=_required_str(msg, "binding_token"),
         workspace=_required_str(msg, "workspace"),
+        session_id=_optional_nullable_str(msg, "session_id"),
         harness=_optional_nullable_str(msg, "harness"),
     )
 

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -634,6 +634,7 @@ def create_hosts_router(
                 request_id=request_id,
                 binding_token=binding_token,
                 workspace=workspace,
+                session_id=body.session_id,
                 harness=harness,
             )
         )

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -6199,6 +6199,7 @@ async def _launch_runner_on_host(
             request_id=request_id,
             binding_token=binding_token,
             workspace=conv.workspace,
+            session_id=conv.id,
             # Canonical harness (see _resolve_harness) so the host runs the
             # same configuration check it does at create-time launch. None
             # (agent not resolvable) skips the host-side check — fail open.
@@ -14212,6 +14213,7 @@ def create_sessions_router(
                         request_id=request_id,
                         binding_token=binding_token,
                         workspace=resp.workspace,
+                        session_id=resp.id,
                         # Already canonical (see _resolve_harness); lets
                         # the host refuse an unconfigured harness before
                         # spawning. None (agent not resolvable) skips the

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -397,6 +397,7 @@ async def test_handle_launch_prints_exact_runner_log_path(
         request_id="req_log",
         binding_token="tok_log",
         workspace=str(workspace),
+        session_id="conv_log",
     )
 
     original_popen = subprocess.Popen
@@ -426,6 +427,7 @@ async def test_handle_launch_prints_exact_runner_log_path(
     assert "↑ Runner started:" in out
     # The exact file path is printed, home-collapsed to ``~`` for readability.
     assert f"log: ~/.omnigent/logs/host-runner/{log_files[0].name}" in out
+    assert "session: conv_log" in out
 
     _cleanup_host(host)
 

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -118,12 +118,14 @@ def test_launch_runner_frame_round_trip() -> None:
         request_id="req_001",
         binding_token="secret_token_xyz",
         workspace="/Users/corey/projects/frontend",
+        session_id="conv_abc123",
     )
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostLaunchRunnerFrame)
     assert decoded.request_id == "req_001"
     assert decoded.binding_token == "secret_token_xyz"
     assert decoded.workspace == "/Users/corey/projects/frontend"
+    assert decoded.session_id == "conv_abc123"
 
 
 def test_launch_runner_result_frame_success_round_trip() -> None:
@@ -273,6 +275,7 @@ def test_launch_runner_frame_legacy_payload_decodes_harness_none() -> None:
     )
     decoded = decode_host_frame(legacy)
     assert isinstance(decoded, HostLaunchRunnerFrame)
+    assert decoded.session_id is None
     assert decoded.harness is None
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Host runner start logs currently show the runner token and log path, but not the conversation they belong to. This passes the conversation ID through the host launch frame so foreground host output can point directly back to the owning `conv_*` session.

ELI5: when the host starts a runner, it now labels the receipt with both the runner and the conversation it is working on.

- Add an optional `session_id` field to `HostLaunchRunnerFrame` and preserve legacy payload compatibility when older servers omit it.
- Populate `session_id` from session and host runner launch paths.
- Print `session: conv_*` under the existing host runner log path and cover the frame round trip plus banner output in focused tests.

## Test Plan

- [x] Added/updated focused tests for host launch frame encoding/decoding and runner launch banner output.
- [ ] Attempted `python -m pytest tests/host/test_frames.py tests/host/test_connect.py -q`, but pytest failed during shared conftest import because the local environment is missing `psutil`.

## Demo

It now shows like:

```
Runner started: runner_token_0c847455b6888182f14a38fc6711babb (pid=35468)                                                                                                   
    log: ~/.omnigent/logs/host-runner/runner-i0vgpvkv.log                                                                                                                       
    session: conv_c71c0c0d19c74578ba9d6b8af69fc02b               
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused test coverage was updated, but the local test run could not execute because `psutil` is not installed in this environment.

## Changelog

Host runner start logs now include the `conv_*` conversation ID alongside the runner token and log path.