### PR TITLE
feat(dev): omnidev manages the omnigent install; lighter pod isolation

### DIFF
--- a/dev/omnidev/Cargo.lock
+++ b/dev/omnidev/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "notify-debouncer-full",
  "ratatui",
  "serde",
+ "serde_json",
  "tokio",
  "toml",
 ]
@@ -684,6 +685,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1136,3 +1150,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/dev/omnidev/Cargo.toml
+++ b/dev/omnidev/Cargo.toml
@@ -19,6 +19,7 @@ notify = "8"
 notify-debouncer-full = "0.5"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.8"
 tokio = { version = "1", features = [
     "rt-multi-thread",

--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -1,8 +1,18 @@
 # omnidev
 
-A per-repo dev **pod** supervisor for the Omnigent repo, as a single
-long-running terminal UI. It replaces the three-terminal local dev flow
-(`omnigent server`, `omnigent host`, `npm run dev`) with one process that:
+Dev tooling for Omnigent, in one binary with two independent capabilities:
+
+1. A per-repo dev **pod supervisor** (bare `omnidev`) — the default.
+2. **Install management** (`omnidev install`/`update`/`check`) — install and
+   keep a git-based omnigent up to date. See
+   [Managing your omnigent install](#managing-your-omnigent-install). These
+   subcommands need no checkout and run anywhere.
+
+## Pod supervisor
+
+A per-repo dev **pod** supervisor, as a single long-running terminal UI. It
+replaces the three-terminal local dev flow (`omnigent server`, `omnigent host`,
+`npm run dev`) with one process that:
 
 - runs each checkout in an **isolated pod** — its own state dir, database,
   artifacts, logs, and auto-allocated ports — so multiple worktrees never
@@ -36,14 +46,22 @@ Run it from anywhere inside the checkout — it walks up to the repo root
 | host   | `uv run omnigent host --server http://127.0.0.1:<p>` | Started once the server is healthy. |
 | vite   | `npm run dev -- --port <p> --strictPort` (cwd `web/`) | `OMNIGENT_URL` points its proxy at the pod's server. |
 
+Before Vite starts (and on a manual Vite restart), omnidev runs `npm install`
+in `web/` when needed — `node_modules/` is missing, or `package.json` /
+`package-lock.json` is newer than it — so a fresh checkout or a new dependency
+doesn't make Vite fail its dependency scan. Output streams into the `vite` pane.
+
 Open the UI at the `ui` URL shown in the header (the Vite dev server).
 
 ## Isolation
 
-All Omnigent state is redirected into the pod dir via environment variables —
-the same pattern `scripts/backend-smoke.sh` uses:
-`HOME`, `TMPDIR`, `XDG_*`, `OMNIGENT_CONFIG_HOME`, `OMNIGENT_DATA_DIR`,
-`OMNIGENT_DATABASE_URI`, and `OMNIGENT_URL`.
+Only Omnigent's own state is isolated per pod — enough that concurrent pods
+never share a database or server pidfile — via `OMNIGENT_DATA_DIR`,
+`OMNIGENT_DATABASE_URI`, and `OMNIGENT_URL`. Everything else (your real
+`HOME`, credentials, config, and uv/npm caches) is inherited, because the
+agents Omnigent runs need it. This is deliberately lighter than the hermetic
+`scripts/backend-smoke.sh` sandbox, which repoints `HOME`/`XDG_*` to touch
+nothing real.
 
 The pod dir defaults to
 `${XDG_CACHE_HOME:-~/.cache}/omnidev/<repo-name>-<hash>/`, keyed to the
@@ -72,3 +90,54 @@ canonical checkout path. Per-process logs are written through to
 | `R` | Restart the backend (server then host) |
 | `c` | Clear the focused pane |
 | `q` / `Ctrl-C` | Quit and tear down all processes |
+
+## Managing your omnigent install
+
+For people who *run* omnigent (installed from git via `uv tool install`) rather
+than develop it. This wraps the fiddly PEP 508 install syntax and adds a daily
+update check — filling a gap, since omnigent's own update notice only works for
+PyPI-wheel installs and skips git installs.
+
+These subcommands manage the global tool and work from **any directory** (no
+checkout needed).
+
+```
+omnidev install     # uv tool install omnigent from git (databricks extra, main)
+omnidev update      # reinstall the latest of the tracked ref/extras
+omnidev check       # check for an update; prompt to update on a TTY
+omnidev refresh     # refresh the check cache from the network (usually detached)
+omnidev shell-hook  # print the daily-check snippet for your shell rc
+```
+
+`install` options: `--ref <branch/tag/sha>` (default `main`), `--extra <name>`
+(repeatable; defaults to `databricks`), `--no-default-extra` (install with no
+extras), `--repo <url>`. The choice is saved to
+`${XDG_CONFIG_HOME:-~/.config}/omnidev/install.toml` so `update` reuses it.
+
+Installing from git **builds the web UI from source**, so Node 22+/npm must be
+on PATH (the PyPI wheel ships the UI prebuilt; the git install does not).
+`omnidev install` fails early with a clear message if `uv` or `npm` is missing.
+
+### Daily update check
+
+Append the hook to your shell rc once to be told, at most once a day, when a
+newer `main` commit is available — and be offered to update on the spot:
+
+```bash
+omnidev shell-hook >> ~/.zshrc     # or ~/.bashrc
+```
+
+The snippet itself guards on `command -v omnidev`, so it's a no-op in shells
+where omnidev isn't on PATH — nothing to fail. (Appending the snippet is
+preferred over `eval "$(omnidev shell-hook)"`: the latter would run omnidev on
+every shell startup and print a "command not found" error whenever omnidev is
+absent.)
+
+On each interactive shell it runs `omnidev check --quiet`, which reads a cached
+result (`${XDG_CACHE_HOME:-~/.cache}/omnidev/omnigent-check.json`) and, when
+stale (>24h), refreshes it in a detached background process — so shell startup
+never blocks on the network. When a newer commit is available it prints a notice
+and, on a terminal, prompts `Update omnigent now? [y/N]`; on yes it runs
+`omnidev update` in the foreground. Declining suppresses that same commit until a
+newer one lands. Set `OMNIGENT_NO_UPDATE_CHECK` in your environment if you want
+to silence omnigent's own separate notice.

--- a/dev/omnidev/src/install.rs
+++ b/dev/omnidev/src/install.rs
@@ -1,0 +1,209 @@
+//! Manage the user's git-based omnigent installation via `uv tool install`.
+//!
+//! None of this needs a local checkout: it drives `uv` and reads the installed
+//! tool's metadata, and any git call targets the remote.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::paths;
+
+pub const DEFAULT_REPO: &str = "https://github.com/omnigent-ai/omnigent.git";
+pub const DEFAULT_REF: &str = "main";
+pub const DEFAULT_EXTRA: &str = "databricks";
+const PYTHON_VERSION: &str = "3.12";
+
+/// Durable record of how the user wants omnigent installed. Persisted so
+/// `update` reinstalls the same repo/ref/extras without re-specifying them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstallConfig {
+    pub repo: String,
+    #[serde(rename = "ref")]
+    pub git_ref: String,
+    pub extras: Vec<String>,
+}
+
+impl Default for InstallConfig {
+    fn default() -> Self {
+        InstallConfig {
+            repo: DEFAULT_REPO.to_string(),
+            git_ref: DEFAULT_REF.to_string(),
+            extras: vec![DEFAULT_EXTRA.to_string()],
+        }
+    }
+}
+
+impl InstallConfig {
+    pub fn load() -> Result<Option<InstallConfig>> {
+        let path = paths::install_config_path()?;
+        match std::fs::read_to_string(&path) {
+            Ok(text) => Ok(Some(
+                toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?,
+            )),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e).with_context(|| format!("reading {}", path.display())),
+        }
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = paths::install_config_path()?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let text = toml::to_string(self).context("serializing install config")?;
+        std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
+    }
+
+    /// The PEP 508 install spec, e.g.
+    /// `omnigent[databricks] @ git+https://github.com/omnigent-ai/omnigent.git@main`.
+    /// With no extras it collapses to the bare `git+<repo>@<ref>` URL.
+    pub fn spec(&self) -> String {
+        let source = format!("git+{}@{}", self.repo, self.git_ref);
+        if self.extras.is_empty() {
+            source
+        } else {
+            format!("omnigent[{}] @ {}", self.extras.join(","), source)
+        }
+    }
+}
+
+/// Fail early with a clear message if the toolchain a git install needs is
+/// missing. Installing from git builds the web UI from source (Node/npm),
+/// unlike the PyPI wheel which ships it prebuilt.
+fn preflight() -> Result<()> {
+    if which("uv").is_none() {
+        bail!("`uv` is not on PATH. Install it first: https://docs.astral.sh/uv/");
+    }
+    if which("npm").is_none() {
+        bail!(
+            "`npm` is not on PATH. Installing omnigent from git builds the web UI \
+             from source and needs Node 22+/npm. Install Node, then retry."
+        );
+    }
+    Ok(())
+}
+
+/// Install omnigent from git per `config`. `reinstall` forces uv past its cache
+/// so a moving ref (e.g. `main`) actually re-resolves.
+pub fn run_uv_install(config: &InstallConfig, reinstall: bool) -> Result<()> {
+    preflight()?;
+    let spec = config.spec();
+
+    let mut cmd = Command::new("uv");
+    cmd.args(["tool", "install", "--force", "--python", PYTHON_VERSION]);
+    if reinstall {
+        cmd.arg("--reinstall");
+    }
+    cmd.arg(&spec);
+
+    eprintln!("omnidev: uv tool install {spec}");
+    let status = cmd
+        .status()
+        .context("running `uv tool install` (is uv installed?)")?;
+    if !status.success() {
+        bail!("`uv tool install` failed ({status})");
+    }
+    Ok(())
+}
+
+/// `install` subcommand: persist intent, install, then record the resolved sha.
+pub fn install(config: &InstallConfig) -> Result<()> {
+    config.save()?;
+    run_uv_install(config, false)?;
+    record_installed_sha(config);
+    println!("omnidev: installed omnigent ({})", config.spec());
+    Ok(())
+}
+
+/// `update` subcommand: reinstall the latest of the persisted ref/extras. Falls
+/// back to defaults when no config has been written yet.
+pub fn update() -> Result<()> {
+    let config = InstallConfig::load()?.unwrap_or_default();
+    config.save()?;
+    run_uv_install(&config, true)?;
+    record_installed_sha(&config);
+    println!("omnidev: updated omnigent ({})", config.spec());
+    Ok(())
+}
+
+/// After a successful install, capture the remote sha of the tracked ref and
+/// stash it in the cache so `check` has a baseline even before the dist-info
+/// reader runs. Best-effort — failures here never fail the install.
+fn record_installed_sha(config: &InstallConfig) {
+    if let Some(sha) = crate::update_check::remote_sha(&config.repo, &config.git_ref) {
+        let _ = crate::update_check::set_installed_sha(&sha);
+    }
+}
+
+/// Read the commit the installed omnigent tool was built from, via its PEP 610
+/// `direct_url.json`. Returns `None` for a non-VCS install or when uv/metadata
+/// can't be read. Never touches the working directory.
+pub fn installed_commit() -> Option<String> {
+    let dir = uv_tool_dir()?;
+    // …/omnigent/**/omnigent-*.dist-info/direct_url.json
+    let omnigent_root = dir.join("omnigent");
+    let dist_info = find_dist_info(&omnigent_root)?;
+    let text = std::fs::read_to_string(dist_info.join("direct_url.json")).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    value
+        .get("vcs_info")?
+        .get("commit_id")?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn uv_tool_dir() -> Option<PathBuf> {
+    let output = Command::new("uv").args(["tool", "dir"]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?;
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+/// Find the `omnigent-*.dist-info` dir under a uv tool's environment. uv lays
+/// tools out as `<tool>/lib/pythonX.Y/site-packages/<pkg>-<ver>.dist-info`, so
+/// we walk rather than hardcode the python version.
+fn find_dist_info(root: &std::path::Path) -> Option<PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with("omnigent-") && name.ends_with(".dist-info") {
+                return Some(path);
+            }
+            stack.push(path);
+        }
+    }
+    None
+}
+
+/// Locate an executable on PATH (portable `which`, no external dep).
+fn which(program: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(program);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}

