### PR TITLE
fix(cursor): add permission_mode to skip native-tool elicitation

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -258,6 +258,7 @@ _LOCAL_DAEMON_ENV_ALLOWLIST: frozenset[str] = frozenset(
         "CLAUDE_CODE_USE_BEDROCK",
         "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
         "COHERE_API_KEY",
+        "CURSOR_API_KEY",
         "DEEPSEEK_API_KEY",
         "GEMINI_API_KEY",
         "GOOGLE_API_KEY",

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -466,6 +466,7 @@ class CursorExecutor(Executor):
         bundle_dir: Path | None = None,
         agent_name: str | None = None,
         skills_filter: str | list[str] = "all",
+        permission_mode: str = "default",
     ) -> None:
         """Create a CursorExecutor.
 
@@ -480,6 +481,13 @@ class CursorExecutor(Executor):
         :param bundle_dir: Reserved for future skill wiring; unused in v1.
         :param agent_name: Optional agent name passed to the SDK.
         :param skills_filter: Accepted for parity; cursor has no skill mechanism here.
+        :param permission_mode: Mirrors :class:`~omnigent.inner.claude_sdk_executor.
+            ClaudeSDKExecutor`'s ``permission_mode``. ``"default"`` (the
+            historical cursor behavior) surfaces a human-consent elicitation
+            card for every Cursor-native tool call, same as an unset
+            ``permission_mode`` always did. ``"auto"`` / ``"bypassPermissions"``
+            skip that elicitation for native tools (Omnigent policy DENY still
+            applies), matching the claude-sdk harness's autonomous mode.
         """
         self._cwd = cwd or (os_env.cwd if os_env is not None else None)
         self._os_env_spec = os_env
@@ -487,6 +495,7 @@ class CursorExecutor(Executor):
         self._api_key = api_key or os.environ.get("CURSOR_API_KEY") or None
         self._bundle_dir = bundle_dir
         self._agent_name = agent_name
+        self._permission_mode = permission_mode
         self._skills_filter = skills_filter
         self._session_states: dict[str, _CursorSessionState] = {}
         # Installed by the runtime adapter; routes a bridged-tool call back into
@@ -544,12 +553,18 @@ class CursorExecutor(Executor):
 
         1. **Policy hard-deny**: if the policy evaluator returns
            ``POLICY_ACTION_DENY``, block immediately without prompting the
-           user (the admin already decided).
+           user (the admin already decided). Runs in EVERY permission mode
+           — including ``auto`` / ``bypassPermissions`` — so a configured
+           Omnigent policy can't be skipped by opting into autonomous mode.
 
         2. **Native elicitation**: for any other outcome (ALLOW, ASK, or no
            evaluator wired), invoke ``_elicitation_handler`` so the user can
            review the call and approve or abort the remainder of the turn
-           from the web-UI approval card.
+           from the web-UI approval card. Skipped entirely when
+           ``permission_mode`` is ``"auto"`` or ``"bypassPermissions"`` —
+           mirrors :meth:`ClaudeSDKExecutor._can_use_tool_gate
+           <omnigent.inner.claude_sdk_executor.ClaudeSDKExecutor._can_use_tool_gate>`,
+           which pre-approves autonomously in those modes.
 
         Cursor native tools execute inside the Cursor process, so they have
         already started by the time the executor observes
@@ -566,6 +581,11 @@ class CursorExecutor(Executor):
                     "block": True,
                     "reason": getattr(verdict, "reason", "") or "blocked by policy",
                 }
+
+        if self._permission_mode in ("auto", "bypassPermissions"):
+            # Autonomous mode: policy ALLOW/ASK/unset all fall through with
+            # no human prompt, same as claude-sdk's equivalent modes.
+            return {"block": False, "reason": ""}
 
         # Stage 2 — native elicitation: surface an approval card so the
         # user can decide whether the rest of the turn should continue.

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -481,13 +481,10 @@ class CursorExecutor(Executor):
         :param bundle_dir: Reserved for future skill wiring; unused in v1.
         :param agent_name: Optional agent name passed to the SDK.
         :param skills_filter: Accepted for parity; cursor has no skill mechanism here.
