### PR TITLE
ci(images): make the Docker build check a required merge gate

### DIFF
--- a/.github/scripts/merge-ready/required.sh
+++ b/.github/scripts/merge-ready/required.sh
@@ -8,6 +8,7 @@
 
 REQUIRED=(
   "Pre-commit checks"
+  "Docker build"
   "Pytest (runtime-harnesses)"
   "Pytest (runtime-policies)"
   "Pytest (runtime-core)"
@@ -37,6 +38,7 @@ REQUIRED=(
 )
 
 ALLOW_SKIP=(
+  "Docker build"
   "Pytest (runtime-harnesses)"
   "Pytest (runtime-policies)"
   "Pytest (runtime-core)"
@@ -73,6 +75,7 @@ is_allow_skip() { printf '%s\n' "${ALLOW_SKIP[@]}" | grep -qxF "$1"; }
 # workflow is still queued or re-running.
 workflow_for() {
   case "$1" in
+    "Docker build")          echo "Docker build" ;;
     "Pytest ("*)             echo "CI" ;;
     "E2E Tests (shard "*)    echo "E2E Tests" ;;
     "E2E UI Tests (shard "*) echo "E2E UI Tests" ;;

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,12 +9,11 @@
 # common breakage without paying for the host/openshell/kubernetes variants or
 # the emulated arm64 leg.
 #
-# Report-only for now: this check is NOT in .github/scripts/merge-ready/
-# required.sh, so it shows on every PR but does not block merge. Once its timing
-# and reliability are proven, promote it to blocking by adding "Docker build" to
-# REQUIRED (and ALLOW_SKIP, since the paths filter can legitimately skip it) in
-# required.sh, and add the `"Docker build"* ) echo "Docker build" ;;` arm to
-# workflow_for() there.
+# Blocking merge-gate check: "Docker build" is in the REQUIRED list in
+# .github/scripts/merge-ready/required.sh. Because of the paths filter below it
+# can legitimately be absent (a PR touching nothing in the image), so it is also
+# in ALLOW_SKIP with a workflow_for() arm, and this workflow's name is in
+# merge-ready.yml's workflow_run list so the gate re-evaluates when it completes.
 name: Docker build
 
 on:

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -27,7 +27,7 @@ on:
   pull_request_target:
     types: [labeled]
   workflow_run:
-    workflows: [PR Template, CI, Lint, E2E UI Tests, E2E Tests, Integration Tests]
+    workflows: [PR Template, CI, Lint, Docker build, E2E UI Tests, E2E Tests, Integration Tests]
     types: [completed]
   issue_comment:
     types: [created]


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #2288, which added a report-only Docker `build`-only check on PRs. It ran on that PR in **~1m28s** (cache-cold) and passed, so this promotes it from report-only to a **blocking merge gate**.

- **`required.sh`** — add `"Docker build"` to `REQUIRED`, and to `ALLOW_SKIP` with a `workflow_for()` arm. The check has a `paths:` filter, so a PR that touches nothing image-relevant won't run it and the check will be *absent*; `evaluate-checks.sh` treats a missing `ALLOW_SKIP` check as green only when its owning workflow legitimately didn't run (path-ignored / conditionally-excluded / fork-or-draft-gated), so a path-skipped PR won't strand the gate.
- **`merge-ready.yml`** — add `Docker build` to the `workflow_run.workflows` list so the gate re-evaluates the moment the build completes, rather than waiting on an unrelated workflow to re-trigger it.
- **`docker-build.yml`** — header comment updated from "report-only" to describe the blocking wiring.

### Maintainer vs. non-maintainer (fork) PRs — no difference

This was the main concern, and it's safe:
- The build runs with `push: false` — no secrets, no registry login, no GHCR write. A fork runs it identically to a maintainer PR (nothing to gate on `github.repository`).
- It already declares `needs: gate` → `security-gate.yml`, so untrusted fork code waits for the security scan before the build runs, same as every Pytest shard.
- Draft PRs produce a `skipped` conclusion that `ALLOW_SKIP` accepts.

The only fork nuance: forks can't write the org's GHA layer cache, so a fork build is always cache-cold (~1.5–3 min) rather than the sub-minute warm case. Still well within tolerance.

## Test Plan

- Sourced `required.sh` and asserted `Docker build` is in `REQUIRED` (28) and `ALLOW_SKIP` (27), and `workflow_for("Docker build")` → `Docker build`.
- `yaml.safe_load` on `merge-ready.yml`; confirmed `Docker build` in the `workflow_run.workflows` list.
- `uv run --extra dev pytest tests/scripts/test_merge_ready_compute_gate.py` — 3 passed.
- This PR itself does **not** touch image paths, so the `Docker build` check should be legitimately absent here and the gate should treat it as an allowed skip — a live test of the ALLOW_SKIP wiring.

## Demo

N/A — CI-only change, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Gate-config change; verified by sourcing `required.sh` and asserting the three wiring points, parsing `merge-ready.yml`, and running the existing merge-ready gate test (3 passed). The ALLOW_SKIP path is additionally exercised live by this very PR, which doesn't touch image paths.

## Changelog

DELETE THIS WHOLE SECTION — CI-only change, not user-facing.

This pull request and its description were written by Isaac.