--- a/dev/omnidev/src/main.rs
+++ b/dev/omnidev/src/main.rs
@@ -1,38 +1,53 @@
-//! omnidev — a per-repo dev pod supervisor TUI for the Omnigent repo.
+//! omnidev — dev tooling for Omnigent.
 //!
-//! Manages one isolated dev instance (its own state dir + ports) and its three
-//! processes (server, host, vite), restarting the backend on Python changes
-//! while Vite handles frontend HMR itself.
+//! Two independent capabilities in one binary:
+//! - **pod supervisor** (bare `omnidev`): manages an isolated dev instance for
+//!   the current checkout — server/host/vite, restarting the backend on Python
+//!   changes while Vite handles frontend HMR.
+//! - **install management** (`omnidev install`/`update`/`check`/…): install and
+//!   keep a git-based omnigent up to date. These need no checkout and run
+//!   anywhere.
 
+mod install;
 mod lock;
 mod logs;
 mod paths;
 mod pod;
 mod ports;
 mod process;
+mod shellhook;
 mod state;
 mod supervisor;
 mod tui;
+mod update_check;
 mod watcher;
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use tokio::sync::mpsc;
 
+use install::InstallConfig;
 use pod::Pod;
 use ports::Ports;
 use state::Shared;
 use supervisor::{Cmd, Supervisor};
 
 #[derive(Parser, Debug)]
