### PR TITLE
refactor(db): enforce scoped uniqueness in app code, drop partial indexes

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -143,8 +143,10 @@ class SqlAgent(Base):
         # may reuse the same name. That "unique only within the template set"
         # rule can't be a partial unique index (MySQL has none), so it is
         # enforced in the store (SqlAlchemyAgentStore.create). This plain index
-        # just backs the name lookup used by that check and by get_by_name.
-        Index("ix_agents_name", "workspace_id", "name", "id"),
+        # backs the (workspace_id, name, kind) lookup that check and get_by_name
+        # do — kind is included so the seek skips same-named session copies
+        # straight to the template row.
+        Index("ix_agents_name", "workspace_id", "name", "kind", "id"),
     )
 
 

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -140,18 +140,11 @@ class SqlAgent(Base):
         CheckConstraint("kind IN (1, 2)", name="ck_agents_kind"),
         Index("ix_agents_created_at", "workspace_id", "created_at", "id"),
         # Template agents have unique names; session-scoped agents (kind=2)
-        # may reuse the same name across conversations. The partial index enforces
-        # uniqueness only within the template set. kind = 1 is the "template" code.
-        # MySQL has no partial index, so the WHERE is dropped there and the
-        # unique spans all kinds (more restrictive; acceptable).
-        Index(
-            "ix_agents_template_name",
-            "workspace_id",
-            "name",
-            unique=True,
-            sqlite_where=text("kind = 1"),
-            postgresql_where=text("kind = 1"),
-        ),
+        # may reuse the same name. That "unique only within the template set"
+        # rule can't be a partial unique index (MySQL has none), so it is
+        # enforced in the store (SqlAlchemyAgentStore.create). This plain index
+        # just backs the name lookup used by that check and by get_by_name.
+        Index("ix_agents_name", "workspace_id", "name", "id"),
     )
 
 
@@ -558,35 +551,29 @@ class SqlConversation(Base):
         # by runner_id (list_conversations_by_runner_id) on every runner
         # reconnect; index it to avoid a full scan.
         Index("ix_conversations_runner_id", "workspace_id", "runner_id", "id"),
-        # Phase 4: partial unique index on (parent_conversation_id,
-        # title) prevents two same-named children under the same
-        # parent (G36 race protection at the DB layer). The
-        # ``sqlite_where`` / ``postgresql_where`` clauses scope the
-        # index so multiple top-level conversations (NULL parent)
-        # remain valid.
-        # MySQL has no partial index, so the WHERE is dropped there and the
-        # unique spans NULL parents too (more restrictive; acceptable).
+        # Unique index on (parent_conversation_id, title) prevents two
+        # same-named children under the same parent (G36 race protection at
+        # the DB layer). Top-level conversations (NULL parent) are exempt
+        # automatically: NULLs are distinct in a unique index, so no WHERE
+        # predicate is needed — keeping it a plain index MySQL can build.
         Index(
             "ix_conversations_parent_title_unique",
             "workspace_id",
             "parent_conversation_id",
             "title",
             unique=True,
-            sqlite_where=text("parent_conversation_id IS NOT NULL"),
-            postgresql_where=text("parent_conversation_id IS NOT NULL"),
             mysql_length={"title": 512},
         ),
-        # Partial composite index for child-session listing
+        # Composite index for child-session listing
         # (list_conversations(kind="sub_agent", parent_conversation_id=...)).
-        # kind = 2 is the "sub_agent" code (enum_codecs.CONVERSATION_KIND).
+        # Non-unique, so no scoping predicate is required; it simply indexes
+        # every parented row rather than only the sub-agent ones.
         Index(
             "idx_conversations_parent",
             "workspace_id",
             "parent_conversation_id",
             text("created_at DESC"),
             text("id DESC"),
-            sqlite_where=text("kind = 2"),
-            postgresql_where=text("kind = 2"),
         ),
     )
 
@@ -929,18 +916,11 @@ class SqlPolicy(Base):
             name="uq_policies_session_id_name_cksum",
         ),
         # Default policies must have unique names; session-scoped policies
