### PR TITLE
fix(web): align project picker menu rows left with uniform height

### DIFF
--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1145,7 +1145,8 @@ function ConversationList({
   );
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const data = event.active.data.current as
-      { label?: string; project?: string | null; isPinned?: boolean } | undefined;
+      | { label?: string; project?: string | null; isPinned?: boolean }
+      | undefined;
     setActiveDrag({
       id: String(event.active.id),
       label: data?.label ?? String(event.active.id),

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1145,8 +1145,7 @@ function ConversationList({
   );
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const data = event.active.data.current as
-      | { label?: string; project?: string | null; isPinned?: boolean }
-      | undefined;
+      { label?: string; project?: string | null; isPinned?: boolean } | undefined;
     setActiveDrag({
       id: String(event.active.id),
       label: data?.label ?? String(event.active.id),
@@ -3142,7 +3141,7 @@ function ProjectPickerMenu({
       </div>
       <div className="max-h-48 overflow-y-auto">
         {filtered.map((name) => (
-          <C.Item key={name} onSelect={() => onSelect(name)}>
+          <C.Item key={name} className="px-2 py-1" onSelect={() => onSelect(name)}>
             <span className="flex-1 truncate text-left">{name}</span>
             {currentProject === name && (
               <CheckMarkIcon className="size-3.5 shrink-0 text-primary" />
@@ -3177,6 +3176,7 @@ function ProjectPickerMenu({
           </div>
         ) : (
           <C.Item
+            className="px-2 py-1"
             // Keep the menu open so the inline input can take over in place.
             onSelect={(e) => {
               e.preventDefault();
@@ -3188,7 +3188,7 @@ function ProjectPickerMenu({
           </C.Item>
         )}
         {currentProject && (
-          <C.Item onSelect={() => onSelect("")}>
+          <C.Item className="px-2 py-1" onSelect={() => onSelect("")}>
             Remove from{" "}
             <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
               {currentProject}


### PR DESCRIPTION
## Related issue

N/A

## Summary

The sidebar's **Add to / Move to project** submenu (`ProjectPickerMenu` in `web/src/shell/Sidebar.tsx`) had misaligned rows: the search box used `px-2 py-1.5`, but the project rows fell back to `DropdownMenuItem`'s defaults (`px-1.5 py-1`), so rows were indented differently from the search input and slightly shorter.

- Give every row (project names, **Create new project**, **Remove from …**, and the inline new-project input) a uniform `px-2 py-1`, so they share one left edge and height.
- `py-1` (not `py-1.5`) keeps the inter-row gap tight while still aligning the left edge with the search field.

## Test Plan

- `cd web && npm test` — 211 files, 3769 tests pass.
- `cd web && npm run build` — `tsc -b && vite build` succeed.
- Visually: search field, all project names, and footer actions now share an 8px left inset and matching row height.

## Demo

_Rows are now left-aligned with the search input and share a uniform height (screenshot to be attached)._

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

CSS-class-only change to a dropdown menu; no logic changed. Verified manually by inspecting the rendered menu, and the existing UI test suite plus the type-checking build pass.

## Changelog

Project picker menu rows now align on the left and share a consistent height

This pull request and its description were written by Isaac.