### PR TITLE
Add Python line counting script

### DIFF
--- a/count_py_lines.py
+++ b/count_py_lines.py
@@ -9,26 +9,43 @@ from pathlib import Path
 def count_lines(path: Path) -> int | None:
     """Return the number of lines in path, or None if it cannot be read."""
     try:
-        with path.open("r", encoding="utf-8") as file:
-            return sum(1 for _ in file)
+        count = 0
+        saw_data = False
+        last_byte = b""
+        with path.open("rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                count += chunk.count(b"\n")
+                saw_data = True
+                last_byte = chunk[-1:]
+        if saw_data and last_byte != b"\n":
+            count += 1
+        return count
     except OSError as exc:
-        print(f"Skipping {path}: {exc}", file=sys.stderr)
-    except UnicodeError as exc:
         print(f"Skipping {path}: {exc}", file=sys.stderr)
     return None
 
 
 def main() -> int:
     folder = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    if not folder.is_dir():
+        print(f"Error: {folder} is not an existing directory", file=sys.stderr)
+        return 1
+
     total = 0
 
-    for path in sorted(folder.rglob("*.py")):
-        line_count = count_lines(path)
-        if line_count is None:
-            continue
+    for directory, directory_names, filenames in folder.walk(follow_symlinks=False):
+        directory_names.sort()
+        for filename in sorted(filenames):
+            path = directory / filename
+            if path.suffix != ".py":
+                continue
 
-        print(f"{path}: {line_count}")
-        total += line_count
+            line_count = count_lines(path)
+            if line_count is None:
+                continue
+
+            print(f"{path}: {line_count}")
+            total += line_count
 
     print(f"Total: {total}")
     return 0

--- a/count_py_lines.py
+++ b/count_py_lines.py
@@ -1,0 +1,38 @@
+"""Count lines in Python files under a folder."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def count_lines(path: Path) -> int | None:
+    """Return the number of lines in path, or None if it cannot be read."""
+    try:
+        with path.open("r", encoding="utf-8") as file:
+            return sum(1 for _ in file)
+    except OSError as exc:
+        print(f"Skipping {path}: {exc}", file=sys.stderr)
+    except UnicodeError as exc:
+        print(f"Skipping {path}: {exc}", file=sys.stderr)
+    return None
+
+
+def main() -> int:
+    folder = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    total = 0
+
+    for path in sorted(folder.rglob("*.py")):
+        line_count = count_lines(path)
+        if line_count is None:
+            continue
+
+        print(f"{path}: {line_count}")
+        total += line_count
+
+    print(f"Total: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add `count_py_lines.py`, a small standard-library script that recursively counts lines in `.py` files for the current directory or an optional folder argument.
- Report unreadable files to stderr and continue counting the remaining files.

## Test Plan

- `python3 count_py_lines.py .`
- `uv run --extra dev pre-commit run --all-files`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the script runs against the repository root and reports per-file counts plus the total. Ran the full pre-commit suite with the dev extra.

## Changelog

Add a helper script for counting Python lines in a folder.