-        # may reuse the same name across conversations. Mirrors
-        # ix_agents_template_name scoping to the 'default' set. scope = 1 is
-        # the "default" code. MySQL has no partial index, so the WHERE is
-        # dropped there and the unique spans all scopes (more restrictive).
-        Index(
-            "ix_policies_default_name_cksum",
-            "workspace_id",
-            "name_cksum",
-            unique=True,
-            sqlite_where=text("scope = 1"),
-            postgresql_where=text("scope = 1"),
-        ),
+        # may reuse the same name. That "unique only within the default set"
+        # rule can't be a partial unique index (MySQL has none), so it is
+        # enforced in the store (add_default / update_default). This plain
+        # index just backs the name_cksum lookup those checks perform.
+        Index("ix_policies_name_cksum", "workspace_id", "name_cksum", "id"),
     )
 
 

--- a/omnigent/db/migrations/versions/z5a2b3c4d5e6_drop_partial_indexes.py
+++ b/omnigent/db/migrations/versions/z5a2b3c4d5e6_drop_partial_indexes.py
@@ -1,0 +1,119 @@
+"""Drop partial indexes for MySQL compatibility.
+
+Revision ID: z5a2b3c4d5e6
+Revises: z4a2b3c4d5e6
+Create Date: 2026-07-09 00:00:00.000000
+
+MySQL has no partial (``WHERE``-predicated) indexes. The four partial indexes
+had leaned on ``sqlite_where`` / ``postgresql_where`` being dialect-scoped, so
+MySQL silently dropped the predicate and built a full unique index that "spans
+all kinds" — correct DDL, but over-restrictive there (session agents/policies
+could not reuse names on MySQL). This replaces them with plain indexes that
+behave identically on every dialect:
+
+- ``ix_conversations_parent_title_unique`` — kept UNIQUE, predicate dropped.
+  The predicate (``parent_conversation_id IS NOT NULL``) was redundant: it
+  keys off the same nullable column, and NULLs are distinct in a unique index,
+  so top-level conversations (NULL parent) stay exempt. Behavior is identical.
+- ``idx_conversations_parent`` — non-unique, predicate dropped. Now indexes
+  every parented row instead of only ``kind = sub_agent`` ones; same query
+  plan for the child-session listing.
+- ``ix_agents_template_name`` (unique, ``kind = template``) → ``ix_agents_name``
+  (plain). Template-name uniqueness moves to the store
+  (``SqlAlchemyAgentStore.create``); the plain index backs the name lookup.
+- ``ix_policies_default_name_cksum`` (unique, ``scope = default``) →
+  ``ix_policies_name_cksum`` (plain). Default-name uniqueness is already
+  enforced in the store (``add_default`` / ``update_default``); the plain
+  index backs its ``name_cksum`` lookup.
+
+Index columns keep the ``workspace_id`` prefix (and ``id`` suffix on the
+non-unique ones) that the surrounding indexes use.
+
+Index-only: no columns change, so no batch table-rebuild (and no SQLite
+foreign_keys guard) is needed — ``DROP INDEX`` / ``CREATE INDEX`` are native on
+every dialect. Downgrade restores the partial indexes (Postgres/SQLite regain
+the ``WHERE`` clauses; MySQL never had them).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "z5a2b3c4d5e6"
+down_revision: str | None = "z4a2b3c4d5e6"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    """Replace the four partial indexes with plain, MySQL-buildable ones."""
+    # conversations: same columns and uniqueness, just no WHERE predicate.
+    op.drop_index("idx_conversations_parent", table_name="conversations")
+    op.drop_index("ix_conversations_parent_title_unique", table_name="conversations")
+    op.create_index(
+        "ix_conversations_parent_title_unique",
+        "conversations",
+        ["workspace_id", "parent_conversation_id", "title"],
+        unique=True,
+        mysql_length={"title": 512},
+    )
+    op.create_index(
+        "idx_conversations_parent",
+        "conversations",
+        ["workspace_id", "parent_conversation_id", sa.text("created_at DESC"), sa.text("id DESC")],
+        unique=False,
+    )
+
+    # agents: uniqueness moves to the store; keep a plain lookup index.
+    op.drop_index("ix_agents_template_name", table_name="agents")
+    op.create_index("ix_agents_name", "agents", ["workspace_id", "name", "id"], unique=False)
+
+    # policies: uniqueness already enforced in the store; keep a plain lookup.
+    op.drop_index("ix_policies_default_name_cksum", table_name="policies")
+    op.create_index(
+        "ix_policies_name_cksum", "policies", ["workspace_id", "name_cksum", "id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Restore the partial indexes (int enum codes: template=1, sub_agent=2, default=1)."""
+    op.drop_index("ix_policies_name_cksum", table_name="policies")
+    op.create_index(
+        "ix_policies_default_name_cksum",
+        "policies",
+        ["workspace_id", "name_cksum"],
+        unique=True,
+        sqlite_where=sa.text("scope = 1"),
+        postgresql_where=sa.text("scope = 1"),
+    )
+
+    op.drop_index("ix_agents_name", table_name="agents")
+    op.create_index(
+        "ix_agents_template_name",
+        "agents",
+        ["workspace_id", "name"],
+        unique=True,
+        sqlite_where=sa.text("kind = 1"),
+        postgresql_where=sa.text("kind = 1"),
+    )
+
+    op.drop_index("idx_conversations_parent", table_name="conversations")
+    op.drop_index("ix_conversations_parent_title_unique", table_name="conversations")
+    op.create_index(
+        "ix_conversations_parent_title_unique",
+        "conversations",
+        ["workspace_id", "parent_conversation_id", "title"],
+        unique=True,
+        sqlite_where=sa.text("parent_conversation_id IS NOT NULL"),
+        postgresql_where=sa.text("parent_conversation_id IS NOT NULL"),
+        mysql_length={"title": 512},
+    )
+    op.create_index(
+        "idx_conversations_parent",
+        "conversations",
+        ["workspace_id", "parent_conversation_id", sa.text("created_at DESC"), sa.text("id DESC")],
+        unique=False,
+        sqlite_where=sa.text("kind = 2"),
+        postgresql_where=sa.text("kind = 2"),
+    )

