### PR TITLE
docs(windows): support native dev workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,13 @@ repos:
       - id: ruff-format
         name: ruff format
         language: system
-        entry: .venv/bin/python -m ruff format --force-exclude
+        entry: uv run ruff format --force-exclude
         types: [python]
 
       - id: ruff-check
         name: ruff check
         language: system
-        entry: .venv/bin/python -m ruff check --fix --force-exclude
+        entry: uv run ruff check --fix --force-exclude
         types: [python]
 
       # Project-specific test-quality lint rules (dev/lint/). Run on test
@@ -25,14 +25,14 @@ repos:
       - id: no-global-asyncio-patch
         name: no globally-clobbering asyncio monkeypatch
         language: system
-        entry: .venv/bin/python dev/lint/lint_no_global_asyncio_patch.py
+        entry: uv run python dev/lint/lint_no_global_asyncio_patch.py
         types: [python]
         files: ^tests/
 
       - id: no-skipped-tests
         name: no unconditional `@pytest.mark.skip`
         language: system
-        entry: .venv/bin/python dev/lint/lint_no_skipped_tests.py
+        entry: uv run python dev/lint/lint_no_skipped_tests.py
         types: [python]
         files: ^tests/
 
@@ -90,7 +90,7 @@ repos:
       - id: sync-version-py
         name: sync omnigent/version.py to pyproject version
         language: system
-        entry: .venv/bin/python scripts/sync_version_py.py
+        entry: uv run python scripts/sync_version_py.py
         files: ^(pyproject\.toml|omnigent/version\.py)$
         pass_filenames: false
 
@@ -101,7 +101,7 @@ repos:
       - id: normalize-uv-lock-registry
         name: normalize uv.lock registry to pypi.org
         language: system
-        entry: .venv/bin/python scripts/normalize_uv_lock_registry.py
+        entry: uv run python scripts/normalize_uv_lock_registry.py
         files: ^uv\.lock$
         pass_filenames: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,26 +9,31 @@ configuration in issues, tests, examples, or logs.
 ## Development setup
 
 This is a Python package with an optional frontend under `web/`. Use
