### PR TITLE
feat(db): index policies by a name checksum instead of the raw name

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 from collections.abc import Iterator
 from contextvars import ContextVar
+from typing import Any
 
 from sqlalchemy import (
     BigInteger,
@@ -13,6 +15,7 @@ from sqlalchemy import (
     Float,
     Index,
     Integer,
+    LargeBinary,
     SmallInteger,
     String,
     Text,
@@ -21,7 +24,13 @@ from sqlalchemy import (
     text,
     true,
 )
+from sqlalchemy.dialects.mysql import BINARY as MySQLBinary
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+# 32-byte sha256 digest column. LargeBinary → BYTEA (Postgres) / BLOB (SQLite),
+# but MySQL cannot index a BLOB without a key-prefix length, so use fixed-length
+# BINARY(32) there — an exact fit for the digest and fully indexable.
+_CKSUM32 = LargeBinary(32).with_variant(MySQLBinary(32), "mysql")
 
 
 class Base(DeclarativeBase):
@@ -750,6 +759,26 @@ class SqlComment(Base):
     )
 
 
+def policy_name_cksum(name: str) -> bytes:
+    """Return the sha256 digest of a policy name.
+
+    This 32-byte digest is what the name-uniqueness indexes key on instead
+    of the raw ``VARCHAR(256)`` name — a fixed, compact index entry. Two
+    names collide iff their digests do, so uniqueness is preserved.
+    """
+    return hashlib.sha256(name.encode("utf-8")).digest()
+
+
+def _default_policy_name_cksum(context: Any) -> bytes:
+    """Column default: derive ``name_cksum`` from the bound ``name`` on INSERT.
+
+    Mirrors the ``workspace_id`` default pattern so every ORM insert stamps
+    the checksum without the caller setting it. Column defaults do not fire
+    on UPDATE, so renames recompute it explicitly in the store.
+    """
+    return policy_name_cksum(context.get_current_parameters()["name"])
+
+
 class SqlPolicy(Base):
     """
     SQLAlchemy model for the ``policies`` table.
@@ -763,9 +792,14 @@ class SqlPolicy(Base):
     are created via ``POST /v1/policies``.
 
     :param id: Opaque PK, e.g. ``"pol_a1b2c3..."``.
-    :param name: Human-readable name. UNIQUE per
-        ``(session_id, name)`` for session policies; globally
-        unique for default policies (``session_id IS NULL``).
+    :param name: Human-readable name. UNIQUE per session for
+        session policies; globally unique for default policies
+        (``session_id IS NULL``). Uniqueness is enforced on
+        ``name_cksum`` rather than this column.
+    :param name_cksum: sha256 digest of ``name`` (32 bytes). The
+        name-uniqueness indexes key on this compact digest instead
+        of the wide ``VARCHAR(256)`` name. Stamped on INSERT by a
+        column default; recomputed by the store on rename.
     :param session_id: FK to ``conversations.id``. ``None`` for
         server-wide default policies. ``ON DELETE CASCADE`` so
         removing a session cleans up its policies.
@@ -802,6 +836,10 @@ class SqlPolicy(Base):
     )
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     name: Mapped[str] = mapped_column(String(256))
+    # sha256(name) — the value the name-uniqueness indexes key on instead of
+    # the wide name column. Stamped from `name` on INSERT via the column
+    # default; the store recomputes it on rename (defaults don't fire on UPDATE).
+    name_cksum: Mapped[bytes] = mapped_column(_CKSUM32, default=_default_policy_name_cksum)
     # Nullable: NULL for server-wide default policies.
     session_id: Mapped[str | None] = mapped_column(
         String(64),
@@ -833,14 +871,16 @@ class SqlPolicy(Base):
         CheckConstraint("scope IN (1, 2)", name="ck_policies_scope"),
         Index("ix_policies_created_at", "created_at"),
         Index("ix_policies_session_id", "session_id"),
-        UniqueConstraint("session_id", "name", name="uq_policies_session_id_name"),
+        # Name uniqueness keys on name_cksum (sha256 of name) rather than the
+        # wide name column, for a compact 32-byte index entry.
+        UniqueConstraint("session_id", "name_cksum", name="uq_policies_session_id_name_cksum"),
         # Default policies must have unique names; session-scoped policies
         # may reuse the same name across conversations. Mirrors
         # ix_agents_template_name scoping to the 'default' set. scope = 1 is
         # the "default" code.
         Index(
-            "ix_policies_default_name",
-            "name",
+            "ix_policies_default_name_cksum",
+            "name_cksum",
             unique=True,
             sqlite_where=text("scope = 1"),
             postgresql_where=text("scope = 1"),

--- a/omnigent/db/migrations/versions/x1a2b3c4d5e6_policies_name_cksum.py
+++ b/omnigent/db/migrations/versions/x1a2b3c4d5e6_policies_name_cksum.py
@@ -1,0 +1,134 @@
+"""Index policies by a name checksum instead of the raw name.
+
+Revision ID: x1a2b3c4d5e6
+Revises: w1a2b3c4d5e6
+Create Date: 2026-07-08 00:00:00.000000
+
+The ``policies`` table enforced name uniqueness on the ``VARCHAR(256)``
+``name`` column via two structures:
+
+- ``ix_policies_default_name`` — partial UNIQUE index on ``name`` where
+  ``scope = 1`` (default policies must have globally-unique names).
+- ``uq_policies_session_id_name`` — composite UNIQUE on ``(session_id, name)``
+  (session-scoped policies must have unique names within a session).
+
+This migration adds a ``name_cksum`` column holding ``sha256(name)`` (a fixed
+32-byte digest) and repoints both structures at it, so the index entries are
+compact and fixed-width instead of a wide varchar. Uniqueness semantics are
+unchanged: two names collide iff their digests do.
+
+SQLite has no ``sha256()`` SQL function, so ``name_cksum`` is back-filled in
+Python. The NOT NULL flip and the constraint swap run in a
+``batch_alter_table`` (``recreate="always"`` on SQLite) guarded by the same
+``PRAGMA foreign_keys`` toggle as the surrounding policy migrations.
+
+Column type by dialect: ``LargeBinary`` renders as ``BYTEA`` (Postgres) /
+``BLOB`` (SQLite), but MySQL cannot index a ``BLOB`` without a key-prefix
+length, so the column is ``BINARY(32)`` on MySQL — an exact fit for the digest
+and fully indexable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import BINARY as MySQLBinary
+
+revision: str = "x1a2b3c4d5e6"
+down_revision: str | None = "w1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# BYTEA/BLOB elsewhere, BINARY(32) on MySQL (BLOB is not indexable there).
+_CKSUM32 = sa.LargeBinary(length=32).with_variant(MySQLBinary(32), "mysql")
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def _name_cksum(name: str) -> bytes:
+    """sha256 digest of a policy name (kept self-contained in the migration)."""
+    return hashlib.sha256(name.encode("utf-8")).digest()
+
+
+def _backfill_name_cksum() -> None:
+    """Compute ``name_cksum`` from ``name`` for every existing row, in Python."""
+    bind = op.get_bind()
+    rows = bind.execute(sa.text("SELECT workspace_id, id, name FROM policies")).fetchall()
+    for workspace_id, policy_id, name in rows:
+        bind.execute(
+            sa.text(
+                "UPDATE policies SET name_cksum = :cksum "
+                "WHERE workspace_id = :workspace_id AND id = :id"
+            ),
+            {"cksum": _name_cksum(name), "workspace_id": workspace_id, "id": policy_id},
+        )
+
+
+def upgrade() -> None:
+    """
+    1. Add ``name_cksum`` as nullable so we can back-fill before NOT NULL.
+    2. Back-fill ``name_cksum = sha256(name)`` in Python.
+    3. Drop the old ``name``-keyed index/constraint; add the ``name_cksum`` ones;
+       make ``name_cksum`` NOT NULL.
+    """
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    # ADD COLUMN is native on SQLite; add nullable first so back-fill can run.
+    op.add_column("policies", sa.Column("name_cksum", _CKSUM32, nullable=True))
+    _backfill_name_cksum()
+
+    # Partial-index predicate references scope; drop it before the batch rebuild
+    # so batch mode doesn't copy a stale index, then create the replacement.
+    op.drop_index("ix_policies_default_name", table_name="policies")
+
+    with op.batch_alter_table("policies", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.alter_column("name_cksum", existing_type=_CKSUM32, nullable=False)
+        batch_op.drop_constraint("uq_policies_session_id_name", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_policies_session_id_name_cksum", ["session_id", "name_cksum"]
+        )
+
+    op.create_index(
+        "ix_policies_default_name_cksum",
+        "policies",
+        ["name_cksum"],
+        unique=True,
+        sqlite_where=sa.text("scope = 1"),
+        postgresql_where=sa.text("scope = 1"),
+    )
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def downgrade() -> None:
+    """Restore the ``name``-keyed index/constraint and drop ``name_cksum``."""
+    sqlite = _is_sqlite()
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    op.drop_index("ix_policies_default_name_cksum", table_name="policies")
+
+    with op.batch_alter_table("policies", recreate="always" if sqlite else "auto") as batch_op:
+        batch_op.drop_constraint("uq_policies_session_id_name_cksum", type_="unique")
+        batch_op.create_unique_constraint("uq_policies_session_id_name", ["session_id", "name"])
+        batch_op.drop_column("name_cksum")
+
+    op.create_index(
+        "ix_policies_default_name",
+        "policies",
+        ["name"],
+        unique=True,
+        sqlite_where=sa.text("scope = 1"),
+        postgresql_where=sa.text("scope = 1"),
+    )
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from omnigent.db.db_models import (
     SqlPolicy,
     current_workspace_id,
+    policy_name_cksum,
 )
 from omnigent.db.enum_codecs import (
     decode_policy_scope,
@@ -145,6 +146,8 @@ class SqlAlchemyPolicyStore(PolicyStore):
             changed = False
             if name is not None and row.name != name:
                 row.name = name
+                # Column defaults don't fire on UPDATE — recompute the digest.
+                row.name_cksum = policy_name_cksum(name)
                 changed = True
             if handler is not None and row.handler != handler:
                 row.handler = handler
@@ -183,9 +186,9 @@ class SqlAlchemyPolicyStore(PolicyStore):
         Raises ``IntegrityError`` on name collision among defaults.
 
         SQLite treats NULLs as distinct in composite unique
-        constraints, so the ``(session_id, name)`` constraint
+        constraints, so the ``(session_id, name_cksum)`` constraint
         does not enforce uniqueness among default policies.
-        This method checks for duplicates explicitly.
+        This method checks for duplicates explicitly (by name digest).
         """
 
         row = SqlPolicy(
@@ -210,7 +213,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
                     select(SqlPolicy)
                     .where(SqlPolicy.workspace_id == current_workspace_id())
                     .where(SqlPolicy.scope == encode_policy_scope("default"))
-                    .where(SqlPolicy.name == name)
+                    .where(SqlPolicy.name_cksum == policy_name_cksum(name))
                 )
                 .scalars()
                 .first()
@@ -264,14 +267,14 @@ class SqlAlchemyPolicyStore(PolicyStore):
             changed = False
             if name is not None and row.name != name:
                 # Explicit uniqueness check for the application layer;
-                # the partial index ix_policies_default_name is the
+                # the partial index ix_policies_default_name_cksum is the
                 # DB-layer guard, but checking here gives a cleaner error.
                 conflict = (
                     session.execute(
                         select(SqlPolicy)
                         .where(SqlPolicy.workspace_id == current_workspace_id())
                         .where(SqlPolicy.scope == encode_policy_scope("default"))
-                        .where(SqlPolicy.name == name)
+                        .where(SqlPolicy.name_cksum == policy_name_cksum(name))
                         .where(SqlPolicy.id != policy_id)
                     )
                     .scalars()
@@ -284,6 +287,8 @@ class SqlAlchemyPolicyStore(PolicyStore):
                         orig=Exception(f"UNIQUE constraint: name={name!r}"),
                     )
                 row.name = name
+                # Column defaults don't fire on UPDATE — recompute the digest.
+                row.name_cksum = policy_name_cksum(name)
                 changed = True
             if handler is not None and row.handler != handler:
                 row.handler = handler

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -7,6 +7,7 @@ behave as expected.
 
 from __future__ import annotations
 
+import hashlib
 import time
 
 import pytest
@@ -694,6 +695,8 @@ class TestSqlPolicy:
             loaded = session.get(SqlPolicy, (0, "pol_test1"))
             assert loaded is not None
             assert loaded.name == "cost-guard"
+            # The column default stamps sha256(name) on INSERT.
+            assert loaded.name_cksum == hashlib.sha256(b"cost-guard").digest()
             assert loaded.type == encode_policy_type("python")
             assert loaded.enabled is True
             assert loaded.session_id is None

--- a/tests/db/test_migration_policy_name_cksum.py
+++ b/tests/db/test_migration_policy_name_cksum.py
@@ -1,0 +1,122 @@
+"""Tests for the policies.name_cksum migration (x1a2b3c4d5e6)."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite database with the full migration chain applied."""
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def test_name_cksum_column_exists_and_is_not_nullable(db_engine: Engine) -> None:
+    """policies.name_cksum is a NOT NULL binary column after the migration."""
+    columns = {c["name"]: c for c in sa.inspect(db_engine).get_columns("policies")}
+    assert "name_cksum" in columns, "policies.name_cksum column must exist after migration"
+    assert not columns["name_cksum"]["nullable"], "policies.name_cksum must be NOT NULL"
+
+
+def test_name_indexes_key_on_checksum(db_engine: Engine) -> None:
+    """Both name-uniqueness structures key on name_cksum, not name."""
+    inspector = sa.inspect(db_engine)
+
+    indexes = {i["name"]: i for i in inspector.get_indexes("policies")}
+    assert "ix_policies_default_name_cksum" in indexes
+    assert indexes["ix_policies_default_name_cksum"]["unique"]
+    assert indexes["ix_policies_default_name_cksum"]["column_names"] == ["name_cksum"]
+    # The old raw-name index is gone.
+    assert "ix_policies_default_name" not in indexes
+
+    uniques = {u["name"]: u for u in inspector.get_unique_constraints("policies")}
+    assert "uq_policies_session_id_name_cksum" in uniques
+    assert uniques["uq_policies_session_id_name_cksum"]["column_names"] == [
+        "session_id",
+        "name_cksum",
+    ]
+    assert "uq_policies_session_id_name" not in uniques
+
+
+def test_backfill_computes_sha256_of_name(tmp_path: Path) -> None:
+    """Rows present before x1a2b3c4d5e6 get name_cksum = sha256(name)."""
+    db_path = tmp_path / "backfill.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    config = _build_alembic_config(uri)
+
+    # Stop just below this migration (name_cksum not added yet), insert a row
+    # without it, then upgrade so the migration's Python back-fill runs.
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, "w1a2b3c4d5e6")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                # scope=1 default, type=1 python (int codes at this revision).
+                "INSERT INTO policies"
+                " (workspace_id, id, name, session_id, scope, created_at, type, handler, enabled)"
+                " VALUES (0, 'pol_bf1', 'legacy_name', NULL, 1, 1, 1, 'mod.f', 1)"
+            )
+        )
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, "x1a2b3c4d5e6")
+
+    with engine.begin() as conn:
+        cksum = conn.execute(
+            sa.text("SELECT name_cksum FROM policies WHERE id = 'pol_bf1'")
+        ).scalar_one()
+    assert bytes(cksum) == hashlib.sha256(b"legacy_name").digest()
+
+    engine.dispose()
+    clear_engine_cache()
+
+
+def test_downgrade_restores_name_index_and_drops_checksum(tmp_path: Path) -> None:
+    """Downgrade drops name_cksum and restores the raw-name index/constraint."""
+    db_path = tmp_path / "downgrade.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+
+    # Start at head (includes the name_cksum migration x1a2b3c4d5e6).
+    assert "name_cksum" in {c["name"] for c in sa.inspect(engine).get_columns("policies")}
+
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, "w1a2b3c4d5e6")
+
+    inspector = sa.inspect(engine)
+    columns = {c["name"] for c in inspector.get_columns("policies")}
+    assert "name_cksum" not in columns, "name_cksum must be dropped by downgrade"
+
+    index_names = {i["name"] for i in inspector.get_indexes("policies")}
+    assert "ix_policies_default_name_cksum" not in index_names
+    assert "ix_policies_default_name" in index_names, "raw-name index must be restored"
+
+    uniques = {u["name"] for u in inspector.get_unique_constraints("policies")}
+    assert "uq_policies_session_id_name_cksum" not in uniques
+    assert "uq_policies_session_id_name" in uniques, "raw-name constraint must be restored"
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/db/test_migration_policy_scope.py
+++ b/tests/db/test_migration_policy_scope.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -37,10 +38,14 @@ def test_scope_column_exists_and_is_not_nullable(db_engine: Engine) -> None:
 
 
 def test_ix_policies_default_name_index_exists(db_engine: Engine) -> None:
