### PR TITLE
fix(hermes): register the Omnigent MCP server for the headless harness

### DIFF
--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -297,6 +297,7 @@ def write_policy_hook_config(
     bridge_dir: Path,
     server_url: str,
     session_id: str,
+    hermes_home: Path | None = None,
 ) -> Path:
     """Write per-session ``HERMES_HOME`` with Omnigent policy hook and MCP server.
 
@@ -305,21 +306,32 @@ def write_policy_hook_config(
     1. A ``pre_tool_call`` shell hook that evaluates tool calls against the
        Omnigent policy engine (same hook the headless ``hermes`` harness uses).
     2. An ``mcp_servers.omnigent`` entry that launches the Omnigent MCP stdio
-       server (``serve-mcp``), exposing Omnigent builtin tools
-       (``sys_session_*``, ``sys_agent_*``, ``load_skill``, ``web_fetch``, etc.)
-       to the Hermes model.
+       server (``serve-mcp --bridge-dir <bridge_dir>``), exposing Omnigent
+       builtin tools (``sys_session_*``, ``sys_agent_*``, ``load_skill``,
+       ``web_fetch``, etc.) to the Hermes model.
 
-    Also copies the user's auth/env files so the TUI can still authenticate
-    with its inference provider. Mirrors
-    :func:`omnigent.inner.hermes_executor._populate_hermes_home`.
+    Also copies the user's auth/env files so Hermes can still authenticate with
+    its inference provider. Shared by the ``hermes-native`` TUI path and the
+    headless ``hermes`` executor. The credential-bearing HERMES_HOME and the
+    runner-shared bridge dir are separable: ``bridge_dir`` (predictable, holds
+    only ``bridge.json`` + the relay's ``tool_relay.json``) is the rendezvous
+    the runner and ``serve-mcp`` agree on, while ``hermes_home`` may be a
+    private tempdir so the copied ``.env`` / ``auth.json`` never land on the
+    predictable path. Defaults to ``bridge_dir/hermes_home`` when unset.
 
-    :param bridge_dir: Per-session bridge dir (parent of the HERMES_HOME).
+    :param bridge_dir: Per-session bridge dir (runner<->serve-mcp rendezvous).
     :param server_url: Omnigent server base URL.
     :param session_id: Omnigent session / conversation ID.
+    :param hermes_home: Where to write the credential-bearing home. ``None``
+        places it under ``bridge_dir``.
     :returns: The HERMES_HOME path.
     """
-    hermes_home = bridge_dir / _HERMES_HOME_SUBDIR
-    hermes_home.mkdir(parents=True, exist_ok=True)
+    if hermes_home is None:
+        hermes_home = bridge_dir / _HERMES_HOME_SUBDIR
+    _ensure_dir(bridge_dir)
+    # Owner-only: the home holds the copied .env / auth.json credentials and the
+    # token-bearing hook wrapper.
+    _ensure_dir(hermes_home)
 
     hook_script_path = str(Path(__file__).resolve().parent / "inner" / "hermes_policy_hook.py")
 

--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -39,7 +39,6 @@ Env vars read at construction:
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 import re
@@ -170,125 +169,6 @@ def _get_conversation_id() -> str | None:
     return None
 
 
