### PR TITLE
feat(ui): allow users to edit policy name when adding a policy

### DIFF
--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -271,6 +271,7 @@ function AddPolicyDialog({
 }) {
   const [selected, setSelected] = useState<string>("");
   const [filter, setFilter] = useState("");
+  const [policyName, setPolicyName] = useState<string>("");
   const [factoryParams, setFactoryParams] = useState<Record<string, string>>({});
   const [paramError, setParamError] = useState<string | null>(null);
   const addPolicy = useAddPolicy(sessionId);
@@ -297,8 +298,10 @@ function AddPolicyDialog({
   const paramKeys = Object.keys(properties);
 
   function handleSelect(handler: string) {
+    const e = registry.find((r) => r.handler === handler);
     setSelected(handler);
     setFilter("");
+    setPolicyName(e ? e.name.toLowerCase().replace(/\s+/g, "_") : "");
     setFactoryParams({});
     setParamError(null);
   }
@@ -326,7 +329,7 @@ function AddPolicyDialog({
       entry.kind === "factory" ? { factory_params: parsedParams ?? {} } : {};
     addPolicy.mutate(
       {
-        name: entry.name.toLowerCase().replace(/\s+/g, "_"),
+        name: policyName || entry.name.toLowerCase().replace(/\s+/g, "_"),
         type: "python",
         handler: entry.handler,
         ...includeFactoryParams,
@@ -334,6 +337,7 @@ function AddPolicyDialog({
       {
         onSuccess: () => {
           setSelected("");
+          setPolicyName("");
           setFactoryParams({});
           onOpenChange(false);
         },
@@ -348,6 +352,7 @@ function AddPolicyDialog({
         // Reset to the policy list on close so reopening never lands mid-config.
         if (!next) {
           setSelected("");
+          setPolicyName("");
           setFactoryParams({});
           setParamError(null);
         }
@@ -359,7 +364,7 @@ function AddPolicyDialog({
           <DialogTitle>Add Policy</DialogTitle>
           <DialogDescription>Choose a policy to apply to this session.</DialogDescription>
         </DialogHeader>
-        <div className="space-y-3 pt-1">
+        <div className="min-w-0 space-y-3 pt-1">
           {!selected &&
             (() => {
               const available = registry.filter((r) => !appliedHandlers.has(r.handler));
@@ -417,6 +422,7 @@ function AddPolicyDialog({
                   type="button"
                   onClick={() => {
                     setSelected("");
+                    setPolicyName("");
                     setFactoryParams({});
                     setParamError(null);
                   }}
@@ -428,6 +434,19 @@ function AddPolicyDialog({
               {entry.description && (
                 <p className="text-xs text-muted-foreground">{entry.description}</p>
               )}
+            </div>
+          )}
+          {entry && (
+            <div>
+              <label className="flex items-center gap-1 text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">name</span>
+              </label>
+              <input
+                type="text"
+                value={policyName}
+                onChange={(e) => setPolicyName(e.target.value)}
+                className="mt-0.5 w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
+              />
             </div>
           )}
           {entry?.kind === "factory" && paramKeys.length > 0 && (
@@ -451,7 +470,9 @@ function AddPolicyDialog({
                       )}
                     </label>
                     {prop?.description && (
-                      <p className="text-[11px] text-muted-foreground">{prop.description}</p>
+                      <p className="break-all text-[11px] text-muted-foreground">
+                        {prop.description}
+                      </p>
                     )}
                     {prop?.type === "boolean" ? (
                       <select

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -53,6 +53,7 @@ function AddDefaultPolicyDialog({
 }) {
   const [selected, setSelected] = useState<string>("");
   const [filter, setFilter] = useState("");
+  const [policyName, setPolicyName] = useState<string>("");
   const [factoryParams, setFactoryParams] = useState<Record<string, string>>({});
   const [paramError, setParamError] = useState<string | null>(null);
   const addPolicy = useAddDefaultPolicy();
@@ -79,8 +80,10 @@ function AddDefaultPolicyDialog({
   const paramKeys = Object.keys(properties);
 
   function handleSelect(handler: string) {
+    const e = registry.find((r) => r.handler === handler);
     setSelected(handler);
     setFilter("");
+    setPolicyName(e ? e.name.toLowerCase().replace(/\s+/g, "_") : "");
     setFactoryParams({});
     setParamError(null);
   }
@@ -101,7 +104,7 @@ function AddDefaultPolicyDialog({
       entry.kind === "factory" ? { factory_params: parsedParams ?? {} } : {};
     addPolicy.mutate(
       {
-        name: entry.name.toLowerCase().replace(/\s+/g, "_"),
+        name: policyName || entry.name.toLowerCase().replace(/\s+/g, "_"),
         type: "python",
         handler: entry.handler,
         ...includeFactoryParams,
@@ -109,6 +112,7 @@ function AddDefaultPolicyDialog({
       {
         onSuccess: () => {
           setSelected("");
+          setPolicyName("");
           setFactoryParams({});
           onOpenChange(false);
         },
@@ -123,6 +127,7 @@ function AddDefaultPolicyDialog({
         // Reset to the policy list on close so reopening never lands mid-config.
         if (!next) {
           setSelected("");
+          setPolicyName("");
           setFactoryParams({});
           setParamError(null);
         }
@@ -134,7 +139,7 @@ function AddDefaultPolicyDialog({
           <DialogTitle>Add Global Policy</DialogTitle>
           <DialogDescription>Choose a policy to apply globally to all sessions.</DialogDescription>
         </DialogHeader>
-        <div className="space-y-3 pt-1">
+        <div className="min-w-0 space-y-3 pt-1">
           {!selected &&
             (() => {
               const available = registry.filter((r) => !appliedHandlers.has(r.handler));
@@ -192,6 +197,7 @@ function AddDefaultPolicyDialog({
                   type="button"
                   onClick={() => {
                     setSelected("");
+                    setPolicyName("");
                     setFactoryParams({});
                     setParamError(null);
                   }}
@@ -203,6 +209,19 @@ function AddDefaultPolicyDialog({
               {entry.description && (
                 <p className="text-xs text-muted-foreground">{entry.description}</p>
               )}
+            </div>
+          )}
+          {entry && (
+            <div>
+              <label className="flex items-center gap-1 text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">name</span>
+              </label>
+              <input
+                type="text"
+                value={policyName}
+                onChange={(e) => setPolicyName(e.target.value)}
+                className="mt-0.5 w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
+              />
             </div>
           )}
           {entry?.kind === "factory" && paramKeys.length > 0 && (
@@ -226,7 +245,9 @@ function AddDefaultPolicyDialog({
                       )}
                     </label>
                     {prop?.description && (
-                      <p className="text-[11px] text-muted-foreground">{prop.description}</p>
+                      <p className="break-all text-[11px] text-muted-foreground">
+                        {prop.description}
+                      </p>
                     )}
                     {prop?.type === "boolean" ? (
                       <select


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add-policy dialogs (session and global) auto-generated the policy name with no way to override it.
- Now shows a pre-filled, editable **name** field after selecting a policy.
- Also fixes parameter description overflow: `min-w-0` on the dialog content div prevents it from expanding the grid parent, and `break-all` handles long unbreakable strings in CEL/prompt policy descriptions.

## Test Plan

1. Open session → agent info → add policy → select any policy → verify a pre-filled name input appears and can be edited.
2. Submit without changing the name — policy created with auto-derived slug.
3. Submit with a custom name — policy created with the custom name.
4. Select CEL Expression Policy — verify the long description text wraps without overflowing the dialog.
5. Same for global policies page (Settings → Policies → Add policy).

## Demo

N/A

## Type of change

- [x] Feature
- [x] UI / frontend change

## Test coverage

- [x] Manual verification completed

## Coverage notes

UI-only state change; covered by manual walkthrough above.

## Changelog

Users can now edit the policy name in the Add Policy dialog before submitting.