### PR TITLE
refactor(web): redesign Appearance settings (Mode / Color theme / Terminal)

### DIFF
--- a/tests/e2e_ui/sessions/test_color_theme.py
+++ b/tests/e2e_ui/sessions/test_color_theme.py
@@ -1,9 +1,9 @@
 """E2E: the Settings → Appearance color-palette picker skins the app and persists.
 
-Alongside the light/dark **mode** cards, ``AppearanceSection``
-(``pages/SettingsPage.tsx``) renders a second ``role="radiogroup"`` labelled
-"Color palette" — one card per palette (Omnigent, Nord, Monokai, Solarized,
-Dracula). Selecting one calls ``applyThemePalette`` (``lib/themePalette.ts``),
+Alongside the light/dark **mode** tiles, ``AppearanceSection``
+(``pages/SettingsPage.tsx``) renders a "Color theme" dropdown (a shadcn
+``Select``) — one option per palette (Omnigent, Dracula, GitHub, Catppuccin,
+Gruvbox). Choosing one calls ``applyThemePalette`` (``lib/themePalette.ts``),
 which sets ``data-theme`` on ``<html>`` and persists the id to
 ``localStorage["omnigent:ui-theme-palette"]``. The default "Omnigent" palette
 carries no override, so choosing it removes the attribute and clears the key.
@@ -37,16 +37,27 @@ def _html_has_dark(page: Page) -> bool:
 
 
 def _theme_radiogroup(page: Page) -> Locator:
-    """The app-theme (mode) radiogroup, matched exactly so it can't also resolve
-    the "Terminal theme" radiogroup (its name contains "Theme" and its cards
-    reuse the Light/Dark labels)."""
-    return page.get_by_role("radiogroup", name="Theme", exact=True)
+    """The appearance-mode radiogroup ("Mode"). Matched exactly so it can't also
+    resolve the "Color theme" / "Terminal theme" radiogroups, whose cards reuse
+    the Light/Dark labels."""
+    return page.get_by_role("radiogroup", name="Mode", exact=True)
+
+
+def _color_theme_select(page: Page) -> Locator:
+    """The color-theme dropdown trigger."""
+    return page.get_by_test_id("color-theme-select")
+
+
+def _pick_palette(page: Page, name: str) -> None:
+    """Open the color-theme dropdown and choose the option with the given name."""
+    _color_theme_select(page).click()
+    page.get_by_role("option", name=name).click()
 
 
 def _open_appearance(page: Page, base_url: str) -> None:
-    """Navigate to the Settings Appearance section and wait for the palette group."""
+    """Navigate to the Settings Appearance section, wait for the color-theme dropdown."""
     page.goto(f"{base_url}/settings/appearance")
-    expect(page.get_by_role("radiogroup", name="Color palette")).to_be_visible(timeout=30_000)
+    expect(_color_theme_select(page)).to_be_visible(timeout=30_000)
 
 
 def test_color_palette_applies_persists_and_resets(
@@ -54,7 +65,7 @@ def test_color_palette_applies_persists_and_resets(
 ) -> None:
     """Selecting a palette skins ``<html>`` + persists; the default clears it.
 