-# Keys from the user's ``~/.hermes/config.yaml`` that the per-session
-# HERMES_HOME needs in order to authenticate with the inference provider.
-# Everything else (secrets, security, agent tuning, terminal, etc.) is
-# either irrelevant to a headless Omnigent turn or actively harmful
-# (e.g. ``secrets.bitwarden`` referencing an unset ``BWS_ACCESS_TOKEN``).
-_USER_CONFIG_KEYS = frozenset(
-    {
-        "model",
-        "providers",
-        "fallback_providers",
-        "credential_pool_strategies",
-    }
-)
-
-
-def _load_user_hermes_config() -> dict:
-    """Load inference-relevant keys from the user's ``~/.hermes/config.yaml``.
-
-    Returns a dict containing only the keys Hermes needs to resolve a
-    model and authenticate (see :data:`_USER_CONFIG_KEYS`), or ``{}``
-    when the file is missing or malformed.
-    """
-    user_config = Path.home() / ".hermes" / "config.yaml"
-    if not user_config.is_file():
-        return {}
-    try:
-        import yaml
-
-        full = yaml.safe_load(user_config.read_text()) or {}
-        return {k: v for k, v in full.items() if k in _USER_CONFIG_KEYS}
-    except Exception:  # noqa: BLE001 — catch YAML parse errors, permission errors, etc.
-        _logger.debug("Failed to load user Hermes config at %s", user_config, exc_info=True)
-        return {}
-
-
-def _populate_hermes_home(
-    hermes_home: Path,
-    hook_script_path: str,
-    server_url: str,
-    session_id: str,
-) -> None:
-    """Populate a per-session ``HERMES_HOME`` with policy hook config.
-
-    Creates a ``config.yaml`` that registers the Omnigent policy hook
-    as a ``pre_tool_call`` shell hook, and writes a wrapper script
-    that exports the server env vars before exec-ing the Python hook.
-
-    The user's ``~/.hermes/config.yaml`` model/provider settings are
-    merged into the per-session config so Hermes can authenticate with
-    the inference provider the user configured via ``hermes model``.
-
-    This mirrors how Codex creates a per-session ``CODEX_HOME`` with
-    its own ``config.toml`` — Hermes scopes all state (config, sessions,
-    hooks, allowlist) to ``HERMES_HOME``.
-
-    :param hermes_home: The per-session HERMES_HOME directory.
-    :param hook_script_path: Absolute path to ``hermes_policy_hook.py``.
-    :param server_url: Omnigent server URL.
-    :param session_id: Conversation / session ID for policy evaluation.
-    """
-    hermes_home.mkdir(parents=True, exist_ok=True)
-
-    # Write the wrapper shell script that sets env vars and execs the hook. It
-    # bakes a one-shot auth token + workspace-routing header, so it is
-    # owner-only (0o700) — the secret is never world-readable.
-    from omnigent.native_policy_hook import policy_hook_wrapper_script
-
-    wrapper = hermes_home / "omnigent-policy-hook.sh"
-    wrapper.write_text(policy_hook_wrapper_script(server_url, session_id, hook_script_path))
-    wrapper.chmod(0o700)
-
-    # Start from the user's config so model/provider/auth settings carry over.
-    # Hermes scopes everything to HERMES_HOME, so without this merge it won't
-    # find the inference provider the user configured via ``hermes model``.
-    user_cfg = _load_user_hermes_config()
-    config: dict = {**user_cfg}
-
-    # Layer Omnigent's policy hook config on top.
-    config["hooks_auto_accept"] = True
-    config["hooks"] = {
-        **config.get("hooks", {}),
-        "pre_tool_call": [
-            {
-                "command": str(wrapper),
-                # One day: must match the server's ``ask_timeout`` so
-                # the hook stays alive while the human responds to the
-                # web-UI approval card (ASK policy).
-                "timeout": 86400,
-            },
-        ],
-    }
-
-    config_path = hermes_home / "config.yaml"
-    # Use JSON for YAML-compatible output (JSON is valid YAML).
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
-
-    # Copy the user's .env file if present (carries API keys like
-    # OPENROUTER_API_KEY, OPENAI_API_KEY, etc.).
-    user_env = Path.home() / ".hermes" / ".env"
-    if user_env.is_file():
-        shutil.copy2(user_env, hermes_home / ".env")
-
-    # Copy the user's auth.json if present (carries provider credentials
-    # stored by ``hermes auth`` / ``hermes model``).
-    user_auth = Path.home() / ".hermes" / "auth.json"
-    if user_auth.is_file():
-        shutil.copy2(user_auth, hermes_home / "auth.json")
-
-    # Pre-populate the allowlist so Hermes never prompts for consent.
-    # Hermes' allowlist format is {"approvals": [{"event": ..., "command": ...}]}.
-    allowlist_path = hermes_home / "shell-hooks-allowlist.json"
-    allowlist_data = {
-        "approvals": [
-            {"event": "pre_tool_call", "command": str(wrapper)},
-        ],
-    }
-    allowlist_path.write_text(json.dumps(allowlist_data, indent=2) + "\n")
-
-
 def _build_hermes_args(
     hermes_path: str,
     message: str,
@@ -390,15 +270,19 @@ class HermesExecutor(Executor):
         self._setup_hermes_home()
 
     def _setup_hermes_home(self) -> None:
-        """Create a per-session ``HERMES_HOME`` with Omnigent policy hooks.
+        """Create a per-session ``HERMES_HOME`` with policy hooks and MCP config.
 
         When the Omnigent server URL and conversation ID are available,
-        creates a temp directory with a ``config.yaml`` that registers the
-        Omnigent policy hook as a Hermes ``pre_tool_call`` shell hook.
+        writes a ``config.yaml`` that registers the Omnigent policy hook as a
+        Hermes ``pre_tool_call`` shell hook and an ``mcp_servers.omnigent``
+        entry (``serve-mcp``) exposing Omnigent builtin tools to the model.
         The ``HERMES_HOME`` env var is passed to the subprocess so Hermes
         reads this config instead of the user's ``~/.hermes/``.
 
-        Mirrors how Codex creates a per-session ``CODEX_HOME``.
+        The home stays a private ``mkdtemp`` (0700) so the copied ``.env`` /
+        ``auth.json`` credentials are never on a predictable path. Only the
+        runner<->serve-mcp coordination files live in the deterministic bridge
+        dir, which ``config.yaml`` points ``serve-mcp`` at.
         """
         server_url = os.environ.get("RUNNER_SERVER_URL", "")
         conv_id = _get_conversation_id()
@@ -409,9 +293,18 @@ class HermesExecutor(Executor):
                 conv_id or "(unset)",
             )
             return
+        from omnigent.hermes_native_bridge import (
+            bridge_dir_for_session_id,
+            write_policy_hook_config,
+        )
+
         self._hermes_home = Path(tempfile.mkdtemp(prefix="hermes_home_"))
-        hook_script = str(Path(__file__).with_name("hermes_policy_hook.py"))
-        _populate_hermes_home(self._hermes_home, hook_script, server_url, conv_id)
+        write_policy_hook_config(
+            bridge_dir_for_session_id(conv_id),
+            server_url,
+            conv_id,
+            hermes_home=self._hermes_home,
+        )
         _logger.debug("Hermes per-session home: %s", self._hermes_home)
 
     def _hermes_session_id(self, session_key: str) -> str | None:
@@ -588,7 +481,9 @@ class HermesExecutor(Executor):
     async def close(self) -> None:
         """Release executor-wide resources."""
         self._session_map.clear()
-        # Best-effort cleanup of the per-session HERMES_HOME.
+        # Best-effort cleanup of the HERMES_HOME subdir only; the parent bridge
+        # dir (tool_relay.json, bridge.json) belongs to the runner-hosted relay
+        # and is cleaned up on session delete.
         if self._hermes_home is not None:
             shutil.rmtree(self._hermes_home, ignore_errors=True)
             self._hermes_home = None

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -14033,6 +14033,20 @@ def create_runner_app(
             await _ensure_comment_relay_started(
                 conv, explicit_bridge_dir=antigravity_bdir, await_notify=False
             )
+        elif harness_name == "hermes":
+            from omnigent.hermes_native_bridge import (
+                bridge_dir_for_session_id as hermes_bridge_dir_for_session,
+            )
+
+            # The headless hermes executor writes bridge.json + mcp_servers into
+            # this same deterministic dir; the relay adds tool_relay.json so
+            # serve-mcp can dispatch Omnigent builtin tools. Hermes starts
+            # serve-mcp lazily, so awaiting delivery would stall the turn.
+            await _ensure_comment_relay_started(
+                conv,
+                explicit_bridge_dir=hermes_bridge_dir_for_session(conv),
+                await_notify=False,
+            )
 
         try:
             response = await _stream_message_to_harness(

--- a/tests/inner/test_hermes_executor.py
+++ b/tests/inner/test_hermes_executor.py
@@ -30,7 +30,6 @@ from omnigent.inner.hermes_executor import (
     _build_hermes_args,
     _extract_last_user_message,
     _parse_session_id,
-    _populate_hermes_home,
     _strip_hermes_metadata,
 )
 
@@ -146,55 +145,78 @@ class TestUtils:
 # ---------------------------------------------------------------------------
 
 
-class TestPopulateHermesHome:
-    """Tests for the per-session HERMES_HOME setup."""
+class TestSetupHermesHome:
+    """The headless executor's HERMES_HOME setup (option B: private-tempdir home,
+    shared bridge dir for the runner<->serve-mcp rendezvous only)."""
 
-    def test_creates_config_with_hook(self, tmp_path: pathlib.Path) -> None:
-        """config.yaml contains the pre_tool_call hook registration."""
-        _populate_hermes_home(
-            tmp_path,
-            "/path/to/hook.py",
-            "http://127.0.0.1:6767",
-            "conv_test123",
+    @pytest.fixture
+    def setup(self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+        """Build an executor with a fake bridge root + session id.
+
+        Returns (home, bridge_dir): the credential-bearing HERMES_HOME (a private
+        tempdir) and the deterministic bridge dir (runner rendezvous)."""
+        import omnigent.hermes_native_bridge as hnb
+
+        monkeypatch.setattr(hnb, "_BRIDGE_ROOT", tmp_path)
+        monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:6767")
+        monkeypatch.setattr(
+            "omnigent.inner.hermes_executor._get_conversation_id",
+            lambda: "conv_test123",
         )
-        config_path = tmp_path / "config.yaml"
-        assert config_path.exists()
-        config = json.loads(config_path.read_text())
+        monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path / "nohome"))
+        executor = HermesExecutor(hermes_path="/usr/bin/hermes-fake", cwd="/tmp")
+        assert executor._hermes_home is not None
+        bridge_dir = hnb.bridge_dir_for_session_id("conv_test123")
+        return executor._hermes_home, bridge_dir
+
+    def test_config_registers_policy_hook(self, setup) -> None:
+        """config.yaml carries the pre_tool_call hook registration."""
+        home, _ = setup
+        config = json.loads((home / "config.yaml").read_text())
         assert config["hooks_auto_accept"] is True
         hooks = config["hooks"]["pre_tool_call"]
         assert len(hooks) == 1
         assert "omnigent-policy-hook.sh" in hooks[0]["command"]
 
-    def test_creates_wrapper_script(self, tmp_path: pathlib.Path) -> None:
-        """Wrapper script exports env vars and execs the Python hook."""
-        _populate_hermes_home(
-            tmp_path,
-            "/path/to/hook.py",
-            "http://127.0.0.1:6767",
-            "conv_test123",
-        )
-        wrapper = tmp_path / "omnigent-policy-hook.sh"
-        assert wrapper.exists()
-        content = wrapper.read_text()
-        assert "http://127.0.0.1:6767" in content
-        assert "conv_test123" in content
-        assert "/path/to/hook.py" in content
+    def test_config_registers_omnigent_mcp_server(self, setup) -> None:
+        """config.yaml carries mcp_servers.omnigent (serve-mcp) pointed at the bridge
+        dir — the parity gap. Fails on the previous setup, which wrote no mcp_servers
+        key: a headless Hermes agent had zero Omnigent tools."""
+        home, bridge_dir = setup
+        omnigent_mcp = json.loads((home / "config.yaml").read_text())["mcp_servers"]["omnigent"]
+        assert omnigent_mcp["args"][:2] == ["-m", "omnigent.claude_native_bridge"]
+        assert "serve-mcp" in omnigent_mcp["args"]
+        assert str(bridge_dir) in omnigent_mcp["args"]  # serve-mcp --bridge-dir <bridge_dir>
 
-    def test_creates_allowlist(self, tmp_path: pathlib.Path) -> None:
-        """shell-hooks-allowlist.json is pre-populated with correct format."""
-        _populate_hermes_home(
-            tmp_path,
-            "/path/to/hook.py",
-            "http://127.0.0.1:6767",
-            "conv_test123",
-        )
-        allowlist_path = tmp_path / "shell-hooks-allowlist.json"
-        assert allowlist_path.exists()
-        allowlist = json.loads(allowlist_path.read_text())
+    def test_credentials_stay_off_the_predictable_bridge_path(self, setup, tmp_path) -> None:
+        """The HERMES_HOME holding .env/auth.json/the token-bearing wrapper is a
+        private tempdir, NOT under the deterministic bridge dir — so credentials never
+        land on a predictable path another local user could pre-create."""
+        home, bridge_dir = setup
+        assert not home.is_relative_to(tmp_path)  # bridge root is tmp_path; home is elsewhere
+        assert (home / "omnigent-policy-hook.sh").is_file()
+        assert not (bridge_dir / "hermes_home").exists()  # no creds under the bridge dir
+
+    def test_home_is_owner_only(self, setup) -> None:
+        """The private HERMES_HOME is 0700 (mkdtemp default) — it holds credentials."""
+        import stat
+
+        home, _ = setup
+        assert stat.S_IMODE(home.stat().st_mode) & 0o077 == 0
+
+    def test_bridge_json_written_for_serve_mcp(self, setup) -> None:
+        """bridge.json (serve-mcp control token) lands in the deterministic bridge
+        dir — the runner<->serve-mcp rendezvous, same as the hermes-native path."""
+        _, bridge_dir = setup
+        assert (bridge_dir / "bridge.json").is_file()
+
+    def test_creates_allowlist(self, setup) -> None:
+        """shell-hooks-allowlist.json is pre-populated so Hermes never prompts."""
+        home, _ = setup
+        allowlist = json.loads((home / "shell-hooks-allowlist.json").read_text())
         approvals = allowlist["approvals"]
         assert len(approvals) == 1
         assert approvals[0]["event"] == "pre_tool_call"
-        assert "omnigent-policy-hook.sh" in approvals[0]["command"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #1926

## Summary

The headless `hermes` harness writes a per-session `HERMES_HOME` with only the policy-hook
config, so a headless Hermes agent has zero Omnigent builtin tools (`sys_*`, `web_*`,
`load_skill`). The native twin `hermes-native` already registers an `mcp_servers.omnigent`
entry via `hermes_native_bridge.write_policy_hook_config`; the headless side never did.

`_setup_hermes_home` now writes an `mcp_servers.omnigent` (`serve-mcp --bridge-dir <dir>`)
entry into `config.yaml` and starts the runner-hosted tool relay for `hermes` turns
(`runner/app.py`, alongside the existing native branches) so `serve-mcp` can dispatch the
builtin tools via `tool_relay.json`. The executor-local `_populate_hermes_home` duplicate is
removed in favor of the shared `write_policy_hook_config`.

`write_policy_hook_config` gains an optional `hermes_home` parameter. The headless path passes
a private `tempfile.mkdtemp()` (0700) so the copied `.env` / `auth.json` credentials stay off
the predictable bridge path; only the runner<->`serve-mcp` coordination files (`bridge.json`,
`tool_relay.json`) live in the deterministic bridge dir. `hermes-native` keeps its existing
default (`bridge_dir/hermes_home`), so that path is unchanged.

No new auth or server infrastructure: `serve-mcp`, the relay, and the bridge-dir layout all
exist for `hermes-native` already.

## Test plan

`tests/inner/test_hermes_executor.py::TestSetupHermesHome` builds the headless executor with a
fake session and asserts the generated `config.yaml` registers `mcp_servers.omnigent` pointed
at the bridge dir, that the credential-bearing `HERMES_HOME` is a private tempdir (not under
the bridge dir), and that `bridge.json` lands in the bridge dir. The `mcp_servers` assertion
fails before the change (`KeyError` — no `mcp_servers` key) and passes after. Full
`tests/inner/test_hermes_executor.py` + `tests/test_hermes_native_bridge.py` +
`tests/runner/test_comment_relay.py` green; `scripts/backend-smoke.sh` green.

## Demo

Live web UI run of the headless `hermes` harness with the Omnigent MCP server
registered. The agent calls `sys_session_get_info` (an Omnigent-only tool -
before this change the headless harness had no Omnigent tools at all); a demo
ASK policy gates it, one approval card parks, Approve runs it:

![approval card](https://raw.githubusercontent.com/dosenr/omnigent/assets/hermes-headless-demo/01-approval-card-dark.png)

![approved, tool ran](https://raw.githubusercontent.com/dosenr/omnigent/assets/hermes-headless-demo/02-complete-dark.png)

(The single approval card also depends on #2220 - without the hook skip the
same call would be policy-evaluated twice and park two cards. Captured with
both PRs applied.)

<details><summary>Terminal transcript (tool list, original demo)</summary>

A headless `hermes` turn (no UI — the demo is the transcript). Before this change the
agent had no Omnigent tools; here it lists them and calls one:

```
Omnigent MCP tool names available to me:
- mcp_omnigent_list_comments
- mcp_omnigent_sys_add_policy
- mcp_omnigent_sys_agent_download
- mcp_omnigent_sys_agent_get
- mcp_omnigent_sys_agent_list
- mcp_omnigent_sys_call_async
- mcp_omnigent_sys_cancel_async
- mcp_omnigent_sys_cancel_task
- mcp_omnigent_sys_os_edit
- mcp_omnigent_sys_os_read
- mcp_omnigent_sys_os_shell
- mcp_omnigent_sys_os_write
- mcp_omnigent_sys_policy_registry
- mcp_omnigent_sys_read_inbox
- mcp_omnigent_sys_session_get_history
- mcp_omnigent_sys_session_get_info
- mcp_omnigent_sys_session_list
- mcp_omnigent_update_comment
I called the session-status tool:
- mcp_omnigent_sys_session_get_info
It returned:
{
  "session_id": "conv_ID",
  "status": "running",
  "title": "List the tool names available to you from the omnigent MCP…",
  "agent_id": "ag_ID",
  "agent_name": "hermes-headless-test",
  "runner_id": "runner_ID",
  "runner_online": true,
  "host_id": "host_ID",
  "parent_session_id": null,
  "sub_agent_name": null,
  "reasoning_effort": null,
  "model": null,
  "workspace": "<workspace>
  "git_branch": null,
  "pending_elicitations": [],
  "pending_elicitation_count": 0
}
```

</details>

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit test added

## Coverage notes

Live integration (a headless hermes turn actually invoking an Omnigent tool) needs a running
runner, the hermes CLI, and provider credentials; verified manually against a live deployment.
The added unit tests cover the config-generation and bridge-dir wiring that was the defect.

## Changelog

Fixed the headless Hermes harness registering no Omnigent MCP server (agent had no builtin tools).

