### PR TITLE
chore(db): index conversations by runner_id

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -531,6 +531,10 @@ class SqlConversation(Base):
         # Agent lookups: find the conversation(s) that own a given agent.
         Index("ix_conversations_agent_id", "agent_id"),
         Index("ix_conversations_root_conversation_id", "root_conversation_id"),
+        # Reconnect/relaunch reconciliation looks up a runner's session(s)
+        # by runner_id (list_conversations_by_runner_id) on every runner
+        # reconnect; index it to avoid a full scan.
+        Index("ix_conversations_runner_id", "runner_id"),
         # Phase 4: partial unique index on (parent_conversation_id,
         # title) prevents two same-named children under the same
         # parent (G36 race protection at the DB layer). The

--- a/omnigent/db/migrations/versions/z2a2b3c4d5e6_add_ix_conversations_runner_id.py
+++ b/omnigent/db/migrations/versions/z2a2b3c4d5e6_add_ix_conversations_runner_id.py
@@ -1,0 +1,36 @@
+"""Add the ``ix_conversations_runner_id`` index.
+
+Revision ID: z2a2b3c4d5e6
+Revises: z1a2b3c4d5e6
+Create Date: 2026-07-08 02:00:00.000000
+
+Reconnect/relaunch reconciliation looks up a runner's session(s) by
+``runner_id`` (``list_conversations_by_runner_id``) on every runner
+reconnect. Four server call sites drive that query; without an index
+each is a full table scan of ``conversations``. Index ``runner_id`` to
+make the lookup selective.
+
+Creating an index is a simple operation on SQLite, PostgreSQL, and
+MySQL alike, so no table rebuild / batch mode is needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "z2a2b3c4d5e6"
+down_revision: str | None = "z1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the ``ix_conversations_runner_id`` index."""
+    op.create_index("ix_conversations_runner_id", "conversations", ["runner_id"])
+
+
+def downgrade() -> None:
+    """Drop the ``ix_conversations_runner_id`` index."""
+    op.drop_index("ix_conversations_runner_id", table_name="conversations")

--- a/tests/db/test_migration_workspace.py
+++ b/tests/db/test_migration_workspace.py
@@ -216,6 +216,21 @@ def test_host_id_index_dropped(db_engine: Engine) -> None:
     )
 
 
+def test_runner_id_is_indexed(db_engine: Engine) -> None:
+    """
+    Verify ``ix_conversations_runner_id`` exists at head.
+
+    Reconnect/relaunch reconciliation queries conversations by
+    ``runner_id`` (``list_conversations_by_runner_id``) on every runner
+    reconnect; without the index (migration ``z2a2b3c4d5e6``) that's a
+    full table scan.
+    """
+    index_names = {ix["name"] for ix in sa.inspect(db_engine).get_indexes("conversations")}
+    assert "ix_conversations_runner_id" in index_names, (
+        f"Expected ix_conversations_runner_id on conversations; got {sorted(index_names)}."
+    )
+
+
 def test_host_id_fk_sets_null_when_host_deleted(db_engine: Engine) -> None:
     """
     After the FK was removed, deleting a host leaves conversations.host_id


### PR DESCRIPTION
## Related issue

N/A — performance/index cleanup, follow-up to #2221.

## Summary

`list_conversations_by_runner_id` powers reconnect/relaunch reconciliation — it looks up a runner's session(s) by `runner_id`, filtering `workspace_id == current_workspace_id() AND runner_id == :runner_id`. Four server call sites drive it (`omnigent/server/app.py:2048`, `:2084`, `:2124`, `:2205`), but `conversations.runner_id` had **no index**, so each lookup was a full table scan.

This adds `ix_conversations_runner_id` on `conversations.runner_id`, mirroring the other single-column lookup indexes on the table (and the `ix_conversations_host_id` index that #2221 removed, which served the analogous — but callerless — host-id query). Migration `z2a2b3c4d5e6` creates it.

## Test Plan

Ran in a worktree off fresh `origin/main` via `uv run --extra dev`:

- `pytest tests/db/test_migration_workspace.py` → 8 passed, including the new `test_runner_id_is_indexed` (applies the full alembic chain to a fresh SQLite DB and asserts the index is present at head).
- `pytest tests/stores/test_conversation_store.py::test_list_conversations_by_runner_id_filters` → passed.
- Verified a **single** alembic head (`z2a2b3c4d5e6`) via the repo's config builder.
- Downgrade→upgrade round-trip: index present at head → absent after `downgrade z1a2b3c4d5e6` → present again after re-upgrade.
- `pre-commit run --files <changed>` and `ruff check` → all pass.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The migration workspace test gained `test_runner_id_is_indexed`, which locks in the index's presence at head; the existing `test_list_conversations_by_runner_id_filters` covers the query the index serves.

---

This pull request and its description were written by Isaac.