-    Fresh load is the default "Omnigent" (its card checked, nothing stored, no
+    Fresh load is the default "Omnigent" (its name shown, nothing stored, no
     ``data-theme``). Picking GitHub sets ``data-theme="github"`` and persists it —
     and survives a reload (re-applied at boot). Returning to Omnigent removes the
     attribute and clears the stored key.
@@ -62,31 +73,29 @@ def test_color_palette_applies_persists_and_resets(
     base_url, _session_id = seeded_session
     _open_appearance(page, base_url)
 
-    # Fresh context → default "Omnigent" palette: card checked, no override, no
-    # persisted preference.
-    expect(page.get_by_role("radio", name="Omnigent")).to_have_attribute("aria-checked", "true")
+    # Fresh context → default "Omnigent": the trigger shows it, no override, and
+    # nothing persisted.
+    expect(_color_theme_select(page)).to_contain_text("Omnigent")
     assert _data_theme(page) is None, "expected no data-theme override on a fresh load"
     assert _stored_palette(page) is None, "expected no persisted palette on a fresh load"
 
     # → GitHub: the data-theme attribute lands on <html> and the choice persists.
-    github = page.get_by_role("radio", name="GitHub")
-    github.click()
-    expect(github).to_have_attribute("aria-checked", "true")
+    _pick_palette(page, "GitHub")
+    expect(_color_theme_select(page)).to_contain_text("GitHub")
     assert _data_theme(page) == "github", "data-theme=github not set after selecting GitHub"
     assert _stored_palette(page) == '"github"'
 
     # Reload: the saved palette is re-applied before first paint (main.tsx), so
-    # <html> still carries data-theme=github and the card stays selected.
+    # <html> still carries data-theme=github and the trigger stays on GitHub.
     page.reload()
-    expect(page.get_by_role("radiogroup", name="Color palette")).to_be_visible(timeout=30_000)
+    expect(_color_theme_select(page)).to_be_visible(timeout=30_000)
     assert _data_theme(page) == "github", "saved palette not re-applied after reload"
-    expect(page.get_by_role("radio", name="GitHub")).to_have_attribute("aria-checked", "true")
+    expect(_color_theme_select(page)).to_contain_text("GitHub")
 
     # → back to Omnigent (the default): the override is removed and the stored
     # key cleared, since the default reverts to the base brand tokens.
-    omnigent = page.get_by_role("radio", name="Omnigent")
-    omnigent.click()
-    expect(omnigent).to_have_attribute("aria-checked", "true")
+    _pick_palette(page, "Omnigent")
+    expect(_color_theme_select(page)).to_contain_text("Omnigent")
     assert _data_theme(page) is None, "<html> kept data-theme after returning to Omnigent"
     assert _stored_palette(page) is None, "the palette key was not cleared for the default"
 
@@ -105,10 +114,8 @@ def test_color_palette_composes_with_dark_mode(
     base_url, _session_id = seeded_session
     _open_appearance(page, base_url)
 
-    # Pick a palette, then Dark mode; the two controls are independent.
-    catppuccin = page.get_by_role("radio", name="Catppuccin")
-    catppuccin.click()
-    expect(catppuccin).to_have_attribute("aria-checked", "true")
+    # Pick a palette (dropdown), then Dark mode (radiogroup) — independent axes.
+    _pick_palette(page, "Catppuccin")
 
     dark = _theme_radiogroup(page).get_by_role("radio", name="Dark")
     dark.click()

--- a/tests/e2e_ui/sessions/test_theme_toggle.py
+++ b/tests/e2e_ui/sessions/test_theme_toggle.py
@@ -2,7 +2,7 @@
 
 The theme control lives on the Settings page (``pages/SettingsPage.tsx``,
 ``AppearanceSection``): three radio cards — System / Light / Dark — under a
-``role="radiogroup"`` labelled "Theme". Each card sets the chosen mode directly
+``role="radiogroup"`` labelled "Mode". Each card sets the chosen mode directly
 (``onClick={() => setTheme(mode)}``); ``aria-checked`` reflects the current
 selection. Unlike the previous sidebar cycle-button, every mode is selectable
 directly regardless of the OS preference (no skipped "redundant" step).
@@ -33,10 +33,10 @@ def _stored_theme(page: Page) -> str | None:
 
 
 def _theme_radiogroup(page: Page) -> Locator:
-    """The app-theme radiogroup, matched exactly so it can't also resolve the
-    Appearance page's "Terminal theme" radiogroup, whose name contains "Theme"
-    and whose cards reuse the Light/Dark labels."""
-    return page.get_by_role("radiogroup", name="Theme", exact=True)
+    """The appearance-mode radiogroup ("Mode"). Matched exactly so it can't also
+    resolve the "Color theme" / "Terminal theme" radiogroups, whose cards reuse
+    the Light/Dark labels."""
+    return page.get_by_role("radiogroup", name="Mode", exact=True)
 
 
 def _open_appearance(page: Page, base_url: str) -> None:

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -6,6 +6,7 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
 
@@ -58,6 +59,33 @@ vi.mock("@/pages/MembersPage", () => ({
 }));
 vi.mock("@/pages/PoliciesPage", () => ({
   PoliciesPage: () => <div>policies-page-stub</div>,
+}));
+// Radix Select uses a portal + pointer events jsdom can't drive, so stub it to
+// a native <select>; lets the color-theme dropdown be exercised via change.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (v: string) => void;
+    children: ReactNode;
+  }) => (
+    <select
+      data-testid="color-theme-select"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
 }));
 
 import { SettingsPage } from "./SettingsPage";
