### PR TITLE
✨ feat(omnidev): Add --trust-lan-origins for device testing

### DIFF
--- a/dev/omnidev/Cargo.lock
+++ b/dev/omnidev/Cargo.lock
@@ -305,6 +305,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +525,7 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm",
+ "if-addrs",
  "libc",
  "notify",
  "notify-debouncer-full",

--- a/dev/omnidev/Cargo.toml
+++ b/dev/omnidev/Cargo.toml
@@ -31,3 +31,4 @@ tokio = { version = "1", features = [
     "sync",
     "signal",
 ] }
+if-addrs = "0.15"

--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -44,7 +44,7 @@ Run it from anywhere inside the checkout — it walks up to the repo root
 |---|---|---|
 | server | `uv run omnigent server --host 127.0.0.1 --port <p> --database-uri … --artifact-location …` | Waited on via `GET /health`. |
 | host   | `uv run omnigent host --server http://127.0.0.1:<p>` | Started once the server is healthy. |
-| vite   | `npm run dev -- --port <p> --strictPort` (cwd `web/`) | `OMNIGENT_URL` points its proxy at the pod's server. |
+| vite   | `npm run dev -- --host <host> --port <p> --strictPort` (cwd `web/`) | `OMNIGENT_URL` points its proxy at the pod's server. |
 
 Before Vite starts (and on a manual Vite restart), omnidev runs `npm install`
 in `web/` when needed — `node_modules/` is missing, or `package.json` /
@@ -73,10 +73,37 @@ canonical checkout path. Per-process logs are written through to
 ```
 --server-port <N>   Force the backend port (default: probe from 6767)
 --vite-port <N>     Force the Vite port (default: probe from 5173)
+--vite-host <ADDR>  Vite bind host (default: 127.0.0.1; use 0.0.0.0 for LAN access)
+--trust-lan-origins Trust this machine's LAN origins (for device testing)
 --pod-dir <PATH>    Use a specific pod dir instead of the per-repo default
 --no-vite           Backend + host only (no frontend)
 --clean             Wipe the pod dir before starting
 ```
+
+`--vite-host 0.0.0.0` exposes the Vite dev server on all interfaces for device
+testing. Vite still proxies API traffic to the pod backend through `127.0.0.1`.
+
+### Testing from a phone or tablet
+
+`--vite-host 0.0.0.0` alone lets a device load the UI, but the backend runs in
+single-user local mode, where its CSRF/CSWSH guard trusts only loopback
+origins. A device loads the UI at `http://<your-lan-ip>:<vite-port>`, so its
+browser stamps that non-loopback origin on every request — and the guard then
+rejects multipart uploads (403) and refuses the live WebSocket stream.
+
+`--trust-lan-origins` fixes that: omnidev enumerates this machine's LAN IPv4
+addresses and trusts the matching `http://<ip>:<vite-port>` origins via the
+server's `OMNIGENT_WS_ALLOWED_ORIGINS` allowlist (merged with any value you
+already export). It stays exact-match — only those origins are trusted, nothing
+is disabled — so it's for dev pods, not deployed servers. The trusted origins
+are printed in the combined log at startup.
+
+```bash
+omnidev --vite-host 0.0.0.0 --trust-lan-origins
+```
+
+This covers IPv4 LAN addresses; mDNS `.local` hostnames and HTTPS origins are
+not auto-trusted (add those to `OMNIGENT_WS_ALLOWED_ORIGINS` yourself).
 
 ## Keys
 

