### PR TITLE
fix(claude-native): emit JSON-parseable toolUseResult on cold resume

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3671,7 +3671,7 @@ def _claude_transcript_record_from_session_item(
                 }
             ],
         }
-        extra["toolUseResult"] = output
+        extra["toolUseResult"] = _json_safe_tool_use_result(output)
     else:
         return None
     return {
@@ -3789,6 +3789,36 @@ def _json_object_from_string(value: object) -> dict[str, Any]:
     except json.JSONDecodeError:
         return {}
     return parsed if isinstance(parsed, dict) else {}
+
+
+def _json_safe_tool_use_result(output: str) -> str:
+    """
+    Return a ``toolUseResult`` value Claude Code can ``JSON.parse``.
+
+    Some built-in result renderers (notably ``TaskOutput``) call
+    ``JSON.parse`` on ``toolUseResult`` when the transcript is resumed.
+    A raw display string such as ``"<retrieval_status>timeout</...>"``
+    throws ``JSON Parse error: Unrecognized token '<'`` at TUI boot,
+    before the input prompt renders — so the whole resume fails and the
+    first web-UI message is never delivered.
+
+    Outputs that are already JSON (e.g. an image content-block array)
+    pass through verbatim; anything else is wrapped as a JSON string
+    literal so the parse always succeeds. The plain-text output still
+    lives verbatim in the ``tool_result`` content block, so this does
+    not change what the model or the web UI sees.
+
+    :param output: The tool result string synthesized for the
+        transcript, e.g. ``"<retrieval_status>timeout</...>"`` or
+        ``'[{"type":"image",...}]'``.
+    :returns: A JSON-parseable string for the record's
+        ``toolUseResult`` field.
+    """
+    try:
+        json.loads(output)
+    except (json.JSONDecodeError, ValueError):
+        return json.dumps(output)
+    return output
 
 
 def _preflight_local_tools(command: str) -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -6241,3 +6241,118 @@ def test_claude_transcript_records_handles_compaction_item() -> None:
     ]
     assert len(boundaries) == 1
     assert boundaries[0]["compactMetadata"]["postTokens"] == 4321
+
+
+@pytest.mark.parametrize(
+    ("output", "expected_parsed"),
+    [
+        # An angle-bracket display string (e.g. a TaskOutput result) is the
+        # regression case: Claude's TaskOutput renderer JSON.parses
+        # toolUseResult on resume and threw "Unrecognized token '<'" at boot.
+        (
+            "<retrieval_status>timeout</retrieval_status>",
+            "<retrieval_status>timeout</retrieval_status>",
+        ),
+        # A <tool_use_error> blob is the same hazard from a different tool.
+        (
+            "<tool_use_error>No task found</tool_use_error>",
+            "<tool_use_error>No task found</tool_use_error>",
+        ),
+        # Ordinary plain text must also round-trip to a string.
+        ("plain text output", "plain text output"),
+        # Already-JSON output (e.g. an image content-block array) must pass
+        # through verbatim, not get double-encoded into a string literal.
+        (
+            '[{"type":"image","source":{"type":"base64","data":"AAA"}}]',
+            [{"type": "image", "source": {"type": "base64", "data": "AAA"}}],
+        ),
+    ],
+)
+def test_claude_transcript_tool_use_result_is_json_parseable(
+    output: str,
+    expected_parsed: object,
+) -> None:
+    """
+    Synthesized ``toolUseResult`` must survive Claude's resume-time parse.
+
+    Claude Code ``JSON.parse``s ``toolUseResult`` for some built-in
+    renderers (``TaskOutput``). A raw ``<...>`` display string crashed
+    the TUI at boot before the input prompt rendered, so the resume
+    failed. The synthesizer must always emit a JSON-parseable value,
+    while leaving the ``tool_result`` content block as the verbatim
+    string the model and web UI see.
+    """
+    items: list[dict[str, Any]] = [
+        {
+            "id": "fco_1",
+            "response_id": "resp_1",
+            "type": "function_call_output",
+            "call_id": "toolu_1",
+            "output": output,
+        }
+    ]
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+    )
+    assert len(records) == 1
+    record = records[0]
+    # toolUseResult must parse without raising, and preserve the value.
+    assert json.loads(record["toolUseResult"]) == expected_parsed
+    # The tool_result content block keeps the raw string unchanged.
+    assert record["message"]["content"][0]["content"] == output
+
+
+def test_json_safe_tool_use_result_wraps_non_json() -> None:
+    """Non-JSON strings become a JSON string literal; JSON passes through."""
+    # A leading '<' is not valid JSON, so it is wrapped.
+    wrapped = claude_native._json_safe_tool_use_result("<x>y</x>")
+    assert json.loads(wrapped) == "<x>y</x>"
+    # A bare number is valid JSON and must not be re-wrapped.
+    assert claude_native._json_safe_tool_use_result("42") == "42"
+    # A JSON object string passes through unchanged.
+    assert claude_native._json_safe_tool_use_result('{"a":1}') == '{"a":1}'
+
+
+def test_tool_use_result_regression_old_flatten_would_crash_resume() -> None:
+    """
+    Pin the resume crash to the old ``toolUseResult = output`` flatten.
+
+    Claude Code ``JSON.parse``s ``toolUseResult`` for its ``TaskOutput``
+    renderer at resume time. A real ``isaac review`` result whose text
+    starts with ``<retrieval_status>...`` is not valid JSON, so the old
+    verbatim flatten crashed the TUI at boot with "Unrecognized token
+    '<'" before the input prompt rendered — the failure the user hit.
+
+    This models both sides of that parse: the pre-fix value would raise,
+    the value the synthesizer emits today does not. It fails if anyone
+    reverts to assigning ``output`` verbatim.
+    """
+    output = (
+        "<retrieval_status>timeout</retrieval_status>\n\n"
+        "<task_id>b51au379y</task_id>\n\n<status>running</status>"
+    )
+
+    # The synthesizer must emit a JSON-parseable toolUseResult. The old
+    # verbatim flatten stored the raw "<...>" string, which threw
+    # "Unrecognized token '<'" when Claude's TaskOutput renderer parsed it
+    # at resume — this assertion fails if that flatten is restored.
+    items: list[dict[str, Any]] = [
+        {
+            "id": "fco_1",
+            "response_id": "resp_1",
+            "type": "function_call_output",
+            "call_id": "toolu_1",
+            "output": output,
+        }
+    ]
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+    )
+    assert len(records) == 1
+    assert json.loads(records[0]["toolUseResult"]) == output


