### PR TITLE
fix(harnesses): run cursor bridge in the declared workspace cwd

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -440,6 +440,42 @@ def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, sessio
     return hooks_file
 
 
+_BRIDGE_SPAWN_CWD_LOCK: asyncio.Lock | None = None
+
+
+def _bridge_spawn_cwd_lock() -> asyncio.Lock:
+    """Process-global lock serialising the cwd change around a bridge spawn.
+
+    Created lazily so it binds to the running event loop.
+    """
+    global _BRIDGE_SPAWN_CWD_LOCK
+    if _BRIDGE_SPAWN_CWD_LOCK is None:
+        _BRIDGE_SPAWN_CWD_LOCK = asyncio.Lock()
+    return _BRIDGE_SPAWN_CWD_LOCK
+
+
+@contextlib.asynccontextmanager
+async def _bridge_spawn_in_cwd(cwd: str) -> AsyncIterator[None]:
+    """Set the process cwd to *cwd* across a cursor-sdk bridge launch.
+
+    ``AsyncClient.launch_bridge`` spawns the bridge subprocess without a
+    ``cwd=`` argument, so the bridge -- and the shell tools Cursor runs inside
+    it -- inherit the launching process's directory. ``--workspace`` only routes
+    indexing, not command execution, so a bridge started from the runner
+    daemon's directory would run ``pwd`` / git / relative paths there rather than
+    in the declared workspace. We chdir only across the spawn and restore
+    afterwards; a process-global lock serialises the window so an overlapping
+    launch can't observe a half-applied cwd.
+    """
+    async with _bridge_spawn_cwd_lock():
+        prev_cwd = os.getcwd()
+        os.chdir(cwd)
+        try:
+            yield
+        finally:
+            os.chdir(prev_cwd)
+
+
 @dataclass
 class _CursorSessionState:
     """Per-Omnigent-conversation SDK session state."""
@@ -693,7 +729,12 @@ class CursorExecutor(Executor):
             hook_script = str(Path(__file__).with_name("cursor_policy_hook.py"))
             state.hooks_file = _write_cursor_hooks(cwd, hook_script, server_url, conv_id)
 
-        client = await AsyncClient.launch_bridge(workspace=cwd)
+        # Spawn the bridge with the process cwd pointing at the workspace so
+        # Cursor's shell tools execute there, not in the runner daemon's
+        # directory (the SDK spawns the bridge without a cwd=). See
+        # _bridge_spawn_in_cwd.
+        async with _bridge_spawn_in_cwd(cwd):
+            client = await AsyncClient.launch_bridge(workspace=cwd)
         try:
             local_kwargs: dict[str, Any] = {
                 "cwd": cwd,

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 import types
 from types import SimpleNamespace
@@ -68,6 +69,7 @@ def _install_fake_sdk(
         "custom_tools": [],
         "custom_tool_results": [],
         "launch_kwargs": [],
+        "launch_cwds": [],
         "sent": [],
         "closed": 0,
         "client_closed": 0,
@@ -126,6 +128,10 @@ def _install_fake_sdk(
         @classmethod
         async def launch_bridge(cls, **kwargs: Any) -> _FakeClient:
             state["launch_kwargs"].append(kwargs)
+            # Record the process cwd at spawn time: the real bridge subprocess
+            # inherits it (the SDK spawns without a cwd=), so the executor must
+            # have chdir'd to the workspace by now.
+            state["launch_cwds"].append(os.getcwd())
             return cls()
 
         # The real AsyncClient exposes ONLY aclose() (no close()); it owns the
@@ -1574,6 +1580,41 @@ async def test_ensure_session_writes_hooks_json(
     # Both files are cleaned up on close.
     assert not hooks_file.exists()
     assert not wrapper.exists()
+
+
+async def test_bridge_spawns_in_workspace_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """The bridge is launched with the process cwd set to the workspace.
+
+    cursor-sdk spawns the bridge subprocess without a ``cwd=``, so it -- and the
+    shell tools Cursor runs in it -- inherit the launching process's directory.
+    The executor must chdir to the declared workspace across the spawn (so
+    commands run in the workspace, not wherever the runner daemon lives) and
+    restore the previous cwd afterwards.
+    """
+    sdk_state = _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
+    # Workspace differs from the process cwd at launch time.
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    daemon_cwd = tmp_path / "daemon-cwd"
+    daemon_cwd.mkdir()
+    monkeypatch.chdir(daemon_cwd)
+    original_cwd = os.getcwd()
+
+    executor = CursorExecutor(api_key="crsr_x", cwd=str(workspace))
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+        assert events  # _ensure_session ran
+    finally:
+        await executor.close()
+
+    # The bridge saw the workspace (not the daemon cwd) as its directory...
+    assert len(sdk_state["launch_cwds"]) == 1
+    assert os.path.realpath(sdk_state["launch_cwds"][0]) == os.path.realpath(str(workspace))
+    # ...and the process cwd was restored afterwards.
+    assert os.getcwd() == original_cwd
 
 
 async def test_hooks_json_not_written_without_server_url(


### PR DESCRIPTION
## Related issue

Closes #2111

## Summary

`cursor-sdk`'s `AsyncClient.launch_bridge` spawns the bridge subprocess without a
`cwd=`, so the bridge — and the shell tools Cursor runs inside it — inherited the
**runner daemon's** directory instead of the spec's `os_env.cwd`. `--workspace`
only routes Cursor's indexing, not command execution, so `pwd` / `git` / relative
paths operated on the wrong tree.

- Add `_bridge_spawn_in_cwd(cwd)` — an async context manager that sets the
  process cwd to the resolved workspace across the `launch_bridge` spawn and
  restores it afterward.
- A process-global `asyncio.Lock` (`_bridge_spawn_cwd_lock`) serialises that
  window so an overlapping launch can't observe a half-applied cwd.
- Applied at the one spawn site in `CursorExecutor`:
  `async with _bridge_spawn_in_cwd(cwd): client = await AsyncClient.launch_bridge(workspace=cwd)`.

The proper fix (`Popen(cwd=...)` on the bridge spawn) belongs upstream in
`cursor-sdk`; this compensates from the executor because the SDK is an external
dependency. The chdir is process-global by necessity, so it's kept as narrow as
possible (only across the spawn) and serialised by the lock.

## Test Plan

```
pytest tests/inner/test_cursor_executor.py -q
```

- Added `test_bridge_spawns_in_workspace_cwd`: asserts the process cwd equals the
  workspace at the moment `launch_bridge` is invoked, and is restored afterward.
- `ruff check` / `ruff format --check` clean.

## Demo

N/A — non-visual harness/backend fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test pins the observable contract (cwd == workspace at spawn time,
restored after). It's not exercised end-to-end against a live Cursor bridge — the
fault is in how the SDK spawns the subprocess, and the test captures the exact
call-site cwd. Follow-up: upstream a `Popen(cwd=...)` in `cursor-sdk` so the
executor-side chdir can be removed.

## Changelog

Cursor sessions now run shell tools in the declared workspace directory instead of the runner's working directory