### PR TITLE
fix(windows): guard os.getuid() call in kiro_native_bridge

### DIFF
--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -17,7 +17,8 @@ from typing import Any
 KIRO_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_KIRO_NATIVE_BRIDGE_DIR"
 KIRO_ACP_RECORD_PATH_ENV_VAR = "KIRO_ACP_RECORD_PATH"
 
-_BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}" / "kiro-native"
+_bridge_uid = os.getuid() if hasattr(os, "getuid") else (os.environ.get("USERNAME") or os.environ.get("USER") or "unknown")
+_BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{_bridge_uid}" / "kiro-native"
 _TMUX_FILE = "tmux.json"
 _FORWARDER_READY_FILE = "kiro_session_forwarder_ready.json"
 _ACP_RECORD_FILE = "kiro_acp_record.jsonl"


### PR DESCRIPTION
## Summary

Fixes #2268 — `os.getuid()` is POSIX-only and doesn't exist on Windows, so `omnigent/kiro_native_bridge.py`'s module-level `_BRIDGE_ROOT` computation crashes on import on every Windows install, breaking local server startup entirely (`omnigent host ""`, and anything else that reaches `_ensure_default_agents` → `claude_native_bridge` → `kiro_native_bridge`).

## Change

Guards the UID lookup with `hasattr(os, "getuid")`, falling back to `USERNAME`/`USER` on platforms without it (i.e. Windows). One-line, no behavior change on POSIX.

## Testing

Verified locally on Windows 11 / Python 3.13.5 / omnigent 0.4.0:
- Before: `omnigent host "" --non-interactive` → `AttributeError: module 'os' has no attribute 'getuid'`, server fails to start.
- After: same command → `✓ Connected as '<host>' (host_...), 0 live runner(s). Listening for sessions.`

## Out of scope

`os.environ.get("TMPDIR", "/tmp")` on the same line also isn't a great default on Windows (no `TMPDIR` convention, `/tmp` resolves to the current drive root) — noted as a follow-up in #2268 but left out of this PR to keep the change minimal and scoped to the actual crash.
