### PR TITLE
test(runner): de-flake interrupt forward-first liveness wait (#2241)

### DIFF
--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -6141,8 +6141,10 @@ async def test_interrupt_forwards_to_harness_before_cancelling() -> None:
         assert not int_task.done(), "interrupt must await the harness forward (forward-first)"
 
         # Release the forward → the harness gets the interrupt, then the cancel runs.
+        # Await directly (no wall-clock bound) — forward-first is proven above, so a
+        # loaded worker can't flake this liveness wait (issue #2241).
         fwd_gate.set()
-        int_resp = await _aio.wait_for(int_task, timeout=15.0)
+        int_resp = await int_task
         assert int_resp.status_code == 204, int_resp.text
         markers = _interrupt_markers(list(_session_histories_ref.get(conv_id, [])))
 


### PR DESCRIPTION
## Related issue

Closes #2241

## Summary

- `test_interrupt_forwards_to_harness_before_cancelling` was flaky on `main` (and PRs), timing out in the `Pytest (misc)` job — the interrupt route completed with `204` but past the test's fixed 15s deadline, so it took the whole job (and the Coverage gate) red.
- Root cause: the final step used `asyncio.wait_for(int_task, timeout=15.0)`, a wall-clock bound on the route's post-forward cancel/teardown. On a loaded `misc` shard the event loop is starved enough that the in-memory teardown finishes correctly but past 15s, so `wait_for` cancels the already-done task and the test fails.
- Fix: forward-first correctness is already proven deterministically by the `shield` block above (the route does not return until the forward is released). The final step is only a *liveness* wait, so it now `await`s the task directly — no wall-clock bound left to exceed. A genuine hang is still caught by the global per-test `pytest-timeout` (300s / 180s in CI), which surfaces a traceback.

## Test Plan

- Target test, 30 consecutive runs on an idle machine: **30/30 passed**.
- Target test under confirmed CPU saturation (28 busy-loops on 14 cores, ~2x oversubscription to mimic the starved `misc` shard), 15 runs: **15/15 passed**.
- Full interrupt-test group (`-k interrupt`, 14 tests): all pass.
- `ruff check` on the file: clean.
- Mechanistic check of the failure mode: for a route that completes correctly but slowly, `await wait_for(task, timeout)` raises `TimeoutError` even though `task.done()` is `True` (the exact symptom), whereas `await task` returns the `204` cleanly.

## Demo

N/A — test-only change with no user-visible behaviour.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is a test-only de-flake — no product code changed, so the existing test itself is the coverage. Verified manually by running the test 30x idle and 15x under 2x CPU oversubscription (0 failures), plus a mechanistic reproduction of the old-vs-new pattern confirming the removed wall-clock bound was the sole flake source. The forward-first semantics remain asserted deterministically by the untouched `shield` block; a real regression (route never completes) is still caught by the global `pytest-timeout`.

