### PR TITLE
docs(windows): add native E2E evidence package

### DIFF
--- a/docs/windows-e2e-evidence.md
+++ b/docs/windows-e2e-evidence.md
@@ -1,0 +1,133 @@
+# Windows native E2E evidence package
+
+Use this package to collect review evidence for native Windows parity PRs. It is
+intended to be filled from a fresh Windows machine against either a specific PR
+branch or the fork-only integration branch.
+
+## Scope
+
+Validate the integrated Windows path:
+
+1. PowerShell installer or manual `uv` setup.
+2. Native smoke/unit checks.
+3. Server and host startup from PowerShell.
+4. psmux-backed terminal creation and browser attach.
+5. Runner transport selection/fallback diagnostics.
+6. Sandbox/egress fail-closed diagnostics for unsupported Windows policies.
+
+## Environment inventory
+
+Record this at the start of the transcript:
+
+```powershell
+$PSVersionTable
+Get-ComputerInfo | Select-Object WindowsProductName, WindowsVersion, OsArchitecture
+where.exe git
+where.exe uv
+where.exe python
+where.exe node
+where.exe npm
+where.exe psmux
+uv --version
+python --version
+node --version
+npm --version
+psmux --version
+```
+
+## Checkout and setup
+
+```powershell
+git clone https://github.com/smota/omnigent.git
+cd omnigent
+git switch windows-parity/integration
+uv sync --extra all --extra dev
+```
+
+If validating a single PR, replace `windows-parity/integration` with the PR
+branch under test.
+
+## Automated validation
+
+```powershell
+uv run python -c "import omnigent; print('import omnigent OK')"
+uv run omnigent --help
+uv run pytest tests/inner/test_proc_and_platform.py tests/runtime/test_process_manager.py -p no:cacheprovider -q
+uv run pytest -m "not posix_only" --collect-only -q
+```
+
+For PR-specific validation, include the targeted test command from the PR body.
+
+## Manual server/host validation
+
+Terminal 1:
+
+```powershell
+uv run omnigent server
+```
+
+Terminal 2:
+
+```powershell
+uv run omnigent host --server http://localhost:6767
+```
+
+Browser:
+
+1. Open the local server URL.
+2. Create a new session using the Windows host.
+3. Create an Omnigent-managed terminal.
+4. Confirm logs identify the Windows terminal backend.
+5. Attach to the terminal and run:
+
+```powershell
+$PSVersionTable.PSVersion
+pwd
+Write-Output "omnigent-windows-terminal-ok"
+```
+
+Capture a screenshot or short recording showing browser attach and command
+output.
+
+## Runner transport evidence
+
+When testing TCP runner transport wiring, capture startup logs that identify the
+selected transport. Include any relevant env/config values and prove UDS-only
+configuration on native Windows fails with an actionable TCP fallback message.
+
+## Sandbox/egress fail-closed evidence
+
+Run or document a spec that requests unsupported Windows network denial, for
+example:
+
+```yaml
+spec_version: 1
+name: windows-network-deny
+os_env:
+  type: caller_process
+  sandbox:
+    type: windows_jobobject
+    allow_network: false
+```
+
+Expected result: validation fails before runtime with a message explaining that
+Windows Job Objects do not hard-enforce network denial and that Linux/macOS
+hardened sandboxes are required for network isolation.
+
+## Evidence checklist for PRs
+
+- [ ] PowerShell transcript attached.
+- [ ] Environment inventory included.
+- [ ] Automated validation commands included.
+- [ ] Browser attach screenshot/recording attached for terminal/UI work.
+- [ ] Runner transport selection logs included for transport work.
+- [ ] Sandbox fail-closed output included for policy work.
+- [ ] Known gaps listed explicitly.
+
+## Known limitations to call out
+
+- Windows Job Objects provide process containment, not bwrap/seatbelt-equivalent
+  filesystem or network isolation.
+- POSIX-only PTY/tmux/pexpect coverage remains Linux/macOS/WSL-only.
+- The broad Windows test sweep should remain non-blocking until execution, not
+  just collection, is deterministic on `windows-latest`.


### PR DESCRIPTION
## Related issue

Refs smota/omnigent#7

## Summary