### PR DESCRIPTION
## Related issue

N/A

## Summary

Resuming a claude-native session from the web UI could crash the `claude` CLI at boot with `JSON Parse error: Unrecognized token '<'`. Its input prompt never rendered, so the readiness gate timed out after 30s and the first message was never delivered — surfaced to the user as a `RuntimeError: Claude Code terminal did not become ready within 30.0s`.

- **Root cause:** on cold resume (session exists, no live terminal), the wrapper rewrites Claude's local `~/.claude/projects/.../<sid>.jsonl` from committed Omnigent items and unconditionally stores the tool result string as `toolUseResult`. Claude Code's `TaskOutput` result renderer `JSON.parse`s that field at resume time, so a plain display string — e.g. an `isaac review` result starting with `<retrieval_status>...` — threw at startup. (The `tool_result` content block is fine; only `toolUseResult` is parsed, and only for certain renderers like `TaskOutput`.)
- **Fix:** add `_json_safe_tool_use_result` — outputs that are already JSON (e.g. image content-block arrays) pass through verbatim; anything else is wrapped as a JSON string literal so the parse always succeeds. The verbatim string still lives in the `tool_result` content block, so what the model and web UI see is unchanged.

## Test Plan

- New unit tests in `tests/test_claude_native.py`:
  - `test_claude_transcript_tool_use_result_is_json_parseable` — parametrized over the crash inputs (`<retrieval_status>…`, `<tool_use_error>…`, plain text, and an already-JSON image array); asserts every synthesized `toolUseResult` parses, preserves its value, and that the `tool_result` content block stays the verbatim string.
  - `test_json_safe_tool_use_result_wraps_non_json` — helper unit test (wraps `<...>`, leaves bare numbers/JSON objects untouched).
  - `test_tool_use_result_regression_old_flatten_would_crash_resume` — regression guard on the exact resume-time parse. Verified it **fails** when the fix is reverted to the old verbatim flatten, and passes with the fix.
- Full module: `pytest tests/test_claude_native.py` → 137 passed.
- End-to-end: regenerated the real poisoned transcript through the fixed helper and resumed the actual `claude` TUI → 0 parse errors, prompt renders.
- `ruff format` + `ruff check`: clean.

## Demo

N/A — non-visual fix (terminal/transcript synthesis).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: reproduced the original `JSON Parse error: Unrecognized token '<'` crash by resuming the real affected session's transcript in the `claude` TUI inside tmux, confirmed the fixed synthesizer regenerates a transcript that boots cleanly (0 parse errors, prompt renders), and confirmed the regression test fails when the fix is reverted.

## Changelog

Fixed a crash when resuming a Claude-native session whose history contained a `TaskOutput` (or similar) result, so resume no longer times out with a terminal-not-ready error.
