### PR TITLE
refactor(runner): add transport locator seam

### DIFF
--- a/omnigent/runner/routing.py
+++ b/omnigent/runner/routing.py
@@ -17,8 +17,10 @@ import httpx
 
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
-from omnigent.runner.transports.ws_tunnel.transport import WSTunnelTransport
-from omnigent.runtime import telemetry
+from omnigent.runner.transport_locator import (
+    RunnerTransportLocator,
+    WSTunnelRunnerTransportLocator,
+)
 from omnigent.runtime.harnesses import _HARNESS_MODULES
 from omnigent.spec import AgentSpec
 
@@ -73,6 +75,8 @@ class RunnerRouter:
         ``WS /v1/runners/{runner_id}/tunnel``.
     :param conversation_store: Store used to read
         ``conversations.runner_id`` affinity.
+    :param transport_locator: Optional transport seam. Defaults to the
+        WebSocket tunnel locator used today.
     """
 
     def __init__(
@@ -80,10 +84,11 @@ class RunnerRouter:
         *,
         registry: TunnelRegistry,
         conversation_store: ConversationStore,
+        transport_locator: RunnerTransportLocator | None = None,
     ) -> None:
         self._registry = registry
         self._conversation_store = conversation_store
-        self._clients: dict[str, httpx.AsyncClient] = {}
+        self._transport_locator = transport_locator or WSTunnelRunnerTransportLocator(registry)
         self._lock = threading.RLock()
 
     def client_for_conversation(self, *, conversation_id: str, harness: str) -> RoutedRunner:
@@ -212,10 +217,8 @@ class RunnerRouter:
         :returns: None.
         """
         with self._lock:
-            clients = list(self._clients.values())
-            self._clients.clear()
-        for client in clients:
-            await client.aclose()
+            locator = self._transport_locator
+        await locator.aclose()
 
     def _routed_pinned_runner(self, runner_id: str, *, harness: str) -> RoutedRunner:
         """
@@ -246,24 +249,10 @@ class RunnerRouter:
 
         :param runner_id: Runner UUID, e.g.
             ``"runner_0123456789abcdef"``.
-        :returns: ``httpx.AsyncClient`` using
-            :class:`WSTunnelTransport`.
+        :returns: ``httpx.AsyncClient`` using the configured transport locator.
         """
         with self._lock:
-            client = self._clients.get(runner_id)
-            if client is None:
-                client = httpx.AsyncClient(
-                    transport=WSTunnelTransport(self._registry, runner_id),
-                    base_url="http://runner",
-                    timeout=httpx.Timeout(5.0, read=None),
-                )
-                # The global httpx instrumentation can't see this client's
-                # custom WSTunnelTransport, so instrument the instance
-                # directly — otherwise server→runner forwards carry no
-                # traceparent and the runner roots a disconnected trace.
-                telemetry.instrument_httpx_client(client)
-                self._clients[runner_id] = client
-            return client
+            return self._transport_locator.client_for_runner(runner_id)
 
 
 def _runner_supports_harness(session: RunnerSession, harness: str) -> bool:

