### PR TITLE
feat(android): add ktlint formatter to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,23 +105,19 @@ jobs:
       # ktlint is invoked by the android-ktlint-* pre-commit hooks. The wrapper
       # script (web/android/bin/ktlint.sh) exits 0 if ktlint is absent, so we
       # install it here before pre-commit runs to ensure the check is enforced.
-      # The SHA-256 is verified against the checksum published alongside each
-      # ktlint release so a corrupted or spoofed download is caught before the
-      # binary is made executable.
+      # The binary is verified against a pinned SHA-256 so a corrupted or spoofed
+      # download is caught before the binary is made executable.
       - name: Install ktlint
         env:
           KTLINT_VERSION: "1.8.0"
+          KTLINT_SHA256: "a3fd620207d5c40da6ca789b95e7f823c54e854b7fade7f613e91096a3706d75"
         run: |
-          cd /tmp
           curl -sSLf \
-            "https://github.com/pinterest/ktlint/releases/download/${KTLINT_VERSION}/ktlint" \
-            -o ktlint
-          curl -sSLf \
-            "https://github.com/pinterest/ktlint/releases/download/${KTLINT_VERSION}/ktlint.sha256" \
-            -o ktlint.sha256
-          sha256sum -c ktlint.sha256
-          chmod +x ktlint
-          sudo mv ktlint /usr/local/bin/ktlint
+            "https://github.com/ktlint/ktlint/releases/download/${KTLINT_VERSION}/ktlint" \
+            -o /tmp/ktlint
+          echo "${KTLINT_SHA256}  /tmp/ktlint" | sha256sum -c
+          chmod +x /tmp/ktlint
+          sudo mv /tmp/ktlint /usr/local/bin/ktlint
 
       - name: Run formatting, lint, and typing checks
         run: uv run pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,14 +105,23 @@ jobs:
       # ktlint is invoked by the android-ktlint-* pre-commit hooks. The wrapper
       # script (web/android/bin/ktlint.sh) exits 0 if ktlint is absent, so we
       # install it here before pre-commit runs to ensure the check is enforced.
+      # The SHA-256 is verified against the checksum published alongside each
+      # ktlint release so a corrupted or spoofed download is caught before the
+      # binary is made executable.
       - name: Install ktlint
         env:
           KTLINT_VERSION: "1.8.0"
         run: |
-          curl -sSL \
+          cd /tmp
+          curl -sSLf \
             "https://github.com/pinterest/ktlint/releases/download/${KTLINT_VERSION}/ktlint" \
-            -o /usr/local/bin/ktlint
-          chmod +x /usr/local/bin/ktlint
+            -o ktlint
+          curl -sSLf \
+            "https://github.com/pinterest/ktlint/releases/download/${KTLINT_VERSION}/ktlint.sha256" \
+            -o ktlint.sha256
+          sha256sum -c ktlint.sha256
+          chmod +x ktlint
+          sudo mv ktlint /usr/local/bin/ktlint
 
       - name: Run formatting, lint, and typing checks
         run: uv run pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,6 +102,18 @@ jobs:
             exit 1
           }
 
+      # ktlint is invoked by the android-ktlint-* pre-commit hooks. The wrapper
+      # script (web/android/bin/ktlint.sh) exits 0 if ktlint is absent, so we
+      # install it here before pre-commit runs to ensure the check is enforced.
+      - name: Install ktlint
+        env:
+          KTLINT_VERSION: "1.8.0"
+        run: |
+          curl -sSL \
+            "https://github.com/pinterest/ktlint/releases/download/${KTLINT_VERSION}/ktlint" \
+            -o /usr/local/bin/ktlint
+          chmod +x /usr/local/bin/ktlint
+
       - name: Run formatting, lint, and typing checks
         run: uv run pre-commit run --all-files --show-diff-on-failure
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,26 @@ repos:
         # fights the tooling).
         exclude: ^(omnigent/server/static/web-ui/assets/|web/.*\.xcassets/|web/.*\.icon/)
 
