### PR TITLE
fix(cli): omni run --harness acp:<slug> fails on colon in synthesized agent name

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5770,22 +5770,34 @@ def _materialize_harness_launcher_file(
     :raises click.ClickException: If *harness* is unsupported.
     """
     _validate_harness(harness)
-    display_name = harness
-    harness = canonicalize_harness(harness) or harness
+    canonical = canonicalize_harness(harness) or harness
+    # An acp:<slug> harness id carries a colon: it canonicalizes to the base
+    # `acp` harness, but the slug selects a user-configured ACP agent resolved
+    # at spawn and must be preserved. So the effective harness id written to
+    # executor.harness is the FULL acp:<slug> (keep the slug), or the canonical
+    # id for every other harness (so aliases still resolve, e.g. kimi ->
+    # kimi-code). The agent NAME and temp filename must be path-safe /
+    # [a-zA-Z0-9_-]+, so the colon is sanitized there only.
+    effective_harness = harness if canonical == "acp" and ":" in harness else canonical
+    # Name preserves the user's input (matching the pre-acp behavior, e.g.
+    # --harness claude -> name "claude"), sanitized for the colon so acp:<slug>
+    # yields a valid [a-zA-Z0-9_-]+ name. Filename uses the canonical/effective
+    # id (also colon-sanitized) as before.
+    display_name = harness.replace(":", "-")
 
     tmpdir = Path(tempfile.mkdtemp(prefix="omnigent-harness-launcher-"))
-    yaml_path = tmpdir / f"{harness}.yaml"
+    yaml_path = tmpdir / f"{effective_harness.replace(':', '-')}.yaml"
 
-    executor: dict[str, str] = {"harness": harness}
+    executor: dict[str, str] = {"harness": effective_harness}
     if model is not None:
         executor["model"] = model
 
     raw = {
         "name": display_name,
-        "prompt": system_prompt or _default_harness_prompt(harness),
+        "prompt": system_prompt or _default_harness_prompt(canonical),
         "executor": executor,
     }
-    if harness in _OS_ENV_HARNESSES:
+    if canonical in _OS_ENV_HARNESSES:
         raw["os_env"] = {"type": "caller_process", "sandbox": {"type": "none"}}
     yaml_path.write_text(yaml.safe_dump(raw, default_flow_style=False))
     return yaml_path

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2349,6 +2349,25 @@ def test_materialize_harness_launcher_file_writes_omnigent_yaml() -> None:
     assert "profile" not in raw["executor"], raw["executor"]
 
 
+def test_materialize_harness_launcher_file_acp_slug() -> None:
+    """``run --harness acp:<slug>`` produces a valid spec that keeps the slug.
+
+    acp:<slug> canonicalizes to the base ``acp`` harness, but the slug selects a
+    configured ACP agent resolved at spawn — so executor.harness must keep the
+    full ``acp:<slug>``. The agent name has no colon (the validator requires
+    [a-zA-Z0-9_-]+), so it is sanitized to ``acp-<slug>``.
+    """
+    import re
+
+    generated = _materialize_harness_launcher_file(
+        harness="acp:qwenacp", model=None, system_prompt=None
+    )
+    raw = yaml.safe_load(generated.read_text())
+    assert raw["executor"]["harness"] == "acp:qwenacp"  # slug preserved for the runner
+    assert raw["name"] == "acp-qwenacp"
+    assert re.fullmatch(r"[a-zA-Z0-9_-]+", raw["name"])  # passes the agent-name validator
+
+
 def test_materialize_harness_launcher_file_kimi_gets_os_env() -> None:
     """``run --harness kimi`` bakes a caller-process ``os_env`` so the SDK kimi
     operates in the user's current directory, matching claude-sdk.


### PR DESCRIPTION
## Related issue

N/A

## Summary

`omni run --harness acp:<slug>` (a configured ACP agent, e.g. `acp:qwenacp`) failed before it could start:

```
Error: invalid agent spec synthesized from omnigent YAML: name: agent name
'acp:qwenacp' must match [a-zA-Z0-9_-]+ (no dots, slashes, whitespace...)
```

The generic ACP harness (#2152) intends `acp:<slug>` as the run-time addressing form — it canonicalizes to the base `acp` harness, and the slug selects a user-configured ACP agent resolved from the `acp:` config block at spawn. But the no-AGENT launcher path (`_materialize_harness_launcher_file`) put the raw harness id straight into the synthesized agent `name`, and the agent-name validator rejects the colon.

**Fix:** keep the full `acp:<slug>` in `executor.harness` (canonicalizing would drop the slug to bare `acp` and lose the agent selection), and sanitize the colon (`:` -> `-`) only for the agent **name** and temp **filename**, which must be `[a-zA-Z0-9_-]+` / path-safe. Non-acp harnesses are unchanged: the name still uses the raw input (`claude` -> `"claude"`) and the executor/filename still canonicalize (`claude` -> `claude-sdk`, `kimi` alias, etc.).

Companion to #2265, which made the same fix on the test-bench side; this is the omni-core CLI run path.

## Test Plan

- `pytest tests/cli/test_cli.py -k "harness or launcher or materialize"` -> 36 passed. New test `test_materialize_harness_launcher_file_acp_slug` asserts executor.harness keeps `acp:qwenacp` while the name is the validator-safe `acp-qwenacp`; existing launcher tests (claude alias -> claude-sdk, kimi os_env, name == raw input) still green.
- Manual: `omni run --harness acp:<slug>` (with the agent configured in `~/.omnigent/config.yaml`'s `acp:` block) now synthesizes a valid spec and launches, instead of erroring on the colon.

## Demo

`N/A` (CLI; no visual change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Launcher-spec synthesis for acp:<slug> (name sanitization + slug preservation) is covered by the new unit test; the aliased/canonical paths for non-acp harnesses are covered by the existing launcher tests. The end-to-end `omni run` against a live ACP agent needs a configured + vendor-authed agent (not in CI), verified by hand.

## Changelog

`omni run --harness acp:<slug>` now launches a configured ACP agent instead of failing on the colon in the synthesized agent name.
