### PR TITLE
feat(hermes): add hermes-acp streaming harness (ACP transport)

### DIFF
--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -43,6 +43,8 @@ from dataclasses import dataclass
 
 from omnigent.harness_install_spec import HarnessInstallSpec
 
+HERMES_MIN_VERSION = "0.19.1"
+
 
 @dataclass(frozen=True)
 class AcpCliHarness:
@@ -54,11 +56,15 @@ class AcpCliHarness:
     :param args: Argv appended after the binary to start the CLI's ACP stdio
         server, e.g. ``("--acp",)`` or ``("agent", "stdio")``.
     :param aliases: Accepted alternate spellings, canonicalized to the row key.
+    :param policy_hook_authoritative: The agent runs the Omnigent tool policy
+        before its own ACP permission request. The client must answer that
+        secondary consent request without evaluating policy a second time.
     """
 
     install: HarnessInstallSpec
     args: tuple[str, ...]
     aliases: tuple[str, ...] = ()
+    policy_hook_authoritative: bool = False
 
     @property
     def label(self) -> str:
@@ -114,5 +120,25 @@ ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
         ),
         args=("agent", "stdio"),
         aliases=("grok-build",),
+    ),
+    # Hermes ACP is the maintained streaming interface. Keep it separate from
+    # the existing ``hermes`` batch harness so choosing one does not silently
+    # change the other's lifecycle.
+    "hermes-acp": AcpCliHarness(
+        install=HarnessInstallSpec(
+            "Hermes ACP",
+            "hermes",
+            None,
+            login_args=("model",),
+            install_hint="curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
+            install_command=(
+                "bash",
+                "-c",
+                "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
+            ),
+            min_version=HERMES_MIN_VERSION,
+        ),
+        args=("acp", "--accept-hooks"),
+        policy_hook_authoritative=True,
     ),
 }

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -303,17 +303,18 @@ def write_policy_hook_config(
     server_url: str,
     session_id: str,
     hermes_home: Path | None = None,
+    *,
+    model: str | None = None,
+    include_omnigent_mcp: bool = True,
 ) -> Path:
-    """Write per-session ``HERMES_HOME`` with Omnigent policy hook and MCP server.
+    """Write per-session ``HERMES_HOME`` with a policy hook and optional MCP server.
 
     Creates a ``config.yaml`` registering:
 
     1. A ``pre_tool_call`` shell hook that evaluates tool calls against the
        Omnigent policy engine (same hook the headless ``hermes`` harness uses).
-    2. An ``mcp_servers.omnigent`` entry that launches the Omnigent MCP stdio
-       server (``serve-mcp --bridge-dir <bridge_dir>``), exposing Omnigent
-       builtin tools (``sys_session_*``, ``sys_agent_*``, ``load_skill``,
-       ``web_fetch``, etc.) to the Hermes model.
+    2. When ``include_omnigent_mcp`` is true, an ``mcp_servers.omnigent`` entry
+       that launches the Omnigent MCP stdio server.
 
     Also copies the user's auth/env files so Hermes can still authenticate with
     its inference provider. Shared by the ``hermes-native`` TUI path and the
@@ -329,6 +330,11 @@ def write_policy_hook_config(
     :param session_id: Omnigent session / conversation ID.
     :param hermes_home: Where to write the credential-bearing home. ``None``
         places it under ``bridge_dir``.
+    :param model: Optional session model. When set, it overrides the user's
+        configured default in this generated home.
+    :param include_omnigent_mcp: Register the Omnigent MCP server in the
+        generated home. ACP callers set this to false because ``session/new``
+        owns MCP delivery.
     :returns: The HERMES_HOME path.
     """
     if hermes_home is None:
@@ -355,6 +361,8 @@ def write_policy_hook_config(
     # Merge user config so model/provider/auth settings carry over.
     user_cfg = _load_user_hermes_config()
     config: _ConfigObject = {**user_cfg}
+    if model is not None:
+        config["model"] = model
 
     config["hooks_auto_accept"] = True
     existing_hooks = config.get("hooks")
@@ -392,6 +400,10 @@ def write_policy_hook_config(
             ],
         },
     }
+    if not include_omnigent_mcp:
+        del config["mcp_servers"]["omnigent"]
+        if not config["mcp_servers"]:
+            del config["mcp_servers"]
 
     config_path = hermes_home / "config.yaml"
     config_path.write_text(json.dumps(config, indent=2) + "\n")

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -210,6 +210,9 @@ class AcpAgentConfig:
         plain user content and lets the agent's own system prompt take effect
         unmodified. When ``omnigent_mcp`` is ``False`` and the agent manages its
         own context, setting this to ``False`` is strongly recommended.
+    :param policy_hook_authoritative: The agent has already evaluated the
+        Omnigent tool policy before it asks for native ACP consent. Answer that
+        secondary request without policy evaluation or another approval card.
     """
 
     command: str
@@ -221,6 +224,7 @@ class AcpAgentConfig:
     env_passthrough: tuple[str, ...] = ()
     permission_mode: str = "auto"
     inject_system_prompt: bool = True
+    policy_hook_authoritative: bool = False
 
 
 class _AcpRequestError(Exception):
@@ -990,6 +994,12 @@ class AcpExecutor(Executor):
             :meth:`_permission_outcome` choose the narrowest grant.
         """
         tool_name, tool_input = self._extract_tool_call(params)
