### PR TITLE
fix(model-catalog): stop misreporting cli-config and cursor workers as credential-less

### DIFF
--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -20,7 +20,11 @@ Enumeration is deterministic per provider kind:
   ``GET <base_url>/v1/models`` with a bearer token (source
   ``"openai-compatible"``).
 - ``subscription`` → a curated static list (source ``"static"``,
-  ``verified: false`` — CLI logins expose no listing API).
+  ``verified: false`` — CLI logins expose no listing API). The cursor
+  harnesses always resolve here: cursor-agent brings its own login.
+- ``cli-config`` → the codex curated static list (source ``"static"``,
+  ``verified: false`` — the credential lives in the CLI's own config
+  file and is resolved by the CLI at launch).
 - anything unresolvable → source ``"none"`` with an explanatory note,
   which doubles as a dead-worker preflight signal.
 """
@@ -43,6 +47,7 @@ from omnigent._platform import default_shell_argv
 from omnigent.model_override import model_family_mismatch
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
+    CLI_CONFIG_KIND,
     DATABRICKS_KIND,
     KEY_KIND,
     OPENAI_FAMILY,
@@ -121,6 +126,12 @@ _PROVIDER_RESOLUTION_HARNESS: dict[str, str] = {
     "native-antigravity": "antigravity",
 }
 
+# cursor-agent always routes through its own stored login — there is no
+# omnigent-side provider config for it to resolve (or fail), so resolution
+# short-circuits to a subscription-style readout instead of reporting the
+# harness as having "no model-provider resolution".
+_CURSOR_HARNESSES: frozenset[str] = frozenset({"cursor", "cursor-native", "native-cursor"})
+
 # Preferred inline family per single-family harness (pi consumes both).
 _KEY_AUTH_FAMILY: dict[str, str] = {
     "claude-sdk": ANTHROPIC_FAMILY,
@@ -176,8 +187,9 @@ class ResolvedModelProvider:
     """The model provider a worker's spawn/launch path would route through.
 
     :param kind: Provider kind — ``"key"`` / ``"gateway"`` / ``"local"``
-        / ``"subscription"`` / ``"databricks"`` from the provider config
-        layer, or ``"none"`` when no usable provider resolved.
+        / ``"subscription"`` / ``"databricks"`` / ``"cli-config"`` from
+        the provider config layer, or ``"none"`` when no usable provider
+        resolved.
     :param family: ``"anthropic"`` / ``"openai"`` for inline-family
         kinds, else ``None``.
     :param profile: Databricks profile for ``kind="databricks"``, e.g.
@@ -188,7 +200,8 @@ class ResolvedModelProvider:
         Never serialized into tool output.
     :param auth_command: Shell command printing a bearer token, for
         providers configured with a dynamic credential.
-    :param cli: ``"claude"`` / ``"codex"`` for ``kind="subscription"``.
+    :param cli: ``"claude"`` / ``"codex"`` / ``"cursor-agent"`` for
+        ``kind="subscription"``; ``"codex"`` for ``kind="cli-config"``.
     :param detail: Non-secret descriptor of how the provider resolved,
         e.g. ``"provider 'openrouter'"`` — used in listing notes.
     """
@@ -347,6 +360,11 @@ def _resolve_model_provider_unsafe(spec: Any, harness: str | None) -> ResolvedMo
     # Imported lazily; workflow.py imports broadly and this module is
     # consumed from the runner's dispatch path.
     from omnigent.runtime.workflow import _resolve_provider_for_build
+
+    if (harness or "") in _CURSOR_HARNESSES:
+        return ResolvedModelProvider(
+            kind=SUBSCRIPTION_KIND, cli="cursor-agent", detail="cursor-agent CLI login"
+        )
 
     harness_type = _PROVIDER_RESOLUTION_HARNESS.get(harness or "")
     if harness_type is None:
@@ -539,6 +557,20 @@ def _provider_from_entry(entry: ProviderEntry, harness_type: str) -> ResolvedMod
         return ResolvedModelProvider(
             kind=SUBSCRIPTION_KIND, cli=entry.cli, detail=f"provider {entry.name!r}"
         )
+    if entry.kind == CLI_CONFIG_KIND:
+        # The provider table (base_url + credential) lives in the CLI's own
+        # config file and the CLI resolves it at launch — there is nothing
+        # to resolve statically here, so the entry is usable as-is. Falling
+        # through to the inline-family loop would misreport it as "no
+        # resolvable credentials" (cli-config entries carry no families).
+        return ResolvedModelProvider(
+            kind=CLI_CONFIG_KIND,
+            cli=entry.cli,
+            detail=(
+                f"provider {entry.name!r} (codex config.toml model provider "
+                f"{entry.model_provider!r})"
+            ),
+        )
     # Inline-family kinds: single-family harnesses get exactly their family;
     # pi takes the first whose credential resolves, anthropic preferred.
     preferred = _KEY_AUTH_FAMILY[harness_type] if harness_type != "pi" else None
@@ -728,6 +760,8 @@ def _listing_for_provider(
         )
     if provider.kind == SUBSCRIPTION_KIND:
         return _static_subscription_listing(provider)
+    if provider.kind == CLI_CONFIG_KIND:
+        return _static_cli_config_listing(provider)
 
     cache_key = _listing_cache_key(provider)
     with _listing_cache_lock:
@@ -765,7 +799,7 @@ def _static_subscription_listing(provider: ResolvedModelProvider) -> ModelListin
     :param provider: A ``kind="subscription"`` provider descriptor.
     :returns: A ``source="static"`` listing with ``verified=False``.
     """
