### PR TITLE
docs(windows): advertise sandbox capabilities

### DIFF
--- a/docs/windows-sandbox-egress.md
+++ b/docs/windows-sandbox-egress.md
@@ -10,7 +10,7 @@ not equivalent to the hardened POSIX sandboxes.
 | --- | --- | --- | --- | --- | --- |
 | `linux_bwrap` | Linux | Yes | Yes | Yes | Yes |
 | `darwin_seatbelt` | macOS | Yes | Yes | Yes | Yes |
-| `windows_job_object` | Windows | Yes | No | No | No |
+| `windows_jobobject` | Windows | Yes | No | No | No |
 | `none` | Any | No | No | No | No |
 
 ## Windows policy

--- a/docs/windows-sandbox-egress.md
+++ b/docs/windows-sandbox-egress.md
@@ -1,0 +1,38 @@
+# Windows sandbox and egress support boundary
+
+Native Windows support currently uses Job Object-style process containment for
+agent process trees. This is useful for cleanup and lifecycle control, but it is
+not equivalent to the hardened POSIX sandboxes.
+
+## Capability matrix
+
+| Backend | Platform | Process containment | Filesystem isolation | Network isolation | Egress rules |
+| --- | --- | --- | --- | --- | --- |
+| `linux_bwrap` | Linux | Yes | Yes | Yes | Yes |
+| `darwin_seatbelt` | macOS | Yes | Yes | Yes | Yes |
+| `windows_job_object` | Windows | Yes | No | No | No |
+| `none` | Any | No | No | No | No |
+
+## Windows policy
+
+On Windows, Job Objects can contain and clean up process trees, but they do not
+provide the filesystem namespace, network namespace, or forced proxy routing
+that Omnigent relies on for hard sandbox and egress enforcement.
+
+Therefore Windows support must stay explicit:
+
+- process containment is supported;
+- filesystem read/write policy is not hard-enforced;
+- `allow_network: false` cannot be guaranteed as a hard network deny;
+- `egress_rules` and `credential_proxy` are unsupported until a backend can
+  force all traffic through the egress proxy;
+- unsupported combinations should fail closed with actionable errors rather
+  than silently degrading.
+
+## Implementation sequence
+
+1. Advertise capabilities through code metadata.
+2. Document the support boundary for reviewers and contributors.
+3. Add fail-closed validation for unsupported Windows sandbox/egress policy
+   combinations.
+4. Only promote Windows CI once those errors are deterministic.

--- a/omnigent/inner/sandbox_capabilities.py
+++ b/omnigent/inner/sandbox_capabilities.py
@@ -49,8 +49,8 @@ _CAPABILITIES: dict[str, SandboxCapabilities] = {
         egress_policy=True,
         notes="seatbelt profile enforces filesystem and network policy",
     ),