--- a/omnigent/runner/transport_locator.py
+++ b/omnigent/runner/transport_locator.py
@@ -1,0 +1,69 @@
+"""Runner transport locator abstractions.
+
+The server talks to runners through an ``httpx.AsyncClient``. Today that client
+uses the WebSocket tunnel registry; this seam keeps that decision in one place
+so Windows-specific runner transports can be added without changing every
+server route that forwards to a runner.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, cast
+
+import httpx
+
+from omnigent.runner.transports.ws_tunnel.transport import WSTunnelTransport
+from omnigent.runtime import telemetry
+
+if TYPE_CHECKING:
+    from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
+
+
+class RunnerTransportLocator(Protocol):
+    """Factory/cache for clients that can reach a runner."""
+
+    def client_for_runner(self, runner_id: str) -> httpx.AsyncClient:
+        """
+        Return a client that routes requests to *runner_id*.
+
+        :param runner_id: Runner UUID, e.g. ``"runner_0123456789abcdef"``.
+        :returns: ``httpx.AsyncClient`` pointed at the selected runner transport.
+        """
+
+    async def aclose(self) -> None:
+        """Close any cached transport clients."""
+
+
+class WSTunnelRunnerTransportLocator:
+    """Default runner transport locator backed by the WebSocket tunnel registry."""
+
+    def __init__(self, registry: object) -> None:
+        """
+        Create a WebSocket-tunnel transport locator.
+
+        :param registry: ``TunnelRegistry`` instance used by
+            :class:`WSTunnelTransport`. Typed as ``object`` to avoid importing the
+            registry at runtime for this small seam.
+        """
+        self._registry = registry
+        self._clients: dict[str, httpx.AsyncClient] = {}
+
+    def client_for_runner(self, runner_id: str) -> httpx.AsyncClient:
+        """Return a cached WebSocket-tunnel client for *runner_id*."""
+        client = self._clients.get(runner_id)
+        if client is None:
+            client = httpx.AsyncClient(
+                transport=WSTunnelTransport(cast("TunnelRegistry", self._registry), runner_id),
+                base_url="http://runner",
+                timeout=httpx.Timeout(5.0, read=None),
+            )
+            telemetry.instrument_httpx_client(client)
+            self._clients[runner_id] = client
+        return client
+
+    async def aclose(self) -> None:
+        """Close cached runner clients."""
+        clients = list(self._clients.values())
+        self._clients.clear()
+        for client in clients:
+            await client.aclose()

--- a/omnigent/server/_runner_transport.py
+++ b/omnigent/server/_runner_transport.py
@@ -1,9 +1,11 @@
-"""Server-side helpers for connecting to a local UDS runner."""
+"""Server-side helpers for connecting to local runner transports."""
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from typing import Any
+from urllib.parse import urljoin, urlparse, urlunparse
 
 import httpx
 
@@ -12,6 +14,74 @@ import httpx
 # type lives in :mod:`websockets.asyncio.client` and varies between
 # library versions.
 RunnerWSFactory = Callable[[str], Any]
+
+
+def build_runner_transport(
+    *,
+    uds_path: str | None = None,
+    tcp_base_url: str | None = None,
+) -> tuple[httpx.AsyncClient, RunnerWSFactory]:
+    """Build the best local runner transport for this platform.
+
+    TCP is cross-platform and wins when configured. UDS remains the POSIX
+    default. Native Windows has no Unix-domain-socket client support in the
+    websockets path, so it fails with an actionable error unless a TCP base URL
+    is provided.
+
+    :param uds_path: Optional Unix-domain-socket path.
+    :param tcp_base_url: Optional TCP runner URL, e.g. ``"http://127.0.0.1:9876"``.
+    :returns: ``(client, ws_factory)`` for the selected runner transport.
+    :raises RuntimeError: If no supported transport is configured.
+    """
+    if tcp_base_url:
+        return build_tcp_runner(tcp_base_url)
+    if uds_path and os.name != "nt":
+        return build_uds_runner(uds_path)
+    if uds_path and os.name == "nt":
+        raise RuntimeError(
+            "runner UDS transport is not supported on native Windows; "
+            "configure a TCP runner base URL instead"
+        )
+    raise RuntimeError("no runner transport configured; provide tcp_base_url or uds_path")
+
+
+def build_tcp_runner(base_url: str) -> tuple[httpx.AsyncClient, RunnerWSFactory]:
+    """Build the HTTP client + WS factory for a TCP-attached runner.
+
+    :param base_url: HTTP(S) runner base URL, e.g. ``"http://127.0.0.1:9876"``.
+    :returns: ``(client, ws_factory)``. The WebSocket factory maps HTTP(S) to
+        WS(S) while preserving host, path prefix, and per-call attach path.
+    """
+    normalized = base_url.rstrip("/")
+    client = httpx.AsyncClient(base_url=normalized, timeout=httpx.Timeout(5.0, read=None))
+
+    def ws_factory(path: str) -> Any:
+        from websockets.asyncio.client import connect as _ws_connect
+
+        return _ws_connect(
+            _http_to_ws_url(_join_base_path(normalized, path)),
+            open_timeout=10,
+        )
+
+    return client, ws_factory
+
+
+def _join_base_path(base_url: str, path: str) -> str:
+    """Join a base URL and absolute API path without dropping base prefixes."""
+    base = base_url.rstrip("/") + "/"
+    return urljoin(base, path.lstrip("/"))
+
+
+def _http_to_ws_url(url: str) -> str:
+    """Convert an HTTP(S) URL to WS(S)."""
+    parsed = urlparse(url)
+    if parsed.scheme == "http":
+        scheme = "ws"
+    elif parsed.scheme == "https":
+        scheme = "wss"
+    else:
+        raise ValueError(f"runner TCP base URL must be http(s), got {parsed.scheme!r}")
+    return urlunparse(parsed._replace(scheme=scheme))
 
 
 def build_uds_runner(uds_path: str) -> tuple[httpx.AsyncClient, RunnerWSFactory]:

--- a/omnigent/server/_runner_transport.py
+++ b/omnigent/server/_runner_transport.py
@@ -15,6 +15,35 @@ import httpx
 # library versions.
 RunnerWSFactory = Callable[[str], Any]
 
+RUNNER_TCP_BASE_URL_ENV = "OMNIGENT_RUNNER_TCP_BASE_URL"
+RUNNER_UDS_PATH_ENV = "OMNIGENT_RUNNER_UDS_PATH"
+
+
+def build_runner_transport_from_env(
+    environ: dict[str, str] | None = None,
+) -> tuple[httpx.AsyncClient, RunnerWSFactory]:
+    """Build a local runner transport from environment configuration.
+
+    ``OMNIGENT_RUNNER_TCP_BASE_URL`` is cross-platform and preferred. The UDS
+    env var remains available for POSIX deployments. On native Windows, UDS-only
+    configuration fails with the same actionable TCP guidance as
+    :func:`build_runner_transport`.
+    """
+    env = os.environ if environ is None else environ
+    return build_runner_transport(
+        tcp_base_url=_non_empty_env(env, RUNNER_TCP_BASE_URL_ENV),
+        uds_path=_non_empty_env(env, RUNNER_UDS_PATH_ENV),
+    )
+
+
+def _non_empty_env(env: dict[str, str], name: str) -> str | None:
+    """Return a stripped env value or ``None`` when unset/blank."""
+    value = env.get(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
 
 def build_runner_transport(
     *,

--- a/tests/runner/test_routing.py
+++ b/tests/runner/test_routing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from omnigent.entities import Conversation
@@ -31,6 +32,25 @@ class _FakeWebSocket:
         :returns: Empty frame string.
         """
         return ""
