### PR TITLE
feat(capabilities): in-session Capabilities panel (#850)

### DIFF
--- a/omnigent/policies/builtins/context.py
+++ b/omnigent/policies/builtins/context.py
@@ -283,6 +283,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
     {
         "handler": "omnigent.policies.builtins.context.detect_task_switch",
         "kind": "factory",
+        "llm_backed": True,
         "name": "Detect Task Switch",
         "description": (
             "Uses the server-level LLM to classify each user message as a "

--- a/omnigent/policies/builtins/prompt.py
+++ b/omnigent/policies/builtins/prompt.py
@@ -34,6 +34,12 @@ from omnigent.policies.schema import PolicyCallable, PolicyEvent, PolicyResponse
 
 _log = logging.getLogger(__name__)
 
+# Dotted handler path of the LLM-backed prompt classifier factory.
+# Single source of truth for the registry entry below and for callers
+# that must tell this LLM-backed policy apart from cheap name-based
+# FunctionPolicies (e.g. the Capabilities ``blocked`` preview).
+PROMPT_POLICY_HANDLER = "omnigent.policies.builtins.prompt.prompt_policy"
+
 # The framework-generated system prompt wrapper. The JSON schema
 # is enforced via structured output, so the envelope focuses on
 # the domain instructions and payload.
@@ -248,8 +254,9 @@ def _extract_response_text(response: Any) -> str:
 
 POLICY_REGISTRY: list[dict[str, Any]] = [
     {
-        "handler": "omnigent.policies.builtins.prompt.prompt_policy",
+        "handler": PROMPT_POLICY_HANDLER,
         "kind": "factory",
+        "llm_backed": True,
         "name": "LLM Prompt Classifier Policy",
         "description": (
             "LLM-backed classifier policy. The author supplies domain "

--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -467,6 +467,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
     {
         "handler": "omnigent.policies.builtins.routing.deny_trivial_to_expensive_model",
         "kind": "factory",
+        "llm_backed": True,
         "name": "Deny Trivial Tasks on Expensive Models",
         "description": (
             "Classifies the user's message as TRIVIAL or COMPLEX using "
@@ -499,6 +500,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
     {
         "handler": "omnigent.policies.builtins.routing.intent_based_authorization",
         "kind": "factory",
+        "llm_backed": True,
         "name": "Intent Based Authorization",
         "description": (
             "Enforces intent-based permissioning: records the user's first message "

--- a/omnigent/policies/registry.py
+++ b/omnigent/policies/registry.py
@@ -49,6 +49,11 @@ class PolicyRegistryEntry:
         factory parameters. Only meaningful when ``kind`` is
         ``"factory"``. ``None`` when the handler takes no
         factory params.
+    :param llm_backed: ``True`` when the handler can call the
+        server-level LLM client while evaluating (a prompt
+        classifier or an LLM-gated router). Consumers that must
+        stay zero-cost — e.g. the read-only capabilities/blocked
+        preview — use this to exclude the policy before evaluating.
     """
 
     handler: str
@@ -57,6 +62,7 @@ class PolicyRegistryEntry:
     description: str
     params_schema: dict[str, Any] | None = None
     internal_only: bool = False
+    llm_backed: bool = False
 
 
 # Module-level singleton. Populated by load_registry().
@@ -122,6 +128,7 @@ def load_registry(
                 description=raw.get("description", ""),
                 params_schema=raw.get("params_schema"),
                 internal_only=raw.get("internal_only", False),
+                llm_backed=raw.get("llm_backed", False),
             )
             _registry.append(entry)
             _registry_by_handler[entry.handler] = entry
@@ -189,6 +196,35 @@ def is_registered_handler(handler: str) -> bool:
     if not _registry_by_handler:
         load_registry()
     return handler in _registry_by_handler
+
+
+def is_llm_backed_handler(handler: str) -> bool:
+    """Return whether *handler* is a registered LLM-backed policy factory.
+
+    An LLM-backed policy calls the server-level LLM client while it
+    evaluates (a prompt classifier, or an LLM-gated router such as
+    intent-based authorization). Callers that must stay zero-cost — the
+    read-only capabilities/blocked preview — consult this to drop such
+    policies from a throwaway probe engine before evaluating, so opening
+    the panel never fires an LLM call per discovered skill.
+
+    New LLM-backed builtins are covered automatically: set
+    ``"llm_backed": True`` on the factory's ``POLICY_REGISTRY`` entry and
+    it flows through here — no string check to edit.
+
+    Follows :func:`is_registered_handler`'s lazy-load convention: an empty
+    registry means "not yet scanned", so the built-ins are scanned on
+    first use. An unregistered handler (custom policy) returns ``False``.
+
+    :param handler: Full dotted import path, e.g.
+        ``"omnigent.policies.builtins.prompt.prompt_policy"``.
+    :returns: ``True`` if the handler is registered and flagged
+        ``llm_backed``.
+    """
+    if not _registry_by_handler:
+        load_registry()
+    entry = _registry_by_handler.get(handler)
+    return entry is not None and entry.llm_backed
 
 
 def get_params_schema(handler: str) -> dict[str, Any] | None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -80,7 +80,11 @@ from omnigent.runner.resource_registry import (
     TerminalLifecycle,
 )
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager, NoLiveHarnessError
-from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
+from omnigent.spec.skill_sources import (
+    SkillSourceContext,
+    classify_skill_source,
+    resolve_harness_skills,
+)
 from omnigent.spec.types import AgentSpec, LocalToolInfo, SkillSpec
 from omnigent.terminals.control_bridge import bridge_tmux_control_to_websocket
 from omnigent.terminals.ws_bridge import (
@@ -17608,6 +17612,49 @@ def create_runner_app(
         entry = await _resolve_session_spec_entry(session_id)
         return _unwrap_resolved_spec(entry) if entry is not None else None
 
+    async def _resolve_session_discovery(
+        session_id: str,
+    ) -> tuple[Any, list[Path], Path | None] | None:
+        """
+        Resolve a session's spec + host-discovery roots (no walk).
+
+        Shared by :func:`_resolve_session_skills` (the cached in-scope
+        merge) and :func:`_resolve_session_skills_enriched` (the full
+        set with provenance), so both root against exactly the same
+        workspace / bundle paths.
+
+        :param session_id: Session/conversation identifier.
+        :returns: ``(spec, roots, bundle_dir)`` or ``None`` when no spec
+            resolves.
+        """
+        entry = await _resolve_session_spec_entry(session_id)
+        spec = _unwrap_resolved_spec(entry) if entry is not None else None
+        if spec is None:
+            return None
+        workspace = await _session_workspace_value(session_id)
+        # Host-discovery roots in priority order: the session workspace
+        # (where the harness runs) first, then the agent bundle workdir.
+        # Both are unioned; ``discover_host_skills`` also scans ``~`` on
+        # each call. Distinct, resolved, non-None paths only.
+        candidate_roots = [
+            Path(workspace).resolve()
+            if workspace is not None
+            else (runner_workspace.resolve() if runner_workspace is not None else None),
+            _resolved_spec_workdir(entry),
+        ]
+        roots: list[Path] = []
+        for candidate in candidate_roots:
+            if candidate is None:
+                continue
+            resolved = candidate.resolve()
+            if resolved not in roots:
+                roots.append(resolved)
+        # No workspace and no bundle workdir: match the cwd fallback the
+        # in-process LoadSkillTool uses so behavior stays consistent.
+        if not roots:
+            roots.append(Path.cwd())
+        return spec, roots, _resolved_spec_workdir(entry)
+
     async def _resolve_session_skills(session_id: str) -> list[SkillSpec]:
         """
         Resolve the merged (bundled + host) skills for a session.
@@ -17653,32 +17700,10 @@ def create_runner_app(
                 return cached_skills
             # TTL elapsed — fall through to re-walk so a skill or plugin
             # installed mid-session surfaces without a session restart.
-        entry = await _resolve_session_spec_entry(session_id)
-        spec = _unwrap_resolved_spec(entry) if entry is not None else None
-        if spec is None:
+        resolved = await _resolve_session_discovery(session_id)
+        if resolved is None:
             return []
-        workspace = await _session_workspace_value(session_id)
-        # Host-discovery roots in priority order: the session workspace
-        # (where the harness runs) first, then the agent bundle workdir.
-        # Both are unioned; ``discover_host_skills`` also scans ``~`` on
-        # each call. Distinct, resolved, non-None paths only.
-        candidate_roots = [
-            Path(workspace).resolve()
-            if workspace is not None
-            else (runner_workspace.resolve() if runner_workspace is not None else None),
-            _resolved_spec_workdir(entry),
-        ]
-        roots: list[Path] = []
-        for candidate in candidate_roots:
-            if candidate is None:
-                continue
-            resolved = candidate.resolve()
-            if resolved not in roots:
-                roots.append(resolved)
-        # No workspace and no bundle workdir: match the cwd fallback the
-        # in-process LoadSkillTool uses so behavior stays consistent.
-        if not roots:
-            roots.append(Path.cwd())
+        spec, roots, bundle_dir = resolved
 
         def _discover() -> list[SkillSpec]:
             """Merge bundled skills with the harness's extra skills off the loop."""
@@ -17700,7 +17725,7 @@ def create_runner_app(
                 roots=tuple(roots),
                 home=Path.home(),
                 skills_filter=spec.skills_filter,
-                bundle_dir=_resolved_spec_workdir(entry),
+                bundle_dir=bundle_dir,
             )
             harness = canonicalize_harness(spec.executor.harness_kind)
             for hs in resolve_harness_skills(ctx, harness):
@@ -17721,8 +17746,68 @@ def create_runner_app(
         )
         return skills
 
+    async def _resolve_session_skills_enriched(
+        session_id: str,
+    ) -> list[tuple[SkillSpec, str, bool]]:
+        """
+        Resolve the **full** skill set for a session, with provenance.
+
+        Unlike :func:`_resolve_session_skills` (which returns only the
+        in-scope merge that feeds the slash-command menu), this returns
+        every skill the agent *could* see — the union of in-scope and
+        out-of-scope host skills — each tagged with its ``source`` and an
+        ``in_scope`` flag. Powers the read-only Capabilities panel's
+        provenance view and its "only skills in scope" toggle.
+
+        In-scope membership is computed by reusing the cached in-scope
+        merge (bundled + host that passed ``skills_filter``); the full
+        set comes from one extra discovery walk with the filter widened to
+        ``"all"``. Bundled skills are always in scope; a host skill is in
+        scope iff it appears in the cached merge.
+
+        :param session_id: Session/conversation identifier.
+        :returns: ``(spec, source, in_scope)`` triples — bundled first,
+            then host skills. Empty when no spec resolver is wired.
+        """
+        in_scope_names = {s.name for s in await _resolve_session_skills(session_id)}
+        resolved = await _resolve_session_discovery(session_id)
+        if resolved is None:
+            return []
+        spec, roots, bundle_dir = resolved
+
+        def _discover_all() -> list[tuple[SkillSpec, str, bool]]:
+            """Walk the full (unfiltered) host set off the loop."""
+            home = Path.home()
+            out: list[tuple[SkillSpec, str, bool]] = [
+                (s, "bundle", True) for s in spec.skills if s.user_invocable
+            ]
+            seen = {s.name for s in spec.skills}
+            seen_dirs = {s.skill_dir.resolve() for s in spec.skills if s.skill_dir is not None}
+            ctx = SkillSourceContext(
+                roots=tuple(roots),
+                home=home,
+                skills_filter="all",
+                bundle_dir=bundle_dir,
+            )
+            harness = canonicalize_harness(spec.executor.harness_kind)
+            for hs in resolve_harness_skills(ctx, harness):
+                if hs.name in seen:
+                    continue
+                if hs.skill_dir is not None and hs.skill_dir.resolve() in seen_dirs:
+                    continue
+                seen.add(hs.name)
+                if hs.skill_dir is not None:
+                    seen_dirs.add(hs.skill_dir.resolve())
+                out.append((hs, classify_skill_source(hs, home=home), hs.name in in_scope_names))
+            return out
+
+        return await asyncio.to_thread(_discover_all)
+
     @app.get("/v1/sessions/{session_id}/skills")
-    async def get_session_skills(session_id: str) -> JSONResponse:
+    async def get_session_skills(
+        session_id: str,
+        include_out_of_scope: bool = False,
+    ) -> JSONResponse:
         """
         Return the merged (bundled + host) skills for a session.
 
@@ -17732,11 +17817,38 @@ def create_runner_app(
         this list onto the session snapshot it serves to clients (the
         web composer's slash-command menu).
 
+        Default (``include_out_of_scope=false``): the in-scope merge only,
+        as ``{"name", "description"}`` — the exact shape the snapshot /
+        slash-command menu consume. With ``include_out_of_scope=true`` the
+        response widens to the **full** set (in-scope ∪ out-of-scope) and
+        each entry additionally carries ``source`` (provenance) and
+        ``in_scope`` (whether ``skills_filter`` admits it) for the
+        read-only Capabilities panel. The extra keys are additive; existing
+        consumers that read only ``name`` / ``description`` are unaffected.
+
         :param session_id: Session/conversation identifier,
             e.g. ``"conv_abc123"``.
-        :returns: JSON ``{"skills": [{"name", "description"}, ...]}``.
-            Empty list when the runner has no spec resolver wired.
+        :param include_out_of_scope: Return the full enriched set instead
+            of the in-scope-only merge.
+        :returns: JSON ``{"skills": [...]}``. Empty list when the runner
+            has no spec resolver wired.
         """
+        if include_out_of_scope:
+            enriched = await _resolve_session_skills_enriched(session_id)
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "skills": [
+                        {
+                            "name": s.name,
+                            "description": s.description,
+                            "source": source,
+                            "in_scope": in_scope,
+                        }
+                        for s, source, in_scope in enriched
+                    ]
+                },
+            )
         skills = await _resolve_session_skills(session_id)
         return JSONResponse(
             status_code=200,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -102,6 +102,7 @@ from omnigent.native_coding_agents import (
     native_coding_agent_for_terminal_name,
     native_coding_agent_for_wrapper_label,
 )
+from omnigent.policies.registry import is_llm_backed_handler
 from omnigent.policies.types import (
     ElicitationRequest,
     EvaluationContext,
@@ -259,6 +260,7 @@ from omnigent.server.schemas import (
     SessionTerminalPendingEvent,
     SessionTodosEvent,
     SessionUsageEvent,
+    SkillCapability,
     SkillSummary,
     SubAgentCapability,
     UpdateSessionRequest,
@@ -10644,6 +10646,114 @@ def _build_policy_engine_from_spec(
     )
 
 
+def _is_llm_backed_policy(policy: Any) -> bool:
+    """
+    Whether a runtime policy can call the server-level LLM while evaluating.
+
+    Every builtin LLM-backed policy — the prompt classifier
+    (``prompt_policy``) and the LLM-gated routers (``intent_based_authorization``,
+    ``detect_task_switch``, ``deny_trivial_to_expensive_model``) — compiles to
+    a :class:`FunctionPolicy` carrying its factory handler path on
+    ``spec.function``. That path is resolved against the policy registry, and
+    the entry's ``llm_backed`` flag is the discriminator. Any other
+    :class:`FunctionPolicy` (``block_skills``, CEL, …) gates cheaply by
+    name/expression and returns ``False``.
+
+    Using the registry flag rather than a hard-coded path check means a
+    FUTURE LLM-backed builtin is covered automatically: mark its
+    ``POLICY_REGISTRY`` entry ``llm_backed: True`` and it is excluded here
+    with no edit to this function.
+
+    :param policy: A runtime policy from ``engine.policies``.
+    :returns: ``True`` for any known LLM-backed policy factory.
+    """
+    func = getattr(getattr(policy, "spec", None), "function", None)
+    path = getattr(func, "path", None)
+    return isinstance(path, str) and is_llm_backed_handler(path)
+
+
+async def _compute_blocked_skills(
+    spec: AgentSpec,
+    session_id: str,
+    conversation_store: ConversationStore,
+    skill_names: list[str],
+    *,
+    user_id: str | None,
+) -> dict[str, bool]:
+    """
+    Read-only "would a policy block loading this skill?" check per name.
+
+    Powers the Capabilities panel's ``blocked`` flag. Builds the session's
+    policy engine (session + agent + admin policies, sub-agent inheritance)
+    and, for each skill name, evaluates a synthetic native ``Skill``
+    tool-call — the same shape ``block_skills`` enforces on. Evaluation is
+    ``read_only=True`` (skips every persistent side effect) and goes
+    straight to the engine rather than the ``/policies/evaluate`` route, so
+    it never enters the ASK / elicitation gate. A name is ``blocked`` when
+    the composed decision is ``DENY``.
+
+    Only cheap, name-based deny rules are consulted: the probe engine is
+    narrowed to non-LLM-backed policies (``block_skills`` and CEL / other
+    :class:`FunctionPolicy` evaluators, which gate by skill name or
+    expression). ALL known LLM-backed policies — the prompt classifier and
+    every LLM-gated router (intent-based authorization, task-switch
+    detection, trivial-model denial), identified via their registry
+    ``llm_backed`` flag — are intentionally excluded: their verdict is
+    content/runtime dependent and not previewable per skill name, and
+    running them here would fire one LLM call per discovered skill. They
+    still apply at actual skill invocation at runtime; ``blocked`` reflects
+    name-based / expression deny rules only.
+
+    Best-effort: if the policy infrastructure is unavailable or evaluation
+    raises, the name defaults to not-blocked so the panel degrades to an
+    empty/false state rather than failing the read.
+
+    :param spec: The session's (context-aware) agent spec.
+    :param session_id: Session/conversation identifier.
+    :param conversation_store: Store the engine reads label/state from.
+    :param skill_names: Skill names to test.
+    :param user_id: Authenticated caller, for the evaluation actor.
+    :returns: ``{skill_name: blocked}``; empty when no policies apply or
+        the engine can't be built.
+    """
+    if not skill_names:
+        return {}
+    try:
+        engine = await asyncio.to_thread(
+            _build_policy_engine_from_spec, spec, session_id, conversation_store
+        )
+    except Exception:  # noqa: BLE001 — best-effort: policy infra down → nothing blocked
+        _logger.debug("Blocked-skills engine build failed for %s", session_id, exc_info=True)
+        return {}
+    # No policies ⇒ nothing can deny; skip the per-skill evaluation entirely.
+    if not engine.policies:
+        return {}
+    # Narrow the probe engine to cheap, name-based deny policies only. Any
+    # LLM-backed policy (prompt classifier or LLM-gated router, flagged
+    # ``llm_backed`` in the registry) left in would fire one LLM call per
+    # skill name. This engine is a fresh throwaway built above, so mutating
+    # its policy list here does not affect the runtime engine used elsewhere.
+    engine.policies = [p for p in engine.policies if not _is_llm_backed_policy(p)]
+    # No name-based policies left ⇒ nothing cheap can deny; short-circuit.
+    if not engine.policies:
+        return dict.fromkeys(skill_names, False)
+    actor = _build_actor(user_id)
+    blocked: dict[str, bool] = {}
+    for name in skill_names:
+        event: dict[str, Any] = {
+            "type": "tool_call",
+            "data": {"name": "Skill", "arguments": {"skill": name}},
+        }
+        try:
+            ctx = _build_evaluation_context(Phase.TOOL_CALL, event["data"], event, actor=actor)
+            result = await engine.evaluate(ctx, read_only=True)
+            blocked[name] = result.action == PolicyAction.DENY
+        except Exception:  # noqa: BLE001 — best-effort: eval error → treat as not blocked
+            _logger.debug("Blocked-skills eval failed for %s/%s", session_id, name, exc_info=True)
+            blocked[name] = False
+    return blocked
+
+
 async def _apply_pending_policy_ask_writes(
     session_id: str,
     conv: Conversation,
@@ -20474,9 +20584,10 @@ def create_sessions_router(
         mcp_servers, local_tools, sub_agents = await asyncio.to_thread(
             _build_session_capability_groups, spec
         )
-        # Skills are runner-owned: reuse the same best-effort, cache-backed
-        # source the session snapshot uses (the runner's GET /skills proxy).
-        # No new runner round-trip is introduced here.
+        # Skills are runner-owned: the runner discovers the full set (in
+        # scope ∪ out of scope) with per-skill ``source`` + ``in_scope``.
+        # Awaited inline (best-effort) since this is an on-demand read, not
+        # the continuously-polled snapshot.
         from omnigent.runtime import get_runner_client, get_runner_router
 
         runner_client: httpx.AsyncClient | None = None
@@ -20492,7 +20603,19 @@ def create_sessions_router(
                 )
         if runner_client is None:
             runner_client = get_runner_client()
-        skills = await _fetch_runner_skills(runner_client, session_id)
+        skills = await _fetch_runner_skill_capabilities(runner_client, session_id)
+        # Layer the policy ``blocked`` flag on server-side (policy is
+        # server-owned). Read-only, best-effort: a name absent from the map
+        # keeps its default ``blocked=False``.
+        blocked_map = await _compute_blocked_skills(
+            spec,
+            session_id,
+            conversation_store,
+            [s.name for s in skills],
+            user_id=user_id,
+        )
+        for skill in skills:
+            skill.blocked = blocked_map.get(skill.name, False)
         return SessionCapabilities(
             session_id=session_id,
             agent_id=conv.agent_id,
@@ -20877,6 +21000,61 @@ async def _load_runner_skills(
     # Nudge any subscribed client to re-read the (now-warm) snapshot so
     # its slash-command menu fills without waiting for the next bind.
     _publish_runner_skills(session_id)
+
+
+async def _fetch_runner_skill_capabilities(
+    runner_client: httpx.AsyncClient | None,
+    session_id: str,
+) -> list[SkillCapability]:
+    """
+    Fetch a session's **full** enriched skill set from its bound runner.
+
+    Backs the read-only Capabilities panel: unlike the snapshot's
+    in-scope-only :func:`_fetch_runner_skills`, this asks the runner for
+    the full set (in-scope ∪ out-of-scope) via ``?include_out_of_scope``,
+    with each skill's ``source`` and ``in_scope`` flag. The ``blocked``
+    flag is layered on afterwards by the caller (policy is server-owned).
+
+    Awaited inline rather than background-cached: the capabilities view is
+    an on-demand read (not the continuously-polled snapshot), so the small
+    round-trip is fine and gives the panel data on first open. Best-effort:
+    a missing/unreachable runner, a non-200, or a malformed payload yields
+    an empty list rather than failing the endpoint.
+
+    :param runner_client: HTTP client pointed at the bound runner, or
+        ``None`` when no runner is bound.
+    :param session_id: Session/conversation identifier,
+        e.g. ``"conv_abc123"``.
+    :returns: Enriched skill capabilities (``blocked`` left at its default
+        ``False`` here), or ``[]`` when unavailable.
+    """
+    if runner_client is None:
+        return []
+    try:
+        resp = await runner_client.get(
+            f"/v1/sessions/{session_id}/skills",
+            params={"include_out_of_scope": "true"},
+            timeout=5.0,
+        )
+    except (httpx.HTTPError, ConnectionError):
+        _logger.debug("Runner skill-capabilities query failed for %s", session_id)
+        return []
+    if resp.status_code != 200:
+        return []
+    try:
+        raw = resp.json().get("skills", [])
+        return [
+            SkillCapability(
+                name=s["name"],
+                description=s["description"],
+                source=s.get("source", "unknown"),
+                in_scope=bool(s.get("in_scope", True)),
+            )
+            for s in raw
+        ]
+    except (ValueError, AttributeError, KeyError, TypeError):
+        _logger.debug("Runner skill-capabilities payload malformed for %s", session_id)
+        return []
 
 
 def _model_options_from_wire(raw_models: Any) -> list[dict[str, Any]]:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -10560,20 +10560,38 @@ def _resolve_session_effective_spec(
     return spec
 
 
+# Cap on how deep the declared-sub-agent tree is walked for the capabilities
+# view. Sub-agent nesting in the wild is shallow (a handful of levels); a
+# pathological or cyclically-authored spec should not recurse without bound.
+_SUB_AGENT_TREE_MAX_DEPTH = 16
+
+
 def _sub_agent_capability_tree(
     sub_agents: list[AgentSpec],
+    *,
+    _depth: int = 0,
 ) -> list[SubAgentCapability]:
     """Build the recursive declared-sub-agent tree for the capabilities view.
 
+    Depth-bounded: recursion stops descending past
+    :data:`_SUB_AGENT_TREE_MAX_DEPTH`, so a pathological or accidentally
+    self-referential spec cannot drive unbounded recursion. Sub-agents have
+    no name-based gating today, so nodes are reported as-is (always in
+    scope) — the cap only bounds traversal.
+
     :param sub_agents: A spec's ``sub_agents`` list.
+    :param _depth: Current recursion depth (internal).
     :returns: One :class:`SubAgentCapability` per declared sub-agent, each
-        carrying its own children recursively.
+        carrying its own children recursively (children truncated to ``[]``
+        at the depth cap).
     """
+    if _depth >= _SUB_AGENT_TREE_MAX_DEPTH:
+        return []
     return [
         SubAgentCapability(
             name=sub.name,
             description=sub.description,
-            sub_agents=_sub_agent_capability_tree(sub.sub_agents),
+            sub_agents=_sub_agent_capability_tree(sub.sub_agents, _depth=_depth + 1),
         )
         for sub in sub_agents
     ]
@@ -10590,9 +10608,11 @@ def _build_session_capability_groups(
 
     ``ToolManager(spec)`` is construction-only (MCP is ``start()``-gated),
     so the local-tool surface is resolved without any runner round-trip or
-    MCP connect. Per-server MCP ``tools`` are intentionally left empty — that
-    discovery needs a live runner ``tools/list`` (Slice D). Skills come from
-    a separate runner-owned source and are added by the caller.
+    MCP connect. Per-server MCP ``tools`` / ``status`` and the per-tool
+    ``blocked`` flags are left at their defaults here — the caller layers
+    them on from a live runner ``tools/list`` round-trip and the policy
+    probe. Skills come from a separate runner-owned source, also added by
+    the caller.
 
     Blocking/CPU-bound (schema build), so run under ``asyncio.to_thread``.
 
@@ -10609,8 +10629,8 @@ def _build_session_capability_groups(
             url=srv.url,
             command=srv.command,
             args=srv.args,
-            # Deferred: per-server tool discovery needs a runner tools/list
-            # round-trip against the live MCP connection (Slice D).
+            # Config-only skeleton; the caller layers on the discovered
+            # ``tools`` + connection ``status`` from a runner tools/list.
             tools=[],
         )
         for srv in spec.mcp_servers
@@ -10716,42 +10736,144 @@ async def _compute_blocked_skills(
     :returns: ``{skill_name: blocked}``; empty when no policies apply or
         the engine can't be built.
     """
-    if not skill_names:
+    return await _compute_blocked_tool_events(
+        spec,
+        session_id,
+        conversation_store,
+        skill_names,
+        event_data_for=lambda name: {"name": "Skill", "arguments": {"skill": name}},
+        user_id=user_id,
+        label="skills",
+    )
+
+
+async def _compute_blocked_tool_events(
+    spec: AgentSpec,
+    session_id: str,
+    conversation_store: ConversationStore,
+    keys: list[str],
+    *,
+    event_data_for: Callable[[str], dict[str, Any]],
+    user_id: str | None,
+    label: str,
+) -> dict[str, bool]:
+    """
+    Shared read-only, name-based, non-LLM "would a policy DENY this?" probe.
+
+    The general core behind every Capabilities ``blocked`` flag (skills,
+    MCP tools, local tools). Builds the session policy engine, strips ALL
+    LLM-backed policies (via :func:`_is_llm_backed_policy` — the prompt
+    classifier and every LLM-gated router, identified by their registry
+    ``llm_backed`` flag, so a future LLM-backed builtin is excluded
+    automatically), then evaluates one synthetic ``read_only=True``
+    ``tool_call`` event per key straight through the engine (never the
+    ASK / elicitation gate). A key is ``blocked`` when the composed
+    decision is ``DENY``.
+
+    Only the per-key event *shape* is caller-specific: ``event_data_for``
+    maps a key to the ``tool_call`` ``data`` payload (``{"name", "arguments"}``).
+    The LLM-exclusion, engine build, and short-circuit logic live here so
+    callers never duplicate it.
+
+    Best-effort: an unbuildable engine or an eval error defaults to
+    not-blocked so the panel degrades to a false/empty state rather than
+    failing the read.
+
+    :param spec: The session's (context-aware) agent spec.
+    :param session_id: Session/conversation identifier.
+    :param conversation_store: Store the engine reads label/state from.
+    :param keys: Opaque keys to test (skill names / tool names).
+    :param event_data_for: Maps a key to the synthetic ``tool_call``
+        event ``data`` payload.
+    :param user_id: Authenticated caller, for the evaluation actor.
+    :param label: Short tag for debug logging, e.g. ``"skills"``.
+    :returns: ``{key: blocked}``; empty when no policies apply or the
+        engine can't be built.
+    """
+    if not keys:
         return {}
     try:
         engine = await asyncio.to_thread(
             _build_policy_engine_from_spec, spec, session_id, conversation_store
         )
     except Exception:  # noqa: BLE001 — best-effort: policy infra down → nothing blocked
-        _logger.debug("Blocked-skills engine build failed for %s", session_id, exc_info=True)
+        _logger.debug("Blocked-%s engine build failed for %s", label, session_id, exc_info=True)
         return {}
-    # No policies ⇒ nothing can deny; skip the per-skill evaluation entirely.
+    # No policies ⇒ nothing can deny; skip the per-key evaluation entirely.
     if not engine.policies:
         return {}
     # Narrow the probe engine to cheap, name-based deny policies only. Any
     # LLM-backed policy (prompt classifier or LLM-gated router, flagged
     # ``llm_backed`` in the registry) left in would fire one LLM call per
-    # skill name. This engine is a fresh throwaway built above, so mutating
-    # its policy list here does not affect the runtime engine used elsewhere.
+    # key. This engine is a fresh throwaway built above, so mutating its
+    # policy list here does not affect the runtime engine used elsewhere.
     engine.policies = [p for p in engine.policies if not _is_llm_backed_policy(p)]
     # No name-based policies left ⇒ nothing cheap can deny; short-circuit.
     if not engine.policies:
-        return dict.fromkeys(skill_names, False)
+        return dict.fromkeys(keys, False)
+    # None of the surviving policies are LLM-backed, so the probe never needs
+    # the server LLM. Clear it so a non-serializable client object cannot leak
+    # into the dispatched event (``event["llm_client"]``) and corrupt CEL
+    # name-deny evaluation — CEL serializes the whole event, and a non-primitive
+    # value makes it abstain (falsely not-blocked). Safe: throwaway engine.
+    engine._llm_client = None
     actor = _build_actor(user_id)
     blocked: dict[str, bool] = {}
-    for name in skill_names:
-        event: dict[str, Any] = {
-            "type": "tool_call",
-            "data": {"name": "Skill", "arguments": {"skill": name}},
-        }
+    for key in keys:
+        data = event_data_for(key)
+        event: dict[str, Any] = {"type": "tool_call", "data": data}
         try:
-            ctx = _build_evaluation_context(Phase.TOOL_CALL, event["data"], event, actor=actor)
+            ctx = _build_evaluation_context(Phase.TOOL_CALL, data, event, actor=actor)
             result = await engine.evaluate(ctx, read_only=True)
-            blocked[name] = result.action == PolicyAction.DENY
+            blocked[key] = result.action == PolicyAction.DENY
         except Exception:  # noqa: BLE001 — best-effort: eval error → treat as not blocked
-            _logger.debug("Blocked-skills eval failed for %s/%s", session_id, name, exc_info=True)
-            blocked[name] = False
+            _logger.debug(
+                "Blocked-%s eval failed for %s/%s", label, session_id, key, exc_info=True
+            )
+            blocked[key] = False
     return blocked
+
+
+async def _compute_blocked_tool_names(
+    spec: AgentSpec,
+    session_id: str,
+    conversation_store: ConversationStore,
+    tool_names: list[str],
+    *,
+    user_id: str | None,
+) -> dict[str, bool]:
+    """
+    Read-only "would a policy block calling this tool?" check per name.
+
+    Powers the ``blocked`` flag on local tools and MCP tools. Reuses the
+    shared :func:`_compute_blocked_tool_events` probe (same non-LLM,
+    name-based deny semantics as the skills flag), evaluating a synthetic
+    ``tool_call`` event whose ``name`` is the tool name and ``arguments``
+    is empty — the shape a bare/namespaced builtin or MCP tool call carries
+    at runtime.
+
+    Callers pass whatever name shape(s) the runtime uses; for MCP tools
+    both the spec-proxied ``<server>__<tool>`` and the connector-native
+    ``mcp__<server>__<tool>`` forms are probed so a name-based deny authored
+    for either surface is reflected.
+
+    :param spec: The session's (context-aware) agent spec.
+    :param session_id: Session/conversation identifier.
+    :param conversation_store: Store the engine reads label/state from.
+    :param tool_names: Tool names to test (bare or namespaced).
+    :param user_id: Authenticated caller, for the evaluation actor.
+    :returns: ``{tool_name: blocked}``; empty when no policies apply or
+        the engine can't be built.
+    """
+    return await _compute_blocked_tool_events(
+        spec,
+        session_id,
+        conversation_store,
+        tool_names,
+        event_data_for=lambda name: {"name": name, "arguments": {}},
+        user_id=user_id,
+        label="tools",
+    )
 
 
 async def _apply_pending_policy_ask_writes(
@@ -20543,10 +20665,12 @@ def create_sessions_router(
           list, from the same runner-owned source as the session
           snapshot (best-effort; empty until the runner fetch warms).
         * ``mcp_servers`` — the agent's MCP server config
-          (secret-free). Per-server ``tools`` is deferred and left
-          empty (Slice D needs a runner ``tools/list`` round-trip).
+          (secret-free), each enriched with its discovered per-server
+          ``tools`` (name + description + policy ``blocked``) and a
+          connection ``status`` / ``error`` read from the runner's live
+          MCP state via a bounded ``tools/list`` round-trip.
         * ``local_tools`` — the agent's effective local/builtin
-          function tools (name + description).
+          function tools (name + description + policy ``blocked``).
         * ``sub_agents`` — the declared sub-agent tree from the spec.
 
         :param request: The incoming FastAPI request.
@@ -20604,10 +20728,29 @@ def create_sessions_router(
         if runner_client is None:
             runner_client = get_runner_client()
         skills = await _fetch_runner_skill_capabilities(runner_client, session_id)
+        # Discover the live per-server MCP tool surface (best-effort, read-only
+        # runner round-trip). Populate each server's ``tools`` + connection
+        # ``status`` / ``error``; servers absent from the discovery degrade to
+        # ``status="unknown"`` with an empty tool list.
+        mcp_schemas, mcp_failures, mcp_discovered = await _fetch_runner_mcp_tools(
+            runner_client, session_id
+        )
+        tools_by_server = _group_mcp_tools_by_server(
+            [srv.name for srv in mcp_servers], mcp_schemas
+        )
+        for server in mcp_servers:
+            server.tools = tools_by_server.get(server.name, [])
+            if server.name in mcp_failures:
+                server.status = "failed"
+                server.error = mcp_failures[server.name]
+            elif mcp_discovered:
+                server.status = "connected"
+            # else: leave default ``status="unknown"`` (runner/MCP unavailable).
         # Layer the policy ``blocked`` flag on server-side (policy is
         # server-owned). Read-only, best-effort: a name absent from the map
-        # keeps its default ``blocked=False``.
-        blocked_map = await _compute_blocked_skills(
+        # keeps its default ``blocked=False``. Skills, local tools, and MCP
+        # tools all share one non-LLM, name-based deny probe.
+        blocked_skills = await _compute_blocked_skills(
             spec,
             session_id,
             conversation_store,
@@ -20615,7 +20758,30 @@ def create_sessions_router(
             user_id=user_id,
         )
         for skill in skills:
-            skill.blocked = blocked_map.get(skill.name, False)
+            skill.blocked = blocked_skills.get(skill.name, False)
+        # Local tools probe with their bare builtin name; MCP tools probe with
+        # BOTH namespaced surfaces (spec-proxied ``<server>__<tool>`` and
+        # connector-native ``mcp__<server>__<tool>``) so a name-based deny
+        # authored for either form is reflected.
+        tool_name_candidates: set[str] = {t.name for t in local_tools}
+        for server in mcp_servers:
+            for tool in server.tools:
+                tool_name_candidates.add(f"{server.name}__{tool.name}")
+                tool_name_candidates.add(f"mcp__{server.name}__{tool.name}")
+        blocked_tools = await _compute_blocked_tool_names(
+            spec,
+            session_id,
+            conversation_store,
+            sorted(tool_name_candidates),
+            user_id=user_id,
+        )
+        for tool in local_tools:
+            tool.blocked = blocked_tools.get(tool.name, False)
+        for server in mcp_servers:
+            for tool in server.tools:
+                tool.blocked = blocked_tools.get(
+                    f"{server.name}__{tool.name}", False
+                ) or blocked_tools.get(f"mcp__{server.name}__{tool.name}", False)
         return SessionCapabilities(
             session_id=session_id,
             agent_id=conv.agent_id,
@@ -21055,6 +21221,105 @@ async def _fetch_runner_skill_capabilities(
     except (ValueError, AttributeError, KeyError, TypeError):
         _logger.debug("Runner skill-capabilities payload malformed for %s", session_id)
         return []
+
+
+async def _fetch_runner_mcp_tools(
+    runner_client: httpx.AsyncClient | None,
+    session_id: str,
+) -> tuple[list[dict[str, Any]], dict[str, str], bool]:
+    """
+    Fetch a session's discovered MCP tool surface from its bound runner.
+
+    Backs the Capabilities panel's per-server MCP ``tools`` + ``status``:
+    issues the same bounded, read-only ``tools/list`` round-trip the MCP
+    proxy uses — ``POST /v1/sessions/{id}/mcp/execute`` with
+    ``{"method": "tools/list"}`` — which the runner services from its live
+    :class:`RunnerMcpManager` state (:meth:`schemas_for`, awaiting any
+    in-flight connect). No tool is executed.
+
+    Awaited inline (best-effort), like the skills fetch: a missing /
+    unreachable runner, a non-200, an RPC error, or a malformed payload
+    yields ``([], {}, False)`` so the panel degrades to ``status="unknown"``
+    per server rather than failing the read.
+
+    :param runner_client: HTTP client pointed at the bound runner, or
+        ``None`` when no runner is bound.
+    :param session_id: Session/conversation identifier,
+        e.g. ``"conv_abc123"``.
+    :returns: ``(schemas, failures, discovered)`` — the raw
+        OpenAI-function-tool schemas (namespaced ``<server>__<tool>``
+        names), the ``{server_name: error}`` connect-failure map, and
+        whether the discovery round-trip succeeded at all.
+    """
+    if runner_client is None:
+        return [], {}, False
+    try:
+        resp = await runner_client.post(
+            f"/v1/sessions/{session_id}/mcp/execute",
+            json={"method": "tools/list", "params": {}},
+            timeout=30.0,
+        )
+    except (httpx.HTTPError, ConnectionError):
+        _logger.debug("Runner MCP tools/list query failed for %s", session_id)
+        return [], {}, False
+    if resp.status_code != 200:
+        return [], {}, False
+    try:
+        payload = resp.json()
+    except ValueError:
+        _logger.debug("Runner MCP tools/list payload malformed for %s", session_id)
+        return [], {}, False
+    if not isinstance(payload, dict) or "error" in payload:
+        # RPC error (no live MCP manager / no spec) → treat as not discovered.
+        return [], {}, False
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        return [], {}, False
+    raw_schemas = result.get("schemas", [])
+    raw_failures = result.get("failures", {})
+    schemas = (
+        [s for s in raw_schemas if isinstance(s, dict)] if isinstance(raw_schemas, list) else []
+    )
+    failures = (
+        {str(k): str(v) for k, v in raw_failures.items()} if isinstance(raw_failures, dict) else {}
+    )
+    return schemas, failures, True
+
+
+def _group_mcp_tools_by_server(
+    server_names: list[str],
+    schemas: list[dict[str, Any]],
+) -> dict[str, list[SessionCapabilityTool]]:
+    """
+    Group runner ``tools/list`` schemas under their owning MCP server.
+
+    Each schema name is namespaced ``<server>__<bare_tool>`` (the shape
+    :class:`RunnerMcpManager` emits). A tool is assigned to the declared
+    server whose ``"<name>__"`` prefix it matches, longest name first so an
+    overlapping prefix (``git`` vs ``github``) resolves to the more specific
+    server — mirroring the runner's own tool routing.
+
+    :param server_names: The spec's declared MCP server names.
+    :param schemas: Raw OpenAI-function-tool schema dicts from the runner.
+    :returns: ``{server_name: [SessionCapabilityTool, ...]}`` — the bare
+        tool name + description per server (``blocked`` left at its default;
+        layered on afterwards). Servers with no discovered tools are absent.
+    """
+    ordered = sorted(server_names, key=len, reverse=True)
+    grouped: dict[str, list[SessionCapabilityTool]] = {}
+    for schema in schemas:
+        name = schema.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        for server in ordered:
+            prefix = f"{server}__"
+            if name.startswith(prefix):
+                bare = name[len(prefix) :]
+                grouped.setdefault(server, []).append(
+                    SessionCapabilityTool(name=bare, description=schema.get("description") or None)
+                )
+                break
+    return grouped
 
 
 def _model_options_from_wire(raw_models: Any) -> list[dict[str, Any]]:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -227,6 +227,9 @@ from omnigent.server.schemas import (
     SandboxStatus,
     ServerStreamEvent,
     SessionAgentChangedEvent,
+    SessionCapabilities,
+    SessionCapabilityMCPServer,
+    SessionCapabilityTool,
     SessionCollaborationModeEvent,
     SessionCreatedEvent,
     SessionCreateMetadata,
@@ -257,6 +260,7 @@ from omnigent.server.schemas import (
     SessionTodosEvent,
     SessionUsageEvent,
     SkillSummary,
+    SubAgentCapability,
     UpdateSessionRequest,
 )
 from omnigent.session_lifecycle import (
@@ -10520,6 +10524,106 @@ def _load_agent_spec_for_session(
     )
 
 
+def _resolve_session_effective_spec(
+    conv: Conversation,
+    agent_store: AgentStore,
+) -> AgentSpec | None:
+    """Resolve the spec of the agent bound to *conv*, context-aware.
+
+    Loads the conversation's bound-agent spec, then — for an
+    omnigent-spawned named sub-agent child (``conv.sub_agent_name`` set,
+    which shares the parent's ``agent_id``) — narrows to THAT sub-agent's
+    spec resolved from the parent bundle. Claude-native sub-agents reuse
+    the parent ``agent_id`` with no ``sub_agent_name`` and so report the
+    parent's spec, exactly as ``GET /sessions/{id}/agent`` does.
+
+    Pure/sync spec traversal — blocking DB/IO (bundle load) only, no
+    runner round-trip and no MCP connect. Run under ``asyncio.to_thread``.
+
+    :param conv: The session conversation (its ``agent_id`` /
+        ``sub_agent_name`` drive resolution).
+    :param agent_store: Store for the bound-agent lookup.
+    :returns: The effective (sub-)agent spec, or ``None`` when the
+        conversation has no agent or the bundle can't be loaded.
+    """
+    spec = _load_agent_spec_for_session(conv, agent_store)
+    if spec is None:
+        return None
+    if conv.sub_agent_name:
+        from omnigent.runtime.workflow import _find_spec_by_name
+
+        sub = _find_spec_by_name(spec, conv.sub_agent_name)
+        if sub is not None:
+            return sub
+    return spec
+
+
+def _sub_agent_capability_tree(
+    sub_agents: list[AgentSpec],
+) -> list[SubAgentCapability]:
+    """Build the recursive declared-sub-agent tree for the capabilities view.
+
+    :param sub_agents: A spec's ``sub_agents`` list.
+    :returns: One :class:`SubAgentCapability` per declared sub-agent, each
+        carrying its own children recursively.
+    """
+    return [
+        SubAgentCapability(
+            name=sub.name,
+            description=sub.description,
+            sub_agents=_sub_agent_capability_tree(sub.sub_agents),
+        )
+        for sub in sub_agents
+    ]
+
+
+def _build_session_capability_groups(
+    spec: AgentSpec,
+) -> tuple[
+    list[SessionCapabilityMCPServer],
+    list[SessionCapabilityTool],
+    list[SubAgentCapability],
+]:
+    """Derive the spec-only capability groups (mcp config, local tools, sub-agents).
+
+    ``ToolManager(spec)`` is construction-only (MCP is ``start()``-gated),
+    so the local-tool surface is resolved without any runner round-trip or
+    MCP connect. Per-server MCP ``tools`` are intentionally left empty — that
+    discovery needs a live runner ``tools/list`` (Slice D). Skills come from
+    a separate runner-owned source and are added by the caller.
+
+    Blocking/CPU-bound (schema build), so run under ``asyncio.to_thread``.
+
+    :param spec: The resolved (sub-)agent spec.
+    :returns: ``(mcp_servers, local_tools, sub_agents)``.
+    """
+    from omnigent.tools.manager import ToolManager
+
+    mcp_servers = [
+        SessionCapabilityMCPServer(
+            name=srv.name,
+            transport=srv.transport,
+            description=srv.description,
+            url=srv.url,
+            command=srv.command,
+            args=srv.args,
+            # Deferred: per-server tool discovery needs a runner tools/list
+            # round-trip against the live MCP connection (Slice D).
+            tools=[],
+        )
+        for srv in spec.mcp_servers
+    ]
+    local_tools: list[SessionCapabilityTool] = []
+    for schema in ToolManager(spec).get_tool_schemas():
+        fn = schema.get("function", {})
+        name = fn.get("name")
+        if not name:
+            continue
+        local_tools.append(SessionCapabilityTool(name=name, description=fn.get("description")))
+    sub_agents = _sub_agent_capability_tree(spec.sub_agents)
+    return mcp_servers, local_tools, sub_agents
+
+
 def _build_policy_engine_from_spec(
     spec: AgentSpec,
     session_id: str,
@@ -20305,6 +20409,99 @@ def create_sessions_router(
                 code=ErrorCode.NOT_FOUND,
             )
         return _to_agent_object(agent, agent_cache)
+
+    @router.get("/sessions/{session_id}/capabilities")
+    async def get_session_capabilities(
+        request: Request,
+        session_id: str,
+    ) -> SessionCapabilities:
+        """
+        Return the consolidated capabilities of the session's agent.
+
+        Read-only observability view over the agent bound to
+        *session_id*. Resolves the agent the same way as
+        ``GET /sessions/{id}/agent`` (under ``LEVEL_READ``, no
+        top-level assertion), so it works identically for a top
+        agent's conversation and a sub-agent's child conversation.
+        For an omnigent-spawned named sub-agent child the capabilities
+        are context-aware — resolved from the child's ``sub_agent_name``
+        against the parent spec.
+
+        Four groups:
+
+        * ``skills`` — the merged (bundled + host-discovered) skill
+          list, from the same runner-owned source as the session
+          snapshot (best-effort; empty until the runner fetch warms).
+        * ``mcp_servers`` — the agent's MCP server config
+          (secret-free). Per-server ``tools`` is deferred and left
+          empty (Slice D needs a runner ``tools/list`` round-trip).
+        * ``local_tools`` — the agent's effective local/builtin
+          function tools (name + description).
+        * ``sub_agents`` — the declared sub-agent tree from the spec.
+
+        :param request: The incoming FastAPI request.
+        :param session_id: Session identifier, e.g. ``"conv_abc123"``.
+        :returns: The session's :class:`SessionCapabilities`.
+        :raises OmnigentError: If the session or agent is not found,
+            or the session has no agent binding.
+        """
+        user_id = _require_user(request, auth_provider)
+        access = await _require_access_and_level(
+            user_id, session_id, LEVEL_READ, permission_store, conversation_store
+        )
+        conv = access.conversation
+        if conv is None:
+            conv = conversation_store.get_conversation(session_id)
+            if conv is None:
+                raise OmnigentError(
+                    f"Session not found: {session_id!r}",
+                    code=ErrorCode.NOT_FOUND,
+                )
+        if conv.agent_id is None:
+            raise OmnigentError(
+                "Session has no agent binding",
+                code=ErrorCode.INTERNAL_ERROR,
+            )
+        # Resolve the effective (context-aware) spec off the loop: the
+        # agent lookup + cold-cache bundle load are blocking DB/IO, and
+        # ToolManager schema construction is CPU-bound.
+        spec = await asyncio.to_thread(_resolve_session_effective_spec, conv, agent_store)
+        if spec is None:
+            raise OmnigentError(
+                f"Agent spec not found for session: {session_id!r}",
+                code=ErrorCode.NOT_FOUND,
+            )
+        mcp_servers, local_tools, sub_agents = await asyncio.to_thread(
+            _build_session_capability_groups, spec
+        )
+        # Skills are runner-owned: reuse the same best-effort, cache-backed
+        # source the session snapshot uses (the runner's GET /skills proxy).
+        # No new runner round-trip is introduced here.
+        from omnigent.runtime import get_runner_client, get_runner_router
+
+        runner_client: httpx.AsyncClient | None = None
+        skills_router = get_runner_router()
+        if skills_router is not None:
+            try:
+                routed = skills_router.client_for_session_resources(session_id)
+                runner_client = routed.client
+            except (LookupError, httpx.HTTPError, OmnigentError):
+                _logger.debug(
+                    "No runner bound for session=%s on capabilities build",
+                    session_id,
+                )
+        if runner_client is None:
+            runner_client = get_runner_client()
+        skills = await _fetch_runner_skills(runner_client, session_id)
+        return SessionCapabilities(
+            session_id=session_id,
+            agent_id=conv.agent_id,
+            sub_agent_name=conv.sub_agent_name,
+            skills=skills,
+            mcp_servers=mcp_servers,
+            local_tools=local_tools,
+            sub_agents=sub_agents,
+        )
 
     @router.get(
         "/sessions/{session_id}/agent/contents",

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -308,27 +308,44 @@ class SessionCapabilityTool(BaseModel):
     :param name: OpenAI-format function name, e.g. ``"sys_os_read"``.
     :param description: One-line summary from the tool schema, or
         ``None`` when the tool declares none.
+    :param blocked: Whether a session policy would DENY calling this
+        tool by name (read-only, name-based deny rules only — the same
+        LLM-excluded probe the skills ``blocked`` flag uses). Local
+        tools are always in scope (allow-list config), so ``blocked``
+        is the only gate that applies to them.
     """
 
     name: str
     description: str | None = None
+    blocked: bool = False
 
 
 class SessionCapabilityMCPServer(MCPServerSummary):
     """
-    An MCP server's config plus a (deferred) per-server tool list.
+    An MCP server's config plus its discovered per-server tool list.
 
     Reuses the secret-free :class:`MCPServerSummary` shape (name,
-    transport, description, url, command, args) and adds ``tools``.
-    Per-server tool discovery needs a runner round-trip (``tools/list``
-    against the live MCP connection), so it is deferred — this field is
-    always empty in this slice.
+    transport, description, url, command, args) and adds the live
+    ``tools`` list plus a per-server connection ``status`` / ``error``,
+    read from the runner's MCP state via a bounded ``tools/list``
+    round-trip against the live connection.
 
-    :param tools: Discovered MCP tools for this server. Always ``[]``
-        for now (Slice D: per-server tool discovery via the runner).
+    :param tools: Discovered MCP tools for this server (name +
+        description + policy ``blocked`` flag). Empty when the server
+        exposes no tools, failed to connect, or the runner is
+        unavailable.
+    :param status: Per-server connection status — ``"connected"`` (the
+        runner reported this server's tool surface), ``"failed"`` (the
+        runner could not connect; see ``error``), or ``"unknown"`` (the
+        runner/MCP state was unavailable, so discovery did not run).
+    :param error: The connect error the runner reported for a
+        ``"failed"`` server, e.g. ``"ConnectError: refused"``; ``None``
+        otherwise.
     """
 
     tools: list[SessionCapabilityTool] = Field(default_factory=list)
+    status: str = "unknown"
+    error: str | None = None
 
 
 class SubAgentCapability(BaseModel):
@@ -372,9 +389,11 @@ class SessionCapabilities(BaseModel):
         flag (whether ``skills_filter`` admits it), and a ``blocked`` flag
         (whether a session policy would deny loading it).
     :param mcp_servers: The agent's MCP server config (secret fields
-        omitted). Each carries a deferred, empty ``tools`` list.
+        omitted). Each carries its discovered ``tools`` list (with a
+        per-tool ``blocked`` flag) and a per-server connection
+        ``status`` / ``error``.
     :param local_tools: The agent's effective local/builtin function
-        tools, name + description only.
+        tools (name + description + policy ``blocked`` flag).
     :param sub_agents: The declared sub-agent tree from the spec.
     """
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -157,6 +157,38 @@ class SkillSummary(BaseModel):
     description: str
 
 
+class SkillCapability(BaseModel):
+    """
+    A discovered skill enriched with provenance and policy state.
+
+    The Capabilities panel's richer view of :class:`SkillSummary`: on top
+    of ``name`` + ``description`` it carries where the skill came from
+    (``source``), whether the agent's ``skills_filter`` admits it
+    (``in_scope``), and whether a session policy would deny loading it by
+    name (``blocked``). The full skill ``content`` is still omitted.
+
+    :param name: Skill identifier, e.g. ``"code-review"`` (host plugin
+        skills are namespaced ``"<plugin>:<skill>"``).
+    :param description: One-line summary from the SKILL.md frontmatter.
+    :param source: Provenance label — one of ``"bundle"`` (shipped with
+        the agent), ``"workspace"`` (project ``.claude`` / ``.agents``),
+        ``"user"`` (``~/.claude`` / ``~/.agents``), ``"plugin"`` (a Claude
+        plugin), ``"codex"`` / ``"cursor"`` (host-specific), or
+        ``"unknown"``.
+    :param in_scope: Whether the agent can actually load this skill given
+        its ``skills_filter``. Bundled skills are always in scope; a
+        host/plugin skill is in scope iff it passes the filter.
+    :param blocked: Whether a session ``block_skills`` (or equivalent)
+        policy would DENY loading this skill by name.
+    """
+
+    name: str
+    description: str
+    source: str = "unknown"
+    in_scope: bool = True
+    blocked: bool = False
+
+
 class PolicySummary(BaseModel):
     """
     Safe subset of a policy's spec for API exposure.
@@ -335,8 +367,10 @@ class SessionCapabilities(BaseModel):
         sub-agent is identified by ``sub_agent_name``).
     :param sub_agent_name: The dispatched sub-agent name when the
         session is a named sub-agent child, else ``None``.
-    :param skills: The merged (bundled + host-discovered) skill list,
-        from the same runner-owned source as the session snapshot.
+    :param skills: The full (bundled + host-discovered) skill list from the
+        runner, each enriched with ``source`` provenance, an ``in_scope``
+        flag (whether ``skills_filter`` admits it), and a ``blocked`` flag
+        (whether a session policy would deny loading it).
     :param mcp_servers: The agent's MCP server config (secret fields
         omitted). Each carries a deferred, empty ``tools`` list.
     :param local_tools: The agent's effective local/builtin function
@@ -348,7 +382,7 @@ class SessionCapabilities(BaseModel):
     session_id: str
     agent_id: str
     sub_agent_name: str | None = None
-    skills: list[SkillSummary] = Field(default_factory=list)
+    skills: list[SkillCapability] = Field(default_factory=list)
     mcp_servers: list[SessionCapabilityMCPServer] = Field(default_factory=list)
     local_tools: list[SessionCapabilityTool] = Field(default_factory=list)
     sub_agents: list[SubAgentCapability] = Field(default_factory=list)

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -262,6 +262,98 @@ class AgentObject(BaseModel):
     builtin: bool = False
 
 
+# ── Session Capabilities ───────────────────────────────────────
+
+
+class SessionCapabilityTool(BaseModel):
+    """
+    Safe summary of a single function tool for the capabilities view.
+
+    Surfaces only the name and one-line description so the panel can
+    list which tools an agent can call without leaking the full
+    parameter schema.
+
+    :param name: OpenAI-format function name, e.g. ``"sys_os_read"``.
+    :param description: One-line summary from the tool schema, or
+        ``None`` when the tool declares none.
+    """
+
+    name: str
+    description: str | None = None
+
+
+class SessionCapabilityMCPServer(MCPServerSummary):
+    """
+    An MCP server's config plus a (deferred) per-server tool list.
+
+    Reuses the secret-free :class:`MCPServerSummary` shape (name,
+    transport, description, url, command, args) and adds ``tools``.
+    Per-server tool discovery needs a runner round-trip (``tools/list``
+    against the live MCP connection), so it is deferred — this field is
+    always empty in this slice.
+
+    :param tools: Discovered MCP tools for this server. Always ``[]``
+        for now (Slice D: per-server tool discovery via the runner).
+    """
+
+    tools: list[SessionCapabilityTool] = Field(default_factory=list)
+
+
+class SubAgentCapability(BaseModel):
+    """
+    A declared sub-agent node in the capabilities tree.
+
+    Built recursively from ``spec.sub_agents`` so the panel can render
+    the full declared sub-agent hierarchy. Read-only and derived purely
+    from the spec — no live child-session status this slice.
+
+    :param name: Sub-agent name as declared in the parent spec, e.g.
+        ``"researcher"``. ``None`` when the spec omits it.
+    :param description: Optional free-text description from the spec.
+    :param sub_agents: This sub-agent's own declared sub-agents, same
+        shape, recursively.
+    """
+
+    name: str | None = None
+    description: str | None = None
+    sub_agents: list[SubAgentCapability] = Field(default_factory=list)
+
+
+class SessionCapabilities(BaseModel):
+    """
+    Consolidated read-only capabilities of a session's bound agent.
+
+    Returned by ``GET /v1/sessions/{session_id}/capabilities``. Resolves
+    the agent bound to the session (context-aware: an omnigent-spawned
+    sub-agent child reports THAT sub-agent's capabilities, resolved from
+    its ``sub_agent_name`` against the parent spec).
+
+    :param object: Fixed resource type, ``"session.capabilities"``.
+    :param session_id: The queried session/conversation id.
+    :param agent_id: The agent row bound to the session. For an
+        omnigent-spawned sub-agent this is the parent's agent id (the
+        sub-agent is identified by ``sub_agent_name``).
+    :param sub_agent_name: The dispatched sub-agent name when the
+        session is a named sub-agent child, else ``None``.
+    :param skills: The merged (bundled + host-discovered) skill list,
+        from the same runner-owned source as the session snapshot.
+    :param mcp_servers: The agent's MCP server config (secret fields
+        omitted). Each carries a deferred, empty ``tools`` list.
+    :param local_tools: The agent's effective local/builtin function
+        tools, name + description only.
+    :param sub_agents: The declared sub-agent tree from the spec.
+    """
+
+    object: str = "session.capabilities"
+    session_id: str
+    agent_id: str
+    sub_agent_name: str | None = None
+    skills: list[SkillSummary] = Field(default_factory=list)
+    mcp_servers: list[SessionCapabilityMCPServer] = Field(default_factory=list)
+    local_tools: list[SessionCapabilityTool] = Field(default_factory=list)
+    sub_agents: list[SubAgentCapability] = Field(default_factory=list)
+
+
 # ── Session Policies ───────────────────────────────────────────
 
 

--- a/omnigent/spec/skill_sources.py
+++ b/omnigent/spec/skill_sources.py
@@ -78,6 +78,62 @@ class SkillSourceContext:
 SkillSource = Callable[[SkillSourceContext], list[SkillSpec]]
 
 
+def _is_under(path: Path, root: Path) -> bool:
+    """Return whether *path* is *root* or nested beneath it."""
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def classify_skill_source(spec: SkillSpec, *, home: Path) -> str:
+    """
+    Classify where a **host** skill was collected from.
+
+    Bundled skills are not passed here — the caller already knows them
+    by construction and labels them ``"bundle"``. This classifies the
+    extra skills a harness surfaces (from ``resolve_harness_skills``):
+
+    * ``"plugin"`` — a namespaced ``<plugin>:<skill>`` (Claude plugins
+      always namespace) or a skill under ``~/.claude/plugins``.
+    * ``"codex"`` / ``"cursor"`` — under ``~/.codex`` / ``~/.cursor``.
+    * ``"user"`` — user-global ``~/.claude`` / ``~/.agents``.
+    * ``"workspace"`` — a project ``.claude`` / ``.agents`` up-tree from
+      the session workspace (the else branch — anything on disk not under
+      the user home).
+    * ``"unknown"`` — no ``skill_dir`` and not namespaced (defensive).
+
+    :param spec: A discovered host skill.
+    :param home: The user home dir (``Path.home()``), injected for tests.
+    :returns: A short source label.
+    """
+    if ":" in spec.name:
+        return "plugin"
+    if spec.skill_dir is None:
+        return "unknown"
+    skill_dir = spec.skill_dir.resolve()
+
+    def under(*parts: str) -> bool:
+        # Resolve the comparison root the SAME way as skill_dir. skill_dir is
+        # fully resolved, so a home dotdir that is itself a symlink (dotfile
+        # managers, container volume mounts, macOS /var -> /private/var) must be
+        # resolved too — otherwise we'd compare a resolved path against a root
+        # whose symlinked tail was appended lexically, and every user/plugin
+        # skill would fall through to "workspace".
+        return _is_under(skill_dir, home.joinpath(*parts).resolve())
+
+    if under(".claude", "plugins"):
+        return "plugin"
+    if under(".codex"):
+        return "codex"
+    if under(".cursor"):
+        return "cursor"
+    if under(".claude") or under(".agents"):
+        return "user"
+    return "workspace"
+
+
 def _dedup(specs: list[SkillSpec]) -> list[SkillSpec]:
     """Return *specs* with later same-name entries dropped (first wins)."""
     seen: set[str] = set()

--- a/openapi.json
+++ b/openapi.json
@@ -3172,7 +3172,7 @@
             "type": "string"
           },
           "local_tools": {
-            "description": "The agent's effective local/builtin function tools, name + description only.",
+            "description": "The agent's effective local/builtin function tools (name + description + policy `blocked` flag).",
             "items": {
               "$ref": "#/components/schemas/SessionCapabilityTool"
             },
@@ -3180,7 +3180,7 @@
             "type": "array"
           },
           "mcp_servers": {
-            "description": "The agent's MCP server config (secret fields omitted). Each carries a deferred, empty `tools` list.",
+            "description": "The agent's MCP server config (secret fields omitted). Each carries its discovered `tools` list (with a per-tool `blocked` flag) and a per-server connection `status` / `error`.",
             "items": {
               "$ref": "#/components/schemas/SessionCapabilityMCPServer"
             },
@@ -3199,9 +3199,9 @@
             "type": "string"
           },
           "skills": {
-            "description": "The merged (bundled + host-discovered) skill list, from the same runner-owned source as the session snapshot.",
+            "description": "The full (bundled + host-discovered) skill list from the runner, each enriched with `source` provenance, an `in_scope` flag (whether `skills_filter` admits it), and a `blocked` flag (whether a session policy would deny loading it).",
             "items": {
-              "$ref": "#/components/schemas/SkillSummary"
+              "$ref": "#/components/schemas/SkillCapability"
             },
             "title": "Skills",
             "type": "array"
@@ -3235,7 +3235,7 @@
         "type": "object"
       },
       "SessionCapabilityMCPServer": {
-        "description": "An MCP server's config plus a (deferred) per-server tool list.\n\nReuses the secret-free `MCPServerSummary` shape (name,\ntransport, description, url, command, args) and adds `tools`.\nPer-server tool discovery needs a runner round-trip (`tools/list`\nagainst the live MCP connection), so it is deferred \u2014 this field is\nalways empty in this slice.",
+        "description": "An MCP server's config plus its discovered per-server tool list.\n\nReuses the secret-free `MCPServerSummary` shape (name,\ntransport, description, url, command, args) and adds the live\n`tools` list plus a per-server connection `status` / `error`,\nread from the runner's MCP state via a bounded `tools/list`\nround-trip against the live connection.",
         "properties": {
           "args": {
             "items": {
@@ -3266,12 +3266,30 @@
             ],
             "title": "Description"
           },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The connect error the runner reported for a `\"failed\"` server, e.g. `\"ConnectError: refused\"`; `None` otherwise.",
+            "title": "Error"
+          },
           "name": {
             "title": "Name",
             "type": "string"
           },
+          "status": {
+            "default": "unknown",
+            "description": "Per-server connection status \u2014 `\"connected\"` (the runner reported this server's tool surface), `\"failed\"` (the runner could not connect; see `error`), or `\"unknown\"` (the runner/MCP state was unavailable, so discovery did not run).",
+            "title": "Status",
+            "type": "string"
+          },
           "tools": {
-            "description": "Discovered MCP tools for this server. Always `[]` for now (Slice D: per-server tool discovery via the runner).",
+            "description": "Discovered MCP tools for this server (name + description + policy `blocked` flag). Empty when the server exposes no tools, failed to connect, or the runner is unavailable.",
             "items": {
               "$ref": "#/components/schemas/SessionCapabilityTool"
             },
@@ -3304,6 +3322,12 @@
       "SessionCapabilityTool": {
         "description": "Safe summary of a single function tool for the capabilities view.\n\nSurfaces only the name and one-line description so the panel can\nlist which tools an agent can call without leaking the full\nparameter schema.",
         "properties": {
+          "blocked": {
+            "default": false,
+            "description": "Whether a session policy would DENY calling this tool by name (read-only, name-based deny rules only \u2014 the same LLM-excluded probe the skills `blocked` flag uses). Local tools are always in scope (allow-list config), so `blocked` is the only gate that applies to them.",
+            "title": "Blocked",
+            "type": "boolean"
+          },
           "description": {
             "anyOf": [
               {
@@ -5407,6 +5431,45 @@
           "objective"
         ],
         "title": "SetCodexGoalRequest",
+        "type": "object"
+      },
+      "SkillCapability": {
+        "description": "A discovered skill enriched with provenance and policy state.\n\nThe Capabilities panel's richer view of `SkillSummary`: on top\nof `name` + `description` it carries where the skill came from\n(`source`), whether the agent's `skills_filter` admits it\n(`in_scope`), and whether a session policy would deny loading it by\nname (`blocked`). The full skill `content` is still omitted.",
+        "properties": {
+          "blocked": {
+            "default": false,
+            "description": "Whether a session `block_skills` (or equivalent) policy would DENY loading this skill by name.",
+            "title": "Blocked",
+            "type": "boolean"
+          },
+          "description": {
+            "description": "One-line summary from the SKILL.md frontmatter.",
+            "title": "Description",
+            "type": "string"
+          },
+          "in_scope": {
+            "default": true,
+            "description": "Whether the agent can actually load this skill given its `skills_filter`. Bundled skills are always in scope; a host/plugin skill is in scope iff it passes the filter.",
+            "title": "In Scope",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Skill identifier, e.g. `\"code-review\"` (host plugin skills are namespaced `\"<plugin>:<skill>\"`).",
+            "title": "Name",
+            "type": "string"
+          },
+          "source": {
+            "default": "unknown",
+            "description": "Provenance label \u2014 one of `\"bundle\"` (shipped with the agent), `\"workspace\"` (project `.claude` / `.agents`), `\"user\"` (`~/.claude` / `~/.agents`), `\"plugin\"` (a Claude plugin), `\"codex\"` / `\"cursor\"` (host-specific), or `\"unknown\"`.",
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "title": "SkillCapability",
         "type": "object"
       },
       "SkillSummary": {
@@ -8062,7 +8125,7 @@
     },
     "/v1/sessions/{session_id}/capabilities": {
       "get": {
-        "description": "Return the consolidated capabilities of the session's agent.\n\nRead-only observability view over the agent bound to\n*session_id*. Resolves the agent the same way as\n`GET /sessions/{id}/agent` (under `LEVEL_READ`, no\ntop-level assertion), so it works identically for a top\nagent's conversation and a sub-agent's child conversation.\nFor an omnigent-spawned named sub-agent child the capabilities\nare context-aware \u2014 resolved from the child's `sub_agent_name`\nagainst the parent spec.\n\nFour groups:\n\n* `skills` \u2014 the merged (bundled + host-discovered) skill\n  list, from the same runner-owned source as the session\n  snapshot (best-effort; empty until the runner fetch warms).\n* `mcp_servers` \u2014 the agent's MCP server config\n  (secret-free). Per-server `tools` is deferred and left\n  empty (Slice D needs a runner `tools/list` round-trip).\n* `local_tools` \u2014 the agent's effective local/builtin\n  function tools (name + description).\n* `sub_agents` \u2014 the declared sub-agent tree from the spec.\n\n**Returns:** The session's `SessionCapabilities`.\n\n**Raises**\n\n- `OmnigentError` \u2014 If the session or agent is not found, or the session has no agent binding.",
+        "description": "Return the consolidated capabilities of the session's agent.\n\nRead-only observability view over the agent bound to\n*session_id*. Resolves the agent the same way as\n`GET /sessions/{id}/agent` (under `LEVEL_READ`, no\ntop-level assertion), so it works identically for a top\nagent's conversation and a sub-agent's child conversation.\nFor an omnigent-spawned named sub-agent child the capabilities\nare context-aware \u2014 resolved from the child's `sub_agent_name`\nagainst the parent spec.\n\nFour groups:\n\n* `skills` \u2014 the merged (bundled + host-discovered) skill\n  list, from the same runner-owned source as the session\n  snapshot (best-effort; empty until the runner fetch warms).\n* `mcp_servers` \u2014 the agent's MCP server config\n  (secret-free), each enriched with its discovered per-server\n  `tools` (name + description + policy `blocked`) and a\n  connection `status` / `error` read from the runner's live\n  MCP state via a bounded `tools/list` round-trip.\n* `local_tools` \u2014 the agent's effective local/builtin\n  function tools (name + description + policy `blocked`).\n* `sub_agents` \u2014 the declared sub-agent tree from the spec.\n\n**Returns:** The session's `SessionCapabilities`.\n\n**Raises**\n\n- `OmnigentError` \u2014 If the session or agent is not found, or the session has no agent binding.",
         "operationId": "get_session_capabilities_v1_sessions__session_id__capabilities_get",
         "parameters": [
           {

--- a/openapi.json
+++ b/openapi.json
@@ -3163,6 +3163,171 @@
         "title": "SessionAgentChangedEvent",
         "type": "object"
       },
+      "SessionCapabilities": {
+        "description": "Consolidated read-only capabilities of a session's bound agent.\n\nReturned by `GET /v1/sessions/{session_id}/capabilities`. Resolves\nthe agent bound to the session (context-aware: an omnigent-spawned\nsub-agent child reports THAT sub-agent's capabilities, resolved from\nits `sub_agent_name` against the parent spec).",
+        "properties": {
+          "agent_id": {
+            "description": "The agent row bound to the session. For an omnigent-spawned sub-agent this is the parent's agent id (the sub-agent is identified by `sub_agent_name`).",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "local_tools": {
+            "description": "The agent's effective local/builtin function tools, name + description only.",
+            "items": {
+              "$ref": "#/components/schemas/SessionCapabilityTool"
+            },
+            "title": "Local Tools",
+            "type": "array"
+          },
+          "mcp_servers": {
+            "description": "The agent's MCP server config (secret fields omitted). Each carries a deferred, empty `tools` list.",
+            "items": {
+              "$ref": "#/components/schemas/SessionCapabilityMCPServer"
+            },
+            "title": "Mcp Servers",
+            "type": "array"
+          },
+          "object": {
+            "default": "session.capabilities",
+            "description": "Fixed resource type, `\"session.capabilities\"`.",
+            "title": "Object",
+            "type": "string"
+          },
+          "session_id": {
+            "description": "The queried session/conversation id.",
+            "title": "Session Id",
+            "type": "string"
+          },
+          "skills": {
+            "description": "The merged (bundled + host-discovered) skill list, from the same runner-owned source as the session snapshot.",
+            "items": {
+              "$ref": "#/components/schemas/SkillSummary"
+            },
+            "title": "Skills",
+            "type": "array"
+          },
+          "sub_agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The dispatched sub-agent name when the session is a named sub-agent child, else `None`.",
+            "title": "Sub Agent Name"
+          },
+          "sub_agents": {
+            "description": "The declared sub-agent tree from the spec.",
+            "items": {
+              "$ref": "#/components/schemas/SubAgentCapability"
+            },
+            "title": "Sub Agents",
+            "type": "array"
+          }
+        },
+        "required": [
+          "session_id",
+          "agent_id"
+        ],
+        "title": "SessionCapabilities",
+        "type": "object"
+      },
+      "SessionCapabilityMCPServer": {
+        "description": "An MCP server's config plus a (deferred) per-server tool list.\n\nReuses the secret-free `MCPServerSummary` shape (name,\ntransport, description, url, command, args) and adds `tools`.\nPer-server tool discovery needs a runner round-trip (`tools/list`\nagainst the live MCP connection), so it is deferred \u2014 this field is\nalways empty in this slice.",
+        "properties": {
+          "args": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Args",
+            "type": "array"
+          },
+          "command": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Command"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "tools": {
+            "description": "Discovered MCP tools for this server. Always `[]` for now (Slice D: per-server tool discovery via the runner).",
+            "items": {
+              "$ref": "#/components/schemas/SessionCapabilityTool"
+            },
+            "title": "Tools",
+            "type": "array"
+          },
+          "transport": {
+            "title": "Transport",
+            "type": "string"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          }
+        },
+        "required": [
+          "name",
+          "transport"
+        ],
+        "title": "SessionCapabilityMCPServer",
+        "type": "object"
+      },
+      "SessionCapabilityTool": {
+        "description": "Safe summary of a single function tool for the capabilities view.\n\nSurfaces only the name and one-line description so the panel can\nlist which tools an agent can call without leaking the full\nparameter schema.",
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "One-line summary from the tool schema, or `None` when the tool declares none.",
+            "title": "Description"
+          },
+          "name": {
+            "description": "OpenAI-format function name, e.g. `\"sys_os_read\"`.",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "SessionCapabilityTool",
+        "type": "object"
+      },
       "SessionChangedFilesInvalidatedEvent": {
         "description": "The session's changed-files list may have changed \u2014 refetch it.\n\nA coarse \"something changed\" signal (per-file events aren't available\nfor git-mode workspaces) emitted by the runner after a file-mutating\ntool. The web treats it as a refetch trigger for the changed-files\npanel; transient (not persisted \u2014 the REST list is source of truth).",
         "properties": {
@@ -5311,6 +5476,45 @@
           "arguments"
         ],
         "title": "SlashCommandData",
+        "type": "object"
+      },
+      "SubAgentCapability": {
+        "description": "A declared sub-agent node in the capabilities tree.\n\nBuilt recursively from `spec.sub_agents` so the panel can render\nthe full declared sub-agent hierarchy. Read-only and derived purely\nfrom the spec \u2014 no live child-session status this slice.",
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional free-text description from the spec.",
+            "title": "Description"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Sub-agent name as declared in the parent spec, e.g. `\"researcher\"`. `None` when the spec omits it.",
+            "title": "Name"
+          },
+          "sub_agents": {
+            "description": "This sub-agent's own declared sub-agents, same shape, recursively.",
+            "items": {
+              "$ref": "#/components/schemas/SubAgentCapability"
+            },
+            "title": "Sub Agents",
+            "type": "array"
+          }
+        },
+        "title": "SubAgentCapability",
         "type": "object"
       },
       "TerminalCommandData": {
@@ -7853,6 +8057,50 @@
         "summary": "Update Mcp Server",
         "tags": [
           "session_mcp_servers"
+        ]
+      }
+    },
+    "/v1/sessions/{session_id}/capabilities": {
+      "get": {
+        "description": "Return the consolidated capabilities of the session's agent.\n\nRead-only observability view over the agent bound to\n*session_id*. Resolves the agent the same way as\n`GET /sessions/{id}/agent` (under `LEVEL_READ`, no\ntop-level assertion), so it works identically for a top\nagent's conversation and a sub-agent's child conversation.\nFor an omnigent-spawned named sub-agent child the capabilities\nare context-aware \u2014 resolved from the child's `sub_agent_name`\nagainst the parent spec.\n\nFour groups:\n\n* `skills` \u2014 the merged (bundled + host-discovered) skill\n  list, from the same runner-owned source as the session\n  snapshot (best-effort; empty until the runner fetch warms).\n* `mcp_servers` \u2014 the agent's MCP server config\n  (secret-free). Per-server `tools` is deferred and left\n  empty (Slice D needs a runner `tools/list` round-trip).\n* `local_tools` \u2014 the agent's effective local/builtin\n  function tools (name + description).\n* `sub_agents` \u2014 the declared sub-agent tree from the spec.\n\n**Returns:** The session's `SessionCapabilities`.\n\n**Raises**\n\n- `OmnigentError` \u2014 If the session or agent is not found, or the session has no agent binding.",
+        "operationId": "get_session_capabilities_v1_sessions__session_id__capabilities_get",
+        "parameters": [
+          {
+            "description": "Session identifier, e.g. `\"conv_abc123\"`.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionCapabilities"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Session Capabilities",
+        "tags": [
+          "sessions"
         ]
       }
     },

--- a/tests/e2e_ui/capabilities/test_capabilities_tab.py
+++ b/tests/e2e_ui/capabilities/test_capabilities_tab.py
@@ -1,0 +1,60 @@
+"""UI journey: the right-rail Capabilities tab and its four sections.
+
+The Capabilities tab is an unconditional rail tab (WorkspacePanel: it is
+always registered, and its endpoint always resolves for a bound session),
+rendering a read-only view of the agent's capabilities. Its panel is
+structured as a panel-level "Only show usable" scope toggle followed by
+four always-present sections — Skills, MCP servers, Local tools, and
+Sub-agents — each of which renders its own empty state rather than
+disappearing when the agent has nothing in that group.
+
+This test pins that baseline for the lone hello_world agent: the tab is
+present, clicking it renders the capabilities panel, the top-level scope
+toggle is present, and all four section headers render. No message is
+sent — the panel is rail state driven by the capabilities endpoint, not a
+function of any turn — so this stays a fast, LLM-free check.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+_CAPABILITIES_PANEL = '[data-testid="capabilities-panel"]'
+_SECTION_TITLES = ("Skills", "MCP servers", "Local tools", "Sub-agents")
+
+
+def test_capabilities_tab_renders_sections_and_scope_toggle(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The Capabilities tab renders its scope toggle and four sections."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # Scope every lookup to the desktop "Workspace" rail so it never
+    # matches the hidden mobile drawer that mirrors the same testids.
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+
+    capabilities_tab = rail.get_by_role("tab", name=re.compile("^Capabilities"))
+    expect(capabilities_tab).to_be_visible(timeout=30_000)
+
+    capabilities_tab.click()
+
+    # The panel resolves once the capabilities endpoint warms; wait on the
+    # panel container rather than any single section.
+    panel = rail.locator(_CAPABILITIES_PANEL)
+    expect(panel).to_be_visible(timeout=30_000)
+
+    # The panel-level scope toggle (Radix Switch, role="switch") governs
+    # the whole view and is present regardless of the agent's config.
+    expect(panel.get_by_role("switch")).to_be_visible()
+
+    # All four sections render their headers unconditionally — each owns an
+    # empty state, so an agent with nothing in a group still shows the header.
+    for title in _SECTION_TITLES:
+        expect(panel.get_by_text(title, exact=True)).to_be_visible()

--- a/tests/runner/test_skills.py
+++ b/tests/runner/test_skills.py
@@ -668,3 +668,51 @@ async def test_codex_bundle_skill_not_duplicated_when_dir_differs_from_name(
     names = [s["name"] for s in resp.json()["skills"]]
     # Exactly one entry for the skill (no phantom dir-named duplicate).
     assert names.count("triage") + names.count("sra--triage") == 1
+
+
+@pytest.mark.asyncio
+async def test_get_session_skills_include_out_of_scope_flags_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``?include_out_of_scope=true`` returns the FULL set — in-scope ∪
+    out-of-scope — with each skill's ``source`` and ``in_scope`` flag.
+
+    With a list ``skills_filter`` that admits only the bundled skill, a
+    workspace host skill is out of scope: the default endpoint omits it,
+    but the enriched endpoint surfaces it with ``in_scope=false`` while the
+    bundled skill stays ``in_scope=true`` (``source="bundle"``).
+    """
+    home = tmp_path / "home"
+    (home / ".claude" / "skills").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    workspace = tmp_path / "workspace"
+    ws_host = workspace / ".claude" / "skills" / "workspace-host"
+    ws_host.mkdir(parents=True)
+    (ws_host / "SKILL.md").write_text(_skill_md("workspace-host", "From the workspace."))
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    bundled = [SkillSpec(name="grill-me", description="Bundled.", content="c")]
+    # List filter admits only "grill-me" host skills → workspace-host is out
+    # of scope. Bundled skills are never filtered.
+    app = _make_app(bundle, bundled, ["grill-me"], workspace=workspace)
+
+    async for c in _client(app):
+        default = await c.get("/v1/sessions/conv_scope/skills")
+        enriched = await c.get(
+            "/v1/sessions/conv_scope/skills", params={"include_out_of_scope": "true"}
+        )
+
+    assert default.status_code == 200, default.text
+    # Default (in-scope only): out-of-scope host skill omitted, shape unchanged.
+    assert default.json()["skills"] == [{"name": "grill-me", "description": "Bundled."}]
+
+    assert enriched.status_code == 200, enriched.text
+    by_name = {s["name"]: s for s in enriched.json()["skills"]}
+    assert by_name["grill-me"]["source"] == "bundle"
+    assert by_name["grill-me"]["in_scope"] is True
+    assert by_name["workspace-host"]["source"] == "workspace"
+    assert by_name["workspace-host"]["in_scope"] is False

--- a/tests/server/routes/test_sessions_capabilities.py
+++ b/tests/server/routes/test_sessions_capabilities.py
@@ -1,0 +1,357 @@
+"""Tests for ``GET /v1/sessions/{id}/capabilities``.
+
+Exercises the consolidated read-only capabilities endpoint: the four
+groups for a top-agent session (skills, mcp config, local tools, declared
+sub-agents), context-aware resolution for a named sub-agent child, the
+deferred-empty per-server MCP tools, and the ``LEVEL_READ`` / GET-only /
+no-write posture. Real-type store stubs — no MagicMock.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from omnigent.entities import Agent, Conversation, ResolvedAccess
+from omnigent.errors import OmnigentError
+from omnigent.server.routes import sessions as sessions_mod
+from omnigent.server.routes.sessions import create_sessions_router
+from omnigent.server.schemas import SkillSummary
+from omnigent.spec import AgentSpec, ExecutorSpec
+from omnigent.spec.types import MCPServerConfig, SkillSpec
+
+# ── Specs ────────────────────────────────────────────────────────
+
+# A nested tree: top -> researcher -> note_taker. The researcher declares
+# its OWN mcp server + skill so a child-session query can be shown to
+# return the researcher's capabilities, not the top agent's.
+_NOTE_TAKER = AgentSpec(
+    spec_version=1,
+    name="note-taker",
+    description="Takes notes",
+    executor=ExecutorSpec(type="claude_sdk"),
+)
+_RESEARCHER = AgentSpec(
+    spec_version=1,
+    name="researcher",
+    description="Researches topics",
+    executor=ExecutorSpec(type="claude_sdk"),
+    skills=[SkillSpec(name="web-search", description="Search the web", content="body")],
+    mcp_servers=[
+        MCPServerConfig(
+            name="arxiv",
+            transport="http",
+            url="https://arxiv.example/sse",
+            description="arXiv MCP",
+        )
+    ],
+    sub_agents=[_NOTE_TAKER],
+)
+_TOP = AgentSpec(
+    spec_version=1,
+    name="top",
+    description="Top agent",
+    executor=ExecutorSpec(type="claude_sdk"),
+    skills=[SkillSpec(name="code-review", description="Review code", content="body")],
+    mcp_servers=[
+        MCPServerConfig(
+            name="github",
+            transport="http",
+            url="https://mcp.example/sse",
+            description="GitHub MCP",
+        )
+    ],
+    sub_agents=[_RESEARCHER],
+)
+
+
+# ── Stubs ────────────────────────────────────────────────────────
+
+
+class _AgentStore:
+    """Agent store stub: get by id."""
+
+    def __init__(self, agents: dict[str, Agent]) -> None:
+        self._agents = dict(agents)
+
+    def get(self, agent_id: str) -> Agent | None:
+        """:returns: The agent if present, else None."""
+        return self._agents.get(agent_id)
+
+
+class _ConversationStore:
+    """Conversation store stub. Records any mutating call so a test can
+    assert the read-only endpoint never writes."""
+
+    def __init__(self, conversations: dict[str, Conversation]) -> None:
+        self._convs = conversations
+        self.write_calls: list[str] = []
+
+    def get_conversation(self, conversation_id: str) -> Conversation | None:
+        """:returns: The conversation if present, else None."""
+        return self._convs.get(conversation_id)
+
+    # Any accidental mutation would go through one of these — record it so
+    # the no-write test fails loudly rather than silently passing.
+    def create_conversation(self, *args: Any, **kwargs: Any) -> None:
+        self.write_calls.append("create_conversation")
+
+    def update_conversation(self, *args: Any, **kwargs: Any) -> None:
+        self.write_calls.append("update_conversation")
+
+    def set_labels(self, *args: Any, **kwargs: Any) -> None:
+        self.write_calls.append("set_labels")
+
+
+class _LoadedStub:
+    """Loaded-bundle stub exposing ``.spec``."""
+
+    def __init__(self, spec: AgentSpec) -> None:
+        self.spec = spec
+
+
+class _AgentCacheStub:
+    """``get_agent_cache()`` stub mapping agent id -> spec."""
+
+    def __init__(self, spec_by_id: dict[str, AgentSpec]) -> None:
+        self._spec_by_id = spec_by_id
+
+    def load(
+        self,
+        agent_id: str,
+        bundle_location: str,
+        *,
+        expand_env: bool = False,
+    ) -> _LoadedStub:
+        del bundle_location, expand_env
+        return _LoadedStub(self._spec_by_id[agent_id])
+
+
+class _PermissionStore:
+    """Minimal permission store: only ``resolve_access`` is exercised for
+    top-level conversations. Levels are keyed by ``(user, conv)``."""
+
+    def __init__(self, grants: dict[tuple[str, str], int]) -> None:
+        self._grants = grants
+
+    def resolve_access(self, user_id: str | None, conversation_id: str) -> ResolvedAccess:
+        level = self._grants.get((user_id or "", conversation_id))
+        return ResolvedAccess(
+            is_admin=False,
+            user_grant_level=level,
+            public_grant_level=None,
+        )
+
+
+class _AuthProvider:
+    """Auth provider stub: reads the user id from the ``X-User`` header."""
+
+    def get_user_id(self, request: Request) -> str | None:
+        return request.headers.get("x-user")
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def _conv(
+    conv_id: str,
+    *,
+    agent_id: str | None = "ag_top",
+    sub_agent_name: str | None = None,
+    parent_conversation_id: str | None = None,
+) -> Conversation:
+    """Build a Conversation entity."""
+    return Conversation(
+        id=conv_id,
+        created_at=1,
+        updated_at=1,
+        root_conversation_id=parent_conversation_id or conv_id,
+        agent_id=agent_id,
+        sub_agent_name=sub_agent_name,
+        parent_conversation_id=parent_conversation_id,
+        kind="sub_agent" if parent_conversation_id else "default",
+        title="Session",
+    )
+
+
+def _agent(agent_id: str = "ag_top") -> Agent:
+    """Build an Agent entity."""
+    return Agent(
+        id=agent_id,
+        created_at=1,
+        name="top",
+        bundle_location="bundle/top",
+        version=1,
+        session_id=None,
+    )
+
+
+def _build_app(
+    conv_store: _ConversationStore,
+    agent_store: _AgentStore,
+    *,
+    auth_provider: _AuthProvider | None = None,
+    permission_store: _PermissionStore | None = None,
+) -> FastAPI:
+    """Mount the sessions router with an OmnigentError handler."""
+    router = create_sessions_router(
+        conversation_store=conv_store,  # type: ignore[arg-type]
+        agent_store=agent_store,  # type: ignore[arg-type]
+        auth_provider=auth_provider,  # type: ignore[arg-type]
+        permission_store=permission_store,  # type: ignore[arg-type]
+    )
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    app.include_router(router, prefix="/v1")
+    return app
+
+
+async def _fake_runner_skills(
+    runner_client: Any,
+    session_id: str,
+) -> list[SkillSummary]:
+    """Stand in for the runner-owned merged-skills fetch."""
+    del runner_client, session_id
+    return [SkillSummary(name="merged-skill", description="from runner")]
+
+
+@pytest.fixture()
+def _patched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the spec loader at the in-memory specs and stub the
+    runner-owned skills source (no runner in these unit tests)."""
+    monkeypatch.setattr(sessions_mod, "get_agent_cache", lambda: _AgentCacheStub({"ag_top": _TOP}))
+    monkeypatch.setattr(sessions_mod, "_fetch_runner_skills", _fake_runner_skills)
+
+
+# ── Tests ────────────────────────────────────────────────────────
+
+
+def test_top_agent_capabilities_all_four_groups(_patched: None) -> None:
+    """A top-agent session returns skills + mcp config + local tools +
+    declared sub-agents."""
+    conv_store = _ConversationStore({"conv_top": _conv("conv_top")})
+    agent_store = _AgentStore({"ag_top": _agent()})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.get("/v1/sessions/conv_top/capabilities")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["object"] == "session.capabilities"
+    assert body["session_id"] == "conv_top"
+    assert body["agent_id"] == "ag_top"
+    assert body["sub_agent_name"] is None
+
+    # 1) merged skills come from the runner-owned source.
+    assert body["skills"] == [{"name": "merged-skill", "description": "from runner"}]
+
+    # 2) mcp config is the top agent's server (secret-free shape).
+    assert [s["name"] for s in body["mcp_servers"]] == ["github"]
+    gh = body["mcp_servers"][0]
+    assert gh["transport"] == "http"
+    assert gh["url"] == "https://mcp.example/sse"
+
+    # 3) local/builtin function tools (name + description), non-empty.
+    names = {t["name"] for t in body["local_tools"]}
+    assert names, "expected a non-empty local/builtin tool surface"
+    assert "load_skill" in names  # skill loader is part of the surface
+    assert all("name" in t and "description" in t for t in body["local_tools"])
+
+    # 4) declared sub-agent tree (recursive).
+    assert [s["name"] for s in body["sub_agents"]] == ["researcher"]
+    assert [s["name"] for s in body["sub_agents"][0]["sub_agents"]] == ["note-taker"]
+
+
+def test_mcp_per_server_tools_present_but_empty(_patched: None) -> None:
+    """Per-server MCP ``tools`` is present but deferred (empty) this slice."""
+    conv_store = _ConversationStore({"conv_top": _conv("conv_top")})
+    agent_store = _AgentStore({"ag_top": _agent()})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    body = client.get("/v1/sessions/conv_top/capabilities").json()
+
+    assert body["mcp_servers"], "expected at least one mcp server"
+    for server in body["mcp_servers"]:
+        assert "tools" in server
+        assert server["tools"] == []
+
+
+def test_sub_agent_child_is_context_aware(_patched: None) -> None:
+    """The SAME endpoint on a named sub-agent child returns THAT sub-agent's
+    capabilities, not the parent's."""
+    conv_store = _ConversationStore(
+        {
+            "conv_top": _conv("conv_top"),
+            # Omnigent-spawned child: shares the parent agent_id, identified
+            # by sub_agent_name.
+            "conv_child": _conv(
+                "conv_child",
+                agent_id="ag_top",
+                sub_agent_name="researcher",
+                parent_conversation_id="conv_top",
+            ),
+        }
+    )
+    agent_store = _AgentStore({"ag_top": _agent()})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    body = client.get("/v1/sessions/conv_child/capabilities").json()
+
+    assert body["session_id"] == "conv_child"
+    assert body["agent_id"] == "ag_top"
+    assert body["sub_agent_name"] == "researcher"
+    # Researcher's OWN mcp server + declared sub-agent — distinct from top.
+    assert [s["name"] for s in body["mcp_servers"]] == ["arxiv"]
+    assert [s["name"] for s in body["sub_agents"]] == ["note-taker"]
+
+
+def test_get_only_rejects_writes(_patched: None) -> None:
+    """The route is GET-only: POST/PUT/DELETE return 405 and never write."""
+    conv_store = _ConversationStore({"conv_top": _conv("conv_top")})
+    agent_store = _AgentStore({"ag_top": _agent()})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    for method in ("post", "put", "delete", "patch"):
+        resp = getattr(client, method)("/v1/sessions/conv_top/capabilities")
+        assert resp.status_code == 405, f"{method} should be rejected"
+
+    # A GET must not have mutated the conversation store either.
+    client.get("/v1/sessions/conv_top/capabilities")
+    assert conv_store.write_calls == []
+
+
+def test_level_read_enforced(_patched: None) -> None:
+    """Permission checks gate the read: a read-granted user gets 200, a user
+    with no grant is denied."""
+    conv_store = _ConversationStore({"conv_top": _conv("conv_top")})
+    agent_store = _AgentStore({"ag_top": _agent()})
+    # alice has READ (level 1); mallory has no grant.
+    perm = _PermissionStore({("alice", "conv_top"): 1})
+    app = _build_app(
+        conv_store,
+        agent_store,
+        auth_provider=_AuthProvider(),
+        permission_store=perm,
+    )
+    client = TestClient(app)
+
+    ok = client.get("/v1/sessions/conv_top/capabilities", headers={"X-User": "alice"})
+    assert ok.status_code == 200, ok.text
+
+    denied = client.get("/v1/sessions/conv_top/capabilities", headers={"X-User": "mallory"})
+    assert denied.status_code == 404, denied.text
+
+    unauthenticated = client.get("/v1/sessions/conv_top/capabilities")
+    assert unauthenticated.status_code == 401, unauthenticated.text

--- a/tests/server/routes/test_sessions_capabilities.py
+++ b/tests/server/routes/test_sessions_capabilities.py
@@ -20,9 +20,17 @@ from omnigent.entities import Agent, Conversation, ResolvedAccess
 from omnigent.errors import OmnigentError
 from omnigent.server.routes import sessions as sessions_mod
 from omnigent.server.routes.sessions import create_sessions_router
-from omnigent.server.schemas import SkillSummary
+from omnigent.server.schemas import SkillCapability
 from omnigent.spec import AgentSpec, ExecutorSpec
-from omnigent.spec.types import MCPServerConfig, SkillSpec
+from omnigent.spec.types import (
+    FunctionPolicySpec,
+    FunctionRef,
+    GuardrailsSpec,
+    MCPServerConfig,
+    Phase,
+    PhaseSelector,
+    SkillSpec,
+)
 
 # ── Specs ────────────────────────────────────────────────────────
 
@@ -218,21 +226,45 @@ def _build_app(
     return app
 
 
-async def _fake_runner_skills(
+async def _fake_runner_skill_capabilities(
     runner_client: Any,
     session_id: str,
-) -> list[SkillSummary]:
-    """Stand in for the runner-owned merged-skills fetch."""
+) -> list[SkillCapability]:
+    """Stand in for the runner-owned enriched-skills fetch."""
     del runner_client, session_id
-    return [SkillSummary(name="merged-skill", description="from runner")]
+    return [
+        SkillCapability(
+            name="merged-skill",
+            description="from runner",
+            source="workspace",
+            in_scope=True,
+        )
+    ]
+
+
+async def _no_blocked_skills(
+    spec: Any,
+    session_id: str,
+    conversation_store: Any,
+    skill_names: list[str],
+    *,
+    user_id: str | None,
+) -> dict[str, bool]:
+    """Stand in for the policy would-block check (nothing blocked)."""
+    del spec, session_id, conversation_store, skill_names, user_id
+    return {}
 
 
 @pytest.fixture()
 def _patched(monkeypatch: pytest.MonkeyPatch) -> None:
     """Point the spec loader at the in-memory specs and stub the
-    runner-owned skills source (no runner in these unit tests)."""
+    runner-owned skills source + policy block check (no runner / policy
+    infra in these unit tests)."""
     monkeypatch.setattr(sessions_mod, "get_agent_cache", lambda: _AgentCacheStub({"ag_top": _TOP}))
-    monkeypatch.setattr(sessions_mod, "_fetch_runner_skills", _fake_runner_skills)
+    monkeypatch.setattr(
+        sessions_mod, "_fetch_runner_skill_capabilities", _fake_runner_skill_capabilities
+    )
+    monkeypatch.setattr(sessions_mod, "_compute_blocked_skills", _no_blocked_skills)
 
 
 # ── Tests ────────────────────────────────────────────────────────
@@ -254,8 +286,17 @@ def test_top_agent_capabilities_all_four_groups(_patched: None) -> None:
     assert body["agent_id"] == "ag_top"
     assert body["sub_agent_name"] is None
 
-    # 1) merged skills come from the runner-owned source.
-    assert body["skills"] == [{"name": "merged-skill", "description": "from runner"}]
+    # 1) merged skills come from the runner-owned source, enriched with
+    #    provenance (source), an in_scope flag, and a policy blocked flag.
+    assert body["skills"] == [
+        {
+            "name": "merged-skill",
+            "description": "from runner",
+            "source": "workspace",
+            "in_scope": True,
+            "blocked": False,
+        }
+    ]
 
     # 2) mcp config is the top agent's server (secret-free shape).
     assert [s["name"] for s in body["mcp_servers"]] == ["github"]
@@ -355,3 +396,367 @@ def test_level_read_enforced(_patched: None) -> None:
 
     unauthenticated = client.get("/v1/sessions/conv_top/capabilities")
     assert unauthenticated.status_code == 401, unauthenticated.text
+
+
+def test_skills_degrade_to_empty_when_runner_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing/unreachable runner yields an empty skills list, not a 500."""
+    monkeypatch.setattr(sessions_mod, "get_agent_cache", lambda: _AgentCacheStub({"ag_top": _TOP}))
+    monkeypatch.setattr(sessions_mod, "_compute_blocked_skills", _no_blocked_skills)
+
+    async def _no_skills(runner_client: Any, session_id: str) -> list[SkillCapability]:
+        del runner_client, session_id
+        return []
+
+    monkeypatch.setattr(sessions_mod, "_fetch_runner_skill_capabilities", _no_skills)
+
+    conv_store = _ConversationStore({"conv_top": _conv("conv_top")})
+    agent_store = _AgentStore({"ag_top": _agent()})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.get("/v1/sessions/conv_top/capabilities")
+
+    assert resp.status_code == 200, resp.text
+    # Graceful degrade: skills empty, but the other groups still resolve.
+    assert resp.json()["skills"] == []
+    assert [s["name"] for s in resp.json()["mcp_servers"]] == ["github"]
+
+
+@pytest.mark.asyncio
+async def test_compute_blocked_skills_flags_denied_names(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A skill denied by a session ``block_skills`` policy is flagged
+    ``blocked=True``; a non-denied one is ``blocked=False``.
+
+    Exercises the real read-only would-block path: a policy engine built
+    from a spec carrying a ``block_skills`` guardrail, evaluated against a
+    synthetic native ``Skill`` tool-call per name (``read_only=True`` — no
+    persistence, no ASK gate).
+    """
+    from omnigent.runtime.policies.builder import build_policy_engine
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+    store = SqlAlchemyConversationStore(db_uri)
+    spec = AgentSpec(
+        spec_version=1,
+        name="guarded",
+        description="Has a block_skills policy",
+        executor=ExecutorSpec(type="claude_sdk"),
+        guardrails=GuardrailsSpec(
+            policies=[
+                FunctionPolicySpec(
+                    name="block",
+                    on=[PhaseSelector(phase=Phase.TOOL_CALL, tool_name=None)],
+                    function=FunctionRef(
+                        path="omnigent.policies.builtins.safety.block_skills",
+                        arguments={"blocked": ["blocked-skill"]},
+                    ),
+                )
+            ]
+        ),
+    )
+    # Bypass get_caps()/get_policy_store(): build the engine straight from
+    # the spec so the test needs no server-cap wiring.
+    monkeypatch.setattr(
+        sessions_mod,
+        "_build_policy_engine_from_spec",
+        lambda sp, sid, cs: build_policy_engine(
+            spec=sp, conversation_id=sid, conversation_store=cs
+        ),
+    )
+
+    blocked = await sessions_mod._compute_blocked_skills(
+        spec,
+        "conv_guarded",
+        store,  # type: ignore[arg-type]
+        ["blocked-skill", "ok-skill"],
+        user_id="alice",
+    )
+
+    assert blocked == {"blocked-skill": True, "ok-skill": False}
+
+
+@pytest.mark.asyncio
+async def test_compute_blocked_skills_never_runs_llm_prompt_policy(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``blocked`` preview consults only cheap, name-based deny rules:
+    an LLM-backed prompt-classifier policy is NEVER invoked, even with many
+    discovered skills, and ``blocked`` still reflects the name-based
+    ``block_skills`` deny.
+
+    Without this guard, a session config with a ``prompt_policy`` on
+    ``tool_call`` fires one LLM classifier call per skill name — ~100+
+    sequential LLM calls on a single read-only Capabilities panel open.
+    """
+    from omnigent.runtime.policies.builder import build_policy_engine
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+    store = SqlAlchemyConversationStore(db_uri)
+
+    class _RecordingLLM:
+        """Spy LLM client: a prompt policy that ran would call ``create``."""
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def create(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            self.calls += 1
+            raise AssertionError("prompt-policy LLM must not run in blocked preview")
+
+    spy = _RecordingLLM()
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="classified",
+        description="Has an LLM prompt policy plus a name-based block",
+        executor=ExecutorSpec(type="claude_sdk"),
+        guardrails=GuardrailsSpec(
+            policies=[
+                # LLM-backed prompt classifier on every tool_call.
+                FunctionPolicySpec(
+                    name="classify",
+                    on=[PhaseSelector(phase=Phase.TOOL_CALL, tool_name=None)],
+                    function=FunctionRef(
+                        path="omnigent.policies.builtins.prompt.prompt_policy",
+                        arguments={"prompt": "Deny risky skills."},
+                    ),
+                ),
+                # Cheap name-based deny — must still be reflected.
+                FunctionPolicySpec(
+                    name="block",
+                    on=[PhaseSelector(phase=Phase.TOOL_CALL, tool_name=None)],
+                    function=FunctionRef(
+                        path="omnigent.policies.builtins.safety.block_skills",
+                        arguments={"blocked": ["blocked-skill"]},
+                    ),
+                ),
+            ]
+        ),
+    )
+
+    def _build(sp: Any, sid: str, cs: Any) -> Any:
+        engine = build_policy_engine(spec=sp, conversation_id=sid, conversation_store=cs)
+        # Inject a live LLM client so the prompt policy WOULD call it if it
+        # were left in the probe engine — the fix must filter it out first.
+        engine._llm_client = spy
+        return engine
+
+    monkeypatch.setattr(sessions_mod, "_build_policy_engine_from_spec", _build)
+
+    names = [f"skill-{i}" for i in range(50)] + ["blocked-skill"]
+    blocked = await sessions_mod._compute_blocked_skills(
+        spec,
+        "conv_classified",
+        store,  # type: ignore[arg-type]
+        names,
+        user_id="alice",
+    )
+
+    # Zero LLM/prompt-policy calls despite 51 skills.
+    assert spy.calls == 0
+    # Name-based deny still reflected; everything else not blocked.
+    assert blocked["blocked-skill"] is True
+    assert all(v is False for k, v in blocked.items() if k != "blocked-skill")
+    assert len(blocked) == len(names)
+
+
+@pytest.mark.asyncio
+async def test_compute_blocked_skills_never_runs_intent_authorization_llm(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Generalized guard: an LLM-backed router other than the prompt
+    classifier is also excluded from the blocked preview.
+
+    ``intent_based_authorization`` fires on ``tool_call`` and, once a
+    session intent is captured, calls the LLM to classify every tool
+    invocation. The synthetic per-skill ``Skill`` tool-call probe would
+    otherwise fire one classifier call per discovered skill. The registry
+    ``llm_backed`` flag must exclude it before the per-skill loop.
+
+    Fails without the generalized fix: the old ``PROMPT_POLICY_HANDLER``
+    string check does not match this factory, so it stays in the probe
+    engine and the spy LLM is invoked.
+    """
+    from omnigent.policies.builtins.routing import _INTENT_KEY
+    from omnigent.runtime.policies.builder import build_policy_engine
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+    store = SqlAlchemyConversationStore(db_uri)
+
+    class _RecordingLLM:
+        """Spy LLM client: an intent check that ran would call ``create``."""
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def create(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            self.calls += 1
+            raise AssertionError("intent-authorization LLM must not run in blocked preview")
+
+    spy = _RecordingLLM()
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="intent-gated",
+        description="Has an LLM-gated intent router plus a name-based block",
+        executor=ExecutorSpec(type="claude_sdk"),
+        guardrails=GuardrailsSpec(
+            policies=[
+                # LLM-backed router on every tool_call — NOT the prompt policy.
+                FunctionPolicySpec(
+                    name="intent",
+                    on=[PhaseSelector(phase=Phase.TOOL_CALL, tool_name=None)],
+                    function=FunctionRef(
+                        path="omnigent.policies.builtins.routing.intent_based_authorization",
+                        arguments={},
+                    ),
+                ),
+                # Cheap name-based deny — must still be reflected.
+                FunctionPolicySpec(
+                    name="block",
+                    on=[PhaseSelector(phase=Phase.TOOL_CALL, tool_name=None)],
+                    function=FunctionRef(
+                        path="omnigent.policies.builtins.safety.block_skills",
+                        arguments={"blocked": ["blocked-skill"]},
+                    ),
+                ),
+            ]
+        ),
+    )
+
+    def _build(sp: Any, sid: str, cs: Any) -> Any:
+        engine = build_policy_engine(spec=sp, conversation_id=sid, conversation_store=cs)
+        engine._llm_client = spy
+        # Pre-seed a captured intent so the tool_call phase would reach the
+        # classification LLM call if the router were left in the probe engine.
+        engine._session_state = {_INTENT_KEY: "Summarize the quarterly report."}
+        return engine
+
+    monkeypatch.setattr(sessions_mod, "_build_policy_engine_from_spec", _build)
+
+    names = [f"skill-{i}" for i in range(50)] + ["blocked-skill"]
+    blocked = await sessions_mod._compute_blocked_skills(
+        spec,
+        "conv_intent",
+        store,  # type: ignore[arg-type]
+        names,
+        user_id="alice",
+    )
+
+    # Zero LLM calls despite 51 skills and a captured intent.
+    assert spy.calls == 0
+    # Name-based deny still reflected; everything else not blocked.
+    assert blocked["blocked-skill"] is True
+    assert all(v is False for k, v in blocked.items() if k != "blocked-skill")
+    assert len(blocked) == len(names)
+
+
+@pytest.mark.asyncio
+async def test_compute_blocked_skills_only_llm_policy_short_circuits(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the ONLY deny policy is LLM-backed, the preview short-circuits to
+    all-not-blocked without invoking the classifier."""
+    from omnigent.runtime.policies.builder import build_policy_engine
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+    store = SqlAlchemyConversationStore(db_uri)
+
+    class _RecordingLLM:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def create(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            self.calls += 1
+            raise AssertionError("prompt-policy LLM must not run in blocked preview")
+
+    spy = _RecordingLLM()
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="llm-only",
+        description="Only an LLM prompt policy",
+        executor=ExecutorSpec(type="claude_sdk"),
+        guardrails=GuardrailsSpec(
+            policies=[
+                FunctionPolicySpec(
+                    name="classify",
+                    on=[PhaseSelector(phase=Phase.TOOL_CALL, tool_name=None)],
+                    function=FunctionRef(
+                        path="omnigent.policies.builtins.prompt.prompt_policy",
+                        arguments={"prompt": "Deny risky skills."},
+                    ),
+                ),
+            ]
+        ),
+    )
+
+    def _build(sp: Any, sid: str, cs: Any) -> Any:
+        engine = build_policy_engine(spec=sp, conversation_id=sid, conversation_store=cs)
+        engine._llm_client = spy
+        # Isolate the LLM policy: drop the always-appended sys_add_policy
+        # guard so that after the preview filters out the LLM policy, ZERO
+        # name-based policies remain — exercising the short-circuit branch.
+        engine.policies = [p for p in engine.policies if sessions_mod._is_llm_backed_policy(p)]
+        assert engine.policies, "expected the prompt policy to be present"
+        return engine
+
+    monkeypatch.setattr(sessions_mod, "_build_policy_engine_from_spec", _build)
+
+    blocked = await sessions_mod._compute_blocked_skills(
+        spec,
+        "conv_llm_only",
+        store,  # type: ignore[arg-type]
+        ["a", "b", "c"],
+        user_id=None,
+    )
+
+    assert spy.calls == 0
+    assert blocked == {"a": False, "b": False, "c": False}
+
+
+@pytest.mark.asyncio
+async def test_compute_blocked_skills_empty_without_policies(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no guardrails, nothing is blocked (and no per-skill eval runs)."""
+    from omnigent.runtime.policies.builder import build_policy_engine
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+    store = SqlAlchemyConversationStore(db_uri)
+    spec = AgentSpec(
+        spec_version=1,
+        name="plain",
+        description="No guardrails",
+        executor=ExecutorSpec(type="claude_sdk"),
+    )
+    monkeypatch.setattr(
+        sessions_mod,
+        "_build_policy_engine_from_spec",
+        lambda sp, sid, cs: build_policy_engine(
+            spec=sp, conversation_id=sid, conversation_store=cs
+        ),
+    )
+
+    blocked = await sessions_mod._compute_blocked_skills(
+        spec,
+        "conv_plain",
+        store,  # type: ignore[arg-type]
+        ["anything"],
+        user_id=None,
+    )
+
+    # build_policy_engine always appends the sys_add_policy guard, so the
+    # engine is non-empty; the Skill tool-call still resolves to ALLOW.
+    assert blocked == {"anything": False}

--- a/tests/server/routes/test_sessions_capabilities.py
+++ b/tests/server/routes/test_sessions_capabilities.py
@@ -760,3 +760,327 @@ async def test_compute_blocked_skills_empty_without_policies(
     # build_policy_engine always appends the sys_add_policy guard, so the
     # engine is non-empty; the Skill tool-call still resolves to ALLOW.
     assert blocked == {"anything": False}
+
+
+# ── MCP per-server tools + status (Slice D) ──────────────────────
+
+# A two-server spec so an endpoint test can show one connected server (with
+# discovered tools) alongside one that failed to connect.
+_TWO_MCP = AgentSpec(
+    spec_version=1,
+    name="two-mcp",
+    description="Two MCP servers",
+    executor=ExecutorSpec(type="claude_sdk"),
+    mcp_servers=[
+        MCPServerConfig(
+            name="github", transport="http", url="https://gh.example/sse", description="GitHub"
+        ),
+        MCPServerConfig(
+            name="broken", transport="http", url="https://x.example/sse", description="Broken"
+        ),
+    ],
+)
+
+
+def _gh_schemas() -> list[dict[str, Any]]:
+    """Two runner ``tools/list`` schemas for the ``github`` server."""
+    return [
+        {
+            "type": "function",
+            "name": "github__search",
+            "description": "Search repos",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        {
+            "type": "function",
+            "name": "github__create_issue",
+            "description": "Open an issue",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    ]
+
+
+def test_mcp_per_server_tools_and_status_populated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The runner's discovered MCP tool surface lands per-server: a connected
+    server carries its tools + ``status="connected"``; a failed one carries an
+    empty tool list + ``status="failed"`` and the connect error."""
+    monkeypatch.setattr(
+        sessions_mod, "get_agent_cache", lambda: _AgentCacheStub({"ag_top": _TWO_MCP})
+    )
+    monkeypatch.setattr(
+        sessions_mod, "_fetch_runner_skill_capabilities", _fake_runner_skill_capabilities
+    )
+    monkeypatch.setattr(sessions_mod, "_compute_blocked_skills", _no_blocked_skills)
+
+    async def _fetch(runner_client: Any, session_id: str) -> tuple[Any, Any, bool]:
+        del runner_client, session_id
+        return _gh_schemas(), {"broken": "ConnectError: refused"}, True
+
+    async def _no_blocked_tools(
+        spec: Any, session_id: str, cs: Any, names: list[str], *, user_id: str | None
+    ) -> dict[str, bool]:
+        del spec, session_id, cs, names, user_id
+        return {}
+
+    monkeypatch.setattr(sessions_mod, "_fetch_runner_mcp_tools", _fetch)
+    monkeypatch.setattr(sessions_mod, "_compute_blocked_tool_names", _no_blocked_tools)
+
+    conv_store = _ConversationStore({"conv_top": _conv("conv_top")})
+    agent_store = _AgentStore({"ag_top": _agent()})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    body = client.get("/v1/sessions/conv_top/capabilities").json()
+    servers = {s["name"]: s for s in body["mcp_servers"]}
+
+    gh = servers["github"]
+    assert gh["status"] == "connected"
+    assert gh["error"] is None
+    assert [t["name"] for t in gh["tools"]] == ["search", "create_issue"]
+    assert gh["tools"][0]["description"] == "Search repos"
+    assert all(t["blocked"] is False for t in gh["tools"])
+
+    broken = servers["broken"]
+    assert broken["status"] == "failed"
+    assert broken["error"] == "ConnectError: refused"
+    assert broken["tools"] == []
+
+
+def test_mcp_degrades_to_unknown_when_runner_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unavailable runner/MCP yields per-server ``status="unknown"`` with
+    empty tools — never a 500."""
+    monkeypatch.setattr(
+        sessions_mod, "get_agent_cache", lambda: _AgentCacheStub({"ag_top": _TWO_MCP})
+    )
+    monkeypatch.setattr(
+        sessions_mod, "_fetch_runner_skill_capabilities", _fake_runner_skill_capabilities
+    )
+    monkeypatch.setattr(sessions_mod, "_compute_blocked_skills", _no_blocked_skills)
+
+    async def _fetch_none(runner_client: Any, session_id: str) -> tuple[Any, Any, bool]:
+        del runner_client, session_id
+        return [], {}, False
+
+    monkeypatch.setattr(sessions_mod, "_fetch_runner_mcp_tools", _fetch_none)
+
+    conv_store = _ConversationStore({"conv_top": _conv("conv_top")})
+    agent_store = _AgentStore({"ag_top": _agent()})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.get("/v1/sessions/conv_top/capabilities")
+    assert resp.status_code == 200, resp.text
+    for server in resp.json()["mcp_servers"]:
+        assert server["status"] == "unknown"
+        assert server["error"] is None
+        assert server["tools"] == []
+
+
+def _cel_deny_spec(name: str, denied_tool: str) -> AgentSpec:
+    """A spec with a single CEL policy that DENYs one tool-call name."""
+    return AgentSpec(
+        spec_version=1,
+        name=name,
+        description="CEL name-based deny",
+        executor=ExecutorSpec(type="claude_sdk"),
+        mcp_servers=[
+            MCPServerConfig(
+                name="github", transport="http", url="https://gh.example/sse", description="GitHub"
+            ),
+        ],
+        guardrails=GuardrailsSpec(
+            policies=[
+                FunctionPolicySpec(
+                    name="deny_one",
+                    on=[PhaseSelector(phase=Phase.TOOL_CALL, tool_name=None)],
+                    function=FunctionRef(
+                        path="omnigent.policies.builtins.cel.cel_policy",
+                        arguments={
+                            "expression": (
+                                f'event.data.name == "{denied_tool}" '
+                                '? {"result": "DENY"} : {"result": "ALLOW"}'
+                            )
+                        },
+                    ),
+                )
+            ]
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("denied", ["github__create_issue", "mcp__github__create_issue"])
+async def test_compute_blocked_tool_names_flags_mcp_tool(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+    denied: str,
+) -> None:
+    """An MCP tool denied by a name-based CEL policy is ``blocked=True`` — for
+    BOTH the spec-proxied ``<server>__<tool>`` and connector-native
+    ``mcp__<server>__<tool>`` surfaces the endpoint probes; a sibling name is
+    ``blocked=False``."""
+    from omnigent.runtime.policies.builder import build_policy_engine
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+    store = SqlAlchemyConversationStore(db_uri)
+    spec = _cel_deny_spec("mcp-guarded", denied)
+    monkeypatch.setattr(
+        sessions_mod,
+        "_build_policy_engine_from_spec",
+        lambda sp, sid, cs: build_policy_engine(
+            spec=sp, conversation_id=sid, conversation_store=cs
+        ),
+    )
+
+    blocked = await sessions_mod._compute_blocked_tool_names(
+        spec,
+        "conv_mcp",
+        store,  # type: ignore[arg-type]
+        [denied, "github__search"],
+        user_id="alice",
+    )
+
+    assert blocked[denied] is True
+    assert blocked["github__search"] is False
+
+
+def test_mcp_tool_blocked_wiring_ors_both_name_shapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The endpoint marks an MCP tool ``blocked`` when the probe denies EITHER
+    the spec-proxied or the connector-native name shape."""
+    monkeypatch.setattr(
+        sessions_mod, "get_agent_cache", lambda: _AgentCacheStub({"ag_top": _TWO_MCP})
+    )
+    monkeypatch.setattr(
+        sessions_mod, "_fetch_runner_skill_capabilities", _fake_runner_skill_capabilities
+    )
+    monkeypatch.setattr(sessions_mod, "_compute_blocked_skills", _no_blocked_skills)
+
+    async def _fetch(runner_client: Any, session_id: str) -> tuple[Any, Any, bool]:
+        del runner_client, session_id
+        return _gh_schemas(), {}, True
+
+    monkeypatch.setattr(sessions_mod, "_fetch_runner_mcp_tools", _fetch)
+
+    async def _blocked_tools(
+        spec: Any, session_id: str, cs: Any, names: list[str], *, user_id: str | None
+    ) -> dict[str, bool]:
+        del spec, session_id, cs, user_id
+        # Deny only the connector-native shape; the endpoint must still flag it.
+        return dict.fromkeys(names, False) | {"mcp__github__create_issue": True}
+
+    monkeypatch.setattr(sessions_mod, "_compute_blocked_tool_names", _blocked_tools)
+
+    conv_store = _ConversationStore({"conv_top": _conv("conv_top")})
+    agent_store = _AgentStore({"ag_top": _agent()})
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    body = client.get("/v1/sessions/conv_top/capabilities").json()
+    tools = {t["name"]: t for t in body["mcp_servers"][0]["tools"]}
+    assert tools["create_issue"]["blocked"] is True
+    assert tools["search"]["blocked"] is False
+
+
+@pytest.mark.asyncio
+async def test_compute_blocked_tool_names_flags_builtin_and_runs_no_llm(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local builtin tool denied by a name policy is ``blocked=True``; a
+    normal one is ``blocked=False``; and NO LLM fires even with an LLM-backed
+    policy present and many tool names."""
+    from omnigent.runtime.policies.builder import build_policy_engine
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+    store = SqlAlchemyConversationStore(db_uri)
+
+    class _RecordingLLM:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def create(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            self.calls += 1
+            raise AssertionError("LLM policy must not run in blocked-tools preview")
+
+    spy = _RecordingLLM()
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="tool-guarded",
+        description="CEL deny + LLM policy",
+        executor=ExecutorSpec(type="claude_sdk"),
+        guardrails=GuardrailsSpec(
+            policies=[
+                FunctionPolicySpec(
+                    name="deny_shell",
+                    on=[PhaseSelector(phase=Phase.TOOL_CALL, tool_name=None)],
+                    function=FunctionRef(
+                        path="omnigent.policies.builtins.cel.cel_policy",
+                        arguments={
+                            "expression": (
+                                'event.data.name == "sys_os_shell" '
+                                '? {"result": "DENY"} : {"result": "ALLOW"}'
+                            )
+                        },
+                    ),
+                ),
+                FunctionPolicySpec(
+                    name="classify",
+                    on=[PhaseSelector(phase=Phase.TOOL_CALL, tool_name=None)],
+                    function=FunctionRef(
+                        path="omnigent.policies.builtins.prompt.prompt_policy",
+                        arguments={"prompt": "Deny risky tools."},
+                    ),
+                ),
+            ]
+        ),
+    )
+
+    def _build(sp: Any, sid: str, cs: Any) -> Any:
+        engine = build_policy_engine(spec=sp, conversation_id=sid, conversation_store=cs)
+        engine._llm_client = spy
+        return engine
+
+    monkeypatch.setattr(sessions_mod, "_build_policy_engine_from_spec", _build)
+
+    names = [f"sys_tool_{i}" for i in range(50)] + ["sys_os_shell", "sys_os_read"]
+    blocked = await sessions_mod._compute_blocked_tool_names(
+        spec,
+        "conv_tool_guarded",
+        store,  # type: ignore[arg-type]
+        names,
+        user_id="alice",
+    )
+
+    assert spy.calls == 0
+    assert blocked["sys_os_shell"] is True
+    assert blocked["sys_os_read"] is False
+    assert all(v is False for k, v in blocked.items() if k != "sys_os_shell")
+
+
+def test_sub_agent_tree_recursion_is_depth_bounded() -> None:
+    """A pathologically deep declared-sub-agent chain is truncated at the depth
+    cap instead of recursing without bound."""
+    depth = sessions_mod._SUB_AGENT_TREE_MAX_DEPTH + 10
+    # Build a linear chain deeper than the cap, innermost first.
+    node = AgentSpec(
+        spec_version=1, name="leaf", description="", executor=ExecutorSpec(type="claude_sdk")
+    )
+    for i in range(depth):
+        node = AgentSpec(
+            spec_version=1,
+            name=f"n{i}",
+            description="",
+            executor=ExecutorSpec(type="claude_sdk"),
+            sub_agents=[node],
+        )
+
+    tree = sessions_mod._sub_agent_capability_tree([node])
+
+    # Walk the single-child chain; it must terminate at exactly the cap.
+    walked = 0
+    level = tree
+    while level:
+        walked += 1
+        level = level[0].sub_agents
+    assert walked == sessions_mod._SUB_AGENT_TREE_MAX_DEPTH

--- a/tests/spec/test_skill_sources.py
+++ b/tests/spec/test_skill_sources.py
@@ -8,8 +8,10 @@ import pytest
 from omnigent.spec.skill_sources import (
     SkillSourceContext,
     _harness_family,
+    classify_skill_source,
     resolve_harness_skills,
 )
+from omnigent.spec.types import SkillSpec
 
 
 def _write_skill(skills_dir: Path, name: str, *, user_invocable: bool | None = None) -> None:
@@ -638,3 +640,97 @@ def test_cursor_provider_tolerates_unreadable_skills_dir(
     # Must not raise.
     out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "cursor-native")
     assert out == []
+
+
+# ── classify_skill_source ────────────────────────────────────────────────
+
+
+def _host_skill(name: str, skill_dir: Path | None) -> SkillSpec:
+    """A minimal host SkillSpec for source classification."""
+    return SkillSpec(name=name, description="d", content="c", skill_dir=skill_dir)
+
+
+def test_classify_source_plugin_by_namespaced_name(tmp_path: Path) -> None:
+    """A ``<plugin>:<skill>`` name classifies as plugin regardless of dir."""
+    home = tmp_path / "home"
+    spec = _host_skill("superpowers:using-superpowers", tmp_path / "somewhere")
+    assert classify_skill_source(spec, home=home) == "plugin"
+
+
+def test_classify_source_plugin_by_dir(tmp_path: Path) -> None:
+    """A skill under ``~/.claude/plugins`` classifies as plugin."""
+    home = tmp_path / "home"
+    d = home / ".claude" / "plugins" / "cache" / "mkt" / "p" / "1.0" / "skills" / "s"
+    spec = _host_skill("s", d)
+    assert classify_skill_source(spec, home=home) == "plugin"
+
+
+def test_classify_source_codex_and_cursor(tmp_path: Path) -> None:
+    """Host-specific dirs classify as their harness."""
+    home = tmp_path / "home"
+    codex = _host_skill("cx", home / ".codex" / "skills" / "cx")
+    cursor = _host_skill("cs", home / ".cursor" / "skills" / "cs")
+    assert classify_skill_source(codex, home=home) == "codex"
+    assert classify_skill_source(cursor, home=home) == "cursor"
+
+
+def test_classify_source_user_global(tmp_path: Path) -> None:
+    """User-global ``~/.claude`` / ``~/.agents`` skills classify as user."""
+    home = tmp_path / "home"
+    claude = _host_skill("u1", home / ".claude" / "skills" / "u1")
+    agents = _host_skill("u2", home / ".agents" / "skills" / "u2")
+    assert classify_skill_source(claude, home=home) == "user"
+    assert classify_skill_source(agents, home=home) == "user"
+
+
+def test_classify_source_workspace(tmp_path: Path) -> None:
+    """A project-local skill (not under home) classifies as workspace."""
+    home = tmp_path / "home"
+    ws = tmp_path / "project" / ".claude" / "skills" / "w"
+    assert classify_skill_source(_host_skill("w", ws), home=home) == "workspace"
+
+
+def test_classify_source_unknown_when_no_dir(tmp_path: Path) -> None:
+    """An unnamespaced skill with no on-disk dir classifies as unknown."""
+    home = tmp_path / "home"
+    assert classify_skill_source(_host_skill("x", None), home=home) == "unknown"
+
+
+def test_classify_source_realistic_user_home_path(tmp_path: Path) -> None:
+    """A realistic absolute ``~/.claude/skills/<name>`` path classifies as user."""
+    home = Path("/Users/alice")
+    d = home / ".claude" / "skills" / "agent-evaluation"
+    assert classify_skill_source(_host_skill("agent-evaluation", d), home=home) == "user"
+
+
+def test_classify_source_symlinked_home_claude_is_user(tmp_path: Path) -> None:
+    """
+    A user skill under a **symlinked** ``~/.claude`` still classifies as user.
+
+    Dotfile managers, container volume mounts, and macOS ``/var`` ->
+    ``/private/var`` make ``~/.claude`` (or its prefix) a symlink, so
+    ``skill_dir.resolve()`` follows it. The comparison root must be resolved
+    the same way or every host skill wrongly falls through to ``workspace``.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    real = tmp_path / "real_claude"
+    skill_dir = real / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (home / ".claude").symlink_to(real)
+    # skill_dir as discovered (through the symlinked path), pre-resolution.
+    discovered = home / ".claude" / "skills" / "demo"
+    assert discovered.resolve() == skill_dir.resolve()  # sanity: symlink in play
+    assert classify_skill_source(_host_skill("demo", discovered), home=home) == "user"
+
+
+def test_classify_source_symlinked_home_plugins_is_plugin(tmp_path: Path) -> None:
+    """A plugin skill under a symlinked ``~/.claude/plugins`` classifies as plugin."""
+    home = tmp_path / "home"
+    home.mkdir()
+    real = tmp_path / "real_claude"
+    skill_dir = real / "plugins" / "cache" / "mkt" / "p" / "1.0" / "skills" / "s"
+    skill_dir.mkdir(parents=True)
+    (home / ".claude").symlink_to(real)
+    discovered = home / ".claude" / "plugins" / "cache" / "mkt" / "p" / "1.0" / "skills" / "s"
+    assert classify_skill_source(_host_skill("s", discovered), home=home) == "plugin"

--- a/web/src/hooks/useSessionCapabilities.ts
+++ b/web/src/hooks/useSessionCapabilities.ts
@@ -1,0 +1,118 @@
+// TanStack Query wrapper for a session's read-only capabilities.
+//
+// Backed by `GET /v1/sessions/{id}/capabilities`, a consolidated,
+// read-only observability endpoint returning the merged skills, MCP
+// server config, local/builtin function tools, and declared sub-agent
+// tree of the agent bound to the session. The endpoint is context-aware:
+// an omnigent-spawned named sub-agent child reports THAT sub-agent's
+// capabilities, so the query is keyed on `conversationId` — navigating
+// into a sub-agent re-fetches and shows the child's capabilities.
+
+import { useQuery } from "@tanstack/react-query";
+import { authenticatedFetch } from "@/lib/identity";
+
+/** Name + one-line description of a skill available to the session. */
+export interface CapabilitySkill {
+  name: string;
+  description: string;
+}
+
+/** Name + optional one-line description of a single function tool. */
+export interface CapabilityTool {
+  name: string;
+  description?: string | null;
+}
+
+/**
+ * An MCP server's secret-free config plus a (deferred) per-server tool
+ * list. `tools` is intentionally empty in this slice — per-server tool
+ * discovery needs a runner round-trip and lands in a later slice.
+ */
+export interface CapabilityMcpServer {
+  name: string;
+  /** Transport type: "http" (SSE endpoint) or "stdio" (spawned subprocess). */
+  transport: string;
+  description?: string | null;
+  /** HTTP SSE endpoint URL. Only present when transport === "http". */
+  url?: string | null;
+  /** Executable to spawn. Only present when transport === "stdio". */
+  command?: string | null;
+  /** Arguments passed to command. Only present when transport === "stdio". */
+  args?: string[];
+  /** Discovered MCP tools. Always empty for now (deferred to a later slice). */
+  tools: CapabilityTool[];
+}
+
+/** A declared sub-agent node in the capabilities tree (recursive). */
+export interface SubAgentCapability {
+  name?: string | null;
+  description?: string | null;
+  sub_agents: SubAgentCapability[];
+}
+
+/** Consolidated, read-only capabilities of a session's bound agent. */
+export interface SessionCapabilities {
+  session_id: string;
+  agent_id: string;
+  /** The dispatched sub-agent name when the session is a named child, else null. */
+  sub_agent_name?: string | null;
+  skills: CapabilitySkill[];
+  mcp_servers: CapabilityMcpServer[];
+  local_tools: CapabilityTool[];
+  sub_agents: SubAgentCapability[];
+}
+
+/** Wire shape of the `GET /v1/sessions/{id}/capabilities` response. */
+interface SessionCapabilitiesWire {
+  object: "session.capabilities";
+  session_id: string;
+  agent_id: string;
+  sub_agent_name?: string | null;
+  skills?: CapabilitySkill[];
+  mcp_servers?: CapabilityMcpServer[];
+  local_tools?: CapabilityTool[];
+  sub_agents?: SubAgentCapability[];
+}
+
+/** TanStack Query key for a session's capabilities. */
+export function sessionCapabilitiesQueryKey(conversationId: string): readonly unknown[] {
+  return ["session-capabilities", conversationId];
+}
+
+async function fetchSessionCapabilities(sessionId: string): Promise<SessionCapabilities> {
+  const res = await authenticatedFetch(
+    `/v1/sessions/${encodeURIComponent(sessionId)}/capabilities`,
+  );
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const json = (await res.json()) as SessionCapabilitiesWire;
+  return {
+    session_id: json.session_id,
+    agent_id: json.agent_id,
+    sub_agent_name: json.sub_agent_name ?? null,
+    skills: json.skills ?? [],
+    mcp_servers: json.mcp_servers ?? [],
+    local_tools: json.local_tools ?? [],
+    sub_agents: json.sub_agents ?? [],
+  };
+}
+
+/**
+ * Fetch the read-only capabilities of the agent bound to a session.
+ *
+ * Keyed on `conversationId` so opening a sub-agent re-fetches and shows
+ * that agent's capabilities. Only fires when `conversationId` is non-null.
+ *
+ * :param conversationId: The session whose capabilities to retrieve,
+ *     or ``null`` to disable the query.
+ */
+export function useSessionCapabilities(conversationId: string | null) {
+  return useQuery({
+    queryKey:
+      conversationId === null
+        ? sessionCapabilitiesQueryKey("__none__")
+        : sessionCapabilitiesQueryKey(conversationId),
+    queryFn: () => fetchSessionCapabilities(conversationId as string),
+    enabled: conversationId !== null,
+    staleTime: 30_000,
+  });
+}

--- a/web/src/hooks/useSessionCapabilities.ts
+++ b/web/src/hooks/useSessionCapabilities.ts
@@ -15,18 +15,25 @@ import { authenticatedFetch } from "@/lib/identity";
 export interface CapabilitySkill {
   name: string;
   description: string;
+  /** Origin of the skill: bundle | workspace | user | plugin | codex | cursor | unknown. */
+  source: string;
+  /** Usable given the agent's skills_filter (bundled always true; host/plugin iff it passes). */
+  in_scope: boolean;
+  /** A name-based policy (block_skills/CEL) would DENY loading this skill. */
+  blocked: boolean;
 }
 
 /** Name + optional one-line description of a single function tool. */
 export interface CapabilityTool {
   name: string;
   description?: string | null;
+  /** A name-based policy would DENY calling this tool. */
+  blocked: boolean;
 }
 
 /**
- * An MCP server's secret-free config plus a (deferred) per-server tool
- * list. `tools` is intentionally empty in this slice — per-server tool
- * discovery needs a runner round-trip and lands in a later slice.
+ * An MCP server's secret-free config, connection status, and discovered
+ * per-server tool list.
  */
 export interface CapabilityMcpServer {
   name: string;
@@ -39,7 +46,11 @@ export interface CapabilityMcpServer {
   command?: string | null;
   /** Arguments passed to command. Only present when transport === "stdio". */
   args?: string[];
-  /** Discovered MCP tools. Always empty for now (deferred to a later slice). */
+  /** Connection status: "connected" | "failed" | "unknown". */
+  status: string;
+  /** Failure detail when the server could not be reached. */
+  error?: string | null;
+  /** Discovered MCP tools exposed by this server. */
   tools: CapabilityTool[];
 }
 

--- a/web/src/lib/sessionWorkspaceState.ts
+++ b/web/src/lib/sessionWorkspaceState.ts
@@ -6,14 +6,20 @@
 
 import type { RightRailTab } from "@/shell/railTabs";
 
-const RAIL_TABS: readonly RightRailTab[] = ["files", "subagents", "terminals", "todos"];
+const RAIL_TABS: readonly RightRailTab[] = [
+  "files",
+  "subagents",
+  "capabilities",
+  "terminals",
+  "todos",
+];
 
 export interface SessionWorkspaceState {
   /** Whether the rail was left open in this session. */
   open?: boolean;
   /** User-chosen rail width (px) for this session. */
   widthPx?: number;
-  /** The selected rail tab (Files / Agents / Shells / Tasks). */
+  /** The selected rail tab (Files / Agents / Capabilities / Shells / Tasks). */
   rightRailTab?: RightRailTab;
   /** Ordered list of open file tabs. */
   openFiles?: string[];

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -148,6 +148,11 @@ vi.mock("./SubagentsPanel", () => ({
     <div data-testid="subagents-panel" data-conversation-id={conversationId} />
   ),
 }));
+vi.mock("./CapabilitiesPanel", () => ({
+  CapabilitiesPanel: ({ conversationId }: { conversationId: string }) => (
+    <div data-testid="capabilities-panel" data-conversation-id={conversationId} />
+  ),
+}));
 vi.mock("./TodoPanel", () => ({
   TodoPanel: () => <div data-testid="todo-panel" />,
 }));
@@ -992,6 +997,27 @@ describe("Subagents tab", () => {
     // Files is the default tab, whose content slot mounts FilesPanel.
     expect(screen.getByRole("tab", { name: /Files/i })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByTestId("files-panel")).toBeInTheDocument();
+  });
+
+  it("shows the Capabilities tab and mounts its panel keyed on the active session", () => {
+    // The Capabilities tab is unconditional — the endpoint always resolves
+    // the session's bound agent. Selecting it mounts CapabilitiesPanel keyed
+    // on the active conversation id so the fetch is context-aware.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+
+    renderShell("/c/conv_abc");
+
+    const capabilitiesTab = screen.getByRole("tab", { name: /Capabilities/i });
+    expect(capabilitiesTab).toBeInTheDocument();
+    fireEvent.mouseDown(capabilitiesTab);
+    expect(screen.getByTestId("capabilities-panel")).toHaveAttribute(
+      "data-conversation-id",
+      "conv_abc",
+    );
   });
 
   it("shows the Agents tab and mounts its panel once there's more than one agent", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -63,6 +63,7 @@ import { MobilePanelDrawer } from "./MobilePanelDrawer";
 import { isMobileViewport, Sidebar } from "./Sidebar";
 import { TitleBarServerPicker } from "./TitleBarServerPicker";
 import { SubagentsPanel } from "./SubagentsPanel";
+import { CapabilitiesPanel } from "./CapabilitiesPanel";
 import { useRootSessionId, useSession } from "@/hooks/useSession";
 import {
   TerminalFirstContextProvider,
@@ -216,6 +217,7 @@ export function AppShell() {
   // push panel of their own. On desktop these are tabs in the workspace rail;
   // on a phone they open as full-screen overlays from the session-menu FAB.
   const [subagentsPanelOpen, setSubagentsPanelOpen] = useState(false);
+  const [capabilitiesPanelOpen, setCapabilitiesPanelOpen] = useState(false);
   const [shellsPanelOpen, setShellsPanelOpen] = useState(false);
   const [todosPanelOpen, setTodosPanelOpen] = useState(false);
   // The right "Workspace" rail (WorkspacePanel) is open by default and
@@ -457,6 +459,10 @@ export function AppShell() {
         // Agents tab is unconditional: the panel always lists at least
         // the main agent (its "main" row), so there's never a dead end.
         subagents: true,
+        // Capabilities tab is unconditional: the endpoint always resolves
+        // the session's bound agent, and the panel renders sensible empty
+        // states per section, so there's never a dead end.
+        capabilities: true,
         // Shells tab: shown by default when the agent's spec declares
         // shell access (the empty state offers "+ New shell"), or once a
         // shell exists for agents that don't. Inventory view: the
@@ -491,7 +497,7 @@ export function AppShell() {
   // convergent even when several tabs vanish at once.
   useEffect(() => {
     if (railTabsAvailable[rightRailTab]) return;
-    const next = (["files", "subagents", "terminals", "todos"] as const).find(
+    const next = (["files", "subagents", "capabilities", "terminals", "todos"] as const).find(
       (t) => railTabsAvailable[t],
     );
     if (next) setRightRailTab(next);
@@ -540,6 +546,7 @@ export function AppShell() {
     setExecutionLogsKey(null);
     setFilesPanelOpen(false);
     setSubagentsPanelOpen(false);
+    setCapabilitiesPanelOpen(false);
     setShellsPanelOpen(false);
     setTodosPanelOpen(false);
     setFilesPanelShowHidden(false);
@@ -688,12 +695,15 @@ export function AppShell() {
       setExecutionLogsKey(null); // close execution-logs panel
       setFilesPanelOpen(false); // close files drawer so the viewer is unobscured
       setSubagentsPanelOpen(false); // close mobile agents drawer
+      setCapabilitiesPanelOpen(false); // close mobile capabilities drawer
       setTodosPanelOpen(false); // close mobile tasks drawer
       // Pull the rail to the Files tab when parked on a tab where the viewer
-      // won't render (Terminals, Subagents, Todos). The Files tab surfaces the
-      // FileViewer inline, so leave it undisturbed.
+      // won't render (Terminals, Subagents, Capabilities, Todos). The Files
+      // tab surfaces the FileViewer inline, so leave it undisturbed.
       setRightRailTab((prev) =>
-        prev === "terminals" || prev === "subagents" || prev === "todos" ? "files" : prev,
+        prev === "terminals" || prev === "subagents" || prev === "capabilities" || prev === "todos"
+          ? "files"
+          : prev,
       );
       // Reveal the rail so the viewer is actually visible — the rail defaults
       // open but a session the user collapsed restores collapsed, so opening a
@@ -877,6 +887,7 @@ export function AppShell() {
     setExecutionLogsKey(null); // close execution-logs panel
     setFilesPanelOpen(false); // close files drawer
     setSubagentsPanelOpen(false); // close mobile agents drawer
+    setCapabilitiesPanelOpen(false); // close mobile capabilities drawer
     setShellsPanelOpen(false); // close mobile shells drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
     setPanelInitialKey(key);
@@ -888,6 +899,7 @@ export function AppShell() {
     setPanelInitialKey(null); // close terminals panel
     setFilesPanelOpen(false); // close files drawer
     setSubagentsPanelOpen(false); // close mobile agents drawer
+    setCapabilitiesPanelOpen(false); // close mobile capabilities drawer
     setShellsPanelOpen(false); // close mobile shells drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
     setExecutionLogsKey(key);
@@ -902,6 +914,7 @@ export function AppShell() {
     setPanelInitialKey(null); // close terminals panel
     setExecutionLogsKey(null); // close execution-logs panel
     setSubagentsPanelOpen(false); // close mobile agents drawer
+    setCapabilitiesPanelOpen(false); // close mobile capabilities drawer
     setShellsPanelOpen(false); // close mobile shells drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
     setFilesPanelOpen(true);
@@ -915,9 +928,24 @@ export function AppShell() {
     setPanelInitialKey(null); // close terminals panel
     setExecutionLogsKey(null); // close execution-logs panel
     setFilesPanelOpen(false); // close files drawer
+    setCapabilitiesPanelOpen(false); // close mobile capabilities drawer
     setShellsPanelOpen(false); // close mobile shells drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
     setSubagentsPanelOpen(true);
+  }
+
+  // Mobile FAB → "Capabilities" opens the read-only capabilities view (the
+  // desktop rail's Capabilities tab) as a full-screen drawer.
+  function openCapabilitiesPanel() {
+    setSelectedFilePath(null); // close file viewer
+    clearFileViewerUrl();
+    setPanelInitialKey(null); // close terminals panel
+    setExecutionLogsKey(null); // close execution-logs panel
+    setFilesPanelOpen(false); // close files drawer
+    setSubagentsPanelOpen(false); // close mobile agents drawer
+    setShellsPanelOpen(false); // close mobile shells drawer
+    setTodosPanelOpen(false); // close mobile tasks drawer
+    setCapabilitiesPanelOpen(true);
   }
 
   // Mobile FAB → "Shells" opens the desktop rail's Shells tab content as a
@@ -930,6 +958,7 @@ export function AppShell() {
     setExecutionLogsKey(null); // close execution-logs panel
     setFilesPanelOpen(false); // close files drawer
     setSubagentsPanelOpen(false); // close mobile agents drawer
+    setCapabilitiesPanelOpen(false); // close mobile capabilities drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
     setShellsPanelOpen(true);
   }
@@ -943,6 +972,7 @@ export function AppShell() {
     setExecutionLogsKey(null); // close execution-logs panel
     setFilesPanelOpen(false); // close files drawer
     setSubagentsPanelOpen(false); // close mobile agents drawer
+    setCapabilitiesPanelOpen(false); // close mobile capabilities drawer
     setShellsPanelOpen(false); // close mobile shells drawer
     setTodosPanelOpen(true);
   }
@@ -1134,6 +1164,7 @@ export function AppShell() {
                     executionLogsOpen,
                     filesPanelOpen,
                     subagentsPanelOpen,
+                    capabilitiesPanelOpen,
                     shellsPanelOpen,
                     todosPanelOpen,
                     hideTerminalsTab,
@@ -1149,6 +1180,7 @@ export function AppShell() {
                     onOpenFiles: openFilesPanel,
                     onOpenShells: openShellsPanel,
                     onOpenSubagents: openSubagentsPanel,
+                    onOpenCapabilities: openCapabilitiesPanel,
                     onOpenTodos: openTodosPanel,
                     onOpenMainExecutionLog: openMainExecutionLog,
                   }}
@@ -1258,6 +1290,16 @@ export function AppShell() {
                   testId="subagents-panel-drawer"
                 >
                   <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
+                </MobilePanelDrawer>
+              )}
+              {conversationId && (
+                <MobilePanelDrawer
+                  open={capabilitiesPanelOpen}
+                  title="Capabilities"
+                  onClose={() => setCapabilitiesPanelOpen(false)}
+                  testId="capabilities-panel-drawer"
+                >
+                  <CapabilitiesPanel conversationId={conversationId} />
                 </MobilePanelDrawer>
               )}
               {conversationId && (

--- a/web/src/shell/CapabilitiesPanel.test.tsx
+++ b/web/src/shell/CapabilitiesPanel.test.tsx
@@ -85,9 +85,9 @@ function renderPanel(
   render(<CapabilitiesPanel conversationId="conv_1" />);
 }
 
-/** Grab the panel-level "Only in scope" toggle switch. */
+/** Grab the panel-level "Only show usable" toggle switch. */
 function scopeToggle(): HTMLElement {
-  return screen.getByRole("switch", { name: /only in scope/i });
+  return screen.getByRole("switch", { name: /only show usable/i });
 }
 
 describe("CapabilitiesPanel loading / error states", () => {

--- a/web/src/shell/CapabilitiesPanel.test.tsx
+++ b/web/src/shell/CapabilitiesPanel.test.tsx
@@ -1,6 +1,12 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useSessionCapabilities, type SessionCapabilities } from "@/hooks/useSessionCapabilities";
+import {
+  useSessionCapabilities,
+  type CapabilityMcpServer,
+  type CapabilitySkill,
+  type CapabilityTool,
+  type SessionCapabilities,
+} from "@/hooks/useSessionCapabilities";
 import { CapabilitiesPanel } from "./CapabilitiesPanel";
 
 vi.mock("@/hooks/useSessionCapabilities", () => ({
@@ -13,6 +19,42 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
+
+/** A usable skill by default (in scope, not blocked); override per test. */
+function makeSkill(overrides: Partial<CapabilitySkill> = {}): CapabilitySkill {
+  return {
+    name: "skill",
+    description: "A skill.",
+    source: "bundle",
+    in_scope: true,
+    blocked: false,
+    ...overrides,
+  };
+}
+
+/** A usable tool by default (not blocked); override per test. */
+function makeTool(overrides: Partial<CapabilityTool> = {}): CapabilityTool {
+  return {
+    name: "tool",
+    description: "A tool.",
+    blocked: false,
+    ...overrides,
+  };
+}
+
+/** A connected server with no tools by default; override per test. */
+function makeServer(overrides: Partial<CapabilityMcpServer> = {}): CapabilityMcpServer {
+  return {
+    name: "server",
+    transport: "http",
+    description: null,
+    url: "https://mcp.example/server",
+    status: "connected",
+    error: null,
+    tools: [],
+    ...overrides,
+  };
+}
 
 /** Minimal capabilities payload, overridable per test. */
 function makeCapabilities(overrides: Partial<SessionCapabilities> = {}): SessionCapabilities {
@@ -43,6 +85,11 @@ function renderPanel(
   render(<CapabilitiesPanel conversationId="conv_1" />);
 }
 
+/** Grab the panel-level "Only in scope" toggle switch. */
+function scopeToggle(): HTMLElement {
+  return screen.getByRole("switch", { name: /only in scope/i });
+}
+
 describe("CapabilitiesPanel loading / error states", () => {
   it("shows a loading state before any data arrives", () => {
     renderPanel({ isLoading: true, data: undefined });
@@ -68,8 +115,8 @@ describe("CapabilitiesPanel sections", () => {
   it("renders skills and local tools with name + description", () => {
     renderPanel({
       data: makeCapabilities({
-        skills: [{ name: "triage-issues", description: "Triage open GitHub issues." }],
-        local_tools: [{ name: "sys_os_read", description: "Read a file." }],
+        skills: [makeSkill({ name: "triage-issues", description: "Triage open GitHub issues." })],
+        local_tools: [makeTool({ name: "sys_os_read", description: "Read a file." })],
       }),
     });
 
@@ -77,29 +124,6 @@ describe("CapabilitiesPanel sections", () => {
     expect(screen.getByText("Triage open GitHub issues.")).toBeInTheDocument();
     expect(screen.getByText("sys_os_read")).toBeInTheDocument();
     expect(screen.getByText("Read a file.")).toBeInTheDocument();
-  });
-
-  it("renders MCP servers with transport and a deferred-tools note", () => {
-    renderPanel({
-      data: makeCapabilities({
-        mcp_servers: [
-          {
-            name: "github",
-            transport: "http",
-            description: "GitHub API",
-            url: "https://mcp.example/github",
-            tools: [],
-          },
-        ],
-      }),
-    });
-
-    expect(screen.getByText("github")).toBeInTheDocument();
-    expect(screen.getByText("http")).toBeInTheDocument();
-    expect(screen.getByText("GitHub API")).toBeInTheDocument();
-    // Per-server tool discovery is deferred, so the row notes it gracefully
-    // rather than rendering an empty tool list.
-    expect(screen.getByText("Inspect tools coming soon")).toBeInTheDocument();
   });
 
   it("renders the sub-agent tree recursively, indenting nested descendants", () => {
@@ -140,8 +164,8 @@ describe("CapabilitiesPanel sections", () => {
     renderPanel({
       data: makeCapabilities({
         skills: [
-          { name: "a", description: "x" },
-          { name: "b", description: "y" },
+          makeSkill({ name: "a", description: "x" }),
+          makeSkill({ name: "b", description: "y" }),
         ],
       }),
     });
@@ -153,6 +177,235 @@ describe("CapabilitiesPanel sections", () => {
   });
 });
 
+describe("CapabilitiesPanel top-level scope filtering", () => {
+  it("defaults the panel-level toggle on and filters skills, local tools, and MCP tools", () => {
+    renderPanel({
+      data: makeCapabilities({
+        skills: [
+          makeSkill({ name: "usable-skill" }),
+          makeSkill({ name: "scoped-out", in_scope: false }),
+          makeSkill({ name: "blocked-skill", blocked: true }),
+        ],
+        local_tools: [
+          makeTool({ name: "usable-tool" }),
+          makeTool({ name: "blocked-tool", blocked: true }),
+        ],
+        mcp_servers: [
+          makeServer({
+            name: "github",
+            tools: [
+              makeTool({ name: "usable-mcp-tool" }),
+              makeTool({ name: "blocked-mcp-tool", blocked: true }),
+            ],
+          }),
+        ],
+        sub_agents: [{ name: "helper", description: "Helps.", sub_agents: [] }],
+      }),
+    });
+
+    expect(scopeToggle()).toBeChecked();
+
+    // Skills: only usable shown.
+    expect(screen.getByText("usable-skill")).toBeInTheDocument();
+    expect(screen.queryByText("scoped-out")).not.toBeInTheDocument();
+    expect(screen.queryByText("blocked-skill")).not.toBeInTheDocument();
+
+    // Local tools: only non-blocked shown.
+    expect(screen.getByText("usable-tool")).toBeInTheDocument();
+    expect(screen.queryByText("blocked-tool")).not.toBeInTheDocument();
+
+    // MCP tools: expand the server, only non-blocked tool shown.
+    fireEvent.click(screen.getByText("github"));
+    expect(screen.getByText("usable-mcp-tool")).toBeInTheDocument();
+    expect(screen.queryByText("blocked-mcp-tool")).not.toBeInTheDocument();
+
+    // Sub-agents are never gated by the toggle.
+    expect(screen.getByText("helper")).toBeInTheDocument();
+  });
+
+  it("reveals blocked / out-of-scope entries with badges when toggled off", () => {
+    renderPanel({
+      data: makeCapabilities({
+        skills: [
+          makeSkill({ name: "usable-skill" }),
+          makeSkill({ name: "scoped-out", in_scope: false }),
+          makeSkill({ name: "blocked-skill", blocked: true }),
+        ],
+        local_tools: [
+          makeTool({ name: "usable-tool" }),
+          makeTool({ name: "blocked-tool", blocked: true }),
+        ],
+        mcp_servers: [
+          makeServer({
+            name: "github",
+            tools: [makeTool({ name: "blocked-mcp-tool", blocked: true })],
+          }),
+        ],
+      }),
+    });
+
+    fireEvent.click(scopeToggle());
+    expect(scopeToggle()).not.toBeChecked();
+
+    // Skill badges.
+    const scopedOutRow = screen.getByText("scoped-out").closest("li") as HTMLElement;
+    expect(within(scopedOutRow).getByText("out of scope")).toBeInTheDocument();
+    const blockedSkillRow = screen.getByText("blocked-skill").closest("li") as HTMLElement;
+    expect(within(blockedSkillRow).getByText("blocked")).toBeInTheDocument();
+
+    // Local tool badge.
+    const blockedToolRow = screen.getByText("blocked-tool").closest("li") as HTMLElement;
+    expect(within(blockedToolRow).getByText("blocked")).toBeInTheDocument();
+
+    // MCP tool badge (after expanding).
+    fireEvent.click(screen.getByText("github"));
+    const blockedMcpRow = screen.getByText("blocked-mcp-tool").closest("li") as HTMLElement;
+    expect(within(blockedMcpRow).getByText("blocked")).toBeInTheDocument();
+  });
+
+  it("reports usable counts in section badges regardless of the toggle", () => {
+    renderPanel({
+      data: makeCapabilities({
+        skills: [
+          makeSkill({ name: "in-and-unblocked" }),
+          makeSkill({ name: "in-but-blocked", blocked: true }),
+          makeSkill({ name: "out-but-unblocked", in_scope: false }),
+        ],
+        local_tools: [makeTool({ name: "ok" }), makeTool({ name: "no", blocked: true })],
+      }),
+    });
+
+    const skillsHeader = screen.getByText("Skills").closest("h3") as HTMLElement;
+    expect(within(skillsHeader).getByText("1")).toBeInTheDocument();
+
+    const toolsHeader = screen.getByText("Local tools").closest("h3") as HTMLElement;
+    expect(within(toolsHeader).getByText("1")).toBeInTheDocument();
+  });
+
+  it("renders each skill's source as a label", () => {
+    renderPanel({
+      data: makeCapabilities({
+        skills: [makeSkill({ name: "user-skill", source: "user" })],
+      }),
+    });
+
+    const row = screen.getByText("user-skill").closest("li") as HTMLElement;
+    expect(within(row).getByText("user")).toBeInTheDocument();
+  });
+
+  it("hints at unavailable skills when none are in scope", () => {
+    renderPanel({
+      data: makeCapabilities({
+        skills: [
+          makeSkill({ name: "scoped-out", in_scope: false }),
+          makeSkill({ name: "blocked-skill", blocked: true }),
+        ],
+      }),
+    });
+
+    expect(
+      screen.getByText("No skills in scope. Toggle off to see 2 unavailable skills."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(scopeToggle());
+    expect(screen.getByText("scoped-out")).toBeInTheDocument();
+    expect(screen.getByText("blocked-skill")).toBeInTheDocument();
+  });
+
+  it("hints at blocked local tools when none are in scope", () => {
+    renderPanel({
+      data: makeCapabilities({
+        local_tools: [makeTool({ name: "blocked-tool", blocked: true })],
+      }),
+    });
+
+    expect(
+      screen.getByText("No local tools in scope. Toggle off to see 1 blocked tool."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("CapabilitiesPanel MCP servers", () => {
+  it("lists servers with transport and status, and is expandable to its tools", () => {
+    renderPanel({
+      data: makeCapabilities({
+        mcp_servers: [
+          makeServer({
+            name: "github",
+            transport: "http",
+            description: "GitHub API",
+            url: "https://mcp.example/github",
+            status: "connected",
+            tools: [makeTool({ name: "create_issue", description: "Open an issue." })],
+          }),
+        ],
+      }),
+    });
+
+    expect(screen.getByText("github")).toBeInTheDocument();
+    expect(screen.getByText("http")).toBeInTheDocument();
+    expect(screen.getByText("connected")).toBeInTheDocument();
+    expect(screen.getByText("GitHub API")).toBeInTheDocument();
+
+    // Tools are collapsed until the server row is clicked.
+    expect(screen.queryByText("create_issue")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("github"));
+    expect(screen.getByText("create_issue")).toBeInTheDocument();
+    expect(screen.getByText("Open an issue.")).toBeInTheDocument();
+  });
+
+  it("surfaces a failed server's status and error", () => {
+    renderPanel({
+      data: makeCapabilities({
+        mcp_servers: [
+          makeServer({
+            name: "broken",
+            transport: "stdio",
+            command: "./mcp-server",
+            url: null,
+            status: "failed",
+            error: "connection refused",
+            tools: [],
+          }),
+        ],
+      }),
+    });
+
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.getByText("connection refused")).toBeInTheDocument();
+  });
+
+  it("shows an empty state for a server with no discovered tools", () => {
+    renderPanel({
+      data: makeCapabilities({
+        mcp_servers: [makeServer({ name: "empty", tools: [] })],
+      }),
+    });
+
+    fireEvent.click(screen.getByText("empty"));
+    expect(screen.getByText("No tools discovered.")).toBeInTheDocument();
+  });
+
+  it("shows an all-blocked hint within a server when the toggle is on", () => {
+    renderPanel({
+      data: makeCapabilities({
+        mcp_servers: [
+          makeServer({
+            name: "locked",
+            tools: [makeTool({ name: "danger", blocked: true })],
+          }),
+        ],
+      }),
+    });
+
+    fireEvent.click(screen.getByText("locked"));
+    expect(
+      screen.getByText("No tools in scope. Toggle off to see 1 blocked tool."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("danger")).not.toBeInTheDocument();
+  });
+});
+
 describe("CapabilitiesPanel collapse / expand", () => {
   /** Grab a section header's collapsible trigger button by its title. */
   function triggerFor(title: string): HTMLButtonElement {
@@ -161,7 +414,9 @@ describe("CapabilitiesPanel collapse / expand", () => {
 
   it("renders every section expanded by default", () => {
     renderPanel({
-      data: makeCapabilities({ skills: [{ name: "triage-issues", description: "Triage." }] }),
+      data: makeCapabilities({
+        skills: [makeSkill({ name: "triage-issues", description: "Triage." })],
+      }),
     });
 
     // Body content is visible and every trigger reports the expanded state.
@@ -175,8 +430,8 @@ describe("CapabilitiesPanel collapse / expand", () => {
     renderPanel({
       data: makeCapabilities({
         skills: [
-          { name: "triage-issues", description: "Triage." },
-          { name: "review-pr", description: "Review." },
+          makeSkill({ name: "triage-issues", description: "Triage." }),
+          makeSkill({ name: "review-pr", description: "Review." }),
         ],
       }),
     });
@@ -195,7 +450,9 @@ describe("CapabilitiesPanel collapse / expand", () => {
 
   it("re-expands a collapsed section on a second click", () => {
     renderPanel({
-      data: makeCapabilities({ skills: [{ name: "triage-issues", description: "Triage." }] }),
+      data: makeCapabilities({
+        skills: [makeSkill({ name: "triage-issues", description: "Triage." })],
+      }),
     });
 
     const trigger = triggerFor("Skills");
@@ -211,8 +468,8 @@ describe("CapabilitiesPanel collapse / expand", () => {
   it("toggles sections independently", () => {
     renderPanel({
       data: makeCapabilities({
-        skills: [{ name: "triage-issues", description: "Triage." }],
-        local_tools: [{ name: "sys_os_read", description: "Read a file." }],
+        skills: [makeSkill({ name: "triage-issues", description: "Triage." })],
+        local_tools: [makeTool({ name: "sys_os_read", description: "Read a file." })],
       }),
     });
 

--- a/web/src/shell/CapabilitiesPanel.test.tsx
+++ b/web/src/shell/CapabilitiesPanel.test.tsx
@@ -1,0 +1,226 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSessionCapabilities, type SessionCapabilities } from "@/hooks/useSessionCapabilities";
+import { CapabilitiesPanel } from "./CapabilitiesPanel";
+
+vi.mock("@/hooks/useSessionCapabilities", () => ({
+  useSessionCapabilities: vi.fn(),
+}));
+
+const useSessionCapabilitiesMock = vi.mocked(useSessionCapabilities);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+/** Minimal capabilities payload, overridable per test. */
+function makeCapabilities(overrides: Partial<SessionCapabilities> = {}): SessionCapabilities {
+  return {
+    session_id: "conv_1",
+    agent_id: "agent_1",
+    sub_agent_name: null,
+    skills: [],
+    mcp_servers: [],
+    local_tools: [],
+    sub_agents: [],
+    ...overrides,
+  };
+}
+
+/** Drive the mocked hook and render the panel. */
+function renderPanel(
+  state: Partial<ReturnType<typeof useSessionCapabilities>> & {
+    data?: SessionCapabilities | undefined;
+  },
+) {
+  useSessionCapabilitiesMock.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    ...state,
+  } as unknown as ReturnType<typeof useSessionCapabilities>);
+  render(<CapabilitiesPanel conversationId="conv_1" />);
+}
+
+describe("CapabilitiesPanel loading / error states", () => {
+  it("shows a loading state before any data arrives", () => {
+    renderPanel({ isLoading: true, data: undefined });
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("shows an error state when the fetch fails with no data", () => {
+    renderPanel({ error: new Error("boom"), data: undefined });
+    expect(screen.getByText("Failed to load capabilities.")).toBeInTheDocument();
+  });
+});
+
+describe("CapabilitiesPanel sections", () => {
+  it("renders empty states for every section when nothing is configured", () => {
+    renderPanel({ data: makeCapabilities() });
+
+    expect(screen.getByText("No skills available.")).toBeInTheDocument();
+    expect(screen.getByText("No MCP servers configured.")).toBeInTheDocument();
+    expect(screen.getByText("No local tools available.")).toBeInTheDocument();
+    expect(screen.getByText("No sub-agents declared.")).toBeInTheDocument();
+  });
+
+  it("renders skills and local tools with name + description", () => {
+    renderPanel({
+      data: makeCapabilities({
+        skills: [{ name: "triage-issues", description: "Triage open GitHub issues." }],
+        local_tools: [{ name: "sys_os_read", description: "Read a file." }],
+      }),
+    });
+
+    expect(screen.getByText("triage-issues")).toBeInTheDocument();
+    expect(screen.getByText("Triage open GitHub issues.")).toBeInTheDocument();
+    expect(screen.getByText("sys_os_read")).toBeInTheDocument();
+    expect(screen.getByText("Read a file.")).toBeInTheDocument();
+  });
+
+  it("renders MCP servers with transport and a deferred-tools note", () => {
+    renderPanel({
+      data: makeCapabilities({
+        mcp_servers: [
+          {
+            name: "github",
+            transport: "http",
+            description: "GitHub API",
+            url: "https://mcp.example/github",
+            tools: [],
+          },
+        ],
+      }),
+    });
+
+    expect(screen.getByText("github")).toBeInTheDocument();
+    expect(screen.getByText("http")).toBeInTheDocument();
+    expect(screen.getByText("GitHub API")).toBeInTheDocument();
+    // Per-server tool discovery is deferred, so the row notes it gracefully
+    // rather than rendering an empty tool list.
+    expect(screen.getByText("Inspect tools coming soon")).toBeInTheDocument();
+  });
+
+  it("renders the sub-agent tree recursively, indenting nested descendants", () => {
+    renderPanel({
+      data: makeCapabilities({
+        sub_agents: [
+          {
+            name: "researcher",
+            description: "Digs through docs.",
+            sub_agents: [{ name: "fetcher", description: "Fetches URLs.", sub_agents: [] }],
+          },
+        ],
+      }),
+    });
+
+    const researcher = screen.getByText("researcher");
+    const fetcher = screen.getByText("fetcher");
+    expect(researcher).toBeInTheDocument();
+    expect(fetcher).toBeInTheDocument();
+    expect(screen.getByText("Digs through docs.")).toBeInTheDocument();
+    expect(screen.getByText("Fetches URLs.")).toBeInTheDocument();
+
+    // The nested child is indented deeper than its parent (tree read).
+    const parentRow = researcher.closest("li");
+    const childRow = fetcher.closest("li");
+    const parentPad = Number.parseInt(
+      parentRow?.getAttribute("style")?.match(/(\d+)px/)?.[1] ?? "0",
+      10,
+    );
+    const childPad = Number.parseInt(
+      childRow?.getAttribute("style")?.match(/(\d+)px/)?.[1] ?? "0",
+      10,
+    );
+    expect(childPad).toBeGreaterThan(parentPad);
+  });
+
+  it("shows the section count badges", () => {
+    renderPanel({
+      data: makeCapabilities({
+        skills: [
+          { name: "a", description: "x" },
+          { name: "b", description: "y" },
+        ],
+      }),
+    });
+
+    // Skills header shows a count of 2.
+    const skillsHeader = screen.getByText("Skills").closest("h3");
+    expect(skillsHeader).not.toBeNull();
+    expect(within(skillsHeader as HTMLElement).getByText("2")).toBeInTheDocument();
+  });
+});
+
+describe("CapabilitiesPanel collapse / expand", () => {
+  /** Grab a section header's collapsible trigger button by its title. */
+  function triggerFor(title: string): HTMLButtonElement {
+    return screen.getByRole("button", { name: new RegExp(title) }) as HTMLButtonElement;
+  }
+
+  it("renders every section expanded by default", () => {
+    renderPanel({
+      data: makeCapabilities({ skills: [{ name: "triage-issues", description: "Triage." }] }),
+    });
+
+    // Body content is visible and every trigger reports the expanded state.
+    expect(screen.getByText("triage-issues")).toBeInTheDocument();
+    for (const title of ["Skills", "MCP servers", "Local tools", "Sub-agents"]) {
+      expect(triggerFor(title)).toHaveAttribute("aria-expanded", "true");
+    }
+  });
+
+  it("collapses a section on header click, hiding its body but keeping the count", () => {
+    renderPanel({
+      data: makeCapabilities({
+        skills: [
+          { name: "triage-issues", description: "Triage." },
+          { name: "review-pr", description: "Review." },
+        ],
+      }),
+    });
+
+    const trigger = triggerFor("Skills");
+    expect(screen.getByText("triage-issues")).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    // Body is gone, but the header — title, icon, and count badge — remains.
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("triage-issues")).not.toBeInTheDocument();
+    expect(screen.getByText("Skills")).toBeInTheDocument();
+    expect(within(trigger).getByText("2")).toBeInTheDocument();
+  });
+
+  it("re-expands a collapsed section on a second click", () => {
+    renderPanel({
+      data: makeCapabilities({ skills: [{ name: "triage-issues", description: "Triage." }] }),
+    });
+
+    const trigger = triggerFor("Skills");
+
+    fireEvent.click(trigger);
+    expect(screen.queryByText("triage-issues")).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("triage-issues")).toBeInTheDocument();
+  });
+
+  it("toggles sections independently", () => {
+    renderPanel({
+      data: makeCapabilities({
+        skills: [{ name: "triage-issues", description: "Triage." }],
+        local_tools: [{ name: "sys_os_read", description: "Read a file." }],
+      }),
+    });
+
+    fireEvent.click(triggerFor("Skills"));
+
+    // Collapsing Skills leaves Local tools untouched.
+    expect(screen.queryByText("triage-issues")).not.toBeInTheDocument();
+    expect(screen.getByText("sys_os_read")).toBeInTheDocument();
+    expect(triggerFor("Local tools")).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/web/src/shell/CapabilitiesPanel.tsx
+++ b/web/src/shell/CapabilitiesPanel.tsx
@@ -7,7 +7,7 @@
 // opening a sub-agent re-fetches and shows THAT agent's capabilities.
 // Read-only — no add / edit / remove controls here.
 //
-// A single panel-level "Only in scope" toggle (default on) governs the
+// A single panel-level "Only show usable" toggle (default on) governs the
 // whole view: it hides skills / tools the agent cannot actually use and,
 // when off, reveals them with explanatory badges. Sub-agents are never
 // gated by it.
@@ -75,7 +75,7 @@ export function CapabilitiesPanel({ conversationId }: CapabilitiesPanelProps) {
       <div className="flex items-center gap-2 border-b border-border px-2.5 py-2">
         <Switch id={toggleId} size="sm" checked={onlyInScope} onCheckedChange={setOnlyInScope} />
         <label htmlFor={toggleId} className="cursor-pointer text-[11px] text-muted-foreground">
-          Only in scope
+          Only show usable
         </label>
       </div>
 

--- a/web/src/shell/CapabilitiesPanel.tsx
+++ b/web/src/shell/CapabilitiesPanel.tsx
@@ -1,13 +1,19 @@
 // Capabilities tab content for the right-side rail. A read-only view of
-// the agent bound to the active session: its merged skills, MCP servers,
-// local/builtin function tools, and declared sub-agent tree.
+// the agent bound to the active session: its merged skills, MCP servers
+// (with per-server tools), local/builtin function tools, and declared
+// sub-agent tree.
 //
 // Context-aware via `conversationId`: the fetch is keyed on it, so
 // opening a sub-agent re-fetches and shows THAT agent's capabilities.
 // Read-only — no add / edit / remove controls here.
+//
+// A single panel-level "Only in scope" toggle (default on) governs the
+// whole view: it hides skills / tools the agent cannot actually use and,
+// when off, reveals them with explanatory badges. Sub-agents are never
+// gated by it.
 
 import type { ComponentType, ReactNode, SVGProps } from "react";
-import { useState } from "react";
+import { useId, useMemo, useState } from "react";
 import {
   BotIcon,
   ChevronRightIcon,
@@ -18,12 +24,25 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Switch } from "@/components/ui/switch";
 import {
   useSessionCapabilities,
   type CapabilityMcpServer,
+  type CapabilitySkill,
+  type CapabilityTool,
   type SubAgentCapability,
 } from "@/hooks/useSessionCapabilities";
 import { cn } from "@/lib/utils";
+
+/** A skill is usable when it's in the agent's scope and not policy-blocked. */
+function isSkillUsable(skill: CapabilitySkill): boolean {
+  return skill.in_scope && !skill.blocked;
+}
+
+/** A tool is usable when it's not policy-blocked. */
+function isToolUsable(tool: CapabilityTool): boolean {
+  return !tool.blocked;
+}
 
 interface CapabilitiesPanelProps {
   /** The active session whose bound-agent capabilities to render. */
@@ -32,6 +51,11 @@ interface CapabilitiesPanelProps {
 
 export function CapabilitiesPanel({ conversationId }: CapabilitiesPanelProps) {
   const { data, isLoading, error } = useSessionCapabilities(conversationId);
+
+  // Panel-level scope filter (default on): governs skills, local tools, and
+  // per-server MCP tools. Sub-agents are never gated by it.
+  const [onlyInScope, setOnlyInScope] = useState(true);
+  const toggleId = useId();
 
   if (isLoading && !data) {
     return <CenteredMessage>Loading…</CenteredMessage>;
@@ -48,45 +72,18 @@ export function CapabilitiesPanel({ conversationId }: CapabilitiesPanelProps) {
       data-testid="capabilities-panel"
       className="flex h-full min-h-0 flex-col overflow-y-auto bg-card"
     >
-      <Section icon={SparklesIcon} title="Skills" count={data.skills.length}>
-        {data.skills.length === 0 ? (
-          <EmptyState>No skills available.</EmptyState>
-        ) : (
-          <ul className="flex flex-col">
-            {data.skills.map((skill) => (
-              <NameDescriptionRow
-                key={skill.name}
-                name={skill.name}
-                description={skill.description}
-              />
-            ))}
-          </ul>
-        )}
-      </Section>
+      <div className="flex items-center gap-2 border-b border-border px-2.5 py-2">
+        <Switch id={toggleId} size="sm" checked={onlyInScope} onCheckedChange={setOnlyInScope} />
+        <label htmlFor={toggleId} className="cursor-pointer text-[11px] text-muted-foreground">
+          Only in scope
+        </label>
+      </div>
 
-      <Section icon={PlugIcon} title="MCP servers" count={data.mcp_servers.length}>
-        {data.mcp_servers.length === 0 ? (
-          <EmptyState>No MCP servers configured.</EmptyState>
-        ) : (
-          <ul className="flex flex-col">
-            {data.mcp_servers.map((server) => (
-              <McpServerRow key={server.name} server={server} />
-            ))}
-          </ul>
-        )}
-      </Section>
+      <SkillsSection skills={data.skills} onlyInScope={onlyInScope} />
 
-      <Section icon={WrenchIcon} title="Local tools" count={data.local_tools.length}>
-        {data.local_tools.length === 0 ? (
-          <EmptyState>No local tools available.</EmptyState>
-        ) : (
-          <ul className="flex flex-col">
-            {data.local_tools.map((tool) => (
-              <NameDescriptionRow key={tool.name} name={tool.name} description={tool.description} />
-            ))}
-          </ul>
-        )}
-      </Section>
+      <McpSection servers={data.mcp_servers} onlyInScope={onlyInScope} />
+
+      <LocalToolsSection tools={data.local_tools} onlyInScope={onlyInScope} />
 
       <Section icon={BotIcon} title="Sub-agents" count={data.sub_agents.length}>
         {data.sub_agents.length === 0 ? (
@@ -156,39 +153,246 @@ function EmptyState({ children }: { children: ReactNode }) {
   return <p className="px-2.5 pb-2 text-xs text-muted-foreground">{children}</p>;
 }
 
-/** A single name + optional description row, shared by skills and tools. */
-function NameDescriptionRow({ name, description }: { name: string; description?: string | null }) {
+// The section count badge always reports the USABLE count (in_scope &&
+// !blocked) so the header reflects what the agent can actually run,
+// regardless of the toggle — the toggle only widens the list to include
+// unavailable skills.
+function SkillsSection({
+  skills,
+  onlyInScope,
+}: {
+  skills: CapabilitySkill[];
+  onlyInScope: boolean;
+}) {
+  const usable = useMemo(() => skills.filter(isSkillUsable), [skills]);
+  const unavailableCount = skills.length - usable.length;
+  const visible = onlyInScope ? usable : skills;
+
+  return (
+    <Section icon={SparklesIcon} title="Skills" count={usable.length}>
+      {skills.length === 0 ? (
+        <EmptyState>No skills available.</EmptyState>
+      ) : visible.length === 0 ? (
+        <EmptyState>
+          No skills in scope. Toggle off to see {unavailableCount} unavailable{" "}
+          {unavailableCount === 1 ? "skill" : "skills"}.
+        </EmptyState>
+      ) : (
+        <ul className="flex flex-col">
+          {visible.map((skill) => (
+            <SkillRow key={skill.name} skill={skill} />
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+/** A skill row: name + source pill, plus out-of-scope / blocked status badges. */
+function SkillRow({ skill }: { skill: CapabilitySkill }) {
   return (
     <li className="flex flex-col gap-0.5 px-2.5 py-1.5">
-      <span className="truncate text-xs font-medium">{name}</span>
-      {description && <span className="text-[11px] text-muted-foreground">{description}</span>}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="truncate text-xs font-medium">{skill.name}</span>
+        <Badge className="border-transparent bg-muted text-[10px] text-muted-foreground">
+          {skill.source}
+        </Badge>
+        {!skill.in_scope && (
+          <Badge className="border-transparent bg-muted text-[10px] text-muted-foreground/80">
+            out of scope
+          </Badge>
+        )}
+        {skill.blocked && (
+          <Badge variant="destructive" className="text-[10px]">
+            blocked
+          </Badge>
+        )}
+      </div>
+      {skill.description && (
+        <span className="text-[11px] text-muted-foreground">{skill.description}</span>
+      )}
     </li>
   );
 }
 
-function McpServerRow({ server }: { server: CapabilityMcpServer }) {
-  // stdio servers carry a spawn command; http servers carry a URL.
-  const endpoint = server.transport === "stdio" ? server.command : server.url;
+// Local tools: the count badge reports the usable (non-blocked) count, and
+// the toggle hides blocked tools when on / reveals them with a badge when off.
+function LocalToolsSection({
+  tools,
+  onlyInScope,
+}: {
+  tools: CapabilityTool[];
+  onlyInScope: boolean;
+}) {
+  const usable = useMemo(() => tools.filter(isToolUsable), [tools]);
+  const blockedCount = tools.length - usable.length;
+  const visible = onlyInScope ? usable : tools;
+
+  return (
+    <Section icon={WrenchIcon} title="Local tools" count={usable.length}>
+      {tools.length === 0 ? (
+        <EmptyState>No local tools available.</EmptyState>
+      ) : visible.length === 0 ? (
+        <EmptyState>
+          No local tools in scope. Toggle off to see {blockedCount} blocked{" "}
+          {blockedCount === 1 ? "tool" : "tools"}.
+        </EmptyState>
+      ) : (
+        <ul className="flex flex-col">
+          {visible.map((tool) => (
+            <ToolRow key={tool.name} tool={tool} />
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+/** A function tool row: name + optional description, with a blocked badge. */
+function ToolRow({ tool }: { tool: CapabilityTool }) {
   return (
     <li className="flex flex-col gap-0.5 px-2.5 py-1.5">
-      <div className="flex items-center gap-1.5">
-        <span className="truncate text-xs font-medium">{server.name}</span>
-        <Badge className="border-transparent bg-muted text-[10px] text-muted-foreground">
-          {server.transport}
-        </Badge>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="truncate text-xs font-medium">{tool.name}</span>
+        {tool.blocked && (
+          <Badge variant="destructive" className="text-[10px]">
+            blocked
+          </Badge>
+        )}
       </div>
-      {server.description && (
-        <span className="text-[11px] text-muted-foreground">{server.description}</span>
+      {tool.description && (
+        <span className="text-[11px] text-muted-foreground">{tool.description}</span>
       )}
-      {endpoint && (
-        <span className="truncate text-[11px] text-muted-foreground/80" title={endpoint}>
-          {endpoint}
-        </span>
+    </li>
+  );
+}
+
+// MCP servers are always listed regardless of the toggle (so their status is
+// always visible); the toggle only filters the tools shown within each server.
+// The section count badge reports the number of servers.
+function McpSection({
+  servers,
+  onlyInScope,
+}: {
+  servers: CapabilityMcpServer[];
+  onlyInScope: boolean;
+}) {
+  return (
+    <Section icon={PlugIcon} title="MCP servers" count={servers.length}>
+      {servers.length === 0 ? (
+        <EmptyState>No MCP servers configured.</EmptyState>
+      ) : (
+        <ul className="flex flex-col">
+          {servers.map((server) => (
+            <McpServerRow key={server.name} server={server} onlyInScope={onlyInScope} />
+          ))}
+        </ul>
       )}
-      {/* Per-server tool discovery needs a runner round-trip, deferred to a
-          later slice — the field is always empty for now, so note it quietly
-          rather than rendering an empty list. */}
-      <span className="text-[11px] italic text-muted-foreground/70">Inspect tools coming soon</span>
+    </Section>
+  );
+}
+
+/** Maps a server status to a badge tone. */
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case "connected":
+      return "border-transparent bg-emerald-500/15 text-emerald-600 dark:text-emerald-400";
+    case "failed":
+      return "border-transparent bg-destructive/15 text-destructive";
+    default:
+      return "border-transparent bg-muted text-muted-foreground/80";
+  }
+}
+
+// A server row is an expandable disclosure: the header shows name, transport,
+// and connection status; expanding lists the server's tools (filtered by the
+// panel-level toggle). Read-only.
+function McpServerRow({
+  server,
+  onlyInScope,
+}: {
+  server: CapabilityMcpServer;
+  onlyInScope: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  // stdio servers carry a spawn command; http servers carry a URL.
+  const endpoint = server.transport === "stdio" ? server.command : server.url;
+
+  const usableTools = useMemo(() => server.tools.filter(isToolUsable), [server.tools]);
+  const blockedCount = server.tools.length - usableTools.length;
+  const visibleTools = onlyInScope ? usableTools : server.tools;
+
+  return (
+    <li>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger className="flex w-full cursor-pointer flex-col gap-0.5 px-2.5 py-1.5 text-left hover:bg-muted/50">
+          <div className="flex items-center gap-1.5">
+            <ChevronRightIcon
+              aria-hidden="true"
+              className={cn(
+                "size-3 shrink-0 text-muted-foreground transition-transform",
+                open ? "rotate-90" : "rotate-0",
+              )}
+            />
+            <span className="truncate text-xs font-medium">{server.name}</span>
+            <Badge className="border-transparent bg-muted text-[10px] text-muted-foreground">
+              {server.transport}
+            </Badge>
+            <Badge className={cn("text-[10px]", statusBadgeClass(server.status))}>
+              {server.status}
+            </Badge>
+            <Badge className="ml-auto border-transparent bg-muted text-[10px] text-muted-foreground tabular-nums">
+              {usableTools.length}
+            </Badge>
+          </div>
+          {server.description && (
+            <span className="pl-[18px] text-[11px] text-muted-foreground">
+              {server.description}
+            </span>
+          )}
+          {endpoint && (
+            <span
+              className="truncate pl-[18px] text-[11px] text-muted-foreground/80"
+              title={endpoint}
+            >
+              {endpoint}
+            </span>
+          )}
+          {server.error && (
+            <span className="pl-[18px] text-[11px] text-destructive">{server.error}</span>
+          )}
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          {server.tools.length === 0 ? (
+            <p className="pb-1.5 pl-[30px] pr-2.5 text-[11px] text-muted-foreground">
+              No tools discovered.
+            </p>
+          ) : visibleTools.length === 0 ? (
+            <p className="pb-1.5 pl-[30px] pr-2.5 text-[11px] text-muted-foreground">
+              No tools in scope. Toggle off to see {blockedCount} blocked{" "}
+              {blockedCount === 1 ? "tool" : "tools"}.
+            </p>
+          ) : (
+            <ul className="flex flex-col pb-1">
+              {visibleTools.map((tool) => (
+                <li key={tool.name} className="flex flex-col gap-0.5 py-1 pl-[30px] pr-2.5">
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <span className="truncate text-[11px] font-medium">{tool.name}</span>
+                    {tool.blocked && (
+                      <Badge variant="destructive" className="text-[10px]">
+                        blocked
+                      </Badge>
+                    )}
+                  </div>
+                  {tool.description && (
+                    <span className="text-[11px] text-muted-foreground">{tool.description}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
     </li>
   );
 }

--- a/web/src/shell/CapabilitiesPanel.tsx
+++ b/web/src/shell/CapabilitiesPanel.tsx
@@ -1,0 +1,229 @@
+// Capabilities tab content for the right-side rail. A read-only view of
+// the agent bound to the active session: its merged skills, MCP servers,
+// local/builtin function tools, and declared sub-agent tree.
+//
+// Context-aware via `conversationId`: the fetch is keyed on it, so
+// opening a sub-agent re-fetches and shows THAT agent's capabilities.
+// Read-only — no add / edit / remove controls here.
+
+import type { ComponentType, ReactNode, SVGProps } from "react";
+import { useState } from "react";
+import {
+  BotIcon,
+  ChevronRightIcon,
+  CornerDownRightIcon,
+  PlugIcon,
+  SparklesIcon,
+  WrenchIcon,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import {
+  useSessionCapabilities,
+  type CapabilityMcpServer,
+  type SubAgentCapability,
+} from "@/hooks/useSessionCapabilities";
+import { cn } from "@/lib/utils";
+
+interface CapabilitiesPanelProps {
+  /** The active session whose bound-agent capabilities to render. */
+  conversationId: string;
+}
+
+export function CapabilitiesPanel({ conversationId }: CapabilitiesPanelProps) {
+  const { data, isLoading, error } = useSessionCapabilities(conversationId);
+
+  if (isLoading && !data) {
+    return <CenteredMessage>Loading…</CenteredMessage>;
+  }
+  if (error && !data) {
+    return <CenteredMessage>Failed to load capabilities.</CenteredMessage>;
+  }
+  if (!data) {
+    return <CenteredMessage>No capabilities to show.</CenteredMessage>;
+  }
+
+  return (
+    <div
+      data-testid="capabilities-panel"
+      className="flex h-full min-h-0 flex-col overflow-y-auto bg-card"
+    >
+      <Section icon={SparklesIcon} title="Skills" count={data.skills.length}>
+        {data.skills.length === 0 ? (
+          <EmptyState>No skills available.</EmptyState>
+        ) : (
+          <ul className="flex flex-col">
+            {data.skills.map((skill) => (
+              <NameDescriptionRow
+                key={skill.name}
+                name={skill.name}
+                description={skill.description}
+              />
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      <Section icon={PlugIcon} title="MCP servers" count={data.mcp_servers.length}>
+        {data.mcp_servers.length === 0 ? (
+          <EmptyState>No MCP servers configured.</EmptyState>
+        ) : (
+          <ul className="flex flex-col">
+            {data.mcp_servers.map((server) => (
+              <McpServerRow key={server.name} server={server} />
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      <Section icon={WrenchIcon} title="Local tools" count={data.local_tools.length}>
+        {data.local_tools.length === 0 ? (
+          <EmptyState>No local tools available.</EmptyState>
+        ) : (
+          <ul className="flex flex-col">
+            {data.local_tools.map((tool) => (
+              <NameDescriptionRow key={tool.name} name={tool.name} description={tool.description} />
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      <Section icon={BotIcon} title="Sub-agents" count={data.sub_agents.length}>
+        {data.sub_agents.length === 0 ? (
+          <EmptyState>No sub-agents declared.</EmptyState>
+        ) : (
+          <ul className="flex flex-col">
+            {data.sub_agents.map((sub, i) => (
+              <SubAgentRow key={sub.name ?? `sub-${i}`} node={sub} depth={0} />
+            ))}
+          </ul>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function CenteredMessage({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full flex-1 items-center justify-center bg-card px-4 py-8 text-center text-xs text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function Section({
+  icon: Icon,
+  title,
+  count,
+  children,
+}: {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  title: string;
+  count: number;
+  children: ReactNode;
+}) {
+  // Default open on first render; collapse state lives locally and is not
+  // persisted across reloads (kept intentionally simple).
+  const [open, setOpen] = useState(true);
+  return (
+    <Collapsible asChild open={open} onOpenChange={setOpen}>
+      <section className="border-b border-border last:border-b-0">
+        <h3>
+          <CollapsibleTrigger className="flex w-full cursor-pointer items-center gap-1.5 px-2.5 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground">
+            <ChevronRightIcon
+              aria-hidden="true"
+              className={cn(
+                "size-3.5 shrink-0 transition-transform",
+                open ? "rotate-90" : "rotate-0",
+              )}
+            />
+            <Icon className="size-3.5 shrink-0" />
+            <span>{title}</span>
+            <Badge className="ml-auto border-transparent bg-muted text-muted-foreground tabular-nums">
+              {count}
+            </Badge>
+          </CollapsibleTrigger>
+        </h3>
+        <CollapsibleContent>
+          <div className="pb-1">{children}</div>
+        </CollapsibleContent>
+      </section>
+    </Collapsible>
+  );
+}
+
+function EmptyState({ children }: { children: ReactNode }) {
+  return <p className="px-2.5 pb-2 text-xs text-muted-foreground">{children}</p>;
+}
+
+/** A single name + optional description row, shared by skills and tools. */
+function NameDescriptionRow({ name, description }: { name: string; description?: string | null }) {
+  return (
+    <li className="flex flex-col gap-0.5 px-2.5 py-1.5">
+      <span className="truncate text-xs font-medium">{name}</span>
+      {description && <span className="text-[11px] text-muted-foreground">{description}</span>}
+    </li>
+  );
+}
+
+function McpServerRow({ server }: { server: CapabilityMcpServer }) {
+  // stdio servers carry a spawn command; http servers carry a URL.
+  const endpoint = server.transport === "stdio" ? server.command : server.url;
+  return (
+    <li className="flex flex-col gap-0.5 px-2.5 py-1.5">
+      <div className="flex items-center gap-1.5">
+        <span className="truncate text-xs font-medium">{server.name}</span>
+        <Badge className="border-transparent bg-muted text-[10px] text-muted-foreground">
+          {server.transport}
+        </Badge>
+      </div>
+      {server.description && (
+        <span className="text-[11px] text-muted-foreground">{server.description}</span>
+      )}
+      {endpoint && (
+        <span className="truncate text-[11px] text-muted-foreground/80" title={endpoint}>
+          {endpoint}
+        </span>
+      )}
+      {/* Per-server tool discovery needs a runner round-trip, deferred to a
+          later slice — the field is always empty for now, so note it quietly
+          rather than rendering an empty list. */}
+      <span className="text-[11px] italic text-muted-foreground/70">Inspect tools coming soon</span>
+    </li>
+  );
+}
+
+// Indentation: each nesting level steps the left gutter in one notch so the
+// declared sub-agent hierarchy reads as a tree.
+const SUBAGENT_BASE_PADDING_PX = 10;
+const SUBAGENT_DEPTH_STEP_PX = 14;
+
+function SubAgentRow({ node, depth }: { node: SubAgentCapability; depth: number }) {
+  return (
+    <>
+      <li
+        className="flex flex-col gap-0.5 py-1.5 pr-2.5"
+        style={{ paddingLeft: SUBAGENT_BASE_PADDING_PX + depth * SUBAGENT_DEPTH_STEP_PX }}
+      >
+        <div className="flex items-center gap-1">
+          {depth > 0 && (
+            <CornerDownRightIcon
+              aria-hidden="true"
+              className="-ml-3 size-3 shrink-0 text-muted-foreground/60"
+            />
+          )}
+          <BotIcon
+            className={cn("size-3.5 shrink-0 text-muted-foreground", depth > 0 && "-ml-0.5")}
+          />
+          <span className="truncate text-xs font-medium">{node.name ?? "(unnamed)"}</span>
+        </div>
+        {node.description && (
+          <span className="pl-[18px] text-[11px] text-muted-foreground">{node.description}</span>
+        )}
+      </li>
+      {node.sub_agents.map((child, i) => (
+        <SubAgentRow key={child.name ?? `sub-${depth}-${i}`} node={child} depth={depth + 1} />
+      ))}
+    </>
+  );
+}

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -15,6 +15,7 @@ const mobileMenu = {
   executionLogsOpen: false,
   filesPanelOpen: false,
   subagentsPanelOpen: false,
+  capabilitiesPanelOpen: false,
   shellsPanelOpen: false,
   todosPanelOpen: false,
   hideTerminalsTab: false,
@@ -30,6 +31,7 @@ const mobileMenu = {
   onOpenFiles: () => {},
   onOpenShells: () => {},
   onOpenSubagents: () => {},
+  onOpenCapabilities: () => {},
   onOpenTodos: () => {},
   onOpenMainExecutionLog: () => {},
 };

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -1,4 +1,5 @@
 import {
+  BlocksIcon,
   BotIcon,
   ChevronLeftIcon,
   EllipsisVerticalIcon,
@@ -46,6 +47,8 @@ interface MobileSessionMenuProps {
   filesPanelOpen: boolean;
   /** True while the mobile agents drawer is open. */
   subagentsPanelOpen: boolean;
+  /** True while the mobile capabilities drawer is open. */
+  capabilitiesPanelOpen: boolean;
   /** True while the mobile shells drawer is open. */
   shellsPanelOpen: boolean;
   /** True while the mobile tasks drawer is open. */
@@ -79,6 +82,8 @@ interface MobileSessionMenuProps {
   onOpenShells: () => void;
   /** Open the mobile agents drawer. */
   onOpenSubagents: () => void;
+  /** Open the mobile capabilities drawer. */
+  onOpenCapabilities: () => void;
   /** Open the mobile tasks drawer. */
   onOpenTodos: () => void;
   /** Open the main execution-log push panel. */
@@ -393,6 +398,7 @@ export function ChatHeader({
           !mobileMenu.executionLogsOpen &&
           !mobileMenu.filesPanelOpen &&
           !mobileMenu.subagentsPanelOpen &&
+          !mobileMenu.capabilitiesPanelOpen &&
           !mobileMenu.shellsPanelOpen &&
           !mobileMenu.todosPanelOpen &&
           (hasRailContent || mobileMenu.debugMode) && (
@@ -447,6 +453,16 @@ export function ChatHeader({
                       ? `${mobileMenu.subagentsWorking}/${mobileMenu.agentCount}`
                       : mobileMenu.agentCount}
                   </span>
+                </DropdownMenuItem>
+                {/* Capabilities — always present (read-only view of the
+                    session's bound-agent skills, MCP servers, tools, and
+                    sub-agents; the panel renders empty states per section). */}
+                <DropdownMenuItem
+                  onSelect={mobileMenu.onOpenCapabilities}
+                  className="gap-2.5 px-2.5 py-2 text-base"
+                >
+                  <BlocksIcon className="size-4" />
+                  Capabilities
                 </DropdownMenuItem>
                 {/* Shells — mirrors the desktop rail's Shells tab: visible
                     when a real shell exists, or when the agent spec declares

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -21,6 +21,11 @@ vi.mock("./InlineTerminalsSection", () => ({
 vi.mock("./SubagentsPanel", () => ({
   SubagentsPanel: () => <div data-testid="subagents-stub" />,
 }));
+vi.mock("./CapabilitiesPanel", () => ({
+  CapabilitiesPanel: ({ conversationId }: { conversationId: string }) => (
+    <div data-testid="capabilities-stub" data-conversation-id={conversationId} />
+  ),
+}));
 vi.mock("./TodoPanel", () => ({
   TodoPanel: () => <div data-testid="todos-stub" />,
 }));
@@ -177,5 +182,19 @@ describe("WorkspacePanel content area", () => {
     // slot and the viewer is unmounted.
     expect(screen.getByTestId("files-panel-stub")).toBeInTheDocument();
     expect(screen.queryByTestId("file-viewer-stub")).toBeNull();
+  });
+
+  it("renders a Capabilities tab that mounts the CapabilitiesPanel for the active session", () => {
+    renderWorkspace({ rightRailTab: "capabilities", selectedFilePath: null });
+
+    // The tab is always present; selecting it mounts the panel keyed on the
+    // active conversation id (context-aware fetch).
+    expect(screen.getByRole("tab", { name: /Capabilities/i })).toBeInTheDocument();
+    expect(screen.getByTestId("capabilities-stub")).toHaveAttribute(
+      "data-conversation-id",
+      "conv_ws",
+    );
+    // The panel owns the content slot — the Files scope view must not also mount.
+    expect(screen.queryByTestId("files-panel-stub")).toBeNull();
   });
 });

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -1,10 +1,11 @@
-import { BotIcon, FileIcon, ListTodoIcon, TerminalIcon, XIcon } from "lucide-react";
+import { BlocksIcon, BotIcon, FileIcon, ListTodoIcon, TerminalIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { FilesPanel } from "./FilesPanel";
 import { FileViewer } from "./FileViewer";
 import type { ChangedSort } from "./FlatFileList";
+import { CapabilitiesPanel } from "./CapabilitiesPanel";
 import { InlineTerminalsSection } from "./InlineTerminalsSection";
 import { SubagentsPanel } from "./SubagentsPanel";
 import { TodoPanel } from "./TodoPanel";
@@ -342,6 +343,13 @@ export function WorkspacePanel({
                 {subagentsWorking > 0 ? `${subagentsWorking}/${agentCount}` : agentCount}
               </span>
             </TabsTrigger>
+            <TabsTrigger
+              value="capabilities"
+              className="h-[32px] gap-[6px] rounded-[8px] px-[12px] text-[13px] leading-5"
+            >
+              <BlocksIcon className="size-4" />
+              Capabilities
+            </TabsTrigger>
             {showShellsTab && (
               <TabsTrigger
                 value="terminals"
@@ -425,6 +433,8 @@ export function WorkspacePanel({
           />
         ) : rightRailTab === "subagents" && rootSessionId ? (
           <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
+        ) : rightRailTab === "capabilities" ? (
+          <CapabilitiesPanel conversationId={conversationId} />
         ) : rightRailTab === "todos" && isClaudeNative ? (
           <TodoPanel frameless />
         ) : rightRailTab === "terminals" && showShellsTab ? (

--- a/web/src/shell/railTabs.ts
+++ b/web/src/shell/railTabs.ts
@@ -9,7 +9,7 @@
  */
 
 /** The selectable tabs in the right workspace rail, in display order. */
-export type RightRailTab = "files" | "subagents" | "terminals" | "todos";
+export type RightRailTab = "files" | "subagents" | "capabilities" | "terminals" | "todos";
 
 /**
  * Count/status badge geometry shared across the rail tabs and the mobile


### PR DESCRIPTION
## Related issue

Closes #850

## Summary

Adds a read-only, **context-aware "Capabilities" side-panel tab** that answers "what can this agent actually do here, right now?" — because capabilities are per-agent/per-session and skills/MCP are runner-owned and discovered per session (the motivation in #850).

- **New tab** `Capabilities` alongside Files / Agents / Shells, grouped into **Skills**, **MCP servers** (expandable to their tools), **Local tools**, and **Sub-agents** (recursive). Each section is collapsible; the panel is read-only (no add/edit/remove).
- **Context-aware:** the panel follows the conversation in view — open a sub-agent and it shows *that* sub-agent's capabilities (each agent/sub-agent is its own session, resolved by `agent_id` + `sub_agent_name`).
- **Scope & policy awareness:** skills carry `source` (bundle / user / plugin / workspace / codex / cursor), `in_scope` (agent `skills_filter`), and `blocked` (a session `block_skills`/CEL policy would deny it). Local tools and MCP tools carry `blocked`. A single **top-level "Only show usable" toggle** (default on) filters the whole panel to what's actually usable; toggling off reveals out-of-scope / blocked items with badges. (Sub-agents have no name-based gating today, so they're always shown.)
- **New consolidated endpoint** `GET /v1/sessions/{id}/capabilities` (LEVEL_READ, GET-only) — spec-derived (local tools, MCP config, declared sub-agents) + merged skills (existing runner `/skills`) + per-server MCP tools via a bounded read-only `tools/list` round-trip. Kept **distinct** from and **complementary to** the existing read-only `GET /v1/sessions/{id}/skills` (which it does not change).

### TL;DR

The agent has skills, MCP tools, plain tools, and helper sub-agents — but today you can't see them in-session. This adds a tab that lists them, shows where each skill came from and whether it's actually usable (some are out-of-scope or blocked by a policy), and a switch to hide the ones the agent can't use.

### Skill source pills

Each skill shows a **source** pill indicating where it was discovered (skills are runner-owned and resolved from several roots, so provenance matters):

| Pill | Meaning |
| --- | --- |
| **bundle** | Shipped inside the agent's own bundle (`skills/`) — always in scope. |
| **user** | Your user-global skills — `~/.claude/skills` (or `~/.agents/skills`). |
| **plugin** | Provided by an installed Claude plugin (`~/.claude/plugins/**/skills`); shown namespaced as `<plugin>:<skill>`. |
| **workspace** | A `.claude/skills` / `.agents/skills` folder found by walking **up** from the session's working directory. |
| **codex** / **cursor** | Host skill directories belonging to those harnesses. |
| **unknown** | Source could not be classified (not expected in normal operation). |

### Scope toggle ("Only show usable")

A single top-level **"Only show usable"** switch (default **on**) controls what the panel lists:

| State | Shows |
| --- | --- |
| **On** (default) | Only capabilities the agent can actually use — in the agent's `skills_filter` scope **and** not denied by a `block_skills` / CEL policy. Section header counts reflect this usable set. |
| **Off** | Everything discovered, with the out-of-scope and policy-**blocked** items revealed and badged. |

Applies across Skills, Local tools, and MCP tools. (Sub-agents have no name-based gating today, so they're always shown.)

### Data flow

```
Capabilities tab (web, keyed on conversationId)
        │  GET /v1/sessions/{id}/capabilities   (read-only, LEVEL_READ)
        ▼
server route ── _load_agent_spec_for_session(conv) ─┬─ local_tools  (ToolManager(spec) schemas)
                                                     ├─ mcp_servers  (spec config) + tools (bounded runner tools/list)
                                                     ├─ sub_agents   (spec.sub_agents, recursive, depth-capped)
                                                     └─ skills       (runner /skills, merged) + source/in_scope/blocked
        │  blocked = name-based policy probe (block_skills/CEL), LLM-backed policies excluded (no LLM calls)
```

## Test Plan

- **Unit / component tests** across the stack: the capabilities endpoint (top-agent + sub-agent/child, LEVEL_READ, GET-only, graceful degrade when the runner is unavailable), skill `source`/`in_scope`/`blocked` computation (incl. a symlinked-home classification regression), the no-LLM `blocked` policy probe (asserts zero LLM calls even with a `tool_call` prompt/`intent_based_authorization` policy present), MCP per-server tools + status, sub-agent recursion depth cap, and the panel UI (context-awareness, collapsible sections, top-level toggle filtering, MCP tool expansion, badges).
- **Manual verification** in a local sandbox (server + host + web): the tab renders each agent's Skills/MCP/Local-tools/Sub-agents; skill `source` classifies correctly (e.g. `plugin`/`user`/`workspace`, no `unknown`); injecting a `block_skills` policy makes those skills `blocked=true` and the top-level toggle hides them (ON) / shows them with a "blocked" badge (OFF).
- Gates green: `ruff` + `pytest` (server routes / spec / policies), `tsc`, `vitest`, `oxlint`, web build. No DB migration.

## Demo


**1. Top-level "Only show usable" toggle filtering blocked skills** — with a session `block_skills` policy blocking `databricks-genie` + `databricks-jobs`: ON (default) hides them (header reads the usable count); OFF reveals them with a red **blocked** badge.

![Capabilities scope toggle](https://raw.githubusercontent.com/simtsc/omnigent/capabilities-demo-assets/capabilities-toggle-demo-v2.gif)

> **How demo 1's "blocked" state was set up (reproducible):** the two blocked skills aren't hardcoded or edited — a session-scoped `block_skills` policy was attached to the demo session via `POST /v1/sessions/{session_id}/policies`. The Capabilities endpoint's read-only probe then reports them `blocked`, and the toggle filters them. Payload:
>
> ```json
> {
>   "name": "block_databricks_skills",
>   "type": "python",
>   "handler": "omnigent.policies.builtins.safety.block_skills",
>   "factory_params": { "blocked": ["databricks-genie", "databricks-jobs"] }
> }
> ```

**2. Collapsing sections** — collapsing and expanding the four sections independently (counts stay visible in the collapsed header).

![Capabilities collapsing sections](https://raw.githubusercontent.com/simtsc/omnigent/capabilities-demo-assets/capabilities-collapse-demo-v2.gif)

**3. Context-awareness across agents** — opening a sub-agent navigates into its conversation and the panel follows, showing *that* agent's capabilities (different Skills / MCP / Local-tools / Sub-agents than the parent).

![Capabilities context-awareness](https://raw.githubusercontent.com/simtsc/omnigent/capabilities-demo-assets/capabilities-context-awareness-demo-v2.gif)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the end-to-end runtime path a unit test can't fully exercise: launching a real session, confirming the tab renders per-agent capabilities, that skill source classification works against real `~/.claude/skills` / plugin paths, and that a live-injected `block_skills` policy is reflected by the top-level "Only show usable" toggle (hidden when on, "blocked" badge when off). All new behavior also has unit/component coverage; the only intentionally-manual surface is the live runner round-trip for MCP tool discovery.

## Changelog

Add a read-only, context-aware Capabilities tab showing an agent's skills (with source + scope/blocked status), MCP servers and their tools, local tools, and sub-agents, with a top-level "Only show usable" filter.


