### PR TITLE
fix(tools): make in-process sys_timer builtin fail cleanly and share validation

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -89,6 +89,12 @@ from omnigent.tools.builtins.sys_terminal import (
     SysTerminalReadTool,
     SysTerminalSendTool,
 )
+from omnigent.tools.builtins.timer import (
+    # Shared with the in-process sys_timer_set tool so the runner's firing
+    # loop validates the same argument shape and delay ceiling the LLM-facing
+    # schema advertises.
+    validate_timer_set_args,
+)
 from omnigent.tools.builtins.update_comment import UpdateCommentTool
 from omnigent.tools.builtins.upload_file import UploadFileTool, safe_resolve
 
@@ -2661,8 +2667,9 @@ def _has_subagent(
 
 
 # ── Timer dispatch (RUNNER_TIMER_DISPATCH.md) ─────────────────
-
-_MAX_TIMER_SECONDS = 1_000_000.0
+# Argument validation and the delay ceiling live in the timer builtin
+# (``validate_timer_set_args``) so this firing path and the LLM-facing
+# schema stay in lockstep.
 
 
 async def _execute_timer_set(
@@ -2683,20 +2690,10 @@ async def _execute_timer_set(
     """
     from omnigent.runner import app as _app
 
-    seconds_raw = args.get("seconds")
-    if not isinstance(seconds_raw, (int, float)) or isinstance(seconds_raw, bool):
-        return json.dumps({"error": "seconds must be a number"})
-    seconds = float(seconds_raw)
-    if seconds < 0:
-        return json.dumps({"error": "seconds must be non-negative"})
-    if seconds > _MAX_TIMER_SECONDS:
-        return json.dumps({"error": f"seconds must be <= {_MAX_TIMER_SECONDS}"})
-    repeat = args.get("repeat", False)
-    if not isinstance(repeat, bool):
-        return json.dumps({"error": "repeat must be a boolean"})
-    note: str | None = args.get("note")
-    if note is not None and not isinstance(note, str):
-        return json.dumps({"error": "note must be a string"})
+    validated = validate_timer_set_args(args)
+    if isinstance(validated, str):
+        return json.dumps({"error": validated})
+    seconds, repeat, note = validated
     if server_client is None or conversation_id is None:
         return json.dumps({"error": "timer requires server_client and conversation_id"})
 

--- a/omnigent/tools/builtins/timer.py
+++ b/omnigent/tools/builtins/timer.py
@@ -4,32 +4,38 @@ LLM-callable timer builtins.
 Two tools:
 
 - :class:`SysTimerSetTool` (``sys_timer_set``) — schedules a timer
-  that fires inbox notifications at a future timestamp.
+  that fires a notification after a delay.
 - :class:`SysTimerCancelTool` (``sys_timer_cancel``) — cancels a
   previously scheduled timer by ``timer_id``.
 
 Both tools are gated on the agent spec's top-level ``timers:`` flag
-(see :attr:`AgentSpec.timers`, defaulting to ``False`` to match the
-inner stack). On the sessions-native path the timer workflow has
-not yet been re-implemented on the runner; ``sys_timer_set`` raises
-``NotImplementedError`` and ``sys_timer_cancel`` always returns
-``status="not_found"``.
+(see :attr:`AgentSpec.timers`, defaulting to ``False``).
+
+These classes own the LLM-facing schema and argument validation.
+The firing itself runs in the runner: ``execute_tool`` intercepts
+``sys_timer_set`` / ``sys_timer_cancel`` and dispatches to
+:func:`omnigent.runner.tool_dispatch._execute_timer_set` /
+``_execute_timer_cancel``, which run the sleep-and-wake loop and own
+the per-session timer registry. The shared :func:`validate_timer_set_args`
+helper keeps both surfaces rejecting the same inputs.
 
 The tools are **synchronous** (``is_async() == False``): the LLM
-gets the ``timer_id`` directly so it can later cancel by ID. The
-firing (when implemented) arrives as a ``[System: timer X fired]``
-system message in the conversation, with ``kind="timer"`` so the
-parent's end-of-turn auto-collect (which consults
-:data:`_DRAIN_KINDS`) does NOT block on pending firings.
+gets the ``timer_id`` back immediately so it can later cancel by ID.
+A firing arrives as a hidden ``[System: timer X fired]`` meta message
+that wakes the session on the normal ingest path.
 
-See ``designs/SERVER_HARNESS_CONTRACT.md`` §Timers and step 10.
+Invoked in-process (off the runner dispatch path) these tools have no
+timer registry to schedule or cancel against, so ``invoke`` validates
+its arguments and then reports that no timer was scheduled or found
+rather than raising.
+
+See ``designs/SERVER_HARNESS_CONTRACT.md`` §Timers.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import uuid
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
@@ -46,21 +52,52 @@ _logger = logging.getLogger(__name__)
 _MAX_TIMER_SECONDS = 1_000_000.0
 
 
+def validate_timer_set_args(
+    args: dict[str, Any],
+) -> tuple[float, bool, str | None] | str:
+    """
+    Validate parsed ``sys_timer_set`` arguments.
+
+    Shared by :meth:`SysTimerSetTool.invoke` and the runner's
+    ``_execute_timer_set`` so both surfaces reject the same inputs with
+    identical messages and honor one delay ceiling.
+
+    :param args: JSON-decoded argument mapping, e.g.
+        ``{"seconds": 5, "repeat": False, "note": "x"}``.
+    :returns: ``(seconds, repeat, note)`` when valid, otherwise an error
+        message naming the first invalid field, e.g.
+        ``"seconds must be a number"``.
+    """
+    seconds_raw = args.get("seconds")
+    # Reject bool explicitly: ``isinstance(True, int)`` is True, so a bare
+    # int/float check would silently coerce ``True`` to ``1.0``.
+    if not isinstance(seconds_raw, (int, float)) or isinstance(seconds_raw, bool):
+        return "seconds must be a number"
+    seconds = float(seconds_raw)
+    if seconds < 0:
+        return "seconds must be non-negative"
+    if seconds > _MAX_TIMER_SECONDS:
+        return f"seconds must be <= {_MAX_TIMER_SECONDS}"
+    repeat = args.get("repeat", False)
+    if not isinstance(repeat, bool):
+        return "repeat must be a boolean"
+    note = args.get("note")
+    if note is not None and not isinstance(note, str):
+        return "note must be a string"
+    return seconds, repeat, note
+
+
 class SysTimerSetTool(Tool):
     """
-    Schedule a timer that fires inbox notifications.
+    Schedule a timer that fires a notification after a delay.
 
     The LLM passes ``seconds`` (delay), optional ``repeat`` (default
-    ``False``), and optional ``note`` (string echoed back in each
-    firing). The tool generates a fresh ``timer_id`` of the form
-    ``"timer_<32-char hex>"``, starts a
-    the runner-side timer task pinned to that id via
-    :class:`SetWorkflowID`, and returns the id immediately.
-
-    Firings arrive later in the conversation as ``[System: timer X
-    fired]`` system messages between iterations (the existing
-    ``async_work_complete`` drain path). Repeating timers continue
-    until ``sys_timer_cancel`` is called.
+    ``False``), and optional ``note`` (echoed back in each firing). On
+    the runner dispatch path the timer is assigned a fresh ``timer_id``
+    of the form ``"timer_<32-char hex>"`` and the id is returned
+    immediately; the firing arrives later as a hidden ``[System: timer X
+    fired]`` meta message that wakes the session. Repeating timers
+    continue until ``sys_timer_cancel`` is called.
     """
 
     @classmethod
@@ -133,105 +170,58 @@ class SysTimerSetTool(Tool):
 
     def invoke(self, arguments: str, ctx: ToolContext) -> str:
         """
-        Generate a ``timer_id``, start the
-        the runner-side timer task, return the id to the LLM.
+        Validate arguments; report that the in-process path scheduled
+        no timer.
+
+        The firing loop runs in the runner, which intercepts
+        ``sys_timer_set`` before this builtin is reached. When
+        ``invoke`` does run (off the runner dispatch path) there is no
+        timer registry to schedule against, so it validates its input
+        for a consistent error surface and then returns a structured
+        error instead of falsely reporting success.
 
         :param arguments: JSON-encoded args, e.g.
             ``'{"seconds": 5, "repeat": false, "note": "x"}'``.
-        :param ctx: Provides ``ctx.conversation_id`` — the
-            conversation the workflow appends firing messages to.
-            Required; the tool fails loud when it's ``None``.
-        :returns: JSON string ``{"timer_id", "status": "scheduled",
-            "seconds", "repeat", "note"}`` on success, or
-            ``{"error": "..."}`` on validation failure.
+        :param ctx: Provides ``ctx.conversation_id`` — required so the
+            argument contract matches the runner path.
+        :returns: JSON string ``{"error": "..."}`` — either a validation
+            failure or a note that no timer was scheduled.
         """
         try:
             args = json.loads(arguments) if arguments else {}
         except json.JSONDecodeError as exc:
             return json.dumps({"error": f"invalid arguments: {exc}"})
 
-        seconds_raw = args.get("seconds")
-        if not isinstance(seconds_raw, (int, float)) or isinstance(seconds_raw, bool):
-            # Reject bool explicitly because Python's ``isinstance(True, int)``
-            # is True; allowing it would silently coerce ``True`` to 1.0.
-            return json.dumps({"error": "seconds must be a number"})
-        seconds = float(seconds_raw)
-        if seconds < 0:
-            return json.dumps({"error": "seconds must be non-negative"})
-        if seconds > _MAX_TIMER_SECONDS:
-            return json.dumps({"error": f"seconds must be <= {_MAX_TIMER_SECONDS}"})
-
-        repeat_raw = args.get("repeat", False)
-        if not isinstance(repeat_raw, bool):
-            return json.dumps({"error": "repeat must be a boolean"})
-        repeat = bool(repeat_raw)
-
-        note_raw = args.get("note")
-        if note_raw is not None and not isinstance(note_raw, str):
-            return json.dumps({"error": "note must be a string"})
-        note: str | None = note_raw
+        validated = validate_timer_set_args(args)
+        if isinstance(validated, str):
+            return json.dumps({"error": validated})
 
         if ctx.conversation_id is None:
-            # Fail loud — the timer workflow needs a stable
-            # destination to append firing messages to.
+            # Match the runner contract: a timer needs a destination
+            # conversation to fire into.
             return json.dumps({"error": "sys_timer_set requires a conversation context"})
-
-        timer_id = f"timer_{uuid.uuid4().hex}"
-        _spawn_timer_workflow(
-            timer_id=timer_id,
-            conversation_id=ctx.conversation_id,
-            seconds=seconds,
-            repeat=repeat,
-            note=note,
-        )
 
         return json.dumps(
             {
-                "timer_id": timer_id,
-                "status": "scheduled",
-                "seconds": seconds,
-                "repeat": repeat,
-                "note": note,
+                "error": (
+                    "sys_timer_set is executed by the runner dispatch path; this "
+                    "in-process call cannot schedule a timer, so none was started."
+                )
             }
         )
-
-
-def _spawn_timer_workflow(
-    *,
-    timer_id: str,
-    conversation_id: str,
-    seconds: float,
-    repeat: bool,
-    note: str | None,
-) -> None:
-    """
-    Stub entry point — raises ``NotImplementedError`` until the
-    runner provides a timer implementation.
-
-    :param timer_id: The workflow id the timer would have been
-        pinned to (the value the LLM uses with ``sys_timer_cancel``).
-    :param conversation_id: Conversation the timer would append
-        firings to.
-    :param seconds: Sleep duration before each firing.
-    :param repeat: Whether the timer loops indefinitely.
-    :param note: Optional caller-supplied note echoed in firings.
-    """
-    del timer_id, conversation_id, seconds, repeat, note
-    raise NotImplementedError(
-        "sys_timer_set is unavailable on the sessions-native path; "
-        "the runner does not yet provide a timer implementation."
-    )
 
 
 class SysTimerCancelTool(Tool):
     """
     Cancel a scheduled timer by ``timer_id``.
 
-    On the sessions-native path no active timer can exist (the
-    timer workflow has not been re-implemented on the runner), so
-    this always returns ``status="not_found"``. Matches the
-    inner-stack semantics where a timer that already fired and
-    cleaned up is indistinguishable from one that never existed.
+    Cancellation is executed by the runner, which intercepts
+    ``sys_timer_cancel`` and drops the timer from its per-session
+    registry. When this builtin runs in-process (off the runner
+    dispatch path) there is no registry to consult, so a valid
+    ``timer_id`` reports ``status="not_found"`` — a timer that already
+    fired and cleaned up is indistinguishable from one that never
+    existed.
     """
 
     @classmethod
@@ -280,14 +270,18 @@ class SysTimerCancelTool(Tool):
 
     def invoke(self, arguments: str, ctx: ToolContext) -> str:
         """
-        Cancel the timer (always ``not_found`` on sessions-native).
+        Report cancellation for a ``timer_id`` (in-process fallback).
+
+        The runner owns the timer registry and intercepts this tool
+        before the builtin is reached; this in-process path has no
+        registry, so a valid id reports ``not_found``.
 
         :param arguments: JSON-encoded args, e.g.
             ``'{"timer_id": "timer_..."}'``.
         :param ctx: Tool context (unused; cancellation is keyed on
             ``timer_id`` alone).
-        :returns: JSON string
-            ``{"timer_id", "status": "not_found"}``.
+        :returns: JSON string ``{"timer_id", "status": "not_found"}``,
+            or ``{"error": "..."}`` for invalid input.
         """
         del ctx  # The tool doesn't need any per-invocation context.
         try:
@@ -299,5 +293,5 @@ class SysTimerCancelTool(Tool):
         if not isinstance(timer_id, str) or not timer_id:
             return json.dumps({"error": "timer_id is required"})
 
-        # No active timer can exist on the sessions-native path.
+        # No timer registry exists on the in-process path.
         return json.dumps({"timer_id": timer_id, "status": "not_found"})

--- a/tests/runner/test_tool_dispatch_timer.py
+++ b/tests/runner/test_tool_dispatch_timer.py
@@ -97,3 +97,26 @@ async def test_timer_firing_posts_hidden_meta_message() -> None:
             ],
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_timer_set_rejects_invalid_args_via_shared_validator() -> None:
+    """
+    The runner dispatch path validates through the shared
+    ``validate_timer_set_args`` helper, so a bad ``seconds`` returns the
+    same message the in-process builtin surfaces and starts no timer
+    task (no wake POST is ever made).
+    """
+    recorder = _TimerPostRecorder()
+    transport = httpx.MockTransport(recorder)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://server") as server_client:
+        output = await execute_tool(
+            tool_name="sys_timer_set",
+            arguments=json.dumps({"seconds": -1}),
+            conversation_id="conv_parent",
+            server_client=server_client,
+        )
+
+    assert json.loads(output) == {"error": "seconds must be non-negative"}
+    assert recorder.posts == []

--- a/tests/tools/builtins/test_timer.py
+++ b/tests/tools/builtins/test_timer.py
@@ -226,7 +226,7 @@ def test_validate_timer_set_args_rejects_bad_shapes(
     Each malformed shape yields an error message (a ``str``), not a
     tuple — the same messages both timer surfaces return to the LLM.
     """
-    result = validate_timer_set_args(args)  # type: ignore[arg-type]
+    result = validate_timer_set_args(args)
     assert isinstance(result, str)
     assert expected_error_substring in result
 

--- a/tests/tools/builtins/test_timer.py
+++ b/tests/tools/builtins/test_timer.py
@@ -25,6 +25,7 @@ from omnigent.tools.base import ToolContext
 from omnigent.tools.builtins.timer import (
     SysTimerCancelTool,
     SysTimerSetTool,
+    validate_timer_set_args,
 )
 from omnigent.tools.manager import ToolManager
 
@@ -167,6 +168,67 @@ def test_set_missing_conversation_id_returns_error() -> None:
     result = json.loads(result_json)
     assert "error" in result
     assert "conversation" in result["error"].lower()
+
+
+def test_set_valid_args_in_process_reports_no_schedule() -> None:
+    """
+    Fully valid args off the runner dispatch path return a structured
+    error, never a raise or a false success.
+
+    The runner intercepts ``sys_timer_set`` before this builtin is
+    reached (see ``tool_dispatch._execute_timer_set``). This guards the
+    in-process fallback: a future non-runner caller must fail cleanly
+    with no ``timer_id`` (there is no scheduled timer to cancel), rather
+    than hit the old ``NotImplementedError`` trap.
+    """
+    result_json = SysTimerSetTool().invoke('{"seconds": 5, "note": "x"}', _STUB_CTX)
+    result = json.loads(result_json)
+    assert "error" in result
+    assert "timer_id" not in result
+    assert result.get("status") != "scheduled"
+
+
+# ─── Shared validation helper ────────────────────────────────
+
+
+def test_validate_timer_set_args_accepts_valid_shapes() -> None:
+    """
+    ``validate_timer_set_args`` returns ``(seconds, repeat, note)`` for
+    valid input — the tuple the runner firing loop and the builtin both
+    consume.
+
+    This is the single contract both surfaces share; a drift here would
+    desync the runner path from the LLM-facing schema.
+    """
+    assert validate_timer_set_args({"seconds": 5}) == (5.0, False, None)
+    assert validate_timer_set_args({"seconds": 5, "repeat": True, "note": "x"}) == (
+        5.0,
+        True,
+        "x",
+    )
+
+
+@pytest.mark.parametrize(
+    "args,expected_error_substring",
+    [
+        ({}, "seconds must be a number"),
+        ({"seconds": -1}, "seconds must be non-negative"),
+        ({"seconds": 10_000_000}, "seconds must be <="),
+        ({"seconds": True}, "seconds must be a number"),
+        ({"seconds": 1, "repeat": "yes"}, "repeat must be a boolean"),
+        ({"seconds": 1, "note": 5}, "note must be a string"),
+    ],
+)
+def test_validate_timer_set_args_rejects_bad_shapes(
+    args: dict[str, object], expected_error_substring: str
+) -> None:
+    """
+    Each malformed shape yields an error message (a ``str``), not a
+    tuple — the same messages both timer surfaces return to the LLM.
+    """
+    result = validate_timer_set_args(args)  # type: ignore[arg-type]
+    assert isinstance(result, str)
+    assert expected_error_substring in result
 
 
 # ─── SysTimerCancelTool argument validation ──────────────────


### PR DESCRIPTION
## Related issue

N/A

## Summary

`sys_timer_set` / `sys_timer_cancel` are already fully implemented on the **runner** path that agents (e.g. Polly) actually use: `execute_tool` in `omnigent/runner/tool_dispatch.py` intercepts both, runs the sleep-and-wake loop (`_execute_timer_set` → `_timer_loop`), and owns the per-session timer registry. The **in-process builtin** (`omnigent/tools/builtins/timer.py`) had drifted out of sync with that reality:

- Its `invoke` success path called a `_spawn_timer_workflow` stub that **raised `NotImplementedError`** — a latent crash for any future non-runner dispatch path.
- Its module/class docstrings claimed timers were "not yet re-implemented on the runner", which is false and misleading.
- Argument validation (seconds/repeat/note + the delay ceiling) was **duplicated** between the builtin and the runner, free to drift.

This PR:
- Extracts the shared validation into `validate_timer_set_args()` in the builtin and has the runner's `_execute_timer_set` call it, so both surfaces reject the same inputs with one `_MAX_TIMER_SECONDS`.
- Replaces the raising stub with a structured `{"error": "...no timer was started"}` return (fail cleanly, no false success) and removes `_spawn_timer_workflow`.
- Corrects the stale docstrings to describe the real ownership (runner fires; builtin owns schema + validation).

No behavior change for agents — timers already fire via the runner. This is hardening + de-duplication + doc accuracy.

**ELI5:** The timer already works when an agent uses it. But a leftover copy of the code in a side path would crash if anyone ever called it, and its comments claimed the timer was unimplemented. We removed the crash, corrected the comments, and made the two copies of the validation share one source.

\`\`\`mermaid
flowchart LR
    LLM[agent call: sys_timer_set] --> ET[runner execute_tool intercept]
    ET --> TS[_execute_timer_set -> _timer_loop fires + wakes]
    TS --> VAL[validate_timer_set_args]
    ET -. off-runner fallback .-> B[builtin invoke]
    B --> VAL
    B --> ERR[structured 'no timer scheduled' error]
\`\`\`

## Test Plan

- \`uv run pytest tests/runner/test_tool_dispatch_timer.py tests/tools/builtins/test_timer.py\` → 27 passed.
- \`uv run ruff check\` on the changed files → clean.
- Added tests: builtin \`invoke\` with valid args off the runner path returns a structured error (no \`timer_id\`, no raise); direct \`validate_timer_set_args\` success + each rejection message; runner \`execute_tool\` invalid-arg surfaces the shared validator's message and starts no timer (no wake POST).

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Timer firing/wake end-to-end is already covered by \`test_timer_firing_posts_hidden_meta_message\`; this PR adds unit coverage for the validation contract and the in-process fallback.