### PR TITLE
feat(auth): read the OIDC email identity from a configurable id_token claim

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -151,6 +151,14 @@ POSTGRES_PASSWORD=change-me-please
 # trusted enterprise directory — it makes any signed email claim the
 # user's identity. Off by default.
 # OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION=1
+#
+# Read the email identity from a different id_token claim. Some IdPs
+# omit the email claim entirely — Microsoft Entra ID commonly issues
+# only preferred_username (the UPN) — which fails login with
+# "Could not determine user email". A custom claim carries no
+# email_verified marker, so set OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION
+# alongside it. Default: email.
+# OMNIGENT_OIDC_EMAIL_CLAIM=preferred_username
 
 # ── Server config file (admins, allowed domains, …) ──────
 # Non-secret settings live in a YAML config file — the same one

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -101,6 +101,10 @@ services:
       # without API Access Management) that omit the claim for
       # directory-provisioned users. Off unless set; see .env.example.
       OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION: "${OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION:-}"
+      # Read the email identity from a different id_token claim — for
+      # IdPs (e.g. Microsoft Entra ID) that issue preferred_username
+      # instead of email. Empty means the default (email); see .env.example.
+      OMNIGENT_OIDC_EMAIL_CLAIM: "${OMNIGENT_OIDC_EMAIL_CLAIM:-}"
       # Opt-in OIDC invites (admin pre-authorizes one off-domain email).
       # Off unless set. The admin list (/data/admins) and the optional
       # allowed-domains file (/data/allowed_domains) need no env var —

--- a/omnigent/server/oidc.py
+++ b/omnigent/server/oidc.py
@@ -163,6 +163,10 @@ class OIDCConfig:
         ``id_token`` email claim without requiring
         ``email_verified``. Only affects the generic-OIDC path;
         GitHub always requires a verified primary email.
+    :param email_claim: Name of the ``id_token`` claim that carries
+        the user's email identity, e.g. ``"preferred_username"`` for
+        IdPs that omit ``email`` (Microsoft Entra ID). Defaults to
+        ``"email"``. Only affects the generic-OIDC path.
     """
 
     issuer: str
@@ -181,6 +185,7 @@ class OIDCConfig:
     userinfo_endpoint: str | None
     allow_invites: bool
     skip_email_verification: bool = False
+    email_claim: str = "email"
 
     @property
     def base_url(self) -> str:
@@ -306,6 +311,25 @@ class OIDCConfig:
                 issuer,
             )
 
+        # Some IdPs carry the email identity in a claim other than
+        # ``email`` (Microsoft Entra ID commonly issues only
+        # ``preferred_username``, the UPN).
+        email_claim = (os.environ.get("OMNIGENT_OIDC_EMAIL_CLAIM") or "email").strip()
+        if email_claim != "email":
+            _logger.warning(
+                "OMNIGENT_OIDC_EMAIL_CLAIM is set: the user identity "
+                "will be read from the %r claim of id_tokens issued by "
+                "%s instead of ``email``.",
+                email_claim,
+                issuer,
+            )
+            if not skip_email_verification:
+                _logger.warning(
+                    "A custom email claim carries no email_verified "
+                    "marker, so logins will be rejected unless "
+                    "OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION is also set."
+                )
+
         # Determine provider type and resolve endpoints.
         is_github = issuer.rstrip("/") == _GITHUB_ISSUER
 
@@ -371,4 +395,5 @@ class OIDCConfig:
             userinfo_endpoint=doc.get("userinfo_endpoint"),
             allow_invites=allow_invites,
             skip_email_verification=skip_email_verification,
+            email_claim=email_claim,
         )

--- a/omnigent/server/routes/auth.py
+++ b/omnigent/server/routes/auth.py
@@ -761,6 +761,12 @@ def _resolve_oidc_email(
     IdPs that omit the claim for directory-managed users (e.g. Okta
     without custom API Access Management).
 
+    ``config.email_claim`` (from ``OMNIGENT_OIDC_EMAIL_CLAIM``) names
+    the claim that carries the email identity, for IdPs that omit
+    ``email`` (Microsoft Entra ID commonly issues only
+    ``preferred_username``). ``email_verified`` refers to the ``email``
+    claim, so a custom claim always needs the verification opt-out too.
+
     :param token_json: The token endpoint response JSON containing
         ``id_token``.
     :param config: The OIDC configuration with JWKS URI and
@@ -788,8 +794,38 @@ def _resolve_oidc_email(
         _logger.warning("id_token validation failed: %s", exc)
         return None
 
-    email = claims.get("email")
+    email = claims.get(config.email_claim)
     if not email:
+        _logger.warning(
+            "Rejecting id_token: no %r claim (claims present: %s). "
+            "IdPs that use a different claim for the email identity "
+            "can set OMNIGENT_OIDC_EMAIL_CLAIM.",
+            config.email_claim,
+            sorted(claims.keys()),
+        )
+        return None
+
+    # ``email_verified`` refers to the ``email`` claim (OIDC core), so
+    # it vouches nothing about a custom identity claim — a token can
+    # carry ``email_verified: true`` for a *different* address than the
+    # one being minted. A custom claim therefore always requires the
+    # explicit opt-out, regardless of ``email_verified``.
+    if config.email_claim != "email":
+        if config.skip_email_verification:
+            _logger.info(
+                "Accepting id_token %s %r; the claim has no verified "
+                "marker (OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION is set)",
+                config.email_claim,
+                email,
+            )
+            return email
+        _logger.warning(
+            "Rejecting id_token: %s %r has no email_verified marker "
+            "(email_verified refers to the email claim); set "
+            "OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION to accept it",
+            config.email_claim,
+            email,
+        )
         return None
 
     # Reject unless the IdP affirmatively verified the email. A signed

--- a/omnigent/server/routes/auth.py
+++ b/omnigent/server/routes/auth.py
@@ -772,9 +772,10 @@ def _resolve_oidc_email(
     :param config: The OIDC configuration with JWKS URI and
         expected issuer/audience.
     :returns: The user's email from the ``id_token`` when present and
-        marked verified; ``None`` if the token is missing/invalid,
-        the email claim is absent, or ``email_verified`` is not
-        truthy (and verification is not skipped via config).
+        marked verified; ``None`` if the token is missing/invalid, the
+        email claim is absent or not a non-empty string, or
+        ``email_verified`` is not truthy (and verification is not
+        skipped via config).
     """
     id_token = token_json.get("id_token")
     if not id_token:
