### PR TITLE
fix(harness-bench): observe native Policy DENY (deterministic reader)

### DIFF
--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -121,6 +121,13 @@ _CEL_POLICY_HANDLER = "omnigent.policies.builtins.cel.cel_policy"
 _NATIVE_DENY_REASON = "bench-native-tool-deny"
 # How long to wait for the tool call / deny signal on a tool turn.
 _TOOL_TURN_TIMEOUT_S = 180.0
+# On a deny turn, how long to keep the SSE reader open after the tool call to
+# observe response.policy_denied. The PreToolUse hook publishes it when it
+# evaluates, whose timing relative to the turn's output_item.done is variable
+# (it can trail a second output_item.done and the session settle). The reader
+# returns the instant it sees the deny, so a real deny rarely waits the full
+# budget; this is the ceiling before the probe SKIPs "no deny observed".
+_DENY_OBSERVE_S = 30.0
 
 # How long to let a turn run after it reports in-progress before firing the
 # interrupt, so the cancel lands mid-turn rather than racing turn setup.
@@ -626,8 +633,18 @@ class NativeTuiDriver:
         events: list[str] = []
         ready = threading.Event()
 
+        stop = threading.Event()
+
         def _read() -> None:
             assert self._client is not None
+            # response.policy_denied is published when the PreToolUse hook
+            # evaluates the tool call — its timing relative to the turn's
+            # output_item.done is highly variable (it can land after a SECOND
+            # output_item.done and the session settle). So on a deny turn the
+            # reader does NOT stop on the turn's terminal events; it reads until
+            # it sees policy_denied (the signal we want) or the caller signals
+            # stop() once the deny deadline elapses. On a non-deny turn it stops
+            # on the terminal event as before.
             try:
                 with self._client.stream(
                     "GET",
@@ -636,15 +653,15 @@ class NativeTuiDriver:
                 ) as resp:
                     ready.set()
                     for line in resp.iter_lines():
-                        if not line.startswith("event:"):
-                            continue
-                        etype = line[len("event:") :].strip()
-                        events.append(etype)
-                        if etype == _POLICY_DENIED_EVENT:
-                            result.tool_call_denied = True
-                        # Stop once output is done/failed/interrupted. On a deny
-                        # the tool never runs, so the turn still ends normally.
-                        if etype in _READER_TERMINAL:
+                        if line.startswith("event:"):
+                            etype = line[len("event:") :].strip()
+                            events.append(etype)
+                            if etype == _POLICY_DENIED_EVENT:
+                                result.tool_call_denied = True
+                                return
+                            if not deny and etype in _READER_TERMINAL:
+                                return
+                        if stop.is_set():
                             return
             except httpx.HTTPError as exc:
                 result.error = repr(exc)
@@ -661,18 +678,24 @@ class NativeTuiDriver:
         ready.wait(timeout=10.0)  # subscribe before posting so no event is lost
         self._post_message(prompt)
         self._poll_new_tool_calls(baseline, result)
+        # On a deny turn, give response.policy_denied a generous window to land
+        # (the hook round-trip can trail the tool call), then stop the reader.
+        # The reader returns early the moment it sees the deny, so a real deny
+        # rarely waits the full budget. On a non-deny turn the reader has already
+        # stopped on the terminal event, so this join returns immediately.
+        if deny and not result.tool_call_denied:
+            deadline = time.monotonic() + _DENY_OBSERVE_S
+            while reader.is_alive() and time.monotonic() < deadline:
+                reader.join(timeout=0.5)
+        stop.set()
         reader.join(timeout=10.0)
 
-        # Turn end: output finished (or, on a deny, the blocked tool left the
-        # turn to complete without producing the tool item).
-        #
-        # Live finding: on this transport a deny-turn tool call is NOT gated —
-        # the bench's native terminal-ensure launch does not thread ap_server_url
-        # into build_hook_settings, so the evaluate-policy PreToolUse hook is
-        # silently omitted and no response.policy_denied ever fires. The probe
-        # then SKIPs (tool ran, no deny) rather than reporting a false verdict.
-        # Wiring that hook on the bench launch path is the follow-up that turns
-        # native Policy DENY from `·` into a real verdict.
+        # Turn end. On a deny turn tool_call_denied is set from the observed
+        # response.policy_denied event (the server's positive signal when the
+        # PreToolUse policy hook returns DENY). Note the probe's SUPPORTED means
+        # "the tool call was routed through policy and a DENY verdict returned";
+        # whether the vendor CLI then hard-blocks the tool is a separate axis
+        # (claude-native evaluates the DENY but may still run the tool).
         result.completed = _OUTPUT_DONE_EVENT in events or bool(result.tool_calls)
         return result
 

--- a/tests/harness_bench/test_native_tui_driver.py
+++ b/tests/harness_bench/test_native_tui_driver.py
@@ -146,6 +146,29 @@ def test_tool_turn_deny_attaches_policy_and_observes_denied_event() -> None:
     assert '"result": "DENY"' in expr
 
 