+      # Android Kotlin formatting + linting via ktlint (config:
+      # web/android/.editorconfig). The wrapper no-ops when ktlint is absent,
+      # so local machines without ktlint installed skip cleanly. CI installs
+      # ktlint before running pre-commit, so the check is enforced there.
+      # Install locally with `brew install ktlint` (macOS) or download from
+      # https://github.com/pinterest/ktlint/releases.
+      - id: android-ktlint-format
+        name: android ktlint format
+        language: system
+        entry: web/android/bin/ktlint.sh --format
+        files: ^web/android/.*\.kts?$
+        exclude: ^web/android/(build|\.gradle)/
+
+      - id: android-ktlint-check
+        name: android ktlint check
+        language: system
+        entry: web/android/bin/ktlint.sh
+        files: ^web/android/.*\.kts?$
+        exclude: ^web/android/(build|\.gradle)/
+
       # iOS Swift formatting + linting via Apple's `swift format` (config:
       # web/ios/.swift-format). The wrapper no-ops when the Swift toolchain
       # is absent, so these run on macOS dev machines but skip the ubuntu-latest

--- a/web/android/.editorconfig
+++ b/web/android/.editorconfig
@@ -1,5 +1,6 @@
 # ktlint reads EditorConfig for Kotlin style settings.
 # https://pinterest.github.io/ktlint/latest/rules/standard/
+root = true
 
 [*.{kt,kts}]
 max_line_length = 100

--- a/web/android/.editorconfig
+++ b/web/android/.editorconfig
@@ -1,0 +1,8 @@
+# ktlint reads EditorConfig for Kotlin style settings.
+# https://pinterest.github.io/ktlint/latest/rules/standard/
+
+[*.{kt,kts}]
+max_line_length = 100
+indent_size = 4
+indent_style = space
+ktlint_standard = enabled

