### PR TITLE
test(windows): add native pytest execution helper

### DIFF
--- a/docs/windows-test-execution.md
+++ b/docs/windows-test-execution.md
@@ -1,0 +1,52 @@
+# Native Windows test execution
+
+This document tracks the executable Windows-safe test strategy. It complements
+the broader QA matrix by separating broad collection from stable execution.
+
+## Commands
+
+From native Windows PowerShell:
+
+```powershell
+uv sync --extra all --extra dev
+.\scripts\windows_safe_pytest.ps1
+```
+
+Collection-only check:
+
+```powershell
+.\scripts\windows_safe_pytest.ps1 -CollectOnly
+```
+
+Stable subset only, without broad collection:
+
+```powershell
+.\scripts\windows_safe_pytest.ps1 -StableOnly
+```
+
+## Why collection and execution are separate
+
+`pytest -m "not posix_only" --collect-only` catches import-time Windows
+regressions across the broad Windows-safe surface. Full execution is promoted in
+smaller groups because many tests exercise services, local environment state,
+or terminal behavior that needs separate stabilization.
+
+## Current stable subset
+
+The initial stable subset includes:
+
+- native process/platform support
+- process manager behavior
+
+As the current Windows PR stack lands, extend the stable subset with runner
+transport selection/routing, sandbox capability metadata, and parser/validator
+fail-closed behavior for unsupported Windows network-deny policy.
+
+## Promotion rule
+
+A test group can move into the stable subset when:
+
+1. It passes repeatedly on native Windows.
+2. It has no dependency on real developer home-directory state.
+3. POSIX-only assumptions are either fixed or marked `posix_only`.
+4. Failure messages are actionable for missing optional Windows dependencies.

--- a/scripts/windows_safe_pytest.ps1
+++ b/scripts/windows_safe_pytest.ps1
@@ -1,0 +1,53 @@
+<#
+Run the current native-Windows-safe pytest checks.
+
+This script intentionally separates collection from execution. Collection should
+stay broad (`-m "not posix_only"`) so new import-time Windows regressions are
+caught early. Execution stays on the stable subset until the broader sweep is
+made deterministic.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$CollectOnly,
+    [switch]$StableOnly
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Command
+    )
+
+    Write-Host "`n==> $Name" -ForegroundColor Cyan
+    Write-Host ("> " + ($Command -join ' ')) -ForegroundColor DarkGray
+    & $Command[0] @($Command[1..($Command.Length - 1)])
+    if ($LASTEXITCODE -ne 0) {
+        throw "Step failed with exit code ${LASTEXITCODE}: $Name"
+    }
+}
+
+Invoke-Step "import smoke" @('uv', 'run', 'python', '-c', "import omnigent; print('import omnigent OK')")
+Invoke-Step "CLI smoke" @('uv', 'run', 'omnigent', '--help')
+
+if (-not $StableOnly) {
+    Invoke-Step "broad Windows-safe collection" @('uv', 'run', 'pytest', '-m', 'not posix_only', '--collect-only', '-q')
+}
+
+if ($CollectOnly) {
+    Write-Host "`nCollection-only mode complete." -ForegroundColor Green
+    exit 0
+}
+
+Invoke-Step "stable Windows unit subset" @(
+    'uv', 'run', 'pytest',
+    'tests/inner/test_proc_and_platform.py',
+    'tests/runtime/test_process_manager.py',
+    '-p', 'no:cacheprovider', '-q'
+)
+
+Write-Host "`nWindows-safe pytest subset complete." -ForegroundColor Green


### PR DESCRIPTION
## Related issue

Refs smota/omnigent#9

## Summary

- Adds `scripts/windows_safe_pytest.ps1`, a native PowerShell helper that separates broad collection from stable execution.
- Adds `docs/windows-test-execution.md` to document the stable Windows subset and promotion rules.
- Initial stable subset covers import/CLI smoke, process/platform support, and process manager behavior.

## Test Plan

```powershell
pwsh -NoProfile -File scripts/windows_safe_pytest.ps1 -StableOnly
```

Result:

```text
21 passed, 6 skipped
```

File hygiene:

