### PR TITLE
fix(hermes): skip Omnigent relay tools in the pre_tool_call hook

### DIFF
--- a/omnigent/inner/hermes_policy_hook.py
+++ b/omnigent/inner/hermes_policy_hook.py
@@ -54,6 +54,13 @@ def main() -> None:
     tool_name = payload.get("tool_name") or "unknown"
     tool_input = payload.get("tool_input") or {}
 
+    # Omnigent relay tools are already gated when the relay dispatches them back
+    # through the server's tool path; gating them here too parks a duplicate approval
+    # card whose long-poll hangs. Hermes' own tools lack the prefix and stay gated.
+    if tool_name.startswith(("mcp_omnigent_", "mcp__omnigent__")):
+        json.dump({}, sys.stdout)
+        return
+
     # Build the evaluation request matching the server's EvaluationRequest
     # schema.
     eval_body: dict[str, object] = {

--- a/tests/inner/test_hermes_policy_hook.py
+++ b/tests/inner/test_hermes_policy_hook.py
@@ -1,0 +1,76 @@
+"""Tests for the Hermes pre_tool_call policy hook's relay-tool skip.
+
+Omnigent relay tools (surfaced into Hermes as ``mcp_omnigent_*``) are gated when
+the relay dispatches them back through the server's tool path. The hook must NOT
+gate them a second time (that parks a duplicate approval card whose long-poll
+hangs, wedging the turn). Hermes' own tools are still gated here.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from omnigent.inner import hermes_policy_hook
+
+
+@pytest.fixture
+def wired_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "http://localhost:6767")
+    monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
+
+
+def _run(monkeypatch: pytest.MonkeyPatch, tool_name: str) -> tuple[dict, bool]:
+    """Run the hook with *tool_name*; return (stdout_json, server_was_called)."""
+    called = {"hit": False}
+
+    def _spy(*_args, **_kwargs):
+        called["hit"] = True
+
+        class _R:
+            def json(self) -> dict:
+                return {"result": "POLICY_ACTION_ALLOW"}
+
+        return _R()
+
+    monkeypatch.setattr("omnigent.native_policy_hook.post_evaluate_with_retry", _spy, raising=True)
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(json.dumps({"tool_name": tool_name, "tool_input": {}})),
+    )
+    out = io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    hermes_policy_hook.main()
+    return json.loads(out.getvalue() or "{}"), called["hit"]
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "mcp_omnigent_sys_session_get_info",  # hermes single-underscore form
+        "mcp_omnigent_sys_os_write",
+        "mcp__omnigent__list_comments",  # native double-underscore form
+    ],
+)
+def test_relay_tools_are_skipped(
+    monkeypatch: pytest.MonkeyPatch, wired_env: None, tool_name: str
+) -> None:
+    result, server_called = _run(monkeypatch, tool_name)
+    # Allow (empty object) WITHOUT hitting /policies/evaluate — the dispatch
+    # gate is the single authoritative gate for these tools.
+    assert result == {}
+    assert server_called is False
+
+
+@pytest.mark.parametrize(
+    "tool_name", ["terminal", "str_replace_editor", "mcp_github_create_issue"]
+)
+def test_native_and_other_mcp_tools_are_still_gated(
+    monkeypatch: pytest.MonkeyPatch, wired_env: None, tool_name: str
+) -> None:
+    _result, server_called = _run(monkeypatch, tool_name)
+    # Hermes' own tools (and non-Omnigent MCP servers) do NOT round-trip the
+    # relay, so the hook stays their policy gate.
+    assert server_called is True


### PR DESCRIPTION
## Related issue

Closes #2219

## Summary

`hermes_policy_hook.py` evaluated `PHASE_TOOL_CALL` policy for every tool, including the
Omnigent relay tools (`mcp_omnigent_*` / `mcp__omnigent__*`). Those tools are already gated
when the relay dispatches them back through the server's tool path (fail-closed, re-checked on
retry), so the hook gated them a second time — parking a duplicate approval card whose hook
long-poll never returns after the first card is resolved, wedging the turn.

Skip those prefixes in the hook, matching the guard the native claude/codex hooks already apply
(`native_policy_hook.hook_payload_to_evaluation_request` skips `mcp__omnigent__*`; Hermes names
the same relay tools `mcp_omnigent_*`, so both forms are matched). Hermes' own tools (shell,
file) and non-Omnigent MCP servers lack the prefix and stay gated by the hook.

## Test plan

`tests/inner/test_hermes_policy_hook.py` asserts the relay tools are allowed without a call to
`/policies/evaluate` (both underscore forms) and that native tools and non-Omnigent MCP servers
still round-trip the hook's policy gate. The relay-skip cases fail before the change (the hook
evaluates them) and pass after. `uv run pytest tests/inner/test_hermes_policy_hook.py` green.

## Demo

Live web UI run (headless `hermes` with the Omnigent MCP server from #2216
registered, demo ASK policy on `sys_session_get_info`): the gated relay call
parks exactly ONE approval card - the dispatch-side policy evaluation. Without
this fix the pre_tool_call hook would evaluate the same call a second time and
park a second card whose long-poll outlives the human's single approval.

![one approval card, not two](https://raw.githubusercontent.com/dosenr/omnigent/assets/hermes-headless-demo/01-approval-card-dark.png)

![approved, tool runs](https://raw.githubusercontent.com/dosenr/omnigent/assets/hermes-headless-demo/02-complete-dark.png)

<details><summary>Original terminal transcript</summary>

This is a hook-logic change with no UI surface, so the demonstration is the test: the relay
tools short-circuit to allow without a `/policies/evaluate` round-trip, while native tools still
round-trip. The `test_relay_tools_are_skipped` cases fail before the change and pass after:

```
$ uv run pytest tests/inner/test_hermes_policy_hook.py -q
......                                                                     [100%]
6 passed
```

End-to-end (a single approval card per gated relay call, no post-resolution wedge) was verified
against a running deployment.

</details>

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit test added

## Coverage notes

The end-to-end behavior (a single approval card per gated relay call, no post-resolution wedge)
was verified against a running deployment; the added unit tests cover the hook-level skip that
was the defect.

## Changelog

Fixed the Hermes `pre_tool_call` hook double-gating Omnigent relay tools, which parked a
duplicate approval card and could wedge the turn.

