### PR TITLE
fix(sessions): keep shared project sessions out of "My sessions"

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -14321,9 +14321,13 @@ def create_sessions_router(
         :returns: List of project names.
         """
         user_id = _require_user(request, auth_provider)
+        # Filing into a project is owner-only, so the sidebar renders project
+        # folders only on "My sessions". Scope to owned sessions so a project
+        # owned by someone else (with a session shared to this user) doesn't
+        # surface as one of their own folders.
         return await asyncio.to_thread(
             conversation_store.list_projects,
-            accessible_by=user_id,
+            owned_by=user_id,
         )
 
     # ── PUT /sessions/{session_id}/read-state ─────────────────────
@@ -14556,6 +14560,12 @@ def create_sessions_router(
         # disabled entirely — no auth_provider).
         user_id = _require_user(request, auth_provider)
         normalized_query = search_query if search_query else None
+        # A specific project folder ("My sessions"-only) must show only the
+        # viewer's own sessions — a session shared with them but filed under a
+        # like-named project belongs on "Shared with me", not in this folder.
+        # The flat list (project=None) and Unfiled (project="") stay unscoped so
+        # shared sessions still surface for the "Shared with me" tab.
+        owned_by = user_id if project else None
         page = await asyncio.to_thread(
             conversation_store.list_conversations,
             limit=limit,
@@ -14564,6 +14574,7 @@ def create_sessions_router(
             agent_id=agent_id,
             agent_name=agent_name,
             accessible_by=user_id,
+            owned_by=owned_by,
             has_agent_id=True,
             # The store treats ``None`` as "no kind filter"; the API
             # spells that ``kind=any`` to keep the param required-ish

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -481,6 +481,7 @@ class ConversationStore(ABC):
         sort_by: str = "created_at",
         search_query: str | None = None,
         accessible_by: str | None = None,
+        owned_by: str | None = None,
         include_archived: bool = False,
         project: str | None = None,
         title: str | None = None,
@@ -563,6 +564,12 @@ class ConversationStore(ABC):
             a UNION subquery: sessions the user has a direct
             grant on, plus sessions with a ``"__public__"`` grant.
             ``None`` disables the filter (returns all sessions).
+        :param owned_by: When set, filter to sessions the user
+            *owns* (an ``owner``-level grant), a stricter form of
+            ``accessible_by`` that excludes sessions merely shared
+            with them. Powers the per-project folder fetch, since
+            projects only ever hold the owner's own sessions.
+            ``None`` disables the filter.
         :param include_archived: When ``False`` (default), archived
             conversations are excluded. When ``True``, archived and
             non-archived conversations are both returned (the caller
@@ -737,6 +744,7 @@ class ConversationStore(ABC):
     def list_projects(
         self,
         accessible_by: str | None = None,
+        owned_by: str | None = None,
     ) -> list[str]:
         """
         Return all distinct sidebar "project" names, ordered ascending.
@@ -753,6 +761,11 @@ class ConversationStore(ABC):
             sessions the user has a permission row for (mirrors the
             ``list_conversations`` ACL filter). ``None`` returns
             projects across all sessions.
+        :param owned_by: When set, restrict to projects that contain at
+            least one session the user owns (an ``owner``-level grant).
+            Projects are a "My sessions"-only surface, so this keeps a
+            project owned by someone else — but with a session shared to
+            the user — from appearing as one of the user's own folders.
         :returns: List of project names ordered alphabetically.
         """
         ...

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1591,6 +1591,7 @@ class SqlAlchemyConversationStore(ConversationStore):
     def list_projects(
         self,
         accessible_by: str | None = None,
+        owned_by: str | None = None,
     ) -> list[str]:
         """
         Return all distinct project names, ordered alphabetically.
@@ -1609,8 +1610,16 @@ class SqlAlchemyConversationStore(ConversationStore):
         :param accessible_by: When set, restrict to sessions that
             ``accessible_by`` has a permission row for (mirrors the
             ``list_conversations`` ACL filter).
+        :param owned_by: When set, restrict to projects that contain at
+            least one session ``owned_by`` owns (an ``owner``-level grant).
+            Filing into a project is owner-only, so the sidebar renders
+            folders only on "My sessions"; scoping by ownership keeps a
+            project shared *with* the user (but owned by someone else) from
+            surfacing as one of their own folders.
         :returns: List of project names ordered ascending.
         """
+        from omnigent.server.auth import LEVEL_OWNER
+
         with self._session() as session:
             # Join to the conversation so archived sessions don't keep an
             # otherwise-empty project alive in the sidebar.
@@ -1635,6 +1644,13 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlSessionPermission.user_id == accessible_by,
                 )
                 stmt = stmt.where(SqlConversationLabel.conversation_id.in_(accessible_ids))
+            if owned_by is not None:
+                owned_ids = select(SqlSessionPermission.conversation_id).where(
+                    SqlSessionPermission.workspace_id == current_workspace_id(),
+                    SqlSessionPermission.user_id == owned_by,
+                    SqlSessionPermission.level >= LEVEL_OWNER,
+                )
+                stmt = stmt.where(SqlConversationLabel.conversation_id.in_(owned_ids))
             return [row[0] for row in session.execute(stmt).all()]
 
     def delete_label(
@@ -1674,6 +1690,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         sort_by: str = "created_at",
         search_query: str | None = None,
         accessible_by: str | None = None,
+        owned_by: str | None = None,
         include_archived: bool = False,
         project: str | None = None,
         title: str | None = None,
@@ -1727,9 +1744,15 @@ class SqlAlchemyConversationStore(ConversationStore):
             empty string ``""``, only return sessions with NO project
             label (i.e., unfiled sessions). ``None`` disables the
             filter.
+        :param owned_by: When set, restrict to sessions the user owns
+            (an ``owner``-level grant) — stricter than ``accessible_by``,
+            which also matches sessions merely shared with them. Powers
+            the per-project folder fetch. ``None`` disables the filter.
         :returns: A :class:`PagedList` of :class:`Conversation`
             objects.
         """
+        from omnigent.server.auth import LEVEL_OWNER
+
         sort_col = self._resolve_sort_column(sort_by)
         with self._session() as session:
             is_desc = order == "desc"
@@ -1771,6 +1794,13 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlSessionPermission.user_id == accessible_by,
                 )
                 stmt = stmt.where(SqlConversation.id.in_(accessible_ids))