+        if self._config.policy_hook_authoritative:
+            logger.info(
+                "acp permission allowed after authoritative agent policy hook: tool=%s",
+                tool_name,
+            )
+            return True, None
         policy_eval = getattr(self, "_policy_evaluator", None)
         # Either bridge can carry the question to the user.
         can_ask = (

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -26,6 +26,8 @@ Env vars read at startup:
 - ``HARNESS_ACP_SEND_MODEL``: ``"1"`` to send the model in ``session/new``.
 - ``HARNESS_ACP_OMNIGENT_MCP``: ``"0"`` to disable Omnigent's MCP relay;
   ``session/new`` still receives an empty ``mcpServers`` array.
+- ``HARNESS_ACP_POLICY_HOOK_AUTHORITATIVE``: ``"1"`` when the agent runs the
+  Omnigent policy hook before its own ACP permission request.
 - ``HARNESS_ACP_OS_ENV``: JSON-encoded :class:`OSEnvSpec`. When unset, falls
   back to ``caller_process`` + ``sandbox=none``.
 - ``HARNESS_ACP_ENV_PASSTHROUGH``: comma-separated environment variable *names*
@@ -68,6 +70,7 @@ _ENV_SESSION_ID_MODE = "HARNESS_ACP_SESSION_ID_MODE"
 _ENV_SEND_MODEL = "HARNESS_ACP_SEND_MODEL"
 _ENV_OMNIGENT_MCP = "HARNESS_ACP_OMNIGENT_MCP"
 _ENV_INJECT_SYSTEM_PROMPT = "HARNESS_ACP_INJECT_SYSTEM_PROMPT"
+_ENV_POLICY_HOOK_AUTHORITATIVE = "HARNESS_ACP_POLICY_HOOK_AUTHORITATIVE"
 _ENV_CWD = "HARNESS_ACP_CWD"
 _ENV_OS_ENV = "HARNESS_ACP_OS_ENV"
 _ENV_ENV_PASSTHROUGH = "HARNESS_ACP_ENV_PASSTHROUGH"
@@ -157,6 +160,10 @@ def _build_acp_executor(extension: AcpExtension = NO_ACP_EXTENSION) -> Executor:
         env_passthrough=_env_passthrough_names(),
         permission_mode=permission_mode,
         inject_system_prompt=inject_system_prompt,
+        policy_hook_authoritative=_env_enabled(
+            _ENV_POLICY_HOOK_AUTHORITATIVE,
+            default=False,
+        ),
     )
     return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env(), extension=extension)
 

--- a/omnigent/inner/hermes_policy_hook.py
+++ b/omnigent/inner/hermes_policy_hook.py
@@ -36,23 +36,32 @@ import os
 import sys
 
 
+def _block(reason: str) -> None:
+    json.dump({"decision": "block", "reason": reason}, sys.stdout)
+
+
 def main() -> None:
     server_url = os.environ.get("_OMNIGENT_SERVER_URL", "")
     session_id = os.environ.get("_OMNIGENT_SESSION_ID", "")
 
     if not server_url or not session_id:
-        # No server wired -- fail open (allow).
-        json.dump({}, sys.stdout)
+        _block("Omnigent policy context is unavailable")
         return
 
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, EOFError, ValueError):
-        json.dump({}, sys.stdout)
+        _block("Malformed Hermes tool hook input")
+        return
+    if not isinstance(payload, dict):
+        _block("Malformed Hermes tool hook input")
         return
 
-    tool_name = payload.get("tool_name") or "unknown"
-    tool_input = payload.get("tool_input") or {}
+    tool_name = payload.get("tool_name")
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_name, str) or not tool_name or not isinstance(tool_input, dict):
+        _block("Malformed Hermes tool hook input")
+        return
 
     # Omnigent relay tools are already gated when the relay dispatches them back
     # through the server's tool path; gating them here too parks a duplicate approval
@@ -69,7 +78,7 @@ def main() -> None:
             "target": "",
             "data": {
                 "name": tool_name,
-                "arguments": tool_input if isinstance(tool_input, dict) else {},
+                "arguments": tool_input,
             },
             "context": {},
         },
@@ -107,8 +116,8 @@ def main() -> None:
             hook_label="hermes pre_tool_call",
             reauth=reauth,
         )
-    except Exception:  # noqa: BLE001 -- fail open on import / unexpected error
-        json.dump({}, sys.stdout)
+    except Exception:  # noqa: BLE001 -- the policy hook must fail closed
+        _block("Omnigent policy evaluation failed")
         return
 
     if resp is None:
@@ -134,9 +143,21 @@ def main() -> None:
             sys.stdout,
         )
         return
+    if not isinstance(result, dict):
+        _block("Malformed policy response")
+        return
 
-    action = result.get("result", "POLICY_ACTION_ALLOW")
+    action = result.get("result")
     reason = result.get("reason", "")
+
+    if not isinstance(action, str) or action not in {
+        "POLICY_ACTION_ALLOW",
+        "POLICY_ACTION_UNSPECIFIED",
+        "POLICY_ACTION_DENY",
+        "POLICY_ACTION_ASK",
+    }:
+        _block("Malformed policy response")
+        return
 
     if action == "POLICY_ACTION_DENY":
         out: dict[str, str] = {"decision": "block"}
