### PR TITLE
fix(web): serialize background flush behind the foreground send chain

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -56,6 +56,12 @@ import {
 } from "./chatStore";
 import { useTerminalActivityStore } from "./terminalActivity";
 
+// The real `send` action, captured before any test stubs it via
+// setState({ send: spy }). Zustand's setState permanently overwrites the
+// action, so beforeEach restores this so a later test (e.g. cross-path
+// ordering) exercises the genuine send() path rather than a leftover spy.
+const realSend = useChatStore.getState().send;
+
 // Stub the viewer-identity lookup for deterministic author stamping on
 // optimistic sends. Defaults to null — the same value the real module
 // returns before identity resolves / in single-user mode — so tests
@@ -364,6 +370,8 @@ beforeEach(() => {
     costControlModeOverride: null,
     codexPlanMode: false,
     abortController: null,
+    // Restore the real send action; a prior test may have stubbed it.
+    send: realSend,
   });
   fetchMock.mockReset();
   fetchMock.mockImplementation(defaultFetchHandler);
@@ -8186,5 +8194,60 @@ describe("chatStore — background cross-session flush", () => {
       file_id: "file_bg_dedupe",
       filename: "shot.png",
     });
+  });
+
+  it("serializes a background flush behind an in-flight foreground send (FIFO across paths)", async () => {
+    // The navigate-away race: a foreground send() for the active conversation is
+    // still in flight (its /events POST held open) when the background flush
+    // fires for another conversation. Both POSTs must go through the one send
+    // chain, so the background POST cannot overtake the foreground one — it
+    // waits until the foreground POST resolves.
+    seedConversationsCache([conv("conv_active", "idle"), conv("conv_bg", "idle")]);
+    useChatStore.setState({
+      conversationId: "conv_active",
+      boundAgentId: "agent_xyz",
+      abortController: new AbortController(),
+      status: "idle",
+      sessionStatus: "idle",
+      queuedMessages: [{ queueId: "q_1", text: "bg-msg", conversationId: "conv_bg" }],
+    });
+
+    // Hold conv_active's foreground POST open; conv_bg's background POST resolves
+    // immediately. Records delivery order across both endpoints.
+    const delivered: string[] = [];
+    let releaseForeground: () => void = () => {};
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_active/events" && init?.method === "POST") {
+        delivered.push("foreground");
+        return new Promise<Response>((resolve) => {
+          releaseForeground = () => resolve(mockResponse({ queued: true, item_id: "ci_fg" }));
+        });
+      }
+      if (url === "/v1/sessions/conv_bg/events" && init?.method === "POST") {
+        delivered.push("background");
+        return mockResponse({ queued: true, item_id: "ci_bg" });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    // Foreground send() takes the first chain slot and its POST is held open.
+    const fg = useChatStore.getState().send("fg-msg", "agent_xyz");
+    await tick();
+    expect(delivered).toEqual(["foreground"]);
+
+    // Background flush fires while the foreground POST is still in flight. It
+    // must NOT deliver yet — it's queued behind the foreground POST on the chain.
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+    await tick();
+    expect(delivered).toEqual(["foreground"]);
+
+    // Release the foreground POST → the background POST is now free to deliver.
+    releaseForeground();
+    await fg;
+    await tick();
+    await tick();
+    expect(delivered).toEqual(["foreground", "background"]);
   });
 });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -754,6 +754,9 @@ export function initChatStore(client: QueryClient): void {
   workspaceInvalidationTimers.clear();
   backgroundFlushInFlight.clear();
   backgroundFlushCooldownUntil.clear();
+  // Reset the POST-ordering chain so a prior run's unresolved send can't block
+  // the next one (production calls this once at boot; tests call it per case).
+  sendChain = Promise.resolve();
   queryClient = client;
 }
 
@@ -1051,6 +1054,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
       set((st) => ({
         queuedMessages: st.queuedMessages.filter((m) => m.queueId !== head.queueId),
       }));
+      // Join the SAME send chain the foreground path uses. A queued message can
+      // hand off from the foreground flush (send() → sendChain) to here the
+      // moment the user navigates away, and the two POST paths would otherwise
+      // race — a background postEvent could overtake a foreground send() still
+      // awaiting its chain slot, delivering out of FIFO order. Taking a slot
+      // here (await priorSend before the upload/post, release in finally)
+      // serializes every POST across both paths through one ordering primitive.
+      const priorSend = sendChain;
+      let releaseSend: () => void = () => {};
+      sendChain = new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      });
       // Upload any attachments, then post the message referencing their
       // server-assigned file_ids — the same two-phase sequence send() runs
       // (no combined endpoint exists: /resources/files stores the blob and
@@ -1063,6 +1078,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // head (preserving this conversation's FIFO order) and set a cooldown so
       // the next trigger backs off instead of hammering a failing runner.
       void (async () => {
+        await priorSend;
         const fileBlocks: ContentBlock[] = [];
         for (const file of head.files ?? []) {
           // Reuse a prior successful upload so the cooldown-paced retry doesn't
@@ -1097,6 +1113,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
         })
         .finally(() => {
           backgroundFlushInFlight.delete(conversationId);
+          // Hand the chain to the next POST (foreground or background) so it
+          // can start its own network work in submission order.
+          releaseSend();
         });
     }
   },


### PR DESCRIPTION
## Related issue

Follow-up to the queued-messages work — fixes the out-of-order delivery you
reproduced on cursor-native by navigating to the terminal after sending a burst.

## Summary

Queued messages could reach the runner **out of FIFO order** when the user
navigated away from a conversation mid-queue.

- The **foreground** flush (`maybeFlushQueuedHead` → `send()`) serializes its
  `/events` POSTs on the module-level `sendChain`.
- The **background** flush (`flushBackgroundQueues` → `postEvent`) **bypassed**
  that chain.

At the navigate-away handoff — when a queued conversation stops being the active
one and its remaining messages move from the foreground path to the background
path — an in-flight foreground `send()` still awaiting its chain slot could be
**overtaken** by a background `postEvent` that fired immediately. The runner
appends messages FIFO as it receives them, so the reordering was entirely
client-side. It surfaced on **cursor-native** because its instant turns flip the
active conversation busy/idle fast, making the race window easy to hit; the
delivered order `Hello, testing, I'm, 1, …` vs. typed `Hello, I'm, testing, 1, …`
is the tell.

**Fix:** `flushBackgroundQueues` now joins the **same `sendChain`** — it takes a
slot (`await priorSend` before the upload/post, releases in `finally`), so every
POST across both paths is ordered through one primitive.

Two supporting changes:
- `initChatStore` resets `sendChain` so a prior run's unresolved send can't block
  the next (production calls it once at boot; tests per case).
- The store test's `beforeEach` restores the real `send` action — a prior test's
  `setState({ send: spy })` otherwise leaks into later cases.

## Test Plan

- **Unit** (`web`, vitest): new `chatStore` test — a background flush fired while
  a foreground `send()`'s POST is held open does **not** deliver until the
  foreground POST resolves (FIFO across paths). Verified it **fails without the
  fix** (background overtakes the held foreground POST) and passes with it.
- 268 `chatStore` tests pass; 332 across store + strip + composer suites.
- **Gates**: `npm run type-check`, tests, prettier all pass.

## Demo

N/A — ordering fix; no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The cross-path ordering invariant is covered by the new store unit test (a
held-open foreground POST must gate the background POST). Manually reproduced on
cursor-native (send burst → navigate to terminal) before the fix and confirmed
FIFO after.

This pull request and its description were written by Isaac.