-#[command(
-    name = "omnidev",
-    about = "Isolated dev pod supervisor for the Omnigent repo"
-)]
+#[command(name = "omnidev", about = "Dev tooling for Omnigent", version)]
 struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    #[command(flatten)]
+    run: RunArgs,
+}
+
+/// Flags for the default (no-subcommand) pod-supervisor run.
+#[derive(clap::Args, Debug)]
+struct RunArgs {
     /// Force the backend server port (default: probe from 6767).
     #[arg(long)]
     server_port: Option<u16>,
@@ -54,10 +69,78 @@ struct Args {
     clean: bool,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Install omnigent from git (defaults to the databricks extra, main).
+    Install {
+        /// Git ref (branch/tag/sha) to track.
+        #[arg(long, default_value = install::DEFAULT_REF)]
+        r#ref: String,
+        /// Extra to include (repeatable). Defaults to `databricks`.
+        #[arg(long = "extra")]
+        extras: Vec<String>,
+        /// Omit the default databricks extra (install with no extras).
+        #[arg(long)]
+        no_default_extra: bool,
+        /// Git repo URL.
+        #[arg(long, default_value = install::DEFAULT_REPO)]
+        repo: String,
+    },
+    /// Reinstall the latest of the tracked ref/extras.
+    Update,
+    /// Check for an omnigent update (the shell hook calls this).
+    Check {
+        /// Print nothing when already up to date.
+        #[arg(long)]
+        quiet: bool,
+    },
+    /// Refresh the update-check cache from the network (usually run detached).
+    Refresh,
+    /// Print a shell snippet to eval from .zshrc/.bashrc for daily checks.
+    ShellHook,
+}
+
+fn main() -> Result<()> {
     let args = Args::parse();
 
+    // Install-management subcommands manage a global tool and must work from
+    // anywhere — dispatch them before any checkout discovery.
+    match args.command {
+        Some(Command::Install {
+            r#ref,
+            extras,
+            no_default_extra,
+            repo,
+        }) => {
+            let extras = if !extras.is_empty() {
+                extras
+            } else if no_default_extra {
+                vec![]
+            } else {
+                vec![install::DEFAULT_EXTRA.to_string()]
+            };
+            let config = InstallConfig {
+                repo,
+                git_ref: r#ref,
+                extras,
+            };
+            install::install(&config)
+        }
+        Some(Command::Update) => install::update(),
+        Some(Command::Check { quiet }) => update_check::check(quiet),
+        Some(Command::Refresh) => update_check::refresh(),
+        Some(Command::ShellHook) => {
+            shellhook::print();
+            Ok(())
+        }
+        None => run_supervisor(args.run),
+    }
+}
+
+/// Default path: the pod supervisor for the current checkout. This is the only
+/// path that requires an Omnigent checkout.
+#[tokio::main]
+async fn run_supervisor(args: RunArgs) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let repo_root = paths::find_repo_root(&cwd)?;
     let pod_dir = match &args.pod_dir {

--- a/dev/omnidev/src/paths.rs
+++ b/dev/omnidev/src/paths.rs
@@ -49,7 +49,8 @@ pub fn default_pod_dir(repo_root: &Path) -> Result<PathBuf> {
     Ok(cache.join("omnidev").join(format!("{slug}-{hash}")))
 }
 
-fn cache_home() -> Result<PathBuf> {
+/// `${XDG_CACHE_HOME:-~/.cache}`.
+pub fn cache_home() -> Result<PathBuf> {
     if let Some(x) = std::env::var_os("XDG_CACHE_HOME") {
         if !x.is_empty() {
             return Ok(PathBuf::from(x));
@@ -57,6 +58,27 @@ fn cache_home() -> Result<PathBuf> {
     }
     let home = std::env::var_os("HOME").context("HOME is not set")?;
     Ok(PathBuf::from(home).join(".cache"))
+}
+
+/// `${XDG_CONFIG_HOME:-~/.config}`.
+pub fn config_home() -> Result<PathBuf> {
+    if let Some(x) = std::env::var_os("XDG_CONFIG_HOME") {
+        if !x.is_empty() {
+            return Ok(PathBuf::from(x));
+        }
+    }
+    let home = std::env::var_os("HOME").context("HOME is not set")?;
+    Ok(PathBuf::from(home).join(".config"))
+}
+
+/// `~/.config/omnidev/install.toml` — durable record of install intent.
+pub fn install_config_path() -> Result<PathBuf> {
+    Ok(config_home()?.join("omnidev").join("install.toml"))
+}
+
+/// `~/.cache/omnidev/omnigent-check.json` — volatile update-check state.
+pub fn check_cache_path() -> Result<PathBuf> {
+    Ok(cache_home()?.join("omnidev").join("omnigent-check.json"))
 }
 
 /// FNV-1a 64-bit, rendered as 8 hex chars. No external dep needed — we only

--- a/dev/omnidev/src/pod.rs
+++ b/dev/omnidev/src/pod.rs
@@ -15,19 +15,10 @@ pub struct Pod {
 
 impl Pod {
     /// Create the pod directory tree (idempotent) and return the pod handle.
-    /// Mirrors the isolation layout proven by `scripts/backend-smoke.sh`.
+    /// Only omnigent's own state is isolated (DB, artifacts, logs); the pod
+    /// otherwise inherits your real home, credentials, config, and caches.
     pub fn create(repo_root: PathBuf, dir: PathBuf, ports: Ports) -> Result<Pod> {
-        for sub in [
-            "home",
-            "tmp",
-            "config/xdg",
-            "data/xdg",
-            "cache/xdg",
-            "config/omnigent",
-            "data/omnigent",
-            "artifacts",
-            "logs",
-        ] {
+        for sub in ["data/omnigent", "artifacts", "logs"] {
             let p = dir.join(sub);
             std::fs::create_dir_all(&p)
                 .with_context(|| format!("creating pod dir {}", p.display()))?;
@@ -70,6 +61,27 @@ impl Pod {
         self.repo_root.join("web")
     }
 
+    /// Whether `web/` needs `npm install` before Vite can start: either
+    /// `node_modules/` is absent, or the lockfile / `package.json` is newer
+    /// than the installed tree (a dependency was added/changed since the last
+    /// install — the case that makes Vite's dependency scan fail).
+    pub fn needs_npm_install(&self) -> bool {
+        let web = self.web_dir();
+        let modules = web.join("node_modules");
+        if !modules.is_dir() {
+            return true;
+        }
+        let mtime = |p: PathBuf| std::fs::metadata(p).and_then(|m| m.modified()).ok();
+        let Some(installed) = mtime(modules) else {
+            return true;
+        };
+        // Reinstall if either manifest is newer than node_modules.
+        [web.join("package-lock.json"), web.join("package.json")]
+            .into_iter()
+            .filter_map(mtime)
+            .any(|t| t > installed)
+    }
+
     /// Directory to watch for backend source changes.
     pub fn omnigent_dir(&self) -> PathBuf {
         self.repo_root.join("omnigent")
@@ -80,18 +92,14 @@ impl Pod {
     }
 
     /// The env overrides applied on top of the inherited parent env for every
-    /// child. Keeps PATH/uv resolvable while redirecting all Omnigent state
-    /// into the pod dir. `OMNIGENT_URL` is the seam `web/vite.config.ts` reads
-    /// to point its proxy at this pod's backend.
+    /// child. We isolate only omnigent's own state — the DB and data dir — so
+    /// concurrent pods don't share a database or pidfile. Everything else
+    /// (real `HOME`, credentials, config, uv/npm caches) is inherited, since
+    /// the agents omnigent runs need it. `OMNIGENT_URL` is the seam
+    /// `web/vite.config.ts` reads to point its proxy at this pod's backend.
     pub fn env(&self) -> Vec<(String, String)> {
         let d = |p: &str| self.dir.join(p).display().to_string();
         vec![
-            ("HOME".into(), d("home")),
-            ("TMPDIR".into(), d("tmp")),
-            ("XDG_CONFIG_HOME".into(), d("config/xdg")),
-            ("XDG_DATA_HOME".into(), d("data/xdg")),
-            ("XDG_CACHE_HOME".into(), d("cache/xdg")),
-            ("OMNIGENT_CONFIG_HOME".into(), d("config/omnigent")),
             ("OMNIGENT_DATA_DIR".into(), d("data/omnigent")),
             ("OMNIGENT_DATABASE_URI".into(), self.db_uri()),
             ("OMNIGENT_URL".into(), self.server_url()),

--- a/dev/omnidev/src/process.rs
+++ b/dev/omnidev/src/process.rs
@@ -50,6 +50,26 @@ impl ProcSpec {
         }
     }
 
+    /// `npm install`, from `web/`. Run before Vite when deps are missing or
+    /// stale so Vite's dependency scan doesn't fail on an unresolved import.
+    ///
+    /// `--loglevel http` makes npm emit a line per package fetch even when its
+    /// stdout is piped (its progress bar is TTY-only), so the pane streams real
+    /// progress. `--no-fund --no-audit` trims the trailing noise.
+    pub fn npm_install(pod: &Pod) -> ProcSpec {
+        ProcSpec {
+            program: "npm".into(),
+            args: vec![
+                "install".into(),
+                "--no-fund".into(),
+                "--no-audit".into(),
+                "--loglevel".into(),
+                "http".into(),
+            ],
+            cwd: pod.web_dir(),
+        }
+    }
+
     /// `npm run dev -- --port <p> --strictPort`, from `web/`. `OMNIGENT_URL`
     /// (in the pod env) points Vite's proxy at this pod's backend.
     pub fn vite(pod: &Pod) -> ProcSpec {

--- a/dev/omnidev/src/shellhook.rs
+++ b/dev/omnidev/src/shellhook.rs
@@ -1,0 +1,19 @@
+//! Emit the shell snippet that runs the daily update check.
+
+/// The snippet to append to `.zshrc`/`.bashrc`
+/// (`omnidev shell-hook >> ~/.zshrc`). All throttling and prompting live inside
+/// `omnidev check`, so this stays trivial and shell-agnostic: run once per
+/// interactive shell, quietly, and never fail the shell if it errors.
+///
+/// It self-guards on `command -v omnidev`, so it's meant to be appended to the
+/// rc (a static no-op when omnidev is absent) rather than run via
+/// `eval "$(omnidev shell-hook)"`, which would invoke omnidev on every shell
+/// startup and error when it isn't on PATH.
+const HOOK: &str = r#"# omnidev: daily omnigent update check
+if [ -n "${PS1:-}" ] && command -v omnidev >/dev/null 2>&1; then
+  omnidev check --quiet || true
+fi"#;
+
+pub fn print() {
+    println!("{HOOK}");
+}

--- a/dev/omnidev/src/supervisor.rs
+++ b/dev/omnidev/src/supervisor.rs
@@ -107,6 +107,7 @@ impl Supervisor {
 
         self.start_backend().await;
         if self.vite_enabled {
+            self.prepare_vite().await;
             self.spawn(ProcId::Vite);
         }
 
@@ -169,6 +170,7 @@ impl Supervisor {
                 if self.vite_enabled {
                     self.event("restarting vite");
                     self.stop(ProcId::Vite).await;
+                    self.prepare_vite().await;
                     self.spawn(ProcId::Vite);
                 }
             }
@@ -250,6 +252,76 @@ impl Supervisor {
                 status,
             });
         });
+    }
+
+    /// Run `npm install` to completion before Vite starts, but only when deps
+    /// are missing or stale — otherwise Vite's dependency scan fails on an
+    /// unresolved import (e.g. a dep added to package.json but not installed).
+    /// Output streams into the Vite pane. A failed/absent install is logged but
+    /// non-fatal: we still let Vite try, so a transient npm hiccup doesn't block
+    /// the whole session.
+    async fn prepare_vite(&self) {
+        if !self.pod.needs_npm_install() {
+            return;
+        }
+        self.set_status(ProcId::Vite, ProcStatus::Starting);
+        self.shared.lock().unwrap().log_proc(
+            ProcId::Vite,
+            "web deps missing or stale — running npm install".into(),
+        );
+
+        let spec = ProcSpec::npm_install(&self.pod);
+        let mut cmd = Command::new(&spec.program);
+        cmd.args(&spec.args)
+            .current_dir(&spec.cwd)
+            .envs(self.env.iter().cloned())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                self.shared
+                    .lock()
+                    .unwrap()
+                    .log_proc(ProcId::Vite, format!("failed to run npm install: {e}"));
+                return;
+            }
+        };
+        if let Some(out) = child.stdout.take() {
+            self.pump(ProcId::Vite, out);
+        }
+        if let Some(err) = child.stderr.take() {
+            self.pump(ProcId::Vite, err);
+        }
+
+        // `--loglevel http` streams a line per package fetch, but npm still
+        // goes quiet during the final tree-build/link phase. A slow heartbeat
+        // covers those gaps so the pane never looks frozen.
+        let started = Instant::now();
+        let mut heartbeat = tokio::time::interval(Duration::from_secs(5));
+        heartbeat.tick().await; // the first tick fires immediately; skip it
+        let status = loop {
+            tokio::select! {
+                result = child.wait() => break result,
+                _ = heartbeat.tick() => {
+                    let secs = started.elapsed().as_secs();
+                    self.shared
+                        .lock()
+                        .unwrap()
+                        .log_proc(ProcId::Vite, format!("… npm install running ({secs}s)"));
+                }
+            }
+        };
+        match status {
+            Ok(s) if s.success() => self.event(format!(
+                "npm install complete ({}s)",
+                started.elapsed().as_secs()
+            )),
+            Ok(s) => self.event(format!("npm install exited {s} — starting Vite anyway")),
+            Err(e) => self.event(format!("npm install wait error: {e}")),
+        }
     }
 
     /// Spawn a task that streams one pipe into the shared buffer, line by line.

--- a/dev/omnidev/src/update_check.rs
+++ b/dev/omnidev/src/update_check.rs
@@ -1,0 +1,228 @@
+//! Daily update check for a git-installed omnigent.
+//!
+//! Fills a real gap: omnigent's own update notice only works for PyPI-wheel
+//! installs and bails on VCS installs. The hot path (`check`) never blocks on
+//! the network — it reads a cache and spawns a detached `refresh` when stale.
+
+use std::io::{IsTerminal, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::install::{self, InstallConfig};
+use crate::paths;
+
+const STALE_SECS: u64 = 24 * 60 * 60;
+const LS_REMOTE_TIMEOUT_SECS: u64 = 5;
+
+/// Volatile update-check state cached between runs.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CheckCache {
+    #[serde(default)]
+    pub last_checked: u64,
+    #[serde(default)]
+    pub remote_sha: Option<String>,
+    #[serde(default)]
+    pub installed_sha: Option<String>,
+    /// The remote sha we already prompted about, so a declined update isn't
+    /// re-nagged until a newer commit lands.
+    #[serde(default)]
+    pub last_prompted_sha: Option<String>,
+}
+
+impl CheckCache {
+    pub fn load() -> CheckCache {
+        let Ok(path) = paths::check_cache_path() else {
+            return CheckCache::default();
+        };
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|t| serde_json::from_str(&t).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = paths::check_cache_path()?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let text = serde_json::to_string_pretty(self).context("serializing check cache")?;
+        std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
+    }
+}
+
+/// Whether the cache indicates an update the user hasn't already declined.
+/// Pure so it can be unit-tested without touching disk or the network.
+///
+/// `installed` is the best-known installed commit (dist-info first, else the
+/// cached `installed_sha`). An update is available when we have a remote sha
+/// that differs from what's installed and that we haven't already prompted for.
+pub fn update_available(cache: &CheckCache, installed: Option<&str>) -> bool {
+    let Some(remote) = cache.remote_sha.as_deref() else {
+        return false;
+    };
+    if Some(remote) == installed {
+        return false;
+    }
+    if cache.last_prompted_sha.as_deref() == Some(remote) {
+        return false;
+    }
+    true
+}
+
+/// Whether `last_checked` is older than the staleness window.
+pub fn is_stale(cache: &CheckCache, now: u64) -> bool {
+    now.saturating_sub(cache.last_checked) > STALE_SECS
+}
+
+fn now_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// The remote HEAD sha of `git_ref` in `repo`, via `git ls-remote` (targets the
+/// remote, so no local checkout is needed). `None` on any failure/timeout.
+pub fn remote_sha(repo: &str, git_ref: &str) -> Option<String> {
+    // `timeout` isn't portable (absent on macOS by default), so bound the call
+    // with git's own connect timeout and a wait guard instead.
+    let mut child = Command::new("git")
+        .args(["ls-remote", repo, git_ref])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let deadline = SystemTime::now() + Duration::from_secs(LS_REMOTE_TIMEOUT_SECS);
+    loop {
+        match child.try_wait().ok()? {
+            Some(_) => break,
+            None => {
+                if SystemTime::now() > deadline {
+                    let _ = child.kill();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+    let output = child.wait_with_output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    // First whitespace-delimited token of the first line is the sha.
+    text.lines()
+        .next()
+        .and_then(|l| l.split_whitespace().next())
+        .map(str::to_string)
+}
+
+/// Record the installed sha into the cache (called after install/update).
+pub fn set_installed_sha(sha: &str) -> Result<()> {
+    let mut cache = CheckCache::load();
+    cache.installed_sha = Some(sha.to_string());
+    cache.save()
+}
+
+/// `refresh` subcommand: hit the network, update `remote_sha` + `last_checked`.
+/// Invoked detached by `check`, but also runnable directly.
+pub fn refresh() -> Result<()> {
+    let config = InstallConfig::load()?.unwrap_or_default();
+    let mut cache = CheckCache::load();
+    cache.remote_sha = remote_sha(&config.repo, &config.git_ref);
+    cache.last_checked = now_epoch();
+    cache.save()
+}
+
+/// Best-known installed commit: the tool's dist-info first (authoritative),
+/// else the sha we recorded at install time.
+fn installed_commit(cache: &CheckCache) -> Option<String> {
+    install::installed_commit().or_else(|| cache.installed_sha.clone())
+}
+
+/// `check` subcommand: the fast hook primitive. Never blocks on the network.
+///
+/// - Stale cache ⇒ spawn a detached `refresh` and return.
+/// - An available update ⇒ notice; on a TTY, prompt and update in the
+///   foreground on yes, else record the decline.
+/// - `quiet` suppresses the "up to date" path so shell startup stays silent.
+pub fn check(quiet: bool) -> Result<()> {
+    let cache = CheckCache::load();
+
+    if is_stale(&cache, now_epoch()) {
+        spawn_detached_refresh();
+        // Still evaluate against whatever we already had cached.
+    }
+
+    let installed = installed_commit(&cache);
+    if !update_available(&cache, installed.as_deref()) {
+        if !quiet {
+            println!("omnigent is up to date.");
+        }
+        return Ok(());
+    }
+
+    let remote = cache.remote_sha.clone().unwrap_or_default();
+    let short = |s: &str| s.chars().take(8).collect::<String>();
+    let installed_desc = installed
+        .as_deref()
+        .map(short)
+        .unwrap_or_else(|| "unknown".to_string());
+    eprintln!(
+        "omnigent update available: {} → {} (git)",
+        installed_desc,
+        short(&remote),
+    );
+
+    // Only prompt on an interactive terminal; scripts/CI just see the notice.
+    if !(std::io::stdin().is_terminal() && std::io::stderr().is_terminal()) {
+        return Ok(());
+    }
+
+    if prompt_yes_no("Update omnigent now? [y/N] ") {
+        install::update()?;
+    } else {
+        // Don't re-nag for this same commit.
+        let mut cache = CheckCache::load();
+        cache.last_prompted_sha = Some(remote);
+        cache.save()?;
+    }
+    Ok(())
+}
+
+/// Prompt on the controlling terminal. Reads from `/dev/tty` so it works even
+/// when the hook's stdin is redirected. Any read failure ⇒ treated as "no".
+fn prompt_yes_no(prompt: &str) -> bool {
+    use std::io::BufRead;
+    let Ok(tty) = std::fs::OpenOptions::new().read(true).open("/dev/tty") else {
+        return false;
+    };
+    eprint!("{prompt}");
+    let _ = std::io::stderr().flush();
+    let mut line = String::new();
+    if std::io::BufReader::new(tty).read_line(&mut line).is_err() {
+        return false;
+    }
+    matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+/// Launch `omnidev refresh` fully detached so shell startup never waits on it.
+fn spawn_detached_refresh() {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let _ = Command::new(exe)
+        .arg("refresh")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+}

--- a/dev/omnidev/tests/install_mgmt.rs
+++ b/dev/omnidev/tests/install_mgmt.rs
@@ -1,0 +1,151 @@
+//! Exercises install-management logic without network or a real install:
+//! spec building, config round-trip, and the update-availability/staleness
+//! decisions.
+
+use std::sync::{Mutex, MutexGuard};
+
+// These modules reference each other via `crate::`, so declare the whole set at
+// the test crate root. Each test target exercises only part of the included
+// source, so allow dead code rather than chase per-item warnings.
+#[allow(dead_code)]
+#[path = "../src/install.rs"]
+mod install;
+#[allow(dead_code)]
+#[path = "../src/paths.rs"]
+mod paths;
+#[allow(dead_code)]
+#[path = "../src/update_check.rs"]
+mod update_check;
+
+use install::InstallConfig;
+use update_check::{is_stale, update_available, CheckCache};
+
+/// Tests here mutate process-global `XDG_*` env vars; serialize them.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+#[test]
+fn spec_default_has_databricks_extra_and_main() {
+    let c = InstallConfig::default();
+    assert_eq!(
+        c.spec(),
+        "omnigent[databricks] @ git+https://github.com/omnigent-ai/omnigent.git@main"
+    );
+}
+
+#[test]
+fn spec_no_extras_is_bare_git_url() {
+    let c = InstallConfig {
+        repo: "https://github.com/omnigent-ai/omnigent.git".into(),
+        git_ref: "main".into(),
+        extras: vec![],
+    };
+    assert_eq!(
+        c.spec(),
+        "git+https://github.com/omnigent-ai/omnigent.git@main"
+    );
+}
+
+#[test]
+fn spec_reflects_custom_ref_and_extras() {
+    let c = InstallConfig {
+        repo: "https://example.com/x.git".into(),
+        git_ref: "dev".into(),
+        extras: vec!["databricks".into(), "kubernetes".into()],
+    };
+    assert_eq!(
+        c.spec(),
+        "omnigent[databricks,kubernetes] @ git+https://example.com/x.git@dev"
+    );
+}
+
+#[test]
+fn config_round_trips_through_disk() {
+    let _guard = lock_env();
+    let tmp = tempdir();
+    std::env::set_var("XDG_CONFIG_HOME", &tmp);
+
+    let c = InstallConfig {
+        repo: "https://github.com/omnigent-ai/omnigent.git".into(),
+        git_ref: "main".into(),
+        extras: vec!["databricks".into()],
+    };
+    c.save().unwrap();
+    let loaded = InstallConfig::load().unwrap().expect("config present");
+    assert_eq!(c, loaded);
+
+    std::env::remove_var("XDG_CONFIG_HOME");
+}
+
+#[test]
+fn missing_config_loads_as_none() {
+    let _guard = lock_env();
+    let tmp = tempdir();
+    std::env::set_var("XDG_CONFIG_HOME", &tmp);
+
+    assert!(InstallConfig::load().unwrap().is_none());
+
+    std::env::remove_var("XDG_CONFIG_HOME");
+}
+
+#[test]
+fn update_available_logic() {
+    let cache = CheckCache {
+        remote_sha: Some("bbbb".into()),
+        ..Default::default()
+    };
+    // Remote differs from installed and wasn't prompted → available.
+    assert!(update_available(&cache, Some("aaaa")));
+    // Installed already matches remote → not available.
+    assert!(!update_available(&cache, Some("bbbb")));
+    // No remote sha known → not available.
+    assert!(!update_available(&CheckCache::default(), Some("aaaa")));
+
+    // Declining a commit (last_prompted_sha == remote) suppresses it.
+    let declined = CheckCache {
+        remote_sha: Some("bbbb".into()),
+        last_prompted_sha: Some("bbbb".into()),
+        ..Default::default()
+    };
+    assert!(!update_available(&declined, Some("aaaa")));
+}
+
+#[test]
+fn staleness_window() {
+    let now = 1_000_000u64;
+    let day = 24 * 60 * 60;
+
+    let fresh = CheckCache {
+        last_checked: now - 10,
+        ..Default::default()
+    };
+    assert!(!is_stale(&fresh, now));
+
+    let old = CheckCache {
+        last_checked: now - day - 1,
+        ..Default::default()
+    };
+    assert!(is_stale(&old, now));
+
+    // Never checked (last_checked == 0) → stale.
+    assert!(is_stale(&CheckCache::default(), now));
+}
+
+/// Minimal unique temp dir without pulling a dev-dependency.
+fn tempdir() -> std::path::PathBuf {
+    let base = std::env::temp_dir();
+    let unique = format!(
+        "omnidev-mgmt-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let dir = base.join(unique);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}

--- a/dev/omnidev/tests/pod_setup.rs
+++ b/dev/omnidev/tests/pod_setup.rs
@@ -2,14 +2,22 @@
 
 use std::fs;
 
-// The crate is a binary, so pull in the modules under test directly.
+// The crate is a binary, so pull in the modules under test directly. Each test
+// target uses only part of the included source, so allow dead code.
+#[allow(dead_code)]
 #[path = "../src/lock.rs"]
 mod lock;
+#[allow(dead_code)]
 #[path = "../src/paths.rs"]
 mod paths;
+#[allow(dead_code)]
+#[path = "../src/pod.rs"]
+mod pod;
+#[allow(dead_code)]
 #[path = "../src/ports.rs"]
 mod ports;
 
+use pod::Pod;
 use ports::Ports;
 
 /// A fake checkout (.git + omnigent/ + web/) is recognized as a root, and a
@@ -41,6 +49,38 @@ fn pod_dir_is_per_repo_and_stable() {
     let b = paths::default_pod_dir(std::path::Path::new("/repos/two")).unwrap();
     assert_eq!(a1, a2);
     assert_ne!(a1, b);
+}
+
+/// npm install is needed when node_modules is missing, and when a manifest is
+/// newer than it; not needed when node_modules is up to date.
+#[test]
+fn needs_npm_install_tracks_manifests() {
+    let repo = tempdir();
+    let web = repo.join("web");
+    fs::create_dir_all(&web).unwrap();
+    fs::write(web.join("package.json"), "{}").unwrap();
+
+    let pod = Pod {
+        repo_root: repo.clone(),
+        dir: repo.join("pod"),
+        ports: Ports {
+            server: 6767,
+            vite: 5173,
+        },
+    };
+
+    // No node_modules yet → install needed.
+    assert!(pod.needs_npm_install());
+
+    // Fresh node_modules created after the manifest → up to date.
+    fs::create_dir_all(web.join("node_modules")).unwrap();
+    assert!(!pod.needs_npm_install());
+
+    // A manifest touched after node_modules → stale, install needed.
+    // (Sleep briefly so the mtime is observably newer on coarse filesystems.)
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    fs::write(web.join("package-lock.json"), "{}").unwrap();
+    assert!(pod.needs_npm_install());
 }
 
 /// Ports probe to bindable values and persist/reuse across calls.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add install-management subcommands to omnidev, for people who *run* omnigent (installed from git via `uv tool install`) rather than develop it. This fills a real gap: omnigent's own update notice only works for PyPI-wheel installs and skips git installs, so a git-installed omnigent never learns it is out of date.
  - `omnidev install` — `uv tool install` from git, defaulting to the `databricks` extra and `main`; `--ref`/`--extra`/`--no-default-extra`/ `--repo` override and persist to `~/.config/omnidev/install.toml`.
  - `omnidev update` — reinstall the latest of the tracked ref/extras (`--reinstall`, required for a moving git ref).
  - `omnidev check` — the shell-hook primitive: reads a cache, refreshes it detached when >24h stale (never blocks the shell), and on an available update prints a notice and, on a TTY, prompts to update in the foreground. A declined commit isn't re-nagged.
  - `omnidev refresh` — the background `git ls-remote` probe.
  - `omnidev shell-hook` — emits the `eval "$(omnidev shell-hook)"` snippet.
- These subcommands need no checkout and dispatch before repo-root discovery, so they run from any directory; bare `omnidev` still launches the pod supervisor. Installing from git builds the web UI from source, so `install` fails early if `uv`/`npm` is missing.
- Lighten pod isolation: only omnigent's own state (`OMNIGENT_DATA_DIR`, `OMNIGENT_DATABASE_URI`, `OMNIGENT_URL`) is isolated per pod. The pod now inherits the real `HOME`, credentials, config, and uv/npm caches — which the agents omnigent runs need — instead of the hermetic `HOME`/`XDG_*`/`TMPDIR` sandbox that cut them off.

## Test Plan

- `cargo build`, `cargo build --release`, `cargo clippy --all-targets`, and `cargo fmt` all clean.
- `cargo test` passes 13 tests (7 new): install-spec builder for default / no-extras / custom ref+extras, install-config round-trip, missing-config, update-availability logic including decline suppression, and the 24h staleness window.
- Manually verified from a scratch dir with no git repo that `omnidev check`, `shell-hook`, etc. run without a "missing checkout" error, while bare `omnidev` still errors as expected; confirmed the CLI surface (`--help`, `install --help`, `shell-hook` output).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The network- and install-driving paths (`uv tool install`, `git ls-remote`, reading the installed tool's `direct_url.json`, the detached refresh, and the TTY prompt) can't run in unit tests, so they were verified manually. Pure logic — spec building, config round-trip, update- availability and staleness decisions — is covered by `tests/install_mgmt.rs`.
