### PR TITLE
feat(policies): add write_branches_blocklist to github_policy

### DIFF
--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -100,8 +100,8 @@ policies:
     factory_params:
       write_repos:
         - myorg/my-repo
-      write_branches:
-        - "feature/*"
+      write_branches_blocklist:
+        - main
   google_policy:
     type: function
     handler: omnigent.policies.builtins.google.gdrive_policy
@@ -273,7 +273,8 @@ Controls GitHub access across MCP tools and `git`/`gh` shell commands. Restricts
 | `read_all` | boolean | `true` | Allow all reads |
 | `read_repos` | string[] | `[]` | Repos readable when `read_all` is false (`owner/repo` or URLs) |
 | `write_repos` | string[] | `[]` | Repos the agent may write to |
-| `write_branches` | string[] | `[]` | Branches writable within allowed repos (empty = any) |
+| `write_branches` | string[] | `[]` | Branches writable within allowed repos (empty = any); matched exactly, no globs |
+| `write_branches_blocklist` | string[] | `[]` | Branches excluded from writes within allowed repos (matched exactly); composes with `write_branches` |
 | `mcp_tool_prefixes` | string[] | `["mcp__github__", "github__"]` | Tool-name prefixes to match |
 | `shell_tools` | string[] | `["sys_os_shell"]` | Shell tools whose commands are parsed for git/gh |
 
@@ -285,9 +286,9 @@ github_access:
     write_repos:
       - myorg/frontend
       - myorg/backend
