### PR TITLE
fix(web): remember the last-picked host in the new-session picker

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -410,6 +410,25 @@ def _hosts_body() -> str:
     )
 
 
+# Two online hosts for the sticky-default test. The composer auto-selects the
+# FIRST online host (alpha) when there's no stored pick; the test then picks
+# beta and asserts it's restored after a reload.
+_HOST_ALPHA = ("host_e2e_alpha", "e2e-host-alpha")
+_HOST_BETA = ("host_e2e_beta", "e2e-host-beta")
+
+
+def _two_hosts_body() -> str:
+    """Stub body for ``GET /v1/hosts``: two online, user-connected hosts."""
+    return json.dumps(
+        {
+            "hosts": [
+                {"host_id": hid, "name": name, "owner": "e2e", "status": "online"}
+                for hid, name in (_HOST_ALPHA, _HOST_BETA)
+            ]
+        }
+    )
+
+
 async def _register_common_routes(
     page,
     *,
@@ -569,6 +588,89 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
             assert body["host_id"] == _HOST_ID, body
             assert body["workspace"] == "/work/repo", body
             assert body.get("terminal_launch_args") == ["--permission-mode", "acceptEdits"], body
+        finally:
+            await browser.close()
+
+
+def test_start_session_remembers_last_picked_host(seeded_session: tuple[str, str]) -> None:
+    """The host chip restores the last explicitly-picked host after a reload.
+
+    With no stored pick the composer auto-selects the first online host
+    (alpha). After the user picks a different host (beta), that choice must be
+    persisted (``omnigent:last-host-choice`` in localStorage) and restored on
+    the next visit — instead of reverting to the first-online default. This is
+    the OSS mirror of the managed complaint where the picker always reverted to
+    the "Databricks Sandbox" default.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_remembers_last_picked_host(base_url, session_id))
+
+
+async def _drive_remembers_last_picked_host(base_url: str, session_id: str) -> None:
+    alpha_id, alpha_name = _HOST_ALPHA
+    beta_id, beta_name = _HOST_BETA
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+
+            # Override the single-host stub with the two-host body (registered
+            # after the common routes so this handler wins).
+            async def handle_two_hosts(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_two_hosts_body()
+                )
+
+            await page.route("**/v1/hosts", handle_two_hosts)
+
+            # Neutralize agent discovery so a leaked native agent from another
+            # test can't switch the picker mid-flow (see _drive_permission_mode).
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=json.dumps({"data": []})
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            # Seed recents for both hosts so the working-directory chip auto-fills
+            # and the composer never blocks on the (host-less) file browser.
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{
+                        "{alpha_id}": ["/work/repo"],
+                        "{beta_id}": ["/work/repo"]
+                    }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            chip = page.get_by_test_id("new-chat-landing-host-chip")
+            # No stored pick yet → auto-selects the first online host (alpha).
+            await expect(chip).to_contain_text(alpha_name)
+
+            # Explicitly pick the second host.
+            await chip.click()
+            await page.get_by_test_id(f"new-chat-landing-host-{beta_id}").click()
+            await expect(chip).to_contain_text(beta_name)
+
+            # Reload: a full document load resets the in-memory landing draft, so
+            # the only thing that can restore the pick is the persisted
+            # preference. The chip must come back on beta, NOT the alpha default.
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            chip = page.get_by_test_id("new-chat-landing-host-chip")
+            await expect(chip).to_contain_text(beta_name)
         finally:
             await browser.close()
 

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -675,6 +675,130 @@ async def _drive_remembers_last_picked_host(base_url: str, session_id: str) -> N
             await browser.close()
 
 
+def _managed_info_body() -> str:
+    """Stub body for ``GET /v1/info``: a managed deployment offering a sandbox.
+
+    ``managed_sandboxes_enabled: true`` + ``sandbox_provider: "lakebox"`` makes
+    the picker offer (and default to) the "Databricks Sandbox" option, exactly
+    the deployment shape behind the original complaint. Every field the SPA
+    reads is supplied so the boot probe resolves to a fully-managed capability
+    set rather than the fail-closed sentinel.
+    """
+    return json.dumps(
+        {
+            "accounts_enabled": False,
+            "login_url": None,
+            "needs_setup": False,
+            "databricks_features": True,
+            "managed_sandboxes_enabled": True,
+            "sandbox_provider": "lakebox",
+            "server_version": "0.0.0-e2e",
+            "smart_routing_enabled": False,
+        }
+    )
+
+
+def test_start_session_managed_remembers_host_over_sandbox_default(
+    seeded_session: tuple[str, str],
+) -> None:
+    """In a managed deployment, a picked host survives reload — not the sandbox.
+
+    This is the original complaint end-to-end: the managed picker defaults to
+    "Databricks Sandbox", so a user who picks a connected host used to lose it
+    on the next visit (the picker reverted to the sandbox default). With the
+    last-host preference persisted, picking the host and reloading must restore
+    the host, NOT snap back to the sandbox default.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_managed_remembers_host(base_url, session_id))
+
+
+async def _drive_managed_remembers_host(base_url: str, session_id: str) -> None:
+    host_id, host_name = _HOST_ALPHA
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+
+            # Managed capability probe: makes the sandbox the offered default.
+            # `/v1/info` is fetched once per document load and module-cached, so
+            # a full reload re-hits this stub and re-enters managed mode.
+            async def handle_info(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_managed_info_body()
+                )
+
+            await page.route("**/v1/info", handle_info)
+
+            # One connected online host alongside the managed sandbox default.
+            async def handle_one_host(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps(
+                        {
+                            "hosts": [
+                                {
+                                    "host_id": host_id,
+                                    "name": host_name,
+                                    "owner": "e2e",
+                                    "status": "online",
+                                }
+                            ]
+                        }
+                    ),
+                )
+
+            await page.route("**/v1/hosts", handle_one_host)
+
+            # Neutralize agent discovery so a leaked native agent from another
+            # test can't switch the picker mid-flow (see _drive_permission_mode).
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=json.dumps({"data": []})
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ "{host_id}": ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            chip = page.get_by_test_id("new-chat-landing-host-chip")
+            # Managed default with no stored pick: the sandbox, labeled by its
+            # provider ("Databricks Sandbox").
+            await expect(chip).to_contain_text("Databricks Sandbox")
+
+            # Explicitly pick the connected host instead.
+            await chip.click()
+            await page.get_by_test_id(f"new-chat-landing-host-{host_id}").click()
+            await expect(chip).to_contain_text(host_name)
+
+            # Reload: the host must be restored, NOT reverted to the sandbox
+            # default — the exact regression this change fixes.
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            chip = page.get_by_test_id("new-chat-landing-host-chip")
+            await expect(chip).to_contain_text(host_name)
+            await expect(chip).not_to_contain_text("Databricks Sandbox")
+        finally:
+            await browser.close()
+
+
 def test_start_session_select_model_and_effort(seeded_session: tuple[str, str]) -> None:
     """Picking a model + reasoning effort rides along to the create call.
 

--- a/web/src/lib/hostPreferences.test.ts
+++ b/web/src/lib/hostPreferences.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readLastHostChoice, writeLastHostChoice, SANDBOX_HOST_CHOICE } from "./hostPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("hostPreferences", () => {
+  it("returns null when nothing is stored", () => {
+    // A first-time visitor has no host on record — read must say so (null)
+    // rather than invent one, so the composer falls back to its default.
+    expect(readLastHostChoice()).toBeNull();
+  });
+
+  it("round-trips a written host id", () => {
+    writeLastHostChoice("host_abc");
+    // The exact id written must come back — this is what restores the picker
+    // on the next visit.
+    expect(readLastHostChoice()).toBe("host_abc");
+  });
+
+  it("round-trips the sandbox sentinel", () => {
+    // The sandbox option has no host id, so it persists as the reserved
+    // sentinel; it must survive the round trip distinctly from any host id.
+    writeLastHostChoice(SANDBOX_HOST_CHOICE);
+    expect(readLastHostChoice()).toBe(SANDBOX_HOST_CHOICE);
+  });
+
+  it("overwrites the previous pick", () => {
+    writeLastHostChoice("host_one");
+    writeLastHostChoice(SANDBOX_HOST_CHOICE);
+    // Only the latest pick matters; the preference is a single slot.
+    expect(readLastHostChoice()).toBe(SANDBOX_HOST_CHOICE);
+  });
+
+  it("never throws when storage is inaccessible", () => {
+    // Private-mode / quota failures surface as throws from the Storage API.
+    // Both helpers must swallow them — a broken preference must not break
+    // session creation.
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    expect(() => writeLastHostChoice("host_x")).not.toThrow();
+    expect(readLastHostChoice()).toBeNull();
+  });
+});

--- a/web/src/lib/hostPreferences.ts
+++ b/web/src/lib/hostPreferences.ts
@@ -1,0 +1,46 @@
+// Persisted, app-global preference for which host the new-session landing
+// composer starts on.
+//
+// Mirrors agentPreferences: the landing screen keeps its live React state as
+// the source of truth; these helpers only seed that state on mount and
+// snapshot it when the user explicitly picks a host (or the managed sandbox),
+// so the next visit starts from the last choice instead of the auto-picked
+// default — the sandbox in managed deployments, the first online host in OSS.
+// The consumer still validates a stored host id against the live host list and
+// falls back to the default when that host is gone or offline.
+
+const STORAGE_KEY = "omnigent:last-host-choice";
+
+// Stored in place of a host id when the user picked the managed-sandbox option,
+// which has no host id of its own (the server provisions the host at create
+// time). A reserved sentinel so it can never collide with a real host id.
+export const SANDBOX_HOST_CHOICE = "__sandbox__";
+
+/**
+ * Read the user's last explicit host choice on the landing composer: a host
+ * id, the {@link SANDBOX_HOST_CHOICE} sentinel, or `null` when nothing is
+ * stored, on a server render (no `window`), or when storage is inaccessible —
+ * never throws.
+ */
+export function readLastHostChoice(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist `choice` (a host id or {@link SANDBOX_HOST_CHOICE}) as the user's
+ * last explicit host pick. Swallows quota/access errors so a failed write
+ * can't break session creation.
+ */
+export function writeLastHostChoice(choice: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, choice);
+  } catch {
+    // localStorage quota or access errors shouldn't break the composer.
+  }
+}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2022,6 +2022,9 @@ export function NewChatLandingScreen() {
     if (sandboxSelected) return;
     if (selectedHostId !== null) return;
 
+    // Read the persisted pick once, as a mount-time seed — deliberately NOT a
+    // dependency: it only matters until the slot is filled, and re-running on
+    // its value would fight an explicit in-session selection.
     const lastChoice = readLastHostChoice();
     if (lastChoice === SANDBOX_HOST_CHOICE) {
       // Wait for the server-info probe before acting on a sandbox pick: until

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -62,6 +62,11 @@ import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
 import { getCliServerUrl } from "@/lib/host";
 import { getOmnigentHostConfig } from "@/lib/host";
 import { readLastAgentId, writeLastAgentId } from "@/lib/agentPreferences";
+import {
+  readLastHostChoice,
+  writeLastHostChoice,
+  SANDBOX_HOST_CHOICE,
+} from "@/lib/hostPreferences";
 import { readLastHarness, writeLastHarness } from "@/lib/harnessPreferences";
 import { readHarnessOptions, writeHarnessOption } from "@/lib/modePreferences";
 import { useBrainHarnessLabels } from "@/lib/agentLabels";
@@ -1714,7 +1719,7 @@ export function NewChatLandingScreen() {
   const serverUrl = getCliServerUrl();
   const { data: agents } = useAvailableAgents();
   const brainHarnessLabels = useBrainHarnessLabels();
-  const { data: hosts } = useHosts();
+  const { data: hosts, isLoading: hostsLoading } = useHosts();
   // Sessions the caller can access, to warn when a new session would share a
   // working directory with a live one (see the conflict tooltip below).
   const { data: directorySessions } = useDirectorySessions(true);
@@ -2006,21 +2011,50 @@ export function NewChatLandingScreen() {
     };
   }, []);
 
-  // Auto-select the FIRST AVAILABLE option, mirroring the menu order, so
-  // a session can be started without an explicit pick: the sandbox when
-  // the server supports it (it's pinned first in the picker), else the
-  // first online host. Only fills an empty slot; explicit choices are
-  // never overridden.
+  // Auto-select an option so a session can be started without an explicit
+  // pick. Prefer the user's last explicit choice (persisted across visits);
+  // otherwise fall back to the FIRST AVAILABLE option in menu order — the
+  // sandbox when the server supports it (it's pinned first in the picker),
+  // else the first online host. Only fills an empty slot; an explicit choice
+  // already in state (or restored from the in-memory draft) is never
+  // overridden.
   useEffect(() => {
     if (sandboxSelected) return;
     if (selectedHostId !== null) return;
+
+    const lastChoice = readLastHostChoice();
+    if (lastChoice === SANDBOX_HOST_CHOICE) {
+      // Wait for the server-info probe before acting on a sandbox pick: until
+      // it resolves we don't know whether the sandbox is offered, and falling
+      // through to a connected host would strand the returning sandbox user
+      // (this effect wouldn't re-run to correct it once a host is set).
+      if (info === "loading") return;
+      if (managedSandboxesEnabled) {
+        setSandboxSelected(true);
+        return;
+      }
+      // Sandbox no longer offered (e.g. an OSS server) — fall through.
+    } else if (lastChoice) {
+      // A persisted host pick can only be honored once the host list has
+      // loaded and shows it online. Wait for the load rather than defaulting
+      // past it — defaulting to the sandbox here would set sandboxSelected and
+      // this effect would then never re-run to restore the host.
+      if (hostsLoading) return;
+      const stored = (hosts ?? []).find((h) => h.host_id === lastChoice && h.status === "online");
+      if (stored) {
+        setSelectedHostId(stored.host_id);
+        return;
+      }
+      // Stored host is gone or offline — fall through to the default.
+    }
+
     if (managedSandboxesEnabled) {
       setSandboxSelected(true);
       return;
     }
     const firstOnline = (hosts ?? []).find((h) => h.status === "online");
     if (firstOnline) setSelectedHostId(firstOnline.host_id);
-  }, [hosts, selectedHostId, sandboxSelected, managedSandboxesEnabled]);
+  }, [hosts, hostsLoading, selectedHostId, sandboxSelected, managedSandboxesEnabled, info]);
 
   // Fall back to the host's home directory when it has no recorded recents, so
   // the working-directory field is pre-filled and the user can send in one
@@ -2475,6 +2509,10 @@ export function NewChatLandingScreen() {
   };
 
   function selectHost(hostId: string) {
+    // Persist the explicit pick even when it matches the current selection, so
+    // clicking the auto-selected host still records it as the sticky default
+    // for the next visit.
+    writeLastHostChoice(hostId);
     // Re-selecting the current host is a no-op. Clearing the workspace here
     // would empty the field for good: the seeding effect's deps (host id,
     // recents, derived home) are all unchanged on a same-host pick, so it
@@ -2491,6 +2529,10 @@ export function NewChatLandingScreen() {
   }
 
   function selectSandbox() {
+    // Persist the explicit sandbox pick (as the reserved sentinel) even when
+    // it's already selected, mirroring selectHost — so the sandbox becomes the
+    // sticky default for the next visit.
+    writeLastHostChoice(SANDBOX_HOST_CHOICE);
     if (sandboxSelected) return;
     // Mirror selectHost: a managed session's host and workspace are both
     // server-chosen, so clear any prior host pick and its workspace.
@@ -3172,6 +3214,7 @@ export function NewChatLandingScreen() {
                     <DropdownMenuItem
                       key={host.host_id}
                       onSelect={() => selectHost(host.host_id)}
+                      data-testid={`new-chat-landing-host-${host.host_id}`}
                       data-active={host.host_id === selectedHostId ? "true" : undefined}
                       className="text-xs data-[active=true]:bg-accent/60"
                     >


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The new-session landing picker always reverted to its auto-select default on every fresh visit — the managed sandbox where it's offered, otherwise the first online host — **ignoring the host the user last picked.**
- Root cause: the only thing that remembered a host selection was the module-scoped in-memory `landingDraft`, which is **cleared on create** and **lost on page refresh**. There was no persisted host preference (the agent picker already has one via `agentPreferences`; the host never got the equivalent).
- Fix: add `hostPreferences` (localStorage, mirroring `agentPreferences`) and have the auto-select effect prefer the user's last explicit choice before falling back to the default. A stored host id is validated against the live list (gone/offline → default); the sandbox pick persists as a reserved sentinel.

**ELI5:** The picker had a sticky note for "which agent" but not "which host", so it forgot your host every time. This adds the host sticky note.

```
Before:  open composer ─► auto-default (sandbox / first host)   [last pick ignored]
After:   open composer ─► last explicit pick (if still valid)   [else same default]
                              persisted in localStorage across create + refresh
```

## Test Plan

- `npm run test` (vitest) — new `hostPreferences.test.ts` + the existing `NewChatDialog` suites: **177 passed / 1 skipped**.
- `tsc -b` clean; `oxlint` no new warnings; `prettier --check` clean.
- Two new e2e_ui Playwright tests: `test_start_session_remembers_last_picked_host` (OSS: two online hosts, pick the second, **reload**, assert it's restored instead of reverting to the first-online default) and `test_start_session_managed_remembers_host_over_sandbox_default` (managed: `/v1/info` stubbed so the default is "Databricks Sandbox" — pick a connected host, **reload**, assert the host is restored and does **not** snap back to the sandbox default; this is the original complaint end to end). Ruff clean; `pytest --collect-only` confirms both collect. (A full headed e2e run needs a built SPA+server+runner+chromium, so it isn't run in this sandbox.)

## Demo

N/A — no headed browser available here to capture a recording. The behavior is exercised end-to-end by the added e2e_ui test (pick host → reload → still selected); the before/after is diagrammed in the Summary.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the new persistence helper (read/write/overwrite/sentinel/error-swallow). The e2e_ui test covers the user-visible contract: an explicit host pick survives a reload. The existing `NewChatDialog` suites cover that the no-preference default is unchanged (managed → sandbox, OSS → first online host).

## Changelog

The new-session picker now remembers the host you last picked instead of resetting to the default.

---

This pull request and its description were written by Isaac.
