### PR TITLE
fix(runtime): exclude "any" harness sentinel from model-change respawn check

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -724,14 +724,20 @@ class HarnessProcessManager:
                 )
                 await self._close_entry(entry)
                 entry = None
-            if entry is not None:
+            if entry is not None and harness != "any":
                 # The model is baked into the subprocess env at spawn time;
                 # a later turn requesting a different model (e.g. after the
                 # user runs ``/model``) must respawn, otherwise the cached
                 # process keeps serving the old model. Only respawn when a
                 # concrete different model is requested — a turn that sets no
                 # model env (``None``) keeps the running process.
-                requested_model = (env or {}).get(_model_env_key(harness))
+                #
+                # ``harness != "any"`` mirrors the harness-mismatch guard
+                # above: closing the entry here with no concrete harness to
+                # respawn from would fall through to the ``NoLiveHarnessError``
+                # raise below, turning a harness-agnostic steering/cancel call
+                # into a hard failure instead of reusing the live subprocess.
+                requested_model = (env or {}).get(_model_env_key(entry.harness))
                 if requested_model is not None and requested_model != entry.model:
                     _logger.info(
                         "harness %s for conversation %s: model changed %r -> %r; respawning",

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -486,6 +486,44 @@ async def test_get_client_any_harness_sentinel_no_subprocess_raises(
         await manager.shutdown()
 
 
+async def test_get_client_any_harness_sentinel_ignores_model_override(
+    manager: HarnessProcessManager,
+) -> None:
+    """A model override passed alongside the ``"any"`` sentinel is a no-op.
+
+    ``"any"`` has no concrete harness to respawn INTO, so the model-change
+    check must skip entirely when ``harness == "any"`` — mirroring the
+    harness-mismatch check's own ``"any"`` exclusion just above it. Before
+    the fix, the check instead built its ``env`` lookup key from the
+    ``harness`` argument itself; ``_model_env_key("any")`` never matched a
+    real ``HARNESS_<H>_MODEL`` key, so this happened to no-op too, but only
+    by accident. A naive fix that keys on ``entry.harness`` instead (so the
+    lookup actually matches) makes things WORSE: it detects the "model
+    changed" and closes the entry, then falls through to
+    ``NoLiveHarnessError`` because ``"any"`` can't be spawned — turning a
+    harness-agnostic steering/cancel call into a hard failure. This test
+    guards the correct behavior: a live subprocess, untouched, no error.
+    """
+    await manager.start()
+    try:
+        client_first = await manager.get_client(
+            "conv_a", _TEST_HARNESS_NAME, env={"HARNESS_TEST_MODEL": "model-a"}
+        )
+        pid_first = (await client_first.get("/pid")).json()["pid"]
+
+        # "any" sentinel + a DIFFERENT model → must NOT respawn or raise.
+        client_second = await manager.get_client(
+            "conv_a", "any", env={"HARNESS_TEST_MODEL": "model-b"}
+        )
+        pid_second = (await client_second.get("/pid")).json()["pid"]
+
+        # Same PID proves the live subprocess was reused untouched.
+        assert pid_second == pid_first
+        assert _pid_alive(pid_second)
+    finally:
+        await manager.shutdown()
+
+
 async def test_get_client_concurrent_first_calls_share_subprocess(
     manager: HarnessProcessManager,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #2224 

## Summary

- `process_manager.py:728`'s model-change respawn check built its lookup key from the `harness` parameter, which can be the `"any"` sentinel used by steering/cancel/interrupt callers — unlike the harness-mismatch check a few lines above, this line didn't exclude `"any"`.
- The wrong key meant the lookup always missed, so respawn was silently skipped for `"any"` calls. This was accidentally the correct end result, but for the wrong reason.
- A naive fix (pointing the lookup at `entry.harness` instead) surfaces a real bug: `"any"` has no harness to respawn into, so a detected model mismatch closes the entry and falls through to `NoLiveHarnessError`, crashing what should be a harmless call.
- Fix: explicitly exclude `"any"` from the model-change check, mirroring the existing harness-mismatch check, so `"any"` calls are a safe, intentional no-op instead of relying on an accidental key mismatch.

## Test Plan

1. `get_client("conv_1", "test", env={"HARNESS_TEST_MODEL": "model-a"})` — spawns a subprocess running `model-a`.
2. `get_client("conv_1", "any", env={"HARNESS_TEST_MODEL": "model-b"})` on the same conversation.
3. Verified the same subprocess is returned, still running `model-a` (safe no-op, no crash).
4. During development, verified that a naive fix (keying the lookup on `entry.harness` without also excluding `"any"`) throws `NoLiveHarnessError` for the same steps above — confirming the explicit `"any"` guard is necessary, not just cosmetic.
5. Ran `uv run pytest tests/runtime/harnesses/test_process_manager.py` (33/33 pass), `uv run pytest tests/runtime/test_process_manager.py` (3/3 pass, unaffected), and the full `uv run pytest tests/runtime/` (1026/1026 pass). Ran `uv run ruff check` / `ruff format --check` / `pre-commit run --files` scoped to the two changed files (all clean) — a repo-wide `ruff check .` currently fails on pre-existing, unrelated broken notebook test fixtures under `web/src/shell/__fixtures__/`.

## Demo

N/A

## Type of change

- [] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [X] Test / CI
- [ ] Breaking change

## Test coverage

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `test_get_client_any_harness_sentinel_ignores_model_override` to `tests/runtime/harnesses/test_process_manager.py`, covering the previously-untested model-change-respawn path for the `"any"` sentinel. The pre-fix code on `main` already passed this test by accident (wrong lookup key never matched, so it silently no-op'd); the test's real value is guarding against the more "obvious" fix (keying the lookup on `entry.harness` without also excluding `"any"`), which I verified during development throws `NoLiveHarnessError` instead.