--- a/dev/omnidev/src/lan.rs
+++ b/dev/omnidev/src/lan.rs
@@ -1,0 +1,114 @@
+//! LAN origin discovery for device testing.
+//!
+//! When Vite binds to `0.0.0.0` (`--vite-host 0.0.0.0`), a phone or tablet on
+//! the same network loads the UI at `http://<lan-ip>:<vite-port>`. Its browser
+//! stamps that non-loopback address as the `Origin` on every request. The
+//! backend runs in local single-user mode, where the origin guard
+//! (`omnigent.server.ws_origin.origin_allowed`) admits only loopback origins —
+//! so multipart uploads get a 403 and the WebSocket stream is refused.
+//!
+//! `--trust-lan-origins` closes that gap by enumerating this machine's LAN
+//! IPv4 addresses and handing the server the matching `http://<ip>:<port>`
+//! origins via `OMNIGENT_WS_ALLOWED_ORIGINS` — the server's own exact-match
+//! allowlist. It stays exact-match (no security disable): only the origins we
+//! name are trusted.
+
+use std::net::Ipv4Addr;
+
+/// Whether an IPv4 address is a usable LAN address to trust as an origin.
+///
+/// Keeps private (RFC 1918) and link-local (169.254/16) addresses — the ones a
+/// device on the same network actually reaches this machine by. Drops loopback
+/// (already trusted), unspecified (`0.0.0.0`), broadcast, documentation, and
+/// multicast, none of which a real device browses to.
+fn is_lan_ipv4(ip: &Ipv4Addr) -> bool {
+    (ip.is_private() || ip.is_link_local())
+        && !ip.is_loopback()
+        && !ip.is_unspecified()
+        && !ip.is_broadcast()
+        && !ip.is_multicast()
+}
+
+/// Build the `http://<ip>:<port>` origins to trust for a given set of LAN
+/// IPv4 addresses.
+///
+/// Split out from interface enumeration so the origin-shaping (which is all we
+/// assert on) is testable without touching the host's real interfaces. The
+/// input is deduplicated and the output is sorted for a stable env value.
+fn origins_for_ips(ips: impl IntoIterator<Item = Ipv4Addr>, vite_port: u16) -> Vec<String> {
+    let mut origins: Vec<String> = ips
+        .into_iter()
+        .filter(is_lan_ipv4)
+        .map(|ip| format!("http://{ip}:{vite_port}"))
+        .collect();
+    origins.sort();
+    origins.dedup();
+    origins
+}
+
+/// Discover the `http://<lan-ip>:<vite-port>` origins for this machine's LAN
+/// interfaces.
+///
+/// Returns an empty vector when no LAN interface is found (e.g. offline) — the
+/// caller then simply trusts nothing extra rather than failing. Interface
+/// enumeration errors are treated the same way: LAN trust is a convenience, so
+/// a lookup failure must not block the pod from starting.
+pub fn trusted_lan_origins(vite_port: u16) -> Vec<String> {
+    let ips = match if_addrs::get_if_addrs() {
+        Ok(ifaces) => ifaces
+            .into_iter()
+            .filter_map(|iface| match iface.addr.ip() {
+                std::net::IpAddr::V4(v4) => Some(v4),
+                std::net::IpAddr::V6(_) => None,
+            }),
+        Err(_) => return Vec::new(),
+    };
+    origins_for_ips(ips, vite_port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_private_and_link_local_drops_loopback_and_public() {
+        assert!(is_lan_ipv4(&Ipv4Addr::new(192, 168, 1, 42)));
+        assert!(is_lan_ipv4(&Ipv4Addr::new(10, 0, 0, 5)));
+        assert!(is_lan_ipv4(&Ipv4Addr::new(172, 16, 3, 9)));
+        assert!(is_lan_ipv4(&Ipv4Addr::new(169, 254, 10, 1)));
+
+        assert!(!is_lan_ipv4(&Ipv4Addr::new(127, 0, 0, 1)));
+        assert!(!is_lan_ipv4(&Ipv4Addr::new(0, 0, 0, 0)));
+        assert!(!is_lan_ipv4(&Ipv4Addr::new(8, 8, 8, 8)));
+        assert!(!is_lan_ipv4(&Ipv4Addr::new(255, 255, 255, 255)));
+    }
+
+    #[test]
+    fn builds_http_origins_with_the_vite_port() {
+        let origins = origins_for_ips([Ipv4Addr::new(192, 168, 1, 42)], 5173);
+        assert_eq!(origins, vec!["http://192.168.1.42:5173"]);
+    }
+
+    #[test]
+    fn filters_and_sorts_and_dedups() {
+        let origins = origins_for_ips(
+            [
+                Ipv4Addr::new(10, 0, 0, 9),
+                Ipv4Addr::new(127, 0, 0, 1), // loopback dropped
+                Ipv4Addr::new(8, 8, 8, 8),   // public dropped
+                Ipv4Addr::new(192, 168, 1, 5),
+                Ipv4Addr::new(10, 0, 0, 9), // duplicate collapsed
+            ],
+            8080,
+        );
+        assert_eq!(
+            origins,
+            vec!["http://10.0.0.9:8080", "http://192.168.1.5:8080"]
+        );
+    }
+
+    #[test]
+    fn no_lan_interfaces_yields_no_origins() {
+        assert!(origins_for_ips([Ipv4Addr::new(127, 0, 0, 1)], 5173).is_empty());
+    }
+}

--- a/dev/omnidev/src/main.rs
+++ b/dev/omnidev/src/main.rs
@@ -9,6 +9,7 @@
 //!   anywhere.
 
 mod install;
+mod lan;
 mod lock;
 mod logs;
 mod paths;
@@ -55,6 +56,15 @@ struct RunArgs {
     /// Force the Vite dev-server port (default: probe from 5173).
     #[arg(long)]
     vite_port: Option<u16>,
+
+    /// Vite dev-server bind host (default: 127.0.0.1; use 0.0.0.0 for LAN access).
+    #[arg(long, default_value = "127.0.0.1")]
+    vite_host: String,
+
+    /// Trust this machine's LAN origins so a phone/tablet on the same network
+    /// can use the UI (uploads + live stream). Pairs with `--vite-host 0.0.0.0`.
+    #[arg(long)]
+    trust_lan_origins: bool,
 
     /// Use this pod directory instead of the per-repo default.
     #[arg(long)]
@@ -158,7 +168,20 @@ async fn run_supervisor(args: RunArgs) -> Result<()> {
     let _lock = lock::acquire(&pod_dir)?;
 
     let ports = Ports::resolve(&pod_dir, args.server_port, args.vite_port)?;
-    let pod = Arc::new(Pod::create(repo_root, pod_dir, ports)?);
+    // LAN origins are keyed to the resolved Vite port, so compute them here
+    // once the port is known. Empty unless `--trust-lan-origins` is set.
+    let trusted_origins = if args.trust_lan_origins {
+        lan::trusted_lan_origins(ports.vite)
+    } else {
+        Vec::new()
+    };
+    let pod = Arc::new(Pod::create(
+        repo_root,
+        pod_dir,
+        ports,
+        args.vite_host,
+        trusted_origins,
+    )?);
 
     let shared = Shared::new(&pod);
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<Cmd>();
@@ -168,7 +191,12 @@ async fn run_supervisor(args: RunArgs) -> Result<()> {
     let _watcher = watcher::spawn(&pod.omnigent_dir(), cmd_tx.clone())?;
 
     // Supervisor runs on the tokio runtime; the TUI drives it via cmd_tx.
-    let supervisor = Supervisor::new(pod.clone(), shared.clone(), !args.no_vite);
+    let supervisor = Supervisor::new(
+        pod.clone(),
+        shared.clone(),
+        !args.no_vite,
+        args.trust_lan_origins,
+    );
     let sup_handle = tokio::spawn(supervisor.run(cmd_rx));
 
     // Run the TUI (owns the terminal) until the user quits.

--- a/dev/omnidev/src/pod.rs
+++ b/dev/omnidev/src/pod.rs
@@ -11,13 +11,23 @@ pub struct Pod {
     pub repo_root: PathBuf,
     pub dir: PathBuf,
     pub ports: Ports,
+    pub vite_host: String,
+    /// LAN origins to trust for device testing (`--trust-lan-origins`); empty
+    /// otherwise. Fed to the server as `OMNIGENT_WS_ALLOWED_ORIGINS`.
+    pub trusted_origins: Vec<String>,
 }
 
 impl Pod {
     /// Create the pod directory tree (idempotent) and return the pod handle.
     /// Only omnigent's own state is isolated (DB, artifacts, logs); the pod
     /// otherwise inherits your real home, credentials, config, and caches.
-    pub fn create(repo_root: PathBuf, dir: PathBuf, ports: Ports) -> Result<Pod> {
+    pub fn create(
+        repo_root: PathBuf,
+        dir: PathBuf,
+        ports: Ports,
+        vite_host: String,
+        trusted_origins: Vec<String>,
+    ) -> Result<Pod> {
         for sub in ["data/omnigent", "artifacts", "logs"] {
             let p = dir.join(sub);
             std::fs::create_dir_all(&p)
@@ -27,6 +37,8 @@ impl Pod {
             repo_root,
             dir,
             ports,
+            vite_host,
+            trusted_origins,
         })
     }
 
@@ -99,11 +111,40 @@ impl Pod {
     /// `web/vite.config.ts` reads to point its proxy at this pod's backend.
     pub fn env(&self) -> Vec<(String, String)> {
         let d = |p: &str| self.dir.join(p).display().to_string();
-        vec![
+        let mut env = vec![
             ("OMNIGENT_DATA_DIR".into(), d("data/omnigent")),
             ("OMNIGENT_DATABASE_URI".into(), self.db_uri()),
             ("OMNIGENT_URL".into(), self.server_url()),
-        ]
+        ];
+        if let Some(allowed) = self.allowed_origins_env() {
+            env.push(("OMNIGENT_WS_ALLOWED_ORIGINS".into(), allowed));
+        }
+        env
+    }
+
+    /// The `OMNIGENT_WS_ALLOWED_ORIGINS` value to inject, or `None` to leave it
+    /// untouched. Merges the trusted LAN origins onto any value inherited from
+    /// the parent environment (comma-separated, order-preserving, deduped) so a
+    /// developer's own allowlist survives. Returns `None` when there are no LAN
+    /// origins to add — then the parent's value (if any) simply passes through.
+    fn allowed_origins_env(&self) -> Option<String> {
+        if self.trusted_origins.is_empty() {
+            return None;
+        }
+        let inherited = std::env::var("OMNIGENT_WS_ALLOWED_ORIGINS").unwrap_or_default();
+        let mut merged: Vec<String> = Vec::new();
+        let parts = inherited
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .chain(self.trusted_origins.iter().cloned());
+        for part in parts {
+            if !merged.contains(&part) {
+                merged.push(part);
+            }
+        }
+        Some(merged.join(","))
     }
 }
 

--- a/dev/omnidev/src/process.rs
+++ b/dev/omnidev/src/process.rs
@@ -70,8 +70,8 @@ impl ProcSpec {
         }
     }
 
-    /// `npm run dev -- --port <p> --strictPort`, from `web/`. `OMNIGENT_URL`
-    /// (in the pod env) points Vite's proxy at this pod's backend.
+    /// `npm run dev -- --host <host> --port <p> --strictPort`, from `web/`.
+    /// `OMNIGENT_URL` (in the pod env) points Vite's proxy at this pod's backend.
     pub fn vite(pod: &Pod) -> ProcSpec {
         ProcSpec {
             program: "npm".into(),
@@ -79,11 +79,55 @@ impl ProcSpec {
                 "run".into(),
                 "dev".into(),
                 "--".into(),
+                "--host".into(),
+                pod.vite_host.clone(),
                 "--port".into(),
                 pod.ports.vite.to_string(),
                 "--strictPort".into(),
             ],
             cwd: pod.web_dir(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::Ports;
+
+    #[test]
+    fn vite_uses_configured_bind_host_but_backend_url_stays_loopback() {
+        let repo = tempdir();
+        let pod_dir = tempdir();
+        let pod = Pod::create(
+            repo,
+            pod_dir,
+            Ports {
+                server: 19191,
+                vite: 19292,
+            },
+            "0.0.0.0".into(),
+            Vec::new(),
+        )
+        .unwrap();
+
+        let vite = ProcSpec::vite(&pod);
+        let host_flag = vite.args.iter().position(|arg| arg == "--host").unwrap();
+        assert_eq!(vite.args[host_flag + 1], "0.0.0.0");
+        assert_eq!(pod.server_url(), "http://127.0.0.1:19191");
+    }
+
+    fn tempdir() -> std::path::PathBuf {
+        let unique = format!(
+            "omnidev-process-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let dir = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
     }
 }

--- a/dev/omnidev/src/supervisor.rs
+++ b/dev/omnidev/src/supervisor.rs
@@ -62,6 +62,9 @@ pub struct Supervisor {
     shared: Arc<Mutex<Shared>>,
     env: Vec<(String, String)>,
     vite_enabled: bool,
+    /// Whether `--trust-lan-origins` was requested, so we can warn if it was
+    /// asked for but no LAN interface turned up any origins to trust.
+    trust_lan_origins: bool,
     slots: [Slot; 3],
     /// Generations we stopped on purpose — their exits are not crashes.
     expected_stops: HashSet<(usize, u64)>,
@@ -71,7 +74,12 @@ pub struct Supervisor {
 }
 
 impl Supervisor {
-    pub fn new(pod: Arc<Pod>, shared: Arc<Mutex<Shared>>, vite_enabled: bool) -> Supervisor {
+    pub fn new(
+        pod: Arc<Pod>,
+        shared: Arc<Mutex<Shared>>,
+        vite_enabled: bool,
+        trust_lan_origins: bool,
+    ) -> Supervisor {
         let env = pod.env();
         let (exit_tx, exit_rx) = mpsc::unbounded_channel();
         Supervisor {
@@ -79,6 +87,7 @@ impl Supervisor {
             shared,
             env,
             vite_enabled,
+            trust_lan_origins,
             slots: Default::default(),
             expected_stops: HashSet::new(),
             gen_counter: 0,
@@ -104,6 +113,14 @@ impl Supervisor {
             self.pod.ports.server,
             self.pod.ports.vite
         ));
+        if !self.pod.trusted_origins.is_empty() {
+            self.event(format!(
+                "trusting LAN origins for device testing: {}",
+                self.pod.trusted_origins.join(", ")
+            ));
+        } else if self.trust_lan_origins {
+            self.event("--trust-lan-origins: no LAN interface found; no extra origins trusted");
+        }
 
         self.start_backend().await;
         if self.vite_enabled {

--- a/dev/omnidev/tests/pod_setup.rs
+++ b/dev/omnidev/tests/pod_setup.rs
@@ -1,6 +1,7 @@
 //! Exercises the non-TUI setup path: repo detection, pod dir tree, ports.
 
 use std::fs;
+use std::sync::{Mutex, MutexGuard};
 
 // The crate is a binary, so pull in the modules under test directly. Each test
 // target uses only part of the included source, so allow dead code.
@@ -67,6 +68,8 @@ fn needs_npm_install_tracks_manifests() {
             server: 6767,
             vite: 5173,
         },
+        vite_host: "127.0.0.1".into(),
+        trusted_origins: Vec::new(),
     };
 
     // No node_modules yet → install needed.
@@ -136,6 +139,92 @@ fn pod_lock_is_exclusive() {
 
     drop(held);
     lock::acquire(&pod).expect("acquire succeeds again after release");
+}
+
+const ALLOWED_ORIGINS_ENV: &str = "OMNIGENT_WS_ALLOWED_ORIGINS";
+
+/// Tests that read/write the process-global allowlist env var; serialize them.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Run `body` with `OMNIGENT_WS_ALLOWED_ORIGINS` set to `value` (or unset when
+/// `None`), restoring the prior value afterward so tests don't leak env state.
+fn with_allowlist_env(value: Option<&str>, body: impl FnOnce()) {
+    let _guard = lock_env();
+    let prev = std::env::var(ALLOWED_ORIGINS_ENV).ok();
+    match value {
+        Some(v) => std::env::set_var(ALLOWED_ORIGINS_ENV, v),
+        None => std::env::remove_var(ALLOWED_ORIGINS_ENV),
+    }
+    body();
+    match prev {
+        Some(v) => std::env::set_var(ALLOWED_ORIGINS_ENV, v),
+        None => std::env::remove_var(ALLOWED_ORIGINS_ENV),
+    }
+}
+
+fn pod_with_trusted(trusted: Vec<String>) -> Pod {
+    Pod {
+        repo_root: std::path::PathBuf::from("/repo"),
+        dir: std::path::PathBuf::from("/pod"),
+        ports: Ports {
+            server: 6767,
+            vite: 5173,
+        },
+        vite_host: "0.0.0.0".into(),
+        trusted_origins: trusted,
+    }
+}
+
+fn allowlist_from_env(pod: &Pod) -> Option<String> {
+    pod.env()
+        .into_iter()
+        .find(|(k, _)| k == ALLOWED_ORIGINS_ENV)
+        .map(|(_, v)| v)
+}
+
+/// With no trusted origins, the pod leaves the allowlist var untouched — even
+/// when the developer's shell already exports one (it passes through inherited).
+#[test]
+fn no_trusted_origins_does_not_set_allowlist() {
+    with_allowlist_env(Some("https://dev.example.com"), || {
+        let pod = pod_with_trusted(Vec::new());
+        assert_eq!(allowlist_from_env(&pod), None);
+    });
+}
+
+/// Trusted origins with no inherited value produce exactly those origins.
+#[test]
+fn trusted_origins_populate_allowlist() {
+    with_allowlist_env(None, || {
+        let pod = pod_with_trusted(vec!["http://192.168.1.42:5173".into()]);
+        assert_eq!(
+            allowlist_from_env(&pod).as_deref(),
+            Some("http://192.168.1.42:5173")
+        );
+    });
+}
+
+/// A developer's inherited allowlist is preserved and the LAN origins are
+/// appended (order-preserving, deduped) rather than clobbered.
+#[test]
+fn trusted_origins_merge_with_inherited_allowlist() {
+    with_allowlist_env(
+        Some("https://dev.example.com, http://192.168.1.42:5173"),
+        || {
+            let pod = pod_with_trusted(vec![
+                "http://192.168.1.42:5173".into(), // already inherited → not duplicated
+                "http://10.0.0.9:5173".into(),
+            ]);
+            assert_eq!(
+                allowlist_from_env(&pod).as_deref(),
+                Some("https://dev.example.com,http://192.168.1.42:5173,http://10.0.0.9:5173")
+            );
+        },
+    );
 }
 
 /// Minimal unique temp dir without pulling a dev-dependency.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a `--trust-lan-origins` flag to omnidev (the dev-pod supervisor) so a
  phone or tablet on the same network can use the UI end to end when Vite is
  bound with `--vite-host 0.0.0.0`. A device loads the UI at
  `http://<lan-ip>:<vite-port>`, so its browser stamps that non-loopback
  address as the `Origin` on every request. The pod's backend runs in
  single-user local mode, where the origin guard trusts only loopback
  origins — so multipart uploads get a 403 and the WebSocket stream is
  refused. The flag closes that gap.
- New `lan.rs` enumerates this machine's LAN IPv4 addresses (private +
  link-local, dropping loopback/public/broadcast/multicast via the
  `if-addrs` crate) and builds the matching `http://<ip>:<vite-port>`
  origins. They're fed to the server through its own exact-match allowlist
  env var `OMNIGENT_WS_ALLOWED_ORIGINS`, merged with any value the developer
  already exports (order-preserving, deduped). It stays exact-match — only
  the enumerated origins are trusted, nothing is disabled — so it covers
  both the upload guard and the WS handshake without weakening CSRF/CSWSH
  protection. Off by default; a no-op unless the flag is passed.
- The trusted origins are printed in the combined log at startup; if the
  flag is set but no LAN interface is found, a warning says so rather than
  silently no-op'ing later.
- README documents the flag and a "Testing from a phone or tablet" section.

## Test Plan

- `cargo build`, `cargo test` (22 passing, incl. new unit tests for LAN IPv4
  filtering, origin construction, and the env-merge onto an inherited
  allowlist), `cargo clippy --all-targets` (clean), `cargo fmt --check`
  (clean).
- Verified the real `if-addrs` enumeration on this machine produces the
  expected `http://<ip>:5173` origins for the host's private/link-local
  interfaces (loopback/public dropped).
- `--help` renders the new flag; `pre-commit` passed on the changed files.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Origin filtering, construction, and the allowlist env-merge have unit tests
(cargo test, 22 passing). The real interface enumeration and the
device-in-browser flow can't be asserted in a unit test, so they were
verified manually: the `if-addrs` call was run on this host and produced the
correct origins, and the resulting `OMNIGENT_WS_ALLOWED_ORIGINS` value was
confirmed to merge with an inherited value. Final confirmation from an actual
LAN device (upload + live stream over `--vite-host 0.0.0.0
--trust-lan-origins`) is recommended but not automatable in CI.
