### PR TITLE
feat(smart-routing): replace RoutingDecisionChip with collapsible RoutingDecisionCard

### DIFF
--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -515,6 +515,10 @@ class RoutingDecisionData(BaseModel):
     tier: Literal["cheap", "medium", "expensive"]
     applied: bool
     rationale: str
+    #: Sub-agent name when this decision was made for a child session and the
+    #: item is being mirrored into the parent's transcript, e.g. ``"claude_code"``.
+    #: ``None`` for session-local routing decisions (the usual case).
+    agent: str | None = None
 
     @field_validator("model")
     @classmethod

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8590,6 +8590,8 @@ async def _emit_server_routing_decision(
     conversation_store: ConversationStore,
     model: str,
     verdict: dict[str, Any],
+    *,
+    agent: str | None = None,
 ) -> None:
     """Persist and publish a ``routing_decision`` transcript chip.
 
@@ -8597,6 +8599,9 @@ async def _emit_server_routing_decision(
     to the runner.  The chip shows the judge's model pick at turn start
     — the same UX the runner-side advisor produced, but driven entirely
     by the server.
+
+    :param agent: Sub-agent name to include when mirroring a child
+        session's routing decision into the parent's transcript.
     """
     import uuid
 
@@ -8604,12 +8609,14 @@ async def _emit_server_routing_decision(
 
     tier = verdict.get("tier", "medium")
     rationale = verdict.get("rationale", "")
-    item_data = {
+    item_data: dict[str, Any] = {
         "model": model,
         "tier": tier if tier in ("cheap", "medium", "expensive") else "medium",
         "applied": True,
         "rationale": rationale if isinstance(rationale, str) else "",
     }
+    if agent is not None:
+        item_data["agent"] = agent
     try:
         parsed_data = parse_item_data("routing_decision", item_data)
     except (ValueError, TypeError):
@@ -8864,6 +8871,18 @@ async def _forward_event_to_runner(
                 _routed_model,
                 _verdict,
             )
+            # Mirror the routing decision into the parent session so the
+            # orchestrator's transcript also shows which model was chosen
+            # for this sub-agent — the decision is otherwise only visible
+            # on the child session screen.
+            if _parent_routing_on and conv.parent_conversation_id is not None:
+                await _emit_server_routing_decision(
+                    conv.parent_conversation_id,
+                    conversation_store,
+                    _routed_model,
+                    _verdict,
+                    agent=agent_name or "",
+                )
     except (httpx.HTTPError, ConnectionError):
         _logger.exception(
             "Forward to runner failed for session=%s; "
@@ -9100,6 +9119,14 @@ async def _dispatch_session_event_to_runner(
                 _native_routed_model,
                 _native_verdict,
             )
+            if _native_parent_routing_on and conv.parent_conversation_id is not None:
+                await _emit_server_routing_decision(
+                    conv.parent_conversation_id,
+                    conversation_store,
+                    _native_routed_model,
+                    _native_verdict,
+                    agent=agent_name or "",
+                )
         return _SessionEventDispatchResult(item_id=None, pending_id=pending_id)
     item_id = await _forward_event_to_runner(
         session_id,

--- a/openapi.json
+++ b/openapi.json
@@ -2812,6 +2812,17 @@
       "RoutingDecisionData": {
         "description": "Data payload for an intelligent model-router decision item.\n\nEmitted by the runner's per-turn cost advisor at the START of an\nadvised turn (see `omnigent.runner.cost_advisor`) and persisted\nas a display-only transcript item so the model the router chose shows\nin the conversation flow the moment the turn begins. Listed in\n`NON_CONTENT_ITEM_TYPES` so the agent loop's history filter\nskips it \u2014 the brain never sees (or answers) its own router note. The\nrunner's harness-input builder also drops every non\nmessage/function_call type, a second guarantee it stays out of the\nmodel's context.",
         "properties": {
+          "agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent"
+          },
           "applied": {
             "description": "`True` when the brain actually ran on `model` this turn (optimize mode, no user pin); `False` when the router only WOULD have picked it (advise/shadow mode, or a user model pin won) \u2014 the UI renders \"would have picked\".",
             "title": "Applied",

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -115,6 +115,23 @@ describe("RoutingDecisionCard — session-level auto-routing", () => {
     expect(card.getAttribute("data-applied")).toBe("false");
   });
 
+  it("shows agent name as row label when mirrored into parent session", () => {
+    render(
+      <RoutingDecisionCard
+        model="databricks-claude-haiku-4-5"
+        tier="cheap"
+        applied
+        rationale="Simple task."
+        agent="claude_code"
+      />,
+    );
+    const card = screen.getByTestId("routing-decision-card");
+    // The agent name replaces the generic "Session" label so the
+    // orchestrator's transcript identifies which sub-agent was routed.
+    expect(card).toHaveTextContent("claude_code");
+    expect(card.textContent).not.toContain("Session");
+  });
+
   it("expands raw verdict JSON behind the chevron", () => {
     render(
       <RoutingDecisionCard

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -94,7 +94,6 @@ describe("RoutingDecisionCard — session-level auto-routing", () => {
     expect(card).toHaveTextContent("· applied");
     expect(card).toHaveTextContent("Session");
     expect(card).toHaveTextContent("opus");
-    expect(card).toHaveTextContent("expensive");
     expect(card).toHaveTextContent("Multi-file refactor needs deep reasoning.");
     expect(card.getAttribute("data-applied")).toBe("true");
   });
@@ -111,7 +110,6 @@ describe("RoutingDecisionCard — session-level auto-routing", () => {
     const card = screen.getByTestId("routing-decision-card");
     expect(card).toHaveTextContent("· advisory");
     expect(card).toHaveTextContent("haiku");
-    expect(card).toHaveTextContent("cheap");
     expect(card.getAttribute("data-applied")).toBe("false");
   });
 

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { RoutingDecisionChip } from "./StatusBlocks";
+import { RoutingDecisionCard, RoutingDecisionChip } from "./StatusBlocks";
 
 afterEach(cleanup);
 
@@ -76,5 +76,57 @@ describe("RoutingDecisionChip — intelligent model router", () => {
     expect(chip.textContent).toContain("Intelligent model router");
     expect(chip.textContent).not.toContain("model control");
     expect(chip.textContent).not.toContain("Model Control");
+  });
+});
+
+describe("RoutingDecisionCard — session-level auto-routing", () => {
+  it("applied verdict: shows model pill with tier and rationale", () => {
+    render(
+      <RoutingDecisionCard
+        model="databricks-claude-opus-4-8"
+        tier="expensive"
+        applied
+        rationale="Multi-file refactor needs deep reasoning."
+      />,
+    );
+    const card = screen.getByTestId("routing-decision-card");
+    expect(card).toHaveTextContent("Intelligent routing");
+    expect(card).toHaveTextContent("· applied");
+    expect(card).toHaveTextContent("Session");
+    expect(card).toHaveTextContent("opus");
+    expect(card).toHaveTextContent("expensive");
+    expect(card).toHaveTextContent("Multi-file refactor needs deep reasoning.");
+    expect(card.getAttribute("data-applied")).toBe("true");
+  });
+
+  it("advisory verdict: shows '· advisory' and the model that would have been picked", () => {
+    render(
+      <RoutingDecisionCard
+        model="databricks-claude-haiku-4-5"
+        tier="cheap"
+        applied={false}
+        rationale="Trivial question."
+      />,
+    );
+    const card = screen.getByTestId("routing-decision-card");
+    expect(card).toHaveTextContent("· advisory");
+    expect(card).toHaveTextContent("haiku");
+    expect(card).toHaveTextContent("cheap");
+    expect(card.getAttribute("data-applied")).toBe("false");
+  });
+
+  it("expands raw verdict JSON behind the chevron", () => {
+    render(
+      <RoutingDecisionCard
+        model="databricks-claude-opus-4-8"
+        tier="expensive"
+        applied
+        rationale="Deep reasoning required."
+      />,
+    );
+    // Collapsed by default — raw JSON not visible.
+    expect(screen.queryByText(/"tier"/)).toBeNull();
+    fireEvent.click(screen.getByTestId("routing-decision-raw-toggle"));
+    expect(screen.getByText(/"tier"/)).toBeInTheDocument();
   });
 });

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -157,6 +157,8 @@ interface RoutingDecisionCardProps {
   tier: "cheap" | "medium" | "expensive";
   applied: boolean;
   rationale: string;
+  /** Sub-agent name when this card is shown in the parent session. */
+  agent?: string;
 }
 
 /**
@@ -165,13 +167,22 @@ interface RoutingDecisionCardProps {
  * rationale, and expandable raw verdict JSON.
  *
  * Shown in place of the muted chip when auto-routing fires at turn start
- * because the agent spec has no explicit model.
+ * because the agent spec has no explicit model. When `agent` is provided
+ * the card is being shown in the parent (orchestrator) session for a child
+ * session's routing decision — the agent name is shown as the row label.
  */
-export function RoutingDecisionCard({ model, tier, applied, rationale }: RoutingDecisionCardProps) {
+export function RoutingDecisionCard({
+  model,
+  tier,
+  applied,
+  rationale,
+  agent,
+}: RoutingDecisionCardProps) {
   const short = shortModelName(model);
+  const rowLabel = agent && agent.length > 0 ? agent : "Session";
   const prettyOutput = useMemo(
-    () => JSON.stringify({ model, tier, applied, rationale }, null, 2),
-    [model, tier, applied, rationale],
+    () => JSON.stringify({ model, tier, applied, rationale, ...(agent ? { agent } : {}) }, null, 2),
+    [model, tier, applied, rationale, agent],
   );
   return (
     <Collapsible
@@ -196,7 +207,7 @@ export function RoutingDecisionCard({ model, tier, applied, rationale }: Routing
         </CollapsibleTrigger>
       </div>
       <div className="flex items-center gap-2 text-xs">
-        <span className="min-w-0 truncate font-mono text-foreground">Session</span>
+        <span className="min-w-0 truncate font-mono text-foreground">{rowLabel}</span>
         <span className="ml-auto shrink-0 inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] leading-none">
           <span className="font-medium text-foreground">{short}</span>
           <span className="text-muted-foreground">· {tier}</span>

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -208,9 +208,8 @@ export function RoutingDecisionCard({
       </div>
       <div className="flex items-center gap-2 text-xs">
         <span className="min-w-0 truncate font-mono text-foreground">{rowLabel}</span>
-        <span className="ml-auto shrink-0 inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] leading-none">
-          <span className="font-medium text-foreground">{short}</span>
-          <span className="text-muted-foreground">· {tier}</span>
+        <span className="ml-auto shrink-0 inline-flex items-center whitespace-nowrap rounded-full border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium leading-none text-foreground">
+          {short}
         </span>
       </div>
       {rationale.length > 0 && (

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -10,12 +10,18 @@
 import {
   AlertCircleIcon,
   BrainCircuitIcon,
+  ChevronRightIcon,
   RotateCcwIcon,
   ShieldXIcon,
   ShrinkIcon,
 } from "lucide-react";
+import { useMemo } from "react";
+import { CodeBlock, CodeBlockHeader, CodeBlockTitle } from "@/components/ai-elements/code-block";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { shortModelName } from "@/components/CostRoutingControl";
+import { cn } from "@/lib/utils";
+import { TOOL_SURFACE_WIDTH_CLASS } from "./toolSurface";
 
 interface ErrorBannerProps {
   message: string;
@@ -143,5 +149,71 @@ export function RoutingDecisionChip({ model, applied, rationale }: RoutingDecisi
       </span>
       {rationale ? <span className="text-muted-foreground/70">{rationale}</span> : null}
     </div>
+  );
+}
+
+interface RoutingDecisionCardProps {
+  model: string;
+  tier: "cheap" | "medium" | "expensive";
+  applied: boolean;
+  rationale: string;
+}
+
+/**
+ * Collapsible card announcing the intelligent model router's session-level
+ * pick. Mirrors the SmartRoutingCard style: same container, model pill,
+ * rationale, and expandable raw verdict JSON.
+ *
+ * Shown in place of the muted chip when auto-routing fires at turn start
+ * because the agent spec has no explicit model.
+ */
+export function RoutingDecisionCard({ model, tier, applied, rationale }: RoutingDecisionCardProps) {
+  const short = shortModelName(model);
+  const prettyOutput = useMemo(
+    () => JSON.stringify({ model, tier, applied, rationale }, null, 2),
+    [model, tier, applied, rationale],
+  );
+  return (
+    <Collapsible
+      defaultOpen={false}
+      className={cn(
+        "group not-prose my-1 flex flex-col gap-1.5 rounded-md border border-border bg-muted/30 px-3 py-2",
+        TOOL_SURFACE_WIDTH_CLASS,
+      )}
+      data-testid="routing-decision-card"
+      data-applied={applied ? "true" : "false"}
+    >
+      <div className="flex items-center gap-1.5 text-xs">
+        <BrainCircuitIcon className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="font-medium">Intelligent routing</span>
+        <span className="text-muted-foreground">{applied ? "· applied" : "· advisory"}</span>
+        <CollapsibleTrigger
+          className="ml-auto cursor-pointer rounded p-0.5 text-muted-foreground hover:text-foreground"
+          aria-label="Show raw routing verdict"
+          data-testid="routing-decision-raw-toggle"
+        >
+          <ChevronRightIcon className="size-3 transition-transform group-data-[state=open]:rotate-90" />
+        </CollapsibleTrigger>
+      </div>
+      <div className="flex items-center gap-2 text-xs">
+        <span className="min-w-0 truncate font-mono text-foreground">Session</span>
+        <span className="ml-auto shrink-0 inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] leading-none">
+          <span className="font-medium text-foreground">{short}</span>
+          <span className="text-muted-foreground">· {tier}</span>
+        </span>
+      </div>
+      {rationale.length > 0 && (
+        <p className="text-xs leading-snug text-muted-foreground">{rationale}</p>
+      )}
+      <CollapsibleContent className="data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=open]:animate-in">
+        <CodeBlock code={prettyOutput} language="json">
+          <CodeBlockHeader>
+            <CodeBlockTitle className="min-w-0">
+              <span className="truncate font-medium uppercase tracking-wide">Verdict</span>
+            </CodeBlockTitle>
+          </CodeBlockHeader>
+        </CodeBlock>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }

--- a/web/src/lib/blockStream.ts
+++ b/web/src/lib/blockStream.ts
@@ -660,6 +660,7 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
         tier: event.tier,
         applied: event.applied,
         rationale: event.rationale,
+        ...(event.agent !== undefined && { agent: event.agent }),
       } satisfies RoutingDecisionBlock;
       return;
     }

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -212,6 +212,8 @@ export interface RoutingDecisionBlock {
   applied: boolean;
   /** The router's one-line rationale; empty string when absent. */
   rationale: string;
+  /** Sub-agent name when mirrored into the parent session; undefined otherwise. */
+  agent?: string;
 }
 
 export interface TerminalCommandBlock {

--- a/web/src/lib/conversationItems.ts
+++ b/web/src/lib/conversationItems.ts
@@ -151,6 +151,8 @@ export interface RoutingDecisionItem extends BaseItem {
   applied: boolean;
   /** The router's one-line rationale. */
   rationale: string;
+  /** Sub-agent name when mirrored into the parent session; undefined otherwise. */
+  agent?: string;
 }
 
 export type ConversationItem =

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -329,6 +329,11 @@ export interface RoutingDecision {
   applied: boolean;
   /** The router's one-line rationale. */
   rationale: string;
+  /**
+   * Sub-agent name when this decision is mirrored into the parent session,
+   * e.g. `"claude_code"`. Absent for session-local routing decisions.
+   */
+  agent?: string;
   itemId: string;
   responseId: string;
 }

--- a/web/src/lib/itemsToBlocks.ts
+++ b/web/src/lib/itemsToBlocks.ts
@@ -277,6 +277,7 @@ function routingDecisionToBlock(item: RoutingDecisionItem): RoutingDecisionBlock
     tier: item.tier,
     applied: item.applied,
     rationale: typeof item.rationale === "string" ? item.rationale : "",
+    ...(item.agent !== undefined && { agent: item.agent }),
   };
 }
 

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -151,6 +151,7 @@ export type Bubble =
       tier: "cheap" | "medium" | "expensive";
       applied: boolean;
       rationale: string;
+      agent?: string;
     };
 
 const TEXT_BLOCK_TYPES = new Set(["text_chunk", "text_done"]);
@@ -450,6 +451,7 @@ function walkBubbles(
         tier: b.tier,
         applied: b.applied,
         rationale: b.rationale,
+        ...(b.agent !== undefined && { agent: b.agent }),
       });
       i += 1;
       continue;

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -995,6 +995,7 @@ function parseOutputItem(data: Record<string, unknown>): StreamEvent | null {
       tier,
       applied: rec.applied === true,
       rationale: typeof rec.rationale === "string" ? rec.rationale : "",
+      ...(typeof rec.agent === "string" && rec.agent.length > 0 && { agent: rec.agent }),
       itemId,
       responseId,
     } satisfies RoutingDecision;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2833,6 +2833,7 @@ export const BubbleView = memo(
           tier={bubble.tier}
           applied={bubble.applied}
           rationale={bubble.rationale}
+          agent={bubble.agent}
         />
       );
     }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -54,7 +54,7 @@ import {
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { ElicitationCard } from "@/components/blocks/ApprovalCard";
 import { BlockRenderer, FilePathAwareMessageResponse } from "@/components/blocks/BlockRenderer";
-import { CompactionMarker, RoutingDecisionChip } from "@/components/blocks/StatusBlocks";
+import { CompactionMarker, RoutingDecisionCard } from "@/components/blocks/StatusBlocks";
 import { SystemMessageView } from "@/components/blocks/SystemMessage";
 import { parseSystemMessage } from "@/lib/systemMessage";
 import { Button } from "@/components/ui/button";
@@ -2828,7 +2828,7 @@ export const BubbleView = memo(
     if (bubble.kind === "compaction") return <CompactionMarker />;
     if (bubble.kind === "routing_decision") {
       return (
-        <RoutingDecisionChip
+        <RoutingDecisionCard
           model={bubble.model}
           tier={bubble.tier}
           applied={bubble.applied}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- When auto-routing fires at first-message time (agent spec has no explicit model), the UI previously showed a minimal muted chip ("Intelligent model router · opus").
- Replace it with a collapsible **RoutingDecisionCard** that mirrors the SmartRoutingCard style: same container, a model+tier pill, rationale text, and an expandable raw verdict JSON block behind a chevron.
- The two routing surfaces — session-level auto-routing (this card) and polly fan-out routing (SmartRoutingCard) — now have a consistent look.
- `RoutingDecisionChip` stays exported for any downstream consumers; only `ChatPage` switches to the card.

## Test Plan

- Added 3 unit tests in `StatusBlocks.test.tsx`: applied verdict, advisory verdict, and chevron expand/collapse.
- All existing chip tests still pass (7 total).
- `npx vitest run` passes for both `StatusBlocks.test.tsx` and `SmartRoutingCard.test.tsx`.
- TypeScript: `tsc --noEmit` clean.

## Demo

<img width="1269" height="808" alt="image" src="https://github.com/user-attachments/assets/fb8bc8d9-e516-4a13-acbc-350c772faa10" />


## Type of change

- [x] Feature
- [x] UI / frontend change

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

Card renders the same data the chip did (`model`, `tier`, `applied`, `rationale`); no new server-side data required.

## Changelog

Added: auto-routing decisions now show as a collapsible card (model pill, tier, rationale, expandable raw verdict) matching the SmartRoutingCard style