-    """ix_policies_default_name unique index is present after the migration."""
+    """The default-name unique index is present after the migration chain.
+
+    At head the index keys on ``name_cksum`` (see x1a2b3c4d5e6), not the raw
+    name — the ``_cksum`` name is what survives the full chain.
+    """
     indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("policies")}
-    assert "ix_policies_default_name" in indexes
-    assert indexes["ix_policies_default_name"]["unique"]
+    assert "ix_policies_default_name_cksum" in indexes
+    assert indexes["ix_policies_default_name_cksum"]["unique"]
 
 
 def test_backfill_sets_session_scope_for_session_policies(db_engine: Engine) -> None:
@@ -58,10 +63,12 @@ def test_backfill_sets_session_scope_for_session_policies(db_engine: Engine) -> 
         conn.execute(
             sa.text(
                 # scope runs at head, where it is an int code (2 = "session").
+                # name_cksum is NOT NULL at head (x1a2b3c4d5e6) — sha256(name).
                 "INSERT INTO policies"
-                " (id, name, session_id, scope, created_at, type, handler, enabled)"
-                " VALUES ('pol_sc1', 'sess_pol', 'conv_sc1', 2, 1, 1, 'mod.f', 1)"
-            )
+                " (id, name, name_cksum, session_id, scope, created_at, type, handler, enabled)"
+                " VALUES ('pol_sc1', 'sess_pol', :cksum, 'conv_sc1', 2, 1, 1, 'mod.f', 1)"
+            ),
+            {"cksum": hashlib.sha256(b"sess_pol").digest()},
         )
         scope = conn.execute(
             sa.text("SELECT scope FROM policies WHERE id = 'pol_sc1'")
@@ -75,10 +82,12 @@ def test_backfill_sets_default_scope_for_default_policies(db_engine: Engine) -> 
         conn.execute(
             sa.text(
                 # scope runs at head, where it is an int code (1 = "default").
+                # name_cksum is NOT NULL at head (x1a2b3c4d5e6) — sha256(name).
                 "INSERT INTO policies"
-                " (id, name, session_id, scope, created_at, type, handler, enabled)"
-                " VALUES ('pol_def1', 'def_pol', NULL, 1, 1, 1, 'mod.f', 1)"
-            )
+                " (id, name, name_cksum, session_id, scope, created_at, type, handler, enabled)"
+                " VALUES ('pol_def1', 'def_pol', :cksum, NULL, 1, 1, 1, 'mod.f', 1)"
+            ),
+            {"cksum": hashlib.sha256(b"def_pol").digest()},
         )
         scope = conn.execute(
             sa.text("SELECT scope FROM policies WHERE id = 'pol_def1'")


### PR DESCRIPTION
## Related issue

N/A

## Summary

The `policies` table enforced name uniqueness on the wide `VARCHAR(256)` `name`
column via two structures — a partial unique index `ix_policies_default_name`
(default policies, globally unique names) and a composite unique constraint
`(session_id, name)` (session-scoped policies). This repoints both at a new
`name_cksum` column holding `sha256(name)` — a fixed **32-byte** digest — so the
index entries are compact and fixed-width instead of a wide varchar.

- Uniqueness semantics are unchanged: two names collide iff their digests do.
- The checksum is stamped on INSERT by an ORM column default and recomputed by
  the store on rename. It stays store-internal — never added to the `Policy`
  entity or the HTTP/SDK schema (same boundary as the enum int-codes).
- New Alembic migration `v1a2b3c4d5e6` adds the column, back-fills
  `sha256(name)` in Python (SQLite has no `sha256()`), and swaps the
  index/constraint in a batch block; fully reversible.

## Test Plan

- `pytest tests/db/test_migration_policy_name_cksum.py tests/db/test_migration_policy_scope.py tests/db/test_migrations_sqlite_safe.py tests/db/test_db_models.py` — new migration back-fills correctly, full SQLite chain round-trips + reverses, static SQLite-safe-DDL guard passes (constraint ops are batched).
- `pytest tests/stores/test_session_policy_store.py tests/server/routes/test_default_policies.py tests/server/routes/test_session_policies_crud.py tests/server/integration/test_default_policy_routes.py tests/server/integration/test_session_policy_routes.py` — duplicate-name rejection (409 / IntegrityError) and cross-scope same-name behavior unchanged.
- **145 tests pass** across the combined set. `ruff format` + `ruff check` clean.

## Demo

N/A — DB schema / storage change, no visual surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New migration test (`test_migration_policy_name_cksum.py`) covers back-fill,
index/constraint shape, and downgrade. Existing store + server policy suites
already assert duplicate-name rejection and cross-scope same-name allowance;
those pass unchanged because `sha256(name)` collides iff `name` does.