+            if owned_by is not None:
+                owned_ids = select(SqlSessionPermission.conversation_id).where(
+                    SqlSessionPermission.workspace_id == current_workspace_id(),
+                    SqlSessionPermission.user_id == owned_by,
+                    SqlSessionPermission.level >= LEVEL_OWNER,
+                )
+                stmt = stmt.where(SqlConversation.id.in_(owned_ids))
             if search_query:
                 pattern = f"%{search_query.lower()}%"
                 title_match = func.lower(SqlConversation.title).like(pattern)

--- a/tests/server/routes/test_sessions_shared_projects.py
+++ b/tests/server/routes/test_sessions_shared_projects.py
@@ -1,0 +1,131 @@
+"""Regression tests: sessions shared into a project stay on "Shared with me".
+
+Projects are a "My sessions"-only sidebar surface — filing a session into a
+project is owner-only. When someone shares a session that happens to carry a
+project label, the recipient should see it under "Shared with me", NOT as one
+of their own project folders under "My sessions".
+
+The sidebar builds project folders from two owner-scoped server surfaces:
+
+- ``GET /v1/sessions/projects`` — the folder *names*, and
+- ``GET /v1/sessions?project=<name>`` — the sessions *inside* a folder.
+
+Both must filter by ownership (an ``owner``-level grant), not mere access, or
+a shared session leaks into the recipient's "My sessions" project view. These
+tests drive the real routes against file-backed SQLite stores with header auth.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from omnigent.errors import OmnigentError
+from omnigent.server.auth import LEVEL_OWNER, LEVEL_READ, UnifiedAuthProvider
+from omnigent.server.routes.sessions import create_sessions_router
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.permission_store.sqlalchemy_store import (
+    SqlAlchemyPermissionStore,
+)
+
+ALICE = "alice@example.com"
+BOB = "bob@example.com"
+PROJECT_LABEL_KEY = "omni_project"
+
+
+def _multi_user_app(db_uri: str) -> FastAPI:
+    """Build a header-auth app mounting the sessions router at ``/v1``."""
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    app.include_router(
+        create_sessions_router(
+            conversation_store=SqlAlchemyConversationStore(db_uri),
+            agent_store=SqlAlchemyAgentStore(db_uri),
+            auth_provider=UnifiedAuthProvider(source="header"),
+            permission_store=SqlAlchemyPermissionStore(db_uri),
+        ),
+        prefix="/v1",
+    )
+    return app
+
+
+def _seed_shared_project_session(db_uri: str) -> str:
+    """Seed a session owned by Bob, filed under a project, and read-shared to
+    Alice. Returns the session id."""
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    perms = SqlAlchemyPermissionStore(db_uri)
+    if agent_store.get("ag_test") is None:
+        agent_store.create(agent_id="ag_test", name="test-agent", bundle_location="ag_test/bundle")
+    conv = conv_store.create_conversation(title="Bob's session", agent_id="ag_test")
+    conv_store.set_labels(conv.id, {PROJECT_LABEL_KEY: "Bob Project"})
+    for user in (ALICE, BOB):
+        perms.ensure_user(user)
+    perms.grant(BOB, conv.id, LEVEL_OWNER)
+    perms.grant(ALICE, conv.id, LEVEL_READ)
+    return conv.id
+
+
+def test_shared_project_not_listed_as_recipients_own_project(db_uri: str) -> None:
+    """A project whose only member is a session shared TO Alice (owned by Bob)
+    must not appear in Alice's project list — folders are her own sessions."""
+    _seed_shared_project_session(db_uri)
+    app = _multi_user_app(db_uri)
+
+    # Bob owns it, so it's his project.
+    bob = TestClient(app).get("/v1/sessions/projects", headers={"X-Forwarded-Email": BOB})
+    assert bob.status_code == 200
+    assert bob.json() == ["Bob Project"]
+
+    # Alice can access the session, but doesn't own it — no folder for her.
+    alice = TestClient(app).get("/v1/sessions/projects", headers={"X-Forwarded-Email": ALICE})
+    assert alice.status_code == 200
+    assert alice.json() == []
+
+
+def test_shared_session_excluded_from_recipients_project_folder(db_uri: str) -> None:
+    """Fetching a project folder's sessions (``?project=``) as Alice excludes a
+    session merely shared with her — it belongs on "Shared with me"."""
+    conv_id = _seed_shared_project_session(db_uri)
+    app = _multi_user_app(db_uri)
+
+    # Bob's folder holds the session.
+    bob = TestClient(app).get(
+        "/v1/sessions?project=Bob%20Project", headers={"X-Forwarded-Email": BOB}
+    )
+    assert bob.status_code == 200
+    assert [s["id"] for s in bob.json()["data"]] == [conv_id]
+
+    # Alice's same-named folder is empty — the shared session isn't hers to file.
+    alice = TestClient(app).get(
+        "/v1/sessions?project=Bob%20Project", headers={"X-Forwarded-Email": ALICE}
+    )
+    assert alice.status_code == 200
+    assert alice.json()["data"] == []
+
+
+def test_shared_session_still_visible_in_flat_list(db_uri: str) -> None:
+    """The fix is scoped to project surfaces: the shared session still shows up
+    in Alice's unfiltered session list, where the "Shared with me" tab reads it
+    (the frontend splits owned vs. shared by permission_level there)."""
+    conv_id = _seed_shared_project_session(db_uri)
+    app = _multi_user_app(db_uri)
+
+    resp = TestClient(app).get("/v1/sessions", headers={"X-Forwarded-Email": ALICE})
+    assert resp.status_code == 200
+    items = {s["id"]: s for s in resp.json()["data"]}
+    assert conv_id in items
+    # Below LEVEL_OWNER, so the frontend files it under "Shared with me".
+    assert items[conv_id]["permission_level"] < LEVEL_OWNER

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4414,3 +4414,68 @@ def test_list_conversations_project_none_disables_filter(
 
     ids = {c.id for c in conversation_store.list_conversations().data}
     assert ids >= {filed.id, unfiled.id}
+
+
+def test_list_projects_owned_by_excludes_shared_only_projects(
+    conversation_store: SqlAlchemyConversationStore,
+    db_uri: str,
+) -> None:
+    """``owned_by`` restricts to projects the user OWNS, not ones merely shared
+    with them — so a project whose sessions are only shared to the user (owned
+    by someone else) does not surface as one of their own sidebar folders."""
+    from omnigent.stores.permission_store.sqlalchemy_store import (
+        SqlAlchemyPermissionStore,
+    )
+
+    mine = conversation_store.create_conversation()
+    shared = conversation_store.create_conversation()
+    conversation_store.set_labels(mine.id, {"omni_project": "Mine"})
+    conversation_store.set_labels(shared.id, {"omni_project": "Shared"})
+
+    perms = SqlAlchemyPermissionStore(db_uri)
+    for user in ("alice@example.com", "bob@example.com"):
+        perms.ensure_user(user)
+    # Bob owns both; Alice only gets a read (level 1) grant on the shared one.
+    perms.grant("bob@example.com", mine.id, 4)
+    perms.grant("alice@example.com", mine.id, 4)
+    perms.grant("bob@example.com", shared.id, 4)
+    perms.grant("alice@example.com", shared.id, 1)
+
+    # accessible_by would leak "Shared" — Alice can access it. owned_by must not.
+    assert conversation_store.list_projects(accessible_by="alice@example.com") == [
+        "Mine",
+        "Shared",
+    ]
+    assert conversation_store.list_projects(owned_by="alice@example.com") == ["Mine"]
+
+
+def test_list_conversations_owned_by_excludes_shared_sessions(
+    conversation_store: SqlAlchemyConversationStore,
+    db_uri: str,
+) -> None:
+    """``owned_by`` on a project filter returns only sessions the user owns; a
+    session shared with them (read grant) under the same project is excluded so
+    it stays out of the owner-only project folder."""
+    from omnigent.stores.permission_store.sqlalchemy_store import (
+        SqlAlchemyPermissionStore,
+    )
+
+    mine = conversation_store.create_conversation()
+    shared = conversation_store.create_conversation()
+    conversation_store.set_labels(mine.id, {"omni_project": "X"})
+    conversation_store.set_labels(shared.id, {"omni_project": "X"})
+
+    perms = SqlAlchemyPermissionStore(db_uri)
+    for user in ("alice@example.com", "bob@example.com"):
+        perms.ensure_user(user)
+    perms.grant("alice@example.com", mine.id, 4)
+    perms.grant("bob@example.com", shared.id, 4)
+    perms.grant("alice@example.com", shared.id, 1)
+
+    ids = {
+        c.id
+        for c in conversation_store.list_conversations(
+            project="X", owned_by="alice@example.com"
+        ).data
+    }
+    assert ids == {mine.id}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Sessions that other people share with you, if they carry a project label, were showing up under **"My sessions"** (inside a project folder) instead of under **"Shared with me"**.

Projects are a **"My sessions"-only** surface — filing a session into a project is owner-only, so the sidebar renders project folders only on the "My sessions" tab. But the two backend surfaces that drive the project view filtered by *any* access grant rather than *ownership*:

- `GET /v1/sessions/projects` → `list_projects(accessible_by=user_id)` — the folder **names** appeared even when the project only held sessions shared *to* the user.
- `GET /v1/sessions?project=X` → `list_conversations(accessible_by=user_id, project=X)` — the sessions *inside* each `ProjectFolder` (a separate server fetch) included shared-in sessions.

The fix adds an `owned_by` filter (grant `level >= LEVEL_OWNER`) to both store methods and wires it through the routes. The flat list (`project=None`) and Unfiled (`project=""`) stay unscoped, so shared sessions still surface for the "Shared with me" tab.

## Test Plan

- `pytest tests/stores/test_conversation_store.py` — 154 passed (incl. 2 new `owned_by` tests).
- `pytest tests/server/routes/test_sessions_shared_projects.py tests/server/routes/test_sessions_crud.py tests/server/routes/test_sessions_cost_labels.py` — 32 passed.
- Confirmed the 2 new route-level project-surface tests **fail without the fix** (genuine regression tests).
- `ruff format` / `ruff check` clean.

## Demo

N/A — backend query-scoping change, no visual change (the frontend split was already correct).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added store-level tests for `owned_by` on `list_projects` and `list_conversations`, plus a new route-level regression test file (`tests/server/routes/test_sessions_shared_projects.py`) that drives the real `/v1/sessions/projects` and `/v1/sessions?project=` routes with multi-user header auth: a session shared into a project doesn't appear as the recipient's project folder or inside it, but does stay in their flat list at a sub-owner `permission_level` (so the frontend files it under "Shared with me").

## Changelog

Sessions shared with you no longer appear under "My sessions" when they belong to a project — they stay under "Shared with me"

This pull request and its description were written by Isaac.
