### PR TITLE
feat(agents): add folder upload and public GitHub repo as agent sources

### DIFF
--- a/omnigent/server/github_bundle.py
+++ b/omnigent/server/github_bundle.py
@@ -1,0 +1,287 @@
+"""Fetch a public GitHub repo and repackage it into an agent bundle.
+
+The server fetches a repo's codeload tarball, strips GitHub's
+``<repo>-<sha>/`` top directory (and an optional subdir), filters editor /
+VCS junk, and re-tars into the canonical bundle shape (``config.yaml`` at the
+tar root) that :func:`omnigent.server.bundles.validate_agent_bundle` expects.
+
+Structure safety is layered: the fetched archive is extracted through
+:func:`omnigent.spec.tar_utils.extract_safe` (path-traversal, symlink,
+decompression-bomb, entry-cap, type-allowlist guards), and the resulting
+bundle is validated again by the caller via ``validate_agent_bundle``. On top
+of those, we cap the *download* size before extraction, since ``extract_safe``
+only sees the buffer once it is fully in memory.
+
+Public repos only: no token is sent, so ``${VAR}`` references stay literal
+(the server never expands tenant uploads) — the repo must hold no resolved
+secrets.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+import httpx
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.spec.tar_utils import (
+    DEFAULT_MAX_BYTES,
+    ExtractionError,
+    extract_safe,
+)
+
+# Path segments / basenames considered editor or VCS junk, dropped during
+# repackage so a checked-in ``.git`` tree or ``node_modules`` can't trip the
+# entry-count / size caps or add noise. Mirrors the client junk filter in
+# ``web/src/lib/agentBundle.ts``.
+_IGNORED_SEGMENTS = frozenset({".git", "node_modules", ".venv", "__pycache__", ".idea", ".vscode"})
+_IGNORED_BASENAMES = frozenset({".DS_Store"})
+
+# Cap the codeload download before extraction. Matches ``extract_safe``'s
+# uncompressed ceiling; a gzip'd repo will always be smaller, so this is a
+# conservative pre-extraction guard rather than an exact bound.
+_MAX_DOWNLOAD_BYTES = DEFAULT_MAX_BYTES
+
+_FETCH_TIMEOUT_SECONDS = 30.0
+
+# owner/repo path segments allow letters, digits, hyphen, underscore, dot.
+_SEGMENT = r"[A-Za-z0-9_.-]+"
+
+
+@dataclass(frozen=True)
+class GithubSource:
+    """A resolved GitHub bundle source."""
+
+    owner: str
+    repo: str
+    #: Tag, branch, or commit SHA. ``None`` means the repo default branch.
+    ref: str | None
+    #: Optional path within the repo where the bundle root lives.
+    subdir: str | None
+
+    @property
+    def codeload_url(self) -> str:
+        """The codeload tarball URL for this source's ref.
+
+        When ``ref`` is ``None`` we target ``HEAD`` so codeload resolves the
+        repo's default branch without an extra API round-trip.
+        """
+        ref = self.ref or "HEAD"
+        return f"https://codeload.github.com/{self.owner}/{self.repo}/tar.gz/{ref}"
+
+
+def parse_github_source(
+    source_url: str,
+    *,
+    ref: str | None = None,
+    subdir: str | None = None,
+) -> GithubSource:
+    """Resolve a user-supplied repo reference into a :class:`GithubSource`.
+
+    Accepts three shapes:
+
+    - ``https://github.com/<owner>/<repo>`` (optionally ``.git`` / trailing
+      slash), with ``ref`` / ``subdir`` supplied as arguments.
+    - ``https://github.com/<owner>/<repo>/tree/<ref>/<subdir...>`` — ``ref``
+      and ``subdir`` parsed from the URL.
+    - ``<owner>/<repo>@<ref>`` shorthand.
+
+    Explicit ``ref`` / ``subdir`` arguments override anything parsed from a
+    ``/tree/`` URL.
+
+    :raises OmnigentError: ``invalid_input`` when the reference can't be parsed
+        into an ``owner/repo``.
+    """
+    url = source_url.strip()
+    if not url:
+        raise OmnigentError("GitHub source URL is required", code=ErrorCode.INVALID_INPUT)
+
+    parsed_ref: str | None = None
+    parsed_subdir: str | None = None
+
+    # github.com URLs first (scheme optional); a /tree/<ref>/<subdir> URL is
+    # more specific than the plain repo URL, so it is matched first. The bare
+    # ``<owner>/<repo>`` shorthand is last so a scheme-less ``github.com/a/b``
+    # can't be mis-parsed as owner=github.com.
+    host = r"(?:https?://)?github\.com/"
+    tree = re.fullmatch(
+        rf"{host}({_SEGMENT})/({_SEGMENT})/tree/([^/]+)(?:/(.+?))?/?",
+        url,
+    )
+    plain = re.fullmatch(rf"{host}({_SEGMENT})/({_SEGMENT}?)(?:\.git)?/?", url)
+    shorthand = re.fullmatch(rf"({_SEGMENT})/({_SEGMENT})(?:@(.+))?", url)
+    if tree:
+        owner, repo, parsed_ref, parsed_subdir = tree.groups()
+    elif plain:
+        owner, repo = plain.groups()
+    elif shorthand:
+        owner, repo, parsed_ref = shorthand.groups()
+    else:
+        raise OmnigentError(
+            "unrecognized GitHub repo URL; expected github.com/<owner>/<repo>, "
+            "a /tree/<ref>/<subdir> URL, or <owner>/<repo>@<ref>",
+            code=ErrorCode.INVALID_INPUT,
+        )
+
+    repo = _strip_git_suffix(repo)
+    if not owner or not repo:
+        raise OmnigentError(
+            "GitHub URL must include both an owner and a repo",
+            code=ErrorCode.INVALID_INPUT,
+        )
+
+    final_ref = ref if ref is not None else parsed_ref
+    final_subdir = subdir if subdir is not None else parsed_subdir
+    return GithubSource(
+        owner=owner,
+        repo=repo,
+        ref=_clean(final_ref),
+        subdir=_normalize_subdir(final_subdir),
+    )
+
+
+def fetch_github_bundle(source: GithubSource) -> bytes:
+    """Fetch and repackage a public GitHub repo into canonical bundle bytes.
+
+    :returns: A gzipped tarball with ``config.yaml`` (or a single top-level
+        YAML) at the root, ready for ``validate_agent_bundle``.
+    :raises OmnigentError: ``invalid_input`` for a missing/private repo (404),
+        an oversize download, a non-tarball response, or a bundle whose subdir
+        is empty; ``internal_error`` for network/transport failures.
+    """
+    raw = _download(source.codeload_url)
+    return _repackage(raw, subdir=source.subdir)
+
+
+# ── Internal helpers ─────────────────────────────────────────────────
+
+
+def _download(url: str) -> bytes:
+    """Stream a codeload tarball, enforcing the download-size cap.
+
+    :raises OmnigentError: ``invalid_input`` on a 4xx (e.g. 404 for a
+        missing/private repo) or when the response exceeds the size cap;
+        ``internal_error`` on transport failure.
+    """
+    buffer = io.BytesIO()
+    total = 0
+    try:
+        with (
+            httpx.Client(follow_redirects=True, timeout=_FETCH_TIMEOUT_SECONDS) as client,
+            client.stream("GET", url) as response,
+        ):
+            if response.status_code == 404:
+                raise OmnigentError(
+                    "GitHub repo or ref not found (is the repo public?)",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            if response.status_code >= 400:
+                raise OmnigentError(
+                    f"failed to fetch GitHub repo: HTTP {response.status_code}",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            for chunk in response.iter_bytes():
+                total += len(chunk)
+                if total > _MAX_DOWNLOAD_BYTES:
+                    raise OmnigentError(
+                        f"GitHub repo exceeds the maximum bundle size "
+                        f"({_MAX_DOWNLOAD_BYTES} bytes)",
+                        code=ErrorCode.INVALID_INPUT,
+                    )
+                buffer.write(chunk)
+    except httpx.HTTPError as exc:
+        raise OmnigentError(
+            f"failed to fetch GitHub repo: {exc}",
+            code=ErrorCode.INTERNAL_ERROR,
+        ) from exc
+    return buffer.getvalue()
+
+
+def _repackage(raw_tar_gz: bytes, *, subdir: str | None) -> bytes:
+    """Extract a codeload tarball and re-tar into canonical bundle bytes.
+
+    Strips GitHub's ``<repo>-<sha>/`` top directory and the optional *subdir*,
+    drops junk, and writes a fresh gzipped tar with the bundle root at the top.
+
+    :raises OmnigentError: ``invalid_input`` when the archive is invalid, the
+        subdir is empty, or nothing survives filtering.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        dest = Path(tmp) / "repo"
+        try:
+            extract_safe(raw_tar_gz, dest)
+        except ExtractionError as exc:
+            raise OmnigentError(
+                f"invalid GitHub repo archive: {exc}",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
+
+        # codeload wraps everything in a single ``<repo>-<sha>/`` directory.
+        top_dirs = [p for p in dest.iterdir() if p.is_dir()]
+        root = top_dirs[0] if len(top_dirs) == 1 else dest
+        if subdir:
+            root = root / subdir
+            if not root.is_dir():
+                raise OmnigentError(
+                    f"subdir not found in GitHub repo: {subdir!r}",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+
+        buffer = io.BytesIO()
+        entry_count = 0
+        with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+            for path in sorted(root.rglob("*")):
+                if not path.is_file():
+                    continue
+                arcname = path.relative_to(root).as_posix()
+                if _is_ignored(arcname):
+                    continue
+                tar.add(path, arcname=arcname)
+                entry_count += 1
+
+        if entry_count == 0:
+            raise OmnigentError(
+                "GitHub repo (or subdir) contains no bundle files",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        return buffer.getvalue()
+
+
+def _is_ignored(arcname: str) -> bool:
+    """Whether a bundle-relative path is editor/VCS junk to skip."""
+    parts = PurePosixPath(arcname).parts
+    if not parts:
+        return True
+    if parts[-1] in _IGNORED_BASENAMES:
+        return True
+    return any(seg in _IGNORED_SEGMENTS for seg in parts)
+
+
+def _strip_git_suffix(repo: str) -> str:
+    return repo[:-4] if repo.endswith(".git") else repo
+
+
+def _clean(value: str | None) -> str | None:
+    if value is None:
+        return None
+    trimmed = value.strip().strip("/")
+    return trimmed or None
+
+
+def _normalize_subdir(value: str | None) -> str | None:
+    """Trim and validate an optional subdir; reject traversal/absolute paths."""
+    subdir = _clean(value)
+    if subdir is None:
+        return None
+    parts = PurePosixPath(subdir).parts
+    if PurePosixPath(subdir).is_absolute() or ".." in parts:
+        raise OmnigentError(
+            f"invalid subdir (no absolute paths or '..'): {subdir!r}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return subdir

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -157,6 +157,7 @@ from omnigent.server.auth import (
     local_single_user_enabled,
 )
 from omnigent.server.bundles import bundle_location, validate_agent_bundle
+from omnigent.server.github_bundle import fetch_github_bundle, parse_github_source
 from omnigent.server.host_registry import HostConnection, HostRegistry, RunnerExitReports
 from omnigent.server.managed_hosts import (
     ManagedHostLaunch,
@@ -14225,6 +14226,93 @@ def create_sessions_router(
                 resp.host_id = launch_host_id
 
         return resp
+
+    # ── POST /sessions/from-github ───────────────────────────────
+    #
+    # MUST be registered before ``GET /sessions/{session_id}`` for the
+    # same reason as ``/sessions/projects`` — literal paths first.
+
+    @router.post(
+        "/sessions/from-github",
+        status_code=201,
+        response_model=None,
+        dependencies=[Depends(require_trusted_origin)],
+    )
+    async def create_session_from_github(
+        request: Request,
+    ) -> CreatedSessionResponse:
+        """
+        Create a session from a public GitHub repo.
+
+        The request body is JSON: ``source_url`` (plus optional ``ref`` /
+        ``subdir``) and a nested ``metadata`` object matching the multipart
+        create's metadata part. The server fetches the repo's codeload
+        tarball, repackages it into the canonical bundle, and runs it through
+        the exact same validation + session-scoped agent creation as an
+        upload. ``${VAR}`` references are never expanded — the repo must hold
+        no resolved secrets.
+
+        :param request: FastAPI request carrying the JSON body.
+        :returns: :class:`CreatedSessionResponse` with the new session id.
+        :raises HTTPException: 422 for a malformed body.
+        :raises OmnigentError: ``invalid_input`` for a bad URL, missing/private
+            repo, oversize download, or a bundle that fails structure
+            validation.
+        """
+        user_id = _require_user(request, auth_provider)
+        if artifact_store is None:
+            raise OmnigentError(
+                "artifact store is not configured",
+                code=ErrorCode.INTERNAL_ERROR,
+            )
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=[
+                    {
+                        "type": "json_invalid",
+                        "loc": ["body"],
+                        "msg": "Invalid JSON",
+                        "input": None,
+                    },
+                ],
+            ) from exc
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=422, detail="expected a JSON object body")
+        source_url = payload.get("source_url")
+        if not isinstance(source_url, str) or not source_url.strip():
+            raise HTTPException(status_code=422, detail="source_url is required")
+        ref = payload.get("ref")
+        subdir = payload.get("subdir")
+
+        # Reuse the multipart metadata validation path: re-serialize the
+        # nested object so there is a single SessionCreateMetadata parser.
+        parsed_metadata = _parse_session_create_metadata(json.dumps(payload.get("metadata") or {}))
+        _reject_reserved_cost_control_label_seed(parsed_metadata.labels)
+
+        source = parse_github_source(
+            source_url,
+            ref=ref if isinstance(ref, str) else None,
+            subdir=subdir if isinstance(subdir, str) else None,
+        )
+        bundle_bytes = await asyncio.to_thread(fetch_github_bundle, source)
+        result = await asyncio.to_thread(
+            _create_session_from_bundle,
+            conversation_store,
+            artifact_store,
+            parsed_metadata,
+            bundle_bytes,
+            None,
+        )
+        if permission_store is not None and user_id is not None:
+            await asyncio.to_thread(permission_store.ensure_user, user_id)
+            await asyncio.to_thread(
+                permission_store.grant, user_id, result.session_id, LEVEL_OWNER
+            )
+        _announce_session_added(user_id, result.session_id)
+        return result
 
     async def _create_bundled_session_from_multipart(
         request: Request,

--- a/tests/server/integration/test_sessions_from_github.py
+++ b/tests/server/integration/test_sessions_from_github.py
@@ -1,0 +1,80 @@
+"""
+Integration tests for ``POST /v1/sessions/from-github``.
+
+The route fetches a public repo's codeload tarball (mocked here with
+``respx``), repackages it, and creates a session-scoped agent through the
+same path as a multipart upload. These tests assert the happy path (201 +
+session_id) and that a fetch failure surfaces as a 4xx rather than a 500.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import httpx
+import pytest
+import respx
+
+pytestmark = pytest.mark.asyncio
+
+_CONFIG = (
+    "spec_version: 1\n"
+    "name: gh-agent\n"
+    "llm:\n"
+    "  model: gh-agent\n"
+    "  api_key: sk-test\n"
+    "executor:\n"
+    "  type: omnigent\n"
+    "  model: gh-agent\n"
+    "  config:\n"
+    "    harness: claude-sdk\n"
+)
+
+
+def _codeload(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content in files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+@respx.mock
+async def test_from_github_creates_session(client: httpx.AsyncClient) -> None:
+    raw = _codeload(
+        {
+            "acme-bot-sha/config.yaml": _CONFIG,
+            "acme-bot-sha/.git/HEAD": "junk",
+        }
+    )
+    respx.get("https://codeload.github.com/acme/bot/tar.gz/HEAD").mock(
+        return_value=httpx.Response(200, content=raw)
+    )
+    resp = await client.post(
+        "/v1/sessions/from-github",
+        json={"source_url": "https://github.com/acme/bot", "metadata": {}},
+    )
+    assert resp.status_code == 201, resp.text
+    assert "session_id" in resp.json()
+
+
+@respx.mock
+async def test_from_github_missing_repo_is_client_error(client: httpx.AsyncClient) -> None:
+    respx.get("https://codeload.github.com/acme/missing/tar.gz/HEAD").mock(
+        return_value=httpx.Response(404)
+    )
+    resp = await client.post(
+        "/v1/sessions/from-github",
+        json={"source_url": "acme/missing", "metadata": {}},
+    )
+    assert resp.status_code < 500, resp.text
+    assert resp.status_code >= 400
+
+
+async def test_from_github_requires_source_url(client: httpx.AsyncClient) -> None:
+    resp = await client.post("/v1/sessions/from-github", json={"metadata": {}})
+    assert resp.status_code == 422, resp.text

--- a/tests/server/test_github_bundle.py
+++ b/tests/server/test_github_bundle.py
@@ -1,0 +1,170 @@
+"""
+Tests for public-GitHub agent-source fetching
+(``omnigent/server/github_bundle.py``).
+
+Covers URL resolution (three accepted shapes + bad input), tarball
+repackaging (GitHub root-strip, optional subdir, junk filtering), the
+download-size guard, and the missing/private-repo 404 path. The repackaged
+bytes are asserted to pass the same ``validate_agent_bundle`` a hand-upload
+goes through, since structure parity is the whole point of the feature.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import httpx
+import pytest
+import respx
+
+from omnigent.errors import OmnigentError
+from omnigent.server.bundles import validate_agent_bundle
+from omnigent.server.github_bundle import (
+    fetch_github_bundle,
+    parse_github_source,
+)
+
+# Minimal valid omnigent config.yaml (directory shape).
+_CONFIG = (
+    "spec_version: 1\n"
+    "name: gh-agent\n"
+    "executor:\n"
+    "  type: omnigent\n"
+    "  model: claude-sonnet-4-20250514\n"
+    "  config:\n"
+    "    harness: claude\n"
+)
+
+
+def _make_codeload(files: dict[str, str]) -> bytes:
+    """Build a codeload-style ``.tar.gz`` from ``{archive_path: content}``."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content in files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _entry_names(bundle: bytes) -> list[str]:
+    with tarfile.open(fileobj=io.BytesIO(bundle), mode="r:*") as tf:
+        return sorted(tf.getnames())
+
+
+# ── URL parsing ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("url", "owner", "repo", "ref", "subdir"),
+    [
+        ("github.com/acme/bot", "acme", "bot", None, None),
+        ("https://github.com/acme/bot", "acme", "bot", None, None),
+        ("https://github.com/acme/bot.git", "acme", "bot", None, None),
+        ("https://github.com/acme/bot/", "acme", "bot", None, None),
+        ("acme/bot@v1.2.0", "acme", "bot", "v1.2.0", None),
+        (
+            "https://github.com/acme/bot/tree/main/agents/foo",
+            "acme",
+            "bot",
+            "main",
+            "agents/foo",
+        ),
+        ("https://github.com/acme/bot/tree/v1.0", "acme", "bot", "v1.0", None),
+    ],
+)
+def test_parse_github_source_shapes(url, owner, repo, ref, subdir):
+    src = parse_github_source(url)
+    assert (src.owner, src.repo, src.ref, src.subdir) == (owner, repo, ref, subdir)
+
+
+def test_parse_github_source_arg_overrides_url():
+    src = parse_github_source("acme/bot", ref="abc123", subdir="sub")
+    assert src.ref == "abc123"
+    assert src.subdir == "sub"
+    assert src.codeload_url == "https://codeload.github.com/acme/bot/tar.gz/abc123"
+
+
+def test_parse_github_source_defaults_to_head():
+    assert parse_github_source("acme/bot").codeload_url.endswith("/tar.gz/HEAD")
+
+
+@pytest.mark.parametrize("bad", ["", "not a url", "acme/bot with space", "acme"])
+def test_parse_github_source_rejects_bad_input(bad):
+    with pytest.raises(OmnigentError):
+        parse_github_source(bad)
+
+
+def test_parse_github_source_rejects_subdir_traversal():
+    with pytest.raises(OmnigentError):
+        parse_github_source("acme/bot", subdir="../evil")
+
+
+# ── Repackage (via fetch_github_bundle + respx) ──────────────────────
+
+
+@respx.mock
+def test_fetch_repackages_and_strips_root_and_junk():
+    raw = _make_codeload(
+        {
+            "acme-bot-sha/config.yaml": _CONFIG,
+            "acme-bot-sha/AGENTS.md": "hello",
+            "acme-bot-sha/.git/HEAD": "ref: refs/heads/main",
+            "acme-bot-sha/node_modules/x/y.js": "junk",
+            "acme-bot-sha/.DS_Store": "junk",
+        }
+    )
+    src = parse_github_source("acme/bot")
+    respx.get(src.codeload_url).mock(return_value=httpx.Response(200, content=raw))
+
+    bundle = fetch_github_bundle(src)
+    assert _entry_names(bundle) == ["AGENTS.md", "config.yaml"]
+    # Structure parity: the repackaged bytes validate exactly like an upload.
+    assert validate_agent_bundle(bundle, enforce_handler_allowlist=True).name == "gh-agent"
+
+
+@respx.mock
+def test_fetch_honors_subdir():
+    raw = _make_codeload(
+        {
+            "acme-bot-sha/agents/foo/config.yaml": _CONFIG,
+            "acme-bot-sha/agents/foo/AGENTS.md": "x",
+            "acme-bot-sha/README.md": "excluded by subdir",
+        }
+    )
+    src = parse_github_source("https://github.com/acme/bot/tree/main/agents/foo")
+    respx.get(src.codeload_url).mock(return_value=httpx.Response(200, content=raw))
+
+    bundle = fetch_github_bundle(src)
+    assert _entry_names(bundle) == ["AGENTS.md", "config.yaml"]
+
+
+@respx.mock
+def test_fetch_missing_subdir_errors():
+    raw = _make_codeload({"acme-bot-sha/config.yaml": _CONFIG})
+    src = parse_github_source("acme/bot", subdir="nope")
+    respx.get(src.codeload_url).mock(return_value=httpx.Response(200, content=raw))
+    with pytest.raises(OmnigentError, match="subdir not found"):
+        fetch_github_bundle(src)
+
+
+@respx.mock
+def test_fetch_404_is_invalid_input():
+    src = parse_github_source("acme/missing")
+    respx.get(src.codeload_url).mock(return_value=httpx.Response(404))
+    with pytest.raises(OmnigentError, match="not found"):
+        fetch_github_bundle(src)
+
+
+@respx.mock
+def test_fetch_rejects_oversize_download(monkeypatch):
+    # Shrink the cap so a tiny fixture trips it deterministically.
+    monkeypatch.setattr("omnigent.server.github_bundle._MAX_DOWNLOAD_BYTES", 16, raising=True)
+    raw = _make_codeload({"acme-bot-sha/config.yaml": _CONFIG})
+    assert len(raw) > 16
+    src = parse_github_source("acme/bot")
+    respx.get(src.codeload_url).mock(return_value=httpx.Response(200, content=raw))
+    with pytest.raises(OmnigentError, match="maximum bundle size"):
+        fetch_github_bundle(src)

--- a/web/src/lib/agentBundle.test.ts
+++ b/web/src/lib/agentBundle.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, it } from "vitest";
 // We mock CompressionStream and verify the config.yaml content
 // that gets fed to the tar/gzip pipeline.
 
-import type { AgentBundleInput } from "./agentBundle";
+import type { AgentBundleInput, BundleFile } from "./agentBundle";
 
 // Capture what buildAgentBundle passes to `new File(...)` by
 // mocking CompressionStream (not in jsdom) to be a passthrough.
@@ -40,8 +40,33 @@ class PassthroughStream {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).CompressionStream = PassthroughStream;
 
-// Now import the function (it will use our mock CompressionStream).
-const { buildAgentBundle } = await import("./agentBundle");
+// Now import the functions (they will use our mock CompressionStream).
+const { buildAgentBundle, buildBundleFromFiles, stripCommonPrefix, pendingAgentDisplay } =
+  await import("./agentBundle");
+
+/** Decode a null-padded tar header field to its leading text. */
+function tarField(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes).split("\u0000")[0];
+}
+
+/** List every tar entry name (walks the 512-byte header chain). */
+async function tarEntryNames(file: File): Promise<string[]> {
+  const tar = new Uint8Array(await file.arrayBuffer());
+  const names: string[] = [];
+  let offset = 0;
+  while (offset + 512 <= tar.length) {
+    const name = tarField(tar.slice(offset, offset + 100));
+    if (name === "") break; // end-of-archive zero block
+    const size = parseInt(tarField(tar.slice(offset + 124, offset + 135)), 8);
+    names.push(name);
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+  return names;
+}
+
+function bf(path: string, content = "x"): BundleFile {
+  return { path, bytes: new TextEncoder().encode(content) };
+}
 
 /** Extract the config.yaml from the raw tar bytes inside the File. */
 async function extractConfigYaml(file: File): Promise<string> {
@@ -196,5 +221,89 @@ describe("buildAgentBundle", () => {
     const yaml = await extractConfigYaml(await buildAgentBundle(input));
     expect(yaml).toContain("harness: openai-agents");
     expect(yaml).toContain("model: gpt-4o");
+  });
+});
+
+describe("stripCommonPrefix", () => {
+  it("removes a shared top-level directory", () => {
+    const out = stripCommonPrefix([bf("my-agent/config.yaml"), bf("my-agent/AGENTS.md")]);
+    expect(out.map((f) => f.path)).toEqual(["config.yaml", "AGENTS.md"]);
+  });
+
+  it("leaves paths unchanged when there is no common directory", () => {
+    const out = stripCommonPrefix([bf("config.yaml"), bf("AGENTS.md")]);
+    expect(out.map((f) => f.path)).toEqual(["config.yaml", "AGENTS.md"]);
+  });
+
+  it("does not strip when only a filename shares the segment", () => {
+    // A single top-level file must not be treated as a directory prefix.
+    const out = stripCommonPrefix([bf("config.yaml")]);
+    expect(out.map((f) => f.path)).toEqual(["config.yaml"]);
+  });
+});
+
+describe("buildBundleFromFiles", () => {
+  it("strips the common prefix and drops junk", async () => {
+    const file = await buildBundleFromFiles([
+      bf("my-agent/config.yaml", "spec_version: 1\nname: x"),
+      bf("my-agent/AGENTS.md"),
+      bf("my-agent/.git/HEAD"),
+      bf("my-agent/node_modules/pkg/index.js"),
+      bf("my-agent/.DS_Store"),
+    ]);
+    const names = await tarEntryNames(file);
+    expect(names.sort()).toEqual(["AGENTS.md", "config.yaml"]);
+  });
+
+  it("accepts a single top-level YAML (no config.yaml)", async () => {
+    const file = await buildBundleFromFiles([bf("agent.yaml", "spec_version: 1\nname: x")]);
+    expect(await tarEntryNames(file)).toEqual(["agent.yaml"]);
+  });
+
+  it("throws when no top-level YAML exists", async () => {
+    await expect(buildBundleFromFiles([bf("my-agent/AGENTS.md")])).rejects.toThrow(/config\.yaml/);
+  });
+
+  it("throws when multiple top-level YAMLs exist", async () => {
+    await expect(buildBundleFromFiles([bf("a.yaml"), bf("b.yaml")])).rejects.toThrow(
+      /top-level YAML/,
+    );
+  });
+
+  it("rejects path traversal", async () => {
+    await expect(buildBundleFromFiles([bf("config.yaml"), bf("../escape.txt")])).rejects.toThrow(
+      /Unsafe file path/,
+    );
+  });
+
+  it("rejects an empty selection", async () => {
+    await expect(buildBundleFromFiles([bf(".DS_Store")])).rejects.toThrow(/No files/);
+  });
+});
+
+describe("pendingAgentDisplay", () => {
+  it("reads form fields", () => {
+    expect(
+      pendingAgentDisplay({
+        kind: "form",
+        input: { name: "f", description: "d", harness: "claude-sdk", model: "m" },
+      }),
+    ).toEqual({ name: "f", description: "d", harness: "claude-sdk" });
+  });
+
+  it("reads bundle fields", () => {
+    const bundle = new File([new Uint8Array()], "agent.tar.gz");
+    expect(pendingAgentDisplay({ kind: "bundle", bundle, name: "b" })).toEqual({
+      name: "b",
+      description: undefined,
+      harness: null,
+    });
+  });
+
+  it("reads github fields", () => {
+    expect(pendingAgentDisplay({ kind: "github", sourceUrl: "acme/bot", name: "bot" })).toEqual({
+      name: "bot",
+      harness: null,
+    });
   });
 });

--- a/web/src/lib/agentBundle.ts
+++ b/web/src/lib/agentBundle.ts
@@ -36,6 +36,65 @@ export interface AgentBundleInput {
 }
 
 /**
+ * A pending custom agent, produced by one of the CreateAgentDialog tabs and
+ * held by NewChatDialog until submit.
+ *
+ * - "form": the classic field form → built into a bundle at submit via
+ *   {@link buildAgentBundle}.
+ * - "bundle": an already-built `.tar.gz` (folder pick, single file, tarball)
+ *   passed straight through to the multipart upload.
+ * - "github": a public repo reference resolved + repackaged server-side via
+ *   `POST /v1/sessions/from-github` (no client-built bundle).
+ */
+export type PendingAgentSource =
+  | { kind: "form"; input: AgentBundleInput }
+  | {
+      kind: "bundle";
+      bundle: File;
+      name: string;
+      description?: string;
+      harness?: string | null;
+    }
+  | {
+      kind: "github";
+      sourceUrl: string;
+      ref?: string;
+      subdir?: string;
+      /** Display name for the picker (the server reads the real name). */
+      name: string;
+    };
+
+/** Display fields for a pending agent, regardless of source variant. */
+export function pendingAgentDisplay(source: PendingAgentSource): {
+  name: string;
+  description?: string;
+  harness: string | null;
+} {
+  if (source.kind === "form") {
+    return {
+      name: source.input.name,
+      description: source.input.description,
+      harness: source.input.harness ?? null,
+    };
+  }
+  if (source.kind === "github") {
+    return { name: source.name, harness: null };
+  }
+  return {
+    name: source.name,
+    description: source.description,
+    harness: source.harness ?? null,
+  };
+}
+
+/** A single file destined for a bundle, keyed by its bundle-relative path. */
+export interface BundleFile {
+  /** Path within the bundle, e.g. "my-agent/tools/mcp/github.yaml". */
+  path: string;
+  bytes: Uint8Array;
+}
+
+/**
  * Build a `.tar.gz` agent bundle from the given input fields.
  *
  * Uses the pako library (already a transitive dep via codemirror) for
@@ -111,6 +170,103 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
   return new File([gzipped.buffer as ArrayBuffer], "agent.tar.gz", {
     type: "application/gzip",
   });
+}
+
+/** Path segments that mark editor/tooling junk we never want in a bundle. */
+const IGNORED_SEGMENTS = [".git", "node_modules", ".venv", "__pycache__", ".idea", ".vscode"];
+/** Basenames dropped regardless of location. */
+const IGNORED_BASENAMES = [".DS_Store"];
+
+/** Client-side ceilings mirroring the server's extract_safe guards. */
+const MAX_BUNDLE_ENTRIES = 10_000;
+const MAX_BUNDLE_BYTES = 500 * 1024 * 1024;
+
+/**
+ * Build a `.tar.gz` agent bundle from a set of files (a picked folder, a
+ * fetched repo, or a single YAML wrapped as one entry).
+ *
+ * Strips the common top-level directory so `config.yaml` lands at the tar
+ * root, filters editor/VCS junk, and validates the bundle structure and size
+ * client-side so obvious problems surface here instead of as a server 400.
+ *
+ * Throws an Error with a user-facing message on any validation failure.
+ */
+export async function buildBundleFromFiles(files: BundleFile[]): Promise<File> {
+  const kept = files.filter((f) => !isIgnoredPath(f.path));
+  if (kept.length === 0) {
+    throw new Error("No files found in the selection.");
+  }
+
+  const stripped = stripCommonPrefix(kept);
+
+  // Path safety (defense-in-depth; webkitRelativePath is normally relative).
+  for (const f of stripped) {
+    const parts = f.path.split("/");
+    if (f.path.startsWith("/") || parts.includes("..")) {
+      throw new Error(`Unsafe file path in bundle: ${f.path}`);
+    }
+  }
+
+  // Structure: a root config.yaml, or exactly one top-level *.yaml / *.yml.
+  const topLevelYaml = stripped.filter((f) => !f.path.includes("/") && /\.ya?ml$/i.test(f.path));
+  const hasConfig = stripped.some((f) => f.path === "config.yaml");
+  if (!hasConfig && topLevelYaml.length !== 1) {
+    if (topLevelYaml.length === 0) {
+      throw new Error(
+        "Bundle must contain a config.yaml (or a single top-level YAML file) at its root.",
+      );
+    }
+    throw new Error(
+      `Bundle has ${topLevelYaml.length} top-level YAML files; expected exactly one (or a config.yaml).`,
+    );
+  }
+
+  // Ceilings mirroring the server.
+  if (stripped.length > MAX_BUNDLE_ENTRIES) {
+    throw new Error(
+      `Bundle has ${stripped.length} files, which exceeds the ${MAX_BUNDLE_ENTRIES} limit.`,
+    );
+  }
+  const totalBytes = stripped.reduce((sum, f) => sum + f.bytes.length, 0);
+  if (totalBytes > MAX_BUNDLE_BYTES) {
+    throw new Error("Bundle exceeds the 500 MB size limit.");
+  }
+
+  const entries: TarEntry[] = stripped.map((f) => ({
+    name: f.path,
+    content: f.bytes,
+  }));
+  const tarBytes = createTar(entries);
+  const gzipped = await gzip(tarBytes);
+  return new File([gzipped.buffer as ArrayBuffer], "agent.tar.gz", {
+    type: "application/gzip",
+  });
+}
+
+/** True if a bundle-relative path is editor/VCS junk to be skipped. */
+function isIgnoredPath(path: string): boolean {
+  const parts = path.split("/");
+  if (IGNORED_BASENAMES.includes(parts[parts.length - 1])) return true;
+  return parts.some((seg) => IGNORED_SEGMENTS.includes(seg));
+}
+
+/**
+ * Remove the shared leading directory segment from every path (folder picks
+ * and GitHub subdirs produce `my-agent/…`). Returns paths unchanged when there
+ * is no common top-level directory.
+ */
+export function stripCommonPrefix(files: BundleFile[]): BundleFile[] {
+  if (files.length === 0) return files;
+  const firstSegs = files.map((f) => f.path.split("/")[0]);
+  const common = firstSegs[0];
+  // Only strip when every path shares the same first segment AND that segment
+  // is a directory prefix (i.e. every path has something after it).
+  const allShared =
+    common !== undefined &&
+    firstSegs.every((s) => s === common) &&
+    files.every((f) => f.path.length > common.length + 1);
+  if (!allShared) return files;
+  return files.map((f) => ({ ...f, path: f.path.slice(common.length + 1) }));
 }
 
 // ── Helpers ──────────────────────────────────────────────────────

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -475,6 +475,47 @@ export async function createBundledSession(
 }
 
 /**
+ * Create a session from a public GitHub repo via
+ * POST /v1/sessions/from-github.
+ *
+ * The server fetches the repo's codeload tarball, repackages it into the
+ * canonical agent bundle (stripping GitHub's `repo-<sha>/` top dir and any
+ * subdir), and runs it through the same validation as a multipart upload.
+ * `${VAR}` references are never expanded server-side, so the repo must keep
+ * them literal and hold no resolved secrets.
+ *
+ * @param source - The repo URL plus optional ref (tag/branch/commit) and
+ *   subdir within the repo where the bundle root lives.
+ * @param metadata - Session-level metadata (workspace, etc.), same shape as
+ *   {@link createBundledSession}.
+ * @returns The created session's id.
+ */
+export async function createSessionFromGithub(
+  source: { source_url: string; ref?: string; subdir?: string },
+  metadata: Parameters<typeof createBundledSession>[1] = {},
+): Promise<{ id: string }> {
+  const res = await authenticatedFetch("/v1/sessions/from-github", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...source, metadata }),
+  });
+  if (!res.ok) {
+    // Surface the server's failure detail (bad URL, 404, oversize, invalid
+    // bundle structure) so the dialog can show it inline.
+    let detail = `${res.status} ${res.statusText}`;
+    try {
+      const err = (await res.json()) as { detail?: string };
+      if (typeof err.detail === "string" && err.detail) detail = err.detail;
+    } catch {
+      // Non-JSON body — keep the status-line fallback.
+    }
+    throw new Error(detail);
+  }
+  const body = (await res.json()) as { session_id: string };
+  return { id: body.session_id };
+}
+
+/**
  * Fork (clone) a session into a new one via
  * POST /v1/sessions/{source_id}/fork.
  *

--- a/web/src/shell/CreateAgentDialog.test.tsx
+++ b/web/src/shell/CreateAgentDialog.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import type { PendingAgentSource } from "@/lib/agentBundle";
+
+// jsdom lacks CompressionStream (used by the bundle builder for the File /
+// Folder tabs). Install a passthrough so the tar bytes flow uncompressed.
+class PassthroughStream {
+  readable: ReadableStream;
+  writable: WritableStream;
+  constructor() {
+    let controller: ReadableStreamDefaultController;
+    this.readable = new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    this.writable = new WritableStream({
+      write(chunk) {
+        controller.enqueue(new Uint8Array(chunk));
+      },
+      close() {
+        controller.close();
+      },
+    });
+  }
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).CompressionStream = PassthroughStream;
+
+const { CreateAgentDialog } = await import("./CreateAgentDialog");
+
+afterEach(cleanup);
+
+function renderDialog() {
+  const onCreate = vi.fn<(source: PendingAgentSource) => void>();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CreateAgentDialog open onOpenChange={() => {}} onCreate={onCreate} />
+    </QueryClientProvider>,
+  );
+  return onCreate;
+}
+
+/** Radix Tabs activates a trigger on mousedown (not click), so fire both. */
+function switchTab(testId: string) {
+  const trigger = screen.getByTestId(testId);
+  fireEvent.mouseDown(trigger);
+  fireEvent.click(trigger);
+}
+
+/** Build a File with a webkitRelativePath (folder-pick shape). */
+function fileWithPath(path: string, content: string): File {
+  const file = new File([content], path.split("/").pop() ?? path, { type: "text/yaml" });
+  Object.defineProperty(file, "webkitRelativePath", { value: path });
+  return file;
+}
+
+describe("CreateAgentDialog tabs", () => {
+  it("Form tab emits a { kind: 'form' } source", () => {
+    const onCreate = renderDialog();
+    fireEvent.change(screen.getByTestId("create-agent-name"), {
+      target: { value: "my-agent" },
+    });
+    fireEvent.change(screen.getByTestId("create-agent-model"), {
+      target: { value: "claude-sonnet-4-20250514" },
+    });
+    fireEvent.click(screen.getByTestId("create-agent-submit"));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    const source = onCreate.mock.calls[0][0];
+    expect(source.kind).toBe("form");
+    if (source.kind === "form") {
+      expect(source.input.name).toBe("my-agent");
+      expect(source.input.model).toBe("claude-sonnet-4-20250514");
+    }
+  });
+
+  it("GitHub tab emits a { kind: 'github' } source with ref + subdir", () => {
+    const onCreate = renderDialog();
+    switchTab("create-agent-tab-github");
+    fireEvent.change(screen.getByTestId("create-agent-github-url"), {
+      target: { value: "https://github.com/acme/bot" },
+    });
+    fireEvent.change(screen.getByTestId("create-agent-github-ref"), {
+      target: { value: "v1.0.0" },
+    });
+    fireEvent.change(screen.getByTestId("create-agent-github-subdir"), {
+      target: { value: "agents/foo" },
+    });
+    fireEvent.click(screen.getByTestId("create-agent-github-submit"));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    const source = onCreate.mock.calls[0][0];
+    expect(source).toMatchObject({
+      kind: "github",
+      sourceUrl: "https://github.com/acme/bot",
+      ref: "v1.0.0",
+      subdir: "agents/foo",
+    });
+  });
+
+  it("Folder tab builds a bundle File from picked files", async () => {
+    const onCreate = renderDialog();
+    switchTab("create-agent-tab-folder");
+    const input = screen.getByTestId("create-agent-folder-input") as HTMLInputElement;
+    const files = [
+      fileWithPath("my-agent/config.yaml", "spec_version: 1\nname: x"),
+      fileWithPath("my-agent/AGENTS.md", "hello"),
+    ];
+    fireEvent.change(input, { target: { files } });
+    await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(1));
+    const source = onCreate.mock.calls[0][0];
+    expect(source.kind).toBe("bundle");
+    if (source.kind === "bundle") {
+      expect(source.bundle).toBeInstanceOf(File);
+      expect(source.bundle.name).toBe("agent.tar.gz");
+    }
+  });
+
+  it("Folder tab surfaces a validation error and does not emit", async () => {
+    const onCreate = renderDialog();
+    switchTab("create-agent-tab-folder");
+    const input = screen.getByTestId("create-agent-folder-input") as HTMLInputElement;
+    // No top-level YAML → buildBundleFromFiles throws.
+    fireEvent.change(input, {
+      target: { files: [fileWithPath("my-agent/AGENTS.md", "hi")] },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("create-agent-upload-error")).toBeInTheDocument(),
+    );
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/shell/CreateAgentDialog.tsx
+++ b/web/src/shell/CreateAgentDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { PlusIcon, TrashIcon } from "lucide-react";
 import {
   Dialog,
@@ -17,8 +17,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BRAIN_HARNESS_LABELS, useBrainHarnessLabels } from "@/lib/agentLabels";
-import type { AgentBundleInput, MCPServerInput } from "@/lib/agentBundle";
+import {
+  buildBundleFromFiles,
+  type BundleFile,
+  type MCPServerInput,
+  type PendingAgentSource,
+} from "@/lib/agentBundle";
 
 /**
  * Harness options for the picker. "default" uses the server's default
@@ -102,13 +108,28 @@ function toMCPInputs(entries: MCPFormEntry[]): MCPServerInput[] | undefined {
   return result.length > 0 ? result : undefined;
 }
 
+/** Derive a display name from a bundle path or filename. */
+function bundleDisplayName(path: string): string {
+  const base = path.split("/")[0] || path;
+  return base.replace(/\.(tar\.gz|ya?ml)$/i, "") || "custom-agent";
+}
+
+/** Derive a display name from a GitHub URL / shorthand (the "repo" segment). */
+function githubDisplayName(url: string): string {
+  const cleaned = url.replace(/^https?:\/\/github\.com\//i, "").replace(/\.git$/i, "");
+  const match = cleaned.match(/^[^/]+\/([^/@]+)/);
+  return match?.[1] ?? "github-agent";
+}
+
 /**
  * Dialog for creating a custom agent from the new-session picker.
  *
- * Collects a name, optional description, optional system instructions,
- * a harness choice, and zero or more MCP server declarations. On submit,
- * passes the agent configuration back to the parent via `onCreate` so it
- * can build a bundle and start a session with it.
+ * Four sources (tabs): a field Form, a File upload (single YAML or a
+ * pre-built `.tar.gz`), a Folder upload (a whole bundle directory), and a
+ * public GitHub repo URL. Each produces a {@link PendingAgentSource} passed
+ * back via `onCreate`; the parent builds/uploads the bundle and starts a
+ * session. Browser uploads keep `${VAR}` references literal (no env), so
+ * secrets must never be committed to a folder or public repo.
  */
 export function CreateAgentDialog({
   open,
@@ -117,13 +138,14 @@ export function CreateAgentDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCreate: (input: AgentBundleInput) => void;
+  onCreate: (source: PendingAgentSource) => void;
 }) {
   const brainHarnessLabels = useBrainHarnessLabels();
   const harnessOptions = Object.entries(brainHarnessLabels).map(([value, label]) => ({
     value,
     label,
   }));
+  const [tab, setTab] = useState<"form" | "file" | "folder" | "github">("form");
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [instructions, setInstructions] = useState("");
@@ -132,7 +154,17 @@ export function CreateAgentDialog({
   const [mcpEntries, setMcpEntries] = useState<MCPFormEntry[]>([]);
   const [nextKey, setNextKey] = useState(0);
 
+  // Non-form tab state.
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [githubUrl, setGithubUrl] = useState("");
+  const [githubRef, setGithubRef] = useState("");
+  const [githubSubdir, setGithubSubdir] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+
   function reset() {
+    setTab("form");
     setName("");
     setDescription("");
     setInstructions("");
@@ -140,6 +172,11 @@ export function CreateAgentDialog({
     setModel("");
     setMcpEntries([]);
     setNextKey(0);
+    setUploadError(null);
+    setBusy(false);
+    setGithubUrl("");
+    setGithubRef("");
+    setGithubSubdir("");
   }
 
   function handleOpenChange(next: boolean) {
@@ -160,23 +197,71 @@ export function CreateAgentDialog({
     setMcpEntries((prev) => prev.map((e) => (e.key === key ? { ...e, ...patch } : e)));
   }
 
-  function handleSubmit() {
-    const trimmedName = name.trim();
-    if (!trimmedName) return;
-
-    onCreate({
-      name: trimmedName,
-      description: description.trim() || undefined,
-      instructions: instructions.trim() || undefined,
-      harness,
-      model: model.trim(),
-      mcpServers: toMCPInputs(mcpEntries),
-    });
+  /** Emit a source and close the dialog. */
+  function emit(source: PendingAgentSource) {
+    onCreate(source);
     reset();
     onOpenChange(false);
   }
 
+  function handleSubmit() {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    emit({
+      kind: "form",
+      input: {
+        name: trimmedName,
+        description: description.trim() || undefined,
+        instructions: instructions.trim() || undefined,
+        harness,
+        model: model.trim(),
+        mcpServers: toMCPInputs(mcpEntries),
+      },
+    });
+  }
+
+  /** Read selected files (single YAML, folder, or tarball) into a bundle. */
+  async function handleFiles(files: FileList | null, kind: "file" | "folder") {
+    setUploadError(null);
+    if (!files || files.length === 0) return;
+    setBusy(true);
+    try {
+      // A single .tar.gz is already a bundle — pass it straight through.
+      if (kind === "file" && files.length === 1 && /\.tar\.gz$/i.test(files[0].name)) {
+        emit({ kind: "bundle", bundle: files[0], name: bundleDisplayName(files[0].name) });
+        return;
+      }
+      const bundleFiles: BundleFile[] = await Promise.all(
+        Array.from(files).map(async (file) => ({
+          // Folder pick carries webkitRelativePath (e.g. "my-agent/config.yaml");
+          // a single file has none, so fall back to its name.
+          path: file.webkitRelativePath || file.name,
+          bytes: new Uint8Array(await file.arrayBuffer()),
+        })),
+      );
+      const bundle = await buildBundleFromFiles(bundleFiles);
+      emit({ kind: "bundle", bundle, name: bundleDisplayName(bundleFiles[0]?.path ?? "agent") });
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function handleGithubSubmit() {
+    const url = githubUrl.trim();
+    if (!url) return;
+    emit({
+      kind: "github",
+      sourceUrl: url,
+      ref: githubRef.trim() || undefined,
+      subdir: githubSubdir.trim() || undefined,
+      name: githubDisplayName(url),
+    });
+  }
+
   const canSubmit = name.trim().length > 0 && model.trim().length > 0;
+  const canSubmitGithub = githubUrl.trim().length > 0 && !busy;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -188,133 +273,293 @@ export function CreateAgentDialog({
           <DialogTitle>Create custom agent</DialogTitle>
         </DialogHeader>
 
-        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
-          {/* Name */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="create-agent-name"
-              className="text-xs font-medium text-muted-foreground"
-            >
-              Name <span className="text-destructive">*</span>
-            </label>
-            <Input
-              id="create-agent-name"
-              data-testid="create-agent-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="my-agent"
-              autoFocus
-            />
-          </div>
+        <Tabs
+          value={tab}
+          onValueChange={(v) => {
+            setUploadError(null);
+            setTab(v as typeof tab);
+          }}
+          className="flex min-h-0 flex-1 flex-col gap-4"
+        >
+          <TabsList className="w-full" data-testid="create-agent-tabs">
+            <TabsTrigger value="form" data-testid="create-agent-tab-form">
+              Form
+            </TabsTrigger>
+            <TabsTrigger value="file" data-testid="create-agent-tab-file">
+              File
+            </TabsTrigger>
+            <TabsTrigger value="folder" data-testid="create-agent-tab-folder">
+              Folder
+            </TabsTrigger>
+            <TabsTrigger value="github" data-testid="create-agent-tab-github">
+              GitHub
+            </TabsTrigger>
+          </TabsList>
 
-          {/* Description */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="create-agent-description"
-              className="text-xs font-medium text-muted-foreground"
-            >
-              Description
-            </label>
-            <Input
-              id="create-agent-description"
-              data-testid="create-agent-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="A short summary of what this agent does"
-            />
-          </div>
-
-          {/* Harness */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium text-muted-foreground">
-              Harness <span className="text-destructive">*</span>
-            </label>
-            <Select value={harness} onValueChange={setHarness}>
-              <SelectTrigger data-testid="create-agent-harness" className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {harnessOptions.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Model */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="create-agent-model"
-              className="text-xs font-medium text-muted-foreground"
-            >
-              Model <span className="text-destructive">*</span>
-            </label>
-            <Input
-              id="create-agent-model"
-              data-testid="create-agent-model"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              placeholder="claude-sonnet-4-20250514"
-            />
-          </div>
-
-          {/* Instructions / System Prompt */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="create-agent-instructions"
-              className="text-xs font-medium text-muted-foreground"
-            >
-              System instructions
-            </label>
-            <Textarea
-              id="create-agent-instructions"
-              data-testid="create-agent-instructions"
-              value={instructions}
-              onChange={(e) => setInstructions(e.target.value)}
-              placeholder="You are a helpful assistant that..."
-              className="min-h-[120px]"
-            />
-          </div>
-
-          {/* MCP Servers */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-muted-foreground">MCP Tools</span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={addMCPServer}
-                data-testid="create-agent-add-mcp"
-                className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+          <TabsContent value="form" className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+            {/* Name */}
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="create-agent-name"
+                className="text-xs font-medium text-muted-foreground"
               >
-                <PlusIcon className="size-3" />
-                Add server
-              </Button>
-            </div>
-            {mcpEntries.map((entry) => (
-              <MCPServerRow
-                key={entry.key}
-                entry={entry}
-                onChange={(patch) => updateMCPEntry(entry.key, patch)}
-                onRemove={() => removeMCPServer(entry.key)}
+                Name <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="create-agent-name"
+                data-testid="create-agent-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="my-agent"
+                autoFocus
               />
-            ))}
-          </div>
-        </div>
+            </div>
+
+            {/* Description */}
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="create-agent-description"
+                className="text-xs font-medium text-muted-foreground"
+              >
+                Description
+              </label>
+              <Input
+                id="create-agent-description"
+                data-testid="create-agent-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="A short summary of what this agent does"
+              />
+            </div>
+
+            {/* Harness */}
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-muted-foreground">
+                Harness <span className="text-destructive">*</span>
+              </label>
+              <Select value={harness} onValueChange={setHarness}>
+                <SelectTrigger data-testid="create-agent-harness" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {harnessOptions.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Model */}
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="create-agent-model"
+                className="text-xs font-medium text-muted-foreground"
+              >
+                Model <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="create-agent-model"
+                data-testid="create-agent-model"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                placeholder="claude-sonnet-4-20250514"
+              />
+            </div>
+
+            {/* Instructions / System Prompt */}
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="create-agent-instructions"
+                className="text-xs font-medium text-muted-foreground"
+              >
+                System instructions
+              </label>
+              <Textarea
+                id="create-agent-instructions"
+                data-testid="create-agent-instructions"
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                placeholder="You are a helpful assistant that..."
+                className="min-h-[120px]"
+              />
+            </div>
+
+            {/* MCP Servers */}
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-muted-foreground">MCP Tools</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={addMCPServer}
+                  data-testid="create-agent-add-mcp"
+                  className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+                >
+                  <PlusIcon className="size-3" />
+                  Add server
+                </Button>
+              </div>
+              {mcpEntries.map((entry) => (
+                <MCPServerRow
+                  key={entry.key}
+                  entry={entry}
+                  onChange={(patch) => updateMCPEntry(entry.key, patch)}
+                  onRemove={() => removeMCPServer(entry.key)}
+                />
+              ))}
+            </div>
+          </TabsContent>
+
+          {/* File tab — a single YAML or a pre-built .tar.gz bundle. */}
+          <TabsContent value="file" className="flex flex-col gap-3">
+            <p className="text-13 text-muted-foreground">
+              Upload a single <code>config.yaml</code> / <code>agent.yaml</code>, or a pre-built{" "}
+              <code>.tar.gz</code> bundle.
+            </p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".yaml,.yml,.tar.gz"
+              className="hidden"
+              data-testid="create-agent-file-input"
+              onChange={(e) => void handleFiles(e.target.files, "file")}
+            />
+            <Button
+              variant="outline"
+              disabled={busy}
+              onClick={() => fileInputRef.current?.click()}
+              data-testid="create-agent-file-pick"
+            >
+              Choose file…
+            </Button>
+            <VarNote />
+          </TabsContent>
+
+          {/* Folder tab — a whole bundle directory (webkitdirectory). */}
+          <TabsContent value="folder" className="flex flex-col gap-3">
+            <p className="text-13 text-muted-foreground">
+              Upload a folder containing <code>config.yaml</code> at its root, plus any bundled
+              instructions, MCP configs, or skills.
+            </p>
+            <input
+              ref={folderInputRef}
+              type="file"
+              // webkitdirectory is a non-standard attribute React doesn't type.
+              {...{ webkitdirectory: "", directory: "" }}
+              multiple
+              className="hidden"
+              data-testid="create-agent-folder-input"
+              onChange={(e) => void handleFiles(e.target.files, "folder")}
+            />
+            <Button
+              variant="outline"
+              disabled={busy}
+              onClick={() => folderInputRef.current?.click()}
+              data-testid="create-agent-folder-pick"
+            >
+              Choose folder…
+            </Button>
+            <VarNote />
+          </TabsContent>
+
+          {/* GitHub tab — a public repo URL, fetched + repackaged server-side. */}
+          <TabsContent value="github" className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="create-agent-github-url"
+                className="text-xs font-medium text-muted-foreground"
+              >
+                Public repo URL <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="create-agent-github-url"
+                data-testid="create-agent-github-url"
+                value={githubUrl}
+                onChange={(e) => setGithubUrl(e.target.value)}
+                placeholder="https://github.com/owner/repo"
+                autoFocus
+              />
+            </div>
+            <div className="flex gap-2">
+              <div className="flex flex-1 flex-col gap-1.5">
+                <label
+                  htmlFor="create-agent-github-ref"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Ref (tag / branch / commit)
+                </label>
+                <Input
+                  id="create-agent-github-ref"
+                  data-testid="create-agent-github-ref"
+                  value={githubRef}
+                  onChange={(e) => setGithubRef(e.target.value)}
+                  placeholder="v1.0.0"
+                />
+              </div>
+              <div className="flex flex-1 flex-col gap-1.5">
+                <label
+                  htmlFor="create-agent-github-subdir"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Subdir
+                </label>
+                <Input
+                  id="create-agent-github-subdir"
+                  data-testid="create-agent-github-subdir"
+                  value={githubSubdir}
+                  onChange={(e) => setGithubSubdir(e.target.value)}
+                  placeholder="agents/my-agent"
+                />
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Pin a ref for reproducibility; the default branch is used otherwise. Public repos
+              only.
+            </p>
+            <VarNote />
+          </TabsContent>
+        </Tabs>
+
+        {uploadError && (
+          <p className="text-13 text-destructive" data-testid="create-agent-upload-error">
+            {uploadError}
+          </p>
+        )}
 
         <DialogFooter>
           <Button variant="ghost" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
-          <Button data-testid="create-agent-submit" onClick={handleSubmit} disabled={!canSubmit}>
-            Create
-          </Button>
+          {tab === "form" && (
+            <Button data-testid="create-agent-submit" onClick={handleSubmit} disabled={!canSubmit}>
+              Create
+            </Button>
+          )}
+          {tab === "github" && (
+            <Button
+              data-testid="create-agent-github-submit"
+              onClick={handleGithubSubmit}
+              disabled={!canSubmitGithub}
+            >
+              Create from GitHub
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/** Inline note reminding users that `${VAR}` refs are uploaded literally. */
+function VarNote() {
+  return (
+    <p className="text-xs text-muted-foreground/80">
+      <code>{"${VAR}"}</code> references are uploaded as-is and never expanded — keep secrets out of
+      the bundle.
+    </p>
   );
 }
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -110,8 +110,8 @@ import { IntelligentModelControl, type CostControlMode } from "@/components/Cost
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";
-import { buildAgentBundle, type AgentBundleInput } from "@/lib/agentBundle";
-import { createBundledSession, launchRunner } from "@/lib/sessionsApi";
+import { buildAgentBundle, pendingAgentDisplay, type PendingAgentSource } from "@/lib/agentBundle";
+import { createBundledSession, createSessionFromGithub, launchRunner } from "@/lib/sessionsApi";
 
 // Hidden from the new-session picker only. `nessie` is superseded by polly.
 // `kimi` / `kimi-code` are the headless SDK harness (kept for sub-agent / `run
@@ -1272,7 +1272,7 @@ function AgentHarnessPicker({
   hasAgents: boolean;
   host: Host | undefined | null;
   onSelectAgent: (agent: AvailableAgent) => void;
-  pendingAgent: AgentBundleInput | null;
+  pendingAgent: PendingAgentSource | null;
   pendingAgentId: string;
   onSelectPending: () => void;
   onCreateCustomAgent: () => void;
@@ -1652,7 +1652,7 @@ function AgentHarnessPicker({
                 className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
               >
                 <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
-                  <span className="truncate">{pendingAgent.name}</span>
+                  <span className="truncate">{pendingAgentDisplay(pendingAgent).name}</span>
                   <span className="truncate text-[11px] text-muted-foreground/70">Custom</span>
                 </div>
               </DropdownMenuItem>
@@ -1742,7 +1742,7 @@ export function NewChatLandingScreen() {
   // form submit, handleCreate detects the pending bundle, builds the
   // tar.gz, and uses multipart POST instead of the normal JSON path.
   const [createAgentOpen, setCreateAgentOpen] = useState(false);
-  const [pendingAgent, setPendingAgent] = useState<AgentBundleInput | null>(null);
+  const [pendingAgent, setPendingAgent] = useState<PendingAgentSource | null>(null);
   // Sentinel id for the pending custom agent in the picker dropdown.
   const PENDING_AGENT_ID = "__pending_custom_agent__";
 
@@ -2062,20 +2062,20 @@ export function NewChatLandingScreen() {
       ? PENDING_AGENT_ID
       : ((agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ??
         null);
-  const selectedAgent = useMemo(
-    () =>
-      effectiveAgentId === PENDING_AGENT_ID && pendingAgent
-        ? ({
-            id: PENDING_AGENT_ID,
-            name: pendingAgent.name,
-            display_name: pendingAgent.name,
-            description: pendingAgent.description ?? null,
-            harness: pendingAgent.harness ?? null,
-            skills: [],
-          } satisfies AvailableAgent)
-        : agentList.find((a) => a.id === effectiveAgentId),
-    [agentList, effectiveAgentId, pendingAgent],
-  );
+  const selectedAgent = useMemo(() => {
+    if (effectiveAgentId === PENDING_AGENT_ID && pendingAgent) {
+      const display = pendingAgentDisplay(pendingAgent);
+      return {
+        id: PENDING_AGENT_ID,
+        name: display.name,
+        display_name: display.name,
+        description: display.description ?? null,
+        harness: display.harness,
+        skills: [],
+      } satisfies AvailableAgent;
+    }
+    return agentList.find((a) => a.id === effectiveAgentId);
+  }, [agentList, effectiveAgentId, pendingAgent]);
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
   const supportsCursorMode = nativeAgentHasCapability(selectedAgent, "cursorMode");
@@ -2542,20 +2542,35 @@ export function NewChatLandingScreen() {
       let data: { id: string };
 
       if (effectiveAgentId === PENDING_AGENT_ID && pendingAgent) {
-        // Custom agent path: build bundle client-side and use multipart POST.
-        // The multipart create only stores the agent + session rows — it does
-        // NOT launch a runner on the host. We must follow up with launchRunner
-        // (POST /v1/hosts/{id}/runners) to bind the session to a runner, the
-        // same way the fork-resume path does.
-        const bundle = await buildAgentBundle(pendingAgent);
+        // Custom agent path: the create call only stores the agent + session
+        // rows — it does NOT launch a runner on the host. We must follow up
+        // with launchRunner (POST /v1/hosts/{id}/runners) to bind the session
+        // to a runner, the same way the fork-resume path does.
         const metadata: Record<string, unknown> = {};
         if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
-        data = await createBundledSession(
-          bundle,
-          metadata as Parameters<typeof createBundledSession>[1],
-        );
-        // Launch the runner on the selected host. The multipart create
-        // only stores DB rows — launchRunner binds + starts the runner.
+        const typedMetadata = metadata as Parameters<typeof createBundledSession>[1];
+        if (pendingAgent.kind === "github") {
+          // Server fetches the repo, repackages, and validates it exactly like
+          // an upload; ${VAR} stays literal (never expanded server-side).
+          data = await createSessionFromGithub(
+            {
+              source_url: pendingAgent.sourceUrl,
+              ref: pendingAgent.ref,
+              subdir: pendingAgent.subdir,
+            },
+            typedMetadata,
+          );
+        } else {
+          // "form" builds the bundle client-side; "bundle" (folder / file /
+          // tarball) is already a built File — both go through multipart POST.
+          const bundle =
+            pendingAgent.kind === "form"
+              ? await buildAgentBundle(pendingAgent.input)
+              : pendingAgent.bundle;
+          data = await createBundledSession(bundle, typedMetadata);
+        }
+        // Launch the runner on the selected host. The create above only
+        // stores DB rows — launchRunner binds + starts the runner.
         if (!sandboxSelected && selectedHostId && workspaceTrimmed) {
           // Create a new worktree, bind an existing one (records the branch
           // for the sidebar + delete flow without creating anything), or
@@ -3613,8 +3628,8 @@ export function NewChatLandingScreen() {
       <CreateAgentDialog
         open={createAgentOpen}
         onOpenChange={setCreateAgentOpen}
-        onCreate={(input) => {
-          setPendingAgent(input);
+        onCreate={(source) => {
+          setPendingAgent(source);
           setPickedAgentId(PENDING_AGENT_ID);
           setPickedHarness(null);
         }}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Lets a user bring a whole agent bundle into the app through two new sources, both funneling into the **existing** multipart upload pipeline so server validation and runner launch are unchanged:

- **Folder / File upload (browser):** a picked folder (`webkitdirectory`), a single `config.yaml`/`agent.yaml`, or a pre-built `.tar.gz`. A new client helper `buildBundleFromFiles()` strips the common top-level directory (so `config.yaml` lands at the tar root), filters editor/VCS junk (`.git/`, `node_modules/`, …), and validates structure + size client-side before upload. Works inside the Electron desktop app via the same browser path.
- **Public GitHub repo (server-side):** a new `POST /v1/sessions/from-github` fetches the repo's codeload tarball, repackages it through `extract_safe` (root-strip + optional subdir + junk filter), and reuses the existing `_create_session_from_bundle` — so the fetched repo passes the **identical** validation as a hand-upload, plus a pre-extraction download-size guard.

The pending-agent value is generalized into a `PendingAgentSource` union (`form | bundle | github`) threaded through `NewChatDialog`; `CreateAgentDialog` becomes tabbed **Form | File | Folder | GitHub**. `${VAR}` references stay literal on all browser/GitHub paths (the server never expands tenant uploads), and the browser/GitHub tabs surface an inline note to that effect.

Scope: public GitHub only (no token handling); the native desktop folder picker is deferred (the folder tab already works in Electron).

## Test Plan

- **Client (vitest):** `agentBundle.test.ts` — prefix strip, junk filter, multi-file tar round-trip, and structure-validation errors (no top-level YAML, multiple top-level YAMLs, `..`/absolute path, empty selection); `CreateAgentDialog.test.tsx` — each tab produces the correct `PendingAgentSource`, folder-tab validation surfaces inline and does not emit. 24 client tests pass.
- **Server (pytest):** `test_github_bundle.py` — URL parsing (3 shapes + bad input + subdir traversal), repackage/root-strip + subdir, junk filter, 404, oversize download; `integration/test_sessions_from_github.py` — end-to-end `/from-github` creating a session, missing repo → 4xx, missing `source_url` → 422. 22 server tests pass.
- `tsc -b` clean; `pre-commit run` (ruff-format, ruff-check, prettier, secret-scan) passes.

## Demo

N/A <!-- TODO: add a screen recording of the File / Folder / GitHub tabs before marking ready for review -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: exercised URL parsing and the fetch→repackage→`validate_agent_bundle` round-trip against synthetic codeload tarballs (root-strip, subdir, junk filter, empty-subdir error) via a scratch script, and ran the full client/server suites. The File tab's `.tar.gz` pass-through is covered indirectly (the folder path exercises `buildBundleFromFiles`); a dedicated `.tar.gz` UI test and a real end-to-end demo recording are still to add before this leaves draft.

## Changelog

Add a custom agent from a local folder, a single YAML / `.tar.gz`, or a public GitHub repo URL
