### PR TITLE
feat(db): store ids as 16-byte binary uuids, drop legacy prefixes

### DIFF
--- a/dev/benchmarks/omnigent/environment.py
+++ b/dev/benchmarks/omnigent/environment.py
@@ -379,7 +379,9 @@ class BenchEnvironment:
         over loopback (single-user ``RESERVED_USER_LOCAL`` owner, no token) and
         launches runners on demand when the server sends ``host.launch_runner``.
         """
-        self.host_id = f"host_bench_{uuid.uuid4().hex[:12]}"
+        # Bare 32-char hex uuid — host_id is a Uuid16 (binary) column, so it
+        # must be a valid uuid (a synthetic "host_bench_…" string no longer fits).
+        self.host_id = uuid.uuid4().hex
         workspace = self._tmp / "host-workspace"
         workspace.mkdir(exist_ok=True)
         self.host_workspace = str(workspace)

--- a/omnigent/claude_native_state.py
+++ b/omnigent/claude_native_state.py
@@ -119,12 +119,23 @@ def _state_dir_for_conversation_id(conversation_id: str) -> Path:
     every byte that lands in the path is hex, so the result is
     always a single child of the state root.
 
-    :param conversation_id: Omnigent conversation id, e.g.
-        ``"conv_abc123"``.
+    Sessions created before ids dropped the ``conv_`` prefix hashed the
+    prefixed string, so their directories live under the legacy digest; when
+    the bare-digest directory is absent, the legacy one is returned (never
+    renamed — files inside may embed their own absolute path).
+
+    :param conversation_id: Omnigent conversation id, bare 32-char hex
+        (a legacy ``conv_``-prefixed form is accepted and normalised).
     :returns: Absolute directory path; not guaranteed to exist.
     """
-    digest = hashlib.sha256(conversation_id.encode("utf-8")).hexdigest()[:_ID_HASH_CHARS]
-    return _claude_native_state_root() / digest
+    bare = conversation_id.removeprefix("conv_")
+    root = _claude_native_state_root()
+    state_dir = root / hashlib.sha256(bare.encode("utf-8")).hexdigest()[:_ID_HASH_CHARS]
+    if not state_dir.exists():
+        legacy = root / hashlib.sha256(f"conv_{bare}".encode()).hexdigest()[:_ID_HASH_CHARS]
+        if legacy.exists():
+            return legacy
+    return state_dir
 
 
 def write_launch_state(conversation_id: str, working_directory: str) -> None:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1133,7 +1133,9 @@ def _preregister_agent(  # type: ignore[explicit-any]  # agent_store / artifact_
     existing = agent_store.get_by_name(spec.name)
     if existing is not None:
         new_loc = f"{existing.id}/{bundle_hash}"
-        if existing.bundle_location != new_loc:
+        # Sha-segment compare: legacy rows keep an ``ag_``-prefixed left
+        # segment (physical artifact key); only the sha encodes content.
+        if existing.bundle_location.rsplit("/", 1)[-1] != bundle_hash:
             artifact_store.put(new_loc, bundle_bytes)
             agent_store.update(existing.id, bundle_location=new_loc)
             # Swap the cache's extracted bundle in lockstep. Without

--- a/omnigent/codex_native_state.py
+++ b/omnigent/codex_native_state.py
@@ -61,12 +61,23 @@ def _state_dir_for_conversation_id(conversation_id: str) -> Path:
     Hashing the conversation id prevents path traversal if a server
     ever returned an attacker-controlled id such as ``"../etc"``.
 
-    :param conversation_id: Omnigent conversation id, e.g.
-        ``"conv_abc123"``.
+    Sessions created before ids dropped the ``conv_`` prefix hashed the
+    prefixed string, so their directories live under the legacy digest; when
+    the bare-digest directory is absent, the legacy one is returned (never
+    renamed — files inside may embed their own absolute path).
+
+    :param conversation_id: Omnigent conversation id, bare 32-char hex
+        (a legacy ``conv_``-prefixed form is accepted and normalised).
     :returns: Absolute directory path; not guaranteed to exist.
     """
-    digest = hashlib.sha256(conversation_id.encode("utf-8")).hexdigest()[:_ID_HASH_CHARS]
-    return _codex_native_state_root() / digest
+    bare = conversation_id.removeprefix("conv_")
+    root = _codex_native_state_root()
+    state_dir = root / hashlib.sha256(bare.encode("utf-8")).hexdigest()[:_ID_HASH_CHARS]
+    if not state_dir.exists():
+        legacy = root / hashlib.sha256(f"conv_{bare}".encode()).hexdigest()[:_ID_HASH_CHARS]
+        if legacy.exists():
+            return legacy
+    return state_dir
 
 
 def write_launch_state(conversation_id: str, working_directory: str) -> None:

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -37,19 +37,113 @@ from omnigent.db.compression import CompressedText
 _CKSUM32 = LargeBinary(32).with_variant(MySQLBinary(32), "mysql")
 
 
+# Hex length of a bare uuid4 id, the canonical Python-side form.
+_UUID_HEX_LEN = 32
+
+# Prefixes ids carried before they became bare 32-char hex. ``uuid_to_bytes``
+# strips exactly these (so old URLs/clients keep resolving) and nothing else —
+# an unknown prefix fails loud rather than silently storing a wrong-typed id's
+# hex tail (e.g. a ``resp_``/``runner_token_`` value mis-passed to a uuid column).
+_LEGACY_ID_PREFIXES = frozenset(
+    {
+        "ag",
+        "conv",
+        "host",
+        "pol",
+        "file",
+        "cmt",
+        # conversation-item per-type prefixes
+        "msg",
+        "fc",
+        "fco",
+        "err",
+        "rs",
+        "cmp",
+        "nt",
+        "rse",
+        "sc",
+        "tc",
+        "rd",
+        # runner-internal conversation binding
+        "agy_conv",
+    }
+)
+
+
+class InvalidUuidError(ValueError):
+    """An id string could not be normalised to a 32-char hex uuid.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` sites keep
+    working. Surfaced (wrapped in ``sqlalchemy.exc.StatementError``) when a
+    malformed id reaches a ``Uuid16`` column bind; the server maps it to a 404
+    so a bad id in a URL is not-found rather than a 500.
+    """
+
+
+def uuid_to_bytes(value: str | uuid.UUID) -> bytes:
+    """Normalise an id to the 16 raw bytes stored in a ``Uuid16`` column.
+
+    Accepts, reducing them all to the same 16 bytes: a :class:`uuid.UUID`
+    object; the bare 32-char hex form (what generators emit); the dashed
+    canonical uuid (``str(uuid4())``); and a legacy id carrying one of the
+    known :data:`_LEGACY_ID_PREFIXES` (``conv_<hex>``, ``ag_<hex>``, …) — so
+    old bookmarked URLs, pasted ids, and pre-migration clients keep resolving.
+    Anything else — a truncated id, non-hex text, an unknown prefix — fails
+    loud rather than silently storing the wrong bytes.
+
+    :param value: A ``uuid.UUID``, or a 32-char hex uuid optionally dashed or
+        legacy-prefixed.
+    :returns: The 16-byte big-endian value.
+    :raises InvalidUuidError: If *value* is not a 32-char hex uuid.
+    """
+    if isinstance(value, uuid.UUID):
+        return value.bytes
+    normalized = value.replace("-", "")
+    if "_" in normalized:
+        prefix, _, tail = normalized.rpartition("_")
+        if prefix in _LEGACY_ID_PREFIXES and len(tail) == _UUID_HEX_LEN:
+            normalized = tail
+    if len(normalized) != _UUID_HEX_LEN:
+        raise InvalidUuidError(f"expected a 32-char hex uuid, got {value!r}")
+    try:
+        return bytes.fromhex(normalized)
+    except ValueError as exc:
+        raise InvalidUuidError(f"invalid hex uuid: {value!r}") from exc
+
+
+def normalize_uuid(value: str | None) -> str | None:
+    """Return the bare 32-char hex form of *value*, or *value* unchanged.
+
+    The forgiving companion to :func:`uuid_to_bytes` for **Python-side** id
+    comparisons (e.g. a store's scope check against an ORM attribute, which
+    always reads back bare hex). A legacy-prefixed or dashed input normalises
+    to bare hex; a malformed input is returned as-is so the comparison simply
+    mismatches — preserving the pre-migration "unknown id = not found"
+    behaviour instead of raising. ``None`` passes through.
+
+    :param value: Any caller-supplied id string, or ``None``.
+    :returns: The bare 32-char hex form, or *value* verbatim if not a uuid.
+    """
+    if value is None:
+        return None
+    try:
+        return uuid_to_bytes(value).hex()
+    except InvalidUuidError:
+        return value
+
+
 class Uuid16(TypeDecorator[str]):
-    """A UUID primary key stored as 16 raw bytes.
+    """A uuid stored as 16 raw bytes, presented to Python as bare 32-char hex.
 
-    Python-side values are bare 32-char hex strings (e.g.
-    ``"a1b2c3d4..."``, no dashes — matching the schema-wide UUID
-    convention); the database stores the 16-byte form —
-    ``BINARY(16)`` on MySQL (fixed-length and fully indexable, the same
-    reasoning as :data:`_CKSUM32`) and ``BLOB`` / ``BYTEA`` elsewhere.
-    Halves the storage of a 32-char hex string and indexes tighter.
-
-    ``process_bind_param`` accepts either a canonical/hex string or a
-    :class:`uuid.UUID`; ``process_result_value`` always returns the
-    bare 32-char hex string (``.hex``, no dashes).
+    Our ids are opaque 128-bit uuid4s stored as raw bytes — ``BYTEA``
+    (PostgreSQL), ``BLOB`` (SQLite / D1), fixed-length ``BINARY(16)`` (MySQL,
+    where a BLOB is not indexable without a key-prefix length). The rest of
+    the system keeps the readable bare 32-char hex form (entities, JSON
+    blobs, URLs, the FTS mirror), so this type converts at the column
+    boundary and nothing else has to change. Binds accept bare, dashed, or
+    legacy-prefixed uuids; results always come back as bare lowercase hex.
+    Result values guard the same driver variance ``CompressedText`` does:
+    ``bytes``, ``memoryview`` (some drivers), or ``str`` (already hex).
     """
 
     impl = LargeBinary(16)
@@ -60,15 +154,19 @@ class Uuid16(TypeDecorator[str]):
             return dialect.type_descriptor(MySQLBinary(16))
         return dialect.type_descriptor(LargeBinary(16))
 
-    def process_bind_param(self, value: str | uuid.UUID | None, dialect: Any) -> bytes | None:  # noqa: ARG002
+    def process_bind_param(self, value: str | uuid.UUID | None, _dialect: object) -> bytes | None:
         if value is None:
             return None
-        return (value if isinstance(value, uuid.UUID) else uuid.UUID(value)).bytes
+        return uuid_to_bytes(value)
 
-    def process_result_value(self, value: bytes | None, dialect: Any) -> str | None:  # noqa: ARG002
+    def process_result_value(
+        self, value: bytes | memoryview | str | None, _dialect: object
+    ) -> str | None:
         if value is None:
             return None
-        return uuid.UUID(bytes=bytes(value)).hex
+        if isinstance(value, str):
+            return value
+        return bytes(value).hex()
 
 
 class OmnigentBase(DeclarativeBase):
@@ -179,7 +277,7 @@ class SqlAgent(OmnigentBase):
         server_default="0",
         default=current_workspace_id,
     )
-    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
     name: Mapped[str] = mapped_column(String(256))
     bundle_location: Mapped[str] = mapped_column(String(512))
@@ -231,12 +329,12 @@ class SqlFile(OmnigentBase):
         server_default="0",
         default=current_workspace_id,
     )
-    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
     filename: Mapped[str] = mapped_column(String(512))
     bytes: Mapped[int] = mapped_column(Integer)
     content_type: Mapped[str | None] = mapped_column(String(256), nullable=True)
-    session_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    session_id: Mapped[str | None] = mapped_column(Uuid16(), nullable=True)
 
     __table_args__ = (
         Index("ix_files_created_at", "workspace_id", "created_at", "id"),
@@ -389,7 +487,7 @@ class SqlSessionPermission(OmnigentBase):
         primary_key=True,
     )
     conversation_id: Mapped[str] = mapped_column(
-        String(64),
+        Uuid16(),
         primary_key=True,
     )
     level: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -426,12 +524,12 @@ class SqlConversationMetadata(OmnigentBase):
         server_default="0",
         default=current_workspace_id,
     )
-    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
     # Enum stored as a stable int code (CONVERSATION_KIND: default=1, sub_agent=2).
     kind: Mapped[int] = mapped_column(SmallInteger, default=1)
     runner_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     # No FK: host records are managed outside this table.
-    host_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    host_id: Mapped[str | None] = mapped_column(Uuid16(), nullable=True)
     sub_agent_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
     external_session_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     session_state: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
@@ -485,8 +583,8 @@ class SqlAgentConfiguration(ConversationBase):
         server_default="0",
         default=current_workspace_id,
     )
-    conversation_id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    agent_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    conversation_id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
+    agent_id: Mapped[str | None] = mapped_column(Uuid16(), nullable=True)
     # Per-session reasoning-effort hint, e.g. "high". Nullable;
     # None means use the agent default.
     reasoning_effort: Mapped[str | None] = mapped_column(String(32), nullable=True)
@@ -548,16 +646,16 @@ class SqlConversation(ConversationBase):
         server_default="0",
         default=current_workspace_id,
     )
-    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int] = mapped_column(Integer)
     title: Mapped[str] = mapped_column(String(768), nullable=False, server_default="")
     parent_conversation_id: Mapped[str | None] = mapped_column(
-        String(64),
+        Uuid16(),
         nullable=True,
     )
     root_conversation_id: Mapped[str] = mapped_column(
-        String(64),
+        Uuid16(),
         nullable=False,
     )
     # Monotonic allocator for the next item position in this conversation.
@@ -646,10 +744,10 @@ class SqlConversationItem(ConversationBase):
     # conversation_id leads id in the PK so a conversation's items stay
     # contiguous for the per-conversation prefix scans that dominate reads.
     conversation_id: Mapped[str] = mapped_column(
-        String(64),
+        Uuid16(),
         primary_key=True,
     )
-    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
     response_id: Mapped[str] = mapped_column(String(64))
     created_at: Mapped[int] = mapped_column(Integer)
     # Enum stored as a stable int code (see omnigent.db.enum_codecs
@@ -749,7 +847,7 @@ class SqlConversationLabel(ConversationBase):
         default=current_workspace_id,
     )
     conversation_id: Mapped[str] = mapped_column(
-        String(64),
+        Uuid16(),
         primary_key=True,
     )
     key: Mapped[str] = mapped_column(String(128), primary_key=True)
@@ -803,8 +901,8 @@ class SqlComment(OmnigentBase):
         server_default="0",
         default=current_workspace_id,
     )
-    id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    conversation_id: Mapped[str] = mapped_column(String(64))
+    id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(Uuid16())
     path: Mapped[str] = mapped_column(String(4096))
     start_index: Mapped[int] = mapped_column(Integer)
     end_index: Mapped[int] = mapped_column(Integer)
@@ -908,7 +1006,7 @@ class SqlPolicy(OmnigentBase):
         server_default="0",
         default=current_workspace_id,
     )
-    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
     name: Mapped[str] = mapped_column(String(256))
     # sha256(name) — the value the name-uniqueness indexes key on instead of
     # the wide name column. Stamped from `name` on INSERT via the column
@@ -916,7 +1014,7 @@ class SqlPolicy(OmnigentBase):
     name_cksum: Mapped[bytes] = mapped_column(_CKSUM32, default=_default_policy_name_cksum)
     # Nullable: NULL for server-wide default policies.
     session_id: Mapped[str | None] = mapped_column(
-        String(64),
+        Uuid16(),
         nullable=True,
     )
     created_at: Mapped[int] = mapped_column(Integer)
@@ -1023,7 +1121,7 @@ class SqlHost(OmnigentBase):
         server_default="0",
         default=current_workspace_id,
     )
-    host_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    host_id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
     owner: Mapped[str] = mapped_column(String(256), nullable=False)
     name: Mapped[str] = mapped_column(String(64), nullable=False)
     # Enum stored as a stable int code (see omnigent.db.enum_codecs
@@ -1190,7 +1288,7 @@ class SqlScheduledTask(OmnigentBase):
     # written into) and every other user-identity column in this schema.
     owner_user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     # Relates to agents.id. No DB foreign key (Rule R032); cascade is app-owned.
-    agent_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    agent_id: Mapped[str] = mapped_column(Uuid16, nullable=False)
     # Per-task overrides — None means fall back to the agent default. Widths
     # mirror the matching conversations.* override columns.
     model_override: Mapped[str | None] = mapped_column(String(128), nullable=True)
@@ -1211,7 +1309,7 @@ class SqlScheduledTask(OmnigentBase):
     # freshest online host, whichever". Always None for managed_sandbox (the
     # sandbox is provisioned/adopted under a deterministic id at fire time, so
     # there is nothing to pin here).
-    host_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    host_id: Mapped[str | None] = mapped_column(Uuid16, nullable=True)
     timezone: Mapped[str] = mapped_column(String(64), nullable=False, server_default="UTC")
     # Enum stored as a stable int code (see omnigent.db.enum_codecs
     # SCHEDULED_TASK_STATE: active=1, paused=2, deleted=3). The
@@ -1220,7 +1318,7 @@ class SqlScheduledTask(OmnigentBase):
     last_run_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # Relates to conversations.id. No DB foreign key (Rule R032); the
     # application nulls this out when the referenced conversation is deleted.
-    last_run_conversation_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_run_conversation_id: Mapped[str | None] = mapped_column(Uuid16, nullable=True)
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
@@ -1282,7 +1380,7 @@ class SqlScheduledTaskRun(OmnigentBase):
     # app-owned.
     scheduled_task_id: Mapped[str] = mapped_column(Uuid16, nullable=False)
     # Relates to conversations.id. No DB foreign key; app nulls on delete.
-    conversation_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    conversation_id: Mapped[str | None] = mapped_column(Uuid16, nullable=True)
     # Enum stored as a stable int code (see omnigent.db.enum_codecs
     # SCHEDULED_TASK_RUN_STATUS: scheduled=1, running=2, succeeded=3, failed=4,
     # skipped=5). The store converts to/from the string name at the

--- a/omnigent/db/migrations/versions/z7a2b3c4d5e6_convert_ids_to_binary_uuid.py
+++ b/omnigent/db/migrations/versions/z7a2b3c4d5e6_convert_ids_to_binary_uuid.py
@@ -1,0 +1,362 @@
+"""Convert opaque uuid id columns from prefixed strings to 16-byte binary.
+
+Revision ID: z7a2b3c4d5e6
+Revises: z6a2b3c4d5e6
+Create Date: 2026-07-09 00:00:00.000000
+
+Our ids were opaque prefixed strings — ``ag_<hex>``, ``conv_<hex>``,
+``host_<hex>``, per-type conversation-item prefixes (``msg_``/``fc_``/…),
+``pol_<hex>``, and the dashed canonical uuid for comments. This migration drops
+the prefixes and stores each id as the 16 raw bytes of its uuid: ``BYTEA``
+(PostgreSQL), ``BLOB`` (SQLite / Cloudflare D1), ``BINARY(16)`` (MySQL) — the
+``Uuid16`` column type. The rest of the system keeps the readable bare 32-char
+hex form (entities, JSON blobs, URLs, the FTS mirror), so only the physical
+column changes.
+
+Columns deliberately NOT converted (kept as strings):
+``omnigent_conversation_metadata.runner_id`` and
+``conversation_items.response_id`` (polymorphic harness task tokens, not our
+uuids), ``omnigent_conversation_metadata.external_session_id`` (harness-native),
+``agents.bundle_location`` (a physical artifact-store key ``<agent_id>/<sha>``),
+``account_tokens.id`` (a secret token), ``hosts.token_hash`` (a sha256), and the
+email / username identity columns.
+
+Strip rule (uniform): drop any dashes, take the trailing 32 hex chars, decode.
+This reduces the ``conv_``/``ag_``/item-prefixed / dashed / already-bare forms
+all to the same 16 bytes, and is idempotent on a bare id.
+
+Total-transform fallback: a value whose trailing 32 chars are not valid hex
+(hand-crafted junk such as an external monitor's ``host_fix_<epoch>`` /
+``host_probe_<epoch>`` host id) would make ``decode``/``UNHEX``/``bytes.fromhex``
+raise and abort the whole migration. Rather than block the deploy or drop the
+row, such a value maps to ``md5(value)`` (16 bytes). Because ``md5`` is a pure
+function of the string and identical across PostgreSQL, MySQL, and Python, a
+junk value and every column that references it (e.g. ``hosts.host_id`` and the
+``omnigent_conversation_metadata.host_id`` copies) map to the SAME bytes, so
+cross-references still resolve. A well-formed id always takes the hex-decode
+branch, so this changes nothing for normal data.
+
+Also rewrites the embedded ``"session_id": "conv_<hex>"`` copy inside
+``conversation_items.data`` (a plain ``Text`` column) and strips the mirrored
+prefixes from the SQLite FTS shadow table, so those cross-references keep
+resolving against the now-bare ids.
+
+Downgrade restores string columns holding the bare 32-char hex form. It cannot
+reintroduce the dropped prefixes — they carried no information (the item type
+lives in ``conversation_items.type`` and ids are opaque) — so downgrade is
+one-way on the prefix.
+
+The MySQL path is modelled on standard MySQL semantics but is not exercised by
+the local (SQLite) or CI test paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# A bare 32-char lowercase-hex uuid — the form every id reduces to after
+# stripping dashes and any prefix. A value matching this is decoded directly;
+# anything else is a non-uuid and falls back to md5 (see the module docstring).
+_BARE_HEX_RE = re.compile(r"^[0-9a-f]{32}$")
+
+revision: str = "z7a2b3c4d5e6"
+down_revision: str | None = "z6a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Table -> id columns holding one of our opaque uuids. Every column here is
+# ``String(64)`` before this migration and ``Uuid16`` (16 raw bytes) after.
+_BINARY_ID_COLUMNS: dict[str, list[str]] = {
+    "agents": ["id"],
+    "files": ["id", "session_id"],
+    "session_permissions": ["conversation_id"],
+    "conversations": [
+        "id",
+        "parent_conversation_id",
+        "root_conversation_id",
+    ],
+    # The conversations split (aa1b/bb2c) copied prefixed ids into these two
+    # tables before this migration runs, so their copies are converted too.
+    "omnigent_conversation_metadata": ["id", "host_id"],
+    "agent_configuration": ["conversation_id", "agent_id"],
+    "conversation_items": ["id", "conversation_id"],
+    "conversation_labels": ["conversation_id"],
+    "comments": ["id", "conversation_id"],
+    "policies": ["id", "session_id"],
+    "hosts": ["host_id"],
+    # scheduled-task tables (added on main just before this migration). Their
+    # own PKs (id, scheduled_task_id) are already created as Uuid16/binary by
+    # that migration; only the string reference columns pointing at converted
+    # tables need converting here.
+    "scheduled_tasks": ["agent_id", "host_id", "last_run_conversation_id"],
+    "scheduled_task_runs": ["conversation_id"],
+}
+
+_FTS_TABLE = "conversation_items_fts"
+_FTS_DIALECTS = frozenset({"sqlite", "cloudflare_d1"})
+
+
+def _id_to_bytes(value: object) -> bytes:
+    """Strip prefix/dashes from an id string and return its 16 raw bytes.
+
+    A value whose trailing 32 chars are valid hex is decoded; any other value
+    (non-uuid junk) falls back to ``md5(value)`` so the conversion never fails.
+    See the module docstring for why this preserves cross-references.
+    """
+    if isinstance(value, (bytes, bytearray)):  # already converted (idempotent)
+        return bytes(value)
+    text_value = str(value)
+    bare = text_value.replace("-", "")[-32:]
+    if _BARE_HEX_RE.match(bare):
+        return bytes.fromhex(bare)
+    # md5 is a stable remap for non-uuid junk, not a security primitive.
+    return hashlib.md5(text_value.encode()).digest()
+
+
+def _bytes_to_id(value: object) -> str:
+    """Return the bare 32-char hex form of a stored 16-byte id (downgrade)."""
+    if isinstance(value, str):  # already hex (idempotent)
+        return value.replace("-", "")[-32:]
+    return bytes(value).hex()
+
+
+def _nullability(bind: sa.Connection) -> dict[tuple[str, str], bool]:
+    """Reflect current NULL-ability for every converted column."""
+    insp = sa.inspect(bind)
+    result: dict[tuple[str, str], bool] = {}
+    for table, cols in _BINARY_ID_COLUMNS.items():
+        by_name = {c["name"]: bool(c["nullable"]) for c in insp.get_columns(table)}
+        for col in cols:
+            result[(table, col)] = by_name[col]
+    return result
+
+
+def _fts_present(bind: sa.Connection) -> bool:
+    row = bind.execute(
+        sa.text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:n").bindparams(
+            n=_FTS_TABLE
+        )
+    ).first()
+    return row is not None
+
+
+# ── upgrade ─────────────────────────────────────────────
+
+
+def upgrade() -> None:
+    """Convert the id columns to 16-byte binary and fix the embedded copies."""
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    nullable = _nullability(bind)
+
+    if dialect == "postgresql":
+        _upgrade_postgresql()
+    elif dialect == "mysql":
+        _upgrade_mysql(nullable)
+    else:  # sqlite / cloudflare_d1
+        _upgrade_sqlite(bind, nullable)
+
+    _rewrite_embedded_session_id()
+
+    if dialect in _FTS_DIALECTS and _fts_present(bind):
+        op.execute(
+            sa.text(
+                f"UPDATE {_FTS_TABLE} SET "
+                "item_id = substr(item_id, -32), "
+                "conversation_id = substr(conversation_id, -32)"
+            )
+        )
+
+
+def _upgrade_postgresql() -> None:
+    """One atomic ALTER per column: strip prefix/dashes and decode hex -> bytea.
+
+    A value whose trailing 32 chars are valid hex is decoded; any other value
+    falls back to ``decode(md5(col), 'hex')`` — the same 16 bytes Python's
+    ``_id_to_bytes`` and MySQL's ``UNHEX(MD5(col))`` produce — so the ALTER
+    never raises on junk and referencing columns stay consistent.
+    """
+    for table, cols in _BINARY_ID_COLUMNS.items():
+        for col in cols:
+            stripped = f"right(replace(\"{col}\", '-', ''), 32)"
+            op.execute(
+                sa.text(
+                    f'ALTER TABLE "{table}" ALTER COLUMN "{col}" TYPE bytea USING '
+                    f"CASE WHEN {stripped} ~ '^[0-9a-f]{{32}}$' "
+                    f"THEN decode({stripped}, 'hex') "
+                    f"ELSE decode(md5(\"{col}\"), 'hex') END"
+                )
+            )
+
+
+def _upgrade_mysql(nullable: dict[tuple[str, str], bool]) -> None:
+    """Reinterpret as binary, decode the trailing 32 chars, then fix to BINARY(16).
+
+    A value whose trailing 32 chars are valid hex is decoded via ``UNHEX``; any
+    other value falls back to ``UNHEX(MD5(col))`` — the same 16 bytes the SQLite
+    (``_id_to_bytes``) and PostgreSQL (``decode(md5(col),'hex')``) paths produce
+    — so ``UNHEX`` never returns NULL on junk and referencing columns stay
+    consistent. A post-UPDATE NULL guard remains as a belt-and-braces check that
+    no non-NULL value slipped through to NULL before the NOT NULL type change.
+
+    The interim ``VARBINARY(64)`` reinterpret keeps the column's real
+    nullability (``null_sql``): MySQL rejects making a PRIMARY KEY column NULL
+    even transiently (error 1171), and the CASE/UNHEX always yields 16 bytes,
+    so no NOT NULL column ever needs to hold NULL mid-conversion.
+
+    The value expression reads the column through ``CONVERT(... USING utf8mb4)``:
+    after the interim reinterpret the column is binary, and MySQL refuses
+    ``REGEXP`` on a binary string against a utf8mb4 pattern (error 3995), so the
+    original ASCII hex is recovered as text before the regex/UNHEX/MD5 run.
+    """
+    bind = op.get_bind()
+    for table, cols in _BINARY_ID_COLUMNS.items():
+        for col in cols:
+            null_sql = "NULL" if nullable[(table, col)] else "NOT NULL"
+            count_nulls = sa.text(f"SELECT COUNT(*) FROM `{table}` WHERE `{col}` IS NULL")
+            nulls_before = bind.execute(count_nulls).scalar_one()
+            op.execute(sa.text(f"ALTER TABLE `{table}` MODIFY `{col}` VARBINARY(64) {null_sql}"))
+            col_text = f"CONVERT(`{col}` USING utf8mb4)"  # binary -> text for regex/UNHEX/MD5
+            stripped = f"RIGHT(REPLACE({col_text}, '-', ''), 32)"
+            op.execute(
+                sa.text(
+                    f"UPDATE `{table}` SET `{col}` = "
+                    f"CASE WHEN {stripped} REGEXP '^[0-9a-f]{{32}}$' "
+                    f"THEN UNHEX({stripped}) "
+                    f"ELSE UNHEX(MD5({col_text})) END "
+                    f"WHERE `{col}` IS NOT NULL"
+                )
+            )
+            nulls_after = bind.execute(count_nulls).scalar_one()
+            if nulls_after != nulls_before:
+                raise RuntimeError(
+                    f"id conversion would lose data: {nulls_after - nulls_before} "
+                    f"value(s) in `{table}`.`{col}` unexpectedly became NULL; "
+                    f"aborting before the type change"
+                )
+            op.execute(sa.text(f"ALTER TABLE `{table}` MODIFY `{col}` BINARY(16) {null_sql}"))
+
+
+def _upgrade_sqlite(bind: sa.Connection, nullable: dict[tuple[str, str], bool]) -> None:
+    """Convert values to raw bytes in place, then change the declared type to BLOB.
+
+    A bound ``bytes`` value is stored verbatim as a BLOB even while the column is
+    still declared ``TEXT`` — SQLite's TEXT affinity does not coerce a BLOB — so
+    the subsequent batch type change copies real 16-byte values, not hex text.
+    """
+    op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    for table, cols in _BINARY_ID_COLUMNS.items():
+        select_cols = ", ".join(f'"{c}"' for c in cols)
+        rows = bind.execute(sa.text(f'SELECT rowid, {select_cols} FROM "{table}"')).fetchall()
+        for row in rows:
+            assignments = {
+                col: _id_to_bytes(row[idx])
+                for idx, col in enumerate(cols, start=1)
+                if row[idx] is not None
+            }
+            if assignments:
+                set_clause = ", ".join(f'"{c}" = :{c}' for c in assignments)
+                bind.execute(
+                    sa.text(f'UPDATE "{table}" SET {set_clause} WHERE rowid = :__rowid'),
+                    {**assignments, "__rowid": row[0]},
+                )
+
+    for table, cols in _BINARY_ID_COLUMNS.items():
+        with op.batch_alter_table(table) as batch:
+            for col in cols:
+                batch.alter_column(
+                    col,
+                    type_=sa.LargeBinary(16),
+                    existing_type=sa.String(64),
+                    existing_nullable=nullable[(table, col)],
+                )
+
+    op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def _rewrite_embedded_session_id() -> None:
+    """Strip the ``conv_`` prefix from the ``session_id`` echoed inside
+    ``conversation_items.data`` (plain Text; both JSON spacings handled).
+
+    Scoped to ``type = 8`` (the ``resource_event`` enum code): only that item
+    type carries a structural ``session_id`` field. Message items may contain
+    the same byte sequence inside user/assistant prose (pasted JSON, debug
+    transcripts) — rewriting those would silently corrupt chat history.
+    """
+    for old in ('"session_id": "conv_', '"session_id":"conv_'):
+        new = old.replace("conv_", "")
+        op.execute(
+            sa.text(
+                "UPDATE conversation_items SET data = REPLACE(data, :old, :new) "
+                "WHERE type = 8 AND data LIKE :like"
+            ).bindparams(old=old, new=new, like=f"%{old}%")
+        )
+
+
+# ── downgrade ───────────────────────────────────────────
+
+
+def downgrade() -> None:
+    """Restore String(64) columns holding the bare 32-char hex form (no prefix)."""
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    nullable = _nullability(bind)
+
+    if dialect == "postgresql":
+        for table, cols in _BINARY_ID_COLUMNS.items():
+            for col in cols:
+                op.execute(
+                    sa.text(
+                        f'ALTER TABLE "{table}" ALTER COLUMN "{col}" TYPE varchar(64) '
+                        f"USING encode(\"{col}\", 'hex')"
+                    )
+                )
+    elif dialect == "mysql":
+        for table, cols in _BINARY_ID_COLUMNS.items():
+            for col in cols:
+                null_sql = "NULL" if nullable[(table, col)] else "NOT NULL"
+                # Interim reinterpret keeps real nullability — MySQL rejects a
+                # transiently-NULL PK column (error 1171).
+                op.execute(
+                    sa.text(f"ALTER TABLE `{table}` MODIFY `{col}` VARBINARY(64) {null_sql}")
+                )
+                op.execute(
+                    sa.text(
+                        f"UPDATE `{table}` SET `{col}` = LOWER(HEX(`{col}`)) "
+                        f"WHERE `{col}` IS NOT NULL"
+                    )
+                )
+                op.execute(sa.text(f"ALTER TABLE `{table}` MODIFY `{col}` VARCHAR(64) {null_sql}"))
+    else:  # sqlite / cloudflare_d1
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+        for table, cols in _BINARY_ID_COLUMNS.items():
+            select_cols = ", ".join(f'"{c}"' for c in cols)
+            rows = bind.execute(sa.text(f'SELECT rowid, {select_cols} FROM "{table}"')).fetchall()
+            for row in rows:
+                assignments = {
+                    col: _bytes_to_id(row[idx])
+                    for idx, col in enumerate(cols, start=1)
+                    if row[idx] is not None
+                }
+                if assignments:
+                    set_clause = ", ".join(f'"{c}" = :{c}' for c in assignments)
+                    bind.execute(
+                        sa.text(f'UPDATE "{table}" SET {set_clause} WHERE rowid = :__rowid'),
+                        {**assignments, "__rowid": row[0]},
+                    )
+        for table, cols in _BINARY_ID_COLUMNS.items():
+            with op.batch_alter_table(table) as batch:
+                for col in cols:
+                    batch.alter_column(
+                        col,
+                        type_=sa.String(64),
+                        existing_type=sa.LargeBinary(16),
+                        existing_nullable=nullable[(table, col)],
+                    )
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -606,66 +606,71 @@ def make_managed_session_maker(
 
 # ── ID generation ──────────────────────────────────────
 
-_ITEM_TYPE_PREFIX: dict[str, str] = {
-    "message": "msg_",
-    "function_call": "fc_",
-    "function_call_output": "fco_",
-    "error": "err_",
-    "reasoning": "rs_",
-    "compaction": "cmp_",
-    "native_tool": "nt_",
-    "resource_event": "rse_",
-    "slash_command": "sc_",
-    "terminal_command": "tc_",
-    "routing_decision": "rd_",
-}
+# Recognised conversation-item types, validated at id generation. The item's
+# type lives in the ``conversation_items.type`` column, not in its id. Kept in
+# parity with ``ITEM_TYPE_TO_DATA_CLS`` (see the db util tests).
+_ITEM_TYPES: frozenset[str] = frozenset(
+    {
+        "message",
+        "function_call",
+        "function_call_output",
+        "error",
+        "reasoning",
+        "compaction",
+        "native_tool",
+        "resource_event",
+        "slash_command",
+        "terminal_command",
+        "routing_decision",
+    }
+)
 
 
 def generate_agent_id() -> str:
     """
     Generate a unique agent identifier.
 
-    :returns: A string of the form ``"ag_<32-char hex>"``,
-        e.g. ``"ag_0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c"``.
+    :returns: A bare 32-char hex uuid,
+        e.g. ``"0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c"``.
     """
-    return f"ag_{uuid.uuid4().hex}"
+    return uuid.uuid4().hex
 
 
 def builtin_agent_id(name: str) -> str:
     """
     Deterministic agent id for a built-in agent, derived from its name.
 
-    Same shape and length as :func:`generate_agent_id` (``ag_`` + 32 hex), but
+    Same shape and length as :func:`generate_agent_id` (bare 32-char hex), but
     stable across processes: a multi-tenant deployment reseeds the built-ins into
     an ephemeral per-pod store, where a random id would change each boot and
     dangle a persisted ``conversation.agent_id``. Do NOT revert built-in seeding
     to :func:`generate_agent_id` (guarded by the ``builtin_agent_id`` tests).
 
     :param name: The built-in agent's unique name, e.g. ``"polly"``.
-    :returns: A deterministic id of the form ``"ag_<32-char hex>"``.
+    :returns: A deterministic bare 32-char hex id.
     """
     digest = hashlib.sha256(f"builtin:{name}".encode()).hexdigest()
-    return f"ag_{digest[:32]}"
+    return digest[:32]
 
 
 def generate_file_id() -> str:
     """
     Generate a unique file identifier.
 
-    :returns: A string of the form ``"file_<32-char hex>"``,
-        e.g. ``"file_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"``.
+    :returns: A bare 32-char hex uuid,
+        e.g. ``"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"``.
     """
-    return f"file_{uuid.uuid4().hex}"
+    return uuid.uuid4().hex
 
 
 def generate_conversation_id() -> str:
     """
     Generate a unique conversation identifier.
 
-    :returns: A string of the form ``"conv_<32-char hex>"``,
-        e.g. ``"conv_e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9"``.
+    :returns: A bare 32-char hex uuid,
+        e.g. ``"e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9"``.
     """
-    return f"conv_{uuid.uuid4().hex}"
+    return uuid.uuid4().hex
 
 
 def generate_task_id() -> str:
@@ -682,25 +687,16 @@ def generate_item_id(item_type: str) -> str:
     """
     Generate a unique conversation-item identifier.
 
-    The prefix is determined by the item type:
+    *item_type* is validated against :data:`_ITEM_TYPES` but no longer encoded
+    into the id — the type lives in the ``conversation_items.type`` column.
 
-    - ``"message"`` -> ``"msg_"``
-    - ``"function_call"`` -> ``"fc_"``
-    - ``"function_call_output"`` -> ``"fco_"``
-    - ``"error"`` -> ``"err_"``
-    - ``"reasoning"`` -> ``"rs_"``
-    - ``"compaction"`` -> ``"cmp_"``
-    - ``"native_tool"`` -> ``"nt_"``
-    - ``"slash_command"`` -> ``"sc_"``
-
-    :param item_type: One of the keys in :data:`_ITEM_TYPE_PREFIX`.
-    :returns: A prefixed identifier, e.g. ``"msg_a1b2c3d4..."``.
+    :param item_type: One of the members of :data:`_ITEM_TYPES`.
+    :returns: A bare 32-char hex uuid, e.g. ``"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"``.
     :raises ValueError: If *item_type* is not a recognised type.
     """
-    prefix = _ITEM_TYPE_PREFIX.get(item_type)
-    if prefix is None:
+    if item_type not in _ITEM_TYPES:
         raise ValueError(f"unknown item type: {item_type!r}")
-    return f"{prefix}{uuid.uuid4().hex}"
+    return uuid.uuid4().hex
 
 
 # ── FTS (SQLite FTS5) ─────────────────────────────────

--- a/omnigent/host/identity.py
+++ b/omnigent/host/identity.py
@@ -41,14 +41,33 @@ class HostIdentity:
     """Identity of a host machine.
 
     :param host_id: Stable identifier, e.g.
-        ``"host_a1b2c3d4e5f67890abcdef1234567890"``.
-        Format: ``host_{uuid4_hex}`` (32-char hex portion).
+        ``"a1b2c3d4e5f67890abcdef1234567890"``.
+        Format: bare 32-char uuid4 hex.
     :param name: Human-readable name displayed in the Web UI
         host picker, e.g. ``"corey-laptop"``.
     """
 
     host_id: str
     name: str
+
+
+# Legacy host-id prefix; older installs persist ``host_<hex>`` in config.yaml.
+_LEGACY_HOST_ID_PREFIX = "host_"
+
+
+def _normalize_host_id(host_id: str) -> str:
+    """Strip the legacy ``host_`` prefix from *host_id* if present.
+
+    Older installs persisted ``host_<hex>`` in config.yaml (or the launch env
+    var); return the prefix-less form so a re-presented legacy id matches the
+    migrated, now prefix-less server-side host row.
+
+    :param host_id: A host id, possibly carrying the legacy prefix.
+    :returns: The bare 32-char hex host id.
+    """
+    if host_id.startswith(_LEGACY_HOST_ID_PREFIX):
+        return host_id[len(_LEGACY_HOST_ID_PREFIX) :]
+    return host_id
 
 
 def load_or_create_host_identity(
@@ -82,7 +101,7 @@ def load_or_create_host_identity(
             "(managed-host launch sets both)"
         )
     if env_host_id is not None and env_name is not None:
-        return HostIdentity(host_id=env_host_id, name=env_name)
+        return HostIdentity(host_id=_normalize_host_id(env_host_id), name=env_name)
 
     cfg: dict[str, object] = {}
     if path.exists():
@@ -92,11 +111,11 @@ def load_or_create_host_identity(
     host_section = cfg.get("host")
     if isinstance(host_section, dict) and "host_id" in host_section and "name" in host_section:
         return HostIdentity(
-            host_id=host_section["host_id"],
+            host_id=_normalize_host_id(host_section["host_id"]),
             name=host_section["name"],
         )
 
-    host_id = f"host_{uuid.uuid4().hex}"
+    host_id = uuid.uuid4().hex
     name = socket.gethostname()
     identity = HostIdentity(host_id=host_id, name=name)
 

--- a/omnigent/onboarding/sandboxes/bootstrap.py
+++ b/omnigent/onboarding/sandboxes/bootstrap.py
@@ -624,7 +624,7 @@ def set_sandbox_host_name(launcher: SandboxLauncher, sandbox_id: str, host_name:
         "cfg=yaml.safe_load(open(p)) if os.path.exists(p) else {}; "
         "cfg=cfg or {}; "
         f"h=cfg.get('host') or {{}}; h['name']='{safe_name}'; "
-        "h.setdefault('host_id', 'host_'+uuid.uuid4().hex); "
+        "h.setdefault('host_id', uuid.uuid4().hex); "
         "cfg['host']=h; "
         "yaml.safe_dump(cfg, open(p,'w'), default_flow_style=False, sort_keys=True)"
     )

--- a/omnigent/opencode_native_state.py
+++ b/omnigent/opencode_native_state.py
@@ -60,11 +60,23 @@ def _state_dir_for_conversation_id(conversation_id: str) -> Path:
     Hashing the conversation id prevents path traversal if a server ever
     returned an attacker-controlled id such as ``"../etc"``.
 
-    :param conversation_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    Sessions created before ids dropped the ``conv_`` prefix hashed the
+    prefixed string, so their directories live under the legacy digest; when
+    the bare-digest directory is absent, the legacy one is returned (never
+    renamed — files inside may embed their own absolute path).
+
+    :param conversation_id: Omnigent conversation id, bare 32-char hex
+        (a legacy ``conv_``-prefixed form is accepted and normalised).
     :returns: Absolute directory path; not guaranteed to exist.
     """
-    digest = hashlib.sha256(conversation_id.encode("utf-8")).hexdigest()[:_ID_HASH_CHARS]
-    return _opencode_native_state_root() / digest
+    bare = conversation_id.removeprefix("conv_")
+    root = _opencode_native_state_root()
+    state_dir = root / hashlib.sha256(bare.encode("utf-8")).hexdigest()[:_ID_HASH_CHARS]
+    if not state_dir.exists():
+        legacy = root / hashlib.sha256(f"conv_{bare}".encode()).hexdigest()[:_ID_HASH_CHARS]
+        if legacy.exists():
+            return legacy
+    return state_dir
 
 
 def write_launch_state(conversation_id: str, working_directory: str) -> None:

--- a/omnigent/runtime/telemetry.py
+++ b/omnigent/runtime/telemetry.py
@@ -328,10 +328,12 @@ def _fastapi_instrumentation_enabled() -> bool:
     return bool(os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip())
 
 
-# Session id as it appears in a request path: ``/v1/sessions/<conv_…>/...``
-# (runner-internal conversations use the ``agy_conv_`` prefix). Used to stamp
-# ``session.id`` onto the auto-created FastAPI server span.
-_SESSION_ID_IN_PATH = re.compile(r"/sessions/((?:agy_)?conv_[0-9a-f]+)")
+# Session id as it appears in a request path (``/v1/sessions/<id>/…``), used to
+# stamp ``session.id`` onto the FastAPI server span. Matches bare 32-char hex
+# plus the legacy ``conv_``/``agy_conv_`` forms so old links keep tagging spans.
+_SESSION_ID_IN_PATH = re.compile(
+    r"/sessions/((?:agy_)?(?:conv_)?[0-9a-f]{32}|(?:agy_)?conv_[0-9a-f]+)"
+)
 
 
 def _fastapi_session_id_hook(span: Any, scope: Mapping[str, Any]) -> None:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -15,6 +15,7 @@ from typing import Any, Protocol
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from sqlalchemy.exc import StatementError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.responses import Response
@@ -22,6 +23,7 @@ from starlette.routing import Mount, Route
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from omnigent._platform import resolve_repo_symlink
+from omnigent.db.db_models import InvalidUuidError
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_plugins import (
     ANTIGRAVITY_NATIVE_CODING_AGENT,
@@ -385,7 +387,9 @@ def _ensure_builtin_agent(
     existing = agent_store.get_by_name(name)
     if existing is not None:
         new_loc = f"{existing.id}/{bundle_hash}"
-        if existing.bundle_location == new_loc:
+        # Sha-segment compare: legacy rows keep an ``ag_``-prefixed left
+        # segment (physical artifact key); only the sha encodes content.
+        if existing.bundle_location.rsplit("/", 1)[-1] == bundle_hash:
             # Row current; evict so a lagging replica's stale cache reloads the bundle.
             agent_cache.evict(existing.id)
             return
@@ -1561,6 +1565,45 @@ def create_app(
         return JSONResponse(
             status_code=exc.http_status,
             content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    @app.exception_handler(StatementError)
+    async def _handle_statement_error(
+        request: Request,  # noqa: ARG001 — FastAPI exception-handler signature requires (request, exc); we only use exc
+        exc: StatementError,
+    ) -> JSONResponse:
+        """
+        Map a malformed-id bind failure to 404; everything else stays a 500.
+
+        A ``Uuid16`` column rejects an id that is not a 32-char hex uuid (after
+        stripping any legacy prefix), raising :class:`InvalidUuidError` wrapped
+        in ``StatementError``. Such an id cannot address any row, so — like the
+        pre-binary varchar behaviour, where it simply didn't match — treat it as
+        not-found instead of an internal error. Any other statement error (real
+        DB failure) falls through to the standard 500 shape.
+
+        :param request: The incoming request (unused — FastAPI signature requirement).
+        :param exc: The SQLAlchemy statement error.
+        :returns: 404 for a malformed id, otherwise a 500 JSON response.
+        """
+        if isinstance(exc.orig, InvalidUuidError):
+            # Keep a trace: a malformed id is usually a client bug, but this
+            # branch would otherwise mask a server-side id-generation defect
+            # as a routine 404.
+            _logger.debug("Malformed id mapped to 404: %s", exc.orig)
+            return JSONResponse(
+                status_code=404,
+                content={"error": {"code": ErrorCode.NOT_FOUND, "message": "Not found."}},
+            )
+        _logger.error("Database error: %s", exc, exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": {
+                    "code": ErrorCode.INTERNAL_ERROR,
+                    "message": "An internal error occurred.",
+                },
+            },
         )
 
     @app.exception_handler(Exception)

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1764,11 +1764,11 @@ async def launch_managed_host(
         startup, or registration fails.
     """
     launcher = config.launcher_factory()
-    host_id = f"host_{uuid.uuid4().hex}"
+    host_id = uuid.uuid4().hex
     # Visible label in the host picker; (owner, name) is the hosts
     # table PK, so embed the host_id's leading hex for uniqueness
     # across a user's managed sandboxes.
-    host_name = f"managed-{host_id[len('host_') : len('host_') + 8]}"
+    host_name = f"managed-{host_id[:8]}"
     try:
         await asyncio.to_thread(launcher.prepare)
         sandbox_id = await asyncio.to_thread(launcher.provision, host_name)

--- a/omnigent/server/routes/default_policies.py
+++ b/omnigent/server/routes/default_policies.py
@@ -40,10 +40,10 @@ from omnigent.stores.policy_store import PolicyStore
 def _generate_default_policy_id() -> str:
     """Generate a unique default policy identifier.
 
-    :returns: A string of the form ``"pol_<32-char hex>"``,
-        e.g. ``"pol_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"``.
+    :returns: A bare 32-char hex uuid,
+        e.g. ``"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"``.
     """
-    return f"pol_{uuid.uuid4().hex}"
+    return uuid.uuid4().hex
 
 
 def _entity_to_response(policy: Policy) -> dict[str, Any]:

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -25,6 +25,7 @@ from collections.abc import Awaitable, Callable
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
 from omnigent.host.frames import (
     HostCreateDirResultFrame,
     HostCreateWorktreeResultFrame,
@@ -132,6 +133,16 @@ def create_host_tunnel_router(
         7. Start sender, receiver, and ping loops.
         8. On disconnect: deregister, set offline in DB.
         """
+        # Legacy hosts dial in with ``host_<hex>`` — normalise to the stored
+        # bare form. Malformed ids are refused here because WebSocket routes
+        # bypass the app's StatementError→404 handler.
+        try:
+            host_id = uuid_to_bytes(host_id).hex()
+        except InvalidUuidError:
+            _logger.warning("Refusing host tunnel: malformed host id %r", host_id)
+            await ws.close(code=4003, reason="invalid host id")
+            return
+
         # Authenticate from the handshake BEFORE accepting the upgrade,
         # so an unauthenticated peer never completes the WS handshake — no
         # acceptance oracle and no pre-auth protocol I/O. ``get_user_id`` reads

--- a/omnigent/server/routes/session_mcp_servers.py
+++ b/omnigent/server/routes/session_mcp_servers.py
@@ -245,7 +245,9 @@ def create_session_mcp_servers_router(
                 )
 
         new_location = bundle_location(agent.id, new_bundle)
-        if new_location != agent.bundle_location:
+        # Sha-segment compare: legacy rows keep an ``ag_``-prefixed left
+        # segment (physical artifact key); only the sha encodes content.
+        if new_location.rsplit("/", 1)[-1] != agent.bundle_location.rsplit("/", 1)[-1]:
             artifact_store.put(new_location, new_bundle)
             updated = agent_store.update(agent.id, new_location)
             if updated is None:

--- a/omnigent/server/routes/session_policies.py
+++ b/omnigent/server/routes/session_policies.py
@@ -42,10 +42,10 @@ from omnigent.stores.policy_store import PolicyStore
 def _generate_policy_id() -> str:
     """Generate a unique policy identifier.
 
-    :returns: A string of the form ``"pol_<32-char hex>"``,
-        e.g. ``"pol_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"``.
+    :returns: A bare 32-char hex uuid,
+        e.g. ``"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"``.
     """
-    return f"pol_{uuid.uuid4().hex}"
+    return uuid.uuid4().hex
 
 
 def _entity_to_response(policy: Policy) -> dict[str, Any]:

--- a/omnigent/stores/comment_store/sqlalchemy_store.py
+++ b/omnigent/stores/comment_store/sqlalchemy_store.py
@@ -6,7 +6,7 @@ import uuid
 
 from sqlalchemy import delete, func, select
 
-from omnigent.db.db_models import SqlComment, current_workspace_id
+from omnigent.db.db_models import SqlComment, current_workspace_id, normalize_uuid
 from omnigent.db.enum_codecs import decode_comment_status, encode_comment_status
 from omnigent.db.utils import (
     get_or_create_engine,
@@ -60,7 +60,7 @@ class SqlAlchemyCommentStore(CommentStore):
         """Fetch a single comment by id, scoped to a conversation. See base class for contract."""
         with self._session() as session:
             row = session.get(SqlComment, (current_workspace_id(), comment_id))
-            if row is None or row.conversation_id != conversation_id:
+            if row is None or row.conversation_id != normalize_uuid(conversation_id):
                 return None
             return _to_entity(row)
 
@@ -81,7 +81,7 @@ class SqlAlchemyCommentStore(CommentStore):
         # backfill (created_at * 1e6) and docs rely on.
         created_us = now_epoch_us()
         row = SqlComment(
-            id=str(uuid.uuid4()),
+            id=uuid.uuid4().hex,
             conversation_id=conversation_id,
             path=path,
             start_index=start_index,
@@ -127,7 +127,7 @@ class SqlAlchemyCommentStore(CommentStore):
         """Update a comment's fields, scoped to a conversation. See base class for contract."""
         with self._session() as session:
             row = session.get(SqlComment, (current_workspace_id(), comment_id))
-            if row is None or row.conversation_id != conversation_id:
+            if row is None or row.conversation_id != normalize_uuid(conversation_id):
                 return None
             if status is not None:
                 row.status = encode_comment_status(status)
@@ -141,7 +141,7 @@ class SqlAlchemyCommentStore(CommentStore):
         """Delete a single comment by id, scoped to a conversation. See base class for contract."""
         with self._session() as session:
             row = session.get(SqlComment, (current_workspace_id(), comment_id))
-            if row is None or row.conversation_id != conversation_id:
+            if row is None or row.conversation_id != normalize_uuid(conversation_id):
                 return None
             entity = _to_entity(row)
             session.delete(row)

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -38,6 +38,7 @@ from omnigent.db.db_models import (
     SqlSessionPermission,
     SqlUserDailyCost,
     current_workspace_id,
+    uuid_to_bytes,
 )
 from omnigent.db.enum_codecs import (
     decode_item_status,
@@ -800,7 +801,9 @@ class SqlAlchemyConversationStore(ConversationStore):
             # want here.
             session.execute(
                 text("UPDATE conversations SET updated_at = updated_at WHERE id = :id"),
-                {"id": conversation_id},
+                # Raw SQL bypasses the Uuid16 decorator; bind the 16-byte form
+                # so the WHERE matches the binary id column.
+                {"id": uuid_to_bytes(conversation_id)},
             )
 
     def create_conversation(
@@ -1603,14 +1606,20 @@ class SqlAlchemyConversationStore(ConversationStore):
                         f"ORDER BY ci.created_at DESC LIMIT :limit"
                     )
                 query = like_pattern
-            params: dict[str, str | int] = {
+            params: dict[str, str | int | bytes] = {
                 "query": query,
                 "limit": limit,
                 "ws": current_workspace_id(),
             }
             if conversation_id is not None:
-                params["cid"] = conversation_id
-            item_ids = [row[0] for row in session.execute(stmt, params).fetchall()]
+                # Raw SQL bypasses Uuid16: the FTS mirror stores hex text, but
+                # conversation_items.conversation_id is 16 raw bytes — bind the
+                # form each branch actually compares against.
+                params["cid"] = conversation_id if use_fts else uuid_to_bytes(conversation_id)
+            item_ids = [
+                item_id.hex() if isinstance(item_id, (bytes, memoryview)) else item_id
+                for item_id in (row[0] for row in session.execute(stmt, params).fetchall())
+            ]
             if not item_ids:
                 return []
             rows = (

--- a/omnigent/stores/file_store/sqlalchemy_store.py
+++ b/omnigent/stores/file_store/sqlalchemy_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from sqlalchemy import and_, asc, desc, or_, select
 
-from omnigent.db.db_models import SqlFile, current_workspace_id
+from omnigent.db.db_models import SqlFile, current_workspace_id, normalize_uuid
 from omnigent.db.utils import (
     generate_file_id,
     get_or_create_engine,
@@ -100,7 +100,7 @@ class SqlAlchemyFileStore(FileStore):
             row = session.get(SqlFile, (current_workspace_id(), file_id))
             if row is None:
                 return None
-            if session_id is not None and row.session_id != session_id:
+            if session_id is not None and row.session_id != normalize_uuid(session_id):
                 return None
             return _to_entity(row)
 
@@ -196,7 +196,7 @@ class SqlAlchemyFileStore(FileStore):
             row = session.get(SqlFile, (current_workspace_id(), file_id))
             if not row:
                 return False
-            if session_id is not None and row.session_id != session_id:
+            if session_id is not None and row.session_id != normalize_uuid(session_id):
                 return False
             session.delete(row)
             return True

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from omnigent.db.db_models import (
     SqlPolicy,
     current_workspace_id,
+    normalize_uuid,
     policy_name_cksum,
 )
 from omnigent.db.enum_codecs import (
@@ -110,7 +111,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         """Return the policy if it belongs to the given session."""
         with self._session() as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
-            if row is None or row.session_id != session_id:
+            if row is None or row.session_id != normalize_uuid(session_id):
                 return None
             return _to_entity(row)
 
@@ -141,7 +142,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         """
         with self._session() as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
-            if row is None or row.session_id != session_id:
+            if row is None or row.session_id != normalize_uuid(session_id):
                 return None
             changed = False
             if name is not None and row.name != name:
@@ -164,7 +165,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         """Delete a policy. Idempotent: returns ``False`` if not found."""
         with self._session() as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
-            if row is None or row.session_id != session_id:
+            if row is None or row.session_id != normalize_uuid(session_id):
                 return False
             session.delete(row)
             return True

--- a/tests/db/test_converters.py
+++ b/tests/db/test_converters.py
@@ -29,7 +29,7 @@ class TestSqlAgentToEntity:
     def test_basic_conversion(self) -> None:
         """All fields on the ORM row map to the corresponding entity fields."""
         row = SqlAgent(
-            id="ag_abc123",
+            id="104c4932179e16161e9ed9298fd5a3e2",
             created_at=1700000000,
             name="research-agent",
             bundle_location="ag_abc123/sha256hash",
@@ -41,7 +41,7 @@ class TestSqlAgentToEntity:
         entity = sql_agent_to_entity(row)
 
         assert isinstance(entity, Agent)
-        assert entity.id == "ag_abc123"
+        assert entity.id == "104c4932179e16161e9ed9298fd5a3e2"
         assert entity.created_at == 1700000000
         assert entity.name == "research-agent"
         assert entity.bundle_location == "ag_abc123/sha256hash"
@@ -53,20 +53,20 @@ class TestSqlAgentToEntity:
     def test_session_scoped_agent_passes_session_id(self) -> None:
         """session_id is forwarded for session-scoped agents."""
         row = SqlAgent(
-            id="ag_sess",
+            id="372d0296768feff7262c605c5553d1da",
             created_at=1700000000,
             name="session-agent",
             bundle_location="ag_sess/hash",
             version=1,
             kind=AGENT_KIND_SESSION,
         )
-        entity = sql_agent_to_entity(row, session_id="conv_xyz")
-        assert entity.session_id == "conv_xyz"
+        entity = sql_agent_to_entity(row, session_id="12b8fd5b4413ededb99560e847b32b0e")
+        assert entity.session_id == "12b8fd5b4413ededb99560e847b32b0e"
 
     def test_nullable_fields_as_none(self) -> None:
         """Optional fields convert cleanly when they are None."""
         row = SqlAgent(
-            id="ag_minimal",
+            id="b9cd9ad3940ded42096b1b1ca99275c1",
             created_at=1700000000,
             name="minimal-agent",
             bundle_location="ag_minimal/hash",
@@ -84,7 +84,7 @@ class TestSqlAgentToEntity:
     def test_special_characters_in_fields(self) -> None:
         """Names and descriptions with unicode / special chars survive conversion."""
         row = SqlAgent(
-            id="ag_unicode",
+            id="babb354a08c7d93e17d1d56ae9e8fa96",
             created_at=1700000000,
             name="agent-with-emoji-\u2603",
             bundle_location="ag_unicode/hash",
@@ -102,7 +102,7 @@ class TestSqlAgentToEntity:
         """Create an Agent entity, build an ORM row from it, convert back, and
         verify all fields match the original."""
         original = Agent(
-            id="ag_roundtrip",
+            id="90fe97c45ce0fd25c67a73f24b325697",
             created_at=1700000000,
             name="round-trip-agent",
             bundle_location="ag_roundtrip/abc123def456",
@@ -140,7 +140,7 @@ class TestSqlAgentToEntity:
         managed = make_managed_session_maker(engine)
 
         original = Agent(
-            id="ag_dbrt",
+            id="66f3422b1183ac0b04cb6f3f313c3f1e",
             created_at=_now(),
             name="db-round-trip",
             bundle_location="ag_dbrt/hash",
@@ -164,7 +164,7 @@ class TestSqlAgentToEntity:
             session.add(row)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, (0, "ag_dbrt"))
+            loaded = session.get(SqlAgent, (0, "66f3422b1183ac0b04cb6f3f313c3f1e"))
             assert loaded is not None
             result = sql_agent_to_entity(loaded)
 
@@ -183,7 +183,7 @@ class TestSqlAgentToEntity:
         managed = make_managed_session_maker(engine)
 
         row = SqlAgent(
-            id="ag_defver",
+            id="5bc53358f0a0e7be94a234cb39730c38",
             created_at=1700000000,
             name="default-version",
             bundle_location="ag_defver/hash",
@@ -193,7 +193,7 @@ class TestSqlAgentToEntity:
             session.add(row)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, (0, "ag_defver"))
+            loaded = session.get(SqlAgent, (0, "5bc53358f0a0e7be94a234cb39730c38"))
             assert loaded is not None
             entity = sql_agent_to_entity(loaded)
             assert entity.version == 1
@@ -201,7 +201,7 @@ class TestSqlAgentToEntity:
     def test_empty_string_description(self) -> None:
         """An empty-string description is preserved (not coerced to None)."""
         row = SqlAgent(
-            id="ag_empty",
+            id="2e58fb3f06227a85bf771cd4fedc5429",
             created_at=1700000000,
             name="empty-desc",
             bundle_location="ag_empty/hash",

--- a/tests/db/test_d1_fts_dialect.py
+++ b/tests/db/test_d1_fts_dialect.py
@@ -95,8 +95,18 @@ def test_fts_lifecycle_on_d1(d1_engine):
 
     # 2. Index two items; only one matches the query.
     with Session(d1_engine) as s:
-        insert_fts(s, "msg_1", "conv_a", "the quick brown fox")
-        insert_fts(s, "msg_2", "conv_a", "lazy dog sleeps")
+        insert_fts(
+            s,
+            "9980c8a9248139f14f4165e5d53088aa",
+            "94c349190e241f85a984b3df8f129696",
+            "the quick brown fox",
+        )
+        insert_fts(
+            s,
+            "0fd4e86b2daa009cd9929641dbd7dab6",
+            "94c349190e241f85a984b3df8f129696",
+            "lazy dog sleeps",
+        )
         s.commit()
 
     # 3. Full-text MATCH finds the right row.
@@ -105,11 +115,11 @@ def test_fts_lifecycle_on_d1(d1_engine):
             text(f"SELECT item_id FROM {_FTS_TABLE} WHERE search_text MATCH :q"),
             {"q": "fox"},
         ).fetchall()
-    assert [r[0] for r in hits] == ["msg_1"]
+    assert [r[0] for r in hits] == ["9980c8a9248139f14f4165e5d53088aa"]
 
     # 4. delete_fts_by_conversation clears the conversation's rows.
     with Session(d1_engine) as s:
-        delete_fts_by_conversation(s, "conv_a")
+        delete_fts_by_conversation(s, "94c349190e241f85a984b3df8f129696")
         s.commit()
     with d1_engine.connect() as conn:
         remaining = conn.execute(text(f"SELECT count(*) FROM {_FTS_TABLE}")).scalar()

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -50,7 +50,7 @@ def _now() -> int:
 
 
 def _make_agent(
-    id: str = "ag_test1",
+    id: str = "0ecf75a6ff1ff86bcc1902eb0951ef45",
     name: str = "test-agent",
     kind: str = "template",
 ) -> SqlAgent:
@@ -58,14 +58,14 @@ def _make_agent(
         id=id,
         created_at=_now(),
         name=name,
-        bundle_location="ag_test1/abc123",
+        bundle_location="0ecf75a6ff1ff86bcc1902eb0951ef45/abc123",
         version=1,
         kind=encode_agent_kind(kind),
     )
 
 
 def _make_conversation(
-    id: str = "conv_test1",
+    id: str = "a9930027fd3e2e979e65844f7af7bf88",
     parent_conversation_id: str | None = None,
     root_conversation_id: str | None = None,
     title: str | None = None,
@@ -83,14 +83,14 @@ def _make_conversation(
 
 
 def _make_agent_configuration(
-    conversation_id: str = "conv_test1",
+    conversation_id: str = "a9930027fd3e2e979e65844f7af7bf88",
     agent_id: str | None = None,
 ) -> SqlAgentConfiguration:
     return SqlAgentConfiguration(conversation_id=conversation_id, agent_id=agent_id)
 
 
 def _make_metadata(
-    id: str = "conv_test1",
+    id: str = "a9930027fd3e2e979e65844f7af7bf88",
     kind: str = "default",
 ) -> SqlConversationMetadata:
     return SqlConversationMetadata(
@@ -100,8 +100,8 @@ def _make_metadata(
 
 
 def _make_item(
-    id: str = "msg_test1",
-    conversation_id: str = "conv_test1",
+    id: str = "a47da81d0587d7c42e53978d629c5ab8",
+    conversation_id: str = "a9930027fd3e2e979e65844f7af7bf88",
     position: int = 0,
 ) -> SqlConversationItem:
     return SqlConversationItem(
@@ -130,7 +130,7 @@ class TestSqlAgent:
             session.add(agent)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, (0, "ag_test1"))
+            loaded = session.get(SqlAgent, (0, "0ecf75a6ff1ff86bcc1902eb0951ef45"))
             assert loaded is not None
             assert loaded.name == "test-agent"
             assert loaded.version == 1
@@ -149,7 +149,7 @@ class TestSqlAgent:
             session.add(agent)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, (0, "ag_test1"))
+            loaded = session.get(SqlAgent, (0, "0ecf75a6ff1ff86bcc1902eb0951ef45"))
             assert loaded is not None
             assert loaded.description == "A test agent"
             assert loaded.updated_at is not None
@@ -164,7 +164,7 @@ class TestSqlAgent:
             session.add(agent)
 
         with managed() as session:
-            loaded = session.get(SqlAgent, (0, "ag_test1"))
+            loaded = session.get(SqlAgent, (0, "0ecf75a6ff1ff86bcc1902eb0951ef45"))
             assert loaded is not None
             assert loaded.kind == encode_agent_kind("session")
 
@@ -173,8 +173,8 @@ class TestSqlAgent:
         engine = get_or_create_engine(db_uri)
         managed = make_managed_session_maker(engine)
 
-        a1 = _make_agent(id="ag_1", name="agent-1", kind="session")
-        a2 = _make_agent(id="ag_2", name="agent-2", kind="session")
+        a1 = _make_agent(id="880b5afda28ad55ff74cbeb9b5fc67fb", name="agent-1", kind="session")
+        a2 = _make_agent(id="0fa804039e209a10554da55135751438", name="agent-2", kind="session")
 
         with managed() as session:
             session.add(a1)
@@ -190,7 +190,7 @@ class TestSqlFile:
         managed = make_managed_session_maker(engine)
 
         f = SqlFile(
-            id="file_test1",
+            id="c9b7bd37959cc093d2b9e9ebf4d9b35b",
             created_at=_now(),
             filename="report.pdf",
             bytes=12345,
@@ -200,7 +200,7 @@ class TestSqlFile:
             session.add(f)
 
         with managed() as session:
-            loaded = session.get(SqlFile, (0, "file_test1"))
+            loaded = session.get(SqlFile, (0, "c9b7bd37959cc093d2b9e9ebf4d9b35b"))
             assert loaded is not None
             assert loaded.filename == "report.pdf"
             assert loaded.bytes == 12345
@@ -211,7 +211,7 @@ class TestSqlFile:
         managed = make_managed_session_maker(engine)
 
         f = SqlFile(
-            id="file_test2",
+            id="aa87c404604d8dda9990e960edcd06b4",
             created_at=_now(),
             filename="data.bin",
             bytes=100,
@@ -220,7 +220,7 @@ class TestSqlFile:
             session.add(f)
 
         with managed() as session:
-            loaded = session.get(SqlFile, (0, "file_test2"))
+            loaded = session.get(SqlFile, (0, "aa87c404604d8dda9990e960edcd06b4"))
             assert loaded is not None
             assert loaded.content_type is None
 
@@ -354,13 +354,13 @@ class TestSqlConversation:
             session.add(conv)
 
         with managed() as session:
-            loaded = session.get(SqlConversation, (0, "conv_test1"))
+            loaded = session.get(SqlConversation, (0, "a9930027fd3e2e979e65844f7af7bf88"))
             assert loaded is not None
             assert loaded.title == "Hello World"
             # Identity/hierarchy columns only; kind/archived live on
             # SqlConversationMetadata, agent binding + overrides on
             # SqlAgentConfiguration.
-            assert loaded.root_conversation_id == "conv_test1"
+            assert loaded.root_conversation_id == "a9930027fd3e2e979e65844f7af7bf88"
             assert loaded.next_position == 0
 
     def test_defaults(self, db_uri: str) -> None:
@@ -374,7 +374,7 @@ class TestSqlConversation:
             session.add(agent_config)
 
         with managed() as session:
-            loaded = session.get(SqlAgentConfiguration, (0, "conv_test1"))
+            loaded = session.get(SqlAgentConfiguration, (0, "a9930027fd3e2e979e65844f7af7bf88"))
             assert loaded is not None
             assert loaded.reasoning_effort is None
             assert loaded.model_override is None
@@ -392,10 +392,12 @@ class TestSqlConversation:
             session.add(meta)
 
         with managed() as session:
-            loaded_meta = session.get(SqlConversationMetadata, (0, "conv_test1"))
+            loaded_meta = session.get(
+                SqlConversationMetadata, (0, "a9930027fd3e2e979e65844f7af7bf88")
+            )
             assert loaded_meta is not None
             assert loaded_meta.kind == encode_conversation_kind("default")
-            loaded_conv = session.get(SqlConversation, (0, "conv_test1"))
+            loaded_conv = session.get(SqlConversation, (0, "a9930027fd3e2e979e65844f7af7bf88"))
             assert loaded_conv is not None
             assert loaded_conv.archived is False
 
@@ -413,15 +415,15 @@ class TestSqlConversation:
         engine = get_or_create_engine(db_uri)
         managed = make_managed_session_maker(engine)
 
-        parent = _make_conversation(id="conv_parent")
-        parent_meta = _make_metadata(id="conv_parent", kind="default")
+        parent = _make_conversation(id="ead6d59a6b650d19dbdf61ec32426f4e")
+        parent_meta = _make_metadata(id="ead6d59a6b650d19dbdf61ec32426f4e", kind="default")
         child = _make_conversation(
-            id="conv_child",
-            parent_conversation_id="conv_parent",
-            root_conversation_id="conv_parent",
+            id="ff5cac23d0beb79fad914046049f32ff",
+            parent_conversation_id="ead6d59a6b650d19dbdf61ec32426f4e",
+            root_conversation_id="ead6d59a6b650d19dbdf61ec32426f4e",
             title="summarizer",
         )
-        child_meta = _make_metadata(id="conv_child", kind="sub_agent")
+        child_meta = _make_metadata(id="ff5cac23d0beb79fad914046049f32ff", kind="sub_agent")
         with managed() as session:
             session.add(parent)
             session.add(parent_meta)
@@ -429,11 +431,13 @@ class TestSqlConversation:
             session.add(child_meta)
 
         with managed() as session:
-            loaded = session.get(SqlConversation, (0, "conv_child"))
+            loaded = session.get(SqlConversation, (0, "ff5cac23d0beb79fad914046049f32ff"))
             assert loaded is not None
-            assert loaded.parent_conversation_id == "conv_parent"
-            assert loaded.root_conversation_id == "conv_parent"
-            loaded_meta = session.get(SqlConversationMetadata, (0, "conv_child"))
+            assert loaded.parent_conversation_id == "ead6d59a6b650d19dbdf61ec32426f4e"
+            assert loaded.root_conversation_id == "ead6d59a6b650d19dbdf61ec32426f4e"
+            loaded_meta = session.get(
+                SqlConversationMetadata, (0, "ff5cac23d0beb79fad914046049f32ff")
+            )
             assert loaded_meta is not None
             assert loaded_meta.kind == encode_conversation_kind("sub_agent")
 
@@ -446,11 +450,11 @@ class TestSqlConversation:
         engine = get_or_create_engine(db_uri)
         managed = make_managed_session_maker(engine)
 
-        parent = _make_conversation(id="conv_parent2")
+        parent = _make_conversation(id="14e0b0bdc49cbf48b2f92ba938beadb9")
         child = _make_conversation(
-            id="conv_child2",
-            parent_conversation_id="conv_parent2",
-            root_conversation_id="conv_parent2",
+            id="6dbb0cf5f866fe63f24768195cc85646",
+            parent_conversation_id="14e0b0bdc49cbf48b2f92ba938beadb9",
+            root_conversation_id="14e0b0bdc49cbf48b2f92ba938beadb9",
             title="child",
         )
         with managed() as session:
@@ -458,13 +462,15 @@ class TestSqlConversation:
             session.add(child)
 
         with managed() as session:
-            p = session.get(SqlConversation, (0, "conv_parent2"))
+            p = session.get(SqlConversation, (0, "14e0b0bdc49cbf48b2f92ba938beadb9"))
             assert p is not None
             session.delete(p)
 
         # Without FK cascade the child is NOT automatically deleted.
         with managed() as session:
-            assert session.get(SqlConversation, (0, "conv_child2")) is not None
+            assert (
+                session.get(SqlConversation, (0, "6dbb0cf5f866fe63f24768195cc85646")) is not None
+            )
 
 
 # ── SqlConversationItem ───────────────────────────────
@@ -482,9 +488,12 @@ class TestSqlConversationItem:
             session.add(item)
 
         with managed() as session:
-            loaded = session.get(SqlConversationItem, (0, "conv_test1", "msg_test1"))
+            loaded = session.get(
+                SqlConversationItem,
+                (0, "a9930027fd3e2e979e65844f7af7bf88", "a47da81d0587d7c42e53978d629c5ab8"),
+            )
             assert loaded is not None
-            assert loaded.conversation_id == "conv_test1"
+            assert loaded.conversation_id == "a9930027fd3e2e979e65844f7af7bf88"
             assert loaded.type == encode_item_type("message")
             assert loaded.position == 0
             assert loaded.status == encode_item_status("completed")
@@ -496,8 +505,8 @@ class TestSqlConversationItem:
         managed = make_managed_session_maker(engine)
 
         conv = _make_conversation()
-        item1 = _make_item(id="msg_1", position=0)
-        item2 = _make_item(id="msg_2", position=0)
+        item1 = _make_item(id="9980c8a9248139f14f4165e5d53088aa", position=0)
+        item2 = _make_item(id="0fd4e86b2daa009cd9929641dbd7dab6", position=0)
 
         with pytest.raises(IntegrityError):
             with managed() as session:
@@ -514,20 +523,29 @@ class TestSqlConversationItem:
         engine = get_or_create_engine(db_uri)
         managed = make_managed_session_maker(engine)
 
-        conv = _make_conversation(id="conv_del")
-        item = _make_item(id="msg_del", conversation_id="conv_del")
+        conv = _make_conversation(id="553a265445caf1cdb034abe0b449485d")
+        item = _make_item(
+            id="79770462a714e18289f416144611383e",
+            conversation_id="553a265445caf1cdb034abe0b449485d",
+        )
         with managed() as session:
             session.add(conv)
             session.add(item)
 
         with managed() as session:
-            c = session.get(SqlConversation, (0, "conv_del"))
+            c = session.get(SqlConversation, (0, "553a265445caf1cdb034abe0b449485d"))
             assert c is not None
             session.delete(c)
 
         # Without FK cascade the item is NOT automatically deleted.
         with managed() as session:
-            assert session.get(SqlConversationItem, (0, "conv_del", "msg_del")) is not None
+            assert (
+                session.get(
+                    SqlConversationItem,
+                    (0, "553a265445caf1cdb034abe0b449485d", "79770462a714e18289f416144611383e"),
+                )
+                is not None
+            )
 
     def test_multiple_items_ordered_by_position(self, db_uri: str) -> None:
         engine = get_or_create_engine(db_uri)
@@ -537,12 +555,12 @@ class TestSqlConversationItem:
         with managed() as session:
             session.add(conv)
             for i in range(5):
-                session.add(_make_item(id=f"msg_{i}", position=i))
+                session.add(_make_item(id=f"{i:032x}", position=i))
 
         with managed() as session:
             items = (
                 session.query(SqlConversationItem)
-                .filter_by(conversation_id="conv_test1")
+                .filter_by(conversation_id="a9930027fd3e2e979e65844f7af7bf88")
                 .order_by(SqlConversationItem.position)
                 .all()
             )
@@ -560,7 +578,7 @@ class TestSqlConversationLabel:
 
         conv = _make_conversation()
         label = SqlConversationLabel(
-            conversation_id="conv_test1",
+            conversation_id="a9930027fd3e2e979e65844f7af7bf88",
             key="sensitivity",
             value="confidential",
             updated_at=_now(),
@@ -572,7 +590,7 @@ class TestSqlConversationLabel:
         with managed() as session:
             loaded = (
                 session.query(SqlConversationLabel)
-                .filter_by(conversation_id="conv_test1", key="sensitivity")
+                .filter_by(conversation_id="a9930027fd3e2e979e65844f7af7bf88", key="sensitivity")
                 .one()
             )
             assert loaded.value == "confidential"
@@ -586,18 +604,26 @@ class TestSqlConversationLabel:
             session.add(conv)
             session.add(
                 SqlConversationLabel(
-                    conversation_id="conv_test1", key="k1", value="v1", updated_at=_now()
+                    conversation_id="a9930027fd3e2e979e65844f7af7bf88",
+                    key="k1",
+                    value="v1",
+                    updated_at=_now(),
                 )
             )
             session.add(
                 SqlConversationLabel(
-                    conversation_id="conv_test1", key="k2", value="v2", updated_at=_now()
+                    conversation_id="a9930027fd3e2e979e65844f7af7bf88",
+                    key="k2",
+                    value="v2",
+                    updated_at=_now(),
                 )
             )
 
         with managed() as session:
             labels = (
-                session.query(SqlConversationLabel).filter_by(conversation_id="conv_test1").all()
+                session.query(SqlConversationLabel)
+                .filter_by(conversation_id="a9930027fd3e2e979e65844f7af7bf88")
+                .all()
             )
             assert len(labels) == 2
 
@@ -616,14 +642,16 @@ class TestSqlSessionPermission:
 
         perm = SqlSessionPermission(
             user_id="alice@example.com",
-            conversation_id="conv_test1",
+            conversation_id="a9930027fd3e2e979e65844f7af7bf88",
             level=2,
         )
         with managed() as session:
             session.add(perm)
 
         with managed() as session:
-            loaded = session.get(SqlSessionPermission, (0, "alice@example.com", "conv_test1"))
+            loaded = session.get(
+                SqlSessionPermission, (0, "alice@example.com", "a9930027fd3e2e979e65844f7af7bf88")
+            )
             assert loaded is not None
             assert loaded.level == 2
 
@@ -637,7 +665,7 @@ class TestSqlSessionPermission:
 
         perm = SqlSessionPermission(
             user_id="bob@example.com",
-            conversation_id="conv_test1",
+            conversation_id="a9930027fd3e2e979e65844f7af7bf88",
             level=99,
         )
         with pytest.raises((IntegrityError, OperationalError)):
@@ -655,8 +683,8 @@ class TestSqlComment:
 
         now = _now()
         comment = SqlComment(
-            id="cmt_test1",
-            conversation_id="conv_test1",
+            id="cccccccccccccccccccccccccccccc01",
+            conversation_id="a9930027fd3e2e979e65844f7af7bf88",
             path="src/App.tsx",
             start_index=10,
             end_index=20,
@@ -673,7 +701,7 @@ class TestSqlComment:
             session.add(comment)
 
         with managed() as session:
-            loaded = session.get(SqlComment, (0, "cmt_test1"))
+            loaded = session.get(SqlComment, (0, "cccccccccccccccccccccccccccccc01"))
             assert loaded is not None
             assert loaded.path == "src/App.tsx"
             assert loaded.body == "Looks good!"
@@ -687,8 +715,8 @@ class TestSqlComment:
 
         now = _now()
         comment = SqlComment(
-            id="cmt_test2",
-            conversation_id="conv_test1",
+            id="cccccccccccccccccccccccccccccc02",
+            conversation_id="a9930027fd3e2e979e65844f7af7bf88",
             path="README.md",
             start_index=0,
             end_index=5,
@@ -703,7 +731,7 @@ class TestSqlComment:
             session.add(comment)
 
         with managed() as session:
-            loaded = session.get(SqlComment, (0, "cmt_test2"))
+            loaded = session.get(SqlComment, (0, "cccccccccccccccccccccccccccccc02"))
             assert loaded is not None
             assert loaded.anchor_content is None
             assert loaded.created_by is None
@@ -718,7 +746,7 @@ class TestSqlPolicy:
         managed = make_managed_session_maker(engine)
 
         policy = SqlPolicy(
-            id="pol_test1",
+            id="21cbc70e914e5189cd9a57cf7d91eaba",
             name="cost-guard",
             scope=encode_policy_scope("default"),
             created_at=_now(),
@@ -730,7 +758,7 @@ class TestSqlPolicy:
             session.add(policy)
 
         with managed() as session:
-            loaded = session.get(SqlPolicy, (0, "pol_test1"))
+            loaded = session.get(SqlPolicy, (0, "21cbc70e914e5189cd9a57cf7d91eaba"))
             assert loaded is not None
             assert loaded.name == "cost-guard"
             # The column default stamps sha256(name) on INSERT.
@@ -746,18 +774,18 @@ class TestSqlPolicy:
 
         conv = _make_conversation()
         p1 = SqlPolicy(
-            id="pol_1",
+            id="12a6858438cb1aa1b9e00dc79bb04dd9",
             name="guard",
-            session_id="conv_test1",
+            session_id="a9930027fd3e2e979e65844f7af7bf88",
             scope=encode_policy_scope("session"),
             created_at=_now(),
             type=encode_policy_type("python"),
             handler="mod:fn",
         )
         p2 = SqlPolicy(
-            id="pol_2",
+            id="532212bcd2f88d1ad1a0072b5a78a740",
             name="guard",
-            session_id="conv_test1",
+            session_id="a9930027fd3e2e979e65844f7af7bf88",
             scope=encode_policy_scope("session"),
             created_at=_now(),
             type=encode_policy_type("python"),
@@ -782,7 +810,7 @@ class TestSqlHost:
         host = SqlHost(
             owner="corey@example.com",
             name="corey-laptop",
-            host_id="host_abc123",
+            host_id="4f64b6ee625f4e8259185c35c6e63f3d",
             status=encode_host_status("online"),
             created_at=now,
             updated_at=now,
@@ -791,9 +819,9 @@ class TestSqlHost:
             session.add(host)
 
         with managed() as session:
-            loaded = session.get(SqlHost, (0, "host_abc123"))
+            loaded = session.get(SqlHost, (0, "4f64b6ee625f4e8259185c35c6e63f3d"))
             assert loaded is not None
-            assert loaded.host_id == "host_abc123"
+            assert loaded.host_id == "4f64b6ee625f4e8259185c35c6e63f3d"
             assert loaded.status == encode_host_status("online")
             assert loaded.token_hash is None
             assert loaded.sandbox_provider is None
@@ -821,7 +849,7 @@ class TestSqlHost:
         h1 = SqlHost(
             owner="a@x.com",
             name="h1",
-            host_id="host_dup",
+            host_id="2690ed5ead1b05791d642d85e6847680",
             status=encode_host_status("online"),
             created_at=now,
             updated_at=now,
@@ -833,7 +861,7 @@ class TestSqlHost:
         h2 = SqlHost(
             owner="b@x.com",
             name="h2",
-            host_id="host_dup",
+            host_id="2690ed5ead1b05791d642d85e6847680",
             status=encode_host_status("offline"),
             created_at=now,
             updated_at=now,

--- a/tests/db/test_migration_agents_session_id.py
+++ b/tests/db/test_migration_agents_session_id.py
@@ -84,10 +84,16 @@ def test_template_agent_kind_stored_and_read(db_engine: Engine) -> None:
                 "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
                 " VALUES (:id, :ts, :name, :loc, 1, 1)"
             ),
-            {"id": "ag_tmpl", "ts": 1700000001, "name": "my-template", "loc": "ag_tmpl/bundle"},
+            {
+                "id": "23803e78ca1677e73a1d8c6275de4150",
+                "ts": 1700000001,
+                "name": "my-template",
+                "loc": "23803e78ca1677e73a1d8c6275de4150/bundle",
+            },
         )
         kind = conn.execute(
-            sa.text("SELECT kind FROM agents WHERE id = :id"), {"id": "ag_tmpl"}
+            sa.text("SELECT kind FROM agents WHERE id = :id"),
+            {"id": "23803e78ca1677e73a1d8c6275de4150"},
         ).scalar_one()
     assert kind == 1
 
@@ -101,10 +107,16 @@ def test_session_agent_kind_stored_and_read(db_engine: Engine) -> None:
                 "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
                 " VALUES (:id, :ts, :name, :loc, 1, 2)"
             ),
-            {"id": "ag_sess", "ts": 1700000001, "name": "my-session", "loc": "ag_sess/bundle"},
+            {
+                "id": "372d0296768feff7262c605c5553d1da",
+                "ts": 1700000001,
+                "name": "my-session",
+                "loc": "372d0296768feff7262c605c5553d1da/bundle",
+            },
         )
         kind = conn.execute(
-            sa.text("SELECT kind FROM agents WHERE id = :id"), {"id": "ag_sess"}
+            sa.text("SELECT kind FROM agents WHERE id = :id"),
+            {"id": "372d0296768feff7262c605c5553d1da"},
         ).scalar_one()
     assert kind == 2
 
@@ -118,7 +130,12 @@ def test_agents_session_id_fk_accepts_existing_session(db_engine: Engine) -> Non
                 "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
                 " VALUES (:id, :ts, :name, :loc, 1, 2)"
             ),
-            {"id": "ag_bound", "ts": 1700000001, "name": "bound-agent", "loc": "ag_bound/bundle"},
+            {
+                "id": "552f255351da28d9c68a67cc9758840d",
+                "ts": 1700000001,
+                "name": "bound-agent",
+                "loc": "552f255351da28d9c68a67cc9758840d/bundle",
+            },
         )
         # The agent binding lives on agent_configuration, paired 1:1 with
         # the conversations row.
@@ -128,20 +145,23 @@ def test_agents_session_id_fk_accepts_existing_session(db_engine: Engine) -> Non
                 " (id, created_at, updated_at, root_conversation_id)"
                 " VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_bound", "ts": 1700000002},
+            {"id": "e6c4a1ce71909cfba7d30a314c5f94ee", "ts": 1700000002},
         )
         conn.execute(
             sa.text(
                 "INSERT INTO agent_configuration (conversation_id, agent_id)"
                 " VALUES (:id, :agent_id)"
             ),
-            {"id": "conv_bound", "agent_id": "ag_bound"},
+            {
+                "id": "e6c4a1ce71909cfba7d30a314c5f94ee",
+                "agent_id": "552f255351da28d9c68a67cc9758840d",
+            },
         )
         stored = conn.execute(
             sa.text("SELECT agent_id FROM agent_configuration WHERE conversation_id = :id"),
-            {"id": "conv_bound"},
+            {"id": "e6c4a1ce71909cfba7d30a314c5f94ee"},
         ).scalar_one()
-    assert stored == "ag_bound"
+    assert stored == "552f255351da28d9c68a67cc9758840d"
 
 
 def test_agents_session_id_fk_rejects_missing_session(db_engine: Engine) -> None:
@@ -157,21 +177,29 @@ def test_agents_session_id_fk_rejects_missing_session(db_engine: Engine) -> None
                 " (id, created_at, updated_at, root_conversation_id)"
                 " VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_missing", "ts": 1700000002},
+            {"id": "5eca720dc2bc6cdc3a99028d7bd0f917", "ts": 1700000002},
         )
         conn.execute(
             sa.text(
                 "INSERT INTO agent_configuration (conversation_id, agent_id)"
                 " VALUES (:id, :agent_id)"
             ),
-            {"id": "conv_missing", "agent_id": "ag_nonexistent"},
+            {
+                "id": "5eca720dc2bc6cdc3a99028d7bd0f917",
+                "agent_id": "5ff5b2e31fe10beb80134394037b17b0",
+            },
         )
     # Clean up
     with db_engine.begin() as conn:
         conn.execute(
-            sa.text("DELETE FROM agent_configuration WHERE conversation_id = 'conv_missing'")
+            sa.text(
+                "DELETE FROM agent_configuration "
+                "WHERE conversation_id = '5eca720dc2bc6cdc3a99028d7bd0f917'"
+            )
         )
-        conn.execute(sa.text("DELETE FROM conversations WHERE id = 'conv_missing'"))
+        conn.execute(
+            sa.text("DELETE FROM conversations WHERE id = '5eca720dc2bc6cdc3a99028d7bd0f917'")
+        )
 
 
 def test_agents_allow_duplicate_template_names_at_db_layer(
@@ -191,11 +219,11 @@ def test_agents_allow_duplicate_template_names_at_db_layer(
                 "        (:id2, :ts, 'dup-template', :loc2, 1, 1)"
             ),
             {
-                "id1": "ag_dup1",
-                "id2": "ag_dup2",
+                "id1": "ef9a08aaf68eccf43b76051e6d818c5e",
+                "id2": "5cdc35664c8c12c1fe200de768af454b",
                 "ts": 1700000001,
-                "loc1": "ag_dup1/bundle",
-                "loc2": "ag_dup2/bundle",
+                "loc1": "ef9a08aaf68eccf43b76051e6d818c5e/bundle",
+                "loc2": "5cdc35664c8c12c1fe200de768af454b/bundle",
             },
         )
         count = conn.execute(
@@ -217,11 +245,11 @@ def test_agents_session_id_allows_duplicate_names_for_distinct_sessions(
                 "        (:id2, :ts, 'shared-name', :loc2, 1, 2)"
             ),
             {
-                "id1": "ag_s1",
-                "id2": "ag_s2",
+                "id1": "122d503fe436c3e819c4e481fc9e959b",
+                "id2": "2db4293f4feb844664bb1f50af9508a7",
                 "ts": 1700000001,
-                "loc1": "ag_s1/bundle",
-                "loc2": "ag_s2/bundle",
+                "loc1": "122d503fe436c3e819c4e481fc9e959b/bundle",
+                "loc2": "2db4293f4feb844664bb1f50af9508a7/bundle",
             },
         )
         count = conn.execute(
@@ -256,8 +284,10 @@ def test_upgrade_does_not_cascade_delete_conversations(tmp_path: Path) -> None:
         conn.execute(
             sa.text(
                 "INSERT INTO agents (id, created_at, name, bundle_location, version)"
-                " VALUES ('ag_tmpl', 1, 'my-template', 'ag_tmpl/b', 1),"
-                "        ('ag_sess', 2, 'my-session', 'ag_sess/b', 1)"
+                " VALUES ('23803e78ca1677e73a1d8c6275de4150', 1, 'my-template',"
+                " '23803e78ca1677e73a1d8c6275de4150/b', 1),"
+                "        ('372d0296768feff7262c605c5553d1da', 2, 'my-session',"
+                " '372d0296768feff7262c605c5553d1da/b', 1)"
             )
         )
         conn.execute(
@@ -266,10 +296,17 @@ def test_upgrade_does_not_cascade_delete_conversations(tmp_path: Path) -> None:
                 # SMALLINT migration (q1), so conversations.kind is still a string.
                 "INSERT INTO conversations"
                 " (id, created_at, updated_at, root_conversation_id, kind, agent_id)"
-                " VALUES ('conv_1', 3, 3, 'conv_1', 'default', 'ag_sess')"
+                " VALUES ('8e32600337d08f59ad381caf96a90659', 3, 3,"
+                " '8e32600337d08f59ad381caf96a90659', 'default',"
+                " '372d0296768feff7262c605c5553d1da')"
             )
         )
-        conn.execute(sa.text("UPDATE agents SET session_id = 'conv_1' WHERE id = 'ag_sess'"))
+        conn.execute(
+            sa.text(
+                "UPDATE agents SET session_id = '8e32600337d08f59ad381caf96a90659'"
+                " WHERE id = '372d0296768feff7262c605c5553d1da'"
+            )
+        )
 
     # Run our migration.
     config2 = _build_alembic_config(uri)
@@ -283,9 +320,11 @@ def test_upgrade_does_not_cascade_delete_conversations(tmp_path: Path) -> None:
             row[0]: row[1] for row in conn.execute(sa.text("SELECT id, kind FROM agents"))
         }
 
-    assert "conv_1" in conv_ids, "Upgrade must not cascade-delete bound conversations"
-    assert agent_kinds.get("ag_sess") == "session"
-    assert agent_kinds.get("ag_tmpl") == "template"
+    assert "8e32600337d08f59ad381caf96a90659" in conv_ids, (
+        "Upgrade must not cascade-delete bound conversations"
+    )
+    assert agent_kinds.get("372d0296768feff7262c605c5553d1da") == "session"
+    assert agent_kinds.get("23803e78ca1677e73a1d8c6275de4150") == "template"
 
     raw_engine.dispose()
     clear_engine_cache()
@@ -320,15 +359,18 @@ def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
             sa.text(
                 "INSERT INTO agents"
                 " (workspace_id, id, created_at, name, bundle_location, version, kind)"
-                " VALUES (0, 'ag_tmpl', 1, 'my-template', 'ag_tmpl/b', 1, 1),"
-                "        (0, 'ag_sess', 2, 'my-session', 'ag_sess/b', 1, 2)"
+                " VALUES (0, '23803e78ca1677e73a1d8c6275de4150', 1,"
+                " 'my-template', '23803e78ca1677e73a1d8c6275de4150/b', 1, 1),"
+                "        (0, '372d0296768feff7262c605c5553d1da', 2,"
+                " 'my-session', '372d0296768feff7262c605c5553d1da/b', 1, 2)"
             )
         )
         conn.execute(
             sa.text(
                 "INSERT INTO conversations"
                 " (workspace_id, id, created_at, updated_at, root_conversation_id, title)"
-                " VALUES (0, 'conv_1', 3, 3, 'conv_1', '')"
+                " VALUES (0, '8e32600337d08f59ad381caf96a90659', 3, 3,"
+                " '8e32600337d08f59ad381caf96a90659', '')"
             )
         )
         # agent_id lives on agent_configuration at head; the bb2c3d4e5f6a
@@ -337,7 +379,8 @@ def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
         conn.execute(
             sa.text(
                 "INSERT INTO agent_configuration (workspace_id, conversation_id, agent_id)"
-                " VALUES (0, 'conv_1', 'ag_sess')"
+                " VALUES (0, '8e32600337d08f59ad381caf96a90659',"
+                " '372d0296768feff7262c605c5553d1da')"
             )
         )
         # kind lives on omnigent_conversation_metadata at head; insert a
@@ -347,7 +390,7 @@ def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
             sa.text(
                 "INSERT INTO omnigent_conversation_metadata"
                 " (workspace_id, id, kind)"
-                " VALUES (0, 'conv_1', 1)"
+                " VALUES (0, '8e32600337d08f59ad381caf96a90659', 1)"
             )
         )
 
@@ -369,8 +412,8 @@ def test_agents_session_id_downgrade_round_trip(tmp_path: Path) -> None:
             row[0]: row[1]
             for row in conn.execute(sa.text("SELECT id, session_id FROM agents ORDER BY id"))
         }
-    assert rows["ag_tmpl"] is None
-    assert rows["ag_sess"] == "conv_1"
+    assert rows["23803e78ca1677e73a1d8c6275de4150"] is None
+    assert rows["372d0296768feff7262c605c5553d1da"] == "8e32600337d08f59ad381caf96a90659"
 
     raw_engine.dispose()
     clear_engine_cache()

--- a/tests/db/test_migration_archived.py
+++ b/tests/db/test_migration_archived.py
@@ -103,12 +103,12 @@ def test_archived_defaults_false_on_insert(db_engine: Engine) -> None:
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_arch_default", "ts": 1700000000},
+            {"id": "a286a63f38f8f5fdf8ccf8486ade862a", "ts": 1700000000},
         )
         conn.commit()
         value = conn.execute(
             sa.text("SELECT archived FROM conversations WHERE id = :id"),
-            {"id": "conv_arch_default"},
+            {"id": "a286a63f38f8f5fdf8ccf8486ade862a"},
         ).scalar_one()
         assert value == 0, f"Expected archived to default to 0 (false); got {value!r}."
 
@@ -125,6 +125,8 @@ def test_archived_backfilled_from_metadata(tmp_path: Path) -> None:
     cfg = _build_alembic_config(uri)
     raw_engine = sa.create_engine(uri)
     try:
+        id_a = "94c349190e241f85a984b3df8f129696"
+        id_b = "bfcc6c068875253adf2f20bf30a19015"
         with raw_engine.begin() as conn:
             cfg.attributes["connection"] = conn
             command.upgrade(cfg, _PRE_MOVE_REVISION)
@@ -132,14 +134,16 @@ def test_archived_backfilled_from_metadata(tmp_path: Path) -> None:
                 sa.text(
                     "INSERT INTO conversations "
                     "(id, created_at, updated_at, root_conversation_id) "
-                    "VALUES ('conv_a', 1, 1, 'conv_a'), ('conv_b', 2, 2, 'conv_b')"
-                )
+                    "VALUES (:a, 1, 1, :a), (:b, 2, 2, :b)"
+                ),
+                {"a": id_a, "b": id_b},
             )
             conn.execute(
                 sa.text(
                     "INSERT INTO omnigent_conversation_metadata (id, kind, archived) "
-                    "VALUES ('conv_a', 1, 1), ('conv_b', 1, 0)"
-                )
+                    "VALUES (:a, 1, 1), (:b, 1, 0)"
+                ),
+                {"a": id_a, "b": id_b},
             )
         with raw_engine.begin() as conn:
             cfg.attributes["connection"] = conn
@@ -148,7 +152,7 @@ def test_archived_backfilled_from_metadata(tmp_path: Path) -> None:
             rows = dict(
                 conn.execute(sa.text("SELECT id, archived FROM conversations ORDER BY id")).all()
             )
-        assert rows == {"conv_a": 1, "conv_b": 0}
+        assert rows == {id_a: 1, id_b: 0}
     finally:
         raw_engine.dispose()
         clear_engine_cache()

--- a/tests/db/test_migration_comments_updated_at.py
+++ b/tests/db/test_migration_comments_updated_at.py
@@ -73,8 +73,20 @@ def test_comments_updated_at_backfilled_from_created_at(tmp_path: Path) -> None:
                     "VALUES (:id, :conv, :path, 0, 5, :body, 'draft', :ts)",
                 ),
                 [
-                    {"id": "cmt_1", "conv": "conv_a", "path": "a.py", "body": "x", "ts": 1_000},
-                    {"id": "cmt_2", "conv": "conv_a", "path": "a.py", "body": "y", "ts": 2_000},
+                    {
+                        "id": "747618b4b2dd94383e50ddf180ceddc3",
+                        "conv": "94c349190e241f85a984b3df8f129696",
+                        "path": "a.py",
+                        "body": "x",
+                        "ts": 1_000,
+                    },
+                    {
+                        "id": "f2686a25fbf1464a1cc2a347237813cd",
+                        "conv": "94c349190e241f85a984b3df8f129696",
+                        "path": "a.py",
+                        "body": "y",
+                        "ts": 2_000,
+                    },
                 ],
             )
 
@@ -92,7 +104,10 @@ def test_comments_updated_at_backfilled_from_created_at(tmp_path: Path) -> None:
         # backfill ignored per-row values and legacy comments would all
         # fingerprint identically.
         us = 1_000_000
-        assert rows == {"cmt_1": (1_000, 1_000 * us), "cmt_2": (2_000, 2_000 * us)}
+        assert rows == {
+            "747618b4b2dd94383e50ddf180ceddc3": (1_000, 1_000 * us),
+            "f2686a25fbf1464a1cc2a347237813cd": (2_000, 2_000 * us),
+        }
     finally:
         engine.dispose()
 

--- a/tests/db/test_migration_host_name_varchar64.py
+++ b/tests/db/test_migration_host_name_varchar64.py
@@ -59,7 +59,8 @@ def test_downgrade_restores_varchar256(tmp_path: Path) -> None:
             sa.text(
                 "INSERT INTO hosts "
                 "(workspace_id, owner, name, host_id, status, created_at, updated_at) "
-                "VALUES (0, 'user@example.com', 'my-laptop', 'host_abc123', 1, "
+                "VALUES (0, 'user@example.com', 'my-laptop',"
+                " '4f64b6ee625f4e8259185c35c6e63f3d', 1, "
                 "1700000000, 1700000001)"
             )
         )

--- a/tests/db/test_migration_host_pk_workspace_host_id.py
+++ b/tests/db/test_migration_host_pk_workspace_host_id.py
@@ -73,7 +73,7 @@ def test_data_survives_upgrade(tmp_path: Path) -> None:
             sa.text(
                 "INSERT INTO hosts "
                 "(workspace_id, owner, name, host_id, status, created_at, updated_at) "
-                "VALUES (0, 'alice@example.com', 'laptop', 'host_abc', 1, "
+                "VALUES (0, 'alice@example.com', 'laptop', 'abb32306b80732bdfa6153b2f5f6eb92', 1, "
                 "1700000000, 1700000001)"
             )
         )
@@ -81,13 +81,18 @@ def test_data_survives_upgrade(tmp_path: Path) -> None:
 
     row = (
         engine.connect()
-        .execute(sa.text("SELECT owner, name, host_id FROM hosts WHERE host_id = 'host_abc'"))
+        .execute(
+            sa.text(
+                "SELECT owner, name, host_id FROM hosts"
+                " WHERE host_id = 'abb32306b80732bdfa6153b2f5f6eb92'"
+            )
+        )
         .fetchone()
     )
     assert row is not None
     assert row[0] == "alice@example.com"
     assert row[1] == "laptop"
-    assert row[2] == "host_abc"
+    assert row[2] == "abb32306b80732bdfa6153b2f5f6eb92"
 
     engine.dispose()
     clear_engine_cache()
@@ -106,7 +111,8 @@ def test_downgrade_restores_old_pk(tmp_path: Path) -> None:
             sa.text(
                 "INSERT INTO hosts "
                 "(workspace_id, owner, name, host_id, status, created_at, updated_at) "
-                "VALUES (0, 'bob@example.com', 'workstation', 'host_xyz', 2, "
+                "VALUES (0, 'bob@example.com', 'workstation',"
+                " '2173662ad94ab46f03cfbdd5f968d22b', 2, "
                 "1700000002, 1700000003)"
             )
         )
@@ -140,7 +146,9 @@ def test_downgrade_restores_old_pk(tmp_path: Path) -> None:
         row = conn.execute(
             sa.text("SELECT host_id FROM hosts WHERE owner = 'bob@example.com'")
         ).scalar_one_or_none()
-    assert row == "host_xyz", f"host_id must survive downgrade; got {row!r}"
+    assert row == "2173662ad94ab46f03cfbdd5f968d22b", (
+        f"host_id must survive downgrade; got {row!r}"
+    )
 
     engine.dispose()
     clear_engine_cache()

--- a/tests/db/test_migration_policy_name_cksum.py
+++ b/tests/db/test_migration_policy_name_cksum.py
@@ -85,7 +85,8 @@ def test_backfill_computes_sha256_of_name(tmp_path: Path) -> None:
                 # scope=1 default, type=1 python (int codes at this revision).
                 "INSERT INTO policies"
                 " (workspace_id, id, name, session_id, scope, created_at, type, handler, enabled)"
-                " VALUES (0, 'pol_bf1', 'legacy_name', NULL, 1, 1, 1, 'mod.f', 1)"
+                " VALUES (0, '2f9bdde44384914ae0d8850527cdfe7d', 'legacy_name',"
+                " NULL, 1, 1, 1, 'mod.f', 1)"
             )
         )
     with engine.begin() as conn:
@@ -94,7 +95,9 @@ def test_backfill_computes_sha256_of_name(tmp_path: Path) -> None:
 
     with engine.begin() as conn:
         cksum = conn.execute(
-            sa.text("SELECT name_cksum FROM policies WHERE id = 'pol_bf1'")
+            sa.text(
+                "SELECT name_cksum FROM policies WHERE id = '2f9bdde44384914ae0d8850527cdfe7d'"
+            )
         ).scalar_one()
     assert bytes(cksum) == hashlib.sha256(b"legacy_name").digest()
 

--- a/tests/db/test_migration_policy_scope.py
+++ b/tests/db/test_migration_policy_scope.py
@@ -57,7 +57,8 @@ def test_backfill_sets_session_scope_for_session_policies(db_engine: Engine) -> 
             sa.text(
                 "INSERT INTO conversations"
                 " (id, created_at, updated_at, root_conversation_id)"
-                " VALUES ('conv_sc1', 1, 1, 'conv_sc1')"
+                " VALUES ('7e75643c5e9dd8d8b8e06424e743c7d5', 1, 1,"
+                " '7e75643c5e9dd8d8b8e06424e743c7d5')"
             )
         )
         conn.execute(
@@ -66,12 +67,13 @@ def test_backfill_sets_session_scope_for_session_policies(db_engine: Engine) -> 
                 # name_cksum is NOT NULL at head (x1a2b3c4d5e6) — sha256(name).
                 "INSERT INTO policies"
                 " (id, name, name_cksum, session_id, scope, created_at, type, handler, enabled)"
-                " VALUES ('pol_sc1', 'sess_pol', :cksum, 'conv_sc1', 2, 1, 1, 'mod.f', 1)"
+                " VALUES ('975d8b3b3c096896c86e3a2c9007130e', 'sess_pol', :cksum,"
+                " '7e75643c5e9dd8d8b8e06424e743c7d5', 2, 1, 1, 'mod.f', 1)"
             ),
             {"cksum": hashlib.sha256(b"sess_pol").digest()},
         )
         scope = conn.execute(
-            sa.text("SELECT scope FROM policies WHERE id = 'pol_sc1'")
+            sa.text("SELECT scope FROM policies WHERE id = '975d8b3b3c096896c86e3a2c9007130e'")
         ).scalar_one()
     assert scope == 2
 
@@ -85,12 +87,13 @@ def test_backfill_sets_default_scope_for_default_policies(db_engine: Engine) -> 
                 # name_cksum is NOT NULL at head (x1a2b3c4d5e6) — sha256(name).
                 "INSERT INTO policies"
                 " (id, name, name_cksum, session_id, scope, created_at, type, handler, enabled)"
-                " VALUES ('pol_def1', 'def_pol', :cksum, NULL, 1, 1, 1, 'mod.f', 1)"
+                " VALUES ('62faa13b832455d2a47b5538702afb21', 'def_pol', :cksum,"
+                " NULL, 1, 1, 1, 'mod.f', 1)"
             ),
             {"cksum": hashlib.sha256(b"def_pol").digest()},
         )
         scope = conn.execute(
-            sa.text("SELECT scope FROM policies WHERE id = 'pol_def1'")
+            sa.text("SELECT scope FROM policies WHERE id = '62faa13b832455d2a47b5538702afb21'")
         ).scalar_one()
     assert scope == 1
 
@@ -107,14 +110,14 @@ def test_scope_round_trip_via_store(db_engine: Engine) -> None:
     session_id = conv_store.create_conversation().id
 
     session_pol = policy_store.create(
-        policy_id="pol_rt_sess",
+        policy_id="45b37dc423a384a33427ddb51b418ee0",
         session_id=session_id,
         name="session_policy",
         type="python",
         handler="mod.func",
     )
     default_pol = policy_store.create_default(
-        policy_id="pol_rt_def",
+        policy_id="a095b97d94573f6bba493e2bd479ad88",
         name="default_policy",
         type="python",
         handler="mod.func",
@@ -135,14 +138,14 @@ def test_list_defaults_uses_scope_filter(db_engine: Engine) -> None:
 
     session_id = conv_store.create_conversation().id
     policy_store.create(
-        policy_id="pol_sess_x",
+        policy_id="76437b0af2988606d009e8ecf550ce62",
         session_id=session_id,
         name="sess_x",
         type="python",
         handler="mod.func",
     )
     policy_store.create_default(
-        policy_id="pol_def_x",
+        policy_id="58bf9f55f214321754995cb4beebed38",
         name="def_x",
         type="python",
         handler="mod.func",
@@ -150,7 +153,7 @@ def test_list_defaults_uses_scope_filter(db_engine: Engine) -> None:
 
     defaults = policy_store.list_defaults()
     assert len(defaults) == 1
-    assert defaults[0].id == "pol_def_x"
+    assert defaults[0].id == "58bf9f55f214321754995cb4beebed38"
     assert defaults[0].scope == "default"
 
 

--- a/tests/db/test_migration_runner_id.py
+++ b/tests/db/test_migration_runner_id.py
@@ -78,15 +78,15 @@ def test_runner_id_round_trip_null_and_value(db_engine: Engine) -> None:
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_null_test", "ts": 1700000000},
+            {"id": "0d42a93a625e91d8b607d375fbd860ad", "ts": 1700000000},
         )
         conn.execute(
             sa.text("INSERT INTO omnigent_conversation_metadata (id, kind) VALUES (:id, 1)"),
-            {"id": "conv_null_test"},
+            {"id": "0d42a93a625e91d8b607d375fbd860ad"},
         )
         result = conn.execute(
             sa.text("SELECT runner_id FROM omnigent_conversation_metadata WHERE id = :id"),
-            {"id": "conv_null_test"},
+            {"id": "0d42a93a625e91d8b607d375fbd860ad"},
         ).scalar_one()
         assert result is None, f"Expected NULL on default-insert; got {result!r}"
 
@@ -97,18 +97,18 @@ def test_runner_id_round_trip_null_and_value(db_engine: Engine) -> None:
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_value_test", "ts": 1700000000},
+            {"id": "ee91e92728c76ca2647ad5459b008754", "ts": 1700000000},
         )
         conn.execute(
             sa.text(
                 "INSERT INTO omnigent_conversation_metadata (id, kind, runner_id) "
                 "VALUES (:id, 1, :rid)"
             ),
-            {"id": "conv_value_test", "rid": "runner-uuid-abc"},
+            {"id": "ee91e92728c76ca2647ad5459b008754", "rid": "runner-uuid-abc"},
         )
         result = conn.execute(
             sa.text("SELECT runner_id FROM omnigent_conversation_metadata WHERE id = :id"),
-            {"id": "conv_value_test"},
+            {"id": "ee91e92728c76ca2647ad5459b008754"},
         ).scalar_one()
         assert result == "runner-uuid-abc", (
             f"Round-trip mismatch: stored 'runner-uuid-abc', got {result!r}. "

--- a/tests/db/test_migration_runner_id_backfill.py
+++ b/tests/db/test_migration_runner_id_backfill.py
@@ -90,8 +90,16 @@ def test_runner_id_backfill_marks_only_unbound_conversations(tmp_path: Path) -> 
                     "VALUES (:id, :ts, :ts, 'default', :runner_id)",
                 ),
                 [
-                    {"id": "conv_bound", "ts": 1700000000, "runner_id": "runner_existing"},
-                    {"id": "conv_unbound", "ts": 1700000001, "runner_id": None},
+                    {
+                        "id": "e6c4a1ce71909cfba7d30a314c5f94ee",
+                        "ts": 1700000000,
+                        "runner_id": "runner_existing",
+                    },
+                    {
+                        "id": "e4ffbe103d61752f313e9b6f9e7d3ede",
+                        "ts": 1700000001,
+                        "runner_id": None,
+                    },
                 ],
             )
 
@@ -99,8 +107,8 @@ def test_runner_id_backfill_marks_only_unbound_conversations(tmp_path: Path) -> 
 
         rows = _conversation_runner_ids(engine)
         assert rows == {
-            "conv_bound": "runner_existing",
-            "conv_unbound": OFFLINE_MIGRATED_RUNNER_ID,
+            "e6c4a1ce71909cfba7d30a314c5f94ee": "runner_existing",
+            "e4ffbe103d61752f313e9b6f9e7d3ede": OFFLINE_MIGRATED_RUNNER_ID,
         }
     finally:
         engine.dispose()
@@ -119,8 +127,16 @@ def test_runner_id_backfill_downgrade_round_trips_sentinel(tmp_path: Path) -> No
                     "VALUES (:id, :ts, :ts, 'default', :runner_id)",
                 ),
                 [
-                    {"id": "conv_bound", "ts": 1700000000, "runner_id": "runner_existing"},
-                    {"id": "conv_unbound", "ts": 1700000001, "runner_id": None},
+                    {
+                        "id": "e6c4a1ce71909cfba7d30a314c5f94ee",
+                        "ts": 1700000000,
+                        "runner_id": "runner_existing",
+                    },
+                    {
+                        "id": "e4ffbe103d61752f313e9b6f9e7d3ede",
+                        "ts": 1700000001,
+                        "runner_id": None,
+                    },
                 ],
             )
         _upgrade(engine, uri, "e9f2a7c4d1b8")
@@ -129,8 +145,8 @@ def test_runner_id_backfill_downgrade_round_trips_sentinel(tmp_path: Path) -> No
 
         rows = _conversation_runner_ids(engine)
         assert rows == {
-            "conv_bound": "runner_existing",
-            "conv_unbound": None,
+            "e6c4a1ce71909cfba7d30a314c5f94ee": "runner_existing",
+            "e4ffbe103d61752f313e9b6f9e7d3ede": None,
         }
     finally:
         engine.dispose()

--- a/tests/db/test_migration_terminal_launch_args.py
+++ b/tests/db/test_migration_terminal_launch_args.py
@@ -94,17 +94,17 @@ def test_terminal_launch_args_round_trip_null_and_json(db_engine: Engine) -> Non
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_tla_null", "ts": 1700000000},
+            {"id": "8c2ab1547c91fcc61ae8226f37d07400", "ts": 1700000000},
         )
         conn.execute(
             sa.text("INSERT INTO omnigent_conversation_metadata (id, kind) VALUES (:id, 1)"),
-            {"id": "conv_tla_null"},
+            {"id": "8c2ab1547c91fcc61ae8226f37d07400"},
         )
         result = conn.execute(
             sa.text(
                 "SELECT terminal_launch_args FROM omnigent_conversation_metadata WHERE id = :id"
             ),
-            {"id": "conv_tla_null"},
+            {"id": "8c2ab1547c91fcc61ae8226f37d07400"},
         ).scalar_one()
         assert result is None, (
             f"Expected NULL terminal_launch_args on default insert; got {result!r}."
@@ -117,7 +117,7 @@ def test_terminal_launch_args_round_trip_null_and_json(db_engine: Engine) -> Non
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_tla_value", "ts": 1700000000},
+            {"id": "d7d570908f410a452a2d6b912bc6f97a", "ts": 1700000000},
         )
         conn.execute(
             sa.text(
@@ -126,7 +126,7 @@ def test_terminal_launch_args_round_trip_null_and_json(db_engine: Engine) -> Non
                 "VALUES (:id, 1, :tla)"
             ),
             {
-                "id": "conv_tla_value",
+                "id": "d7d570908f410a452a2d6b912bc6f97a",
                 "tla": '["--dangerously-skip-permissions", "--model", "opus"]',
             },
         )
@@ -134,7 +134,7 @@ def test_terminal_launch_args_round_trip_null_and_json(db_engine: Engine) -> Non
             sa.text(
                 "SELECT terminal_launch_args FROM omnigent_conversation_metadata WHERE id = :id"
             ),
-            {"id": "conv_tla_value"},
+            {"id": "d7d570908f410a452a2d6b912bc6f97a"},
         ).scalar_one()
         assert result == '["--dangerously-skip-permissions", "--model", "opus"]', (
             f"Round-trip mismatch on terminal_launch_args; got {result!r}."

--- a/tests/db/test_migration_title_not_null.py
+++ b/tests/db/test_migration_title_not_null.py
@@ -53,12 +53,12 @@ def test_title_defaults_empty_string_on_insert(db_engine: Engine) -> None:
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_title_default", "ts": 1700000000},
+            {"id": "8d75d48b8389fad0b52fbe8d8befc274", "ts": 1700000000},
         )
         conn.commit()
         value = conn.execute(
             sa.text("SELECT title FROM conversations WHERE id = :id"),
-            {"id": "conv_title_default"},
+            {"id": "8d75d48b8389fad0b52fbe8d8befc274"},
         ).scalar_one()
     assert value == "", f"Expected title to default to '' (empty string); got {value!r}."
 
@@ -80,7 +80,7 @@ def test_downgrade_restores_nullable_and_nullifies_empty_titles(tmp_path: Path) 
                 "(id, created_at, updated_at, root_conversation_id, title) "
                 "VALUES (:id, :ts, :ts, :id, '')"
             ),
-            {"id": "conv_downgrade_test", "ts": 1700000001},
+            {"id": "c53e320807888eb5da3a3395ef5382df", "ts": 1700000001},
         )
         conn.commit()
 
@@ -92,7 +92,7 @@ def test_downgrade_restores_nullable_and_nullifies_empty_titles(tmp_path: Path) 
                 "(id, created_at, updated_at, root_conversation_id, title) "
                 "VALUES (:id, :ts, :ts, :id, :title)"
             ),
-            {"id": "conv_titled", "ts": 1700000002, "title": "My Session"},
+            {"id": "4b6eaa7b9f9ea8f43b9407d4702c3838", "ts": 1700000002, "title": "My Session"},
         )
         conn.commit()
 
@@ -111,7 +111,7 @@ def test_downgrade_restores_nullable_and_nullifies_empty_titles(tmp_path: Path) 
     with engine.connect() as conn:
         value = conn.execute(
             sa.text("SELECT title FROM conversations WHERE id = :id"),
-            {"id": "conv_downgrade_test"},
+            {"id": "c53e320807888eb5da3a3395ef5382df"},
         ).scalar_one_or_none()
     assert value is None, (
         f"Expected empty-string title to be restored to NULL after downgrade; got {value!r}"
@@ -121,7 +121,7 @@ def test_downgrade_restores_nullable_and_nullifies_empty_titles(tmp_path: Path) 
     with engine.connect() as conn:
         value = conn.execute(
             sa.text("SELECT title FROM conversations WHERE id = :id"),
-            {"id": "conv_titled"},
+            {"id": "4b6eaa7b9f9ea8f43b9407d4702c3838"},
         ).scalar_one_or_none()
     assert value == "My Session", f"Real title should be unchanged after downgrade; got {value!r}"
 

--- a/tests/db/test_migration_title_varchar768.py
+++ b/tests/db/test_migration_title_varchar768.py
@@ -58,12 +58,12 @@ def test_title_defaults_empty_string_on_insert(db_engine: Engine) -> None:
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_varchar768_default", "ts": 1700000000},
+            {"id": "a1adcf5b39ef2505cd38547a126f515c", "ts": 1700000000},
         )
         conn.commit()
         value = conn.execute(
             sa.text("SELECT title FROM conversations WHERE id = :id"),
-            {"id": "conv_varchar768_default"},
+            {"id": "a1adcf5b39ef2505cd38547a126f515c"},
         ).scalar_one()
     assert value == "", f"Expected title to default to '' (empty string); got {value!r}."
 
@@ -78,12 +78,12 @@ def test_existing_title_survives_upgrade(db_engine: Engine) -> None:
                 "(id, created_at, updated_at, root_conversation_id, title) "
                 "VALUES (:id, :ts, :ts, :id, :title)"
             ),
-            {"id": "conv_long_title", "ts": 1700000001, "title": long_title},
+            {"id": "812666757ac2b1a2797f39e488744ad4", "ts": 1700000001, "title": long_title},
         )
         conn.commit()
         value = conn.execute(
             sa.text("SELECT title FROM conversations WHERE id = :id"),
-            {"id": "conv_long_title"},
+            {"id": "812666757ac2b1a2797f39e488744ad4"},
         ).scalar_one()
     assert value == long_title, f"Long title should survive upgrade; got {value!r}"
 
@@ -102,7 +102,7 @@ def test_downgrade_restores_text_type(tmp_path: Path) -> None:
                 "(id, created_at, updated_at, root_conversation_id, title) "
                 "VALUES (:id, :ts, :ts, :id, :title)"
             ),
-            {"id": "conv_downgrade_varchar", "ts": 1700000002, "title": "My Session"},
+            {"id": "0b80bd3a209bdc9d986651e997302b1f", "ts": 1700000002, "title": "My Session"},
         )
         conn.commit()
 
@@ -125,7 +125,7 @@ def test_downgrade_restores_text_type(tmp_path: Path) -> None:
     with engine.connect() as conn:
         value = conn.execute(
             sa.text("SELECT title FROM conversations WHERE id = :id"),
-            {"id": "conv_downgrade_varchar"},
+            {"id": "0b80bd3a209bdc9d986651e997302b1f"},
         ).scalar_one_or_none()
     assert value == "My Session", f"Title should survive downgrade; got {value!r}"
 

--- a/tests/db/test_migration_workspace.py
+++ b/tests/db/test_migration_workspace.py
@@ -93,15 +93,15 @@ def test_workspace_round_trip_null_and_value(db_engine: Engine) -> None:
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_ws_null", "ts": 1700000000},
+            {"id": "5221a3ae03d21ff063a9255347dde591", "ts": 1700000000},
         )
         conn.execute(
             sa.text("INSERT INTO omnigent_conversation_metadata (id, kind) VALUES (:id, 1)"),
-            {"id": "conv_ws_null"},
+            {"id": "5221a3ae03d21ff063a9255347dde591"},
         )
         result = conn.execute(
             sa.text("SELECT workspace FROM omnigent_conversation_metadata WHERE id = :id"),
-            {"id": "conv_ws_null"},
+            {"id": "5221a3ae03d21ff063a9255347dde591"},
         ).scalar_one()
         assert result is None, f"Expected NULL workspace on default insert; got {result!r}."
 
@@ -112,7 +112,7 @@ def test_workspace_round_trip_null_and_value(db_engine: Engine) -> None:
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_ws_cli", "ts": 1700000000},
+            {"id": "36d62d2d69c0f58390b4d2c17633053e", "ts": 1700000000},
         )
         conn.execute(
             sa.text(
@@ -121,13 +121,13 @@ def test_workspace_round_trip_null_and_value(db_engine: Engine) -> None:
                 "VALUES (:id, 1, :ws)"
             ),
             {
-                "id": "conv_ws_cli",
+                "id": "36d62d2d69c0f58390b4d2c17633053e",
                 "ws": "/Users/corey/projects/myapp",
             },
         )
         result = conn.execute(
             sa.text("SELECT workspace FROM omnigent_conversation_metadata WHERE id = :id"),
-            {"id": "conv_ws_cli"},
+            {"id": "36d62d2d69c0f58390b4d2c17633053e"},
         ).scalar_one()
         assert result == "/Users/corey/projects/myapp", (
             f"Round-trip mismatch: stored '/Users/corey/projects/myapp', got {result!r}."
@@ -155,7 +155,7 @@ def test_check_constraint_blocks_host_id_without_workspace(
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_ws_host_no_ws", "ts": 1700000000},
+            {"id": "565b00780d56b2fdaeb275f4013906dc", "ts": 1700000000},
         )
         with pytest.raises(IntegrityError) as exc_info:
             conn.execute(
@@ -165,8 +165,8 @@ def test_check_constraint_blocks_host_id_without_workspace(
                     "VALUES (:id, 1, :hid)"
                 ),
                 {
-                    "id": "conv_ws_host_no_ws",
-                    "hid": "host_abc",
+                    "id": "565b00780d56b2fdaeb275f4013906dc",
+                    "hid": "abb32306b80732bdfa6153b2f5f6eb92",
                 },
             )
         # The constraint name should appear in the error so failures
@@ -197,7 +197,12 @@ def test_check_constraint_allows_host_id_with_workspace(
                 "(owner, name, host_id, status, created_at, updated_at) "
                 "VALUES (:o, :n, :hid, 1, :ts, :ts)"
             ),
-            {"o": "alice@test.com", "n": "laptop", "hid": "host_abc", "ts": 1700000000},
+            {
+                "o": "alice@test.com",
+                "n": "laptop",
+                "hid": "abb32306b80732bdfa6153b2f5f6eb92",
+                "ts": 1700000000,
+            },
         )
         conn.execute(
             sa.text(
@@ -205,7 +210,7 @@ def test_check_constraint_allows_host_id_with_workspace(
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_ws_host_ok", "ts": 1700000000},
+            {"id": "8ebb129f4017d3388ddf25bd4d2d731c", "ts": 1700000000},
         )
         conn.execute(
             sa.text(
@@ -214,8 +219,8 @@ def test_check_constraint_allows_host_id_with_workspace(
                 "VALUES (:id, 1, :hid, :ws)"
             ),
             {
-                "id": "conv_ws_host_ok",
-                "hid": "host_abc",
+                "id": "8ebb129f4017d3388ddf25bd4d2d731c",
+                "hid": "abb32306b80732bdfa6153b2f5f6eb92",
                 "ws": "/Users/corey/universe/src/foo",
             },
         )
@@ -225,9 +230,9 @@ def test_check_constraint_allows_host_id_with_workspace(
             sa.text(
                 "SELECT host_id, workspace FROM omnigent_conversation_metadata WHERE id = :id"
             ),
-            {"id": "conv_ws_host_ok"},
+            {"id": "8ebb129f4017d3388ddf25bd4d2d731c"},
         ).one()
-        assert result.host_id == "host_abc"
+        assert result.host_id == "abb32306b80732bdfa6153b2f5f6eb92"
         assert result.workspace == "/Users/corey/universe/src/foo"
 
 
@@ -278,7 +283,12 @@ def test_host_id_fk_sets_null_when_host_deleted(db_engine: Engine) -> None:
                 "(owner, name, host_id, status, created_at, updated_at) "
                 "VALUES (:o, :n, :hid, 1, :ts, :ts)"
             ),
-            {"o": "alice@test.com", "n": "laptop", "hid": "host_del", "ts": 1700000000},
+            {
+                "o": "alice@test.com",
+                "n": "laptop",
+                "hid": "3b3efe73c63e0259558065798f210e5d",
+                "ts": 1700000000,
+            },
         )
         conn.execute(
             sa.text(
@@ -286,7 +296,7 @@ def test_host_id_fk_sets_null_when_host_deleted(db_engine: Engine) -> None:
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_fk", "ts": 1700000000},
+            {"id": "d6d79856e6b3f398cfd001d84952622e", "ts": 1700000000},
         )
         conn.execute(
             sa.text(
@@ -294,23 +304,30 @@ def test_host_id_fk_sets_null_when_host_deleted(db_engine: Engine) -> None:
                 "(id, kind, host_id, workspace) "
                 "VALUES (:id, 1, :hid, :ws)"
             ),
-            {"id": "conv_fk", "hid": "host_del", "ws": "/ws/foo"},
+            {
+                "id": "d6d79856e6b3f398cfd001d84952622e",
+                "hid": "3b3efe73c63e0259558065798f210e5d",
+                "ws": "/ws/foo",
+            },
         )
         conn.commit()
 
-        conn.execute(sa.text("DELETE FROM hosts WHERE host_id = :hid"), {"hid": "host_del"})
+        conn.execute(
+            sa.text("DELETE FROM hosts WHERE host_id = :hid"),
+            {"hid": "3b3efe73c63e0259558065798f210e5d"},
+        )
         conn.commit()
 
         row = conn.execute(
             sa.text(
                 "SELECT host_id, workspace FROM omnigent_conversation_metadata WHERE id = :id"
             ),
-            {"id": "conv_fk"},
+            {"id": "d6d79856e6b3f398cfd001d84952622e"},
         ).one()
         # No FK cascade: host_id is left dangling after host deletion.
         # The application (host store / disconnect handler) is responsible
         # for nulling host_id when a host is removed.
-        assert row.host_id == "host_del", (
+        assert row.host_id == "3b3efe73c63e0259558065798f210e5d", (
             "Without a DB FK, host deletion must not auto-null host_id."
         )
         assert row.workspace == "/ws/foo", "workspace must be untouched."
@@ -335,7 +352,7 @@ def test_check_constraint_allows_cli_session_workspace_no_host(
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)"
             ),
-            {"id": "conv_cli_ws_only", "ts": 1700000000},
+            {"id": "77049ba7474822eaa4e24c45c2c24999", "ts": 1700000000},
         )
         conn.execute(
             sa.text(
@@ -344,7 +361,7 @@ def test_check_constraint_allows_cli_session_workspace_no_host(
                 "VALUES (:id, 1, :ws)"
             ),
             {
-                "id": "conv_cli_ws_only",
+                "id": "77049ba7474822eaa4e24c45c2c24999",
                 "ws": "/Users/corey/projects/cli-launched",
             },
         )
@@ -355,7 +372,7 @@ def test_check_constraint_allows_cli_session_workspace_no_host(
             sa.text(
                 "SELECT host_id, workspace FROM omnigent_conversation_metadata WHERE id = :id"
             ),
-            {"id": "conv_cli_ws_only"},
+            {"id": "77049ba7474822eaa4e24c45c2c24999"},
         ).one()
         assert result.host_id is None
         assert result.workspace == "/Users/corey/projects/cli-launched"

--- a/tests/db/test_migration_workspace_id.py
+++ b/tests/db/test_migration_workspace_id.py
@@ -93,11 +93,14 @@ def test_existing_rows_and_omitted_inserts_default_to_zero(db_engine: Engine) ->
             sa.text(
                 "INSERT INTO agents"
                 " (id, created_at, name, bundle_location, version, kind)"
-                " VALUES ('ag_ws', 1, 'n', 'loc', 1, 1)"  # kind=1 → 'template'
+                # kind=1 → 'template'
+                " VALUES ('465b23e9d6a8efc606433caadd4a96d7', 1, 'n', 'loc', 1, 1)"
             )
         )
         workspace_id = conn.execute(
-            sa.text("SELECT workspace_id FROM agents WHERE id = 'ag_ws'")
+            sa.text(
+                "SELECT workspace_id FROM agents WHERE id = '465b23e9d6a8efc606433caadd4a96d7'"
+            )
         ).scalar_one()
     assert workspace_id == DEFAULT_WORKSPACE_ID
 
@@ -108,13 +111,13 @@ def test_agent_round_trip_via_store(db_engine: Engine) -> None:
 
     store = SqlAlchemyAgentStore(str(db_engine.url))
     created = store.create(
-        agent_id="ag_rt",
+        agent_id="c8596df60b081551fdd8e352e7aef4ea",
         name="round-trip",
         bundle_location="loc",
     )
     fetched = store.get(created.id)
     assert fetched is not None
-    assert fetched.id == "ag_rt"
+    assert fetched.id == "c8596df60b081551fdd8e352e7aef4ea"
 
 
 def test_downgrade_removes_workspace_id_and_restores_pk(tmp_path: Path) -> None:

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -465,23 +465,23 @@ def test_initialize_or_verify_schema_reports_manual_retry_when_auto_migration_fa
 def test_generate_item_id_supports_slash_command() -> None:
     """Append path raises ``ValueError`` here if the prefix is missing."""
     item_id = generate_item_id("slash_command")
-    assert item_id.startswith("sc_")
+    assert re.fullmatch(r"[0-9a-f]{32}", item_id)
 
 
 def test_generate_item_id_supports_error_item() -> None:
-    """Append path raises ``ValueError`` here if the error prefix is missing."""
+    """``generate_item_id`` raises ``ValueError`` here if ``error`` is unknown."""
     item_id = generate_item_id("error")
-    assert item_id.startswith("err_")
+    assert re.fullmatch(r"[0-9a-f]{32}", item_id)
 
 
 def test_generate_item_id_supports_resource_event() -> None:
     """Regression: ``resource_event`` (terminal launch/close lifecycle) was
     registered in the read-path map (``ITEM_TYPE_TO_DATA_CLS``) but missing
-    from ``_ITEM_TYPE_PREFIX``, so every such item failed ``generate_item_id``
+    from ``_ITEM_TYPES``, so every such item failed ``generate_item_id``
     with 'unknown item type' and never persisted (relay-persist traceback flood
     on every terminal launch/close)."""
     item_id = generate_item_id("resource_event")
-    assert item_id.startswith("rse_")
+    assert re.fullmatch(r"[0-9a-f]{32}", item_id)
 
 
 def test_item_type_id_and_data_registries_cover_the_same_types() -> None:
@@ -494,13 +494,13 @@ def test_item_type_id_and_data_registries_cover_the_same_types() -> None:
     loud unit-test failure instead of a per-item production traceback — exactly
     how ``resource_event`` slipped through (added to the data map, forgotten in
     the id map)."""
-    from omnigent.db.utils import _ITEM_TYPE_PREFIX
+    from omnigent.db.utils import _ITEM_TYPES
     from omnigent.entities.conversation import ITEM_TYPE_TO_DATA_CLS
 
-    assert set(_ITEM_TYPE_PREFIX) == set(ITEM_TYPE_TO_DATA_CLS), (
+    assert set(_ITEM_TYPES) == set(ITEM_TYPE_TO_DATA_CLS), (
         "item-type registries diverged — "
-        f"only in id/write path: {set(_ITEM_TYPE_PREFIX) - set(ITEM_TYPE_TO_DATA_CLS)}; "
-        f"only in data/read path: {set(ITEM_TYPE_TO_DATA_CLS) - set(_ITEM_TYPE_PREFIX)}"
+        f"only in id/write path: {set(_ITEM_TYPES) - set(ITEM_TYPE_TO_DATA_CLS)}; "
+        f"only in data/read path: {set(ITEM_TYPE_TO_DATA_CLS) - set(_ITEM_TYPES)}"
     )
 
 
@@ -511,11 +511,11 @@ def test_builtin_agent_id_is_deterministic_and_name_specific() -> None:
 
 
 def test_builtin_agent_id_matches_generated_id_shape_and_length() -> None:
-    """Pins both to ``ag_`` + 32 hex (35 chars) so a built-in id stays
+    """Pins both to a bare 32-char hex id so a built-in id stays
     indistinguishable from a generated one and the two can't diverge in length."""
     built_in = builtin_agent_id("nessie")
-    assert re.fullmatch(r"ag_[0-9a-f]{32}", built_in)
-    assert len(built_in) == len(generate_agent_id()) == 35
+    assert re.fullmatch(r"[0-9a-f]{32}", built_in)
+    assert len(built_in) == len(generate_agent_id()) == 32
 
 
 def test_extract_search_text_for_slash_command_with_output() -> None:
@@ -571,7 +571,7 @@ def test_extract_search_text_for_resource_event_item() -> None:
     """Runner resource replay persists cleanly and indexes stable ids."""
     item = NewConversationItem(
         type="resource_event",
-        response_id="conv_1",
+        response_id="8e32600337d08f59ad381caf96a90659",
         data=ResourceEventData(
             event_type="session.resource.created",
             resource_id="resource_codex_conv_1",

--- a/tests/db/test_utils_extended.py
+++ b/tests/db/test_utils_extended.py
@@ -23,7 +23,7 @@ from sqlalchemy import text
 
 from omnigent.db.db_models import SqlUser
 from omnigent.db.utils import (
-    _ITEM_TYPE_PREFIX,
+    _ITEM_TYPES,
     clear_engine_cache,
     delete_fts_by_conversation,
     ensure_fts_table,
@@ -159,21 +159,22 @@ class TestManagedSessionMaker:
 class TestIdGenerators:
     def test_generate_file_id_format(self) -> None:
         fid = generate_file_id()
-        assert re.fullmatch(r"file_[0-9a-f]{32}", fid)
+        assert re.fullmatch(r"[0-9a-f]{32}", fid)
 
     def test_generate_conversation_id_format(self) -> None:
         cid = generate_conversation_id()
-        assert re.fullmatch(r"conv_[0-9a-f]{32}", cid)
+        assert re.fullmatch(r"[0-9a-f]{32}", cid)
 
     def test_generate_task_id_format(self) -> None:
+        # response ids stay prefixed: the column is a polymorphic harness token,
+        # not a bare uuid, so it is not narrowed to Uuid16.
         tid = generate_task_id()
         assert re.fullmatch(r"resp_[0-9a-f]{32}", tid)
 
     def test_generate_item_id_all_types(self) -> None:
-        for item_type, prefix in _ITEM_TYPE_PREFIX.items():
+        for item_type in _ITEM_TYPES:
             item_id = generate_item_id(item_type)
-            assert item_id.startswith(prefix), f"{item_type} should start with {prefix}"
-            assert len(item_id) == len(prefix) + 32
+            assert re.fullmatch(r"[0-9a-f]{32}", item_id), f"{item_type} -> {item_id}"
 
     def test_generate_item_id_unknown_type_raises(self) -> None:
         with pytest.raises(ValueError, match="unknown item type"):
@@ -202,8 +203,18 @@ class TestFtsHelpers:
         managed = make_managed_session_maker(engine)
 
         with managed() as session:
-            insert_fts(session, "msg_1", "conv_1", "hello world")
-            insert_fts(session, "msg_2", "conv_1", "goodbye world")
+            insert_fts(
+                session,
+                "9980c8a9248139f14f4165e5d53088aa",
+                "8e32600337d08f59ad381caf96a90659",
+                "hello world",
+            )
+            insert_fts(
+                session,
+                "0fd4e86b2daa009cd9929641dbd7dab6",
+                "8e32600337d08f59ad381caf96a90659",
+                "goodbye world",
+            )
 
         with managed() as session:
             rows = session.execute(
@@ -213,7 +224,7 @@ class TestFtsHelpers:
                 )
             ).fetchall()
             assert len(rows) == 1
-            assert rows[0][0] == "msg_1"
+            assert rows[0][0] == "9980c8a9248139f14f4165e5d53088aa"
 
     def test_delete_fts_by_conversation(self, db_uri: str) -> None:
         engine = get_or_create_engine(db_uri)
@@ -223,16 +234,27 @@ class TestFtsHelpers:
         managed = make_managed_session_maker(engine)
 
         with managed() as session:
-            insert_fts(session, "msg_a", "conv_del", "searchable text")
-            insert_fts(session, "msg_b", "conv_keep", "also searchable")
+            insert_fts(
+                session,
+                "83cd574b729d39c61cf72d568188531a",
+                "553a265445caf1cdb034abe0b449485d",
+                "searchable text",
+            )
+            insert_fts(
+                session,
+                "0917d69fc9d16f420210e37ed3ef5f31",
+                "aacdf565fffe01a05b5f40d6c4ac83d7",
+                "also searchable",
+            )
 
         with managed() as session:
-            delete_fts_by_conversation(session, "conv_del")
+            delete_fts_by_conversation(session, "553a265445caf1cdb034abe0b449485d")
 
         with managed() as session:
             deleted = session.execute(
                 text(
-                    "SELECT item_id FROM conversation_items_fts WHERE conversation_id = 'conv_del'"
+                    "SELECT item_id FROM conversation_items_fts"
+                    " WHERE conversation_id = '553a265445caf1cdb034abe0b449485d'"
                 )
             ).fetchall()
             assert len(deleted) == 0
@@ -240,7 +262,7 @@ class TestFtsHelpers:
             kept = session.execute(
                 text(
                     "SELECT item_id FROM conversation_items_fts "
-                    "WHERE conversation_id = 'conv_keep'"
+                    "WHERE conversation_id = 'aacdf565fffe01a05b5f40d6c4ac83d7'"
                 )
             ).fetchall()
             assert len(kept) == 1

--- a/tests/db/test_uuid16.py
+++ b/tests/db/test_uuid16.py
@@ -1,0 +1,103 @@
+"""Unit tests for the ``Uuid16`` column type and its id-normalisation helpers.
+
+Pins the contract the binary-id migration relies on: which legacy forms bind,
+which malformed forms fail loud, the forgiving Python-side normaliser, and the
+driver-variance guards on result decoding.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.db.db_models import (
+    InvalidUuidError,
+    Uuid16,
+    normalize_uuid,
+    uuid_to_bytes,
+)
+
+_HEX = "a1b2c3d4e5f67890abcdef1234567890"
+
+
+class TestUuidToBytes:
+    def test_bare_hex(self) -> None:
+        assert uuid_to_bytes(_HEX) == bytes.fromhex(_HEX)
+
+    def test_dashed_canonical(self) -> None:
+        dashed = f"{_HEX[:8]}-{_HEX[8:12]}-{_HEX[12:16]}-{_HEX[16:20]}-{_HEX[20:]}"
+        assert uuid_to_bytes(dashed) == bytes.fromhex(_HEX)
+
+    @pytest.mark.parametrize(
+        "prefix",
+        [
+            "conv_",
+            "ag_",
+            "host_",
+            "pol_",
+            "file_",
+            "cmt_",
+            "msg_",
+            "fc_",
+            "fco_",
+            "err_",
+            "rs_",
+            "cmp_",
+            "nt_",
+            "rse_",
+            "sc_",
+            "tc_",
+            "rd_",
+            "agy_conv_",
+        ],
+    )
+    def test_known_legacy_prefixes_strip(self, prefix: str) -> None:
+        assert uuid_to_bytes(prefix + _HEX) == bytes.fromhex(_HEX)
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            # unknown prefixes must fail loud, not silently store the hex tail
+            "resp_" + _HEX,
+            "runner_" + _HEX,
+            "runner_token_" + _HEX,
+            "junk_" + _HEX,
+            # malformed shapes
+            "conv_short",
+            _HEX[:30],
+            "z" * 32,
+            "",
+        ],
+    )
+    def test_rejects_unknown_or_malformed(self, bad: str) -> None:
+        with pytest.raises(InvalidUuidError):
+            uuid_to_bytes(bad)
+
+
+class TestNormalizeUuid:
+    def test_legacy_and_bare_collapse(self) -> None:
+        assert normalize_uuid("conv_" + _HEX) == _HEX
+        assert normalize_uuid(_HEX) == _HEX
+
+    def test_malformed_passes_through_for_mismatch_semantics(self) -> None:
+        # A store scope-compare against bare hex must simply not match.
+        assert normalize_uuid("nonexistent-id") == "nonexistent-id"
+
+    def test_none_passes_through(self) -> None:
+        assert normalize_uuid(None) is None
+
+
+class TestUuid16ResultDecoding:
+    """Driver-variance guards, mirroring ``CompressedText``'s decode()."""
+
+    def test_bytes(self) -> None:
+        assert Uuid16().process_result_value(bytes.fromhex(_HEX), None) == _HEX
+
+    def test_memoryview(self) -> None:
+        value = memoryview(bytes.fromhex(_HEX))
+        assert Uuid16().process_result_value(value, None) == _HEX
+
+    def test_str_passthrough(self) -> None:
+        assert Uuid16().process_result_value(_HEX, None) == _HEX
+
+    def test_none(self) -> None:
+        assert Uuid16().process_result_value(None, None) is None

--- a/tests/db/test_workspace_scope.py
+++ b/tests/db/test_workspace_scope.py
@@ -38,26 +38,34 @@ def test_workspace_scope_sets_and_resets() -> None:
 def test_insert_stamps_scoped_workspace(db_uri: str) -> None:
     """An ORM insert stamps ``workspace_id`` from the active context."""
     store = SqlAlchemyAgentStore(db_uri)
-    store.create(agent_id="ag_ws0", name="n0", bundle_location="loc")
+    store.create(agent_id="ce2e8b9df3fda6a891350c75625640bf", name="n0", bundle_location="loc")
     with workspace_scope(42):
-        store.create(agent_id="ag_ws42", name="n42", bundle_location="loc")
+        store.create(
+            agent_id="dcfa34ef0735a8784bdfa70b6cad0142", name="n42", bundle_location="loc"
+        )
 
     engine = sa.create_engine(db_uri)
     with engine.connect() as conn:
-        stored = dict(conn.exec_driver_sql("SELECT id, workspace_id FROM agents").fetchall())
+        # Raw driver read bypasses the Uuid16 type, so ids come back as the raw
+        # 16 bytes — decode to bare hex to compare (this test checks workspace_id).
+        rows = conn.exec_driver_sql("SELECT id, workspace_id FROM agents").fetchall()
+        stored = {(k.hex() if isinstance(k, (bytes, bytearray)) else k): v for k, v in rows}
     engine.dispose()
-    assert stored == {"ag_ws0": 0, "ag_ws42": 42}
+    assert stored == {
+        "ce2e8b9df3fda6a891350c75625640bf": 0,
+        "dcfa34ef0735a8784bdfa70b6cad0142": 42,
+    }
 
 
 def test_reads_are_isolated_per_workspace(db_uri: str) -> None:
     """A row created in one workspace is invisible from another."""
     store = SqlAlchemyAgentStore(db_uri)
-    store.create(agent_id="ag_default", name="d", bundle_location="loc")
+    store.create(agent_id="dfcff8d2c8d4ff3cd5be9f2a7194d409", name="d", bundle_location="loc")
     with workspace_scope(42):
-        store.create(agent_id="ag_tenant", name="t", bundle_location="loc")
+        store.create(agent_id="da4899778b7c60ee14cfaee729dbb171", name="t", bundle_location="loc")
         # In workspace 42: sees its own row, not workspace 0's.
-        assert store.get("ag_tenant") is not None
-        assert store.get("ag_default") is None
+        assert store.get("da4899778b7c60ee14cfaee729dbb171") is not None
+        assert store.get("dfcff8d2c8d4ff3cd5be9f2a7194d409") is None
     # Back in the default workspace: the reverse.
-    assert store.get("ag_default") is not None
-    assert store.get("ag_tenant") is None
+    assert store.get("dfcff8d2c8d4ff3cd5be9f2a7194d409") is not None
+    assert store.get("da4899778b7c60ee14cfaee729dbb171") is None

--- a/tests/e2e/omnigent/test_repl_session_lifecycle.py
+++ b/tests/e2e/omnigent/test_repl_session_lifecycle.py
@@ -688,7 +688,9 @@ def test_repl_full_session_lifecycle(
     try:
         _wait_ready(child)
         result = _drive_turn(child, "SESSION_LIFECYCLE_OK", mock_llm_server_url)
-        assert result.session_id.startswith("conv_")
+        # Conversation ids are bare 32-char hex (stored in a Uuid16 column);
+        # runner ids keep their runtime ``runner_`` prefix (not a DB id).
+        assert re.fullmatch(r"[0-9a-f]{32}", result.session_id)
         assert result.runner_id.startswith("runner_")
 
         submit_prompt(child, "/history")

--- a/tests/e2e/omnigent/test_run_omnigent_resumption.py
+++ b/tests/e2e/omnigent/test_run_omnigent_resumption.py
@@ -80,6 +80,17 @@ def _make_nonce() -> str:
     return "nonce" + uuid.uuid4().hex[:12]
 
 
+def _row_id_to_hex(value: object) -> str:
+    """Render a conversation id read via raw sqlite3 as bare 32-char hex.
+
+    The ``id`` column is a Uuid16 (16-byte BLOB), so ``sqlite3`` hands it
+    back as ``bytes``; ``--resume`` expects the hex string form.
+    """
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return bytes(value).hex()
+    return str(value)
+
+
 def _argv_run_omnigent(
     *,
     omnigent_python: Path,
@@ -594,7 +605,7 @@ def test_run_omnigent_session_id_pins_the_specific_conversation(
         f"store. If >1, an unrelated test polluted the dir or the "
         f"HOME isolation broke."
     )
-    conv_a_id = rows[0][0]
+    conv_a_id = _row_id_to_hex(rows[0][0])
 
     # ── Run 2: plant nonce B, FRESH conversation (no
     # --continue / --session). A regression where -p mode
@@ -640,7 +651,7 @@ def test_run_omnigent_session_id_pins_the_specific_conversation(
         f"If 1, plant B threaded onto convA (the silent-resume "
         f"regression). If >2, leakage from another test."
     )
-    conv_b_id = rows[0][0]
+    conv_b_id = _row_id_to_hex(rows[0][0])
     assert conv_b_id != conv_a_id
 
     # ── Run 3: --resume convA_id must recover nonce A

--- a/tests/e2e/test_host_e2e.py
+++ b/tests/e2e/test_host_e2e.py
@@ -92,7 +92,9 @@ def _spawn_host_daemon(
     """
     omni_dir = tmp_path / ".omnigent"
     omni_dir.mkdir(parents=True, exist_ok=True)
-    host_id = f"host_{uuid.uuid4().hex}"
+    # Bare 32-char hex — host_id is a Uuid16 column, and the API returns the
+    # bare form, so _wait_for_host_online's comparison must see the same.
+    host_id = uuid.uuid4().hex
     host_name = f"e2e-host-{uuid.uuid4().hex[:12]}"
     (omni_dir / "config.yaml").write_text(
         yaml.safe_dump(
@@ -682,7 +684,9 @@ def _spawn_host_daemon_for_mock_claude(
     """
     omni_dir = tmp_path / ".omnigent"
     omni_dir.mkdir(parents=True, exist_ok=True)
-    host_id = f"host_{uuid.uuid4().hex}"
+    # Bare 32-char hex — host_id is a Uuid16 column, and the API returns the
+    # bare form, so _wait_for_host_online's comparison must see the same.
+    host_id = uuid.uuid4().hex
     host_name = f"e2e-host-{uuid.uuid4().hex[:12]}"
     (omni_dir / "config.yaml").write_text(
         yaml.safe_dump(

--- a/tests/e2e_ui/fork_session/test_fork_from_middle.py
+++ b/tests/e2e_ui/fork_session/test_fork_from_middle.py
@@ -113,7 +113,7 @@ def test_fork_from_middle_truncates_history(
     # Land in a DIFFERENT session — a URL still on the source means
     # navigation never fired; a visible dialog means the fork call failed.
     expect(page).to_have_url(
-        re.compile(rf"/c/(?!{re.escape(session_id)})conv_[0-9a-f]+"),
+        re.compile(rf"/c/(?!{re.escape(session_id)})[0-9a-f]{{32}}"),
         timeout=30_000,
     )
     expect(dialog).not_to_be_visible()

--- a/tests/e2e_ui/fork_session/test_fork_switch_agent.py
+++ b/tests/e2e_ui/fork_session/test_fork_switch_agent.py
@@ -151,7 +151,7 @@ def test_fork_switch_agent_carries_history(
 
     # The switch fork succeeds and navigates to a NEW session id.
     expect(page).to_have_url(
-        re.compile(rf"/c/(?!{re.escape(session_id)})conv_[0-9a-f]+"),
+        re.compile(rf"/c/(?!{re.escape(session_id)})[0-9a-f]{{32}}"),
         timeout=30_000,
     )
     expect(dialog).not_to_be_visible()
@@ -245,7 +245,7 @@ def test_fork_into_pi_labels_model_picker_pi(
 
     # Land on the new Pi-bound fork (a distinct session id).
     expect(page).to_have_url(
-        re.compile(rf"/c/(?!{re.escape(session_id)})conv_[0-9a-f]+"),
+        re.compile(rf"/c/(?!{re.escape(session_id)})[0-9a-f]{{32}}"),
         timeout=30_000,
     )
     fork_id = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]

--- a/tests/e2e_ui/sessions/test_clone_session.py
+++ b/tests/e2e_ui/sessions/test_clone_session.py
@@ -96,7 +96,7 @@ def test_clone_session_copies_transcript_and_navigates(
     # landed back on the source); a visible dialog means the fork call
     # failed and surfaced an inline error instead.
     expect(page).to_have_url(
-        re.compile(rf"/c/(?!{re.escape(session_id)})conv_[0-9a-f]+"),
+        re.compile(rf"/c/(?!{re.escape(session_id)})[0-9a-f]{{32}}"),
         timeout=30_000,
     )
     expect(dialog).not_to_be_visible()
@@ -195,7 +195,7 @@ def test_clone_dialog_offers_cross_family_native_target_and_forks(
 
     # The fork succeeds and navigates to a NEW session id.
     expect(page).to_have_url(
-        re.compile(rf"/c/(?!{re.escape(session_id)})conv_[0-9a-f]+"),
+        re.compile(rf"/c/(?!{re.escape(session_id)})[0-9a-f]{{32}}"),
         timeout=30_000,
     )
     fork_id = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]

--- a/tests/host/test_identity.py
+++ b/tests/host/test_identity.py
@@ -23,13 +23,11 @@ def test_create_identity_when_no_config(tmp_path: Path) -> None:
     identity = load_or_create_host_identity(config_path)
 
     assert config_path.exists(), "config.yaml should be created on first call"
-    # host_id format: host_{32 hex chars}
-    assert identity.host_id.startswith("host_"), (
-        f"host_id should start with 'host_', got {identity.host_id!r}"
+    # host_id format: a bare 32-char hex uuid4 (no prefix).
+    assert len(identity.host_id) == 32, (
+        f"host_id should be a bare 32-char hex uuid, got {identity.host_id!r}"
     )
-    hex_part = identity.host_id[len("host_") :]
-    assert len(hex_part) == 32, f"hex portion should be 32 chars (uuid4), got {len(hex_part)}"
-    int(hex_part, 16)  # raises ValueError if not valid hex
+    int(identity.host_id, 16)  # raises ValueError if not valid hex
 
     # Name defaults to machine hostname.
     assert identity.name == socket.gethostname()
@@ -48,14 +46,14 @@ def test_load_existing_identity(tmp_path: Path) -> None:
         yaml.safe_dump(
             {
                 "server": "http://example.com",
-                "host": {"host_id": "host_aabbccdd", "name": "my-laptop"},
+                "host": {"host_id": "d6d0ccebce7b4b706d21e23696bb462a", "name": "my-laptop"},
             }
         )
     )
 
     identity = load_or_create_host_identity(config_path)
 
-    assert identity.host_id == "host_aabbccdd"
+    assert identity.host_id == "d6d0ccebce7b4b706d21e23696bb462a"
     assert identity.name == "my-laptop"
 
 
@@ -112,13 +110,13 @@ def test_env_override_returns_identity_without_touching_config(
     must not read or write config.yaml (managed sandboxes are
     disposable; the server owns their identity).
     """
-    monkeypatch.setenv("OMNIGENT_HOST_ID", "host_env_override")
+    monkeypatch.setenv("OMNIGENT_HOST_ID", "329c39d03aad39ccf2f8597d596676bd")
     monkeypatch.setenv("OMNIGENT_HOST_NAME", "managed-env")
     config_path = tmp_path / "config.yaml"
 
     identity = load_or_create_host_identity(config_path)
 
-    assert identity.host_id == "host_env_override"
+    assert identity.host_id == "329c39d03aad39ccf2f8597d596676bd"
     assert identity.name == "managed-env"
     # The identity file must not be materialized by the env path.
     assert not config_path.exists()
@@ -129,7 +127,7 @@ def test_env_override_requires_both_vars(tmp_path: Path, monkeypatch: pytest.Mon
     Setting only one identity env var is a launcher bug — fail loud
     instead of mixing a server-chosen id with a generated name.
     """
-    monkeypatch.setenv("OMNIGENT_HOST_ID", "host_env_override")
+    monkeypatch.setenv("OMNIGENT_HOST_ID", "329c39d03aad39ccf2f8597d596676bd")
     monkeypatch.delenv("OMNIGENT_HOST_NAME", raising=False)
 
     with pytest.raises(ValueError, match="must be set together"):

--- a/tests/repl/test_resume_picker.py
+++ b/tests/repl/test_resume_picker.py
@@ -63,7 +63,7 @@ class _TtyPickResult:
     """
     Result from driving the resume picker through a pseudo-terminal.
 
-    :param selected: Selected conversation id, e.g. ``"conv_0001"``,
+    :param selected: Selected conversation id, e.g. ``"c7934759fbb38c6e5bbecc1903d2c011"``,
         or ``None`` when the picker cancelled.
     :param rendered: Plain rendered picker transcript captured from
         the prompt-toolkit output stream.
@@ -670,7 +670,7 @@ def test_last_message_preview_from_entities_skips_meta_messages() -> None:
     """
     items = [
         ConversationItem(
-            id="msg_meta",
+            id="00f7a759442a8656f0cdbc9951cf7c1a",
             type="message",
             status="completed",
             response_id="turn_skill",
@@ -682,7 +682,7 @@ def test_last_message_preview_from_entities_skips_meta_messages() -> None:
             ),
         ),
         ConversationItem(
-            id="msg_visible",
+            id="54abbec68f5c80d43d1ec374c48c730d",
             type="message",
             status="completed",
             response_id="turn_visible",
@@ -769,14 +769,14 @@ def test_pick_conversation_from_store_scopes_by_agent_name(
     conv_store = SqlAlchemyConversationStore(db_uri)
     agent_store = SqlAlchemyAgentStore(db_uri)
     agent_store.create(
-        agent_id="ag_one",
+        agent_id="e9b83f6f16155dc05644581c7041f53b",
         name="agent_one",
-        bundle_location="ag_one/dummy",
+        bundle_location="e9b83f6f16155dc05644581c7041f53b/dummy",
     )
     agent_store.create(
-        agent_id="ag_two",
+        agent_id="92b6ac2f8ecd0752b4c88d4f8b692be1",
         name="agent_two",
-        bundle_location="ag_two/dummy",
+        bundle_location="92b6ac2f8ecd0752b4c88d4f8b692be1/dummy",
     )
     # No conversations are bound to either name, so the scoped list is empty.
     out = io.StringIO()
@@ -802,9 +802,9 @@ def test_pick_conversation_from_store_finds_session_scoped_agent_by_name(
     """Session-scoped agents with no template row remain resumable by name."""
     conv_store = SqlAlchemyConversationStore(db_uri)
     created = conv_store.create_session_with_agent(
-        agent_id="ag_session_resume",
+        agent_id="ca2bab107b2b200f0512ef5285de4dee",
         agent_name="session_scoped_resume_agent",
-        agent_bundle_location="ag_session_resume/dummy",
+        agent_bundle_location="ca2bab107b2b200f0512ef5285de4dee/dummy",
         agent_description=None,
         title="resume me",
     )
@@ -836,7 +836,7 @@ class _BadgeRow:
     silently passing.
     """
 
-    id: str = "conv_test"
+    id: str = "e1f7c651c9f97fac088ea70ef633409d"
     title: str | None = "test"
     created_at: int = 0
     labels: dict[str, str] | None = None
@@ -983,11 +983,11 @@ async def test_cross_agent_picker_selection_returns_id_with_runtime_badge_render
 
     rows = [
         _BadgeRow(
-            id="conv_one",
+            id="dbb8b733fdfaca2c150b42317d3829f6",
             title="claude session",
             labels={"omnigent.wrapper": "claude-code-native-ui"},
         ),
-        _BadgeRow(id="conv_two", title="chat session", labels={}),
+        _BadgeRow(id="f8fb0016d56510e7e6b3ee8618d78415", title="chat session", labels={}),
     ]
     client = _FakeAPClient(rows=rows)
     out = io.StringIO()
@@ -1001,7 +1001,7 @@ async def test_cross_agent_picker_selection_returns_id_with_runtime_badge_render
     assert "[chat]" in rendered
     # The selection routed correctly. If this fails, the picker's
     # index→id mapping in the cross-agent path is off.
-    assert selected == "conv_two"
+    assert selected == "f8fb0016d56510e7e6b3ee8618d78415"
 
 
 async def test_wrapper_label_picker_filters_and_lists_without_agent_filter(
@@ -1018,13 +1018,13 @@ async def test_wrapper_label_picker_filters_and_lists_without_agent_filter(
     monkeypatch.setenv("OMNIGENT_CLAUDE_NATIVE_STATE_DIR", str(tmp_path / "state"))
     rows = [
         _BadgeRow(
-            id="conv_claude_1",
+            id="ad9fa6806e0d3c94166f9b4dafcc1069",
             title="claude one",
             labels={"omnigent.wrapper": "claude-code-native-ui"},
         ),
-        _BadgeRow(id="conv_chat", title="chat one", labels={}),
+        _BadgeRow(id="11dc2163ab84c5afa09348998a2b6690", title="chat one", labels={}),
         _BadgeRow(
-            id="conv_claude_2",
+            id="260b9c4331a54a53fc1d1c5720cb4bc2",
             title="claude two",
             labels={"omnigent.wrapper": "claude-code-native-ui"},
         ),
@@ -1040,16 +1040,16 @@ async def test_wrapper_label_picker_filters_and_lists_without_agent_filter(
         out=out,
         in_=io.StringIO("2\n"),
     )
-    assert selected == "conv_claude_2"
+    assert selected == "260b9c4331a54a53fc1d1c5720cb4bc2"
     assert client.sessions.last_kwargs == {
         "limit": 200,
         "agent_id": None,
         "order": "desc",
     }
     rendered = out.getvalue()
-    assert "conv_claude_1" in rendered
-    assert "conv_claude_2" in rendered
-    assert "conv_chat" not in rendered
+    assert "ad9fa6806e0d3c94166f9b4dafcc1069" in rendered
+    assert "260b9c4331a54a53fc1d1c5720cb4bc2" in rendered
+    assert "11dc2163ab84c5afa09348998a2b6690" not in rendered
     # No launch state was recorded for these fake rows, so the
     # picker should not render empty workspace placeholders.
     assert "Workspace" not in rendered
@@ -1072,7 +1072,7 @@ def test_render_workspace_cell_no_state_returns_none(
     from omnigent.repl._resume_picker import _render_workspace_cell
 
     monkeypatch.setenv("OMNIGENT_CLAUDE_NATIVE_STATE_DIR", str(tmp_path / "state"))
-    row = _BadgeRow(id="conv_no_state", labels={"omnigent.wrapper": "x"})
+    row = _BadgeRow(id="fdae2ccf4f08f386de6f9dabb02ddf22", labels={"omnigent.wrapper": "x"})
     cell = _render_workspace_cell(row, current_cwd=tmp_path.resolve())
     assert cell is None
 
@@ -1094,8 +1094,10 @@ def test_render_workspace_cell_matching_cwd_no_flag(
 
     monkeypatch.setenv("OMNIGENT_CLAUDE_NATIVE_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.chdir(tmp_path)
-    write_launch_state("conv_match", str(tmp_path.resolve()))
-    row = _BadgeRow(id="conv_match", labels={"omnigent.wrapper": "claude-code-native-ui"})
+    write_launch_state("d27bd0e48c10689c10e6ae23e869877a", str(tmp_path.resolve()))
+    row = _BadgeRow(
+        id="d27bd0e48c10689c10e6ae23e869877a", labels={"omnigent.wrapper": "claude-code-native-ui"}
+    )
 
     cell = _render_workspace_cell(row, current_cwd=tmp_path.resolve())
     assert cell is not None
@@ -1127,8 +1129,10 @@ def test_render_workspace_cell_mismatched_cwd_shows_cd_flag(
     recorded.mkdir()
     current = tmp_path / "current"
     current.mkdir()
-    write_launch_state("conv_mismatch", str(recorded.resolve()))
-    row = _BadgeRow(id="conv_mismatch", labels={"omnigent.wrapper": "claude-code-native-ui"})
+    write_launch_state("3d86a9c5a27d38d42e1ff818058816e3", str(recorded.resolve()))
+    row = _BadgeRow(
+        id="3d86a9c5a27d38d42e1ff818058816e3", labels={"omnigent.wrapper": "claude-code-native-ui"}
+    )
 
     cell = _render_workspace_cell(row, current_cwd=current.resolve())
     assert cell is not None
@@ -1164,9 +1168,9 @@ def test_workspace_metadata_appears_in_wrapper_picker_list(
     workspace = tmp_path / "ws-marker"
     workspace.mkdir()
     monkeypatch.chdir(workspace)
-    write_launch_state("conv_ws", str(workspace.resolve()))
+    write_launch_state("3ed07f9b6e6fd72020467ffd0f5dfd80", str(workspace.resolve()))
     row = _BadgeRow(
-        id="conv_ws",
+        id="3ed07f9b6e6fd72020467ffd0f5dfd80",
         title="with ws",
         labels={"omnigent.wrapper": "claude-code-native-ui"},
     )
@@ -1181,7 +1185,7 @@ def test_workspace_metadata_appears_in_wrapper_picker_list(
     )
 
     rendered = out.getvalue()
-    assert selected == "conv_ws"
+    assert selected == "3ed07f9b6e6fd72020467ffd0f5dfd80"
     workspace_text = str(workspace.resolve())
     assert "Workspace" not in rendered
     assert workspace_text in rendered, (
@@ -1189,7 +1193,7 @@ def test_workspace_metadata_appears_in_wrapper_picker_list(
         "either dropped on the way to item rendering or item "
         "rendering regressed."
     )
-    assert rendered.index(workspace_text) < rendered.index("conv_ws"), (
+    assert rendered.index(workspace_text) < rendered.index("3ed07f9b6e6fd72020467ffd0f5dfd80"), (
         f"Workspace metadata should render before the conversation id. Output:\n{rendered!r}"
     )
 
@@ -1212,9 +1216,9 @@ def test_render_workspace_cell_codex_native_uses_codex_state(
     monkeypatch.setenv("OMNIGENT_CLAUDE_NATIVE_STATE_DIR", str(tmp_path / "claude-state"))
     workspace = tmp_path / "codex-workspace"
     workspace.mkdir()
-    write_launch_state("conv_codex_ws", str(workspace.resolve()))
+    write_launch_state("07e373dac8325f8b8821267a54336f42", str(workspace.resolve()))
     row = _BadgeRow(
-        id="conv_codex_ws",
+        id="07e373dac8325f8b8821267a54336f42",
         title="codex ws",
         labels={"omnigent.wrapper": "codex-native-ui"},
     )
@@ -1242,7 +1246,7 @@ def test_workspace_metadata_omits_unrecorded_workspace_segment(
 
     monkeypatch.setenv("OMNIGENT_CLAUDE_NATIVE_STATE_DIR", str(tmp_path / "state"))
     row = _BadgeRow(
-        id="conv_without_ws",
+        id="eadade68b1f6e5f2f5e0c57a00d8d378",
         title="without ws",
         labels={"omnigent.wrapper": "claude-code-native-ui"},
     )
@@ -1257,6 +1261,6 @@ def test_workspace_metadata_omits_unrecorded_workspace_segment(
     )
 
     rendered = out.getvalue()
-    assert selected == "conv_without_ws"
+    assert selected == "eadade68b1f6e5f2f5e0c57a00d8d378"
     assert "Workspace" not in rendered
     assert "—" not in rendered

--- a/tests/repl/test_session_log.py
+++ b/tests/repl/test_session_log.py
@@ -48,7 +48,7 @@ def test_default_log_path_uses_default_dir_when_none() -> None:
     directory the legacy non-AP path writes to. Keeps the
     user's mental model consistent across paths.
     """
-    path = default_log_path("conv_abc1234567890def_extra", None)
+    path = default_log_path("86f918829b75e808604b560cdd723920", None)
     assert path.parent == DEFAULT_LOG_DIR, (
         f"Expected the parent to be {DEFAULT_LOG_DIR}, got "
         f"{path.parent}. If different, the legacy --log location "
@@ -58,12 +58,13 @@ def test_default_log_path_uses_default_dir_when_none() -> None:
 
 def test_default_log_path_filename_shape(tmp_path: Path) -> None:
     """
-    Filename is ``{YYYYMMDD-HHMMSS}-{conv_short}.json``. We don't
+    Filename is ``{YYYYMMDD-HHMMSS}-{conv-short}.json``. We don't
     pin the exact timestamp (race against the clock) but verify
     the structure: 15-char timestamp + dash + 16-char conv-short
     + ``.json``.
     """
-    path = default_log_path("conv_abc1234567890def_extra", tmp_path)
+    conv_id = "86f918829b75e808604b560cdd723920"
+    path = default_log_path(conv_id, tmp_path)
     name = path.name
     assert name.endswith(".json"), (
         f"Expected .json suffix, got {name!r}. Readers grep for this extension to find logs."
@@ -77,7 +78,7 @@ def test_default_log_path_filename_shape(tmp_path: Path) -> None:
     assert len(parts[0]) == 8, f"YYYYMMDD prefix should be 8 chars, got {parts[0]!r}."
     assert len(parts[1]) == 6, f"HHMMSS should be 6 chars, got {parts[1]!r}."
     # The conv slug is the FIRST 16 chars of the conversation id.
-    assert parts[2] == "conv_abc12345678", (
+    assert parts[2] == conv_id[:16], (
         f"Conv slug should be the first 16 chars of the conversation "
         f"id, got {parts[2]!r}. If different, the slug truncation "
         f"length changed (we rely on it to keep filenames short)."

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -464,12 +464,12 @@ async def test_session_labels_for_runner_spawn_timeout_is_quiet(
         with caplog.at_level(logging.DEBUG, logger="omnigent.runner.app"):
             labels = await _session_labels_for_runner_spawn(
                 server_client=client,
-                session_id="conv_slow",
+                session_id="1dbe53c9796da07f3960b9226435a5c8",
             )
 
     assert labels == {}
     assert [(request.method, request.url.path) for request in transport.requests] == [
-        ("GET", "/v1/sessions/conv_slow/labels")
+        ("GET", "/v1/sessions/1dbe53c9796da07f3960b9226435a5c8/labels")
     ]
     timeout = transport.requests[0].extensions.get("timeout")
     assert isinstance(timeout, dict)
@@ -515,7 +515,7 @@ async def test_session_labels_for_runner_spawn_empty_200_body_recovers(
         with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
             labels = await _session_labels_for_runner_spawn(
                 server_client=client,
-                session_id="conv_empty",
+                session_id="2d4033c255b393808b12437cbdc9c47f",
             )
 
     # Recovered to the fallback instead of raising JSONDecodeError —
@@ -561,7 +561,11 @@ class _FakeFileServerClient:
         if url.endswith("/content"):
             return _Response(body=b"png-bytes")
         return _Response(
-            payload={"id": "file_img", "filename": "photo.png", "content_type": "image/png"}
+            payload={
+                "id": "07b38328508bae2010c8b9933a310846",
+                "filename": "photo.png",
+                "content_type": "image/png",
+            }
         )
 
 
@@ -580,14 +584,18 @@ async def test_sessions_native_resolves_file_id_before_harness() -> None:
 
     async with _runner_client(app) as client:
         resp = await client.post(
-            "/v1/sessions/conv_file/events",
+            "/v1/sessions/d43f93c220661ddaf203a63b45050304/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_abc",
+                "agent_id": "0e36e3219954d2deaef06b8e2a936f38",
                 "model": "test-agent",
                 "content": [
-                    {"type": "input_image", "file_id": "file_img", "filename": "photo.png"},
+                    {
+                        "type": "input_image",
+                        "file_id": "07b38328508bae2010c8b9933a310846",
+                        "filename": "photo.png",
+                    },
                     {"type": "input_text", "text": "what is this?"},
                 ],
             },
@@ -596,11 +604,11 @@ async def test_sessions_native_resolves_file_id_before_harness() -> None:
     assert resp.status_code == 202
     assert server_client.get_calls == [
         # file_id blocks are resolved first (before the harness sees them)...
-        "/v1/sessions/conv_file/resources/files/file_img",
-        "/v1/sessions/conv_file/resources/files/file_img/content",
+        "/v1/sessions/d43f93c220661ddaf203a63b45050304/resources/files/07b38328508bae2010c8b9933a310846",
+        "/v1/sessions/d43f93c220661ddaf203a63b45050304/resources/files/07b38328508bae2010c8b9933a310846/content",
         # ...then the cold in-memory cache is rehydrated from the store
         # (empty here) before the turn is dispatched.
-        "/v1/sessions/conv_file/items",
+        "/v1/sessions/d43f93c220661ddaf203a63b45050304/items",
     ]
     for _ in range(20):
         if harness_client.posted_bodies:
@@ -674,11 +682,11 @@ async def test_runner_session_tool_schemas_use_resolved_bundle_workdir(tmp_path:
     )
     async with _runner_client(app) as client:
         resp = await client.post(
-            "/v1/sessions/conv_bundle/events",
+            "/v1/sessions/c7f36aa769270cac30144784fad50acc/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_bundle",
+                "agent_id": "31ebfedf721b44dabd76f662cb70a400",
                 "model": "bundle-agent",
                 "content": [{"type": "input_text", "text": "hi"}],
                 "harness": "openai-agents",
@@ -813,11 +821,11 @@ async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
     )
     async with _runner_client(app) as client:
         resp = await client.post(
-            "/v1/sessions/conv_bundle/events",
+            "/v1/sessions/c7f36aa769270cac30144784fad50acc/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_bundle",
+                "agent_id": "31ebfedf721b44dabd76f662cb70a400",
                 "model": "bundle-agent",
                 "content": [{"type": "input_text", "text": "hi"}],
                 "harness": "openai-agents",
@@ -867,11 +875,11 @@ async def test_sessions_native_marks_and_clears_in_flight_turn() -> None:
     )
     async with _runner_client(app) as client:
         resp = await client.post(
-            "/v1/sessions/conv_live/events",
+            "/v1/sessions/ce84b0dc308668bb715607e42ae268b0/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_live",
+                "agent_id": "e61df75e32ee590087e03aa37b33abac",
                 "model": "plain-agent",
                 "content": [{"type": "input_text", "text": "hi"}],
                 "harness": "openai-agents",
@@ -886,8 +894,10 @@ async def test_sessions_native_marks_and_clears_in_flight_turn() -> None:
 
     # Live turn was registered with the reaper's in-flight guard on
     # response.created, then cleared once the stream ended.
-    assert pm.marked_in_flight == [("conv_live", "resp_live")], pm.marked_in_flight
-    assert pm.cleared_in_flight == ["conv_live"], pm.cleared_in_flight
+    assert pm.marked_in_flight == [("ce84b0dc308668bb715607e42ae268b0", "resp_live")], (
+        pm.marked_in_flight
+    )
+    assert pm.cleared_in_flight == ["ce84b0dc308668bb715607e42ae268b0"], pm.cleared_in_flight
 
 
 class _StreamErrorHarnessClient(_ScriptedHarnessClient):
@@ -962,11 +972,11 @@ async def test_sessions_native_clears_in_flight_when_stream_errors() -> None:
     )
     async with _runner_client(app) as client:
         resp = await client.post(
-            "/v1/sessions/conv_drop/events",
+            "/v1/sessions/9217a860245985f541fd686eb2a32b73/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_drop",
+                "agent_id": "965906f5d9fb596610dda599a80faaee",
                 "model": "plain-agent",
                 "content": [{"type": "input_text", "text": "hi"}],
                 "harness": "openai-agents",
@@ -980,8 +990,10 @@ async def test_sessions_native_clears_in_flight_when_stream_errors() -> None:
             await asyncio.sleep(0.05)
 
     # Marked live on response.created, then cleared despite the mid-stream drop.
-    assert pm.marked_in_flight == [("conv_drop", "resp_drop")], pm.marked_in_flight
-    assert pm.cleared_in_flight == ["conv_drop"], pm.cleared_in_flight
+    assert pm.marked_in_flight == [("9217a860245985f541fd686eb2a32b73", "resp_drop")], (
+        pm.marked_in_flight
+    )
+    assert pm.cleared_in_flight == ["9217a860245985f541fd686eb2a32b73"], pm.cleared_in_flight
 
 
 @pytest.mark.asyncio
@@ -1001,14 +1013,14 @@ async def test_stop_session_clears_in_flight_marker() -> None:
 
     gate = _aio.Event()  # never set → harness blocks after response.created
     app, pm, hc = _build_interrupt_app(gate)
-    conv_id = "conv_stop_clear"
+    conv_id = "a136ad3e8265e86eba8564d6cda81a14"
     async with _runner_client(app) as client:
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_stop",
+                "agent_id": "b528b24f9d6ece39ef11de7fb6dfeedf",
                 "model": "test-agent",
                 "content": [{"type": "input_text", "text": "blocked"}],
                 "harness": "openai-agents",
@@ -1146,14 +1158,14 @@ async def test_sessions_native_clears_in_flight_on_lazy_spec_error() -> None:
         spec_resolver=_resolver,
         server_client=NullServerClient(),  # type: ignore[arg-type]
     )
-    conv_id = "conv_lazy"
+    conv_id = "a15313a5b85c6fa97a92d1e2d74d44dc"
     async with _runner_client(app) as client:
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_lazy",
+                "agent_id": "4d198b17724988de49d7ac2b4d29605b",
                 "model": "plain-agent",
                 "content": [{"type": "input_text", "text": "hi"}],
                 "harness": "openai-agents",
@@ -1231,11 +1243,11 @@ async def test_sessions_native_dispatches_builtin_tool_with_runner_workspace(
     )
     async with _runner_client(app) as client:
         resp = await client.post(
-            "/v1/sessions/conv_builtin/events",
+            "/v1/sessions/f690906478f5c81a97fd4301a80cb213/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_bundle",
+                "agent_id": "31ebfedf721b44dabd76f662cb70a400",
                 "model": "bundle-agent",
                 "content": [{"type": "input_text", "text": "write a file"}],
                 "harness": "openai-agents",
@@ -1290,11 +1302,11 @@ async def test_mcp_execute_dispatches_builtin_tool_with_runner_workspace(
     )
     async with _runner_client(app) as client:
         seed_resp = await client.post(
-            "/v1/sessions/conv_execute_builtin/events",
+            "/v1/sessions/38f6cf055029a2a23b227a8305f76c9d/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_bundle",
+                "agent_id": "31ebfedf721b44dabd76f662cb70a400",
                 "model": "bundle-agent",
                 "content": [{"type": "input_text", "text": "seed"}],
                 "harness": "openai-agents",
@@ -1307,7 +1319,7 @@ async def test_mcp_execute_dispatches_builtin_tool_with_runner_workspace(
             await asyncio.sleep(0.05)
 
         execute_resp = await client.post(
-            "/v1/sessions/conv_execute_builtin/mcp/execute",
+            "/v1/sessions/38f6cf055029a2a23b227a8305f76c9d/mcp/execute",
             json={
                 "method": "tools/call",
                 "params": {
@@ -1331,12 +1343,15 @@ async def test_mcp_execute_dispatches_full_namespaced_mcp_tool_name() -> None:
     async with _runner_client(app) as client:
         seed_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_execute_mcp", "agent_id": "ag_abc"},
+            json={
+                "session_id": "6a09e2c1b63301fc6be99bb645418905",
+                "agent_id": "0e36e3219954d2deaef06b8e2a936f38",
+            },
         )
         assert seed_resp.status_code == 201, seed_resp.text
 
         execute_resp = await client.post(
-            "/v1/sessions/conv_execute_mcp/mcp/execute",
+            "/v1/sessions/6a09e2c1b63301fc6be99bb645418905/mcp/execute",
             json={
                 "method": "tools/call",
                 "params": {
@@ -1361,11 +1376,11 @@ async def test_sessions_native_path_injects_mcp_schemas() -> None:
     app, _mcp_manager, harness_client, _server_client = _build_app_with_mcp_tool()
     async with _runner_client(app) as client:
         resp = await client.post(
-            "/v1/sessions/conv_abc/events",
+            "/v1/sessions/4e92b5a0c0ee6db3f874f9c4a3f855a5/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_abc",
+                "agent_id": "0e36e3219954d2deaef06b8e2a936f38",
                 "model": "test-agent",
                 "input": [{"type": "input_text", "text": "hi"}],
                 "harness": "openai-agents",
@@ -1396,11 +1411,11 @@ async def test_action_required_marker_round_trips_to_relayed_frame() -> None:
     app, _mcp_manager, _client, server_client = _build_app_with_mcp_tool()
     async with _runner_client(app) as client:
         resp = await client.post(
-            "/v1/sessions/conv_abc/events?stream=true",
+            "/v1/sessions/4e92b5a0c0ee6db3f874f9c4a3f855a5/events?stream=true",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_abc",
+                "agent_id": "0e36e3219954d2deaef06b8e2a936f38",
                 "model": "test-agent",
                 "content": [{"type": "input_text", "text": "hi"}],
                 "harness": "openai-agents",
@@ -1493,13 +1508,16 @@ async def test_create_session_threads_resolved_bundle_dir_to_codex_spawn_env(
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_codex", "agent_id": "ag_codex"},
+            json={
+                "session_id": "415c9954e2fe4b9276083a4d2c66f689",
+                "agent_id": "12c8c7631b209d1027416b4bf7604999",
+            },
         )
 
     assert resp.status_code == 201
     assert pm.get_client_calls
     conversation_id, harness, env = pm.get_client_calls[-1]
-    assert conversation_id == "conv_codex"
+    assert conversation_id == "415c9954e2fe4b9276083a4d2c66f689"
     assert harness == "codex"
     assert env is not None
     assert env["HARNESS_CODEX_BUNDLE_DIR"] == str(bundle_dir)
@@ -1543,17 +1561,20 @@ async def test_create_session_threads_cursor_bridge_dir_without_dead_guard_env(
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_cursor", "agent_id": "ag_cursor"},
+            json={
+                "session_id": "0229f28e408c700b084b2a2e265f9b3c",
+                "agent_id": "209bc0df7e730c9f33fcda57504c2623",
+            },
         )
 
     assert resp.status_code == 201
     assert pm.get_client_calls
     conversation_id, harness, env = pm.get_client_calls[-1]
-    assert conversation_id == "conv_cursor"
+    assert conversation_id == "0229f28e408c700b084b2a2e265f9b3c"
     assert harness == "cursor-native"
     assert env == {
         cursor_native_bridge.BRIDGE_DIR_ENV_VAR: str(
-            cursor_native_bridge.bridge_dir_for_session_id("conv_cursor")
+            cursor_native_bridge.bridge_dir_for_session_id("0229f28e408c700b084b2a2e265f9b3c")
         )
     }
     assert "HARNESS_CURSOR_NATIVE_REQUEST_SESSION_ID" not in env
@@ -1589,17 +1610,20 @@ async def test_create_session_threads_kiro_bridge_dir(
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_kiro", "agent_id": "ag_kiro"},
+            json={
+                "session_id": "823dbd1aab969b5a813fac59bb977a77",
+                "agent_id": "2c515637c67d0717ad0bebc2747b71bc",
+            },
         )
 
     assert resp.status_code == 201
     assert pm.get_client_calls
     conversation_id, harness, env = pm.get_client_calls[-1]
-    assert conversation_id == "conv_kiro"
+    assert conversation_id == "823dbd1aab969b5a813fac59bb977a77"
     assert harness == "kiro-native"
     assert env == {
         kiro_native_bridge.KIRO_NATIVE_BRIDGE_DIR_ENV_VAR: str(
-            kiro_native_bridge.bridge_dir_for_session_id("conv_kiro")
+            kiro_native_bridge.bridge_dir_for_session_id("823dbd1aab969b5a813fac59bb977a77")
         )
     }
 
@@ -1610,10 +1634,10 @@ async def test_create_session_threads_workspace_to_pi_cwd(
 ) -> None:
     """Pi pre-spawn receives the session workspace, not the bundle dir."""
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config-home"))
-    session_id = "conv_pi_worktree"
+    session_id = "18f39ab73f49285e4dab0c80ff7b8455"
     runner_workspace = tmp_path / "runner-workspace"
     runner_workspace.mkdir()
-    bundle_dir = tmp_path / "runner-specs" / "ag_pi-v1"
+    bundle_dir = tmp_path / "runner-specs" / "86c64e0f9cab937bd04c79b9957dd55a-v1"
     bundle_dir.mkdir(parents=True)
     worktree = tmp_path / "repo-worktrees" / "feature-x"
     worktree.mkdir(parents=True)
@@ -1638,7 +1662,7 @@ async def test_create_session_threads_workspace_to_pi_cwd(
                     200,
                     json={
                         "id": session_id,
-                        "agent_id": "ag_pi",
+                        "agent_id": "86c64e0f9cab937bd04c79b9957dd55a",
                         "created_at": 1.0,
                         "workspace": str(worktree),
                     },
@@ -1656,7 +1680,7 @@ async def test_create_session_threads_workspace_to_pi_cwd(
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": session_id, "agent_id": "ag_pi"},
+            json={"session_id": session_id, "agent_id": "86c64e0f9cab937bd04c79b9957dd55a"},
         )
 
     assert resp.status_code == 201
@@ -1678,10 +1702,10 @@ async def test_create_session_threads_runner_workspace_to_pi_cwd_when_session_wo
 ) -> None:
     """Pi pre-spawn falls back to runner workspace when session workspace is empty."""
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config-home"))
-    session_id = "conv_pi_runner_workspace"
+    session_id = "3f1d20a97a7d0ba93e02cf17aeb92367"
     runner_workspace = tmp_path / "runner-workspace"
     runner_workspace.mkdir()
-    bundle_dir = tmp_path / "runner-specs" / "ag_pi-v1"
+    bundle_dir = tmp_path / "runner-specs" / "86c64e0f9cab937bd04c79b9957dd55a-v1"
     bundle_dir.mkdir(parents=True)
     spec = AgentSpec(
         spec_version=1,
@@ -1704,7 +1728,7 @@ async def test_create_session_threads_runner_workspace_to_pi_cwd_when_session_wo
                     200,
                     json={
                         "id": session_id,
-                        "agent_id": "ag_pi",
+                        "agent_id": "86c64e0f9cab937bd04c79b9957dd55a",
                         "created_at": 1.0,
                         "workspace": workspace_value,
                     },
@@ -1722,7 +1746,7 @@ async def test_create_session_threads_runner_workspace_to_pi_cwd_when_session_wo
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": session_id, "agent_id": "ag_pi"},
+            json={"session_id": session_id, "agent_id": "86c64e0f9cab937bd04c79b9957dd55a"},
         )
 
     assert resp.status_code == 201
@@ -1739,11 +1763,17 @@ async def test_create_session_threads_runner_workspace_to_pi_cwd_when_session_wo
     ("session_json", "expected"),
     [
         # Host-spawned (web UI): bound to a host -> auto-create.
-        ({"id": "conv_x", "host_id": "host_abc"}, True),
+        (
+            {
+                "id": "8af356d908005a65f872c246158c6293",
+                "host_id": "abb32306b80732bdfa6153b2f5f6eb92",
+            },
+            True,
+        ),
         # Top-level CLI session: no host_id and no parent, but the runner
         # still owns the Codex app-server and terminal.
-        ({"id": "conv_x", "host_id": None}, True),
-        ({"id": "conv_x"}, True),
+        ({"id": "8af356d908005a65f872c246158c6293", "host_id": None}, True),
+        ({"id": "8af356d908005a65f872c246158c6293"}, True),
     ],
 )
 @pytest.mark.asyncio
@@ -1764,7 +1794,10 @@ async def test_codex_top_level_session_needs_runner_terminal_for_all_session_sha
         async def get(self, url: str, *, timeout: float) -> httpx.Response:
             return httpx.Response(200, json=session_json, request=httpx.Request("GET", url))
 
-    assert await _codex_session_needs_runner_terminal(_Client(), "conv_x") is expected
+    assert (
+        await _codex_session_needs_runner_terminal(_Client(), "8af356d908005a65f872c246158c6293")
+        is expected
+    )
 
 
 @pytest.mark.asyncio
@@ -1790,7 +1823,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     import omnigent.codex_native_app_server as codex_app_mod
     import omnigent.runner.app as runner_app_mod
 
-    session_id = "conv_codex_resume"
+    session_id = "76cbdcbbf84d4149b2a7d7441b6966c1"
     thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
@@ -1816,7 +1849,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
             Return the session snapshot consumed by the runner helper.
 
             :param url: Request path, e.g.
-                ``"/v1/sessions/conv_codex_resume"``.
+                ``"/v1/sessions/76cbdcbbf84d4149b2a7d7441b6966c1"``.
             :param kwargs: Request keyword arguments such as
                 ``{"timeout": 10.0}`` or ``{"params": {"limit": 1000}}``.
             :returns: HTTP 200 response carrying launch config.
@@ -1827,7 +1860,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
                     json={
                         "data": [
                             {
-                                "id": "msg_user_1",
+                                "id": "b1649a5cbfec3f92bec12275c14f4b5f",
                                 "response_id": "codex_turn_1",
                                 "type": "message",
                                 "role": "user",
@@ -1945,7 +1978,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
             :param resource_role: Private runner resource marker.
             :returns: Terminal resource view.
             """
-            assert session_id == "conv_codex_resume"
+            assert session_id == "76cbdcbbf84d4149b2a7d7441b6966c1"
             assert terminal_name == "codex"
             assert session_key == "main"
             assert resource_role == CODEX_NATIVE_TERMINAL_ROLE
@@ -2082,8 +2115,8 @@ async def test_auto_create_codex_terminal_fork_clones_rollout_and_resumes(
         FORK_SOURCE_LABEL_KEY,
     )
 
-    session_id = "conv_codex_clone"
-    source_id = "conv_codex_source"
+    session_id = "8aedf63f5e4046ae21b35fec5b35da50"
+    source_id = "f143372bb481f9e85ffe3415f56f744f"
     source_thread = "019e96aa-0be2-7343-8d3b-6f914d60936b"
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -2128,7 +2161,7 @@ async def test_auto_create_codex_terminal_fork_clones_rollout_and_resumes(
             """
             Return the clone's snapshot carrying fork labels but no thread id.
 
-            :param url: Request path, e.g. ``"/v1/sessions/conv_codex_clone"``.
+            :param url: Request path, e.g. ``"/v1/sessions/8aedf63f5e4046ae21b35fec5b35da50"``.
             :param timeout: Request timeout in seconds.
             :returns: HTTP 200 response with fork labels.
             """
@@ -2349,8 +2382,8 @@ async def test_auto_create_codex_terminal_fork_builds_rollout_from_items_and_res
         FORK_SOURCE_LABEL_KEY,
     )
 
-    session_id = "conv_codex_sdkfork"
-    source_id = "conv_sdk_source"
+    session_id = "70a19efac3ec27549a70acbb4d0c635a"
+    source_id = "4bd4c10aa9a3237eb5213cbeda70b70f"
     codeword = "swordfish-7281"
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -2600,7 +2633,7 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
     import omnigent.runner.app as runner_app_mod
     from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 
-    session_id = "conv_codex_worktree"
+    session_id = "54e4d4410c43954c11e702f5a8646483"
     # Three distinct dirs so the assertion can only pass for the worktree:
     #   runner_env  — OMNIGENT_RUNNER_WORKSPACE (claude-native's source)
     #   bundle_dir  — ResolvedSpec.workdir (what the bug used)
@@ -2636,7 +2669,7 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
             Return the session snapshot with a worktree ``workspace``.
 
             :param url: Request path, e.g.
-                ``"/v1/sessions/conv_codex_worktree"``.
+                ``"/v1/sessions/54e4d4410c43954c11e702f5a8646483"``.
             :param timeout: Request timeout in seconds.
             :returns: HTTP 200 response carrying the worktree workspace.
             """
@@ -2850,7 +2883,7 @@ async def test_auto_create_codex_terminal_starts_relay_at_session_creation(
     import omnigent.codex_native_app_server as codex_app_mod
     import omnigent.runner.app as runner_app_mod
 
-    session_id = "conv_codex_relay_start"
+    session_id = "de154ca6405fb8912623984a14a2b044"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
@@ -3012,7 +3045,7 @@ async def test_claude_native_first_turn_not_blocked_by_cold_bridge_notify(
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
-    session_id = f"conv_{uuid.uuid4().hex[:12]}"
+    session_id = uuid.uuid4().hex
     # claude-native pins the bridge tree under /tmp (see _ensure_secure_dir);
     # use the real per-user bridge dir like tests/runner/test_comment_relay.py
     # and rmtree it on teardown rather than redirecting _BRIDGE_ROOT.
@@ -3077,7 +3110,7 @@ async def test_claude_native_first_turn_not_blocked_by_cold_bridge_notify(
                     "type": "message",
                     "role": "user",
                     "model": "claude-agent",
-                    "agent_id": "ag_claude",
+                    "agent_id": "3a9725fd4de1720e83e53a632da41da8",
                     "content": [{"type": "input_text", "text": "hi"}],
                 },
             )
@@ -3305,7 +3338,7 @@ async def test_auto_create_antigravity_cold_starts_real_conversation(
     PATCHes it onto the session as ``external_session_id`` so a later ``--resume``
     continues it.
     """
-    session_id = "conv_agy_coldstart"
+    session_id = "72a4f9222c7ac0f45ba2736b57b51f62"
     state, start_cascade_calls, reader_calls, patch_calls = await _run_antigravity_auto_create(
         tmp_path,
         monkeypatch,
@@ -3345,7 +3378,7 @@ async def test_auto_create_antigravity_cold_start_scopes_to_pane_agy(
     session. With a resolvable pane the cold-start uses the pane-scoped port
     (61000) even though a lower foreign candidate (52548) exists.
     """
-    session_id = "conv_agy_paneScoped"
+    session_id = "4130b87cea0f50aab661215a1c220d2a"
     state, start_cascade_calls, _reader_calls, patch_calls = await _run_antigravity_auto_create(
         tmp_path,
         monkeypatch,
@@ -3379,7 +3412,7 @@ async def test_auto_create_antigravity_cold_start_falls_back_when_no_pane(
     ``_terminal_tmux_pane`` yields no socket/target the pane cannot be scoped, so
     the cold-start falls back to ``_candidate_agy_rpc_ports()[0]``.
     """
-    session_id = "conv_agy_noPaneFallback"
+    session_id = "dd3b597d06f41a0914a65689398c6047"
     state, start_cascade_calls, _reader_calls, patch_calls = await _run_antigravity_auto_create(
         tmp_path,
         monkeypatch,
@@ -3410,7 +3443,7 @@ async def test_auto_create_antigravity_cold_start_waits_when_pane_agy_absent(
     deadline, leaving the placeholder for the reader to bind later. No
     ``StartCascade``, no ``external_session_id`` PATCH.
     """
-    session_id = "conv_agy_paneEarlyPoll"
+    session_id = "b4741a5530a1e4f6de788ecc6bf2ed16"
     state, start_cascade_calls, _reader_calls, patch_calls = await _run_antigravity_auto_create(
         tmp_path,
         monkeypatch,
@@ -3441,7 +3474,7 @@ async def test_auto_create_antigravity_cold_start_falls_back_when_port_unattribu
     port is ``None``. Since agy exists here, the lone candidate is ours and the
     candidate fallback is safe.
     """
-    session_id = "conv_agy_paneNoPort"
+    session_id = "09ac5119b8cc54502810b565d8206821"
     state, start_cascade_calls, _reader_calls, patch_calls = await _run_antigravity_auto_create(
         tmp_path,
         monkeypatch,
@@ -3472,7 +3505,7 @@ async def test_auto_create_antigravity_resume_skips_cold_start(
     resume id verbatim, and — since no cold-start runs — no ``external_session_id``
     PATCH is issued (it already holds the resume id).
     """
-    session_id = "conv_agy_resume"
+    session_id = "ac8a43ec8a770428cdb9eb718114efc5"
     resume_id = "68caaeac-2eaf-4e2c-9b95-721b022f4903"
     state, start_cascade_calls, _reader_calls, patch_calls = await _run_antigravity_auto_create(
         tmp_path,
@@ -3507,7 +3540,7 @@ async def test_cold_start_agy_conversation_returns_early_on_real_id_in_bridge_st
     import omnigent.runner.app as runner_app_mod
 
     monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
-    session_id = "conv_agy_guard"
+    session_id = "0f44894f77886259ee71e892a9e2afd7"
     real_id = "68caaeac-2eaf-4e2c-9b95-721b022f4903"  # NOT an agy_conv_* placeholder
     assert not bridge_mod.is_placeholder_conversation_id(real_id)
 
@@ -3569,7 +3602,7 @@ async def test_auto_create_antigravity_cold_start_port_timeout_keeps_placeholder
     is never called, bridge state retains the ``agy_conv_*`` placeholder, and no
     ``external_session_id`` PATCH is issued (there is no real id to record).
     """
-    session_id = "conv_agy_noport"
+    session_id = "3d781eaf3cbda148c8f3212c7c21ea04"
     state, start_cascade_calls, reader_calls, patch_calls = await _run_antigravity_auto_create(
         tmp_path,
         monkeypatch,
@@ -3610,7 +3643,7 @@ async def test_auto_create_antigravity_wires_reader_task_and_interaction_bridge(
     from omnigent.antigravity_native_interactions import agy_elicitation_id
     from omnigent.antigravity_native_steps import pending_interaction
 
-    session_id = "conv_agy_wiring"
+    session_id = "b68c3f1da613f48fb4126e965ab594a3"
     monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
@@ -3791,7 +3824,7 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
     import omnigent.antigravity_native_rpc as rpc_mod
     import omnigent.runner.app as runner_app_mod
 
-    session_id = "conv_agy_mcp"
+    session_id = "1fd85439049bbfc88cbf04221bad5079"
     monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
@@ -3928,7 +3961,7 @@ async def test_auto_create_antigravity_prepends_gemini_dir_to_generated_flags(
     import omnigent.antigravity_native_rpc as rpc_mod
     import omnigent.runner.app as runner_app_mod
 
-    session_id = "conv_agy_argv"
+    session_id = "976793baf55bcdf96830aa376e394f80"
     monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
@@ -4022,7 +4055,7 @@ async def test_auto_create_antigravity_prepends_gemini_dir_to_generated_flags(
     assert captured_spec["args"] == [f"--gemini_dir={iso_gemini}", *generated_tail]
 
 
-@pytest.mark.parametrize("parent_host_id", ["host_parent", None])
+@pytest.mark.parametrize("parent_host_id", ["21506f91db53823dba9a99e9b0db742d", None])
 @pytest.mark.asyncio
 async def test_codex_subagent_always_needs_runner_terminal(
     parent_host_id: str | None,
@@ -4043,7 +4076,7 @@ async def test_codex_subagent_always_needs_runner_terminal(
     ``False``, the regression has reappeared.
 
     :param parent_host_id: The parent session's ``host_id`` value to simulate;
-        ``"host_parent"`` (web-UI parent) or ``None`` (CLI-driven parent).
+        ``"21506f91db53823dba9a99e9b0db742d"`` (web-UI parent) or ``None`` (CLI-driven parent).
     """
     from omnigent.runner.app import _codex_session_needs_runner_terminal
 
@@ -4057,26 +4090,29 @@ async def test_codex_subagent_always_needs_runner_terminal(
             :returns: Fake Omnigent session response.
             """
             del timeout
-            if url.endswith("/conv_child"):
+            if url.endswith("/ff5cac23d0beb79fad914046049f32ff"):
                 return httpx.Response(
                     200,
                     json={
-                        "id": "conv_child",
-                        "parent_session_id": "conv_parent",
+                        "id": "ff5cac23d0beb79fad914046049f32ff",
+                        "parent_session_id": "ead6d59a6b650d19dbdf61ec32426f4e",
                         "host_id": None,
                     },
                     request=httpx.Request("GET", url),
                 )
-            if url.endswith("/conv_parent"):
+            if url.endswith("/ead6d59a6b650d19dbdf61ec32426f4e"):
                 return httpx.Response(
                     200,
-                    json={"id": "conv_parent", "host_id": parent_host_id},
+                    json={"id": "ead6d59a6b650d19dbdf61ec32426f4e", "host_id": parent_host_id},
                     request=httpx.Request("GET", url),
                 )
             return httpx.Response(404, request=httpx.Request("GET", url))
 
     # True for both parent host_ids; a False for the None parent = regressed.
-    assert await _codex_session_needs_runner_terminal(_Client(), "conv_child") is True
+    assert (
+        await _codex_session_needs_runner_terminal(_Client(), "ff5cac23d0beb79fad914046049f32ff")
+        is True
+    )
 
 
 @pytest.mark.asyncio
@@ -4088,7 +4124,10 @@ async def test_codex_session_needs_runner_terminal_false_without_client() -> Non
     """
     from omnigent.runner.app import _codex_session_needs_runner_terminal
 
-    assert await _codex_session_needs_runner_terminal(None, "conv_x") is False
+    assert (
+        await _codex_session_needs_runner_terminal(None, "8af356d908005a65f872c246158c6293")
+        is False
+    )
 
 
 @pytest.mark.asyncio
@@ -4124,7 +4163,7 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
     # module on each call, so patching the module attribute takes effect.
     monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _raise_no_thread)
 
-    session_id = "conv_codex_cleanup_test"
+    session_id = "2053b47e49239a8c24e3cd30cdb21c8e"
     _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
     try:
         await _codex_discover_thread_and_forward(
@@ -4186,7 +4225,7 @@ async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
 
     monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _raise)
 
-    session_id = "conv_codex_startup_error_test"
+    session_id = "5cb1fea582a3bd8aad3619ca820af75b"
     _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
     try:
         await _codex_discover_thread_and_forward(
@@ -4215,16 +4254,19 @@ async def test_create_session() -> None:
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "8e32600337d08f59ad381caf96a90659",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
     assert resp.status_code == 201
     body = resp.json()
-    assert body["id"] == "conv_1"
-    assert body["agent_id"] == "ag_1"
+    assert body["id"] == "8e32600337d08f59ad381caf96a90659"
+    assert body["agent_id"] == "880b5afda28ad55ff74cbeb9b5fc67fb"
     assert body["status"] == "idle"
     assert "created_at" in body
     assert body["items"] == []
-    assert pm.has_session("conv_1")
+    assert pm.has_session("8e32600337d08f59ad381caf96a90659")
 
 
 @pytest.mark.asyncio
@@ -4248,19 +4290,22 @@ async def test_create_session_preserves_existing_event_queue() -> None:
     # Simulate the relay's GET /stream having already attached (lazily
     # created the queue) before init runs.
     sentinel: asyncio.Queue[Any] = asyncio.Queue()
-    _session_event_queues_ref["conv_pre"] = sentinel
+    _session_event_queues_ref["943f9d13fadeff4db5bb295673530474"] = sentinel
     try:
         async with _runner_client(app) as client:
             resp = await client.post(
                 "/v1/sessions",
-                json={"session_id": "conv_pre", "agent_id": "ag_1"},
+                json={
+                    "session_id": "943f9d13fadeff4db5bb295673530474",
+                    "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+                },
             )
         assert resp.status_code == 201
         # Same object → a relay already blocked on it keeps receiving
         # events that ``_publish_event`` enqueues after init.
-        assert _session_event_queues_ref.get("conv_pre") is sentinel
+        assert _session_event_queues_ref.get("943f9d13fadeff4db5bb295673530474") is sentinel
     finally:
-        _session_event_queues_ref.pop("conv_pre", None)
+        _session_event_queues_ref.pop("943f9d13fadeff4db5bb295673530474", None)
 
 
 @pytest.mark.asyncio
@@ -4273,13 +4318,16 @@ async def test_has_active_work_reports_process_manager_turns() -> None:
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "8e32600337d08f59ad381caf96a90659",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
 
     assert resp.status_code == 201
     assert app.state.has_active_work() is False
 
-    pm.mark_turn_active("conv_1")
+    pm.mark_turn_active("8e32600337d08f59ad381caf96a90659")
 
     assert app.state.has_active_work() is True
 
@@ -4291,7 +4339,7 @@ async def test_create_session_missing_fields() -> None:
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_1"},
+            json={"session_id": "8e32600337d08f59ad381caf96a90659"},
         )
     assert resp.status_code == 400
 
@@ -4303,7 +4351,10 @@ async def test_create_session_scaffold_mode() -> None:
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "8e32600337d08f59ad381caf96a90659",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
     assert resp.status_code == 501
 
@@ -4315,9 +4366,12 @@ async def test_get_session_status_idle() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "8e32600337d08f59ad381caf96a90659",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
-        resp = await client.get("/v1/sessions/conv_1")
+        resp = await client.get("/v1/sessions/8e32600337d08f59ad381caf96a90659")
     assert resp.status_code == 200
     assert resp.json()["status"] == "idle"
 
@@ -4329,10 +4383,13 @@ async def test_get_session_status_running() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "8e32600337d08f59ad381caf96a90659",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
-        pm.mark_turn_active("conv_1")
-        resp = await client.get("/v1/sessions/conv_1")
+        pm.mark_turn_active("8e32600337d08f59ad381caf96a90659")
+        resp = await client.get("/v1/sessions/8e32600337d08f59ad381caf96a90659")
     assert resp.status_code == 200
     assert resp.json()["status"] == "running"
 
@@ -4353,15 +4410,18 @@ async def test_delete_session() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "8e32600337d08f59ad381caf96a90659",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
-        resp = await client.delete("/v1/sessions/conv_1")
+        resp = await client.delete("/v1/sessions/8e32600337d08f59ad381caf96a90659")
     assert resp.status_code == 200
     body = resp.json()
     assert body["deleted"] is True
-    assert body["session_id"] == "conv_1"
-    assert "conv_1" in pm.released
-    assert not pm.has_session("conv_1")
+    assert body["session_id"] == "8e32600337d08f59ad381caf96a90659"
+    assert "8e32600337d08f59ad381caf96a90659" in pm.released
+    assert not pm.has_session("8e32600337d08f59ad381caf96a90659")
 
 
 @pytest.mark.asyncio
@@ -4371,13 +4431,16 @@ async def test_delete_session_with_active_turn() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "8e32600337d08f59ad381caf96a90659",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
-        pm.mark_turn_active("conv_1")
-        resp = await client.delete("/v1/sessions/conv_1")
+        pm.mark_turn_active("8e32600337d08f59ad381caf96a90659")
+        resp = await client.delete("/v1/sessions/8e32600337d08f59ad381caf96a90659")
     assert resp.status_code == 200
-    assert "conv_1" in pm.cancelled
-    assert "conv_1" in pm.released
+    assert "8e32600337d08f59ad381caf96a90659" in pm.cancelled
+    assert "8e32600337d08f59ad381caf96a90659" in pm.released
 
 
 @pytest.mark.asyncio
@@ -4389,7 +4452,10 @@ async def test_session_stream_receives_events() -> None:
         # Create the session first.
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_s", "agent_id": "ag_1"},
+            json={
+                "session_id": "4ee52d986b72704408b5ff36fe8421e0",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
 
         import asyncio
@@ -4398,7 +4464,9 @@ async def test_session_stream_receives_events() -> None:
 
         async def _subscribe() -> None:
             """Subscribe to SSE and collect events until [DONE]."""
-            async with client.stream("GET", "/v1/sessions/conv_s/stream") as stream:
+            async with client.stream(
+                "GET", "/v1/sessions/4ee52d986b72704408b5ff36fe8421e0/stream"
+            ) as stream:
                 async for line in stream.aiter_lines():
                     if line.startswith("data: "):
                         payload = line[6:]
@@ -4413,7 +4481,7 @@ async def test_session_stream_receives_events() -> None:
         # session_stream. The stream stays open across turns;
         # deleting the session sends [DONE].
         resp = await client.post(
-            "/v1/sessions/conv_s/events",
+            "/v1/sessions/4ee52d986b72704408b5ff36fe8421e0/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -4429,7 +4497,7 @@ async def test_session_stream_receives_events() -> None:
         await asyncio.sleep(0.05)
 
         # Delete the session to close the stream ([DONE]).
-        await client.delete("/v1/sessions/conv_s")
+        await client.delete("/v1/sessions/4ee52d986b72704408b5ff36fe8421e0")
 
         await asyncio.wait_for(sub_task, timeout=5.0)
 
@@ -4457,12 +4525,17 @@ async def test_session_stream_emits_heartbeat_on_idle() -> None:
         async with _runner_client(app) as client:
             await client.post(
                 "/v1/sessions",
-                json={"session_id": "conv_hb", "agent_id": "ag_1"},
+                json={
+                    "session_id": "2fa978f2a04f84d78d2dde3c4de2a306",
+                    "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+                },
             )
             collected: list[dict[str, Any]] = []
 
             async def _subscribe() -> None:
-                async with client.stream("GET", "/v1/sessions/conv_hb/stream") as stream:
+                async with client.stream(
+                    "GET", "/v1/sessions/2fa978f2a04f84d78d2dde3c4de2a306/stream"
+                ) as stream:
                     async for line in stream.aiter_lines():
                         if line.startswith("data: "):
                             payload = line[6:]
@@ -4472,7 +4545,7 @@ async def test_session_stream_emits_heartbeat_on_idle() -> None:
 
             sub_task = asyncio.create_task(_subscribe())
             await asyncio.sleep(0.2)
-            await client.delete("/v1/sessions/conv_hb")
+            await client.delete("/v1/sessions/2fa978f2a04f84d78d2dde3c4de2a306")
             await asyncio.wait_for(sub_task, timeout=5.0)
 
         heartbeats = [e for e in collected if e.get("type") == "session.heartbeat"]
@@ -4587,13 +4660,16 @@ async def test_turn_sequencing_buffers_concurrent_message() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_buf", "agent_id": "ag_1"},
+            json={
+                "session_id": "49ed0bd1f0cae058f05f48057e9f98cf",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
 
         async def _run_first_turn() -> None:
             """Start the first turn and drain its response."""
             resp = await client.post(
-                "/v1/sessions/conv_buf/events",
+                "/v1/sessions/49ed0bd1f0cae058f05f48057e9f98cf/events",
                 json={
                     "type": "message",
                     "role": "user",
@@ -4614,7 +4690,7 @@ async def test_turn_sequencing_buffers_concurrent_message() -> None:
 
         # Second message while turn active → 202 buffered.
         resp2 = await client.post(
-            "/v1/sessions/conv_buf/events",
+            "/v1/sessions/49ed0bd1f0cae058f05f48057e9f98cf/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -4643,7 +4719,10 @@ async def test_turn_lifecycle_events() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_lc", "agent_id": "ag_1"},
+            json={
+                "session_id": "490f8ac07b3f7ac2c9b265eec87eb0e8",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
 
         import asyncio
@@ -4652,7 +4731,9 @@ async def test_turn_lifecycle_events() -> None:
 
         async def _sub() -> None:
             """Collect events until [DONE]."""
-            async with client.stream("GET", "/v1/sessions/conv_lc/stream") as stream:
+            async with client.stream(
+                "GET", "/v1/sessions/490f8ac07b3f7ac2c9b265eec87eb0e8/stream"
+            ) as stream:
                 async for line in stream.aiter_lines():
                     if line.startswith("data: "):
                         payload = line[6:]
@@ -4664,7 +4745,7 @@ async def test_turn_lifecycle_events() -> None:
         await asyncio.sleep(0.05)
 
         resp = await client.post(
-            "/v1/sessions/conv_lc/events",
+            "/v1/sessions/490f8ac07b3f7ac2c9b265eec87eb0e8/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -4677,7 +4758,7 @@ async def test_turn_lifecycle_events() -> None:
             pass
         await asyncio.sleep(0.05)
 
-        await client.delete("/v1/sessions/conv_lc")
+        await client.delete("/v1/sessions/490f8ac07b3f7ac2c9b265eec87eb0e8")
         await asyncio.wait_for(task, timeout=5.0)
 
     lifecycle_events = [e for e in collected if e.get("type") != "session.heartbeat"]
@@ -4706,11 +4787,14 @@ async def test_delete_during_active_turn_cleans_state() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_del", "agent_id": "ag_1"},
+            json={
+                "session_id": "553a265445caf1cdb034abe0b449485d",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         # Start a turn (don't drain — turn stays active).
         await client.post(
-            "/v1/sessions/conv_del/events",
+            "/v1/sessions/553a265445caf1cdb034abe0b449485d/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -4722,7 +4806,7 @@ async def test_delete_during_active_turn_cleans_state() -> None:
 
         # Buffer a second message.
         await client.post(
-            "/v1/sessions/conv_del/events",
+            "/v1/sessions/553a265445caf1cdb034abe0b449485d/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -4733,9 +4817,9 @@ async def test_delete_during_active_turn_cleans_state() -> None:
         )
 
         # DELETE while turn active.
-        del_resp = await client.delete("/v1/sessions/conv_del")
+        del_resp = await client.delete("/v1/sessions/553a265445caf1cdb034abe0b449485d")
         assert del_resp.status_code == 200
-        assert "conv_del" in pm.released
+        assert "553a265445caf1cdb034abe0b449485d" in pm.released
 
 
 @pytest.mark.asyncio
@@ -4749,13 +4833,16 @@ async def test_post_turn_continuation() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_cont", "agent_id": "ag_1"},
+            json={
+                "session_id": "68d532c6117d7c15ec58a38e9c7f4790",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
 
         async def _first() -> None:
             """Run and drain the first turn."""
             resp = await client.post(
-                "/v1/sessions/conv_cont/events",
+                "/v1/sessions/68d532c6117d7c15ec58a38e9c7f4790/events",
                 json={
                     "type": "message",
                     "role": "user",
@@ -4772,7 +4859,7 @@ async def test_post_turn_continuation() -> None:
 
         # Buffer a second message while the first turn is active.
         resp2 = await client.post(
-            "/v1/sessions/conv_cont/events",
+            "/v1/sessions/68d532c6117d7c15ec58a38e9c7f4790/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -4969,14 +5056,17 @@ async def test_midturn_message_not_double_delivered_to_harness() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_dup", "agent_id": "ag_1"},
+            json={
+                "session_id": "ede98a0180773a70b1e81cc854ff7d8a",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
 
         # Turn 1 starts fire-and-forget (202) and its background task
         # blocks inside the harness stream on `gate`. The 0.05s yield lets
         # the runner mark the turn active before the second message lands.
         resp1 = await client.post(
-            "/v1/sessions/conv_dup/events",
+            "/v1/sessions/ede98a0180773a70b1e81cc854ff7d8a/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -4992,7 +5082,7 @@ async def test_midturn_message_not_double_delivered_to_harness() -> None:
         # on the gate) → the runner buffers it AND forwards it as a live
         # mid-turn injection with a correlation id.
         resp2 = await client.post(
-            "/v1/sessions/conv_dup/events",
+            "/v1/sessions/ede98a0180773a70b1e81cc854ff7d8a/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -5173,12 +5263,12 @@ async def test_native_buffered_messages_each_delivered_once_in_order(
     async def _post(text: str) -> httpx.Response:
         """POST one user message carrying an agent_id (drives spec resolve)."""
         return await client.post(
-            "/v1/sessions/conv_nat/events",
+            "/v1/sessions/11b4a5755857531509b492c3f9a7a1a6/events",
             json={
                 "type": "message",
                 "role": "user",
                 "model": "test-agent",
-                "agent_id": "ag_native",
+                "agent_id": "0c5de81a62eeb73d54466214cf37e5db",
                 "content": [{"type": "input_text", "text": text}],
             },
         )
@@ -5255,7 +5345,11 @@ class _GatedFileServerClient:
         self.meta_fetch_started.set()
         await self.release.wait()
         return _GatedFileServerClient._Resp(
-            payload={"id": "file_gated", "filename": "a.png", "content_type": "image/png"}
+            payload={
+                "id": "c531a3c97ad5fca15709d73d1f734a0c",
+                "filename": "a.png",
+                "content_type": "image/png",
+            }
         )
 
     class _Resp:
@@ -5317,13 +5411,17 @@ async def test_messages_reach_harness_in_submission_order() -> None:
         async def _post_alpha() -> httpx.Response:
             """POST the first message (gated image + text)."""
             return await client.post(
-                "/v1/sessions/conv_ord/events",
+                "/v1/sessions/ea532aed7642ec833ab31a5649c3495b/events",
                 json={
                     "type": "message",
                     "role": "user",
                     "model": "test-agent",
                     "content": [
-                        {"type": "input_image", "file_id": "file_gated", "filename": "a.png"},
+                        {
+                            "type": "input_image",
+                            "file_id": "c531a3c97ad5fca15709d73d1f734a0c",
+                            "filename": "a.png",
+                        },
                         {"type": "input_text", "text": "alpha-first"},
                     ],
                     "harness": "openai-agents",
@@ -5344,7 +5442,7 @@ async def test_messages_reach_harness_in_submission_order() -> None:
         async def _post_bravo() -> httpx.Response:
             """POST the second message (plain text)."""
             return await client.post(
-                "/v1/sessions/conv_ord/events",
+                "/v1/sessions/ea532aed7642ec833ab31a5649c3495b/events",
                 json={
                     "type": "message",
                     "role": "user",
@@ -5405,13 +5503,18 @@ async def test_buffered_continuation_skips_transient_idle() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_skip", "agent_id": "ag_1"},
+            json={
+                "session_id": "daec53e4bab215026ded66b565924480",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
 
         collected: list[dict[str, Any]] = []
 
         async def _sub() -> None:
-            async with client.stream("GET", "/v1/sessions/conv_skip/stream") as stream:
+            async with client.stream(
+                "GET", "/v1/sessions/daec53e4bab215026ded66b565924480/stream"
+            ) as stream:
                 async for line in stream.aiter_lines():
                     if line.startswith("data: "):
                         payload = line[6:]
@@ -5424,7 +5527,7 @@ async def test_buffered_continuation_skips_transient_idle() -> None:
 
         async def _first() -> None:
             resp = await client.post(
-                "/v1/sessions/conv_skip/events",
+                "/v1/sessions/daec53e4bab215026ded66b565924480/events",
                 json={
                     "type": "message",
                     "role": "user",
@@ -5440,7 +5543,7 @@ async def test_buffered_continuation_skips_transient_idle() -> None:
         await _aio.sleep(0.05)
 
         await client.post(
-            "/v1/sessions/conv_skip/events",
+            "/v1/sessions/daec53e4bab215026ded66b565924480/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -5454,7 +5557,7 @@ async def test_buffered_continuation_skips_transient_idle() -> None:
         await _aio.wait_for(turn_task, timeout=5.0)
         await _aio.sleep(0.3)
 
-        await client.delete("/v1/sessions/conv_skip")
+        await client.delete("/v1/sessions/daec53e4bab215026ded66b565924480")
         await _aio.wait_for(sub_task, timeout=5.0)
 
     statuses = [e["status"] for e in collected if e.get("type") == "session.status"]
@@ -5481,13 +5584,18 @@ async def test_cancelled_turn_publishes_idle_so_client_unsticks() -> None:
     async with _runner_client(app) as client:
         await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_cancel", "agent_id": "ag_1"},
+            json={
+                "session_id": "1a6237b81972b420cfd54818b51d1e21",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
 
         collected: list[dict[str, Any]] = []
 
         async def _sub() -> None:
-            async with client.stream("GET", "/v1/sessions/conv_cancel/stream") as stream:
+            async with client.stream(
+                "GET", "/v1/sessions/1a6237b81972b420cfd54818b51d1e21/stream"
+            ) as stream:
                 async for line in stream.aiter_lines():
                     if line.startswith("data: "):
                         payload = line[6:]
@@ -5500,7 +5608,7 @@ async def test_cancelled_turn_publishes_idle_so_client_unsticks() -> None:
 
         async def _stuck() -> None:
             resp = await client.post(
-                "/v1/sessions/conv_cancel/events",
+                "/v1/sessions/1a6237b81972b420cfd54818b51d1e21/events",
                 json={
                     "type": "message",
                     "role": "user",
@@ -5517,7 +5625,7 @@ async def test_cancelled_turn_publishes_idle_so_client_unsticks() -> None:
 
         # DELETE cancels the turn task — exercises `_drain_streaming_response`'s
         # CancelledError path.
-        del_resp = await client.delete("/v1/sessions/conv_cancel")
+        del_resp = await client.delete("/v1/sessions/1a6237b81972b420cfd54818b51d1e21")
         assert del_resp.status_code == 200
 
         gate.set()  # unblock the stuck stream so the test can finish
@@ -5680,7 +5788,10 @@ async def test_session_creation_auto_starts_turn_for_unanswered_user_message() -
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_recover_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "5f35011bda530550543bf0c329c309f1",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert resp.status_code == 201
         # "running" proves the recovery turn was started during
@@ -5733,7 +5844,7 @@ async def test_session_creation_does_not_replay_trailing_user_for_codex_native(
 
     import omnigent.runner.app as runner_app_mod
 
-    session_id = "conv_codex_failed_recover"
+    session_id = "c5bceafbef391eeff567c144d1d33f3f"
     runner_app_mod._session_histories_ref.pop(session_id, None)
 
     monkeypatch.setattr(
@@ -5756,7 +5867,7 @@ async def test_session_creation_does_not_replay_trailing_user_for_codex_native(
         async with _runner_client(app) as client:
             resp = await client.post(
                 "/v1/sessions",
-                json={"session_id": session_id, "agent_id": "ag_1"},
+                json={"session_id": session_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
             )
             assert resp.status_code == 201
             assert resp.json()["status"] == "idle"
@@ -5791,7 +5902,7 @@ async def test_catch_up_scan_skips_codex_native_history_entries(
 
     import omnigent.runner.app as runner_app_mod
 
-    session_id = "conv_codex_catchup_skip"
+    session_id = "97990a9c3b849bb4710a9fb1e9fdc6c8"
     saved_histories = dict(runner_app_mod._session_histories_ref)
     runner_app_mod._session_histories_ref.clear()
     missed_user_item = {
@@ -5837,7 +5948,7 @@ async def test_catch_up_scan_skips_codex_native_history_entries(
         async with _runner_client(app) as client:
             resp = await client.post(
                 "/v1/sessions",
-                json={"session_id": session_id, "agent_id": "ag_1"},
+                json={"session_id": session_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
             )
             assert resp.status_code == 201
             assert resp.json()["status"] == "idle"
@@ -5897,7 +6008,10 @@ async def test_session_creation_stays_idle_for_completed_conversation() -> None:
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_idle_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "92613c24e132e95e80519e59b2134a38",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert resp.status_code == 201
         # "idle" proves no recovery turn was started. "running"
@@ -5942,7 +6056,10 @@ async def test_session_creation_auto_starts_turn_for_pending_tool_call() -> None
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_recover_tc", "agent_id": "ag_1"},
+            json={
+                "session_id": "f74b6cc12acef4605aa5808eb214b53c",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert resp.status_code == 201
         assert resp.json()["status"] == "running"
@@ -5969,7 +6086,10 @@ async def test_session_creation_no_recovery_for_empty_history() -> None:
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_fresh", "agent_id": "ag_1"},
+            json={
+                "session_id": "19f000886345b9519ac5977b97d3a795",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert resp.status_code == 201
         assert resp.json()["status"] == "idle"
@@ -6025,7 +6145,10 @@ async def test_history_load_paginates_beyond_100_items() -> None:
         # Create session — loads history via pagination.
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_paginate", "agent_id": "ag_1"},
+            json={
+                "session_id": "1371f04fe2cf189fe4246131ddff016d",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert resp.status_code == 201
         assert resp.json()["status"] == "idle"
@@ -6033,7 +6156,7 @@ async def test_history_load_paginates_beyond_100_items() -> None:
         # Now send a message to trigger a turn — the turn uses
         # _session_histories which should have all 150 items.
         resp2 = await client.post(
-            "/v1/sessions/conv_paginate/events",
+            "/v1/sessions/1371f04fe2cf189fe4246131ddff016d/events",
             json={
                 "type": "message",
                 "role": "user",
@@ -6105,7 +6228,10 @@ async def test_resume_sends_full_history_plus_new_message_to_harness() -> None:
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_resume_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "b76becb60586615cf61d0894efbbbfe0",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         # History ends with assistant — session stays idle (no recovery).
         assert resp.status_code == 201
@@ -6113,11 +6239,11 @@ async def test_resume_sends_full_history_plus_new_message_to_harness() -> None:
 
         # Now send a new message (simulating user typing after resume).
         resp2 = await client.post(
-            "/v1/sessions/conv_resume_1/events",
+            "/v1/sessions/b76becb60586615cf61d0894efbbbfe0/events",
             json={
                 "type": "message",
                 "role": "user",
-                "agent_id": "ag_1",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
                 "model": "test-agent",
                 "content": [{"type": "input_text", "text": "Postresume"}],
             },
@@ -6216,7 +6342,10 @@ async def test_compaction_item_in_history_expands_and_discards_prior() -> None:
         # Session has a trailing user message → crash recovery fires.
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_compact_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "f29d4764cd2a1682c103dff3562976eb",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert resp.status_code == 201
         assert resp.json()["status"] == "running"
@@ -6308,7 +6437,10 @@ async def test_error_item_in_history_is_surfaced_as_error_block_not_dropped() ->
         # Trailing user message → crash recovery starts a turn, replaying history.
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_err_1", "agent_id": "ag_1"},
+            json={
+                "session_id": "e65fe670b242ca2ea48eb8930779d5ff",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert resp.status_code == 201
         assert resp.json()["status"] == "running"
@@ -6380,7 +6512,10 @@ async def test_crash_recovery_with_compaction_uses_post_compaction_history() -> 
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_compact_cr", "agent_id": "ag_1"},
+            json={
+                "session_id": "ebfd802a516c4aa95f33f58c894aad31",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert resp.status_code == 201
         # History ends with assistant message (post-compaction) → idle.
@@ -6648,7 +6783,7 @@ async def test_interrupt_forwards_to_harness_before_cancelling() -> None:
     app, _pm, _hc = _build_fwd_blocking_app(gate, fwd_gate)
 
     async with _runner_client(app) as client:
-        conv_id = "conv_fwd_first"
+        conv_id = "d741917a64f51f2d41226b88d53daf58"
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={
@@ -6713,7 +6848,7 @@ async def test_interrupt_inserts_cancellation_items_in_history() -> None:
     app, _pm, _hc = _build_interrupt_app(gate)
 
     async with _runner_client(app) as client:
-        conv_id = "conv_int"
+        conv_id = "85b147537400967b1fb8542367423306"
 
         # Start the turn — it blocks after the first function_call
         # frame, before the second one and response.completed.
@@ -6831,7 +6966,7 @@ async def test_interrupt_cancel_floor_finalizes_stuck_turn() -> None:
     app, _pm, _hc = _build_interrupt_app(gate)
 
     async with _runner_client(app) as client:
-        conv_id = "conv_stuck_int"
+        conv_id = "97d2b96d733e685433e2b3864eb97652"
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={
@@ -6881,7 +7016,7 @@ async def test_stop_session_cancels_inprocess_turn() -> None:
     app, _pm, _hc = _build_interrupt_app(gate)
 
     async with _runner_client(app) as client:
-        conv_id = "conv_stuck_stop"
+        conv_id = "422963919abf3c166633d99ea20f2b8e"
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={
@@ -6957,13 +7092,13 @@ async def test_interrupt_during_setup_phase_recovers_stuck_turn() -> None:
         server_client=NullServerClient(),  # type: ignore[arg-type]
     )
 
-    conv_id = "conv_setup_cancel"
+    conv_id = "9fb432c546c7dbf9f34c6acbc861b05f"
     # agent_id is required for the background turn's setup to invoke the resolver.
     msg = {
         "type": "message",
         "role": "user",
         "model": "test-agent",
-        "agent_id": "ag_1",
+        "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
         "content": [{"type": "input_text", "text": "do something"}],
         "harness": "openai-agents",
     }
@@ -7029,7 +7164,7 @@ async def test_interrupt_marker_instructs_model_to_disregard_abandoned_request()
     app, _pm, _hc = _build_interrupt_app(gate)
 
     async with _runner_client(app) as client:
-        conv_id = "conv_int_disregard"
+        conv_id = "86ba5bc9053ae8771fdb988e882f04b5"
         resp = await client.post(
             f"/v1/sessions/{conv_id}/events",
             json={
@@ -7097,8 +7232,8 @@ async def test_external_session_status_idle_delivers_forwarded_native_output_to_
     from omnigent.runner import app as runner_app
     from omnigent.runner.tool_dispatch import execute_tool
 
-    parent_id = "conv_parent_native_complete"
-    child_id = "conv_child_native_complete"
+    parent_id = "d4cfd8ebd7ef0ae6f6f0c4310d2df7ce"
+    child_id = "66a84f142181a489d004f744cc76c67b"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
@@ -7157,7 +7292,7 @@ async def test_external_session_status_idle_delivers_forwarded_native_output_to_
         runner_app._session_inboxes_ref.pop(parent_id, None)
         runner_app._session_histories_ref.pop(child_id, None)
 
-    assert "sub-agent task conv_child_native_complete completed" in inbox_output
+    assert "sub-agent task 66a84f142181a489d004f744cc76c67b completed" in inbox_output
     assert "worker:native returned: AP_NATIVE_DONE" in inbox_output
     assert "LOCAL_SHOULD_NOT_WIN" not in inbox_output
 
@@ -7175,8 +7310,8 @@ async def test_external_session_status_running_fans_out_child_busy_to_parent() -
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_native_status_fanout"
-    child_id = "conv_child_native_status_fanout"
+    parent_id = "d72e6c2c5866b0f946739fa5a9f964f7"
+    child_id = "8c9f35bc1cb0566b101c59941a576689"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -7251,8 +7386,8 @@ async def test_external_status_sequence_coalesces_duplicates_but_emits_task_stat
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_native_status_sequence"
-    child_id = "conv_child_native_status_sequence"
+    parent_id = "75115d379fc444a3731a92c930150c8e"
+    child_id = "2d88f6c2b566daadfb256052a0ee5abe"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -7350,8 +7485,8 @@ async def test_external_status_idle_fans_out_forwarded_output_preview_to_parent(
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_native_preview_fanout"
-    child_id = "conv_child_native_preview_fanout"
+    parent_id = "83676fab214be9a9ba799712c450e385"
+    child_id = "ffa0293c16d5a9e5e6c362846277c631"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -7424,8 +7559,8 @@ async def test_external_status_idle_without_output_omits_stale_history_preview()
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_native_no_preview"
-    child_id = "conv_child_native_no_preview"
+    parent_id = "1dc34bd0fea39227de4779abc14c4b74"
+    child_id = "f7423fb08cf726ea957c2f907d85edbd"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     server_client = _WakeRecordingServerClient(parent_id)
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
@@ -7513,7 +7648,7 @@ class _WakeRecordingServerClient(NullServerClient):
     def __init__(self, parent_id: str) -> None:
         """
         :param parent_id: Parent session whose ``/events`` POSTs to capture,
-            e.g. ``"conv_parent_wake"``.
+            e.g. ``"bf881b8f7e32add48bfcd6afc476452a"``.
         """
         self._parent_events_path = f"/v1/sessions/{parent_id}/events"
         self.wake_posts: list[dict[str, Any]] = []
@@ -7522,7 +7657,7 @@ class _WakeRecordingServerClient(NullServerClient):
     async def post(self, url: str, **kwargs: Any) -> NullServerClient._Response:
         """Capture a wake POST to the watched parent, else defer to the base.
 
-        :param url: Request URL, e.g. ``"/v1/sessions/conv_parent_wake/events"``.
+        :param url: Request URL, e.g. ``"/v1/sessions/bf881b8f7e32add48bfcd6afc476452a/events"``.
         :param kwargs: Request kwargs; the wake notice is in ``json``.
         :returns: Stub 200 response from :class:`NullServerClient`.
         """
@@ -7549,8 +7684,8 @@ async def test_native_subagent_completion_wakes_idle_parent() -> None:
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_wake"
-    child_id = "conv_child_wake"
+    parent_id = "bf881b8f7e32add48bfcd6afc476452a"
+    child_id = "7ec2f4cd958a2c2a8c02bd3c03cbacc6"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     server_client = _WakeRecordingServerClient(parent_id)
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
@@ -7614,7 +7749,7 @@ async def test_external_status_for_untracked_session_does_not_wake() -> None:
     wake is scheduled. A regression that dropped the ``entry is not None`` guard
     would either 500 (None.delivered) or post a spurious wake — both caught here.
     """
-    orphan_id = "conv_not_a_subagent"
+    orphan_id = "28e85f4c5fb460c5185e374605bc4364"
     server_client = _WakeRecordingServerClient(orphan_id)
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
@@ -7654,8 +7789,8 @@ async def test_tracked_subagent_status_without_parent_inbox_returns_503() -> Non
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_missing_inbox"
-    child_id = "conv_child_missing_inbox"
+    parent_id = "41bd085f8d34ad9201cd59c372312a1a"
+    child_id = "6d17e94dcad6a73de34441f490d140b4"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -7702,8 +7837,8 @@ def test_subagent_terminal_delivery_retry_uses_latest_undelivered_report() -> No
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_retry_missing_inbox"
-    child_id = "conv_child_retry_missing_inbox"
+    parent_id = "05f117c03074f5d4b0ebe450f79b0684"
+    child_id = "01a9880c1386637a7d0a154ecb2c4a72"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     runner_app.register_subagent_work(
         parent_session_id=parent_id,
@@ -7754,8 +7889,8 @@ def test_subagent_terminal_delivery_handles_missing_output() -> None:
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_missing_output"
-    child_id = "conv_child_missing_output"
+    parent_id = "9c98fbe12742d712819dd26553a7a9ee"
+    child_id = "c2a7357e26dc400e4aa6e5c25c611853"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     runner_app._session_inboxes_ref[parent_id] = session_inbox
     runner_app.register_subagent_work(
@@ -7792,7 +7927,7 @@ async def test_known_subagent_status_without_work_entry_returns_503() -> None:
     metadata. Returning 503 forces the AP/forwarder path to preserve the
     failed delivery instead of reporting success.
     """
-    child_id = "conv_child_missing_work_entry"
+    child_id = "38c56dfa64cb80c126c49429f7e482cd"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -7804,7 +7939,7 @@ async def test_known_subagent_status_without_work_entry_returns_503() -> None:
             "/v1/sessions",
             json={
                 "session_id": child_id,
-                "agent_id": "ag_missing_work_entry",
+                "agent_id": "6eadea15d6e06f43d026b25b656a73ec",
                 "sub_agent_name": "worker",
             },
         )
@@ -7836,8 +7971,8 @@ async def test_repeated_idle_status_wakes_parent_only_once() -> None:
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_wake_once"
-    child_id = "conv_child_wake_once"
+    parent_id = "f42f428f0217c078c09803aea44cd57b"
+    child_id = "e63625ecd31e483b65e5333e6195cc13"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     server_client = _WakeRecordingServerClient(parent_id)
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
@@ -7896,9 +8031,9 @@ async def test_delete_session_clears_pending_subagent_wake() -> None:
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_delete_clears_wake"
-    first_child_id = "conv_child_before_delete"
-    second_child_id = "conv_child_after_delete"
+    parent_id = "514616cf803ec0ca696db4cdf75be6f6"
+    first_child_id = "7cb2d00b228b559198a369204d1e1ffd"
+    second_child_id = "06e5e6cd8edde087a16afcd0aa6a37f8"
     first_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     second_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     server_client = _WakeRecordingServerClient(parent_id)
@@ -7912,7 +8047,7 @@ async def test_delete_session_clears_pending_subagent_wake() -> None:
         async with _runner_client(app) as client:
             create_resp = await client.post(
                 "/v1/sessions",
-                json={"session_id": parent_id, "agent_id": "ag_parent_delete_wake"},
+                json={"session_id": parent_id, "agent_id": "727cdb9ef83160bc29658b70782734ac"},
             )
             assert create_resp.status_code == 201, create_resp.text
 
@@ -7983,9 +8118,9 @@ async def test_subagent_completion_during_parent_wake_turn_posts_followup_wake()
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_wake_turn_race"
-    first_child_id = "conv_child_initial_wake"
-    second_child_id = "conv_child_followup_wake"
+    parent_id = "44026e683bcf8dd047e509d974196bf9"
+    first_child_id = "1a9cf84a190d53d5e9b6ec4e9c534f31"
+    second_child_id = "e3099fa95ced5bb8786b79a131429c78"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     server_client = _WakeRecordingServerClient(parent_id)
     gate = asyncio.Event()
@@ -8029,7 +8164,7 @@ async def test_subagent_completion_during_parent_wake_turn_posts_followup_wake()
                 json={
                     "type": "message",
                     "role": "user",
-                    "agent_id": "ag_parent_wake_turn",
+                    "agent_id": "3006a2a399391aa72a65a507ff92dae3",
                     "model": "test-agent",
                     "harness": "openai-agents",
                     "content": [{"type": "input_text", "text": "wake notice"}],
@@ -8094,10 +8229,10 @@ async def test_parent_idle_with_stuck_wake_flag_posts_recovery_wake() -> None:
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_rewake_after_consume"
-    child_a = "conv_child_round1_a"
-    child_b = "conv_child_round1_b"
-    child_c = "conv_child_round2_c"
+    parent_id = "22b91e208e5501fb8d2b502837391f04"
+    child_a = "27cb54833afaf691aacb1bb7ec7ce66b"
+    child_b = "06bc724cd3a9b5ee75c95a057a561cfb"
+    child_c = "8cc1d911d72dee40ec6956d369f0b55a"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     server_client = _WakeRecordingServerClient(parent_id)
     gate = asyncio.Event()
@@ -8148,7 +8283,7 @@ async def test_parent_idle_with_stuck_wake_flag_posts_recovery_wake() -> None:
                 json={
                     "type": "message",
                     "role": "user",
-                    "agent_id": "ag_parent_rewake",
+                    "agent_id": "7c04e18ef7e3a769f7eecca21b049374",
                     "model": "test-agent",
                     "harness": "openai-agents",
                     "content": [{"type": "input_text", "text": "wake notice"}],
@@ -8309,10 +8444,10 @@ async def test_parent_idle_with_stuck_wake_flag_and_drained_inbox_clears_flag() 
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_rewake_drained_inbox"
-    child_a = "conv_child_drained_a"
-    child_b = "conv_child_drained_b"
-    child_c = "conv_child_drained_c"
+    parent_id = "8f0e87b24df3f773e7f8de693347dad9"
+    child_a = "95dae25caa3d012baa1a1309cde1674b"
+    child_b = "f92aa6bcffbfc5ed559a93d8c9404572"
+    child_c = "41967d48eb327dd8f2f6e4442977c813"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     server_client = _WakeRecordingServerClient(parent_id)
     gate = asyncio.Event()
@@ -8363,7 +8498,7 @@ async def test_parent_idle_with_stuck_wake_flag_and_drained_inbox_clears_flag() 
                 json={
                     "type": "message",
                     "role": "user",
-                    "agent_id": "ag_parent_drained",
+                    "agent_id": "d99814e82ffc3ad874ca24f44a86ffc7",
                     "model": "test-agent",
                     "harness": "openai-agents",
                     "content": [{"type": "input_text", "text": "wake notice"}],
@@ -8518,8 +8653,8 @@ async def test_replayed_idle_status_after_inbox_drain_is_acknowledged() -> None:
     from omnigent.runner import app as runner_app
     from omnigent.runner.tool_dispatch import execute_tool
 
-    parent_id = "conv_parent_drain_replay"
-    child_id = "conv_child_drain_replay"
+    parent_id = "fde99284fcd969bcadb10a80290e6dc5"
+    child_id = "6ce8004b6fc222e4a2794d177dc55042"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     server_client = _WakeRecordingServerClient(parent_id)
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
@@ -8560,7 +8695,7 @@ async def test_replayed_idle_status_after_inbox_drain_is_acknowledged() -> None:
                 "/v1/sessions",
                 json={
                     "session_id": child_id,
-                    "agent_id": "ag_drain_replay",
+                    "agent_id": "c14cab5182af3847da17636fdc7644e0",
                     "sub_agent_name": "worker",
                 },
             )
@@ -8605,8 +8740,12 @@ async def test_concurrent_subagent_completions_coalesce_into_one_wake() -> None:
     """
     from omnigent.runner import app as runner_app
 
-    parent_id = "conv_parent_fanout"
-    child_ids = ["conv_child_fan_a", "conv_child_fan_b", "conv_child_fan_c"]
+    parent_id = "0c51258a4c62e5c390402b8473ae8271"
+    child_ids = [
+        "cef7ed6e3019655ad11ad769184a43a7",
+        "62e17066cdf6a5a732c054faefb7ef39",
+        "a0c5b28f0854df92006a4ff0c857ac3a",
+    ]
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     server_client = _WakeRecordingServerClient(parent_id)
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
@@ -8727,7 +8866,10 @@ async def test_events_interrupt_on_native_session_injects_escape_without_marker(
         # interrupt dispatch can detect "claude-native".
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_int", "agent_id": "ag_1"},
+            json={
+                "session_id": "664449321754215750a1d43e89fca21e",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -8738,7 +8880,7 @@ async def test_events_interrupt_on_native_session_injects_escape_without_marker(
         # both ``_session_histories`` and ``_session_event_queues`` from
         # the test without any subscribe / sleep dance.
         int_resp = await client.post(
-            "/v1/sessions/conv_native_int/events",
+            "/v1/sessions/664449321754215750a1d43e89fca21e/events",
             json={"type": "interrupt"},
         )
 
@@ -8746,11 +8888,11 @@ async def test_events_interrupt_on_native_session_injects_escape_without_marker(
         # DELETE clears ``_session_histories`` and pops the queue from
         # ``_session_event_queues``, so reading after delete would
         # always see empty.
-        captured_history = list(_session_histories_ref.get("conv_native_int", []))
-        queue = _session_event_queues_ref.get("conv_native_int")
+        captured_history = list(_session_histories_ref.get("664449321754215750a1d43e89fca21e", []))
+        queue = _session_event_queues_ref.get("664449321754215750a1d43e89fca21e")
         assert queue is not None, (
             "Session creation should have initialized the event queue "
-            "for ``conv_native_int``; ``_session_event_queues_ref`` is "
+            "for ``664449321754215750a1d43e89fca21e``; ``_session_event_queues_ref`` is "
             "missing the entry, so we couldn't drain it to verify the "
             "interrupt handler did not enqueue a synthesized idle."
         )
@@ -8774,7 +8916,7 @@ async def test_events_interrupt_on_native_session_injects_escape_without_marker(
         f"canonical name."
     )
     bridge_dir, timeout_s = captured_inject[0]
-    assert bridge_dir == bridge_dir_for_conversation_id("conv_native_int")
+    assert bridge_dir == bridge_dir_for_conversation_id("664449321754215750a1d43e89fca21e")
     # 1.0s short timeout: UI stop must feel snappy. If this becomes
     # the helper's 30s default, the user's click would hang on any
     # missing tmux.json.
@@ -8867,7 +9009,7 @@ async def test_message_turn_lifecycle_status_suppressed_for_terminal_backed_harn
     """
     from omnigent.runner.app import _session_event_queues_ref
 
-    session_id = f"conv_ts_{harness.replace('-', '_')}"
+    session_id = uuid.uuid4().hex
     spec = AgentSpec(
         spec_version=1,
         name="t",
@@ -8890,7 +9032,7 @@ async def test_message_turn_lifecycle_status_suppressed_for_terminal_backed_harn
         # resolve the harness and decide whether to suppress turn status.
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": session_id, "agent_id": "ag_1"},
+            json={"session_id": session_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
         # Native session creation may try to auto-create a terminal. This
@@ -8913,7 +9055,7 @@ async def test_message_turn_lifecycle_status_suppressed_for_terminal_backed_harn
                 "type": "message",
                 "role": "user",
                 "content": [{"type": "input_text", "text": "test"}],
-                "agent_id": "ag_1",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
             },
         )
         assert msg_resp.status_code in (200, 202), msg_resp.text
@@ -9002,17 +9144,20 @@ async def test_events_interrupt_on_native_session_503_skips_cleanup_when_inject_
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_int_fail", "agent_id": "ag_1"},
+            json={
+                "session_id": "57ac398df7e3972b95ddba8d6109f396",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         int_resp = await client.post(
-            "/v1/sessions/conv_native_int_fail/events",
+            "/v1/sessions/57ac398df7e3972b95ddba8d6109f396/events",
             json={"type": "interrupt"},
         )
 
-        captured_history = list(_session_histories_ref.get("conv_native_int_fail", []))
-        queue = _session_event_queues_ref.get("conv_native_int_fail")
+        captured_history = list(_session_histories_ref.get("57ac398df7e3972b95ddba8d6109f396", []))
+        queue = _session_event_queues_ref.get("57ac398df7e3972b95ddba8d6109f396")
         assert queue is not None, (
             "Session creation should have initialized the event queue; "
             "the failure path still needs the queue to exist so we can "
@@ -9191,7 +9336,7 @@ async def test_events_codex_native_settings_change_uses_thread_settings_update(
     from omnigent import codex_native_app_server
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = "conv_codex_native_settings"
+    conv_id = "524fe55f9d5a7f66fec5c5401a930b84"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     bridge_dir = codex_native_bridge.bridge_dir_for_bridge_id(conv_id)
     codex_native_bridge.write_bridge_state(
@@ -9258,7 +9403,7 @@ async def test_events_codex_native_settings_change_uses_thread_settings_update(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -9362,7 +9507,7 @@ async def test_codex_native_model_options_returns_503_until_bridge_state_exists(
     """
     from omnigent import codex_native_app_server
 
-    conv_id = "conv_codex_native_model_options_not_ready"
+    conv_id = "d2f0a2d856bc03c1674d3d634b4f250c"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
 
     def _client_for_transport(
@@ -9410,7 +9555,7 @@ async def test_codex_native_model_options_returns_503_until_bridge_state_exists(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -9441,7 +9586,7 @@ async def test_codex_native_model_options_query_model_list(
     from omnigent import codex_native_app_server
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = "conv_codex_native_model_options"
+    conv_id = "68ba0a62ebe928d26adf37c8974ce1eb"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     bridge_dir = codex_native_bridge.bridge_dir_for_bridge_id(conv_id)
     codex_native_bridge.write_bridge_state(
@@ -9541,7 +9686,7 @@ async def test_codex_native_model_options_query_model_list(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -9594,7 +9739,7 @@ async def test_events_codex_native_plan_mode_requires_loaded_bridge(
     persist a false Plan indicator even though Codex app-server never received
     ``thread/settings/update``.
     """
-    conv_id = "conv_codex_native_plan_no_bridge"
+    conv_id = "290b63ecec11a7ae5b93da19be2d9195"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
 
     codex_native_spec = AgentSpec(
@@ -9610,8 +9755,8 @@ async def test_events_codex_native_plan_mode_requires_loaded_bridge(
         """
         Return the codex-native spec for any agent id.
 
-        :param agent_id: Agent identifier, e.g. ``"ag_1"``.
-        :param session_id: Session identifier, e.g. ``"conv_abc123"``.
+        :param agent_id: Agent identifier, e.g. ``"880b5afda28ad55ff74cbeb9b5fc67fb"``.
+        :param session_id: Session identifier, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
         :returns: Codex-native agent spec.
         """
         del agent_id, session_id
@@ -9627,7 +9772,7 @@ async def test_events_codex_native_plan_mode_requires_loaded_bridge(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -9666,7 +9811,7 @@ async def test_events_interrupt_on_codex_native_uses_turn_interrupt_without_mark
     from omnigent.runner.app import _session_histories_ref
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = "conv_codex_native_int"
+    conv_id = "83d1472d16e3e635c84ca44f29624fca"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     bridge_dir = codex_native_bridge.bridge_dir_for_bridge_id(conv_id)
     codex_native_bridge.write_bridge_state(
@@ -9732,7 +9877,7 @@ async def test_events_interrupt_on_codex_native_uses_turn_interrupt_without_mark
         # Seeds _session_spec_cache so the dispatch detects "codex-native".
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -9814,7 +9959,7 @@ async def test_events_stop_session_on_codex_native_uses_turn_interrupt_without_m
     from omnigent.runner.app import _session_histories_ref
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = "conv_codex_native_stop"
+    conv_id = "fa87fda193a47e99e6a2599e44032807"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     bridge_dir = codex_native_bridge.bridge_dir_for_bridge_id(conv_id)
     codex_native_bridge.write_bridge_state(
@@ -9879,7 +10024,7 @@ async def test_events_stop_session_on_codex_native_uses_turn_interrupt_without_m
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -9960,7 +10105,7 @@ async def test_events_stop_on_codex_native_cancels_mcp_startup_without_active_tu
     from omnigent import codex_native_app_server
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = f"conv_codex_native_mcp_{event_type}"
+    conv_id = f"36ea25fd09df4a2d85136100fbecd3e9{event_type}"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     # Abort the session-create auto-terminal path before it reaches
     # ``clear_bridge_state`` — otherwise the seeded bridge state below is
@@ -10038,7 +10183,7 @@ async def test_events_stop_on_codex_native_cancels_mcp_startup_without_active_tu
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -10096,7 +10241,7 @@ async def test_events_interrupt_on_codex_native_with_turn_and_mcp_stops_both(
     from omnigent import codex_native_app_server
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = "conv_codex_native_dual_stop"
+    conv_id = "14fb6a0dde97fc0f7a58a84e1be2c538"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     # Keep the seeded bridge state alive through session create (see the
     # sister startup-cancel test for why auto-create must abort early).
@@ -10172,7 +10317,7 @@ async def test_events_interrupt_on_codex_native_with_turn_and_mcp_stops_both(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -10211,7 +10356,7 @@ async def test_events_interrupt_on_codex_native_without_turn_or_mcp_is_noop(
     from omnigent import codex_native_app_server
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = "conv_codex_native_idle_stop"
+    conv_id = "5cb0fd92163581dee07e5462a93d5021"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     # Keep the seeded bridge state alive through session create (see the
     # sister startup-cancel test for why auto-create must abort early).
@@ -10274,7 +10419,7 @@ async def test_events_interrupt_on_codex_native_without_turn_or_mcp_is_noop(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -10317,7 +10462,7 @@ async def test_events_interrupt_and_stop_on_pi_native_enqueue_bridge_interrupt(
     from omnigent.runner.app import _session_histories_ref
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = f"conv_pi_native_{event_type}"
+    conv_id = uuid.uuid4().hex
     monkeypatch.setattr(pi_native_bridge, "_BRIDGE_ROOT", tmp_path / "pi-bridge")
 
     pi_native_spec = AgentSpec(
@@ -10343,7 +10488,7 @@ async def test_events_interrupt_and_stop_on_pi_native_enqueue_bridge_interrupt(
         # Seeds _session_spec_cache so the dispatch detects "pi-native".
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -10490,8 +10635,8 @@ def test_interrupted_sessions_isolated_per_app_instance() -> None:
         "the same object, the set is module-global again and flags leak across apps."
     )
 
-    app1.state.interrupted_sessions.add("conv_x")
-    assert "conv_x" not in app2.state.interrupted_sessions, (
+    app1.state.interrupted_sessions.add("8af356d908005a65f872c246158c6293")
+    assert "8af356d908005a65f872c246158c6293" not in app2.state.interrupted_sessions, (
         "app2 must not observe app1's interrupt flag. If it does, "
         "_interrupted_sessions is shared process-global state and a stale flag "
         "would fire a bogus [System: interrupted] marker on app2's next turn."
@@ -10553,20 +10698,23 @@ async def test_events_stop_session_on_native_kills_tmux_and_publishes_idle(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_stop", "agent_id": "ag_1"},
+            json={
+                "session_id": "1fb90dd3b9d3f24e2356ace505314db1",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         stop_resp = await client.post(
-            "/v1/sessions/conv_native_stop/events",
+            "/v1/sessions/1fb90dd3b9d3f24e2356ace505314db1/events",
             json={"type": "stop_session"},
         )
 
-        captured_history = list(_session_histories_ref.get("conv_native_stop", []))
-        queue = _session_event_queues_ref.get("conv_native_stop")
+        captured_history = list(_session_histories_ref.get("1fb90dd3b9d3f24e2356ace505314db1", []))
+        queue = _session_event_queues_ref.get("1fb90dd3b9d3f24e2356ace505314db1")
         assert queue is not None, (
             "Session creation should have initialized the event queue "
-            "for ``conv_native_stop``; without it ``_publish_event`` had "
+            "for ``1fb90dd3b9d3f24e2356ace505314db1``; without it ``_publish_event`` had "
             "nowhere to land its idle event."
         )
         queued_events: list[dict[str, Any]] = []
@@ -10590,7 +10738,7 @@ async def test_events_stop_session_on_native_kills_tmux_and_publishes_idle(
         f"wrong canonical name."
     )
     bridge_dir, timeout_s = captured_kill[0]
-    assert bridge_dir == bridge_dir_for_conversation_id("conv_native_stop")
+    assert bridge_dir == bridge_dir_for_conversation_id("1fb90dd3b9d3f24e2356ace505314db1")
     # 1.0s short timeout: the UI stop must feel snappy. The helper's
     # 30s default would hang the user's click on a missing tmux.json.
     assert timeout_s == 1.0
@@ -10639,8 +10787,8 @@ async def test_stop_session_on_native_subagent_reclaims_work_entry(
     from omnigent.runner import app as runner_app
     from omnigent.spec.types import ExecutorSpec
 
-    parent_id = "conv_parent_stop_reclaim"
-    worker_id = "conv_worker_stop_reclaim"
+    parent_id = "c4315225d4a12d320df065ed1ac8baad"
+    worker_id = "8dcfd4c64c7a29cddaefa4af686da1da"
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
 
     monkeypatch.setattr(claude_native_bridge, "kill_session", lambda *a, **k: None)
@@ -10674,7 +10822,7 @@ async def test_stop_session_on_native_subagent_reclaims_work_entry(
         async with _runner_client(app) as client:
             create_resp = await client.post(
                 "/v1/sessions",
-                json={"session_id": worker_id, "agent_id": "ag_1"},
+                json={"session_id": worker_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
             )
             assert create_resp.status_code == 201, create_resp.text
             stop_resp = await client.post(
@@ -10713,8 +10861,8 @@ async def test_stop_session_on_native_subagent_without_parent_inbox_returns_204(
     from omnigent.runner import app as runner_app
     from omnigent.spec.types import ExecutorSpec
 
-    parent_id = "conv_parent_stop_missing_inbox"
-    worker_id = "conv_worker_stop_missing_inbox"
+    parent_id = "a87dd01585f0c6f0f82f73d74e4124c0"
+    worker_id = "d2af8cd6293253c5937d8c7d35fb3d6b"
 
     monkeypatch.setattr(claude_native_bridge, "kill_session", lambda *a, **k: None)
 
@@ -10752,7 +10900,7 @@ async def test_stop_session_on_native_subagent_without_parent_inbox_returns_204(
         async with _runner_client(app) as client:
             create_resp = await client.post(
                 "/v1/sessions",
-                json={"session_id": worker_id, "agent_id": "ag_1"},
+                json={"session_id": worker_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
             )
             assert create_resp.status_code == 201, create_resp.text
             stop_resp = await client.post(
@@ -10816,16 +10964,19 @@ async def test_events_stop_session_on_native_returns_503_when_kill_fails(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_stop_fail", "agent_id": "ag_1"},
+            json={
+                "session_id": "baabd23def56efdbe0b84b9c924aa6a6",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         stop_resp = await client.post(
-            "/v1/sessions/conv_native_stop_fail/events",
+            "/v1/sessions/baabd23def56efdbe0b84b9c924aa6a6/events",
             json={"type": "stop_session"},
         )
 
-        queue = _session_event_queues_ref.get("conv_native_stop_fail")
+        queue = _session_event_queues_ref.get("baabd23def56efdbe0b84b9c924aa6a6")
         assert queue is not None
         queued_events: list[dict[str, Any]] = []
         while not queue.empty():
@@ -10899,12 +11050,15 @@ async def test_events_stop_session_on_non_native_session_is_204_noop(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_default_stop", "agent_id": "ag_1"},
+            json={
+                "session_id": "aec413c7f4d6fc308bcaa55ad32c3b98",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_default_stop/events",
+            "/v1/sessions/aec413c7f4d6fc308bcaa55ad32c3b98/events",
             json={"type": "stop_session"},
         )
 
@@ -10945,7 +11099,7 @@ async def test_events_stop_session_closes_terminal_and_publishes_deleted(
     # ``claude:main`` terminal, mirroring what the host-spawned
     # auto-create path leaves behind. Private-attr seed matches the
     # existing resource-registry test convention (no real tmux).
-    conv_id = "conv_native_stop_term"
+    conv_id = "778e0486ee2f733acdf021ca8334d0bd"
     terminal_registry = TerminalRegistry(
         conversation_link_base_url="http://127.0.0.1:8000",
     )
@@ -10974,7 +11128,7 @@ async def test_events_stop_session_closes_terminal_and_publishes_deleted(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
         # Precondition: the terminal is live before the stop, so a later
@@ -11033,8 +11187,8 @@ async def test_required_terminal_exit_publishes_deleted_and_failed(tmp_path: Pat
     from omnigent.runner.app import _session_event_queues_ref
     from tests.runner.helpers import make_test_terminal_instance
 
-    parent_id = f"conv_parent_required_exit_{uuid.uuid4().hex[:12]}"
-    conv_id = f"conv_required_exit_{uuid.uuid4().hex[:12]}"
+    parent_id = uuid.uuid4().hex
+    conv_id = uuid.uuid4().hex
     parent_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     terminal_registry = TerminalRegistry()
     instance = make_test_terminal_instance("worker", "main", tmp_path)
@@ -11176,8 +11330,8 @@ async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path:
     from omnigent.runner.app import _session_event_queues_ref
     from tests.runner.helpers import make_test_terminal_instance
 
-    parent_id = f"conv_parent_idle_exit_{uuid.uuid4().hex[:12]}"
-    conv_id = f"conv_idle_exit_{uuid.uuid4().hex[:12]}"
+    parent_id = uuid.uuid4().hex
+    conv_id = uuid.uuid4().hex
     parent_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     terminal_registry = TerminalRegistry()
     instance = make_test_terminal_instance("worker", "main", tmp_path)
@@ -11301,7 +11455,7 @@ async def test_required_terminal_clean_quit_publishes_idle_not_failed(
         TerminalLifecycle,
     )
 
-    conv_id = f"conv_clean_quit_{terminal_name}_{uuid.uuid4().hex[:12]}"
+    conv_id = uuid.uuid4().hex
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     pm._sessions.add(conv_id)
     app = create_runner_app(
@@ -11373,7 +11527,7 @@ async def test_external_idle_status_makes_required_terminal_exit_clean(tmp_path:
     from omnigent.runner.app import _session_event_queues_ref
     from tests.runner.helpers import make_test_terminal_instance
 
-    conv_id = f"conv_kiro_external_idle_exit_{uuid.uuid4().hex[:12]}"
+    conv_id = uuid.uuid4().hex
     terminal_registry = TerminalRegistry()
     instance = make_test_terminal_instance("kiro", "main", tmp_path)
     terminal_registry._by_conversation.setdefault(conv_id, {})[("kiro", "main")] = instance
@@ -11510,23 +11664,28 @@ async def test_events_effort_change_on_native_session_types_slash_command(
         # Seed _session_spec_cache so /events can detect "claude-native".
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_effort", "agent_id": "ag_1"},
+            json={
+                "session_id": "c7e9584b9bb34910a0068521106c1abc",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
         # Drain creation-time events (the claude-native auto-create path
         # enqueues session.terminal_pending) so the post-effort_change
         # drain below isolates only what the control event emits.
-        _drain_session_event_queue(_session_event_queues_ref.get("conv_native_effort"))
+        _drain_session_event_queue(
+            _session_event_queues_ref.get("c7e9584b9bb34910a0068521106c1abc")
+        )
 
         resp = await client.post(
-            "/v1/sessions/conv_native_effort/events",
+            "/v1/sessions/c7e9584b9bb34910a0068521106c1abc/events",
             json={"type": "effort_change", "effort": "high"},
         )
 
         # Drain the event queue before delete clears it, so we can
         # assert that effort_change does NOT enqueue spurious events
         # (it's a control signal, not a session-state change).
-        queue = _session_event_queues_ref.get("conv_native_effort")
+        queue = _session_event_queues_ref.get("c7e9584b9bb34910a0068521106c1abc")
         queued_events: list[dict[str, Any]] = []
         if queue is not None:
             while not queue.empty():
@@ -11547,7 +11706,7 @@ async def test_events_effort_change_on_native_session_types_slash_command(
         f"Expected one inject_slash_command call from native effort_change, got {len(captured)}."
     )
     bridge_dir, command, timeout_s = captured[0]
-    assert bridge_dir == bridge_dir_for_conversation_id("conv_native_effort")
+    assert bridge_dir == bridge_dir_for_conversation_id("c7e9584b9bb34910a0068521106c1abc")
     # Body contract: ``/effort high`` is the literal Claude Code's TUI
     # accepts. A regression in shape (``/efforthigh``, ``effort high``,
     # missing leading slash) would either 404 on the slash router or
@@ -11632,12 +11791,15 @@ async def test_events_effort_change_on_native_session_skips_inject_for_unsupport
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_effort_skip", "agent_id": "ag_1"},
+            json={
+                "session_id": "1c88519bd9daa4e9bc2df649fe4685fc",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_native_effort_skip/events",
+            "/v1/sessions/1c88519bd9daa4e9bc2df649fe4685fc/events",
             json={"type": "effort_change", "effort": effort_value},
         )
 
@@ -11701,12 +11863,15 @@ async def test_events_effort_change_on_native_session_returns_503_when_bridge_no
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_effort_fail", "agent_id": "ag_1"},
+            json={
+                "session_id": "876bea5691e426b42ecc3cc2c02cbf92",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_native_effort_fail/events",
+            "/v1/sessions/876bea5691e426b42ecc3cc2c02cbf92/events",
             json={"type": "effort_change", "effort": "high"},
         )
 
@@ -11777,12 +11942,15 @@ async def test_events_effort_change_on_non_native_session_is_204_noop(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_default_effort", "agent_id": "ag_1"},
+            json={
+                "session_id": "df1b63ea1861c5d7765dd4541f60d99a",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_default_effort/events",
+            "/v1/sessions/df1b63ea1861c5d7765dd4541f60d99a/events",
             json={"type": "effort_change", "effort": "high"},
         )
 
@@ -11854,22 +12022,27 @@ async def test_events_compact_on_native_session_types_slash_command(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_compact", "agent_id": "ag_1"},
+            json={
+                "session_id": "f70a14aaa23f51a5c4d915b9a29b0cd3",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
         # Drain creation-time events (claude-native auto-create enqueues
         # session.terminal_pending) so the drain below isolates only
         # what /compact emits.
-        _drain_session_event_queue(_session_event_queues_ref.get("conv_native_compact"))
+        _drain_session_event_queue(
+            _session_event_queues_ref.get("f70a14aaa23f51a5c4d915b9a29b0cd3")
+        )
 
         resp = await client.post(
-            "/v1/sessions/conv_native_compact/events",
+            "/v1/sessions/f70a14aaa23f51a5c4d915b9a29b0cd3/events",
             json={"type": "compact"},
         )
 
         # Drain the event queue: /compact is a control signal and must
         # not enqueue session.status events.
-        queue = _session_event_queues_ref.get("conv_native_compact")
+        queue = _session_event_queues_ref.get("f70a14aaa23f51a5c4d915b9a29b0cd3")
         queued_events: list[dict[str, Any]] = []
         if queue is not None:
             while not queue.empty():
@@ -11890,7 +12063,7 @@ async def test_events_compact_on_native_session_types_slash_command(
         f"Expected one inject_slash_command call from native compact, got {len(captured)}."
     )
     bridge_dir, command, timeout_s, auto_confirm = captured[0]
-    assert bridge_dir == bridge_dir_for_conversation_id("conv_native_compact")
+    assert bridge_dir == bridge_dir_for_conversation_id("f70a14aaa23f51a5c4d915b9a29b0cd3")
     # Body contract: the literal ``/compact`` is what Claude Code's TUI
     # accepts. A shape regression (``compact``, missing slash) would
     # land as plain prompt text instead of running compaction.
@@ -11957,12 +12130,15 @@ async def test_events_compact_on_native_session_returns_503_when_bridge_not_read
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_compact_fail", "agent_id": "ag_1"},
+            json={
+                "session_id": "22126529b89836ff13480ca578a6dcf5",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_native_compact_fail/events",
+            "/v1/sessions/22126529b89836ff13480ca578a6dcf5/events",
             json={"type": "compact"},
         )
 
@@ -12013,7 +12189,7 @@ async def test_events_compact_on_codex_native_injects_slash_command(
         del agent_id, session_id
         return codex_native_spec
 
-    conv_id = "conv_codex_compact"
+    conv_id = "9864122f95f2f013c9599f4014725784"
     terminal_registry = TerminalRegistry()
     instance = make_test_terminal_instance("codex", "main", tmp_path)
     terminal_registry._by_conversation.setdefault(conv_id, {})[("codex", "main")] = instance
@@ -12029,7 +12205,7 @@ async def test_events_compact_on_codex_native_injects_slash_command(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
         _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
@@ -12096,7 +12272,7 @@ async def test_events_compact_on_codex_native_returns_204_when_no_terminal() -> 
         del agent_id, session_id
         return codex_native_spec
 
-    conv_id = "conv_codex_compact_no_term"
+    conv_id = "4be2f8fe2204fade6a89dafade0a0fd2"
     # Empty registry — no codex terminal registered.
     terminal_registry = TerminalRegistry()
 
@@ -12111,7 +12287,7 @@ async def test_events_compact_on_codex_native_returns_204_when_no_terminal() -> 
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -12158,7 +12334,7 @@ async def test_events_compact_on_codex_native_returns_503_on_tmux_failure(
         del agent_id, session_id
         return codex_native_spec
 
-    conv_id = "conv_codex_compact_fail"
+    conv_id = "e5d09a0ff8458b2d6abb7f0c7deda0d3"
     terminal_registry = TerminalRegistry()
     instance = make_test_terminal_instance("codex", "main", tmp_path)
     terminal_registry._by_conversation.setdefault(conv_id, {})[("codex", "main")] = instance
@@ -12174,7 +12350,7 @@ async def test_events_compact_on_codex_native_returns_503_on_tmux_failure(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -12251,7 +12427,7 @@ async def test_events_compact_on_cursor_native_pastes_summarize_and_raises_spinn
         del agent_id, session_id
         return cursor_native_spec
 
-    conv_id = "conv_cursor_compact"
+    conv_id = "764ebbade28dd774a5d673378c034933"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -12262,7 +12438,7 @@ async def test_events_compact_on_cursor_native_pastes_summarize_and_raises_spinn
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
         # Drain creation-time events so the drain below isolates only what
@@ -12370,7 +12546,7 @@ async def test_events_compact_on_cursor_native_503_dismisses_spinner_on_inject_f
         del agent_id, session_id
         return cursor_native_spec
 
-    conv_id = f"conv_cursor_compact_fail_{label}"
+    conv_id = uuid.uuid4().hex
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -12381,7 +12557,7 @@ async def test_events_compact_on_cursor_native_503_dismisses_spinner_on_inject_f
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
         _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
@@ -12445,7 +12621,7 @@ async def test_events_compact_on_pi_native_enqueues_compact_payload(
     from omnigent.runner.app import _session_event_queues_ref
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = "conv_pi_native_compact"
+    conv_id = "03f435963d78fe4ea313325f729eefc5"
     monkeypatch.setattr(pi_native_bridge, "_BRIDGE_ROOT", tmp_path / "pi-bridge")
 
     pi_native_spec = AgentSpec(
@@ -12470,7 +12646,7 @@ async def test_events_compact_on_pi_native_enqueues_compact_payload(
         # Seeds _session_spec_cache so the dispatch detects "pi-native".
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
         # Drain creation-time events (pi-native auto-create enqueues
@@ -12531,7 +12707,7 @@ async def test_events_compact_on_pi_native_returns_503_when_inbox_unwritable(
     import omnigent.pi_native_bridge as pi_native_bridge
     from omnigent.spec.types import ExecutorSpec
 
-    conv_id = "conv_pi_native_compact_fail"
+    conv_id = "9c52b3dbe1d543718c1678a256017326"
     monkeypatch.setattr(pi_native_bridge, "_BRIDGE_ROOT", tmp_path / "pi-bridge")
 
     def _boom(*_args: Any, **_kwargs: Any) -> str:
@@ -12561,7 +12737,7 @@ async def test_events_compact_on_pi_native_returns_503_when_inbox_unwritable(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -12618,7 +12794,7 @@ async def test_events_compact_on_qwen_native_submits_compress_and_raises_spinner
         del agent_id, session_id
         return qwen_native_spec
 
-    conv_id = "conv_qwen_compact"
+    conv_id = "233c1fedaaeb18c91267904e79b7d10c"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -12629,7 +12805,7 @@ async def test_events_compact_on_qwen_native_submits_compress_and_raises_spinner
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
         _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
@@ -12689,7 +12865,7 @@ async def test_events_compact_on_qwen_native_503_dismisses_spinner_on_submit_fai
         del agent_id, session_id
         return qwen_native_spec
 
-    conv_id = "conv_qwen_compact_fail"
+    conv_id = "7c94e9a0306b300d81233cccef543a84"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -12700,7 +12876,7 @@ async def test_events_compact_on_qwen_native_503_dismisses_spinner_on_submit_fai
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
         _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
@@ -12873,7 +13049,7 @@ async def _drive_opencode_native_compact(
         async with _runner_client(app) as http_client:
             create_resp = await http_client.post(
                 "/v1/sessions",
-                json={"session_id": conv_id, "agent_id": "ag_1"},
+                json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
             )
             assert create_resp.status_code == 201, create_resp.text
             _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
@@ -12999,7 +13175,7 @@ async def test_events_compact_on_opencode_native_summarizes_from_assistant_messa
     resp, client = await _drive_opencode_native_compact(
         monkeypatch,
         tmp_path,
-        conv_id="conv_opencode_compact_msg",
+        conv_id="f67241520c2101c4de5f81b976467bad",
         session_payload={"id": "ses_x"},
         messages=[
             {
@@ -13038,7 +13214,7 @@ async def test_events_compact_on_opencode_native_summarizes_from_session_model(
     resp, client = await _drive_opencode_native_compact(
         monkeypatch,
         tmp_path,
-        conv_id="conv_opencode_compact_session",
+        conv_id="7b333fd1a0e1c32b3961f98930f41bf3",
         session_payload={
             "id": "ses_x",
             "model": {"providerID": "anthropic", "id": "claude-opus-4"},
@@ -13067,7 +13243,7 @@ async def test_events_compact_on_opencode_native_summarizes_from_model_override(
     resp, client = await _drive_opencode_native_compact(
         monkeypatch,
         tmp_path,
-        conv_id="conv_opencode_compact_override",
+        conv_id="e45977bad8d13b2fdc00eb2bbdae2bd7",
         session_payload={"id": "ses_x"},
         messages=[],
         model_override="openai/gpt-5",
@@ -13092,7 +13268,7 @@ async def test_events_compact_on_opencode_native_204_when_model_unresolvable(
     resp, client = await _drive_opencode_native_compact(
         monkeypatch,
         tmp_path,
-        conv_id="conv_opencode_compact_none",
+        conv_id="90c89e7e5e9131aa4bb062fd427927ae",
         session_payload={"id": "ses_x"},
         messages=[],
         model_override=None,
@@ -13123,7 +13299,7 @@ async def test_events_compact_on_opencode_native_503_when_summarize_raises(
     resp, client = await _drive_opencode_native_compact(
         monkeypatch,
         tmp_path,
-        conv_id="conv_opencode_compact_fail",
+        conv_id="309c268a432cb4dbda4e8c15585578ee",
         session_payload={"id": "ses_x"},
         messages=[
             {
@@ -13201,12 +13377,15 @@ async def test_events_compact_on_non_native_session_is_204_noop(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_default_compact", "agent_id": "ag_1"},
+            json={
+                "session_id": "49f1d65e8b591ac277b7fca4e50f228c",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_default_compact/events",
+            "/v1/sessions/49f1d65e8b591ac277b7fca4e50f228c/events",
             json={"type": "compact"},
         )
 
@@ -13307,11 +13486,11 @@ async def test_events_native_dispatch_resolves_bridge_id_via_label_lookup(
         server_client=NullServerClient(),  # type: ignore[arg-type]
     )
 
-    conv_id = "conv_fork_bridge_check"
+    conv_id = "94e59ac02c7c81b1f65ba05e6481d759"
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": conv_id, "agent_id": "ag_1"},
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
         )
         assert create_resp.status_code == 201, create_resp.text
 
@@ -13393,23 +13572,28 @@ async def test_events_model_change_on_native_session_types_slash_command(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_model", "agent_id": "ag_1"},
+            json={
+                "session_id": "57c7c1acc5eeec3978c5e62043da51a4",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
         # Drain creation-time events (claude-native auto-create enqueues
         # session.terminal_pending) so the drain below isolates only
         # what model_change emits.
-        _drain_session_event_queue(_session_event_queues_ref.get("conv_native_model"))
+        _drain_session_event_queue(
+            _session_event_queues_ref.get("57c7c1acc5eeec3978c5e62043da51a4")
+        )
 
         resp = await client.post(
-            "/v1/sessions/conv_native_model/events",
+            "/v1/sessions/57c7c1acc5eeec3978c5e62043da51a4/events",
             json={"type": "model_change", "model": "claude-opus-4-7"},
         )
 
         # Drain the event queue before delete clears it. model_change
         # is a control signal, not a state change — no events should
         # land on the SSE queue.
-        queue = _session_event_queues_ref.get("conv_native_model")
+        queue = _session_event_queues_ref.get("57c7c1acc5eeec3978c5e62043da51a4")
         queued_events: list[dict[str, Any]] = []
         if queue is not None:
             while not queue.empty():
@@ -13477,14 +13661,19 @@ async def test_events_model_change_on_kiro_session_types_slash_command(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_kiro_model", "agent_id": "ag_1"},
+            json={
+                "session_id": "b07013b8f257ae8e087e343a0d7008a3",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
         # Drain kiro auto-create events so nothing below trips on them.
-        _drain_session_event_queue(_session_event_queues_ref.get("conv_kiro_model"))
+        _drain_session_event_queue(
+            _session_event_queues_ref.get("b07013b8f257ae8e087e343a0d7008a3")
+        )
 
         resp = await client.post(
-            "/v1/sessions/conv_kiro_model/events",
+            "/v1/sessions/b07013b8f257ae8e087e343a0d7008a3/events",
             json={"type": "model_change", "model": "claude-haiku-4.5"},
         )
 
@@ -13557,12 +13746,15 @@ async def test_events_model_change_on_native_session_skips_inject_for_empty_or_n
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_model_skip", "agent_id": "ag_1"},
+            json={
+                "session_id": "5aaed5c8eac5f60a5030e6e830602018",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_native_model_skip/events",
+            "/v1/sessions/5aaed5c8eac5f60a5030e6e830602018/events",
             json={"type": "model_change", "model": model_value},
         )
 
@@ -13622,12 +13814,15 @@ async def test_events_model_change_on_native_session_returns_503_when_bridge_not
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_native_model_fail", "agent_id": "ag_1"},
+            json={
+                "session_id": "75db03d3ecf58400bd53ce0326f49c4d",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_native_model_fail/events",
+            "/v1/sessions/75db03d3ecf58400bd53ce0326f49c4d/events",
             json={"type": "model_change", "model": "claude-opus-4-7"},
         )
 
@@ -13694,12 +13889,15 @@ async def test_events_model_change_on_non_native_session_is_204_noop(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_default_model", "agent_id": "ag_1"},
+            json={
+                "session_id": "3bd7b988ac7f00912b39823dbb0c6956",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_default_model/events",
+            "/v1/sessions/3bd7b988ac7f00912b39823dbb0c6956/events",
             json={"type": "model_change", "model": "claude-opus-4-7"},
         )
 
@@ -13752,12 +13950,15 @@ async def test_events_model_change_on_cursor_native_session_types_slash_command(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_cursor_model", "agent_id": "ag_1"},
+            json={
+                "session_id": "c42dbcb16fd3a87ee8f5d1fe4cabfdf8",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_cursor_model/events",
+            "/v1/sessions/c42dbcb16fd3a87ee8f5d1fe4cabfdf8/events",
             json={"type": "model_change", "model": "gpt-5.2"},
         )
 
@@ -13814,12 +14015,15 @@ async def test_events_model_change_on_cursor_native_session_skips_inject_for_emp
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_cursor_model_skip", "agent_id": "ag_1"},
+            json={
+                "session_id": "1f86fc567a3d953efdbbc6409ca286e3",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_cursor_model_skip/events",
+            "/v1/sessions/1f86fc567a3d953efdbbc6409ca286e3/events",
             json={"type": "model_change", "model": model_value},
         )
 
@@ -13870,12 +14074,15 @@ async def test_events_model_change_on_cursor_native_session_returns_503_when_not
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_cursor_model_fail", "agent_id": "ag_1"},
+            json={
+                "session_id": "ccf1b995c37a1ae8339d408fb227dff5",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_cursor_model_fail/events",
+            "/v1/sessions/ccf1b995c37a1ae8339d408fb227dff5/events",
             json={"type": "model_change", "model": "gpt-5.2"},
         )
 
@@ -13924,12 +14131,15 @@ async def test_events_effort_change_on_cursor_native_session_is_disabled_noop(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_cursor_effort", "agent_id": "ag_1"},
+            json={
+                "session_id": "6d57cf20b7c9680bd7bfe465b4b666d5",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
 
         resp = await client.post(
-            "/v1/sessions/conv_cursor_effort/events",
+            "/v1/sessions/6d57cf20b7c9680bd7bfe465b4b666d5/events",
             json={"type": "effort_change", "effort": effort_value},
         )
 
@@ -14006,7 +14216,7 @@ async def test_auto_create_claude_terminal_registers_permission_hook(
             )
 
     await _auto_create_claude_terminal(
-        "conv_abc",
+        "4e92b5a0c0ee6db3f874f9c4a3f855a5",
         _FakeResourceRegistry(),
         lambda _sid, _evt: None,
         server_client=NullServerClient(),  # type: ignore[arg-type]
@@ -14028,7 +14238,9 @@ async def test_auto_create_claude_terminal_registers_permission_hook(
 
     # The hook reads the server URL back out of this file at hook time,
     # so it must be written with the runner's Omnigent server URL.
-    config = read_permission_hook_config(bridge_dir_for_bridge_id("conv_abc"))
+    config = read_permission_hook_config(
+        bridge_dir_for_bridge_id("4e92b5a0c0ee6db3f874f9c4a3f855a5")
+    )
     assert config["ap_server_url"] == "http://127.0.0.1:8000"
 
     # The forwarder must get a refresh-capable httpx.Auth (not just a
@@ -14122,7 +14334,7 @@ async def test_auto_create_pi_terminal_launches_required_terminal(
     published: list[dict[str, Any]] = []
 
     await _auto_create_pi_terminal(
-        "conv_pi",
+        "47f049b9d13df4db397c7f46859b825f",
         _FakeResourceRegistry(),  # type: ignore[arg-type]
         lambda _sid, evt: published.append(evt),
         server_client=NullServerClient(),  # type: ignore[arg-type]
@@ -14220,7 +14432,7 @@ async def test_auto_create_kiro_terminal_launches_required_terminal_with_isolate
     published: list[dict[str, Any]] = []
 
     await _auto_create_kiro_terminal(
-        "conv_kiro",
+        "823dbd1aab969b5a813fac59bb977a77",
         _FakeResourceRegistry(),  # type: ignore[arg-type]
         lambda _sid, evt: published.append(evt),
         server_client=NullServerClient(),  # type: ignore[arg-type]
@@ -14251,27 +14463,29 @@ async def test_auto_create_kiro_terminal_launches_required_terminal_with_isolate
     assert "OPENAI_API_KEY" not in spec.env
     assert "OPENAI_API_KEY" in spec.env_unset
     assert spec.env[kiro_native_bridge.KIRO_NATIVE_BRIDGE_DIR_ENV_VAR] == str(
-        kiro_native_bridge.bridge_dir_for_session_id("conv_kiro")
+        kiro_native_bridge.bridge_dir_for_session_id("823dbd1aab969b5a813fac59bb977a77")
     )
     assert spec.env[kiro_native_bridge.KIRO_ACP_RECORD_PATH_ENV_VAR] == str(
         kiro_native_bridge.acp_record_path(
-            kiro_native_bridge.bridge_dir_for_session_id("conv_kiro")
+            kiro_native_bridge.bridge_dir_for_session_id("823dbd1aab969b5a813fac59bb977a77")
         )
     )
     assert any(evt.get("type") == "session.resource.created" for evt in published)
     assert forwarder_calls
     assert forwarder_calls[0]["base_url"] == "http://127.0.0.1:6767"
-    assert forwarder_calls[0]["session_id"] == "conv_kiro"
+    assert forwarder_calls[0]["session_id"] == "823dbd1aab969b5a813fac59bb977a77"
     assert forwarder_calls[0]["agent_name"] == "kiro-native-ui"
     assert forwarder_calls[0]["workspace"] == str(tmp_path)
     assert permission_mirror_calls
     assert permission_mirror_calls[0]["base_url"] == "http://127.0.0.1:6767"
-    assert permission_mirror_calls[0]["session_id"] == "conv_kiro"
+    assert permission_mirror_calls[0]["session_id"] == "823dbd1aab969b5a813fac59bb977a77"
     # The Omnigent MCP tool relay is seeded for this session's bridge dir.
     assert relay_calls == [
         {
-            "session_id": "conv_kiro",
-            "explicit_bridge_dir": kiro_native_bridge.bridge_dir_for_session_id("conv_kiro"),
+            "session_id": "823dbd1aab969b5a813fac59bb977a77",
+            "explicit_bridge_dir": kiro_native_bridge.bridge_dir_for_session_id(
+                "823dbd1aab969b5a813fac59bb977a77"
+            ),
             "await_notify": False,
         }
     ]
@@ -14349,7 +14563,7 @@ async def test_auto_create_kiro_terminal_skips_mcp_wiring_without_relay(
 
     # No ``ensure_comment_relay`` argument -> the MCP wiring gate stays closed.
     await _auto_create_kiro_terminal(
-        "conv_kiro_no_relay",
+        "17b3209fb5684c628f95edee0042e455",
         _FakeResourceRegistry(),  # type: ignore[arg-type]
         lambda _sid, _evt: None,
         server_client=NullServerClient(),  # type: ignore[arg-type]
@@ -14454,7 +14668,7 @@ async def test_auto_create_pi_terminal_inherits_agent_sandbox(
     )
 
     await _auto_create_pi_terminal(
-        "conv_pi_sandbox_none",
+        "28a25c47fe4fd8ccde95c80bab47c1c7",
         _FakeResourceRegistry(),  # type: ignore[arg-type]
         lambda _sid, _evt: None,
         server_client=NullServerClient(),  # type: ignore[arg-type]
@@ -14539,7 +14753,7 @@ async def test_auto_create_claude_terminal_passes_session_effort(
     )
 
     await _auto_create_claude_terminal(
-        "conv_effort",
+        "f89fd41f6eefee45b2117ac0fcbc73fa",
         _FakeResourceRegistry(),
         lambda _sid, _evt: None,
         server_client=fake_client,
@@ -14681,7 +14895,7 @@ async def test_auto_create_claude_terminal_inherits_agent_sandbox(
     )
 
     await _auto_create_claude_terminal(
-        "conv_sandbox_none",
+        "e27fc87ef2a8d798895ce8c1e66db82d",
         _FakeResourceRegistry(),
         lambda _sid, _evt: None,
         server_client=fake_client,
@@ -14794,7 +15008,7 @@ async def test_auto_create_claude_terminal_injects_ucode_gateway_config(
     )
 
     await _auto_create_claude_terminal(
-        "conv_ucode",
+        "13efa494411f3ae60211e6be5635062a",
         _FakeResourceRegistry(),
         lambda _sid, _evt: None,
         server_client=fake_client,
@@ -14890,7 +15104,7 @@ async def _run_auto_create_cursor_terminal(
     )
     try:
         await _auto_create_cursor_terminal(
-            "conv_cursor_model",
+            "c42dbcb16fd3a87ee8f5d1fe4cabfdf8",
             _FakeResourceRegistry(),  # type: ignore[arg-type]
             lambda _sid, _evt: None,
             server_client=fake_client,
@@ -15090,7 +15304,7 @@ async def test_auto_create_claude_terminal_forwarder_skips_replayed_transcript_o
 
                 return _LabelsResponse()
 
-            assert url == "/v1/sessions/conv_resume"
+            assert url == "/v1/sessions/5cdbea97a2fb0c659bc09605401e2bb2"
 
             class _SnapResponse(NullServerClient._Response):
                 """Snapshot response carrying the parametrized resume id."""
@@ -15127,7 +15341,7 @@ async def test_auto_create_claude_terminal_forwarder_skips_replayed_transcript_o
             )
 
     await _auto_create_claude_terminal(
-        "conv_resume",
+        "5cdbea97a2fb0c659bc09605401e2bb2",
         _FakeResourceRegistry(),
         lambda _sid, _evt: None,
         server_client=_SnapshotServerClient(),  # type: ignore[arg-type]
@@ -15189,7 +15403,7 @@ class _PublishedEvent:
     One event captured from the runner's per-session publisher.
 
     :param session_id: Routing session id the event was published under,
-        e.g. ``"conv_emit"``.
+        e.g. ``"c74c7a36c4736e2153ed6046d16bcf76"``.
     :param event: The published SSE event dict.
     """
 
@@ -15260,7 +15474,7 @@ async def test_auto_create_claude_terminal_emits_resource_created_event(
         published.append(_PublishedEvent(session_id=session_id, event=event))
 
     await _auto_create_claude_terminal(
-        "conv_emit",
+        "c74c7a36c4736e2153ed6046d16bcf76",
         _ViewResourceRegistry(),
         _capture,
         server_client=NullServerClient(),  # type: ignore[arg-type]
@@ -15275,7 +15489,7 @@ async def test_auto_create_claude_terminal_emits_resource_created_event(
     )
     # Routed under the session id so the Omnigent relay forwards it to that
     # session's web stream.
-    assert created[0].session_id == "conv_emit"
+    assert created[0].session_id == "c74c7a36c4736e2153ed6046d16bcf76"
     resource = created[0].event["resource"]
     assert resource["type"] == "terminal"
     assert resource["id"] == "terminal_claude_main"
@@ -15300,8 +15514,8 @@ def test_publish_terminal_pending_emits_pending_then_clear() -> None:
     def _capture(session_id: str, event: dict[str, Any]) -> None:
         published.append(_PublishedEvent(session_id=session_id, event=event))
 
-    _publish_terminal_pending(_capture, "conv_pending", True)
-    _publish_terminal_pending(_capture, "conv_pending", False)
+    _publish_terminal_pending(_capture, "7cef62c6518d5591cc7991974e33ec4c", True)
+    _publish_terminal_pending(_capture, "7cef62c6518d5591cc7991974e33ec4c", False)
 
     assert [p.event for p in published] == [
         {"type": "session.terminal_pending", "pending": True},
@@ -15309,7 +15523,7 @@ def test_publish_terminal_pending_emits_pending_then_clear() -> None:
     ]
     # Routed under the session id so the Omnigent relay forwards it to that
     # session's web stream.
-    assert all(p.session_id == "conv_pending" for p in published)
+    assert all(p.session_id == "7cef62c6518d5591cc7991974e33ec4c" for p in published)
 
 
 def test_publish_native_terminal_start_error_emits_failed_status_only(
@@ -15340,7 +15554,7 @@ def test_publish_native_terminal_start_error_emits_failed_status_only(
     with caplog.at_level(logging.WARNING):
         error = _publish_native_terminal_start_error(
             _capture,
-            "conv_codex",
+            "415c9954e2fe4b9276083a4d2c66f689",
             "Codex",
             ImportError("Native Codex requires the 'codex' CLI on PATH."),
         )
@@ -15362,7 +15576,7 @@ def test_publish_native_terminal_start_error_emits_failed_status_only(
             "error": error,
         },
     ]
-    assert all(p.session_id == "conv_codex" for p in published)
+    assert all(p.session_id == "415c9954e2fe4b9276083a4d2c66f689" for p in published)
 
 
 def test_terminal_lookup_miss_log_explains_stopped_registered_terminal(
@@ -15389,7 +15603,9 @@ def test_terminal_lookup_miss_log_explains_stopped_registered_terminal(
         private_dir=tmp_path,
         running=False,
     )
-    terminal_registry._by_conversation["conv_lookup"] = {("claude", "main"): instance}
+    terminal_registry._by_conversation["49b1b4ef0f1c9ba81d232a6f31dfeb24"] = {
+        ("claude", "main"): instance
+    }
     resource_registry = SessionResourceRegistry(terminal_registry=terminal_registry)
 
     _terminal_lookup_miss_log_state.clear()
@@ -15397,12 +15613,12 @@ def test_terminal_lookup_miss_log_explains_stopped_registered_terminal(
         with caplog.at_level(logging.INFO, logger="omnigent.runner.app"):
             _log_terminal_lookup_miss(
                 resource_registry,
-                "conv_lookup",
+                "49b1b4ef0f1c9ba81d232a6f31dfeb24",
                 "terminal_claude_main",
             )
             _log_terminal_lookup_miss(
                 resource_registry,
-                "conv_lookup",
+                "49b1b4ef0f1c9ba81d232a6f31dfeb24",
                 "terminal_claude_main",
             )
     finally:
@@ -15504,7 +15720,7 @@ async def test_auto_create_claude_terminal_resets_stale_bridge_id_label(
     )
 
     await _auto_create_claude_terminal(
-        "conv_relay_label_fix",
+        "9a0bec6675dc7ac693d7bf6f53cfb984",
         _FakeResourceRegistry(),
         lambda _sid, _evt: None,
         server_client=fake_client,
@@ -15525,9 +15741,11 @@ async def test_auto_create_claude_terminal_resets_stale_bridge_id_label(
     import json as _json
 
     patch_body = _json.loads(patch_requests[0].content)
-    assert patch_body.get("labels", {}).get(BRIDGE_ID_LABEL_KEY) == "conv_relay_label_fix", (
+    assert (
+        patch_body.get("labels", {}).get(BRIDGE_ID_LABEL_KEY) == "9a0bec6675dc7ac693d7bf6f53cfb984"
+    ), (
         f"PATCH must set {BRIDGE_ID_LABEL_KEY!r} to the session_id "
-        f"'conv_relay_label_fix' so _ensure_comment_relay_started finds the "
+        f"'9a0bec6675dc7ac693d7bf6f53cfb984' so _ensure_comment_relay_started finds the "
         f"correct bridge dir; got {patch_body.get('labels', {})!r}"
     )
 
@@ -15612,7 +15830,7 @@ async def test_auto_create_claude_terminal_honours_cleared_bridge_label(
             200,
             json={
                 "reasoning_effort": None,
-                "labels": {BRIDGE_ID_LABEL_KEY: "conv_cleared-cleared"},
+                "labels": {BRIDGE_ID_LABEL_KEY: "b3e788af0ecd4516439ee859b8c74536-cleared"},
             },
             request=req,
         )
@@ -15623,15 +15841,17 @@ async def test_auto_create_claude_terminal_honours_cleared_bridge_label(
     )
 
     await _auto_create_claude_terminal(
-        "conv_cleared",
+        "b3e788af0ecd4516439ee859b8c74536",
         _FakeResourceRegistry(),
         lambda _sid, _evt: None,
         server_client=fake_client,
     )
     await fake_client.aclose()
 
-    cleared_dir = claude_native_bridge.bridge_dir_for_bridge_id("conv_cleared-cleared")
-    natural_dir = claude_native_bridge.bridge_dir_for_bridge_id("conv_cleared")
+    cleared_dir = claude_native_bridge.bridge_dir_for_bridge_id(
+        "b3e788af0ecd4516439ee859b8c74536-cleared"
+    )
+    natural_dir = claude_native_bridge.bridge_dir_for_bridge_id("b3e788af0ecd4516439ee859b8c74536")
     # The isolated cleared dir is prepared; the natural (live-sibling) dir is not.
     assert cleared_dir.exists()
     assert not natural_dir.exists()
@@ -15646,7 +15866,10 @@ async def test_auto_create_claude_terminal_honours_cleared_bridge_label(
     patch_requests = [r for r in recorded_requests if r.method == "PATCH"]
     assert len(patch_requests) == 1
     patch_body = _json.loads(patch_requests[0].content)
-    assert patch_body.get("labels", {}).get(BRIDGE_ID_LABEL_KEY) == "conv_cleared-cleared"
+    assert (
+        patch_body.get("labels", {}).get(BRIDGE_ID_LABEL_KEY)
+        == "b3e788af0ecd4516439ee859b8c74536-cleared"
+    )
 
 
 @dataclass
@@ -15657,14 +15880,14 @@ class _AutoCreateScenario:
     :param case_id: Human-readable scenario id used as the pytest id,
         e.g. ``"clear_rotation_target_skips"``.
     :param active_session_id: ``active_session_id`` to seed into the
-        shared bridge config, e.g. ``"conv_old"``. ``None`` seeds no
+        shared bridge config, e.g. ``"3bb59abc6e20b834cbb2269f28880895"``. ``None`` seeds no
         bridge dir at all (models a genuinely fresh session).
     :param terminal_under: Session id to seed a live ``claude:main``
-        terminal under in the registry, e.g. ``"conv_old"``. ``None``
+        terminal under in the registry, e.g. ``"3bb59abc6e20b834cbb2269f28880895"``. ``None``
         seeds no terminal (models a dead/absent original terminal).
     :param bridge_id_label: Value returned for the new session's
         ``BRIDGE_ID_LABEL_KEY`` label, e.g. ``"bridge_shared"`` for a
-        rotation target (shares the original's bridge) or ``"conv_new"``
+        rotation target (shares the original's bridge) or ``"2d1b1a96e3e08f2cd43c0cc4b695ac5d"``
         for a fresh session (own bridge).
     :param expect_auto_create: Whether the guard should invoke
         ``_auto_create_claude_terminal`` for the new session.
@@ -15700,8 +15923,8 @@ class _LabelsAndEmptyHistoryServerClient:
         """
         Return a canned snapshot or empty items page for *url*.
 
-        :param url: Request path, e.g. ``"/v1/sessions/conv_new"`` or
-            ``"/v1/sessions/conv_new/items"``.
+        :param url: Request path, e.g. ``"/v1/sessions/2d1b1a96e3e08f2cd43c0cc4b695ac5d"`` or
+            ``"/v1/sessions/2d1b1a96e3e08f2cd43c0cc4b695ac5d/items"``.
         :returns: A response object exposing ``status_code`` and
             ``json()`` matching the subset the runner reads.
         """
@@ -15729,8 +15952,8 @@ _AUTO_CREATE_SCENARIOS = [
     # the live terminal that is about to be transferred onto conv_new.
     _AutoCreateScenario(
         case_id="clear_rotation_target_skips",
-        active_session_id="conv_old",
-        terminal_under="conv_old",
+        active_session_id="3bb59abc6e20b834cbb2269f28880895",
+        terminal_under="3bb59abc6e20b834cbb2269f28880895",
         bridge_id_label="bridge_shared",
         expect_auto_create=False,
     ),
@@ -15740,14 +15963,14 @@ _AUTO_CREATE_SCENARIOS = [
         case_id="fresh_session_creates",
         active_session_id=None,
         terminal_under=None,
-        bridge_id_label="conv_new",
+        bridge_id_label="2d1b1a96e3e08f2cd43c0cc4b695ac5d",
         expect_auto_create=True,
     ),
     # The bridge's active session is conv_new itself (e.g. a relaunch
     # after the terminal died) — not a rotation, so auto-create proceeds.
     _AutoCreateScenario(
         case_id="active_is_self_creates",
-        active_session_id="conv_new",
+        active_session_id="2d1b1a96e3e08f2cd43c0cc4b695ac5d",
         terminal_under=None,
         bridge_id_label="bridge_shared",
         expect_auto_create=True,
@@ -15756,7 +15979,7 @@ _AUTO_CREATE_SCENARIOS = [
     # exists under it — nothing to transfer in, so auto-create proceeds.
     _AutoCreateScenario(
         case_id="dead_terminal_under_active_creates",
-        active_session_id="conv_old",
+        active_session_id="3bb59abc6e20b834cbb2269f28880895",
         terminal_under=None,
         bridge_id_label="bridge_shared",
         expect_auto_create=True,
@@ -15832,7 +16055,7 @@ async def test_create_session_auto_create_guard_skips_rotation_targets(
         Record the auto-create call instead of launching a real Claude.
 
         :param session_id: Session id the guard chose to auto-create for,
-            e.g. ``"conv_new"``.
+            e.g. ``"2d1b1a96e3e08f2cd43c0cc4b695ac5d"``.
         :param resource_registry: Unused — the real launch path is stubbed.
         :param publish_event: Unused — the real launch path is stubbed.
         :param _kwargs: Absorbs keyword args added to the real function
@@ -15874,7 +16097,10 @@ async def test_create_session_auto_create_guard_skips_rotation_targets(
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_new", "agent_id": "ag_1"},
+            json={
+                "session_id": "2d1b1a96e3e08f2cd43c0cc4b695ac5d",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
     assert resp.status_code == 201, resp.text
 
@@ -15883,7 +16109,7 @@ async def test_create_session_auto_create_guard_skips_rotation_targets(
         # Claude — the guard only suppresses true rotation targets. An
         # empty ``created`` here would mean the guard over-fired and a
         # host-spawned session would never get a terminal.
-        assert created == ["conv_new"], (
+        assert created == ["2d1b1a96e3e08f2cd43c0cc4b695ac5d"], (
             f"Expected auto-create for {scenario.case_id}; got {created}"
         )
     else:
@@ -15901,15 +16127,15 @@ class _AntigravityAutoCreateScenario:
     :param case_id: Human-readable scenario id used as the pytest id,
         e.g. ``"clear_rotation_target_skips"``.
     :param bridge_state_session: ``session_id`` to seed into the shared
-        bridge state, e.g. ``"conv_old"``. ``None`` seeds no bridge state
+        bridge state, e.g. ``"3bb59abc6e20b834cbb2269f28880895"``. ``None`` seeds no bridge state
         at all (models a genuinely fresh session).
     :param terminal_under: Session id to seed a live ``antigravity:main``
-        terminal under in the registry, e.g. ``"conv_old"``. ``None``
+        terminal under in the registry, e.g. ``"3bb59abc6e20b834cbb2269f28880895"``. ``None``
         seeds no terminal (models a dead/absent original terminal).
     :param bridge_id_label: Value returned for the new session's
         :data:`ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY` label, e.g.
         ``"bridge_shared"`` for a rotation target (shares the original's
-        bridge) or ``"conv_new"`` for a fresh session (own bridge).
+        bridge) or ``"2d1b1a96e3e08f2cd43c0cc4b695ac5d"`` for a fresh session (own bridge).
     :param expect_auto_create: Whether the guard should invoke
         ``_auto_create_antigravity_terminal`` for the new session.
     """
@@ -15925,10 +16151,10 @@ class _AntigravitySnapshotServerClient:
     """
     Server-client stub for the antigravity auto-create guard route test.
 
-    Answers the two GETs the antigravity branch issues for ``conv_new``: the
-    session snapshot (``/v1/sessions/conv_new`` — non-``None`` so
+    Answers the two GETs the antigravity branch issues for that session: the
+    session snapshot (``/v1/sessions/2d1b1a96e3e08f2cd43c0cc4b695ac5d`` — non-``None`` so
     ``_session_payload_for_host_spawn_check`` reports the session needs a
-    terminal) and the labels lookup (``/v1/sessions/conv_new/labels`` — returns
+    terminal) and the labels lookup (``/v1/sessions/<id>/labels`` — returns
     the bridge-id label so the transfer-inbound check can resolve the shared
     bridge dir). A real stub class — not ``MagicMock`` — so an unexpected call
     shape fails loudly instead of silently returning a mock.
@@ -15945,8 +16171,8 @@ class _AntigravitySnapshotServerClient:
         """
         Return a canned snapshot or labels payload for *url*.
 
-        :param url: Request path, e.g. ``"/v1/sessions/conv_new"`` or
-            ``"/v1/sessions/conv_new/labels"``.
+        :param url: Request path, e.g. ``"/v1/sessions/2d1b1a96e3e08f2cd43c0cc4b695ac5d"`` or
+            ``"/v1/sessions/2d1b1a96e3e08f2cd43c0cc4b695ac5d/labels"``.
         :returns: A response object exposing ``status_code`` and ``json()``
             matching the subset the runner reads.
         """
@@ -15969,7 +16195,7 @@ class _AntigravitySnapshotServerClient:
             return _Response({"labels": labels})
         # The session snapshot: non-None so the host-spawn check reports the
         # session needs a terminal, and carries the same labels.
-        return _Response({"id": "conv_new", "labels": labels})
+        return _Response({"id": "2d1b1a96e3e08f2cd43c0cc4b695ac5d", "labels": labels})
 
 
 _ANTIGRAVITY_AUTO_CREATE_SCENARIOS = [
@@ -15977,8 +16203,8 @@ _ANTIGRAVITY_AUTO_CREATE_SCENARIOS = [
     # live agy terminal that is about to be transferred onto conv_new.
     _AntigravityAutoCreateScenario(
         case_id="clear_rotation_target_skips",
-        bridge_state_session="conv_old",
-        terminal_under="conv_old",
+        bridge_state_session="3bb59abc6e20b834cbb2269f28880895",
+        terminal_under="3bb59abc6e20b834cbb2269f28880895",
         bridge_id_label="bridge_shared",
         expect_auto_create=False,
     ),
@@ -15988,14 +16214,14 @@ _ANTIGRAVITY_AUTO_CREATE_SCENARIOS = [
         case_id="fresh_session_creates",
         bridge_state_session=None,
         terminal_under=None,
-        bridge_id_label="conv_new",
+        bridge_id_label="2d1b1a96e3e08f2cd43c0cc4b695ac5d",
         expect_auto_create=True,
     ),
     # The bridge's recorded session is conv_new itself (e.g. a relaunch after
     # the terminal died) — not a rotation, so auto-create proceeds.
     _AntigravityAutoCreateScenario(
         case_id="active_is_self_creates",
-        bridge_state_session="conv_new",
+        bridge_state_session="2d1b1a96e3e08f2cd43c0cc4b695ac5d",
         terminal_under=None,
         bridge_id_label="bridge_shared",
         expect_auto_create=True,
@@ -16004,7 +16230,7 @@ _ANTIGRAVITY_AUTO_CREATE_SCENARIOS = [
     # it — nothing to transfer in, so auto-create proceeds.
     _AntigravityAutoCreateScenario(
         case_id="dead_terminal_under_active_creates",
-        bridge_state_session="conv_old",
+        bridge_state_session="3bb59abc6e20b834cbb2269f28880895",
         terminal_under=None,
         bridge_id_label="bridge_shared",
         expect_auto_create=True,
@@ -16086,7 +16312,7 @@ async def test_create_session_antigravity_auto_create_guard_skips_rotation_targe
         Record the auto-create call instead of launching a real agy.
 
         :param session_id: Session id the guard chose to auto-create for,
-            e.g. ``"conv_new"``.
+            e.g. ``"2d1b1a96e3e08f2cd43c0cc4b695ac5d"``.
         :param resource_registry: Unused — the real launch path is stubbed.
         :param publish_event: Unused — the real launch path is stubbed.
         :param _kwargs: Absorbs keyword args added to the real function
@@ -16130,7 +16356,10 @@ async def test_create_session_antigravity_auto_create_guard_skips_rotation_targe
     async with _runner_client(app) as client:
         resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_new", "agent_id": "ag_1"},
+            json={
+                "session_id": "2d1b1a96e3e08f2cd43c0cc4b695ac5d",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
     assert resp.status_code == 201, resp.text
 
@@ -16139,7 +16368,7 @@ async def test_create_session_antigravity_auto_create_guard_skips_rotation_targe
         # the guard only suppresses true rotation targets. An empty ``created``
         # here would mean the guard over-fired and a host-spawned session would
         # never get a terminal.
-        assert created == ["conv_new"], (
+        assert created == ["2d1b1a96e3e08f2cd43c0cc4b695ac5d"], (
             f"Expected auto-create for {scenario.case_id}; got {created}"
         )
     else:
@@ -16236,7 +16465,7 @@ async def test_create_session_terminal_ensure_routes_claude_native(
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
-    sid = "conv_ensure"
+    sid = "babf6c60e977e4e5f2654080d24cab40"
     auto_create_calls: list[str] = []
     launch_calls: list[str] = []
 
@@ -16333,7 +16562,7 @@ async def test_create_session_terminal_ensure_failure_returns_json_without_live_
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
-    sid = "conv_ensure_failure"
+    sid = "aefc71354fadf0dd2ae5c224c40e772c"
 
     async def _failing_auto_create(
         session_id: str,
@@ -16473,7 +16702,7 @@ async def test_create_session_terminal_ensure_routes_codex_native(
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
-    sid = "conv_codex_ensure"
+    sid = "ad2c1855c982b13e9c4df55b75d26ef8"
     auto_create_calls: list[str] = []
     auto_create_kwargs: list[dict[str, object]] = []
     launch_calls: list[str] = []
@@ -16490,7 +16719,7 @@ async def test_create_session_terminal_ensure_routes_codex_native(
         Record the codex-native ensure path.
 
         :param session_id: Session id being ensured, e.g.
-            ``"conv_codex_ensure"``.
+            ``"ad2c1855c982b13e9c4df55b75d26ef8"``.
         :param resource_registry: Runner resource registry collaborator.
         :param publish_event: Runner event publisher collaborator.
         :param kwargs: Additional keyword arguments such as
@@ -16518,7 +16747,7 @@ async def test_create_session_terminal_ensure_routes_codex_native(
 
         :param self: Bound registry instance.
         :param session_id: Session id being queried, e.g.
-            ``"conv_codex_ensure"``.
+            ``"ad2c1855c982b13e9c4df55b75d26ef8"``.
         :param terminal_id: Terminal resource id, e.g.
             ``"terminal_codex_main"``.
         :returns: Existing resource view or ``None``.
@@ -16547,7 +16776,7 @@ async def test_create_session_terminal_ensure_routes_codex_native(
 
         :param self: Bound registry instance.
         :param session_id: Session id being queried, e.g.
-            ``"conv_codex_ensure"``.
+            ``"ad2c1855c982b13e9c4df55b75d26ef8"``.
         :param terminal_id: Terminal resource id, e.g.
             ``"terminal_codex_main"``.
         :returns: ``"codex-native"`` for native seeded terminals.
@@ -16567,7 +16796,7 @@ async def test_create_session_terminal_ensure_routes_codex_native(
 
         :param self: Bound registry instance.
         :param session_id: Session id being modified, e.g.
-            ``"conv_codex_ensure"``.
+            ``"ad2c1855c982b13e9c4df55b75d26ef8"``.
         :param terminal_id: Terminal resource id, e.g.
             ``"terminal_codex_main"``.
         :returns: ``True`` to allow replacement.
@@ -16591,7 +16820,7 @@ async def test_create_session_terminal_ensure_routes_codex_native(
 
         :param self: Bound registry instance.
         :param session_id: Session id being launched, e.g.
-            ``"conv_codex_ensure"``.
+            ``"ad2c1855c982b13e9c4df55b75d26ef8"``.
         :param terminal_name: Terminal name, e.g. ``"codex"``.
         :param session_key: Terminal session key, e.g. ``"main"``.
         :param kwargs: Additional launch keyword arguments.
@@ -16660,7 +16889,7 @@ async def test_late_status_for_deleted_sub_agent_child_is_not_a_spurious_503() -
     ``503 subagent_delivery_not_confirmed`` (which Omnigent then retries) plus an
     unbounded leak of the name map across deleted sessions.
     """
-    child_id = "conv_child_late_status_after_delete"
+    child_id = "045873be7e66575e49c755387fecf59a"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
@@ -16672,7 +16901,7 @@ async def test_late_status_for_deleted_sub_agent_child_is_not_a_spurious_503() -
             "/v1/sessions",
             json={
                 "session_id": child_id,
-                "agent_id": "ag_late_status_after_delete",
+                "agent_id": "2c81960171b1c893befb5cc2598ecf5c",
                 "sub_agent_name": "worker",
             },
         )
@@ -16703,7 +16932,7 @@ class _RecordedPatch:
     """
     A PATCH captured from the REPL terminal auto-create helper.
 
-    :param url: Request path, e.g. ``"/v1/sessions/conv_repl"``.
+    :param url: Request path, e.g. ``"/v1/sessions/11c50cd73e9c32ccb0af5b9db291db8b"``.
     :param json: JSON body, e.g. ``{"labels": {"omnigent.ui": "terminal"}}``.
     """
 
@@ -16735,7 +16964,7 @@ async def test_auto_create_repl_terminal_launches_attach_and_stamps_label(
     """
     from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, UI_MODE_TERMINAL_VALUE
 
-    session_id = "conv_repl"
+    session_id = "11c50cd73e9c32ccb0af5b9db291db8b"
     workspace = tmp_path / "workspace"
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(workspace))
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
@@ -16765,7 +16994,7 @@ async def test_auto_create_repl_terminal_launches_attach_and_stamps_label(
             :param resource_role: Private runner resource marker.
             :returns: Terminal resource view.
             """
-            assert session_id == "conv_repl"
+            assert session_id == "11c50cd73e9c32ccb0af5b9db291db8b"
             assert terminal_name == "tui"
             assert session_key == "main"
             # The REPL role marks the pane for recreate-on-attach (a
@@ -16793,7 +17022,7 @@ async def test_auto_create_repl_terminal_launches_attach_and_stamps_label(
             """
             Record the PATCH and return a 200.
 
-            :param url: Request path, e.g. ``"/v1/sessions/conv_repl"``.
+            :param url: Request path, e.g. ``"/v1/sessions/11c50cd73e9c32ccb0af5b9db291db8b"``.
             :param kwargs: Request keyword arguments carrying ``json``.
             :returns: HTTP 200 response.
             """
@@ -16878,7 +17107,7 @@ async def test_auto_create_repl_terminal_inherits_agent_sandbox(
     """
     from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 
-    session_id = "conv_repl_sandbox_none"
+    session_id = "f75bf7158ce8716ae3b934522271979c"
     workspace = tmp_path / "workspace"
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(workspace))
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
@@ -17047,7 +17276,10 @@ async def test_create_session_repl_terminal_dispatch(
         terminal_registry=TerminalRegistry(),
     )
 
-    body: dict[str, Any] = {"session_id": "conv_dispatch", "agent_id": "ag_dispatch"}
+    body: dict[str, Any] = {
+        "session_id": "5eef02d60f39cba3fbd0ae188348643f",
+        "agent_id": "26def1563ee359def46b274c20739c03",
+    }
     if sub_agent_name is not None:
         body["sub_agent_name"] = sub_agent_name
     async with _runner_client(app) as client:
@@ -17057,7 +17289,7 @@ async def test_create_session_repl_terminal_dispatch(
     # Dispatch fired exactly for the SDK top-level case. An unexpected
     # entry here means natives/sub-agents grew a REPL pane; a missing
     # one means SDK sessions lost the embedded web TUI.
-    assert created_sessions == (["conv_dispatch"] if expect_created else [])
+    assert created_sessions == (["5eef02d60f39cba3fbd0ae188348643f"] if expect_created else [])
 
 
 # ── Sub-agent wake-POST status check + bounded retry ──────────────────
@@ -17069,7 +17301,7 @@ class _WakePost:
     A single recorded POST made by ``_QueuedResponseServerClient``.
 
     :param url: The path the wake notice was POSTed to, e.g.
-        ``"/v1/sessions/conv_parent123/events"``.
+        ``"/v1/sessions/0349c7f62dcaa06b868e9c088c39f062/events"``.
     :param notice: The injected notice text pulled out of the request body.
     """
 
@@ -17105,7 +17337,7 @@ class _QueuedResponseServerClient:
         """
         Record the POST and return the next queued response.
 
-        :param url: Target path, e.g. ``"/v1/sessions/conv_p/events"``.
+        :param url: Target path, e.g. ``"/v1/sessions/b460374fc8e697b296708f52dc9d8179/events"``.
         :param json: Wake-notice request body in the ingest message shape.
         :param timeout: Per-request timeout (recorded only, not enforced).
         :returns: The next pre-built response from the queue.
@@ -17174,7 +17406,7 @@ async def test_wake_post_retries_transient_503_then_succeeds(
     reconnects. The wake POST must treat that as a failure and retry, not
     accept it as delivered.
     """
-    parent_id = "conv_parent_503_then_ok"
+    parent_id = "dd17997e050fc080efac96bc9ec22b55"
     client = _QueuedResponseServerClient(
         [_wake_response(503, parent_id), _wake_response(200, parent_id)]
     )
@@ -17215,7 +17447,7 @@ async def test_wake_post_persistent_503_returns_failure(
     surfaced as a delivery failure (so the caller releases the debounce flag
     and logs), never swallowed as a success.
     """
-    parent_id = "conv_parent_always_503"
+    parent_id = "a25887ef53cb74bba721c20edf204d10"
     client = _QueuedResponseServerClient(
         [_wake_response(503, parent_id) for _ in range(_WAKE_POST_MAX_ATTEMPTS)]
     )
@@ -17250,7 +17482,7 @@ async def test_wake_post_permanent_4xx_not_retried(
     A 400 is a client-side rejection that retrying cannot fix, so the loop
     must give up after one attempt rather than burn the whole budget.
     """
-    parent_id = "conv_parent_400"
+    parent_id = "43cc3eccd350fed1b91854b2adf5ec3e"
     client = _QueuedResponseServerClient([_wake_response(400, parent_id)])
 
     delivered = await _deliver_subagent_wake_post(
@@ -17362,7 +17594,7 @@ async def test_cancel_auto_forwarder_task_cancels_and_awaits_registered_task() -
     """
     import omnigent.runner.app as runner_app_mod
 
-    session_id = "conv_fwd_cancel_awaits"
+    session_id = "f98115a89870f7e364064c9d06c52ee7"
     run = _ForwarderRun()
 
     async def _parked() -> None:
@@ -17419,7 +17651,7 @@ async def test_register_auto_forwarder_task_replaces_incumbent_and_survives_stal
     """
     import omnigent.runner.app as runner_app_mod
 
-    session_id = "conv_fwd_stale_evict"
+    session_id = "f14ef86c47cc555be7e4c5eb00e88a9a"
     run_a = _ForwarderRun()
     run_b = _ForwarderRun()
 
@@ -17489,27 +17721,29 @@ async def test_auto_forwarder_registry_isolates_sessions_and_evicts_completed() 
     try:
         task_a = asyncio.create_task(_parked(run_a))
         task_b = asyncio.create_task(_parked(run_b))
-        runner_app_mod._register_auto_forwarder_task("conv_fwd_sess_a", task_a)
-        runner_app_mod._register_auto_forwarder_task("conv_fwd_sess_b", task_b)
+        runner_app_mod._register_auto_forwarder_task("4263b99f5e92593cafda836bdb6b7690", task_a)
+        runner_app_mod._register_auto_forwarder_task("414de30f273a0a21428e869a1d7a2a3d", task_b)
         await asyncio.sleep(0)
 
-        await runner_app_mod._cancel_auto_forwarder_task("conv_fwd_sess_a")
+        await runner_app_mod._cancel_auto_forwarder_task("4263b99f5e92593cafda836bdb6b7690")
 
         assert run_a.cancelled is True
         # Session B's forwarder is untouched by session A's cancel — keying
         # by session id must not regress to whole-registry cancellation.
         assert run_b.cancelled is False
         assert not task_b.done()
-        assert runner_app_mod._AUTO_FORWARDER_TASKS.get("conv_fwd_sess_b") is task_b
+        assert (
+            runner_app_mod._AUTO_FORWARDER_TASKS.get("414de30f273a0a21428e869a1d7a2a3d") is task_b
+        )
 
         # Natural completion evicts the entry (no leak for finished tasks).
         task_b.cancel()
         await asyncio.wait({task_b})
         await asyncio.sleep(0)
-        assert "conv_fwd_sess_b" not in runner_app_mod._AUTO_FORWARDER_TASKS
+        assert "414de30f273a0a21428e869a1d7a2a3d" not in runner_app_mod._AUTO_FORWARDER_TASKS
     finally:
-        runner_app_mod._AUTO_FORWARDER_TASKS.pop("conv_fwd_sess_a", None)
-        runner_app_mod._AUTO_FORWARDER_TASKS.pop("conv_fwd_sess_b", None)
+        runner_app_mod._AUTO_FORWARDER_TASKS.pop("4263b99f5e92593cafda836bdb6b7690", None)
+        runner_app_mod._AUTO_FORWARDER_TASKS.pop("414de30f273a0a21428e869a1d7a2a3d", None)
         await _drain_forwarder_runs([run_a, run_b])
 
 
@@ -17539,7 +17773,7 @@ async def test_auto_create_claude_terminal_recreate_cancels_prior_forwarder(
     monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
 
-    session_id = "conv_fwd_recreate"
+    session_id = "f3e241b72bac7d5e33d7a9819e0fa865"
     runs: list[_ForwarderRun] = []
 
     async def _parking_forwarder(**kwargs: Any) -> None:
@@ -17650,7 +17884,7 @@ async def test_auto_create_codex_terminal_recreate_cancels_prior_forwarder(
     import omnigent.codex_native_app_server as codex_app_mod
     import omnigent.runner.app as runner_app_mod
 
-    session_id = "conv_codex_fwd_recreate"
+    session_id = "a3f4361a350851cfb9eb3db2bf2b0380"
     thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
     monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
@@ -17676,7 +17910,7 @@ async def test_auto_create_codex_terminal_recreate_cancels_prior_forwarder(
                     json={
                         "data": [
                             {
-                                "id": "msg_user_1",
+                                "id": "b1649a5cbfec3f92bec12275c14f4b5f",
                                 "response_id": "codex_turn_1",
                                 "type": "message",
                                 "role": "user",
@@ -17892,11 +18126,14 @@ async def test_events_interrupt_on_kiro_native_routes_to_escape(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_kiro_int", "agent_id": "ag_1"},
+            json={
+                "session_id": "cd6b589814147431cc1a92ec2c979998",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
         int_resp = await client.post(
-            "/v1/sessions/conv_kiro_int/events",
+            "/v1/sessions/cd6b589814147431cc1a92ec2c979998/events",
             json={"type": "interrupt"},
         )
 
@@ -17908,7 +18145,9 @@ async def test_events_interrupt_on_kiro_native_routes_to_escape(
         f"kiro-native interrupt dispatch entry is missing."
     )
     bridge_dir, timeout_s = captured[0]
-    assert bridge_dir == kiro_native_bridge.bridge_dir_for_session_id("conv_kiro_int")
+    assert bridge_dir == kiro_native_bridge.bridge_dir_for_session_id(
+        "cd6b589814147431cc1a92ec2c979998"
+    )
     assert timeout_s == 1.0
 
 
@@ -17951,14 +18190,17 @@ async def test_events_stop_session_on_kiro_native_kills_tmux_and_publishes_idle(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_kiro_stop", "agent_id": "ag_1"},
+            json={
+                "session_id": "cd2a2b575af18bbc3a38fd025e379be0",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
         stop_resp = await client.post(
-            "/v1/sessions/conv_kiro_stop/events",
+            "/v1/sessions/cd2a2b575af18bbc3a38fd025e379be0/events",
             json={"type": "stop_session"},
         )
-        queue = _session_event_queues_ref.get("conv_kiro_stop")
+        queue = _session_event_queues_ref.get("cd2a2b575af18bbc3a38fd025e379be0")
         queued_events: list[dict[str, Any]] = []
         while queue is not None and not queue.empty():
             item = queue.get_nowait()
@@ -17971,7 +18213,9 @@ async def test_events_stop_session_on_kiro_native_kills_tmux_and_publishes_idle(
         f"kiro-native stop dispatch entry is missing."
     )
     bridge_dir, timeout_s = captured[0]
-    assert bridge_dir == kiro_native_bridge.bridge_dir_for_session_id("conv_kiro_stop")
+    assert bridge_dir == kiro_native_bridge.bridge_dir_for_session_id(
+        "cd2a2b575af18bbc3a38fd025e379be0"
+    )
     assert timeout_s == 1.0
     idle_events = [
         e for e in queued_events if e.get("type") == "session.status" and e.get("status") == "idle"
@@ -18021,14 +18265,17 @@ async def test_events_interrupt_on_kiro_native_503_skips_idle_when_inject_fails(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_kiro_int_fail", "agent_id": "ag_1"},
+            json={
+                "session_id": "b756aafcdc68c0ed2cf92b34085be5bb",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
         int_resp = await client.post(
-            "/v1/sessions/conv_kiro_int_fail/events",
+            "/v1/sessions/b756aafcdc68c0ed2cf92b34085be5bb/events",
             json={"type": "interrupt"},
         )
-        queue = _session_event_queues_ref.get("conv_kiro_int_fail")
+        queue = _session_event_queues_ref.get("b756aafcdc68c0ed2cf92b34085be5bb")
         queued_events: list[dict[str, Any]] = []
         while queue is not None and not queue.empty():
             item = queue.get_nowait()
@@ -18091,14 +18338,17 @@ async def test_events_stop_session_on_kiro_native_503_when_kill_fails(
     async with _runner_client(app) as client:
         create_resp = await client.post(
             "/v1/sessions",
-            json={"session_id": "conv_kiro_stop_fail", "agent_id": "ag_1"},
+            json={
+                "session_id": "695c27b61206353f312efe5f6a7ca0f6",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
+            },
         )
         assert create_resp.status_code == 201, create_resp.text
         stop_resp = await client.post(
-            "/v1/sessions/conv_kiro_stop_fail/events",
+            "/v1/sessions/695c27b61206353f312efe5f6a7ca0f6/events",
             json={"type": "stop_session"},
         )
-        queue = _session_event_queues_ref.get("conv_kiro_stop_fail")
+        queue = _session_event_queues_ref.get("695c27b61206353f312efe5f6a7ca0f6")
         queued_events: list[dict[str, Any]] = []
         while queue is not None and not queue.empty():
             item = queue.get_nowait()

--- a/tests/runtime/policies/test_approval.py
+++ b/tests/runtime/policies/test_approval.py
@@ -334,10 +334,12 @@ def test_elicitation_request_event_url_mode(monkeypatch: pytest.MonkeyPatch) -> 
         policy_names=["shell_gate"],
         content_preview="rm -rf /",
     )
-    event = _elicitation_request_event("elicit_abc", req, session_id="conv_123")
+    event = _elicitation_request_event(
+        "elicit_abc", req, session_id="0099dc8be6d82871e2e450424d46d1b7"
+    )
     params = event["params"]
     assert params["mode"] == "url"
-    assert params["url"] == "/approve/conv_123/elicit_abc"
+    assert params["url"] == "/approve/0099dc8be6d82871e2e450424d46d1b7/elicit_abc"
     # Message and extras are still present.
     assert params["message"] == "approve shell?"
 
@@ -354,7 +356,9 @@ def test_elicitation_request_event_form_mode_explicit(monkeypatch: pytest.Monkey
         policy_names=["gate"],
         content_preview="ls",
     )
-    event = _elicitation_request_event("elicit_abc", req, session_id="conv_123")
+    event = _elicitation_request_event(
+        "elicit_abc", req, session_id="0099dc8be6d82871e2e450424d46d1b7"
+    )
     params = event["params"]
     assert params["mode"] == "form"
     assert "url" not in params

--- a/tests/runtime/policies/test_builder_session_policies.py
+++ b/tests/runtime/policies/test_builder_session_policies.py
@@ -48,9 +48,9 @@ def test_stored_python_policy_to_spec() -> None:
     so the engine skips phase filtering (callable self-selects).
     """
     stored = StoredPolicy(
-        id="pol_abc",
+        id="836115190a01c5c536c2bdbbeff76c6c",
         name="rate_limit",
-        session_id="conv_123",
+        session_id="0099dc8be6d82871e2e450424d46d1b7",
         scope="session",
         created_at=1000,
         type="python",
@@ -71,9 +71,9 @@ def test_stored_python_policy_to_spec() -> None:
 def test_stored_python_policy_without_factory_params() -> None:
     """A stored Python policy with no factory_params gets ``arguments=None``."""
     stored = StoredPolicy(
-        id="pol_def",
+        id="da881c94710f663083e832772c9846a5",
         name="simple",
-        session_id="conv_123",
+        session_id="0099dc8be6d82871e2e450424d46d1b7",
         scope="session",
         created_at=1000,
         type="python",
@@ -95,9 +95,9 @@ def test_stored_url_policy_raises() -> None:
     store a guardrail that never enforces).
     """
     stored = StoredPolicy(
-        id="pol_url",
+        id="0649a4ce3cc08828d91e43d38b2d5f4c",
         name="external",
-        session_id="conv_123",
+        session_id="0099dc8be6d82871e2e450424d46d1b7",
         scope="session",
         created_at=1000,
         type="url",
@@ -115,7 +115,7 @@ def test_stored_url_policy_raises() -> None:
 
 def test_load_session_policy_specs_none_store() -> None:
     """When ``policy_store`` is ``None``, returns an empty list."""
-    assert _load_session_policy_specs("conv_123", None) == []
+    assert _load_session_policy_specs("0099dc8be6d82871e2e450424d46d1b7", None) == []
 
 
 def test_load_session_policy_specs_caches_result(db_uri: str) -> None:
@@ -127,7 +127,7 @@ def test_load_session_policy_specs_caches_result(db_uri: str) -> None:
     conv = conv_store.create_conversation()
     store = SqlAlchemyPolicyStore(db_uri)
     store.create(
-        policy_id="pol_cache",
+        policy_id="761d8d3f506e256fe5a0a871cf9599fc",
         session_id=conv.id,
         name="cache_test",
         type="python",
@@ -138,7 +138,7 @@ def test_load_session_policy_specs_caches_result(db_uri: str) -> None:
 
     first = _load_session_policy_specs(conv.id, store)
     store.create(
-        policy_id="pol_cache2",
+        policy_id="05a4f08244fca2e47f8fcf558fac5d4c",
         session_id=conv.id,
         name="cache_test2",
         type="python",
@@ -159,7 +159,7 @@ def test_invalidate_session_policy_specs_cache(db_uri: str) -> None:
     conv = conv_store.create_conversation()
     store = SqlAlchemyPolicyStore(db_uri)
     store.create(
-        policy_id="pol_inv1",
+        policy_id="7b281600bfa993299f67187e524a49fb",
         session_id=conv.id,
         name="inv_policy1",
         type="python",
@@ -172,7 +172,7 @@ def test_invalidate_session_policy_specs_cache(db_uri: str) -> None:
     assert len(first) == 1
 
     store.create(
-        policy_id="pol_inv2",
+        policy_id="31ec3b5f905b29ebddd6f7a1a5570547",
         session_id=conv.id,
         name="inv_policy2",
         type="python",
@@ -194,7 +194,7 @@ def test_load_session_policy_specs_filters_disabled(db_uri: str) -> None:
     conv = conv_store.create_conversation()
     store = SqlAlchemyPolicyStore(db_uri)
     store.create(
-        policy_id="pol_enabled",
+        policy_id="fd0deac497210bc17cba2e1c66afe833",
         session_id=conv.id,
         name="enabled_policy",
         type="python",
@@ -202,7 +202,7 @@ def test_load_session_policy_specs_filters_disabled(db_uri: str) -> None:
         enabled=True,
     )
     store.create(
-        policy_id="pol_disabled",
+        policy_id="96eef7369235e1bacfd949e6447f0eeb",
         session_id=conv.id,
         name="disabled_policy",
         type="python",
@@ -225,7 +225,7 @@ def test_load_session_policy_specs_rejects_enabled_url(db_uri: str) -> None:
     conv = conv_store.create_conversation()
     store = SqlAlchemyPolicyStore(db_uri)
     store.create(
-        policy_id="pol_url",
+        policy_id="0649a4ce3cc08828d91e43d38b2d5f4c",
         session_id=conv.id,
         name="external",
         type="url",
@@ -265,7 +265,7 @@ def test_build_engine_includes_session_policies(db_uri: str) -> None:
     conv = conv_store.create_conversation()
     policy_store = SqlAlchemyPolicyStore(db_uri)
     policy_store.create(
-        policy_id="pol_test",
+        policy_id="b52655498c35d115250d7f89a3422b5f",
         session_id=conv.id,
         name="test_policy",
         type="python",
@@ -294,7 +294,7 @@ def test_build_engine_no_store_returns_noop(db_uri: str) -> None:
 
     engine = build_policy_engine(
         spec=_make_minimal_spec(),
-        conversation_id="conv_nonexistent",
+        conversation_id="ad563e906854634c49e1a6fd2fbb31d4",
         conversation_store=conv_store,
         policy_store=None,
     )
@@ -338,7 +338,7 @@ def test_build_engine_ordering_session_agent_admin(db_uri: str) -> None:
     conv = conv_store.create_conversation()
     policy_store = SqlAlchemyPolicyStore(db_uri)
     policy_store.create(
-        policy_id="pol_session",
+        policy_id="28cb2620dd5d5ba3cb7560b76843cc03",
         session_id=conv.id,
         name="session_policy",
         type="python",
@@ -385,7 +385,7 @@ def test_subagent_inherits_root_session_policies(db_uri: str) -> None:
 
     policy_store = SqlAlchemyPolicyStore(db_uri)
     policy_store.create(
-        policy_id="pol_root",
+        policy_id="c6de31de238a26c347a7c3d8d5a74c3a",
         session_id=root_conv.id,
         name="root_guard",
         type="python",
@@ -426,14 +426,14 @@ def test_subagent_deduplicates_same_name_policy(db_uri: str) -> None:
     policy_store = SqlAlchemyPolicyStore(db_uri)
     # Same-name policy on both root and child.
     policy_store.create(
-        policy_id="pol_root",
+        policy_id="c6de31de238a26c347a7c3d8d5a74c3a",
         session_id=root_conv.id,
         name="shared_guard",
         type="python",
         handler=handler,
     )
     policy_store.create(
-        policy_id="pol_child",
+        policy_id="86507aab3e1f97f6b1bace6058204f1a",
         session_id=child_conv.id,
         name="shared_guard",
         type="python",
@@ -469,7 +469,7 @@ def test_root_session_does_not_double_load(db_uri: str) -> None:
 
     policy_store = SqlAlchemyPolicyStore(db_uri)
     policy_store.create(
-        policy_id="pol_root",
+        policy_id="c6de31de238a26c347a7c3d8d5a74c3a",
         session_id=root_conv.id,
         name="root_only",
         type="python",
@@ -511,14 +511,14 @@ def test_load_default_policy_specs_skips_url_type(db_uri: str) -> None:
     # Insert a url-type default directly via the store (bypassing the route
     # guard that rejects url defaults at creation time).
     store.create_default(
-        policy_id="dpol_url",
+        policy_id="fe00550b91828f5ab080225d7982fa8a",
         name="url_default",
         type="url",
         handler="https://example.com/eval",
         enabled=True,
     )
     store.create_default(
-        policy_id="dpol_ok",
+        policy_id="9630be719cf8872a30e0d820fc737c30",
         name="python_default",
         type="python",
         handler="myorg.policies.allow_all",
@@ -540,14 +540,14 @@ def test_load_default_policy_specs_filters_disabled(db_uri: str) -> None:
     """
     store = SqlAlchemyPolicyStore(db_uri)
     store.create_default(
-        policy_id="dpol_enabled",
+        policy_id="8b0c52d27883a504e03b87ac6d10abae",
         name="enabled_default",
         type="python",
         handler="myorg.policies.allow_all",
         enabled=True,
     )
     store.create_default(
-        policy_id="dpol_disabled",
+        policy_id="b5edc7521a4113f7a2931c06458f8416",
         name="disabled_default",
         type="python",
         handler="myorg.policies.deny_all",
@@ -568,7 +568,7 @@ def test_load_default_policy_specs_caches_result(db_uri: str) -> None:
     """
     store = SqlAlchemyPolicyStore(db_uri)
     store.create_default(
-        policy_id="dpol_cache",
+        policy_id="5be4b4fa96edbc18615a67e62dc34dae",
         name="cache_test",
         type="python",
         handler="myorg.policies.allow_all",
@@ -579,7 +579,7 @@ def test_load_default_policy_specs_caches_result(db_uri: str) -> None:
     first = _load_default_policy_specs(store)
     # Add a second default policy directly — bypasses the cache.
     store.create_default(
-        policy_id="dpol_cache2",
+        policy_id="3577c758d2840a6ed1149b2a04611222",
         name="cache_test2",
         type="python",
         handler="myorg.policies.allow_all",
@@ -598,7 +598,7 @@ def test_invalidate_default_policy_specs_cache(db_uri: str) -> None:
     """
     store = SqlAlchemyPolicyStore(db_uri)
     store.create_default(
-        policy_id="dpol_inv1",
+        policy_id="b991d86d83432c7b91fc08127e31a153",
         name="inv_policy1",
         type="python",
         handler="myorg.policies.allow_all",
@@ -610,7 +610,7 @@ def test_invalidate_default_policy_specs_cache(db_uri: str) -> None:
     assert len(first) == 1
 
     store.create_default(
-        policy_id="dpol_inv2",
+        policy_id="2574142d58ba1496e7339bc1043fa206",
         name="inv_policy2",
         type="python",
         handler="myorg.policies.allow_all",
@@ -635,7 +635,7 @@ def test_build_engine_includes_db_default_policies(db_uri: str) -> None:
     conv = conv_store.create_conversation()
     policy_store = SqlAlchemyPolicyStore(db_uri)
     policy_store.create_default(
-        policy_id="dpol_test",
+        policy_id="ed307f905af1d035ee90159d05a92d70",
         name="db_default_policy",
         type="python",
         handler=handler,
@@ -680,14 +680,14 @@ def test_build_engine_ordering_session_agent_db_default_admin(db_uri: str) -> No
     conv = conv_store.create_conversation()
     policy_store = SqlAlchemyPolicyStore(db_uri)
     policy_store.create(
-        policy_id="pol_session",
+        policy_id="28cb2620dd5d5ba3cb7560b76843cc03",
         session_id=conv.id,
         name="session_policy",
         type="python",
         handler=handler,
     )
     policy_store.create_default(
-        policy_id="dpol_db",
+        policy_id="efbd7a351c1b7024b7671f1c5096cac3",
         name="db_default_policy",
         type="python",
         handler=handler,

--- a/tests/runtime/policies/test_conversation_isolation.py
+++ b/tests/runtime/policies/test_conversation_isolation.py
@@ -143,7 +143,7 @@ async def test_deny_on_one_conversation_does_not_leak_to_other(
 async def test_seeding_isolated_across_conversations(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """Seeding on conv_a does not trigger writes on conv_b.
+    """Seeding on 94c349190e241f85a984b3df8f129696 does not trigger writes on conv_b.
     Each call to ``build_policy_engine`` is scoped by
     conversation_id — proved by observing B's state is
     unchanged by A's seed."""

--- a/tests/runtime/policies/test_function_policy.py
+++ b/tests/runtime/policies/test_function_policy.py
@@ -322,7 +322,7 @@ async def test_two_arg_callable_receives_config() -> None:
     policy = FunctionPolicy(spec, fn)
     await policy.evaluate(
         EvaluationContext(phase=Phase.REQUEST, content="x"),
-        {"labels": {"integrity": "1"}, "conversation_id": "conv_42"},
+        {"labels": {"integrity": "1"}, "conversation_id": "27516b8b4fee85f40b55fac38c353546"},
     )
     # The callable observed the spec's static config, not the
     # engine's runtime label/conversation bundle.

--- a/tests/runtime/test_subagent_block_notifier.py
+++ b/tests/runtime/test_subagent_block_notifier.py
@@ -972,7 +972,7 @@ async def test_observe_no_op_when_child_conversation_missing(
         loop=asyncio.get_event_loop(),
     )
 
-    notifier.observe("conv_does_not_exist", _request_event("elicit_ghost"))
+    notifier.observe("1d0b12236c77f69f5073a53583de1a3f", _request_event("elicit_ghost"))
     # Yield a few times to surface any dispatch that might fire from a
     # mis-handled missing-conv case.
     for _ in range(4):
@@ -1049,7 +1049,7 @@ def _make_conv(*, id: str, title: str | None) -> Conversation:
     ``updated_at`` / ``root_conversation_id`` so this helper supplies
     plausible values for the ones the projector doesn't read.
 
-    :param id: Conversation id, e.g. ``"conv_x"``.
+    :param id: Conversation id, e.g. ``"8af356d908005a65f872c246158c6293"``.
     :param title: Title to project, e.g. ``"codex:auth-refactor"`` or
         ``None``.
     :returns: A :class:`Conversation`.
@@ -1061,7 +1061,7 @@ def _make_conv(*, id: str, title: str | None) -> Conversation:
         root_conversation_id=id,
         title=title,
         kind="sub_agent",
-        agent_id="ag_x",
+        agent_id="d7a89f58205a70539a16fa4b7bd06270",
         labels={},
     )
 
@@ -1070,7 +1070,7 @@ def test_child_label_handles_named_subagent_title() -> None:
     """
     A standard ``"<agent>:<title>"`` titles project to ``"<agent>/<title>"``.
     """
-    conv = _make_conv(id="conv_x", title="codex:auth-refactor")
+    conv = _make_conv(id="8af356d908005a65f872c246158c6293", title="codex:auth-refactor")
     assert _child_label(conv) == "codex/auth-refactor"
 
 
@@ -1079,5 +1079,5 @@ def test_child_label_falls_back_to_id_for_titleless_session() -> None:
     A conversation with no title labels by id so the notice always
     names something the parent agent can act on.
     """
-    conv = _make_conv(id="conv_naked", title="")
-    assert _child_label(conv) == "conv_naked"
+    conv = _make_conv(id="fd996830e1375c7af31f7164fdab4de0", title="")
+    assert _child_label(conv) == "fd996830e1375c7af31f7164fdab4de0"

--- a/tests/runtime/test_telemetry.py
+++ b/tests/runtime/test_telemetry.py
@@ -538,12 +538,14 @@ def test_fastapi_session_id_hook_stamps_session_id(
     """
     tracer = otel_trace.get_tracer("test")
     span = tracer.start_span("POST /v1/sessions/{id}/events")
-    telemetry._fastapi_session_id_hook(span, {"path": "/v1/sessions/conv_deadbeef/events"})
+    telemetry._fastapi_session_id_hook(
+        span, {"path": "/v1/sessions/e8d54a2f98774dc2988c895df854a815/events"}
+    )
     span.end()
 
     exported = in_memory_exporter.get_finished_spans()
     assert exported[-1].attributes is not None
-    assert exported[-1].attributes.get("session.id") == "conv_deadbeef"
+    assert exported[-1].attributes.get("session.id") == "e8d54a2f98774dc2988c895df854a815"
 
 
 def test_fastapi_session_id_hook_ignores_non_session_paths(
@@ -575,14 +577,14 @@ def test_tracing_context_stamps_session_id_on_agent_span(
     """
     from omnigent.inner.tracing import TracingContext
 
-    tctx = TracingContext(session_id="conv_abc123")
+    tctx = TracingContext(session_id="d1f9214d74c38b9f9a9db17ed8352dc4")
     agent_span = tctx.start_agent_span("my-agent", "hello")
     tctx.end_agent_span(agent_span, response="hi")
 
     exported = in_memory_exporter.get_finished_spans()
     agent_spans = [s for s in exported if s.name == "agent:my-agent"]
     assert agent_spans, "expected an agent span to be exported"
-    assert agent_spans[-1].attributes.get("session.id") == "conv_abc123"
+    assert agent_spans[-1].attributes.get("session.id") == "d1f9214d74c38b9f9a9db17ed8352dc4"
 
 
 def test_set_session_id_stamps_current_span(
@@ -598,11 +600,11 @@ def test_set_session_id_stamps_current_span(
     """
     tracer = otel_trace.get_tracer("test")
     with tracer.start_as_current_span("POST /v1/sessions"):
-        telemetry.set_session_id("conv_cafef00d")
+        telemetry.set_session_id("7bf6ff2daf0081cc71f6620b5f550430")
         telemetry.set_session_id(None)  # no-op, must not raise or clear
 
     exported = in_memory_exporter.get_finished_spans()
-    assert exported[-1].attributes.get("session.id") == "conv_cafef00d"
+    assert exported[-1].attributes.get("session.id") == "7bf6ff2daf0081cc71f6620b5f550430"
 
 
 def test_session_scope_processor_stamps_every_span() -> None:
@@ -620,7 +622,7 @@ def test_session_scope_processor_stamps_every_span() -> None:
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     tracer = provider.get_tracer("test")
 
-    with telemetry.session_scope("conv_generic01"):
+    with telemetry.session_scope("15ccc6868d9fc724f74fa2435e716ef0"):
         with tracer.start_as_current_span("server.request"):
             with tracer.start_as_current_span("db.query"):  # child span, never stamped by hand
                 pass
@@ -628,8 +630,10 @@ def test_session_scope_processor_stamps_every_span() -> None:
         pass
 
     spans = {s.name: s for s in exporter.get_finished_spans()}
-    assert spans["server.request"].attributes.get("session.id") == "conv_generic01"
-    assert spans["db.query"].attributes.get("session.id") == "conv_generic01"
+    assert (
+        spans["server.request"].attributes.get("session.id") == "15ccc6868d9fc724f74fa2435e716ef0"
+    )
+    assert spans["db.query"].attributes.get("session.id") == "15ccc6868d9fc724f74fa2435e716ef0"
     assert "session.id" not in (spans["outside.scope"].attributes or {})
 
 

--- a/tests/server/integration/test_builtin_agents.py
+++ b/tests/server/integration/test_builtin_agents.py
@@ -62,7 +62,7 @@ def _register_builtin_agent(
 
     :param agent_store: Store the agent row is written to.
     :param artifact_store: Store the bundle bytes are written to.
-    :param agent_id: Agent id, e.g. ``"ag_codex"``.
+    :param agent_id: Agent id, e.g. ``"12c8c7631b209d1027416b4bf7604999"``.
     :param name: Agent name, e.g. ``"codex-native-ui"``.
     :param bundle: Gzipped agent bundle bytes from
         :func:`build_agent_bundle`.
@@ -109,14 +109,25 @@ async def test_list_builtin_agents_returns_registered_templates(
     against a built-in. ``mcp_servers`` is empty here because the test
     agents have no real bundle (the spec load fails gracefully).
     """
-    agent_store.create("ag_builtin_1", "claude-native-ui", "ag_builtin_1/bundle")
-    agent_store.create("ag_builtin_2", "research-agent", "ag_builtin_2/bundle")
+    agent_store.create(
+        "2d2cd1e48ffdf8a4c7195e954e2e912c",
+        "claude-native-ui",
+        "2d2cd1e48ffdf8a4c7195e954e2e912c/bundle",
+    )
+    agent_store.create(
+        "01bda0a6f702a638bbee8d871441e659",
+        "research-agent",
+        "01bda0a6f702a638bbee8d871441e659/bundle",
+    )
 
     resp = await agents_client.get("/v1/agents")
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert {a["id"] for a in body["data"]} == {"ag_builtin_1", "ag_builtin_2"}
+    assert {a["id"] for a in body["data"]} == {
+        "2d2cd1e48ffdf8a4c7195e954e2e912c",
+        "01bda0a6f702a638bbee8d871441e659",
+    }
     assert {a["name"] for a in body["data"]} == {"claude-native-ui", "research-agent"}
     assert body["has_more"] is False
     # No loadable bundle → harness degrades to None rather than failing
@@ -156,7 +167,7 @@ async def test_list_builtin_agents_exposes_harness_from_spec(
     _register_builtin_agent(
         agent_store,
         artifact_store,
-        agent_id="ag_harness",
+        agent_id="67914bd6ac8bd25239a14ef060e99e70",
         name="custom-reviewer",
         bundle=bundle,
     )
@@ -164,7 +175,7 @@ async def test_list_builtin_agents_exposes_harness_from_spec(
     resp = await agents_client.get("/v1/agents")
 
     assert resp.status_code == 200, resp.text
-    entry = next(a for a in resp.json()["data"] if a["id"] == "ag_harness")
+    entry = next(a for a in resp.json()["data"] if a["id"] == "67914bd6ac8bd25239a14ef060e99e70")
     # Proves the spec's harness traversed the load → AgentObject path.
     # A None here means the bundle failed to load; a different value
     # means the route read the wrong spec field.
@@ -191,7 +202,7 @@ async def test_list_builtin_agents_exposes_declared_terminals_from_spec(
     _register_builtin_agent(
         agent_store,
         artifact_store,
-        agent_id="ag_terminals",
+        agent_id="5668ffcb1258cd047cfd400e190ed38c",
         name="terminal-agent",
         bundle=bundle,
     )
@@ -199,7 +210,7 @@ async def test_list_builtin_agents_exposes_declared_terminals_from_spec(
     resp = await agents_client.get("/v1/agents")
 
     assert resp.status_code == 200, resp.text
-    entry = next(a for a in resp.json()["data"] if a["id"] == "ag_terminals")
+    entry = next(a for a in resp.json()["data"] if a["id"] == "5668ffcb1258cd047cfd400e190ed38c")
     # Both declared names in spec order — proves the spec's terminals
     # block traversed the load → AgentObject path verbatim.
     assert entry["terminals"] == ["shell", "py"]
@@ -240,7 +251,7 @@ async def test_list_builtin_agents_exposes_bundled_skills_from_spec(
     _register_builtin_agent(
         agent_store,
         artifact_store,
-        agent_id="ag_skilled",
+        agent_id="66614758344e352ba3d265401d826803",
         name="skilled-agent",
         bundle=bundle,
     )
@@ -248,7 +259,7 @@ async def test_list_builtin_agents_exposes_bundled_skills_from_spec(
     resp = await agents_client.get("/v1/agents")
 
     assert resp.status_code == 200, resp.text
-    entry = next(a for a in resp.json()["data"] if a["id"] == "ag_skilled")
+    entry = next(a for a in resp.json()["data"] if a["id"] == "66614758344e352ba3d265401d826803")
     # Both bundled skills traversed the load → AgentObject path with the
     # exact name + description the composer menu renders. A missing or
     # renamed entry means the landing "/" menu regressed to empty.
@@ -283,7 +294,7 @@ async def test_catalog_keeps_custom_agent_distinct_from_builtin_claude_and_codex
     _register_builtin_agent(
         agent_store,
         artifact_store,
-        agent_id="ag_claude",
+        agent_id="3a9725fd4de1720e83e53a632da41da8",
         name="claude-native-ui",
         bundle=build_agent_bundle(
             name="claude-native-ui",
@@ -293,7 +304,7 @@ async def test_catalog_keeps_custom_agent_distinct_from_builtin_claude_and_codex
     _register_builtin_agent(
         agent_store,
         artifact_store,
-        agent_id="ag_codex",
+        agent_id="12c8c7631b209d1027416b4bf7604999",
         name="codex-native-ui",
         bundle=build_agent_bundle(
             name="codex-native-ui",
@@ -303,7 +314,7 @@ async def test_catalog_keeps_custom_agent_distinct_from_builtin_claude_and_codex
     _register_builtin_agent(
         agent_store,
         artifact_store,
-        agent_id="ag_custom",
+        agent_id="f157d3110ddee6bc0f8e1b893270c8a6",
         name="databricks-coding-agent",
         description="Custom coding agent",
         bundle=build_agent_bundle(
@@ -317,17 +328,21 @@ async def test_catalog_keeps_custom_agent_distinct_from_builtin_claude_and_codex
     assert resp.status_code == 200, resp.text
     by_id = {a["id"]: a for a in resp.json()["data"]}
     # All three discoverable in the one catalog the picker reads.
-    assert by_id.keys() >= {"ag_claude", "ag_codex", "ag_custom"}
+    assert by_id.keys() >= {
+        "3a9725fd4de1720e83e53a632da41da8",
+        "12c8c7631b209d1027416b4bf7604999",
+        "f157d3110ddee6bc0f8e1b893270c8a6",
+    }
     # Each carries its own harness — the custom agent is neither the
     # Claude nor the Codex kind. A shared/wrong value here is exactly the
     # mis-badging this contract guards against.
-    assert by_id["ag_claude"]["harness"] == "claude-sdk"
-    assert by_id["ag_codex"]["harness"] == "codex"
-    assert by_id["ag_custom"]["harness"] == "openai-agents"
+    assert by_id["3a9725fd4de1720e83e53a632da41da8"]["harness"] == "claude-sdk"
+    assert by_id["12c8c7631b209d1027416b4bf7604999"]["harness"] == "codex"
+    assert by_id["f157d3110ddee6bc0f8e1b893270c8a6"]["harness"] == "openai-agents"
     # The custom agent keeps its registered name and description (the
     # picker's label), distinct from both built-ins.
-    assert by_id["ag_custom"]["name"] == "databricks-coding-agent"
-    assert by_id["ag_custom"]["description"] == "Custom coding agent"
+    assert by_id["f157d3110ddee6bc0f8e1b893270c8a6"]["name"] == "databricks-coding-agent"
+    assert by_id["f157d3110ddee6bc0f8e1b893270c8a6"]["description"] == "Custom coding agent"
 
 
 async def test_list_builtin_agents_empty_when_none_registered(
@@ -378,7 +393,7 @@ async def test_catalog_entry_exposes_availability_and_reason(
     _register_builtin_agent(
         agent_store,
         artifact_store,
-        agent_id="ag_avail",
+        agent_id="77b35426aef3c1495c2912cecb232108",
         name="codex-reviewer",
         bundle=bundle,
     )
@@ -386,7 +401,7 @@ async def test_catalog_entry_exposes_availability_and_reason(
     resp = await agents_client.get("/v1/agents")
 
     assert resp.status_code == 200, resp.text
-    entry = next(a for a in resp.json()["data"] if a["id"] == "ag_avail")
+    entry = next(a for a in resp.json()["data"] if a["id"] == "77b35426aef3c1495c2912cecb232108")
     # availability gates whether the picker can launch the entry;
     # unavailable_reason explains a disabled one. Both absent from the
     # AgentObject schema today, so these key lookups fail (the xfail).
@@ -417,7 +432,7 @@ async def test_catalog_description_falls_back_to_spec_when_row_unset(
     _register_builtin_agent(
         agent_store,
         artifact_store,
-        agent_id="ag_specdesc",
+        agent_id="7152784735902dd2219239e9577daf2d",
         name="hoverable-agent",
         bundle=bundle,
         description=None,
@@ -426,7 +441,7 @@ async def test_catalog_description_falls_back_to_spec_when_row_unset(
     resp = await agents_client.get("/v1/agents")
 
     assert resp.status_code == 200, resp.text
-    entry = next(a for a in resp.json()["data"] if a["id"] == "ag_specdesc")
+    entry = next(a for a in resp.json()["data"] if a["id"] == "7152784735902dd2219239e9577daf2d")
     # The stored column is None, so a non-None value here can only have
     # come from the spec via the load → AgentObject fallback path.
     assert entry["description"] == "Planned and split across sub-agents."
@@ -454,7 +469,7 @@ async def test_catalog_description_prefers_stored_row_over_spec(
     _register_builtin_agent(
         agent_store,
         artifact_store,
-        agent_id="ag_storeddesc",
+        agent_id="92b7d16d5c148ea2cfc43786bb1c696e",
         name="relabelled-agent",
         bundle=bundle,
         description="Curated catalog label.",
@@ -463,7 +478,7 @@ async def test_catalog_description_prefers_stored_row_over_spec(
     resp = await agents_client.get("/v1/agents")
 
     assert resp.status_code == 200, resp.text
-    entry = next(a for a in resp.json()["data"] if a["id"] == "ag_storeddesc")
+    entry = next(a for a in resp.json()["data"] if a["id"] == "92b7d16d5c148ea2cfc43786bb1c696e")
     # Stored value present → it wins; the differing spec description
     # proves the route didn't blindly overwrite with the bundle's.
     assert entry["description"] == "Curated catalog label."

--- a/tests/server/integration/test_comments_rest_e2e.py
+++ b/tests/server/integration/test_comments_rest_e2e.py
@@ -57,7 +57,7 @@ def _seed_session(db_uri: str, *, with_agent: bool = False) -> str:
     if with_agent:
         agent_store = SqlAlchemyAgentStore(db_uri)
         agent = agent_store.create(
-            agent_id="ag_test",
+            agent_id="087b7cb7ac30abf4debfaa578d052ec6",
             name="test-agent",
             bundle_location="fake/bundle",
         )
@@ -235,7 +235,7 @@ async def test_comment_on_nonexistent_session_returns_404(
     headers = {"X-Forwarded-Email": ALICE}
 
     resp = await auth_client.post(
-        "/v1/sessions/conv_does_not_exist/comments",
+        "/v1/sessions/1d0b12236c77f69f5073a53583de1a3f/comments",
         json={
             "path": "src/foo.py",
             "body": "Hello",

--- a/tests/server/integration/test_comments_routes.py
+++ b/tests/server/integration/test_comments_routes.py
@@ -40,7 +40,7 @@ def _seed_session_with_grants(
     :param db_uri: SQLite URI for the per-test database.
     :param grants: Mapping of ``{user_email: level}`` to grant on the new
         session, e.g. ``{"alice@example.com": LEVEL_EDIT}``.
-    :returns: The newly created conversation ID, e.g. ``"conv_abc123"``.
+    :returns: The newly created conversation ID, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
     """
     conv_store = SqlAlchemyConversationStore(db_uri)
     conversation = conv_store.create_conversation()
@@ -219,7 +219,7 @@ async def test_admin_cannot_add_comment_to_nonexistent_session(
 ) -> None:
     """Admin bypass must not allow orphan comments on missing sessions."""
     admin = "admin@example.com"
-    missing_session_id = "conv_does_not_exist"
+    missing_session_id = "1d0b12236c77f69f5073a53583de1a3f"
     perm_store = SqlAlchemyPermissionStore(db_uri)
     perm_store.ensure_user(admin, is_admin=True)
 

--- a/tests/server/integration/test_default_policy_routes.py
+++ b/tests/server/integration/test_default_policy_routes.py
@@ -146,7 +146,7 @@ async def test_create_default_policy(
     assert body["type"] == "python"
     assert body["handler"] == "omnigent.policies.builtins.safety.ask_on_os_tools"
     assert body["enabled"] is True
-    assert body["id"].startswith("pol_")
+    assert len(body["id"]) == 32
     assert body["created_by"] == "admin@example.com"
 
 
@@ -369,7 +369,7 @@ async def test_get_nonexistent_returns_404(
     """GET /v1/policies/{id} with a bad ID returns 404."""
     _make_admin(db_uri)
     resp = await auth_client.get(
-        "/v1/policies/dpol_nonexistent",
+        "/v1/policies/21ed01e726fff00d3f8c012b8e44749b",
         headers=_admin_headers(),
     )
     assert resp.status_code == 404
@@ -382,7 +382,7 @@ async def test_update_nonexistent_returns_404(
     """PATCH /v1/policies/{id} with a bad ID returns 404."""
     _make_admin(db_uri)
     resp = await auth_client.patch(
-        "/v1/policies/dpol_nonexistent",
+        "/v1/policies/21ed01e726fff00d3f8c012b8e44749b",
         json={"name": "x"},
         headers=_admin_headers(),
     )

--- a/tests/server/integration/test_host_liveness_staleness_e2e.py
+++ b/tests/server/integration/test_host_liveness_staleness_e2e.py
@@ -99,7 +99,7 @@ async def host_aware_client(
         yield client
 
 
-_HOST_ID = "host_stale_repro"
+_HOST_ID = "9b2ec6de30f5e014c7056afe505510c3"
 
 # How far in the past to push the host's last-seen to model a host
 # that crashed "a while ago". The freshness window (on the order of the
@@ -113,7 +113,7 @@ async def _session_host_online(client: httpx.AsyncClient, session_id: str) -> bo
 
     :param client: Test HTTP client wired to the app.
     :param session_id: Session whose host liveness to read,
-        e.g. ``"conv_abc123"``.
+        e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
     :returns: ``True`` when the bound host is online and fresh,
         ``False`` when it is offline/stale, ``None`` when the session
         has no host binding.

--- a/tests/server/integration/test_host_runner_launch_worktree.py
+++ b/tests/server/integration/test_host_runner_launch_worktree.py
@@ -51,7 +51,7 @@ from tests.server.helpers import create_test_agent
 
 pytestmark = pytest.mark.asyncio
 
-_HOST_ID = "host_runner_wt"
+_HOST_ID = "51dc949aba31e24ca8f047d6fba31a0d"
 _SOURCE_REPO = "/Users/alice/myrepo"
 
 

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -52,7 +52,7 @@ from tests.server.helpers import (
 
 pytestmark = pytest.mark.asyncio
 
-_HOST_ID = "host_binding_test"
+_HOST_ID = "3f866cafac81246fb60ae6ceb1a738da"
 
 
 def _websocket_scope(path: str) -> dict[str, object]:
@@ -570,7 +570,11 @@ async def test_managed_session_create_validator_errors_serialize_as_422(
     """
     resp = await managed_session_env.client.post(
         "/v1/sessions",
-        json={"agent_id": "ag_x", "host_type": "managed", "workspace": "/tmp/w"},
+        json={
+            "agent_id": "d7a89f58205a70539a16fa4b7bd06270",
+            "host_type": "managed",
+            "workspace": "/tmp/w",
+        },
     )
     assert resp.status_code == 422, resp.text
     detail = resp.json()["detail"]
@@ -1062,7 +1066,7 @@ async def test_resumable_managed_wake_ignores_stale_db_liveness(
     host_store = HostStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
     host_store.register_managed_host(
-        host_id="host_stale_live_islo",
+        host_id="40bb7200abc8ed27d5b2fcbfad8e89d2",
         name="managed-stale-live-islo",
         owner=RESERVED_USER_LOCAL,
         token="tok-stale-live-islo",
@@ -1071,13 +1075,13 @@ async def test_resumable_managed_wake_ignores_stale_db_liveness(
         token_expires_at=9_999_999_999,
     )
     host_store.upsert_on_connect(
-        host_id="host_stale_live_islo",
+        host_id="40bb7200abc8ed27d5b2fcbfad8e89d2",
         name="managed-stale-live-islo",
         owner=RESERVED_USER_LOCAL,
     )
     conv = conv_store.create_conversation(
         agent_id=None,
-        host_id="host_stale_live_islo",
+        host_id="40bb7200abc8ed27d5b2fcbfad8e89d2",
         workspace="/root/workspace",
     )
     fake = FakeSandboxLauncher(can_resume=True)
@@ -1105,7 +1109,7 @@ async def test_resumable_managed_wake_ignores_stale_db_liveness(
         host_registry=SimpleNamespace(get=lambda _host_id: None),
     )
 
-    assert host_store.is_online("host_stale_live_islo") is True
+    assert host_store.is_online("40bb7200abc8ed27d5b2fcbfad8e89d2") is True
     assert (
         await sessions_module._maybe_relaunch_managed_sandbox(
             session_id=conv.id,
@@ -1128,7 +1132,7 @@ async def test_resumable_managed_wake_drops_fresh_local_tunnels_when_provider_pa
     host_store = HostStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
     host_store.register_managed_host(
-        host_id="host_stale_tunnel_islo",
+        host_id="055e31f38d07908f171ebad4ff5cbe9c",
         name="managed-stale-tunnel-islo",
         owner=RESERVED_USER_LOCAL,
         token="tok-stale-tunnel-islo",
@@ -1137,19 +1141,19 @@ async def test_resumable_managed_wake_drops_fresh_local_tunnels_when_provider_pa
         token_expires_at=9_999_999_999,
     )
     host_store.upsert_on_connect(
-        host_id="host_stale_tunnel_islo",
+        host_id="055e31f38d07908f171ebad4ff5cbe9c",
         name="managed-stale-tunnel-islo",
         owner=RESERVED_USER_LOCAL,
     )
     conv = conv_store.create_conversation(
         agent_id=None,
-        host_id="host_stale_tunnel_islo",
+        host_id="055e31f38d07908f171ebad4ff5cbe9c",
         workspace="/root/workspace",
     )
     conv_store.set_runner_id(conv.id, "runner_stale_tunnel")
     conv = conv_store.get_conversation(conv.id)
     assert conv is not None
-    assert host_store.is_online("host_stale_tunnel_islo") is True
+    assert host_store.is_online("055e31f38d07908f171ebad4ff5cbe9c") is True
 
     fake = FakeSandboxLauncher(can_resume=True)
     fake.provider = "islo"  # type: ignore[misc]
@@ -1204,7 +1208,7 @@ async def test_resumable_managed_wake_drops_fresh_local_tunnels_when_provider_pa
         is True
     )
     assert calls == ["wake"]
-    assert host_deregistered == ["host_stale_tunnel_islo"]
+    assert host_deregistered == ["055e31f38d07908f171ebad4ff5cbe9c"]
     assert runner_deregistered == ["runner_stale_tunnel"]
 
 
@@ -1214,10 +1218,10 @@ async def test_managed_wake_fails_when_runner_never_reconnects(
     """A wake cannot publish ready if the launched runner tunnel times out."""
     from omnigent.server.routes import sessions as sessions_module
 
-    session_id = "conv_wake_runner_timeout"
+    session_id = "1a9de2e74d453be7cd665c5290b481b9"
     conv = SimpleNamespace(
         id=session_id,
-        host_id="host_wake_runner_timeout",
+        host_id="cae8b33eab0bd659c87b00dd29946ade",
         workspace="/root/workspace",
         agent_id=None,
         sub_agent_name=None,
@@ -1276,7 +1280,7 @@ async def test_managed_launch_fails_when_runner_never_connects(
     """Initial managed launch settlement also depends on the runner tunnel."""
     from omnigent.server.routes import sessions as sessions_module
 
-    session_id = "conv_launch_runner_timeout"
+    session_id = "1a41e11887aca4570e42c0be40f24833"
     conv = SimpleNamespace(id=session_id)
     tracker = ManagedLaunchTracker()
     tracker.begin(session_id)
@@ -1303,7 +1307,7 @@ async def test_managed_launch_fails_when_runner_never_connects(
     await sessions_module._bind_and_launch_managed_runner(
         session_id=session_id,
         managed=ManagedHostLaunch(
-            host_id="host_launch_runner_timeout",
+            host_id="3c8cdcdb61903904849174c864620a5c",
             workspace="/root/workspace",
         ),
         sandbox_config=ManagedSandboxConfig(

--- a/tests/server/integration/test_host_tunnel_route.py
+++ b/tests/server/integration/test_host_tunnel_route.py
@@ -24,7 +24,7 @@ from omnigent.stores.host_store import HostStore
 
 pytestmark = pytest.mark.asyncio
 
-_HOST_ID = "host_test_001"
+_HOST_ID = "1444b179a19322377dcc75cf7fcd1bd2"
 _TUNNEL_PATH = f"/v1/hosts/{_HOST_ID}/tunnel"
 
 
@@ -36,7 +36,7 @@ def _websocket_scope(
     """Build an ASGI WebSocket scope for a test path.
 
     :param path: WebSocket path, e.g.
-        ``"/v1/hosts/host_test_001/tunnel"``.
+        ``"/v1/hosts/1444b179a19322377dcc75cf7fcd1bd2/tunnel"``.
     :param client_host: ASGI client host, e.g. ``"127.0.0.1"``.
     :returns: A minimal ASGI WebSocket scope accepted by FastAPI.
     """
@@ -560,7 +560,7 @@ async def test_same_owner_reconnect_still_accepts(db_uri: str) -> None:
 def _managed_scope(path: str, token: str) -> dict[str, object]:
     """Build a WebSocket scope carrying a managed-host launch token.
 
-    :param path: WebSocket path, e.g. ``"/v1/hosts/host_x/tunnel"``.
+    :param path: WebSocket path, e.g. ``"/v1/hosts/5d23e459b50e20479abf5d3fa8e2f936/tunnel"``.
     :param token: Raw launch token for the managed-host header.
     :returns: ASGI WebSocket scope with the token header set.
     """
@@ -636,7 +636,7 @@ async def test_managed_token_authenticates_as_record_owner(
         # never downgrade into the anonymous/local auth path.
         (None, None, "no-such-token", 3600),
         # Token scoped to a DIFFERENT host id than the path.
-        ("host_other_sandbox", "tunnel-token-scoped", "tunnel-token-scoped", 3600),
+        ("33fc174daced5821a9bfb975aa99b086", "tunnel-token-scoped", "tunnel-token-scoped", 3600),
         # Expired token.
         (_HOST_ID, "tunnel-token-expired", "tunnel-token-expired", -1),
     ],

--- a/tests/server/integration/test_hosts_api.py
+++ b/tests/server/integration/test_hosts_api.py
@@ -31,7 +31,7 @@ from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissi
 
 pytestmark = pytest.mark.asyncio
 
-_HOST_ID = "host_api_test"
+_HOST_ID = "33296f9b15e02671c34e013dd711407e"
 
 
 def _websocket_scope(path: str) -> dict[str, object]:
@@ -192,7 +192,7 @@ async def test_list_hosts_reports_sandbox_provider_for_managed_host(
     """
     app, _reg, host_store, _cs = host_api_app
     host_store.register_managed_host(
-        host_id="host_managed_sb",
+        host_id="b8a8862c405a01143b4373e2b155b02a",
         name="sandbox-host",
         # Auth is disabled in this fixture, so list_hosts resolves the
         # caller to the reserved "local" owner — the managed host must
@@ -214,7 +214,7 @@ async def test_list_hosts_reports_sandbox_provider_for_managed_host(
         "Either register_managed_host didn't persist or the owner "
         "filter excluded it."
     )
-    assert hosts[0]["host_id"] == "host_managed_sb"
+    assert hosts[0]["host_id"] == "b8a8862c405a01143b4373e2b155b02a"
     # Pre-registered managed hosts start offline until the in-sandbox
     # host process dials the tunnel.
     assert hosts[0]["status"] == "offline"
@@ -306,7 +306,7 @@ async def test_get_host_404(
     """
     app, _reg, _hs, _cs = host_api_app
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/v1/hosts/host_nonexistent")
+        resp = await client.get("/v1/hosts/aababcc3941edb738172734a9ab7bb8c")
     assert resp.status_code == 404
 
 
@@ -614,7 +614,7 @@ async def test_launch_runner_404_unknown_host(
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(
-            "/v1/hosts/host_nonexistent/runners",
+            "/v1/hosts/aababcc3941edb738172734a9ab7bb8c/runners",
             json={"session_id": conv.id, "workspace": "/tmp"},
         )
     assert resp.status_code == 404
@@ -700,8 +700,10 @@ async def test_list_hosts_filters_by_owner(
     host enumeration is possible across users.
     """
     _app, _reg, host_store, _cs = multi_user_app
-    host_store.upsert_on_connect("host_alice", "alice-laptop", "alice@test.com")
-    host_store.upsert_on_connect("host_bob", "bob-laptop", "bob@test.com")
+    host_store.upsert_on_connect(
+        "f54bb9272002938a3a934bfcb6bb228a", "alice-laptop", "alice@test.com"
+    )
+    host_store.upsert_on_connect("774d8c150c0060ddb61a91b23b64a0d0", "bob-laptop", "bob@test.com")
 
     async with AsyncClient(transport=ASGITransport(app=_app), base_url="http://test") as client:
         # Alice sees only her host.
@@ -711,8 +713,8 @@ async def test_list_hosts_filters_by_owner(
         )
         assert resp.status_code == 200
         host_ids = {h["host_id"] for h in resp.json()["hosts"]}
-        assert host_ids == {"host_alice"}, (
-            f"Alice should only see host_alice, got {host_ids}. "
+        assert host_ids == {"f54bb9272002938a3a934bfcb6bb228a"}, (
+            f"Alice should only see f54bb9272002938a3a934bfcb6bb228a, got {host_ids}. "
             "Owner filtering on GET /v1/hosts is broken."
         )
 
@@ -722,7 +724,9 @@ async def test_list_hosts_filters_by_owner(
             headers={"x-test-user": "bob@test.com"},
         )
         host_ids = {h["host_id"] for h in resp.json()["hosts"]}
-        assert host_ids == {"host_bob"}, f"Bob should only see host_bob, got {host_ids}."
+        assert host_ids == {"774d8c150c0060ddb61a91b23b64a0d0"}, (
+            f"Bob should only see 774d8c150c0060ddb61a91b23b64a0d0, got {host_ids}."
+        )
 
 
 async def test_get_host_403_wrong_owner(
@@ -736,11 +740,13 @@ async def test_get_host_403_wrong_owner(
     which is an information leak.
     """
     _app, _reg, host_store, _cs = multi_user_app
-    host_store.upsert_on_connect("host_alice2", "alice-laptop", "alice@test.com")
+    host_store.upsert_on_connect(
+        "294391bc835cde1130ef2a02dcd2b7b3", "alice-laptop", "alice@test.com"
+    )
 
     async with AsyncClient(transport=ASGITransport(app=_app), base_url="http://test") as client:
         resp = await client.get(
-            "/v1/hosts/host_alice2",
+            "/v1/hosts/294391bc835cde1130ef2a02dcd2b7b3",
             headers={"x-test-user": "bob@test.com"},
         )
     assert resp.status_code == 403, (
@@ -760,11 +766,13 @@ async def test_launch_runner_403_wrong_owner(
     machine — a critical security violation.
     """
     _app, registry, host_store, conv_store = multi_user_app
-    host_store.upsert_on_connect("host_alice3", "alice-laptop", "alice@test.com")
+    host_store.upsert_on_connect(
+        "a20f57f124c33161e2e17a8998af5b1f", "alice-laptop", "alice@test.com"
+    )
     from omnigent.host.frames import HostHelloFrame
 
     registry.register(
-        "host_alice3",
+        "a20f57f124c33161e2e17a8998af5b1f",
         type(
             "FakeWS",
             (),
@@ -780,7 +788,7 @@ async def test_launch_runner_403_wrong_owner(
 
     async with AsyncClient(transport=ASGITransport(app=_app), base_url="http://test") as client:
         resp = await client.post(
-            "/v1/hosts/host_alice3/runners",
+            "/v1/hosts/a20f57f124c33161e2e17a8998af5b1f/runners",
             json={"session_id": conv.id, "workspace": "/tmp"},
             headers={"x-test-user": "bob@test.com"},
         )
@@ -895,7 +903,7 @@ async def test_tunnel_rejects_unauthenticated_when_auth_enabled(
     hijack or enumerate other users' hosts.
     """
     app, registry, host_store, _cs = multi_user_app
-    host_id = "host_unauth"
+    host_id = "3eeb18892635b9ed8ba2d060c8f58dd4"
     path = f"/v1/hosts/{host_id}/tunnel"
     # No x-test-user header -> stub auth returns None -> unauthenticated.
     comm = ApplicationCommunicator(app, _websocket_scope(path))
@@ -924,7 +932,7 @@ async def test_tunnel_accepts_authenticated_owner(
     the authenticated happy path.
     """
     app, registry, host_store, _cs = multi_user_app
-    host_id = "host_alice_ws"
+    host_id = "d66146fe4cc6b0dc1d342f6a89475046"
     path = f"/v1/hosts/{host_id}/tunnel"
     scope = _websocket_scope(path)
     # Authenticated as alice via the stub's x-test-user header.
@@ -980,8 +988,10 @@ async def test_resolve_host_launch_enforces_host_and_session_ownership(
     perm = SqlAlchemyPermissionStore(db_uri)
 
     # Alice owns an online host and a session.
-    host_store.upsert_on_connect("host_alice", "alice-laptop", "alice@test.com")
-    _register_fake_host(registry, "host_alice", "alice@test.com")
+    host_store.upsert_on_connect(
+        "f54bb9272002938a3a934bfcb6bb228a", "alice-laptop", "alice@test.com"
+    )
+    _register_fake_host(registry, "f54bb9272002938a3a934bfcb6bb228a", "alice@test.com")
     conv = conv_store.create_conversation(agent_id=None)
     perm.ensure_user("alice@test.com")
     perm.grant("alice@test.com", conv.id, LEVEL_OWNER)
@@ -996,7 +1006,7 @@ async def test_resolve_host_launch_enforces_host_and_session_ownership(
     # Happy path: Alice owns both → returns the resolved target.
     target = resolve_host_launch(
         user_id="alice@test.com",
-        host_id="host_alice",
+        host_id="f54bb9272002938a3a934bfcb6bb228a",
         session_id=conv.id,
         **stores,
     )
@@ -1009,7 +1019,7 @@ async def test_resolve_host_launch_enforces_host_and_session_ownership(
     with pytest.raises(HTTPException) as exc:
         resolve_host_launch(
             user_id="bob@test.com",
-            host_id="host_alice",
+            host_id="f54bb9272002938a3a934bfcb6bb228a",
             session_id=conv.id,
             **stores,
         )
@@ -1017,12 +1027,12 @@ async def test_resolve_host_launch_enforces_host_and_session_ownership(
 
     # Bob owns his own host but targets Alice's SESSION → 404. Blocks
     # the launch_runner session-hijack (binding her session to his runner).
-    host_store.upsert_on_connect("host_bob", "bob-laptop", "bob@test.com")
-    _register_fake_host(registry, "host_bob", "bob@test.com")
+    host_store.upsert_on_connect("774d8c150c0060ddb61a91b23b64a0d0", "bob-laptop", "bob@test.com")
+    _register_fake_host(registry, "774d8c150c0060ddb61a91b23b64a0d0", "bob@test.com")
     with pytest.raises(HTTPException) as exc:
         resolve_host_launch(
             user_id="bob@test.com",
-            host_id="host_bob",
+            host_id="774d8c150c0060ddb61a91b23b64a0d0",
             session_id=conv.id,
             **stores,
         )
@@ -1033,18 +1043,18 @@ async def test_resolve_host_launch_enforces_host_and_session_ownership(
     with pytest.raises(HTTPException) as exc:
         resolve_host_launch(
             user_id="alice@test.com",
-            host_id="host_missing",
+            host_id="b76b800b737d646b3ae8e06071d622c3",
             session_id=conv.id,
             **stores,
         )
     assert exc.value.status_code == 404
 
     # Host known but offline (in the store, no live connection) → 409.
-    host_store.upsert_on_connect("host_offline", "alice-old", "alice@test.com")
+    host_store.upsert_on_connect("3d9665477127e41f42de3f4109418173", "alice-old", "alice@test.com")
     with pytest.raises(HTTPException) as exc:
         resolve_host_launch(
             user_id="alice@test.com",
-            host_id="host_offline",
+            host_id="3d9665477127e41f42de3f4109418173",
             session_id=conv.id,
             **stores,
         )
@@ -1063,8 +1073,8 @@ async def test_launch_runner_rejects_other_users_session(
     perm = app.state.permission_store
 
     # Bob's own, online host.
-    host_store.upsert_on_connect("host_bob", "bob-laptop", "bob@test.com")
-    _register_fake_host(registry, "host_bob", "bob@test.com")
+    host_store.upsert_on_connect("774d8c150c0060ddb61a91b23b64a0d0", "bob-laptop", "bob@test.com")
+    _register_fake_host(registry, "774d8c150c0060ddb61a91b23b64a0d0", "bob@test.com")
 
     # Alice's session (owned by Alice).
     conv = conv_store.create_conversation(agent_id=None)
@@ -1073,7 +1083,7 @@ async def test_launch_runner_rejects_other_users_session(
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(
-            "/v1/hosts/host_bob/runners",
+            "/v1/hosts/774d8c150c0060ddb61a91b23b64a0d0/runners",
             json={"session_id": conv.id, "workspace": "/tmp"},
             headers={"x-test-user": "bob@test.com"},
         )
@@ -1104,13 +1114,15 @@ async def test_failed_connect_does_not_offline_another_users_host(
     app, _registry, host_store, _cs = multi_user_app
 
     # Alice's host is registered and online.
-    host_store.upsert_on_connect("host_dos", "alice-laptop", "alice@test.com")
-    before = host_store.get_host("host_dos")
+    host_store.upsert_on_connect(
+        "be2a05c6f9530d33276f7c4b34bc39ad", "alice-laptop", "alice@test.com"
+    )
+    before = host_store.get_host("be2a05c6f9530d33276f7c4b34bc39ad")
     assert before is not None
     assert before.status == "online"
 
     # Bob (a different authenticated user) connects to Alice's host_id.
-    scope = _websocket_scope("/v1/hosts/host_dos/tunnel")
+    scope = _websocket_scope("/v1/hosts/be2a05c6f9530d33276f7c4b34bc39ad/tunnel")
     scope["headers"] = [(b"x-test-user", b"bob@test.com")]
     comm = ApplicationCommunicator(app, scope)
     await comm.send_input({"type": "websocket.connect"})
@@ -1122,7 +1134,7 @@ async def test_failed_connect_does_not_offline_another_users_host(
     with contextlib.suppress(Exception):
         await comm.wait(timeout=2.0)
 
-    after = host_store.get_host("host_dos")
+    after = host_store.get_host("be2a05c6f9530d33276f7c4b34bc39ad")
     assert after is not None
     # Bob never claimed the host_id...
     assert after.owner == "alice@test.com"

--- a/tests/server/integration/test_hosts_create_directory.py
+++ b/tests/server/integration/test_hosts_create_directory.py
@@ -42,7 +42,7 @@ pytestmark = [
     pytest.mark.flaky(reruns=2, reruns_delay=1),
 ]
 
-_HOST_ID = "host_mkdir_test"
+_HOST_ID = "f28abbfd54a8b22204184b69d9bfd49f"
 _HOST_NAME = "mkdir-test-laptop"
 
 
@@ -296,7 +296,7 @@ async def test_create_directory_unknown_host_returns_404(
     app, _reg, _hs, _cs = mkdir_app
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(
-            "/v1/hosts/host_does_not_exist/directories",
+            "/v1/hosts/7139b7e896ef9478abca6480107d1677/directories",
             json={"path": "/tmp/x"},
         )
 

--- a/tests/server/integration/test_hosts_filesystem.py
+++ b/tests/server/integration/test_hosts_filesystem.py
@@ -47,7 +47,7 @@ pytestmark = [
     pytest.mark.flaky(reruns=2, reruns_delay=1),
 ]
 
-_HOST_ID = "host_fs_test"
+_HOST_ID = "9ab0645ef9c07bb922a404d4ec2466a9"
 _HOST_NAME = "fs-test-laptop"
 
 
@@ -361,7 +361,7 @@ async def test_list_filesystem_unknown_host_returns_404(
     """
     app, _reg, _hs, _cs = fs_app
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/v1/hosts/host_does_not_exist/filesystem")
+        resp = await client.get("/v1/hosts/7139b7e896ef9478abca6480107d1677/filesystem")
     assert resp.status_code == 404
 
 
@@ -379,12 +379,12 @@ async def test_list_filesystem_offline_host_returns_409(
     app, _reg, host_store, _cs = fs_app
     # Persist the host record but never register a tunnel.
     host_store.upsert_on_connect(
-        host_id="host_offline",
+        host_id="3d9665477127e41f42de3f4109418173",
         name="offline-host",
         owner="local",
     )
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/v1/hosts/host_offline/filesystem")
+        resp = await client.get("/v1/hosts/3d9665477127e41f42de3f4109418173/filesystem")
     assert resp.status_code == 409
 
 
@@ -519,7 +519,7 @@ async def test_list_filesystem_owner_check_blocks_other_users(
 
     # Persist a host owned by alice.
     host_store.upsert_on_connect(
-        host_id="host_alice",
+        host_id="f54bb9272002938a3a934bfcb6bb228a",
         name="alice-laptop",
         owner="alice@example.com",
     )
@@ -528,7 +528,7 @@ async def test_list_filesystem_owner_check_blocks_other_users(
         transport=ASGITransport(app=auth_app), base_url="http://test"
     ) as client:
         resp = await client.get(
-            "/v1/hosts/host_alice/filesystem",
+            "/v1/hosts/f54bb9272002938a3a934bfcb6bb228a/filesystem",
             headers={"X-Test-User": "bob@example.com"},
         )
     assert resp.status_code == 403

--- a/tests/server/integration/test_hosts_management_e2e.py
+++ b/tests/server/integration/test_hosts_management_e2e.py
@@ -135,9 +135,9 @@ async def test_get_host_detail_includes_runners_field(
     access.
     """
     app, _hr, host_store, *_ = management_app
-    host_store.upsert_on_connect("host_detail", "detail-laptop", "local")
+    host_store.upsert_on_connect("93de036146aa8e2618c0c24ab8f8f4cc", "detail-laptop", "local")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/v1/hosts/host_detail")
+        resp = await client.get("/v1/hosts/93de036146aa8e2618c0c24ab8f8f4cc")
     assert resp.status_code == 200
     body = resp.json()
     assert "runners" in body, "response must contain a 'runners' key"
@@ -160,10 +160,10 @@ async def test_launch_runner_missing_session_id_returns_422(
     a 500.
     """
     app, _hr, host_store, *_ = management_app
-    host_store.upsert_on_connect("host_validate", "laptop", "local")
+    host_store.upsert_on_connect("4a4ec6c71dc0085128719ef31db86c45", "laptop", "local")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(
-            "/v1/hosts/host_validate/runners",
+            "/v1/hosts/4a4ec6c71dc0085128719ef31db86c45/runners",
             json={"workspace": "/tmp/test"},
         )
     assert resp.status_code == 422, f"Expected 422 for missing session_id, got {resp.status_code}"
@@ -179,11 +179,11 @@ async def test_launch_runner_missing_workspace_returns_422(
     Both ``session_id`` and ``workspace`` are required fields.
     """
     app, _hr, host_store, *_ = management_app
-    host_store.upsert_on_connect("host_validate2", "laptop", "local")
+    host_store.upsert_on_connect("9fd95280b78ff59e9c3664b00ffca9bf", "laptop", "local")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(
-            "/v1/hosts/host_validate2/runners",
-            json={"session_id": "conv_fake"},
+            "/v1/hosts/9fd95280b78ff59e9c3664b00ffca9bf/runners",
+            json={"session_id": "5ab79713d8c7904f4f4bf10b2da5df62"},
         )
     assert resp.status_code == 422, f"Expected 422 for missing workspace, got {resp.status_code}"
 
@@ -206,7 +206,7 @@ async def test_list_hosts_stale_host_reported_offline(
     """
     app, _hr, host_store, *_ = management_app
     # Register the host so it has status="online" in the DB.
-    host_store.upsert_on_connect("host_stale", "stale-laptop", "local")
+    host_store.upsert_on_connect("f5422856c5f2a0d1189fdd49de0c469c", "stale-laptop", "local")
 
     # Verify it initially shows as online. Other tests sharing this
     # xdist worker's host store leave rows behind (host rows are not
@@ -216,8 +216,10 @@ async def test_list_hosts_stale_host_reported_offline(
         resp = await client.get("/v1/hosts")
     assert resp.status_code == 200, resp.text
     hosts = resp.json()["hosts"]
-    stale = next((h for h in hosts if h["host_id"] == "host_stale"), None)
-    assert stale is not None, f"host_stale missing from {[h['host_id'] for h in hosts]}"
+    stale = next((h for h in hosts if h["host_id"] == "f5422856c5f2a0d1189fdd49de0c469c"), None)
+    assert stale is not None, (
+        f"f5422856c5f2a0d1189fdd49de0c469c missing from {[h['host_id'] for h in hosts]}"
+    )
     assert stale["status"] == "online"
 
     # Manually backdate updated_at to simulate a crashed host.
@@ -231,7 +233,9 @@ async def test_list_hosts_stale_host_reported_offline(
     stale_time = int(time.time()) - 600
     with Session(host_store._engine) as session:
         session.execute(
-            update(SqlHost).where(SqlHost.host_id == "host_stale").values(updated_at=stale_time)
+            update(SqlHost)
+            .where(SqlHost.host_id == "f5422856c5f2a0d1189fdd49de0c469c")
+            .values(updated_at=stale_time)
         )
         session.commit()
 
@@ -239,8 +243,10 @@ async def test_list_hosts_stale_host_reported_offline(
         resp = await client.get("/v1/hosts")
     assert resp.status_code == 200, resp.text
     hosts = resp.json()["hosts"]
-    stale = next((h for h in hosts if h["host_id"] == "host_stale"), None)
-    assert stale is not None, f"host_stale missing from {[h['host_id'] for h in hosts]}"
+    stale = next((h for h in hosts if h["host_id"] == "f5422856c5f2a0d1189fdd49de0c469c"), None)
+    assert stale is not None, (
+        f"f5422856c5f2a0d1189fdd49de0c469c missing from {[h['host_id'] for h in hosts]}"
+    )
     assert stale["status"] == "offline", (
         "A host with a stale last_seen_at should be reported as offline. "
         "The liveness check (host_is_live) is missing from the list route."
@@ -262,11 +268,11 @@ async def test_get_host_detail_offline_status(
     list shows offline but the detail view shows online.
     """
     app, _hr, host_store, *_ = management_app
-    host_store.upsert_on_connect("host_off", "off-laptop", "local")
-    host_store.set_offline("host_off")
+    host_store.upsert_on_connect("ba0a675ffb72378982f8ef434478adc8", "off-laptop", "local")
+    host_store.set_offline("ba0a675ffb72378982f8ef434478adc8")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/v1/hosts/host_off")
+        resp = await client.get("/v1/hosts/ba0a675ffb72378982f8ef434478adc8")
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "offline"
-    assert body["host_id"] == "host_off"
+    assert body["host_id"] == "ba0a675ffb72378982f8ef434478adc8"

--- a/tests/server/integration/test_hosts_worktrees.py
+++ b/tests/server/integration/test_hosts_worktrees.py
@@ -42,7 +42,7 @@ pytestmark = [
     pytest.mark.flaky(reruns=2, reruns_delay=1),
 ]
 
-_HOST_ID = "host_wt_test"
+_HOST_ID = "7f6bda8f5e302e51cee65f7094f3d49e"
 _HOST_NAME = "wt-test-laptop"
 
 
@@ -240,7 +240,7 @@ async def test_list_worktrees_unknown_host_404(
     """An unknown host id yields 404 (existence is gated before the offline check)."""
     app, _reg, _hs, _cs = wt_app
     # Use a host id that no other test or tunnel registers — never "offline", just absent.
-    unknown_id = "host_wt_does_not_exist"
+    unknown_id = "1e498b8cd21815434fca9278770ff1d1"
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get(
             f"/v1/hosts/{unknown_id}/worktrees",

--- a/tests/server/integration/test_mcp_proxy.py
+++ b/tests/server/integration/test_mcp_proxy.py
@@ -203,7 +203,7 @@ async def test_mcp_nonexistent_session_returns_error(
     """
     resp = await _post_mcp(
         client,
-        "conv_does_not_exist_mcp",
+        "3628cfc9b00f747da23485e2534458a6",
         _jsonrpc("tools/list", rpc_id=10),
     )
     assert resp.status_code == 200

--- a/tests/server/integration/test_oidc_default_policies.py
+++ b/tests/server/integration/test_oidc_default_policies.py
@@ -140,7 +140,7 @@ async def test_oidc_admin_can_crud_default_policies(
     create = await oidc_policy_client.post("/v1/policies", json=_policy_payload(), headers=headers)
     assert create.status_code == 200, create.text
     pid = create.json()["id"]
-    assert pid.startswith("pol_")
+    assert len(pid) == 32
 
     # List — the created policy is present.
     listing = await oidc_policy_client.get("/v1/policies", headers=headers)

--- a/tests/server/integration/test_policy_deny_lifecycle_e2e.py
+++ b/tests/server/integration/test_policy_deny_lifecycle_e2e.py
@@ -175,7 +175,7 @@ async def _attach_deny_policy(
     )
     assert resp.status_code == 200, f"policy create failed: {resp.status_code} {resp.text}"
     body = resp.json()
-    assert body["id"].startswith("pol_")
+    assert len(body["id"]) == 32
     return body["id"]
 
 

--- a/tests/server/integration/test_session_host_launch.py
+++ b/tests/server/integration/test_session_host_launch.py
@@ -53,7 +53,7 @@ from tests.server.helpers import create_test_agent
 
 pytestmark = pytest.mark.asyncio
 
-_HOST_ID = "host_weblaunch_test"
+_HOST_ID = "c2d81b1a6812ae1cf32221c5a2a70ba0"
 _WORKSPACE = "/work/repo"
 
 
@@ -674,7 +674,7 @@ async def _stop_host_session(
 
     :param client: Test HTTP client.
     :param comm: Connected host communicator.
-    :param session_id: Session to stop, e.g. ``"conv_abc123"``.
+    :param session_id: Session to stop, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
     :returns: The ``runner_id`` the host was told to stop.
     """
     from omnigent.runtime import set_runner_client
@@ -999,7 +999,7 @@ async def test_host_session_message_waits_for_bound_runner_before_relaunch(
     async def _staged_get_runner_client(sid: str, router: object) -> httpx.AsyncClient | None:
         """Simulate the pinned runner becoming routable during grace.
 
-        :param sid: Session id being routed, e.g. ``"conv_abc123"``.
+        :param sid: Session id being routed, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
         :param router: Real app runner router (unused in this staged
             resolver).
         :returns: ``None`` first, then the fake runner client.
@@ -1162,7 +1162,7 @@ async def test_relaunch_posts_session_init_before_forwarding_message(
         """Return the fake runner after the relaunch helper runs.
 
         :param session_id_arg: Session id being routed, e.g.
-            ``"conv_abc123"``.
+            ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
         :param runner_router_arg: Real app runner router (unused here).
         :param tunnel_registry_arg: Real app tunnel registry (unused here).
         :param runner_id: Relaunched runner id expected to connect.

--- a/tests/server/integration/test_session_policy_routes.py
+++ b/tests/server/integration/test_session_policy_routes.py
@@ -37,7 +37,7 @@ def _seed_session_with_grants(
     :param db_uri: SQLite URI for the per-test database.
     :param grants: Mapping of ``{user_email: level}`` to grant on the new
         session, e.g. ``{"alice@example.com": LEVEL_EDIT}``.
-    :returns: The newly created conversation ID, e.g. ``"conv_abc123"``.
+    :returns: The newly created conversation ID, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
     """
     conv_store = SqlAlchemyConversationStore(db_uri)
     conversation = conv_store.create_conversation()
@@ -149,7 +149,7 @@ async def test_create_policy(
     assert body["enabled"] is True
     assert body["source"] == "session"
     assert body["object"] == "session.policy"
-    assert body["id"].startswith("pol_")
+    assert len(body["id"]) == 32
     assert body["created_at"] > 0
     assert body["updated_at"] is None
 
@@ -372,7 +372,7 @@ async def test_get_nonexistent_returns_404(
     """
     session_id = _seed_session_with_grants(db_uri, {"alice@example.com": LEVEL_READ})
     resp = await auth_client.get(
-        f"/v1/sessions/{session_id}/policies/spol_nonexistent",
+        f"/v1/sessions/{session_id}/policies/1849035e76954fbd652b51dff31a4a96",
         headers={"X-Forwarded-Email": "alice@example.com"},
     )
     assert resp.status_code == 404

--- a/tests/server/integration/test_session_worktree_create.py
+++ b/tests/server/integration/test_session_worktree_create.py
@@ -35,7 +35,7 @@ from tests.server.helpers import create_test_agent
 
 pytestmark = pytest.mark.asyncio
 
-_HOST_ID = "host_wt_create"
+_HOST_ID = "2b8753b34a61b09af35a01136d40fadf"
 _SOURCE_REPO = "/Users/alice/myrepo"
 
 

--- a/tests/server/integration/test_session_worktree_delete.py
+++ b/tests/server/integration/test_session_worktree_delete.py
@@ -29,7 +29,7 @@ from omnigent.stores.host_store import HostStore
 
 pytestmark = pytest.mark.asyncio
 
-_HOST_ID = "host_wt_delete"
+_HOST_ID = "a65b7d8e4613a95946c9134383308ac7"
 
 
 class _FakeWebSocket:

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -98,7 +98,7 @@ def _seed_child(
     ``agent_name`` fields in the summary are always ``None``.
 
     :param conv_store: Store for the child conversation.
-    :param parent_id: Parent conversation id, e.g. ``"conv_parent1"``.
+    :param parent_id: Parent conversation id, e.g. ``"0c4b962f26d3fb76dce69d9dade142f5"``.
     :param title: Sub-agent title in the canonical
         ``"{agent_type}:{session_name}"`` format,
         e.g. ``"researcher:auth"``.
@@ -121,7 +121,7 @@ async def test_child_sessions_404_for_nonexistent_session(
     client: httpx.AsyncClient,
 ) -> None:
     """Route returns 404 when the parent session does not exist."""
-    resp = await client.get("/v1/sessions/conv_nonexistent/child_sessions")
+    resp = await client.get("/v1/sessions/ad563e906854634c49e1a6fd2fbb31d4/child_sessions")
     assert resp.status_code == 404
 
 
@@ -1491,7 +1491,7 @@ async def test_native_subagent_message_uses_native_terminal_forward(
         """
         Route the native child message to the fake runner.
 
-        :param session_id: Session being routed, e.g. ``"conv_child"``.
+        :param session_id: Session being routed, e.g. ``"ff5cac23d0beb79fad914046049f32ff"``.
         :param runner_router: Real runner router, unused.
         :returns: The fake runner client.
         """
@@ -1609,7 +1609,7 @@ async def test_multipart_create_with_parent_links_child(
     # The created agent identifiers prove the response contract the
     # runner's bundle-mode handle depends on; a missing/empty agent_id
     # would make sys_session_create fail loud on the runner side.
-    assert body["agent_id"].startswith("ag_")
+    assert len(body["agent_id"]) == 32
     assert body["agent_name"] == "bundle-child"
 
     snap = await client.get(f"/v1/sessions/{child_id}")
@@ -1640,7 +1640,7 @@ async def test_multipart_create_with_unknown_parent_404s(
     bundle = build_agent_bundle(name="bundle-orphan")
     resp = await client.post(
         "/v1/sessions",
-        data={"metadata": json.dumps({"parent_session_id": "conv_missing"})},
+        data={"metadata": json.dumps({"parent_session_id": "5eca720dc2bc6cdc3a99028d7bd0f917"})},
         files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
     )
     assert resp.status_code == 404, resp.text

--- a/tests/server/integration/test_sessions_content_type_csrf.py
+++ b/tests/server/integration/test_sessions_content_type_csrf.py
@@ -47,35 +47,35 @@ _VALID_JSON_BODY = {"hello": "world"}
 # exists. ``term_x`` / ``env_x`` are likewise never resolved.
 _JSON_ONLY_ENDPOINTS = [
     pytest.param(
-        "/v1/sessions/conv_missing/hooks/permission-request",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/hooks/permission-request",
         id="claude_permission_request_hook",
     ),
     pytest.param(
-        "/v1/sessions/conv_missing/hooks/codex-elicitation-request",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/hooks/codex-elicitation-request",
         id="codex_elicitation_request_hook",
     ),
     pytest.param(
-        "/v1/sessions/conv_missing/hooks/antigravity-elicitation-request",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/hooks/antigravity-elicitation-request",
         id="antigravity_elicitation_request_hook",
     ),
     pytest.param(
-        "/v1/sessions/conv_missing/policies/evaluate",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/policies/evaluate",
         id="evaluate_policy",
     ),
     pytest.param(
-        "/v1/sessions/conv_missing/resources/terminals",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/resources/terminals",
         id="create_session_terminal",
     ),
     pytest.param(
-        "/v1/sessions/conv_missing/resources/terminals/term_x/transfer",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/resources/terminals/term_x/transfer",
         id="transfer_session_terminal",
     ),
     pytest.param(
-        "/v1/sessions/conv_missing/resources/environments/env_x/shell",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/resources/environments/env_x/shell",
         id="run_environment_shell",
     ),
     pytest.param(
-        "/v1/sessions/conv_missing/mcp",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/mcp",
         id="mcp_proxy",
     ),
 ]
@@ -176,11 +176,11 @@ async def test_json_only_endpoint_rejects_missing_content_type(
     "url",
     [
         pytest.param(
-            "/v1/sessions/conv_missing/hooks/permission-request",
+            "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/hooks/permission-request",
             id="claude_permission_request_hook",
         ),
         pytest.param(
-            "/v1/sessions/conv_missing/hooks/codex-elicitation-request",
+            "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/hooks/codex-elicitation-request",
             id="codex_elicitation_request_hook",
         ),
     ],
@@ -249,7 +249,7 @@ async def test_create_terminal_reached_with_application_json(
     415 would mean the guard wrongly blocked a correct JSON request.
     """
     resp = await client.post(
-        "/v1/sessions/conv_missing/resources/terminals",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/resources/terminals",
         json={"terminal": "shell", "session_key": "main"},
     )
     assert resp.status_code == 404, (
@@ -269,7 +269,7 @@ async def test_mcp_proxy_reached_with_application_json(
     here would mean the guard blocked a valid MCP request.
     """
     resp = await client.post(
-        "/v1/sessions/conv_missing/mcp",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/mcp",
         json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
     )
     assert resp.status_code == 200, resp.text
@@ -324,7 +324,7 @@ async def test_create_session_accepts_application_json(
     resp = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
     assert resp.status_code == 201, resp.text
     # Real session id returned → JSON create reached the handler and succeeded.
-    assert resp.json()["id"].startswith("conv_")
+    assert len(resp.json()["id"]) == 32
 
 
 async def test_create_session_accepts_multipart_bundled_create(

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -187,14 +187,14 @@ def _create_child_session(
     Create a child conversation under a parent session.
 
     :param db_uri: Test database URI.
-    :param parent_id: Parent session id, e.g. ``"conv_parent"``.
+    :param parent_id: Parent session id, e.g. ``"ead6d59a6b650d19dbdf61ec32426f4e"``.
     :param agent_id: Agent id inherited by the child.
     :param title: Sub-agent title in ``"<agent>:<name>"`` form, e.g.
         ``"codex-child:approval"``. Must be unique per parent — the DB
         enforces ``(parent_conversation_id, title)`` uniqueness, so a
         fan-out test creating multiple children under one parent must
         pass distinct titles.
-    :returns: Child session id, e.g. ``"conv_child"``.
+    :returns: Child session id, e.g. ``"ff5cac23d0beb79fad914046049f32ff"``.
     """
     store = SqlAlchemyConversationStore(db_uri)
     child = store.create_conversation(
@@ -973,7 +973,7 @@ class _InputRequiredRunnerClient:
         Record the execute payload and return the scripted response.
 
         :param url: Runner path, e.g.
-            ``"/v1/sessions/conv_child/mcp/execute"``.
+            ``"/v1/sessions/ff5cac23d0beb79fad914046049f32ff/mcp/execute"``.
         :param json: The request body.
         :param timeout: Forward timeout (ignored by the stub).
         :returns: A real ``httpx.Response`` with the scripted JSON.
@@ -1268,7 +1268,7 @@ async def test_resolve_url_unknown_session_returns_404(
     URL fails loud rather than silently no-op'ing.
     """
     resp = await client.post(
-        "/v1/sessions/conv_does_not_exist/elicitations/elicit_nope/resolve",
+        "/v1/sessions/1d0b12236c77f69f5073a53583de1a3f/elicitations/elicit_nope/resolve",
         json={"action": "accept"},
     )
     assert resp.status_code == 404, resp.text
@@ -1417,7 +1417,7 @@ async def test_elicitation_page_unknown_session_returns_404(
     Requesting the page for a nonexistent session returns 404.
     """
     resp = await client.get(
-        "/v1/sessions/conv_does_not_exist/elicitations/elicit_nope",
+        "/v1/sessions/1d0b12236c77f69f5073a53583de1a3f/elicitations/elicit_nope",
     )
     assert resp.status_code == 404, resp.text
 
@@ -1456,13 +1456,13 @@ def test_mrtr_response_url_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         rpc_id=1,
         elicitation_id="elicit_abc",
         message="Approve?",
-        request_state='{"elicitation_id":"elicit_abc","session_id":"conv_123"}',
-        session_id="conv_123",
+        request_state='{"elicitation_id":"elicit_abc","session_id":"0099dc8be6d82871e2e450424d46d1b7"}',
+        session_id="0099dc8be6d82871e2e450424d46d1b7",
     )
     body = json.loads(resp.body)
     params = body["result"]["inputRequests"]["elicit_abc"]["params"]
     assert params["mode"] == "url"
-    assert params["url"] == "/approve/conv_123/elicit_abc"
+    assert params["url"] == "/approve/0099dc8be6d82871e2e450424d46d1b7/elicit_abc"
     assert params["message"] == "Approve?"
 
 
@@ -1481,7 +1481,7 @@ def test_mrtr_response_form_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         elicitation_id="elicit_abc",
         message="Approve?",
         request_state="{}",
-        session_id="conv_123",
+        session_id="0099dc8be6d82871e2e450424d46d1b7",
     )
     body = json.loads(resp.body)
     params = body["result"]["inputRequests"]["elicit_abc"]["params"]

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -50,7 +50,7 @@ async def _create_session(
     Create a session and return the response JSON.
 
     :param client: The test HTTP client.
-    :param agent_id: Agent to bind, e.g. ``"ag_abc123"``.
+    :param agent_id: Agent to bind, e.g. ``"104c4932179e16161e9ed9298fd5a3e2"``.
     :param initial_message: When set, seed the session with a
         user message.
     :param title: Optional session title.
@@ -311,7 +311,9 @@ async def test_list_sessions_includes_workspace_and_host_id(
 
     # Register the host first — conversations.host_id is an FK to the
     # hosts table, so binding a non-existent host_id would fail the FK.
-    host = HostStore(db_uri).upsert_on_connect("host_test", "test-laptop", "owner@example.com")
+    host = HostStore(db_uri).upsert_on_connect(
+        "6b9c07bfb42f687d53af44f018adebec", "test-laptop", "owner@example.com"
+    )
     # set_host_id writes host_id + workspace together (the
     # ck_conversations_workspace_required_for_host constraint forbids a
     # host_id with a NULL workspace).
@@ -531,7 +533,7 @@ async def test_external_session_superseded_publishes_redirect_event(
         f"/v1/sessions/{session['id']}/events",
         json={
             "type": "external_session_superseded",
-            "data": {"target_conversation_id": "conv_new"},
+            "data": {"target_conversation_id": "2d1b1a96e3e08f2cd43c0cc4b695ac5d"},
         },
     )
     assert resp.status_code in (200, 202)
@@ -540,7 +542,7 @@ async def test_external_session_superseded_publishes_redirect_event(
     assert len(superseded) == 1
     event = superseded[0]
     assert event["conversation_id"] == session["id"]
-    assert event["target_conversation_id"] == "conv_new"
+    assert event["target_conversation_id"] == "2d1b1a96e3e08f2cd43c0cc4b695ac5d"
     assert event["reason"] == "clear"
 
 
@@ -583,7 +585,7 @@ async def test_external_session_superseded_drains_pending_inputs(
             f"/v1/sessions/{session['id']}/events",
             json={
                 "type": "external_session_superseded",
-                "data": {"target_conversation_id": "conv_new"},
+                "data": {"target_conversation_id": "2d1b1a96e3e08f2cd43c0cc4b695ac5d"},
             },
         )
         assert resp.status_code in (200, 202)
@@ -636,7 +638,7 @@ async def test_external_subagent_start_mints_child_session(
     assert resp.status_code in (200, 202), f"unexpected status {resp.status_code}: {resp.text}"
     body = resp.json()
     child_id = body["child_session_id"]
-    assert child_id.startswith("conv_")
+    assert len(child_id) == 32
     assert body["queued"] is False
 
     # The child should appear under the parent in child_sessions.
@@ -1031,7 +1033,7 @@ async def test_skill_slash_command_persists_visible_item_and_hidden_meta_message
         await fake_runner.aclose()
 
     assert resp.json()["queued"] is True
-    assert resp.json()["item_id"].startswith("sc_")
+    assert len(resp.json()["item_id"]) == 32
 
     items_resp = await client.get(f"/v1/sessions/{session['id']}/items")
     assert items_resp.status_code == 200, items_resp.text
@@ -1289,7 +1291,11 @@ async def test_external_user_message_folds_pending_image_into_durable_item(
     pending_inputs.record(
         session["id"],
         [
-            {"type": "input_image", "file_id": "file_real_99", "filename": "diagram.png"},
+            {
+                "type": "input_image",
+                "file_id": "b08c893483887826e2b9f67165106700",
+                "filename": "diagram.png",
+            },
             {"type": "input_text", "text": "explain this diagram"},
         ],
     )
@@ -1322,7 +1328,7 @@ async def test_external_user_message_folds_pending_image_into_durable_item(
         # — so reloading history shows the image, not just the caption.
         assert user_msg["content"][0] == {
             "type": "input_image",
-            "file_id": "file_real_99",
+            "file_id": "b08c893483887826e2b9f67165106700",
             "filename": "diagram.png",
         }
         expected_text = "[Attached: /tmp/diagram.png]\n\nexplain this diagram"
@@ -1737,7 +1743,7 @@ async def test_patch_session_404_for_nonexistent(
 ) -> None:
     """PATCH returns 404 for a session that doesn't exist."""
     resp = await client.patch(
-        "/v1/sessions/conv_nonexistent",
+        "/v1/sessions/ad563e906854634c49e1a6fd2fbb31d4",
         json={"title": "nope"},
     )
     assert resp.status_code == 404
@@ -1948,7 +1954,7 @@ async def test_get_session_agent_name_is_spec_name_after_switch(
     target_row = agent_store.get(target_agent["id"])
     assert target_row is not None and target_row.bundle_location is not None
     builtin = agent_store.create(
-        "ag_builtin_claude_test",
+        "35316537082e723a63887635649d702d",
         "claude-native-ui",
         target_row.bundle_location,
     )
@@ -2248,7 +2254,7 @@ async def test_list_session_items_404_for_nonexistent(
     client: httpx.AsyncClient,
 ) -> None:
     """Items endpoint returns 404 for a session that doesn't exist."""
-    resp = await client.get("/v1/sessions/conv_nonexistent/items")
+    resp = await client.get("/v1/sessions/ad563e906854634c49e1a6fd2fbb31d4/items")
     assert resp.status_code == 404
 
 
@@ -2830,7 +2836,7 @@ async def test_publish_status_keeps_failed_sticky_against_trailing_idle(
         "omnigent.server.routes.sessions.session_stream.publish",
         lambda _session_id, event: published.append(event),
     )
-    sid = "conv_sticky_failed"
+    sid = "ee38ff3453b8ccac61b85acb8c670b59"
     sessions_module._session_status_cache.pop(sid, None)
     try:
         sessions_module._publish_status(sid, "failed")
@@ -2871,7 +2877,7 @@ async def test_publish_status_tracks_in_flight_response_id(
         "omnigent.server.routes.sessions.session_stream.publish",
         lambda _session_id, _event: None,
     )
-    sid = "conv_active_resp"
+    sid = "dcc9f70cf10c73bb49c3b465b929747c"
     sessions_module._session_status_cache.pop(sid, None)
     sessions_module._session_active_response_cache.pop(sid, None)
     try:
@@ -2952,7 +2958,7 @@ async def test_patch_runner_rebind_clears_stale_failed_status(
         """
         Return the recovering runner client for the patched session.
 
-        :param _session_id: Session id being rebound, e.g. ``"conv_abc123"``.
+        :param _session_id: Session id being rebound, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
         :param _runner_router: Ignored runner router placeholder.
         :returns: Runner client stub.
         """
@@ -2967,7 +2973,7 @@ async def test_patch_runner_rebind_clears_stale_failed_status(
         """
         Skip relay startup; this test targets the PATCH init branch.
 
-        :param _session_id: Session id, e.g. ``"conv_abc123"``.
+        :param _session_id: Session id, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
         :param _runner_id: Runner id, e.g. ``"runner_recovered"``.
         :param _runner_client: Runner client stub.
         :param _conversation_store: Conversation store from the route.
@@ -7173,9 +7179,7 @@ async def test_external_codex_subagent_start_mints_child_session(
 
     assert resp.status_code == 202, f"unexpected status {resp.status_code}: {resp.text}"
     child_id = resp.json()["child_session_id"]
-    assert child_id.startswith("conv_"), (
-        f"child_session_id must start with conv_; got {child_id!r}"
-    )
+    assert len(child_id) == 32, f"child_session_id must start with conv_; got {child_id!r}"
 
     children_resp = await client.get(f"/v1/sessions/{parent['id']}/child_sessions")
     assert children_resp.status_code == 200

--- a/tests/server/integration/test_sessions_permissions.py
+++ b/tests/server/integration/test_sessions_permissions.py
@@ -246,7 +246,7 @@ def _register_online_host(app: FastAPI, host_id: str, owner: str) -> None:
     exposing ``send_text``/``receive_text``.
 
     :param app: The app whose ``host_store``/``host_registry`` to use.
-    :param host_id: Host id to register, e.g. ``"host_alice"``.
+    :param host_id: Host id to register, e.g. ``"f54bb9272002938a3a934bfcb6bb228a"``.
     :param owner: Owning user, e.g. ``"alice@example.com"``.
     """
     app.state.host_store.upsert_on_connect(host_id, f"{owner}-laptop", owner)
@@ -2460,8 +2460,8 @@ async def test_create_session_rejects_other_users_host(
     would have enqueued the stat frame to Alice's connection.
     """
     # Alice owns an online host.
-    _register_online_host(host_perm_app, "host_alice", "alice@example.com")
-    alice_conn = host_perm_app.state.host_registry.get("host_alice")
+    _register_online_host(host_perm_app, "f54bb9272002938a3a934bfcb6bb228a", "alice@example.com")
+    alice_conn = host_perm_app.state.host_registry.get("f54bb9272002938a3a934bfcb6bb228a")
     assert alice_conn is not None
 
     # A bindable BUILT-IN (template) agent: session_id IS NULL, so any
@@ -2470,15 +2470,17 @@ async def test_create_session_rejects_other_users_host(
     # check (see designs/BUILTIN_AGENTS.md); creating a template here
     # isolates the host-owner check.
     SqlAlchemyAgentStore(db_uri).create(
-        "ag_builtin_xuser", "builtin-xuser-agent", "ag_builtin_xuser/bundle"
+        "f2b40a7cc3eaec4ee8cbb151e1021c75",
+        "builtin-xuser-agent",
+        "f2b40a7cc3eaec4ee8cbb151e1021c75/bundle",
     )
 
     # Bob targets Alice's host.
     resp = await host_perm_client.post(
         "/v1/sessions",
         json={
-            "agent_id": "ag_builtin_xuser",
-            "host_id": "host_alice",
+            "agent_id": "f2b40a7cc3eaec4ee8cbb151e1021c75",
+            "host_id": "f54bb9272002938a3a934bfcb6bb228a",
             "workspace": "/tmp",
         },
         headers={"X-Forwarded-Email": "bob@example.com"},
@@ -2561,8 +2563,8 @@ async def test_bob_cannot_create_worktree_session_on_alice_host(
     reach Alice's host and the empty-queue assertion below would fail —
     a regression the workspace-only test can't catch.
     """
-    _register_online_host(host_perm_app, "host_alice", "alice@example.com")
-    alice_conn = host_perm_app.state.host_registry.get("host_alice")
+    _register_online_host(host_perm_app, "f54bb9272002938a3a934bfcb6bb228a", "alice@example.com")
+    alice_conn = host_perm_app.state.host_registry.get("f54bb9272002938a3a934bfcb6bb228a")
     assert alice_conn is not None
 
     # Bob owns an agent he is allowed to bind (passes the agent
@@ -2575,7 +2577,7 @@ async def test_bob_cannot_create_worktree_session_on_alice_host(
         "/v1/sessions",
         json={
             "agent_id": bob_agent["id"],
-            "host_id": "host_alice",
+            "host_id": "f54bb9272002938a3a934bfcb6bb228a",
             "workspace": "/Users/alice/repo",
             "git": {"branch_name": "feature/x"},
         },
@@ -2609,8 +2611,8 @@ async def test_bob_cannot_clean_up_alice_worktree_via_delete(
     ``host.remove_worktree`` frame reaches Alice's host. Alice's
     session (and its worktree) survive.
     """
-    _register_online_host(host_perm_app, "host_alice", "alice@example.com")
-    alice_conn = host_perm_app.state.host_registry.get("host_alice")
+    _register_online_host(host_perm_app, "f54bb9272002938a3a934bfcb6bb228a", "alice@example.com")
+    alice_conn = host_perm_app.state.host_registry.get("f54bb9272002938a3a934bfcb6bb228a")
     assert alice_conn is not None
 
     # Alice owns a worktree session. Built via the store + an explicit
@@ -2618,7 +2620,7 @@ async def test_bob_cannot_clean_up_alice_worktree_via_delete(
     conv_store = SqlAlchemyConversationStore(db_uri)
     conv = conv_store.create_conversation(
         agent_id=None,
-        host_id="host_alice",
+        host_id="f54bb9272002938a3a934bfcb6bb228a",
         workspace="/Users/alice/repo-worktrees/feature-x",
         git_branch="feature/x",
     )
@@ -2770,7 +2772,7 @@ async def _end_stream_via_close(session_id: str, task: asyncio.Task[Any]) -> htt
     subscribers whose slot is already registered, and the stream task
     may not have subscribed yet — until the request task completes.
 
-    :param session_id: The streamed session, e.g. ``"conv_abc123"``.
+    :param session_id: The streamed session, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
     :param task: The background ``client.get(...)`` request task.
     :returns: The completed (fully buffered) SSE response.
     """

--- a/tests/server/integration/test_sessions_policy_evaluate.py
+++ b/tests/server/integration/test_sessions_policy_evaluate.py
@@ -712,15 +712,20 @@ def test_native_ask_gate_lock_keys_by_session_and_policy() -> None:
     """
     from omnigent.server.routes.sessions import _native_ask_gate_lock
 
-    lock_a = _native_ask_gate_lock("conv_1", "session_cost_guard")
+    lock_a = _native_ask_gate_lock("8e32600337d08f59ad381caf96a90659", "session_cost_guard")
     # Same key → same lock: this is what makes parallel tool calls that
     # all trip one checkpoint share a single gate.
-    assert _native_ask_gate_lock("conv_1", "session_cost_guard") is lock_a
+    assert (
+        _native_ask_gate_lock("8e32600337d08f59ad381caf96a90659", "session_cost_guard") is lock_a
+    )
     # Different policy on the same session → different lock, so a cost ask
     # and (say) a destructive-file ask can prompt concurrently.
-    assert _native_ask_gate_lock("conv_1", "other_policy") is not lock_a
+    assert _native_ask_gate_lock("8e32600337d08f59ad381caf96a90659", "other_policy") is not lock_a
     # Different session → different lock, so sessions stay independent.
-    assert _native_ask_gate_lock("conv_2", "session_cost_guard") is not lock_a
+    assert (
+        _native_ask_gate_lock("19b2d8e5c4e1733f25034907cb7d05ed", "session_cost_guard")
+        is not lock_a
+    )
 
 
 async def test_concurrent_cost_asks_serialize_and_collapse_sibling(

--- a/tests/server/integration/test_utility_endpoints.py
+++ b/tests/server/integration/test_utility_endpoints.py
@@ -29,12 +29,12 @@ async def test_health_returns_ok(client: httpx.AsyncClient) -> None:
 
 async def test_health_with_session_id(client: httpx.AsyncClient) -> None:
     """Health with a session_id query param includes a session object."""
-    resp = await client.get("/health", params={"session_id": "conv_fake"})
+    resp = await client.get("/health", params={"session_id": "5ab79713d8c7904f4f4bf10b2da5df62"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "ok"
     assert "session" in data
-    assert data["session"]["id"] == "conv_fake"
+    assert data["session"]["id"] == "5ab79713d8c7904f4f4bf10b2da5df62"
     assert "runner_online" in data["session"]
 
 
@@ -42,13 +42,15 @@ async def test_health_with_batch_session_ids(client: httpx.AsyncClient) -> None:
     """Health with comma-separated session_ids returns a sessions dict."""
     resp = await client.get(
         "/health",
-        params={"session_ids": "conv_a,conv_b"},
+        params={
+            "session_ids": "94c349190e241f85a984b3df8f129696,bfcc6c068875253adf2f20bf30a19015"
+        },
     )
     assert resp.status_code == 200
     data = resp.json()
     assert "sessions" in data
-    assert "conv_a" in data["sessions"]
-    assert "conv_b" in data["sessions"]
+    assert "94c349190e241f85a984b3df8f129696" in data["sessions"]
+    assert "bfcc6c068875253adf2f20bf30a19015" in data["sessions"]
 
 
 # ── GET /api/version ─────────────────────────────────────

--- a/tests/server/routes/test_auth_helpers.py
+++ b/tests/server/routes/test_auth_helpers.py
@@ -194,7 +194,9 @@ async def test_permissions_disabled_returns_empty_access(
     conv_store: SqlAlchemyConversationStore,
 ) -> None:
     """With no permission store, the helper is a no-op (level None, no fetch)."""
-    access = await require_access_and_level(None, "conv_whatever", LEVEL_READ, None, conv_store)
+    access = await require_access_and_level(
+        None, "a42067bcc66e9b4bfaa3215131aefc96", LEVEL_READ, None, conv_store
+    )
 
     assert access.level is None
     assert access.conversation is None
@@ -222,7 +224,7 @@ async def test_missing_conversation_raises_404(
 
     with pytest.raises(OmnigentError) as exc:
         await require_access_and_level(
-            ALICE, "conv_does_not_exist", LEVEL_READ, perm_store, conv_store
+            ALICE, "1d0b12236c77f69f5073a53583de1a3f", LEVEL_READ, perm_store, conv_store
         )
 
     assert exc.value.code == ErrorCode.NOT_FOUND

--- a/tests/server/routes/test_comments_crud.py
+++ b/tests/server/routes/test_comments_crud.py
@@ -74,7 +74,7 @@ async def test_add_comment_nonexistent_session_returns_404_without_persisting(
     client: httpx.AsyncClient, db_uri: str
 ) -> None:
     """Adding a comment to a nonexistent single-user session returns 404."""
-    missing_session_id = "conv_does_not_exist"
+    missing_session_id = "1d0b12236c77f69f5073a53583de1a3f"
 
     resp = await client.post(
         f"/v1/sessions/{missing_session_id}/comments",

--- a/tests/server/routes/test_default_policies.py
+++ b/tests/server/routes/test_default_policies.py
@@ -81,7 +81,7 @@ async def test_create_default_policy(policy_client: httpx.AsyncClient) -> None:
     assert body["handler"] == _REGISTERED_HANDLER
     assert body["object"] == "default_policy"
     assert body["enabled"] is True
-    assert body["id"].startswith("pol_")
+    assert len(body["id"]) == 32
 
 
 async def test_create_url_policy_rejected(policy_client: httpx.AsyncClient) -> None:
@@ -155,7 +155,7 @@ async def test_get_default_policy(policy_client: httpx.AsyncClient) -> None:
 
 async def test_get_default_policy_not_found(policy_client: httpx.AsyncClient) -> None:
     """Getting a nonexistent policy returns 404."""
-    resp = await policy_client.get("/v1/policies/pol_nonexistent")
+    resp = await policy_client.get("/v1/policies/087a5ba1a5c50583fc5bd2e3f035d3df")
     assert resp.status_code == 404
 
 
@@ -178,7 +178,7 @@ async def test_update_default_policy(policy_client: httpx.AsyncClient) -> None:
 async def test_update_default_policy_not_found(policy_client: httpx.AsyncClient) -> None:
     """Patching a nonexistent policy returns 404."""
     resp = await policy_client.patch(
-        "/v1/policies/pol_nonexistent",
+        "/v1/policies/087a5ba1a5c50583fc5bd2e3f035d3df",
         json={"name": "renamed"},
     )
     assert resp.status_code == 404
@@ -213,6 +213,6 @@ async def test_delete_default_policy(policy_client: httpx.AsyncClient) -> None:
 
 async def test_delete_default_policy_idempotent(policy_client: httpx.AsyncClient) -> None:
     """Deleting a nonexistent policy still returns deleted: true."""
-    resp = await policy_client.delete("/v1/policies/pol_nonexistent")
+    resp = await policy_client.delete("/v1/policies/087a5ba1a5c50583fc5bd2e3f035d3df")
     assert resp.status_code == 200
     assert resp.json()["deleted"] is True

--- a/tests/server/routes/test_session_policies_crud.py
+++ b/tests/server/routes/test_session_policies_crud.py
@@ -92,7 +92,7 @@ async def test_create_session_policy(client: httpx.AsyncClient, session_id: str)
     assert body["type"] == "url"
     assert body["object"] == "session.policy"
     assert body["source"] == "session"
-    assert body["id"].startswith("pol_")
+    assert len(body["id"]) == 32
 
 
 async def test_create_session_policy_duplicate_name(
@@ -111,7 +111,7 @@ async def test_create_session_policy_nonexistent_session(
 ) -> None:
     """Creating a policy for a nonexistent session returns 404."""
     resp = await client.post(
-        "/v1/sessions/conv_nonexistent/policies",
+        "/v1/sessions/ad563e906854634c49e1a6fd2fbb31d4/policies",
         json=_policy_payload(),
     )
     assert resp.status_code == 404
@@ -165,7 +165,7 @@ async def test_list_session_policies_nonexistent_session(
     client: httpx.AsyncClient,
 ) -> None:
     """Listing policies for a nonexistent session returns 404."""
-    resp = await client.get("/v1/sessions/conv_nonexistent/policies")
+    resp = await client.get("/v1/sessions/ad563e906854634c49e1a6fd2fbb31d4/policies")
     assert resp.status_code == 404
 
 
@@ -187,7 +187,7 @@ async def test_get_session_policy(client: httpx.AsyncClient, session_id: str) ->
 
 async def test_get_session_policy_not_found(client: httpx.AsyncClient, session_id: str) -> None:
     """Getting a nonexistent policy returns 404."""
-    resp = await client.get(f"/v1/sessions/{session_id}/policies/pol_nonexistent")
+    resp = await client.get(f"/v1/sessions/{session_id}/policies/087a5ba1a5c50583fc5bd2e3f035d3df")
     assert resp.status_code == 404
 
 
@@ -213,7 +213,7 @@ async def test_update_session_policy(client: httpx.AsyncClient, session_id: str)
 async def test_update_session_policy_not_found(client: httpx.AsyncClient, session_id: str) -> None:
     """Patching a nonexistent policy returns 404."""
     resp = await client.patch(
-        f"/v1/sessions/{session_id}/policies/pol_nonexistent",
+        f"/v1/sessions/{session_id}/policies/087a5ba1a5c50583fc5bd2e3f035d3df",
         json={"name": "new_name"},
     )
     assert resp.status_code == 404

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -33,37 +33,37 @@ class _ConversationStore:
         :returns: None.
         """
         self._conversations = {
-            "conv_proxy": Conversation(
-                id="conv_proxy",
+            "79b22ebd2309e48fdeb450c65611d51b": Conversation(
+                id="79b22ebd2309e48fdeb450c65611d51b",
                 created_at=1,
                 updated_at=1,
-                root_conversation_id="conv_proxy",
-                agent_id="ag_test",
+                root_conversation_id="79b22ebd2309e48fdeb450c65611d51b",
+                agent_id="087b7cb7ac30abf4debfaa578d052ec6",
             ),
-            "conv_local": Conversation(
-                id="conv_local",
+            "5d29bee4350489d66feafecfebd94a97": Conversation(
+                id="5d29bee4350489d66feafecfebd94a97",
                 created_at=1,
                 updated_at=1,
-                root_conversation_id="conv_local",
-                agent_id="ag_test",
+                root_conversation_id="5d29bee4350489d66feafecfebd94a97",
+                agent_id="087b7cb7ac30abf4debfaa578d052ec6",
             ),
-            "conv_claude": Conversation(
-                id="conv_claude",
+            "64a784c3aa907d1774f44313546947c6": Conversation(
+                id="64a784c3aa907d1774f44313546947c6",
                 created_at=1,
                 updated_at=1,
-                root_conversation_id="conv_claude",
-                agent_id="ag_test",
+                root_conversation_id="64a784c3aa907d1774f44313546947c6",
+                agent_id="087b7cb7ac30abf4debfaa578d052ec6",
                 labels={
                     "omnigent.ui": "terminal",
                     "omnigent.wrapper": "claude-code-native-ui",
                 },
             ),
-            "conv_kiro": Conversation(
-                id="conv_kiro",
+            "823dbd1aab969b5a813fac59bb977a77": Conversation(
+                id="823dbd1aab969b5a813fac59bb977a77",
                 created_at=1,
                 updated_at=1,
-                root_conversation_id="conv_kiro",
-                agent_id="ag_kiro",
+                root_conversation_id="823dbd1aab969b5a813fac59bb977a77",
+                agent_id="2c515637c67d0717ad0bebc2747b71bc",
                 labels={
                     "omnigent.ui": "terminal",
                     "omnigent.wrapper": "kiro-native-ui",
@@ -74,14 +74,14 @@ class _ConversationStore:
             # ref and the regular native wrapper label (NOT the
             # internal "-subagent" label), so the native message
             # bypass runs on its first message.
-            "conv_child_native": Conversation(
-                id="conv_child_native",
+            "01d6217454439d2ce8fdace0d4e089b2": Conversation(
+                id="01d6217454439d2ce8fdace0d4e089b2",
                 created_at=1,
                 updated_at=1,
-                root_conversation_id="conv_parent",
+                root_conversation_id="ead6d59a6b650d19dbdf61ec32426f4e",
                 kind="sub_agent",
-                parent_conversation_id="conv_parent",
-                agent_id="ag_test",
+                parent_conversation_id="ead6d59a6b650d19dbdf61ec32426f4e",
+                agent_id="087b7cb7ac30abf4debfaa578d052ec6",
                 labels={
                     "omnigent.ui": "terminal",
                     "omnigent.wrapper": "claude-code-native-ui",
@@ -89,30 +89,30 @@ class _ConversationStore:
             ),
             # A three-level spawn lineage for the file-copy tests:
             # conv_gp (root) -> conv_p (child) -> conv_c (grandchild).
-            "conv_gp": Conversation(
-                id="conv_gp",
+            "46b658cc1407206c877965810133b32f": Conversation(
+                id="46b658cc1407206c877965810133b32f",
                 created_at=1,
                 updated_at=1,
-                root_conversation_id="conv_gp",
-                agent_id="ag_test",
+                root_conversation_id="46b658cc1407206c877965810133b32f",
+                agent_id="087b7cb7ac30abf4debfaa578d052ec6",
             ),
-            "conv_p": Conversation(
-                id="conv_p",
+            "b460374fc8e697b296708f52dc9d8179": Conversation(
+                id="b460374fc8e697b296708f52dc9d8179",
                 created_at=1,
                 updated_at=1,
-                root_conversation_id="conv_gp",
+                root_conversation_id="46b658cc1407206c877965810133b32f",
                 kind="sub_agent",
-                parent_conversation_id="conv_gp",
-                agent_id="ag_test",
+                parent_conversation_id="46b658cc1407206c877965810133b32f",
+                agent_id="087b7cb7ac30abf4debfaa578d052ec6",
             ),
-            "conv_c": Conversation(
-                id="conv_c",
+            "405bfe154d5c0e795a2b87021bc897bf": Conversation(
+                id="405bfe154d5c0e795a2b87021bc897bf",
                 created_at=1,
                 updated_at=1,
-                root_conversation_id="conv_gp",
+                root_conversation_id="46b658cc1407206c877965810133b32f",
                 kind="sub_agent",
-                parent_conversation_id="conv_p",
-                agent_id="ag_test",
+                parent_conversation_id="b460374fc8e697b296708f52dc9d8179",
+                agent_id="087b7cb7ac30abf4debfaa578d052ec6",
             ),
         }
         self.appended_items: list[Any] = []
@@ -275,7 +275,7 @@ class _FakeRunnerClient:
         :param exc: Exception to raise on every request.
         :param exc_paths: Per-URL exception overrides — raise only when
             the request targets that exact path, e.g.
-            ``{"/v1/sessions/conv_x/events": ConnectionError("boom")}``.
+            ``{"/v1/sessions/8af356d908005a65f872c246158c6293/events": ConnectionError("boom")}``.
             Lets a test pass one stage (terminal ensure) and fail the
             next (message forward) on the same client.
         :param responses: Per-URL JSON response overrides.
@@ -479,7 +479,7 @@ def _runner_payload() -> dict[str, object]:
                 "id": DEFAULT_ENVIRONMENT_ID,
                 "object": "session.resource",
                 "type": "environment",
-                "session_id": "conv_proxy",
+                "session_id": "79b22ebd2309e48fdeb450c65611d51b",
                 "name": "Primary environment",
                 "metadata": {
                     "environment_type": "caller_process",
@@ -490,7 +490,7 @@ def _runner_payload() -> dict[str, object]:
                 "id": "terminal_runner_s1",
                 "object": "session.resource",
                 "type": "terminal",
-                "session_id": "conv_proxy",
+                "session_id": "79b22ebd2309e48fdeb450c65611d51b",
                 "name": "runner:s1",
                 "environment": DEFAULT_ENVIRONMENT_ID,
                 "metadata": {
@@ -524,12 +524,12 @@ async def test_get_session_labels_uses_labels_only_path(
     fake_runner = _FakeRunnerClient(payload={"status": "running"})
     set_runner_client(fake_runner)  # type: ignore[arg-type]
 
-    resp = await client.get("/v1/sessions/conv_claude/labels")
+    resp = await client.get("/v1/sessions/64a784c3aa907d1774f44313546947c6/labels")
 
     assert resp.status_code == 200
     assert resp.headers["cache-control"] == "no-store"
     assert resp.json() == {
-        "id": "conv_claude",
+        "id": "64a784c3aa907d1774f44313546947c6",
         "labels": {
             "omnigent.ui": "terminal",
             "omnigent.wrapper": "claude-code-native-ui",
@@ -547,11 +547,13 @@ async def test_list_session_resources_proxies_to_bound_runner(
     fake_router = _FakeRunnerRouter(fake_runner)
     set_runner_router(fake_router)  # type: ignore[arg-type]
 
-    resp = await client.get("/v1/sessions/conv_proxy/resources")
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources")
 
     assert resp.status_code == 200
-    assert fake_router.resource_calls == ["conv_proxy"]
-    assert fake_runner.calls == [("GET", "/v1/sessions/conv_proxy/resources")]
+    assert fake_router.resource_calls == ["79b22ebd2309e48fdeb450c65611d51b"]
+    assert fake_runner.calls == [
+        ("GET", "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources")
+    ]
     body = resp.json()
     ids = [resource["id"] for resource in body["data"]]
     assert ids == [DEFAULT_ENVIRONMENT_ID, "terminal_runner_s1"]
@@ -565,7 +567,7 @@ async def test_list_session_resources_validates_session_before_proxy(
     fake_router = _FakeRunnerRouter(fake_runner)
     set_runner_router(fake_router)  # type: ignore[arg-type]
 
-    resp = await client.get("/v1/sessions/conv_missing/resources")
+    resp = await client.get("/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/resources")
 
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "not_found"
@@ -582,7 +584,7 @@ async def test_list_session_resources_rejects_malformed_runner_response(
     )
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
-    resp = await client.get("/v1/sessions/conv_proxy/resources")
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources")
 
     assert resp.status_code == 502
     assert resp.json()["detail"] == "runner session-resources endpoint returned malformed response"
@@ -592,7 +594,7 @@ async def test_list_session_resources_rejects_malformed_runner_response(
 async def test_list_session_resources_local_fallback_lists_default(
     client: httpx.AsyncClient,
 ) -> None:
-    resp = await client.get("/v1/sessions/conv_local/resources")
+    resp = await client.get("/v1/sessions/5d29bee4350489d66feafecfebd94a97/resources")
 
     assert resp.status_code == 200
     body = resp.json()
@@ -601,7 +603,7 @@ async def test_list_session_resources_local_fallback_lists_default(
             "id": DEFAULT_ENVIRONMENT_ID,
             "object": "session.resource",
             "type": "environment",
-            "session_id": "conv_local",
+            "session_id": "5d29bee4350489d66feafecfebd94a97",
             "name": "Primary environment",
             "metadata": {
                 "environment_type": "caller_process",
@@ -627,7 +629,7 @@ async def test_claude_native_message_forwards_to_runner_without_persisting(
     set_runner_client(fake_runner)  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_claude/events",
+        "/v1/sessions/64a784c3aa907d1774f44313546947c6/events",
         json={
             "type": "message",
             "data": {
@@ -646,12 +648,12 @@ async def test_claude_native_message_forwards_to_runner_without_persisting(
     assert body["queued"] is True
     assert body["pending_id"].startswith("pending_")
     assert fake_runner.calls == [
-        ("POST", "/v1/sessions/conv_claude/resources/terminals"),
-        ("POST", "/v1/sessions/conv_claude/events"),
+        ("POST", "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals"),
+        ("POST", "/v1/sessions/64a784c3aa907d1774f44313546947c6/events"),
     ]
     assert fake_runner.post_json_calls == [
         (
-            "/v1/sessions/conv_claude/resources/terminals",
+            "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals",
             {
                 "terminal": "claude",
                 "session_key": "main",
@@ -659,7 +661,7 @@ async def test_claude_native_message_forwards_to_runner_without_persisting(
             },
         ),
         (
-            "/v1/sessions/conv_claude/events",
+            "/v1/sessions/64a784c3aa907d1774f44313546947c6/events",
             {
                 "type": "message",
                 "role": "user",
@@ -668,7 +670,7 @@ async def test_claude_native_message_forwards_to_runner_without_persisting(
                 "harness": "claude-native",
                 # Forwarded so the runner resolves the harness spec on the
                 # first message (before POST /v1/sessions caches it).
-                "agent_id": "ag_test",
+                "agent_id": "087b7cb7ac30abf4debfaa578d052ec6",
             },
         ),
     ]
@@ -685,7 +687,7 @@ async def test_claude_native_assistant_message_rejected_not_forwarded(
     set_runner_client(fake_runner)  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_claude/events",
+        "/v1/sessions/64a784c3aa907d1774f44313546947c6/events",
         json={
             "type": "message",
             "data": {
@@ -716,7 +718,7 @@ async def test_claude_native_message_surfaces_runner_sse_failure(
     )
     fake_runner = _FakeRunnerClient(
         text_responses={
-            "/v1/sessions/conv_claude/events": (
+            "/v1/sessions/64a784c3aa907d1774f44313546947c6/events": (
                 200,
                 sse,
                 {"content-type": "text/event-stream"},
@@ -727,7 +729,7 @@ async def test_claude_native_message_surfaces_runner_sse_failure(
     set_runner_client(fake_runner)  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_claude/events",
+        "/v1/sessions/64a784c3aa907d1774f44313546947c6/events",
         json={
             "type": "message",
             "data": {
@@ -742,8 +744,8 @@ async def test_claude_native_message_surfaces_runner_sse_failure(
         "Claude terminal message delivery failed: tmux target missing"
     )
     assert fake_runner.calls == [
-        ("POST", "/v1/sessions/conv_claude/resources/terminals"),
-        ("POST", "/v1/sessions/conv_claude/events"),
+        ("POST", "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals"),
+        ("POST", "/v1/sessions/64a784c3aa907d1774f44313546947c6/events"),
     ]
 
 
@@ -766,7 +768,7 @@ async def test_claude_native_message_tunnel_close_mid_forward_returns_502(
         exc_paths={
             # Ensure (terminals POST) succeeds via the default payload;
             # only the message-forward leg drops the tunnel.
-            "/v1/sessions/conv_claude/events": ConnectionError(
+            "/v1/sessions/64a784c3aa907d1774f44313546947c6/events": ConnectionError(
                 "tunnel closed before request completed"
             ),
         },
@@ -775,7 +777,7 @@ async def test_claude_native_message_tunnel_close_mid_forward_returns_502(
     set_runner_client(fake_runner)  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_claude/events",
+        "/v1/sessions/64a784c3aa907d1774f44313546947c6/events",
         json={
             "type": "message",
             "data": {
@@ -791,8 +793,8 @@ async def test_claude_native_message_tunnel_close_mid_forward_returns_502(
     assert resp.json()["detail"] == "Claude terminal message delivery failed"
     # Ensure ran (and passed) before the forward leg hit the drop.
     assert fake_runner.calls == [
-        ("POST", "/v1/sessions/conv_claude/resources/terminals"),
-        ("POST", "/v1/sessions/conv_claude/events"),
+        ("POST", "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals"),
+        ("POST", "/v1/sessions/64a784c3aa907d1774f44313546947c6/events"),
     ]
 
 
@@ -825,7 +827,7 @@ async def test_native_subagent_terminal_boot_failure_wakes_parent(
     # bypass takes the terminal-failure branch.
     fake_runner = _FakeRunnerClient(
         responses={
-            "/v1/sessions/conv_child_native/resources/terminals": (
+            "/v1/sessions/01d6217454439d2ce8fdace0d4e089b2/resources/terminals": (
                 503,
                 {
                     "error": {
@@ -840,7 +842,7 @@ async def test_native_subagent_terminal_boot_failure_wakes_parent(
     set_runner_client(fake_runner)  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_child_native/events",
+        "/v1/sessions/01d6217454439d2ce8fdace0d4e089b2/events",
         json={
             "type": "message",
             "data": {
@@ -858,8 +860,8 @@ async def test_native_subagent_terminal_boot_failure_wakes_parent(
     # parent-wake status forward. A third call, or the forward missing,
     # both indicate a regression.
     assert fake_runner.calls == [
-        ("POST", "/v1/sessions/conv_child_native/resources/terminals"),
-        ("POST", "/v1/sessions/conv_child_native/events"),
+        ("POST", "/v1/sessions/01d6217454439d2ce8fdace0d4e089b2/resources/terminals"),
+        ("POST", "/v1/sessions/01d6217454439d2ce8fdace0d4e089b2/events"),
     ], f"expected ensure + status-forward; saw {fake_runner.calls!r}"
 
     # The second POST is the parent-wake edge. It must be a failed
@@ -868,7 +870,7 @@ async def test_native_subagent_terminal_boot_failure_wakes_parent(
     # (runner: ``output or "...turn failed"``). Asserting the exact
     # payload proves the parent is notified — not left running forever.
     forward_url, forward_body = fake_runner.post_json_calls[-1]
-    assert forward_url == "/v1/sessions/conv_child_native/events"
+    assert forward_url == "/v1/sessions/01d6217454439d2ce8fdace0d4e089b2/events"
     assert forward_body == {
         "type": "external_session_status",
         "data": {
@@ -897,7 +899,7 @@ async def test_native_subagent_terminal_boot_failure_surfaces_unreachable_runner
     """
     fake_runner = _FakeRunnerClient(
         responses={
-            "/v1/sessions/conv_child_native/resources/terminals": (
+            "/v1/sessions/01d6217454439d2ce8fdace0d4e089b2/resources/terminals": (
                 503,
                 {
                     "error": {
@@ -935,7 +937,7 @@ async def test_native_subagent_terminal_boot_failure_surfaces_unreachable_runner
     set_runner_client(fake_runner)  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_child_native/events",
+        "/v1/sessions/01d6217454439d2ce8fdace0d4e089b2/events",
         json={
             "type": "message",
             "data": {
@@ -949,7 +951,10 @@ async def test_native_subagent_terminal_boot_failure_surfaces_unreachable_runner
     # be delivered, so the route must not pretend the message landed.
     assert resp.status_code == 503, resp.text
     # The forward was attempted on the child's events endpoint.
-    assert fake_runner.post_json_calls[-1][0] == "/v1/sessions/conv_child_native/events"
+    assert (
+        fake_runner.post_json_calls[-1][0]
+        == "/v1/sessions/01d6217454439d2ce8fdace0d4e089b2/events"
+    )
     assert fake_runner.post_json_calls[-1][1]["type"] == "external_session_status"
     assert fake_runner.post_json_calls[-1][1]["data"]["status"] == "failed"
 
@@ -966,7 +971,7 @@ def _env_only_payload() -> dict[str, object]:
                 "id": DEFAULT_ENVIRONMENT_ID,
                 "object": "session.resource",
                 "type": "environment",
-                "session_id": "conv_proxy",
+                "session_id": "79b22ebd2309e48fdeb450c65611d51b",
                 "name": "Primary environment",
                 "metadata": {"environment_type": "caller_process", "role": "primary"},
             },
@@ -983,7 +988,7 @@ def _single_resource_payload() -> dict[str, object]:
         "id": DEFAULT_ENVIRONMENT_ID,
         "object": "session.resource",
         "type": "environment",
-        "session_id": "conv_proxy",
+        "session_id": "79b22ebd2309e48fdeb450c65611d51b",
         "name": "Primary environment",
         "metadata": {"environment_type": "caller_process", "role": "primary"},
     }
@@ -997,12 +1002,12 @@ async def test_list_environments_proxies_to_runner(
     fake_runner = _FakeRunnerClient(payload=_env_only_payload())
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
-    resp = await client.get("/v1/sessions/conv_proxy/resources/environments")
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments")
 
     assert resp.status_code == 200
     assert resp.json()["object"] == "list"
     assert fake_runner.calls == [
-        ("GET", "/v1/sessions/conv_proxy/resources/environments"),
+        ("GET", "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments"),
     ]
 
 
@@ -1022,12 +1027,12 @@ async def test_list_terminals_forwards_pagination_params_to_runner(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_proxy/resources/terminals?order=asc&limit=1000&bogus=1",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals?order=asc&limit=1000&bogus=1",
     )
 
     assert resp.status_code == 200
     assert fake_runner.calls == [
-        ("GET", "/v1/sessions/conv_proxy/resources/terminals"),
+        ("GET", "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals"),
     ]
     # Exactly the runner endpoint's supported pagination params are
     # forwarded; an unknown param (``bogus``) must be dropped so the
@@ -1045,7 +1050,7 @@ async def test_list_environments_rejects_unknown_session(
     fake_runner = _FakeRunnerClient(payload=_env_only_payload())
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
-    resp = await client.get("/v1/sessions/conv_missing/resources/environments")
+    resp = await client.get("/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/resources/environments")
 
     assert resp.status_code == 404
     assert not fake_runner.calls
@@ -1059,12 +1064,17 @@ async def test_get_resource_by_id_proxies_to_runner(
     fake_runner = _FakeRunnerClient(payload=_single_resource_payload())
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
-    resp = await client.get(f"/v1/sessions/conv_proxy/resources/{DEFAULT_ENVIRONMENT_ID}")
+    resp = await client.get(
+        f"/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/{DEFAULT_ENVIRONMENT_ID}"
+    )
 
     assert resp.status_code == 200
     assert resp.json()["id"] == DEFAULT_ENVIRONMENT_ID
     assert fake_runner.calls == [
-        ("GET", f"/v1/sessions/conv_proxy/resources/{DEFAULT_ENVIRONMENT_ID}"),
+        (
+            "GET",
+            f"/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/{DEFAULT_ENVIRONMENT_ID}",
+        ),
     ]
 
 
@@ -1075,7 +1085,7 @@ async def test_get_resource_by_id_404_from_runner(
     """GET /resources/{id} surfaces runner 404."""
     fake_runner = _FakeRunnerClient(
         responses={
-            "/v1/sessions/conv_proxy/resources/nonexistent": (
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/nonexistent": (
                 404,
                 {"error": {"code": "not_found", "message": "Resource 'nonexistent' not found"}},
             ),
@@ -1083,7 +1093,7 @@ async def test_get_resource_by_id_404_from_runner(
     )
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
-    resp = await client.get("/v1/sessions/conv_proxy/resources/nonexistent")
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/nonexistent")
 
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "not_found"
@@ -1124,7 +1134,7 @@ async def test_create_terminal_proxies_to_runner(
         "id": "terminal_bash_s1",
         "object": "session.resource",
         "type": "terminal",
-        "session_id": "conv_proxy",
+        "session_id": "79b22ebd2309e48fdeb450c65611d51b",
         "name": "bash:s1",
         "environment": DEFAULT_ENVIRONMENT_ID,
         "metadata": {
@@ -1137,14 +1147,14 @@ async def test_create_terminal_proxies_to_runner(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_proxy/resources/terminals",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals",
         json={"terminal": "bash", "session_key": "s1"},
     )
 
     assert resp.status_code == 200
     assert resp.json()["id"] == "terminal_bash_s1"
     assert fake_runner.calls == [
-        ("POST", "/v1/sessions/conv_proxy/resources/terminals"),
+        ("POST", "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals"),
     ]
 
 
@@ -1163,7 +1173,7 @@ async def test_create_terminal_rejected_without_agent_terminal_access(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_proxy/resources/terminals",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals",
         json={"terminal": "bash", "session_key": "s1"},
     )
 
@@ -1189,7 +1199,7 @@ async def test_create_terminal_rejected_for_undeclared_name(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_proxy/resources/terminals",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals",
         json={"terminal": "zsh", "session_key": "s1"},
     )
 
@@ -1218,7 +1228,7 @@ async def test_create_terminal_native_bootstrap_exempt_from_gate(
         "id": "terminal_claude_main",
         "object": "session.resource",
         "type": "terminal",
-        "session_id": "conv_proxy",
+        "session_id": "79b22ebd2309e48fdeb450c65611d51b",
         "name": "claude:main",
         "metadata": {"terminal_name": "claude", "session_key": "main", "running": True},
     }
@@ -1226,14 +1236,14 @@ async def test_create_terminal_native_bootstrap_exempt_from_gate(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_proxy/resources/terminals",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals",
         json={"terminal": "claude", "session_key": "main", "ensure_native_terminal": True},
     )
 
     assert resp.status_code == 200
     assert resp.json()["id"] == "terminal_claude_main"
     assert fake_runner.calls == [
-        ("POST", "/v1/sessions/conv_proxy/resources/terminals"),
+        ("POST", "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals"),
     ]
 
 
@@ -1273,7 +1283,7 @@ async def test_create_terminal_bootstrap_markers_do_not_bypass_gate_for_other_sh
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_proxy/resources/terminals",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals",
         json=body,
     )
 
@@ -1344,7 +1354,7 @@ async def test_create_terminal_surfaces_runner_error_without_crashing(
         surface.
     :returns: None.
     """
-    path = "/v1/sessions/conv_proxy/resources/terminals"
+    path = "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals"
     fake_runner = _FakeRunnerClient(responses={path: (runner_status, runner_payload)})
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
@@ -1379,13 +1389,16 @@ async def test_delete_terminal_proxies_to_runner(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.delete(
-        "/v1/sessions/conv_proxy/resources/terminals/terminal_bash_s1",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals/terminal_bash_s1",
     )
 
     assert resp.status_code == 200
     assert resp.json()["deleted"] is True
     assert fake_runner.calls == [
-        ("DELETE", "/v1/sessions/conv_proxy/resources/terminals/terminal_bash_s1"),
+        (
+            "DELETE",
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals/terminal_bash_s1",
+        ),
     ]
 
 
@@ -1398,7 +1411,7 @@ async def test_transfer_terminal_authorizes_sessions_and_proxies_to_runner(
         "id": "terminal_bash_s1",
         "object": "session.resource",
         "type": "terminal",
-        "session_id": "conv_local",
+        "session_id": "5d29bee4350489d66feafecfebd94a97",
         "name": "bash:s1",
         "environment": DEFAULT_ENVIRONMENT_ID,
         "metadata": {
@@ -1412,22 +1425,25 @@ async def test_transfer_terminal_authorizes_sessions_and_proxies_to_runner(
     set_runner_router(router)  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_proxy/resources/terminals/terminal_bash_s1/transfer",
-        json={"target_session_id": "conv_local"},
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals/terminal_bash_s1/transfer",
+        json={"target_session_id": "5d29bee4350489d66feafecfebd94a97"},
     )
 
     assert resp.status_code == 200
-    assert resp.json()["session_id"] == "conv_local"
+    assert resp.json()["session_id"] == "5d29bee4350489d66feafecfebd94a97"
     assert fake_runner.calls == [
-        ("POST", "/v1/sessions/conv_proxy/resources/terminals/terminal_bash_s1/transfer"),
+        (
+            "POST",
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals/terminal_bash_s1/transfer",
+        ),
     ]
     assert fake_runner.post_json_calls == [
         (
-            "/v1/sessions/conv_proxy/resources/terminals/terminal_bash_s1/transfer",
-            {"target_session_id": "conv_local"},
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals/terminal_bash_s1/transfer",
+            {"target_session_id": "5d29bee4350489d66feafecfebd94a97"},
         ),
     ]
-    assert router.resource_calls == ["conv_proxy"]
+    assert router.resource_calls == ["79b22ebd2309e48fdeb450c65611d51b"]
 
 
 @pytest.mark.asyncio
@@ -1492,11 +1508,12 @@ async def test_transfer_terminal_surfaces_runner_error_without_crashing(
         surface.
     :returns: None.
     """
-    path = "/v1/sessions/conv_proxy/resources/terminals/terminal_bash_s1/transfer"
+    session_id = "79b22ebd2309e48fdeb450c65611d51b"
+    path = f"/v1/sessions/{session_id}/resources/terminals/terminal_bash_s1/transfer"
     fake_runner = _FakeRunnerClient(responses={path: (runner_status, runner_payload)})
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
-    resp = await client.post(path, json={"target_session_id": "conv_local"})
+    resp = await client.post(path, json={"target_session_id": "5d29bee4350489d66feafecfebd94a97"})
 
     # http_status is derived from the surfaced code: 503 proves the runner's
     # ``runner_unavailable`` propagated; a 500 would mean it was masked by the
@@ -1520,7 +1537,7 @@ async def test_delete_terminal_surfaces_runner_404(
     """DELETE /resources/terminals/{id} surfaces runner 404."""
     fake_runner = _FakeRunnerClient(
         responses={
-            "/v1/sessions/conv_proxy/resources/terminals/terminal_nope_s1": (
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals/terminal_nope_s1": (
                 404,
                 {"error": {"code": "not_found", "message": "Terminal not found"}},
             ),
@@ -1529,7 +1546,7 @@ async def test_delete_terminal_surfaces_runner_404(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.delete(
-        "/v1/sessions/conv_proxy/resources/terminals/terminal_nope_s1",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals/terminal_nope_s1",
     )
 
     assert resp.status_code == 404
@@ -1640,19 +1657,19 @@ async def test_upload_and_list_session_files(
 ) -> None:
     """POST + GET /resources/files round-trips through server."""
     resp = await file_client.post(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
         files={"file": ("report.txt", b"hello world", "text/plain")},
     )
     assert resp.status_code == 201
     body = resp.json()
     assert body["object"] == "session.resource"
     assert body["type"] == "file"
-    assert body["session_id"] == "conv_proxy"
+    assert body["session_id"] == "79b22ebd2309e48fdeb450c65611d51b"
     assert body["name"] == "report.txt"
     file_id = body["id"]
 
     list_resp = await file_client.get(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
     )
     assert list_resp.status_code == 200
     ids = [f["id"] for f in list_resp.json()["data"]]
@@ -1665,13 +1682,13 @@ async def test_get_session_file_validates_ownership(
 ) -> None:
     """GET /resources/files/{id} 404s for wrong session."""
     upload = await file_client.post(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
         files={"file": ("owned.txt", b"data", "text/plain")},
     )
     file_id = upload.json()["id"]
 
     resp = await file_client.get(
-        f"/v1/sessions/conv_local/resources/files/{file_id}",
+        f"/v1/sessions/5d29bee4350489d66feafecfebd94a97/resources/files/{file_id}",
     )
     assert resp.status_code == 404
 
@@ -1682,13 +1699,13 @@ async def test_download_session_file_content(
 ) -> None:
     """GET /resources/files/{id}/content returns raw bytes."""
     upload = await file_client.post(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
         files={"file": ("hello.txt", b"hello world", "text/plain")},
     )
     file_id = upload.json()["id"]
 
     resp = await file_client.get(
-        f"/v1/sessions/conv_proxy/resources/files/{file_id}/content",
+        f"/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files/{file_id}/content",
     )
     assert resp.status_code == 200
     assert resp.content == b"hello world"
@@ -1715,7 +1732,7 @@ async def test_download_session_file_html_is_attachment_not_inline(
     nosniff headers neutralize that.
     """
     upload = await file_client.post(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
         files={
             "file": (
                 "evil.html",
@@ -1727,7 +1744,7 @@ async def test_download_session_file_html_is_attachment_not_inline(
     file_id = upload.json()["id"]
 
     resp = await file_client.get(
-        f"/v1/sessions/conv_proxy/resources/files/{file_id}/content",
+        f"/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files/{file_id}/content",
     )
     assert resp.status_code == 200
     # The bytes are still served verbatim — we don't mangle content,
@@ -1746,19 +1763,19 @@ async def test_delete_session_file(
 ) -> None:
     """DELETE /resources/files/{id} removes the file."""
     upload = await file_client.post(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
         files={"file": ("temp.txt", b"gone", "text/plain")},
     )
     file_id = upload.json()["id"]
 
     resp = await file_client.delete(
-        f"/v1/sessions/conv_proxy/resources/files/{file_id}",
+        f"/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files/{file_id}",
     )
     assert resp.status_code == 200
     assert resp.json()["deleted"] is True
 
     get_resp = await file_client.get(
-        f"/v1/sessions/conv_proxy/resources/files/{file_id}",
+        f"/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files/{file_id}",
     )
     assert get_resp.status_code == 404
 
@@ -1792,26 +1809,28 @@ def test_ancestor_session_ids_stops_on_parent_cycle(
     file_conv_store: _ConversationStore,
 ) -> None:
     """A malformed parent cycle terminates at the first repeated session."""
-    file_conv_store._conversations["conv_cycle_a"] = Conversation(
-        id="conv_cycle_a",
+    file_conv_store._conversations["1c5312db831f2aff90bd83b0acb5b98a"] = Conversation(
+        id="1c5312db831f2aff90bd83b0acb5b98a",
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_cycle_a",
+        root_conversation_id="1c5312db831f2aff90bd83b0acb5b98a",
         kind="sub_agent",
-        parent_conversation_id="conv_cycle_b",
-        agent_id="ag_test",
+        parent_conversation_id="1204226336299fc62295d6aa5cc5975b",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
     )
-    file_conv_store._conversations["conv_cycle_b"] = Conversation(
-        id="conv_cycle_b",
+    file_conv_store._conversations["1204226336299fc62295d6aa5cc5975b"] = Conversation(
+        id="1204226336299fc62295d6aa5cc5975b",
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_cycle_a",
+        root_conversation_id="1c5312db831f2aff90bd83b0acb5b98a",
         kind="sub_agent",
-        parent_conversation_id="conv_cycle_a",
-        agent_id="ag_test",
+        parent_conversation_id="1c5312db831f2aff90bd83b0acb5b98a",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
     )
 
-    assert _ancestor_session_ids(file_conv_store, "conv_cycle_a") == ["conv_cycle_b"]
+    assert _ancestor_session_ids(file_conv_store, "1c5312db831f2aff90bd83b0acb5b98a") == [
+        "1204226336299fc62295d6aa5cc5975b"
+    ]
 
 
 @pytest.mark.asyncio
@@ -1820,16 +1839,18 @@ async def test_copy_files_from_direct_parent(
     file_store: Any,
 ) -> None:
     """A child copies one parent-owned file into its own namespace."""
-    parent_file = await _upload_file(file_client, "conv_p", "doc.txt", b"parent bytes")
+    parent_file = await _upload_file(
+        file_client, "b460374fc8e697b296708f52dc9d8179", "doc.txt", b"parent bytes"
+    )
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [parent_file]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [parent_file]},
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["object"] == "session.files.copied"
-    assert body["session_id"] == "conv_c"
+    assert body["session_id"] == "405bfe154d5c0e795a2b87021bc897bf"
     entry = body["mapping"][parent_file]
     new_id = entry["new_id"]
     # A copy, not an alias: the new row is distinct from the source.
@@ -1840,15 +1861,15 @@ async def test_copy_files_from_direct_parent(
     assert entry["content_type"] == "text/plain"
 
     # The new row is child-scoped and readable by the child only.
-    copied = file_store.get(new_id, session_id="conv_c")
+    copied = file_store.get(new_id, session_id="405bfe154d5c0e795a2b87021bc897bf")
     assert copied is not None
     assert copied.filename == "doc.txt"
     # The source row is unchanged and still owned by the parent.
-    assert file_store.get(parent_file, session_id="conv_p") is not None
+    assert file_store.get(parent_file, session_id="b460374fc8e697b296708f52dc9d8179") is not None
 
     # The bytes match the source.
     content = await file_client.get(
-        f"/v1/sessions/conv_c/resources/files/{new_id}/content",
+        f"/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files/{new_id}/content",
     )
     assert content.status_code == 200
     assert content.content == b"parent bytes"
@@ -1860,8 +1881,8 @@ async def test_copy_files_rejects_empty_file_ids(
 ) -> None:
     """The request body requires at least one file id."""
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": []},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": []},
     )
 
     assert resp.status_code == 422, resp.text
@@ -1873,8 +1894,8 @@ async def test_copy_files_rejects_blank_file_id(
 ) -> None:
     """Each requested file id must be non-empty."""
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [""]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [""]},
     )
 
     assert resp.status_code == 422, resp.text
@@ -1886,8 +1907,11 @@ async def test_copy_files_rejects_duplicate_file_ids(
 ) -> None:
     """Duplicate source ids are rejected instead of copied twice."""
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": ["file_same", "file_same"]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={
+            "source_session_id": "b460374fc8e697b296708f52dc9d8179",
+            "file_ids": ["247a8c2023856d2eabf41f938df8f032", "247a8c2023856d2eabf41f938df8f032"],
+        },
     )
 
     assert resp.status_code == 400, resp.text
@@ -1900,12 +1924,12 @@ async def test_copy_files_multi_file_mapping(
     file_store: Any,
 ) -> None:
     """A multi-file copy returns a complete source→new mapping."""
-    f1 = await _upload_file(file_client, "conv_p", "a.txt", b"aaa")
-    f2 = await _upload_file(file_client, "conv_p", "b.txt", b"bbb")
+    f1 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "a.txt", b"aaa")
+    f2 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "b.txt", b"bbb")
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [f1, f2]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [f1, f2]},
     )
     assert resp.status_code == 200, resp.text
     mapping = resp.json()["mapping"]
@@ -1913,7 +1937,7 @@ async def test_copy_files_multi_file_mapping(
     new_ids = {entry["new_id"] for entry in mapping.values()}
     assert len(new_ids) == 2
     for new_id in new_ids:
-        assert file_store.get(new_id, session_id="conv_c") is not None
+        assert file_store.get(new_id, session_id="405bfe154d5c0e795a2b87021bc897bf") is not None
 
 
 @pytest.mark.asyncio
@@ -1922,15 +1946,17 @@ async def test_copy_files_from_grandparent_in_chain(
     file_store: Any,
 ) -> None:
     """Copying from a grandparent (two levels up) is authorized."""
-    gp_file = await _upload_file(file_client, "conv_gp", "root.txt", b"grandparent")
+    gp_file = await _upload_file(
+        file_client, "46b658cc1407206c877965810133b32f", "root.txt", b"grandparent"
+    )
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_gp", "file_ids": [gp_file]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "46b658cc1407206c877965810133b32f", "file_ids": [gp_file]},
     )
     assert resp.status_code == 200, resp.text
     new_id = resp.json()["mapping"][gp_file]["new_id"]
-    assert file_store.get(new_id, session_id="conv_c") is not None
+    assert file_store.get(new_id, session_id="405bfe154d5c0e795a2b87021bc897bf") is not None
 
 
 @pytest.mark.asyncio
@@ -1940,19 +1966,21 @@ async def test_copy_files_rejects_source_outside_lineage(
 ) -> None:
     """A source session not in the destination's lineage is forbidden."""
     # conv_proxy is a top-level session with no link to conv_c's chain.
-    foreign_file = await _upload_file(file_client, "conv_proxy", "x.txt", b"foreign")
+    foreign_file = await _upload_file(
+        file_client, "79b22ebd2309e48fdeb450c65611d51b", "x.txt", b"foreign"
+    )
 
-    before = file_store.list(session_id="conv_c").data
+    before = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_proxy", "file_ids": [foreign_file]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "79b22ebd2309e48fdeb450c65611d51b", "file_ids": [foreign_file]},
     )
     assert resp.status_code == 403
     assert resp.json()["error"]["code"] == "forbidden"
 
     # Nothing was copied into the destination.
-    after = file_store.list(session_id="conv_c").data
+    after = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
     assert len(after) == len(before)
 
 
@@ -1962,20 +1990,23 @@ async def test_copy_files_missing_source_file_is_all_or_nothing(
     file_store: Any,
 ) -> None:
     """A missing source file fails the whole request with no partial copy."""
-    good = await _upload_file(file_client, "conv_p", "good.txt", b"ok")
+    good = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "good.txt", b"ok")
 
-    before = file_store.list(session_id="conv_c").data
+    before = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [good, "file_does_not_exist"]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={
+            "source_session_id": "b460374fc8e697b296708f52dc9d8179",
+            "file_ids": [good, "65f7ae83b2200f8c848848e9afc4b8af"],
+        },
     )
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "not_found"
 
     # The valid file in the batch must NOT have been committed: validation
     # is all-or-nothing, so the destination is unchanged.
-    after = file_store.list(session_id="conv_c").data
+    after = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
     assert len(after) == len(before)
 
 
@@ -1992,20 +2023,25 @@ async def test_copy_files_missing_blob_surfaces_before_any_write(
     absent blob — is caught during validation and copies nothing, preserving
     the "missing blob surfaces before any child row is created" guarantee.
     """
-    good = await _upload_file(file_client, "conv_p", "good.txt", b"ok")
-    dangling = await _upload_file(file_client, "conv_p", "gone.txt", b"bye")
+    good = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "good.txt", b"ok")
+    dangling = await _upload_file(
+        file_client, "b460374fc8e697b296708f52dc9d8179", "gone.txt", b"bye"
+    )
     # Drop the blob but leave the metadata row — a dangling source.
     artifact_store.delete(dangling)
-    before = file_store.list(session_id="conv_c").data
+    before = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [good, dangling]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={
+            "source_session_id": "b460374fc8e697b296708f52dc9d8179",
+            "file_ids": [good, dangling],
+        },
     )
     assert resp.status_code == 404, resp.text
     assert resp.json()["error"]["code"] == "not_found"
     # The valid file in the batch was NOT committed — validation is all-or-nothing.
-    after = file_store.list(session_id="conv_c").data
+    after = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
     assert len(after) == len(before)
 
 
@@ -2023,10 +2059,10 @@ async def test_copy_files_midbatch_write_failure_persists_no_resource_events(
     ``session.resource.created`` for it — clients must not see a phantom
     file that was rolled back.
     """
-    f1 = await _upload_file(file_client, "conv_p", "a.txt", b"aa")
-    f2 = await _upload_file(file_client, "conv_p", "b.txt", b"bb")
+    f1 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "a.txt", b"aa")
+    f2 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "b.txt", b"bb")
     file_conv_store.appended_items.clear()
-    before = file_store.list(session_id="conv_c").data
+    before = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
 
     real_put = artifact_store.put
     calls = {"n": 0}
@@ -2040,15 +2076,15 @@ async def test_copy_files_midbatch_write_failure_persists_no_resource_events(
     artifact_store.put = _put_then_fail  # type: ignore[assignment]
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [f1, f2]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [f1, f2]},
     )
     assert resp.status_code == 500, resp.text
     assert resp.json()["error"]["code"] == "internal_error"
     assert "Failed to copy files" in resp.json()["error"]["message"]
 
     # First file's row + blob rolled back: destination unchanged.
-    after = file_store.list(session_id="conv_c").data
+    after = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
     assert len(after) == len(before)
     # No phantom resource event persisted for the rolled-back first file.
     events = [i for i in file_conv_store.appended_items if i.type == "resource_event"]
@@ -2064,8 +2100,8 @@ async def test_copy_files_rollback_deletes_blobs_when_row_delete_fails(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Rollback still attempts blob cleanup if row cleanup fails."""
-    f1 = await _upload_file(file_client, "conv_p", "a.txt", b"aa")
-    f2 = await _upload_file(file_client, "conv_p", "b.txt", b"bb")
+    f1 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "a.txt", b"aa")
+    f2 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "b.txt", b"bb")
 
     real_put = artifact_store.put
     calls = {"n": 0}
@@ -2093,8 +2129,8 @@ async def test_copy_files_rollback_deletes_blobs_when_row_delete_fails(
     caplog.set_level(logging.WARNING, logger="omnigent.server.routes.sessions")
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [f1, f2]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [f1, f2]},
     )
 
     assert resp.status_code == 500, resp.text
@@ -2111,8 +2147,8 @@ async def test_copy_files_rollback_logs_blob_delete_failures(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Rollback logs blob cleanup failures after deleting rows."""
-    f1 = await _upload_file(file_client, "conv_p", "a.txt", b"aa")
-    f2 = await _upload_file(file_client, "conv_p", "b.txt", b"bb")
+    f1 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "a.txt", b"aa")
+    f2 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "b.txt", b"bb")
 
     real_put = artifact_store.put
     calls = {"n": 0}
@@ -2140,8 +2176,8 @@ async def test_copy_files_rollback_logs_blob_delete_failures(
     caplog.set_level(logging.WARNING, logger="omnigent.server.routes.sessions")
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [f1, f2]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [f1, f2]},
     )
 
     assert resp.status_code == 500, resp.text
@@ -2155,18 +2191,18 @@ async def test_copy_files_self_source_is_rejected(
     file_store: Any,
 ) -> None:
     """A session may not name ITSELF as the source — lineage is ancestors only."""
-    own = await _upload_file(file_client, "conv_c", "self.txt", b"mine")
-    before = file_store.list(session_id="conv_c").data
+    own = await _upload_file(file_client, "405bfe154d5c0e795a2b87021bc897bf", "self.txt", b"mine")
+    before = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_c", "file_ids": [own]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "405bfe154d5c0e795a2b87021bc897bf", "file_ids": [own]},
     )
     assert resp.status_code == 403, resp.text
     assert resp.json()["error"]["code"] == "forbidden"
 
     # Nothing copied — the destination is unchanged.
-    after = file_store.list(session_id="conv_c").data
+    after = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
     assert len(after) == len(before)
 
 
@@ -2186,10 +2222,10 @@ async def test_copy_files_rejects_over_count_before_any_blob_read(
     import omnigent.server.server_config as server_config
 
     monkeypatch.setattr(server_config, "copy_file_count_limit", lambda: 2)
-    f1 = await _upload_file(file_client, "conv_p", "a.txt", b"a")
-    f2 = await _upload_file(file_client, "conv_p", "b.txt", b"b")
-    f3 = await _upload_file(file_client, "conv_p", "c.txt", b"c")
-    before = file_store.list(session_id="conv_c").data
+    f1 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "a.txt", b"a")
+    f2 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "b.txt", b"b")
+    f3 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "c.txt", b"c")
+    before = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
 
     get_calls = {"n": 0}
     real_get = artifact_store.get
@@ -2201,14 +2237,14 @@ async def test_copy_files_rejects_over_count_before_any_blob_read(
     artifact_store.get = _counting_get  # type: ignore[assignment]
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [f1, f2, f3]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [f1, f2, f3]},
     )
     assert resp.status_code == 400, resp.text
     assert resp.json()["error"]["code"] == "invalid_input"
     # No blob was read and nothing was copied.
     assert get_calls["n"] == 0
-    after = file_store.list(session_id="conv_c").data
+    after = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
     assert len(after) == len(before)
 
 
@@ -2223,9 +2259,9 @@ async def test_copy_files_rejects_over_total_bytes_before_any_blob_read(
     import omnigent.server.server_config as server_config
 
     monkeypatch.setattr(server_config, "copy_total_bytes_limit", lambda: 5)
-    f1 = await _upload_file(file_client, "conv_p", "a.txt", b"aaa")
-    f2 = await _upload_file(file_client, "conv_p", "b.txt", b"bbb")
-    before = file_store.list(session_id="conv_c").data
+    f1 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "a.txt", b"aaa")
+    f2 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "b.txt", b"bbb")
+    before = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
 
     get_calls = {"n": 0}
     real_get = artifact_store.get
@@ -2237,13 +2273,13 @@ async def test_copy_files_rejects_over_total_bytes_before_any_blob_read(
     artifact_store.get = _counting_get  # type: ignore[assignment]
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [f1, f2]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [f1, f2]},
     )
     assert resp.status_code == 400, resp.text
     assert resp.json()["error"]["code"] == "invalid_input"
     assert get_calls["n"] == 0
-    after = file_store.list(session_id="conv_c").data
+    after = file_store.list(session_id="405bfe154d5c0e795a2b87021bc897bf").data
     assert len(after) == len(before)
 
 
@@ -2258,12 +2294,12 @@ async def test_copy_files_at_limit_boundary_succeeds(
 
     monkeypatch.setattr(server_config, "copy_file_count_limit", lambda: 2)
     monkeypatch.setattr(server_config, "copy_total_bytes_limit", lambda: 6)
-    f1 = await _upload_file(file_client, "conv_p", "a.txt", b"aaa")
-    f2 = await _upload_file(file_client, "conv_p", "b.txt", b"bbb")
+    f1 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "a.txt", b"aaa")
+    f2 = await _upload_file(file_client, "b460374fc8e697b296708f52dc9d8179", "b.txt", b"bbb")
 
     resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [f1, f2]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [f1, f2]},
     )
     assert resp.status_code == 200, resp.text
     mapping = resp.json()["mapping"]
@@ -2275,16 +2311,18 @@ async def test_copy_files_then_download_returns_bytes(
     file_client: httpx.AsyncClient,
 ) -> None:
     """After copy, the child can download the copied content."""
-    parent_file = await _upload_file(file_client, "conv_p", "payload.bin", b"\x00\x01\x02data")
+    parent_file = await _upload_file(
+        file_client, "b460374fc8e697b296708f52dc9d8179", "payload.bin", b"\x00\x01\x02data"
+    )
 
     copy_resp = await file_client.post(
-        "/v1/sessions/conv_c/resources/files:copy",
-        json={"source_session_id": "conv_p", "file_ids": [parent_file]},
+        "/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files:copy",
+        json={"source_session_id": "b460374fc8e697b296708f52dc9d8179", "file_ids": [parent_file]},
     )
     new_id = copy_resp.json()["mapping"][parent_file]["new_id"]
 
     resp = await file_client.get(
-        f"/v1/sessions/conv_c/resources/files/{new_id}/content",
+        f"/v1/sessions/405bfe154d5c0e795a2b87021bc897bf/resources/files/{new_id}/content",
     )
     assert resp.status_code == 200
     assert resp.content == b"\x00\x01\x02data"
@@ -2299,7 +2337,7 @@ async def test_files_route_not_captured_as_resource_id(
 ) -> None:
     """'files' is a typed collection route, not a resource id."""
     resp = await file_client.get(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
     )
     assert resp.status_code == 200
     assert resp.json()["object"] == "list"
@@ -2311,12 +2349,12 @@ async def test_files_appear_in_unified_inventory(
 ) -> None:
     """Uploaded files appear in GET /resources with type 'file'."""
     upload = await file_client.post(
-        "/v1/sessions/conv_local/resources/files",
+        "/v1/sessions/5d29bee4350489d66feafecfebd94a97/resources/files",
         files={"file": ("report.txt", b"data", "text/plain")},
     )
     file_id = upload.json()["id"]
 
-    resp = await file_client.get("/v1/sessions/conv_local/resources")
+    resp = await file_client.get("/v1/sessions/5d29bee4350489d66feafecfebd94a97/resources")
     assert resp.status_code == 200
     body = resp.json()
     ids = [r["id"] for r in body["data"]]
@@ -2324,7 +2362,7 @@ async def test_files_appear_in_unified_inventory(
     file_resource = next(r for r in body["data"] if r["id"] == file_id)
     assert file_resource["type"] == "file"
     assert file_resource["object"] == "session.resource"
-    assert file_resource["session_id"] == "conv_local"
+    assert file_resource["session_id"] == "5d29bee4350489d66feafecfebd94a97"
 
 
 @pytest.mark.asyncio
@@ -2335,22 +2373,22 @@ async def test_delete_for_session_cleans_up_all_files(
     """delete_all_for_session removes all session files."""
     for name in ("a.txt", "b.txt", "c.txt"):
         await file_client.post(
-            "/v1/sessions/conv_proxy/resources/files",
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
             files={"file": (name, b"data", "text/plain")},
         )
 
     list_resp = await file_client.get(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
     )
     assert len(list_resp.json()["data"]) == 3
 
     # Use the injected file_store fixture directly — no closure
     # introspection needed.
-    deleted_ids = file_store.delete_all_for_session("conv_proxy")
+    deleted_ids = file_store.delete_all_for_session("79b22ebd2309e48fdeb450c65611d51b")
     assert len(deleted_ids) == 3
 
     list_after = await file_client.get(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
     )
     assert len(list_after.json()["data"]) == 0
 
@@ -2371,24 +2409,24 @@ def test_resource_lifecycle_event_schemas_in_union() -> None:
         {
             "type": "session.resource.created",
             "resource": {
-                "id": "file_abc",
+                "id": "2e6cfcecf239b5c4a5e4548682173207",
                 "object": "session.resource",
                 "type": "file",
-                "session_id": "conv_1",
+                "session_id": "8e32600337d08f59ad381caf96a90659",
                 "name": "test.txt",
                 "metadata": {},
             },
         }
     )
     assert isinstance(created, SessionResourceCreatedEvent)
-    assert created.resource["id"] == "file_abc"
+    assert created.resource["id"] == "2e6cfcecf239b5c4a5e4548682173207"
 
     deleted = adapter.validate_python(
         {
             "type": "session.resource.deleted",
             "resource_id": "terminal_bash_s1",
             "resource_type": "terminal",
-            "session_id": "conv_1",
+            "session_id": "8e32600337d08f59ad381caf96a90659",
         }
     )
     assert isinstance(deleted, SessionResourceDeletedEvent)
@@ -2466,7 +2504,7 @@ async def test_filesystem_list_proxies_to_runner(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem",
     )
     assert resp.status_code == 200
     assert resp.json()["object"] == "list"
@@ -2474,7 +2512,7 @@ async def test_filesystem_list_proxies_to_runner(
     assert fake_runner.calls == [
         (
             "GET",
-            "/v1/sessions/conv_proxy/resources/environments/default/filesystem?limit=20&order=desc",
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem?limit=20&order=desc",
         ),
     ]
 
@@ -2488,7 +2526,7 @@ async def test_filesystem_list_forwards_custom_limit_and_order(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem?limit=1000&order=asc",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem?limit=1000&order=asc",
     )
 
     assert resp.status_code == 200
@@ -2496,7 +2534,7 @@ async def test_filesystem_list_forwards_custom_limit_and_order(
     assert fake_runner.calls == [
         (
             "GET",
-            "/v1/sessions/conv_proxy/resources/environments/default/filesystem?limit=1000&order=asc",
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem?limit=1000&order=asc",
         ),
     ]
 
@@ -2510,7 +2548,7 @@ async def test_filesystem_list_forwards_after_cursor(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem"
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem"
         "?limit=100&order=asc&after=README.md",
     )
 
@@ -2532,7 +2570,7 @@ async def test_filesystem_list_forwards_before_cursor(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem"
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem"
         "?limit=50&order=asc&before=src",
     )
 
@@ -2552,7 +2590,7 @@ async def test_filesystem_list_omits_absent_cursors(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem?limit=50",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem?limit=50",
     )
 
     assert resp.status_code == 200
@@ -2573,7 +2611,7 @@ async def test_filesystem_path_forwards_pagination_params(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem/src"
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem/src"
         "?limit=1000&order=asc",
     )
 
@@ -2594,7 +2632,7 @@ async def test_filesystem_path_omits_absent_cursors(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem/src"
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem/src"
         "?limit=100&order=asc",
     )
 
@@ -2623,7 +2661,7 @@ async def test_filesystem_read_proxies_to_runner(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem/hello.txt",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem/hello.txt",
     )
     assert resp.status_code == 200
     assert resp.json()["content"] == "hello world"
@@ -2638,13 +2676,16 @@ async def test_filesystem_write_proxies_to_runner(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.put(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem/new.txt",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem/new.txt",
         json={"content": "hello", "encoding": "utf-8"},
     )
     assert resp.status_code == 200
     assert resp.json()["created"] is True
     assert fake_runner.calls == [
-        ("PUT", "/v1/sessions/conv_proxy/resources/environments/default/filesystem/new.txt"),
+        (
+            "PUT",
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem/new.txt",
+        ),
     ]
 
 
@@ -2655,12 +2696,14 @@ async def test_filesystem_write_publishes_changed_files_invalidation(
     """Successful filesystem writes publish a session filesystem invalidation."""
     fake_runner = _FakeRunnerClient(payload=_fs_write_payload())
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
-    stream = session_stream.subscribe("conv_proxy", ready_event={"type": "test.ready"})
+    stream = session_stream.subscribe(
+        "79b22ebd2309e48fdeb450c65611d51b", ready_event={"type": "test.ready"}
+    )
     try:
         assert await anext(stream) == {"type": "test.ready"}
 
         resp = await client.put(
-            "/v1/sessions/conv_proxy/resources/environments/default/filesystem/new.txt",
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem/new.txt",
             json={"content": "hello", "encoding": "utf-8"},
         )
         event = await asyncio.wait_for(anext(stream), timeout=1)
@@ -2670,7 +2713,7 @@ async def test_filesystem_write_publishes_changed_files_invalidation(
     assert resp.status_code == 200
     assert event == {
         "type": "session.changed_files.invalidated",
-        "session_id": "conv_proxy",
+        "session_id": "79b22ebd2309e48fdeb450c65611d51b",
         "environment_id": "default",
     }
 
@@ -2684,13 +2727,16 @@ async def test_filesystem_edit_proxies_to_runner(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.patch(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem/hello.txt",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem/hello.txt",
         json={"old_text": "hello", "new_text": "goodbye"},
     )
     assert resp.status_code == 200
     assert resp.json()["replacements"] == 1
     assert fake_runner.calls == [
-        ("PATCH", "/v1/sessions/conv_proxy/resources/environments/default/filesystem/hello.txt"),
+        (
+            "PATCH",
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem/hello.txt",
+        ),
     ]
 
 
@@ -2703,7 +2749,7 @@ async def test_filesystem_delete_proxies_to_runner(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.delete(
-        "/v1/sessions/conv_proxy/resources/environments/default/filesystem/old.txt",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/filesystem/old.txt",
     )
     assert resp.status_code == 200
     assert resp.json()["deleted"] is True
@@ -2718,7 +2764,7 @@ async def test_filesystem_proxy_validates_session(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/conv_missing/resources/environments/default/filesystem",
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/resources/environments/default/filesystem",
     )
     assert resp.status_code == 404
     assert not fake_runner.calls
@@ -2751,7 +2797,7 @@ async def test_shell_proxies_to_runner(
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.post(
-        "/v1/sessions/conv_proxy/resources/environments/default/shell",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/shell",
         json={"command": "echo hello"},
     )
     assert resp.status_code == 200
@@ -2761,7 +2807,10 @@ async def test_shell_proxies_to_runner(
     assert body["exit_code"] == 0
     assert body["timed_out"] is False
     assert fake_runner.calls == [
-        ("POST", "/v1/sessions/conv_proxy/resources/environments/default/shell"),
+        (
+            "POST",
+            "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default/shell",
+        ),
     ]
     assert published == []
 
@@ -2777,18 +2826,18 @@ async def test_session_file_cleanup_on_delete(
 ) -> None:
     """Session file cleanup removes metadata and artifact bytes."""
     upload = await file_client.post(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
         files={"file": ("cleanup.txt", b"session data", "text/plain")},
     )
     file_id = upload.json()["id"]
     assert artifact_store.get(file_id) is not None
 
-    deleted_ids = file_store.delete_all_for_session("conv_proxy")
+    deleted_ids = file_store.delete_all_for_session("79b22ebd2309e48fdeb450c65611d51b")
     assert file_id in deleted_ids
     for fid in deleted_ids:
         artifact_store.delete(fid)
 
-    assert file_store.get(file_id, session_id="conv_proxy") is None
+    assert file_store.get(file_id, session_id="79b22ebd2309e48fdeb450c65611d51b") is None
     assert file_id not in artifact_store._blobs
 
 
@@ -2802,7 +2851,7 @@ async def test_file_upload_persists_resource_event(
 ) -> None:
     """Uploading a file persists a resource_event conversation item."""
     await file_client.post(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
         files={"file": ("persist.txt", b"data", "text/plain")},
     )
 
@@ -2820,14 +2869,14 @@ async def test_file_delete_persists_resource_event(
 ) -> None:
     """Deleting a file persists a resource_event conversation item."""
     upload = await file_client.post(
-        "/v1/sessions/conv_proxy/resources/files",
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
         files={"file": ("del.txt", b"gone", "text/plain")},
     )
     file_id = upload.json()["id"]
     file_conv_store.appended_items.clear()
 
     await file_client.delete(
-        f"/v1/sessions/conv_proxy/resources/files/{file_id}",
+        f"/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files/{file_id}",
     )
 
     events = [i for i in file_conv_store.appended_items if i.type == "resource_event"]
@@ -2978,7 +3027,7 @@ async def test_relay_persists_terminal_resource_created_from_runner() -> None:
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     events = [i for i in store.appended_items if i.type == "resource_event"]
     # Exactly one durable item — the created event. Zero would mean the
@@ -2992,7 +3041,7 @@ async def test_relay_persists_terminal_resource_created_from_runner() -> None:
     assert events[0].data.resource is not None
     assert events[0].data.resource["id"] == "terminal_zsh_s1"
     # Resource events thread on the session id (matches the REST path).
-    assert events[0].response_id == "conv_proxy"
+    assert events[0].response_id == "79b22ebd2309e48fdeb450c65611d51b"
 
 
 @pytest.mark.asyncio
@@ -3013,14 +3062,14 @@ async def test_relay_persists_terminal_resource_deleted_from_runner() -> None:
                     "type": "session.resource.deleted",
                     "resource_id": "terminal_zsh_s1",
                     "resource_type": "terminal",
-                    "session_id": "conv_proxy",
+                    "session_id": "79b22ebd2309e48fdeb450c65611d51b",
                 }
             ),
             "data: [DONE]\n\n",
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     events = [i for i in store.appended_items if i.type == "resource_event"]
     assert len(events) == 1, f"expected 1 resource_event, got {store.appended_items}"
@@ -3053,14 +3102,18 @@ async def test_relay_persists_failed_status_error_labels_from_runner() -> None:
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     assert (
-        store._conversations["conv_proxy"].labels["omnigent.last_task_error_code"]
+        store._conversations["79b22ebd2309e48fdeb450c65611d51b"].labels[
+            "omnigent.last_task_error_code"
+        ]
         == "required_terminal_exited"
     )
     assert (
-        store._conversations["conv_proxy"].labels["omnigent.last_task_error_message"]
+        store._conversations["79b22ebd2309e48fdeb450c65611d51b"].labels[
+            "omnigent.last_task_error_message"
+        ]
         == "Required terminal exited unexpectedly"
     )
 
@@ -3096,9 +3149,11 @@ async def test_relay_truncates_long_error_message_before_persisting() -> None:
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
-    stored = store._conversations["conv_proxy"].labels["omnigent.last_task_error_message"]
+    stored = store._conversations["79b22ebd2309e48fdeb450c65611d51b"].labels[
+        "omnigent.last_task_error_message"
+    ]
     assert len(stored) <= _LABEL_VALUE_MAX_LEN
 
 
@@ -3148,7 +3203,7 @@ async def test_relay_persists_routing_decision_before_assistant_output() -> None
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     # Arrival order is preserved, and the router item lands BEFORE the
     # assistant message. If the order flipped (or the routing item were
@@ -3182,7 +3237,7 @@ async def test_relay_routing_decision_live_event_carries_persisted_id() -> None:
     routing_seen = asyncio.Event()
 
     async def _consume() -> None:
-        async for event in session_stream.subscribe("conv_proxy"):
+        async for event in session_stream.subscribe("79b22ebd2309e48fdeb450c65611d51b"):
             published.append(event)
             item = event.get("item")
             if isinstance(item, dict) and item.get("type") == "routing_decision":
@@ -3209,7 +3264,7 @@ async def test_relay_routing_decision_live_event_carries_persisted_id() -> None:
                 "data: [DONE]\n\n",
             ]
         )
-        await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+        await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
         await asyncio.wait_for(routing_seen.wait(), timeout=1)
     finally:
         consumer.cancel()
@@ -3267,7 +3322,7 @@ async def test_relay_drops_malformed_routing_decision() -> None:
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     routing = [i for i in store.appended_items if i.type == "routing_decision"]
     # Empty-model frame dropped — zero persisted. A persisted item would
@@ -3305,7 +3360,7 @@ async def test_relay_does_not_persist_session_level_response_error() -> None:
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     errors = [i for i in store.appended_items if i.type == "error"]
     assert errors == []
@@ -3355,7 +3410,7 @@ async def test_relay_persists_in_turn_response_error_once_from_runner() -> None:
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     errors = [i for i in store.appended_items if i.type == "error"]
     # One durable error proves the first in-turn frame was persisted;
@@ -3384,7 +3439,7 @@ async def test_relay_dedupes_duplicate_error_persistence_but_forwards_live_frame
     live_errors_seen = asyncio.Event()
 
     async def _consume() -> None:
-        async for event in session_stream.subscribe("conv_proxy"):
+        async for event in session_stream.subscribe("79b22ebd2309e48fdeb450c65611d51b"):
             published.append(event)
             if len([item for item in published if item.get("type") == "response.error"]) == 2:
                 live_errors_seen.set()
@@ -3425,7 +3480,7 @@ async def test_relay_dedupes_duplicate_error_persistence_but_forwards_live_frame
             ]
         )
 
-        await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+        await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
         await asyncio.wait_for(live_errors_seen.wait(), timeout=1)
     finally:
         consumer.cancel()
@@ -3455,11 +3510,11 @@ async def test_native_dispatch_fast_fails_and_consumes_message_on_terminal_error
     from omnigent.server.routes.sessions import _dispatch_session_event_to_runner
 
     store = _ConversationStore()
-    conv = store.get_conversation("conv_claude")
+    conv = store.get_conversation("64a784c3aa907d1774f44313546947c6")
     assert conv is not None
     client = _FakeRunnerClient(
         responses={
-            "/v1/sessions/conv_claude/resources/terminals": (
+            "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals": (
                 500,
                 {
                     "error": {
@@ -3476,7 +3531,7 @@ async def test_native_dispatch_fast_fails_and_consumes_message_on_terminal_error
     )
 
     result = await _dispatch_session_event_to_runner(
-        "conv_claude",
+        "64a784c3aa907d1774f44313546947c6",
         conv,
         body,
         store,  # type: ignore[arg-type]
@@ -3490,7 +3545,7 @@ async def test_native_dispatch_fast_fails_and_consumes_message_on_terminal_error
     assert result.pending_id is None
     assert result.item_id is not None
     assert [call[0] for call in client.post_json_calls] == [
-        "/v1/sessions/conv_claude/resources/terminals"
+        "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals"
     ]
     messages = [i for i in store.appended_items if i.type == "message"]
     errors = [i for i in store.appended_items if i.type == "error"]
@@ -3517,7 +3572,7 @@ async def test_kiro_native_dispatch_forwards_without_persisting() -> None:
 
     pending_inputs.reset_for_tests()
     store = _ConversationStore()
-    conv = store.get_conversation("conv_kiro")
+    conv = store.get_conversation("823dbd1aab969b5a813fac59bb977a77")
     assert conv is not None
     client = _FakeRunnerClient()
     body = SessionEventInput(
@@ -3527,7 +3582,7 @@ async def test_kiro_native_dispatch_forwards_without_persisting() -> None:
 
     try:
         result = await _dispatch_session_event_to_runner(
-            "conv_kiro",
+            "823dbd1aab969b5a813fac59bb977a77",
             conv,
             body,
             store,  # type: ignore[arg-type]
@@ -3542,15 +3597,15 @@ async def test_kiro_native_dispatch_forwards_without_persisting() -> None:
         assert result.pending_id is not None
         assert result.pending_id.startswith("pending_")
         assert [call[0] for call in client.post_json_calls] == [
-            "/v1/sessions/conv_kiro/resources/terminals",
-            "/v1/sessions/conv_kiro/events",
+            "/v1/sessions/823dbd1aab969b5a813fac59bb977a77/resources/terminals",
+            "/v1/sessions/823dbd1aab969b5a813fac59bb977a77/events",
         ]
-        pending = pending_inputs.snapshot_for("conv_kiro")
+        pending = pending_inputs.snapshot_for("823dbd1aab969b5a813fac59bb977a77")
         assert len(pending) == 1
         assert pending[0]["content"] == [{"type": "input_text", "text": "hello"}]
         assert store.appended_items == []
         forwarded = client.post_json_calls[1][1]
-        assert forwarded["agent_id"] == "ag_kiro"
+        assert forwarded["agent_id"] == "2c515637c67d0717ad0bebc2747b71bc"
         assert forwarded["model"] == "kiro-native-ui"
     finally:
         pending_inputs.reset_for_tests()
@@ -3564,10 +3619,12 @@ async def test_kiro_native_dispatch_clears_pending_when_injection_fails() -> Non
 
     pending_inputs.reset_for_tests()
     store = _ConversationStore()
-    conv = store.get_conversation("conv_kiro")
+    conv = store.get_conversation("823dbd1aab969b5a813fac59bb977a77")
     assert conv is not None
     client = _FakeRunnerClient(
-        responses={"/v1/sessions/conv_kiro/events": (500, {"error": "tmux failed"})}
+        responses={
+            "/v1/sessions/823dbd1aab969b5a813fac59bb977a77/events": (500, {"error": "tmux failed"})
+        }
     )
     body = SessionEventInput(
         type="message",
@@ -3577,7 +3634,7 @@ async def test_kiro_native_dispatch_clears_pending_when_injection_fails() -> Non
     try:
         with pytest.raises(HTTPException):
             await _dispatch_session_event_to_runner(
-                "conv_kiro",
+                "823dbd1aab969b5a813fac59bb977a77",
                 conv,
                 body,
                 store,  # type: ignore[arg-type]
@@ -3589,11 +3646,11 @@ async def test_kiro_native_dispatch_clears_pending_when_injection_fails() -> Non
             )
 
         assert [call[0] for call in client.post_json_calls] == [
-            "/v1/sessions/conv_kiro/resources/terminals",
-            "/v1/sessions/conv_kiro/events",
+            "/v1/sessions/823dbd1aab969b5a813fac59bb977a77/resources/terminals",
+            "/v1/sessions/823dbd1aab969b5a813fac59bb977a77/events",
         ]
         assert store.appended_items == []
-        assert pending_inputs.snapshot_for("conv_kiro") == []
+        assert pending_inputs.snapshot_for("823dbd1aab969b5a813fac59bb977a77") == []
     finally:
         pending_inputs.reset_for_tests()
 
@@ -3606,15 +3663,15 @@ async def test_kiro_external_prompt_matches_pending_and_reports_skipped_input() 
 
     pending_inputs.reset_for_tests()
     store = _ConversationStore()
-    conv = store.get_conversation("conv_kiro")
+    conv = store.get_conversation("823dbd1aab969b5a813fac59bb977a77")
     assert conv is not None
     first = pending_inputs.record(
-        "conv_kiro",
+        "823dbd1aab969b5a813fac59bb977a77",
         [{"type": "input_text", "text": "!!!! XOXOX !!!!"}],
         created_by="alice@example.com",
     )
     second = pending_inputs.record(
-        "conv_kiro",
+        "823dbd1aab969b5a813fac59bb977a77",
         [{"type": "input_text", "text": "tell me a joke"}],
         created_by="alice@example.com",
     )
@@ -3632,14 +3689,14 @@ async def test_kiro_external_prompt_matches_pending_and_reports_skipped_input() 
 
     try:
         item_id = await _persist_external_conversation_item(
-            "conv_kiro",
+            "823dbd1aab969b5a813fac59bb977a77",
             conv,
             body,
             store,  # type: ignore[arg-type]
         )
 
         assert item_id == "item_2"
-        assert pending_inputs.snapshot_for("conv_kiro") == []
+        assert pending_inputs.snapshot_for("823dbd1aab969b5a813fac59bb977a77") == []
         assert [item.type for item in store.appended_items] == ["message", "error", "message"]
         skipped_user, skipped_error, matched_user = store.appended_items
         assert skipped_user.data.role == "user"
@@ -3667,11 +3724,11 @@ async def test_native_dispatch_reports_malformed_runner_error_body() -> None:
     from omnigent.server.routes.sessions import _dispatch_session_event_to_runner
 
     store = _ConversationStore()
-    conv = store.get_conversation("conv_claude")
+    conv = store.get_conversation("64a784c3aa907d1774f44313546947c6")
     assert conv is not None
     client = _FakeRunnerClient(
         text_responses={
-            "/v1/sessions/conv_claude/resources/terminals": (
+            "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals": (
                 500,
                 "Internal Server Error",
                 {"content-type": "text/plain"},
@@ -3684,7 +3741,7 @@ async def test_native_dispatch_reports_malformed_runner_error_body() -> None:
     )
 
     result = await _dispatch_session_event_to_runner(
-        "conv_claude",
+        "64a784c3aa907d1774f44313546947c6",
         conv,
         body,
         store,  # type: ignore[arg-type]
@@ -3720,14 +3777,14 @@ async def test_native_dispatch_transport_error_does_not_fallback_to_forwarding()
     from omnigent.server.routes.sessions import _dispatch_session_event_to_runner
 
     store = _ConversationStore()
-    conv = store.get_conversation("conv_claude")
+    conv = store.get_conversation("64a784c3aa907d1774f44313546947c6")
     assert conv is not None
     client = _FakeRunnerClient(
         exc=httpx.ConnectError(
             "connection refused",
             request=httpx.Request(
                 "POST",
-                "/v1/sessions/conv_claude/resources/terminals",
+                "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals",
             ),
         )
     )
@@ -3737,7 +3794,7 @@ async def test_native_dispatch_transport_error_does_not_fallback_to_forwarding()
     )
 
     result = await _dispatch_session_event_to_runner(
-        "conv_claude",
+        "64a784c3aa907d1774f44313546947c6",
         conv,
         body,
         store,  # type: ignore[arg-type]
@@ -3750,7 +3807,7 @@ async def test_native_dispatch_transport_error_does_not_fallback_to_forwarding()
 
     assert result.pending_id is None
     assert [call[0] for call in client.post_json_calls] == [
-        "/v1/sessions/conv_claude/resources/terminals"
+        "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals"
     ]
     assert [i.type for i in store.appended_items] == ["message", "error"]
     errors = [i for i in store.appended_items if i.type == "error"]
@@ -3781,7 +3838,7 @@ async def test_native_dispatch_tunnel_close_is_definitive_ensure_error() -> None
     from omnigent.server.routes.sessions import _dispatch_session_event_to_runner
 
     store = _ConversationStore()
-    conv = store.get_conversation("conv_claude")
+    conv = store.get_conversation("64a784c3aa907d1774f44313546947c6")
     assert conv is not None
     client = _FakeRunnerClient(exc=ConnectionError("tunnel closed before request completed"))
     body = SessionEventInput(
@@ -3790,7 +3847,7 @@ async def test_native_dispatch_tunnel_close_is_definitive_ensure_error() -> None
     )
 
     result = await _dispatch_session_event_to_runner(
-        "conv_claude",
+        "64a784c3aa907d1774f44313546947c6",
         conv,
         body,
         store,  # type: ignore[arg-type]
@@ -3827,11 +3884,11 @@ async def test_native_dispatch_persists_error_for_each_user_retry() -> None:
     from omnigent.server.routes.sessions import _dispatch_session_event_to_runner
 
     store = _ConversationStore()
-    conv = store.get_conversation("conv_claude")
+    conv = store.get_conversation("64a784c3aa907d1774f44313546947c6")
     assert conv is not None
     client = _FakeRunnerClient(
         responses={
-            "/v1/sessions/conv_claude/resources/terminals": (
+            "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals": (
                 500,
                 {
                     "error": {
@@ -3849,7 +3906,7 @@ async def test_native_dispatch_persists_error_for_each_user_retry() -> None:
             data={"role": "user", "content": [{"type": "input_text", "text": text}]},
         )
         result = await _dispatch_session_event_to_runner(
-            "conv_claude",
+            "64a784c3aa907d1774f44313546947c6",
             conv,
             body,
             store,  # type: ignore[arg-type]
@@ -3870,8 +3927,8 @@ async def test_native_dispatch_persists_error_for_each_user_retry() -> None:
     # more would mean one retry wrote duplicate banners.
     assert len(errors) == 2
     assert [call[0] for call in client.post_json_calls] == [
-        "/v1/sessions/conv_claude/resources/terminals",
-        "/v1/sessions/conv_claude/resources/terminals",
+        "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals",
+        "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals",
     ]
     assert all(
         e.data.message == "Native Claude requires the 'claude' CLI on PATH." for e in errors
@@ -3891,11 +3948,11 @@ async def test_native_dispatch_records_same_error_after_recovery_boundary() -> N
     from omnigent.server.routes.sessions import _dispatch_session_event_to_runner
 
     store = _ConversationStore()
-    conv = store.get_conversation("conv_claude")
+    conv = store.get_conversation("64a784c3aa907d1774f44313546947c6")
     assert conv is not None
     client = _FakeRunnerClient(
         responses={
-            "/v1/sessions/conv_claude/resources/terminals": (
+            "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals": (
                 500,
                 {
                     "error": {
@@ -3912,7 +3969,7 @@ async def test_native_dispatch_records_same_error_after_recovery_boundary() -> N
         data={"role": "user", "content": [{"type": "input_text", "text": "first retry"}]},
     )
     await _dispatch_session_event_to_runner(
-        "conv_claude",
+        "64a784c3aa907d1774f44313546947c6",
         conv,
         first,
         store,  # type: ignore[arg-type]
@@ -3923,7 +3980,7 @@ async def test_native_dispatch_records_same_error_after_recovery_boundary() -> N
         created_by=None,
     )
     store.append(
-        "conv_claude",
+        "64a784c3aa907d1774f44313546947c6",
         [
             NewConversationItem(
                 type="message",
@@ -3941,7 +3998,7 @@ async def test_native_dispatch_records_same_error_after_recovery_boundary() -> N
         data={"role": "user", "content": [{"type": "input_text", "text": "second retry"}]},
     )
     await _dispatch_session_event_to_runner(
-        "conv_claude",
+        "64a784c3aa907d1774f44313546947c6",
         conv,
         second,
         store,  # type: ignore[arg-type]
@@ -3979,7 +4036,7 @@ async def test_relay_skips_malformed_resource_created_from_runner() -> None:
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     events = [i for i in store.appended_items if i.type == "resource_event"]
     assert events == []
@@ -3998,13 +4055,13 @@ async def test_relay_skips_malformed_resource_created_from_runner() -> None:
             "type": "session.resource.deleted",
             "resource_id": "",
             "resource_type": "terminal",
-            "session_id": "conv_proxy",
+            "session_id": "79b22ebd2309e48fdeb450c65611d51b",
         },
         {
             "type": "session.resource.deleted",
             "resource_id": "terminal_zsh_s1",
             "resource_type": "",
-            "session_id": "conv_proxy",
+            "session_id": "79b22ebd2309e48fdeb450c65611d51b",
         },
     ],
 )
@@ -4023,7 +4080,7 @@ async def test_relay_skips_empty_resource_id_or_type_from_runner(
     store = _ConversationStore()
     client = _FakeStreamingRunnerClient([_sse_frame(frame_payload), "data: [DONE]\n\n"])
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     events = [i for i in store.appended_items if i.type == "resource_event"]
     assert events == []
@@ -4092,7 +4149,7 @@ async def test_relay_pairs_function_call_output_with_call_response_id() -> None:
         ]
     )
 
-    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+    await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
     outputs = [i for i in store.appended_items if i.type == "function_call_output"]
     # Exactly one output — the single tool result in the stream. Zero
@@ -4134,7 +4191,7 @@ async def test_relay_publishes_inflight_frames_and_discards_on_exit() -> None:
     published: list[dict[str, Any]] = []
 
     async def _consume() -> None:
-        async for event in session_stream.subscribe("conv_proxy"):
+        async for event in session_stream.subscribe("79b22ebd2309e48fdeb450c65611d51b"):
             published.append(event)
 
     try:
@@ -4165,8 +4222,8 @@ async def test_relay_publishes_inflight_frames_and_discards_on_exit() -> None:
             ]
         )
 
-        await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
-        session_stream.close("conv_proxy")
+        await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
+        session_stream.close("79b22ebd2309e48fdeb450c65611d51b")
         await consumer
 
         # Producer: the relay published the lifecycle + text frames that
@@ -4182,7 +4239,7 @@ async def test_relay_publishes_inflight_frames_and_discards_on_exit() -> None:
         # Leak fix: the relay's teardown discarded the entry. A non-empty
         # result means the finally discard was dropped and a Stop / runner
         # death would strand stale text (replayed on the next reload).
-        assert inflight_text.snapshot_for("conv_proxy") == [], (
+        assert inflight_text.snapshot_for("79b22ebd2309e48fdeb450c65611d51b") == [], (
             "relay exit must discard the in-flight entry"
         )
     finally:
@@ -4207,7 +4264,7 @@ async def test_relay_fences_cancelled_turn_and_resumes_on_next_turn(
     from omnigent.server.routes import sessions as sessions_module
     from omnigent.server.routes.sessions import _relay_runner_stream
 
-    sid = "conv_fenced"
+    sid = "693c79ed3286f353bfb89489e0f4f643"
     published: list[dict[str, Any]] = []
 
     def _capture(session_id: str, event: dict[str, Any]) -> None:
@@ -4276,7 +4333,7 @@ async def test_relay_flushes_partial_text_on_failed_turn_before_error_item() -> 
     from omnigent.server.routes.sessions import _relay_runner_stream
 
     inflight_text.reset_for_tests()
-    sid = "conv_proxy"
+    sid = "79b22ebd2309e48fdeb450c65611d51b"
     store = _ConversationStore()
     # In-flight replay snapshots probed at deterministic points: after the
     # deltas (entry populated) and after the failed terminal (entry cleared).
@@ -4365,7 +4422,7 @@ async def test_relay_flushes_final_text_on_fenced_response_completed(
     from omnigent.server.routes.sessions import _relay_runner_stream
 
     inflight_text.reset_for_tests()
-    sid = "conv_fence_completed"
+    sid = "0324351dd7cff62baefd1172b4d99a31"
     store = _ConversationStore()
     published: list[dict[str, Any]] = []
     real_publish = session_stream.publish
@@ -4434,7 +4491,7 @@ async def test_relay_persists_pre_stop_narration_on_fenced_incomplete(
     from omnigent.server.routes.sessions import _relay_runner_stream
 
     inflight_text.reset_for_tests()
-    sid = "conv_fence_incomplete"
+    sid = "b47007d2de93605dd8229a49620b190a"
     store = _ConversationStore()
     published: list[dict[str, Any]] = []
     real_publish = session_stream.publish
@@ -4507,7 +4564,7 @@ async def test_relay_lets_elicitation_resolved_pass_the_fence(
 
     inflight_text.reset_for_tests()
     pending_elicitations.reset_for_tests()
-    sid = "conv_fence_elicit"
+    sid = "9a77e31b1f918849f16318b90d8759a3"
     store = _ConversationStore()
     published: list[dict[str, Any]] = []
     real_publish = session_stream.publish
@@ -4579,7 +4636,7 @@ async def test_relay_suppresses_fenced_deltas_until_running_when_no_terminal_arr
     from omnigent.server.routes import sessions as sessions_module
     from omnigent.server.routes.sessions import _relay_runner_stream
 
-    sid = "conv_fence_no_terminal"
+    sid = "7e19212006f58af9e334464ad92d69d8"
     published: list[dict[str, Any]] = []
 
     def _capture(session_id: str, event: dict[str, Any]) -> None:
@@ -4694,7 +4751,7 @@ async def test_relay_interleaves_text_segments_with_tool_calls() -> None:
     )
 
     try:
-        await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+        await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
         # Persisted order interleaves narration with its tool calls — the
         # first text lands BEFORE call_1, not pooled after every tool.
@@ -4772,7 +4829,7 @@ async def test_relay_flush_drops_committed_text_from_inflight_replay(
         ]
     )
     try:
-        await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+        await _relay_runner_stream("79b22ebd2309e48fdeb450c65611d51b", client, store)  # type: ignore[arg-type]
 
         # The narration committed as its own message...
         msgs = [i for i in store.appended_items if i.type == "message"]
@@ -4782,7 +4839,7 @@ async def test_relay_flush_drops_committed_text_from_inflight_replay(
         # ...and the flush dropped it from the replay, so a reconnect here
         # gets nothing. If reset_text were removed, snapshot_for would
         # replay the committed text and double-render it.
-        assert inflight_text.snapshot_for("conv_proxy") == [], (
+        assert inflight_text.snapshot_for("79b22ebd2309e48fdeb450c65611d51b") == [], (
             "flushed (committed) text must not replay on mid-turn reconnect"
         )
     finally:
@@ -4877,7 +4934,7 @@ class _SubagentTerminalStore:
 def _make_subagent_conv(child_id: str, *, wrapper: str, kind: str = "sub_agent") -> Conversation:
     """Build a sub-agent conversation row for terminal-delivery relay tests.
 
-    :param child_id: Child session id, e.g. ``"conv_cc_child"``.
+    :param child_id: Child session id, e.g. ``"81c8ded726a170a0b623598bcc465efc"``.
     :param wrapper: ``omnigent.wrapper`` label, e.g.
         ``"claude-code-native-ui"`` or ``"codex-native-ui"``.
     :param kind: Conversation kind, ``"sub_agent"`` or ``"default"``.
@@ -4887,9 +4944,9 @@ def _make_subagent_conv(child_id: str, *, wrapper: str, kind: str = "sub_agent")
         id=child_id,
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_parent",
-        parent_conversation_id="conv_parent",
-        agent_id="ag_test",
+        root_conversation_id="ead6d59a6b650d19dbdf61ec32426f4e",
+        parent_conversation_id="ead6d59a6b650d19dbdf61ec32426f4e",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         kind=kind,
         labels={"omnigent.ui": "terminal", "omnigent.wrapper": wrapper},
     )
@@ -4924,7 +4981,7 @@ async def test_relay_never_delivers_terminal_on_pty_status(
     """
     from omnigent.server.routes.sessions import _relay_runner_stream
 
-    child_id = "conv_relay_nodeliver"
+    child_id = "d30d5c132923e646113e9a2bfb28f15a"
     store = _SubagentTerminalStore(
         _make_subagent_conv(child_id, wrapper=wrapper, kind=kind),
         assistant_text="work in progress",

--- a/tests/server/routes/test_session_updates_ws.py
+++ b/tests/server/routes/test_session_updates_ws.py
@@ -139,13 +139,15 @@ def _seed_session(
     conversation_store, agent_store, permission_store = stores
     # The conversations.agent_id FK requires a real agent row; create one
     # idempotently (the same agent backs every seeded session).
-    if agent_store.get("ag_test") is None:
+    if agent_store.get("087b7cb7ac30abf4debfaa578d052ec6") is None:
         agent_store.create(
-            agent_id="ag_test",
+            agent_id="087b7cb7ac30abf4debfaa578d052ec6",
             name="test-agent",
-            bundle_location="ag_test/bundle",
+            bundle_location="087b7cb7ac30abf4debfaa578d052ec6/bundle",
         )
-    conv = conversation_store.create_conversation(title=title, agent_id="ag_test")
+    conv = conversation_store.create_conversation(
+        title=title, agent_id="087b7cb7ac30abf4debfaa578d052ec6"
+    )
     permission_store.ensure_user(owner)
     permission_store.grant(owner, conv.id, LEVEL_OWNER)
     return conv.id
@@ -219,7 +221,7 @@ def test_child_busy_rollup_flows_through_updates_stream(
         kind="sub_agent",
         title="coder:auth",
         parent_conversation_id=parent_id,
-        agent_id="ag_test",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
     )
     sessions_routes._session_status_cache.pop(parent_id, None)
     sessions_routes._session_status_cache[child.id] = "waiting"
@@ -732,7 +734,7 @@ def test_daily_cost_recorded_for_owned_session_without_a_policy(app: FastAPI, st
 
     The policy gate that previously suppressed the ``user_daily_cost`` write on
     no-policy sessions has been removed, so the daily rollup accrues for any
-    owned session that records spend. Here ``ag_test`` has no guardrails/policy,
+    owned session that records spend. Here the owned session has no guardrails/policy,
     yet posting cumulative spend must still land in the owner's daily rollup. A
     regression that re-added the gate would leave ``get_daily_cost`` at 0.0.
     """
@@ -806,7 +808,7 @@ def test_daily_cost_attributed_via_root_for_sub_agent_without_owner_grant(
     # root_conversation_id from the parent automatically.
     child = conversation_store.create_conversation(
         title="sub-agent",
-        agent_id="ag_test",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         parent_conversation_id=parent_id,
     )
     # Sanity: child has no owner grant (the gap being fixed).

--- a/tests/server/routes/test_sessions_cost_labels.py
+++ b/tests/server/routes/test_sessions_cost_labels.py
@@ -166,13 +166,15 @@ def _seed_session(
     :returns: The new session/conversation id.
     """
     conversation_store, agent_store, permission_store = stores
-    if agent_store.get("ag_test") is None:
+    if agent_store.get("087b7cb7ac30abf4debfaa578d052ec6") is None:
         agent_store.create(
-            agent_id="ag_test",
+            agent_id="087b7cb7ac30abf4debfaa578d052ec6",
             name="test-agent",
-            bundle_location="ag_test/bundle",
+            bundle_location="087b7cb7ac30abf4debfaa578d052ec6/bundle",
         )
-    conv = conversation_store.create_conversation(title="advised session", agent_id="ag_test")
+    conv = conversation_store.create_conversation(
+        title="advised session", agent_id="087b7cb7ac30abf4debfaa578d052ec6"
+    )
     if owner is not None:
         permission_store.ensure_user(owner)
         permission_store.grant(owner, conv.id, LEVEL_OWNER)
@@ -399,7 +401,7 @@ def test_create_session_rejects_cost_control_label_seed(
     resp = TestClient(app).post(
         "/v1/sessions",
         json={
-            "agent_id": "ag_test",
+            "agent_id": "087b7cb7ac30abf4debfaa578d052ec6",
             "labels": {COST_CONTROL_PLAN_LABEL: _FORGED_PLAN},
         },
         # Sentinel Origin: first-party client past the require_trusted_origin guard.
@@ -447,7 +449,7 @@ def test_create_session_with_ordinary_labels_succeeds(
 
     resp = TestClient(app).post(
         "/v1/sessions",
-        json={"agent_id": "ag_test", "labels": {"team": "ml"}},
+        json={"agent_id": "087b7cb7ac30abf4debfaa578d052ec6", "labels": {"team": "ml"}},
         # Sentinel Origin: first-party client past the require_trusted_origin guard.
         headers={"X-Forwarded-Email": ALICE, "Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
     )

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -90,7 +90,7 @@ async def test_get_session(
 
 async def test_get_session_not_found(client: httpx.AsyncClient) -> None:
     """Getting a nonexistent session returns 404."""
-    resp = await client.get("/v1/sessions/conv_nonexistent_12345")
+    resp = await client.get("/v1/sessions/4fe12335002377c209e501c3fe3bcffc")
     assert resp.status_code == 404
 
 
@@ -110,7 +110,7 @@ async def test_delete_session(
 
 async def test_delete_session_not_found(client: httpx.AsyncClient) -> None:
     """Deleting a nonexistent session returns 404."""
-    resp = await client.delete("/v1/sessions/conv_nonexistent_12345")
+    resp = await client.delete("/v1/sessions/4fe12335002377c209e501c3fe3bcffc")
     assert resp.status_code == 404
 
 
@@ -166,7 +166,7 @@ async def test_patch_session_title(
 async def test_patch_session_not_found(client: httpx.AsyncClient) -> None:
     """Patching a nonexistent session returns 404."""
     resp = await client.patch(
-        "/v1/sessions/conv_nonexistent_12345",
+        "/v1/sessions/4fe12335002377c209e501c3fe3bcffc",
         json={"title": "New Title"},
         headers={"Content-Type": "application/json"},
     )

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -59,7 +59,7 @@ class _AgentStore:
         """
         Record the create call and store the new agent.
 
-        :param agent_id: New agent ID, e.g. ``"ag_abc123"``.
+        :param agent_id: New agent ID, e.g. ``"104c4932179e16161e9ed9298fd5a3e2"``.
         :param name: Agent name.
         :param bundle_location: Bundle location string.
         :param description: Optional description.
@@ -138,7 +138,7 @@ class _ConversationStore:
         """
         Record the fork call and return a fixed new conversation.
 
-        :param source_conversation_id: Source ID, e.g. ``"conv_src"``.
+        :param source_conversation_id: Source ID, e.g. ``"e9f8f58523cec9a57d3bdf93be543e8c"``.
         :param title: Optional title for the fork.
         :param agent_id: Agent ID override. When ``None``, inherits
             the source's ``agent_id``.
@@ -196,7 +196,7 @@ class _ConversationStore:
         # Also store items under the fork ID so list_items returns
         # the copied items (mirrors real store behavior, including the
         # up-to-and-including-last-item-of-the-response truncation).
-        fork_id = "conv_forked"
+        fork_id = "c538360473d41c84c1eee13918fbeca0"
         source_items = list(self._items.get(source_conversation_id, []))
         if up_to_response_id is not None:
             cutoff_index = max(
@@ -248,8 +248,8 @@ class _ConversationStore:
 
 
 def _make_conversation(
-    conv_id: str = "conv_src",
-    agent_id: str | None = "ag_test",
+    conv_id: str = "e9f8f58523cec9a57d3bdf93be543e8c",
+    agent_id: str | None = "087b7cb7ac30abf4debfaa578d052ec6",
     title: str = "Source Chat",
     kind: str = "default",
 ) -> Conversation:
@@ -309,17 +309,17 @@ def _build_app(
 
     :param store: The conversation store stub.
     :param agent_store: The agent store stub. Defaults to a
-        pre-populated stub with ``ag_test``.
+        pre-populated stub with ``087b7cb7ac30abf4debfaa578d052ec6``.
     :returns: A configured FastAPI app ready for TestClient.
     """
     if agent_store is None:
         agent_store = _AgentStore(
             agents={
-                "ag_test": Agent(
-                    id="ag_test",
+                "087b7cb7ac30abf4debfaa578d052ec6": Agent(
+                    id="087b7cb7ac30abf4debfaa578d052ec6",
                     created_at=1,
                     name="test-agent",
-                    bundle_location="ag_test/fakehash",
+                    bundle_location="087b7cb7ac30abf4debfaa578d052ec6/fakehash",
                     version=1,
                 ),
             }
@@ -361,18 +361,21 @@ async def test_fork_session_happy_path() -> None:
     reconfigure the forked agent independently.
     """
     conv = _make_conversation()
-    items = [_make_item("msg_1", "Hello"), _make_item("msg_2", "World")]
+    items = [
+        _make_item("9980c8a9248139f14f4165e5d53088aa", "Hello"),
+        _make_item("0fd4e86b2daa009cd9929641dbd7dab6", "World"),
+    ]
     conv_store = _ConversationStore(
-        conversations={"conv_src": conv},
-        items_by_conv={"conv_src": items},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={"e9f8f58523cec9a57d3bdf93be543e8c": items},
     )
     agent_store = _AgentStore(
         agents={
-            "ag_test": Agent(
-                id="ag_test",
+            "087b7cb7ac30abf4debfaa578d052ec6": Agent(
+                id="087b7cb7ac30abf4debfaa578d052ec6",
                 created_at=1,
                 name="test-agent",
-                bundle_location="ag_test/fakehash",
+                bundle_location="087b7cb7ac30abf4debfaa578d052ec6/fakehash",
                 version=1,
                 description="A test agent",
             ),
@@ -380,16 +383,18 @@ async def test_fork_session_happy_path() -> None:
     )
     client = TestClient(_build_app(conv_store, agent_store=agent_store))
 
-    resp = client.post("/v1/sessions/conv_src/fork", json={"title": "My Fork"})
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={"title": "My Fork"}
+    )
 
     assert resp.status_code == 201, f"Expected 201 Created, got {resp.status_code}: {resp.text}"
     body = resp.json()
-    assert body["id"] == "conv_forked"
+    assert body["id"] == "c538360473d41c84c1eee13918fbeca0"
     # The agent_id should be the cloned agent, NOT the original.
-    assert body["agent_id"] != "ag_test", (
+    assert body["agent_id"] != "087b7cb7ac30abf4debfaa578d052ec6", (
         "Fork should be bound to a cloned agent, not the source's agent"
     )
-    assert body["agent_id"].startswith("ag_"), "Cloned agent ID must use the ag_ prefix"
+    assert len(body["agent_id"]) == 32, "Cloned agent ID must use the ag_ prefix"
     assert body["status"] == "idle", "Freshly forked session should be idle"
     # 2 items copied from the source — proves the store's items were
     # included in the response, not an empty list.
@@ -419,11 +424,11 @@ async def test_fork_session_happy_path() -> None:
     # multiple times; 0 means it never forked.
     assert len(conv_store.fork_calls) == 1
     fork_call = conv_store.fork_calls[0]
-    assert fork_call["source"] == "conv_src"
+    assert fork_call["source"] == "e9f8f58523cec9a57d3bdf93be543e8c"
     assert fork_call["title"] == "My Fork"
     # The store receives the clone's bundle/name/description so it can mint
     # the session-scoped agent row in the same transaction.
-    assert fork_call["cloned_agent_bundle_location"] == "ag_test/fakehash"
+    assert fork_call["cloned_agent_bundle_location"] == "087b7cb7ac30abf4debfaa578d052ec6/fakehash"
     assert fork_call["cloned_agent_description"] == "A test agent"
     # The clone keeps the source's ROOT name — no "(fork …)" suffix. Being
     # session-scoped it's exempt from the unique built-in-name index, so no
@@ -447,18 +452,18 @@ async def test_fork_session_up_to_response_id_passes_through_and_truncates() -> 
     """
     conv = _make_conversation()
     items = [
-        _make_item("msg_1", "Q1", response_id="resp_001"),
-        _make_item("msg_2", "A1", response_id="resp_001"),
-        _make_item("msg_3", "Q2", response_id="resp_002"),
+        _make_item("9980c8a9248139f14f4165e5d53088aa", "Q1", response_id="resp_001"),
+        _make_item("0fd4e86b2daa009cd9929641dbd7dab6", "A1", response_id="resp_001"),
+        _make_item("8b30166735242c192258d4974f662a5f", "Q2", response_id="resp_002"),
     ]
     conv_store = _ConversationStore(
-        conversations={"conv_src": conv},
-        items_by_conv={"conv_src": items},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={"e9f8f58523cec9a57d3bdf93be543e8c": items},
     )
     client = TestClient(_build_app(conv_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/fork",
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
         json={"up_to_response_id": "resp_001"},
     )
 
@@ -484,13 +489,17 @@ async def test_fork_session_400_unknown_up_to_response_id() -> None:
     """
     conv = _make_conversation()
     conv_store = _ConversationStore(
-        conversations={"conv_src": conv},
-        items_by_conv={"conv_src": [_make_item("msg_1", "Q1")]},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Q1")
+            ]
+        },
     )
     client = TestClient(_build_app(conv_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/fork",
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
         json={"up_to_response_id": "resp_nope"},
     )
 
@@ -511,7 +520,7 @@ async def test_fork_session_404_missing_source() -> None:
     store = _ConversationStore(conversations={})
     client = TestClient(_build_app(store))
 
-    resp = client.post("/v1/sessions/conv_missing/fork", json={})
+    resp = client.post("/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/fork", json={})
 
     # The route should return 404, not 500 or 201.
     assert resp.status_code == 404, (
@@ -534,10 +543,10 @@ async def test_fork_session_400_sub_agent() -> None:
     endpoint must reject them.
     """
     conv = _make_conversation(kind="sub_agent")
-    store = _ConversationStore(conversations={"conv_src": conv})
+    store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
     client = TestClient(_build_app(store))
 
-    resp = client.post("/v1/sessions/conv_src/fork", json={})
+    resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
 
     assert resp.status_code == 400, (
         f"Expected 400 for sub-agent source, got {resp.status_code}: {resp.text}"
@@ -557,10 +566,10 @@ async def test_fork_session_400_no_agent_binding() -> None:
     orphaned fork.
     """
     conv = _make_conversation(agent_id=None)
-    store = _ConversationStore(conversations={"conv_src": conv})
+    store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
     client = TestClient(_build_app(store))
 
-    resp = client.post("/v1/sessions/conv_src/fork", json={})
+    resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
 
     # 400 for invalid request (no agent binding).
     assert resp.status_code == 400, (
@@ -609,7 +618,7 @@ class _StubAgentCache:
     """Agent cache stub mapping agent_id → harness_kind.
 
     :param harness_by_id: Map of agent_id → harness_kind to return from
-        ``load``, e.g. ``{"ag_test": "claude_sdk"}``.
+        ``load``, e.g. ``{"087b7cb7ac30abf4debfaa578d052ec6": "claude_sdk"}``.
     """
 
     def __init__(self, harness_by_id: dict[str, str]) -> None:
@@ -626,7 +635,7 @@ class _StubAgentCache:
         """
         Return a loaded-agent stub for *agent_id*.
 
-        :param agent_id: Agent id to resolve, e.g. ``"ag_codex"``.
+        :param agent_id: Agent id to resolve, e.g. ``"12c8c7631b209d1027416b4bf7604999"``.
         :param bundle_location: Ignored — the stub keys on agent_id.
         :param expand_env: Ignored — accepted to match the real
             ``AgentCache.load`` signature (this kwarg exists;
@@ -646,41 +655,41 @@ class _StubAgentCache:
 def _switch_agent_store() -> _AgentStore:
     """Build an agent store with a source agent and switchable targets.
 
-    :returns: A store holding ``ag_test`` (source), ``ag_claude_native``
-        and ``ag_codex_native`` (bindable built-ins), and
-        ``ag_session_scoped`` (a session-scoped agent that must be
+    :returns: A store holding ``087b7cb7…`` (source), ``280d725b…``
+        and ``44b4151dd6cdfed6ee19430832398e05`` (bindable built-ins), and
+        ``a98bb825ebd41391c19637c58fe3c0b7`` (a session-scoped agent that must be
         rejected as a switch target).
     """
     return _AgentStore(
         agents={
-            "ag_test": Agent(
-                id="ag_test",
+            "087b7cb7ac30abf4debfaa578d052ec6": Agent(
+                id="087b7cb7ac30abf4debfaa578d052ec6",
                 created_at=1,
                 name="source-agent",
-                bundle_location="ag_test/hash",
+                bundle_location="087b7cb7ac30abf4debfaa578d052ec6/hash",
                 version=1,
             ),
-            "ag_claude_native": Agent(
-                id="ag_claude_native",
+            "280d725b404d2915f9e9d6cccce91303": Agent(
+                id="280d725b404d2915f9e9d6cccce91303",
                 created_at=1,
                 name="claude-code",
-                bundle_location="ag_claude_native/hash",
+                bundle_location="280d725b404d2915f9e9d6cccce91303/hash",
                 version=1,
             ),
-            "ag_codex_native": Agent(
-                id="ag_codex_native",
+            "44b4151dd6cdfed6ee19430832398e05": Agent(
+                id="44b4151dd6cdfed6ee19430832398e05",
                 created_at=1,
                 name="codex",
-                bundle_location="ag_codex_native/hash",
+                bundle_location="44b4151dd6cdfed6ee19430832398e05/hash",
                 version=1,
             ),
-            "ag_session_scoped": Agent(
-                id="ag_session_scoped",
+            "a98bb825ebd41391c19637c58fe3c0b7": Agent(
+                id="a98bb825ebd41391c19637c58fe3c0b7",
                 created_at=1,
                 name="scoped",
-                bundle_location="ag_session_scoped/hash",
+                bundle_location="a98bb825ebd41391c19637c58fe3c0b7/hash",
                 version=1,
-                session_id="conv_other",
+                session_id="aef8aa8b6e9cf6eda406cb88cf33708c",
             ),
         }
     )
@@ -697,15 +706,19 @@ async def test_fork_switch_binds_target_agent_bundle() -> None:
     """
     conv = _make_conversation()
     conv_store = _ConversationStore(
-        conversations={"conv_src": conv},
-        items_by_conv={"conv_src": [_make_item("msg_1", "Hello")]},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hello")
+            ]
+        },
     )
     agent_store = _switch_agent_store()
     client = TestClient(_build_app(conv_store, agent_store=agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/fork",
-        json={"agent_id": "ag_codex_native"},
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"agent_id": "44b4151dd6cdfed6ee19430832398e05"},
     )
 
     assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
@@ -713,7 +726,7 @@ async def test_fork_switch_binds_target_agent_bundle() -> None:
     # TARGET agent's bundle (not ag_test/hash) — not a separate create call.
     assert len(agent_store.create_calls) == 0
     fork_call = conv_store.fork_calls[0]
-    assert fork_call["cloned_agent_bundle_location"] == "ag_codex_native/hash", (
+    assert fork_call["cloned_agent_bundle_location"] == "44b4151dd6cdfed6ee19430832398e05/hash", (
         "Switch must clone the target agent's bundle; cloning the source's "
         "bundle would launch the wrong harness."
     )
@@ -722,7 +735,7 @@ async def test_fork_switch_binds_target_agent_bundle() -> None:
     assert fork_call["cloned_agent_name"] == "codex"
     # The fork binds the cloned agent id it asked the store to create.
     assert fork_call["agent_id"] is not None
-    assert fork_call["agent_id"] != "ag_test"
+    assert fork_call["agent_id"] != "087b7cb7ac30abf4debfaa578d052ec6"
 
 
 @pytest.mark.asyncio
@@ -734,12 +747,12 @@ async def test_fork_switch_404_session_scoped_target() -> None:
     leak/alias it across sessions, so only built-in agents are bindable.
     """
     conv = _make_conversation()
-    conv_store = _ConversationStore(conversations={"conv_src": conv})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
     client = TestClient(_build_app(conv_store, agent_store=_switch_agent_store()))
 
     resp = client.post(
-        "/v1/sessions/conv_src/fork",
-        json={"agent_id": "ag_session_scoped"},
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"agent_id": "a98bb825ebd41391c19637c58fe3c0b7"},
     )
 
     assert resp.status_code == 404, (
@@ -753,12 +766,12 @@ async def test_fork_switch_404_session_scoped_target() -> None:
 async def test_fork_switch_404_unknown_target() -> None:
     """Switching to a non-existent agent id is rejected with 404."""
     conv = _make_conversation()
-    conv_store = _ConversationStore(conversations={"conv_src": conv})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
     client = TestClient(_build_app(conv_store, agent_store=_switch_agent_store()))
 
     resp = client.post(
-        "/v1/sessions/conv_src/fork",
-        json={"agent_id": "ag_does_not_exist"},
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"agent_id": "566230693b3591362a085cffdb224484"},
     )
 
     assert resp.status_code == 404, (
@@ -880,21 +893,30 @@ async def test_fork_switch_model_and_carry_gating(
     """
     conv = _make_conversation()
     conv_store = _ConversationStore(
-        conversations={"conv_src": conv},
-        items_by_conv={"conv_src": [_make_item("msg_1", "Hi")]},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hi")
+            ]
+        },
     )
     agent_store = _switch_agent_store()
     # Target every switch at ag_claude_native; the stub cache, not the
     # bundle, dictates the harness each agent reports.
     monkeypatch.setattr(
         "omnigent.server.routes.sessions.get_agent_cache",
-        lambda: _StubAgentCache({"ag_test": source_harness, "ag_claude_native": target_harness}),
+        lambda: _StubAgentCache(
+            {
+                "087b7cb7ac30abf4debfaa578d052ec6": source_harness,
+                "280d725b404d2915f9e9d6cccce91303": target_harness,
+            }
+        ),
     )
     client = TestClient(_build_app(conv_store, agent_store=agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/fork",
-        json={"agent_id": "ag_claude_native"},
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"agent_id": "280d725b404d2915f9e9d6cccce91303"},
     )
 
     assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
@@ -932,16 +954,20 @@ async def test_fork_no_switch_native_source_carries_history(
     """
     conv = _make_conversation()
     conv_store = _ConversationStore(
-        conversations={"conv_src": conv},
-        items_by_conv={"conv_src": [_make_item("msg_1", "Hi")]},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hi")
+            ]
+        },
     )
     monkeypatch.setattr(
         "omnigent.server.routes.sessions.get_agent_cache",
-        lambda: _StubAgentCache({"ag_test": "claude-native"}),
+        lambda: _StubAgentCache({"087b7cb7ac30abf4debfaa578d052ec6": "claude-native"}),
     )
     client = TestClient(_build_app(conv_store))
 
-    resp = client.post("/v1/sessions/conv_src/fork", json={})
+    resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
 
     assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
     fork_call = conv_store.fork_calls[0]
@@ -985,16 +1011,20 @@ async def test_fork_cursor_pi_native_carry_gating(
     """
     conv = _make_conversation()
     conv_store = _ConversationStore(
-        conversations={"conv_src": conv},
-        items_by_conv={"conv_src": [_make_item("msg_1", "Hi")]},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hi")
+            ]
+        },
     )
     monkeypatch.setattr(
         "omnigent.server.routes.sessions.get_agent_cache",
-        lambda: _StubAgentCache({"ag_test": harness}),
+        lambda: _StubAgentCache({"087b7cb7ac30abf4debfaa578d052ec6": harness}),
     )
     client = TestClient(_build_app(conv_store))
 
-    resp = client.post("/v1/sessions/conv_src/fork", json={})
+    resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
 
     assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
     fork_call = conv_store.fork_calls[0]
@@ -1033,16 +1063,20 @@ async def test_fork_reversed_native_spelling_carry_gating(
     """
     conv = _make_conversation()
     conv_store = _ConversationStore(
-        conversations={"conv_src": conv},
-        items_by_conv={"conv_src": [_make_item("msg_1", "Hi")]},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hi")
+            ]
+        },
     )
     monkeypatch.setattr(
         "omnigent.server.routes.sessions.get_agent_cache",
-        lambda: _StubAgentCache({"ag_test": harness}),
+        lambda: _StubAgentCache({"087b7cb7ac30abf4debfaa578d052ec6": harness}),
     )
     client = TestClient(_build_app(conv_store))
 
-    resp = client.post("/v1/sessions/conv_src/fork", json={})
+    resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
 
     assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
     fork_call = conv_store.fork_calls[0]
@@ -1055,25 +1089,29 @@ async def test_fork_reversed_native_spelling_carry_gating(
 @pytest.mark.asyncio
 async def test_fork_clone_reuses_source_agent_name_verbatim() -> None:
     """The fork clone reuses the source agent's name as-is — no suffix added."""
-    conv = _make_conversation(agent_id="ag_src")
+    conv = _make_conversation(agent_id="30f9aa4d441e344d3eb273f8cc13e4a5")
     conv_store = _ConversationStore(
-        conversations={"conv_src": conv},
-        items_by_conv={"conv_src": [_make_item("msg_1", "Hi")]},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv},
+        items_by_conv={
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
+                _make_item("9980c8a9248139f14f4165e5d53088aa", "Hi")
+            ]
+        },
     )
     agent_store = _AgentStore(
         agents={
-            "ag_src": Agent(
-                id="ag_src",
+            "30f9aa4d441e344d3eb273f8cc13e4a5": Agent(
+                id="30f9aa4d441e344d3eb273f8cc13e4a5",
                 created_at=1,
                 name="claude-native-ui",
-                bundle_location="ag_claude/hash",
+                bundle_location="3a9725fd4de1720e83e53a632da41da8/hash",
                 version=1,
             ),
         }
     )
     client = TestClient(_build_app(conv_store, agent_store=agent_store))
 
-    resp = client.post("/v1/sessions/conv_src/fork", json={})
+    resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
 
     assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
     assert conv_store.fork_calls[0]["cloned_agent_name"] == "claude-native-ui", (

--- a/tests/server/routes/test_sessions_input_policy_deny.py
+++ b/tests/server/routes/test_sessions_input_policy_deny.py
@@ -32,13 +32,13 @@ def route_client(db_uri: str) -> Iterator[tuple[TestClient, str]]:
     conversation_store = SqlAlchemyConversationStore(db_uri)
     agent_store = SqlAlchemyAgentStore(db_uri)
     agent_store.create(
-        agent_id="ag_test",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         name="test-agent",
-        bundle_location="ag_test/bundle",
+        bundle_location="087b7cb7ac30abf4debfaa578d052ec6/bundle",
     )
     conv = conversation_store.create_conversation(
         title="policy session",
-        agent_id="ag_test",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
     )
 
     app = FastAPI()

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -98,7 +98,7 @@ class _HeartbeatRunnerClient:
 
         :param method: HTTP method, e.g. ``"GET"``.
         :param path: Request path, e.g.
-            ``"/v1/sessions/conv_abc/stream"``.
+            ``"/v1/sessions/4e92b5a0c0ee6db3f874f9c4a3f855a5/stream"``.
         :param timeout: Timeout object passed by the relay.
         :returns: Fake streaming response.
         """
@@ -125,7 +125,7 @@ async def test_runner_relay_ready_waits_for_runner_heartbeat() -> None:
 
     try:
         handle = await sessions_module._ensure_runner_relay_ready(
-            "conv_ready",
+            "a7f039e9f1311474878eb7d4699c1013",
             "runner_ready",
             fake_runner,  # type: ignore[arg-type]
             conversation_store=None,
@@ -134,10 +134,13 @@ async def test_runner_relay_ready_waits_for_runner_heartbeat() -> None:
         assert handle is not None
         assert handle.ready.is_set()
         assert fake_runner.stream_calls[0][0] == "GET"
-        assert fake_runner.stream_calls[0][1] == "/v1/sessions/conv_ready/stream"
+        assert (
+            fake_runner.stream_calls[0][1]
+            == "/v1/sessions/a7f039e9f1311474878eb7d4699c1013/stream"
+        )
     finally:
         release.set()
-        handle = sessions_module._runner_relay_tasks.get("conv_ready")
+        handle = sessions_module._runner_relay_tasks.get("a7f039e9f1311474878eb7d4699c1013")
         if handle is not None:
             await asyncio.wait_for(handle.task, timeout=1.0)
         sessions_module._runner_relay_tasks.clear()
@@ -237,7 +240,7 @@ class _ScriptedRunnerClient:
 
         :param method: HTTP method, e.g. ``"GET"``.
         :param path: Request path, e.g.
-            ``"/v1/sessions/conv_abc/stream"``.
+            ``"/v1/sessions/4e92b5a0c0ee6db3f874f9c4a3f855a5/stream"``.
         :param timeout: Timeout object passed by the relay.
         :returns: Fake streaming response.
         """
@@ -433,7 +436,7 @@ async def test_relay_publishes_failed_status_on_tunnel_close() -> None:
     sessions_module._runner_relay_tasks.clear()
     gate = asyncio.Event()
     fake_runner = _TunnelCloseRunnerClient(gate)
-    session_id = "conv_tunnel_close"
+    session_id = "03048a276e8a91fab748c87a77d638bf"
 
     collector = None
     try:
@@ -517,7 +520,7 @@ async def test_relay_persists_disconnect_error_labels_on_tunnel_close() -> None:
     gate = asyncio.Event()
     fake_runner = _TunnelCloseRunnerClient(gate)
     store = _RecordingLabelStore()
-    session_id = "conv_tunnel_close_labels"
+    session_id = "82fe36b7ca1bfb567bfbcce4eaa487a1"
 
     try:
         handle = await sessions_module._ensure_runner_relay_ready(
@@ -580,7 +583,7 @@ async def test_runner_recovery_clears_persisted_disconnect_error_labels() -> Non
     gate = asyncio.Event()
     fake_runner = _TunnelCloseRunnerClient(gate)
     store = _RecordingLabelStore()
-    session_id = "conv_runner_recovery_labels"
+    session_id = "51af098ee822b1a024acb911f3cdf297"
 
     try:
         # Disconnect first: the relay persists the runner_disconnected

--- a/tests/server/routes/test_sessions_shared_projects.py
+++ b/tests/server/routes/test_sessions_shared_projects.py
@@ -67,9 +67,15 @@ def _seed_shared_project_session(db_uri: str) -> str:
     agent_store = SqlAlchemyAgentStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
     perms = SqlAlchemyPermissionStore(db_uri)
-    if agent_store.get("ag_test") is None:
-        agent_store.create(agent_id="ag_test", name="test-agent", bundle_location="ag_test/bundle")
-    conv = conv_store.create_conversation(title="Bob's session", agent_id="ag_test")
+    if agent_store.get("087b7cb7ac30abf4debfaa578d052ec6") is None:
+        agent_store.create(
+            agent_id="087b7cb7ac30abf4debfaa578d052ec6",
+            name="test-agent",
+            bundle_location="087b7cb7ac30abf4debfaa578d052ec6/bundle",
+        )
+    conv = conv_store.create_conversation(
+        title="Bob's session", agent_id="087b7cb7ac30abf4debfaa578d052ec6"
+    )
     conv_store.set_labels(conv.id, {PROJECT_LABEL_KEY: "Bob Project"})
     for user in (ALICE, BOB):
         perms.ensure_user(user)

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -72,7 +72,7 @@ class _ConversationStore:
             created_at=1,
             updated_at=1,
             root_conversation_id=conversation_id,
-            agent_id="ag_test",
+            agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         )
 
     def list_conversations(
@@ -103,7 +103,7 @@ class _ConversationStore:
                     created_at=1,
                     updated_at=1,
                     root_conversation_id=root_conversation_id or "",
-                    agent_id="ag_test",
+                    agent_id="087b7cb7ac30abf4debfaa578d052ec6",
                 )
             ]
         return PagedList(
@@ -166,11 +166,11 @@ async def test_session_snapshot_reads_latest_items_then_returns_chronological() 
     ]
     conv_store = _ConversationStore(newest_first)
 
-    snapshot = await _get_session_snapshot(conv_store, "conv_test")  # type: ignore[arg-type]
+    snapshot = await _get_session_snapshot(conv_store, "e1f7c651c9f97fac088ea70ef633409d")  # type: ignore[arg-type]
 
     assert conv_store.list_items_calls == [
         {
-            "conversation_id": "conv_test",
+            "conversation_id": "e1f7c651c9f97fac088ea70ef633409d",
             "limit": 100,
             "after": None,
             "before": None,
@@ -179,7 +179,7 @@ async def test_session_snapshot_reads_latest_items_then_returns_chronological() 
         }
     ]
     assert [item.id for item in snapshot.items] == ["item_103", "item_104", "item_105"]
-    assert snapshot.agent_id == "ag_test"
+    assert snapshot.agent_id == "087b7cb7ac30abf4debfaa578d052ec6"
     assert snapshot.status == "idle"
 
 
@@ -194,19 +194,23 @@ async def test_session_snapshot_populates_runner_online_from_session_lookup() ->
         Return scripted liveness for the requested session ids.
 
         :param session_ids: Session ids to resolve, e.g.
-            ``["conv_shared"]``.
+            ``["1949523062921b6989466e2fc257925a"]``.
         :returns: Session-scoped split liveness by id.
         """
         lookup_calls.append(session_ids)
-        return {"conv_shared": SessionLiveness(runner_online=False, host_online=False)}
+        return {
+            "1949523062921b6989466e2fc257925a": SessionLiveness(
+                runner_online=False, host_online=False
+            )
+        }
 
     snapshot = await _get_session_snapshot(
         conv_store,
-        "conv_shared",  # type: ignore[arg-type]
+        "1949523062921b6989466e2fc257925a",  # type: ignore[arg-type]
         liveness_lookup=_liveness_lookup,
     )
 
-    assert lookup_calls == [["conv_shared"]]
+    assert lookup_calls == [["1949523062921b6989466e2fc257925a"]]
     assert snapshot.runner_online is False
     assert snapshot.host_online is False
 
@@ -225,16 +229,16 @@ async def test_session_snapshot_surfaces_runner_exit_report_as_failed() -> None:
     from omnigent.server.host_registry import RunnerExitReports
 
     conv = Conversation(
-        id="conv_crashed",
+        id="87876a3cec563d43c2430b633747c7b7",
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_crashed",
-        agent_id="ag_test",
+        root_conversation_id="87876a3cec563d43c2430b633747c7b7",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         runner_id="runner_dead",
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_crashed": conv},
+        conversations={"87876a3cec563d43c2430b633747c7b7": conv},
     )
     reports = RunnerExitReports()
     daemon_error = "runner process exited with code 1\n--- runner log tail ---\nboom"
@@ -242,7 +246,7 @@ async def test_session_snapshot_surfaces_runner_exit_report_as_failed() -> None:
 
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_crashed",
+        "87876a3cec563d43c2430b633747c7b7",
         runner_exit_reports=reports,
     )
 
@@ -266,11 +270,11 @@ async def test_session_snapshot_surfaces_status_error_labels_as_last_task_error(
     failure banner instead of ``last_task_error=None``.
     """
     conv = Conversation(
-        id="conv_failed_terminal",
+        id="bb66c1adb93f9520bc882bcd05c838e2",
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_failed_terminal",
-        agent_id="ag_test",
+        root_conversation_id="bb66c1adb93f9520bc882bcd05c838e2",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         labels={
             "omnigent.last_task_error_code": "required_terminal_exited",
             "omnigent.last_task_error_message": "Required terminal exited unexpectedly",
@@ -278,12 +282,12 @@ async def test_session_snapshot_surfaces_status_error_labels_as_last_task_error(
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_failed_terminal": conv},
+        conversations={"bb66c1adb93f9520bc882bcd05c838e2": conv},
     )
 
     snapshot = await _get_session_snapshot(  # type: ignore[arg-type]
         conv_store,
-        "conv_failed_terminal",
+        "bb66c1adb93f9520bc882bcd05c838e2",
     )
 
     assert snapshot.last_task_error == {
@@ -302,22 +306,22 @@ async def test_session_snapshot_no_exit_report_stays_unfailed() -> None:
     from omnigent.server.host_registry import RunnerExitReports
 
     conv = Conversation(
-        id="conv_ok",
+        id="428fdbbaac5e190e6360103acc4fe6c5",
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_ok",
-        agent_id="ag_test",
+        root_conversation_id="428fdbbaac5e190e6360103acc4fe6c5",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         runner_id="runner_live",
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_ok": conv},
+        conversations={"428fdbbaac5e190e6360103acc4fe6c5": conv},
     )
     reports = RunnerExitReports()  # empty — no crash recorded
 
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_ok",
+        "428fdbbaac5e190e6360103acc4fe6c5",
         runner_exit_reports=reports,
     )
 
@@ -360,18 +364,18 @@ async def test_session_snapshot_queries_runner_on_cache_miss(
     conv_store = _ConversationStore([_message_item("item_1", "hi")])
     snapshot = await _get_session_snapshot(
         conv_store,
-        "conv_cache_miss",  # type: ignore[arg-type]
+        "cef2fb55a9d4841cff0b30b2826d91f1",  # type: ignore[arg-type]
     )
 
     # Runner was queried for this session's status.
-    assert "/v1/sessions/conv_cache_miss" in fake_client.get_calls[0]
+    assert "/v1/sessions/cef2fb55a9d4841cff0b30b2826d91f1" in fake_client.get_calls[0]
     assert snapshot.status == "running"
 
     # Verify the cache is warm: a second call should NOT query the
     # runner again (proves the cache was populated).
     snapshot2 = await _get_session_snapshot(
         conv_store,
-        "conv_cache_miss",  # type: ignore[arg-type]
+        "cef2fb55a9d4841cff0b30b2826d91f1",  # type: ignore[arg-type]
     )
     # Still "running" from the cached value.
     assert snapshot2.status == "running"
@@ -410,7 +414,7 @@ async def test_session_snapshot_defaults_idle_when_runner_unreachable(
     conv_store = _ConversationStore([_message_item("item_1", "hi")])
     snapshot = await _get_session_snapshot(
         conv_store,
-        "conv_no_runner",  # type: ignore[arg-type]
+        "68dcdb50d850d9c2b905cad807dad25f",  # type: ignore[arg-type]
     )
 
     assert snapshot.status == "idle"
@@ -477,19 +481,19 @@ async def test_session_snapshot_uses_router_when_singleton_unset(
     conv_store = _ConversationStore([_message_item("item_1", "hi")])
     snapshot = await _get_session_snapshot(
         conv_store,
-        "conv_router_only",  # type: ignore[arg-type]
+        "3ce755917a74a49f0c8feaf50f058ed9",  # type: ignore[arg-type]
     )
 
-    assert fake_router.resolved_for == ["conv_router_only"], (
+    assert fake_router.resolved_for == ["3ce755917a74a49f0c8feaf50f058ed9"], (
         "snapshot should have consulted the runner_router on cache miss "
         "instead of synthesizing a default status"
     )
     assert snapshot.status == "running"
     # Status is synchronous; the skills GET is now a background fetch.
-    await _drain_runner_skills("conv_router_only")
+    await _drain_runner_skills("3ce755917a74a49f0c8feaf50f058ed9")
     assert fake_client.get_calls == [
-        "/v1/sessions/conv_router_only",
-        "/v1/sessions/conv_router_only/skills",
+        "/v1/sessions/3ce755917a74a49f0c8feaf50f058ed9",
+        "/v1/sessions/3ce755917a74a49f0c8feaf50f058ed9/skills",
     ]
 
 
@@ -542,16 +546,16 @@ async def test_session_snapshot_includes_skills_from_runner(
     # First poll returns [] and kicks the background fetch; a later poll serves them.
     first = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_skills",
+        "6dc1e933ea5626723a7c79af592a4dc8",
     )
     assert first.skills == []
-    await _drain_runner_skills("conv_skills")
+    await _drain_runner_skills("6dc1e933ea5626723a7c79af592a4dc8")
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_skills",
+        "6dc1e933ea5626723a7c79af592a4dc8",
     )
 
-    assert "/v1/sessions/conv_skills/skills" in fake_client.get_calls
+    assert "/v1/sessions/6dc1e933ea5626723a7c79af592a4dc8/skills" in fake_client.get_calls
     assert [s.name for s in snapshot.skills] == ["triage-issues", "mlflow-bug"]
     assert snapshot.skills[0].description == "Triage issues."
 
@@ -807,24 +811,24 @@ async def test_session_snapshot_serves_static_cursor_model_options(
     monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
 
     conv = Conversation(
-        id="conv_cursor_options",
+        id="4747fb03a3b45bb1f96bf130f4d704e5",
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_cursor_options",
-        agent_id="ag_test",
+        root_conversation_id="4747fb03a3b45bb1f96bf130f4d704e5",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         labels={
             _mod._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: _mod._CURSOR_NATIVE_WRAPPER_LABEL_VALUE,
         },
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_cursor_options": conv},
+        conversations={"4747fb03a3b45bb1f96bf130f4d704e5": conv},
     )
 
     # First snapshot already carries the full catalog — no kick-and-empty.
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_cursor_options",
+        "4747fb03a3b45bb1f96bf130f4d704e5",
     )
 
     # No runner round-trip for cursor model options (served statically).
@@ -834,7 +838,7 @@ async def test_session_snapshot_serves_static_cursor_model_options(
     # base-id namespace only — no flattened effort variants leak through.
     assert not any("-high" in i or "-xhigh" in i for i in ids)
     # The cache must stay untouched — that's what makes it refresh_state-proof.
-    assert "conv_cursor_options" not in _mod._model_options_cache
+    assert "4747fb03a3b45bb1f96bf130f4d704e5" not in _mod._model_options_cache
 
 
 @pytest.mark.asyncio
@@ -857,7 +861,7 @@ async def test_session_snapshot_refresh_state_reloads_model_options(
     _mod._runner_skills_inflight.clear()
     _mod._model_options_cache.clear()
     _mod._model_options_inflight.clear()
-    _mod._model_options_cache["conv_codex_refresh"] = [
+    _mod._model_options_cache["3626053dfa9668a8604cc06e0b590ae0"] = [
         {
             "id": "stale-model",
             "model": "stale-provider-model",
@@ -908,35 +912,38 @@ async def test_session_snapshot_refresh_state_reloads_model_options(
     monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
 
     conv = Conversation(
-        id="conv_codex_refresh",
+        id="3626053dfa9668a8604cc06e0b590ae0",
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_codex_refresh",
-        agent_id="ag_test",
+        root_conversation_id="3626053dfa9668a8604cc06e0b590ae0",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         labels={
             _mod._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: _mod._CODEX_NATIVE_WRAPPER_LABEL_VALUE,
         },
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_codex_refresh": conv},
+        conversations={"3626053dfa9668a8604cc06e0b590ae0": conv},
     )
 
     refreshed = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_codex_refresh",
+        "3626053dfa9668a8604cc06e0b590ae0",
         refresh_state=True,
     )
     # Refresh must not echo the stale cached row. If this is "stale-model",
     # browser reloads would not recover after the server-side cache shape is fixed.
     assert [m["id"] for m in refreshed.model_options] == []
-    await _drain_model_options("conv_codex_refresh")
+    await _drain_model_options("3626053dfa9668a8604cc06e0b590ae0")
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_codex_refresh",
+        "3626053dfa9668a8604cc06e0b590ae0",
     )
 
-    assert "/v1/sessions/conv_codex_refresh/codex-model-options" in fake_client.get_calls
+    assert (
+        "/v1/sessions/3626053dfa9668a8604cc06e0b590ae0/codex-model-options"
+        in fake_client.get_calls
+    )
     assert [m["id"] for m in snapshot.model_options] == ["fresh-model"]
     assert snapshot.model_options[0]["displayName"] == "Fresh Model"
 
@@ -1005,35 +1012,37 @@ async def test_session_snapshot_retries_empty_model_options(
     monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
 
     conv = Conversation(
-        id="conv_codex_empty_then_ready",
+        id="a17f935755fe66e4a0f42878eee28820",
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_codex_empty_then_ready",
-        agent_id="ag_test",
+        root_conversation_id="a17f935755fe66e4a0f42878eee28820",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         labels={
             _mod._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: _mod._CODEX_NATIVE_WRAPPER_LABEL_VALUE,
         },
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_codex_empty_then_ready": conv},
+        conversations={"a17f935755fe66e4a0f42878eee28820": conv},
     )
 
     first = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_codex_empty_then_ready",
+        "a17f935755fe66e4a0f42878eee28820",
     )
     assert first.model_options == []
-    await _drain_model_options("conv_codex_empty_then_ready")
+    await _drain_model_options("a17f935755fe66e4a0f42878eee28820")
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_codex_empty_then_ready",
+        "a17f935755fe66e4a0f42878eee28820",
     )
 
     # Two codex-model-options calls means the empty catalog was not cached;
     # one call would recreate the missing-picker regression.
     assert (
-        fake_client.get_calls.count("/v1/sessions/conv_codex_empty_then_ready/codex-model-options")
+        fake_client.get_calls.count(
+            "/v1/sessions/a17f935755fe66e4a0f42878eee28820/codex-model-options"
+        )
         == 2
     )
     assert [m["id"] for m in snapshot.model_options] == ["gpt-5.5"]
@@ -1117,35 +1126,37 @@ async def test_session_snapshot_retries_503_model_options(
     monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
 
     conv = Conversation(
-        id="conv_codex_503_then_ready",
+        id="a5cf1ddab988dcc43e643401b70c56d0",
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_codex_503_then_ready",
-        agent_id="ag_test",
+        root_conversation_id="a5cf1ddab988dcc43e643401b70c56d0",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         labels={
             _mod._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: _mod._CODEX_NATIVE_WRAPPER_LABEL_VALUE,
         },
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_codex_503_then_ready": conv},
+        conversations={"a5cf1ddab988dcc43e643401b70c56d0": conv},
     )
 
     first = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_codex_503_then_ready",
+        "a5cf1ddab988dcc43e643401b70c56d0",
     )
     assert first.model_options == []
-    await _drain_model_options("conv_codex_503_then_ready")
+    await _drain_model_options("a5cf1ddab988dcc43e643401b70c56d0")
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_codex_503_then_ready",
+        "a5cf1ddab988dcc43e643401b70c56d0",
     )
 
     # Two calls proves the transient 503 did not terminate discovery; one
     # call would leave the cache cold forever until another snapshot request.
     assert (
-        fake_client.get_calls.count("/v1/sessions/conv_codex_503_then_ready/codex-model-options")
+        fake_client.get_calls.count(
+            "/v1/sessions/a5cf1ddab988dcc43e643401b70c56d0/codex-model-options"
+        )
         == 2
     )
     assert [m["id"] for m in snapshot.model_options] == ["gpt-5.4"]
@@ -1204,9 +1215,9 @@ async def test_session_snapshot_publishes_skills_event_when_fetch_resolves(
 
     conv_store = _ConversationStore([_message_item("item_1", "hi")])
     # First poll serves [] and kicks the background fetch.
-    first = await _get_session_snapshot(conv_store, "conv_push")  # type: ignore[arg-type]
+    first = await _get_session_snapshot(conv_store, "38aed2dc1dc1b08dbbaa1cf9592d7ae5")  # type: ignore[arg-type]
     assert first.skills == []
-    await _drain_runner_skills("conv_push")
+    await _drain_runner_skills("38aed2dc1dc1b08dbbaa1cf9592d7ae5")
 
     # Exactly one session.skills event for this session was published when
     # the fetch resolved. A missing event means the push regressed and the
@@ -1215,7 +1226,8 @@ async def test_session_snapshot_publishes_skills_event_when_fetch_resolves(
     skills_events = [
         e
         for e in published
-        if e.get("type") == "session.skills" and e.get("conversation_id") == "conv_push"
+        if e.get("type") == "session.skills"
+        and e.get("conversation_id") == "38aed2dc1dc1b08dbbaa1cf9592d7ae5"
     ]
     assert len(skills_events) == 1, (
         f"Expected exactly 1 session.skills publish on fetch resolve, "
@@ -1247,7 +1259,7 @@ async def test_session_snapshot_skills_empty_without_runner(
 
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_no_runner_skills",
+        "6222f438412b74067ff5915857f79312",
     )
 
     assert snapshot.skills == []
@@ -1287,7 +1299,7 @@ async def test_session_snapshot_skills_empty_on_malformed_runner_payload(
 
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_malformed_skills",
+        "21ad0587558979245a26b40ebe2638ef",
     )
 
     assert snapshot.skills == []
@@ -1344,15 +1356,15 @@ async def test_session_snapshot_prefers_router_over_singleton(
     conv_store = _ConversationStore([_message_item("item_1", "hi")])
     snapshot = await _get_session_snapshot(
         conv_store,
-        "conv_prefer_router",  # type: ignore[arg-type]
+        "1cef6d7d1ef0c577c6ccfc690e5bc8ed",  # type: ignore[arg-type]
     )
 
     assert snapshot.status == "running"
     # Status is synchronous; the skills GET is now a background fetch.
-    await _drain_runner_skills("conv_prefer_router")
+    await _drain_runner_skills("1cef6d7d1ef0c577c6ccfc690e5bc8ed")
     assert router_client.get_calls == [
-        "/v1/sessions/conv_prefer_router",
-        "/v1/sessions/conv_prefer_router/skills",
+        "/v1/sessions/1cef6d7d1ef0c577c6ccfc690e5bc8ed",
+        "/v1/sessions/1cef6d7d1ef0c577c6ccfc690e5bc8ed/skills",
     ]
     assert singleton_client.get_calls == [], (
         "singleton should not have been queried when the router resolved a client"
@@ -1395,7 +1407,7 @@ def _graph_conv(
 ) -> Conversation:
     """Build a spawn-tree conversation with optional priced ``session_usage``.
 
-    :param conv_id: This conversation's id, e.g. ``"conv_child"``.
+    :param conv_id: This conversation's id, e.g. ``"ff5cac23d0beb79fad914046049f32ff"``.
     :param root: Shared spawn-tree root id (every node in a tree shares it).
     :param parent: Parent conversation id, or ``None`` for the tree root.
     :param cost: ``total_cost_usd`` to record, or ``None`` for an unpriced
@@ -1418,7 +1430,7 @@ def _graph_conv(
         updated_at=1,
         root_conversation_id=root,
         parent_conversation_id=parent,
-        agent_id="ag_test",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         kind="default" if parent is None else "sub_agent",
         session_usage=usage,
     )
@@ -1433,14 +1445,27 @@ async def test_session_snapshot_cost_sums_subagent_subtree() -> None:
     its spend on its own child conversation, so without the subtree sum the
     parent's badge would never reflect it.
     """
-    parent = _graph_conv("conv_parent", root="conv_parent", parent=None, cost=1.0)
-    child = _graph_conv("conv_child", root="conv_parent", parent="conv_parent", cost=2.5)
+    parent = _graph_conv(
+        "ead6d59a6b650d19dbdf61ec32426f4e",
+        root="ead6d59a6b650d19dbdf61ec32426f4e",
+        parent=None,
+        cost=1.0,
+    )
+    child = _graph_conv(
+        "ff5cac23d0beb79fad914046049f32ff",
+        root="ead6d59a6b650d19dbdf61ec32426f4e",
+        parent="ead6d59a6b650d19dbdf61ec32426f4e",
+        cost=2.5,
+    )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_parent": parent, "conv_child": child},
+        conversations={
+            "ead6d59a6b650d19dbdf61ec32426f4e": parent,
+            "ff5cac23d0beb79fad914046049f32ff": child,
+        },
     )
 
-    snapshot = await _get_session_snapshot(conv_store, "conv_parent")  # type: ignore[arg-type]
+    snapshot = await _get_session_snapshot(conv_store, "ead6d59a6b650d19dbdf61ec32426f4e")  # type: ignore[arg-type]
 
     # 3.5 = parent $1.00 + sub-agent $2.50. If this reads 1.00, the snapshot
     # regressed to the parent's own session_usage and dropped the subtree sum —
@@ -1455,13 +1480,18 @@ async def test_session_snapshot_cost_is_own_usage_for_childless_session() -> Non
     Guards the fallback: a childless session's subtree is just itself, so the
     badge must equal the conversation's own ``total_cost_usd`` (not None/0).
     """
-    solo = _graph_conv("conv_solo", root="conv_solo", parent=None, cost=0.42)
+    solo = _graph_conv(
+        "6d996c055256e5975b8e5683c4d77d47",
+        root="6d996c055256e5975b8e5683c4d77d47",
+        parent=None,
+        cost=0.42,
+    )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_solo": solo},
+        conversations={"6d996c055256e5975b8e5683c4d77d47": solo},
     )
 
-    snapshot = await _get_session_snapshot(conv_store, "conv_solo")  # type: ignore[arg-type]
+    snapshot = await _get_session_snapshot(conv_store, "6d996c055256e5975b8e5683c4d77d47")  # type: ignore[arg-type]
 
     # 0.42 = the session's own cost; no descendants to add.
     assert snapshot.total_cost_usd == 0.42
@@ -1477,27 +1507,30 @@ async def test_session_snapshot_sums_by_model_over_subtree() -> None:
     and child share the same model, their buckets must be summed.
     """
     parent = _graph_conv(
-        "conv_parent",
-        root="conv_parent",
+        "ead6d59a6b650d19dbdf61ec32426f4e",
+        root="ead6d59a6b650d19dbdf61ec32426f4e",
         parent=None,
         cost=1.0,
         tokens={"input_tokens": 100, "output_tokens": 20},
         by_model={"model-a": {"input_tokens": 100, "output_tokens": 20, "total_cost_usd": 1.0}},
     )
     child = _graph_conv(
-        "conv_child",
-        root="conv_parent",
-        parent="conv_parent",
+        "ff5cac23d0beb79fad914046049f32ff",
+        root="ead6d59a6b650d19dbdf61ec32426f4e",
+        parent="ead6d59a6b650d19dbdf61ec32426f4e",
         cost=2.5,
         tokens={"input_tokens": 400, "output_tokens": 80},
         by_model={"model-a": {"input_tokens": 400, "output_tokens": 80, "total_cost_usd": 2.5}},
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_parent": parent, "conv_child": child},
+        conversations={
+            "ead6d59a6b650d19dbdf61ec32426f4e": parent,
+            "ff5cac23d0beb79fad914046049f32ff": child,
+        },
     )
 
-    snapshot = await _get_session_snapshot(conv_store, "conv_parent")  # type: ignore[arg-type]
+    snapshot = await _get_session_snapshot(conv_store, "ead6d59a6b650d19dbdf61ec32426f4e")  # type: ignore[arg-type]
 
     # The per-model buckets must be parent + child summed.
     assert snapshot.usage_by_model is not None
@@ -1513,13 +1546,18 @@ async def test_session_snapshot_usage_by_model_none_when_unrecorded() -> None:
     ``None`` (no row rendered) rather than an empty dict — an empty dict
     would imply models were tracked but none contributed.
     """
-    solo = _graph_conv("conv_solo", root="conv_solo", parent=None, cost=None)
+    solo = _graph_conv(
+        "6d996c055256e5975b8e5683c4d77d47",
+        root="6d996c055256e5975b8e5683c4d77d47",
+        parent=None,
+        cost=None,
+    )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_solo": solo},
+        conversations={"6d996c055256e5975b8e5683c4d77d47": solo},
     )
 
-    snapshot = await _get_session_snapshot(conv_store, "conv_solo")  # type: ignore[arg-type]
+    snapshot = await _get_session_snapshot(conv_store, "6d996c055256e5975b8e5683c4d77d47")  # type: ignore[arg-type]
 
     assert snapshot.usage_by_model is None
 
@@ -1534,27 +1572,30 @@ async def test_session_snapshot_usage_by_model_merges_differing_models() -> None
     differently-modeled worker would hide that model's spend.
     """
     parent = _graph_conv(
-        "conv_parent",
-        root="conv_parent",
+        "ead6d59a6b650d19dbdf61ec32426f4e",
+        root="ead6d59a6b650d19dbdf61ec32426f4e",
         parent=None,
         cost=0.10,
         tokens={"input_tokens": 1000},
         by_model={"model-a": {"input_tokens": 1000, "total_cost_usd": 0.10}},
     )
     child = _graph_conv(
-        "conv_child",
-        root="conv_parent",
-        parent="conv_parent",
+        "ff5cac23d0beb79fad914046049f32ff",
+        root="ead6d59a6b650d19dbdf61ec32426f4e",
+        parent="ead6d59a6b650d19dbdf61ec32426f4e",
         cost=0.04,
         tokens={"input_tokens": 150},
         by_model={"model-b": {"input_tokens": 150, "total_cost_usd": 0.04}},
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_parent": parent, "conv_child": child},
+        conversations={
+            "ead6d59a6b650d19dbdf61ec32426f4e": parent,
+            "ff5cac23d0beb79fad914046049f32ff": child,
+        },
     )
 
-    snapshot = await _get_session_snapshot(conv_store, "conv_parent")  # type: ignore[arg-type]
+    snapshot = await _get_session_snapshot(conv_store, "ead6d59a6b650d19dbdf61ec32426f4e")  # type: ignore[arg-type]
 
     assert snapshot.usage_by_model is not None
     # Both models present (typed ModelUsage), each with its own attributed
@@ -1579,54 +1620,64 @@ def test_publish_subtree_cost_to_ancestors_publishes_each_ancestor_subtree(
     publish to the originating child.
     """
     g = _graph_conv(
-        "conv_g",
-        root="conv_g",
+        "8463f762110b86b1ba33ddf7a8fc1172",
+        root="8463f762110b86b1ba33ddf7a8fc1172",
         parent=None,
         cost=1.0,
         tokens={"input_tokens": 10},
         by_model={"model-a": {"input_tokens": 10, "total_cost_usd": 1.0}},
     )
     p = _graph_conv(
-        "conv_p",
-        root="conv_g",
-        parent="conv_g",
+        "b460374fc8e697b296708f52dc9d8179",
+        root="8463f762110b86b1ba33ddf7a8fc1172",
+        parent="8463f762110b86b1ba33ddf7a8fc1172",
         cost=2.0,
         tokens={"input_tokens": 20},
         by_model={"model-a": {"input_tokens": 20, "total_cost_usd": 2.0}},
     )
     c = _graph_conv(
-        "conv_c",
-        root="conv_g",
-        parent="conv_p",
+        "405bfe154d5c0e795a2b87021bc897bf",
+        root="8463f762110b86b1ba33ddf7a8fc1172",
+        parent="b460374fc8e697b296708f52dc9d8179",
         cost=4.0,
         tokens={"input_tokens": 40},
         by_model={"model-a": {"input_tokens": 40, "total_cost_usd": 4.0}},
     )
     conv_store = _ConversationStore(
         [],
-        conversations={"conv_g": g, "conv_p": p, "conv_c": c},
+        conversations={
+            "8463f762110b86b1ba33ddf7a8fc1172": g,
+            "b460374fc8e697b296708f52dc9d8179": p,
+            "405bfe154d5c0e795a2b87021bc897bf": c,
+        },
     )
     recorder = _UsageStreamRecorder()
     monkeypatch.setattr(_sessions_mod, "session_stream", recorder)
 
-    _publish_subtree_cost_to_ancestors(conv_store, "conv_c")  # type: ignore[arg-type]
+    _publish_subtree_cost_to_ancestors(conv_store, "405bfe154d5c0e795a2b87021bc897bf")  # type: ignore[arg-type]
 
     by_conv = {pub.conversation_id: pub.event for pub in recorder.published}
     # Only the two ancestors are re-published — never the originating child.
     # A "conv_c" entry would mean the helper republished the node that already
     # got its own session.usage event (double broadcast); a missing ancestor
     # would mean the parent-to-root walk stopped early.
-    assert set(by_conv) == {"conv_p", "conv_g"}
+    assert set(by_conv) == {"b460374fc8e697b296708f52dc9d8179", "8463f762110b86b1ba33ddf7a8fc1172"}
     # parent subtree = parent $2 + child $4. A wrong value means the walk
     # summed the wrong subtree (parent-only, or the whole tree w/ grandparent).
-    assert by_conv["conv_p"]["total_cost_usd"] == 6.0
+    assert by_conv["b460374fc8e697b296708f52dc9d8179"]["total_cost_usd"] == 6.0
     # grandparent subtree = $1 + $2 + $4 (itself + both descendants).
-    assert by_conv["conv_g"]["total_cost_usd"] == 7.0
+    assert by_conv["8463f762110b86b1ba33ddf7a8fc1172"]["total_cost_usd"] == 7.0
     # The per-model breakdown rolls up the same subtree alongside the cost.
-    assert by_conv["conv_p"]["usage_by_model"]["model-a"]["input_tokens"] == 60
-    assert by_conv["conv_g"]["usage_by_model"]["model-a"]["input_tokens"] == 70
+    assert (
+        by_conv["b460374fc8e697b296708f52dc9d8179"]["usage_by_model"]["model-a"]["input_tokens"]
+        == 60
+    )
+    assert (
+        by_conv["8463f762110b86b1ba33ddf7a8fc1172"]["usage_by_model"]["model-a"]["input_tokens"]
+        == 70
+    )
     # The payload is a session.usage broadcast the web client renders as the badge.
-    assert by_conv["conv_p"]["type"] == "session.usage"
+    assert by_conv["b460374fc8e697b296708f52dc9d8179"]["type"] == "session.usage"
 
 
 # ── _truncate_label ──────────────────────────────────────────────────────────
@@ -1679,9 +1730,11 @@ async def test_persist_error_labels_truncates_long_message() -> None:
     long_message = "Runner MCP execute failed: " + "x" * 300
     error = ErrorDetail(code="mcp_error", message=long_message)
 
-    await _persist_session_status_error_labels("conv_123", error, _MockStore())  # type: ignore[arg-type]
+    await _persist_session_status_error_labels(
+        "0099dc8be6d82871e2e450424d46d1b7", error, _MockStore()
+    )  # type: ignore[arg-type]
 
-    stored = captured["conv_123"]["omnigent.last_task_error_message"]
+    stored = captured["0099dc8be6d82871e2e450424d46d1b7"]["omnigent.last_task_error_message"]
     assert len(stored) <= _LABEL_VALUE_MAX_LEN
     # The diagnostic prefix survives so the reload-visible reason is still useful.
     assert stored.startswith("Runner MCP execute failed: ")
@@ -1700,7 +1753,15 @@ async def test_persist_error_labels_short_message_stored_verbatim() -> None:
 
     error = ErrorDetail(code="runner_error", message="Process exited with code 1")
 
-    await _persist_session_status_error_labels("conv_456", error, _MockStore())  # type: ignore[arg-type]
+    await _persist_session_status_error_labels(
+        "d6e1678fb446a1cf5a892e0df60aaba3", error, _MockStore()
+    )  # type: ignore[arg-type]
 
-    assert captured["conv_456"]["omnigent.last_task_error_message"] == "Process exited with code 1"
-    assert captured["conv_456"]["omnigent.last_task_error_code"] == "runner_error"
+    assert (
+        captured["d6e1678fb446a1cf5a892e0df60aaba3"]["omnigent.last_task_error_message"]
+        == "Process exited with code 1"
+    )
+    assert (
+        captured["d6e1678fb446a1cf5a892e0df60aaba3"]["omnigent.last_task_error_code"]
+        == "runner_error"
+    )

--- a/tests/server/routes/test_sessions_switch_agent.py
+++ b/tests/server/routes/test_sessions_switch_agent.py
@@ -216,8 +216,8 @@ class _HarnessAgentCacheStub:
 
 
 def _conv(
-    conv_id: str = "conv_src",
-    agent_id: str | None = "ag_session_scoped",
+    conv_id: str = "e9f8f58523cec9a57d3bdf93be543e8c",
+    agent_id: str | None = "a98bb825ebd41391c19637c58fe3c0b7",
     kind: str = "default",
 ) -> Conversation:
     """Build a Conversation entity.
@@ -315,13 +315,24 @@ def _patch_family_helpers(
 # that built-in — what "switch back" resolves to, and the no-op target the
 # route now rejects (same bundle as the current agent). The switch *targets*
 # are built-ins with a DIFFERENT bundle.
-_CURRENT = _agent("ag_session_scoped", "claude (switch src)", "bundle/claude-sdk", "conv_src")
-_BUILTIN_ORIGIN = _agent("ag_builtin_origin", "claude", "bundle/claude-sdk", None)
-_BUILTIN_CLAUDE = _agent("ag_builtin_claude", "claude-native-ui", "bundle/claude-native", None)
-_BUILTIN_CODEX = _agent("ag_builtin_codex", "codex-native-ui", "bundle/codex", None)
-_BUILTIN_CURSOR = _agent("ag_builtin_cursor", "cursor-native-ui", "bundle/cursor", None)
-_BUILTIN_PI = _agent("ag_builtin_pi", "pi-native-ui", "bundle/pi", None)
-_BUILTIN_QWEN = _agent("ag_builtin_qwen", "qwen-native-ui", "bundle/qwen", None)
+_CURRENT = _agent(
+    "a98bb825ebd41391c19637c58fe3c0b7",
+    "claude (switch src)",
+    "bundle/claude-sdk",
+    "e9f8f58523cec9a57d3bdf93be543e8c",
+)
+_BUILTIN_ORIGIN = _agent("c1030c25bd9d756e4aef6c4e96a7e126", "claude", "bundle/claude-sdk", None)
+_BUILTIN_CLAUDE = _agent(
+    "52adb39f0c5ea92b5563da5327dac08f", "claude-native-ui", "bundle/claude-native", None
+)
+_BUILTIN_CODEX = _agent(
+    "6fa6e4f714621b090e80bd25b0b00e64", "codex-native-ui", "bundle/codex", None
+)
+_BUILTIN_CURSOR = _agent(
+    "d373c637b68c84d23322fc8cb06e14f4", "cursor-native-ui", "bundle/cursor", None
+)
+_BUILTIN_PI = _agent("4145a5c0a210faef9129717c0317ed79", "pi-native-ui", "bundle/pi", None)
+_BUILTIN_QWEN = _agent("ec99b28a23f0c9a5bf70c63df08dd14d", "qwen-native-ui", "bundle/qwen", None)
 
 
 # ── Tests ────────────────────────────────────────────────────────
@@ -335,11 +346,11 @@ async def test_switch_same_family_native_carries_history(
     rebuild, applies target labels, and resolves the previous built-in.
     """
     conv_store = _ConversationStore(
-        conversations={"conv_src": _conv()},
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()},
         items_by_conv={
-            "conv_src": [
+            "e9f8f58523cec9a57d3bdf93be543e8c": [
                 ConversationItem(
-                    id="msg_1",
+                    id="9980c8a9248139f14f4165e5d53088aa",
                     type="message",
                     status="completed",
                     response_id="r1",
@@ -351,9 +362,9 @@ async def test_switch_same_family_native_carries_history(
     )
     agent_store = _AgentStore(
         {
-            "ag_session_scoped": _CURRENT,
-            "ag_builtin_claude": _BUILTIN_CLAUDE,
-            "ag_builtin_origin": _BUILTIN_ORIGIN,
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "52adb39f0c5ea92b5563da5327dac08f": _BUILTIN_CLAUDE,
+            "c1030c25bd9d756e4aef6c4e96a7e126": _BUILTIN_ORIGIN,
         }
     )
     labels = {"omnigent.ui": "terminal", "omnigent.wrapper": "claude-code-native-ui"}
@@ -361,20 +372,21 @@ async def test_switch_same_family_native_carries_history(
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_claude"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "52adb39f0c5ea92b5563da5327dac08f"},
     )
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["status"] == "idle"
     # Bound to a freshly cloned session-scoped agent, not the built-in itself.
-    assert body["agent_id"].startswith("ag_") and body["agent_id"] != "ag_builtin_claude"
+    assert len(body["agent_id"]) == 32 and body["agent_id"] != "52adb39f0c5ea92b5563da5327dac08f"
     # 1 item returned — the in-place transcript is preserved (not copied/empty).
     assert len(body["items"]) == 1
 
     assert len(conv_store.switch_calls) == 1, "route must call switch exactly once"
     call = conv_store.switch_calls[0]
-    assert call["conversation_id"] == "conv_src"
+    assert call["conversation_id"] == "e9f8f58523cec9a57d3bdf93be543e8c"
     assert call["new_agent_bundle_location"] == "bundle/claude-native"
     # Same family → keep model settings AND carry native history (target native).
     assert call["copy_model_settings"] is True
@@ -382,7 +394,7 @@ async def test_switch_same_family_native_carries_history(
     assert call["presentation_labels"] == labels
     # The origin built-in shares the current agent's bundle → that's the
     # built-in to offer for "Switch back" (NOT the switched-to target).
-    assert call["previous_builtin_id"] == "ag_builtin_origin"
+    assert call["previous_builtin_id"] == "c1030c25bd9d756e4aef6c4e96a7e126"
 
 
 @pytest.mark.asyncio
@@ -397,13 +409,21 @@ async def test_switch_cross_family_resets_model_but_carries_history(
     native transcript from this session's own Omnigent items, a conversion
     that doesn't depend on the source harness.
     """
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
-    agent_store = _AgentStore({"ag_session_scoped": _CURRENT, "ag_builtin_codex": _BUILTIN_CODEX})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
+    agent_store = _AgentStore(
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "6fa6e4f714621b090e80bd25b0b00e64": _BUILTIN_CODEX,
+        }
+    )
     # native=True with same_family=False → model resets, history still carries.
     _patch_family_helpers(monkeypatch, same_family=False, native=True, labels={})
     client = TestClient(_build_app(conv_store, agent_store))
 
-    resp = client.post("/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_codex"})
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "6fa6e4f714621b090e80bd25b0b00e64"},
+    )
 
     assert resp.status_code == 200, resp.text
     call = conv_store.switch_calls[0]
@@ -457,24 +477,27 @@ async def test_switch_cursor_pi_native_targets_carry_history_gating(
     False. ``carry_history_into_native`` is True only for the harness with a
     rebuildable session file (pi-native), False for cursor-native.
     """
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
     agent_store = _AgentStore(
         {
-            "ag_session_scoped": _CURRENT,
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
             target_agent.id: target_agent,
-            "ag_builtin_origin": _BUILTIN_ORIGIN,
+            "c1030c25bd9d756e4aef6c4e96a7e126": _BUILTIN_ORIGIN,
         }
     )
     monkeypatch.setattr(
         sessions_mod,
         "get_agent_cache",
         lambda: _HarnessAgentCacheStub(
-            {"ag_session_scoped": "claude_sdk", target_agent.id: target_harness}
+            {"a98bb825ebd41391c19637c58fe3c0b7": "claude_sdk", target_agent.id: target_harness}
         ),
     )
     client = TestClient(_build_app(conv_store, agent_store))
 
-    resp = client.post("/v1/sessions/conv_src/switch-agent", json={"agent_id": target_agent.id})
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": target_agent.id},
+    )
 
     assert resp.status_code == 200, resp.text
     call = conv_store.switch_calls[0]
@@ -490,15 +513,19 @@ async def test_switch_400_noop_same_bundle() -> None:
     """Switching to the built-in the session already runs (same bundle) is a
     no-op and rejected with 400 — no store mutation.
     """
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
     # _BUILTIN_ORIGIN shares the current clone's bundle_location.
     agent_store = _AgentStore(
-        {"ag_session_scoped": _CURRENT, "ag_builtin_origin": _BUILTIN_ORIGIN}
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "c1030c25bd9d756e4aef6c4e96a7e126": _BUILTIN_ORIGIN,
+        }
     )
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_origin"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "c1030c25bd9d756e4aef6c4e96a7e126"},
     )
 
     assert resp.status_code == 400, resp.text
@@ -518,9 +545,12 @@ async def test_switch_publishes_agent_changed_event(
     bound web client keeps treating the session as the old harness and
     drops the first post-switch optimistic bubble on idle churn.
     """
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
     agent_store = _AgentStore(
-        {"ag_session_scoped": _CURRENT, "ag_builtin_claude": _BUILTIN_CLAUDE}
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "52adb39f0c5ea92b5563da5327dac08f": _BUILTIN_CLAUDE,
+        }
     )
     _patch_family_helpers(monkeypatch, same_family=True, native=True, labels={})
 
@@ -538,7 +568,8 @@ async def test_switch_publishes_agent_changed_event(
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_claude"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "52adb39f0c5ea92b5563da5327dac08f"},
     )
 
     assert resp.status_code == 200, resp.text
@@ -549,8 +580,8 @@ async def test_switch_publishes_agent_changed_event(
     event = changed[0]
     # Published on the switched session's channel — a wrong id would deliver
     # the refresh signal to some other session's subscribers.
-    assert event["_conversation_id"] == "conv_src"
-    assert event["conversation_id"] == "conv_src"
+    assert event["_conversation_id"] == "e9f8f58523cec9a57d3bdf93be543e8c"
+    assert event["conversation_id"] == "e9f8f58523cec9a57d3bdf93be543e8c"
     # agent_id must be the agent the store actually bound (the fresh
     # clone) — that's the durable reference clients re-bind to.
     call = conv_store.switch_calls[0]
@@ -570,10 +601,13 @@ async def test_switch_rejected_publishes_no_event(
     """A rejected switch (no-op same-bundle target, 400) publishes nothing —
     clients must not refetch a snapshot for a binding that didn't change.
     """
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
     # _BUILTIN_ORIGIN shares the current clone's bundle_location → 400.
     agent_store = _AgentStore(
-        {"ag_session_scoped": _CURRENT, "ag_builtin_origin": _BUILTIN_ORIGIN}
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "c1030c25bd9d756e4aef6c4e96a7e126": _BUILTIN_ORIGIN,
+        }
     )
     published: list[dict[str, object]] = []
 
@@ -586,7 +620,8 @@ async def test_switch_rejected_publishes_no_event(
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_origin"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "c1030c25bd9d756e4aef6c4e96a7e126"},
     )
 
     assert resp.status_code == 400, resp.text
@@ -603,9 +638,12 @@ async def test_switch_schedules_runner_resource_reset(
     cached primary OSEnv is dropped) and no lingering native terminal shadows
     the next harness's transcript rebuild.
     """
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
     agent_store = _AgentStore(
-        {"ag_session_scoped": _CURRENT, "ag_builtin_claude": _BUILTIN_CLAUDE}
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "52adb39f0c5ea92b5563da5327dac08f": _BUILTIN_CLAUDE,
+        }
     )
     _patch_family_helpers(monkeypatch, same_family=True, native=True, labels={})
     reset_calls: list[str] = []
@@ -617,7 +655,8 @@ async def test_switch_schedules_runner_resource_reset(
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_claude"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "52adb39f0c5ea92b5563da5327dac08f"},
     )
 
     assert resp.status_code == 200, resp.text
@@ -626,7 +665,7 @@ async def test_switch_schedules_runner_resource_reset(
     # the route stopped wiring the reset — the new agent's sandbox would never
     # take effect on the cached primary env and a stale terminal could shadow
     # the rebuild.
-    assert reset_calls == ["conv_src"]
+    assert reset_calls == ["e9f8f58523cec9a57d3bdf93be543e8c"]
 
 
 class _RunnerClientStub:
@@ -648,7 +687,7 @@ class _RunnerClientStub:
         """Record the POST and return a real response of the stubbed status.
 
         :param url: Runner-relative URL, e.g.
-            ``"/v1/sessions/conv_src/reset-state"``.
+            ``"/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/reset-state"``.
         :param timeout: Per-request timeout in seconds (unused).
         :returns: An ``httpx.Response`` so production's
             ``raise_for_status`` behaves exactly as on a live client.
@@ -675,9 +714,12 @@ async def test_switch_reset_publishes_changed_files_invalidated_after_reset(
     publishing before the reset would have clients refetch the OLD agent's
     still-cached env.
     """
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
     agent_store = _AgentStore(
-        {"ag_session_scoped": _CURRENT, "ag_builtin_claude": _BUILTIN_CLAUDE}
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "52adb39f0c5ea92b5563da5327dac08f": _BUILTIN_CLAUDE,
+        }
     )
     _patch_family_helpers(monkeypatch, same_family=True, native=True, labels={})
     runner = _RunnerClientStub()
@@ -698,14 +740,15 @@ async def test_switch_reset_publishes_changed_files_invalidated_after_reset(
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_claude"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "52adb39f0c5ea92b5563da5327dac08f"},
     )
 
     assert resp.status_code == 200, resp.text
     # The real reset ran (TestClient drains background tasks) and hit the
     # runner's dedicated endpoint — a different URL means the old env was
     # never closed and the event below would advertise a stale refetch.
-    assert runner.posts == ["/v1/sessions/conv_src/reset-state"]
+    assert runner.posts == ["/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/reset-state"]
     types = [e["type"] for e in published]
     # Exactly one invalidation per switch; zero means the Files tab never
     # learns availability changed until the 60 s staleTime + a refetch
@@ -716,8 +759,8 @@ async def test_switch_reset_publishes_changed_files_invalidated_after_reset(
     # invalidation was published while the old env was still cached.
     assert types.index("session.agent_changed") < types.index("session.changed_files.invalidated")
     event = published[types.index("session.changed_files.invalidated")]
-    assert event["_conversation_id"] == "conv_src"
-    assert event["session_id"] == "conv_src"
+    assert event["_conversation_id"] == "e9f8f58523cec9a57d3bdf93be543e8c"
+    assert event["session_id"] == "e9f8f58523cec9a57d3bdf93be543e8c"
     # The web client keys filesystem queries by the default environment.
     assert event["environment_id"] == "default"
 
@@ -750,9 +793,12 @@ async def test_switch_reset_failure_publishes_no_changed_files_event(
         ``"post_fails"`` (reset POST raises), ``"post_500"`` (reset POST
         returns HTTP 500), or ``"no_client"`` (no runner client resolved).
     """
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
     agent_store = _AgentStore(
-        {"ag_session_scoped": _CURRENT, "ag_builtin_claude": _BUILTIN_CLAUDE}
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "52adb39f0c5ea92b5563da5327dac08f": _BUILTIN_CLAUDE,
+        }
     )
     _patch_family_helpers(monkeypatch, same_family=True, native=True, labels={})
 
@@ -776,7 +822,8 @@ async def test_switch_reset_failure_publishes_no_changed_files_event(
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_claude"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "52adb39f0c5ea92b5563da5327dac08f"},
     )
 
     assert resp.status_code == 200, resp.text
@@ -796,7 +843,10 @@ async def test_switch_404_missing_session() -> None:
     agent_store = _AgentStore({})
     client = TestClient(_build_app(conv_store, agent_store))
 
-    resp = client.post("/v1/sessions/conv_missing/switch-agent", json={"agent_id": "ag_x"})
+    resp = client.post(
+        "/v1/sessions/5eca720dc2bc6cdc3a99028d7bd0f917/switch-agent",
+        json={"agent_id": "d7a89f58205a70539a16fa4b7bd06270"},
+    )
 
     assert resp.status_code == 404, resp.text
     assert conv_store.switch_calls == []
@@ -805,12 +855,15 @@ async def test_switch_404_missing_session() -> None:
 @pytest.mark.asyncio
 async def test_switch_400_sub_agent() -> None:
     """400 when the session is a sub-agent (only top-level can switch)."""
-    conv_store = _ConversationStore(conversations={"conv_src": _conv(kind="sub_agent")})
-    agent_store = _AgentStore({"ag_session_scoped": _CURRENT})
+    conv_store = _ConversationStore(
+        conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv(kind="sub_agent")}
+    )
+    agent_store = _AgentStore({"a98bb825ebd41391c19637c58fe3c0b7": _CURRENT})
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_claude"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "52adb39f0c5ea92b5563da5327dac08f"},
     )
 
     assert resp.status_code == 400, resp.text
@@ -820,12 +873,22 @@ async def test_switch_400_sub_agent() -> None:
 @pytest.mark.asyncio
 async def test_switch_404_target_not_bindable() -> None:
     """404 when the target is a session-scoped agent (not a built-in)."""
-    other_session_agent = _agent("ag_other", "other", "bundle/x", "conv_other")
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
-    agent_store = _AgentStore({"ag_session_scoped": _CURRENT, "ag_other": other_session_agent})
+    other_session_agent = _agent(
+        "8bc4385e0f8fc6477c59127fd15ea45e", "other", "bundle/x", "aef8aa8b6e9cf6eda406cb88cf33708c"
+    )
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
+    agent_store = _AgentStore(
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "8bc4385e0f8fc6477c59127fd15ea45e": other_session_agent,
+        }
+    )
     client = TestClient(_build_app(conv_store, agent_store))
 
-    resp = client.post("/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_other"})
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "8bc4385e0f8fc6477c59127fd15ea45e"},
+    )
 
     # Session-scoped target → not bindable, mapped to 404, nothing mutated.
     assert resp.status_code == 404, resp.text
@@ -835,16 +898,22 @@ async def test_switch_404_target_not_bindable() -> None:
 @pytest.mark.asyncio
 async def test_switch_409_when_busy(monkeypatch: pytest.MonkeyPatch) -> None:
     """409 when a turn is running — switching mid-turn is rejected."""
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
     agent_store = _AgentStore(
-        {"ag_session_scoped": _CURRENT, "ag_builtin_claude": _BUILTIN_CLAUDE}
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "52adb39f0c5ea92b5563da5327dac08f": _BUILTIN_CLAUDE,
+        }
     )
     # Mark the session as running in the relay status cache.
-    monkeypatch.setitem(sessions_mod._session_status_cache, "conv_src", "running")
+    monkeypatch.setitem(
+        sessions_mod._session_status_cache, "e9f8f58523cec9a57d3bdf93be543e8c", "running"
+    )
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_claude"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "52adb39f0c5ea92b5563da5327dac08f"},
     )
 
     assert resp.status_code == 409, resp.text
@@ -857,9 +926,12 @@ async def test_switch_400_unloadable_target_bundle(monkeypatch: pytest.MonkeyPat
     """400 when the target bundle can't load — fails before deleting the old
     agent, so the session is left untouched.
     """
-    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": _conv()})
     agent_store = _AgentStore(
-        {"ag_session_scoped": _CURRENT, "ag_builtin_claude": _BUILTIN_CLAUDE}
+        {
+            "a98bb825ebd41391c19637c58fe3c0b7": _CURRENT,
+            "52adb39f0c5ea92b5563da5327dac08f": _BUILTIN_CLAUDE,
+        }
     )
     _patch_family_helpers(
         monkeypatch, same_family=True, native=False, labels={}, raise_on_load=True
@@ -867,7 +939,8 @@ async def test_switch_400_unloadable_target_bundle(monkeypatch: pytest.MonkeyPat
     client = TestClient(_build_app(conv_store, agent_store))
 
     resp = client.post(
-        "/v1/sessions/conv_src/switch-agent", json={"agent_id": "ag_builtin_claude"}
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/switch-agent",
+        json={"agent_id": "52adb39f0c5ea92b5563da5327dac08f"},
     )
 
     assert resp.status_code == 400, resp.text

--- a/tests/server/routes/test_sessions_upload_limits.py
+++ b/tests/server/routes/test_sessions_upload_limits.py
@@ -31,11 +31,13 @@ def upload_client(db_uri: str, tmp_path) -> Iterator[tuple[TestClient, str]]:
     file_store = SqlAlchemyFileStore(db_uri)
     artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
     agent_store.create(
-        agent_id="ag_test",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         name="test-agent",
-        bundle_location="ag_test/bundle",
+        bundle_location="087b7cb7ac30abf4debfaa578d052ec6/bundle",
     )
-    conv = conversation_store.create_conversation(title="upload session", agent_id="ag_test")
+    conv = conversation_store.create_conversation(
+        title="upload session", agent_id="087b7cb7ac30abf4debfaa578d052ec6"
+    )
 
     app = FastAPI()
 

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -144,11 +144,13 @@ def _build_liveness_app(
     host_store = HostStore(db_uri)
     artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
     # Online host so a host-bound session reports host_online=True.
-    host_store.upsert_on_connect("host_live", "laptop", "alice@example.com")
+    host_store.upsert_on_connect("2fd786c75c03cfbbec099a6820c08b62", "laptop", "alice@example.com")
     # A host that EXISTS (so the conversations.host_id FK is satisfied) but
     # is offline, for the runner-down + host-offline state.
-    host_store.upsert_on_connect("host_offline", "old-laptop", "alice@example.com")
-    host_store.set_offline("host_offline")
+    host_store.upsert_on_connect(
+        "3d9665477127e41f42de3f4109418173", "old-laptop", "alice@example.com"
+    )
+    host_store.set_offline("3d9665477127e41f42de3f4109418173")
 
     app = create_app(
         agent_store=SqlAlchemyAgentStore(db_uri),
@@ -199,11 +201,11 @@ async def test_health_batch_reports_strict_runner_and_host_liveness(
     _register_live_runner(app, "rnr_live")
     # (b) runner bound but tunnel NOT registered, host online.
     runner_down_host_up = conversation_store.create_conversation(
-        runner_id="rnr_dead", host_id="host_live", workspace="/tmp/ws"
+        runner_id="rnr_dead", host_id="2fd786c75c03cfbbec099a6820c08b62", workspace="/tmp/ws"
     )
     # (c) runner bound but tunnel down, host offline (unknown host id).
     runner_down_host_down = conversation_store.create_conversation(
-        runner_id="rnr_dead2", host_id="host_offline", workspace="/tmp/ws"
+        runner_id="rnr_dead2", host_id="3d9665477127e41f42de3f4109418173", workspace="/tmp/ws"
     )
     # (d) runner bound but tunnel down, NO host binding.
     runner_down_no_host = conversation_store.create_conversation(runner_id="rnr_dead3")
@@ -211,7 +213,7 @@ async def test_health_batch_reports_strict_runner_and_host_liveness(
     # tunnel/host state only — the stopped marker is no longer consulted by
     # liveness. Bind a (down) runner so this isn't the no-runner terminal.
     stopped = conversation_store.create_conversation(
-        runner_id="rnr_dead4", host_id="host_live", workspace="/tmp/ws"
+        runner_id="rnr_dead4", host_id="2fd786c75c03cfbbec099a6820c08b62", workspace="/tmp/ws"
     )
     conversation_store.set_labels(stopped.id, {"omnigent.stopped": "true"})
 
@@ -222,7 +224,7 @@ async def test_health_batch_reports_strict_runner_and_host_liveness(
             runner_down_host_down.id,
             runner_down_no_host.id,
             stopped.id,
-            "conv_unknown",
+            "fee171f70cf25c4cff8203046e727fd4",
         ]
     )
     transport = httpx.ASGITransport(app=app)
@@ -278,7 +280,7 @@ async def test_health_batch_reports_strict_runner_and_host_liveness(
         "host_version": None,
     }
     # Unknown id (no conversation row) ⇒ reachable, no host.
-    assert sessions["conv_unknown"] == {
+    assert sessions["fee171f70cf25c4cff8203046e727fd4"] == {
         "runner_online": True,
         "host_online": None,
         "host_version": None,
@@ -301,7 +303,7 @@ async def test_health_single_session_reports_both_liveness_fields(
     wired = _build_liveness_app(db_uri, tmp_path)
     # Dead runner on a live host: the runner-down-but-host-alive state.
     conv = wired.conversation_store.create_conversation(
-        runner_id="rnr_dead", host_id="host_live", workspace="/tmp/ws"
+        runner_id="rnr_dead", host_id="2fd786c75c03cfbbec099a6820c08b62", workspace="/tmp/ws"
     )
     app = wired.app
 
@@ -346,13 +348,13 @@ async def test_health_reports_host_version_from_live_registry(
     # host_live is already online in the host_store (DB) via the builder;
     # registering it in the in-memory registry is what carries the version.
     app.state.host_registry.register(
-        "host_live",
+        "2fd786c75c03cfbbec099a6820c08b62",
         _StubWebSocket(),
         HostHelloFrame(version="9.9.9-test", frame_protocol_version=1, name="laptop"),
         "alice@example.com",
     )
     conv = wired.conversation_store.create_conversation(
-        runner_id="rnr_dead", host_id="host_live", workspace="/tmp/ws"
+        runner_id="rnr_dead", host_id="2fd786c75c03cfbbec099a6820c08b62", workspace="/tmp/ws"
     )
 
     transport = httpx.ASGITransport(app=app)
@@ -441,7 +443,9 @@ async def test_health_unbound_fork_of_coding_session_reads_offline(
     # Unbound forks: no runner_id, no host_id. The label is the only
     # difference between them.
     coding_fork = conversation_store.create_conversation()
-    conversation_store.set_labels(coding_fork.id, {"omnigent.fork.source_id": "conv_src"})
+    conversation_store.set_labels(
+        coding_fork.id, {"omnigent.fork.source_id": "e9f8f58523cec9a57d3bdf93be543e8c"}
+    )
     chat_fork = conversation_store.create_conversation()
 
     app = create_app(
@@ -1046,7 +1050,7 @@ async def test_api_only_unknown_path_gets_json_404(
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
         for headers in ({"accept": "text/html"}, {"accept": "application/json"}):
-            resp = await c.get("/c/conv_abc", headers=headers)
+            resp = await c.get("/c/4e92b5a0c0ee6db3f874f9c4a3f855a5", headers=headers)
             assert resp.status_code == 404, headers
             assert resp.json() == {"detail": "Not Found"}, headers
 

--- a/tests/server/test_identity_migration.py
+++ b/tests/server/test_identity_migration.py
@@ -113,8 +113,8 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
     with Session(engine) as s:
         s.add(
             SqlComment(
-                id="cmt_1",
-                conversation_id="conv_x",
+                id="747618b4b2dd94383e50ddf180ceddc3",
+                conversation_id="8af356d908005a65f872c246158c6293",
                 path="a.py",
                 start_index=0,
                 end_index=1,
@@ -128,7 +128,7 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
         )
         s.add(
             SqlPolicy(
-                id="pol_1",
+                id="12a6858438cb1aa1b9e00dc79bb04dd9",
                 name="p",
                 session_id=None,
                 scope=encode_policy_scope("default"),
@@ -152,7 +152,7 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
             SqlHost(
                 owner="alice",
                 name="laptop",
-                host_id="h1",
+                host_id="a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
                 status=encode_host_status("offline"),
                 created_at=1,
                 updated_at=1,
@@ -163,8 +163,14 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
     remap_identities(engine, {"alice": "alice@example.com"}, dry_run=False)
 
     with Session(engine) as s:
-        assert s.get(SqlComment, (0, "cmt_1")).created_by == "alice@example.com"
-        assert s.get(SqlPolicy, (0, "pol_1")).created_by == "alice@example.com"
+        assert (
+            s.get(SqlComment, (0, "747618b4b2dd94383e50ddf180ceddc3")).created_by
+            == "alice@example.com"
+        )
+        assert (
+            s.get(SqlPolicy, (0, "12a6858438cb1aa1b9e00dc79bb04dd9")).created_by
+            == "alice@example.com"
+        )
         assert s.get(SqlAccountToken, (0, "tok_1")).created_by == "alice@example.com"
         host_owners = s.execute(select(SqlHost.owner)).scalars().all()
         assert host_owners == ["alice@example.com"]

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -1472,7 +1472,7 @@ async def test_relaunch_rejects_unconfigured_provider(db_uri: str) -> None:
     """
     host_store = HostStore(db_uri)
     host = host_store.register_managed_host(
-        host_id="host_relaunch_mismatch",
+        host_id="8369cb15e751573a1ee641d5fa09c70a",
         name="managed-mismatch",
         owner=_OWNER,
         token="tok",
@@ -1507,7 +1507,7 @@ async def test_host_resume_supported_requires_resumable_matching_launcher(db_uri
     """The wake gate requires matching provider, sandbox id, and ``can_resume``."""
     host_store = HostStore(db_uri)
     host = host_store.register_managed_host(
-        host_id="host_resume_gate",
+        host_id="292a6322075a34e482fde44975da10f3",
         name="managed-resume-gate",
         owner=_OWNER,
         token="tok-resume-gate",
@@ -1526,7 +1526,7 @@ async def test_host_resume_supported_requires_resumable_matching_launcher(db_uri
     assert host_resume_supported(host, _injected_config(mismatched)) is False
 
     no_sandbox = host_store.register_managed_host(
-        host_id="host_resume_no_sandbox",
+        host_id="0c3d744a455047df9a3c0acf432d08dd",
         name="managed-resume-no-sandbox",
         owner=_OWNER,
         token="tok-resume-no-sandbox",
@@ -1582,7 +1582,7 @@ async def test_resume_managed_host_force_wakes_fresh_online_row(db_uri: str) -> 
     """A local missing-tunnel wake can bypass stale cross-replica DB freshness."""
     host_store = HostStore(db_uri)
     host_store.register_managed_host(
-        host_id="host_resume_force",
+        host_id="62d4405ba38711fe34bebfeb5a7adaf2",
         name="managed-resume-force",
         owner=_OWNER,
         token="tok-resume-force",
@@ -1591,27 +1591,29 @@ async def test_resume_managed_host_force_wakes_fresh_online_row(db_uri: str) -> 
         token_expires_at=now_epoch() + 3600,
     )
     host_store.upsert_on_connect(
-        host_id="host_resume_force",
+        host_id="62d4405ba38711fe34bebfeb5a7adaf2",
         name="managed-resume-force",
         owner=_OWNER,
     )
-    assert host_store.is_online("host_resume_force") is True
+    assert host_store.is_online("62d4405ba38711fe34bebfeb5a7adaf2") is True
     fake = _IsloFakeLauncher(can_resume=True)
 
-    await resume_managed_host("host_resume_force", host_store, _injected_config(fake), force=True)
+    await resume_managed_host(
+        "62d4405ba38711fe34bebfeb5a7adaf2", host_store, _injected_config(fake), force=True
+    )
 
     assert fake.resumed == ["sb-resume-force"]
     assert len(fake.host_starts) == 1
     assert host_store.resolve_launch_token("tok-resume-force") is None
     resolved = host_store.resolve_launch_token(fake.host_starts[0].token)
-    assert resolved is not None and resolved.host_id == "host_resume_force"
+    assert resolved is not None and resolved.host_id == "62d4405ba38711fe34bebfeb5a7adaf2"
 
 
 async def test_resume_managed_host_noops_for_non_resumable_provider(db_uri: str) -> None:
     """Non-resumable providers fall through without mutating the host row."""
     host_store = HostStore(db_uri)
     host_store.register_managed_host(
-        host_id="host_resume_noop",
+        host_id="249d058fbcde7b2ce941479cdb8c82d7",
         name="managed-resume-noop",
         owner=_OWNER,
         token="tok-resume-noop",
@@ -1621,11 +1623,13 @@ async def test_resume_managed_host_noops_for_non_resumable_provider(db_uri: str)
     )
     fake = FakeSandboxLauncher(can_resume=False)
 
-    await resume_managed_host("host_resume_noop", host_store, _injected_config(fake))
+    await resume_managed_host(
+        "249d058fbcde7b2ce941479cdb8c82d7", host_store, _injected_config(fake)
+    )
 
     assert fake.resumed == []
     assert fake.host_starts == []
-    host = host_store.get_host("host_resume_noop")
+    host = host_store.get_host("249d058fbcde7b2ce941479cdb8c82d7")
     assert host is not None
     assert host.status == "offline"
     assert host.sandbox_id == "sb-resume-noop"
@@ -1636,7 +1640,7 @@ async def test_resume_managed_host_failure_preserves_existing_row_and_token(db_u
     """A failed wake leaves the dormant host retryable."""
     host_store = HostStore(db_uri)
     host_store.register_managed_host(
-        host_id="host_resume_fail",
+        host_id="efbef7dede7be6577770cbb1287992f2",
         name="managed-resume-fail",
         owner=_OWNER,
         token="tok-resume-fail",
@@ -1647,12 +1651,14 @@ async def test_resume_managed_host_failure_preserves_existing_row_and_token(db_u
     fake = _IsloFakeLauncher(can_resume=True, fail_on_resume=True)
 
     with pytest.raises(HTTPException) as exc:
-        await resume_managed_host("host_resume_fail", host_store, _injected_config(fake))
+        await resume_managed_host(
+            "efbef7dede7be6577770cbb1287992f2", host_store, _injected_config(fake)
+        )
 
     assert exc.value.status_code == 502
     assert "managed host wake failed" in exc.value.detail
     assert fake.host_starts == []
-    host = host_store.get_host("host_resume_fail")
+    host = host_store.get_host("efbef7dede7be6577770cbb1287992f2")
     assert host is not None
     assert host.status == "offline"
     assert host.sandbox_id == "sb-resume-fail"
@@ -1671,7 +1677,7 @@ async def test_terminate_managed_host_terminates_and_deletes_row(db_uri: str) ->
     fake = FakeSandboxLauncher()
     host_store = HostStore(db_uri)
     host = host_store.register_managed_host(
-        host_id="host_term_1",
+        host_id="62a91eb065624754c6a6dfb5869dd7e8",
         name="managed-term1",
         owner=_OWNER,
         token="tok-term-1",
@@ -1683,7 +1689,7 @@ async def test_terminate_managed_host_terminates_and_deletes_row(db_uri: str) ->
     await terminate_managed_host(host, host_store, _injected_config(fake))
 
     assert fake.terminated == ["sb-term-1"]
-    assert host_store.get_host("host_term_1") is None
+    assert host_store.get_host("62a91eb065624754c6a6dfb5869dd7e8") is None
     assert host_store.resolve_launch_token("tok-term-1") is None
 
 
@@ -1704,7 +1710,7 @@ async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(
     monkeypatch.setattr(fake, "terminate", _explode)
     host_store = HostStore(db_uri)
     host = host_store.register_managed_host(
-        host_id="host_term_2",
+        host_id="057e7fa3f1cdb40c0ec393a3d42affc7",
         name="managed-term2",
         owner=_OWNER,
         token="tok-term-2",
@@ -1715,7 +1721,7 @@ async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(
 
     await terminate_managed_host(host, host_store, _injected_config(fake))
 
-    assert host_store.get_host("host_term_2") is None
+    assert host_store.get_host("057e7fa3f1cdb40c0ec393a3d42affc7") is None
     assert host_store.resolve_launch_token("tok-term-2") is None
 
 
@@ -1730,7 +1736,7 @@ async def test_terminate_managed_host_skips_mismatched_provider(db_uri: str) -> 
     fake = FakeSandboxLauncher()  # provider "modal"
     host_store = HostStore(db_uri)
     host = host_store.register_managed_host(
-        host_id="host_term_3",
+        host_id="487212fd2b157b6ab6a6d6d3ef06ce5b",
         name="managed-term3",
         owner=_OWNER,
         token="tok-term-3",
@@ -1743,12 +1749,12 @@ async def test_terminate_managed_host_skips_mismatched_provider(db_uri: str) -> 
     await terminate_managed_host(host, host_store, _injected_config(fake))
     # No cross-provider terminate was attempted.
     assert fake.terminated == []
-    assert host_store.get_host("host_term_3") is None
+    assert host_store.get_host("487212fd2b157b6ab6a6d6d3ef06ce5b") is None
     assert host_store.resolve_launch_token("tok-term-3") is None
 
     # config=None behaves the same: row deleted, nothing terminated.
     host2 = host_store.register_managed_host(
-        host_id="host_term_4",
+        host_id="b114bf90a8fd155ce6007c3bb262aa79",
         name="managed-term4",
         owner=_OWNER,
         token="tok-term-4",
@@ -1757,7 +1763,7 @@ async def test_terminate_managed_host_skips_mismatched_provider(db_uri: str) -> 
         token_expires_at=now_epoch() + 3600,
     )
     await terminate_managed_host(host2, host_store, None)
-    assert host_store.get_host("host_term_4") is None
+    assert host_store.get_host("b114bf90a8fd155ce6007c3bb262aa79") is None
 
 
 def test_parse_modal_secrets_thread_to_launcher(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/server/test_performance_metrics.py
+++ b/tests/server/test_performance_metrics.py
@@ -888,7 +888,11 @@ async def test_create_app_metrics_middleware_counts_http_requests(
 
     resp = await client.get(
         "/health",
-        params={"session_ids": "conv_one,conv_two"},
+        # Valid bare-hex ids: session_ids bind to Uuid16, so a non-uuid would
+        # now 404 the batch (InvalidUuidError) instead of returning 200-empty.
+        params={
+            "session_ids": "dbb8b733fdfaca2c150b42317d3829f6,f8fb0016d56510e7e6b3ee8618d78415"
+        },
     )
 
     after = app.state.server_metrics.snapshot()

--- a/tests/stores/test_agent_store.py
+++ b/tests/stores/test_agent_store.py
@@ -12,9 +12,11 @@ from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 
 def test_create_and_get(agent_store: SqlAlchemyAgentStore) -> None:
     agent = agent_store.create(
-        agent_id="ag_test_gpt4", name="gpt-4", bundle_location="ag_test_gpt4/fakehash"
+        agent_id="88089a8b5dd4eb29fe17d41b2b028cfa",
+        name="gpt-4",
+        bundle_location="ag_test_gpt4/fakehash",
     )
-    assert agent.id.startswith("ag_")
+    assert len(agent.id) == 32
     assert agent.name == "gpt-4"
 
     fetched = agent_store.get(agent.id)
@@ -24,12 +26,14 @@ def test_create_and_get(agent_store: SqlAlchemyAgentStore) -> None:
 
 
 def test_get_nonexistent(agent_store: SqlAlchemyAgentStore) -> None:
-    assert agent_store.get("ag_nonexistent") is None
+    assert agent_store.get("5ff5b2e31fe10beb80134394037b17b0") is None
 
 
 def test_get_by_name(agent_store: SqlAlchemyAgentStore) -> None:
     agent_store.create(
-        agent_id="ag_test_claude", name="claude", bundle_location="ag_test_claude/fakehash"
+        agent_id="d949d15d8243d399d68ce236abee269d",
+        name="claude",
+        bundle_location="ag_test_claude/fakehash",
     )
     found = agent_store.get_by_name("claude")
     assert found is not None
@@ -43,10 +47,16 @@ def test_create_rejects_duplicate_template_name(agent_store: SqlAlchemyAgentStor
     The DB has no partial unique index (MySQL can't build one), so the store's
     create() is the guard.
     """
-    agent_store.create(agent_id="ag_dup_a", name="dup-name", bundle_location="ag_dup_a/fakehash")
+    agent_store.create(
+        agent_id="7881b57b13260d58fd37b103ee69db65",
+        name="dup-name",
+        bundle_location="ag_dup_a/fakehash",
+    )
     with pytest.raises(IntegrityError):
         agent_store.create(
-            agent_id="ag_dup_b", name="dup-name", bundle_location="ag_dup_b/fakehash"
+            agent_id="d924ef7a50570dbbf38c67b059afc7ef",
+            name="dup-name",
+            bundle_location="ag_dup_b/fakehash",
         )
 
 
@@ -64,7 +74,9 @@ def test_get_by_name_and_list_hide_session_scoped_agents(
                 "(id, created_at, updated_at, root_conversation_id) "
                 "VALUES (:id, :ts, :ts, :id)",
             ),
-            {"id": "conv_agent_store_session", "ts": 1700000000},
+            # Raw SQL bypasses the Uuid16 TypeDecorator, so bind 16 raw bytes;
+            # a 32-char hex string overflows the BINARY(16) column on MySQL.
+            {"id": bytes.fromhex("3e2c8fc48e056223d18a47a8d4660491"), "ts": 1700000000},
         )
         conn.execute(
             sa.text(
@@ -73,14 +85,14 @@ def test_get_by_name_and_list_hide_session_scoped_agents(
                 "VALUES (:id, :ts, :name, :loc, 1, 2)",  # kind=2 → 'session'
             ),
             {
-                "id": "ag_agent_store_session",
+                "id": bytes.fromhex("6ec5d35246127ba7b23bd47aa95208ec"),
                 "ts": 1700000001,
                 "name": "session-only-agent",
                 "loc": "ag_agent_store_session/bundle",
             },
         )
     template_agent = agent_store.create(
-        agent_id="ag_agent_store_template",
+        agent_id="ee6a8659002db5242a56278b73f7a06d",
         name="template-agent",
         bundle_location="ag_agent_store_template/bundle",
     )
@@ -94,7 +106,7 @@ def test_get_by_name_and_list_hide_session_scoped_agents(
 
 def test_create_with_description(agent_store: SqlAlchemyAgentStore) -> None:
     agent = agent_store.create(
-        agent_id="ag_test_helper",
+        agent_id="81b344a1abb05d6096989e2aff583e37",
         name="helper",
         bundle_location="ag_test_helper/fakehash",
         description="A helper agent",
@@ -104,7 +116,9 @@ def test_create_with_description(agent_store: SqlAlchemyAgentStore) -> None:
 
 def test_delete(agent_store: SqlAlchemyAgentStore) -> None:
     agent = agent_store.create(
-        agent_id="ag_test_temp", name="temp", bundle_location="ag_test_temp/fakehash"
+        agent_id="ef3b53ae229c2fa6af1e4189fa27b74e",
+        name="temp",
+        bundle_location="ag_test_temp/fakehash",
     )
     assert agent_store.delete(agent.id) is True
     assert agent_store.get(agent.id) is None
@@ -114,7 +128,7 @@ def test_delete(agent_store: SqlAlchemyAgentStore) -> None:
 def test_list_pagination(agent_store: SqlAlchemyAgentStore) -> None:
     for i in range(5):
         agent_store.create(
-            agent_id=f"ag_test_{i}", name=f"agent-{i}", bundle_location=f"ag_test_{i}/fakehash"
+            agent_id=f"{i:032x}", name=f"agent-{i}", bundle_location=f"{i:032x}/fakehash"
         )
 
     page1 = agent_store.list(limit=2)
@@ -132,10 +146,14 @@ def test_list_pagination(agent_store: SqlAlchemyAgentStore) -> None:
 
 def test_list_returns_newest_first(agent_store: SqlAlchemyAgentStore) -> None:
     a1 = agent_store.create(
-        agent_id="ag_test_first", name="first", bundle_location="ag_test_first/fakehash"
+        agent_id="7dc777d26c3e1b66897f9fa0bf4848fb",
+        name="first",
+        bundle_location="ag_test_first/fakehash",
     )
     a2 = agent_store.create(
-        agent_id="ag_test_second", name="second", bundle_location="ag_test_second/fakehash"
+        agent_id="c7ba0ac9893ab0ecef5f36f17b808045",
+        name="second",
+        bundle_location="ag_test_second/fakehash",
     )
     page = agent_store.list()
     ids = {a.id for a in page.data}
@@ -147,7 +165,7 @@ def test_list_returns_newest_first(agent_store: SqlAlchemyAgentStore) -> None:
 def test_list_order_asc(agent_store: SqlAlchemyAgentStore) -> None:
     for i in range(3):
         agent_store.create(
-            agent_id=f"ag_test_{i}", name=f"agent-{i}", bundle_location=f"ag_test_{i}/fakehash"
+            agent_id=f"{i:032x}", name=f"agent-{i}", bundle_location=f"{i:032x}/fakehash"
         )
     page_desc = agent_store.list(order="desc")
     page_asc = agent_store.list(order="asc")
@@ -157,7 +175,7 @@ def test_list_order_asc(agent_store: SqlAlchemyAgentStore) -> None:
 def test_list_before_cursor(agent_store: SqlAlchemyAgentStore) -> None:
     for i in range(5):
         agent_store.create(
-            agent_id=f"ag_test_{i}", name=f"agent-{i}", bundle_location=f"ag_test_{i}/fakehash"
+            agent_id=f"{i:032x}", name=f"agent-{i}", bundle_location=f"{i:032x}/fakehash"
         )
     # Paginate with after, then use before on the last page's first item
     # to go backwards and verify no overlap.
@@ -171,7 +189,7 @@ def test_list_before_cursor(agent_store: SqlAlchemyAgentStore) -> None:
 def test_list_asc_with_after_cursor(agent_store: SqlAlchemyAgentStore) -> None:
     for i in range(5):
         agent_store.create(
-            agent_id=f"ag_test_{i}", name=f"agent-{i}", bundle_location=f"ag_test_{i}/fakehash"
+            agent_id=f"{i:032x}", name=f"agent-{i}", bundle_location=f"{i:032x}/fakehash"
         )
     page1 = agent_store.list(limit=2, order="asc")
     assert len(page1.data) == 2
@@ -197,7 +215,7 @@ def test_list_asc_with_after_cursor(agent_store: SqlAlchemyAgentStore) -> None:
 def test_update_agent(agent_store: SqlAlchemyAgentStore) -> None:
     """update() changes bundle_location, bumps version, sets updated_at."""
     agent = agent_store.create(
-        agent_id="ag_test_upd",
+        agent_id="409a6849f6efefc6ba8da809a29b9b0b",
         name="updatable",
         bundle_location="ag_test_upd/hash1",
     )
@@ -205,7 +223,7 @@ def test_update_agent(agent_store: SqlAlchemyAgentStore) -> None:
     assert agent.version == 1
     assert agent.updated_at is None
 
-    updated = agent_store.update("ag_test_upd", "ag_test_upd/hash2")
+    updated = agent_store.update("409a6849f6efefc6ba8da809a29b9b0b", "ag_test_upd/hash2")
     assert updated is not None
     assert updated.version == 2
     assert updated.bundle_location == "ag_test_upd/hash2"
@@ -216,18 +234,18 @@ def test_update_agent(agent_store: SqlAlchemyAgentStore) -> None:
 
 def test_update_nonexistent_agent(agent_store: SqlAlchemyAgentStore) -> None:
     """update() returns None for a nonexistent agent."""
-    assert agent_store.update("ag_nonexistent", "loc") is None
+    assert agent_store.update("5ff5b2e31fe10beb80134394037b17b0", "loc") is None
 
 
 def test_update_increments_version(agent_store: SqlAlchemyAgentStore) -> None:
     """Multiple updates increment version monotonically."""
     agent_store.create(
-        agent_id="ag_test_ver",
+        agent_id="9dafdd1d4311d9f16337323a6d653308",
         name="versioned",
         bundle_location="ag_test_ver/h1",
     )
-    v2 = agent_store.update("ag_test_ver", "ag_test_ver/h2")
-    v3 = agent_store.update("ag_test_ver", "ag_test_ver/h3")
+    v2 = agent_store.update("9dafdd1d4311d9f16337323a6d653308", "ag_test_ver/h2")
+    v3 = agent_store.update("9dafdd1d4311d9f16337323a6d653308", "ag_test_ver/h3")
     assert v2 is not None and v2.version == 2
     assert v3 is not None and v3.version == 3
 
@@ -235,7 +253,7 @@ def test_update_increments_version(agent_store: SqlAlchemyAgentStore) -> None:
 def test_create_agent_has_version_1(agent_store: SqlAlchemyAgentStore) -> None:
     """Newly created agents start at version 1."""
     agent = agent_store.create(
-        agent_id="ag_test_v1",
+        agent_id="3b1917f10e098e91d3e2fe6bd30104ef",
         name="fresh",
         bundle_location="ag_test_v1/hash",
     )
@@ -248,17 +266,34 @@ def test_create_agent_has_version_1(agent_store: SqlAlchemyAgentStore) -> None:
 
 def test_get_names_returns_id_to_name_mapping(agent_store: SqlAlchemyAgentStore) -> None:
     """get_names batch-fetches agent names by ID."""
-    agent_store.create(agent_id="ag_names_a", name="alpha", bundle_location="ag_names_a/hash")
-    agent_store.create(agent_id="ag_names_b", name="beta", bundle_location="ag_names_b/hash")
-    result = agent_store.get_names(["ag_names_a", "ag_names_b"])
-    assert result == {"ag_names_a": "alpha", "ag_names_b": "beta"}
+    agent_store.create(
+        agent_id="3f1269c64e8e0dae1e03bd1472ff4d84",
+        name="alpha",
+        bundle_location="ag_names_a/hash",
+    )
+    agent_store.create(
+        agent_id="1dd1e3e87699fdd5c6d60680291dbaef", name="beta", bundle_location="ag_names_b/hash"
+    )
+    result = agent_store.get_names(
+        ["3f1269c64e8e0dae1e03bd1472ff4d84", "1dd1e3e87699fdd5c6d60680291dbaef"]
+    )
+    assert result == {
+        "3f1269c64e8e0dae1e03bd1472ff4d84": "alpha",
+        "1dd1e3e87699fdd5c6d60680291dbaef": "beta",
+    }
 
 
 def test_get_names_omits_missing_ids(agent_store: SqlAlchemyAgentStore) -> None:
     """get_names silently omits IDs not found in the store."""
-    agent_store.create(agent_id="ag_names_c", name="gamma", bundle_location="ag_names_c/hash")
-    result = agent_store.get_names(["ag_names_c", "ag_nonexistent"])
-    assert result == {"ag_names_c": "gamma"}
+    agent_store.create(
+        agent_id="e78cb9ee170f482daddce8809f06daec",
+        name="gamma",
+        bundle_location="ag_names_c/hash",
+    )
+    result = agent_store.get_names(
+        ["e78cb9ee170f482daddce8809f06daec", "5ff5b2e31fe10beb80134394037b17b0"]
+    )
+    assert result == {"e78cb9ee170f482daddce8809f06daec": "gamma"}
 
 
 def test_get_names_empty_input(agent_store: SqlAlchemyAgentStore) -> None:
@@ -280,5 +315,5 @@ def test_list_empty(agent_store: SqlAlchemyAgentStore) -> None:
 
 def test_delete_nonexistent_returns_false(agent_store: SqlAlchemyAgentStore) -> None:
     """delete returns False for an ID that was never created."""
-    result = agent_store.delete("ag_never_existed")
+    result = agent_store.delete("5996d55aa263c10a717e2ee631f46409")
     assert result is False

--- a/tests/stores/test_comment_store.py
+++ b/tests/stores/test_comment_store.py
@@ -36,7 +36,7 @@ def test_add_returns_comment_with_id(store: SqlAlchemyCommentStore) -> None:
     one of the field mappings is broken.
     """
     comment = store.add(
-        conversation_id="conv_abc",
+        conversation_id="4e92b5a0c0ee6db3f874f9c4a3f855a5",
         path="src/app.py",
         body="Needs a null check",
         start_index=4,
@@ -45,7 +45,7 @@ def test_add_returns_comment_with_id(store: SqlAlchemyCommentStore) -> None:
 
     # The store must assign a non-empty UUID-style id.
     assert comment.id, "add() must return a Comment with a non-empty id"
-    assert comment.conversation_id == "conv_abc", (
+    assert comment.conversation_id == "4e92b5a0c0ee6db3f874f9c4a3f855a5", (
         "conversation_id must be echoed back exactly as given"
     )
     assert comment.path == "src/app.py"
@@ -75,7 +75,7 @@ def test_add_stores_created_by(store: SqlAlchemyCommentStore) -> None:
     back onto the entity.
     """
     comment = store.add(
-        conversation_id="conv_author",
+        conversation_id="bc66b3c6d6a8fddc36e804f8117ce753",
         path="src/app.py",
         body="Review this",
         start_index=0,
@@ -90,7 +90,7 @@ def test_add_stores_created_by(store: SqlAlchemyCommentStore) -> None:
     )
 
     # get() must also return the stored author.
-    fetched = store.get(comment.id, "conv_author")
+    fetched = store.get(comment.id, "bc66b3c6d6a8fddc36e804f8117ce753")
     assert fetched is not None
     assert fetched.created_by == "alice@example.com", (
         f"Expected created_by='alice@example.com' from get(), got {fetched.created_by!r}. "
@@ -105,14 +105,14 @@ def test_add_is_persisted_and_retrievable(store: SqlAlchemyCommentStore) -> None
     in-memory.
     """
     comment = store.add(
-        conversation_id="conv_persist",
+        conversation_id="13e400f5eb2c30843ef6962d4d7755e2",
         path="utils.py",
         body="Add type hint",
         start_index=0,
         end_index=10,
     )
 
-    listed = store.list_for_conversation("conv_persist")
+    listed = store.list_for_conversation("13e400f5eb2c30843ef6962d4d7755e2")
 
     # Exactly one comment should exist for this fresh conversation.
     assert len(listed) == 1, (
@@ -129,21 +129,21 @@ def test_add_is_persisted_and_retrievable(store: SqlAlchemyCommentStore) -> None
 def test_list_for_conversation_returns_all_comments(store: SqlAlchemyCommentStore) -> None:
     """``list_for_conversation`` without path filter returns all comments."""
     store.add(
-        conversation_id="conv_list",
+        conversation_id="e4607e40f7b85bc408d00d2e11aec4d2",
         path="a.py",
         body="First",
         start_index=0,
         end_index=5,
     )
     store.add(
-        conversation_id="conv_list",
+        conversation_id="e4607e40f7b85bc408d00d2e11aec4d2",
         path="b.py",
         body="Second",
         start_index=0,
         end_index=6,
     )
 
-    all_comments = store.list_for_conversation("conv_list")
+    all_comments = store.list_for_conversation("e4607e40f7b85bc408d00d2e11aec4d2")
 
     # Both comments must be returned.
     assert len(all_comments) == 2, (
@@ -160,22 +160,22 @@ def test_list_for_conversation_with_path_filter(store: SqlAlchemyCommentStore) -
     A comment on a.py must not appear when listing b.py.
     """
     store.add(
-        conversation_id="conv_filter",
+        conversation_id="e409b3624c5039913b6f0657675b9acd",
         path="a.py",
         body="On A",
         start_index=0,
         end_index=4,
     )
     store.add(
-        conversation_id="conv_filter",
+        conversation_id="e409b3624c5039913b6f0657675b9acd",
         path="b.py",
         body="On B",
         start_index=0,
         end_index=4,
     )
 
-    a_only = store.list_for_conversation("conv_filter", path="a.py")
-    b_only = store.list_for_conversation("conv_filter", path="b.py")
+    a_only = store.list_for_conversation("e409b3624c5039913b6f0657675b9acd", path="a.py")
+    b_only = store.list_for_conversation("e409b3624c5039913b6f0657675b9acd", path="b.py")
 
     # Each filtered list must contain exactly the matching comment.
     assert len(a_only) == 1, (
@@ -192,7 +192,7 @@ def test_list_for_conversation_returns_empty_for_unknown_conversation(
     store: SqlAlchemyCommentStore,
 ) -> None:
     """``list_for_conversation`` returns [] for a conversation with no comments."""
-    result = store.list_for_conversation("conv_nobody")
+    result = store.list_for_conversation("690f81b3f95c89d694ed36677e79b8d5")
 
     # The result must be an empty list, not None or an error.
     assert result == [], f"Expected [] for an unknown conversation, got {result!r}"
@@ -204,14 +204,14 @@ def test_list_for_conversation_isolation(store: SqlAlchemyCommentStore) -> None:
     The conversation_id must act as an isolation boundary.
     """
     store.add(
-        conversation_id="conv_A",
+        conversation_id="016472d05105672ff7823ebd24f63f54",
         path="x.py",
         body="Only in A",
         start_index=0,
         end_index=9,
     )
 
-    b_comments = store.list_for_conversation("conv_B")
+    b_comments = store.list_for_conversation("6a9338d893871f06de26f91e33256762")
 
     # Conversation B must see zero comments even though conv_A has one.
     assert b_comments == [], (
@@ -241,21 +241,21 @@ def test_list_for_conversation_ordered_by_created_at(
     monkeypatch.setattr(_comment_store_mod, "now_epoch_us", _fake_now_us)
 
     c1 = store.add(
-        conversation_id="conv_order",
+        conversation_id="55b5a773fd6bb455278827feb67a0127",
         path="z.py",
         body="First added",
         start_index=0,
         end_index=5,
     )
     c2 = store.add(
-        conversation_id="conv_order",
+        conversation_id="55b5a773fd6bb455278827feb67a0127",
         path="a.py",
         body="Second added",
         start_index=0,
         end_index=6,
     )
 
-    listed = store.list_for_conversation("conv_order")
+    listed = store.list_for_conversation("55b5a773fd6bb455278827feb67a0127")
 
     # Must be chronological: c1 was added first.
     assert listed[0].id == c1.id, (
@@ -275,14 +275,14 @@ def test_get_returns_comment_by_id(store: SqlAlchemyCommentStore) -> None:
     returned entity has stale/missing field values.
     """
     comment = store.add(
-        conversation_id="conv_get",
+        conversation_id="63cd814e740a2275ab480c351f81868f",
         path="read_me.py",
         body="Checked via get",
         start_index=2,
         end_index=15,
     )
 
-    fetched = store.get(comment.id, "conv_get")
+    fetched = store.get(comment.id, "63cd814e740a2275ab480c351f81868f")
 
     # Must return the same comment, not None.
     assert fetched is not None, (
@@ -290,7 +290,7 @@ def test_get_returns_comment_by_id(store: SqlAlchemyCommentStore) -> None:
         "The row was not persisted or get() is not querying correctly."
     )
     assert fetched.id == comment.id
-    assert fetched.conversation_id == "conv_get"
+    assert fetched.conversation_id == "63cd814e740a2275ab480c351f81868f"
     assert fetched.path == "read_me.py"
     assert fetched.start_index == 2
     assert fetched.end_index == 15
@@ -306,7 +306,7 @@ def test_get_returns_none_for_missing_id(store: SqlAlchemyCommentStore) -> None:
 
     Verifies the no-row path returns None rather than raising.
     """
-    result = store.get("nonexistent-uuid-for-get", "conv_9f8e7d")
+    result = store.get("00000000000000000000000000000000", "d6610fc1b7529112f8d20ddb46157fcd")
 
     assert result is None, (
         f"Expected None for an unknown comment id, got {result!r}. "
@@ -323,7 +323,7 @@ def test_get_returns_none_for_wrong_conversation(store: SqlAlchemyCommentStore) 
     broken and any conversation could read another's comments by id.
     """
     comment = store.add(
-        conversation_id="conv_a1b2c3",
+        conversation_id="a360e9ad819305d9cc7e6bcdbb715734",
         path="owned.py",
         body="Belongs to conv_owner",
         start_index=0,
@@ -331,14 +331,14 @@ def test_get_returns_none_for_wrong_conversation(store: SqlAlchemyCommentStore) 
     )
 
     # Same id, but scoped to a different conversation -> not found.
-    cross = store.get(comment.id, "conv_d4e5f6")
+    cross = store.get(comment.id, "0588a1f3d6aaf7721d0346dc9acda91a")
     assert cross is None, (
         f"Expected None for a comment owned by a different conversation, got {cross!r}. "
         "get() must scope by conversation_id so callers cannot read across conversations."
     )
 
     # The owning conversation still sees it.
-    owned = store.get(comment.id, "conv_a1b2c3")
+    owned = store.get(comment.id, "a360e9ad819305d9cc7e6bcdbb715734")
     assert owned is not None and owned.id == comment.id, (
         "get() scoped to the owning conversation must still return the comment."
     )
@@ -351,18 +351,18 @@ def test_get_does_not_mutate_status(store: SqlAlchemyCommentStore) -> None:
     comment must still be visible with the original status in listings.
     """
     comment = store.add(
-        conversation_id="conv_get_immut",
+        conversation_id="353741d964e52efa38e74f95262504c1",
         path="stable.py",
         body="Should not change",
         start_index=0,
         end_index=6,
     )
 
-    store.get(comment.id, "conv_get_immut")
-    store.get(comment.id, "conv_get_immut")
+    store.get(comment.id, "353741d964e52efa38e74f95262504c1")
+    store.get(comment.id, "353741d964e52efa38e74f95262504c1")
 
     # The listing must show the original draft status unchanged.
-    listed = store.list_for_conversation("conv_get_immut")
+    listed = store.list_for_conversation("353741d964e52efa38e74f95262504c1")
     assert len(listed) == 1
     assert listed[0].status == "draft", (
         f"Status changed after get() calls — expected 'draft', got {listed[0].status!r}. "
@@ -376,14 +376,16 @@ def test_get_does_not_mutate_status(store: SqlAlchemyCommentStore) -> None:
 def test_update_comment_status(store: SqlAlchemyCommentStore) -> None:
     """``update_comment`` with status= changes the status field only."""
     comment = store.add(
-        conversation_id="conv_upd",
+        conversation_id="59531909b1769df186f9668695aa3600",
         path="api.py",
         body="Original",
         start_index=0,
         end_index=8,
     )
 
-    updated = store.update_comment(comment.id, "conv_upd", status="addressed")
+    updated = store.update_comment(
+        comment.id, "59531909b1769df186f9668695aa3600", status="addressed"
+    )
 
     assert updated is not None, "update_comment must return the updated Comment"
     # Status must be the new value.
@@ -401,14 +403,14 @@ def test_update_comment_status(store: SqlAlchemyCommentStore) -> None:
 def test_update_comment_body(store: SqlAlchemyCommentStore) -> None:
     """``update_comment`` with body= changes the body field only."""
     comment = store.add(
-        conversation_id="conv_upd_body",
+        conversation_id="5a3f8f94d838a8024b482475e2ce5c2f",
         path="api.py",
         body="Old text",
         start_index=0,
         end_index=8,
     )
 
-    updated = store.update_comment(comment.id, "conv_upd_body", body="New text")
+    updated = store.update_comment(comment.id, "5a3f8f94d838a8024b482475e2ce5c2f", body="New text")
 
     assert updated is not None
     assert updated.body == "New text", f"Expected body 'New text', got {updated.body!r}"
@@ -422,14 +424,16 @@ def test_update_comment_body(store: SqlAlchemyCommentStore) -> None:
 def test_update_comment_both_fields(store: SqlAlchemyCommentStore) -> None:
     """``update_comment`` with both status= and body= updates both."""
     comment = store.add(
-        conversation_id="conv_upd_both",
+        conversation_id="708fc3472d67328c52fec6bfc43f6182",
         path="x.py",
         body="Before",
         start_index=0,
         end_index=6,
     )
 
-    updated = store.update_comment(comment.id, "conv_upd_both", status="addressed", body="After")
+    updated = store.update_comment(
+        comment.id, "708fc3472d67328c52fec6bfc43f6182", status="addressed", body="After"
+    )
 
     assert updated is not None
     assert updated.status == "addressed"
@@ -438,7 +442,9 @@ def test_update_comment_both_fields(store: SqlAlchemyCommentStore) -> None:
 
 def test_update_comment_returns_none_for_missing(store: SqlAlchemyCommentStore) -> None:
     """``update_comment`` returns ``None`` when the comment id does not exist."""
-    result = store.update_comment("nonexistent-uuid-xyz", "conv_5c6d7e", status="addressed")
+    result = store.update_comment(
+        "00000000000000000000000000000000", "55170ff064f7338e4b05f102f14ddbe4", status="addressed"
+    )
 
     # Must return None, not raise, for an unknown id.
     assert result is None, f"Expected None for an unknown comment id, got {result!r}"
@@ -452,21 +458,23 @@ def test_update_comment_wrong_conversation_is_noop(store: SqlAlchemyCommentStore
     the stored status is left unchanged.
     """
     comment = store.add(
-        conversation_id="conv_1a2b3c",
+        conversation_id="a108c9671b5941a44e5e53fef4204487",
         path="api.py",
         body="Original",
         start_index=0,
         end_index=8,
     )
 
-    result = store.update_comment(comment.id, "conv_4d5e6f", status="addressed")
+    result = store.update_comment(
+        comment.id, "fb660c10d90982cbb634c240244a7c0c", status="addressed"
+    )
     assert result is None, (
         f"Expected None updating a comment owned by another conversation, got {result!r}. "
         "update_comment must scope by conversation_id."
     )
 
     # The comment must still be draft when read by its real owner.
-    owned = store.get(comment.id, "conv_1a2b3c")
+    owned = store.get(comment.id, "a108c9671b5941a44e5e53fef4204487")
     assert owned is not None and owned.status == "draft", (
         "A cross-conversation update_comment must not have mutated the comment."
     )
@@ -478,14 +486,14 @@ def test_update_comment_wrong_conversation_is_noop(store: SqlAlchemyCommentStore
 def test_delete_returns_comment_and_removes_it(store: SqlAlchemyCommentStore) -> None:
     """``delete`` returns the deleted Comment and removes it from the store."""
     comment = store.add(
-        conversation_id="conv_del",
+        conversation_id="553a265445caf1cdb034abe0b449485d",
         path="delete_me.py",
         body="To be deleted",
         start_index=0,
         end_index=13,
     )
 
-    deleted = store.delete(comment.id, "conv_del")
+    deleted = store.delete(comment.id, "553a265445caf1cdb034abe0b449485d")
 
     # The deleted entity must be returned with correct fields.
     assert deleted is not None, "delete() must return the deleted Comment, not None"
@@ -493,7 +501,7 @@ def test_delete_returns_comment_and_removes_it(store: SqlAlchemyCommentStore) ->
     assert deleted.body == "To be deleted"
 
     # The comment must no longer appear in listings.
-    remaining = store.list_for_conversation("conv_del")
+    remaining = store.list_for_conversation("553a265445caf1cdb034abe0b449485d")
     assert remaining == [], (
         f"Comment still visible after delete: {remaining}. "
         "The DELETE statement did not execute or did not commit."
@@ -502,7 +510,7 @@ def test_delete_returns_comment_and_removes_it(store: SqlAlchemyCommentStore) ->
 
 def test_delete_returns_none_for_missing(store: SqlAlchemyCommentStore) -> None:
     """``delete`` returns ``None`` when the comment id does not exist."""
-    result = store.delete("no-such-comment-id", "conv_2b3c4d")
+    result = store.delete("00000000000000000000000000000000", "615ac506e4c8194eb6a15a4035360ccd")
 
     assert result is None, f"Expected None for an unknown comment id, got {result!r}"
 
@@ -515,21 +523,21 @@ def test_delete_wrong_conversation_is_noop(store: SqlAlchemyCommentStore) -> Non
     returns ``None`` and the comment remains readable by its real owner.
     """
     comment = store.add(
-        conversation_id="conv_7a8b9c",
+        conversation_id="b79ec71dbcdd4708acad646daa9a022b",
         path="keep.py",
         body="Must survive a cross-conversation delete",
         start_index=0,
         end_index=4,
     )
 
-    result = store.delete(comment.id, "conv_0d1e2f")
+    result = store.delete(comment.id, "869d69d8f07ffc6bb081041acade5c97")
     assert result is None, (
         f"Expected None deleting a comment owned by another conversation, got {result!r}. "
         "delete must scope by conversation_id."
     )
 
     # The comment must still exist for its real owner.
-    owned = store.get(comment.id, "conv_7a8b9c")
+    owned = store.get(comment.id, "b79ec71dbcdd4708acad646daa9a022b")
     assert owned is not None and owned.id == comment.id, (
         "A cross-conversation delete must not have removed the comment."
     )
@@ -538,23 +546,23 @@ def test_delete_wrong_conversation_is_noop(store: SqlAlchemyCommentStore) -> Non
 def test_delete_does_not_affect_other_comments(store: SqlAlchemyCommentStore) -> None:
     """Deleting one comment leaves other comments untouched."""
     c1 = store.add(
-        conversation_id="conv_del_iso",
+        conversation_id="a2c6d1428ff14a4ba58383086a770bea",
         path="f.py",
         body="Will survive",
         start_index=0,
         end_index=12,
     )
     c2 = store.add(
-        conversation_id="conv_del_iso",
+        conversation_id="a2c6d1428ff14a4ba58383086a770bea",
         path="f.py",
         body="Will be deleted",
         start_index=50,
         end_index=65,
     )
 
-    store.delete(c2.id, "conv_del_iso")
+    store.delete(c2.id, "a2c6d1428ff14a4ba58383086a770bea")
 
-    remaining = store.list_for_conversation("conv_del_iso")
+    remaining = store.list_for_conversation("a2c6d1428ff14a4ba58383086a770bea")
     # Only c1 must remain.
     assert len(remaining) == 1, (
         f"Expected 1 remaining comment after deleting c2, got {len(remaining)}"
@@ -569,23 +577,23 @@ def test_delete_does_not_affect_other_comments(store: SqlAlchemyCommentStore) ->
 def test_remove_conversation_deletes_all_comments(store: SqlAlchemyCommentStore) -> None:
     """``remove_conversation`` removes every comment for the given conversation."""
     store.add(
-        conversation_id="conv_rm",
+        conversation_id="df67bfa0ae95aba2ef18cf456626bac4",
         path="a.py",
         body="First",
         start_index=0,
         end_index=5,
     )
     store.add(
-        conversation_id="conv_rm",
+        conversation_id="df67bfa0ae95aba2ef18cf456626bac4",
         path="b.py",
         body="Second",
         start_index=0,
         end_index=6,
     )
 
-    store.remove_conversation("conv_rm")
+    store.remove_conversation("df67bfa0ae95aba2ef18cf456626bac4")
 
-    remaining = store.list_for_conversation("conv_rm")
+    remaining = store.list_for_conversation("df67bfa0ae95aba2ef18cf456626bac4")
     assert remaining == [], (
         f"Expected [] after remove_conversation, got {remaining}. "
         "remove_conversation did not delete all comments."
@@ -597,23 +605,23 @@ def test_remove_conversation_does_not_affect_other_conversations(
 ) -> None:
     """``remove_conversation`` only removes comments for the specified conversation."""
     store.add(
-        conversation_id="conv_keep",
+        conversation_id="aacdf565fffe01a05b5f40d6c4ac83d7",
         path="safe.py",
         body="Survives",
         start_index=0,
         end_index=8,
     )
     store.add(
-        conversation_id="conv_gone",
+        conversation_id="af99a53c5b9b2b0c348a388382d563fd",
         path="gone.py",
         body="Removed",
         start_index=0,
         end_index=7,
     )
 
-    store.remove_conversation("conv_gone")
+    store.remove_conversation("af99a53c5b9b2b0c348a388382d563fd")
 
-    kept = store.list_for_conversation("conv_keep")
+    kept = store.list_for_conversation("aacdf565fffe01a05b5f40d6c4ac83d7")
     # conv_keep must still have its comment after conv_gone is purged.
     assert len(kept) == 1, (
         f"Expected conv_keep to still have 1 comment, got {len(kept)}. "
@@ -627,7 +635,7 @@ def test_remove_conversation_is_noop_for_unknown_conversation(
 ) -> None:
     """``remove_conversation`` does not raise when no comments exist for the id."""
     # Should not raise — idempotent delete.
-    store.remove_conversation("conv_nobody_here")
+    store.remove_conversation("cbf8681fc01242145feae6727cdb9157")
 
 
 # ── updated_at & get_comments_fingerprints ──────────────────────────────────────
@@ -663,7 +671,7 @@ def test_add_sets_updated_at_equal_to_created_at(
 ) -> None:
     """A freshly created comment's ``updated_at`` equals ``created_at``."""
     comment = store.add(
-        conversation_id="conv_fp",
+        conversation_id="840c7e6167d54b9d8f4cb718ecfc086c",
         path="src/app.py",
         body="first",
         start_index=0,
@@ -680,14 +688,16 @@ def test_update_comment_bumps_updated_at_and_persists(
 ) -> None:
     """A body/status mutation moves ``updated_at`` to the write time."""
     comment = store.add(
-        conversation_id="conv_fp",
+        conversation_id="840c7e6167d54b9d8f4cb718ecfc086c",
         path="src/app.py",
         body="first",
         start_index=0,
         end_index=5,
     )
     clock["now"] = 2_000
-    updated = store.update_comment(comment.id, "conv_fp", status="addressed")
+    updated = store.update_comment(
+        comment.id, "840c7e6167d54b9d8f4cb718ecfc086c", status="addressed"
+    )
 
     assert updated is not None
     # updated_at must move to the mutation time while created_at is
@@ -697,7 +707,7 @@ def test_update_comment_bumps_updated_at_and_persists(
     assert updated.updated_at == 2_000 * _US
     assert updated.created_at == 1_000
     # The bump must be persisted, not just present on the returned entity.
-    fetched = store.get(comment.id, "conv_fp")
+    fetched = store.get(comment.id, "840c7e6167d54b9d8f4cb718ecfc086c")
     assert fetched is not None
     assert fetched.updated_at == 2_000 * _US
 
@@ -707,14 +717,14 @@ def test_update_comment_with_no_fields_does_not_bump_updated_at(
 ) -> None:
     """A no-op update (both fields ``None``) leaves ``updated_at`` alone."""
     comment = store.add(
-        conversation_id="conv_fp",
+        conversation_id="840c7e6167d54b9d8f4cb718ecfc086c",
         path="src/app.py",
         body="first",
         start_index=0,
         end_index=5,
     )
     clock["now"] = 2_000
-    updated = store.update_comment(comment.id, "conv_fp")
+    updated = store.update_comment(comment.id, "840c7e6167d54b9d8f4cb718ecfc086c")
 
     assert updated is not None
     # Nothing changed, so the fingerprint input must not move — a bump
@@ -734,34 +744,60 @@ def test_get_comments_fingerprints_omits_conversations_without_comments(
 ) -> None:
     """Conversations with no comments are absent from the result map."""
     store.add(
-        conversation_id="conv_with",
+        conversation_id="69a8f8a1a39c17d4f15f04cac522771e",
         path="src/app.py",
         body="x",
         start_index=0,
         end_index=1,
     )
-    result = store.get_comments_fingerprints(["conv_with", "conv_without"])
+    result = store.get_comments_fingerprints(
+        ["69a8f8a1a39c17d4f15f04cac522771e", "8f438881877c0cdd47df9fff30c8e06e"]
+    )
     # Absent (not a zero-count entry) is the contract — the route maps
     # absence to the comments_count=0 / comments_updated_at=None shape.
-    assert set(result) == {"conv_with"}
+    assert set(result) == {"69a8f8a1a39c17d4f15f04cac522771e"}
 
 
 def test_get_comments_fingerprints_batches_counts_and_max_updated_at(
     store: SqlAlchemyCommentStore, clock: dict[str, int]
 ) -> None:
     """One batched call returns exact per-conversation count + max."""
-    store.add(conversation_id="conv_a", path="a.py", body="a1", start_index=0, end_index=1)
+    store.add(
+        conversation_id="94c349190e241f85a984b3df8f129696",
+        path="a.py",
+        body="a1",
+        start_index=0,
+        end_index=1,
+    )
     clock["now"] = 1_500
-    store.add(conversation_id="conv_a", path="a.py", body="a2", start_index=2, end_index=3)
+    store.add(
+        conversation_id="94c349190e241f85a984b3df8f129696",
+        path="a.py",
+        body="a2",
+        start_index=2,
+        end_index=3,
+    )
     clock["now"] = 3_000
-    store.add(conversation_id="conv_b", path="b.py", body="b1", start_index=0, end_index=1)
+    store.add(
+        conversation_id="bfcc6c068875253adf2f20bf30a19015",
+        path="b.py",
+        body="b1",
+        start_index=0,
+        end_index=1,
+    )
 
-    result = store.get_comments_fingerprints(["conv_a", "conv_b"])
+    result = store.get_comments_fingerprints(
+        ["94c349190e241f85a984b3df8f129696", "bfcc6c068875253adf2f20bf30a19015"]
+    )
 
     # Exact values prove the aggregate is grouped per conversation: a
     # cross-conversation max would report 3_000 for conv_a.
-    assert result["conv_a"] == CommentsFingerprint(count=2, last_updated_at=1_500 * _US)
-    assert result["conv_b"] == CommentsFingerprint(count=1, last_updated_at=3_000 * _US)
+    assert result["94c349190e241f85a984b3df8f129696"] == CommentsFingerprint(
+        count=2, last_updated_at=1_500 * _US
+    )
+    assert result["bfcc6c068875253adf2f20bf30a19015"] == CommentsFingerprint(
+        count=1, last_updated_at=3_000 * _US
+    )
 
 
 def test_get_comments_fingerprints_reflects_edit(
@@ -769,12 +805,20 @@ def test_get_comments_fingerprints_reflects_edit(
 ) -> None:
     """An in-place mutation moves ``last_updated_at`` with count unchanged."""
     comment = store.add(
-        conversation_id="conv_fp", path="a.py", body="x", start_index=0, end_index=1
+        conversation_id="840c7e6167d54b9d8f4cb718ecfc086c",
+        path="a.py",
+        body="x",
+        start_index=0,
+        end_index=1,
     )
-    before = store.get_comments_fingerprints(["conv_fp"])["conv_fp"]
+    before = store.get_comments_fingerprints(["840c7e6167d54b9d8f4cb718ecfc086c"])[
+        "840c7e6167d54b9d8f4cb718ecfc086c"
+    ]
     clock["now"] = 2_000
-    store.update_comment(comment.id, "conv_fp", status="addressed")
-    after = store.get_comments_fingerprints(["conv_fp"])["conv_fp"]
+    store.update_comment(comment.id, "840c7e6167d54b9d8f4cb718ecfc086c", status="addressed")
+    after = store.get_comments_fingerprints(["840c7e6167d54b9d8f4cb718ecfc086c"])[
+        "840c7e6167d54b9d8f4cb718ecfc086c"
+    ]
 
     # The edit is invisible to the count, so the timestamp alone must
     # carry it — this is the reason the updated_at column exists.
@@ -787,13 +831,25 @@ def test_get_comments_fingerprints_reflects_delete_of_older_comment(
 ) -> None:
     """Deleting a non-newest comment changes the count, not the max."""
     older = store.add(
-        conversation_id="conv_fp", path="a.py", body="old", start_index=0, end_index=1
+        conversation_id="840c7e6167d54b9d8f4cb718ecfc086c",
+        path="a.py",
+        body="old",
+        start_index=0,
+        end_index=1,
     )
     clock["now"] = 2_000
-    store.add(conversation_id="conv_fp", path="a.py", body="new", start_index=2, end_index=3)
+    store.add(
+        conversation_id="840c7e6167d54b9d8f4cb718ecfc086c",
+        path="a.py",
+        body="new",
+        start_index=2,
+        end_index=3,
+    )
 
-    store.delete(older.id, "conv_fp")
-    after = store.get_comments_fingerprints(["conv_fp"])["conv_fp"]
+    store.delete(older.id, "840c7e6167d54b9d8f4cb718ecfc086c")
+    after = store.get_comments_fingerprints(["840c7e6167d54b9d8f4cb718ecfc086c"])[
+        "840c7e6167d54b9d8f4cb718ecfc086c"
+    ]
 
     # max(updated_at) is blind to this delete (the surviving comment is
     # the newest) — the count drop is what makes the fingerprint move.

--- a/tests/stores/test_conversation_labels.py
+++ b/tests/stores/test_conversation_labels.py
@@ -306,7 +306,7 @@ def test_get_conversation_missing_returns_none(
     """get_conversation on a non-existent ID returns None,
     not a zero-value Conversation. Must not attempt the
     label fetch for a missing parent (no SELECT error)."""
-    got = conversation_store.get_conversation("conv_does_not_exist")
+    got = conversation_store.get_conversation("1d0b12236c77f69f5073a53583de1a3f")
     assert got is None
 
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -26,7 +26,7 @@ from omnigent.stores.host_store import HostStore
 
 def test_create_and_get(conversation_store: SqlAlchemyConversationStore) -> None:
     conv = conversation_store.create_conversation()
-    assert conv.id.startswith("conv_")
+    assert len(conv.id) == 32
 
     fetched = conversation_store.get_conversation(conv.id)
     assert fetched is not None
@@ -34,7 +34,7 @@ def test_create_and_get(conversation_store: SqlAlchemyConversationStore) -> None
 
 
 def test_get_nonexistent(conversation_store: SqlAlchemyConversationStore) -> None:
-    assert conversation_store.get_conversation("conv_none") is None
+    assert conversation_store.get_conversation("c55a64c3f6f954fe0fc8738ba3f45f26") is None
 
 
 def test_get_conversations_bulk(
@@ -52,7 +52,7 @@ def test_get_conversations_bulk(
     # across the batch or dropped for the unlabeled row.
     conversation_store.set_labels(a.id, {"omnigent.ui": "terminal"})
 
-    result = conversation_store.get_conversations([a.id, b.id, "conv_missing"])
+    result = conversation_store.get_conversations([a.id, b.id, "5eca720dc2bc6cdc3a99028d7bd0f917"])
 
     # The unknown id is omitted rather than mapped to None — the caller
     # treats absence as "no longer resolves".
@@ -155,7 +155,7 @@ def test_list_latest_message_items_for_conversations(
     )
 
     result = conversation_store.list_latest_message_items_for_conversations(
-        [conv_a.id, conv_b.id, conv_empty.id, "conv_missing"],
+        [conv_a.id, conv_b.id, conv_empty.id, "5eca720dc2bc6cdc3a99028d7bd0f917"],
         per_conversation_limit=2,
     )
 
@@ -173,11 +173,11 @@ def test_list_latest_message_items_for_conversations(
             texts.append(item.data.content[0]["text"])
         return texts
 
-    assert set(result) == {conv_a.id, conv_b.id, conv_empty.id, "conv_missing"}
+    assert set(result) == {conv_a.id, conv_b.id, conv_empty.id, "5eca720dc2bc6cdc3a99028d7bd0f917"}
     assert _texts(conv_a.id) == ["alpha new", "alpha old"]
     assert _texts(conv_b.id) == ["bravo new", "bravo middle"]
     assert result[conv_empty.id] == []
-    assert result["conv_missing"] == []
+    assert result["5eca720dc2bc6cdc3a99028d7bd0f917"] == []
 
 
 def test_ranked_latest_message_items_omits_search_text(
@@ -196,7 +196,7 @@ def test_ranked_latest_message_items_omits_search_text(
         _ranked_latest_message_items,
     )
 
-    ranked = _ranked_latest_message_items(["conv_x"])
+    ranked = _ranked_latest_message_items(["8af356d908005a65f872c246158c6293"])
     columns = {c.key for c in ranked.c}
     assert "search_text" not in columns
     # The columns _to_item + the preview actually consume must all be present.
@@ -242,7 +242,10 @@ def test_update_title(conversation_store: SqlAlchemyConversationStore) -> None:
     assert updated is not None
     assert updated.title == "Chat 1"
 
-    assert conversation_store.update_conversation("conv_none", title="x") is None
+    assert (
+        conversation_store.update_conversation("c55a64c3f6f954fe0fc8738ba3f45f26", title="x")
+        is None
+    )
 
 
 def test_update_archived_round_trip(
@@ -355,8 +358,8 @@ def test_append_and_list_items(conversation_store: SqlAlchemyConversationStore) 
         ],
     )
     assert len(items) == 2
-    assert items[0].id.startswith("msg_")
-    assert items[1].id.startswith("msg_")
+    assert len(items[0].id) == 32
+    assert len(items[1].id) == 32
 
     page = conversation_store.list_items(conv.id)
     assert len(page.data) == 2
@@ -449,8 +452,8 @@ def test_append_function_call_items(
             ),
         ],
     )
-    assert items[0].id.startswith("fc_")
-    assert items[1].id.startswith("fco_")
+    assert len(items[0].id) == 32
+    assert len(items[1].id) == 32
 
 
 def test_append_tool_output_with_nul_bytes(
@@ -488,7 +491,7 @@ def test_append_tool_output_with_nul_bytes(
     # append() returning normally (not raising DataError) is the
     # primary reproduction: pre-fix this INSERT aborted on Postgres.
     item_id = items[0].id
-    assert item_id.startswith("fco_")
+    assert len(item_id) == 32
 
     # The payload round-trips faithfully: NUL is preserved in the data
     # column (json.dumps escapes it to the literal 6-char
@@ -507,7 +510,7 @@ def test_append_tool_output_with_nul_bytes(
     with engine.connect() as conn:
         row = conn.execute(
             text("SELECT data, search_text FROM conversation_items WHERE id = :id"),
-            {"id": item_id},
+            {"id": bytes.fromhex(item_id)},  # id column is now 16-byte binary
         ).one()
     assert "\x00" not in row.search_text
     assert "\x00" not in row.data
@@ -533,7 +536,7 @@ def test_append_reasoning_item(conversation_store: SqlAlchemyConversationStore) 
             ),
         ],
     )
-    assert items[0].id.startswith("rs_")
+    assert len(items[0].id) == 32
 
 
 def test_append_error_item_round_trips_for_history(
@@ -567,7 +570,7 @@ def test_append_error_item_round_trips_for_history(
         ],
     )
 
-    assert persisted.id.startswith("err_")
+    assert len(persisted.id) == 32
     [read_back] = conversation_store.list_items(conv.id).data
     assert read_back.id == persisted.id
     assert read_back.response_id == "resp_failed"
@@ -1477,7 +1480,7 @@ def test_list_items_type_filter_returns_only_matching_type(
                 response_id="resp_001",
                 data=CompactionData(
                     summary="Summary text",
-                    last_item_id="msg_001",
+                    last_item_id="7ae6efab548a4e13ae0ac9efc56d841e",
                     model="openai/gpt-4o",
                     token_count=50,
                 ),
@@ -1543,7 +1546,7 @@ def test_list_items_type_filter_with_order_and_limit(
                 response_id="resp_001",
                 data=CompactionData(
                     summary="First summary",
-                    last_item_id="msg_010",
+                    last_item_id="7cd616150a23fe70bf378669c79387f2",
                     model="openai/gpt-4o",
                     token_count=100,
                 ),
@@ -1558,7 +1561,7 @@ def test_list_items_type_filter_with_order_and_limit(
                 response_id="resp_002",
                 data=CompactionData(
                     summary="Second summary",
-                    last_item_id="msg_020",
+                    last_item_id="cb01aedfa2199bc66feb77ba3b82f90a",
                     model="openai/gpt-4o",
                     token_count=120,
                 ),
@@ -1817,7 +1820,7 @@ def test_list_conversations_sort_by_updated_at(
         kind=None,
     )
     assert by_created.data[0].id == conv_b.id, (
-        "Expected conv_b first when sorting by created_at desc."
+        "Expected bfcc6c068875253adf2f20bf30a19015 first when sorting by created_at desc."
     )
 
     # sort_by=updated_at desc → conv_a first (updated more recently)
@@ -1827,8 +1830,8 @@ def test_list_conversations_sort_by_updated_at(
         kind=None,
     )
     assert by_updated.data[0].id == conv_a.id, (
-        "Expected conv_a first when sorting by updated_at desc, "
-        "because it was updated at t=300 vs conv_b at t=200."
+        "Expected 94c349190e241f85a984b3df8f129696 first when sorting by updated_at desc, "
+        "because it was updated at t=300 vs bfcc6c068875253adf2f20bf30a19015 at t=200."
     )
 
 
@@ -2070,14 +2073,14 @@ def test_list_child_conversation_ids_by_parent_groups_direct_subagents(
     )
 
     result = conversation_store.list_child_conversation_ids_by_parent(
-        [parent_a.id, parent_b.id, "conv_missing", parent_a.id]
+        [parent_a.id, parent_b.id, "5eca720dc2bc6cdc3a99028d7bd0f917", parent_a.id]
     )
 
-    assert set(result) == {parent_a.id, parent_b.id, "conv_missing"}
+    assert set(result) == {parent_a.id, parent_b.id, "5eca720dc2bc6cdc3a99028d7bd0f917"}
     assert len(result[parent_a.id]) == 2
     assert sorted(result[parent_a.id]) == sorted([child_a1.id, child_a2.id])
     assert result[parent_b.id] == [child_b.id]
-    assert result["conv_missing"] == []
+    assert result["5eca720dc2bc6cdc3a99028d7bd0f917"] == []
     # A grandchild is a direct child of child_a1, not of parent_a — the helper
     # groups by the immediate parent and does not widen to nested descendants.
     assert nested.id not in result[parent_a.id]
@@ -2110,8 +2113,16 @@ def test_list_conversations_filtered_by_agent_id_returns_matching_only(
     :param conversation_store: The conversation store fixture.
     :param agent_store: The agent store fixture.
     """
-    alpha = agent_store.create(agent_id="ag_alpha", name="alpha", bundle_location="ag_alpha/h")
-    beta = agent_store.create(agent_id="ag_beta", name="beta", bundle_location="ag_beta/h")
+    alpha = agent_store.create(
+        agent_id="f1e73205d3a559f97d5e9021d95832d2",
+        name="alpha",
+        bundle_location="f1e73205d3a559f97d5e9021d95832d2/h",
+    )
+    beta = agent_store.create(
+        agent_id="c796e62af763f9d951301fead40d20de",
+        name="beta",
+        bundle_location="c796e62af763f9d951301fead40d20de/h",
+    )
     conv1 = conversation_store.create_conversation(agent_id=alpha.id)
     conv2 = conversation_store.create_conversation(agent_id=alpha.id)
     conv3 = conversation_store.create_conversation(agent_id=beta.id)
@@ -2138,7 +2149,11 @@ def test_list_conversations_agent_id_none_disables_filter(
     :param conversation_store: The conversation store fixture.
     :param agent_store: The agent store fixture.
     """
-    alpha = agent_store.create(agent_id="ag_alpha2", name="alpha2", bundle_location="ag_alpha2/h")
+    alpha = agent_store.create(
+        agent_id="1b8cb3bf470399f2dab62adfc4e0a47e",
+        name="alpha2",
+        bundle_location="1b8cb3bf470399f2dab62adfc4e0a47e/h",
+    )
     conv_with_agent = conversation_store.create_conversation(agent_id=alpha.id)
     conv_without_agent = conversation_store.create_conversation()
 
@@ -2164,7 +2179,11 @@ def test_list_conversations_filter_distinct_by_agent_id(
     :param conversation_store: The conversation store fixture.
     :param agent_store: The agent store fixture.
     """
-    alpha = agent_store.create(agent_id="ag_alpha3", name="alpha3", bundle_location="ag_alpha3/h")
+    alpha = agent_store.create(
+        agent_id="088b0cf9ba41af7589984807d30c5789",
+        name="alpha3",
+        bundle_location="088b0cf9ba41af7589984807d30c5789/h",
+    )
     conv = conversation_store.create_conversation(agent_id=alpha.id)
 
     page = conversation_store.list_conversations(agent_id=alpha.id)
@@ -2192,7 +2211,11 @@ def test_list_conversations_filter_orders_by_sort_by(
     """
     import omnigent.stores.conversation_store.sqlalchemy_store as store_mod
 
-    alpha = agent_store.create(agent_id="ag_alpha4", name="alpha4", bundle_location="ag_alpha4/h")
+    alpha = agent_store.create(
+        agent_id="56d6facd8237c8523d783d591fa43baa",
+        name="alpha4",
+        bundle_location="56d6facd8237c8523d783d591fa43baa/h",
+    )
 
     # Create two conversations at distinct timestamps so
     # ``updated_at`` differs.
@@ -2320,7 +2343,7 @@ def _register_host(db_uri: str, host_id: str) -> None:
     with the ``conversation_store`` fixture so both hit the same DB.
 
     :param db_uri: SQLite URI shared with the conversation store.
-    :param host_id: Host identifier to register, e.g. ``"host_abc123"``.
+    :param host_id: Host identifier to register, e.g. ``"4f64b6ee625f4e8259185c35c6e63f3d"``.
     """
     HostStore(db_uri).upsert_on_connect(host_id, f"laptop-{host_id}", RESERVED_USER_LOCAL)
 
@@ -2357,17 +2380,17 @@ def test_create_conversation_with_host_id(
     dropping the column or the row→entity converter is skipping it.
     """
     # host_id is an FK to hosts.host_id, so the host must exist first.
-    _register_host(db_uri, "host_abc123")
+    _register_host(db_uri, "4f64b6ee625f4e8259185c35c6e63f3d")
     conv = conversation_store.create_conversation(
-        host_id="host_abc123",
+        host_id="4f64b6ee625f4e8259185c35c6e63f3d",
         workspace="/Users/corey/projects/myapp",
     )
-    assert conv.host_id == "host_abc123"
+    assert conv.host_id == "4f64b6ee625f4e8259185c35c6e63f3d"
     assert conv.workspace == "/Users/corey/projects/myapp"
 
     fetched = conversation_store.get_conversation(conv.id)
     assert fetched is not None
-    assert fetched.host_id == "host_abc123"
+    assert fetched.host_id == "4f64b6ee625f4e8259185c35c6e63f3d"
     assert fetched.workspace == "/Users/corey/projects/myapp"
 
 
@@ -2422,7 +2445,7 @@ def test_set_host_id(
     statement is not executing or not committing.
     """
     # host_id is an FK to hosts.host_id, so the host must exist first.
-    _register_host(db_uri, "host_def456")
+    _register_host(db_uri, "292dfcdf8a31f1319b469f4fa179ac6b")
     # Pre-set workspace so the host_id update doesn't violate the
     # workspace-required-for-host check constraint.
     conv = conversation_store.create_conversation(
@@ -2431,12 +2454,12 @@ def test_set_host_id(
     assert conv.host_id is None
     assert conv.workspace == "/Users/corey/projects/myapp"
 
-    updated = conversation_store.set_host_id(conv.id, "host_def456")
-    assert updated.host_id == "host_def456"
+    updated = conversation_store.set_host_id(conv.id, "292dfcdf8a31f1319b469f4fa179ac6b")
+    assert updated.host_id == "292dfcdf8a31f1319b469f4fa179ac6b"
 
     fetched = conversation_store.get_conversation(conv.id)
     assert fetched is not None
-    assert fetched.host_id == "host_def456"
+    assert fetched.host_id == "292dfcdf8a31f1319b469f4fa179ac6b"
     assert fetched.workspace == "/Users/corey/projects/myapp"
 
 
@@ -2453,7 +2476,9 @@ def test_set_host_id_missing_conversation_raises(
     from omnigent.stores.conversation_store import ConversationNotFoundError
 
     with pytest.raises(ConversationNotFoundError):
-        conversation_store.set_host_id("conv_nonexistent", "host_xyz")
+        conversation_store.set_host_id(
+            "ad563e906854634c49e1a6fd2fbb31d4", "2173662ad94ab46f03cfbdd5f968d22b"
+        )
 
 
 def test_set_host_id_with_workspace_satisfies_constraint(
@@ -2470,17 +2495,17 @@ def test_set_host_id_with_workspace_satisfies_constraint(
     request.
     """
     # host_id is an FK to hosts.host_id, so the host must exist first.
-    _register_host(db_uri, "host_with_workspace")
+    _register_host(db_uri, "8f48061706cb92d5e7cd7c4aadc56ef0")
     conv = conversation_store.create_conversation()
     assert conv.host_id is None
     assert conv.workspace is None
 
     updated = conversation_store.set_host_id(
         conv.id,
-        "host_with_workspace",
+        "8f48061706cb92d5e7cd7c4aadc56ef0",
         workspace="/Users/corey/projects/myapp",
     )
-    assert updated.host_id == "host_with_workspace"
+    assert updated.host_id == "8f48061706cb92d5e7cd7c4aadc56ef0"
     assert updated.workspace == "/Users/corey/projects/myapp"
 
 
@@ -2499,13 +2524,13 @@ def test_clear_host_binding_nulls_all_binding_fields(
     worktree-cleanup paths (git_branch IS NOT NULL); a leftover runner_id
     would block the picker's retry on the atomic set_runner_id CAS.
     """
-    _register_host(db_uri, "host_to_unbind")
+    _register_host(db_uri, "873f058a4a48002a654a80be0ee09bfb")
     conv = conversation_store.create_conversation()
     # Fully bind it the way a worktree launch would: host + worktree path
     # + branch, then a runner.
     conversation_store.set_host_id(
         conv.id,
-        "host_to_unbind",
+        "873f058a4a48002a654a80be0ee09bfb",
         workspace="/Users/corey/repo-worktrees/feature-x",
         git_branch="feature/x",
     )
@@ -2514,7 +2539,7 @@ def test_clear_host_binding_nulls_all_binding_fields(
     assert bound is not None
     # Precondition: every binding field is set (so the assertions below
     # prove clearing, not a no-op on already-empty fields).
-    assert bound.host_id == "host_to_unbind"
+    assert bound.host_id == "873f058a4a48002a654a80be0ee09bfb"
     assert bound.workspace == "/Users/corey/repo-worktrees/feature-x"
     assert bound.git_branch == "feature/x"
     assert bound.runner_id == "runner_token_abc"
@@ -2542,7 +2567,7 @@ def test_clear_host_binding_missing_conversation_raises(
     from omnigent.stores.conversation_store import ConversationNotFoundError
 
     with pytest.raises(ConversationNotFoundError):
-        conversation_store.clear_host_binding("conv_nonexistent")
+        conversation_store.clear_host_binding("ad563e906854634c49e1a6fd2fbb31d4")
 
 
 def test_create_session_with_agent_records_workspace(
@@ -2559,9 +2584,9 @@ def test_create_session_with_agent_records_workspace(
     session is running.
     """
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_session_ws",
+        agent_id="28373c2f7c4d68719e6dbc4b9599b9b0",
         agent_name="cli-test-agent",
-        agent_bundle_location="ag_session_ws/bundle1",
+        agent_bundle_location="28373c2f7c4d68719e6dbc4b9599b9b0/bundle1",
         agent_description=None,
         workspace="/Users/corey/projects/cli-launch",
     )
@@ -2585,9 +2610,9 @@ def test_create_session_with_agent_workspace_defaults_to_none(
     that path through the public method.
     """
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_session_no_ws",
+        agent_id="f8ec0ed35d503406f640ae51bf44c7f7",
         agent_name="no-ws-agent",
-        agent_bundle_location="ag_session_no_ws/bundle1",
+        agent_bundle_location="f8ec0ed35d503406f640ae51bf44c7f7/bundle1",
         agent_description=None,
     )
     fetched = conversation_store.get_conversation(created.conversation.id)
@@ -2609,9 +2634,9 @@ def test_create_session_with_agent_records_terminal_launch_args(
     of the list, and the runner would launch with the wrong args.
     """
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_session_tla",
+        agent_id="df7e0acd3e245704fe6b286dbfd4ded9",
         agent_name="cli-test-agent",
-        agent_bundle_location="ag_session_tla/bundle1",
+        agent_bundle_location="df7e0acd3e245704fe6b286dbfd4ded9/bundle1",
         agent_description=None,
         terminal_launch_args=["--dangerously-skip-permissions", "--model", "opus"],
     )
@@ -2640,9 +2665,9 @@ def test_create_session_with_agent_terminal_launch_args_defaults_to_none(
     launch with zero extra args".
     """
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_session_no_tla",
+        agent_id="a4b69df8a4ccfd0bea607c33acb68493",
         agent_name="no-tla-agent",
-        agent_bundle_location="ag_session_no_tla/bundle1",
+        agent_bundle_location="a4b69df8a4ccfd0bea607c33acb68493/bundle1",
         agent_description=None,
     )
     fetched = conversation_store.get_conversation(created.conversation.id)
@@ -2666,9 +2691,9 @@ def test_create_session_with_agent_links_parent_and_inherits_root(
     """
     parent = conversation_store.create_conversation(runner_id="runner_swa1")
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_session_child",
+        agent_id="9d05fc5310e5daf30deff6eaf5ecfbc8",
         agent_name="bundle-child-agent",
-        agent_bundle_location="ag_session_child/bundle1",
+        agent_bundle_location="9d05fc5310e5daf30deff6eaf5ecfbc8/bundle1",
         agent_description=None,
         parent_conversation_id=parent.id,
         runner_id=parent.runner_id,
@@ -2697,9 +2722,9 @@ def test_create_session_with_agent_top_level_unchanged(
     no parent link, and the row roots its own tree.
     """
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_session_top",
+        agent_id="8d0934d981d62b34d0e1fe28b44c55e4",
         agent_name="top-level-agent",
-        agent_bundle_location="ag_session_top/bundle1",
+        agent_bundle_location="8d0934d981d62b34d0e1fe28b44c55e4/bundle1",
         agent_description=None,
     )
     fetched = conversation_store.get_conversation(created.conversation.id)
@@ -2726,14 +2751,14 @@ def test_create_session_with_agent_missing_parent_fails_loud(
 
     with pytest.raises(ConversationNotFoundError):
         conversation_store.create_session_with_agent(
-            agent_id="ag_session_orphan",
+            agent_id="bcde8586d4addf002f0c904bbd000dad",
             agent_name="orphan-agent",
-            agent_bundle_location="ag_session_orphan/bundle1",
+            agent_bundle_location="bcde8586d4addf002f0c904bbd000dad/bundle1",
             agent_description=None,
-            parent_conversation_id="conv_does_not_exist",
+            parent_conversation_id="1d0b12236c77f69f5073a53583de1a3f",
         )
     # The transaction rolled back: no agent row leaked either.
-    assert conversation_store.get_conversation("conv_does_not_exist") is None
+    assert conversation_store.get_conversation("1d0b12236c77f69f5073a53583de1a3f") is None
 
 
 def test_create_conversation_records_terminal_launch_args(
@@ -2793,9 +2818,9 @@ def test_update_conversation_replaces_terminal_launch_args(
     would make repeated resumes accumulate stale/conflicting flags.
     """
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_session_tla_update",
+        agent_id="1e86f0ad04829bc03ee95dfa02291e33",
         agent_name="update-agent",
-        agent_bundle_location="ag_session_tla_update/bundle1",
+        agent_bundle_location="1e86f0ad04829bc03ee95dfa02291e33/bundle1",
         agent_description=None,
         terminal_launch_args=["--model", "opus"],
     )
@@ -2829,9 +2854,9 @@ def test_update_conversation_terminal_launch_args_empty_list_distinct_from_none(
     caller clearing args back to none-extra would be silently ignored.
     """
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_session_tla_empty",
+        agent_id="85f2913caabe8215094e0d0cba22ad57",
         agent_name="empty-agent",
-        agent_bundle_location="ag_session_tla_empty/bundle1",
+        agent_bundle_location="85f2913caabe8215094e0d0cba22ad57/bundle1",
         agent_description=None,
         terminal_launch_args=["--model", "opus"],
     )
@@ -2862,7 +2887,7 @@ def test_set_host_id_no_workspace_fails_when_row_has_none(
     assert conv.workspace is None
 
     with pytest.raises((IntegrityError, OperationalError)):
-        conversation_store.set_host_id(conv.id, "host_no_ws")
+        conversation_store.set_host_id(conv.id, "1aaae06a39eb66a54f9d97f8e9592155")
 
 
 # ── Workspace ───────────────────────────────────────
@@ -2928,7 +2953,7 @@ def test_create_conversation_with_host_id_no_workspace_raises(
     from sqlalchemy.exc import IntegrityError, OperationalError
 
     with pytest.raises((IntegrityError, OperationalError)):
-        conversation_store.create_conversation(host_id="host_abc")
+        conversation_store.create_conversation(host_id="abb32306b80732bdfa6153b2f5f6eb92")
 
 
 # ── External session id ─────────────────────────────
@@ -3033,7 +3058,7 @@ def test_set_external_session_id_missing_conversation_raises(
 
     with pytest.raises(ConversationNotFoundError):
         conversation_store.set_external_session_id(
-            "conv_does_not_exist",
+            "1d0b12236c77f69f5073a53583de1a3f",
             "sid-1",
         )
 
@@ -3052,12 +3077,12 @@ def test_fork_conversation_copies_items(
     mutated.
     """
     agent_store.create(
-        agent_id="ag_fork_test",
+        agent_id="971f31bb0aac3f2d93931ee788150527",
         name="fork-test",
-        bundle_location="ag_fork_test/fakehash",
+        bundle_location="971f31bb0aac3f2d93931ee788150527/fakehash",
     )
     source = conversation_store.create_conversation(
-        agent_id="ag_fork_test",
+        agent_id="971f31bb0aac3f2d93931ee788150527",
         title="Original",
     )
     conversation_store.append(
@@ -3087,10 +3112,10 @@ def test_fork_conversation_copies_items(
 
     # The fork is a new conversation with a different ID.
     assert fork.id != source.id
-    assert fork.id.startswith("conv_")
+    assert len(fork.id) == 32
     assert fork.title == "My Fork"
     # Agent binding is copied from the source.
-    assert fork.agent_id == "ag_fork_test"
+    assert fork.agent_id == "971f31bb0aac3f2d93931ee788150527"
 
     # Items are deep-copied — same count, different IDs, same data.
     fork_items = conversation_store.list_items(fork.id)
@@ -3123,11 +3148,11 @@ def test_fork_conversation_preserves_created_by(
     conversation does not blank out who authored each message.
     """
     agent_store.create(
-        agent_id="ag_fork_attr",
+        agent_id="3d56c2bb70655f419c942112eaa0e339",
         name="fork-attr",
-        bundle_location="ag_fork_attr/fakehash",
+        bundle_location="3d56c2bb70655f419c942112eaa0e339/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_attr")
+    source = conversation_store.create_conversation(agent_id="3d56c2bb70655f419c942112eaa0e339")
     conversation_store.append(
         source.id,
         [
@@ -3165,12 +3190,12 @@ def test_fork_conversation_default_title(
 ) -> None:
     """When no title is given, fork derives one from the source title."""
     agent_store.create(
-        agent_id="ag_fork_title",
+        agent_id="909c5b9f4c8a48c5d3ea9f34e6a6cc47",
         name="fork-title",
-        bundle_location="ag_fork_title/fakehash",
+        bundle_location="909c5b9f4c8a48c5d3ea9f34e6a6cc47/fakehash",
     )
     source = conversation_store.create_conversation(
-        agent_id="ag_fork_title",
+        agent_id="909c5b9f4c8a48c5d3ea9f34e6a6cc47",
         title="Chat about Python",
     )
     fork = conversation_store.fork_conversation(source.id)
@@ -3184,16 +3209,16 @@ def test_fork_conversation_empty_source(
 ) -> None:
     """Forking a conversation with no items produces an empty fork."""
     agent_store.create(
-        agent_id="ag_fork_empty",
+        agent_id="bd68e16fae506630f309e6e4a0674c0d",
         name="fork-empty",
-        bundle_location="ag_fork_empty/fakehash",
+        bundle_location="bd68e16fae506630f309e6e4a0674c0d/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_empty")
+    source = conversation_store.create_conversation(agent_id="bd68e16fae506630f309e6e4a0674c0d")
     fork = conversation_store.fork_conversation(source.id)
 
     fork_items = conversation_store.list_items(fork.id)
     assert fork_items.data == [], "Fork of an empty conversation should have no items"
-    assert fork.agent_id == "ag_fork_empty"
+    assert fork.agent_id == "bd68e16fae506630f309e6e4a0674c0d"
 
 
 def test_fork_conversation_nonexistent_raises(
@@ -3201,7 +3226,7 @@ def test_fork_conversation_nonexistent_raises(
 ) -> None:
     """Forking a non-existent conversation raises LookupError."""
     with pytest.raises(LookupError, match="conversation not found"):
-        conversation_store.fork_conversation("conv_does_not_exist")
+        conversation_store.fork_conversation("1d0b12236c77f69f5073a53583de1a3f")
 
 
 def test_fork_conversation_copies_labels(
@@ -3210,11 +3235,11 @@ def test_fork_conversation_copies_labels(
 ) -> None:
     """Labels on the source conversation are copied to the fork."""
     agent_store.create(
-        agent_id="ag_fork_labels",
+        agent_id="f1afc45b190c3da9cec1acf12aa3600f",
         name="fork-labels",
-        bundle_location="ag_fork_labels/fakehash",
+        bundle_location="f1afc45b190c3da9cec1acf12aa3600f/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_labels")
+    source = conversation_store.create_conversation(agent_id="f1afc45b190c3da9cec1acf12aa3600f")
     conversation_store.set_labels(source.id, {"sensitivity": "high", "dept": "eng"})
 
     fork = conversation_store.fork_conversation(source.id)
@@ -3247,11 +3272,11 @@ def test_fork_conversation_drops_instance_scoped_labels(
     contract (#657). It must be dropped so the clone opts in afresh.
     """
     agent_store.create(
-        agent_id="ag_fork_instance",
+        agent_id="f88a23d7428c44557a974c2e07787713",
         name="fork-instance",
-        bundle_location="ag_fork_instance/fakehash",
+        bundle_location="f88a23d7428c44557a974c2e07787713/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_instance")
+    source = conversation_store.create_conversation(agent_id="f88a23d7428c44557a974c2e07787713")
     conversation_store.set_labels(
         source.id,
         {
@@ -3294,11 +3319,11 @@ def test_fork_conversation_stamps_source_external_session_id(
     own on first launch. Sources without a native session get no label.
     """
     agent_store.create(
-        agent_id="ag_fork_ext",
+        agent_id="f27f858bf73f99ab4bdef6152e0f8729",
         name="fork-ext",
-        bundle_location="ag_fork_ext/fakehash",
+        bundle_location="f27f858bf73f99ab4bdef6152e0f8729/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_ext")
+    source = conversation_store.create_conversation(agent_id="f27f858bf73f99ab4bdef6152e0f8729")
     conversation_store.set_external_session_id(source.id, "claude-uuid-abc")
 
     fork = conversation_store.fork_conversation(source.id)
@@ -3323,11 +3348,11 @@ def test_fork_conversation_no_external_session_id_no_directive(
 ) -> None:
     """A source with no native session id stamps no fork directive."""
     agent_store.create(
-        agent_id="ag_fork_noext",
+        agent_id="51b730ece6dd86c0b9d83180634d3eb9",
         name="fork-noext",
-        bundle_location="ag_fork_noext/fakehash",
+        bundle_location="51b730ece6dd86c0b9d83180634d3eb9/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_noext")
+    source = conversation_store.create_conversation(agent_id="51b730ece6dd86c0b9d83180634d3eb9")
 
     fork = conversation_store.fork_conversation(source.id)
 
@@ -3349,7 +3374,7 @@ def _append_three_responses(
 
     :param conversation_store: Store to append into.
     :param conversation_id: Target conversation id, e.g.
-        ``"conv_abc123"``.
+        ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
     """
     for index in (1, 2, 3):
         conversation_store.append(
@@ -3387,11 +3412,11 @@ def test_fork_conversation_up_to_response_truncates_items(
     and drop everything after it, while leaving the source untouched.
     """
     agent_store.create(
-        agent_id="ag_fork_trunc",
+        agent_id="1e63c4993591d0eed8605bac4927a143",
         name="fork-trunc",
-        bundle_location="ag_fork_trunc/fakehash",
+        bundle_location="1e63c4993591d0eed8605bac4927a143/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_trunc")
+    source = conversation_store.create_conversation(agent_id="1e63c4993591d0eed8605bac4927a143")
     _append_three_responses(conversation_store, source.id)
 
     fork = conversation_store.fork_conversation(source.id, up_to_response_id="resp_002")
@@ -3429,11 +3454,11 @@ def test_fork_conversation_truncated_drops_external_session_directive(
     )
 
     agent_store.create(
-        agent_id="ag_fork_trunc_ext",
+        agent_id="ab940db594b0b58507f706fa30a355b9",
         name="fork-trunc-ext",
-        bundle_location="ag_fork_trunc_ext/fakehash",
+        bundle_location="ab940db594b0b58507f706fa30a355b9/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_trunc_ext")
+    source = conversation_store.create_conversation(agent_id="ab940db594b0b58507f706fa30a355b9")
     conversation_store.set_external_session_id(source.id, "claude-uuid-trunc")
     _append_three_responses(conversation_store, source.id)
 
@@ -3471,11 +3496,11 @@ def test_fork_conversation_cross_family_drops_external_session_directive(
     )
 
     agent_store.create(
-        agent_id="ag_fork_xfam",
+        agent_id="203798a08983a6a0d0290e53cf717e65",
         name="fork-xfam",
-        bundle_location="ag_fork_xfam/fakehash",
+        bundle_location="203798a08983a6a0d0290e53cf717e65/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_xfam")
+    source = conversation_store.create_conversation(agent_id="203798a08983a6a0d0290e53cf717e65")
     # A codex thread id on the source: resumable only by a codex target.
     conversation_store.set_external_session_id(source.id, "codex-thread-xfam")
     _append_three_responses(conversation_store, source.id)
@@ -3511,11 +3536,11 @@ def test_fork_conversation_up_to_last_response_keeps_external_directive(
     from omnigent.stores.conversation_store import FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY
 
     agent_store.create(
-        agent_id="ag_fork_trunc_last",
+        agent_id="c774126dd8d6bf6ca0d1baba1893dec2",
         name="fork-trunc-last",
-        bundle_location="ag_fork_trunc_last/fakehash",
+        bundle_location="c774126dd8d6bf6ca0d1baba1893dec2/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_trunc_last")
+    source = conversation_store.create_conversation(agent_id="c774126dd8d6bf6ca0d1baba1893dec2")
     conversation_store.set_external_session_id(source.id, "claude-uuid-last")
     _append_three_responses(conversation_store, source.id)
 
@@ -3540,11 +3565,11 @@ def test_fork_conversation_up_to_unknown_response_raises(
     and create nothing.
     """
     agent_store.create(
-        agent_id="ag_fork_trunc_bad",
+        agent_id="8114524af82a012591d6af5a76e7773c",
         name="fork-trunc-bad",
-        bundle_location="ag_fork_trunc_bad/fakehash",
+        bundle_location="8114524af82a012591d6af5a76e7773c/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_trunc_bad")
+    source = conversation_store.create_conversation(agent_id="8114524af82a012591d6af5a76e7773c")
     _append_three_responses(conversation_store, source.id)
 
     with pytest.raises(ValueError, match="resp_nope"):
@@ -3563,29 +3588,29 @@ def test_fork_clone_agent_is_session_scoped(
     "Codex" entries in the fork dialog.
     """
     agent_store.create(
-        agent_id="ag_fork_src",
+        agent_id="2f9e296b0ecfc976c94f8630a80881f8",
         name="claude-native-ui",
-        bundle_location="ag_fork_src/hash",
+        bundle_location="2f9e296b0ecfc976c94f8630a80881f8/hash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_src")
+    source = conversation_store.create_conversation(agent_id="2f9e296b0ecfc976c94f8630a80881f8")
 
     fork = conversation_store.fork_conversation(
         source.id,
-        agent_id="ag_clone_ok",
-        cloned_agent_name="claude-native-ui (fork ag_clone_o)",
-        cloned_agent_bundle_location="ag_fork_src/hash",
+        agent_id="42176d50dd2adf7a0ad796da46b94968",
+        cloned_agent_name="claude-native-ui (fork 267eeb019e971bf79ab32a875543d2ed)",
+        cloned_agent_bundle_location="2f9e296b0ecfc976c94f8630a80881f8/hash",
         cloned_agent_description=None,
     )
 
-    assert fork.agent_id == "ag_clone_ok"
-    cloned = agent_store.get("ag_clone_ok")
+    assert fork.agent_id == "42176d50dd2adf7a0ad796da46b94968"
+    cloned = agent_store.get("42176d50dd2adf7a0ad796da46b94968")
     assert cloned is not None
     assert cloned.session_id == fork.id, "clone must be bound to the fork session"
     # The clone is session-scoped, so it must NOT leak into the built-in
     # list (the source built-in is the only template-name row).
     builtin_ids = {a.id for a in agent_store.list(limit=100).data}
-    assert "ag_clone_ok" not in builtin_ids
-    assert "ag_fork_src" in builtin_ids
+    assert "42176d50dd2adf7a0ad796da46b94968" not in builtin_ids
+    assert "2f9e296b0ecfc976c94f8630a80881f8" in builtin_ids
 
 
 def test_fork_clone_agent_failure_leaves_no_orphan(
@@ -3601,25 +3626,25 @@ def test_fork_clone_agent_failure_leaves_no_orphan(
     failure rolls it back too.
     """
     agent_store.create(
-        agent_id="ag_fork_src2",
+        agent_id="778757750ea50dc358d584451281795d",
         name="codex-native-ui",
-        bundle_location="ag_fork_src2/hash",
+        bundle_location="778757750ea50dc358d584451281795d/hash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_src2")
+    source = conversation_store.create_conversation(agent_id="778757750ea50dc358d584451281795d")
     _append_three_responses(conversation_store, source.id)
 
     before = {a.id for a in agent_store.list(limit=100).data}
     with pytest.raises(ValueError, match="resp_nope"):
         conversation_store.fork_conversation(
             source.id,
-            agent_id="ag_clone_orphan",
-            cloned_agent_name="codex-native-ui (fork ag_clone_o)",
-            cloned_agent_bundle_location="ag_fork_src2/hash",
+            agent_id="77511ca47f5b6c6085061ccf10622eb5",
+            cloned_agent_name="codex-native-ui (fork 267eeb019e971bf79ab32a875543d2ed)",
+            cloned_agent_bundle_location="778757750ea50dc358d584451281795d/hash",
             up_to_response_id="resp_nope",
         )
 
     # The clone must not exist at all, and the built-in list is unchanged.
-    assert agent_store.get("ag_clone_orphan") is None
+    assert agent_store.get("77511ca47f5b6c6085061ccf10622eb5") is None
     after = {a.id for a in agent_store.list(limit=100).data}
     assert after == before
 
@@ -3651,11 +3676,11 @@ def test_fork_conversation_copies_reasoning_effort(
 ) -> None:
     """Fork inherits the source's reasoning_effort setting."""
     agent_store.create(
-        agent_id="ag_fork_re",
+        agent_id="1452a86e49ece29f759b09f04d96c57b",
         name="fork-reasoning",
-        bundle_location="ag_fork_re/fakehash",
+        bundle_location="1452a86e49ece29f759b09f04d96c57b/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_re")
+    source = conversation_store.create_conversation(agent_id="1452a86e49ece29f759b09f04d96c57b")
     conversation_store.update_conversation(source.id, reasoning_effort="high")
 
     fork = conversation_store.fork_conversation(source.id)
@@ -3672,11 +3697,11 @@ def test_fork_conversation_copies_terminal_launch_args(
 ) -> None:
     """Fork inherits the source's terminal_launch_args setting."""
     agent_store.create(
-        agent_id="ag_fork_tla",
+        agent_id="864e495d9e1b288de879148957c0ae9a",
         name="fork-tla",
-        bundle_location="ag_fork_tla/fakehash",
+        bundle_location="864e495d9e1b288de879148957c0ae9a/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_tla")
+    source = conversation_store.create_conversation(agent_id="864e495d9e1b288de879148957c0ae9a")
     conversation_store.update_conversation(
         source.id,
         terminal_launch_args=["--dangerously-skip-permissions"],
@@ -3706,11 +3731,11 @@ def test_fork_conversation_copy_model_settings_false_resets(
     the default (``True``) still copies them.
     """
     agent_store.create(
-        agent_id="ag_fork_cms",
+        agent_id="6bfca10f1de66d54bdff530d697d1b68",
         name="fork-cms",
-        bundle_location="ag_fork_cms/fakehash",
+        bundle_location="6bfca10f1de66d54bdff530d697d1b68/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_cms")
+    source = conversation_store.create_conversation(agent_id="6bfca10f1de66d54bdff530d697d1b68")
     conversation_store.update_conversation(
         source.id, reasoning_effort="high", model_override="claude-opus-4"
     )
@@ -3752,11 +3777,11 @@ def test_fork_conversation_carry_history_into_native_stamps_label(
     from omnigent.stores.conversation_store import FORK_CARRY_HISTORY_LABEL_KEY
 
     agent_store.create(
-        agent_id="ag_fork_carry",
+        agent_id="69ca49f61d21b0fe5219340e39afecf4",
         name="fork-carry",
-        bundle_location="ag_fork_carry/fakehash",
+        bundle_location="69ca49f61d21b0fe5219340e39afecf4/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_carry")
+    source = conversation_store.create_conversation(agent_id="69ca49f61d21b0fe5219340e39afecf4")
 
     carried = conversation_store.fork_conversation(source.id, carry_history_into_native=True)
     assert carried.labels.get(FORK_CARRY_HISTORY_LABEL_KEY) == "1", (
@@ -3778,23 +3803,23 @@ def test_fork_conversation_agent_id_override(
     instead of the source's agent.
     """
     agent_store.create(
-        agent_id="ag_original",
+        agent_id="6239422fb5e1335506bb6dedf0f5e8cb",
         name="original-agent",
-        bundle_location="ag_original/fakehash",
+        bundle_location="6239422fb5e1335506bb6dedf0f5e8cb/fakehash",
     )
     agent_store.create(
-        agent_id="ag_cloned",
+        agent_id="ef45a1fbab40c51165f0fe615492ef91",
         name="cloned-agent",
-        bundle_location="ag_original/fakehash",
+        bundle_location="6239422fb5e1335506bb6dedf0f5e8cb/fakehash",
     )
-    source = conversation_store.create_conversation(agent_id="ag_original")
+    source = conversation_store.create_conversation(agent_id="6239422fb5e1335506bb6dedf0f5e8cb")
 
     fork = conversation_store.fork_conversation(
         source.id,
-        agent_id="ag_cloned",
+        agent_id="ef45a1fbab40c51165f0fe615492ef91",
     )
 
-    assert fork.agent_id == "ag_cloned", (
+    assert fork.agent_id == "ef45a1fbab40c51165f0fe615492ef91", (
         "Fork should use the overridden agent_id, not the source's"
     )
 
@@ -3825,9 +3850,9 @@ def test_switch_conversation_agent_cross_family_resets_and_relabels(
 
     # A real session binds a session-scoped agent (agent.session_id == conv).
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_switch_old",
+        agent_id="af75a9579488e3520ba6842699e43323",
         agent_name="claude (switch src)",
-        agent_bundle_location="ag_switch_old/hash",
+        agent_bundle_location="af75a9579488e3520ba6842699e43323/hash",
         agent_description="old",
     )
     conv_id = created.conversation.id
@@ -3867,23 +3892,23 @@ def test_switch_conversation_agent_cross_family_resets_and_relabels(
     }
     updated = conversation_store.switch_conversation_agent(
         conv_id,
-        new_agent_id="ag_switch_new",
+        new_agent_id="9d2c8d5e342b7da390dc38351c49fb72",
         new_agent_name="codex (switch new)",
-        new_agent_bundle_location="ag_switch_new/hash",
+        new_agent_bundle_location="9d2c8d5e342b7da390dc38351c49fb72/hash",
         new_agent_description="new",
         copy_model_settings=False,  # cross-family
         carry_history_into_native=True,  # native target
         presentation_labels=target_labels,
-        previous_builtin_id="ag_builtin_claude",
+        previous_builtin_id="52adb39f0c5ea92b5563da5327dac08f",
     )
 
     # New agent bound; old session-scoped agent deleted (unique session_id
     # index would otherwise be violated by leaving both).
-    assert updated.agent_id == "ag_switch_new"
-    assert agent_store.get("ag_switch_old") is None, (
+    assert updated.agent_id == "9d2c8d5e342b7da390dc38351c49fb72"
+    assert agent_store.get("af75a9579488e3520ba6842699e43323") is None, (
         "old session-scoped agent must be deleted on switch"
     )
-    new_agent = agent_store.get("ag_switch_new")
+    new_agent = agent_store.get("9d2c8d5e342b7da390dc38351c49fb72")
     assert new_agent is not None and new_agent.session_id == conv_id, (
         "new agent must be session-scoped to this conversation"
     )
@@ -3898,7 +3923,7 @@ def test_switch_conversation_agent_cross_family_resets_and_relabels(
     assert updated.labels[UI_MODE_LABEL_KEY] == UI_MODE_TERMINAL_VALUE
     assert updated.labels[WRAPPER_LABEL_KEY] == CODEX_NATIVE_WRAPPER_VALUE
     assert updated.labels[FORK_CARRY_HISTORY_LABEL_KEY] == "1"
-    assert updated.labels[SWITCH_PREVIOUS_BUILTIN_LABEL_KEY] == "ag_builtin_claude"
+    assert updated.labels[SWITCH_PREVIOUS_BUILTIN_LABEL_KEY] == "52adb39f0c5ea92b5563da5327dac08f"
     assert instance_label not in updated.labels, "instance-scoped labels must not survive a switch"
     assert "omnigent.codex_native.bypass_sandbox" not in updated.labels, (
         "the dangerous bypass opt-in must not survive a switch (re-confirm per context)"
@@ -3926,9 +3951,9 @@ def test_switch_conversation_agent_same_family_keeps_model_settings(
     )
 
     created = conversation_store.create_session_with_agent(
-        agent_id="ag_switch_old2",
+        agent_id="06efca8dd5c2e87b8cfed1aae99cc239",
         agent_name="claude-native-ui",
-        agent_bundle_location="ag_switch_old2/hash",
+        agent_bundle_location="06efca8dd5c2e87b8cfed1aae99cc239/hash",
         agent_description=None,
     )
     conv_id = created.conversation.id
@@ -3941,15 +3966,15 @@ def test_switch_conversation_agent_same_family_keeps_model_settings(
             UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
             WRAPPER_LABEL_KEY: "claude-code-native-ui",
             # A stale previous-builtin pointer from an earlier switch.
-            SWITCH_PREVIOUS_BUILTIN_LABEL_KEY: "ag_stale_builtin",
+            SWITCH_PREVIOUS_BUILTIN_LABEL_KEY: "a8361389acc16b7721305a16d0ec739e",
         },
     )
 
     updated = conversation_store.switch_conversation_agent(
         conv_id,
-        new_agent_id="ag_switch_new2",
+        new_agent_id="6b49de4c1bc8cb4d4c02a933f68bd3b1",
         new_agent_name="claude (switch new)",
-        new_agent_bundle_location="ag_switch_new2/hash",
+        new_agent_bundle_location="6b49de4c1bc8cb4d4c02a933f68bd3b1/hash",
         new_agent_description=None,
         copy_model_settings=True,  # same family (anthropic native → sdk)
         carry_history_into_native=False,  # SDK target rebuilds nothing
@@ -3989,18 +4014,20 @@ def test_get_session_connectivity_batches_runner_and_host(
     - an unknown id is absent from the result (callers treat that as
       reachable, matching the legacy single-row path).
     """
-    _register_host(db_uri, "host_conn")
+    _register_host(db_uri, "a6bfc420101272fcd5906a9eff904dfd")
     runner_bound = conversation_store.create_conversation(runner_id="runner_xyz")
-    host_bound = conversation_store.create_conversation(host_id="host_conn", workspace="/tmp/ws")
+    host_bound = conversation_store.create_conversation(
+        host_id="a6bfc420101272fcd5906a9eff904dfd", workspace="/tmp/ws"
+    )
 
     result = conversation_store.get_session_connectivity(
-        [runner_bound.id, host_bound.id, "conv_unknown"]
+        [runner_bound.id, host_bound.id, "fee171f70cf25c4cff8203046e727fd4"]
     )
 
     assert set(result) == {runner_bound.id, host_bound.id}
     assert result[runner_bound.id].runner_id == "runner_xyz"
     assert result[runner_bound.id].host_id is None
-    assert result[host_bound.id].host_id == "host_conn"
+    assert result[host_bound.id].host_id == "a6bfc420101272fcd5906a9eff904dfd"
     assert result[host_bound.id].runner_id is None
     # None of these are forks of a coding session, so needs_workspace is
     # off across the board — a True here would wrongly force the online
@@ -4023,7 +4050,9 @@ def test_get_session_connectivity_reports_needs_workspace_for_fork(
     dropping the first message.
     """
     fork = conversation_store.create_conversation()
-    conversation_store.set_labels(fork.id, {"omnigent.fork.source_id": "conv_src"})
+    conversation_store.set_labels(
+        fork.id, {"omnigent.fork.source_id": "e9f8f58523cec9a57d3bdf93be543e8c"}
+    )
     plain = conversation_store.create_conversation()
 
     result = conversation_store.get_session_connectivity([fork.id, plain.id])
@@ -4424,8 +4453,12 @@ def test_fork_seeds_next_position_from_copied_items(
 ) -> None:
     """A full fork seeds the clone's allocator from the number of copied items,
     so the clone's first append is scan-free and collision-free."""
-    agent_store.create(agent_id="ag_fork_pos", name="fork-pos", bundle_location="ag_fork_pos/h")
-    source = conversation_store.create_conversation(agent_id="ag_fork_pos")
+    agent_store.create(
+        agent_id="ff3484a650590e134422ae11acaae3ac",
+        name="fork-pos",
+        bundle_location="ff3484a650590e134422ae11acaae3ac/h",
+    )
+    source = conversation_store.create_conversation(agent_id="ff3484a650590e134422ae11acaae3ac")
     conversation_store.append(
         source.id, [_user_message(f"s{i}", response_id="resp_1") for i in range(3)]
     )
@@ -4445,9 +4478,11 @@ def test_truncated_fork_seeds_next_position_from_copied_items(
     """A truncated fork seeds the allocator from the count of the *copied*
     items, not the source length, so the shorter clone stays collision-free."""
     agent_store.create(
-        agent_id="ag_fork_trunc", name="fork-trunc", bundle_location="ag_fork_trunc/h"
+        agent_id="1e63c4993591d0eed8605bac4927a143",
+        name="fork-trunc",
+        bundle_location="1e63c4993591d0eed8605bac4927a143/h",
     )
-    source = conversation_store.create_conversation(agent_id="ag_fork_trunc")
+    source = conversation_store.create_conversation(agent_id="1e63c4993591d0eed8605bac4927a143")
     conversation_store.append(
         source.id,
         [_user_message("a", "resp_1"), _user_message("b", "resp_1")],

--- a/tests/stores/test_conversation_store_split_db.py
+++ b/tests/stores/test_conversation_store_split_db.py
@@ -49,7 +49,9 @@ def _count(db: Path, table: str) -> int:
 def _col(db: Path, table: str, col: str, where: str = "") -> list:
     with sqlite3.connect(str(db)) as conn:
         q = f"SELECT {col} FROM {table}" + (f" WHERE {where}" if where else "")
-        return [r[0] for r in conn.execute(q).fetchall()]
+        rows = [r[0] for r in conn.execute(q).fetchall()]
+        # id columns are 16-byte blobs; present them as bare hex.
+        return [v.hex() if isinstance(v, bytes) else v for v in rows]
 
 
 # ── Table placement ────────────────────────────────────
@@ -66,7 +68,7 @@ def test_tables_live_in_correct_db(
 
     # AP tables in conv_db only
     for t in ("conversations", "conversation_items", "conversation_labels"):
-        assert t in conv_tables, f"{t} missing from conv_db"
+        assert t in conv_tables, f"{t} missing from 9b7e62bfe9e16274877fe2868bffae5e"
 
     # Omnigent tables in omnigent_db
     for t in ("omnigent_conversation_metadata", "agents", "hosts", "policies", "comments"):
@@ -113,10 +115,10 @@ def test_create_sub_agent_conversation(
     assert child.kind == "sub_agent"
     assert child.parent_conversation_id == parent.id
     # kind lives in metadata
-    kind_code = _col(omnigent_db, "omnigent_conversation_metadata", "kind", f"id='{child.id}'")
+    kind_code = _col(omnigent_db, "omnigent_conversation_metadata", "kind", f"id=X'{child.id}'")
     assert kind_code == [2]
     # title and parent link live in AP
-    parent_id_col = _col(conv_db, "conversations", "parent_conversation_id", f"id='{child.id}'")
+    parent_id_col = _col(conv_db, "conversations", "parent_conversation_id", f"id=X'{child.id}'")
     assert parent_id_col == [parent.id]
 
 
@@ -256,7 +258,7 @@ def test_set_runner_id_lands_in_omnigent_db(
     conv = store.create_conversation(title="runner")
     store.set_runner_id(conv.id, "runner_xyz")
     runner_ids = _col(
-        omnigent_db, "omnigent_conversation_metadata", "runner_id", f"id='{conv.id}'"
+        omnigent_db, "omnigent_conversation_metadata", "runner_id", f"id=X'{conv.id}'"
     )
     assert runner_ids == ["runner_xyz"]
 
@@ -427,26 +429,28 @@ def test_agent_store_resolves_session_id_across_dbs(
     from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 
     created = store.create_session_with_agent(
-        agent_id="ag_split_1",
+        agent_id="112c4ebea353b873df12de9d02f539ab",
         agent_name="session-agent",
-        agent_bundle_location="ag_split_1/bundle",
+        agent_bundle_location="112c4ebea353b873df12de9d02f539ab/bundle",
         agent_description=None,
         title="split session",
     )
     # Agent row lands in the Omnigent DB; the binding in the AP DB's
     # agent_configuration table.
     assert _count(omnigent_db, "agents") == 1
-    assert _col(conv_db, "agent_configuration", "agent_id") == ["ag_split_1"]
+    assert _col(conv_db, "agent_configuration", "agent_id") == ["112c4ebea353b873df12de9d02f539ab"]
 
     agent_store = SqlAlchemyAgentStore(
         f"sqlite:///{omnigent_db}",
         f"sqlite:///{conv_db}",
     )
-    agent = agent_store.get("ag_split_1")
+    agent = agent_store.get("112c4ebea353b873df12de9d02f539ab")
     assert agent is not None
     assert agent.session_id == created.conversation.id
 
-    updated = agent_store.update("ag_split_1", "ag_split_1/bundle2")
+    updated = agent_store.update(
+        "112c4ebea353b873df12de9d02f539ab", "112c4ebea353b873df12de9d02f539ab/bundle2"
+    )
     assert updated is not None
     assert updated.session_id == created.conversation.id
 
@@ -476,7 +480,7 @@ def test_update_conversation_archives_without_metadata_row(
     with sqlite3.connect(str(omnigent_db)) as conn:
         conn.execute(
             "DELETE FROM omnigent_conversation_metadata WHERE id IN (?, ?)",
-            (parent.id, child.id),
+            (bytes.fromhex(parent.id), bytes.fromhex(child.id)),
         )
         conn.commit()
     assert _count(omnigent_db, "omnigent_conversation_metadata") == 0
@@ -510,9 +514,9 @@ def test_delete_conversation_deletes_session_scoped_agent(
 ) -> None:
     """Deleting a session deletes the session-scoped agent row backing it."""
     created = store.create_session_with_agent(
-        agent_id="ag_del_1",
+        agent_id="d6f21846ee961735d477aae06247b99c",
         agent_name="del-agent",
-        agent_bundle_location="ag_del_1/bundle",
+        agent_bundle_location="d6f21846ee961735d477aae06247b99c/bundle",
         agent_description=None,
         title="del session",
     )
@@ -535,8 +539,12 @@ def test_delete_conversation_keeps_template_agent(
         f"sqlite:///{omnigent_db}",
         f"sqlite:///{conv_db}",
     )
-    template = agent_store.create("ag_tmpl_1", "shared-template", "ag_tmpl_1/bundle")
+    template = agent_store.create(
+        "191cbf904e3223e9e00ac9a1abfe79a5",
+        "shared-template",
+        "191cbf904e3223e9e00ac9a1abfe79a5/bundle",
+    )
     conv = store.create_conversation(title="uses template", agent_id=template.id)
 
     asyncio.run(store.delete_conversation(conv.id))
-    assert _col(omnigent_db, "agents", "id") == ["ag_tmpl_1"]
+    assert _col(omnigent_db, "agents", "id") == ["191cbf904e3223e9e00ac9a1abfe79a5"]

--- a/tests/stores/test_file_store.py
+++ b/tests/stores/test_file_store.py
@@ -14,7 +14,7 @@ def file_store(db_uri: str) -> SqlAlchemyFileStore:
 
 def test_create_and_get(file_store: SqlAlchemyFileStore) -> None:
     f = file_store.create(filename="data.csv", bytes=1024)
-    assert f.id.startswith("file_")
+    assert len(f.id) == 32
     assert f.filename == "data.csv"
     assert f.bytes == 1024
 
@@ -24,7 +24,7 @@ def test_create_and_get(file_store: SqlAlchemyFileStore) -> None:
 
 
 def test_get_nonexistent(file_store: SqlAlchemyFileStore) -> None:
-    assert file_store.get("file_nonexistent") is None
+    assert file_store.get("0017bdafc0b60ad65aff5ea44c8e294d") is None
 
 
 def test_create_with_content_type(file_store: SqlAlchemyFileStore) -> None:
@@ -83,13 +83,13 @@ def test_list_asc_with_after_cursor(file_store: SqlAlchemyFileStore) -> None:
 def test_create_for_session(file_store: SqlAlchemyFileStore) -> None:
     """Session-scoped create records session_id on the file."""
     f = file_store.create(
-        session_id="conv_abc",
+        session_id="4e92b5a0c0ee6db3f874f9c4a3f855a5",
         filename="report.pdf",
         bytes=5000,
         content_type="application/pdf",
     )
-    assert f.id.startswith("file_")
-    assert f.session_id == "conv_abc"
+    assert len(f.id) == 32
+    assert f.session_id == "4e92b5a0c0ee6db3f874f9c4a3f855a5"
     assert f.filename == "report.pdf"
     assert f.bytes == 5000
 
@@ -99,28 +99,28 @@ def test_get_for_session_validates_ownership(
 ) -> None:
     """get_for_session returns None if file belongs to another session."""
     f = file_store.create(
-        session_id="conv_abc",
+        session_id="4e92b5a0c0ee6db3f874f9c4a3f855a5",
         filename="owned.txt",
         bytes=10,
     )
-    assert file_store.get(f.id, session_id="conv_abc") is not None
-    assert file_store.get(f.id, session_id="conv_other") is None
+    assert file_store.get(f.id, session_id="4e92b5a0c0ee6db3f874f9c4a3f855a5") is not None
+    assert file_store.get(f.id, session_id="aef8aa8b6e9cf6eda406cb88cf33708c") is None
 
 
 def test_list_for_session_scopes_to_session(
     file_store: SqlAlchemyFileStore,
 ) -> None:
     """list_for_session only returns files owned by that session."""
-    file_store.create("a1.txt", 1, session_id="conv_a")
-    file_store.create("a2.txt", 2, session_id="conv_a")
-    file_store.create("b1.txt", 3, session_id="conv_b")
+    file_store.create("a1.txt", 1, session_id="94c349190e241f85a984b3df8f129696")
+    file_store.create("a2.txt", 2, session_id="94c349190e241f85a984b3df8f129696")
+    file_store.create("b1.txt", 3, session_id="bfcc6c068875253adf2f20bf30a19015")
     file_store.create("global.txt", 4)
 
-    page_a = file_store.list(session_id="conv_a")
+    page_a = file_store.list(session_id="94c349190e241f85a984b3df8f129696")
     assert len(page_a.data) == 2
-    assert all(f.session_id == "conv_a" for f in page_a.data)
+    assert all(f.session_id == "94c349190e241f85a984b3df8f129696" for f in page_a.data)
 
-    page_b = file_store.list(session_id="conv_b")
+    page_b = file_store.list(session_id="bfcc6c068875253adf2f20bf30a19015")
     assert len(page_b.data) == 1
     assert page_b.data[0].filename == "b1.txt"
 
@@ -129,10 +129,10 @@ def test_delete_for_session_validates_ownership(
     file_store: SqlAlchemyFileStore,
 ) -> None:
     """delete_for_session refuses to delete a file from another session."""
-    f = file_store.create("mine.txt", 10, session_id="conv_abc")
-    assert file_store.delete(f.id, session_id="conv_other") is False
+    f = file_store.create("mine.txt", 10, session_id="4e92b5a0c0ee6db3f874f9c4a3f855a5")
+    assert file_store.delete(f.id, session_id="aef8aa8b6e9cf6eda406cb88cf33708c") is False
     assert file_store.get(f.id) is not None
-    assert file_store.delete(f.id, session_id="conv_abc") is True
+    assert file_store.delete(f.id, session_id="4e92b5a0c0ee6db3f874f9c4a3f855a5") is True
     assert file_store.get(f.id) is None
 
 
@@ -140,17 +140,20 @@ def test_delete_all_for_session(
     file_store: SqlAlchemyFileStore,
 ) -> None:
     """delete_all_for_session removes all session files and returns ids."""
-    f1 = file_store.create("a.txt", 1, session_id="conv_abc")
-    f2 = file_store.create("b.txt", 2, session_id="conv_abc")
-    file_store.create("c.txt", 3, session_id="conv_other")
+    f1 = file_store.create("a.txt", 1, session_id="4e92b5a0c0ee6db3f874f9c4a3f855a5")
+    f2 = file_store.create("b.txt", 2, session_id="4e92b5a0c0ee6db3f874f9c4a3f855a5")
+    file_store.create("c.txt", 3, session_id="aef8aa8b6e9cf6eda406cb88cf33708c")
     global_f = file_store.create("global.txt", 4)
 
-    deleted_ids = file_store.delete_all_for_session("conv_abc")
+    deleted_ids = file_store.delete_all_for_session("4e92b5a0c0ee6db3f874f9c4a3f855a5")
     assert set(deleted_ids) == {f1.id, f2.id}
     assert file_store.get(f1.id) is None
     assert file_store.get(f2.id) is None
-    other_page = file_store.list(session_id="conv_other")
-    assert file_store.get(other_page.data[0].id, session_id="conv_other") is not None
+    other_page = file_store.list(session_id="aef8aa8b6e9cf6eda406cb88cf33708c")
+    assert (
+        file_store.get(other_page.data[0].id, session_id="aef8aa8b6e9cf6eda406cb88cf33708c")
+        is not None
+    )
     assert file_store.get(global_f.id) is not None
 
 
@@ -161,11 +164,11 @@ def test_list_include_unscoped_returns_session_and_global_files(
     file_store: SqlAlchemyFileStore,
 ) -> None:
     """list with include_unscoped=True includes global (session_id=NULL) files."""
-    file_store.create("session.txt", 10, session_id="conv_x")
+    file_store.create("session.txt", 10, session_id="8af356d908005a65f872c246158c6293")
     file_store.create("global.txt", 20)
-    file_store.create("other.txt", 30, session_id="conv_y")
+    file_store.create("other.txt", 30, session_id="1dacb16c401901ed250049177f59e84e")
 
-    page = file_store.list(session_id="conv_x", include_unscoped=True)
+    page = file_store.list(session_id="8af356d908005a65f872c246158c6293", include_unscoped=True)
     filenames = {f.filename for f in page.data}
     assert "session.txt" in filenames
     assert "global.txt" in filenames
@@ -176,10 +179,10 @@ def test_list_include_unscoped_false_excludes_global_files(
     file_store: SqlAlchemyFileStore,
 ) -> None:
     """list with include_unscoped=False (default) excludes global files."""
-    file_store.create("session.txt", 10, session_id="conv_x")
+    file_store.create("session.txt", 10, session_id="8af356d908005a65f872c246158c6293")
     file_store.create("global.txt", 20)
 
-    page = file_store.list(session_id="conv_x", include_unscoped=False)
+    page = file_store.list(session_id="8af356d908005a65f872c246158c6293", include_unscoped=False)
     filenames = {f.filename for f in page.data}
     assert "session.txt" in filenames
     assert "global.txt" not in filenames
@@ -199,5 +202,5 @@ def test_list_empty(file_store: SqlAlchemyFileStore) -> None:
 
 def test_delete_nonexistent_returns_false(file_store: SqlAlchemyFileStore) -> None:
     """delete returns False for an ID that was never created."""
-    result = file_store.delete("file_never_existed")
+    result = file_store.delete("e36b9de8c847c2a002707eaf64724dbf")
     assert result is False

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -54,13 +54,13 @@ def test_upsert_creates_host_on_first_connect(
     in upsert_on_connect is broken.
     """
     host = host_store.upsert_on_connect(
-        host_id="host_aaa",
+        host_id="bdda8ba7e34130318b54dd872eb160af",
         name="test-laptop",
         owner="alice@example.com",
     )
 
     # Upsert returns the entity with all fields populated.
-    assert host.host_id == "host_aaa"
+    assert host.host_id == "bdda8ba7e34130318b54dd872eb160af"
     assert host.name == "test-laptop"
     assert host.owner == "alice@example.com"
     # New host is marked online immediately.
@@ -69,9 +69,9 @@ def test_upsert_creates_host_on_first_connect(
     assert host.updated_at == host.created_at
 
     # Verify the row survives a fresh get.
-    fetched = host_store.get_host("host_aaa")
+    fetched = host_store.get_host("bdda8ba7e34130318b54dd872eb160af")
     assert fetched is not None
-    assert fetched.host_id == "host_aaa"
+    assert fetched.host_id == "bdda8ba7e34130318b54dd872eb160af"
     assert fetched.name == "test-laptop"
     assert fetched.status == "online"
 
@@ -88,18 +88,18 @@ def test_upsert_updates_existing_host_on_reconnect(
     path is broken.
     """
     host_store.upsert_on_connect(
-        host_id="host_bbb_old",
+        host_id="74d106ce261c29485a5dfb880a2cb15f",
         name="laptop",
         owner="bob@example.com",
     )
-    host_store.set_offline("host_bbb_old")
+    host_store.set_offline("74d106ce261c29485a5dfb880a2cb15f")
     updated = host_store.upsert_on_connect(
-        host_id="host_bbb_new",
+        host_id="ebfb0eac338c147444dc6dbf3f0503fc",
         name="laptop",
         owner="bob@example.com",
     )
 
-    assert updated.host_id == "host_bbb_new"
+    assert updated.host_id == "ebfb0eac338c147444dc6dbf3f0503fc"
     assert updated.status == "online"
 
 
@@ -112,13 +112,13 @@ def test_upsert_persists_configured_harnesses(host_store: HostStore) -> None:
     no readiness data and the web picker never warns.
     """
     host_store.upsert_on_connect(
-        host_id="host_ch1",
+        host_id="e8d515c60f315ca35b4109564e238669",
         name="laptop",
         owner="alice@example.com",
         configured_harnesses={"claude-sdk": True, "codex": "needs-auth"},
     )
 
-    fetched = host_store.get_host("host_ch1")
+    fetched = host_store.get_host("e8d515c60f315ca35b4109564e238669")
     assert fetched is not None
     # Exact equality: the False bit is the actionable "warn" value.
     assert fetched.configured_harnesses == {"claude-sdk": True, "codex": "needs-auth"}
@@ -135,29 +135,29 @@ def test_upsert_reconnect_overwrites_and_nulls_configured_harnesses(
     pre-readiness build would keep advertising obsolete bits forever.
     """
     host_store.upsert_on_connect(
-        host_id="host_ch2",
+        host_id="54e092213a38acc19cfd13ffb160a2b7",
         name="laptop2",
         owner="alice@example.com",
         configured_harnesses={"codex": False},
     )
     # Reconnect with fresh values — the user ran `omnigent setup`.
     host_store.upsert_on_connect(
-        host_id="host_ch2",
+        host_id="54e092213a38acc19cfd13ffb160a2b7",
         name="laptop2",
         owner="alice@example.com",
         configured_harnesses={"codex": True},
     )
-    fetched = host_store.get_host("host_ch2")
+    fetched = host_store.get_host("54e092213a38acc19cfd13ffb160a2b7")
     assert fetched is not None
     assert fetched.configured_harnesses == {"codex": True}
 
     # Reconnect without the map: back to unknown, not the stale value.
     host_store.upsert_on_connect(
-        host_id="host_ch2",
+        host_id="54e092213a38acc19cfd13ffb160a2b7",
         name="laptop2",
         owner="alice@example.com",
     )
-    fetched = host_store.get_host("host_ch2")
+    fetched = host_store.get_host("54e092213a38acc19cfd13ffb160a2b7")
     assert fetched is not None
     assert fetched.configured_harnesses is None
 
@@ -174,7 +174,7 @@ def test_malformed_configured_harnesses_column_reads_as_none(
     a JSONDecodeError here would take down GET /v1/hosts entirely.
     """
     host_store.upsert_on_connect(
-        host_id="host_ch3",
+        host_id="2da3abf4db79c0504dbda7b88dbf521d",
         name="laptop3",
         owner="alice@example.com",
         configured_harnesses={"codex": True},
@@ -183,12 +183,12 @@ def test_malformed_configured_harnesses_column_reads_as_none(
     with Session(engine) as session:
         session.execute(
             update(SqlHost)
-            .where(SqlHost.host_id == "host_ch3")
+            .where(SqlHost.host_id == "2da3abf4db79c0504dbda7b88dbf521d")
             .values(configured_harnesses="{not json")
         )
         session.commit()
 
-    fetched = host_store.get_host("host_ch3")
+    fetched = host_store.get_host("2da3abf4db79c0504dbda7b88dbf521d")
     assert fetched is not None
     assert fetched.configured_harnesses is None
 
@@ -220,31 +220,31 @@ def test_reconnect_with_rotated_host_id_repoints_bound_conversations(
     conversations = SqlAlchemyConversationStore(db_uri)
 
     host_store.upsert_on_connect(
-        host_id="host_rot_old",
+        host_id="a1ed1ab71de2311e20488a989e61701c",
         name="dev-laptop",
         owner="dana@example.com",
     )
     # Bind a conversation to the old host_id (workspace is required by
     # the ck_conversations_workspace_required_for_host check constraint).
     conv = conversations.create_conversation(
-        host_id="host_rot_old",
+        host_id="a1ed1ab71de2311e20488a989e61701c",
         workspace="/Users/dana/proj",
     )
 
     # Same (owner, name), rotated host_id — this used to raise.
     updated = host_store.upsert_on_connect(
-        host_id="host_rot_new",
+        host_id="b1b5efd7dfc33b5a6241f1866ffb00e6",
         name="dev-laptop",
         owner="dana@example.com",
     )
 
-    assert updated.host_id == "host_rot_new"
+    assert updated.host_id == "b1b5efd7dfc33b5a6241f1866ffb00e6"
     assert updated.status == "online"
     # The binding followed the rotation — the conversation now points at
     # the new host_id, not the old (dangling) one or NULL.
     rebound = conversations.get_conversation(conv.id)
     assert rebound is not None
-    assert rebound.host_id == "host_rot_new", (
+    assert rebound.host_id == "b1b5efd7dfc33b5a6241f1866ffb00e6", (
         "conversation must be repointed to the rotated host_id so the "
         "session stays bound to the reconnected host"
     )
@@ -270,31 +270,33 @@ def test_reown_host_id_across_owner_change_preserves_conversation_binding(
 
     conversations = SqlAlchemyConversationStore(db_uri)
     host_store.upsert_on_connect(
-        host_id="host_flip",
+        host_id="a0c8ab2431b35377abb4232febeded94",
         name="laptop",
         owner="admin@example.com",
         allow_host_id_reown=True,
     )
-    conv = conversations.create_conversation(host_id="host_flip", workspace="/home/me/proj")
+    conv = conversations.create_conversation(
+        host_id="a0c8ab2431b35377abb4232febeded94", workspace="/home/me/proj"
+    )
 
     # Auth flipped to header mode: same machine, same host_id, new owner.
     reowned = host_store.upsert_on_connect(
-        host_id="host_flip",
+        host_id="a0c8ab2431b35377abb4232febeded94",
         name="laptop",
         owner="local",
         allow_host_id_reown=True,
     )
 
-    assert reowned.host_id == "host_flip"
+    assert reowned.host_id == "a0c8ab2431b35377abb4232febeded94"
     assert reowned.owner == "local"
     assert reowned.status == "online"
     # The conversation binding survives the owner change (host_id unchanged).
     rebound = conversations.get_conversation(conv.id)
     assert rebound is not None
-    assert rebound.host_id == "host_flip"
+    assert rebound.host_id == "a0c8ab2431b35377abb4232febeded94"
     # Exactly one row for this host_id — re-owned, not duplicated.
     online = host_store.list_hosts(owner="local")
-    assert [h.host_id for h in online] == ["host_flip"]
+    assert [h.host_id for h in online] == ["a0c8ab2431b35377abb4232febeded94"]
     assert host_store.list_hosts(owner="admin@example.com") == []
 
 
@@ -312,11 +314,13 @@ def test_reown_disabled_rejects_foreign_owner_claiming_host_id(
     """
     from sqlalchemy.exc import IntegrityError
 
-    host_store.upsert_on_connect(host_id="host_x", name="alice-box", owner="alice@example.com")
+    host_store.upsert_on_connect(
+        host_id="5d23e459b50e20479abf5d3fa8e2f936", name="alice-box", owner="alice@example.com"
+    )
 
     with pytest.raises(IntegrityError):
         host_store.upsert_on_connect(
-            host_id="host_x",
+            host_id="5d23e459b50e20479abf5d3fa8e2f936",
             name="bob-box",
             owner="bob@example.com",
         )
@@ -336,13 +340,13 @@ def test_set_offline(host_store: HostStore) -> None:
     statement is not executing or not committing.
     """
     host_store.upsert_on_connect(
-        host_id="host_ccc",
+        host_id="7b463227e479b3a677307588a5d9e44f",
         name="laptop",
         owner="carol@example.com",
     )
-    host_store.set_offline("host_ccc")
+    host_store.set_offline("7b463227e479b3a677307588a5d9e44f")
 
-    fetched = host_store.get_host("host_ccc")
+    fetched = host_store.get_host("7b463227e479b3a677307588a5d9e44f")
     assert fetched is not None
     assert fetched.status == "offline"
 
@@ -356,7 +360,7 @@ def test_set_offline_noop_for_unknown_host(
     The disconnect callback may fire after a failed registration;
     it must not raise.
     """
-    host_store.set_offline("host_nonexistent")
+    host_store.set_offline("aababcc3941edb738172734a9ab7bb8c")
 
 
 def test_heartbeat_advances_updated_at_without_changing_status(
@@ -371,13 +375,13 @@ def test_heartbeat_advances_updated_at_without_changing_status(
     past the TTL and wrongly drop offline; if it flipped ``status``,
     it would fight the connect/disconnect writers.
     """
-    host_store.upsert_on_connect("host_hb", "laptop", "alice@example.com")
+    host_store.upsert_on_connect("12b05166b1e4ccd4dce299285b12442f", "laptop", "alice@example.com")
     # Stand last-seen well in the past, as if the last touch was long ago.
-    _set_updated_at(db_uri, "host_hb", now_epoch() - 10_000)
+    _set_updated_at(db_uri, "12b05166b1e4ccd4dce299285b12442f", now_epoch() - 10_000)
 
-    host_store.heartbeat("host_hb")
+    host_store.heartbeat("12b05166b1e4ccd4dce299285b12442f")
 
-    fetched = host_store.get_host("host_hb")
+    fetched = host_store.get_host("12b05166b1e4ccd4dce299285b12442f")
     assert fetched is not None
     # Last-seen jumped back to ~now (within a generous window for clock
     # granularity), proving the heartbeat wrote a fresh timestamp.
@@ -392,7 +396,7 @@ def test_heartbeat_noop_for_unknown_host(host_store: HostStore) -> None:
 
     A heartbeat can race a just-deregistered host; it must not raise.
     """
-    host_store.heartbeat("host_nonexistent")
+    host_store.heartbeat("aababcc3941edb738172734a9ab7bb8c")
 
 
 def test_is_online_true_for_fresh_online_host(host_store: HostStore) -> None:
@@ -402,8 +406,8 @@ def test_is_online_true_for_fresh_online_host(host_store: HostStore) -> None:
     This is the live-host happy path that keeps a connected session in
     the Connected group.
     """
-    host_store.upsert_on_connect("host_fresh", "laptop", "alice@example.com")
-    assert host_store.is_online("host_fresh") is True
+    host_store.upsert_on_connect("c077de8b7f1cdaa48fa9edde307f5105", "laptop", "alice@example.com")
+    assert host_store.is_online("c077de8b7f1cdaa48fa9edde307f5105") is True
 
 
 def test_is_online_false_for_stale_online_host(
@@ -418,11 +422,13 @@ def test_is_online_false_for_stale_online_host(
     older than the freshness window it must read as offline, even though
     ``set_offline`` never ran.
     """
-    host_store.upsert_on_connect("host_stale", "laptop", "alice@example.com")
+    host_store.upsert_on_connect("f5422856c5f2a0d1189fdd49de0c469c", "laptop", "alice@example.com")
     # One second past the window — unambiguously stale.
-    _set_updated_at(db_uri, "host_stale", now_epoch() - HOST_LIVENESS_TTL_S - 1)
+    _set_updated_at(
+        db_uri, "f5422856c5f2a0d1189fdd49de0c469c", now_epoch() - HOST_LIVENESS_TTL_S - 1
+    )
 
-    assert host_store.is_online("host_stale") is False
+    assert host_store.is_online("f5422856c5f2a0d1189fdd49de0c469c") is False
 
 
 def test_is_online_false_for_offline_and_unknown(host_store: HostStore) -> None:
@@ -432,10 +438,10 @@ def test_is_online_false_for_offline_and_unknown(host_store: HostStore) -> None:
     A clean disconnect (set_offline) and a never-seen host_id both must
     read as not-live regardless of timestamps.
     """
-    host_store.upsert_on_connect("host_off", "laptop", "alice@example.com")
-    host_store.set_offline("host_off")
-    assert host_store.is_online("host_off") is False
-    assert host_store.is_online("host_never_seen") is False
+    host_store.upsert_on_connect("ba0a675ffb72378982f8ef434478adc8", "laptop", "alice@example.com")
+    host_store.set_offline("ba0a675ffb72378982f8ef434478adc8")
+    assert host_store.is_online("ba0a675ffb72378982f8ef434478adc8") is False
+    assert host_store.is_online("d75a658a60c6bbad9c213a6e5cfbabf3") is False
 
 
 def test_online_host_ids_returns_only_live_hosts(
@@ -456,16 +462,29 @@ def test_online_host_ids_returns_only_live_hosts(
     """
     # Distinct (host_id, name) per row — the hosts unique constraint is
     # (workspace_id, owner, name), so reusing one name would collide.
-    host_store.upsert_on_connect("host_live", "laptop-live", "alice@example.com")
-    host_store.upsert_on_connect("host_stale2", "laptop-stale", "alice@example.com")
-    host_store.upsert_on_connect("host_offline", "laptop-off", "alice@example.com")
-    host_store.set_offline("host_offline")
-    _set_updated_at(db_uri, "host_stale2", now_epoch() - HOST_LIVENESS_TTL_S - 1)
+    host_store.upsert_on_connect(
+        "2fd786c75c03cfbbec099a6820c08b62", "laptop-live", "alice@example.com"
+    )
+    host_store.upsert_on_connect(
+        "1b82e794a2b66c37d902e663a89e0d91", "laptop-stale", "alice@example.com"
+    )
+    host_store.upsert_on_connect(
+        "3d9665477127e41f42de3f4109418173", "laptop-off", "alice@example.com"
+    )
+    host_store.set_offline("3d9665477127e41f42de3f4109418173")
+    _set_updated_at(
+        db_uri, "1b82e794a2b66c37d902e663a89e0d91", now_epoch() - HOST_LIVENESS_TTL_S - 1
+    )
 
     result = host_store.online_host_ids(
-        ["host_live", "host_stale2", "host_offline", "host_unknown"]
+        [
+            "2fd786c75c03cfbbec099a6820c08b62",
+            "1b82e794a2b66c37d902e663a89e0d91",
+            "3d9665477127e41f42de3f4109418173",
+            "5342cd866f93bf4bad2f138f44f3609b",
+        ]
     )
-    assert result == {"host_live"}
+    assert result == {"2fd786c75c03cfbbec099a6820c08b62"}
 
 
 def test_online_host_ids_empty_input_skips_query(host_store: HostStore) -> None:
@@ -491,7 +510,7 @@ def test_host_is_live_boundary_is_inclusive() -> None:
     """
     now = now_epoch()
     at_ttl = Host(
-        host_id="host_edge",
+        host_id="85816a8fc5fccd5874bf61da46a4c0ef",
         name="laptop",
         owner="a@example.com",
         status="online",
@@ -499,7 +518,7 @@ def test_host_is_live_boundary_is_inclusive() -> None:
         updated_at=now - HOST_LIVENESS_TTL_S,
     )
     just_past = Host(
-        host_id="host_edge",
+        host_id="85816a8fc5fccd5874bf61da46a4c0ef",
         name="laptop",
         owner="a@example.com",
         status="online",
@@ -519,9 +538,15 @@ def test_list_hosts_filters_by_owner(
     If alice sees bob's host, the WHERE clause on ``owner`` is missing
     or broken.
     """
-    host_store.upsert_on_connect("host_d1", "alice-laptop", "alice@example.com")
-    host_store.upsert_on_connect("host_d2", "bob-laptop", "bob@example.com")
-    host_store.upsert_on_connect("host_d3", "alice-arca", "alice@example.com")
+    host_store.upsert_on_connect(
+        "dd631c2a902eeead6632bb7a15d2a36d", "alice-laptop", "alice@example.com"
+    )
+    host_store.upsert_on_connect(
+        "af2aefbe4a416df7641bf8ca520f838f", "bob-laptop", "bob@example.com"
+    )
+    host_store.upsert_on_connect(
+        "58d8ac102d1d1b3db3f5056a7c8e196b", "alice-arca", "alice@example.com"
+    )
 
     alice_hosts = host_store.list_hosts("alice@example.com")
     bob_hosts = host_store.list_hosts("bob@example.com")
@@ -531,8 +556,8 @@ def test_list_hosts_filters_by_owner(
     assert len(bob_hosts) == 1
 
     alice_ids = {h.host_id for h in alice_hosts}
-    assert alice_ids == {"host_d1", "host_d3"}
-    assert bob_hosts[0].host_id == "host_d2"
+    assert alice_ids == {"dd631c2a902eeead6632bb7a15d2a36d", "58d8ac102d1d1b3db3f5056a7c8e196b"}
+    assert bob_hosts[0].host_id == "af2aefbe4a416df7641bf8ca520f838f"
 
 
 def test_list_hosts_empty_for_unknown_owner(
@@ -557,7 +582,7 @@ def test_get_host_returns_none_for_unknown(
     If it raises or returns a default, the None-return contract is
     violated.
     """
-    assert host_store.get_host("host_nonexistent") is None
+    assert host_store.get_host("aababcc3941edb738172734a9ab7bb8c") is None
 
 
 def test_upsert_replaces_host_id_on_owner_name_conflict(
@@ -572,18 +597,18 @@ def test_upsert_replaces_host_id_on_owner_name_conflict(
     on (owner, name) is missing or the IntegrityError fallback is
     broken.
     """
-    host_store.upsert_on_connect("host_old", "laptop", "eve@example.com")
-    host_store.upsert_on_connect("host_new", "laptop", "eve@example.com")
+    host_store.upsert_on_connect("660d14a93e762f508ff74112a7a81eea", "laptop", "eve@example.com")
+    host_store.upsert_on_connect("9b4beb1282718551dd43288ed246fdae", "laptop", "eve@example.com")
 
     hosts = host_store.list_hosts("eve@example.com")
     # Exactly one row — the old host_id was replaced, not duplicated.
     assert len(hosts) == 1
-    assert hosts[0].host_id == "host_new"
+    assert hosts[0].host_id == "9b4beb1282718551dd43288ed246fdae"
     assert hosts[0].name == "laptop"
     assert hosts[0].status == "online"
 
     # Old host_id is gone from the DB.
-    assert host_store.get_host("host_old") is None
+    assert host_store.get_host("660d14a93e762f508ff74112a7a81eea") is None
 
 
 def test_upsert_conflict_preserves_created_at(
@@ -597,21 +622,21 @@ def test_upsert_conflict_preserves_created_at(
     it with the current time instead of leaving it untouched.
     """
     original = host_store.upsert_on_connect(
-        "host_first",
+        "4a7dab2e281a9dc8db539e9f59919109",
         "arca",
         "frank@example.com",
     )
     original_created = original.created_at
 
     host_store.upsert_on_connect(
-        "host_second",
+        "a9dac0e66482a6e9ab8a4aae5135f59b",
         "arca",
         "frank@example.com",
     )
 
     fetched = host_store.list_hosts("frank@example.com")
     assert len(fetched) == 1
-    assert fetched[0].host_id == "host_second"
+    assert fetched[0].host_id == "a9dac0e66482a6e9ab8a4aae5135f59b"
     # created_at from the original registration is preserved.
     assert fetched[0].created_at == original_created
     # updated_at should be >= the original (reconnect bumps it).
@@ -631,7 +656,7 @@ def test_register_managed_host_and_resolve_token_roundtrip(db_uri: str) -> None:
     """
     store = HostStore(db_uri)
     store.register_managed_host(
-        host_id="host_managed_1",
+        host_id="e932ccae9eeb8f2a86f7ebfc5089c28d",
         name="managed-m1",
         owner="alice@example.com",
         token="raw-launch-token-1",
@@ -642,7 +667,7 @@ def test_register_managed_host_and_resolve_token_roundtrip(db_uri: str) -> None:
 
     resolved = store.resolve_launch_token("raw-launch-token-1")
     assert resolved is not None
-    assert resolved.host_id == "host_managed_1"
+    assert resolved.host_id == "e932ccae9eeb8f2a86f7ebfc5089c28d"
     assert resolved.name == "managed-m1"
     assert resolved.owner == "alice@example.com"
     assert resolved.sandbox_provider == "modal"
@@ -659,7 +684,7 @@ def test_resolve_launch_token_rejects_unknown_and_expired(db_uri: str) -> None:
     """
     store = HostStore(db_uri)
     store.register_managed_host(
-        host_id="host_managed_2",
+        host_id="e5e05ec590da46a0e27bb138d343ffe7",
         name="managed-m2",
         owner="alice@example.com",
         token="raw-launch-token-2",
@@ -683,7 +708,7 @@ def test_register_managed_host_relaunch_rotates_credential(db_uri: str) -> None:
     """
     store = HostStore(db_uri)
     first = store.register_managed_host(
-        host_id="host_managed_3",
+        host_id="a687a760841c785578a03f4677f8db3c",
         name="managed-m3",
         owner="alice@example.com",
         token="generation-1-token",
@@ -693,7 +718,7 @@ def test_register_managed_host_relaunch_rotates_credential(db_uri: str) -> None:
     )
 
     second = store.register_managed_host(
-        host_id="host_managed_3",
+        host_id="a687a760841c785578a03f4677f8db3c",
         name="managed-m3",
         owner="alice@example.com",
         token="generation-2-token",
@@ -711,7 +736,7 @@ def test_register_managed_host_relaunch_rotates_credential(db_uri: str) -> None:
     assert store.resolve_launch_token("generation-1-token") is None
     resolved = store.resolve_launch_token("generation-2-token")
     assert resolved is not None
-    assert resolved.host_id == "host_managed_3"
+    assert resolved.host_id == "a687a760841c785578a03f4677f8db3c"
     assert resolved.sandbox_id == "sb-gen2"
 
 
@@ -724,7 +749,7 @@ def test_managed_columns_survive_connect(db_uri: str) -> None:
     """
     store = HostStore(db_uri)
     store.register_managed_host(
-        host_id="host_managed_4",
+        host_id="d55a61010459cea88ed2af0fe916139b",
         name="managed-m4",
         owner="alice@example.com",
         token="raw-launch-token-4",
@@ -734,7 +759,7 @@ def test_managed_columns_survive_connect(db_uri: str) -> None:
     )
 
     connected = store.upsert_on_connect(
-        host_id="host_managed_4",
+        host_id="d55a61010459cea88ed2af0fe916139b",
         name="managed-m4",
         owner="alice@example.com",
     )
@@ -754,7 +779,7 @@ def test_delete_host_removes_row_and_revokes_token(db_uri: str) -> None:
     """
     store = HostStore(db_uri)
     store.register_managed_host(
-        host_id="host_managed_5",
+        host_id="dcf4eb5fc0b04985ec45f79cfda95566",
         name="managed-m5",
         owner="alice@example.com",
         token="raw-launch-token-5",
@@ -763,12 +788,12 @@ def test_delete_host_removes_row_and_revokes_token(db_uri: str) -> None:
         token_expires_at=now_epoch() + 3600,
     )
 
-    store.delete_host("host_managed_5")
-    assert store.get_host("host_managed_5") is None
+    store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566")
+    assert store.get_host("dcf4eb5fc0b04985ec45f79cfda95566") is None
     assert store.resolve_launch_token("raw-launch-token-5") is None
     assert store.list_hosts("alice@example.com") == []
     # Second delete is a no-op, not an error.
-    store.delete_host("host_managed_5")
+    store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566")
 
 
 def test_revoke_launch_token_keeps_row_but_stops_resolution(db_uri: str) -> None:
@@ -780,7 +805,7 @@ def test_revoke_launch_token_keeps_row_but_stops_resolution(db_uri: str) -> None
     """
     store = HostStore(db_uri)
     store.register_managed_host(
-        host_id="host_managed_revoke",
+        host_id="f59827fa9468170e62cf28104d2a5251",
         name="managed-revoke",
         owner="alice@example.com",
         token="raw-launch-token-revoke",
@@ -792,16 +817,16 @@ def test_revoke_launch_token_keeps_row_but_stops_resolution(db_uri: str) -> None
     # broken register would make the post-revoke assertion vacuous.
     assert store.resolve_launch_token("raw-launch-token-revoke") is not None
 
-    store.revoke_launch_token("host_managed_revoke")
+    store.revoke_launch_token("f59827fa9468170e62cf28104d2a5251")
 
     # The credential is dead but the row (and its managed binding)
     # survives — a deleted row here would null the session's host_id.
     assert store.resolve_launch_token("raw-launch-token-revoke") is None
-    host = store.get_host("host_managed_revoke")
+    host = store.get_host("f59827fa9468170e62cf28104d2a5251")
     assert host is not None
     assert host.sandbox_provider == "modal"
     # Unknown host: no-op, not an error.
-    store.revoke_launch_token("host_never_existed")
+    store.revoke_launch_token("b4cfac8495d21e1a300c27de5203e52d")
 
 
 def test_managed_host_raw_token_never_stored(db_uri: str) -> None:
@@ -815,7 +840,7 @@ def test_managed_host_raw_token_never_stored(db_uri: str) -> None:
 
     store = HostStore(db_uri)
     store.register_managed_host(
-        host_id="host_managed_6",
+        host_id="64c92d9b75006275f995c5041380a170",
         name="managed-m6",
         owner="alice@example.com",
         token="raw-launch-token-6",
@@ -827,7 +852,7 @@ def test_managed_host_raw_token_never_stored(db_uri: str) -> None:
     engine = get_or_create_engine(db_uri)
     with Session(engine) as session:
         row = session.execute(
-            select(SqlHost).where(SqlHost.host_id == "host_managed_6")
+            select(SqlHost).where(SqlHost.host_id == "64c92d9b75006275f995c5041380a170")
         ).scalar_one()
         assert row.token_hash == hash_host_launch_token("raw-launch-token-6")
         assert row.token_hash != "raw-launch-token-6"
@@ -843,7 +868,7 @@ def test_register_managed_host_refuses_cross_owner_recredential(db_uri: str) -> 
     """
     store = HostStore(db_uri)
     store.register_managed_host(
-        host_id="host_managed_7",
+        host_id="58f80f7592c6a72ba121eb5aedde8a82",
         name="managed-m7",
         owner="alice@example.com",
         token="alice-token-7",
@@ -854,7 +879,7 @@ def test_register_managed_host_refuses_cross_owner_recredential(db_uri: str) -> 
 
     with pytest.raises(ValueError, match="different owner"):
         store.register_managed_host(
-            host_id="host_managed_7",
+            host_id="58f80f7592c6a72ba121eb5aedde8a82",
             name="managed-m7-bob",
             owner="bob@example.com",
             token="bob-token-7",

--- a/tests/stores/test_permission_store.py
+++ b/tests/stores/test_permission_store.py
@@ -983,7 +983,7 @@ def test_check_access_public_grant_fallback(store: SqlAlchemyPermissionStore, db
 
 def test_check_access_none_user(store: SqlAlchemyPermissionStore) -> None:
     """check_access returns False when user_id is None."""
-    assert store.check_access(None, "conv_any", required_level=1) is False
+    assert store.check_access(None, "483e55280c4ee1d3ddf0492148f9eeb5", required_level=1) is False
 
 
 def test_check_access_no_grants(store: SqlAlchemyPermissionStore, db_uri: str) -> None:
@@ -1033,7 +1033,7 @@ def test_get_permission_level_public_fallback(
 
 def test_get_permission_level_none_user(store: SqlAlchemyPermissionStore) -> None:
     """get_permission_level returns None for None user_id."""
-    assert store.get_permission_level(None, "conv_any") is None
+    assert store.get_permission_level(None, "483e55280c4ee1d3ddf0492148f9eeb5") is None
 
 
 def test_get_permission_level_no_grants(store: SqlAlchemyPermissionStore, db_uri: str) -> None:

--- a/tests/stores/test_scheduled_task_store.py
+++ b/tests/stores/test_scheduled_task_store.py
@@ -47,28 +47,28 @@ def test_create_returns_scheduled_task_with_all_fields(
         prompt="Triage the inbox",
         cron_expression="0 9 * * *",
         owner_user_id="alice@example.com",
-        agent_id="ag_abc",
+        agent_id=_uid("ag_abc"),
         timezone="America/Los_Angeles",
         model_override="claude-opus-4-7",
         reasoning_effort="high",
         workspace="/home/alice/repo",
         base_branch="main",
         execution_target="connected_host",
-        host_id="host_abc123",
+        host_id=_uid("host_abc123"),
     )
     assert task.id == _uid("st_1")
     assert task.name == "nightly triage"
     assert task.prompt == "Triage the inbox"
     assert task.cron_expression == "0 9 * * *"
     assert task.owner_user_id == "alice@example.com"
-    assert task.agent_id == "ag_abc"
+    assert task.agent_id == _uid("ag_abc")
     assert task.timezone == "America/Los_Angeles"
     assert task.model_override == "claude-opus-4-7"
     assert task.reasoning_effort == "high"
     assert task.workspace == "/home/alice/repo"
     assert task.base_branch == "main"
     assert task.execution_target == "connected_host"
-    assert task.host_id == "host_abc123"
+    assert task.host_id == _uid("host_abc123")
     assert task.state == "active"
     assert task.last_run_at is None
     assert task.last_run_conversation_id is None
@@ -84,7 +84,7 @@ def test_create_minimal_defaults(store: SqlAlchemyScheduledTaskStore) -> None:
         prompt="do a thing",
         cron_expression="* * * * *",
         owner_user_id="bob@example.com",
-        agent_id="ag_min",
+        agent_id=_uid("ag_min"),
         timezone="UTC",
     )
     assert task.model_override is None
@@ -111,7 +111,7 @@ def test_state_round_trips_as_string(store: SqlAlchemyScheduledTaskStore) -> Non
             prompt="p",
             cron_expression="* * * * *",
             owner_user_id="u",
-            agent_id="ag",
+            agent_id=_uid("ag"),
             timezone="UTC",
             state=name,
         )
@@ -128,7 +128,7 @@ def test_create_rejects_invalid_state(store: SqlAlchemyScheduledTaskStore) -> No
             prompt="p",
             cron_expression="* * * * *",
             owner_user_id="u",
-            agent_id="ag",
+            agent_id=_uid("ag"),
             timezone="UTC",
             state="bogus",
         )
@@ -150,7 +150,7 @@ def test_execution_target_round_trips_as_string(store: SqlAlchemyScheduledTaskSt
             prompt="p",
             cron_expression="* * * * *",
             owner_user_id="u",
-            agent_id="ag",
+            agent_id=_uid("ag"),
             timezone="UTC",
             execution_target=name,
         )
@@ -167,7 +167,7 @@ def test_create_rejects_invalid_execution_target(store: SqlAlchemyScheduledTaskS
             prompt="p",
             cron_expression="* * * * *",
             owner_user_id="u",
-            agent_id="ag",
+            agent_id=_uid("ag"),
             timezone="UTC",
             execution_target="bogus",
         )
@@ -183,15 +183,15 @@ def test_update_execution_target_and_host_id_read_back(
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     updated = store.update(
-        _uid("st_upd_target"), execution_target="managed_sandbox", host_id="host_xyz"
+        _uid("st_upd_target"), execution_target="managed_sandbox", host_id=_uid("host_xyz")
     )
     assert updated is not None
     assert updated.execution_target == "managed_sandbox"
-    assert updated.host_id == "host_xyz"
+    assert updated.host_id == _uid("host_xyz")
 
 
 def test_update_state_reads_back(store: SqlAlchemyScheduledTaskStore) -> None:
@@ -202,7 +202,7 @@ def test_update_state_reads_back(store: SqlAlchemyScheduledTaskStore) -> None:
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     updated = store.update(_uid("st_upd_state"), state="paused")
@@ -221,7 +221,7 @@ def test_create_recurring_task(store: SqlAlchemyScheduledTaskStore) -> None:
         prompt="p",
         cron_expression="0 9 * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     assert task.cron_expression == "0 9 * * *"
@@ -235,7 +235,7 @@ def test_update_changes_cron_expression(store: SqlAlchemyScheduledTaskStore) -> 
         prompt="p",
         cron_expression="0 9 * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     updated = store.update(_uid("st_recron"), cron_expression="0 0 * * *")
@@ -251,7 +251,7 @@ def test_get_returns_created_task(store: SqlAlchemyScheduledTaskStore) -> None:
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag_1",
+        agent_id=_uid("ag_1"),
         timezone="UTC",
     )
     fetched = store.get(_uid("st_get"))
@@ -283,7 +283,7 @@ def test_list_orders_by_created_at_then_id(store: SqlAlchemyScheduledTaskStore) 
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     store.create(
@@ -292,7 +292,7 @@ def test_list_orders_by_created_at_then_id(store: SqlAlchemyScheduledTaskStore) 
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     ids = [r.id for r in store.list()]
@@ -307,7 +307,7 @@ def test_list_active_excludes_non_active(store: SqlAlchemyScheduledTaskStore) ->
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
         state="active",
     )
@@ -318,7 +318,7 @@ def test_list_active_excludes_non_active(store: SqlAlchemyScheduledTaskStore) ->
             prompt="p",
             cron_expression="* * * * *",
             owner_user_id="u",
-            agent_id="ag",
+            agent_id=_uid("ag"),
             timezone="UTC",
             state=other_state,
         )
@@ -337,7 +337,7 @@ def test_update_changes_fields_and_stamps_updated_at(store: SqlAlchemyScheduledT
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     updated = store.update(
@@ -347,7 +347,7 @@ def test_update_changes_fields_and_stamps_updated_at(store: SqlAlchemyScheduledT
         base_branch="develop",
         state="paused",
         last_run_at=1700000000,
-        last_run_conversation_id="conv_x",
+        last_run_conversation_id=_uid("conv_x"),
     )
     assert updated is not None
     assert updated.name == "after"
@@ -355,7 +355,7 @@ def test_update_changes_fields_and_stamps_updated_at(store: SqlAlchemyScheduledT
     assert updated.base_branch == "develop"
     assert updated.state == "paused"
     assert updated.last_run_at == 1700000000
-    assert updated.last_run_conversation_id == "conv_x"
+    assert updated.last_run_conversation_id == _uid("conv_x")
     assert updated.updated_at is not None
 
 
@@ -367,7 +367,7 @@ def test_update_noop_leaves_updated_at_none(store: SqlAlchemyScheduledTaskStore)
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     result = store.update(_uid("st_noop"), name="n")  # same value
@@ -391,7 +391,7 @@ def test_delete_removes_task(store: SqlAlchemyScheduledTaskStore) -> None:
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     assert store.delete(_uid("st_del")) is True
@@ -414,7 +414,7 @@ def test_create_run_and_list_runs(store: SqlAlchemyScheduledTaskStore) -> None:
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     store.create_run(
@@ -422,7 +422,7 @@ def test_create_run_and_list_runs(store: SqlAlchemyScheduledTaskStore) -> None:
         scheduled_task_id=_uid("st_runs"),
         status="succeeded",
         scheduled_at=100,
-        conversation_id="conv_1",
+        conversation_id=_uid("conv_1"),
         fired_at=101,
         finished_at=102,
     )
@@ -440,7 +440,7 @@ def test_create_run_and_list_runs(store: SqlAlchemyScheduledTaskStore) -> None:
     assert runs[0].error == "boom"
     assert runs[0].error_code == "rate_limited"
     assert runs[1].error_code is None
-    assert runs[1].conversation_id == "conv_1"
+    assert runs[1].conversation_id == _uid("conv_1")
     assert runs[1].fired_at == 101
     assert runs[1].finished_at == 102
 
@@ -454,7 +454,7 @@ def test_list_runs_scoped_to_task(store: SqlAlchemyScheduledTaskStore) -> None:
             prompt="p",
             cron_expression="* * * * *",
             owner_user_id="u",
-            agent_id="ag",
+            agent_id=_uid("ag"),
             timezone="UTC",
         )
     store.create_run(
@@ -484,7 +484,7 @@ def test_run_status_round_trips_as_string(store: SqlAlchemyScheduledTaskStore) -
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     for i, name in enumerate(("scheduled", "running", "succeeded", "failed", "skipped")):
@@ -506,7 +506,7 @@ def test_create_run_rejects_invalid_status_name(store: SqlAlchemyScheduledTaskSt
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     with pytest.raises(ValueError, match=r"scheduled_task_runs\.status"):
@@ -529,10 +529,10 @@ def test_update_host_id_can_be_cleared_to_null(store: SqlAlchemyScheduledTaskSto
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
         execution_target="connected_host",
-        host_id="host_abc",
+        host_id=_uid("host_abc"),
     )
     updated = store.update(_uid("st_clear_host"), execution_target="managed_sandbox", host_id=None)
     assert updated is not None
@@ -553,10 +553,10 @@ def test_update_last_run_conversation_id_can_be_cleared_to_null(
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
-    store.update(_uid("st_clear_conv"), last_run_conversation_id="conv_abc")
+    store.update(_uid("st_clear_conv"), last_run_conversation_id=_uid("conv_abc"))
     updated = store.update(_uid("st_clear_conv"), last_run_conversation_id=None)
     assert updated is not None
     assert updated.last_run_conversation_id is None
@@ -575,16 +575,16 @@ def test_update_omitting_nullable_param_leaves_field_unchanged(
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
-        host_id="host_keep",
+        host_id=_uid("host_keep"),
     )
-    store.update(_uid("st_omit"), last_run_conversation_id="conv_keep")
+    store.update(_uid("st_omit"), last_run_conversation_id=_uid("conv_keep"))
     # Update name only — host_id and last_run_conversation_id must be untouched.
     updated = store.update(_uid("st_omit"), name="new_name")
     assert updated is not None
-    assert updated.host_id == "host_keep"
-    assert updated.last_run_conversation_id == "conv_keep"
+    assert updated.host_id == _uid("host_keep")
+    assert updated.last_run_conversation_id == _uid("conv_keep")
 
 
 def test_update_clearing_already_null_field_is_noop_for_updated_at(
@@ -597,7 +597,7 @@ def test_update_clearing_already_null_field_is_noop_for_updated_at(
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     # host_id starts NULL; passing None should be a no-op (no updated_at).
@@ -617,7 +617,7 @@ def test_delete_also_removes_associated_runs(store: SqlAlchemyScheduledTaskStore
         prompt="p",
         cron_expression="* * * * *",
         owner_user_id="u",
-        agent_id="ag",
+        agent_id=_uid("ag"),
         timezone="UTC",
     )
     store.create_run(
@@ -646,7 +646,7 @@ def test_delete_does_not_remove_other_tasks_runs(store: SqlAlchemyScheduledTaskS
             prompt="p",
             cron_expression="* * * * *",
             owner_user_id="u",
-            agent_id="ag",
+            agent_id=_uid("ag"),
             timezone="UTC",
         )
         store.create_run(

--- a/tests/stores/test_session_policy_store.py
+++ b/tests/stores/test_session_policy_store.py
@@ -35,7 +35,7 @@ def session_id(db_uri: str) -> str:
     ``conversations.id`` — raw strings fail the FK check.
 
     :param db_uri: Per-test SQLite URI.
-    :returns: A conversation ID, e.g. ``"conv_abc123"``.
+    :returns: A conversation ID, e.g. ``"d1f9214d74c38b9f9a9db17ed8352dc4"``.
     """
     conv_store = SqlAlchemyConversationStore(db_uri)
     return conv_store.create_conversation().id
@@ -66,14 +66,14 @@ def test_create_returns_policy_with_correct_fields(
     map correctly.
     """
     policy = store.create(
-        policy_id="pol_test1",
+        policy_id="21cbc70e914e5189cd9a57cf7d91eaba",
         session_id=session_id,
         name="block_push",
         type="python",
         handler="github_mcp_policy.block_push",
     )
 
-    assert policy.id == "pol_test1"
+    assert policy.id == "21cbc70e914e5189cd9a57cf7d91eaba"
     assert policy.session_id == session_id
     assert policy.scope == "session"
     assert policy.name == "block_push"
@@ -90,7 +90,7 @@ def test_create_url_type(
 ) -> None:
     """``create_session_policy`` with ``type="url"`` stores an HTTP endpoint handler."""
     policy = store.create(
-        policy_id="pol_url1",
+        policy_id="850f7326576e58d827c93254ddd37859",
         session_id=session_id,
         name="external_eval",
         type="url",
@@ -107,7 +107,7 @@ def test_create_duplicate_name_raises(
 ) -> None:
     """``create_session_policy`` with a duplicate ``(session_id, name)`` raises IntegrityError."""
     store.create(
-        policy_id="pol_dup1",
+        policy_id="545045eca9c6eb6b4d328f2d4776127d",
         session_id=session_id,
         name="dup_policy",
         type="python",
@@ -115,7 +115,7 @@ def test_create_duplicate_name_raises(
     )
     with pytest.raises(IntegrityError):
         store.create(
-            policy_id="pol_dup2",
+            policy_id="568e203a2cd253403e2d849333f3a1a9",
             session_id=session_id,
             name="dup_policy",
             type="python",
@@ -130,14 +130,14 @@ def test_create_same_name_different_sessions(
 ) -> None:
     """Two sessions may have policies with the same name."""
     p1 = store.create(
-        policy_id="pol_s1",
+        policy_id="6057393a9ceea2c3beb1260a0b4e7a28",
         session_id=session_id,
         name="shared_name",
         type="python",
         handler="mod.func",
     )
     p2 = store.create(
-        policy_id="pol_s2",
+        policy_id="0813a850ccdb6f9c9ce85258f824cb4e",
         session_id=other_session_id,
         name="shared_name",
         type="python",
@@ -157,13 +157,13 @@ def test_get_returns_policy(
 ) -> None:
     """``get_session_policy`` returns the policy when it belongs to the session."""
     created = store.create(
-        policy_id="pol_get1",
+        policy_id="d091f405442fb649d0ab930564bb4c4e",
         session_id=session_id,
         name="get_policy",
         type="python",
         handler="mod.func",
     )
-    fetched = store.get("pol_get1", session_id)
+    fetched = store.get("d091f405442fb649d0ab930564bb4c4e", session_id)
 
     assert fetched is not None
     assert fetched.id == created.id
@@ -175,7 +175,7 @@ def test_get_returns_none_for_missing(
     session_id: str,
 ) -> None:
     """``get_session_policy`` returns ``None`` when the policy does not exist."""
-    assert store.get("pol_nonexistent", session_id) is None
+    assert store.get("087a5ba1a5c50583fc5bd2e3f035d3df", session_id) is None
 
 
 def test_get_returns_none_for_wrong_session(
@@ -188,13 +188,13 @@ def test_get_returns_none_for_wrong_session(
     Prevents cross-session data leakage.
     """
     store.create(
-        policy_id="pol_wrong",
+        policy_id="6965422b949aaa2efc377beba6215000",
         session_id=session_id,
         name="owned_policy",
         type="python",
         handler="mod.func",
     )
-    assert store.get("pol_wrong", other_session_id) is None
+    assert store.get("6965422b949aaa2efc377beba6215000", other_session_id) is None
 
 
 # ── list_for_session ────────────────────────────────────────────────────────
@@ -211,14 +211,14 @@ def test_list_for_session_returns_policies_in_order(
     must not appear.
     """
     store.create(
-        policy_id="pol_list1",
+        policy_id="3af4d9de715e3e8b06b2f822970abd4a",
         session_id=session_id,
         name="first",
         type="python",
         handler="mod.a",
     )
     store.create(
-        policy_id="pol_list2",
+        policy_id="3c253fc0ed81800d81cb7cbb6397534f",
         session_id=session_id,
         name="second",
         type="url",
@@ -226,7 +226,7 @@ def test_list_for_session_returns_policies_in_order(
     )
     # Different session — should not appear.
     store.create(
-        policy_id="pol_other",
+        policy_id="a768c0b59d204dfbc4fdacbd5f7ee2c2",
         session_id=other_session_id,
         name="other",
         type="python",
@@ -257,13 +257,13 @@ def test_update_changes_name(
 ) -> None:
     """``update_session_policy`` with ``name=`` changes the name and bumps ``updated_at``."""
     store.create(
-        policy_id="pol_upd1",
+        policy_id="bda355216e7cfc74b4a5e99e18a77765",
         session_id=session_id,
         name="old_name",
         type="python",
         handler="mod.func",
     )
-    updated = store.update("pol_upd1", session_id, name="new_name")
+    updated = store.update("bda355216e7cfc74b4a5e99e18a77765", session_id, name="new_name")
 
     assert updated is not None
     assert updated.name == "new_name"
@@ -277,13 +277,13 @@ def test_update_changes_enabled(
 ) -> None:
     """``update_session_policy`` with ``enabled=False`` disables the policy."""
     store.create(
-        policy_id="pol_upd2",
+        policy_id="a47e5adf5d657541bfab9cf3ddc212fa",
         session_id=session_id,
         name="toggle_policy",
         type="python",
         handler="mod.func",
     )
-    updated = store.update("pol_upd2", session_id, enabled=False)
+    updated = store.update("a47e5adf5d657541bfab9cf3ddc212fa", session_id, enabled=False)
 
     assert updated is not None
     assert updated.enabled is False
@@ -295,13 +295,13 @@ def test_update_changes_handler(
 ) -> None:
     """``update_session_policy`` with ``handler=`` changes the handler path."""
     store.create(
-        policy_id="pol_upd3",
+        policy_id="9a054e5f00dd887f19433ce8e4bac50e",
         session_id=session_id,
         name="handler_policy",
         type="python",
         handler="mod.old_func",
     )
-    updated = store.update("pol_upd3", session_id, handler="mod.new_func")
+    updated = store.update("9a054e5f00dd887f19433ce8e4bac50e", session_id, handler="mod.new_func")
 
     assert updated is not None
     assert updated.handler == "mod.new_func"
@@ -313,13 +313,13 @@ def test_update_noop_does_not_bump_timestamp(
 ) -> None:
     """``update_session_policy`` with no changes does not bump ``updated_at``."""
     store.create(
-        policy_id="pol_noop",
+        policy_id="3149668342eedf489ffc3186ea5bff28",
         session_id=session_id,
         name="noop_policy",
         type="python",
         handler="mod.func",
     )
-    updated = store.update("pol_noop", session_id)
+    updated = store.update("3149668342eedf489ffc3186ea5bff28", session_id)
 
     assert updated is not None
     assert updated.updated_at is None
@@ -330,7 +330,7 @@ def test_update_returns_none_for_missing(
     session_id: str,
 ) -> None:
     """``update_session_policy`` returns ``None`` when the policy does not exist."""
-    assert store.update("pol_missing", session_id, name="x") is None
+    assert store.update("ef6cdebfba3f61098ef9d109f3a75a05", session_id, name="x") is None
 
 
 def test_update_returns_none_for_wrong_session(
@@ -340,13 +340,15 @@ def test_update_returns_none_for_wrong_session(
 ) -> None:
     """``update_session_policy`` returns ``None`` for a different session."""
     store.create(
-        policy_id="pol_xsess",
+        policy_id="c7a1ffd25a9c5a71e2bccef623dabfcd",
         session_id=session_id,
         name="xsess_policy",
         type="python",
         handler="mod.func",
     )
-    assert store.update("pol_xsess", other_session_id, enabled=False) is None
+    assert (
+        store.update("c7a1ffd25a9c5a71e2bccef623dabfcd", other_session_id, enabled=False) is None
+    )
 
 
 # ── delete_session_policy ───────────────────────────────────────────────────
@@ -358,14 +360,14 @@ def test_delete_removes_policy(
 ) -> None:
     """``delete_session_policy`` removes the policy and returns ``True``."""
     store.create(
-        policy_id="pol_del1",
+        policy_id="8b733f758f705ef3e4ca2595c24928ff",
         session_id=session_id,
         name="to_delete",
         type="python",
         handler="mod.func",
     )
-    assert store.delete("pol_del1", session_id) is True
-    assert store.get("pol_del1", session_id) is None
+    assert store.delete("8b733f758f705ef3e4ca2595c24928ff", session_id) is True
+    assert store.get("8b733f758f705ef3e4ca2595c24928ff", session_id) is None
 
 
 def test_delete_idempotent(
@@ -373,7 +375,7 @@ def test_delete_idempotent(
     session_id: str,
 ) -> None:
     """``delete_session_policy`` on a missing policy returns ``False``."""
-    assert store.delete("pol_missing", session_id) is False
+    assert store.delete("ef6cdebfba3f61098ef9d109f3a75a05", session_id) is False
 
 
 def test_delete_wrong_session(
@@ -383,14 +385,14 @@ def test_delete_wrong_session(
 ) -> None:
     """``delete_session_policy`` returns ``False`` for a different session."""
     store.create(
-        policy_id="pol_del_x",
+        policy_id="280d6902ae146405886c3f44b6218ed8",
         session_id=session_id,
         name="xdel_policy",
         type="python",
         handler="mod.func",
     )
-    assert store.delete("pol_del_x", other_session_id) is False
-    assert store.get("pol_del_x", session_id) is not None
+    assert store.delete("280d6902ae146405886c3f44b6218ed8", other_session_id) is False
+    assert store.get("280d6902ae146405886c3f44b6218ed8", session_id) is not None
 
 
 # ── Default (server-wide) policy methods ──────────────────────────────────────
@@ -399,12 +401,12 @@ def test_delete_wrong_session(
 def test_create_default_returns_policy(store: SqlAlchemyPolicyStore) -> None:
     """create_default inserts a server-wide policy with session_id=None."""
     policy = store.create_default(
-        policy_id="dpol_1",
+        policy_id="d6e3889d86599a09d266a5ec5b5fb31f",
         name="default_block",
         type="python",
         handler="mod.default_handler",
     )
-    assert policy.id == "dpol_1"
+    assert policy.id == "d6e3889d86599a09d266a5ec5b5fb31f"
     assert policy.session_id is None
     assert policy.scope == "default"
     assert policy.name == "default_block"
@@ -418,7 +420,7 @@ def test_create_default_returns_policy(store: SqlAlchemyPolicyStore) -> None:
 def test_create_default_with_factory_params(store: SqlAlchemyPolicyStore) -> None:
     """create_default stores factory_params as JSON."""
     policy = store.create_default(
-        policy_id="dpol_fp",
+        policy_id="9bcde4e26c73ca5a771e9348ef473825",
         name="parameterized",
         type="python",
         handler="mod.func",
@@ -430,7 +432,7 @@ def test_create_default_with_factory_params(store: SqlAlchemyPolicyStore) -> Non
 def test_create_default_with_created_by(store: SqlAlchemyPolicyStore) -> None:
     """create_default stores the created_by field."""
     policy = store.create_default(
-        policy_id="dpol_cb",
+        policy_id="f26ce3338728ddfb93a1a548d0ed03e5",
         name="audited",
         type="python",
         handler="mod.func",
@@ -442,14 +444,14 @@ def test_create_default_with_created_by(store: SqlAlchemyPolicyStore) -> None:
 def test_create_default_duplicate_name_raises(store: SqlAlchemyPolicyStore) -> None:
     """create_default with a duplicate name raises IntegrityError."""
     store.create_default(
-        policy_id="dpol_dup1",
+        policy_id="30ef9eac105234195d267465c6e27eff",
         name="unique_default",
         type="python",
         handler="mod.func",
     )
     with pytest.raises(IntegrityError):
         store.create_default(
-            policy_id="dpol_dup2",
+            policy_id="b7355b4ee664fda76c12eea17a1d07ae",
             name="unique_default",
             type="python",
             handler="mod.func2",
@@ -462,14 +464,14 @@ def test_create_default_same_name_as_session_policy_ok(
 ) -> None:
     """A default policy may share a name with a session-scoped policy."""
     store.create(
-        policy_id="pol_session",
+        policy_id="28cb2620dd5d5ba3cb7560b76843cc03",
         session_id=session_id,
         name="shared_name",
         type="python",
         handler="mod.func",
     )
     default = store.create_default(
-        policy_id="dpol_shared",
+        policy_id="4897f0f26bbf333ebb62fe5ed5c6f199",
         name="shared_name",
         type="python",
         handler="mod.default_func",
@@ -480,20 +482,20 @@ def test_create_default_same_name_as_session_policy_ok(
 def test_get_default_returns_policy(store: SqlAlchemyPolicyStore) -> None:
     """get_default fetches a default policy by ID."""
     store.create_default(
-        policy_id="dpol_get",
+        policy_id="edac9ea84a69598e9ccb73c3336c8031",
         name="fetchable",
         type="python",
         handler="mod.func",
     )
-    fetched = store.get_default("dpol_get")
+    fetched = store.get_default("edac9ea84a69598e9ccb73c3336c8031")
     assert fetched is not None
-    assert fetched.id == "dpol_get"
+    assert fetched.id == "edac9ea84a69598e9ccb73c3336c8031"
     assert fetched.name == "fetchable"
 
 
 def test_get_default_returns_none_for_missing(store: SqlAlchemyPolicyStore) -> None:
     """get_default returns None when policy does not exist."""
-    assert store.get_default("dpol_missing") is None
+    assert store.get_default("ab7b605870f3262e4176d537fff85e35") is None
 
 
 def test_get_default_returns_none_for_session_policy(
@@ -502,19 +504,23 @@ def test_get_default_returns_none_for_session_policy(
 ) -> None:
     """get_default returns None for a session-scoped policy."""
     store.create(
-        policy_id="pol_sess_only",
+        policy_id="6a59a557f19ec1d10d08765fc49f4418",
         session_id=session_id,
         name="session_only",
         type="python",
         handler="mod.func",
     )
-    assert store.get_default("pol_sess_only") is None
+    assert store.get_default("6a59a557f19ec1d10d08765fc49f4418") is None
 
 
 def test_list_defaults_returns_all_in_order(store: SqlAlchemyPolicyStore) -> None:
     """list_defaults returns all default policies ordered by created_at ASC."""
-    store.create_default(policy_id="dpol_l1", name="first", type="python", handler="mod.a")
-    store.create_default(policy_id="dpol_l2", name="second", type="python", handler="mod.b")
+    store.create_default(
+        policy_id="c403c06c83b3dc07d28c88443ec88e3d", name="first", type="python", handler="mod.a"
+    )
+    store.create_default(
+        policy_id="e168997069dd3cb0a9863963a5a50e12", name="second", type="python", handler="mod.b"
+    )
     defaults = store.list_defaults()
     assert len(defaults) == 2
     assert defaults[0].name == "first"
@@ -527,14 +533,14 @@ def test_list_defaults_excludes_session_policies(
 ) -> None:
     """list_defaults does not return session-scoped policies."""
     store.create(
-        policy_id="pol_sess",
+        policy_id="f3e2af0e0194687a8b55783bcab39d8a",
         session_id=session_id,
         name="session_pol",
         type="python",
         handler="mod.func",
     )
     store.create_default(
-        policy_id="dpol_only",
+        policy_id="2bff8a0a808c93bc1ed430d4115029f2",
         name="default_only",
         type="python",
         handler="mod.func",
@@ -552,12 +558,12 @@ def test_list_defaults_empty(store: SqlAlchemyPolicyStore) -> None:
 def test_update_default_changes_name(store: SqlAlchemyPolicyStore) -> None:
     """update_default with name= changes the name and bumps updated_at."""
     store.create_default(
-        policy_id="dpol_upd1",
+        policy_id="11f91e658f317b54d430ec7c45186f14",
         name="old_name",
         type="python",
         handler="mod.func",
     )
-    updated = store.update_default("dpol_upd1", name="new_name")
+    updated = store.update_default("11f91e658f317b54d430ec7c45186f14", name="new_name")
     assert updated is not None
     assert updated.name == "new_name"
     assert updated.updated_at is not None
@@ -566,12 +572,12 @@ def test_update_default_changes_name(store: SqlAlchemyPolicyStore) -> None:
 def test_update_default_changes_handler(store: SqlAlchemyPolicyStore) -> None:
     """update_default with handler= changes the handler."""
     store.create_default(
-        policy_id="dpol_upd2",
+        policy_id="20bb4920c807fa9012956b59ae70c00f",
         name="handler_pol",
         type="python",
         handler="mod.old_func",
     )
-    updated = store.update_default("dpol_upd2", handler="mod.new_func")
+    updated = store.update_default("20bb4920c807fa9012956b59ae70c00f", handler="mod.new_func")
     assert updated is not None
     assert updated.handler == "mod.new_func"
 
@@ -579,12 +585,12 @@ def test_update_default_changes_handler(store: SqlAlchemyPolicyStore) -> None:
 def test_update_default_changes_enabled(store: SqlAlchemyPolicyStore) -> None:
     """update_default with enabled=False disables the policy."""
     store.create_default(
-        policy_id="dpol_upd3",
+        policy_id="9c22a1b2dfcfb077e9aedd1ef51c83f2",
         name="toggle_default",
         type="python",
         handler="mod.func",
     )
-    updated = store.update_default("dpol_upd3", enabled=False)
+    updated = store.update_default("9c22a1b2dfcfb077e9aedd1ef51c83f2", enabled=False)
     assert updated is not None
     assert updated.enabled is False
 
@@ -592,19 +598,19 @@ def test_update_default_changes_enabled(store: SqlAlchemyPolicyStore) -> None:
 def test_update_default_noop_does_not_bump_timestamp(store: SqlAlchemyPolicyStore) -> None:
     """update_default with no changes does not bump updated_at."""
     store.create_default(
-        policy_id="dpol_noop",
+        policy_id="f9af01a46b13c2b85c1f2c78ef637de2",
         name="noop_pol",
         type="python",
         handler="mod.func",
     )
-    updated = store.update_default("dpol_noop")
+    updated = store.update_default("f9af01a46b13c2b85c1f2c78ef637de2")
     assert updated is not None
     assert updated.updated_at is None
 
 
 def test_update_default_returns_none_for_missing(store: SqlAlchemyPolicyStore) -> None:
     """update_default returns None when policy does not exist."""
-    assert store.update_default("dpol_missing", name="x") is None
+    assert store.update_default("ab7b605870f3262e4176d537fff85e35", name="x") is None
 
 
 def test_update_default_returns_none_for_session_policy(
@@ -613,48 +619,48 @@ def test_update_default_returns_none_for_session_policy(
 ) -> None:
     """update_default returns None for a session-scoped policy."""
     store.create(
-        policy_id="pol_not_default",
+        policy_id="088193fca01626315b9eb95e3386d419",
         session_id=session_id,
         name="not_default",
         type="python",
         handler="mod.func",
     )
-    assert store.update_default("pol_not_default", name="new") is None
+    assert store.update_default("088193fca01626315b9eb95e3386d419", name="new") is None
 
 
 def test_update_default_duplicate_name_raises(store: SqlAlchemyPolicyStore) -> None:
     """update_default rejects a name that collides with another default."""
     store.create_default(
-        policy_id="dpol_ren1",
+        policy_id="38ffbd2a7ed69c629bc17fb1b3f8ec04",
         name="name_a",
         type="python",
         handler="mod.func",
     )
     store.create_default(
-        policy_id="dpol_ren2",
+        policy_id="c3d271f156340112c2b47aeeedabbe92",
         name="name_b",
         type="python",
         handler="mod.func",
     )
     with pytest.raises(IntegrityError):
-        store.update_default("dpol_ren2", name="name_a")
+        store.update_default("c3d271f156340112c2b47aeeedabbe92", name="name_a")
 
 
 def test_delete_default_removes_policy(store: SqlAlchemyPolicyStore) -> None:
     """delete_default removes the policy and returns True."""
     store.create_default(
-        policy_id="dpol_del1",
+        policy_id="7b26ccf04a2a0b3d35d7df2644362cef",
         name="to_delete",
         type="python",
         handler="mod.func",
     )
-    assert store.delete_default("dpol_del1") is True
-    assert store.get_default("dpol_del1") is None
+    assert store.delete_default("7b26ccf04a2a0b3d35d7df2644362cef") is True
+    assert store.get_default("7b26ccf04a2a0b3d35d7df2644362cef") is None
 
 
 def test_delete_default_idempotent(store: SqlAlchemyPolicyStore) -> None:
     """delete_default on a missing policy returns False."""
-    assert store.delete_default("dpol_missing") is False
+    assert store.delete_default("ab7b605870f3262e4176d537fff85e35") is False
 
 
 def test_delete_default_rejects_session_policy(
@@ -663,10 +669,10 @@ def test_delete_default_rejects_session_policy(
 ) -> None:
     """delete_default returns False for a session-scoped policy."""
     store.create(
-        policy_id="pol_no_del",
+        policy_id="8e2f6fb3fda2fb90e2c97fcb29940858",
         session_id=session_id,
         name="cant_delete_as_default",
         type="python",
         handler="mod.func",
     )
-    assert store.delete_default("pol_no_del") is False
+    assert store.delete_default("8e2f6fb3fda2fb90e2c97fcb29940858") is False

--- a/tests/test_native_state_legacy_dirs.py
+++ b/tests/test_native_state_legacy_dirs.py
@@ -1,0 +1,77 @@
+"""Legacy state-dir fallback for the claude/codex/opencode native wrappers.
+
+Sessions created before ids dropped the ``conv_`` prefix named their state
+directory ``sha256("conv_<hex>")[:N]``; lookups now receive the bare id. The
+state-dir resolver must find the legacy directory (without renaming it) and
+must converge to one directory regardless of which id form the caller holds.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+import omnigent.claude_native_state as claude_state
+import omnigent.codex_native_state as codex_state
+import omnigent.opencode_native_state as opencode_state
+
+_HEX = "12dcd7df501e40e9a506a5b0058cbafc"
+
+_MODULES = [
+    pytest.param(claude_state, "OMNIGENT_CLAUDE_NATIVE_STATE_DIR", id="claude"),
+    pytest.param(codex_state, "OMNIGENT_CODEX_NATIVE_STATE_DIR", id="codex"),
+    pytest.param(opencode_state, "OMNIGENT_OPENCODE_NATIVE_STATE_DIR", id="opencode"),
+]
+
+
+def _digest(value: str, module) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()[: module._ID_HASH_CHARS]
+
+
+@pytest.mark.parametrize(("module", "env_var"), _MODULES)
+def test_legacy_prefixed_dir_found_for_bare_id(
+    module, env_var: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(env_var, str(tmp_path))
+    legacy_dir = tmp_path / _digest(f"conv_{_HEX}", module)
+    legacy_dir.mkdir()
+
+    resolved = module._state_dir_for_conversation_id(_HEX)
+
+    assert resolved == legacy_dir, "pre-migration session state must stay reachable"
+
+
+@pytest.mark.parametrize(("module", "env_var"), _MODULES)
+def test_bare_dir_wins_when_present(
+    module, env_var: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(env_var, str(tmp_path))
+    bare_dir = tmp_path / _digest(_HEX, module)
+    bare_dir.mkdir()
+    (tmp_path / _digest(f"conv_{_HEX}", module)).mkdir()  # stale legacy sibling
+
+    assert module._state_dir_for_conversation_id(_HEX) == bare_dir
+
+
+@pytest.mark.parametrize(("module", "env_var"), _MODULES)
+def test_prefixed_and_bare_inputs_converge(
+    module, env_var: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(env_var, str(tmp_path))
+
+    # No dirs exist: both forms must point at the SAME (bare-digest) location,
+    # so a pasted legacy id and a DB-read bare id never split state.
+    from_bare = module._state_dir_for_conversation_id(_HEX)
+    from_prefixed = module._state_dir_for_conversation_id(f"conv_{_HEX}")
+    assert from_bare == from_prefixed == tmp_path / _digest(_HEX, module)
+
+
+@pytest.mark.parametrize(("module", "env_var"), _MODULES)
+def test_fresh_session_uses_bare_digest(
+    module, env_var: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(env_var, str(tmp_path))
+    resolved = module._state_dir_for_conversation_id(_HEX)
+    assert resolved == tmp_path / _digest(_HEX, module)

--- a/tests/test_resume_dispatch.py
+++ b/tests/test_resume_dispatch.py
@@ -112,12 +112,12 @@ def test_dispatch_by_runtime_claude_native_remote_routes_to_wrapper(
     monkeypatch.setattr("omnigent.claude_native.run_claude_native", _capture)
 
     resume_dispatch._dispatch_by_runtime(
-        target="conv_abc",
+        target="4e92b5a0c0ee6db3f874f9c4a3f855a5",
         server="https://example.com/",  # trailing slash — must be normalized
     )
 
     # session_id preserves the Omnigent conv id end-to-end.
-    assert captured["session_id"] == "conv_abc"
+    assert captured["session_id"] == "4e92b5a0c0ee6db3f874f9c4a3f855a5"
     # Trailing slash stripped — the wrapper expects a bare base URL.
     assert captured["server"] == "https://example.com"
     # No leaking claude args; the wrapper builds its own.
@@ -152,11 +152,11 @@ def test_dispatch_by_runtime_codex_native_remote_routes_to_wrapper(
     monkeypatch.setattr("omnigent.codex_native.run_codex_native", _capture)
 
     resume_dispatch._dispatch_by_runtime(
-        target="conv_abc",
+        target="4e92b5a0c0ee6db3f874f9c4a3f855a5",
         server="https://example.com/",
     )
 
-    assert captured["session_id"] == "conv_abc"
+    assert captured["session_id"] == "4e92b5a0c0ee6db3f874f9c4a3f855a5"
     assert captured["server"] == "https://example.com"
     assert captured["codex_args"] == ()
 
@@ -189,11 +189,11 @@ def test_dispatch_by_runtime_codex_native_local_routes_to_wrapper(
     monkeypatch.setattr("omnigent.codex_native.run_codex_native", _capture)
 
     resume_dispatch._dispatch_by_runtime(
-        target="conv_codex",
+        target="415c9954e2fe4b9276083a4d2c66f689",
         server=None,
     )
 
-    assert captured["session_id"] == "conv_codex"
+    assert captured["session_id"] == "415c9954e2fe4b9276083a4d2c66f689"
     assert captured["server"] is None
     assert captured["codex_args"] == ()
 
@@ -215,11 +215,11 @@ def test_dispatch_by_runtime_kiro_native_remote_routes_to_wrapper(
     monkeypatch.setattr("omnigent.kiro_native.run_kiro_native", _capture)
 
     resume_dispatch._dispatch_by_runtime(
-        target="conv_kiro",
+        target="823dbd1aab969b5a813fac59bb977a77",
         server="https://example.com/",
     )
 
-    assert captured["session_id"] == "conv_kiro"
+    assert captured["session_id"] == "823dbd1aab969b5a813fac59bb977a77"
     assert captured["server"] == "https://example.com"
     assert captured["kiro_args"] == ()
 
@@ -256,11 +256,11 @@ def test_dispatch_by_runtime_antigravity_native_remote_routes_to_wrapper(
     monkeypatch.setattr("omnigent.antigravity_native.run_antigravity_native", _capture)
 
     resume_dispatch._dispatch_by_runtime(
-        target="conv_agy",
+        target="a8bcbee631c58ddb98fb5e3f54a1592a",
         server="https://example.com/",
     )
 
-    assert captured["session_id"] == "conv_agy"
+    assert captured["session_id"] == "a8bcbee631c58ddb98fb5e3f54a1592a"
     assert captured["server"] == "https://example.com"
     assert captured["antigravity_args"] == ()
 
@@ -293,11 +293,11 @@ def test_dispatch_by_runtime_antigravity_native_local_routes_to_wrapper(
     monkeypatch.setattr("omnigent.antigravity_native.run_antigravity_native", _capture)
 
     resume_dispatch._dispatch_by_runtime(
-        target="conv_agy_local",
+        target="e85224ee39457def1d20bcce5b74ed8c",
         server=None,
     )
 
-    assert captured["session_id"] == "conv_agy_local"
+    assert captured["session_id"] == "e85224ee39457def1d20bcce5b74ed8c"
     assert captured["server"] is None
     assert captured["antigravity_args"] == ()
 
@@ -330,11 +330,11 @@ def test_dispatch_by_runtime_claude_native_local_still_routes_to_wrapper(
     monkeypatch.setattr("omnigent.claude_native.run_claude_native", _capture)
 
     resume_dispatch._dispatch_by_runtime(
-        target="conv_claude",
+        target="64a784c3aa907d1774f44313546947c6",
         server=None,
     )
 
-    assert captured["session_id"] == "conv_claude"
+    assert captured["session_id"] == "64a784c3aa907d1774f44313546947c6"
     assert captured["server"] is None
     assert captured["claude_args"] == ()
 
@@ -356,12 +356,12 @@ def test_dispatch_by_runtime_non_wrapper_local_raises_with_hint(
 
     with pytest.raises(click.ClickException) as excinfo:
         resume_dispatch._dispatch_by_runtime(
-            target="conv_chat",
+            target="11dc2163ab84c5afa09348998a2b6690",
             server=None,
         )
 
     msg = excinfo.value.message
-    assert "conv_chat" in msg
+    assert "11dc2163ab84c5afa09348998a2b6690" in msg
     assert "omnigent run --resume" in msg
     assert "<agent.yaml>" in msg
 
@@ -385,9 +385,9 @@ def test_read_wrapper_label_local_reads_persistent_store(
     db_path = tmp_path / "chat.db"
     store = SqlAlchemyConversationStore(f"sqlite:///{db_path}")
     created = store.create_session_with_agent(
-        agent_id="ag_codex",
+        agent_id="12c8c7631b209d1027416b4bf7604999",
         agent_name="codex-native-ui",
-        agent_bundle_location="ag_codex/bundle",
+        agent_bundle_location="12c8c7631b209d1027416b4bf7604999/bundle",
         agent_description=None,
         labels={"omnigent.wrapper": "codex-native-ui"},
     )
@@ -426,12 +426,12 @@ def test_dispatch_by_runtime_non_claude_native_remote_raises_with_hint(
 
     with pytest.raises(click.ClickException) as excinfo:
         resume_dispatch._dispatch_by_runtime(
-            target="conv_xyz",
+            target="12b8fd5b4413ededb99560e847b32b0e",
             server="https://example.com",
         )
     msg = excinfo.value.message
     # All three load-bearing pieces of the hint must appear.
-    assert "conv_xyz" in msg
+    assert "12b8fd5b4413ededb99560e847b32b0e" in msg
     assert "omnigent run --resume" in msg
     assert "https://example.com" in msg
 
@@ -458,12 +458,12 @@ def test_read_wrapper_label_remote_returns_label_when_present(
         :returns: A 200 response with a labelled body.
         """
         del headers, timeout
-        assert url.endswith("/v1/sessions/conv_abc"), url
+        assert url.endswith("/v1/sessions/4e92b5a0c0ee6db3f874f9c4a3f855a5"), url
         return httpx.Response(
             200,
             json={
-                "id": "conv_abc",
-                "agent_id": "ag_1",
+                "id": "4e92b5a0c0ee6db3f874f9c4a3f855a5",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
                 "status": "idle",
                 "created_at": 1,
                 "labels": {"omnigent.wrapper": "claude-code-native-ui"},
@@ -478,7 +478,7 @@ def test_read_wrapper_label_remote_returns_label_when_present(
 
     result = resume_dispatch._read_wrapper_label_remote(
         server="https://example.com",
-        conv_id="conv_abc",
+        conv_id="4e92b5a0c0ee6db3f874f9c4a3f855a5",
     )
     assert result == "claude-code-native-ui"
 
@@ -499,8 +499,8 @@ def test_read_wrapper_label_remote_returns_none_when_label_missing(
         return httpx.Response(
             200,
             json={
-                "id": "conv_abc",
-                "agent_id": "ag_1",
+                "id": "4e92b5a0c0ee6db3f874f9c4a3f855a5",
+                "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb",
                 "status": "idle",
                 "created_at": 1,
                 "labels": {"some.other": "label"},
@@ -515,7 +515,7 @@ def test_read_wrapper_label_remote_returns_none_when_label_missing(
 
     result = resume_dispatch._read_wrapper_label_remote(
         server="https://example.com",
-        conv_id="conv_abc",
+        conv_id="4e92b5a0c0ee6db3f874f9c4a3f855a5",
     )
     assert result is None
 
@@ -545,7 +545,7 @@ def test_read_wrapper_label_remote_raises_on_404(
     with pytest.raises(click.ClickException) as excinfo:
         resume_dispatch._read_wrapper_label_remote(
             server="https://example.com",
-            conv_id="conv_missing",
+            conv_id="5eca720dc2bc6cdc3a99028d7bd0f917",
         )
-    assert "conv_missing" in excinfo.value.message
+    assert "5eca720dc2bc6cdc3a99028d7bd0f917" in excinfo.value.message
     assert "not found" in excinfo.value.message

--- a/tests/test_sessions_native_messages.py
+++ b/tests/test_sessions_native_messages.py
@@ -17,11 +17,11 @@ def _conversation_with_wrapper(wrapper: str) -> Conversation:
     :returns: Conversation with that label and a bound agent_id.
     """
     return Conversation(
-        id="conv_test",
+        id="e1f7c651c9f97fac088ea70ef633409d",
         created_at=0,
         updated_at=0,
-        root_conversation_id="conv_test",
-        agent_id="ag_native_test",
+        root_conversation_id="e1f7c651c9f97fac088ea70ef633409d",
+        agent_id="d5de5cef9504e12d06e729f3071d4f48",
         labels={"omnigent.wrapper": wrapper},
     )
 
@@ -61,7 +61,7 @@ def test_codex_native_session_uses_codex_harness_for_web_messages() -> None:
         "content": [{"type": "input_text", "text": "hello"}],
         "model": "codex-native-ui",
         "harness": "codex-native",
-        "agent_id": "ag_native_test",
+        "agent_id": "d5de5cef9504e12d06e729f3071d4f48",
     }
 
 
@@ -78,7 +78,7 @@ def test_kiro_native_session_uses_kiro_harness_for_web_messages() -> None:
         "content": [{"type": "input_text", "text": "hello"}],
         "model": "kiro-native-ui",
         "harness": "kiro-native",
-        "agent_id": "ag_native_test",
+        "agent_id": "d5de5cef9504e12d06e729f3071d4f48",
     }
 
 
@@ -101,7 +101,7 @@ def test_antigravity_native_session_uses_antigravity_harness_for_web_messages() 
         "content": [{"type": "input_text", "text": "hello"}],
         "model": "antigravity-native-ui",
         "harness": "antigravity-native",
-        "agent_id": "ag_native_test",
+        "agent_id": "d5de5cef9504e12d06e729f3071d4f48",
     }
 
 
@@ -205,11 +205,11 @@ def test_custom_native_harness_session_without_wrapper_label_is_native(
     from omnigent.server.routes import sessions as sessions_routes
 
     conv = Conversation(
-        id="conv_polly",
+        id="0e877e3fab4a2d5f5e386ef9f791eec0",
         created_at=0,
         updated_at=0,
-        root_conversation_id="conv_polly",
-        agent_id="ag_polly",
+        root_conversation_id="0e877e3fab4a2d5f5e386ef9f791eec0",
+        agent_id="61fc939de6af22c5349fa22ba6e62aca",
         labels={},  # chat-first: no wrapper / ui presentation labels
     )
     monkeypatch.setattr(sessions_routes, "_resolve_harness", lambda _c: "codex-native")
@@ -232,11 +232,11 @@ def test_custom_sdk_harness_session_is_not_native(
     from omnigent.server.routes import sessions as sessions_routes
 
     conv = Conversation(
-        id="conv_sdk",
+        id="9842b654446e37e810871eba75f58608",
         created_at=0,
         updated_at=0,
-        root_conversation_id="conv_sdk",
-        agent_id="ag_sdk",
+        root_conversation_id="9842b654446e37e810871eba75f58608",
+        agent_id="112e3284aa0a61b1b971de591fae1a26",
         labels={},
     )
     monkeypatch.setattr(sessions_routes, "_resolve_harness", lambda _c: "claude-sdk")

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -143,7 +143,7 @@ def session_fixture(
     # reads ctx.conversation_id directly (tasks table removed).
     ctx = ToolContext(
         task_id="task_placeholder",
-        agent_id="ag_parent",
+        agent_id="2759f8a97fd91216cb3e0d7a1f60c7f6",
         conversation_id=parent_conv.id,
     )
 
@@ -567,12 +567,12 @@ def test_peek_unknown_conversation_id_returns_not_found(
     """
     tool = SysSessionGetHistoryTool()
     raw = tool.invoke(
-        json.dumps({"conversation_id": "conv_does_not_exist"}),
+        json.dumps({"conversation_id": "1d0b12236c77f69f5073a53583de1a3f"}),
         session_fixture.ctx,
     )
     payload = json.loads(raw)
     assert payload["error"] == "session_not_found"
-    assert payload["conversation_id"] == "conv_does_not_exist"
+    assert payload["conversation_id"] == "1d0b12236c77f69f5073a53583de1a3f"
 
 
 def test_peek_out_of_tree_conversation_is_rejected(
@@ -811,12 +811,12 @@ def test_close_unknown_conversation_id_returns_not_found(
     ``session_not_found`` (no DB mutation).
     """
     raw = SysSessionCloseTool().invoke(
-        json.dumps({"conversation_id": "conv_ghost"}),
+        json.dumps({"conversation_id": "761ec01d1fb0a45d2e3159d0d47a5e70"}),
         session_fixture.ctx,
     )
     payload = json.loads(raw)
     assert payload["error"] == "session_not_found"
-    assert payload["conversation_id"] == "conv_ghost"
+    assert payload["conversation_id"] == "761ec01d1fb0a45d2e3159d0d47a5e70"
 
 
 def test_close_out_of_tree_conversation_is_rejected(

--- a/tests/tools/builtins/test_sys_terminal.py
+++ b/tests/tools/builtins/test_sys_terminal.py
@@ -79,7 +79,7 @@ def ctx(tmp_path: Path) -> ToolContext:
         task_id="task_test",
         agent_id="agent_test",
         workspace=tmp_path,
-        conversation_id="conv_test",
+        conversation_id="e1f7c651c9f97fac088ea70ef633409d",
     )
 
 
@@ -735,7 +735,7 @@ def _build_idle_fixture(
     parent_conv = conv_store.create_conversation(kind="default")
     ctx = ToolContext(
         task_id="task_placeholder",
-        agent_id="ag_test",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
         conversation_id=parent_conv.id,
     )
     return parent_conv.id, ctx


### PR DESCRIPTION
## Related issue

N/A

## Summary

Omnigent-minted ids were `uuid4` hex decorated with a textual prefix (`ag_`, `conv_`, `host_`, `pol_`, `file_`, the per-item-type prefixes) stored in `varchar(64)`. The prefixes carry no information — nothing in the codebase parses them — and the decorated string doubles the storage of every id and index key.

- **Generators now emit bare 32-char hex** (`uuid4().hex`); the item type lives only in `conversation_items.type`.
- **The 19 id columns are stored as 16 raw bytes** via a new `Uuid16` TypeDecorator: `BYTEA` (Postgres), `BLOB` (SQLite/D1), `BINARY(16)` (MySQL). Python-side ids stay readable bare hex strings everywhere (entities, URLs, JSON, FTS) — the type converts only at the column boundary.
- **Migration `z6a2b3c4d5e6`** strips prefixes and retypes in one transaction, rewrites the embedded `resource_event` `session_id` copies (scoped to `type = 8` so message prose is never touched), strips the SQLite FTS mirror, and fail-louds on MySQL `UNHEX` NULLs. Downgrade restores bare-hex `varchar`.
- **Backwards compatible for every inbound legacy id**: `uuid_to_bytes` strips the known legacy prefixes at every bind (old bookmarked URLs, pasted ids, pre-migration clients keep resolving); `normalize_uuid` guards Python-side scope compares in the comment/file/policy stores; `_normalize_host_id` covers hosts with pre-migration `config.yaml`; native-harness state dirs fall back to the legacy digest; a malformed id maps to 404 (HTTP) or a clean close (host tunnel WS).
- **Deliberately excluded** (stay strings): `response_id` (polymorphic harness task token — 7 observed shapes), `runner_id`, `external_session_id`, `bundle_location` (physical artifact-store key), account token/hash columns, email identity columns.

*Scope note: this PR originally narrowed ids to `varchar(32)`; review discussion moved it to 16-byte binary storage, and it has been rebased onto the conversations split (#2341), whose two new tables (`omnigent_conversation_metadata`, `agent_configuration`) are included in the conversion.*

**ELI5:** an id like `conv_a1b2…` was 37 letters in the database; the `conv_` part was decoration. We now store just the 16 raw bytes the id really is. You still see the same readable hex everywhere, and old links with the prefix still work.

```
 write / query (Python -> DB)                     read (DB -> Python)
 "conv_a1b2…"  --strip-->  "a1b2…"                16 bytes --hex()--> "a1b2…"
 "a1b2…"       --------->  fromhex --> 16 bytes   (uniform: one-shot migration,
 (compat lives here, in Uuid16.bind)               no legacy rows can exist)
```

## Test Plan

- `tests/db` + `tests/stores` + comments/policies/hosts-tunnel/sessions/telemetry/builtin-agent suites: **1134 passed** after the fixes; new `tests/db/test_uuid16.py` (35 cases) pins the bind/normalise/decode contract, and `tests/test_native_state_legacy_dirs.py` pins the legacy state-dir fallback.
- Migration verified on a **copy of a real dev DB** through the full chain (splits → z6): all 19 columns 16-byte, zero orphaned cross-references, embedded `session_id` + FTS mirrors correct, downgrade → re-upgrade round-trip clean; seeded prose-vs-structural rows prove message content is untouched.
- Legacy compat proven end-to-end: `get_conversation("conv_"+id)` and comment get/delete with prefixed session ids resolve against migrated data; unknown prefixes (`resp_…`) fail loud.
- Postgres rehearsal: `verify_ids_migration_on_fork.py` (dry-run census incl. post-strip PK-collision preflight, apply, full after-verification, downgrade round-trip) to be run against a Lakebase fork before deploy.

## Demo

N/A (no visual change — ids in the UI render as bare hex instead of prefixed).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = running the alembic chain (upgrade + downgrade round-trip) against a copy of a real dev database and asserting byte-level storage, cross-reference integrity, and JSON/FTS rewrites. The MySQL migration path is written and guarded but has no test harness in this repo; the Postgres path is exercised by the fork-rehearsal script rather than CI. Deploy note: old code and the new schema are mutually incompatible on Postgres, so code + migration must cut over together (no rolling deploy).

## Changelog

Ids are now bare 32-character hex (no `conv_`/`ag_`/`host_` prefixes) stored as 16-byte binary; existing prefixed ids in URLs, configs, and clients keep working.

This pull request and its description were written by Isaac.
