### PR TITLE
fix(claude-native): stop delivering false idle for sub-agents with live background tasks

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -11,7 +11,7 @@ import os
 import tempfile
 import time
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import httpx
@@ -221,6 +221,10 @@ def _hold_assistant_item_for_deltas(
 # hook signal and drop the heuristic.
 _SUBAGENT_IDLE_QUIESCENCE_S = 5.0
 
+# Bound a child session's background-task wait when Claude never emits a
+# follow-up Stop hook after the shell exits.
+_BACKGROUND_TASK_WAIT_MAX_S = 20 * 60.0
+
 # Meta-file glob inside ``~/.claude/projects/<encoded>/<session>/subagents/``.
 # One per Claude Task-tool subagent; appears alongside the matching
 # ``agent-<id>.jsonl`` transcript.
@@ -410,6 +414,12 @@ class HookForwardState:
     event_cursor: int
     byte_offset: int | None = None
     cursor_fingerprint: str | None = None
+    background_task_wait_started_at: float | None = None
+
+
+def _background_wait_wall_time() -> float:
+    """Return the persisted background-task wait clock."""
+    return time.time()
 
 
 @dataclass(frozen=True)
@@ -1105,6 +1115,12 @@ async def forward_claude_transcript_to_session(
                         # ``state.current_response_id`` is the active turn's id
                         # (the user-message reset only fires on the next turn).
                         response_id=state.current_response_id,
+                    )
+                    hook_state = await _maybe_fire_background_task_wait_fallback(
+                        client=client,
+                        session_id=current_session_id,
+                        bridge_dir=bridge_dir,
+                        state=hook_state,
                     )
                     subagent_state = await _forward_available_subagents(
                         client=client,
@@ -2784,6 +2800,7 @@ async def _forward_available_status_events(
             cursor_fingerprint=_jsonl_cursor_fingerprint(
                 bridge_dir / _HOOKS_FILE, result.byte_offset
             ),
+            background_task_wait_started_at=state.background_task_wait_started_at,
         )
         await _write_hook_state_async(bridge_dir, durable)
         return durable
@@ -2796,6 +2813,7 @@ async def _forward_available_status_events(
             cursor_fingerprint=_jsonl_cursor_fingerprint(
                 bridge_dir / _HOOKS_FILE, record.byte_offset
             ),
+            background_task_wait_started_at=durable.background_task_wait_started_at,
         )
         # Subagent lifecycle hooks land in the same hooks.jsonl as parent
         # events because subagent processes inherit the parent's hook
@@ -3033,6 +3051,12 @@ async def _forward_available_status_events(
         effective_status = status
         if status == "idle" and record.background_task_count > 0:
             effective_status = "waiting"
+            if next_durable.background_task_wait_started_at is None:
+                next_durable = replace(
+                    next_durable, background_task_wait_started_at=_background_wait_wall_time()
+                )
+        elif status in {"idle", "failed"}:
+            next_durable = replace(next_durable, background_task_wait_started_at=None)
         try:
             await post_external_session_status(
                 client,
@@ -3099,7 +3123,47 @@ async def _forward_available_status_events(
         event_cursor=result.event_cursor,
         byte_offset=result.byte_offset,
         cursor_fingerprint=_jsonl_cursor_fingerprint(bridge_dir / _HOOKS_FILE, result.byte_offset),
+        background_task_wait_started_at=durable.background_task_wait_started_at,
     )
+    await _write_hook_state_async(bridge_dir, durable)
+    return durable
+
+
+async def _maybe_fire_background_task_wait_fallback(
+    *,
+    client: httpx.AsyncClient,
+    session_id: str,
+    bridge_dir: Path,
+    state: HookForwardState,
+) -> HookForwardState:
+    """Post a bounded fallback idle when a background-task wait is stranded."""
+    started_at = state.background_task_wait_started_at
+    if started_at is None:
+        return state
+    waited_s = max(0.0, _background_wait_wall_time() - started_at)
+    if waited_s < _BACKGROUND_TASK_WAIT_MAX_S:
+        return state
+    try:
+        await post_external_session_status(
+            client, session_id=session_id, status="idle", background_task_count=0
+        )
+    except httpx.HTTPError:
+        _logger.warning(
+            "Failed to post fallback idle after background-task wait timeout; "
+            "session=%s waited_s=%.1f",
+            session_id,
+            waited_s,
+            exc_info=True,
+        )
+        return state
+    _logger.warning(
+        "Posted fallback idle after background-task wait timeout; "
+        "session=%s waited_s=%.1f max_wait_s=%.1f",
+        session_id,
+        waited_s,
+        _BACKGROUND_TASK_WAIT_MAX_S,
+    )
+    durable = replace(state, background_task_wait_started_at=None)
     await _write_hook_state_async(bridge_dir, durable)
     return durable
 
@@ -4792,16 +4856,27 @@ def _read_hook_state(bridge_dir: Path) -> HookForwardState | None:
     event_cursor = raw.get("event_cursor")
     byte_offset = raw.get("byte_offset")
     cursor_fingerprint = raw.get("cursor_fingerprint")
+    background_task_wait_started_at = raw.get("background_task_wait_started_at")
     if not isinstance(event_cursor, int) or event_cursor < 0:
         return None
     if byte_offset is not None and (not isinstance(byte_offset, int) or byte_offset < 0):
         return None
     if cursor_fingerprint is not None and not isinstance(cursor_fingerprint, str):
         return None
+    if background_task_wait_started_at is not None and (
+        isinstance(background_task_wait_started_at, bool)
+        or not isinstance(background_task_wait_started_at, (int, float))
+    ):
+        return None
     return HookForwardState(
         event_cursor=event_cursor,
         byte_offset=byte_offset,
         cursor_fingerprint=cursor_fingerprint,
+        background_task_wait_started_at=(
+            None
+            if background_task_wait_started_at is None
+            else float(background_task_wait_started_at)
+        ),
     )
 
 
@@ -4822,6 +4897,8 @@ def _write_hook_state(bridge_dir: Path, state: HookForwardState) -> None:
         payload["byte_offset"] = state.byte_offset
     if state.cursor_fingerprint is not None:
         payload["cursor_fingerprint"] = state.cursor_fingerprint
+    if state.background_task_wait_started_at is not None:
+        payload["background_task_wait_started_at"] = state.background_task_wait_started_at
     _write_json_atomic(bridge_dir / _HOOK_STATE_FILE, payload)
 
 

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3166,7 +3166,7 @@ def _background_task_delivery_status(
     background_task_count: int | None,
     conv: Conversation,
 ) -> str:
-    """Collapse a background-task ``waiting`` back to ``idle``.
+    """Collapse a top-level background-task ``waiting`` back to ``idle``.
 
     A claude-native session relabels its ``Stop`` turn-end ``idle`` to
     ``waiting`` (in the forwarder) while background shells linger. The turn
@@ -3174,10 +3174,11 @@ def _background_task_delivery_status(
     misreports the session as mid-turn everywhere the status is read as a
     turn gate: the composer queues each send behind "Steer", the sidebar dot
     spins, and because ``waiting`` keeps ``_session_active_response_cache``
-    populated a reconnect reopens the settled turn's streaming bubble. For a
-    sub-agent it also hangs the orchestrator — the terminal-delivery branch
-    in ``post_event`` keys off ``idle``/``failed`` and no follow-up ``Stop``
-    ever comes.
+    populated a reconnect reopens the settled turn's streaming bubble.
+    A Claude-native sub-agent is different: terminal delivery is one-shot,
+    so collapsing its live background-task wait would falsely tell its parent
+    that work completed. The forwarder's durable timeout supplies a bounded
+    fallback if Claude never emits the later terminal edge.
 
     The tally alone already drives every background-shell affordance at
     ``idle`` (the in-chat "N background tasks still running" indicator reads
@@ -3185,21 +3186,21 @@ def _background_task_delivery_status(
     for the shells. Normalizing here rather than in the forwarder also covers
     runners that predate the change.
 
-    Codex-internal children keep ``waiting``: they never emit a claude-native
-    ``Stop`` hook, and their status is consumed inside the app-server thread
-    tree rather than through this delivery branch.
+    All children keep ``waiting``. Codex-internal children never emit a
+    claude-native ``Stop`` hook, and Claude-native children must not terminally
+    deliver until their background shell completes.
 
     :param status: The incoming external status, e.g. ``"waiting"``.
     :param background_task_count: Parsed background-shell tally, or ``None``.
     :param conv: The conversation the status is for.
-    :returns: ``"idle"`` for a background-task ``waiting`` on any non-codex
-        session; otherwise ``status`` unchanged.
+    :returns: ``"idle"`` for a top-level background-task ``waiting``;
+        otherwise ``status`` unchanged.
     """
     if (
         status == "waiting"
         and background_task_count is not None
         and background_task_count > 0
-        and not _is_codex_native_subagent(conv)
+        and conv.kind != "sub_agent"
     ):
         return "idle"
     return status

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -1753,20 +1753,11 @@ async def test_subagent_idle_forward_recovers_via_parent_when_child_runner_stale
     assert recovered_for == [child["id"]]
 
 
-async def test_subagent_background_task_waiting_delivers_to_parent_as_idle(
+async def test_subagent_background_task_waiting_does_not_deliver_to_parent(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A sub-agent's background-task ``waiting`` still delivers terminal status.
-
-    Regression for the parent-orchestrator hang: a claude-native sub-agent
-    relabels its ``Stop`` turn-end ``idle`` to ``waiting`` when a background
-    shell lingers. The terminal-delivery branch only fires for
-    ``idle``/``failed``, so an un-collapsed ``waiting`` would skip delivery and
-    the parent would wait forever. The server must collapse the sub-agent's
-    background-task ``waiting`` to ``idle`` so delivery (here, the recovery
-    path) still runs for the child.
-    """
+    """A live child background task does not terminally deliver to its parent."""
     child = await _create_native_child(client, name="orch-bg-waiting")
 
     async def _forward_none(*_args: Any, **_kwargs: Any) -> None:
@@ -1792,11 +1783,10 @@ async def test_subagent_background_task_waiting_delivers_to_parent_as_idle(
         },
     )
 
-    # Delivery fired despite the incoming `waiting`: the collapse to `idle`
-    # let the terminal-status branch run for THIS child (recovery invoked,
-    # 202 Accepted) instead of silently skipping and stranding the parent.
+    # ``waiting`` remains non-terminal while the child reports a live shell.
+    # The forwarder's bounded fallback handles a missing later Stop edge.
     assert resp.status_code == 202, resp.text
-    assert recovered_for == [child["id"]]
+    assert recovered_for == []
 
 
 async def test_subagent_idle_forward_503s_when_recovery_also_fails(

--- a/tests/server/routes/test_sessions_background_task_status.py
+++ b/tests/server/routes/test_sessions_background_task_status.py
@@ -102,12 +102,9 @@ def test_failure_clears_tally_and_wins_over_count() -> None:
 # ── background-task delivery status (ended-turn collapse) ───────────────────
 
 
-def test_subagent_background_waiting_delivers_as_idle() -> None:
-    # Regression: a claude-native sub-agent relabels its Stop turn-end to
-    # `waiting` for background shells, but the parent's terminal-delivery gate
-    # keys off idle/failed — `waiting` would hang the orchestrator. The turn
-    # ended, so deliver `idle` (the tally still drives the child spinner).
-    assert _background_task_delivery_status("waiting", 1, _conv("sub_agent")) == "idle"
+def test_subagent_background_waiting_remains_non_terminal() -> None:
+    # A live Claude-native child shell must not terminally deliver its parent.
+    assert _background_task_delivery_status("waiting", 1, _conv("sub_agent")) == "waiting"
 
 
 def test_top_level_background_waiting_delivers_as_idle() -> None:

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -7766,6 +7766,56 @@ async def test_forwarder_posts_waiting_when_stop_has_background_tasks(
 
 
 @pytest.mark.asyncio
+async def test_background_task_wait_fallback_is_durable_and_fires_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stranded background-task wait gets one bounded terminal fallback."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    started_at = 100.0
+    monkeypatch.setattr(forwarder, "_background_wait_wall_time", lambda: started_at)
+    state = forwarder.HookForwardState(
+        event_cursor=4,
+        byte_offset=12,
+        cursor_fingerprint="cursor",
+        background_task_wait_started_at=started_at,
+    )
+    forwarder._write_hook_state(bridge_dir, state)
+    assert forwarder._read_hook_state(bridge_dir) == state
+
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(200, json={})
+
+    monkeypatch.setattr(
+        forwarder,
+        "_background_wait_wall_time",
+        lambda: started_at + forwarder._BACKGROUND_TASK_WAIT_MAX_S,
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ap"
+    ) as client:
+        settled = await forwarder._maybe_fire_background_task_wait_fallback(
+            client=client, session_id="conv_abc", bridge_dir=bridge_dir, state=state
+        )
+        assert (
+            await forwarder._maybe_fire_background_task_wait_fallback(
+                client=client, session_id="conv_abc", bridge_dir=bridge_dir, state=settled
+            )
+        ) == settled
+
+    assert settled.background_task_wait_started_at is None
+    assert bodies == [
+        {
+            "type": "external_session_status",
+            "data": {"status": "idle", "background_task_count": 0},
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_post_external_session_status_includes_and_omits_response_id() -> None:
     """
     ``post_external_session_status`` attaches ``response_id`` only when given.


### PR DESCRIPTION
## Related issue

N/A — finalizes the existing draft PR #2193.

## Summary

- Keep a Claude-native sub-agent in non-terminal `waiting` when its Stop hook reports live background shells, so its parent is not told the work completed early.
- Persist a 20-minute wait marker and emit one fallback `idle` only if no later terminal hook arrives, avoiding an unbounded parent wait.

## Test Plan

- `OMNIGENT_DATABASE_URI=sqlite:///:memory: uv run --extra dev pytest tests/server/routes/test_sessions_background_task_status.py tests/server/integration/test_sessions_child_sessions.py tests/test_claude_native_forwarder.py -q` (210 passed)
- `OMNIGENT_DATABASE_URI=sqlite:///:memory: uv run --extra dev pytest tests/server/routes -q` (918 passed)
- `uv run --extra dev ruff format --check …` and `uv run --extra dev ruff check …` (passed)
- `uv run --extra dev pre-commit run --all-files`: all applicable hooks passed; the VS Code extension hook could not run because `editors/vscode/node_modules/.bin/tsc` is absent in this checkout.

## Demo

N/A — non-visual lifecycle fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression tests cover non-terminal child delivery, durable wait-state serialization, and exactly-once fallback idle delivery.

## Changelog

Claude-native sub-agents now wait for their live background tasks before reporting completion to their parent.