```bash
uv run pre-commit run trailing-whitespace --files scripts/windows_safe_pytest.ps1 docs/windows-test-execution.md
uv run pre-commit run end-of-file-fixer --files scripts/windows_safe_pytest.ps1 docs/windows-test-execution.md
```

## Demo

N/A — test execution helper/docs, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The helper was run on native Windows through PowerShell. The broad collection mode is intentionally separate and will become clean as the existing POSIX-skip/import-fix PRs land.




## Controlled user evidence plan

Reviewer-facing evidence to collect before/while reviewing:

1. Run stable-only helper:
   ```powershell
   .\scripts\windows_safe_pytest.ps1 -StableOnly
   ```
2. Run collection-only helper after POSIX-skip PRs are applied:
   ```powershell
   .\scripts\windows_safe_pytest.ps1 -CollectOnly
   ```
3. Capture exact pass/skip/error counts.
4. Attach transcript to smota/omnigent#9.

Screenshot priority: terminal output showing `21 passed, 6 skipped` or newer stable-subset summary.

## Controlled user evidence results (2026-07-09)

Executed on native Windows 10 Home ARM64 from the integration branch after syncing the open PR stack.

Artifacts are published for reviewers on the public evidence branch: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity

- `00_environment.txt` — Windows/toolchain inventory (`uv 0.11.23`, Python `3.11.15`, Node `v24.16.0`, npm `11.18.0`, `psmux` / tmux `3.3.6`).
- `01_import_cli_smoke.txt` — `import omnigent` and `uv run omnigent --help` succeeded.
- `02_windows_safe_stable.txt` — stable Windows helper result: `21 passed, 6 skipped`.
- `03_runner_transport_tests.txt` — runner routing/transport tests: `18 passed`.
- `04_sandbox_fail_closed_tests.txt` — sandbox fail-closed tests: `6 passed`.
- `05_psmux_diagnostics_test.txt` — missing-`psmux` diagnostic test: `1 passed`.
- `06_precommit_key_windows_docs.txt` — whitespace/newline hooks over changed Windows docs: `EXIT=0`.
- `07_collect_only.txt` — broad collection check: `14709/14725 tests collected`, `EXIT=0`.
- `desktop-evidence-summary.png` — desktop print screen published in the public evidence bundle.

Key transcript excerpts:

```text
# stable Windows helper
21 passed, 6 skipped in 2.30s

# runner transport/routing
18 passed in 2.27s

# sandbox fail-closed
6 passed in 0.38s

# psmux diagnostic
1 passed in 0.14s

# broad collect-only
14709/14725 tests collected (16 deselected) in 11.47s
```

Notes:

- This is the executed follow-up to the `Controlled user evidence plan` already added to the open PRs.
- The psmux-specific review path includes terminal `attach/reconnect` coverage in the evidence plan; this run collected CLI/test evidence and a local print screen, while browser attach/reconnect screenshots remain the only manual visual item to capture if reviewers require them.

## Evidence correction: invalid screenshots withdrawn (2026-07-09)

The earlier browser/desktop screenshots are withdrawn: they showed GitHub pages or an empty/locked desktop, not the real Omnigent application/terminal state. Please disregard those screenshot comments.

Authoritative reviewer evidence is now the public native Windows terminal/tool output bundle:

- Evidence correction note: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-correction.md
- Evidence summary: https://github.com/smota/omnigent/tree/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/evidence-summary.md
- Environment/toolchain transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/00_environment.txt
- CLI smoke transcript: https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/01_import_cli_smoke.txt
- Stable Windows helper transcript (`21 passed, 6 skipped`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/02_windows_safe_stable.txt
- Runner transport/routing transcript (`18 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/03_runner_transport_tests.txt
- Sandbox fail-closed transcript (`6 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/04_sandbox_fail_closed_tests.txt
- psmux diagnostic transcript (`1 passed`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/05_psmux_diagnostics_test.txt
- Broad collect-only transcript (`14709/14725 tests collected`, `EXIT=0`): https://raw.githubusercontent.com/smota/omnigent/evidence/windows-parity-browser-2026-07-09/.pi/evidence/windows-parity/07_collect_only.txt

Visual evidence will only be re-added if captured from an unlocked interactive Windows desktop showing the real Omnigent terminal/application window.
