### PR TITLE
fix(tests): make test_interrupt_forwards_to_harness_before_cancelling deterministic

### DIFF
--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -6537,10 +6537,12 @@ class _ForwardBlockingHarnessClient(_BlockingHarnessClient):
         """
         super().__init__(sse_frames, gate)
         self._fwd_gate = fwd_gate
+        self.fwd_seen: asyncio.Event = asyncio.Event()
 
     async def post(self, url: str, *, json: dict[str, Any], timeout: Any = None) -> Any:
         """Block an interrupt forward on ``fwd_gate``; pass other posts through."""
         if isinstance(json, dict) and json.get("type") == "interrupt":
+            self.fwd_seen.set()
             await self._fwd_gate.wait()
         return await super().post(url, json=json, timeout=timeout)
 
@@ -6618,8 +6620,10 @@ async def test_interrupt_forwards_to_harness_before_cancelling() -> None:
         int_task = _aio.create_task(
             client.post(f"/v1/sessions/{conv_id}/events", json={"type": "interrupt"})
         )
-        with pytest.raises(_aio.TimeoutError):
-            await _aio.wait_for(_aio.shield(int_task), timeout=0.5)
+        # Wait until the route is actually blocked on fwd_gate — deterministic
+        # proof the forward is in-flight. This replaces a flaky 0.5 s sleep that
+        # could race on loaded CI machines.
+        await _aio.wait_for(_hc.fwd_seen.wait(), timeout=5.0)
         assert not int_task.done(), "interrupt must await the harness forward (forward-first)"
 
         # Release the forward → the harness gets the interrupt, then the cancel runs.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `test_interrupt_forwards_to_harness_before_cancelling` was flaky with `TimeoutError` because it used a 0.5 s `wait_for`/`shield` window to assert the interrupt route was blocked — too short on loaded CI machines
- Adds a `fwd_seen: asyncio.Event` to `_ForwardBlockingHarnessClient` that is set the moment `post()` enters the `fwd_gate.wait()` call, providing provable in-flight status
- The test now waits for `fwd_seen` (5 s timeout) instead of relying on wall-clock timing before asserting `not int_task.done()`

## Test Plan

- Run `pytest tests/runner/test_app_sessions_native.py::test_interrupt_forwards_to_harness_before_cancelling` — passes deterministically
- The assertion it replaced (`not int_task.done()` after the fwd_seen wait) is now race-free: `fwd_gate.wait()` in `post()` cannot return until after `fwd_gate.set()` in the test, so the route is guaranteed to still be in flight when the assert runs

## Demo

N/A

## Type of change

- [x] Test / CI

## Test coverage

- [x] Existing tests cover this change

## Coverage notes

Change is limited to the test helper and the test body; no production code modified.