-        :param permission_mode: Mirrors :class:`~omnigent.inner.claude_sdk_executor.
-            ClaudeSDKExecutor`'s ``permission_mode``. ``"default"`` (the
-            historical cursor behavior) surfaces a human-consent elicitation
-            card for every Cursor-native tool call, same as an unset
-            ``permission_mode`` always did. ``"auto"`` / ``"bypassPermissions"``
-            skip that elicitation for native tools (Omnigent policy DENY still
-            applies), matching the claude-sdk harness's autonomous mode.
+        :param permission_mode: Mirrors ``ClaudeSDKExecutor``'s
+            ``permission_mode``. ``"default"`` elicits on every native tool
+            call (historical behavior). ``"auto"`` / ``"bypassPermissions"``
+            skip elicitation for native tools (a policy DENY still applies).
         """
         self._cwd = cwd or (os_env.cwd if os_env is not None else None)
         self._os_env_spec = os_env
@@ -553,18 +550,15 @@ class CursorExecutor(Executor):
 
         1. **Policy hard-deny**: if the policy evaluator returns
            ``POLICY_ACTION_DENY``, block immediately without prompting the
-           user (the admin already decided). Runs in EVERY permission mode
-           — including ``auto`` / ``bypassPermissions`` — so a configured
-           Omnigent policy can't be skipped by opting into autonomous mode.
+           user (the admin already decided). Runs in every permission mode,
+           including ``auto`` / ``bypassPermissions``.
 
         2. **Native elicitation**: for any other outcome (ALLOW, ASK, or no
            evaluator wired), invoke ``_elicitation_handler`` so the user can
            review the call and approve or abort the remainder of the turn
-           from the web-UI approval card. Skipped entirely when
-           ``permission_mode`` is ``"auto"`` or ``"bypassPermissions"`` —
-           mirrors :meth:`ClaudeSDKExecutor._can_use_tool_gate
-           <omnigent.inner.claude_sdk_executor.ClaudeSDKExecutor._can_use_tool_gate>`,
-           which pre-approves autonomously in those modes.
+           from the web-UI approval card. Skipped when ``permission_mode``
+           is ``"auto"`` / ``"bypassPermissions"``, mirroring
+           ``ClaudeSDKExecutor._can_use_tool_gate``.
 
         Cursor native tools execute inside the Cursor process, so they have
         already started by the time the executor observes
@@ -718,12 +712,18 @@ class CursorExecutor(Executor):
             local_kwargs: dict[str, Any] = {
                 "cwd": cwd,
                 "custom_tools": self._make_custom_tools(tools, loop) or None,
-                # Bypass cursor's own TUI approval prompts so native tool calls
-                # reach the executor's event stream and can be gated via the
-                # web-UI elicitation card (see _evaluate_native_tool_policy).
-                # Without this cursor may pause internally for its own approval
-                # before emitting a ToolCallRequest event.
-                "auto_review": True,
+                # auto_review is deliberately left unset. A prior version set
+                # it to True to "bypass cursor's own TUI approval", but the
+                # Local SDK's true default (no auto_review, no
+                # sandbox_options) already runs tool calls without any gate
+                # of cursor's own. auto_review=True instead re-enables Smart
+                # Auto Review, which can HOLD (ask a human) on a call — fatal
+                # in Local SDK mode, since requestApproval() is hardcoded in
+                # the bridge to always deny with "Local SDK runs cannot
+                # request interactive approval ...". Reproduced live: an MCP
+                # call failed with that exact message under auto_review=True
+                # and succeeded once it was unset. Omnigent's own
+                # _evaluate_native_tool_policy gate is unaffected either way.
             }
             # Tell the SDK to read project-level settings (including hooks.json).
             if state.hooks_file is not None:

--- a/omnigent/inner/cursor_harness.py
+++ b/omnigent/inner/cursor_harness.py
@@ -32,6 +32,12 @@ Env vars read at startup:
   cursor has no skill mechanism here). Defaults to ``"all"``.
 - ``HARNESS_CURSOR_BUNDLE_DIR`` / ``HARNESS_CURSOR_AGENT_NAME``:
   reserved for future use.
+- ``HARNESS_CURSOR_PERMISSION_MODE``: mirrors
+  ``HARNESS_CLAUDE_SDK_PERMISSION_MODE``. ``None``/unset keeps the
+  historical ``"default"`` behavior (every Cursor-native tool call surfaces
+  a human-consent elicitation card). ``"auto"`` / ``"bypassPermissions"``
+  skip that elicitation for native tools, matching claude-sdk's autonomous
+  modes. A configured Omnigent policy DENY still applies in every mode.
 """
 
 from __future__ import annotations
@@ -57,6 +63,7 @@ _ENV_OS_ENV = "HARNESS_CURSOR_OS_ENV"
 _ENV_SKILLS_FILTER = "HARNESS_CURSOR_SKILLS_FILTER"
 _ENV_BUNDLE_DIR = "HARNESS_CURSOR_BUNDLE_DIR"
 _ENV_AGENT_NAME = "HARNESS_CURSOR_AGENT_NAME"