-    write_branches:
-      - "feature/*"
-      - "fix/*"
+    write_branches_blocklist:
+      - main
+      - master
 ```
 
 ### Google Workspace

--- a/omnigent/policies/builtins/github.py
+++ b/omnigent/policies/builtins/github.py
@@ -25,7 +25,10 @@ policy is stateless and only ever inspects ``tool_call`` events):
 - Reads are allowed everywhere when ``read_all`` is ``True`` (default). When
   ``read_all`` is ``False``, reads are restricted to ``read_repos``.
 - Writes are restricted to ``write_repos`` and, when ``write_branches`` is set,
-  to those branches.
+  to those branches. ``write_branches_blocklist`` instead excludes specific
+  branches, so any other branch on an allowed repo remains writable — the two
+  compose: a branch must be in ``write_branches`` (if set) and absent from
+  ``write_branches_blocklist`` (if set).
 - When a *shell* command is a gated read/write but its target repo (or, for a
   branch-restricted write, its target branch) cannot be determined from the
   command text — e.g. ``git push origin main``, where ``origin`` is a local
@@ -866,6 +869,7 @@ def github_policy(
     read_repos: list[str] | None = None,
     write_repos: list[str] | None = None,
     write_branches: list[str] | None = None,
+    write_branches_blocklist: list[str] | None = None,
     mcp_tool_prefixes: list[str] | None = None,
     shell_tools: list[str] | None = None,
     deny_reason: str = "GitHub operation blocked by policy.",
@@ -883,6 +887,10 @@ def github_policy(
     :param write_branches: Branches writable within an allowed repo, e.g.
         ``["main", "develop"]``. ``None`` / empty means branches are not
         restricted (any branch on an allowed repo is writable).
+    :param write_branches_blocklist: Branches excluded from writes within an
+        allowed repo, e.g. ``["main", "master"]``. ``None`` / empty excludes
+        nothing. Composes with ``write_branches`` — a branch must pass both
+        (be allowlisted, if set, and not blocklisted) to be writable.
     :param mcp_tool_prefixes: GitHub MCP server name-prefixes to strip when
         canonicalizing MCP tool names. ``None`` uses the standard
         ``mcp__github__`` / ``github__``.
@@ -899,12 +907,22 @@ def github_policy(
     allowed_read_repos = _normalize_repos(read_repos)
     allowed_write_repos = _normalize_repos(write_repos)
     allowed_write_branches = _normalize_branches(write_branches)
+    blocked_write_branches = _normalize_branches(write_branches_blocklist)
     prefixes = (
         tuple(mcp_tool_prefixes) if mcp_tool_prefixes is not None else _DEFAULT_TOOL_PREFIXES
     )
     shell_tool_names = (
         frozenset(shell_tools) if shell_tools is not None else frozenset(_DEFAULT_SHELL_TOOLS)
     )
+
+    def _branch_restriction_desc() -> str:
+        """Describe the active branch restriction(s) for an undeterminable-branch message."""
+        parts = []
+        if allowed_write_branches:
+            parts.append(f"restricted to branches {sorted(allowed_write_branches)}")
+        if blocked_write_branches:
+            parts.append(f"blocked for branches {sorted(blocked_write_branches)}")
+        return " and ".join(parts)
 
     def _gate_read_repo(
         repos: set[str], *, undeterminable: PolicyResponse
@@ -937,13 +955,15 @@ def github_policy(
         no_branch: PolicyResponse,
     ) -> PolicyResponse | None:
         """
-        Apply the write repo + branch allowlists to a write operation.
+        Apply the write repo + branch allowlist/blocklist to a write operation.
 
-        Any branch the call names is checked against ``write_branches``. A
-        *branch-targeted* write (file write, push, branch create) with no
-        determinable branch additionally fails to *no_branch*, because it would
-        otherwise land on the repo's default branch unchecked. A write that is
-        not branch-targeted (issue, comment, PR merge by number) is governed by
+        Any branch the call names is checked against ``write_branches`` (must be
+        a member, if set) and ``write_branches_blocklist`` (must not be a
+        member, if set). A *branch-targeted* write (file write, push, branch
+        create) with no determinable branch additionally fails to *no_branch*
+        when either restriction is active, because it would otherwise land on
+        the repo's default branch unchecked. A write that is not
+        branch-targeted (issue, comment, PR merge by number) is governed by
         ``write_repos`` alone when it names no branch.
 
         :param repos: Target repos extracted from the call (may be empty).
@@ -963,14 +983,27 @@ def github_policy(
                 f"{deny_reason} Write is restricted to the configured repos; "
                 f"this call targets {sorted(repos)}."
             )
-        if allowed_write_branches:
+        if allowed_write_branches or blocked_write_branches:
             if branches:
-                bad = branches - allowed_write_branches
-                if bad:
-                    return _deny(
-                        f"{deny_reason} Write is restricted to branches "
-                        f"{sorted(allowed_write_branches)}; this call targets {sorted(bad)}."
-                    )
+                not_allowlisted = (
+                    branches - allowed_write_branches if allowed_write_branches else set()
+                )
+                blocklisted = (
+                    branches & blocked_write_branches if blocked_write_branches else set()
+                )
+                if not_allowlisted or blocklisted:
+                    reasons = []
+                    if not_allowlisted:
+                        reasons.append(
+                            f"restricted to branches {sorted(allowed_write_branches)} "
+                            f"(targets {sorted(not_allowlisted)})"
+                        )
+                    if blocklisted:
+                        reasons.append(
+                            f"blocked for branches {sorted(blocked_write_branches)} "
+                            f"(targets {sorted(blocklisted)})"
+                        )
+                    return _deny(f"{deny_reason} Write is " + " and ".join(reasons) + ".")
             elif branch_targeted:
                 return no_branch
         return None
@@ -1014,9 +1047,8 @@ def github_policy(
             branch_targeted=_mcp_base(canonical) in _MCP_BRANCH_WRITE_TOOLS,
             no_repo=_deny(f"{deny_reason} Write call carries no identifiable target repo."),
             no_branch=_deny(
-                f"{deny_reason} Write is restricted to branches "
-                f"{sorted(allowed_write_branches)} and this call's target branch could "
-                f"not be determined."
+                f"{deny_reason} Write is {_branch_restriction_desc()} and this call's "
+                f"target branch could not be determined."
             ),
         )
 
@@ -1133,8 +1165,9 @@ POLICY_REGISTRY: list[dict[str, Any]] = [  # type: ignore[explicit-any]
             "Controls GitHub access across MCP tools (official per-operation server and the "
             "github_read_api_call / github_write_api_call HTTP-proxy wrapper) and git/gh shell "
             "commands run via sys_os_shell. Restricts reads to read_repos (unless read_all), and "
-            "writes to write_repos plus optional write_branches. Shell commands whose target repo "
-            "or branch cannot be determined return ASK for human approval."
+            "writes to write_repos plus optional write_branches / write_branches_blocklist. "
+            "Shell commands whose target repo or branch cannot be determined return ASK for "
+            "human approval."
         ),
         "params_schema": {
             "type": "object",
@@ -1158,6 +1191,13 @@ POLICY_REGISTRY: list[dict[str, Any]] = [  # type: ignore[explicit-any]
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Branches writable within an allowed repo. Empty = any branch.",
+                },
+                "write_branches_blocklist": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Branches excluded from writes within an allowed repo. "
+                    "Composes with write_branches (a branch must be allowlisted, if set, "
+                    "and not blocklisted).",
                 },
                 "mcp_tool_prefixes": {
                     "type": "array",

--- a/tests/policies/builtins/test_github.py
+++ b/tests/policies/builtins/test_github.py
@@ -217,6 +217,67 @@ def test_pr_create_gates_base_not_head() -> None:
     assert result is not None and result["result"] == "DENY"
 
 
+def test_write_branch_blocklisted_denied() -> None:
+    """A write to a blocklisted branch is denied even with no allowlist set."""
+    policy = github_policy(write_repos=[_REPO], write_branches_blocklist=["main"])
+    event = tc(
+        "mcp__github__create_or_update_file", {"owner": "octo", "repo": "hello", "branch": "main"}
+    )
+    result = policy(event)
+    assert result is not None and result["result"] == "DENY"
+
+
+def test_write_branch_not_blocklisted_allowed() -> None:
+    """Any branch outside the blocklist is writable — the blocklist is exclusion-only."""
+    policy = github_policy(write_repos=[_REPO], write_branches_blocklist=["main"])
+    event = tc(
+        "mcp__github__create_or_update_file", {"owner": "octo", "repo": "hello", "branch": "dev"}
+    )
+    assert policy(event) is None
+
+
+def test_branch_targeted_write_without_branch_denied_under_blocklist() -> None:
+    """A file write with no branch arg fails closed when a blocklist is active.
+
+    A missing branch means the repo's default branch, which could be a
+    blocklisted branch (e.g. ``main``) — so the safe decision is DENY.
+    """
+    policy = github_policy(write_repos=[_REPO], write_branches_blocklist=["main"])
+    result = policy(tc("mcp__github__create_or_update_file", {"owner": "octo", "repo": "hello"}))
+    assert result is not None and result["result"] == "DENY"
+
+
+def test_write_branch_allowlist_and_blocklist_compose() -> None:
+    """A branch must be allowlisted and not blocklisted — both restrictions apply together."""
+    policy = github_policy(
+        write_repos=[_REPO], write_branches=["main", "dev"], write_branches_blocklist=["dev"]
+    )
+    allowed = tc(
+        "mcp__github__create_or_update_file", {"owner": "octo", "repo": "hello", "branch": "main"}
+    )
+    assert policy(allowed) is None
+
+    blocked = tc(
+        "mcp__github__create_or_update_file", {"owner": "octo", "repo": "hello", "branch": "dev"}
+    )
+    result = policy(blocked)
+    assert result is not None and result["result"] == "DENY"
+
+    not_allowlisted = tc(
+        "mcp__github__create_or_update_file",
+        {"owner": "octo", "repo": "hello", "branch": "release"},
+    )
+    result = policy(not_allowlisted)
+    assert result is not None and result["result"] == "DENY"
+
+
+@pytest.mark.parametrize("tool", ["merge_pull_request", "add_issue_comment", "create_issue"])
+def test_non_branch_write_without_branch_allowed_under_blocklist(tool: str) -> None:
+    """Non-branch writes ignore write_branches_blocklist, same as write_branches."""
+    policy = github_policy(write_repos=[_REPO], write_branches_blocklist=["main"])
+    assert policy(tc(f"mcp__github__{tool}", {"owner": "octo", "repo": "hello"})) is None
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Layer 1 — HTTP-proxy wrapper (github_read_api_call / github_write_api_call)
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Lets a `github_policy` config exclude specific branches from writes (e.g. main/master) while leaving all other branches writable, composing with the existing `write_branches` allowlist.

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

N/A

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
- Added optional config `write_branches_blocklist` to `github_policy` for excluding main/master branches from being writable

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->
- Added positive & negative unit tests to `tests/policies/builtins/test_github.py`

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Add writeable-branch blocklist to github policy