--- a/web/android/app/src/main/java/ai/omnigent/android/BlobDownloadScript.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/BlobDownloadScript.kt
@@ -13,7 +13,10 @@ package ai.omnigent.android
  */
 object BlobDownloadScript {
     /** JS that reads [url] (a blob:/data: URL) and posts it to the native side. */
-    fun fetchAsBase64(url: String, suggestedName: String): String {
+    fun fetchAsBase64(
+        url: String,
+        suggestedName: String,
+    ): String {
         val u = jsString(url)
         val name = jsString(suggestedName)
         return """
@@ -42,6 +45,6 @@ object BlobDownloadScript {
                 })
                 .catch(() => {});
             })();
-        """.trimIndent()
+            """.trimIndent()
     }
 }

--- a/web/android/app/src/main/java/ai/omnigent/android/BlobSaver.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/BlobSaver.kt
@@ -22,7 +22,9 @@ import java.util.concurrent.Executors
  * Trust is enforced upstream by the bridge's origin allowlist + main-frame gate,
  * so this class does no origin checking of its own.
  */
-class BlobSaver(private val context: Context) {
+class BlobSaver(
+    private val context: Context,
+) {
     private val main = Handler(Looper.getMainLooper())
     private val io = Executors.newSingleThreadExecutor()
 
@@ -31,7 +33,11 @@ class BlobSaver(private val context: Context) {
         io.shutdown()
     }
 
-    fun save(base64: String, mimeType: String, suggestedName: String) {
+    fun save(
+        base64: String,
+        mimeType: String,
+        suggestedName: String,
+    ) {
         io.execute {
             val bytes =
                 try {
@@ -54,7 +60,11 @@ class BlobSaver(private val context: Context) {
     }
 
     @RequiresApi(Build.VERSION_CODES.Q)
-    private fun saveViaMediaStore(name: String, mimeType: String, bytes: ByteArray): Boolean =
+    private fun saveViaMediaStore(
+        name: String,
+        mimeType: String,
+        bytes: ByteArray,
+    ): Boolean =
         runCatching {
             val resolver = context.contentResolver
             val values =
@@ -73,7 +83,10 @@ class BlobSaver(private val context: Context) {
             true
         }.getOrDefault(false)
 
-    private fun saveToAppDownloads(name: String, bytes: ByteArray): Boolean =
+    private fun saveToAppDownloads(
+        name: String,
+        bytes: ByteArray,
+    ): Boolean =
         runCatching {
             val dir =
                 context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
@@ -86,7 +99,9 @@ class BlobSaver(private val context: Context) {
         // Basename past either separator style — a Windows-flavored "foo\bar.txt"
         // suggestion should save as "bar.txt", not "foo_bar.txt".
         val cleaned =
-            suggested.substringAfterLast('/').substringAfterLast('\\')
+            suggested
+                .substringAfterLast('/')
+                .substringAfterLast('\\')
                 .replace(Regex("[^A-Za-z0-9._-]"), "_")
         // "" / "." / ".." aren't usable names — on the API 28 File path "." and
         // ".." resolve to a directory, so the write would fail. Fall back instead.

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -195,7 +195,13 @@ class MainActivity : ComponentActivity() {
                             if (webView.canGoBack()) webView.goBack() else finish()
                         }
                     }
-                    val fallback = Runnable { if (!acted) { acted = true; navigate() } }
+                    val fallback =
+                        Runnable {
+                            if (!acted) {
+                                acted = true
+                                navigate()
+                            }
+                        }
                     webView.postDelayed(fallback, BACK_FALLBACK_MS)
                     webView.evaluateJavascript(
                         "!!(window.__omnigentNativeHandleBack && window.__omnigentNativeHandleBack())",
@@ -298,18 +304,24 @@ class MainActivity : ComponentActivity() {
         val secure = origin.startsWith("https://")
         // Matches the server's session_cookie_name: __Host- prefix on HTTPS.
         val name = if (secure) "__Host-ap_session" else "ap_session"
-        val cookie = buildString {
-            append(name).append('=').append(token).append("; Path=/")
-            if (secure) append("; Secure")
-            append("; SameSite=Lax")
-        }
+        val cookie =
+            buildString {
+                append(name).append('=').append(token).append("; Path=/")
+                if (secure) append("; Secure")
+                append("; SameSite=Lax")
+            }
         val cookies = CookieManager.getInstance()
         cookies.setAcceptCookie(true)
         authLog("onSessionToken: injecting $name (token len=${token.length})")
         cookies.setCookie(origin, cookie) { accepted ->
             // setCookie's callback is async — re-check the WebView is still alive.
             if (isDestroyed || !::webView.isInitialized) return@setCookie
-            authLog("setCookie accepted=$accepted present=${cookies.getCookie(origin)?.contains(name) == true}")
+            authLog(
+                "setCookie accepted=$accepted present=${cookies
+                    .getCookie(
+                        origin,
+                    )?.contains(name) == true}",
+            )
             // A rejected cookie means the reload would land unauthenticated,
             // bounce to login, and re-launch the browser — burning the retry
             // budget on a failure that retrying can't fix. Stay put instead.
@@ -398,7 +410,8 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun navigatePathOf(intent: Intent?): String? =
-        intent?.getStringExtra(NativeNotificationManager.EXTRA_NAVIGATE_PATH)
+        intent
+            ?.getStringExtra(NativeNotificationManager.EXTRA_NAVIGATE_PATH)
             ?.takeIf { it.startsWith("/") }
 
     private fun emitNotificationActivation(path: String?) {
@@ -450,19 +463,28 @@ class MainActivity : ComponentActivity() {
         ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
 
     private fun ensureNotificationPermission() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return // granted at install < API 33
+        // Notification permission is granted at install time below API 33.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
         if (!hasPermission(Manifest.permission.POST_NOTIFICATIONS)) {
             requestNotifications.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 
     /** Back [OmnigentWebChromeClient.onShowFileChooser] with a document picker. */
-    private fun chooseFiles(callback: ValueCallback<Array<Uri>>, acceptTypes: Array<String>): Boolean {
+    private fun chooseFiles(
+        callback: ValueCallback<Array<Uri>>,
+        acceptTypes: Array<String>,
+    ): Boolean {
         pendingFileCallback?.onReceiveValue(null) // cancel any in-flight chooser
         pendingFileCallback = callback
         // Keep MIME types as-is; resolve ".pdf"-style extension tokens to MIME so
         // the declared accept constraint isn't silently widened to */*.
-        val mimeTypes = acceptTypes.mapNotNull(::mimeTypeFor).toTypedArray().ifEmpty { arrayOf("*/*") }
+        val mimeTypes =
+            acceptTypes
+                .mapNotNull(
+                    ::mimeTypeFor,
+                ).toTypedArray()
+                .ifEmpty { arrayOf("*/*") }
         return try {
             pickFiles.launch(mimeTypes)
             true
@@ -477,11 +499,20 @@ class MainActivity : ComponentActivity() {
     private fun mimeTypeFor(accept: String): String? {
         val token = accept.trim()
         return when {
-            token.isEmpty() -> null
-            token.contains('/') -> token // already a MIME type / wildcard
-            else ->
-                MimeTypeMap.getSingleton()
+            token.isEmpty() -> {
+                null
+            }
+
+            token.contains('/') -> {
+                token
+            }
+
+            // already a MIME type / wildcard
+            else -> {
+                MimeTypeMap
+                    .getSingleton()
                     .getMimeTypeFromExtension(token.removePrefix(".").lowercase())
+            }
         }
     }
 
@@ -501,7 +532,11 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun downloadFile(url: String, contentDisposition: String?, mimeType: String?) {
+    private fun downloadFile(
+        url: String,
+        contentDisposition: String?,
+        mimeType: String?,
+    ) {
         val name = URLUtil.guessFileName(url, contentDisposition, mimeType)
 
         // Agent-generated files arrive as blob:/data: URLs, which DownloadManager

--- a/web/android/app/src/main/java/ai/omnigent/android/NativeNotificationManager.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/NativeNotificationManager.kt
@@ -21,8 +21,11 @@ import java.util.concurrent.atomic.AtomicInteger
  * [MainActivity] on API 33+): [post] drops silently if disabled or revoked, so
  * the web layer keeps working without OS toasts.
  */
-class NativeNotificationManager(private val context: Context) {
+class NativeNotificationManager(
+    private val context: Context,
+) {
     private val manager = NotificationManagerCompat.from(context)
+
     // Ids at/above BADGE_NOTIFICATION_ID + 1 so per-session toasts never collide
     // with the reserved badge-summary notification.
     private val nextId = AtomicInteger(BADGE_NOTIFICATION_ID + 1)
@@ -37,10 +40,15 @@ class NativeNotificationManager(private val context: Context) {
         manager.createNotificationChannel(channel)
     }
 
-    fun notify(title: String, body: String?, navigatePath: String?) {
+    fun notify(
+        title: String,
+        body: String?,
+        navigatePath: String?,
+    ) {
         val id = nextId.getAndIncrement()
         val builder =
-            NotificationCompat.Builder(context, CHANNEL_ID)
+            NotificationCompat
+                .Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle(title)
                 .setContentText(body.orEmpty())
@@ -63,11 +71,13 @@ class NativeNotificationManager(private val context: Context) {
     fun setBadgeCount(count: Int) {
         if (count <= 0) return
         val summary =
-            NotificationCompat.Builder(context, CHANNEL_ID)
+            NotificationCompat
+                .Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle(context.getString(R.string.app_name))
-                .setContentText(context.resources.getQuantityString(R.plurals.badge_text, count, count))
-                .setNumber(count)
+                .setContentText(
+                    context.resources.getQuantityString(R.plurals.badge_text, count, count),
+                ).setNumber(count)
                 .setSilent(true)
                 .setOngoing(false)
                 .build()
@@ -80,7 +90,10 @@ class NativeNotificationManager(private val context: Context) {
      * throw `SecurityException` even after `areNotificationsEnabled()` — we drop
      * silently rather than crash.
      */
-    private fun post(id: Int, notification: Notification) {
+    private fun post(
+        id: Int,
+        notification: Notification,
+    ) {
         if (!manager.areNotificationsEnabled()) return
         try {
             manager.notify(id, notification)
@@ -92,7 +105,10 @@ class NativeNotificationManager(private val context: Context) {
     // requestCode is the notification's own id, so each notification gets a
     // distinct PendingIntent — otherwise FLAG_UPDATE_CURRENT would let two paths
     // with colliding hashes overwrite each other's extras and mis-route a tap.
-    private fun activationIntent(navigatePath: String, requestCode: Int): PendingIntent {
+    private fun activationIntent(
+        navigatePath: String,
+        requestCode: Int,
+    ): PendingIntent {
         val intent =
             Intent(context, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP

--- a/web/android/app/src/main/java/ai/omnigent/android/OidcLoginManager.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OidcLoginManager.kt
@@ -48,7 +48,11 @@ class OidcLoginManager {
      * flight (a second concurrent call is ignored). The caller uses the result so
      * a no-op call isn't counted against a retry budget.
      */
-    fun start(activity: Activity, origin: String, onSession: (String) -> Unit): Boolean {
+    fun start(
+        activity: Activity,
+        origin: String,
+        onSession: (String) -> Unit,
+    ): Boolean {
         if (!inFlight.compareAndSet(false, true)) return false
         sessionCallback = onSession
         io.execute {
@@ -59,7 +63,9 @@ class OidcLoginManager {
                 if (ticket != null) {
                     main.post { launchTab(activity, origin + ticket.loginUrl) }
                     token = pollForToken(origin, ticket.id)
-                    authLog("poll -> ${if (token != null) "token (len=${token.length})" else "no token"}")
+                    authLog(
+                        "poll -> ${if (token != null) "token (len=${token.length})" else "no token"}",
+                    )
                 }
             } catch (_: InterruptedException) {
                 // shutdown() interrupted the poll — the host is going away; drop.
@@ -82,7 +88,10 @@ class OidcLoginManager {
         io.shutdownNow() // interrupts the polling sleep so the task exits promptly
     }
 
-    private data class Ticket(val id: String, val loginUrl: String)
+    private data class Ticket(
+        val id: String,
+        val loginUrl: String,
+    )
 
     private fun requestTicket(origin: String): Ticket? {
         val conn = (URL("$origin/auth/cli-login").openConnection() as HttpURLConnection)
@@ -108,32 +117,53 @@ class OidcLoginManager {
         }
     }
 
-    private fun launchTab(activity: Activity, url: String) {
+    private fun launchTab(
+        activity: Activity,
+        url: String,
+    ) {
         // Full system browser (not a Custom Tab): the IdP flow page renders blank
         // in an in-app Custom Tab on some setups but works in the browser. Still
         // RFC 8252 — the system browser is the canonical external user-agent.
         authLog("opening login in browser") // URL carries the one-time ticket — not logged
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).addCategory(Intent.CATEGORY_BROWSABLE)
+        val intent =
+            Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse(url),
+            ).addCategory(Intent.CATEGORY_BROWSABLE)
         runCatching { activity.startActivity(intent) }
     }
 
-    private fun pollForToken(origin: String, ticket: String): String? {
+    private fun pollForToken(
+        origin: String,
+        ticket: String,
+    ): String? {
         val deadline = System.currentTimeMillis() + POLL_TIMEOUT_MS
         val encoded = Uri.encode(ticket)
         while (System.currentTimeMillis() < deadline) {
             Thread.sleep(POLL_INTERVAL_MS) // throws InterruptedException on shutdownNow()
-            val conn = (URL("$origin/auth/cli-poll?ticket=$encoded").openConnection() as HttpURLConnection)
+            val conn = (
+                URL(
+                    "$origin/auth/cli-poll?ticket=$encoded",
+                ).openConnection() as HttpURLConnection
+            )
             conn.requestMethod = "GET"
             conn.connectTimeout = HTTP_TIMEOUT_MS
             conn.readTimeout = HTTP_TIMEOUT_MS
             try {
                 when (conn.responseCode) {
-                    202 -> continue // still pending
+                    202 -> {
+                        continue
+                    }
+
+                    // still pending
                     200 -> {
                         val body = conn.inputStream.bufferedReader().use { it.readText() }
                         return JSONObject(body).optString("token").ifEmpty { null }
                     }
-                    else -> return null // 410 expired/rejected, or other
+
+                    else -> {
+                        return null
+                    } // 410 expired/rejected, or other
                 }
             } catch (_: Throwable) {
                 if (Thread.currentThread().isInterrupted) return null // shutdown mid-request

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentBridgeListener.kt
@@ -24,7 +24,6 @@ class OmnigentBridgeListener(
     private val notifications: NativeNotificationManager,
     private val blobSaver: BlobSaver,
 ) : WebViewCompat.WebMessageListener {
-
     override fun onPostMessage(
         view: WebView,
         message: WebMessageCompat,
@@ -42,7 +41,10 @@ class OmnigentBridgeListener(
             }
 
         when (json.optString("method")) {
-            "setBadgeCount" -> notifications.setBadgeCount(json.optInt("count", 0))
+            "setBadgeCount" -> {
+                notifications.setBadgeCount(json.optInt("count", 0))
+            }
+
             "notify" -> {
                 val params = json.optJSONObject("params") ?: return
                 val title = params.optString("title").ifEmpty { return }
@@ -52,12 +54,14 @@ class OmnigentBridgeListener(
                     navigatePath = params.optString("navigatePath").ifEmpty { null },
                 )
             }
-            "blobBase64" ->
+
+            "blobBase64" -> {
                 blobSaver.save(
                     base64 = json.optString("base64").ifEmpty { return },
                     mimeType = json.optString("mimeType").ifEmpty { "application/octet-stream" },
                     suggestedName = json.optString("name"),
                 )
+            }
         }
     }
 

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebChromeClient.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebChromeClient.kt
@@ -18,11 +18,13 @@ import android.webkit.WebView
  */
 class OmnigentWebChromeClient(
     /** Open a file picker for [acceptTypes]; return true if it was launched. */
-    private val onChooseFiles: (callback: ValueCallback<Array<Uri>>, acceptTypes: Array<String>) -> Boolean,
+    private val onChooseFiles: (
+        callback: ValueCallback<Array<Uri>>,
+        acceptTypes: Array<String>,
+    ) -> Boolean,
     /** Grant or deny a WebView permission request (currently audio capture). */
     private val onPermission: (PermissionRequest) -> Unit,
 ) : WebChromeClient() {
-
     override fun onShowFileChooser(
         webView: WebView,
         filePathCallback: ValueCallback<Array<Uri>>,

--- a/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OmnigentWebViewClient.kt
@@ -24,8 +24,11 @@ class OmnigentWebViewClient(
     private val onPageReady: (url: String?) -> Unit,
     private val onLoginRequired: () -> Unit,
 ) : WebViewClient() {
-
-    override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+    override fun onPageStarted(
+        view: WebView,
+        url: String?,
+        favicon: Bitmap?,
+    ) {
         super.onPageStarted(view, url, favicon)
 
         val origin = originOf(url)
@@ -60,12 +63,18 @@ class OmnigentWebViewClient(
         }
     }
 
-    override fun onPageFinished(view: WebView, url: String?) {
+    override fun onPageFinished(
+        view: WebView,
+        url: String?,
+    ) {
         super.onPageFinished(view, url)
         onPageReady(url)
     }
 
-    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+    override fun shouldOverrideUrlLoading(
+        view: WebView,
+        request: WebResourceRequest,
+    ): Boolean {
         val url = request.url
         val scheme = url.scheme?.lowercase()
 

--- a/web/android/app/src/main/java/ai/omnigent/android/Origins.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/Origins.kt
@@ -17,9 +17,10 @@ fun originOf(url: String?): String? {
     // The pinned origin and every page URL both flow through here, so they
     // canonicalize identically.
     val port = uri.port
-    val hasExplicitPort = port != -1 &&
-        !(scheme == "https" && port == 443) &&
-        !(scheme == "http" && port == 80)
+    val hasExplicitPort =
+        port != -1 &&
+            !(scheme == "https" && port == 443) &&
+            !(scheme == "http" && port == 80)
     return if (hasExplicitPort) "$scheme://$host:$port" else "$scheme://$host"
 }
 

--- a/web/android/app/src/main/java/ai/omnigent/android/ServerStore.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/ServerStore.kt
@@ -7,7 +7,9 @@ import android.content.Context
  * [ConnectActivity]. Mirrors the iOS shell's `ConnectView` model (entry +
  * recents); the native UI here is intentionally minimal.
  */
-class ServerStore(context: Context) {
+class ServerStore(
+    context: Context,
+) {
     private val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
     fun hasServer(): Boolean = !prefs.getString(KEY_CURRENT, null).isNullOrBlank()
@@ -17,7 +19,8 @@ class ServerStore(context: Context) {
 
     /** Recently-connected servers, most recent first. */
     fun recentServers(): List<String> =
-        prefs.getString(KEY_RECENTS, null)
+        prefs
+            .getString(KEY_RECENTS, null)
             ?.split("\n")
             ?.filter { it.isNotBlank() }
             .orEmpty()
@@ -37,6 +40,7 @@ class ServerStore(context: Context) {
         const val KEY_CURRENT = "current_server_url"
         const val KEY_RECENTS = "recent_server_urls"
         const val MAX_RECENTS = 8
+
         // 10.0.2.2 is the host loopback from the Android emulator.
         const val DEFAULT_DEBUG_SERVER = "http://10.0.2.2:8000"
     }

--- a/web/android/bin/ktlint.sh
+++ b/web/android/bin/ktlint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Guarded wrapper around `ktlint`, invoked by the android-ktlint-* pre-commit
+# hooks. On CI the lint workflow installs ktlint before running pre-commit.
+# On developer machines, install ktlint (e.g. `brew install ktlint`) to enable
+# the hooks locally; the wrapper exits 0 cleanly if ktlint is absent so that a
+# missing binary doesn't block commits on machines without it installed.
+set -euo pipefail
+
+if ! command -v ktlint >/dev/null 2>&1; then
+  exit 0
+fi
+
+exec ktlint "$@"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds **ktlint 1.8.0** formatting enforcement for the Android Kotlin sources, closing the gap where Python (ruff), web (Prettier), and iOS (swift-format) all had enforced style but Kotlin had none.
- Follows the same wrapper-script pattern as iOS: `web/android/bin/ktlint.sh` exits 0 when ktlint is absent locally, so developers without it aren't blocked. CI installs ktlint before pre-commit runs, so the gate is always enforced there.
- Applies an initial `ktlint --format` pass to existing sources so the hook is green from the first run.

**Files added/changed:**

| File | Purpose |
|---|---|
| `web/android/.editorconfig` | ktlint style config (4-space indent, 100-char line length, standard rule set) |
| `web/android/bin/ktlint.sh` | Wrapper: runs ktlint if present, no-ops otherwise |
| `.pre-commit-config.yaml` | `android-ktlint-format` (fix) + `android-ktlint-check` (gate) hooks |
| `.github/workflows/lint.yml` | Installs ktlint before pre-commit in the CI lint job |
| `web/android/**/*.kt` | Initial format pass — trailing whitespace, import ordering, brace style |

## Test Plan

- Ran `ktlint "web/android/**/*.kt" "web/android/**/*.kts"` locally — exits 0 with no errors.
- Ran `pre-commit run --files ...` on the modified non-Kotlin files — all hooks passed.
- CI lint workflow will install ktlint 1.8.0 and run the new hooks on every PR.

## Demo

N/A

## Type of change

- [x] Test / CI

## Test coverage

- [x] Manual verification completed
- [x] Not applicable

## Coverage notes

CI-only change; verified locally that ktlint exits clean on the existing Kotlin sources after the initial format pass.