+_ENV_PERMISSION_MODE = "HARNESS_CURSOR_PERMISSION_MODE"
 
 
 def _resolve_os_env() -> OSEnvSpec:
@@ -136,6 +143,7 @@ def _build_cursor_executor() -> Executor:
         bundle_dir=bundle_dir,
         agent_name=os.environ.get(_ENV_AGENT_NAME, "").strip() or None,
         skills_filter=_resolve_skills_filter(),
+        permission_mode=os.environ.get(_ENV_PERMISSION_MODE, "").strip() or "default",
     )
 
 

--- a/omnigent/inner/cursor_harness.py
+++ b/omnigent/inner/cursor_harness.py
@@ -33,11 +33,9 @@ Env vars read at startup:
 - ``HARNESS_CURSOR_BUNDLE_DIR`` / ``HARNESS_CURSOR_AGENT_NAME``:
   reserved for future use.
 - ``HARNESS_CURSOR_PERMISSION_MODE``: mirrors
-  ``HARNESS_CLAUDE_SDK_PERMISSION_MODE``. ``None``/unset keeps the
-  historical ``"default"`` behavior (every Cursor-native tool call surfaces
-  a human-consent elicitation card). ``"auto"`` / ``"bypassPermissions"``
-  skip that elicitation for native tools, matching claude-sdk's autonomous
-  modes. A configured Omnigent policy DENY still applies in every mode.
+  ``HARNESS_CLAUDE_SDK_PERMISSION_MODE``. Unset defaults to ``"default"``
+  (elicit on every native tool call). ``"auto"`` / ``"bypassPermissions"``
+  skip that elicitation, matching claude-sdk's autonomous modes.
 """
 
 from __future__ import annotations

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1696,6 +1696,14 @@ def _build_cursor_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_CURSOR_OS_ENV"] = os_env_payload
+    # Permission mode: controls whether Cursor's native tools (Read/Write/
+    # Bash, executing inside the Cursor process itself) surface a
+    # human-consent elicitation card. Mirrors the claude-sdk builder above.
+    # Omitted when not set — harness falls back to ``"default"`` (always
+    # elicit), the historical cursor behavior.
+    permission_mode = spec.executor.config.get("permission_mode")
+    if permission_mode is not None:
+        env["HARNESS_CURSOR_PERMISSION_MODE"] = str(permission_mode)
     return env
 
 

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -252,6 +252,25 @@ def test_build_host_daemon_env_local_forwards_bedrock_skip_auth(
     assert env["CLAUDE_CODE_SKIP_BEDROCK_AUTH"] == "1"
 
 
+def test_build_host_daemon_env_local_forwards_cursor_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CURSOR_API_KEY reaches the local daemon env.
+
+    The cursor harness's ambient-key fallback (``_build_cursor_spawn_env``)
+    reads ``CURSOR_API_KEY`` from the daemon's own environment when the spec
+    declares no explicit auth. Without it in the allowlist, an
+    ``omnigent setup``-free ``CURSOR_API_KEY`` export never reaches the
+    harness and every cursor session falls back to demanding an explicit key.
+    """
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_test_key")
+
+    env = _build_host_daemon_env(server_url=None)
+
+    assert env["CURSOR_API_KEY"] == "crsr_test_key"
+
+
 def test_build_host_daemon_env_remote_strips_provider_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1519,6 +1519,78 @@ async def test_run_turn_native_tool_ask_user_denies(
     assert not any(isinstance(e, TurnComplete) for e in events)
 
 
+@pytest.mark.parametrize("mode", ["auto", "bypassPermissions"])
+async def test_run_turn_native_tool_auto_mode_skips_elicitation(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+) -> None:
+    """``permission_mode="auto"``/``"bypassPermissions"`` never call the
+    elicitation handler for native tools — policy ALLOW/ASK/unset all fall
+    through autonomously, mirroring ClaudeSDKExecutor's equivalent modes."""
+    script = {
+        "messages": [
+            _assistant("Running."),
+            _tool("bash", "t1", "running", args={"cmd": "ls"}),
+            _tool("bash", "t1", "completed", result="file.txt"),
+            _assistant("Done."),
+        ],
+        "status": "finished",
+        "result": "Done.",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+    executor = CursorExecutor(api_key="crsr_x", permission_mode=mode)
+    executor._policy_evaluator = _policy_ask("PHASE_TOOL_CALL")
+
+    handler_called = False
+
+    async def _handler(_name: str, _args: dict[str, Any]) -> bool:
+        nonlocal handler_called
+        handler_called = True
+        return False  # would abort the turn if it were ever invoked
+
+    executor._elicitation_handler = _handler
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    assert not handler_called, "elicitation handler must not be called in autonomous mode"
+    assert any(isinstance(e, TurnComplete) for e in events)
+    assert not any(isinstance(e, ExecutorError) for e in events)
+
+
+async def test_run_turn_native_tool_auto_mode_still_honors_policy_deny(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hard POLICY_ACTION_DENY still blocks the tool call in ``"auto"``
+    mode — autonomous mode only skips human elicitation, not admin policy."""
+    script = {
+        "messages": [
+            _assistant("Running."),
+            _tool("bash", "t1", "running", args={"cmd": "rm -rf /"}),
+        ],
+        "status": "finished",
+        "result": "",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+    executor = CursorExecutor(api_key="crsr_x", permission_mode="auto")
+
+    async def _deny_policy(phase: str, _data: dict[str, Any]) -> Any:
+        action = "POLICY_ACTION_DENY" if phase == "PHASE_TOOL_CALL" else "POLICY_ACTION_ALLOW"
+        return SimpleNamespace(action=action, reason="admin blocked")
+
+    executor._policy_evaluator = _deny_policy
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert "admin blocked" in errors[0].message
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
 # ---------------------------------------------------------------------------
 # preToolUse hook: .cursor/hooks.json writing and cleanup
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1636,11 +1636,15 @@ async def test_ensure_session_writes_hooks_json(
     # ...so it must be owner-only (the baked token is never world-readable).
     assert wrapper.stat().st_mode & 0o777 == 0o700
 
-    # auto_review=True must be passed so cursor's own TUI approval prompts
-    # are bypassed in favour of the executor's native elicitation card.
+    # auto_review is deliberately NOT set: leaving it unset (the SDK's true
+    # Local-SDK default) lets tool calls run without cursor's own Smart Auto
+    # Review classifier able to HOLD on one and hit the hardcoded "Local SDK
+    # runs cannot request interactive approval" dead end. Omnigent's own
+    # policy/elicitation gate (_evaluate_native_tool_policy) remains the sole
+    # approval authority for native tools regardless.
     local_opts = sdk_state.get("local_options", [])
     assert local_opts, "LocalAgentOptions was never constructed"
-    assert local_opts[0].auto_review is True
+    assert local_opts[0].auto_review is None
 
     await executor.close()
     # Both files are cleaned up on close.

--- a/tests/inner/test_cursor_harness.py
+++ b/tests/inner/test_cursor_harness.py
@@ -88,6 +88,24 @@ def test_executor_factory_unset_optional_env_passes_none(
     assert captured["bundle_dir"] is None
     assert captured["agent_name"] is None
     assert captured["skills_filter"] == "all"
+    assert captured["permission_mode"] == "default"
+
+
+def test_executor_factory_reads_permission_mode_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_CURSOR_PERMISSION_MODE", "auto")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.cursor_harness.CursorExecutor.__init__",
+        _fake_init,
+    ):
+        cursor_harness._build_cursor_executor()
+
+    assert captured["permission_mode"] == "auto"
 
 
 def test_executor_factory_decodes_os_env_and_skills(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/runtime/test_cursor_spawn_env.py
+++ b/tests/runtime/test_cursor_spawn_env.py
@@ -44,11 +44,14 @@ def _make_spec(
     model: str | None = "gpt-5",
     name: str = "test-cursor",
     auth: ApiKeyAuth | DatabricksAuth | None = None,
+    permission_mode: str | None = None,
 ) -> AgentSpec:
     """Build a minimal cursor :class:`AgentSpec` for the spawn-env tests."""
     config: dict[str, object] = {"harness": "cursor"}
     if model is not None:
         config["model"] = model
+    if permission_mode is not None:
+        config["permission_mode"] = permission_mode
     return AgentSpec(
         spec_version=1,
         name=name,
@@ -68,6 +71,20 @@ def test_no_model_produces_no_model_env_var() -> None:
     """A spec with no model omits ``HARNESS_CURSOR_MODEL`` (cursor's default applies)."""
     env = _build_cursor_spawn_env(_make_spec(model=None))
     assert "HARNESS_CURSOR_MODEL" not in env
+
+
+def test_permission_mode_threads_into_env_var() -> None:
+    """``executor.config.permission_mode`` is encoded into
+    ``HARNESS_CURSOR_PERMISSION_MODE``, mirroring the claude-sdk builder."""
+    env = _build_cursor_spawn_env(_make_spec(permission_mode="auto"))
+    assert env["HARNESS_CURSOR_PERMISSION_MODE"] == "auto"
+
+
+def test_no_permission_mode_omits_env_var() -> None:
+    """A spec with no ``permission_mode`` omits the env var (wrap defaults to
+    ``"default"`` — always elicit on native tools, the historical behavior)."""
+    env = _build_cursor_spawn_env(_make_spec(permission_mode=None))
+    assert "HARNESS_CURSOR_PERMISSION_MODE" not in env
 
 
 def test_api_key_auth_sets_api_key_env_var() -> None:


### PR DESCRIPTION
## Summary

The `cursor` harness had three related bugs that made it behave inconsistently with `claude-sdk` and, in one case, break outright for headless Local SDK runs:

1. **No `permission_mode` for native tools.** `CursorExecutor` always surfaces a human-consent elicitation card for every Cursor-native tool call (Read/Write/Bash), regardless of the Omnigent policy outcome, because those tools execute inside the Cursor process itself and had no equivalent to `ClaudeSDKExecutor`'s `permission_mode`. MCP-bridged tools were already auto-approved for both harnesses, but native tools only ever asked under `cursor` — a real surprise when swapping harnesses on the same agent spec.
   - Added a `permission_mode` parameter to `CursorExecutor` (default: `"default"`, preserving today's always-elicit behavior).
   - Threaded through `cursor_harness.py` via a new `HARNESS_CURSOR_PERMISSION_MODE` env var, mirroring `HARNESS_CLAUDE_SDK_PERMISSION_MODE`.
   - Wired `executor.config.permission_mode` from the agent spec through `_build_cursor_spawn_env` in `workflow.py`.
   - A policy hard `POLICY_ACTION_DENY` still blocks the tool call in every mode — `auto`/`bypassPermissions` only skip the *human* elicitation step, not admin policy.

2. **`auto_review=True` was hardcoded and breaks Local SDK runs.** The existing code set `auto_review=True` on the theory that it was needed to bypass cursor's own TUI approval so `ToolCallRequest` events reach the executor's event stream. That's not correct for Local SDK runs: per the cursor-sdk docs, the true default (neither `auto_review` nor `sandbox_options` set) already "runs every tool call without restriction ... no human-in-the-loop prompt in headless mode". Setting `auto_review=True` instead re-enables cursor's own Smart Auto Review classifier, an independent decision layer that can HOLD (ask a human) on a tool call it isn't confident about — fatal in Local SDK mode, since the bridge's `requestApproval()` is hardcoded (confirmed by reading the vendored bundle, `cursor_sdk/_vendor/bridge/.../@cursor/sdk/dist/cjs/973.js`) to always return `{"approved": false, "reason": "Local SDK runs cannot request interactive approval for ..."}`, with no interactive channel available to answer it. Reproduced live: an MCP call failed with exactly that message under `auto_review=True` and succeeded once it was removed.

3. **`CURSOR_API_KEY` missing from the local daemon env allowlist.** `_build_host_daemon_env`'s allowlist covers every other provider key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) but omitted `CURSOR_API_KEY`, so an ambient key exported in the caller's shell (or set once via `cursor-agent login` / `omnigent setup`) never reached the spawned daemon process — `_build_cursor_spawn_env`'s ambient-key fallback reads it from the harness subprocess's own environment, which inherits from the daemon. Without this, the cursor harness always demanded an explicit `executor.auth.api_key`, unlike every other harness.

## Test plan

- [x] `tests/inner/test_cursor_executor.py`: added `test_run_turn_native_tool_auto_mode_skips_elicitation` (parametrized `auto`/`bypassPermissions`), `test_run_turn_native_tool_auto_mode_still_honors_policy_deny`; updated `test_ensure_session_writes_hooks_json` to assert `auto_review` stays unset.
- [x] `tests/inner/test_cursor_harness.py`: added `test_executor_factory_reads_permission_mode_env`; asserted the new default in `test_executor_factory_reads_env_vars`.
- [x] `tests/runtime/test_cursor_spawn_env.py`: added `test_permission_mode_threads_into_env_var` / `test_no_permission_mode_omits_env_var`.
- [x] `tests/cli/test_backend.py`: added `test_build_host_daemon_env_local_forwards_cursor_api_key`.
- [x] Ran the full set above plus the pre-existing cursor suites — 107 passed, 1 pre-existing unrelated failure (`test_create_app_returns_fastapi_with_required_routes`, a FastAPI version mismatch in my ad-hoc test env; reproduces on `main` without this change too).
- [x] All three fixes reproduced and verified end-to-end against a live Omnigent session running the `cursor` harness, not just unit tests.

Assisted-by: Claude Sonnet 5