+
+
+class _FakeTransportLocator:
+    """Transport locator test double."""
+
+    def __init__(self) -> None:
+        self.client = httpx.AsyncClient(base_url="http://runner-test")
+        self.requested: list[str] = []
+        self.closed = False
+
+    def client_for_runner(self, runner_id: str) -> httpx.AsyncClient:
+        """Record and return a stable client."""
+        self.requested.append(runner_id)
+        return self.client
+
+    async def aclose(self) -> None:
+        """Close the fake client."""
+        self.closed = True
+        await self.client.aclose()
 
 
 class _ConversationStore:
@@ -196,13 +216,22 @@ async def test_runner_router_uses_pinned_runner_when_multiple_online() -> None:
     registry.register("runner_one", _FakeWebSocket(), _hello(harnesses=["codex"]))
     registry.register("runner_two", _FakeWebSocket(), _hello(harnesses=["codex"]))
     store = _ConversationStore({"conv_test": _conversation(runner_id="runner_two")})
-    router = RunnerRouter(registry=registry, conversation_store=store)  # type: ignore[arg-type]
+    locator = _FakeTransportLocator()
+    router = RunnerRouter(
+        registry=registry,
+        conversation_store=store,  # type: ignore[arg-type]
+        transport_locator=locator,
+    )
     try:
         routed = router.client_for_conversation(conversation_id="conv_test", harness="codex")
 
         assert routed.runner_id == "runner_two"
+        assert routed.client is locator.client
+        assert locator.requested == ["runner_two"]
     finally:
         await router.aclose()
+
+    assert locator.closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_runner_transport.py
+++ b/tests/server/test_runner_transport.py
@@ -116,3 +116,36 @@ def test_build_runner_transport_requires_a_transport() -> None:
     """Missing transport config fails loud instead of guessing."""
     with pytest.raises(RuntimeError, match="provide tcp_base_url or uds_path"):
         rt.build_runner_transport()
