### PR TITLE
🐛 fix(ios): Copy button, copy confirmation, and status-line overlap

### DIFF
--- a/web/src/hooks/useIOSNativeKeyboardInset.test.ts
+++ b/web/src/hooks/useIOSNativeKeyboardInset.test.ts
@@ -1,0 +1,57 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { useIOSNativeKeyboardVisible } from "./useIOSNativeKeyboardInset";
+
+// The iOS shell hides the native Liquid Glass Chat/Terminal bar whenever an
+// editable element is focused (it reads that as the on-screen keyboard opening).
+// `copyText`'s execCommand fallback briefly focuses a hidden textarea to run the
+// copy — marked `data-clipboard-helper` so it must NOT count as editable focus,
+// otherwise a copy would dismiss the bar for the rest of the session (WebKit
+// doesn't reliably fire `focusout` when a focused node is removed).
+
+function setIOS(on: boolean): void {
+  if (on) {
+    (window as unknown as Record<string, unknown>).omnigentNative = { kind: "ios" };
+  } else {
+    delete (window as unknown as Record<string, unknown>).omnigentNative;
+  }
+}
+
+afterEach(() => {
+  cleanup();
+  setIOS(false);
+  document.body.innerHTML = "";
+});
+
+describe("useIOSNativeKeyboardVisible editable-focus detection", () => {
+  it("does not report keyboard-visible when a clipboard-helper textarea is focused", () => {
+    setIOS(true);
+    const { result } = renderHook(() => useIOSNativeKeyboardVisible(true, true));
+    expect(result.current).toBe(false);
+
+    const helper = document.createElement("textarea");
+    helper.setAttribute("data-clipboard-helper", "");
+    document.body.appendChild(helper);
+    act(() => {
+      helper.focus();
+      window.dispatchEvent(new Event("focusin"));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("reports keyboard-visible when a real textarea is focused", () => {
+    setIOS(true);
+    const { result } = renderHook(() => useIOSNativeKeyboardVisible(true, true));
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+    act(() => {
+      input.focus();
+      window.dispatchEvent(new Event("focusin"));
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/web/src/hooks/useIOSNativeKeyboardInset.ts
+++ b/web/src/hooks/useIOSNativeKeyboardInset.ts
@@ -101,5 +101,10 @@ function getIOSNativeKeyboardInset(): number {
 function isEditableElementFocused(): boolean {
   const active = document.activeElement;
   if (!(active instanceof HTMLElement)) return false;
+  // The transient textarea `copyText`'s execCommand fallback focuses is not a
+  // real editing surface — treating it as one would hide the native bar for
+  // the rest of the session, since WebKit doesn't reliably fire `focusout`
+  // when a focused element is removed. Exclude it via its marker attribute.
+  if (active.hasAttribute("data-clipboard-helper")) return false;
   return active.matches('input, textarea, select, [contenteditable="true"]');
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -580,15 +580,13 @@
      view (the in-page pill is suppressed in the iOS shell). Height is the
      shared bottom inset — the native bar footprint (sourced from the shell, see
      nativeInsets.ts) plus the home-indicator safe area — so it can never drift
-     from the bar's real size. Chat sits 1rem tighter: its composer status line
-     already cushions the gap to the bar. */
-  [data-ios-native] .omnigent-native-bottom-spacer {
+     from the bar's real size. Chat reserves the same footprint: its composer
+     status line (host / harness / context ring) is content the bar must clear,
+     not spare cushion, so trimming the reserve here let the bar overlap it. */
+  [data-ios-native] .omnigent-native-bottom-spacer,
+  [data-ios-native] .omnigent-native-bottom-spacer--chat {
     height: var(--omnigent-inset-bottom);
     flex: none;
-  }
-
-  [data-ios-native] .omnigent-native-bottom-spacer--chat {
-    height: calc(var(--omnigent-inset-bottom) - 1rem);
   }
 
   [data-ios-native] .terminal-first-switcher {

--- a/web/src/lib/clipboard.test.ts
+++ b/web/src/lib/clipboard.test.ts
@@ -63,6 +63,9 @@ describe("copyText", () => {
         expect(selectedTextAreas[0]?.selectionStart).toBe(0);
         expect(selectedTextAreas[0]?.selectionEnd).toBe("first line\nsecond line".length);
         expect(document.body.contains(selectedTextAreas[0] ?? null)).toBe(true);
+        // Marked so editable-focus detection ignores it: focusing this helper
+        // must not read as the keyboard opening and hide the iOS native bar.
+        expect(selectedTextAreas[0]?.hasAttribute("data-clipboard-helper")).toBe(true);
 
         const event = new Event("copy", {
           bubbles: true,

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -31,6 +31,12 @@ function copyTextWithExecCommand(text: string): boolean {
 
   textArea.value = text;
   textArea.setAttribute("readonly", "");
+  // Mark this as a transient clipboard helper. The iOS shell hides the native
+  // Liquid Glass bar whenever an editable element is focused (it reads that as
+  // the keyboard opening); focusing this textarea to run execCommand would
+  // otherwise dismiss the bar for the rest of the session. Editable-focus
+  // detection excludes elements carrying this marker.
+  textArea.setAttribute("data-clipboard-helper", "");
   textArea.style.position = "fixed";
   textArea.style.top = "0";
   textArea.style.left = "0";

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -177,6 +177,9 @@ import {
   useCodexGoalState,
   type CodexGoal,
 } from "@/components/codex";
+import { copyText } from "@/lib/clipboard";
+import { showToast } from "@/components/ui/toast";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 
 // Matches both wordings the native executors emit: "[Attached: <path>]"
 // (claude/pi/cursor) and "[Attached file: <path>]" (codex). Capturing group
@@ -2841,6 +2844,52 @@ export const BubbleView = memo(
   (prev, next) => bubblesEqual(prev.bubble, next.bubble),
 );
 
+/**
+ * Copy-to-clipboard handler for a message bubble's "Copy" action.
+ *
+ * Uses the shared {@link copyText} helper (async Clipboard API with an
+ * `execCommand` fallback) rather than `navigator.clipboard.writeText`
+ * directly — the latter is undefined in the iOS webview and on non-secure
+ * origins, where a bare guard made the button silently no-op. Drives the
+ * inline check-icon confirmation for 2s, and on mobile (where the desktop
+ * hover affordance and tooltip aren't visible) also fires a toast so the
+ * copy is confirmed.
+ *
+ * @param getText - Produces the text to copy at click time.
+ * @returns `{ isCopied, handleCopy }` for the action button.
+ */
+function useCopyMessage(getText: () => string): {
+  isCopied: boolean;
+  handleCopy: () => void;
+} {
+  const [isCopied, setIsCopied] = useState(false);
+  const timeoutRef = useRef<number>(0);
+  const isMobile = useIsMobileViewport();
+
+  useEffect(() => () => window.clearTimeout(timeoutRef.current), []);
+
+  const handleCopy = useCallback(() => {
+    if (isCopied) return;
+    const text = getText();
+    if (!text) return;
+    copyText(text).then(
+      () => {
+        setIsCopied(true);
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = window.setTimeout(() => setIsCopied(false), 2000);
+        if (isMobile) {
+          showToast(<span className="text-sm">Copied to clipboard</span>, { duration: 1500 });
+        }
+      },
+      (error) => {
+        console.warn("Failed to copy message", error);
+      },
+    );
+  }, [getText, isCopied, isMobile]);
+
+  return { isCopied, handleCopy };
+}
+
 function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   const sessionId = useChatStore((s) => s.conversationId);
   // Author labels only matter once the session is shared with someone else.
@@ -2876,20 +2925,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   const showAuthorBadge = shouldShowAuthorBadge(author, getCurrentAuthorId(), isSessionShared);
   // Equality selector so Zustand only re-renders the matching bubble.
   const flashing = useChatStore((s) => s.flashItemId === bubble.itemId);
-  const [isCopied, setIsCopied] = useState(false);
-  const copyTimeoutRef = useRef<number>(0);
-
-  const handleCopy = async () => {
-    if (!text || !navigator?.clipboard?.writeText) return;
-    try {
-      await navigator.clipboard.writeText(text);
-      setIsCopied(true);
-      window.clearTimeout(copyTimeoutRef.current);
-      copyTimeoutRef.current = window.setTimeout(() => setIsCopied(false), 2000);
-    } catch {
-      // ignore clipboard errors
-    }
-  };
+  const { isCopied, handleCopy } = useCopyMessage(() => text);
 
   return (
     <Message
@@ -3027,8 +3063,10 @@ function AssistantBubble({ bubble }: { bubble: Extract<Bubble, { kind: "assistan
   // common case. The "Working…" shimmer for the empty-items / streaming
   // gap is rendered at the page level, not inside this component.
   const sessionStatus = useChatStore((s) => s.sessionStatus);
-  const [isCopied, setIsCopied] = useState(false);
-  const copyTimeoutRef = useRef<number>(0);
+  // Getter computes the markdown lazily at click time — the hook must run
+  // before the early return below (rules of hooks), but `markdownText` is
+  // derived after it.
+  const { isCopied, handleCopy } = useCopyMessage(() => collectBubbleMarkdown(bubble.items));
   // null outside AppShell's provider (isolated tests) → hide the action.
   const forkDialog = useForkDialog();
 
@@ -3040,18 +3078,6 @@ function AssistantBubble({ bubble }: { bubble: Extract<Bubble, { kind: "assistan
   // width to match the composer, not the default w-fit shrink-to-content.
   const hasElicitation = bubble.items.some((it) => it.kind === "elicitation");
   const isWide = hasElicitation || containsMarkdownTable(bubble.items);
-
-  const handleCopy = async () => {
-    if (!markdownText || !navigator?.clipboard?.writeText) return;
-    try {
-      await navigator.clipboard.writeText(markdownText);
-      setIsCopied(true);
-      window.clearTimeout(copyTimeoutRef.current);
-      copyTimeoutRef.current = window.setTimeout(() => setIsCopied(false), 2000);
-    } catch {
-      // ignore clipboard errors
-    }
-  };
 
   return (
     <>

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -131,6 +131,51 @@ describe("UserBubble copy button", () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledWith("copy me please"));
   });
 
+  it("falls back to execCommand when the async clipboard is unavailable", async () => {
+    // The iOS webview / non-secure origins expose no navigator.clipboard, which
+    // is exactly where the old direct-writeText guard made this button a silent
+    // no-op. copyText() must fall through to the execCommand path instead.
+    vi.stubGlobal("navigator", {});
+    const realExecCommand = document.execCommand;
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    try {
+      renderBubble(userBubble("copy via fallback"));
+      fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+      await waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+    } finally {
+      document.execCommand = realExecCommand;
+    }
+  });
+
+  it("shows a toast confirmation on a mobile viewport", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const real = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: /max-width/.test(query),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+    const onToast = vi.fn();
+    window.addEventListener("omnigent:toast", onToast);
+
+    try {
+      renderBubble(userBubble("copy me please"));
+      fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+      await waitFor(() => expect(onToast).toHaveBeenCalled());
+    } finally {
+      window.removeEventListener("omnigent:toast", onToast);
+      window.matchMedia = real;
+    }
+  });
+
   it("does not render a copy button for an attachments-only message (no text)", () => {
     renderBubble(
       userBubble("", {


### PR DESCRIPTION
## Related issue

N/A

## Summary

Three related fixes to the mobile / iOS chat surface:

- **Message copy button now works on mobile.** The user and assistant
  bubble copy actions called `navigator.clipboard.writeText` directly and
  silently no-op'd when it was absent (the iOS webview / non-secure
  origins). They now route through the shared `copyText()` helper, which
  falls back to an `execCommand` textarea copy. Deduplicated the two inline
  handlers into a shared `useCopyMessage` hook.
- **Visual confirmation on copy.** On a mobile viewport the copy action
  fires a "Copied to clipboard" toast in addition to the inline check icon
  (which is easy to miss on a phone). Desktop is unchanged (icon + tooltip).
- **Native Chat/Terminal bar no longer disappears after copy.** The
  `execCommand` fallback focuses a hidden textarea, which the iOS
  keyboard-visible check mistook for the keyboard opening and hid the
  native Liquid Glass bar — and WebKit doesn't reliably fire `focusout`
  when the focused node is removed, so it stayed hidden. The helper textarea
  is now marked `data-clipboard-helper` and excluded from editable-focus
  detection.
- **iOS Chat/Terminal bar no longer overlaps the composer status line.**
  The chat-view bottom spacer reserved 1rem less than the bar's footprint,
  so the bar rode up over the host / harness / context-ring row. It now
  reserves the full footprint (iOS-only, chat-view-only).

## Test Plan

- `npx tsc -b` — clean.
- `npx oxlint` on changed files — no new findings.
- `npx vitest run` on the affected suites (clipboard, keyboard-inset hook,
  ChatPage user bubble) — 23 passing, including new coverage:
  - clipboard-helper textarea is not treated as editable focus, while a
    real textarea is;
  - copy falls back to `execCommand` when the async clipboard is absent;
  - a mobile viewport fires the copy toast;
  - the fallback textarea carries the `data-clipboard-helper` marker.
- CSS + WKWebView-specific behavior verified by inspecting the Vite-served
  compiled CSS; on-device visual confirmation still pending (see notes).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The clipboard, keyboard-inset, and copy-button paths have unit coverage
(23 tests, listed in the Test Plan). The two behaviors that can't be
exercised in jsdom — the iOS status-line/bar overlap (CSS var math) and the
real WKWebview clipboard/native-bar interaction — were verified by reading
the Vite-served compiled CSS and by reasoning from the shell's focus/keyboard
hooks; final on-device visual confirmation in the iOS app is still
recommended before release.
