### PR TITLE
test: raise the runner-connect budget in the external-runner integration test

### DIFF
--- a/tests/server/integration/test_external_runner_connects.py
+++ b/tests/server/integration/test_external_runner_connects.py
@@ -112,11 +112,13 @@ def test_external_runner_connects_to_local_server(
 
         try:
             # Poll until the server reports the runner as online.
-            # The runner needs to connect the WS tunnel and send its
-            # hello frame; budget 10s.
+            # The runner needs to connect the WS tunnel and send its hello
+            # frame; budget 60s (hard cap — the loop exits as soon as it
+            # is online, so only starved CI workers ever use the tail).
             online = False
             status_url = f"{base_url}/v1/runners/{runner.runner_id}/status"
-            for _attempt in range(20):
+            deadline = time.monotonic() + 60.0
+            while time.monotonic() < deadline:
                 time.sleep(0.5)
                 if runner.proc.poll() is not None:
                     pytest.fail(
@@ -136,7 +138,7 @@ def test_external_runner_connects_to_local_server(
             # failed — either the runner_id / binding-token mismatch
             # (Bug 1) or the allow-list rejection (Bug 2).
             assert online, (
-                f"Runner {runner.runner_id} did not come online within 10s. "
+                f"Runner {runner.runner_id} did not come online within 60s. "
                 f"Runner process alive: {runner.proc.poll() is None}"
             )
         finally:


### PR DESCRIPTION
## Related issue

N/A (CI flake)

## Summary

The external-runner integration test polls for the runner to come online with a 10s budget, which flakes when a loaded CI worker starves the runner process. Raised to a 60s hard cap - the loop exits the moment the runner reports online, so only starved workers ever use the tail.

This PR originally also touched `test_interrupt_forwards_to_harness`; that test was fixed better in #2232 (direct awaits under pytest's global timeout), so the hunk is dropped and the PR is now this single budget change.

## Test Plan

Existing test, unchanged assertions; only the poll ceiling moves. Collected and green locally.

## Demo

N/A (test-only change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Existing tests cover this change

## Coverage notes

Test-only: a poll-budget increase in one integration test.