### PR TITLE
ci(images): publish nightly + release only, add PR build check

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,82 @@
+# Build-only Docker check for PRs. Compensates for retiring per-commit main
+# publishes (oss-publish-images.yml now builds on tags + nightly only): a broken
+# Dockerfile / lockfile / frontend build would otherwise not surface until the
+# nightly rebuild or a release. Builds the server image single-arch (linux/amd64)
+# with the GHA layer cache and runs a `omnigent --help` CLI smoke. It never pushes.
+#
+# Scope: the server target exercises the shared builder stage (Python deps +
+# web SPA build) that all four published variants inherit, so it catches the
+# common breakage without paying for the host/openshell/kubernetes variants or
+# the emulated arm64 leg.
+#
+# Report-only for now: this check is NOT in .github/scripts/merge-ready/
+# required.sh, so it shows on every PR but does not block merge. Once its timing
+# and reliability are proven, promote it to blocking by adding "Docker build" to
+# REQUIRED (and ALLOW_SKIP, since the paths filter can legitimately skip it) in
+# required.sh, and add the `"Docker build"* ) echo "Docker build" ;;` arm to
+# workflow_for() there.
+name: Docker build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    # Only build when something that lands in the image changes. Mirrors the
+    # publish workflow's former push paths (web/** IS included here — the image
+    # bakes the SPA, so a web-only PR can still break the build).
+    paths:
+      - 'deploy/docker/Dockerfile'
+      - 'deploy/docker/entrypoint.py'
+      - 'omnigent/**'
+      - 'web/**'
+      - 'sdks/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'uv.lock'
+      - 'web/package-lock.json'
+      - '.github/workflows/docker-build.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-build-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  # Security precondition gate (security-gate.yml): untrusted PRs wait for the
+  # scan before the build runs on their code; trusted authors pass through.
+  gate:
+    uses: ./.github/workflows/security-gate.yml
+
+  build:
+    name: Docker build
+    needs: gate
+    # Draft PRs skip the build (ready_for_review re-fires the workflow), matching
+    # the pytest job in ci.yml.
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      # Single-arch (amd64) build, no push. load: true imports the result into
+      # the runner's Docker so the smoke step below can run it. Shares the same
+      # type=gha cache the publish workflow writes, so warm PRs reuse layers.
+      - name: Build server image (amd64, no push)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          push: false
+          load: true
+          tags: omnigent-server:pr-${{ github.event.pull_request.number || github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: CLI smoke
+        run: docker run --rm omnigent-server:pr-${{ github.event.pull_request.number || github.sha }} omnigent --help

--- a/.github/workflows/oss-publish-images.yml
+++ b/.github/workflows/oss-publish-images.yml
@@ -12,10 +12,8 @@
 #                   `pip install omnigent` resolves to. Pre-releases never move it.
 #   :latest-rc      the highest version OVERALL, max(release, rc) — the newest
 #                   thing tagged, pre-release or not.
-#   :latest-dev     the most recent main build (bleeding edge); moves on every
-#                   qualifying main commit.
-#   :latest-nightly the most recent main build as of the daily cron; retagged
-#                   from :latest-dev once a day (no rebuild).
+#   :latest-nightly the most recent nightly main build (bleeding edge); moves
+#                   once a day when the scheduled build rebuilds main HEAD.
 # Ordering for :latest / :latest-rc uses PEP 440 (1.2.3rc1 < 1.2.3), which
 # `sort -V` gets wrong, so the max is computed with .github/scripts/
 # oss-publish-images/maxver.py (Python `packaging`).
@@ -25,33 +23,21 @@
 name: Publish images (public)
 
 on:
+  # Release builds only — every v* tag push publishes the immutable version pin
+  # and moves the floating release tags. Per-commit main builds were retired in
+  # favour of the nightly rebuild below; PRs get a build-only check (docker-build.yml)
+  # so a broken image is caught before merge without a push.
   push:
-    branches: [main]
     tags: ['v*']
-    # Only rebuild when something that lands in the image changes.
-    paths:
-      - 'deploy/docker/Dockerfile'
-      - 'deploy/docker/entrypoint.py'
-      - 'omnigent/**'
-      - 'web/**'
-      - 'sdks/**'
-      - 'pyproject.toml'
-      - 'setup.py'
-      - 'uv.lock'
-      - 'web/package-lock.json'
-      - '.github/workflows/oss-publish-images.yml'
-  # Daily nightly promotion (07:00 UTC). Retags the current :latest-dev as
-  # :latest-nightly — handled by promote-nightly, not a rebuild.
+  # Nightly rebuild of main HEAD (07:00 UTC): the build-and-push job publishes
+  # :sha-<short> + :latest-nightly. This is what keeps bleeding-edge ~1 day
+  # fresh now that main commits no longer each trigger a build.
   schedule:
     - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
       bump_latest:
         description: 'Also move :latest to this build (manual release of latest). Off by default.'
-        type: boolean
-        default: false
-      force_nightly:
-        description: 'Promote :latest-dev -> :latest-nightly now (runs only the nightly job). Off by default.'
         type: boolean
         default: false
       reconcile_floating:
@@ -73,10 +59,11 @@ jobs:
     permissions:
       contents: read
       packages: write # push the image to GHCR via GITHUB_TOKEN
-    # Gated to this repository; inert in forks and mirrors. Skip the (re)build
-    # on schedule, force_nightly, and reconcile_floating dispatches — those only
-    # drive the promote-nightly / reconcile-floating jobs.
-    if: github.repository == 'omnigent-ai/omnigent' && github.event_name != 'schedule' && !inputs.force_nightly && !inputs.reconcile_floating
+    # Gated to this repository; inert in forks and mirrors. Runs on tag pushes,
+    # the nightly schedule (rebuild of main HEAD), and bump_latest dispatches.
+    # Skipped on reconcile_floating dispatches — that only drives the
+    # reconcile-floating retag job.
+    if: github.repository == 'omnigent-ai/omnigent' && !inputs.reconcile_floating
     runs-on: ubuntu-latest
     # Multi-arch: the linux/arm64 leg cross-builds under QEMU emulation on this
     # amd64 runner, which roughly doubles the host-image build time (emulated
@@ -141,9 +128,9 @@ jobs:
             KUBERNETES_TAGS="${KUBERNETES_TAGS},${KUBERNETES_IMAGE}:$1"
           }
 
-          # Every qualifying main commit moves :latest-dev (bleeding edge).
+          # The nightly rebuild of main moves :latest-nightly (bleeding edge).
           if [ "${GH_REF}" = "refs/heads/main" ]; then
-            add_tag "latest-dev"
+            add_tag "latest-nightly"
           fi
 
           if [[ "${GH_REF}" == refs/tags/v* ]]; then
@@ -328,43 +315,6 @@ jobs:
             kubernetes-sbom.cdx.json
             kubernetes-sbom.spdx.json
           retention-days: 90
-
-  promote-nightly:
-    # Daily cron (or a manual force_nightly dispatch): move :latest-nightly to
-    # the current main build by retagging :latest-dev with `crane tag`
-    # (digest-preserving, no rebuild).
-    if: github.repository == 'omnigent-ai/omnigent' && (github.event_name == 'schedule' || inputs.force_nightly)
-    permissions:
-      contents: read
-      packages: write # retag within GHCR via GITHUB_TOKEN
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Set up crane
-        uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0  # v0.6
-        with:
-          version: v0.21.6
-
-      - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Promote latest-dev -> latest-nightly
-        run: |
-          set -euo pipefail
-          # crane tag points a new tag at an EXISTING manifest digest without
-          # re-serializing it, so :latest-nightly keeps :latest-dev's exact digest.
-          for img in ghcr.io/omnigent-ai/omnigent-server ghcr.io/omnigent-ai/omnigent-host ghcr.io/omnigent-ai/omnigent-server-openshell ghcr.io/omnigent-ai/omnigent-server-kubernetes; do
-            if crane digest "${img}:latest-dev" >/dev/null 2>&1; then
-              crane tag "${img}:latest-dev" latest-nightly
-              echo "promoted ${img}:latest-dev -> :latest-nightly ($(crane digest "${img}:latest-nightly"))"
-            else
-              echo "::warning::${img}:latest-dev not found yet; skipping nightly promotion"
-            fi
-          done
 
   reconcile-floating:
     # Manual reconcile (workflow_dispatch with reconcile_floating=true): repoint


### PR DESCRIPTION
## Related issue

N/A

## Summary

Every PR merged into `main` triggered a full multi-arch image publish (four variants × amd64 + emulated arm64) — far more often than the images are actually consumed. This reduces the publish cadence and compensates for the lost per-merge build validation with a build-only PR check.

- **`oss-publish-images.yml` — publish on nightly + release only.** Dropped the per-commit `push: branches: [main]` trigger (kept `tags: ['v*']`). The existing daily cron (07:00 UTC) now **rebuilds main HEAD** and publishes `:sha-<short>` + `:latest-nightly` directly.
- **Retired `:latest-dev`.** With per-commit builds gone, `:latest-dev` (per-commit) and `:latest-nightly` (daily) would carry identical bits, so the nightly build tags `:latest-nightly` directly. This let me delete the now-dead `promote-nightly` retag job and the `force_nightly` dispatch input. `:latest`, `:latest-rc`, `:vX.Y.Z`, and the `reconcile-floating` job are unchanged.
- **`docker-build.yml` (new) — build-only PR check.** On PRs touching image-relevant paths (including `web/**`, since the image bakes the SPA), builds the server image single-arch (`linux/amd64`) with the shared `type=gha` layer cache and runs a `omnigent --help` smoke. **It never pushes.** Reuses the existing `security-gate.yml` and skips draft PRs, matching `ci.yml`.

**Report-only for now:** the new check is intentionally *not* in `merge-ready/required.sh`, so it surfaces on every PR without blocking merge. Promoting it to a blocking gate later is a documented one-step edit (add `"Docker build"` to `REQUIRED`/`ALLOW_SKIP` + a `workflow_for()` arm).

### ELI5

We were taking a full "print the shipping boxes" run on every single change, even though almost nobody grabs a box between the daily batch. Now we print once a night and on real releases. To make sure a change doesn't quietly break the box-printing machine in between, every PR does a dry run that builds a box but throws it away.

### Note for reviewers

Retiring per-commit publishes means `:latest-nightly` moves once a day (not per merge), and per-commit `:sha-<short>` tags are only produced for the nightly build + releases, not for every main commit. No workflow, script, or deploy manifest in the repo consumes `:latest-dev` or a mid-day per-commit `:sha` tag (grep-verified) — but flag it if any external consumer does.

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflows — parse clean; confirmed triggers (`oss-publish` push = `{tags: [v*]}` only), remaining jobs (`build-and-push`, `generate-sbom`, `reconcile-floating`), and dispatch inputs (`bump_latest`, `reconcile_floating`).
- Grep-verified zero residual references to `latest-dev` / `force_nightly` in `.github/`, and no external consumer of `:latest-dev` / the publish workflow.
- `pre-commit` / `actionlint` are not installed locally; the repo's PyYAML `check-yaml` hook is satisfied by the parse check above. Full `actionlint` runs on this PR via `Pre-commit checks`.

## Demo

N/A — CI-only change, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Workflow-only change; no unit-testable code path. Verified manually by parsing both YAML files and asserting the resulting trigger/job/input structure (see Test Plan), and by grepping the repo for stale references and external consumers of the retired tags. The new `docker-build.yml` build+smoke will exercise itself on this very PR (it touches `.github/workflows/docker-build.yml`, which is in its own paths filter).

## Changelog

DELETE THIS WHOLE SECTION — CI-only change, not user-facing.

This pull request and its description were written by Isaac.
