### PR TITLE
fix(tests): stop test_interrupt_forwards flaking under misc-shard load

### DIFF
--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -6611,7 +6611,12 @@ async def test_interrupt_forwards_to_harness_before_cancelling() -> None:
             },
         )
         assert resp.status_code == 202
-        await _aio.wait_for(_hc.post_seen.wait(), timeout=15.0)
+        # Await these events / the interrupt task directly rather than through
+        # asyncio.wait_for: a wall-clock timeout races task completion when the
+        # loaded misc shard starves the event loop — the interrupt could return
+        # 204 yet still raise TimeoutError because the timer fired first. pytest's
+        # global --timeout guards against a genuine hang.
+        await _hc.post_seen.wait()
 
         # The interrupt route must block on the (still-blocked) harness forward —
         # forward-first awaits it before cancelling. If it completes here, the
@@ -6623,12 +6628,12 @@ async def test_interrupt_forwards_to_harness_before_cancelling() -> None:
         # Wait until the route is actually blocked on fwd_gate — deterministic
         # proof the forward is in-flight. This replaces a flaky 0.5 s sleep that
         # could race on loaded CI machines.
-        await _aio.wait_for(_hc.fwd_seen.wait(), timeout=5.0)
+        await _hc.fwd_seen.wait()
         assert not int_task.done(), "interrupt must await the harness forward (forward-first)"
 
         # Release the forward → the harness gets the interrupt, then the cancel runs.
         fwd_gate.set()
-        int_resp = await _aio.wait_for(int_task, timeout=15.0)
+        int_resp = await int_task
         assert int_resp.status_code == 204, int_resp.text
         markers = _interrupt_markers(list(_session_histories_ref.get(conv_id, [])))
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

`Pytest (misc)` has been intermittently red on `main` (3 of 5 recent runs at one
point), always on the single async test
`tests/runner/test_app_sessions_native.py::test_interrupt_forwards_to_harness_before_cancelling`.

The test awaited an **already-unblocked** task through a wall-clock timer:

```python
fwd_gate.set()
int_resp = await asyncio.wait_for(int_task, timeout=15.0)   # flaked here
```

Under the misc shard's 8-worker CPU contention the event loop gets starved past
15s, so `wait_for`'s timer cancels the await **even though the interrupt already
returned 204** — the failing traceback showed
`int_task = <Task finished ... result=<Response [204 No Content]>>` alongside the
`TimeoutError`. Nothing in the interrupt path is actually broken; only the test's
synchronization was fragile.

Fix: drop the wall-clock timers and `await` directly — the interrupt task plus the
`post_seen` / `fwd_seen` events. The task is unblocked one line earlier
(`fwd_gate.set()`), so there is no correct reason to race it against a wall clock;
pytest's global `--timeout=300` remains the genuine-hang backstop. Widening the
timeout would only lower the odds (a starvation spike past the budget still trips
it); plain `await` removes the race entirely. **Test-only change — no production
code touched.**

## Test Plan

- `pytest tests/runner/test_app_sessions_native.py::test_interrupt_forwards_to_harness_before_cancelling` — passes in isolation.
- Stress repro: ran the interrupt/codex-native subset of the file **5×** under `-n 8` with **all cores pegged by CPU hogs** (far worse loop starvation than CI). Before the change this reliably produced the `TimeoutError`; after, the test is **5/5 green**.
- `pre-commit run --files tests/runner/test_app_sessions_native.py` — all hooks pass.

## Demo

N/A — non-visual, test-only change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Manual verification = the stress reproduction described in the Test Plan (5×
`-n 8` under saturated CPU). The change only hardens the existing test's async
waits; the behavior it asserts (forward-first interrupt, single marker, 204) is
unchanged, so no new test is warranted.

This pull request and its description were written by Isaac.