### PR TITLE
fix(server): return retryable 503 (runner_recycling) when a planned runner recycle aborts an in-flight relayed request

### DIFF
--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -34,6 +34,14 @@ class ErrorCode:
         §Elicitation completion invariant.
     :cvar RUNNER_UNAVAILABLE: No online runner can serve the
         requested dispatch (HTTP 503).
+    :cvar RUNNER_RECYCLING: An in-flight request relayed to a runner
+        over its tunnel was aborted because the tunnel was closed for a
+        *planned* recycle (a server-issued ``host.stop_runner``, a
+        managed runner-token TTL expiry, or a graceful shutdown). The
+        request never completed, but a retry succeeds against the
+        replacement runner generation — so this is a retryable HTTP 503
+        (paired with a ``Retry-After`` header) rather than an opaque
+        500. Distinct from RUNNER_UNAVAILABLE (no runner online at all).
     :cvar UNAUTHORIZED: No valid authentication credentials (HTTP 401).
     :cvar FORBIDDEN: Authenticated but insufficient permissions (HTTP 403).
     :cvar RUNNER_CAPABILITY_MISMATCH: The selected runner cannot
@@ -56,6 +64,7 @@ class ErrorCode:
     INTERNAL_ERROR = "internal_error"
     HARNESS_PROTOCOL_VIOLATION = "harness_protocol_violation"
     RUNNER_UNAVAILABLE = "runner_unavailable"
+    RUNNER_RECYCLING = "runner_recycling"
     RUNNER_CAPABILITY_MISMATCH = "runner_capability_mismatch"
     # Keep the string equal to frames.HARNESS_NOT_CONFIGURED_ERROR_CODE —
     # the host's wire error code passes through as the API error code.