-[`uv`](https://docs.astral.sh/uv/) for local development:
+[`uv`](https://docs.astral.sh/uv/) for local development.
 
-**Supported dev OS: macOS or Linux.** Native Windows is not supported for
-development — some test dependencies are POSIX-only (`pexpect`/`pyte` are
-excluded on Windows), a few modules import POSIX stdlib or call `os.getuid()`
-at import time, and the `pre-commit` hooks assume the Unix `.venv/bin/` layout,
-so `pytest` and `pre-commit` cannot pass natively. On Windows, use
-**WSL2 (Ubuntu)** and clone into the **Linux** filesystem (`~/…`, not `/mnt/c`);
-this matches CI. Git Bash is not sufficient — it runs native-Windows Python.
+**Supported dev OS:** macOS, Linux, and native Windows for core/server/web
+workflows. POSIX terminal-wrapper coverage is still Linux/macOS/WSL-only:
+`pexpect`, `pyte`, raw PTY, tmux control-mode, `termios`, `fcntl`, Unix signals,
+and fork-specific tests are marked `posix_only` and intentionally skipped on
+native Windows. On Windows, use WSL2 when you need that POSIX coverage; use
+native PowerShell/Windows Terminal when you are working on core package, server,
+web UI, SDK-harness, Job Object, or psmux-backed terminal code.
 
 Install local prerequisites first:
 
 - [`uv`](https://docs.astral.sh/uv/getting-started/installation/) for Python
   environments and dependency management.
-- `tmux`, required for native Claude/Codex terminals launched by the local host
+- `tmux`, required on Linux/macOS for POSIX native terminal-wrapper tests
   (`brew install tmux` on macOS, or `apt install tmux` on Debian/Ubuntu).
-- `bubblewrap` (`bwrap`), **Linux only**, used to OS-sandbox those native
-  Claude/Codex/Pi terminals (`apt install bubblewrap` on Debian/Ubuntu). macOS
-  uses the built-in `seatbelt` sandbox and needs nothing extra.
+- `psmux`, required on native Windows for Omnigent-managed interactive
+  terminals.
+- `bubblewrap` (`bwrap`), **Linux only**, used to OS-sandbox native
+  terminals (`apt install bubblewrap` on Debian/Ubuntu). macOS uses the
+  built-in `seatbelt` sandbox and needs nothing extra; Windows uses Job Object
+  process containment, not filesystem/network isolation parity.
 - Node.js 22 LTS or newer with `npm` when working on `web/`.
+
+POSIX shell setup:
 
 ```bash
 git clone https://github.com/omnigent-ai/omnigent.git
@@ -40,11 +45,31 @@ uv sync --extra all --extra dev
 source .venv/bin/activate    # or prefix commands with `uv run`
 ```
 
+Native Windows PowerShell setup:
+
+```powershell
+git clone https://github.com/omnigent-ai/omnigent.git
+cd omnigent
+
+uv python install
+uv venv --python (Get-Content .python-version)
+uv sync --extra all --extra dev
+```
+
 Common checks:
 
 ```bash
-uv run pytest                      # Python tests (e2e/live skipped by default)
+uv run pytest                      # full POSIX suite on Linux/macOS/WSL
 uv run ruff check . && uv run ruff format --check .
+uv run pre-commit run --all-files
+```
+
+Native Windows supported subset:
+
+```powershell
+uv run pytest -m "not posix_only"
+uv run ruff check .
+uv run ruff format --check .
 uv run pre-commit run --all-files
 ```
 

--- a/docs/windows-upstream-related-work.md
+++ b/docs/windows-upstream-related-work.md
@@ -1,0 +1,52 @@
+# Windows native development scope
+
+This note tracks the Windows support boundary used by contributor workflow and
+incremental Windows parity work.
+
+## Prerequisite work
+
+- PowerShell installer and Windows setup/import fixes are tracked by the
+  Windows installer workstream.
+- psmux-backed terminal launch, terminal tools, and browser terminal attach are
+  tracked by the Windows terminal backend workstream.
+
+## Native Windows supported scope
+
+Native Windows development is supported for core/server/web work that does not
+require POSIX PTY behavior:
+
+- package setup with `uv`
+- core Python modules and server/API routes
+- stores/spec/parser/runtime tests that avoid POSIX terminal wrappers
+- SDK-harness and Job Object containment work
+- psmux-backed Omnigent-managed terminals
+- web lint/build/test commands under `web/`
+
+Use this baseline command for Windows-safe Python coverage:
+
+```powershell
+uv run pytest -m "not posix_only"
+```
+
+If a broader run still discovers collection failures, mark the affected tests
+`posix_only` and add a module-level Windows skip before importing POSIX-only
+modules.
+
+## POSIX-only scope
+
+Use Linux, macOS, or WSL2 for coverage that requires:
+
+- `pexpect` or `pyte`
+- raw `pty`, `termios`, or `fcntl`
+- tmux control-mode semantics
+- Unix signals, fork behavior, or Unix-domain-socket-only behavior
+- hard filesystem/network sandbox enforcement through bwrap or seatbelt
+
+These tests should carry the `posix_only` marker and skip cleanly on native
+Windows instead of failing during import collection.
+
+## Pre-commit portability
+
+Local pre-commit hooks should use `uv run ...` rather than hardcoded virtualenv
+paths such as `.venv/bin/python` or `.venv\\Scripts\\python.exe`. This keeps the
+same hook definitions usable from POSIX shells and native Windows PowerShell.

--- a/tests/e2e/_native_resume_helpers.py
+++ b/tests/e2e/_native_resume_helpers.py
@@ -38,7 +38,19 @@ test files (``test_claude_native_cli_resume_e2e.py`` /
 ``test_codex_native_cli_resume_e2e.py``) stay thin and free of duplication.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import contextlib
 import os

--- a/tests/e2e/omnigent/_pexpect_harness.py
+++ b/tests/e2e/omnigent/_pexpect_harness.py
@@ -22,7 +22,19 @@ Design reference: ``designs/OMNIGENT_INTEGRATION.md`` §Phase 0
 shared infrastructure.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import atexit
 import contextlib

--- a/tests/e2e/omnigent/_repl_test_helpers.py
+++ b/tests/e2e/omnigent/_repl_test_helpers.py
@@ -12,7 +12,19 @@ folded into ``_pexpect_harness.py`` as part of a deliberate
 foundation-update commit.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import pexpect
 

--- a/tests/e2e/omnigent/conftest.py
+++ b/tests/e2e/omnigent/conftest.py
@@ -38,7 +38,7 @@ def _resolve_venv_python() -> Path:
 
     Git worktrees don't have their own ``.venv`` — they share the
     main checkout's venv. Walk up the directory tree from the
-    current repo root, looking for ``.venv/bin/python`` in this
+    current repo root, looking for the platform's venv Python in this
     directory then in each parent, stopping when we find one.
     Stops at the filesystem root if none is found (which surfaces
     the misconfiguration loudly from the fixture).
@@ -49,13 +49,18 @@ def _resolve_venv_python() -> Path:
     """
     current = _OMNIGENT_REPO
     while True:
-        candidate = current / ".venv" / "bin" / "python"
-        if candidate.is_file():
-            return candidate
+        candidates = (
+            [current / ".venv" / "Scripts" / "python.exe"]
+            if os.name == "nt"
+            else [current / ".venv" / "bin" / "python"]
+        )
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate
         if current.parent == current:
             # Reached filesystem root without finding a venv.
             raise RuntimeError(
-                f"no .venv/bin/python found walking up from "
+                f"no .venv Python found walking up from "
                 f"{_OMNIGENT_REPO} — worktrees share the main "
                 f"checkout's venv, so one parent of this path "
                 f"should contain ``.venv``."
@@ -81,7 +86,8 @@ def omnigent_python() -> Path:
 
     :returns: Absolute path to the Omnigent ``.venv`` Python
         interpreter, e.g.
-        ``"/path/to/omnigent/.venv/bin/python"``.
+        ``"/path/to/omnigent/.venv/bin/python"`` or
+        ``"C:\\path\\to\\omnigent\\.venv\\Scripts\\python.exe"``.
     :raises RuntimeError: If the interpreter is not present at
         the expected path — indicates the Omnigent checkout is
         missing or its .venv hasn't been created.

--- a/tests/e2e/omnigent/test_host_ctrl_c_stop_server.py
+++ b/tests/e2e/omnigent/test_host_ctrl_c_stop_server.py
@@ -27,7 +27,19 @@ wired to the wrong default, fires for a reused server, or if ``y`` fails to
 actually terminate the server — none of which a mock-based test would catch.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import contextlib
 import os

--- a/tests/e2e/omnigent/test_repl_overview_subagent_visibility.py
+++ b/tests/e2e/omnigent/test_repl_overview_subagent_visibility.py
@@ -18,7 +18,19 @@ harness, and user message.
 - The wrapped harness invocation fails, so the worker never comes up.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import contextlib
 import subprocess

--- a/tests/e2e/omnigent/test_repl_overview_terminal_visibility.py
+++ b/tests/e2e/omnigent/test_repl_overview_terminal_visibility.py
@@ -23,7 +23,19 @@ mock-compatible and exercises the same terminal-launch + overview path.
 - ``sys_terminal_launch`` fails to register the instance.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import contextlib
 from pathlib import Path

--- a/tests/e2e/omnigent/test_repl_session_lifecycle.py
+++ b/tests/e2e/omnigent/test_repl_session_lifecycle.py
@@ -7,7 +7,19 @@ resume, and runner recovery. The mock LLM server provides
 deterministic responses so no real Databricks credentials are required.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import contextlib
 import os

--- a/tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py
+++ b/tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py
@@ -47,7 +47,19 @@ Two test scenarios:
   ``codex_worker``.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import subprocess
 from pathlib import Path

--- a/tests/e2e/omnigent/test_run_omnigent_sessions_default.py
+++ b/tests/e2e/omnigent/test_run_omnigent_sessions_default.py
@@ -7,7 +7,19 @@ Driven under a pseudo-terminal via :mod:`pexpect` because the
 REPL's TUI requires a TTY to render.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import re
 import sys

--- a/tests/frontends/sdk/test_ctrl_c.py
+++ b/tests/frontends/sdk/test_ctrl_c.py
@@ -24,7 +24,19 @@ raising :class:`KeyboardInterrupt`, which the host's run loop
 catches and breaks on.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import sys
 import time

--- a/tests/frontends/sdk/test_double_render.py
+++ b/tests/frontends/sdk/test_double_render.py
@@ -24,7 +24,19 @@ path (or otherwise breaks the streaming/replace serialization) shows
 the raw markdown alongside the rendered table — this assertion fails.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import contextlib
 import fcntl

--- a/tests/frontends/sdk/test_overflow_render.py
+++ b/tests/frontends/sdk/test_overflow_render.py
@@ -55,7 +55,19 @@ on CI (duplication detected) with no product regression. Driving
 exact same guard.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import contextlib
 import fcntl

--- a/tests/frontends/sdk/test_overlay_refresh.py
+++ b/tests/frontends/sdk/test_overlay_refresh.py
@@ -40,7 +40,19 @@ must appear without the test pressing any key. Without the fix,
 the second sentinel never shows up and the test times out.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import contextlib
 import sys

--- a/tests/frontends/sdk/test_overlay_search.py
+++ b/tests/frontends/sdk/test_overlay_search.py
@@ -36,7 +36,19 @@ drives the UI SDK's overlay through that exact interaction:
   keystroke.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import sys
 import time

--- a/tests/frontends/sdk/test_overlay_tab_refresh.py
+++ b/tests/frontends/sdk/test_overlay_tab_refresh.py
@@ -33,7 +33,19 @@ Without the fix, the second ``expect`` would time out because
 the new content never gets painted.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import sys
 import time
@@ -114,9 +126,9 @@ sys.path.insert(0, str(_DRIVER.parent))
 # That's intentional: the driver is a throwaway script the pexpect
 # subprocess executes, and the only thing the test itself needs
 # from it is the two sentinel strings.
-import contextlib  # noqa: E402 — must come after the sys.path insert above so mypy picks up the driver module reliably
+import contextlib
 
-from _overlay_tab_driver import (  # type: ignore[import-not-found]  # noqa: E402
+from _overlay_tab_driver import (  # type: ignore[import-not-found]
     _MAIN_SENTINEL,
     _SUB_SENTINEL,
 )

--- a/tests/frontends/sdk/test_prompt_expansion.py
+++ b/tests/frontends/sdk/test_prompt_expansion.py
@@ -7,7 +7,19 @@ long prompts stayed in a one-row horizontally-scrolled viewport even
 though the prompt buffer contained the full text.
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import os
 import sys

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -9,7 +9,19 @@ and ``_forward_pty_to_ws`` PTY→WS frame coalescing (queued bursts merge
 into one frame; a lone keystroke still flushes immediately).
 """
 
+# ruff: noqa: E402 - Windows module skip must run before POSIX-only imports.
+
 from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.posix_only
+
+if os.name == "nt":
+    pytest.skip("POSIX-only test; requires PTY/tmux/pexpect", allow_module_level=True)
+
 
 import asyncio
 import contextlib


### PR DESCRIPTION
## Related issue

Closes #2

## Summary

- Documents the supported native Windows contributor workflow and the boundary between Windows-safe coverage and POSIX-only PTY/tmux/pexpect coverage.
- Makes local pre-commit Python hooks platform-neutral by invoking tools through `uv run` instead of `.venv/bin/python`.
- Marks POSIX-only terminal/e2e modules so native Windows collection skips them before importing POSIX-only modules, and resolves the e2e venv Python path on both POSIX and Windows.

ELI5: Windows can now run the parts of the developer workflow that do not need Unix terminal plumbing; tests that need Unix terminal plumbing politely step aside instead of crashing during import.

```mermaid
flowchart TD
    A[Contributor checkout] --> B{Native Windows?}
    B -- yes --> C[uv run pre-commit]
    B -- yes --> D[uv run pytest -m "not posix_only"]
    B -- no / WSL --> E[full POSIX terminal coverage]
    D --> F[POSIX-only tests skip before import]
```

## Test Plan

- `uv run pre-commit run ruff-format --all-files`
- `uv run pre-commit run ruff-check --all-files`
- `uv run pre-commit run no-global-asyncio-patch --all-files`
- `uv run pre-commit run no-skipped-tests --all-files`
- `uv run pre-commit run sync-version-py --all-files`
- `uv run pre-commit run normalize-uv-lock-registry --all-files`
- `python - <<'PY' ... yaml.safe_load(open('.pre-commit-config.yaml')) ... PY`
- `uv run pytest tests/db tests/entities tests/spec tests/stores tests/server tests/tools -m "not posix_only" --ignore=tests/tools/builtins/test_sys_terminal.py --collect-only -q` → 4061 tests collected on native Windows.
- `uv run pytest <POSIX-only terminal/e2e files> -q` → all selected modules skipped on native Windows before POSIX imports; pytest exits 5 because the selection contains only skipped modules.

Known current-main limitations observed during broader local validation: full `-m "not posix_only"` collection still depends on the separate Windows setup/import fix PR for native bridge modules that call `os.getuid()` at import time.

## Demo

N/A — docs/test/pre-commit portability change, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was run on native Windows because the main behavior is platform-specific test collection and hook invocation. No screenshots are needed for this non-visual workflow change.




## Controlled user evidence plan

Reviewer-facing evidence to collect before/while reviewing:

1. Fresh native Windows checkout.
2. Run setup and platform-neutral pre-commit path:
   ```powershell
   uv sync --extra all --extra dev
   uv run pre-commit run --all-files
   ```
3. Run broad collection:
   ```powershell
   uv run pytest -m "not posix_only" --collect-only -q
   ```
4. Run a POSIX-only selected module and capture that it skips before POSIX imports.
5. Attach transcript to smota/omnigent#2.

Screenshot priority: terminal screenshot of pre-commit and collection summary.

## Controlled user evidence results (2026-07-09)

Executed on native Windows 10 Home ARM64 from the integration branch after syncing the open PR stack.

Artifacts are published for reviewers on the public evidence branch: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity

- `00_environment.txt` — Windows/toolchain inventory (`uv 0.11.23`, Python `3.11.15`, Node `v24.16.0`, npm `11.18.0`, `psmux` / tmux `3.3.6`).
- `01_import_cli_smoke.txt` — `import omnigent` and `uv run omnigent --help` succeeded.
- `02_windows_safe_stable.txt` — stable Windows helper result: `21 passed, 6 skipped`.
- `03_runner_transport_tests.txt` — runner routing/transport tests: `18 passed`.
- `04_sandbox_fail_closed_tests.txt` — sandbox fail-closed tests: `6 passed`.
- `05_psmux_diagnostics_test.txt` — missing-`psmux` diagnostic test: `1 passed`.
- `06_precommit_key_windows_docs.txt` — whitespace/newline hooks over changed Windows docs: `EXIT=0`.
- `07_collect_only.txt` — broad collection check: `14709/14725 tests collected`, `EXIT=0`.
- `desktop-evidence-summary.png` — desktop print screen published in the public evidence bundle.

Key transcript excerpts:

```text
# stable Windows helper
21 passed, 6 skipped in 2.30s

# runner transport/routing
18 passed in 2.27s

# sandbox fail-closed
6 passed in 0.38s

# psmux diagnostic
1 passed in 0.14s

# broad collect-only
14709/14725 tests collected (16 deselected) in 11.47s
```

Notes:

- This is the executed follow-up to the `Controlled user evidence plan` already added to the open PRs.
- The psmux-specific review path includes terminal `attach/reconnect` coverage in the evidence plan; this run collected CLI/test evidence and a local print screen, while browser attach/reconnect screenshots remain the only manual visual item to capture if reviewers require them.

## Evidence correction: invalid screenshots withdrawn (2026-07-09)

The earlier browser/desktop screenshots are withdrawn: they showed GitHub pages or an empty/locked desktop, not the real Omnigent application/terminal state. Please disregard those screenshot comments.

Authoritative reviewer evidence is now the public native Windows terminal/tool output bundle:

- Evidence correction note: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-correction.md
- Evidence summary: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-summary.md
- Environment/toolchain transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/00_environment.txt
- CLI smoke transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/01_import_cli_smoke.txt
- Stable Windows helper transcript (`21 passed, 6 skipped`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/02_windows_safe_stable.txt
- Runner transport/routing transcript (`18 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/03_runner_transport_tests.txt
- Sandbox fail-closed transcript (`6 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/04_sandbox_fail_closed_tests.txt
- psmux diagnostic transcript (`1 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/05_psmux_diagnostics_test.txt
- Broad collect-only transcript (`14709/14725 tests collected`, `EXIT=0`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/07_collect_only.txt

Visual evidence will only be re-added if captured from an unlocked interactive Windows desktop showing the real Omnigent terminal/application window.