-    ids = _SUBSCRIPTION_STATIC_MODELS.get(provider.cli or "", ())
+    ids = _subscription_static_ids(provider.cli or "")
     return ModelListing(
         source="static",
         verified=False,
@@ -774,6 +808,47 @@ def _static_subscription_listing(provider: ResolvedModelProvider) -> ModelListin
             f"curated aliases for the {provider.cli or 'unknown'} CLI login "
             "(subscription logins expose no model-listing API; availability "
             "depends on the logged-in plan)"
+        ),
+    )
+
+
+def _subscription_static_ids(cli: str) -> tuple[str, ...]:
+    """Return the curated model ids for a subscription CLI.
+
+    :param cli: The CLI short-name, e.g. ``"claude"`` or ``"cursor-agent"``.
+    :returns: Curated model ids; empty for an unknown CLI.
+    """
+    if cli == "cursor-agent":
+        # Reuse the web picker's curated base-model catalog (derived from
+        # ``cursor-agent models``); imported lazily to keep this module off
+        # the TUI launcher's import path.
+        from omnigent.cursor_native import cursor_base_model_options
+
+        return tuple(str(option["id"]) for option in cursor_base_model_options())
+    return _SUBSCRIPTION_STATIC_MODELS.get(cli, ())
+
+
+def _static_cli_config_listing(provider: ResolvedModelProvider) -> ModelListing:
+    """Build the curated static listing for a ``cli-config`` provider.
+
+    A ``cli-config`` provider pins a custom ``[model_providers.X]`` table in
+    the codex CLI's own ``config.toml``; its credential (an auth command /
+    env key in that file) is resolved by codex at launch, so the listing is
+    the codex curated ids with a note saying the credential is the CLI's to
+    resolve — not a "no credentials" preflight failure.
+
+    :param provider: A ``kind="cli-config"`` provider descriptor.
+    :returns: A ``source="static"`` listing with ``verified=False``.
+    """
+    ids = _SUBSCRIPTION_STATIC_MODELS.get(provider.cli or "", ())
+    return ModelListing(
+        source="static",
+        verified=False,
+        models=tuple(ModelEntry(id=i, family=model_family_token(i)) for i in ids),
+        note=(
+            f"curated ids for {provider.detail}; its credential lives in the "
+            "CLI's own config file and is resolved by the CLI at launch, so "
+            "it cannot be verified from here"
         ),
     )
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -188,6 +188,52 @@ def test_resolve_provider_subscription_default(
     assert provider.cli == "claude"
 
 
+def test_resolve_provider_cli_config_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config default resolves as usable, never "no credentials".
+
+    The entry's credential lives in the codex CLI's own ``config.toml``
+    (an auth command / env key codex runs at launch), so the catalog has
+    nothing to resolve statically — falling into the inline-family loop
+    used to misreport the worker as having no resolvable credentials.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(
+        monkeypatch,
+        tmp_path,
+        "providers:\n  codex-gateway:\n    kind: cli-config\n    cli: codex\n"
+        "    model_provider: Databricks\n    default: true\n",
+    )
+    provider = resolve_model_provider(_worker_spec("codex-native"), "codex-native")
+    assert provider.kind == "cli-config"
+    assert provider.cli == "codex"
+    assert "codex-gateway" in provider.detail
+    assert "Databricks" in provider.detail
+
+
+@pytest.mark.parametrize("harness", ["cursor", "cursor-native", "native-cursor"])
+def test_resolve_provider_cursor_is_cli_login(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, harness: str
+) -> None:
+    """Cursor harnesses resolve to cursor-agent's own login, not ``none``.
+
+    cursor-agent has no omnigent-side provider config — it always brings
+    its own stored login — so the resolution must not fall through to the
+    "harness has no model-provider resolution" dead-worker note.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    :param harness: The cursor harness spelling under test.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    provider = resolve_model_provider(_worker_spec(harness), harness)
+    assert provider.kind == "subscription"
+    assert provider.cli == "cursor-agent"
+
+
 def test_resolve_provider_spec_databricks_auth_wins(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -732,6 +778,49 @@ def test_subscription_listing_is_static_and_unverified(
         "claude-haiku-4-5",
     ]
     assert "CLI login" in listing.note
+
+
+def test_cli_config_listing_is_static_and_unverified(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config provider yields the codex curated list, not a dead row.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(
+        monkeypatch,
+        tmp_path,
+        "providers:\n  codex-gateway:\n    kind: cli-config\n    cli: codex\n"
+        "    model_provider: Databricks\n    default: true\n",
+    )
+    listing = list_models_for_worker(_worker_spec("codex-native"), "codex-native")
+    assert listing.source == "static"
+    assert listing.verified is False
+    assert [m.id for m in listing.models] == ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]
+    # The note must say the CLI resolves the credential itself — this row
+    # is a working worker, not a credentials preflight failure.
+    assert "resolved by the CLI at launch" in listing.note
+    assert "cannot run here" not in listing.note
+
+
+def test_cursor_listing_is_static_with_curated_base_models(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cursor worker lists the curated cursor-agent base models.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    listing = list_models_for_worker(_worker_spec("cursor-native"), "cursor-native")
+    assert listing.source == "static"
+    assert listing.verified is False
+    ids = [m.id for m in listing.models]
+    # Spot-check the picker catalog rather than pinning the whole list —
+    # it is regenerated when cursor ships models.
+    assert "composer-2.5" in ids
+    assert "cannot run here" not in listing.note
 
 
 def test_none_listing_explains_dead_worker(


### PR DESCRIPTION
## Related issue

Closes #2236

## Summary

- `resolve_model_provider` misreported two kinds of healthy workers as un-bootable in `sys_list_models` and preflights built on it:
  - a **`cli-config` provider** fell through `_provider_from_entry`'s inline-family loop (cli-config entries carry no families — the credential is an auth command / env key in the codex CLI's own `config.toml`, resolved by codex at launch) and came back as "configures no family with resolvable credentials", even though the launch path routes it fine;
  - the **cursor harnesses** were absent from `_PROVIDER_RESOLUTION_HARNESS`, hitting the "harness has no model-provider resolution" dead-worker note, even though cursor-agent always brings its own stored login.
- Both now mirror the `subscription` readout: static, `verified: false` listings. `cli-config` lists the codex curated ids with a note that the CLI resolves the credential itself; cursor resolves to a `cursor-agent` CLI login serving the curated base-model catalog (`cursor_base_model_options`, imported lazily).

ELI5: the preflight used to look for a key in omnigent's own pocket, and when the worker kept the key in *its* pocket (codex's config.toml, cursor's login), the preflight cried "no key!" even though the worker could unlock the door just fine. Now the preflight says "the worker holds its own key" instead.

```
resolve_model_provider(spec, harness)
  ├─ cursor harness ──────────────► subscription (cursor-agent CLI login)   [was: "no resolution"]
  └─ _provider_from_entry(entry)
       ├─ databricks ────────────► gateway listing (unchanged)
       ├─ subscription ──────────► static curated list (unchanged)
       ├─ cli-config ────────────► static codex list, CLI-resolved note    [was: fell into ▼]
       └─ inline families ───────► live /v1/models listing (unchanged)
```

## Test Plan

- `uv run pytest tests/test_model_catalog.py` — 46 passed (6 new: cli-config resolution + listing, cursor resolution across all three harness spellings + listing).
- `uv run pytest tests/tools/builtins/test_list_models.py tests/test_model_override.py` — 109 passed.
- `pre-commit run --files omnigent/model_catalog.py tests/test_model_catalog.py` — clean.
- Manual: on a host with a real `cli-config` Databricks AI Gateway provider and a logged-in cursor-agent, `resolve_model_provider`/`list_models_for_worker` now return `cli-config | provider 'codex-databricks' …` with the GPT ids and `subscription | cursor-agent CLI login` with the cursor base models — previously both returned `none` with dead-worker notes while actual dispatches booted fine.

## Demo

N/A (no UI change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification reproduced the original false negatives on a live deployment (codex worker behind a `cli-config` Databricks AI Gateway entry, cursor-native worker with cursor-agent login) and confirmed both now resolve as usable; unit tests pin both regressions.

## Changelog

`sys_list_models` no longer misreports codex `cli-config` providers and cursor workers as having no usable model provider.

This pull request and its description were written by Isaac.
