### PR TITLE
✨ feat(ci): Add manual Electron build workflow for Linux and Windows

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -1,0 +1,88 @@
+name: Electron Build
+
+# Manually-triggered build of the Electron desktop shell (web/electron) for
+# Linux and Windows. Each platform packages on its own native runner —
+# electron-builder does not reliably cross-compile installers — and uploads the
+# installers as downloadable workflow artifacts. Unsigned: no signing creds are
+# wired here, so `CSC_IDENTITY_AUTO_DISCOVERY=false` forces an unsigned build
+# rather than failing when a cert is absent. No publishing / release upload.
+#
+# Run it from the Actions tab (Run workflow). macOS is intentionally omitted —
+# its signed/notarized build lives elsewhere.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  # One build per ref: back-to-back manual dispatches on the same ref queue
+  # instead of running concurrently (keyed on ref only — including run_id would
+  # make every run its own group, defeating the serialization).
+  group: electron-build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      # Keep building the other platform even if one fails, so a Windows-only
+      # break still yields the Linux installers (and vice versa).
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            build-script: build:linux
+          - os: windows-latest
+            platform: win
+            build-script: build:win
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up Node
+        uses: ./.github/actions/setup-node
+        with:
+          # Node 22.x per web/electron/README.md ("Prerequisites").
+          node-version: "22"
+          cache-dependency-path: web/electron/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web/electron
+        run: npm ci --no-audit --no-fund
+
+      - name: Build ${{ matrix.platform }} app
+        working-directory: web/electron
+        env:
+          # No signing credentials in CI: force an unsigned build instead of
+          # letting electron-builder fail hunting for a certificate.
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          # electron-builder downloads Electron/tooling from GitHub; the token
+          # lifts the anonymous rate limit that otherwise flakes downloads.
+          GH_TOKEN: ${{ github.token }}
+        run: npm run ${{ matrix.build-script }} -- --publish never
+
+      - name: Upload installers
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: omnigent-desktop-${{ matrix.platform }}
+          # Ship only the distributables, not electron-builder's unpacked
+          # intermediates (dist/linux-unpacked, dist/win-unpacked, blockmaps).
+          path: |
+            web/electron/dist/*.AppImage
+            web/electron/dist/*.deb
+            web/electron/dist/*.exe
+          if-no-files-found: error
+          retention-days: 14

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -5,7 +5,11 @@
   "description": "Omnigent desktop shell (Electron edition) — a thin native wrapper around the server-served web UI.",
   "private": true,
   "main": "src/main.js",
-  "author": "Databricks, Inc.",
+  "homepage": "https://omnigent.ai",
+  "author": {
+    "name": "Databricks, Inc.",
+    "email": "support@omnigent.ai"
+  },
   "scripts": {
     "start": "electron .",
     "dev": "electron .",
@@ -85,6 +89,7 @@
     "linux": {
       "icon": "icons/icon.png",
       "category": "Development",
+      "maintainer": "Databricks, Inc. <support@omnigent.ai>",
       "target": [
         "AppImage",
         "deb"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add `.github/workflows/electron-build.yml`, a `workflow_dispatch`-only
  pipeline that packages the Electron desktop shell (`web/electron`) for
  Linux and Windows. A 2-way matrix builds each platform on its own native
  runner (`ubuntu-latest` → AppImage + .deb, `windows-latest` → NSIS .exe)
  since electron-builder does not reliably cross-compile installers, and
  uploads the distributables as workflow artifacts (14-day retention).
- Reuses the repo's `./.github/actions/setup-node` composite action (pinned
  to Node 22 per web/electron/README.md, npm cache keyed on the electron
  lockfile), runs `npm ci` then `npm run build:linux`/`build:win`. Builds
  are unsigned (`CSC_IDENTITY_AUTO_DISCOVERY=false` so a missing cert
  doesn't fail the build) and never publish; macOS is omitted (its
  signed/notarized build lives elsewhere). `fail-fast: false` so one
  platform breaking still yields the other's installers.
- Fix `web/electron/package.json` metadata the Linux `.deb` build requires:
  add `homepage`, expand `author` from a bare string to `{ name, email }`,
  and set `linux.maintainer`. Without these, electron-builder's fpm packager
  aborts the `.deb` target ("specify project homepage / author email /
  .deb maintainer") — a pre-existing config gap the new Linux job would hit.

## Test Plan

- `actionlint .github/workflows/electron-build.yml` — clean.
- Validated the workflow YAML and package.json parse (yaml.safe_load /
  JSON.parse).
- Locally in `web/electron`: `npm ci` resolves cleanly, and
  `npm run build:linux -- --publish never` produces BOTH
  `Omnigent-<ver>-<arch>.AppImage` and
  `omnigent-desktop-electron_<ver>_<arch>.deb` after the metadata fix
  (before it, the .deb target failed as described above). Confirmed the
  workflow's artifact globs (`*.AppImage`, `*.deb`, `*.exe`) match the
  real output names.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CI workflow + build-config change with no unit-testable surface; verified
by linting the workflow (actionlint) and by running the Linux build locally
end-to-end, which produced both the AppImage and .deb and proved the
package.json metadata fix. The Windows job could not be exercised locally
(macOS host), but it uses the same already-working `build:win` (nsis) script
on `windows-latest`; the first manual run from the Actions tab will confirm
it end-to-end.
