### PR TITLE
feat(cli): add `omnigent debug logs` command

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11902,6 +11902,113 @@ def debug_migrate_accounts_to_oidc(
         click.echo("\nDone. Flip OMNIGENT_AUTH_PROVIDER=oidc and restart.\n")
 
 
+@debug.command("logs")
+@click.option(
+    "--type",
+    "log_type",
+    type=click.Choice(["runner", "server", "cli"], case_sensitive=False),
+    default="runner",
+    show_default=True,
+    help="Log category: runner (host-runner subprocess), server (local server), "
+    "or cli (CLI diagnostics).",
+)
+@click.option(
+    "--list",
+    "list_only",
+    is_flag=True,
+    default=False,
+    help="List available log files with size and timestamp instead of showing content.",
+)
+@click.option(
+    "--lines",
+    "-n",
+    default=50,
+    show_default=True,
+    metavar="N",
+    help="Lines to show from the end of the log (0 = entire file).",
+)
+@click.option(
+    "--follow",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Follow the latest log file in real-time (like tail -f).",
+)
+def debug_logs(log_type: str, list_only: bool, lines: int, follow: bool) -> None:
+    """Show runner, server, or CLI diagnostic logs.
+
+    Prints the tail of the most recent log file for the chosen category.
+    Use ``--list`` to see all available files, or ``--follow`` to stream
+    new output as it is written.
+
+    \b
+    Log locations (relative to ~/.omnigent or $OMNIGENT_DATA_DIR):
+      runner  logs/host-runner/runner-*.log
+      server  logs/server/local-server-*.log
+      cli     logs/cli-*.log
+
+    \b
+    Examples:
+      # Tail the most recent runner log (default)
+      omnigent debug logs
+      # List all runner log files with sizes
+      omnigent debug logs --list
+      # Follow the latest server log in real-time
+      omnigent debug logs --type server --follow
+      # Show the full latest CLI diagnostics log
+      omnigent debug logs --type cli -n 0
+    """
+    import subprocess
+
+    from omnigent.host.local_server import _local_data_dir
+
+    data_dir = _local_data_dir()
+
+    _log_configs: dict[str, tuple[Path, str]] = {
+        "runner": (data_dir / "logs" / "host-runner", "runner-*.log"),
+        "server": (data_dir / "logs" / "server", "local-server-*.log"),
+        "cli": (data_dir / "logs", "cli-*.log"),
+    }
+
+    log_dir, pattern = _log_configs[log_type]
+
+    if not log_dir.exists():
+        raise click.ClickException(f"No {log_type} logs found — {log_dir} does not exist.")
+
+    # Exclude symlinks (e.g. latest-cli.log), sort newest first.
+    log_files = sorted(
+        (f for f in log_dir.glob(pattern) if not f.is_symlink()),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+
+    if not log_files:
+        raise click.ClickException(f"No {log_type} log files found in {log_dir}.")
+
+    if list_only:
+        click.echo(f"{log_type} logs in {log_dir}:")
+        for f in log_files:
+            stat = f.stat()
+            size_kb = stat.st_size / 1024
+            mtime = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(stat.st_mtime))
+            click.echo(f"  {mtime}  {size_kb:6.1f} KB  {f.name}")
+        return
+
+    latest = log_files[0]
+    click.echo(f"# {latest}", err=True)
+
+    if follow:
+        subprocess.run(["tail", "-f", str(latest)])
+        return
+
+    content = latest.read_text(errors="replace")
+    if lines > 0:
+        tail_lines = content.splitlines()[-lines:]
+        content = "\n".join(tail_lines)
+
+    click.echo(content)
+
+
 def _workspace_mount_probe_matches(candidate: str, probe: httpx.Response) -> bool:
     """Whether a ``/api/2.0/omnigent`` mount probe answered like omnigent.
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11906,20 +11906,21 @@ def debug_migrate_accounts_to_oidc(
 @click.option(
     "--type",
     "log_type",
-    type=click.Choice(["runner", "server", "cli"], case_sensitive=False),
+    type=click.Choice(["runner", "host-runner", "server", "cli"], case_sensitive=False),
     default="runner",
     show_default=True,
-    help="Log category: runner (host-runner subprocess), server (local server), "
-    "or cli (CLI diagnostics).",
+    help="Log category: runner (local CLI runner via omnigent run), "
+    "host-runner (runner spawned by a host daemon), "
+    "server (local server), or cli (CLI diagnostics).",
 )
 @click.option(
     "--session",
     "session_id",
     default=None,
     metavar="SESSION_ID",
-    help="Filter runner logs by session id, e.g. conv_abc123. "
-    "Only applies to --type runner. Shows all log files for the session, "
-    "oldest first.",
+    help="Filter host-runner logs by session id, e.g. conv_abc123. "
+    "Only applies to --type host-runner. Shows all log files for the "
+    "session, oldest first.",
 )
 @click.option(
     "--list",
@@ -11934,6 +11935,7 @@ def debug_migrate_accounts_to_oidc(
     default=50,
     show_default=True,
     metavar="N",
+    type=click.IntRange(min=0),
     help="Lines to show from the end of the log (0 = entire file). "
     "With --session, applied per file.",
 )
@@ -11943,7 +11945,8 @@ def debug_migrate_accounts_to_oidc(
     is_flag=True,
     default=False,
     help="Follow the latest log file in real-time (like tail -f). "
-    "With --session, follows the most recent file for the session.",
+    "With --session, follows the most recent file for the session. "
+    "Not supported on Windows.",
 )
 def debug_logs(
     log_type: str, session_id: str | None, list_only: bool, lines: int, follow: bool
@@ -11954,25 +11957,26 @@ def debug_logs(
     Use ``--list`` to see all available files, or ``--follow`` to stream
     new output as it is written.
 
-    Pass ``--session SESSION_ID`` (runner logs only) to scope output to
-    all log files produced for a specific session across relaunches.
+    Pass ``--session SESSION_ID`` (``--type host-runner`` only) to scope
+    output to all log files produced for a specific session across relaunches.
 
     \b
     Log locations (relative to ~/.omnigent or $OMNIGENT_DATA_DIR):
-      runner  logs/host-runner/runner-*.log
-      server  logs/server/local-server-*.log
-      cli     logs/cli-*.log
+      runner       logs/runner/runner-*.log
+      host-runner  logs/host-runner/runner-*.log
+      server       logs/server/*server*.log
+      cli          logs/cli-*.log
 
     \b
     Examples:
-      # Tail the most recent runner log (default)
+      # Tail the most recent local runner log (default)
       omnigent debug logs
-      # List all runner log files with sizes
+      # List all local runner log files with sizes
       omnigent debug logs --list
-      # Show all logs for a specific session (across relaunches)
-      omnigent debug logs --session conv_abc123
-      # List log files for a session
-      omnigent debug logs --session conv_abc123 --list
+      # Show host-runner logs for a specific session (across relaunches)
+      omnigent debug logs --type host-runner --session conv_abc123
+      # List host-runner log files for a session
+      omnigent debug logs --type host-runner --session conv_abc123 --list
       # Follow the latest server log in real-time
       omnigent debug logs --type server --follow
       # Show the full latest CLI diagnostics log
@@ -11983,14 +11987,19 @@ def debug_logs(
 
     from omnigent.host.local_server import _local_data_dir
 
-    if session_id is not None and log_type != "runner":
-        raise click.UsageError("--session is only supported with --type runner")
+    if session_id is not None and log_type != "host-runner":
+        raise click.UsageError("--session is only supported with --type host-runner")
+
+    if follow and IS_WINDOWS:
+        raise click.UsageError("--follow is not supported on Windows")
 
     data_dir = _local_data_dir()
 
     _log_configs: dict[str, tuple[Path, str]] = {
-        "runner": (data_dir / "logs" / "host-runner", "runner-*.log"),
-        "server": (data_dir / "logs" / "server", "local-server-*.log"),
+        "runner": (data_dir / "logs" / "runner", "runner-*.log"),
+        "host-runner": (data_dir / "logs" / "host-runner", "runner-*.log"),
+        # Covers both server-*.log (omnigent run) and local-server-*.log (daemon).
+        "server": (data_dir / "logs" / "server", "*server*.log"),
         "cli": (data_dir / "logs", "cli-*.log"),
     }
 
@@ -12014,15 +12023,15 @@ def debug_logs(
     if not log_files:
         if session_id is not None:
             raise click.ClickException(
-                f"No runner logs found for session {session_id!r}. "
-                "Logs use the session id in their filename only for runners "
-                "launched after this feature was added."
+                f"No host-runner logs found for session {session_id!r}. "
+                "Session ids appear in filenames only for runners launched "
+                "after this feature was added."
             )
         raise click.ClickException(f"No {log_type} log files found in {log_dir}.")
 
     if list_only:
         header = (
-            f"runner logs for session {session_id!r} in {log_dir}:"
+            f"host-runner logs for session {session_id!r} in {log_dir}:"
             if session_id
             else f"{log_type} logs in {log_dir}:"
         )

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11913,6 +11913,15 @@ def debug_migrate_accounts_to_oidc(
     "or cli (CLI diagnostics).",
 )
 @click.option(
+    "--session",
+    "session_id",
+    default=None,
+    metavar="SESSION_ID",
+    help="Filter runner logs by session id, e.g. conv_abc123. "
+    "Only applies to --type runner. Shows all log files for the session, "
+    "oldest first.",
+)
+@click.option(
     "--list",
     "list_only",
     is_flag=True,
@@ -11925,21 +11934,28 @@ def debug_migrate_accounts_to_oidc(
     default=50,
     show_default=True,
     metavar="N",
-    help="Lines to show from the end of the log (0 = entire file).",
+    help="Lines to show from the end of the log (0 = entire file). "
+    "With --session, applied per file.",
 )
 @click.option(
     "--follow",
     "-f",
     is_flag=True,
     default=False,
-    help="Follow the latest log file in real-time (like tail -f).",
+    help="Follow the latest log file in real-time (like tail -f). "
+    "With --session, follows the most recent file for the session.",
 )
-def debug_logs(log_type: str, list_only: bool, lines: int, follow: bool) -> None:
+def debug_logs(
+    log_type: str, session_id: str | None, list_only: bool, lines: int, follow: bool
+) -> None:
     """Show runner, server, or CLI diagnostic logs.
 
     Prints the tail of the most recent log file for the chosen category.
     Use ``--list`` to see all available files, or ``--follow`` to stream
     new output as it is written.
+
+    Pass ``--session SESSION_ID`` (runner logs only) to scope output to
+    all log files produced for a specific session across relaunches.
 
     \b
     Log locations (relative to ~/.omnigent or $OMNIGENT_DATA_DIR):
@@ -11953,14 +11969,22 @@ def debug_logs(log_type: str, list_only: bool, lines: int, follow: bool) -> None
       omnigent debug logs
       # List all runner log files with sizes
       omnigent debug logs --list
+      # Show all logs for a specific session (across relaunches)
+      omnigent debug logs --session conv_abc123
+      # List log files for a session
+      omnigent debug logs --session conv_abc123 --list
       # Follow the latest server log in real-time
       omnigent debug logs --type server --follow
       # Show the full latest CLI diagnostics log
       omnigent debug logs --type cli -n 0
     """
+    import re
     import subprocess
 
     from omnigent.host.local_server import _local_data_dir
+
+    if session_id is not None and log_type != "runner":
+        raise click.UsageError("--session is only supported with --type runner")
 
     data_dir = _local_data_dir()
 
@@ -11975,6 +11999,11 @@ def debug_logs(log_type: str, list_only: bool, lines: int, follow: bool) -> None
     if not log_dir.exists():
         raise click.ClickException(f"No {log_type} logs found — {log_dir} does not exist.")
 
+    if session_id is not None:
+        # Sanitize the same way connect.py does so the glob matches.
+        slug = re.sub(r"[^\w-]", "", session_id)[:32]
+        pattern = f"runner-{slug}-*.log"
+
     # Exclude symlinks (e.g. latest-cli.log), sort newest first.
     log_files = sorted(
         (f for f in log_dir.glob(pattern) if not f.is_symlink()),
@@ -11983,10 +12012,21 @@ def debug_logs(log_type: str, list_only: bool, lines: int, follow: bool) -> None
     )
 
     if not log_files:
+        if session_id is not None:
+            raise click.ClickException(
+                f"No runner logs found for session {session_id!r}. "
+                "Logs use the session id in their filename only for runners "
+                "launched after this feature was added."
+            )
         raise click.ClickException(f"No {log_type} log files found in {log_dir}.")
 
     if list_only:
-        click.echo(f"{log_type} logs in {log_dir}:")
+        header = (
+            f"runner logs for session {session_id!r} in {log_dir}:"
+            if session_id
+            else f"{log_type} logs in {log_dir}:"
+        )
+        click.echo(header)
         for f in log_files:
             stat = f.stat()
             size_kb = stat.st_size / 1024
@@ -11994,19 +12034,29 @@ def debug_logs(log_type: str, list_only: bool, lines: int, follow: bool) -> None
             click.echo(f"  {mtime}  {size_kb:6.1f} KB  {f.name}")
         return
 
-    latest = log_files[0]
-    click.echo(f"# {latest}", err=True)
-
     if follow:
+        # Follow the most recent file only (tail -f can only track one file).
+        latest = log_files[0]
+        click.echo(f"# {latest}", err=True)
         subprocess.run(["tail", "-f", str(latest)])
         return
 
-    content = latest.read_text(errors="replace")
-    if lines > 0:
-        tail_lines = content.splitlines()[-lines:]
-        content = "\n".join(tail_lines)
-
-    click.echo(content)
+    if session_id is not None:
+        # Show all files for the session, oldest first, with separators.
+        for f in reversed(log_files):
+            click.echo(f"# {f}", err=True)
+            content = f.read_text(errors="replace")
+            if lines > 0:
+                content = "\n".join(content.splitlines()[-lines:])
+            click.echo(content)
+            click.echo()
+    else:
+        latest = log_files[0]
+        click.echo(f"# {latest}", err=True)
+        content = latest.read_text(errors="replace")
+        if lines > 0:
+            content = "\n".join(content.splitlines()[-lines:])
+        click.echo(content)
 
 
 def _workspace_mount_probe_matches(candidate: str, probe: httpx.Response) -> bool:

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1055,10 +1055,18 @@ class HostProcess:
         try:
             log_dir = _runner_log_dir()
             log_dir.mkdir(parents=True, exist_ok=True)
+            # Embed the session id so operators can find all logs for a
+            # session with `omnigent debug logs --session <id>`. Cap at 32
+            # chars to keep filenames manageable; strip anything non-word to
+            # guard against unexpected id shapes from older servers.
+            import re
             import tempfile
 
+            _session_slug = (
+                re.sub(r"[^\w-]", "", frame.session_id)[:32] + "-" if frame.session_id else ""
+            )
             _log_fd, _log_name = tempfile.mkstemp(
-                prefix="runner-",
+                prefix=f"runner-{_session_slug}",
                 suffix=".log",
                 dir=log_dir,
             )


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds `omnigent debug logs` under the `debug` subgroup so operators can inspect runner, server, and CLI diagnostic log files without navigating `~/.omnigent/logs/` manually.
- Embeds the session id in each runner log filename (`runner-conv_abc123-<random>.log`) so all runner relaunches for a session are traceable.
- Adds `--session SESSION_ID` to filter and display all log files produced for a specific session across relaunches, oldest-first.
- Also supports `--type [runner|server|cli]`, `--list` to enumerate files, `-n N` for tail depth, and `-f/--follow` for live streaming.

## Test Plan

```
# List all runner log files
omnigent debug logs --list

# Tail last 50 lines of the newest runner log
omnigent debug logs

# Show all logs for a specific session (across relaunches)
omnigent debug logs --session conv_abc123

# List log files for a session
omnigent debug logs --session conv_abc123 --list

# Show the full latest CLI diagnostics log
omnigent debug logs --type cli -n 0

# Follow the latest server log in real-time
omnigent debug logs --type server --follow
```

## Demo

N/A (CLI-only, non-visual change)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Manual verification completed

## Coverage notes

Tested all invocation modes against real log directories. The filename change in `connect.py` is additive (old `runner-<random>.log` files remain readable by `debug logs`; `--session` simply returns no results for them with a clear error message).

## Changelog

`omnigent debug logs` tails runner, server, or CLI diagnostic logs; `--session` scopes runner logs to a specific session across relaunches