- Adds `docs/windows-e2e-evidence.md`, a repeatable evidence package for native Windows validation.
- Covers environment inventory, setup, automated checks, server/host startup, psmux browser attach evidence, runner transport logs, and sandbox fail-closed diagnostics.

## Test Plan

- `uv run pre-commit run trailing-whitespace --files docs/windows-e2e-evidence.md`
- `uv run pre-commit run end-of-file-fixer --files docs/windows-e2e-evidence.md`

## Demo

N/A — documentation checklist/template. The document defines when screenshots/recordings are required for future Windows E2E evidence.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Validated file hygiene for the new evidence document. The actual native Windows transcript/screenshots will be collected against the integration branch or PR stack using this checklist.




## Controlled user evidence plan

Reviewer-facing evidence to collect before/while reviewing:

1. Use `docs/windows-e2e-evidence.md` as the master checklist.
2. Attach the completed PowerShell transcript to smota/omnigent#7.
3. Attach browser terminal screenshots/recordings for psmux attach/reconnect.
4. Attach runner transport logs and sandbox fail-closed output.
5. Link all captured artifacts back to this PR and the central discussion.

Screenshot priority: full browser terminal attach and PR checks summary.

## Controlled user evidence results (2026-07-09)

Executed on native Windows 10 Home ARM64 from the integration branch after syncing the open PR stack.

Artifacts are published for reviewers on the public evidence branch: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity

- `00_environment.txt` — Windows/toolchain inventory (`uv 0.11.23`, Python `3.11.15`, Node `v24.16.0`, npm `11.18.0`, `psmux` / tmux `3.3.6`).
- `01_import_cli_smoke.txt` — `import omnigent` and `uv run omnigent --help` succeeded.
- `02_windows_safe_stable.txt` — stable Windows helper result: `21 passed, 6 skipped`.
- `03_runner_transport_tests.txt` — runner routing/transport tests: `18 passed`.
- `04_sandbox_fail_closed_tests.txt` — sandbox fail-closed tests: `6 passed`.
- `05_psmux_diagnostics_test.txt` — missing-`psmux` diagnostic test: `1 passed`.
- `06_precommit_key_windows_docs.txt` — whitespace/newline hooks over changed Windows docs: `EXIT=0`.
- `07_collect_only.txt` — broad collection check: `14709/14725 tests collected`, `EXIT=0`.
- `desktop-evidence-summary.png` — desktop print screen published in the public evidence bundle.

Key transcript excerpts:

```text
# stable Windows helper
21 passed, 6 skipped in 2.30s

# runner transport/routing
18 passed in 2.27s

# sandbox fail-closed
6 passed in 0.38s

# psmux diagnostic
1 passed in 0.14s

# broad collect-only
14709/14725 tests collected (16 deselected) in 11.47s
```

Notes:

- This is the executed follow-up to the `Controlled user evidence plan` already added to the open PRs.
- The psmux-specific review path includes terminal `attach/reconnect` coverage in the evidence plan; this run collected CLI/test evidence and a local print screen, while browser attach/reconnect screenshots remain the only manual visual item to capture if reviewers require them.

## Evidence correction: invalid screenshots withdrawn (2026-07-09)

The earlier browser/desktop screenshots are withdrawn: they showed GitHub pages or an empty/locked desktop, not the real Omnigent application/terminal state. Please disregard those screenshot comments.

Authoritative reviewer evidence is now the public native Windows terminal/tool output bundle:

- Evidence correction note: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-correction.md
- Evidence summary: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-summary.md
- Environment/toolchain transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/00_environment.txt
- CLI smoke transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/01_import_cli_smoke.txt
- Stable Windows helper transcript (`21 passed, 6 skipped`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/02_windows_safe_stable.txt
- Runner transport/routing transcript (`18 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/03_runner_transport_tests.txt
- Sandbox fail-closed transcript (`6 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/04_sandbox_fail_closed_tests.txt
- psmux diagnostic transcript (`1 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/05_psmux_diagnostics_test.txt
- Broad collect-only transcript (`14709/14725 tests collected`, `EXIT=0`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/07_collect_only.txt

Visual evidence will only be re-added if captured from an unlocked interactive Windows desktop showing the real Omnigent terminal/application window.
