### PR TITLE
fix(hermes): confirm web-message delivery by the session's new user row, not any store write

### DIFF
--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -69,15 +69,19 @@ _SETTLE_STABLE_POLLS = 3
 # i-th queued web message), scrambling EVERY later message's reconciliation.
 #
 # The settle heuristic cannot tell "static banner" from "ready prompt", so we
-# confirm delivery against Hermes' OWN store instead: an accepted turn writes a
-# new ``messages`` row (Hermes flushes a row per agentic step), so a new row
-# appearing is the authoritative "message accepted" signal. If none appears we
-# re-deliver ONCE — safe against double-delivery precisely because the store
-# confirmed nothing landed — and otherwise raise so the turn fails cleanly (its
-# optimistic bubble rolls back) rather than silently desyncing the FIFO.
+# confirm delivery against Hermes' OWN store instead: Hermes records an accepted
+# injected message as a new ``user`` row, so a new user row (scoped to this
+# terminal's session when the forwarder has discovered it) is the authoritative
+# "message accepted" signal. The store also gains ``assistant``/``tool`` rows for
+# every agentic step of an in-flight turn — those must NOT count as the ack, or a
+# paste dropped mid-turn (steering) is falsely confirmed by the agent's own work
+# log and the loss goes undetected. If no user row appears we re-deliver ONCE —
+# safe against double-delivery precisely because the store confirmed nothing
+# landed — and otherwise raise so the turn fails cleanly (its optimistic bubble
+# rolls back) rather than silently desyncing the FIFO.
 _RETRY_SETTLE_S = 10.0
-# How long to wait for Hermes to persist a new ``messages`` row confirming it
-# accepted the injected turn. Generous: assistant rows stream within seconds of
+# How long to wait for Hermes to persist the new ``user`` row confirming it
+# accepted the injected turn. Generous: the row lands within seconds of
 # acceptance, so a confirmation this slow means the keystrokes were dropped.
 _DELIVERY_CONFIRM_TIMEOUT_S = 12.0
 _DELIVERY_POLL_INTERVAL_S = 0.3
@@ -632,20 +636,29 @@ def _state_db_path(bridge_dir: Path) -> Path | None:
     return None
 
 
-def _max_message_id(db_path: Path) -> int:
-    """Return ``MAX(messages.id)`` in the Hermes ``state.db``, or ``0`` on error.
+def _last_user_row_id(db_path: Path, hermes_session_id: str | None = None) -> int:
+    """Return the highest ``user`` row id in the Hermes ``state.db``, or ``0`` on error.
 
-    A missing file, a not-yet-created ``messages`` table, or a transient
-    mid-checkpoint read error all collapse to ``0`` — the delivery check only
-    needs a monotonically-increasing high-water mark, and a freshly-created
-    session legitimately starts at ``0``.
+    Only ``role = 'user'`` rows count: an in-flight turn appends
+    ``assistant``/``tool`` rows for every agentic step, and on a shared store a
+    sibling session appends rows of its own — neither is evidence that THIS
+    terminal accepted an injected message. With *hermes_session_id* the count is
+    further scoped to that session's rows. A missing file, a not-yet-created
+    ``messages`` table, or a transient mid-checkpoint read error all collapse to
+    ``0`` — the delivery check only needs a monotonically-increasing high-water
+    mark, and a freshly-created session legitimately starts at ``0``.
     """
+    query = "SELECT MAX(id) FROM messages WHERE role = 'user'"
+    params: tuple[str, ...] = ()
+    if hermes_session_id is not None:
+        query += " AND session_id = ?"
+        params = (hermes_session_id,)
     try:
         con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2.0)
     except sqlite3.Error:
         return 0
     try:
-        row = con.execute("SELECT MAX(id) FROM messages").fetchone()
+        row = con.execute(query, params).fetchone()
         return int(row[0]) if row and row[0] is not None else 0
     except sqlite3.Error:
         return 0
@@ -653,17 +666,37 @@ def _max_message_id(db_path: Path) -> int:
         con.close()
 
 
-def _await_new_message(db_path: Path, baseline_id: int, timeout_s: float) -> bool:
-    """Poll until ``MAX(messages.id) > baseline_id`` or *timeout_s* elapses.
+def _forwarder_session_id(bridge_dir: Path) -> str | None:
+    """Best-effort read of the Hermes session id the forwarder has bound.
 
-    A new ``messages`` row is Hermes' own record that it accepted the injected
-    turn (it flushes a row per agentic step), so this is the authoritative
-    "message landed" signal — far more reliable than scraping the pane. Always
-    checks at least once, even with a zero timeout.
+    The forwarder persists its discovery in the bridge dir; before it has bound
+    (e.g. the very first message of a fresh terminal) this is ``None`` and the
+    delivery check falls back to role-only scoping.
+    """
+    try:
+        from omnigent.hermes_native_forwarder import _read_state
+
+        return _read_state(bridge_dir).hermes_session_id
+    except Exception:  # noqa: BLE001 — confirmation must degrade, never block injection
+        return None
+
+
+def _await_new_message(
+    db_path: Path,
+    baseline_id: int,
+    timeout_s: float,
+    hermes_session_id: str | None = None,
+) -> bool:
+    """Poll until a ``user`` row with id > *baseline_id* appears or *timeout_s* elapses.
+
+    A new user row (scoped to *hermes_session_id* when known) is Hermes' own
+    record that it accepted the injected turn — far more reliable than scraping
+    the pane, and immune to the agent's own step rows landing mid-confirmation.
+    Always checks at least once, even with a zero timeout.
     """
     deadline = time.monotonic() + timeout_s
     while True:
-        if _max_message_id(db_path) > baseline_id:
+        if _last_user_row_id(db_path, hermes_session_id) > baseline_id:
             return True
         if time.monotonic() >= deadline:
             return False
@@ -740,9 +773,13 @@ def inject_user_message(
     the first paste can be silently dropped — and a dropped first message
     permanently off-by-ones the server's pending-input FIFO, scrambling every
     later turn. To prevent that, when Hermes' ``state.db`` is readable we confirm
-    the turn landed (a new ``messages`` row appears); if it didn't we re-deliver
-    ONCE (safe — the store proved nothing landed, so this can't double-submit) and
-    otherwise raise so the turn fails cleanly instead of desyncing the FIFO.
+    the turn landed: a new ``user`` row appears, scoped to this terminal's
+    session when the forwarder has bound one. Only user rows count — a paste can
+    also be dropped mid-turn (steering), and the in-flight turn's own
+    assistant/tool step rows must not masquerade as the ack. If no user row
+    appears we re-deliver ONCE (safe — the store proved nothing landed, so this
+    can't double-submit) and otherwise raise so the turn fails cleanly instead
+    of desyncing the FIFO.
 
     :param bridge_dir: The hermes-native bridge dir holding ``tmux.json``.
     :param content: User text (non-empty).
@@ -762,10 +799,12 @@ def inject_user_message(
             "hermes terminal is no longer running (the TUI exited); restart the session"
         )
     needle = _submit_needle(content)
-    # Snapshot the store high-water mark BEFORE delivery so a new row afterwards
-    # is unambiguous proof Hermes accepted this turn.
+    # Snapshot the user-row high-water mark BEFORE delivery so a newer user row
+    # afterwards is unambiguous proof Hermes accepted this turn. Baseline and
+    # confirmation must use the same scoping or the check defeats itself.
     db_path = _state_db_path(bridge_dir)
-    baseline_id = _max_message_id(db_path) if db_path is not None else None
+    hermes_session_id = _forwarder_session_id(bridge_dir) if db_path is not None else None
+    baseline_id = _last_user_row_id(db_path, hermes_session_id) if db_path is not None else None
 
     _deliver_once(
         socket_path, tmux_target, content, bridge_dir, needle, settle_timeout_s=timeout_s
@@ -775,15 +814,20 @@ def inject_user_message(
         # No readable store to confirm against — best-effort single delivery,
         # preserving prior behavior for setups without a per-session HERMES_HOME.
         return
-    if _await_new_message(db_path, baseline_id or 0, _DELIVERY_CONFIRM_TIMEOUT_S):
+    if _await_new_message(
+        db_path, baseline_id or 0, _DELIVERY_CONFIRM_TIMEOUT_S, hermes_session_id
+    ):
         return
     # The first delivery did not land (the TUI was still initializing). Re-deliver
-    # once — the store confirmed no row was written, so there is no double-submit
-    # risk — giving the pane a longer settle to let MCP startup finish.
+    # once — the store confirmed no user row was written, so there is no
+    # double-submit risk — giving the pane a longer settle to let MCP startup
+    # finish.
     _deliver_once(
         socket_path, tmux_target, content, bridge_dir, needle, settle_timeout_s=_RETRY_SETTLE_S
     )
-    if _await_new_message(db_path, baseline_id or 0, _DELIVERY_CONFIRM_TIMEOUT_S):
+    if _await_new_message(
+        db_path, baseline_id or 0, _DELIVERY_CONFIRM_TIMEOUT_S, hermes_session_id
+    ):
         return
     raise RuntimeError(
         "hermes did not accept the message (the TUI may still be initializing); "

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -95,9 +95,9 @@ def test_inject_user_message_single_delivery_when_store_confirms(tmp_path, monke
     calls: list[tuple[str, ...]] = []
     _patch_inject_tmux(monkeypatch, calls)
     monkeypatch.setattr(b, "_state_db_path", lambda _bd: tmp_path / "state.db")
-    # Baseline 0, then a new row (id=1) confirms delivery on the first check.
+    # Baseline 0, then a new user row (id=1) confirms delivery on the first check.
     ids = iter([0, 1])
-    monkeypatch.setattr(b, "_max_message_id", lambda _p: next(ids))
+    monkeypatch.setattr(b, "_last_user_row_id", lambda _p, _s=None: next(ids))
 
     b.inject_user_message(tmp_path, content="do something now")
 
@@ -115,7 +115,7 @@ def test_inject_user_message_retries_once_when_first_not_confirmed(tmp_path, mon
     monkeypatch.setattr(b, "_state_db_path", lambda _bd: tmp_path / "state.db")
     # baseline=0 → confirm#1 sees 0 (fail) → confirm#2 sees 1 (success after retry).
     seq = iter([0, 0, 1])
-    monkeypatch.setattr(b, "_max_message_id", lambda _p: next(seq))
+    monkeypatch.setattr(b, "_last_user_row_id", lambda _p, _s=None: next(seq))
 
     b.inject_user_message(tmp_path, content="do something now")
 
@@ -131,7 +131,7 @@ def test_inject_user_message_raises_when_never_confirmed(tmp_path, monkeypatch) 
     _patch_inject_tmux(monkeypatch, calls)
     monkeypatch.setattr(b, "_DELIVERY_CONFIRM_TIMEOUT_S", 0.0)
     monkeypatch.setattr(b, "_state_db_path", lambda _bd: tmp_path / "state.db")
-    monkeypatch.setattr(b, "_max_message_id", lambda _p: 0)  # never advances
+    monkeypatch.setattr(b, "_last_user_row_id", lambda _p, _s=None: 0)  # never advances
 
     with pytest.raises(RuntimeError, match="did not accept"):
         b.inject_user_message(tmp_path, content="do something now")
@@ -156,30 +156,38 @@ def test_state_db_path_prefers_per_session_home(tmp_path, monkeypatch) -> None:
     assert b._state_db_path(tmp_path) == home / "state.db"
 
 
-def test_max_message_id_reads_high_water_mark(tmp_path) -> None:
+def test_last_user_row_id_counts_only_user_rows(tmp_path) -> None:
     db = tmp_path / "state.db"
     # Missing file → 0.
-    assert b._max_message_id(db) == 0
+    assert b._last_user_row_id(db) == 0
     con = sqlite3.connect(str(db))
     con.executescript(b._MESSAGES_DDL)
     # Empty table → 0.
-    assert b._max_message_id(db) == 0
-    con.execute(
+    assert b._last_user_row_id(db) == 0
+    con.executemany(
         "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?,?,?,?,?)",
-        (7, "s1", "user", "hi", 0.0),
+        [
+            (7, "s1", "user", "hi", 0.0),
+            (8, "s1", "assistant", "step", 0.0),  # agent step — not an ack
+            (9, "s2", "user", "other convo", 0.0),
+        ],
     )
     con.commit()
     con.close()
-    assert b._max_message_id(db) == 7
+    # Unscoped: highest user row anywhere (agent step at id=8 never counts).
+    assert b._last_user_row_id(db) == 9
+    # Scoped: only this session's user rows.
+    assert b._last_user_row_id(db, "s1") == 7
+    assert b._last_user_row_id(db, "s3") == 0
 
 
 def test_await_new_message_checks_at_least_once(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(b.time, "sleep", lambda *_a, **_k: None)
     # Even with a zero timeout, one check runs: baseline 5, current 6 → True.
-    monkeypatch.setattr(b, "_max_message_id", lambda _p: 6)
+    monkeypatch.setattr(b, "_last_user_row_id", lambda _p, _s=None: 6)
     assert b._await_new_message(tmp_path / "state.db", 5, 0.0) is True
     # No advance → False.
-    monkeypatch.setattr(b, "_max_message_id", lambda _p: 5)
+    monkeypatch.setattr(b, "_last_user_row_id", lambda _p, _s=None: 5)
     assert b._await_new_message(tmp_path / "state.db", 5, 0.0) is False
 
 
@@ -480,3 +488,121 @@ def test_mint_hermes_session_id_returns_uuid() -> None:
     # Should be a valid UUID4 string.
     parsed = uuid.UUID(sid, version=4)
     assert str(parsed) == sid
+
+
+_CONFIRM_SCHEMA = """
+CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, cwd TEXT, started_at REAL);
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT,
+    active INTEGER NOT NULL DEFAULT 1
+);
+"""
+
+
+def _seed_confirm_store(db: Path, session_id: str = "s1") -> None:
+    """A mid-turn store: one earlier user turn plus the agent's step so far."""
+    con = sqlite3.connect(db)
+    con.executescript(_CONFIRM_SCHEMA)
+    con.execute("INSERT INTO sessions VALUES (?,?,?,?)", (session_id, "cli", "/w", 1000.0))
+    con.execute(
+        "INSERT INTO messages(session_id, role, content) VALUES (?,?,?)",
+        (session_id, "user", "earlier ask"),
+    )
+    con.execute(
+        "INSERT INTO messages(session_id, role, content) VALUES (?,?,?)",
+        (session_id, "assistant", "working on it"),
+    )
+    con.commit()
+    con.close()
+
+
+def _insert_row(db: Path, session_id: str, role: str, content: str) -> None:
+    con = sqlite3.connect(db)
+    con.execute(
+        "INSERT INTO messages(session_id, role, content) VALUES (?,?,?)",
+        (session_id, role, content),
+    )
+    con.commit()
+    con.close()
+
+
+def _bind_forwarder_session(bridge_dir: Path, session_id: str) -> None:
+    from omnigent import hermes_native_forwarder as fwd
+
+    fwd._write_state(
+        bridge_dir,
+        fwd._ForwardState(hermes_session_id=session_id, last_id=0, launch_epoch_s=0.0),
+    )
+
+
+def test_confirm_rejects_agent_step_rows(tmp_path, monkeypatch) -> None:
+    """A dropped paste must not be acked by the agent's own mid-turn step row.
+
+    Steering injects while a turn is running, so the store gains assistant/tool
+    rows every few seconds; only a new *user* row is Hermes' record that it
+    accepted the injected message."""
+    calls: list[tuple[str, ...]] = []
+    _patch_inject_tmux(monkeypatch, calls)
+    db = tmp_path / "state.db"
+    _seed_confirm_store(db)
+    _bind_forwarder_session(tmp_path, "s1")
+    monkeypatch.setattr(b, "_state_db_path", lambda _bd: db)
+    monkeypatch.setattr(b, "_DELIVERY_CONFIRM_TIMEOUT_S", 0.05)
+    deliveries: list[int] = []
+
+    def _swallowed_paste_while_agent_works(*_a, **_k):
+        deliveries.append(1)
+        # The paste is dropped; the in-flight turn's next step lands instead.
+        _insert_row(db, "s1", "assistant", "next agentic step")
+
+    monkeypatch.setattr(b, "_deliver_once", _swallowed_paste_while_agent_works)
+
+    with pytest.raises(RuntimeError, match="did not accept"):
+        b.inject_user_message(tmp_path, content="STOP - change of plan")
+    assert len(deliveries) == 2, "retry must fire; the agent row is not an ack"
+
+
+def test_confirm_rejects_other_sessions_user_rows(tmp_path, monkeypatch) -> None:
+    """On a shared state.db another session's user row must not ack our paste."""
+    calls: list[tuple[str, ...]] = []
+    _patch_inject_tmux(monkeypatch, calls)
+    db = tmp_path / "state.db"
+    _seed_confirm_store(db, session_id="s1")
+    _bind_forwarder_session(tmp_path, "s1")
+    monkeypatch.setattr(b, "_state_db_path", lambda _bd: db)
+    monkeypatch.setattr(b, "_DELIVERY_CONFIRM_TIMEOUT_S", 0.05)
+    deliveries: list[int] = []
+
+    def _swallowed_paste_while_sibling_writes(*_a, **_k):
+        deliveries.append(1)
+        _insert_row(db, "s2", "user", "a different conversation's message")
+
+    monkeypatch.setattr(b, "_deliver_once", _swallowed_paste_while_sibling_writes)
+
+    with pytest.raises(RuntimeError, match="did not accept"):
+        b.inject_user_message(tmp_path, content="hello")
+    assert len(deliveries) == 2
+
+
+def test_confirm_accepts_own_user_row(tmp_path, monkeypatch) -> None:
+    """The true ack — our message's own user row — confirms on the first try."""
+    calls: list[tuple[str, ...]] = []
+    _patch_inject_tmux(monkeypatch, calls)
+    db = tmp_path / "state.db"
+    _seed_confirm_store(db)
+    _bind_forwarder_session(tmp_path, "s1")
+    monkeypatch.setattr(b, "_state_db_path", lambda _bd: db)
+    monkeypatch.setattr(b, "_DELIVERY_CONFIRM_TIMEOUT_S", 0.05)
+    deliveries: list[int] = []
+
+    def _accepted_paste(*_a, **_k):
+        deliveries.append(1)
+        _insert_row(db, "s1", "user", "hello")
+
+    monkeypatch.setattr(b, "_deliver_once", _accepted_paste)
+
+    b.inject_user_message(tmp_path, content="hello")
+    assert len(deliveries) == 1


### PR DESCRIPTION
## Related issue

Closes #2173

## Summary

- The web→TUI delivery check confirmed against the store's global `MAX(messages.id)` — no role or session filter — so **any** row landing in the 12s confirmation window acked a dropped paste. The in-flight turn's own assistant/tool step rows land every few seconds, so a steering message whose paste the TUI dropped was "confirmed" within one agentic step, the one-shot retry never fired, and the message was silently lost (plus the pending-input FIFO went permanently off-by-one).
- Fix: scope the baseline and the confirmation to `role = 'user'` rows — Hermes' actual record of accepting an injected message — and to the terminal's own Hermes session once the forwarder has bound one (its persisted state lives in the same bridge dir; before binding, role-only scoping already kills the primary false-ack source).
- Content matching was deliberately not added: TUI-side text normalization could misjudge a successful delivery as missed and double-submit, which is worse than the loss being fixed here.

ELI5: the front desk slips your note under a busy craftsman's door and then checks whether his logbook *got thicker* to decide if he saw it. But he logs every step of his own work too — so when the note slides under the rug, the next "applied another coat" entry convinces the front desk the note was received. Now the front desk only accepts a new **"note received:"** entry, in **his** column of the logbook.

```
before:  paste dropped ── agent's own step row lands ──> MAX(id) grew ──> "delivered" ✅(false), no retry
after:   paste dropped ── agent's own step row lands ──> no new user row ──> retry ──> still none ──> RuntimeError
```

## Test Plan

- New regression tests against a real sqlite store with the paste stubbed as dropped:
  - `test_confirm_rejects_agent_step_rows` — the steering case: an assistant step row lands mid-confirmation; the bridge must retry and then raise instead of false-acking. **Red on main** (returns success, 1 delivery), green with the fix (2 deliveries, `RuntimeError`).
  - `test_confirm_rejects_other_sessions_user_rows` — a sibling session's user row on a shared store must not ack. Red on main, green with the fix.
  - `test_confirm_accepts_own_user_row` — the true ack still confirms on the first attempt (no over-correction).
  - `test_last_user_row_id_counts_only_user_rows` — pins the scoped query at each filter level.
- Live repro before the fix (stubbed tmux, real store): quiet store → honest retry + error after 24.4s; one unrelated assistant row → false "delivered" in 0.6s with the message never written. The only variable is the unrelated write.
- `pytest tests/test_hermes_native_bridge.py`: 36 passed. `tests/test_hermes_native.py` + `tests/test_hermes_native_permissions.py`: 30 passed.

## Demo

Red→green comparison (the two rejection tests fail on main because the bridge false-acks; with the fix the drop is retried and surfaced):

![red/green: delivery confirmation provenance](https://raw.githubusercontent.com/tomsen-ai/omnigent/demo-assets/hermes-delivery-confirm-red-green.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The false-ack is reproduced deterministically (the fake delivery inserts the confounding row itself), so the provenance rule — only this session's user rows count as the ack — is pinned by CI rather than by timing.

## Changelog

Steering messages into a hermes terminal session are no longer silently lost when the TUI drops the paste mid-turn — the bridge now detects the drop, retries once, and surfaces a clean failure otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)
