### PR TITLE
fix(web): surface server error message in stop-session dialog

### DIFF
--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2794,9 +2794,12 @@ function ConversationRow({
             </DialogDescription>
           </DialogHeader>
           {stopSession.isError && (
-            // 503 = runner couldn't deliver the kill; keep the dialog open.
             <p className="text-sm text-destructive" role="alert">
-              Couldn't stop the session — it may still be running. Try again in a moment.
+              Couldn't stop the session
+              {stopSession.error instanceof Error && stopSession.error.message
+                ? `: ${stopSession.error.message}`
+                : " — it may still be running"}
+              . Try again in a moment.
             </p>
           )}
           <DialogFooter>


### PR DESCRIPTION
## Related issue

N/A

## Summary

<img width="1714" height="636" alt="Screenshot From 2026-07-08 23-12-07" src="https://github.com/user-attachments/assets/a84d1ace-2cf7-49d9-ace6-83ec2612d8e4" />


The "Stop session" dialog previously showed a hardcoded error message ("Couldn't stop the session — it may still be running") on failure. The actual server error (e.g. `503 Service Unavailable`) was only visible in the browser developer console.

Now the dialog surfaces the real error message from the API response so users can diagnose the issue without opening dev tools.

## Test Plan

- Existing tests in `Sidebar.stop.test.tsx` pass (they don't assert on the exact error text).
- Manual verification: trigger a stop-session failure (e.g. when the runner is unavailable) and confirm the dialog now shows the server's error message instead of the generic one.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Existing tests cover this change
- [x] Manual verification completed

## Coverage notes

The error message rendering is a minor UI tweak. Existing tests verify the stop-session dialog lifecycle (open, confirm, reset). The actual error text is dynamic and best verified manually by triggering a stop failure.

## Changelog

Stop-session dialog now shows the actual server error instead of a generic message.