@@ -76,6 +85,10 @@ _CODE_TO_HTTP_STATUS: dict[str, int] = {
     # can fix them; investigation needed in the harness wrap).
     ErrorCode.HARNESS_PROTOCOL_VIOLATION: 500,
     ErrorCode.RUNNER_UNAVAILABLE: 503,
+    # A planned runner recycle aborted an in-flight relayed request:
+    # retryable against the replacement generation (the HTTP boundary
+    # pairs this with a Retry-After header).
+    ErrorCode.RUNNER_RECYCLING: 503,
     ErrorCode.RUNNER_CAPABILITY_MISMATCH: 503,
     # 412 Precondition Failed: the request is well-formed but the host
     # can't satisfy it until the user runs `omnigent setup` there —

--- a/omnigent/runner/transports/ws_tunnel/registry.py
+++ b/omnigent/runner/transports/ws_tunnel/registry.py
@@ -52,6 +52,40 @@ from omnigent.runner.transports.ws_tunnel.frames import (
 _logger = logging.getLogger(__name__)
 
 
+# Default Retry-After hint (seconds) for a client whose in-flight request
+# was aborted by a *planned* runner recycle. The replacement runner
+# generation is typically already registering, so a short backoff suffices.
+RUNNER_RECYCLING_RETRY_AFTER_S = 2
+
+
+class TunnelRecyclingError(ConnectionError):
+    """In-flight tunnel request aborted by a *planned* runner recycle.
+
+    Subclasses :class:`ConnectionError` so every existing
+    ``except ConnectionError`` call site keeps catching it unchanged, but
+    carries a machine-readable retry hint so the HTTP boundary can surface
+    a retryable ``503 runner_recycling`` (plus ``Retry-After``) instead of
+    an opaque ``500 internal_error``.
+
+    Raised ONLY on the graceful path — a clean WebSocket closure that maps
+    to a server-issued ``host.stop_runner`` / managed runner-token TTL
+    recycle / orderly shutdown — never on an abnormal tunnel drop (which
+    keeps the plain :class:`ConnectionError`, unchanged 500 behaviour).
+
+    :param message: Human-readable detail.
+    :param retry_after_s: Suggested client backoff before retrying.
+    """
+
+    def __init__(
+        self,
+        message: str = "tunnel closed for a planned runner recycle",
+        *,
+        retry_after_s: float = RUNNER_RECYCLING_RETRY_AFTER_S,
+    ) -> None:
+        super().__init__(message)
+        self.retry_after_s = retry_after_s
+
+
 class WebSocketLike(Protocol):
     """Minimal WebSocket protocol used by the registry + transport.
 
@@ -300,13 +334,15 @@ class TunnelRegistry:
         self,
         runner_id: str,
         session: RunnerSession | None = None,
+        *,
+        recycling: bool = False,
     ) -> RunnerSession | None:
         """Remove a session and abort all its in-flight requests.
 
         Called by the WS route handler when the tunnel closes for
         any reason (clean shutdown, network error, etc.). The abort
         ensures awaiters of in-flight requests don't hang — they
-        get a ConnectionError and propagate it up.
+        get an error and propagate it up.
 
         :param runner_id: Runner id to remove, e.g.
             ``"runner_0123456789abcdef"``.
@@ -314,6 +350,14 @@ class TunnelRegistry:
             deregistration only removes the registry entry if the
             current entry is this exact session object. This prevents
             stale route handlers from deleting a newer tunnel.
+        :param recycling: True when the tunnel closed as part of a
+            *planned* runner recycle (clean WebSocket closure —
+            server-issued ``host.stop_runner`` / managed runner-token
+            TTL expiry / graceful shutdown). In-flight requests are
+            then aborted with a retryable :class:`TunnelRecyclingError`
+            instead of a bare ``ConnectionError``, so the HTTP boundary
+            can return ``503 runner_recycling`` rather than ``500``.
+            Defaults to False (abnormal drop — unchanged behaviour).
         :returns: The removed session, or ``None`` when the runner is
             already offline or the guard did not match.
         """
@@ -325,16 +369,19 @@ class TunnelRegistry:
             in_flight_count = len(removed.in_flight)
             if in_flight_count:
                 _logger.warning(
-                    "Deregistering runner %s; aborting %d in-flight request(s)",
+                    "Deregistering runner %s (%s); aborting %d in-flight request(s)",
                     runner_id,
+                    "planned recycle" if recycling else "tunnel closed",
                     in_flight_count,
                 )
             else:
                 _logger.info("Deregistering runner %s; no in-flight requests", runner_id)
-            self._abort_session_inflight(
-                removed,
-                ConnectionError("tunnel closed before request completed"),
+            abort_error: BaseException = (
+                TunnelRecyclingError()
+                if recycling
+                else ConnectionError("tunnel closed before request completed")
             )
+            self._abort_session_inflight(removed, abort_error)
         _retire_session_writer(removed, code=4003, reason="tunnel closed")
         return removed
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -40,6 +40,7 @@ from omnigent.harness_plugins import (
     QWEN_NATIVE_CODING_AGENT,
 )
 from omnigent.resources import examples as _examples_resources
+from omnigent.runner.transports.ws_tunnel.registry import TunnelRecyclingError
 from omnigent.runtime import (
     get_terminal_registry,
     pending_elicitations,
@@ -95,6 +96,37 @@ from omnigent.stores.policy_store import PolicyStore
 from omnigent.stores.scheduled_task_store import ScheduledTaskStore
 
 _logger = logging.getLogger(__name__)
+
+
+def build_tunnel_recycling_response(retry_after_s: float) -> JSONResponse:
+    """Build the retryable 503 for a request aborted by a planned recycle.
+
+    A :class:`~omnigent.runner.transports.ws_tunnel.registry.TunnelRecyclingError`
+    means an in-flight request relayed to a runner was aborted because the
+    runner tunnel was closed for a *planned* recycle (server-issued
+    ``host.stop_runner`` / managed runner-token TTL expiry / graceful
+    shutdown). The request never completed, but a retry succeeds against the
+    replacement runner generation — so return a retryable ``503`` with the
+    machine-readable ``runner_recycling`` code and a ``Retry-After`` header,
+    not an opaque ``500``.
+
+    :param retry_after_s: Suggested client backoff, in seconds.
+    :returns: A 503 JSON response carrying a ``Retry-After`` header.
+    """
+    retry_after = max(1, round(retry_after_s))
+    return JSONResponse(
+        status_code=503,
+        content={
+            "error": {
+                "code": ErrorCode.RUNNER_RECYCLING,
+                "message": (
+                    "The runner is recycling (planned restart); the request "
+                    "was not completed. Retry after a short delay."
+                ),
+            },
+        },
+        headers={"Retry-After": str(retry_after)},
+    )
 
 
 def _server_version() -> str:
@@ -1666,6 +1698,35 @@ def create_app(
                 },
             },
         )
+
+    @app.exception_handler(TunnelRecyclingError)
+    async def _handle_tunnel_recycling(
+        request: Request,  # noqa: ARG001 — FastAPI signature; we only use exc
+        exc: TunnelRecyclingError,
+    ) -> JSONResponse:
+        """Surface a *planned* runner recycle as a retryable 503.
+
+        A runner recycle (server-issued ``host.stop_runner`` / managed
+        runner-token TTL expiry / graceful shutdown) closes the tunnel and
+        aborts any in-flight relayed request. Without this handler the bare
+        ``ConnectionError`` fell through to the catch-all below as an opaque
+        ``500 internal_error`` — indistinguishable from a real fault, so
+        callers could not know to retry. Because a recycle fires on a
+        schedule (a new runner generation roughly every 15 min), that 500
+        was systematic, not a rare race. Return ``503 runner_recycling``
+        with a ``Retry-After`` header so callers retry against the
+        replacement generation. Scoped to the planned-recycle path only:
+        abnormal tunnel drops keep the plain ``ConnectionError`` / 500.
+
+        :param request: The incoming request (unused — FastAPI signature).
+        :param exc: The recycling error carrying the retry hint.
+        :returns: A retryable 503 JSON response with ``Retry-After``.
+        """
+        _logger.info(
+            "Runner recycling aborted an in-flight relayed request; "
+            "returning retryable 503 (runner_recycling)"
+        )
+        return build_tunnel_recycling_response(exc.retry_after_s)
 
     @app.exception_handler(Exception)
     async def _handle_unhandled_exception(

--- a/omnigent/server/routes/runner_tunnel.py
+++ b/omnigent/server/routes/runner_tunnel.py
@@ -46,6 +46,12 @@ PING_INTERVAL_S = 30.0
 PING_MISS_THRESHOLD = 3
 RUNNER_ID_MISMATCH_CLOSE_CODE = 4004
 _ON_RUNNER_CONNECT_TIMEOUT_SEC = 30.0
+# WebSocket normal-closure code (RFC 6455 §7.4.1). A runner closes the
+# tunnel with this on the graceful path — a server-issued host.stop_runner
+# / managed runner-token TTL recycle / orderly shutdown. We treat it as a
+# *planned* recycle so in-flight relayed requests aborted by the ensuing
+# deregister surface as a retryable 503 rather than an opaque 500.
+_WS_NORMAL_CLOSURE_CODE = 1000
 
 # Lifetime of a managed runner's minted owner bearer (POST
 # /v1/runners/{id}/token). Short by design: the runner re-mints on demand
@@ -515,6 +521,10 @@ def create_runner_tunnel_router(
                         runner_id,
                     )
 
+            # Whether the tunnel closed on the graceful path (clean
+            # normal-closure) vs. an abnormal drop — decides whether
+            # in-flight requests are aborted retryably (planned recycle).
+            planned_close = False
             try:
                 done, _pending = await asyncio.wait(
                     {sender_task, ping_task, receive_task},
@@ -546,6 +556,10 @@ def create_runner_tunnel_router(
                             getattr(exc, "code", None),
                             getattr(exc, "reason", None),
                         )
+                        # A clean normal-closure is the graceful recycle path;
+                        # mark it so the deregister below aborts in-flight
+                        # requests retryably (503 runner_recycling), not 500.
+                        planned_close = getattr(exc, "code", None) == _WS_NORMAL_CLOSURE_CODE
                     else:
                         _logger.warning(
                             "Tunnel helper task failed for runner %s: %s",
@@ -563,7 +577,7 @@ def create_runner_tunnel_router(
                     receive_task,
                     return_exceptions=True,
                 )
-                registry.deregister(runner_id, session)
+                registry.deregister(runner_id, session, recycling=planned_close)
                 if on_runner_disconnect is not None:
                     try:
                         await on_runner_disconnect(runner_id)

--- a/omnigent/server/routes/runner_tunnel.py
+++ b/omnigent/server/routes/runner_tunnel.py
@@ -46,12 +46,33 @@ PING_INTERVAL_S = 30.0
 PING_MISS_THRESHOLD = 3
 RUNNER_ID_MISMATCH_CLOSE_CODE = 4004
 _ON_RUNNER_CONNECT_TIMEOUT_SEC = 30.0
-# WebSocket normal-closure code (RFC 6455 §7.4.1). A runner closes the
-# tunnel with this on the graceful path — a server-issued host.stop_runner
-# / managed runner-token TTL recycle / orderly shutdown. We treat it as a
-# *planned* recycle so in-flight relayed requests aborted by the ensuing
-# deregister surface as a retryable 503 rather than an opaque 500.
-_WS_NORMAL_CLOSURE_CODE = 1000
+# WebSocket close codes that mark a *planned* runner recycle (vs. an
+# abnormal drop). A runner closes the tunnel with one of these on the
+# graceful path — a server-issued host.stop_runner / managed runner-token
+# TTL recycle / orderly shutdown:
+#   1000  normal closure (RFC 6455 §7.4.1)
+#   1001  "going away"     — sent on an orderly runner shutdown
+#   1012  "service restart"
+# 1001/1012 mirror serve.py's ``_TUNNEL_RECYCLE_CLOSE_CODES`` — the same
+# taxonomy the runner uses to recognise a routine ingress recycle from the
+# other side of the tunnel. Treating all three as planned means an in-flight
+# relayed request aborted by the ensuing deregister surfaces as a retryable
+# 503 rather than an opaque 500. Gating on 1000 alone would miss the common
+# orderly-shutdown path, which closes with 1001.
+_PLANNED_RECYCLE_CLOSE_CODES = frozenset({1000, 1001, 1012})
+
+
+def _is_planned_recycle_close(code: object) -> bool:
+    """Whether a WebSocket close ``code`` marks a planned runner recycle.
+
+    :param code: The close code from the tunnel's disconnect, or ``None``
+        when the helper task ended without one.
+    :returns: True for a clean normal-closure / going-away / service-restart
+        (a planned recycle whose in-flight requests should abort retryably),
+        False for any abnormal or unknown close.
+    """
+    return code in _PLANNED_RECYCLE_CLOSE_CODES
+
 
 # Lifetime of a managed runner's minted owner bearer (POST
 # /v1/runners/{id}/token). Short by design: the runner re-mints on demand
@@ -556,10 +577,11 @@ def create_runner_tunnel_router(
                             getattr(exc, "code", None),
                             getattr(exc, "reason", None),
                         )
-                        # A clean normal-closure is the graceful recycle path;
-                        # mark it so the deregister below aborts in-flight
-                        # requests retryably (503 runner_recycling), not 500.
-                        planned_close = getattr(exc, "code", None) == _WS_NORMAL_CLOSURE_CODE
+                        # A clean normal-closure / going-away / service-
+                        # restart is the graceful recycle path; mark it so the
+                        # deregister below aborts in-flight requests retryably
+                        # (503 runner_recycling), not 500.
+                        planned_close = _is_planned_recycle_close(getattr(exc, "code", None))
                     else:
                         _logger.warning(
                             "Tunnel helper task failed for runner %s: %s",

--- a/tests/runner/transports/ws_tunnel/test_registry.py
+++ b/tests/runner/transports/ws_tunnel/test_registry.py
@@ -389,3 +389,43 @@ async def test_online_runner_ids_returns_insertion_order() -> None:
     assert reg.online_runner_ids() == ["r1", "r2", "r3"]
     reg.deregister("r2")
     assert reg.online_runner_ids() == ["r1", "r3"]
+
+
+@pytest.mark.asyncio
+async def test_deregister_recycling_aborts_inflight_with_retryable_error() -> None:
+    """Planned recycle (recycling=True) -> in-flight requests fail with a
+    retryable TunnelRecyclingError carrying a Retry-After hint, so the HTTP
+    boundary can return 503 runner_recycling instead of an opaque 500."""
+    from omnigent.runner.transports.ws_tunnel.registry import TunnelRecyclingError
+
+    reg = TunnelRegistry()
+    reg.register("r1", _NoopWS(), _hello())
+    state = reg.open_request("r1", "req1")
+
+    reg.deregister("r1", recycling=True)
+
+    assert state.head_future.done()
+    with pytest.raises(TunnelRecyclingError) as excinfo:
+        state.head_future.result()
+    assert excinfo.value.retry_after_s >= 1
+    # Subclass of ConnectionError so existing `except ConnectionError`
+    # call sites keep catching it unchanged.
+    assert isinstance(excinfo.value, ConnectionError)
+
+
+@pytest.mark.asyncio
+async def test_deregister_default_uses_plain_connection_error() -> None:
+    """An abnormal drop (default recycling=False) stays a plain
+    ConnectionError -> unchanged 500 behaviour; NOT the retryable subclass."""
+    from omnigent.runner.transports.ws_tunnel.registry import TunnelRecyclingError
+
+    reg = TunnelRegistry()
+    reg.register("r1", _NoopWS(), _hello())
+    state = reg.open_request("r1", "req1")
+
+    reg.deregister("r1")
+
+    assert state.head_future.done()
+    with pytest.raises(ConnectionError) as excinfo:
+        state.head_future.result()
+    assert not isinstance(excinfo.value, TunnelRecyclingError)

--- a/tests/server/integration/test_runner_tunnel_route.py
+++ b/tests/server/integration/test_runner_tunnel_route.py
@@ -28,13 +28,38 @@ from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
 from omnigent.runner.transports.ws_tunnel.serve import dispatch_via_asgi
 from omnigent.runner.transports.ws_tunnel.transport import WSTunnelTransport
 from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
-from omnigent.server.routes.runner_tunnel import create_runner_tunnel_router
+from omnigent.server.routes.runner_tunnel import (
+    _is_planned_recycle_close,
+    create_runner_tunnel_router,
+)
 from tests.runner.helpers import NullServerClient
 
 pytestmark = pytest.mark.asyncio
 
 _RUNNER_ID = "runner-route-test-1"
 _TUNNEL_PATH = f"/v1/runners/{_RUNNER_ID}/tunnel"
+
+
+@pytest.mark.parametrize(
+    "code,planned",
+    [
+        (1000, True),  # normal closure
+        (1001, True),  # "going away" — the code an orderly runner shutdown sends
+        (1012, True),  # "service restart"
+        (1006, False),  # abnormal closure — a genuine drop
+        (1011, False),  # internal error
+        (4004, False),  # a server-issued fatal app code
+        (None, False),  # helper task ended without a close code
+    ],
+)
+async def test_is_planned_recycle_close_covers_recycle_taxonomy(
+    code: object, planned: bool
+) -> None:
+    """A planned recycle closes with 1000/1001/1012; anything else is an
+    abnormal drop. Gating on 1000 alone would miss 1001, the common
+    orderly-shutdown code, so its in-flight requests must abort retryably
+    (503) rather than as an opaque 500 (Polly review, PR #2281)."""
+    assert _is_planned_recycle_close(code) is planned
 
 
 @dataclass(frozen=True)

--- a/tests/server/test_tunnel_recycling_response.py
+++ b/tests/server/test_tunnel_recycling_response.py
@@ -1,0 +1,107 @@
+"""HTTP-boundary behaviour for a planned runner recycle.
+
+A runner recycle (server-issued ``host.stop_runner`` / managed runner-token
+TTL expiry / graceful shutdown) closes the tunnel and aborts any in-flight
+relayed request. This must surface to the caller as a retryable
+``503 runner_recycling`` (with ``Retry-After``), not an opaque
+``500 internal_error`` — otherwise a caller such as ``sys_session_create``
+cannot tell a recoverable recycle from a real fault, and won't retry.
+
+These tests exercise the two boundary halves:
+- ``build_tunnel_recycling_response`` returns the right status/code/header.
+- the registered exception handler routes a ``TunnelRecyclingError`` raised
+  from a route to that response (proving Starlette dispatches the
+  ConnectionError subclass to the specific handler, not the 500 catch-all) —
+  i.e. a create that hits a recycle window now gets the retryable error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from omnigent.errors import ErrorCode
+from omnigent.runner.transports.ws_tunnel.registry import (
+    RUNNER_RECYCLING_RETRY_AFTER_S,
+    TunnelRecyclingError,
+)
+from omnigent.server.app import build_tunnel_recycling_response
+
+
+def test_build_tunnel_recycling_response_shape() -> None:
+    resp = build_tunnel_recycling_response(RUNNER_RECYCLING_RETRY_AFTER_S)
+    assert resp.status_code == 503
+    assert resp.headers["Retry-After"] == str(RUNNER_RECYCLING_RETRY_AFTER_S)
+    import json
+
+    body = json.loads(bytes(resp.body))
+    assert body["error"]["code"] == ErrorCode.RUNNER_RECYCLING
+
+
+def test_build_tunnel_recycling_response_retry_after_floor() -> None:
+    """Retry-After never drops below 1s even for a sub-second hint."""
+    resp = build_tunnel_recycling_response(0.1)
+    assert int(resp.headers["Retry-After"]) >= 1
+
+
+def _app_with_handler() -> FastAPI:
+    app = FastAPI()
+
+    async def _handle(request: Request, exc: TunnelRecyclingError) -> JSONResponse:
+        return build_tunnel_recycling_response(exc.retry_after_s)
+
+    app.add_exception_handler(TunnelRecyclingError, _handle)
+
+    @app.post("/v1/sessions")
+    async def _create() -> JSONResponse:  # pragma: no cover - raises
+        # Mirrors an in-flight relayed request aborted mid-recycle.
+        raise TunnelRecyclingError()
+
+    return app
+
+
+def test_recycle_during_create_returns_retryable_503() -> None:
+    client = TestClient(_app_with_handler(), raise_server_exceptions=False)
+    resp = client.post("/v1/sessions")
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == ErrorCode.RUNNER_RECYCLING
+    assert int(resp.headers["Retry-After"]) >= 1
+
+
+def test_real_create_app_registers_recycling_handler(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+) -> None:
+    """The *production* app (create_app) wires the recycling handler.
+
+    Guards the wiring the minimal-app tests above assume: if a future
+    refactor drops the ``@app.exception_handler(TunnelRecyclingError)``
+    registration, the recycling error would fall through to the catch-all
+    500 handler and callers would stop retrying. Builds the real app with
+    the same SQLite-backed stores the integration suite uses.
+    """
+    from omnigent.runtime.agent_cache import AgentCache
+    from omnigent.server.app import create_app
+    from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+    from omnigent.stores.artifact_store.local import LocalArtifactStore
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+    from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    app = create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+    )
+    assert TunnelRecyclingError in app.exception_handlers

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -53,6 +53,8 @@ def test_omnigent_error_with_harness_violation_code_returns_500() -> None:
         (ErrorCode.CONFLICT, 409),
         (ErrorCode.INTERNAL_ERROR, 500),
         (ErrorCode.HARNESS_PROTOCOL_VIOLATION, 500),
+        (ErrorCode.RUNNER_UNAVAILABLE, 503),
+        (ErrorCode.RUNNER_RECYCLING, 503),
     ],
 )
 def test_all_error_codes_have_http_status_mapping(code: str, expected_status: int) -> None:
@@ -65,3 +67,22 @@ def test_all_error_codes_have_http_status_mapping(code: str, expected_status: in
     default.
     """
     assert _CODE_TO_HTTP_STATUS[code] == expected_status
+
+
+def test_runner_recycling_string_value() -> None:
+    """The wire string is a contract clients dispatch on to decide to retry."""
+    assert ErrorCode.RUNNER_RECYCLING == "runner_recycling"
+
+
+def test_runner_recycling_maps_to_503() -> None:
+    """A planned recycle aborted an in-flight relayed request — retryable 503,
+    not an opaque 500. If this drifts, clients stop retrying a recoverable
+    condition (or retry an unrecoverable one)."""
+    assert _CODE_TO_HTTP_STATUS[ErrorCode.RUNNER_RECYCLING] == 503
+
+
+def test_omnigent_error_with_runner_recycling_code_returns_503() -> None:
+    """End-to-end status resolution for the recycling code."""
+    err = OmnigentError("runner recycling", code=ErrorCode.RUNNER_RECYCLING)
+    assert err.http_status == 503
+    assert err.code == ErrorCode.RUNNER_RECYCLING


### PR DESCRIPTION
## Problem — a scheduled, server-initiated recycle surfaces to clients as an unretryable 500

When the server closes a runner tunnel for a **planned recycle** — a server-issued `host.stop_runner`, a managed runner-token TTL expiry (`_MANAGED_RUNNER_TOKEN_TTL_S`, 30 min), or a graceful shutdown — `TunnelRegistry.deregister()` aborts every in-flight request the server was relaying to that runner. Today those aborts raise a bare:

```
ConnectionError("tunnel closed before request completed")
```

which is not an `OmnigentError`, so it falls through the catch-all exception handler as an opaque **`500 internal_error`** — indistinguishable from a genuine server fault. A client whose request was aborted mid-recycle (e.g. a session create relayed to a host-bound runner) therefore has no signal that a **retry will succeed** against the replacement runner generation.

This is an **API-contract issue, not a rare race**: in a multi-runner host a fresh runner generation is spun up on a schedule (roughly every ~15 min, with the old generation retired ~30 min after it started), so a planned recycle — and the resulting 500 on any request in flight at that instant — is a *recurring, expected* event. A planned/graceful teardown should return a **retryable** error, not a generic 500.

This is the same class of "tunnel-close collateral is fixable, not inherent" that #1114 (*ws-tunnel closed mid-stream escapes as Unhandled ASGI exception; SSE stream truncated ungracefully*) established for the SSE-stream path; this PR addresses the request/relay path for the **planned** teardown.

## Fix — classify the planned-recycle abort as retryable (`503 runner_recycling` + `Retry-After`)

Tightly scoped to **error classification** — no drain window, no request rerouting:

- **`TunnelRecyclingError(ConnectionError)`** (registry) carries a `retry_after_s` hint. Subclassing `ConnectionError` means every existing `except ConnectionError` call site keeps catching it **unchanged**.
- **`TunnelRegistry.deregister(..., recycling=True)`** aborts in-flight requests with `TunnelRecyclingError`. The default (`recycling=False`, an abnormal drop) keeps the plain `ConnectionError` and its existing 500 behaviour — **no change** to the unplanned-drop path.
- The **runner tunnel route** sets `recycling=True` only on a clean WebSocket **normal-closure (1000)** — the graceful path — and never on an abnormal disconnect (e.g. ping-timeout `4003`).
- A new **`ErrorCode.RUNNER_RECYCLING` → 503** and a server exception handler map `TunnelRecyclingError` to `503 runner_recycling` with a `Retry-After` header, so callers know to retry.

### Why 503 + a distinct code
`RUNNER_UNAVAILABLE` already means "no runner online at all." A planned recycle is different: the request simply landed in the teardown window and a retry against the next generation succeeds. A distinct machine-readable `runner_recycling` code lets clients branch precisely, and `Retry-After` gives them a backoff.

## Tests

- `deregister(recycling=True)` aborts in-flight with a retryable `TunnelRecyclingError` (and default stays a plain `ConnectionError`, not the subclass).
- `RUNNER_RECYCLING` string value + `→ 503` mapping.
- Response builder shape (status / code / `Retry-After`, sub-second floor).
- Boundary: a route that raises `TunnelRecyclingError` returns `503 runner_recycling` + `Retry-After` (proving Starlette dispatches the `ConnectionError` subclass to the specific handler, not the 500 catch-all).
- The production `create_app` registers the handler.

All new + affected suites pass (`tests/test_errors.py`, `tests/runner/transports/ws_tunnel/`, `tests/server/integration/test_runner_tunnel_route.py`, and the new boundary test); `ruff check` + `ruff format --check` clean on the diff.

## Scope / non-goals
Deliberately excluded (possible follow-ups): a **graceful drain window** (stop routing new requests to a retiring runner and allow in-flight completion before closing the tunnel), and any in-flight **rerouting**. This PR only ensures the planned-recycle teardown is *reported* retryably.