+
+
+def test_build_runner_transport_from_env_prefers_tcp(tmp_path: Any) -> None:
+    """Runtime env selection prefers cross-platform TCP over POSIX UDS."""
+    client, _factory = rt.build_runner_transport_from_env(
+        {
+            rt.RUNNER_TCP_BASE_URL_ENV: " http://127.0.0.1:7777 ",
+            rt.RUNNER_UDS_PATH_ENV: str(tmp_path / "runner.sock"),
+        }
+    )
+    try:
+        assert client.base_url == httpx.URL("http://127.0.0.1:7777")
+    finally:
+        client._transport.__dict__.clear()
+
+
+def test_build_runner_transport_from_env_rejects_blank_config() -> None:
+    """Blank env values are treated as missing config and fail loud."""
+    with pytest.raises(RuntimeError, match="provide tcp_base_url or uds_path"):
+        rt.build_runner_transport_from_env(
+            {
+                rt.RUNNER_TCP_BASE_URL_ENV: "  ",
+                rt.RUNNER_UDS_PATH_ENV: "",
+            }
+        )
+
+
+def test_build_runner_transport_from_env_windows_uds_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows UDS-only env config points operators at TCP."""
+    monkeypatch.setattr(rt.os, "name", "nt")
+
+    with pytest.raises(RuntimeError, match="TCP runner base URL"):
+        rt.build_runner_transport_from_env({rt.RUNNER_UDS_PATH_ENV: "runner.sock"})

--- a/tests/server/test_runner_transport.py
+++ b/tests/server/test_runner_transport.py
@@ -59,3 +59,60 @@ def test_build_uds_runner_ws_factory_uses_unix_connect(
         "terminal_bash_s1/attach?read_only=false"
     )
     assert captured["kwargs"].get("open_timeout") == 10
+
+
+def test_build_tcp_runner_returns_tcp_client() -> None:
+    """The TCP client targets the configured loopback runner URL."""
+    client, _factory = rt.build_tcp_runner("http://127.0.0.1:9876")
+    try:
+        assert client.base_url == httpx.URL("http://127.0.0.1:9876")
+    finally:
+        client._transport.__dict__.clear()
+
+
+def test_build_tcp_runner_ws_factory_uses_websocket_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The TCP WS factory maps http(s) base URLs to ws(s) attach URLs."""
+    captured: dict[str, Any] = {}
+
+    def fake_connect(uri: str, **kwargs: Any) -> Any:
+        captured["uri"] = uri
+        captured["kwargs"] = kwargs
+        return "FAKE_TCP_CM"
+
+    monkeypatch.setattr("websockets.asyncio.client.connect", fake_connect)
+
+    _client, factory = rt.build_tcp_runner("https://runner.example/base")
+    result = factory("/v1/sessions/conv_abc/resources/terminals/t1/attach?read_only=false")
+
+    assert result == "FAKE_TCP_CM"
+    assert captured["uri"] == (
+        "wss://runner.example/base/v1/sessions/conv_abc/resources/terminals/"
+        "t1/attach?read_only=false"
+    )
+    assert captured["kwargs"].get("open_timeout") == 10
+
+
+def test_build_runner_transport_prefers_tcp_over_uds(tmp_path: Any) -> None:
+    """A configured TCP URL wins over UDS and works on every platform."""
+    client, _factory = rt.build_runner_transport(
+        uds_path=str(tmp_path / "runner.sock"),
+        tcp_base_url="http://127.0.0.1:9999",
+    )
+    try:
+        assert client.base_url == httpx.URL("http://127.0.0.1:9999")
+    finally:
+        client._transport.__dict__.clear()
+
+
+def test_build_runner_transport_rejects_windows_uds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Native Windows gets an actionable TCP fallback hint for UDS-only config."""
+    monkeypatch.setattr(rt.os, "name", "nt")
+
+    with pytest.raises(RuntimeError, match="TCP runner base URL"):
+        rt.build_runner_transport(uds_path="runner.sock")
+
+
+def test_build_runner_transport_requires_a_transport() -> None:
+    """Missing transport config fails loud instead of guessing."""
+    with pytest.raises(RuntimeError, match="provide tcp_base_url or uds_path"):
+        rt.build_runner_transport()


### PR DESCRIPTION
## Related issue

Refs #5

## Summary

- Adds a `RunnerTransportLocator` seam that owns runner client creation/caching.
- Keeps current behavior on WebSocket tunnel transport while removing direct `WSTunnelTransport` construction from `RunnerRouter`.
- Adds routing coverage proving the router delegates runner client lookup through the locator and closes it.

ELI5: this does not change how runners are reached today; it moves the “how do I get to this runner?” decision behind a small plug point so a Windows-specific transport/fallback can be added in a follow-up PR.

```mermaid
flowchart LR
    A[RunnerRouter] --> B[RunnerTransportLocator]
    B --> C[WSTunnelRunnerTransportLocator today]
    B -. future .-> D[Windows TCP / fallback locator]
    C --> E[WSTunnelTransport]
```

## Test Plan

- `uv run ruff check omnigent/runner/routing.py omnigent/runner/transport_locator.py tests/runner/test_routing.py`
- `uv run pytest tests/runner/test_routing.py -q`

## Demo

N/A — internal transport seam/refactor, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Updated the runner routing unit tests to verify the transport locator seam without changing current WebSocket-tunnel behavior.




## Controlled user evidence plan

Reviewer-facing evidence to collect before/while reviewing:

1. Run unit tests for transport locator and env selection:
   ```powershell
   uv run pytest tests/server/test_runner_transport.py tests/runner/test_routing.py -q
   ```
2. Run with TCP configured:
   ```powershell
   $env:OMNIGENT_RUNNER_TCP_BASE_URL = "http://127.0.0.1:<port>"
   ```
   Capture logs/tool output proving TCP selection.
3. Run UDS-only config on native Windows:
   ```powershell
   $env:OMNIGENT_RUNNER_UDS_PATH = "runner.sock"
   Remove-Item Env:\OMNIGENT_RUNNER_TCP_BASE_URL -ErrorAction SilentlyContinue
   ```
   Capture the actionable TCP fallback error.
4. Attach transcript to smota/omnigent#5 and smota/omnigent#8.

Screenshot priority: terminal output showing TCP env selection and UDS-only failure message.

## Controlled user evidence results (2026-07-09)

Executed on native Windows 10 Home ARM64 from the integration branch after syncing the open PR stack.

Artifacts are published for reviewers on the public evidence branch: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity

- `00_environment.txt` — Windows/toolchain inventory (`uv 0.11.23`, Python `3.11.15`, Node `v24.16.0`, npm `11.18.0`, `psmux` / tmux `3.3.6`).
- `01_import_cli_smoke.txt` — `import omnigent` and `uv run omnigent --help` succeeded.
- `02_windows_safe_stable.txt` — stable Windows helper result: `21 passed, 6 skipped`.
- `03_runner_transport_tests.txt` — runner routing/transport tests: `18 passed`.
- `04_sandbox_fail_closed_tests.txt` — sandbox fail-closed tests: `6 passed`.
- `05_psmux_diagnostics_test.txt` — missing-`psmux` diagnostic test: `1 passed`.
- `06_precommit_key_windows_docs.txt` — whitespace/newline hooks over changed Windows docs: `EXIT=0`.
- `07_collect_only.txt` — broad collection check: `14709/14725 tests collected`, `EXIT=0`.
- `desktop-evidence-summary.png` — desktop print screen published in the public evidence bundle.

Key transcript excerpts:

```text
# stable Windows helper
21 passed, 6 skipped in 2.30s

# runner transport/routing
18 passed in 2.27s

# sandbox fail-closed
6 passed in 0.38s

# psmux diagnostic
1 passed in 0.14s

# broad collect-only
14709/14725 tests collected (16 deselected) in 11.47s
```

Notes:

- This is the executed follow-up to the `Controlled user evidence plan` already added to the open PRs.
- The psmux-specific review path includes terminal `attach/reconnect` coverage in the evidence plan; this run collected CLI/test evidence and a local print screen, while browser attach/reconnect screenshots remain the only manual visual item to capture if reviewers require them.

## Evidence correction: invalid screenshots withdrawn (2026-07-09)

The earlier browser/desktop screenshots are withdrawn: they showed GitHub pages or an empty/locked desktop, not the real Omnigent application/terminal state. Please disregard those screenshot comments.

Authoritative reviewer evidence is now the public native Windows terminal/tool output bundle:

- Evidence correction note: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-correction.md
- Evidence summary: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-summary.md
- Environment/toolchain transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/00_environment.txt
- CLI smoke transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/01_import_cli_smoke.txt
- Stable Windows helper transcript (`21 passed, 6 skipped`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/02_windows_safe_stable.txt
- Runner transport/routing transcript (`18 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/03_runner_transport_tests.txt
- Sandbox fail-closed transcript (`6 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/04_sandbox_fail_closed_tests.txt
- psmux diagnostic transcript (`1 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/05_psmux_diagnostics_test.txt
- Broad collect-only transcript (`14709/14725 tests collected`, `EXIT=0`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/07_collect_only.txt

Visual evidence will only be re-added if captured from an unlocked interactive Windows desktop showing the real Omnigent terminal/application window.