-    "windows_job_object": SandboxCapabilities(
-        backend="windows_job_object",
+    "windows_jobobject": SandboxCapabilities(
+        backend="windows_jobobject",
         platform="windows",
         process_containment=True,
         filesystem_isolation=False,
@@ -97,7 +97,7 @@ def default_sandbox_backend_for_platform(platform: str | None = None) -> str:
     """Return the default sandbox backend name for a platform family."""
     name = platform or os.name
     if name == "nt":
-        return "windows_job_object"
+        return "windows_jobobject"
     if name == "posix":
         if os.uname().sysname == "Darwin":
             return "darwin_seatbelt"

--- a/omnigent/inner/sandbox_capabilities.py
+++ b/omnigent/inner/sandbox_capabilities.py
@@ -1,0 +1,112 @@
+"""Sandbox capability metadata by platform/backend."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SandboxCapabilities:
+    """Security capabilities advertised by an OS sandbox backend.
+
+    :param backend: Sandbox backend identifier.
+    :param platform: Platform family the backend runs on.
+    :param process_containment: Whether child process cleanup/containment is
+        provided.
+    :param filesystem_isolation: Whether read/write path policy is hard-enforced.
+    :param network_isolation: Whether network deny/isolation can be hard-enforced.
+    :param egress_policy: Whether L7 egress rules can be enforced by forcing all
+        traffic through the Omnigent egress proxy.
+    :param notes: Short human-readable support boundary.
+    """
+
+    backend: str
+    platform: str
+    process_containment: bool
+    filesystem_isolation: bool
+    network_isolation: bool
+    egress_policy: bool
+    notes: str
+
+
+_CAPABILITIES: dict[str, SandboxCapabilities] = {
+    "linux_bwrap": SandboxCapabilities(
+        backend="linux_bwrap",
+        platform="linux",
+        process_containment=True,
+        filesystem_isolation=True,
+        network_isolation=True,
+        egress_policy=True,
+        notes="bubblewrap enforces filesystem, process, and network isolation",
+    ),
+    "darwin_seatbelt": SandboxCapabilities(
+        backend="darwin_seatbelt",
+        platform="darwin",
+        process_containment=True,
+        filesystem_isolation=True,
+        network_isolation=True,
+        egress_policy=True,
+        notes="seatbelt profile enforces filesystem and network policy",
+    ),
+    "windows_job_object": SandboxCapabilities(
+        backend="windows_job_object",
+        platform="windows",
+        process_containment=True,
+        filesystem_isolation=False,
+        network_isolation=False,
+        egress_policy=False,
+        notes=(
+            "Windows Job Object support contains and cleans up process trees but "
+            "does not provide filesystem isolation or network/egress policy"
+        ),
+    ),
+    "none": SandboxCapabilities(
+        backend="none",
+        platform="any",
+        process_containment=False,
+        filesystem_isolation=False,
+        network_isolation=False,
+        egress_policy=False,
+        notes="no OS sandbox isolation",
+    ),
+}
+
+
+def sandbox_capabilities(backend: str) -> SandboxCapabilities:
+    """Return capability metadata for *backend*.
+
+    Unknown backends are treated as unsupported/no-isolation so policy callers
+    can fail closed instead of assuming a secure default.
+    """
+    return _CAPABILITIES.get(
+        backend,
+        SandboxCapabilities(
+            backend=backend,
+            platform="unknown",
+            process_containment=False,
+            filesystem_isolation=False,
+            network_isolation=False,
+            egress_policy=False,
+            notes="unknown sandbox backend; no capabilities advertised",
+        ),
+    )
+
+
+def default_sandbox_backend_for_platform(platform: str | None = None) -> str:
+    """Return the default sandbox backend name for a platform family."""
+    name = platform or os.name
+    if name == "nt":
+        return "windows_job_object"
+    if name == "posix":
+        if os.uname().sysname == "Darwin":
+            return "darwin_seatbelt"
+        return "linux_bwrap"
+    return "none"
+
+
+__all__ = [
+    "SandboxCapabilities",
+    "default_sandbox_backend_for_platform",
+    "sandbox_capabilities",
+]

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -818,6 +818,7 @@ def _parse_os_env_sandbox(
     overflow = _parse_cwd_hidden_scan_overflow(raw.get("cwd_hidden_scan_overflow"))
     env_passthrough = _parse_env_passthrough(raw.get("env_passthrough"))
     egress_rules = _parse_egress_rules(raw.get("egress_rules"))
+    allow_network = bool(raw.get("allow_network", True))
     raw_type = raw.get("type")
     if raw_type is None:
         # No ``type:`` field in the sandbox block -- resolve via the
@@ -830,6 +831,15 @@ def _parse_os_env_sandbox(
         sandbox_type = _default_sandbox_for_platform().type
     else:
         sandbox_type = str(raw_type)
+    if sandbox_type == "windows_jobobject" and not allow_network:
+        raise OmnigentError(
+            "os_env.sandbox.allow_network=false is not supported with "
+            "sandbox.type=windows_jobobject: Windows Job Objects contain "
+            "process trees but do not hard-enforce network denial. Use a "
+            "Linux/macOS hardened sandbox for network isolation or set "
+            "allow_network=true on Windows.",
+            code=ErrorCode.INVALID_INPUT,
+        )
     if egress_rules and sandbox_type not in ("linux_bwrap", "darwin_seatbelt"):
         raise OmnigentError(
             "os_env.sandbox.egress_rules requires sandbox.type=linux_bwrap "
@@ -870,7 +880,7 @@ def _parse_os_env_sandbox(
         read_paths=[str(p) for p in read_paths_raw] if read_paths_raw is not None else None,
         write_paths=[str(p) for p in write_paths_raw] if write_paths_raw is not None else None,
         write_files=[str(p) for p in write_files_raw] if write_files_raw is not None else None,
-        allow_network=bool(raw.get("allow_network", True)),
+        allow_network=allow_network,
         cwd_allow_hidden=cwd_allow_hidden,
         cwd_hidden_scan_max_entries=max_entries,
         cwd_hidden_scan_overflow=overflow,

--- a/omnigent/spec/validator.py
+++ b/omnigent/spec/validator.py
@@ -471,10 +471,9 @@ def _validate_compaction(spec: AgentSpec, result: ValidationResult) -> None:
 
 
 # Set of sandbox backends that hard-enforce network isolation
-# (and therefore can host an L7 egress proxy). Mirrors the loader's
-# allow-list in ``omnigent/inner/loader.py``. ``none`` is excluded
-# — it doesn't install a namespace or SBPL, so egress rules would be
-# inert decoration on the policy.
+# (and therefore can host an L7 egress proxy). Mirrors the parser's
+# allow-list. ``none`` and ``windows_jobobject`` are excluded: neither
+# can enforce network deny/egress policy.
 _EGRESS_CAPABLE_BACKENDS = frozenset({"linux_bwrap", "darwin_seatbelt"})
 
 
@@ -518,6 +517,7 @@ def _validate_os_env(spec: AgentSpec, result: ValidationResult) -> None:
     egress_rules = (
         list(getattr(sandbox, "egress_rules", None) or []) if sandbox is not None else []
     )
+    allow_network = bool(getattr(sandbox, "allow_network", True)) if sandbox is not None else True
 
     if start_in_scratch and fork:
         result.add(
@@ -531,6 +531,16 @@ def _validate_os_env(spec: AgentSpec, result: ValidationResult) -> None:
             "os_env.start_in_scratch",
             "os_env.start_in_scratch requires an active sandbox; "
             "sandbox.type=none does not create a scratch tmpdir",
+        )
+
+    if sandbox_type == "windows_jobobject" and not allow_network:
+        result.add(
+            "os_env.sandbox.allow_network",
+            "os_env.sandbox.allow_network=false is not supported with "
+            "sandbox.type=windows_jobobject: Windows Job Objects contain "
+            "process trees but do not hard-enforce network denial. Use a "
+            "Linux/macOS hardened sandbox for network isolation or set "
+            "allow_network=true on Windows.",
         )
 
     if egress_rules and sandbox_type not in _EGRESS_CAPABLE_BACKENDS:

--- a/tests/inner/test_sandbox_capabilities.py
+++ b/tests/inner/test_sandbox_capabilities.py
@@ -1,0 +1,42 @@
+"""Tests for sandbox capability metadata."""
+
+from __future__ import annotations
+
+from omnigent.inner.sandbox_capabilities import (
+    default_sandbox_backend_for_platform,
+    sandbox_capabilities,
+)
+
+
+def test_windows_job_object_capabilities_are_process_only() -> None:
+    """Windows metadata is explicit about containment but no egress isolation."""
+    caps = sandbox_capabilities("windows_job_object")
+
+    assert caps.platform == "windows"
+    assert caps.process_containment is True
+    assert caps.filesystem_isolation is False
+    assert caps.network_isolation is False
+    assert caps.egress_policy is False
+    assert "Job Object" in caps.notes
+
+
+def test_egress_capable_backends_are_marked() -> None:
+    """Linux/macOS hardened backends advertise egress-policy support."""
+    assert sandbox_capabilities("linux_bwrap").egress_policy is True
+    assert sandbox_capabilities("darwin_seatbelt").egress_policy is True
+
+
+def test_unknown_backend_fails_closed() -> None:
+    """Unknown backend metadata must not imply any isolation capability."""
+    caps = sandbox_capabilities("future_backend")
+
+    assert caps.backend == "future_backend"
+    assert caps.process_containment is False
+    assert caps.filesystem_isolation is False
+    assert caps.network_isolation is False
+    assert caps.egress_policy is False
+
+
+def test_default_windows_backend() -> None:
+    """Native Windows defaults to process containment metadata."""
+    assert default_sandbox_backend_for_platform("nt") == "windows_job_object"

--- a/tests/inner/test_sandbox_capabilities.py
+++ b/tests/inner/test_sandbox_capabilities.py
@@ -8,9 +8,9 @@ from omnigent.inner.sandbox_capabilities import (
 )
 
 
-def test_windows_job_object_capabilities_are_process_only() -> None:
+def test_windows_jobobject_capabilities_are_process_only() -> None:
     """Windows metadata is explicit about containment but no egress isolation."""
-    caps = sandbox_capabilities("windows_job_object")
+    caps = sandbox_capabilities("windows_jobobject")
 
     assert caps.platform == "windows"
     assert caps.process_containment is True
@@ -39,4 +39,4 @@ def test_unknown_backend_fails_closed() -> None:
 
 def test_default_windows_backend() -> None:
     """Native Windows defaults to process containment metadata."""
-    assert default_sandbox_backend_for_platform("nt") == "windows_job_object"
+    assert default_sandbox_backend_for_platform("nt") == "windows_jobobject"

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -3487,3 +3487,19 @@ def test_parse_credential_proxy_https_primitive_allowed_on_macos(tmp_path: Path)
     proxy = spec.os_env.sandbox.credential_proxy
     assert proxy is not None
     assert proxy.entries[0].scheme == "bearer"
+
+
+def test_parse_windows_jobobject_rejects_network_deny(tmp_path: Path) -> None:
+    """Windows Job Objects cannot hard-enforce ``allow_network: false``."""
+    config = {
+        "spec_version": 1,
+        "name": "windows-network-deny",
+        "os_env": {
+            "type": "caller_process",
+            "sandbox": {"type": "windows_jobobject", "allow_network": False},
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+
+    with pytest.raises(OmnigentError, match=r"windows_jobobject"):
+        parse(tmp_path)

--- a/tests/spec/test_validator.py
+++ b/tests/spec/test_validator.py
@@ -684,3 +684,20 @@ def test_os_env_no_validation_when_absent() -> None:
     result = validate(spec)
     os_env_errors = [e for e in result.errors if e.path.startswith("os_env")]
     assert os_env_errors == [], f"absent os_env should not produce errors, got: {result.errors}"
+
+
+def test_os_env_windows_jobobject_rejects_network_deny() -> None:
+    """Programmatic specs get the same Windows network-deny guard."""
+    spec = _minimal_spec(
+        os_env=_os_env(
+            type="windows_jobobject",
+            allow_network=False,
+        ),
+    )
+
+    result = validate(spec)
+
+    assert not result.valid
+    matches = [e for e in result.errors if e.path == "os_env.sandbox.allow_network"]
+    assert matches, f"expected allow_network error, got: {result.errors}"
+    assert "windows_jobobject" in matches[0].message


### PR DESCRIPTION
## Related issue

Refs #3

## Summary

- Adds explicit sandbox capability metadata for Linux bwrap, macOS seatbelt, Windows Job Object containment, and no-sandbox mode.
- Documents the Windows sandbox/egress support boundary: process containment is supported, but filesystem isolation, hard network denial, egress rules, and credential proxy enforcement are not.
- Adds tests that keep Windows capability metadata fail-closed for unsupported/unknown backends.

ELI5: Windows can clean up the agent process tree, but that is not the same as a Linux/macOS security sandbox. This PR writes that difference into code and docs before enforcement is added.

```mermaid
flowchart TD
    A[Sandbox backend] --> B{Can hard-isolate network?}
    B -- yes --> C[egress_rules allowed]
    B -- no --> D[Windows: metadata says unsupported]
    D --> E[next PR: fail closed]
```

## Test Plan

- `uv run ruff format omnigent/inner/sandbox_capabilities.py tests/inner/test_sandbox_capabilities.py`
- `uv run ruff check omnigent/inner/sandbox_capabilities.py tests/inner/test_sandbox_capabilities.py`
- `uv run pytest tests/inner/test_sandbox_capabilities.py -q`

## Demo

N/A — metadata/docs/test change, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused unit tests cover the new capability metadata and fail-closed default for unknown backends. Enforcement is intentionally left for the follow-up fail-closed PR.




## Controlled user evidence plan

Reviewer-facing evidence to collect before/while reviewing:

1. Run focused parser/validator/capability tests:
   ```powershell
   uv run pytest tests/inner/test_sandbox_capabilities.py tests/spec/test_parser.py::test_parse_windows_jobobject_rejects_network_deny tests/spec/test_validator.py::test_os_env_windows_jobobject_rejects_network_deny -q
   ```
2. Run a user-facing invalid spec with `windows_jobobject` and `allow_network: false`.
3. Capture the fail-closed error explaining that Windows Job Objects do not hard-enforce network denial.
4. Attach transcript to smota/omnigent#3.

Screenshot priority: terminal output showing the fail-closed error.

## Controlled user evidence results (2026-07-09)

Executed on native Windows 10 Home ARM64 from the integration branch after syncing the open PR stack.

Artifacts are published for reviewers on the public evidence branch: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity

- `00_environment.txt` — Windows/toolchain inventory (`uv 0.11.23`, Python `3.11.15`, Node `v24.16.0`, npm `11.18.0`, `psmux` / tmux `3.3.6`).
- `01_import_cli_smoke.txt` — `import omnigent` and `uv run omnigent --help` succeeded.
- `02_windows_safe_stable.txt` — stable Windows helper result: `21 passed, 6 skipped`.
- `03_runner_transport_tests.txt` — runner routing/transport tests: `18 passed`.
- `04_sandbox_fail_closed_tests.txt` — sandbox fail-closed tests: `6 passed`.
- `05_psmux_diagnostics_test.txt` — missing-`psmux` diagnostic test: `1 passed`.
- `06_precommit_key_windows_docs.txt` — whitespace/newline hooks over changed Windows docs: `EXIT=0`.
- `07_collect_only.txt` — broad collection check: `14709/14725 tests collected`, `EXIT=0`.
- `desktop-evidence-summary.png` — desktop print screen published in the public evidence bundle.

Key transcript excerpts:

```text
# stable Windows helper
21 passed, 6 skipped in 2.30s

# runner transport/routing
18 passed in 2.27s

# sandbox fail-closed
6 passed in 0.38s

# psmux diagnostic
1 passed in 0.14s

# broad collect-only
14709/14725 tests collected (16 deselected) in 11.47s
```

Notes:

- This is the executed follow-up to the `Controlled user evidence plan` already added to the open PRs.
- The psmux-specific review path includes terminal `attach/reconnect` coverage in the evidence plan; this run collected CLI/test evidence and a local print screen, while browser attach/reconnect screenshots remain the only manual visual item to capture if reviewers require them.

## Evidence correction: invalid screenshots withdrawn (2026-07-09)

The earlier browser/desktop screenshots are withdrawn: they showed GitHub pages or an empty/locked desktop, not the real Omnigent application/terminal state. Please disregard those screenshot comments.

Authoritative reviewer evidence is now the public native Windows terminal/tool output bundle:

- Evidence correction note: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-correction.md
- Evidence summary: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-summary.md
- Environment/toolchain transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/00_environment.txt
- CLI smoke transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/01_import_cli_smoke.txt
- Stable Windows helper transcript (`21 passed, 6 skipped`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/02_windows_safe_stable.txt
- Runner transport/routing transcript (`18 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/03_runner_transport_tests.txt
- Sandbox fail-closed transcript (`6 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/04_sandbox_fail_closed_tests.txt
- psmux diagnostic transcript (`1 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/05_psmux_diagnostics_test.txt
- Broad collect-only transcript (`14709/14725 tests collected`, `EXIT=0`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/07_collect_only.txt

Visual evidence will only be re-added if captured from an unlocked interactive Windows desktop showing the real Omnigent terminal/application window.