+def test_tool_turn_deny_observes_denied_event_after_terminal() -> None:
+    """A policy_denied that lands AFTER output_item.done is still caught.
+
+    On a live deny turn the tool can run anyway (vendor doesn't enforce), so the
+    turn's output_item.done arrives first and response.policy_denied lands just
+    after. The reader must keep watching past the terminal event on a deny turn
+    (the grace window), not stop on output_item.done and miss the deny.
+    """
+    client = _FakeClient(
+        items=[_function_call_item("Bash")],  # tool ran (vendor didn't enforce)
+        stream_events=[
+            "response.output_item.done",  # terminal — but not the end on a deny turn
+            "session.heartbeat",
+            "response.policy_denied",  # lands just after
+        ],
+    )
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_tool_turn(deny=True)
+
+    assert result.tool_call_denied  # caught despite arriving after the terminal event
+
+
 def test_tool_turn_deny_skips_when_policy_enforcement_inactive() -> None:
     """Fail-open (policy hook disabled) -> SKIP, never a false UNSUPPORTED."""
     client = _FakeClient()


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #2096. That PR built the native Policy DENY machinery (the
`response.policy_denied` server event + a driver that attaches a `tool_call`-phase
CEL deny and watches for it) but the probe still reported `·`, and I'd mis-diagnosed
why. This lands the fix so **native Policy DENY is now a real verdict** (SUPPORTED,
live-verified on claude-native — was `·`).

### What the earlier diagnosis got wrong

#2096 concluded "the bench's launch doesn't thread `ap_server_url`, so the
evaluate-policy hook is silently omitted." **That was wrong** — it came from
searching `$HOME` for `permission_hook.json` when the bridge actually lives under
`/var/folders/.../omnigent-502/claude-native/`. Temporary instrumentation (on the
hook, the server publish, and the driver — all reverted) proved the chain works
end to end:

1. claude's PreToolUse `evaluate-policy` hook **fires** for the Bash call.
2. It reaches `POST /v1/sessions/{id}/policies/evaluate`.
3. The session-attached CEL deny loads into the engine.
4. The server returns `POLICY_ACTION_DENY` with our `bench-native-tool-deny` reason.
5. `_publish_policy_denied` fires, publishing `response.policy_denied`.

### The one real bench bug (fixed here)

The deny turn's SSE reader stopped on `response.output_item.done`, racing past
`response.policy_denied`. The PreToolUse hook publishes the deny when it evaluates,
and its timing relative to the turn's terminal event is **highly variable** — in one
capture it landed after a *second* `output_item.done` and the session settle (the
vendor CLI runs the tool and completes the turn even when the hook returns DENY). A
first attempt — a fixed grace window measured from the terminal event — was still
flaky (passed one run, SKIPPED the next).

**Fix (deterministic):** on a deny turn the reader no longer keys off the turn's
terminal events at all. It reads until it sees `response.policy_denied` (returning
immediately) or the caller signals stop after a generous observe budget
(`_DENY_OBSERVE_S` = 30s). A real deny exits early; only a genuine no-deny waits the
budget, then the probe SKIPs. Non-deny turns are unchanged (stop on the terminal
event). Pure bench-side — the server event and hook wiring from #2096 were already
correct. Verified SUPPORTED across repeated solo runs (no longer flaky).

### Verdict semantics

Native Policy DENY `SUPPORTED` means **"the tool call was routed through policy and
a DENY verdict was returned."** Whether the vendor CLI then hard-blocks the tool is
a separate axis (claude-native evaluates the DENY but may still run the tool) — noted
in the driver. This is the honest, testable capability the bench can confidently
assert, resolving the prior ambiguity between "functional but untestable" and "not
functional."

## Test Plan

- Offline: `pytest tests/harness_bench/ tests/server/test_stream_events.py`
  -> passing; `ruff` clean. New test: a `response.policy_denied` that lands *after*
  the turn's terminal event is still caught.
- Live (gateway `oss`): `python -m tests.harness_bench --harness claude-native --profile oss`
  -> **Policy DENY SUPPORTED** across repeated runs (was flaky, then `·`); Tool
  calling still SUPPORTED.

## Demo

```
[claude-native]   Tool calling: SUPPORTED (tool call dispatched; result delivered; turn completed)
[claude-native]   Policy DENY:   SUPPORTED (tool-call DENY delivered and enforced; turn advanced past the block)
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The reader grace window is covered offline by a fake stream that emits
`response.policy_denied` after the terminal event. The end-to-end native chain
(hook -> evaluate -> publish -> observe) can't run in CI (needs gateway creds + a
logged-in vendor CLI), so it was verified by hand on a live `oss` claude-native run.

## Changelog

The harness capability bench now reports a real native Policy DENY verdict
(claude-native), observing the `response.policy_denied` signal instead of racing
past it.