@@ -157,7 +178,7 @@ def main() -> None:
             out["reason"] = f"Tool '{tool_name}' requires approval"
         json.dump(out, sys.stdout)
     else:
-        # ALLOW or UNSPECIFIED — empty JSON means no objection.
+        # ALLOW or UNSPECIFIED means no objection.
         json.dump({}, sys.stdout)
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10916,7 +10916,11 @@ def _build_spawn_env_from_spec(
             # Builtin ACP CLI harnesses (one catalog row each) share a single
             # builder; the row supplies the command, label, and install info.
             env = _build_acp_cli_spawn_env(
-                effective_spec, harness=harness, cwd=cwd, workdir=workdir
+                effective_spec,
+                harness=harness,
+                cwd=cwd,
+                workdir=workdir,
+                session_id=session_id,
             )
         else:
             builder_path = spawn_env_builders().get(harness)

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1515,21 +1515,24 @@ def _build_acp_cli_spawn_env(
     harness: str,
     cwd: Path | None = None,
     workdir: Path | None = None,
+    session_id: str | None = None,
 ) -> dict[str, str]:
     """Build the generic-ACP env for one builtin ACP CLI harness (catalog row).
 
     Rows in :data:`omnigent.acp_cli_harnesses.ACP_CLI_HARNESSES` all run the
     shared ``omnigent/inner/acp_harness.py`` wrap; this maps a row + spec to
-    the ``HARNESS_ACP_*`` vars it reads. Like goose/acp, a vendor ACP CLI owns
-    its own auth and model, so no provider/gateway credential and no model var
-    is wired. The binary resolves via the ``OMNIGENT_<NAME>_PATH`` env
-    override, then the config ``harness.<name>.command`` path, then PATH plus
-    the common global install dirs.
+    the ``HARNESS_ACP_*`` vars it reads. A vendor ACP CLI owns its own auth and
+    model unless its row prepares a vendor-native per-session configuration.
+    No provider or gateway credential is wired here. The binary resolves via
+    the ``OMNIGENT_<NAME>_PATH`` env override, then the config
+    ``harness.<name>.command`` path, then PATH plus the common global install
+    dirs.
 
     :param spec: The agent spec.
     :param harness: The catalog row key, e.g. ``"grok"``.
     :param workdir: Accepted for signature parity with the other builders; the
         ACP wrap consumes no bundle dir.
+    :param session_id: Session identifier used by rows with per-session state.
     :returns: A dict of ``HARNESS_ACP_*`` env-var overrides for the spawn.
     """
     from omnigent._platform import resolve_cli_binary
@@ -1554,7 +1557,66 @@ def _build_acp_cli_spawn_env(
     # back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_ACP_CWD.
     if cwd is not None:
         env["HARNESS_ACP_CWD"] = str(cwd)
-    os_env_payload = _serialize_os_env(spec.os_env)
+    child_os_env = spec.os_env
+    if harness == "hermes-acp":
+        server_url = os.environ.get("RUNNER_SERVER_URL", "").strip()
+        if not session_id or not server_url:
+            raise RuntimeError("hermes-acp requires a session id and RUNNER_SERVER_URL")
+        if spec.skills_filter != "all":
+            raise RuntimeError(
+                "hermes-acp does not support restrictive skills_filter; "
+                "use the default 'all' skill selection"
+            )
+
+        from omnigent.hermes_native_bridge import (
+            bridge_dir_for_session_id,
+            write_policy_hook_config,
+        )
+        from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+
+        bridge_dir = bridge_dir_for_session_id(session_id)
+        model = _resolve_spec_model(spec)
+        if model is not None and model.startswith(("databricks-", "databricks/")):
+            model = None
+        hermes_home = write_policy_hook_config(
+            bridge_dir,
+            server_url,
+            session_id,
+            model=model,
+            include_omnigent_mcp=False,
+        )
+        env["HERMES_HOME"] = str(hermes_home)
+        env["HERMES_ACP_SKIP_CONFIGURED_MCP"] = "1"
+        passthrough_names = ["HERMES_HOME", "HERMES_ACP_SKIP_CONFIGURED_MCP"]
+        managed_dir = os.environ.get("OMNIGENT_HERMES_MANAGED_DIR", "").strip()
+        if managed_dir:
+            env["HERMES_MANAGED_DIR"] = managed_dir
+            env["_OMNIGENT_SERVER_URL"] = server_url
+            env["_OMNIGENT_SESSION_ID"] = session_id
+            passthrough_names.extend(
+                [
+                    "HERMES_MANAGED_DIR",
+                    "_OMNIGENT_SERVER_URL",
+                    "_OMNIGENT_SESSION_ID",
+                ]
+            )
+
+        if child_os_env is None:
+            child_os_env = OSEnvSpec(sandbox=OSEnvSandboxSpec(type="none"))
+        sandbox = child_os_env.sandbox or OSEnvSandboxSpec()
+        passthrough = list(sandbox.env_passthrough or ())
+        for name in passthrough_names:
+            if name not in passthrough:
+                passthrough.append(name)
+        child_os_env = replace(
+            child_os_env,
+            sandbox=replace(sandbox, env_passthrough=passthrough),
+        )
+
+    if row.policy_hook_authoritative:
+        env["HARNESS_ACP_POLICY_HOOK_AUTHORITATIVE"] = "1"
+
+    os_env_payload = _serialize_os_env(child_os_env)
     if os_env_payload is not None:
         env["HARNESS_ACP_OS_ENV"] = os_env_payload
     # Permission stance for approval cards. Absent leaves the harness wrap on its

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1702,6 +1702,7 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         # ACP-family builtin, sorted by id, before the non-ACP harnesses.
         "Devin",
         "Grok Build",
+        "Hermes ACP",
         "Copilot",
         "Kiro",
         "Kimi Code",
@@ -1865,7 +1866,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1887,7 +1888,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1904,7 +1905,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["15", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2095,14 +2096,15 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
         ("5", "_manage_hermes_harness"),
         ("8", "_manage_qwen_harness"),
         ("9", "_manage_goose_harness"),
-        # 10-11 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
-        # every row after them shifted down by two when that block landed.
+        # 10-12 are the builtin ACP CLI rows (Devin, Grok Build, and Hermes ACP,
+        # sorted by id); every row after them shifted down by three.
         ("10", "_show_acp_cli_harness"),
         ("11", "_show_acp_cli_harness"),
-        ("12", "_manage_copilot_harness"),
-        ("13", "_manage_kiro_harness"),
-        ("14", "_manage_kimi_harness"),
-        ("16", "_add_acp_agent"),
+        ("12", "_show_acp_cli_harness"),
+        ("13", "_manage_copilot_harness"),
+        ("14", "_manage_kiro_harness"),
+        ("15", "_manage_kimi_harness"),
+        ("17", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(

--- a/tests/e2e/test_hermes_acp_e2e.py
+++ b/tests/e2e/test_hermes_acp_e2e.py
@@ -1,0 +1,67 @@
+"""Opt-in live check for the builtin Hermes ACP harness."""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+
+from omnigent.hermes_native_bridge import bridge_dir_for_session_id
+from omnigent.inner import acp_harness
+from omnigent.inner.executor import ExecutorError, TextChunk, TurnComplete
+from omnigent.runtime.workflow import _build_acp_cli_spawn_env
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("OMNIGENT_E2E_HERMES_ACP") != "1" or shutil.which("hermes") is None,
+    reason=(
+        "hermes ACP e2e is opt-in: set OMNIGENT_E2E_HERMES_ACP=1 with the "
+        "hermes binary and a configured provider"
+    ),
+)
+
+
+@pytest.mark.asyncio
+async def test_builtin_hermes_acp_streams_and_completes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The catalog builder and generic ACP wrapper complete one real turn."""
+    session_id = "e2e_hermes_acp"
+    bridge_dir = bridge_dir_for_session_id(session_id)
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:6767")
+    spec = AgentSpec(
+        spec_version=1,
+        name="hermes-acp-e2e",
+        instructions="Reply briefly.",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "hermes-acp"}),
+    )
+    wrapper_env = _build_acp_cli_spawn_env(
+        spec,
+        harness="hermes-acp",
+        session_id=session_id,
+    )
+    for name, value in wrapper_env.items():
+        monkeypatch.setenv(name, value)
+
+    executor = acp_harness._build_acp_executor()
+    chunks: list[str] = []
+    final: TurnComplete | None = None
+    try:
+        async for event in executor.run_turn(
+            [{"role": "user", "content": "Reply with exactly PONG."}],
+            tools=[],
+            system_prompt="Reply with exactly the requested word.",
+        ):
+            if isinstance(event, TextChunk):
+                chunks.append(event.text)
+            elif isinstance(event, TurnComplete):
+                final = event
+            elif isinstance(event, ExecutorError):
+                pytest.fail(f"executor error: {event.message}")
+    finally:
+        await executor.close()
+        shutil.rmtree(bridge_dir, ignore_errors=True)
+
+    assert final is not None
+    assert "PONG" in "".join(chunks) + (final.response or "")

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -733,6 +733,21 @@ async def test_decide_permission_card_names_the_tool() -> None:
     ex._elicitation_handler.assert_awaited_once_with("Ran command", {"command": "rm -rf build"})
 
 
+@pytest.mark.asyncio
+async def test_authoritative_policy_hook_prevents_second_policy_evaluation() -> None:
+    """A hook-governed agent's native consent request is not a second policy gate."""
+    ex = AcpExecutor(AcpAgentConfig(command="x", policy_hook_authoritative=True))
+    params = _seed_tool_call(ex)
+    ex._policy_evaluator = AsyncMock()
+    ex._elicitation_handler = AsyncMock()
+    ex._elicitation_choice_handler = AsyncMock()
+
+    assert await ex._decide_permission(params) == (True, None)
+    ex._policy_evaluator.assert_not_awaited()
+    ex._elicitation_handler.assert_not_awaited()
+    ex._elicitation_choice_handler.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Scoped approval: the agent's own permission options
 # ---------------------------------------------------------------------------
@@ -1304,6 +1319,18 @@ def test_harness_wrap_inject_system_prompt_defaults_to_true(
     ex = acp_harness._build_acp_executor()
     assert isinstance(ex, AcpExecutor)
     assert ex._config.inject_system_prompt is True
+
+
+def test_harness_wrap_reads_authoritative_policy_hook(monkeypatch: pytest.MonkeyPatch) -> None:
+    from omnigent.inner import acp_harness
+
+    monkeypatch.setenv("HARNESS_ACP_COMMAND", "hermes acp --accept-hooks")
+    monkeypatch.setenv("HARNESS_ACP_POLICY_HOOK_AUTHORITATIVE", "1")
+
+    ex = acp_harness._build_acp_executor()
+
+    assert isinstance(ex, AcpExecutor)
+    assert ex._config.policy_hook_authoritative is True
 
 
 def test_harness_wrap_reads_env_passthrough_names(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/inner/test_hermes_policy_hook.py
+++ b/tests/inner/test_hermes_policy_hook.py
@@ -22,28 +22,136 @@ def wired_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
 
 
-def _run(monkeypatch: pytest.MonkeyPatch, tool_name: str) -> tuple[dict, bool]:
-    """Run the hook with *tool_name*; return (stdout_json, server_was_called)."""
+_ALLOW_RESULT = {"result": "POLICY_ACTION_ALLOW"}
+
+
+def _invoke(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: object,
+    result: object = _ALLOW_RESULT,
+) -> tuple[dict, bool]:
+    """Run the hook; return its output and whether policy evaluation ran."""
     called = {"hit": False}
 
     def _spy(*_args, **_kwargs):
         called["hit"] = True
 
         class _R:
-            def json(self) -> dict:
-                return {"result": "POLICY_ACTION_ALLOW"}
+            def json(self) -> object:
+                return result
 
-        return _R()
+        return _R(), None
 
     monkeypatch.setattr("omnigent.native_policy_hook.post_evaluate_with_retry", _spy, raising=True)
     monkeypatch.setattr(
         "sys.stdin",
-        io.StringIO(json.dumps({"tool_name": tool_name, "tool_input": {}})),
+        io.StringIO(json.dumps(payload)),
     )
     out = io.StringIO()
     monkeypatch.setattr("sys.stdout", out)
     hermes_policy_hook.main()
     return json.loads(out.getvalue() or "{}"), called["hit"]
+
+
+def _run(monkeypatch: pytest.MonkeyPatch, tool_name: str) -> tuple[dict, bool]:
+    return _invoke(monkeypatch, {"tool_name": tool_name, "tool_input": {}})
+
+
+@pytest.mark.parametrize(
+    ("failure", "reason"),
+    [
+        ("missing_context", "Omnigent policy context is unavailable"),
+        ("malformed_input", "Malformed Hermes tool hook input"),
+        ("non_object_input", "Malformed Hermes tool hook input"),
+        ("evaluation_error", "Omnigent policy evaluation failed"),
+    ],
+)
+def test_authoritative_hook_failures_block(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+    reason: str,
+) -> None:
+    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "http://localhost:6767")
+    monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
+    payload = json.dumps({"tool_name": "terminal", "tool_input": {}})
+
+    if failure == "missing_context":
+        monkeypatch.delenv("_OMNIGENT_SESSION_ID")
+    elif failure == "malformed_input":
+        payload = "not json"
+    elif failure == "non_object_input":
+        payload = "[]"
+    else:
+
+        def _raise(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("private failure detail")
+
+        monkeypatch.setattr(
+            "omnigent.native_policy_hook.post_evaluate_with_retry",
+            _raise,
+        )
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    out = io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+
+    hermes_policy_hook.main()
+
+    assert json.loads(out.getvalue()) == {"decision": "block", "reason": reason}
+
+
+def test_non_object_policy_response_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+    wired_env: None,
+) -> None:
+    output, _called = _invoke(
+        monkeypatch,
+        {"tool_name": "terminal", "tool_input": {}},
+        [],
+    )
+    assert output == {
+        "decision": "block",
+        "reason": "Malformed policy response",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"tool_name": ["terminal"], "tool_input": {}},
+        {"tool_name": "", "tool_input": {}},
+        {"tool_name": "terminal"},
+        {"tool_name": "terminal", "tool_input": None},
+        {"tool_name": "terminal", "tool_input": []},
+    ],
+)
+def test_malformed_tool_fields_block(
+    monkeypatch: pytest.MonkeyPatch,
+    wired_env: None,
+    payload: dict[str, object],
+) -> None:
+    output, _called = _invoke(monkeypatch, payload)
+    assert output == {
+        "decision": "block",
+        "reason": "Malformed Hermes tool hook input",
+    }
+
+
+@pytest.mark.parametrize("result", [{}, {"result": "garbage"}, {"result": []}])
+def test_malformed_policy_action_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+    wired_env: None,
+    result: dict[str, object],
+) -> None:
+    output, _called = _invoke(
+        monkeypatch,
+        {"tool_name": "terminal", "tool_input": {}},
+        result,
+    )
+    assert output == {
+        "decision": "block",
+        "reason": "Malformed policy response",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_acp_cli_harnesses.py
+++ b/tests/test_acp_cli_harnesses.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES, AcpCliHarness
+from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES, HERMES_MIN_VERSION, AcpCliHarness
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_install_spec import HarnessInstallSpec
 from omnigent.harness_plugins import (
@@ -33,7 +33,7 @@ from omnigent.harness_plugins import (
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.onboarding.harness_install import ui_setup_steps
 from omnigent.runtime.workflow import _build_acp_cli_spawn_env
-from omnigent.spec.types import AgentSpec, ExecutorSpec
+from omnigent.spec.types import AgentSpec, ExecutorSpec, LLMConfig
 
 _FAKE_ROW = AcpCliHarness(
     install=HarnessInstallSpec(
@@ -53,6 +53,8 @@ def _spec(
     os_env: OSEnvSpec | None = None,
     *,
     permission_mode: str | None = None,
+    model: str | None = None,
+    skills_filter: str | list[str] = "all",
 ) -> AgentSpec:
     config: dict[str, object] = {"harness": harness}
     if permission_mode is not None:
@@ -61,7 +63,9 @@ def _spec(
         spec_version=1,
         name=f"test-{harness}",
         instructions="Test agent.",
-        executor=ExecutorSpec(type="omnigent", config=config),
+        executor=ExecutorSpec(type="omnigent", config=config, model=model),
+        llm=LLMConfig(model=model) if model is not None else None,
+        skills_filter=skills_filter,
         os_env=os_env,
     )
 
@@ -133,10 +137,213 @@ def test_runner_dispatch_routes_catalog_rows(monkeypatch: pytest.MonkeyPatch) ->
     assert shlex.split(env["HARNESS_ACP_COMMAND"])[-2:] == ["agent", "stdio"]
 
 
+def test_runner_dispatch_passes_session_context_to_hermes_acp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from omnigent.runner.app import _build_spawn_env_from_spec
+
+    bridge_dir = tmp_path / "bridge"
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://server.example")
+    monkeypatch.setattr(
+        "omnigent.hermes_native_bridge.bridge_dir_for_session_id",
+        lambda session_id: bridge_dir if session_id == "conv_runner" else None,
+    )
+    monkeypatch.setattr(
+        "omnigent.hermes_native_bridge.write_policy_hook_config",
+        lambda path, _server_url, _session_id, **_kwargs: path / "home",
+    )
+
+    env = _build_spawn_env_from_spec(
+        _spec("hermes-acp"),
+        "hermes-acp",
+        session_id="conv_runner",
+    )
+
+    assert env is not None
+    assert env["HERMES_HOME"] == str(bridge_dir / "home")
+
+
 def test_fake_row_login_command() -> None:
     assert _FAKE_ROW.login_command == "fakecli login --device"
     assert _FAKE_ROW.label == "Fake CLI"
     assert _FAKE_ROW.binary == "fakecli"
+
+
+def test_hermes_acp_is_a_catalog_row_without_replacing_batch_hermes() -> None:
+    row = ACP_CLI_HARNESSES["hermes-acp"]
+
+    assert row.args == ("acp", "--accept-hooks")
+    assert row.binary == "hermes"
+    assert HERMES_MIN_VERSION == "0.19.1"
+    assert row.install.min_version == HERMES_MIN_VERSION
+    assert row.policy_hook_authoritative is True
+    assert harness_modules()["hermes-acp"] == "omnigent.inner.acp_harness"
+    assert harness_modules()["hermes"] == "omnigent.inner.hermes_harness"
+
+
+def test_hermes_acp_spawn_env_prepares_policy_home_and_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[Path, str, str, str | None, bool]] = []
+    bridge_dir = tmp_path / "bridge"
+    hermes_home = bridge_dir / "hermes_home"
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://server.example")
+    monkeypatch.setenv("OMNIGENT_HERMES_MANAGED_DIR", "/etc/omnigent/hermes-managed")
+    monkeypatch.setattr(
+        "omnigent.hermes_native_bridge.bridge_dir_for_session_id",
+        lambda session_id: bridge_dir,
+    )
+
+    def _write_policy_hook_config(
+        path: Path,
+        server_url: str,
+        session_id: str,
+        *,
+        model: str | None = None,
+        include_omnigent_mcp: bool = True,
+    ) -> Path:
+        calls.append((path, server_url, session_id, model, include_omnigent_mcp))
+        return hermes_home
+
+    monkeypatch.setattr(
+        "omnigent.hermes_native_bridge.write_policy_hook_config",
+        _write_policy_hook_config,
+    )
+
+    env = _build_acp_cli_spawn_env(
+        _spec(
+            "hermes-acp",
+            os_env=OSEnvSpec(),
+            model="hermes-model",
+        ),
+        harness="hermes-acp",
+        session_id="conv_123",
+    )
+
+    assert calls == [(bridge_dir, "https://server.example", "conv_123", "hermes-model", False)]
+    assert env["HERMES_HOME"] == str(hermes_home)
+    assert env["HERMES_MANAGED_DIR"] == "/etc/omnigent/hermes-managed"
+    assert env["HERMES_ACP_SKIP_CONFIGURED_MCP"] == "1"
+    assert env["HARNESS_ACP_POLICY_HOOK_AUTHORITATIVE"] == "1"
+    assert "HARNESS_ACP_SESSION_NEW_EXTRAS" not in env
+    sandbox = json.loads(env["HARNESS_ACP_OS_ENV"])["sandbox"]
+    assert sandbox["type"] == OSEnvSandboxSpec().type
+    assert set(sandbox["env_passthrough"]) >= {
+        "HERMES_HOME",
+        "HERMES_MANAGED_DIR",
+        "HERMES_ACP_SKIP_CONFIGURED_MCP",
+        "_OMNIGENT_SERVER_URL",
+        "_OMNIGENT_SESSION_ID",
+    }
+
+
+def test_hermes_managed_dir_reaches_the_filtered_acp_child(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The managed wrapper carries the policy context into the ACP child."""
+    from omnigent.inner.acp_harness import _build_acp_executor
+
+    monkeypatch.setenv("OMNIGENT_HERMES_MANAGED_DIR", "/etc/omnigent/hermes-managed")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://server.example")
+    monkeypatch.setattr(
+        "omnigent.hermes_native_bridge.bridge_dir_for_session_id",
+        lambda _session_id: tmp_path / "bridge",
+    )
+    monkeypatch.setattr(
+        "omnigent.hermes_native_bridge.write_policy_hook_config",
+        lambda bridge_dir, _server_url, _session_id, **_kwargs: bridge_dir / "home",
+    )
+
+    wrapper_env = _build_acp_cli_spawn_env(
+        _spec("hermes-acp"),
+        harness="hermes-acp",
+        session_id="conv_managed",
+    )
+    for name, value in wrapper_env.items():
+        monkeypatch.setenv(name, value)
+
+    child_env = _build_acp_executor()._build_spawn_env()
+
+    assert child_env["_OMNIGENT_SERVER_URL"] == "https://server.example"
+    assert child_env["_OMNIGENT_SESSION_ID"] == "conv_managed"
+    assert child_env["HERMES_ACP_SKIP_CONFIGURED_MCP"] == "1"
+
+
+@pytest.mark.parametrize("model", ["databricks-hermes", "databricks/hermes"])
+def test_hermes_acp_does_not_write_gateway_model_into_vendor_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    model: str,
+) -> None:
+    captured: list[str | None] = []
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://server.example")
+    monkeypatch.setattr(
+        "omnigent.hermes_native_bridge.bridge_dir_for_session_id",
+        lambda _session_id: tmp_path / "bridge",
+    )
+
+    def _write(
+        bridge_dir: Path,
+        _server_url: str,
+        _session_id: str,
+        *,
+        model: str | None = None,
+        include_omnigent_mcp: bool = True,
+    ) -> Path:
+        assert include_omnigent_mcp is False
+        captured.append(model)
+        return bridge_dir / "home"
+
+    monkeypatch.setattr("omnigent.hermes_native_bridge.write_policy_hook_config", _write)
+
+    _build_acp_cli_spawn_env(
+        _spec("hermes-acp", model=model),
+        harness="hermes-acp",
+        session_id="conv_gateway_model",
+    )
+
+    assert captured == [None]
+
+
+@pytest.mark.parametrize("skills_filter", [["safe-skill"], []])
+def test_hermes_acp_rejects_restrictive_skill_filter_before_writing_home(
+    monkeypatch: pytest.MonkeyPatch,
+    skills_filter: list[str],
+) -> None:
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://server.example")
+    called = False
+
+    def _unexpected_write(*_args: object, **_kwargs: object) -> Path:
+        nonlocal called
+        called = True
+        return Path("/unused")
+
+    monkeypatch.setattr(
+        "omnigent.hermes_native_bridge.write_policy_hook_config",
+        _unexpected_write,
+    )
+
+    with pytest.raises(RuntimeError, match="does not support restrictive skills_filter"):
+        _build_acp_cli_spawn_env(
+            _spec("hermes-acp", skills_filter=skills_filter),
+            harness="hermes-acp",
+            session_id="conv_123",
+        )
+
+    assert called is False
+
+
+def test_hermes_acp_spawn_env_requires_session_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RUNNER_SERVER_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="session id and RUNNER_SERVER_URL"):
+        _build_acp_cli_spawn_env(_spec("hermes-acp"), harness="hermes-acp")
 
 
 # ---------------------------------------------------------------------------
@@ -188,10 +395,28 @@ def test_catalog_row_is_fully_registered(name: str) -> None:
 
 
 @pytest.mark.parametrize("name", sorted(ACP_CLI_HARNESSES))
-def test_catalog_row_spawn_env_builds(name: str) -> None:
+def test_catalog_row_spawn_env_builds(
+    name: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     """The shared builder produces a launchable command for every real row."""
     row = ACP_CLI_HARNESSES[name]
-    env = _build_acp_cli_spawn_env(_spec(name), harness=name)
+    if name == "hermes-acp":
+        monkeypatch.setenv("RUNNER_SERVER_URL", "https://server.example")
+        monkeypatch.setattr(
+            "omnigent.hermes_native_bridge.bridge_dir_for_session_id",
+            lambda _session_id: tmp_path / "bridge",
+        )
+        monkeypatch.setattr(
+            "omnigent.hermes_native_bridge.write_policy_hook_config",
+            lambda bridge_dir, _server_url, _session_id, **_kwargs: bridge_dir / "home",
+        )
+    env = _build_acp_cli_spawn_env(
+        _spec(name),
+        harness=name,
+        session_id="conv_catalog",
+    )
     argv = shlex.split(env["HARNESS_ACP_COMMAND"])
     assert argv[0], "argv[0] must resolve to a non-empty binary"
     if row.args:

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -323,6 +323,53 @@ def test_write_policy_hook_config_creates_expected_files(tmp_path) -> None:
     assert len(bridge_config["token"]) > 0
 
 
+def test_write_policy_hook_config_can_leave_mcp_to_acp_transport(tmp_path) -> None:
+    bridge_dir = tmp_path / "bridge"
+
+    hermes_home = b.write_policy_hook_config(
+        bridge_dir,
+        "http://localhost:6767",
+        "session-acp",
+        include_omnigent_mcp=False,
+    )
+
+    config = json.loads((hermes_home / "config.yaml").read_text())
+    assert "omnigent" not in config.get("mcp_servers", {})
+    assert config["hooks"]["pre_tool_call"]
+
+
+def test_acp_home_does_not_copy_user_configured_mcp(tmp_path, monkeypatch) -> None:
+    bridge_dir = tmp_path / "bridge"
+    user_hermes = tmp_path / ".hermes"
+    user_hermes.mkdir()
+
+    import yaml
+
+    (user_hermes / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "model": "user-default",
+                "mcp_servers": {
+                    "omnigent": {"command": "stale-omnigent-mcp"},
+                    "other": {"command": "other-mcp"},
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(b.Path, "home", staticmethod(lambda: tmp_path))
+
+    hermes_home = b.write_policy_hook_config(
+        bridge_dir,
+        "http://localhost:6767",
+        "session-acp-user-config",
+        include_omnigent_mcp=False,
+    )
+
+    config = json.loads((hermes_home / "config.yaml").read_text())
+    assert config["model"] == "user-default"
+    assert "mcp_servers" not in config
+
+
 def test_write_policy_hook_config_copies_user_files(tmp_path, monkeypatch) -> None:
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
@@ -357,6 +404,27 @@ def test_write_policy_hook_config_merges_user_model(tmp_path, monkeypatch) -> No
     assert config["model"] == "claude-sonnet-4-20250514"
     assert config["providers"] == {"anthropic": {}}
     assert config["hooks_auto_accept"] is True
+
+
+def test_write_policy_hook_config_overrides_user_model_for_session(tmp_path, monkeypatch) -> None:
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    user_hermes = tmp_path / ".hermes"
+    user_hermes.mkdir()
+
+    import yaml
+
+    (user_hermes / "config.yaml").write_text(yaml.dump({"model": "user-default"}))
+    monkeypatch.setattr(b.Path, "home", staticmethod(lambda: tmp_path))
+
+    hermes_home = b.write_policy_hook_config(
+        bridge_dir,
+        "http://localhost:6767",
+        "s3",
+        model="session-model",
+    )
+    config = json.loads((hermes_home / "config.yaml").read_text())
+    assert config["model"] == "session-model"
 
 
 def test_read_hermes_home_returns_path_when_exists(tmp_path) -> None:


### PR DESCRIPTION
## Related issue

Closes #2151

## Summary

The current `hermes` harness waits for a batch turn to finish. This adds a separate `hermes-acp`
harness that carries Hermes' ACP stream through the shared `AcpExecutor`, without changing what
`hermes` means.

```text
hermes acp --accept-hooks -> shared AcpExecutor -> Omnigent events
             |
             +-> per-session HERMES_HOME -> model and pre_tool_call hook
managed configured MCP          -> suppressed by Hermes 0.19.1 guard
session/new                     -> MCP servers through shared AcpExecutor
```

- Register Hermes as one declarative builtin ACP row. The shared executor owns transport, session
  lifecycle, streaming, and MCP delivery.
- Build the per-session `HERMES_HOME` through the existing Hermes bridge. It carries the selected
  vendor model and the existing Omnigent policy hook, but no configured MCP. Require Hermes 0.19.1
  and suppress managed configured MCP startup so the shared executor remains the sole owner of MCP
  delivery through `session/new`.
- Keep the hook authoritative for Hermes tool policy. Once it allows a call, the later Hermes ACP
  permission request continues without evaluating policy again or creating a second card.
- Reject restrictive skill selection because current Hermes ACP does not apply it. A requested
  restriction therefore cannot silently widen.
- Fail closed when the shared Hermes hook lacks policy context, receives malformed input or response,
  or cannot evaluate policy. This correction also applies to the existing batch and native Hermes modes
  that use the same hook.

Generic native-tool classification and dispatch correlation are provided by #2387 on `main`.

## Test Plan

- `pytest -q tests/test_acp_cli_harnesses.py tests/inner/test_acp_executor.py tests/inner/test_hermes_policy_hook.py tests/test_hermes_native_bridge.py tests/cli/test_configure_models.py`: `312 passed`.
- The opt-in `tests/e2e/test_hermes_acp_e2e.py` drives the catalog builder and generic ACP wrapper
  against a real configured Hermes CLI. It skipped because the live opt-in flag was absent.
- Ruff check and format check passed on all changed files.
- Targeted Pyrefly reported `0 errors`.
- Applicable changed-file pre-commit hooks passed.

## Demo

The surface remains the normal Omnigent streaming transcript and tool cards. These existing captures
show the Hermes ACP stream and the same cards after reload:

![Completed Hermes native and bridged turn](https://raw.githubusercontent.com/dosenr/omnigent/assets/hermes-acp-demo-v2/05-complete-dark-v2.png)

![The same tool cards after reload](https://raw.githubusercontent.com/dosenr/omnigent/assets/hermes-acp-demo-v2/06-complete-light-v2.png)

The restack changes the shared ACP integration point, not this rendered surface.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover catalog registration, the Hermes 0.19.1 minimum, per-session configuration,
user-config filtering, restrictive-skill rejection, managed environment filtering, MCP precedence, one
policy evaluation per Hermes tool call, and fail-closed hook boundaries. The opt-in E2E covers one real
streaming turn through the builtin row and shared executor.

Manual verification confirmed that the one-commit restack retains current ACP prompt injection,
permission scopes, permission mode, extension handling, and #2387 correlation behavior.

## Changelog

Hermes sessions can use the shared streaming ACP harness without replacing the existing batch harness.