@@ -795,15 +796,17 @@ def _resolve_oidc_email(
         return None
 
     email = claims.get(config.email_claim)
-    if not email:
+    if not isinstance(email, str) or not email.strip():
         _logger.warning(
-            "Rejecting id_token: no %r claim (claims present: %s). "
+            "Rejecting id_token: %r claim is missing or not a non-empty string "
+            "(claims present: %s). "
             "IdPs that use a different claim for the email identity "
             "can set OMNIGENT_OIDC_EMAIL_CLAIM.",
             config.email_claim,
             sorted(claims.keys()),
         )
         return None
+    email = email.strip()
 
     # ``email_verified`` refers to the ``email`` claim (OIDC core), so
     # it vouches nothing about a custom identity claim — a token can

--- a/tests/server/test_oidc_callback.py
+++ b/tests/server/test_oidc_callback.py
@@ -320,10 +320,11 @@ def test_callback_custom_email_claim_admits_upn(
     claim configured via ``OMNIGENT_OIDC_EMAIL_CLAIM`` and the
     verification opt-out set (a custom claim has no ``email_verified``
     marker), the UPN mints the session. Before the fix this token was
-    rejected outright.
+    rejected outright. Surrounding whitespace is removed before the
+    identity is normalized.
     """
     client, keys = callback_client
-    token = keys.sign_id_token({"preferred_username": "Dana@Example.com"})
+    token = keys.sign_id_token({"preferred_username": " Dana@Example.com "})
 
     resp = _do_callback(client, token)
 
@@ -333,6 +334,33 @@ def test_callback_custom_email_claim_admits_upn(
     decoded = jwt.decode(session_cookie, _TEST_SECRET, algorithms=["HS256"])
     # The UPN flowed into the session sub, normalized like an email.
     assert decoded["sub"] == "dana@example.com"
+
+
+@pytest.mark.parametrize(
+    "callback_client",
+    [{"email_claim": "preferred_username", "skip_email_verification": True}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "claim_value",
+    [
+        pytest.param(["dana@example.com"], id="list"),
+        pytest.param({"value": "dana@example.com"}, id="object"),
+        pytest.param("   ", id="blank"),
+    ],
+)
+def test_callback_custom_email_claim_rejects_invalid_value(
+    callback_client: tuple[TestClient, _IdpKeys],
+    claim_value: object,
+) -> None:
+    """A malformed configured identity claim is rejected cleanly."""
+    client, keys = callback_client
+    token = keys.sign_id_token({"preferred_username": claim_value})
+
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 400, resp.text
+    assert resp.cookies.get("ap_session") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/server/test_oidc_callback.py
+++ b/tests/server/test_oidc_callback.py
@@ -44,7 +44,10 @@ _ISSUER = "https://accounts.google.com"
 _CLIENT_ID = "cid"
 
 
-def _oidc_config(skip_email_verification: bool = False) -> OIDCConfig:
+def _oidc_config(
+    skip_email_verification: bool = False,
+    email_claim: str = "email",
+) -> OIDCConfig:
     """Build a generic-OIDC config over plain HTTP (so TestClient cookies stick).
 
     ``allowed_domains=None`` means admit-all, so the test isolates the
@@ -52,6 +55,8 @@ def _oidc_config(skip_email_verification: bool = False) -> OIDCConfig:
 
     :param skip_email_verification: Waive the ``email_verified`` gate,
         as ``OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION`` would.
+    :param email_claim: Claim carrying the email identity, as
+        ``OMNIGENT_OIDC_EMAIL_CLAIM`` would set it.
     """
     return OIDCConfig(
         issuer=_ISSUER,
@@ -70,6 +75,7 @@ def _oidc_config(skip_email_verification: bool = False) -> OIDCConfig:
         userinfo_endpoint=None,
         allow_invites=False,
         skip_email_verification=skip_email_verification,
+        email_claim=email_claim,
     )
 
 
@@ -124,15 +130,20 @@ def callback_client(
     ``post`` — exposed on ``app.state.pending_id_token`` so ``_do_callback``
     can set the signed token the IdP should return.
 
-    Indirect parametrization (``request.param``, default ``False``) sets
-    the config's ``skip_email_verification`` flag.
+    Indirect parametrization (``request.param``, default ``False``)
+    sets the config's ``skip_email_verification`` flag; a dict param is
+    passed to :func:`_oidc_config` as keyword arguments instead.
     """
     keys = _IdpKeys()
     perm_store = SqlAlchemyPermissionStore(db_uri)
     admins = tmp_path / "admins"
     admins.write_text("")
 
-    config = _oidc_config(skip_email_verification=getattr(request, "param", False))
+    param = getattr(request, "param", False)
+    if isinstance(param, dict):
+        config = _oidc_config(**param)
+    else:
+        config = _oidc_config(skip_email_verification=param)
     provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
 
     # The signed id_token the mocked token endpoint will return. Each
@@ -292,6 +303,99 @@ def test_callback_skip_verification_flag_admits_unverified(
     assert session_cookie is not None
     decoded = jwt.decode(session_cookie, _TEST_SECRET, algorithms=["HS256"])
     assert decoded["sub"] == "carol@example.com"
+
+
+@pytest.mark.parametrize(
+    "callback_client",
+    [{"email_claim": "preferred_username", "skip_email_verification": True}],
+    indirect=True,
+)
+def test_callback_custom_email_claim_admits_upn(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """``email_claim`` reads the identity from an alternate claim.
+
+    Models Microsoft Entra ID id_tokens that carry only
+    ``preferred_username`` (the UPN) and no ``email`` claim: with the
+    claim configured via ``OMNIGENT_OIDC_EMAIL_CLAIM`` and the
+    verification opt-out set (a custom claim has no ``email_verified``
+    marker), the UPN mints the session. Before the fix this token was
+    rejected outright.
+    """
+    client, keys = callback_client
+    token = keys.sign_id_token({"preferred_username": "Dana@Example.com"})
+
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 302, resp.text
+    session_cookie = resp.cookies.get("ap_session")
+    assert session_cookie is not None
+    decoded = jwt.decode(session_cookie, _TEST_SECRET, algorithms=["HS256"])
+    # The UPN flowed into the session sub, normalized like an email.
+    assert decoded["sub"] == "dana@example.com"
+
+
+@pytest.mark.parametrize(
+    "callback_client",
+    [{"email_claim": "preferred_username"}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "claims",
+    [
+        pytest.param({"preferred_username": "dana@example.com"}, id="no-verified-marker"),
+        pytest.param(
+            {
+                "preferred_username": "dana@example.com",
+                "email": "attacker@evil.example",
+                "email_verified": True,
+            },
+            id="verified-refers-to-a-different-claim",
+        ),
+    ],
+)
+def test_callback_custom_email_claim_still_requires_verification_optout(
+    callback_client: tuple[TestClient, _IdpKeys],
+    claims: dict[str, object],
+) -> None:
+    """A custom claim always requires the verification opt-out.
+
+    ``email_verified`` refers to the ``email`` claim, so it vouches
+    nothing about a custom identity claim — a token carrying
+    ``email_verified: true`` for a *different* address must not smuggle
+    the custom claim past the gate. Without
+    ``OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION`` both shapes are rejected.
+    """
+    client, keys = callback_client
+    token = keys.sign_id_token(claims)
+
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 400, resp.text
+    assert resp.cookies.get("ap_session") is None
+
+
+@pytest.mark.parametrize(
+    "callback_client",
+    [{"email_claim": "preferred_username", "skip_email_verification": True}],
+    indirect=True,
+)
+def test_callback_custom_email_claim_absent_rejected(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """When the configured claim is absent, the login is rejected.
+
+    A verified ``email`` claim is not a silent fallback: the operator
+    configured ``preferred_username`` as the identity claim, so a token
+    without it must not mint a session from a different claim.
+    """
+    client, keys = callback_client
+    token = keys.sign_id_token({"email": "dana@example.com", "email_verified": True})
+
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 400, resp.text
+    assert resp.cookies.get("ap_session") is None
 
 
 @pytest.mark.parametrize("verified_value", [True, "true", "True", "TRUE"])


### PR DESCRIPTION
## Related issue

Closes #2222

## Summary

- `_resolve_oidc_email` reads only the `email` claim and returns `None` when it is absent, so native OIDC login against Microsoft Entra ID - which commonly issues id_tokens carrying the identity only in `preferred_username` (the UPN) - fails with "Could not determine user email" and nothing actionable in the log.
- Adds `OMNIGENT_OIDC_EMAIL_CLAIM` (default `email`), mirroring oauth2-proxy's `--oidc-email-claim`: names the id_token claim that carries the email identity. The default path is byte-for-byte unchanged; only the generic-OIDC path is affected (GitHub OAuth has no id_token).
- A custom claim always requires the existing `OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION` opt-out: `email_verified` refers to the `email` claim (OIDC core), so it vouches nothing about a custom identity claim - a token carrying `email_verified: true` for a *different* address must not smuggle the custom claim past the gate. No fallback chain: a token missing the configured claim is rejected even when a verified `email` claim is present.
- The absent-claim rejection now logs the configured claim and the claim names present, so the Entra failure is diagnosable from the server log.

## Test Plan

Four new/extended tests in `tests/server/test_oidc_callback.py` (the mirrored area suite), driving the real callback route with signature-valid RS256 id_tokens:

- a UPN-only token (no `email` claim) mints a session with `OMNIGENT_OIDC_EMAIL_CLAIM=preferred_username` plus the verification opt-out - fails before the change with "Could not determine user email"
- a custom claim without the opt-out is rejected, both with no verified marker and with `email_verified: true` referring to a different `email` claim (the smuggling shape)
- a token missing the configured claim is rejected even when a verified `email` claim is present (no silent fallback)\n- Malformed custom claim values (list, object, or whitespace-only) return 400 without minting a session; surrounding whitespace on a valid identity is removed before normalization.

`uv run pytest tests/server/test_oidc_callback.py`: 19 passed. `ruff` and `pre-commit` clean.

## Demo

Driven against a **real Microsoft Entra ID (v2.0) id_token** from our tenant.
It carries `preferred_username` (the UPN) and **no `email` claim** - exactly the
case this PR addresses. Default config rejects it; pointing `OMNIGENT_OIDC_EMAIL_CLAIM`
at `preferred_username` resolves the identity and login succeeds. Run through the
shipped `_resolve_oidc_email` with full JWKS signature validation against the
tenant's real keys (iss/aud verified). All values redacted.

![OIDC email-claim red-green](https://raw.githubusercontent.com/dosenr/omnigent/assets/oidc-email-claim-demo/2223-demo.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The callback tests verify real RS256 signatures against a per-test JWKS key, so the claim-resolution and verification-gate behavior is exercised end-to-end through the route; no live IdP is required.