--- a/omnigent/db/migrations/versions/z5a2b3c4d5e6_drop_partial_indexes.py
+++ b/omnigent/db/migrations/versions/z5a2b3c4d5e6_drop_partial_indexes.py
@@ -67,7 +67,9 @@ def upgrade() -> None:
 
     # agents: uniqueness moves to the store; keep a plain lookup index.
     op.drop_index("ix_agents_template_name", table_name="agents")
-    op.create_index("ix_agents_name", "agents", ["workspace_id", "name", "id"], unique=False)
+    op.create_index(
+        "ix_agents_name", "agents", ["workspace_id", "name", "kind", "id"], unique=False
+    )
 
     # policies: uniqueness already enforced in the store; keep a plain lookup.
     op.drop_index("ix_policies_default_name_cksum", table_name="policies")

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from sqlalchemy import and_, asc, desc, or_, select
+from sqlalchemy.exc import IntegrityError
 
 from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
@@ -71,6 +72,21 @@ class SqlAlchemyAgentStore(AgentStore):
             description=description,
         )
         with self._session() as session:
+            # Template names are unique within a workspace. This can't be a
+            # partial unique index (MySQL has none), so enforce it here.
+            conflict = session.execute(
+                select(SqlAgent.id).where(
+                    SqlAgent.workspace_id == current_workspace_id(),
+                    SqlAgent.name == name,
+                    SqlAgent.kind == encode_agent_kind("template"),
+                )
+            ).first()
+            if conflict is not None:
+                raise IntegrityError(
+                    "Duplicate template agent name",
+                    params={"name": name},
+                    orig=Exception(f"UNIQUE constraint: name={name!r}"),
+                )
             session.add(row)
             return sql_agent_to_entity(row)
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -701,7 +701,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 # session close.
                 return _to_conversation(row)
         except IntegrityError as exc:
-            # Translate the partial-unique-index violation into a
+            # Translate the unique-index violation into a
             # clean exception type the spawn/send tools can map
             # to a name_already_exists tool error. Other integrity
             # violations (FK, check constraints) re-raise.
@@ -714,10 +714,10 @@ class SqlAlchemyConversationStore(ConversationStore):
             # check, which would misclassify any future unique
             # constraint added to the conversations table.
             msg = str(exc).lower()