@@ -146,21 +174,34 @@ describe("SettingsPage", () => {
     expect(screen.getByTestId("terminal-theme-auto")).toHaveAttribute("aria-checked", "false");
   });
 
-  it("renders the color palette picker, defaults to Omnigent, and applies a palette on click", () => {
+  it("renders the color theme dropdown, defaults to Omnigent, and applies a palette on change", () => {
     localStorage.clear();
     renderPage("/settings/appearance");
 
-    // The palette picker is its own radiogroup, distinct from the mode cards.
-    expect(screen.getByRole("radiogroup", { name: "Color palette" })).toBeInTheDocument();
+    const select = screen.getByTestId("color-theme-select") as HTMLSelectElement;
     // Nothing stored → the default (Omnigent) palette is selected and no
     // data-theme override is applied to the document.
-    expect(screen.getByTestId("palette-omni")).toHaveAttribute("aria-checked", "true");
+    expect(select.value).toBe("omni");
+    expect(document.documentElement.getAttribute("data-theme")).toBeNull();
 
-    // Choosing a palette selects it, applies it live to <html>, and persists it.
-    fireEvent.click(screen.getByTestId("palette-github"));
-    expect(screen.getByTestId("palette-github")).toHaveAttribute("aria-checked", "true");
+    // Choosing a palette applies it live to <html> and persists it.
+    fireEvent.change(select, { target: { value: "github" } });
+    expect(select.value).toBe("github");
     expect(document.documentElement.getAttribute("data-theme")).toBe("github");
     expect(localStorage.getItem("omnigent:ui-theme-palette")).toBe(JSON.stringify("github"));
+  });
+
+  it("moves the mode selection with arrow keys (radiogroup keyboard nav)", () => {
+    renderPage("/settings/appearance");
+
+    // Arrow keys move within the mode radiogroup and select as focus moves (the
+    // WAI-ARIA radiogroup pattern). themeCards order is System / Light / Dark,
+    // so ArrowRight from System selects Light.
+    const system = screen.getByTestId("theme-system");
+    system.focus();
+    fireEvent.keyDown(system, { key: "ArrowRight" });
+
+    expect(mocks.setTheme).toHaveBeenCalledWith("light");
   });
 
   it("shows the default UI font size and steps it up, persisting the choice", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -24,7 +24,17 @@
  *   list. Not clickable; each row reveals Delete / Unarchive on hover.
  */
 
-import { lazy, type ReactNode, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  lazy,
+  type ReactNode,
+  Suspense,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   ArchiveRestoreIcon,
   KeyRoundIcon,
@@ -45,6 +55,13 @@ import { useTheme } from "next-themes";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Dialog,
   DialogContent,
@@ -102,6 +119,7 @@ import {
 } from "@/lib/terminalThemePreferences";
 import {
   applyThemePalette,
+  isThemePalette,
   PALETTES,
   type PaletteSwatch,
   readThemePalette,
@@ -193,57 +211,271 @@ const terminalThemeCards: { mode: TerminalThemeMode; label: string; icon: typeof
   { mode: "dark", label: "Dark", icon: MoonIcon },
 ];
 
-function TerminalThemeControl() {
-  const [mode, setMode] = useState(() => readTerminalThemeMode());
-
+/**
+ * Checkmark badge pinned to the top-right corner of a selected card. Shared by
+ * every appearance radiogroup so "selected" reads identically everywhere.
+ */
+function SelectedBadge() {
   return (
-    <div className="flex flex-col gap-3">
-      <span className="text-sm font-medium">Terminal theme</span>
-      <span className="text-sm text-muted-foreground">
-        Use a light or dark terminal, or match the app.
-      </span>
-      <div className="grid grid-cols-3 gap-3" role="radiogroup" aria-label="Terminal theme">
-        {terminalThemeCards.map(({ mode: cardMode, label, icon: Icon }) => {
-          const selected = mode === cardMode;
-          return (
-            <button
-              key={cardMode}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              data-testid={`terminal-theme-${cardMode}`}
-              onClick={() => {
-                setMode(cardMode);
-                writeTerminalThemeMode(cardMode);
-              }}
-              className={cn(
-                "flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors hover:bg-muted",
-                selected ? "border-primary bg-primary/5" : "border-border",
-              )}
-            >
-              <Icon className="size-6 text-muted-foreground" />
-              <span className="text-sm font-medium">{label}</span>
-            </button>
-          );
-        })}
+    <span
+      aria-hidden
+      className="absolute right-1.5 top-1.5 flex size-4 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm"
+    >
+      <CheckIcon className="size-3" />
+    </span>
+  );
+}
+
+/**
+ * Shared card styling for the appearance radiogroups. Selected cards carry the
+ * accent border + a subtle accent wash (paired with <SelectedBadge/>); the rest
+ * highlight their border and lift on hover. focus-visible keeps the global
+ * outline ring, so keyboard focus stays visually distinct from selection.
+ */
+function themeCardClass(selected: boolean, layout?: string) {
+  return cn(
+    "relative flex flex-col rounded-lg border-2 transition-[color,background-color,border-color,box-shadow]",
+    selected
+      ? "border-primary bg-primary/5"
+      : "border-border hover:border-border-strong hover:bg-muted hover:shadow-sm",
+    layout,
+  );
+}
+
+/** Centered icon + label body shared by the Mode and Terminal theme cards. */
+function iconCardBody(Icon: typeof SunIcon, label: string) {
+  return (
+    <>
+      <Icon className="size-6 text-muted-foreground" />
+      <span className="text-sm font-medium">{label}</span>
+    </>
+  );
+}
+
+// Neutral light/dark window tones for the Mode preview tiles. These are about
+// light-vs-dark only (not the color theme), so they stay grayscale.
+const LIGHT_MODE_PREVIEW: PaletteSwatch = {
+  bg: "#e9ebee",
+  card: "#ffffff",
+  accent: "#aab2bd",
+  border: "#d7dbe0",
+  text: "#11171c",
+};
+const DARK_MODE_PREVIEW: PaletteSwatch = {
+  bg: "#0d1218",
+  card: "#232a33",
+  accent: "#5b6672",
+  border: "#2b333d",
+  text: "#e6edf3",
+};
+
+/**
+ * Mini app-window mock for a Mode tile, reusing {@link PaletteSwatchPreview}. A
+ * light or dark two-pane window; "system" shows one window split diagonally —
+ * light on the near side, dark on the far — to signal "follow the OS".
+ */
+function ModePreview({ variant }: { variant: ThemeMode }) {
+  if (variant === "light") return <PaletteSwatchPreview swatch={LIGHT_MODE_PREVIEW} />;
+  if (variant === "dark") return <PaletteSwatchPreview swatch={DARK_MODE_PREVIEW} />;
+  return (
+    <div className="relative h-16 w-full">
+      <PaletteSwatchPreview swatch={LIGHT_MODE_PREVIEW} />
+      <div
+        aria-hidden
+        className="absolute inset-0"
+        style={{ clipPath: "polygon(62% 0, 100% 0, 100% 100%, 38% 100%)" }}
+      >
+        <PaletteSwatchPreview swatch={DARK_MODE_PREVIEW} />
       </div>
     </div>
   );
 }
 
+/** Small swatch chip (canvas + accent dot) for the color-theme dropdown. */
+function PaletteChip({ swatch }: { swatch: PaletteSwatch }) {
+  return (
+    <span
+      aria-hidden
+      className="flex size-5 shrink-0 items-center justify-center rounded-md border"
+      style={{ backgroundColor: swatch.bg, borderColor: swatch.border }}
+    >
+      <span className="size-2 rounded-full" style={{ backgroundColor: swatch.accent }} />
+    </span>
+  );
+}
+
+/** One option in a {@link CardRadioGroup}. */
+interface CardRadioOption<T extends string> {
+  value: T;
+  testId: string;
+  body: ReactNode;
+  /** Optional native tooltip (used for the palette blurbs). */
+  title?: string;
+}
+
 /**
- * Color-theme (palette) picker — the second appearance axis, shown under the
- * same "Theme" heading as the mode cards. Renders a swatch grid of the
- * available palettes (see lib/themePalette.ts); selecting one applies it live
- * to <html> via `data-theme`, persists it, and composes with the light/dark
- * mode picker above.
+ * Accessible card radiogroup shared by all three appearance pickers. Implements
+ * the WAI-ARIA radiogroup pattern: a roving tabindex (only the selected card is
+ * tabbable), arrow keys move selection within the group, and Enter/Space select
+ * the focused card. `labelledBy` points at the subsection heading so the group's
+ * accessible name matches its visible label.
+ */
+function CardRadioGroup<T extends string>({
+  labelledBy,
+  value,
+  onSelect,
+  items,
+  className,
+  cardClassName,
+}: {
+  labelledBy: string;
+  value: T;
+  onSelect: (value: T) => void;
+  items: readonly CardRadioOption<T>[];
+  className?: string;
+  cardClassName?: string;
+}) {
+  // Keep a handle on each card so arrow-key navigation can move focus as it
+  // moves selection (selection-follows-focus, per the radiogroup pattern).
+  const refs = useRef(new Map<T, HTMLButtonElement | null>());
+
+  return (
+    <div role="radiogroup" aria-labelledby={labelledBy} className={className}>
+      {items.map((item, index) => {
+        const selected = item.value === value;
+        return (
+          <button
+            key={item.value}
+            ref={(el) => {
+              refs.current.set(item.value, el);
+            }}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
+            title={item.title}
+            data-testid={item.testId}
+            onClick={() => onSelect(item.value)}
+            onKeyDown={(event) => {
+              const forward = event.key === "ArrowRight" || event.key === "ArrowDown";
+              const backward = event.key === "ArrowLeft" || event.key === "ArrowUp";
+              if (!forward && !backward) return;
+              event.preventDefault();
+              const nextIndex = (index + (forward ? 1 : -1) + items.length) % items.length;
+              const next = items[nextIndex].value;
+              onSelect(next);
+              refs.current.get(next)?.focus();
+            }}
+            className={themeCardClass(selected, cardClassName)}
+          >
+            {selected && <SelectedBadge />}
+            {item.body}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** A labeled Appearance subsection: heading + one-line helper + its control. */
+function ThemeSubsection({
+  labelId,
+  title,
+  helper,
+  children,
+}: {
+  labelId: string;
+  title: string;
+  helper: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col">
+        <span id={labelId} className="text-sm font-medium">
+          {title}
+        </span>
+        <span className="text-sm text-muted-foreground">{helper}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** Appearance mode: System / Light / Dark. */
+function ModeControl() {
+  const { theme, setTheme } = useTheme();
+  const mode = normalizeThemeMode(theme);
+  const labelId = useId();
+  return (
+    <ThemeSubsection
+      labelId={labelId}
+      title="Mode"
+      helper="Follow your system, or force light or dark."
+    >
+      <CardRadioGroup<ThemeMode>
+        labelledBy={labelId}
+        value={mode}
+        onSelect={(next) => setTheme(next)}
+        className="grid grid-cols-3 gap-3"
+        cardClassName="gap-2 p-2"
+        items={themeCards.map((card) => ({
+          value: card.mode,
+          testId: `theme-${card.mode}`,
+          body: (
+            <>
+              <ModePreview variant={card.mode} />
+              <span className="text-center text-sm font-medium">{card.label}</span>
+            </>
+          ),
+        }))}
+      />
+    </ThemeSubsection>
+  );
+}
+
+/** Terminal light/dark/match-app theme — its own section. */
+function TerminalThemeControl() {
+  const [mode, setMode] = useState(() => readTerminalThemeMode());
+  const labelId = useId();
+  const choose = useCallback((next: TerminalThemeMode) => {
+    setMode(next);
+    writeTerminalThemeMode(next);
+  }, []);
+  return (
+    <ThemeSubsection
+      labelId={labelId}
+      title="Terminal theme"
+      helper="Use a light or dark terminal, or match the app."
+    >
+      <CardRadioGroup<TerminalThemeMode>
+        labelledBy={labelId}
+        value={mode}
+        onSelect={choose}
+        className="grid grid-cols-3 gap-3"
+        cardClassName="items-center gap-2 p-4"
+        items={terminalThemeCards.map((card) => ({
+          value: card.mode,
+          testId: `terminal-theme-${card.mode}`,
+          body: iconCardBody(card.icon, card.label),
+        }))}
+      />
+    </ThemeSubsection>
+  );
+}
+
+/**
+ * Color-theme (palette) picker — a dropdown (à la Codex). Each option shows a
+ * swatch chip + name and the trigger mirrors the current selection. Choosing
+ * one applies it live to <html> via `data-theme`, persists it, and composes on
+ * top of the chosen light/dark mode.
  */
 function ColorThemeControl() {
-  // Render each swatch in the currently-resolved mode so the previews match
-  // what the app looks like right now.
+  // Render each chip in the currently-resolved mode so it matches the app now.
   const { resolvedTheme } = useTheme();
   const isDark = normalizeResolvedTheme(resolvedTheme) === "dark";
   const [palette, setPalette] = useState<ThemePalette>(() => readThemePalette());
+  const labelId = useId();
 
   const choose = useCallback((next: ThemePalette) => {
     setPalette(next);
@@ -251,37 +483,40 @@ function ColorThemeControl() {
     applyThemePalette(next);
   }, []);
 
+  const selected = PALETTES.find((p) => p.id === palette) ?? PALETTES[0];
+
   return (
-    <div
-      role="radiogroup"
-      aria-label="Color palette"
-      className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
+    <ThemeSubsection
+      labelId={labelId}
+      title="Color theme"
+      helper="Applies on top of your chosen mode."
     >
-      {PALETTES.map((p) => {
-        const selected = palette === p.id;
-        return (
-          <button
-            key={p.id}
-            type="button"
-            role="radio"
-            aria-checked={selected}
-            title={p.blurb}
-            data-testid={`palette-${p.id}`}
-            onClick={() => choose(p.id)}
-            className={cn(
-              "flex flex-col gap-2 rounded-xl border-2 p-2 text-left transition-colors hover:bg-muted",
-              selected ? "border-primary" : "border-border",
-            )}
-          >
-            <PaletteSwatchPreview swatch={isDark ? p.dark : p.light} />
-            <span className="flex items-center justify-between gap-1 px-0.5 text-sm font-medium">
-              {p.label}
-              {selected && <CheckIcon className="size-3.5 text-primary" />}
-            </span>
-          </button>
-        );
-      })}
-    </div>
+      <Select
+        value={palette}
+        onValueChange={(next) => {
+          if (isThemePalette(next)) choose(next);
+        }}
+      >
+        <SelectTrigger
+          aria-labelledby={labelId}
+          data-testid="color-theme-select"
+          className="w-full max-w-xs gap-2"
+        >
+          <SelectValue>
+            <PaletteChip swatch={isDark ? selected.dark : selected.light} />
+            <span>{selected.label}</span>
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {PALETTES.map((p) => (
+            <SelectItem key={p.id} value={p.id} data-testid={`palette-${p.id}`}>
+              <PaletteChip swatch={isDark ? p.dark : p.light} />
+              <span>{p.label}</span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </ThemeSubsection>
   );
 }
 
@@ -330,52 +565,28 @@ function PaletteSwatchPreview({ swatch }: { swatch: PaletteSwatch }) {
 }
 
 function AppearanceSection() {
-  // Embedded: the host owns the theme (embed.tsx forces light), so the
-  // selector would be a no-op — match ThemeModeMenu and hide it.
+  // Embedded: the host owns light/dark, so the Mode and Color theme pickers
+  // would be no-ops — hide them and say so (matching ThemeModeMenu). Terminal
+  // theme and the font controls are per-device prefs that don't conflict with
+  // host theming, so they stay visible.
   const isEmbedded = useIsEmbedded();
-  const { theme, setTheme } = useTheme();
-  const mode = normalizeThemeMode(theme);
 
   return (
     <Section title="Appearance" description="Choose how Omnigent looks on this device.">
       <div className="flex flex-col gap-8">
-        {/* One "Theme" group: appearance mode (System / Light / Dark) on top,
-            then the color palette swatches. Both are hidden when embedded — the
-            host owns theming there. */}
-        <div className="flex flex-col gap-4">
-          <span className="text-sm font-medium">Theme</span>
-          {isEmbedded ? (
+        {isEmbedded ? (
+          <div className="flex flex-col gap-3">
+            <span className="text-sm font-medium">Theme</span>
             <p className="text-sm text-muted-foreground">
               Theme is controlled by the host application.
             </p>
-          ) : (
-            <>
-              <div className="grid grid-cols-3 gap-3" role="radiogroup" aria-label="Theme">
-                {themeCards.map(({ mode: cardMode, label, icon: Icon }) => {
-                  const selected = mode === cardMode;
-                  return (
-                    <button
-                      key={cardMode}
-                      type="button"
-                      role="radio"
-                      aria-checked={selected}
-                      data-testid={`theme-${cardMode}`}
-                      onClick={() => setTheme(cardMode)}
-                      className={cn(
-                        "flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors hover:bg-muted",
-                        selected ? "border-primary bg-primary/5" : "border-border",
-                      )}
-                    >
-                      <Icon className="size-6 text-muted-foreground" />
-                      <span className="text-sm font-medium">{label}</span>
-                    </button>
-                  );
-                })}
-              </div>
-              <ColorThemeControl />
-            </>
-          )}
-        </div>
+          </div>
+        ) : (
+          <>
+            <ModeControl />
+            <ColorThemeControl />
+          </>
+        )}
 
         <TerminalThemeControl />
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Redesigns the **Appearance** settings page so its two orthogonal choices no longer sit conflated under one "Theme" heading.

- **Mode** (System / Light / Dark) and **Color theme** are now separate, clearly-labeled subsections, each with a one-line helper ("Follow your system, or force light or dark." / "Applies on top of your chosen mode."). **Terminal theme** stays its own section.
- **Mode** cards show a mini app-window preview instead of a bare icon — light / dark windows, and a diagonally split tile for System (à la Codex).
- **Color theme** moves into a dropdown (the app's shadcn `Select`) with a swatch chip per option; the trigger mirrors the current selection and the open list checks the active one.
- **Consistent selection everywhere**: one treatment across the card groups — accent border + a corner checkmark badge — driven by a small shared, keyboard-navigable radiogroup (roving tabindex, arrow keys move + select), with focus-visible kept distinct from selected. Groups are labeled via `aria-labelledby` off their headings.

No available options or their names change — only organization, layout, and interaction consistency.

## Test Plan

- `npm run type-check` — clean
- `npm run lint` (oxlint) — no new issues
- `npm test` (Vitest): `SettingsPage.test.tsx` + `themePalette.test.ts` — dropdown apply/persist, Mode arrow-key nav, terminal + font controls — 36 passing
- `npm run build` — production bundle + LightningCSS minification succeed
- Updated Playwright e2e (`tests/e2e_ui/sessions/test_color_theme.py`, `test_theme_toggle.py`): drive the color-theme dropdown (open + pick) and the renamed "Mode" radiogroup
- Ran a local server + Vite dev server and exercised all three groups in light and dark, including keyboard nav

## Demo

Appearance → **Mode** (System / Light / Dark preview tiles; System split light/dark) + **Color theme** dropdown (swatch chips) + **Terminal theme**.

_Screenshot/recording to be attached by author._

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

- Vitest covers the color-theme dropdown (default + apply/persist, via a native-`<select>` mock following the repo's `ResumeWithDirectoryDialog` pattern) and the Mode radiogroup's arrow-key navigation; Terminal + font controls unchanged.
- `test_color_theme.py` / `test_theme_toggle.py` (Playwright) updated for the dropdown and the renamed "Mode" radiogroup. Not run on the local dev box (Playwright/browsers aren't installed there); CI's e2e_ui job runs them.
- Manually verified Mode / Color theme / Terminal across light + dark and keyboard nav in a live local stack.

## Changelog

Redesigned Appearance settings: separate Mode and Color theme sections, app-preview Mode tiles, and a color-theme dropdown.