### PR TITLE
ci(benchmark): fix nightly timeout (cap full-turn iterations) + corpus/label tweaks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ on:
       items_per_session:
         description: "Seeded items per session"
         required: false
-        default: "50"
+        default: "200"
 
 permissions:
   contents: read
@@ -46,7 +46,7 @@ env:
   ITERATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.iterations || '200' }}
   RUNS: ${{ github.event_name == 'workflow_dispatch' && inputs.runs || '3' }}
   SESSIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.sessions || '5000' }}
-  ITEMS: ${{ github.event_name == 'workflow_dispatch' && inputs.items_per_session || '50' }}
+  ITEMS: ${{ github.event_name == 'workflow_dispatch' && inputs.items_per_session || '200' }}
 
 concurrency:
   # Never cancel a scheduled run mid-flight (each is a distinct data point);

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,7 +20,7 @@ on:
       iterations:
         description: "Requests per run"
         required: false
-        default: "200"
+        default: "100"
       runs:
         description: "Timed runs per journey"
         required: false
@@ -43,7 +43,7 @@ env:
   OMNIGENT_SKIP_WEB_UI: "true"
   UV_INDEX_URL: https://pypi.org/simple
   PIP_INDEX_URL: https://pypi.org/simple
-  ITERATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.iterations || '200' }}
+  ITERATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.iterations || '100' }}
   RUNS: ${{ github.event_name == 'workflow_dispatch' && inputs.runs || '3' }}
   SESSIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.sessions || '5000' }}
   ITEMS: ${{ github.event_name == 'workflow_dispatch' && inputs.items_per_session || '200' }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,4 +1,4 @@
-name: Performance Benchmark
+name: Benchmark
 
 # Nightly run of the HTTP user-journey performance benchmark
 # (dev/benchmarks/omnigent). Seeds a sizeable corpus, boots a real server
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       iterations:
-        description: "Sequential operations per latency run"
+        description: "Requests per run"
         required: false
         default: "200"
       runs:

--- a/dev/benchmarks/omnigent/README.md
+++ b/dev/benchmarks/omnigent/README.md
@@ -69,6 +69,14 @@ These drive a real agent turn end-to-end — `POST …/events` → server → **
 → in-process executor → mock LLM → stream back → `idle`. Selecting any of them
 boots `BenchEnvironment(with_runner=True)` automatically.
 
+Each turn costs ~1 s+ (vs. the millisecond HTTP journeys), so these journeys
+cap their latency iterations (`Journey.max_iterations`, currently 5) — a large
+`--iterations` tuned for the HTTP journeys is clamped down for them so the run
+stays within the CI time budget, with `--runs` providing the repeats. The cap
+only lowers the count, never raises it. A cold start never deletes its session,
+so sessions accumulate across a run; keeping the count small also keeps that
+drift negligible (~2 ms/turn).
+
 | Journey | Operation timed |
 | --- | --- |
 | `session_cold_start` | Create+bind a fresh session and drive its first turn to `idle` (runner spawn + executor construction + turn) |

--- a/dev/benchmarks/omnigent/journeys.py
+++ b/dev/benchmarks/omnigent/journeys.py
@@ -64,6 +64,11 @@ class Journey:
     :param needs_runner: Whether this journey drives a full agent turn and so
         requires ``BenchEnvironment(with_runner=True)`` (mock LLM + runner).
         HTTP/DB journeys leave this ``False``.
+    :param max_iterations: Upper bound on latency iterations for this journey,
+        clamping ``--iterations`` down (never up). Full-turn journeys cost ~1s+
+        per op, so 100+ iterations would blow the CI time budget; they cap at a
+        few samples per run and lean on ``--runs`` for repeats. ``None`` (HTTP
+        journeys) means no cap.
     :param description: Human-readable one-liner for ``--list``.
     """
 
@@ -74,6 +79,7 @@ class Journey:
     teardown: Callable[[BenchEnvironment, JourneyContext], Awaitable[None]] | None = None
     concurrency_safe: bool = False
     needs_runner: bool = False
+    max_iterations: int | None = None
     description: str = ""
 
     async def run_setup(self, env: BenchEnvironment) -> JourneyContext:
@@ -259,6 +265,13 @@ async def _measure_load_history(env: BenchEnvironment, ctx: JourneyContext) -> N
 _TURN_REPLY = "Hello there, this is a mock benchmark reply."
 _TURN_PROMPT = "Say hello."
 
+# Iteration cap for full-turn journeys. At ~1s+ per turn, matching the HTTP
+# journeys' iteration count would overrun the CI time budget, so we take a few
+# samples per run and lean on --runs for repeats. Sessions accumulate across a
+# run (a cold start never deletes its session), so a small count also keeps that
+# drift negligible.
+_RUNNER_MAX_ITERATIONS = 5
+
 
 async def _setup_turn_agent(env: BenchEnvironment, *, stream: bool = False) -> str:
     """Register the agent + a reset-surviving reply; return the agent id.
@@ -377,6 +390,7 @@ ALL_JOURNEYS: dict[str, Journey] = {
             measure=_measure_session_cold_start,
             setup=_setup_turn_agent,
             needs_runner=True,
+            max_iterations=_RUNNER_MAX_ITERATIONS,
             description="Create+bind a fresh session and drive its first turn to idle.",
         ),
         Journey(
@@ -385,6 +399,7 @@ ALL_JOURNEYS: dict[str, Journey] = {
             measure=_measure_warm_turn,
             setup=_setup_warm_session,
             needs_runner=True,
+            max_iterations=_RUNNER_MAX_ITERATIONS,
             description="Drive a turn on an already-warm session (steady-state overhead).",
         ),
         Journey(
@@ -393,6 +408,7 @@ ALL_JOURNEYS: dict[str, Journey] = {
             measure=_measure_time_to_first_token,
             setup=_setup_streaming_session,
             needs_runner=True,
+            max_iterations=_RUNNER_MAX_ITERATIONS,
             description="Post a turn; time to the first streamed output_text delta.",
         ),
         Journey(
@@ -401,6 +417,7 @@ ALL_JOURNEYS: dict[str, Journey] = {
             measure=_measure_interrupt,
             setup=_setup_interrupt_session,
             needs_runner=True,
+            max_iterations=_RUNNER_MAX_ITERATIONS,
             description="Interrupt a running (gated) turn; time to cancellation.",
         ),
     )

--- a/dev/benchmarks/omnigent/run.py
+++ b/dev/benchmarks/omnigent/run.py
@@ -67,6 +67,18 @@ def _backend_of(database_uri: str | None) -> str:
     return "other"
 
 
+def _effective_iterations(journey: Journey, requested: int) -> int:
+    """Clamp *requested* iterations down to the journey's ``max_iterations``.
+
+    Full-turn journeys cost ~1s+ per op and cap themselves so a large
+    ``--iterations`` (tuned for the millisecond HTTP journeys) doesn't overrun
+    the CI time budget. The cap only ever lowers the count, never raises it.
+    """
+    if journey.max_iterations is not None:
+        return min(requested, journey.max_iterations)
+    return requested
+
+
 async def _run_journey(
     journey: Journey, env: BenchEnvironment, args: argparse.Namespace
 ) -> tuple[str, list[RunResult]]:
@@ -76,6 +88,7 @@ async def _run_journey(
     concurrency-safe; otherwise as sequential latency.
     """
     as_throughput = args.concurrency > 1 and journey.concurrency_safe
+    iterations = _effective_iterations(journey, args.iterations)
     results: list[RunResult] = []
     for _ in range(args.runs):
         if as_throughput:
@@ -90,7 +103,7 @@ async def _run_journey(
             )
         else:
             results.append(
-                await run_latency(journey, env, iterations=args.iterations, warmup=args.warmup)
+                await run_latency(journey, env, iterations=iterations, warmup=args.warmup)
             )
     return ("throughput" if as_throughput else "latency"), results
 

--- a/tests/benchmarks/test_benchmark_smoke.py
+++ b/tests/benchmarks/test_benchmark_smoke.py
@@ -111,6 +111,34 @@ def test_build_report_shape() -> None:
     assert "list_sessions" in _d(report["journeys"])
 
 
+# ── per-journey iteration cap (no server) ────────────────────
+
+
+def test_effective_iterations_clamps_capped_journey() -> None:
+    """A journey with ``max_iterations`` clamps a larger request down, not up."""
+    capped = ALL_JOURNEYS["session_cold_start"]
+    assert capped.max_iterations is not None
+    # Requesting more than the cap is clamped to the cap; less is left alone.
+    assert bench_run._effective_iterations(capped, 200) == capped.max_iterations
+    assert bench_run._effective_iterations(capped, 1) == 1
+
+
+def test_effective_iterations_uncapped_journey_passthrough() -> None:
+    """An HTTP journey (no cap) uses the requested count verbatim."""
+    uncapped = ALL_JOURNEYS["list_sessions"]
+    assert uncapped.max_iterations is None
+    assert bench_run._effective_iterations(uncapped, 200) == 200
+
+
+def test_runner_journeys_are_capped() -> None:
+    """Every full-turn journey caps its iterations; HTTP journeys do not."""
+    for journey in ALL_JOURNEYS.values():
+        if journey.needs_runner:
+            assert journey.max_iterations is not None, journey.name
+        else:
+            assert journey.max_iterations is None, journey.name
+
+
 # ── end-to-end smoke (boots the server) ──────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Benchmark workflow tuning, plus a fix for the nightly run timing out.

- **Fix the 30-min CI timeout.** The nightly benchmark was SIGTERM'd inside the first full-turn journey. `--iterations` applied uniformly, but the four runner journeys cost ~1s+ per op (vs. ~ms for the HTTP journeys), so 200 iterations × 3 runs was ~20 min for `session_cold_start` alone. Added a `max_iterations` field to `Journey` that clamps `--iterations` down per journey (never up) and capped the runner journeys at **5 samples per run**, leaning on `--runs` for the repeats. The full runner suite now finishes in ~2.4 min locally (was 20+ min), with meaningful cross-run percentiles.
- **Seeded items-per-session default `50 → 200`** — a denser per-session corpus. Updated both the `workflow_dispatch` input default and the `ITEMS` env fallback so manual and scheduled runs agree.
- **HTTP iterations default `200 → 100`** — matches `run.py`'s own CLI default.
- **Cosmetic:** workflow renamed `Performance Benchmark → Benchmark`; iterations input label `Sequential operations per latency run → Requests per run`.

### Why 5 samples/run and not "1 iteration × N runs"

All `--runs` execute inside one shared `BenchEnvironment`, so splitting samples across runs vs. iterations produces the *same* state accumulation — the per-run sample count is the real lever. A cold start never deletes its session, so sessions accumulate within a run, but the effect is small (~2 ms/turn, well under run-to-run noise), and a small count keeps it negligible while still yielding a real p50/p95 distribution.

## Test Plan

- New unit tests (no server boot) for the clamp helper: over-cap requests clamp to the cap, sub-cap pass through, every runner journey is capped and every HTTP journey is not. All pass.
- `ruff check` clean on the changed files.
- End-to-end: ran all four runner journeys at the CI config (`--iterations 100 --runs 3`, clamped to 5×3) against a throwaway SQLite DB — **144 s wall, zero failures**, percentiles populated across runs. Reproduced the original failure first (single cold-start turn is ~1.1 s and flat; the timeout was pure volume, not a hang), confirming the diagnosis.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added unit tests for the `_effective_iterations` clamp and the runner-journey cap invariant. Manually verified the full runner suite end-to-end at the CI config (144 s, zero failures) — the harness itself boots a server + runner, which the normal test lane doesn't do at this scale, so the wall-clock/timeout behaviour is verified by hand rather than in CI.
