### PR TITLE
docs(harness-bench): explain each probe in plain terms + example output

### DIFF
--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -61,6 +61,33 @@ stdout report drops the grid and prints only the legend + notes -- no duplicate
 table. When stdout is redirected to a file, the report keeps the full grid so
 the file is self-contained.
 
+### Example output
+
+A live `--rich` run of the four SDK harnesses on the `oss` profile:
+
+```console
+$ uv run --no-sync python -m tests.harness_bench --profile oss --rich \
+    --harness claude-sdk --harness codex --harness pi --harness openai-agents
+
+                              Harness capability matrix (live)
+┌───────────────────────────┬────────────┬───────────┬──────────────┬─────────────┬────────────────┬───────────┐
+│ Harness                   │ Basic turn │ Streaming │ Tool calling │ Policy DENY │ Model override │ Interrupt │
+├───────────────────────────┼────────────┼───────────┼──────────────┼─────────────┼────────────────┼───────────┤
+│ claude-sdk  [full-server] │     ✓      │     ✓     │      ✓       │     ✓       │       ✓        │     ✓     │
+│ codex       [full-server] │     ✓      │     ✓     │      ✓       │     ·       │       ✓        │     ✓     │
+│ pi          [full-server] │     ✓      │     ✓     │      ✓       │     ✓       │       ✓        │     ✓     │
+│ openai-agents [full-server] │   ✓      │     ✓     │      ✓       │     ✓       │       ✓        │     ✓     │
+└───────────────────────────┴────────────┴───────────┴──────────────┴─────────────┴────────────────┴───────────┘
+Legend: `✓` SUPPORTED · `~` PARTIAL · `✗` UNSUPPORTED · `—` NOT_APPLICABLE · `?` UNKNOWN · `·` SKIPPED · `!!` DRIFT
+
+Notes:
+- codex / Policy DENY: · model never attempted the tool; tool-call DENY path not exercised
+```
+
+The `·` in codex / Policy DENY is a clean SKIP, not a failure: the model simply
+never reached for the gated tool, so the deny path had nothing to block (see the
+Notes line). Every non-`✓` cell gets a matching Notes entry.
+
 ## Transport selection
 
 A profile's `transport` field is the harness *family* marker, not the literal
@@ -76,9 +103,22 @@ driver the run uses:
 
 ## What it reports (P0 dimensions)
 
-`basic_turn`, `streaming`, `tool_calling`, `interrupt`, `policy_deny`,
-`model_override`. Verdicts map to the support-matrix glyphs
-(`✓ ~ ✗ — ?`), plus `·` skipped and `!! DRIFT`.
+The six P0 dimensions are `basic_turn`, `streaming`, `tool_calling`,
+`policy_deny`, `model_override`, `interrupt`. Each probe drives one real turn
+and watches what the harness does:
+
+| Probe | In plain terms |
+| --- | --- |
+| **Basic turn** | Can it hold a conversation at all? Asks it to echo a marker and checks the marker comes back -- the "is it alive" test. |
+| **Streaming** | Does the answer arrive incrementally (word-by-word) or all at once at the end? Counts the token-level chunks. |
+| **Tool calling** | Can it use a tool (run a command, read a file) mid-answer, not just chat? |
+| **Policy DENY** | If a policy says "block that tool", does the harness actually enforce it? |
+| **Model override** | If you ask for a specific model, does it actually run that one? |
+| **Interrupt** | If you stop it mid-answer, does it actually stop? |
+
+Each cell is a verdict: **✓** works, **✗** doesn't, **·** couldn't be tested
+here (see below), **!!** the harness *declared* it works but the probe observed
+otherwise (drift).
 
 A `·` always means "the bench did not measure this here", never "the harness
 lacks it". In particular Tool calling and Policy DENY only get a real verdict


### PR DESCRIPTION
## Summary

The harness capability bench (`tests/harness_bench/`) renders a matrix of
verdicts per capability dimension, but the README only listed the dimension
identifiers (`basic_turn`, `streaming`, ...) with the glyph legend. A reader who
had not built the bench could not tell what each probe actually checks or how to
read a `·`.

This adds two docs-only sections to `tests/harness_bench/README.md`:

- **What each probe does** -- a table describing the six P0 dimensions (Basic
  turn, Streaming, Tool calling, Policy DENY, Model override, Interrupt) in plain
  terms, plus a short verdict-glyph key (`✓` works, `✗` doesn't, `·` not tested
  here, `!!` drift).
- **Example output** -- a live `--rich` run of the four SDK harnesses on the
  `oss` profile, illustrating how a diagnosed `·` SKIP (codex / Policy DENY)
  reads against its Notes line, so a skipped cell is never opaque.

No code change; behavior is unchanged.

## Test Plan

Docs only. Verified the markdown renders (table + fenced console block) and that
no formatting hook applies to this path -- `web-prettier` is scoped to `^web/`,
so `tests/harness_bench/README.md` has no prettier gate. `git status` shows only
the README modified (no `uv.lock` drift).

## Demo

N/A -- documentation only, no UI or frontend change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] UI / frontend change

## Test coverage

- [ ] Added or updated automated tests
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Documentation-only change to a README; there is no behavior to cover with an
automated test. Verified manually by rendering the markdown and confirming the
described probes and glyphs match the current bench output and legend.