-            is_partial_index_violation = "ix_conversations_parent_title_unique" in msg or (
+            is_title_unique_violation = "ix_conversations_parent_title_unique" in msg or (
                 "unique" in msg and "parent_conversation_id" in msg and "title" in msg
             )
-            if is_partial_index_violation:
+            if is_title_unique_violation:
                 raise NameAlreadyExistsError(
                     f"sub-agent name already exists under parent "
                     f"{parent_conversation_id!r}: title={title!r}"

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -266,9 +266,9 @@ class SqlAlchemyPolicyStore(PolicyStore):
                 return None
             changed = False
             if name is not None and row.name != name:
-                # Explicit uniqueness check for the application layer;
-                # the partial index ix_policies_default_name_cksum is the
-                # DB-layer guard, but checking here gives a cleaner error.
+                # Default-policy name uniqueness is enforced here in the
+                # application layer (no partial unique index — MySQL has
+                # none), so this check is the guard, not just a nicer error.
                 conflict = (
                     session.execute(
                         select(SqlPolicy)

--- a/tests/db/test_migration_agents_session_id.py
+++ b/tests/db/test_migration_agents_session_id.py
@@ -9,7 +9,6 @@ import pytest
 import sqlalchemy as sa
 from alembic import command
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import IntegrityError
 
 from omnigent.db.utils import (
     _build_alembic_config,
@@ -55,11 +54,18 @@ def test_ix_conversations_agent_id_added(db_engine: Engine) -> None:
     assert "ix_conversations_agent_id" in index_names
 
 
-def test_agents_name_unique_index_exists(db_engine: Engine) -> None:
-    """ix_agents_template_name unique index must still exist."""
+def test_agents_name_index_exists(db_engine: Engine) -> None:
+    """The template-name partial unique index is replaced by a plain name index.
+
+    Template-name uniqueness now lives in the store (MySQL has no partial
+    indexes); the DB keeps only a non-unique lookup index on
+    ``(workspace_id, name, id)``.
+    """
     indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("agents")}
-    assert "ix_agents_template_name" in indexes
-    assert indexes["ix_agents_template_name"]["unique"]
+    assert "ix_agents_template_name" not in indexes
+    assert "ix_agents_name" in indexes
+    assert not indexes["ix_agents_name"]["unique"]
+    assert indexes["ix_agents_name"]["column_names"] == ["workspace_id", "name", "id"]
 
 
 def test_template_agent_kind_stored_and_read(db_engine: Engine) -> None:
@@ -142,26 +148,35 @@ def test_agents_session_id_fk_rejects_missing_session(db_engine: Engine) -> None
         conn.execute(sa.text("DELETE FROM conversations WHERE id = 'conv_missing'"))
 
 
-def test_agents_template_name_unique_index_rejects_duplicate_template(
+def test_agents_allow_duplicate_template_names_at_db_layer(
     db_engine: Engine,
 ) -> None:
-    """Two template agents may not share the same name (ix_agents_template_name)."""
-    with pytest.raises(IntegrityError):
-        with db_engine.begin() as conn:
-            conn.execute(
-                sa.text(
-                    "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
-                    " VALUES (:id1, :ts, 'dup-template', :loc1, 1, 1),"
-                    "        (:id2, :ts, 'dup-template', :loc2, 1, 1)"
-                ),
-                {
-                    "id1": "ag_dup1",
-                    "id2": "ag_dup2",
-                    "ts": 1700000001,
-                    "loc1": "ag_dup1/bundle",
-                    "loc2": "ag_dup2/bundle",
-                },
-            )
+    """The DB no longer rejects duplicate template names.
+
+    Uniqueness moved from a partial unique index to the store layer (MySQL
+    has no partial indexes), so a raw double-insert succeeds; the guard lives
+    in ``SqlAlchemyAgentStore.create`` (see tests/stores/test_agent_store.py).
+    """
+    with db_engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents (id, created_at, name, bundle_location, version, kind)"
+                " VALUES (:id1, :ts, 'dup-template', :loc1, 1, 1),"
+                "        (:id2, :ts, 'dup-template', :loc2, 1, 1)"
+            ),
+            {
+                "id1": "ag_dup1",
+                "id2": "ag_dup2",
+                "ts": 1700000001,
+                "loc1": "ag_dup1/bundle",
+                "loc2": "ag_dup2/bundle",
+            },
+        )
+        count = conn.execute(
+            sa.text("SELECT COUNT(*) FROM agents WHERE name = 'dup-template'")
+        ).scalar_one()
+        assert count == 2
+        conn.execute(sa.text("DELETE FROM agents WHERE name = 'dup-template'"))
 
 
 def test_agents_session_id_allows_duplicate_names_for_distinct_sessions(

--- a/tests/db/test_migration_agents_session_id.py
+++ b/tests/db/test_migration_agents_session_id.py
@@ -59,13 +59,14 @@ def test_agents_name_index_exists(db_engine: Engine) -> None:
 
     Template-name uniqueness now lives in the store (MySQL has no partial
     indexes); the DB keeps only a non-unique lookup index on
-    ``(workspace_id, name, id)``.
+    ``(workspace_id, name, kind, id)`` — kind is included so the template
+    lookup seeks past same-named session copies.
     """
     indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("agents")}
     assert "ix_agents_template_name" not in indexes
     assert "ix_agents_name" in indexes
     assert not indexes["ix_agents_name"]["unique"]
-    assert indexes["ix_agents_name"]["column_names"] == ["workspace_id", "name", "id"]
+    assert indexes["ix_agents_name"]["column_names"] == ["workspace_id", "name", "kind", "id"]
 
 
 def test_template_agent_kind_stored_and_read(db_engine: Engine) -> None:

--- a/tests/db/test_migration_policy_name_cksum.py
+++ b/tests/db/test_migration_policy_name_cksum.py
@@ -42,12 +42,17 @@ def test_name_indexes_key_on_checksum(db_engine: Engine) -> None:
     inspector = sa.inspect(db_engine)
 
     indexes = {i["name"]: i for i in inspector.get_indexes("policies")}
-    assert "ix_policies_default_name_cksum" in indexes
-    assert indexes["ix_policies_default_name_cksum"]["unique"]
-    # Leads with workspace_id (PK inclusion) but still keys on name_cksum, not name.
-    assert indexes["ix_policies_default_name_cksum"]["column_names"] == [
+    # At head the partial unique index is replaced by a plain name_cksum
+    # lookup index (see z5a2b3c4d5e6); default-name uniqueness lives in the
+    # store. It still keys on name_cksum, not the raw name.
+    assert "ix_policies_default_name_cksum" not in indexes
+    assert "ix_policies_name_cksum" in indexes
+    assert not indexes["ix_policies_name_cksum"]["unique"]
+    # Leads with workspace_id (PK inclusion), keys on name_cksum, ends with id.
+    assert indexes["ix_policies_name_cksum"]["column_names"] == [
         "workspace_id",
         "name_cksum",
+        "id",
     ]
     # The old raw-name index is gone.
     assert "ix_policies_default_name" not in indexes

--- a/tests/db/test_migration_policy_scope.py
+++ b/tests/db/test_migration_policy_scope.py
@@ -37,15 +37,17 @@ def test_scope_column_exists_and_is_not_nullable(db_engine: Engine) -> None:
     assert not columns["scope"]["nullable"], "policies.scope must be NOT NULL"
 
 
-def test_ix_policies_default_name_index_exists(db_engine: Engine) -> None:
-    """The default-name unique index is present after the migration chain.
+def test_ix_policies_name_cksum_index_exists(db_engine: Engine) -> None:
+    """The default-name lookup index is present after the migration chain.
 
-    At head the index keys on ``name_cksum`` (see x1a2b3c4d5e6), not the raw
-    name — the ``_cksum`` name is what survives the full chain.
+    At head the partial unique index (``ix_policies_default_name_cksum``) has
+    been replaced by a plain non-unique ``name_cksum`` index (see
+    z5a2b3c4d5e6); default-name uniqueness lives in the store.
     """
     indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("policies")}
-    assert "ix_policies_default_name_cksum" in indexes
-    assert indexes["ix_policies_default_name_cksum"]["unique"]
+    assert "ix_policies_default_name_cksum" not in indexes
+    assert "ix_policies_name_cksum" in indexes
+    assert not indexes["ix_policies_name_cksum"]["unique"]
 
 
 def test_backfill_sets_session_scope_for_session_policies(db_engine: Engine) -> None:

--- a/tests/stores/test_agent_store.py
+++ b/tests/stores/test_agent_store.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
 import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
 
 from omnigent.db.utils import get_or_create_engine
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
@@ -33,6 +35,19 @@ def test_get_by_name(agent_store: SqlAlchemyAgentStore) -> None:
     assert found is not None
     assert found.name == "claude"
     assert agent_store.get_by_name("missing") is None
+
+
+def test_create_rejects_duplicate_template_name(agent_store: SqlAlchemyAgentStore) -> None:
+    """Template names are unique within a workspace, enforced by the store.
+
+    The DB has no partial unique index (MySQL can't build one), so the store's
+    create() is the guard.
+    """
+    agent_store.create(agent_id="ag_dup_a", name="dup-name", bundle_location="ag_dup_a/fakehash")
+    with pytest.raises(IntegrityError):
+        agent_store.create(
+            agent_id="ag_dup_b", name="dup-name", bundle_location="ag_dup_b/fakehash"
+        )
 
 
 def test_get_by_name_and_list_hide_session_scoped_agents(

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1753,10 +1753,10 @@ def test_create_null_parent_allows_duplicate_titles(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
     """Top-level conversations (NULL parent) are NOT subject to the unique constraint."""
-    # Both conversations share title=None and parent=None.
-    # The partial index excludes NULL parents, so two NULL-NULL
-    # rows are valid. Without the WHERE clause on the index,
-    # this would raise.
+    # Both conversations share title="" and parent=None. The unique index on
+    # (parent_conversation_id, title) still allows this: a NULL in any indexed
+    # column makes the key distinct, so top-level rows never collide even
+    # without a WHERE predicate.
     a = conversation_store.create_conversation()
     b = conversation_store.create_conversation()
     assert a.id != b.id


### PR DESCRIPTION
## Related issue

N/A

## Summary

MySQL has no partial (`WHERE`-predicated) indexes. The four scoped indexes on
`agents` / `policies` / `conversations` leaned on `sqlite_where` /
`postgresql_where` kwargs being **dialect-scoped** — SQLAlchemy silently omits
them when generating MySQL DDL. That kept MySQL from erroring, but produced a
*full* unique index that **over-restricts on MySQL**: session agents / session
policies could not reuse names there (they can on SQLite/Postgres). This
replaces the partials with plain indexes that behave **identically on all three
dialects**, moving the two genuinely-scoped uniqueness rules into the store:

- **`ix_conversations_parent_title_unique`** — kept UNIQUE, predicate dropped.
  The `WHERE parent_conversation_id IS NOT NULL` was redundant with NULL-distinct
  semantics (top-level conversations have a NULL parent, so they never collide in
  a plain unique index). **No behavior change.**
- **`idx_conversations_parent`** — non-unique perf index, predicate dropped. Now
  indexes every parented row instead of only sub-agents; same query plan for the
  child-session listing.
- **`ix_agents_template_name` → `ix_agents_name`** (plain, non-unique).
  Template-name uniqueness now enforced in `SqlAlchemyAgentStore.create` via a
  workspace-scoped pre-insert check (there was **no** app-level check before —
  the DB index was the only guard).
- **`ix_policies_default_name_cksum` → `ix_policies_name_cksum`** (plain,
  non-unique). Default-name uniqueness was **already** enforced in the store
  (`add_default` / `update_default`); the partial index was just a backstop.

Migration `z5a2b3c4d5e6` (index-only, off `z4a2b3c4d5e6`): drops the partials,
creates the plain replacements; downgrade restores the partials.

> **Note for reviewers:** this intentionally supersedes the prior approach
> (documented in the removed *"MySQL has no partial index, so the WHERE is
> dropped there and the unique spans all kinds — more restrictive; acceptable"*
> comments). Behavior on SQLite/Postgres is unchanged; on **MySQL** session
> agents/policies can now reuse names, matching the other dialects.

**ELI5:** MySQL can't express "unique only for *some* rows." We were faking it
in a way that quietly forbade name-reuse on MySQL. Now the database keeps a
plain index and the "unique only for templates / defaults" rule is checked in
code — so every database behaves the same.

## Test Plan

```
pytest tests/db/test_migrations_sqlite_safe.py \
       tests/db/test_migration_agents_session_id.py \
       tests/db/test_migration_policy_scope.py \
       tests/db/test_migration_policy_name_cksum.py \
       tests/stores/test_agent_store.py \
       tests/stores/test_conversation_store.py
# → 201 passed
```

- `test_full_migration_chain_round_trips_on_sqlite` exercises `z5`'s **upgrade
  and downgrade** on SQLite; the SQLite-unsafe-DDL static guard passes (index
  ops are native, no batch rebuild needed).
- Verified a single Alembic head (`z5a2b3c4d5e6` → `z4a2b3c4d5e6`).
- `pre-commit run --files <changed>` clean.

## Demo

N/A — no user-visible / UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `test_create_rejects_duplicate_template_name` (store-level guard for the
new app-level enforcement). Updated the migration tests to assert the new plain
index shape (`workspace_id`-prefixed, `id`-suffixed, non-unique) and that the DB
now allows duplicate template names at the raw layer, since enforcement moved to
the store.

This pull request and its description were written by Isaac.
