### PR TITLE
feat(doc-sync): title site PRs after the docs change, not the PR number

### DIFF
--- a/.github/agents/doc-drafter/config.yaml
+++ b/.github/agents/doc-drafter/config.yaml
@@ -159,7 +159,13 @@ prompt: |
   the affected `<img>` (MDX supports JSX comments; the build is unaffected).
 
   ## Output contract (your final assistant text)
-  After a line containing exactly `<!-- DOC_DRAFT_SUMMARY -->`, emit:
+  On the line IMMEDIATELY BEFORE `<!-- DOC_DRAFT_SUMMARY -->`, emit a single
+  `DOC_PR_TITLE:` line — a concise, imperative summary of what the docs now cover,
+  grounded in the diff (e.g. `DOC_PR_TITLE: document SMALLINT enum-column storage`).
+  Keep it under 60 characters, no trailing period, and do NOT prefix it with
+  `docs:` (the workflow adds that). This becomes the docs PR title.
+
+  Then, after a line containing exactly `<!-- DOC_DRAFT_SUMMARY -->`, emit:
   - `## Changes documented` — one bullet per file you created, edited, or deleted
     (pages and `components/DocsSidebarFull.js`): `path — what changed` (say
     "deleted" / "removed section" for removals). If you made no edits, write

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -598,6 +598,22 @@ jobs:
           m = re.search(r"<!--\s*DOC_DRAFT_SUMMARY\s*-->", raw)
           summary = raw[m.end():].strip() if m else "_(drafter produced edits but no summary)_"
 
+          # Title the docs PR after the DOCS change, not the source PR number (which
+          # already appears in the body). Prefer the drafter's DOC_PR_TITLE line; fall
+          # back to the source PR title, then to the old "document #N" form. LLM output
+          # is untrusted, so sanitize: first line only, strip control chars, collapse
+          # whitespace, drop a stray leading "docs:" (added below), and cap length.
+          mt = re.search(r"^\s*DOC_PR_TITLE:\s*(.+?)\s*$", raw, re.MULTILINE)
+          # Collapse whitespace (incl. tabs) to single spaces FIRST, so a stray tab
+          # separates words rather than being stripped and joining them, then drop
+          # any remaining non-whitespace control chars.
+          draft_title = re.sub(r"\s+", " ", mt.group(1) if mt else "").strip()
+          draft_title = re.sub(r"[\x00-\x1f\x7f]", "", draft_title)
+          draft_title = re.sub(r"^docs:\s*", "", draft_title, flags=re.IGNORECASE).strip()[:60].strip()
+          pr_title = f"docs: {draft_title or title or f'document {code}#{pr}'}"
+          pathlib.Path("/tmp/site_pr_title.txt").write_text(pr_title)
+          print(f"pr_title={pr_title!r}")
+
           # Tag the maintainer who MERGED the PR — the author may be an outside
           # contributor with no site access, but a maintainer always merges. Fall back
           # to the author when there's no usable merger (e.g. a manual run on an
@@ -644,6 +660,10 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="auto/docs/pr-${PR_NUMBER}"
+          # Descriptive PR/commit title from the sitepr step (drafter's DOC_PR_TITLE,
+          # else the source PR title, else "docs: document #N"). The PR number lives
+          # in the body, so it's kept out of the title.
+          PR_TITLE="$(cat /tmp/site_pr_title.txt)"
           git config user.name  "omnigent-ci[bot]"
           git config user.email "294685417+omnigent-ci[bot]@users.noreply.github.com"
           # Credentials are NOT persisted in .git/config (so the unsandboxed drafter
@@ -686,7 +706,7 @@ jobs:
 
           git checkout -B "$BRANCH"
           git add -A
-          git commit -m "docs: document ${CODE_REPO}#${PR_NUMBER}"
+          git commit -m "$PR_TITLE"
           # --force is safe here: the guard above ensured the branch carries only
           # bot commits.
           git push --force "$PUSH_URL" "$BRANCH"
@@ -705,12 +725,13 @@ jobs:
             # --add-label backfills PRs opened before the label existed; it's a no-op
             # when already present.
             gh pr edit "$EXISTING" --repo "$SITE_REPO_SLUG" \
+              --title "$PR_TITLE" \
               --add-label "automated-docs" --add-label "$VERSION_LABEL" \
               --body-file /tmp/site_pr_body.md || true
             echo "Updated site PR #$EXISTING."
           else
             if gh pr create --repo "$SITE_REPO_SLUG" --base "$DOCS_BRANCH" --head "$BRANCH" \
-                --title "docs: document ${CODE_REPO}#${PR_NUMBER}" \
+                --title "$PR_TITLE" \
                 --label automated-docs --label "$VERSION_LABEL" --body-file /tmp/site_pr_body.md; then
               EXISTING="$(gh pr list --repo "$SITE_REPO_SLUG" --head "$BRANCH" --state open \
                   --json number --jq '.[0].number // empty' 2>/dev/null || true)"


### PR DESCRIPTION
## Related issue

N/A

## Summary

The doc-sync workflow drafts a PR to `omnigent-ai/omnigent-site` for every merged
PR that needs docs. That site PR was titled `docs: document omnigent-ai/omnigent#N`
— but the source PR number already appears **twice** in the body, so the title
carried no information about the actual change.

- **doc-drafter** now emits a `DOC_PR_TITLE:` line (just before its
  `DOC_DRAFT_SUMMARY` block) summarizing what the docs now cover — concise,
  imperative, grounded in the diff, no `docs:` prefix.
- **doc-sync.yml** parses and sanitizes that line (it's untrusted LLM output:
  collapse whitespace, strip control chars, drop a stray leading `docs:`, cap 60
  chars) and titles the commit + site PR `docs: <title>`. Fallback chain if the
  line is missing: **drafter title → source PR title → old `document #N` form**,
  so it degrades gracefully and never breaks the run.
- Also pass `--title` on the `gh pr edit` **update** path — it previously never
  refreshed the title, so a re-draft kept a stale one.

Result: `docs: document omnigent-ai/omnigent#2090` → `docs: document SMALLINT enum-column storage`.

## Test Plan

- Replayed the exact `sitepr` parse/sanitize/fallback logic against 7 input
  shapes (normal, `docs:`-prefixed, missing line → source title, missing both →
  `#N`, control-chars/tabs, overlong >60, case-insensitive `DOCS:` prefix) — all
  produce the expected title.
- `python3 -c 'yaml.safe_load(...)'` on both edited files — valid YAML.
- `pre-commit run --files <the two files>` — passed.
- Not exercised end-to-end: the live drafter agent actually emitting
  `DOC_PR_TITLE` (needs a full CI run with LLM creds). The workflow-side parsing
  and the missing-line fallback are covered above, so a missing/garbled line
  degrades to the source PR title rather than failing.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The changed logic is a shell/Python step inside a GitHub workflow with no unit-test
harness. Verified manually by replaying the title parse/sanitize/fallback logic in
Python against the input shapes listed in the Test Plan, plus YAML validation and
pre-commit. The end-to-end drafter emission is left to CI; a missing `DOC_PR_TITLE`
falls back to the source PR title.

## Changelog

Doc-sync site PRs are now titled after the documentation change instead of the source PR number.
