### PR TITLE
feat(claude-sdk): add a Vertex AI gateway path for Claude

### DIFF
--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -72,6 +72,44 @@ gateway / `auth.type: databricks` does not apply. Authenticate it with
 `auth: {type: api_key, api_key: ${CURSOR_API_KEY}}`, and choose a Cursor model
 id (e.g. `auto`, `gpt-5`) rather than a `databricks-*` id.
 
+### Claude on Vertex AI
+
+`harness: claude-sdk` can also route to Claude models hosted on Google's
+Vertex AI, as an alternative to the Databricks gateway or direct Anthropic
+API. Opt in via `executor.config` — the same `vertex`/`project`/`location`
+keys the [Antigravity](#antigravity-gemini) harness uses:
+
+```yaml
+executor:
+  harness: claude-sdk
+  model: claude-sonnet-4-5-20250929   # Anthropic's native dash-dated id
+  config:
+    vertex: true
+    project: my-gcp-project
+    location: global                  # or a region, e.g. us-east5
+```
+
+Vertex's Anthropic integration uses a different wire shape than the plain
+Anthropic API the Claude CLI's `ANTHROPIC_BASE_URL` normally targets
+(`:rawPredict`/`:streamRawPredict` instead of `/v1/messages`, the model id
+in the URL path using Vertex's `@`-dated form instead of Anthropic's
+dash-dated form, `anthropic_version` injected into the body, and GCP OAuth2
+bearer auth instead of an Anthropic API key). A local
+[`VertexAnthropicGatewayShim`](../omnigent/inner/vertex_anthropic_shim.py)
+translates transparently, so the CLI is never aware it's talking to Vertex.
+
+GCP credentials are resolved via Application Default Credentials
+(`gcloud auth application-default login`, or `GOOGLE_APPLICATION_CREDENTIALS`
+for a service account key) in Omnigent's own process — not inside the Claude
+CLI subprocess the harness spawns, which may be sandboxed. This is the reason
+to prefer this path over Claude's own native `CLAUDE_CODE_USE_VERTEX=1`
+support: that reads GCP credentials directly inside the CLI process, which
+would expose them to a sandboxed subprocess.
+
+Mutually exclusive with the Databricks/generic gateway path (`auth.type:
+databricks`, or an `auth.type: api_key` with a `base_url`) — a spec setting
+both raises at executor construction time.
+
 The `kiro-native` harness is the native Kiro CLI terminal path used by
 `omnigent kiro`. It requires `kiro-cli` on `PATH` and Kiro's own login/auth; it
 does not use Databricks, OpenAI, or Anthropic provider credentials. Plain

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -83,6 +83,7 @@ from .sandbox import (
     with_additional_write_files,
     with_additional_write_roots,
 )
+from .vertex_anthropic_shim import PLACEHOLDER_API_KEY, VertexAnthropicGatewayShim
 
 logger = logging.getLogger(__name__)
 
@@ -1422,6 +1423,8 @@ class ClaudeSDKExecutor(Executor):
         base_url_override: str | None = None,
         gateway_auth_command: str | None = None,
         gateway_auth_refresh_interval_ms: str | None = None,
+        vertex_project: str | None = None,
+        vertex_location: str = "global",
         retry_policy: RetryPolicy | None = None,
         bundle_dir: pathlib.Path | None = None,
         agent_name: str | None = None,
@@ -1469,6 +1472,22 @@ class ClaudeSDKExecutor(Executor):
             gateway_auth_refresh_interval_ms: Refresh TTL as a string,
                 e.g. ``"900000"``. Set from
                 ``HARNESS_CLAUDE_SDK_GATEWAY_AUTH_REFRESH_INTERVAL_MS``.
+            vertex_project: GCP project id with Claude enabled on Vertex
+                AI. When set, routes through
+                :class:`~omnigent.inner.vertex_anthropic_shim.VertexAnthropicGatewayShim`
+                instead of the generic/Databricks gateway path — Vertex's
+                Claude integration uses a different wire shape
+                (``:rawPredict``/``:streamRawPredict``, GCP OAuth2 bearer
+                auth resolved from Application Default Credentials in
+                this process, never inside the sandboxed CLI subprocess)
+                that the generic gateway shim doesn't translate. Set from
+                ``HARNESS_CLAUDE_SDK_VERTEX_PROJECT``. Mutually exclusive
+                with ``gateway=True`` — a spec that sets both is a config
+                error (see the constructor's validation).
+            vertex_location: Vertex location, e.g. ``"global"`` or
+                ``"us-east5"``. Set from
+                ``HARNESS_CLAUDE_SDK_VERTEX_LOCATION``, defaulting to
+                ``"global"``. Ignored unless *vertex_project* is set.
             bundle_dir: Materialized agent-bundle root, when the agent
                 ships its own ``skills/`` directory. Used to expose
                 bundled skills to Claude via ``--plugin-dir <bundle>``
@@ -1509,6 +1528,17 @@ class ClaudeSDKExecutor(Executor):
                 "Set executor.profile in the agent spec, or configure a "
                 "Databricks provider with `omnigent setup`, to route through "
                 "the Databricks Anthropic gateway."
+            )
+        # Fail loud: the two transports set ANTHROPIC_BASE_URL in
+        # incompatible ways (a real upstream to intercept vs. a sentinel
+        # this executor invents itself); combining them would silently
+        # pick whichever wins the extra_env update order.
+        if gateway and vertex_project is not None:
+            raise ValueError(
+                "ClaudeSDKExecutor got both gateway=True and vertex_project="
+                f"{vertex_project!r}; these are mutually exclusive transports. "
+                "Vertex AI is its own gateway-like path — do not also set "
+                "executor.profile / a generic gateway provider."
             )
         self._cwd = cwd
         self._os_env_spec = os_env
@@ -1597,6 +1627,16 @@ class ClaudeSDKExecutor(Executor):
         # Started on the first gateway turn — __init__ has no event loop.
         self._gateway_shim: ClaudeGatewayShim | None = None
 
+        # Lazily-started local proxy that translates Anthropic Messages
+        # API requests into Vertex AI's rawPredict/streamRawPredict shape
+        # (see vertex_anthropic_shim.py). Started on the first turn, same
+        # lifecycle as _gateway_shim, but a distinct attribute — the two
+        # transports are mutually exclusive (validated above) and proxy
+        # fundamentally different upstream contracts.
+        self._vertex_project = vertex_project
+        self._vertex_location = vertex_location
+        self._vertex_shim: VertexAnthropicGatewayShim | None = None
+
         # Eagerly resolve the gateway transport env so errors surface at
         # construction time.
         self._extra_env: dict[str, str] = {}
@@ -1615,6 +1655,17 @@ class ClaudeSDKExecutor(Executor):
                     "~/.databrickscfg profile."
                 )
             self._extra_env.update(gateway_env)
+        elif vertex_project is not None:
+            # No real upstream ANTHROPIC_BASE_URL exists to intercept here
+            # (unlike the gateway path) — Claude's own Vertex support goes
+            # through CLAUDE_CODE_USE_VERTEX, not ANTHROPIC_BASE_URL, and
+            # that path reads GCP credentials directly inside the CLI
+            # subprocess, which is exactly what this transport avoids. This
+            # sentinel exists only so an unexpected failure to reach
+            # _route_options_through_gateway_shim (a future bug, not a
+            # normal outcome) produces an obviously-broken URL instead of
+            # a silently wrong one.
+            self._extra_env["ANTHROPIC_BASE_URL"] = "https://vertex-anthropic.invalid"
         self._extra_env[_CLAUDE_CODE_ENABLE_TOOL_SEARCH_ENV] = "true"
 
         # Retry policy → Anthropic SDK env vars passed to the Claude
@@ -1648,8 +1699,17 @@ class ClaudeSDKExecutor(Executor):
         from its requests (experimental betas are disabled there),
         which silences opus thinking; the shim restores the field. See
         the :mod:`~omnigent.inner.claude_gateway_shim` module
-        docstring for the full failure chain. No-op off the gateway
-        path.
+        docstring for the full failure chain.
+
+        On the Vertex AI path (mutually exclusive with the gateway path;
+        validated in ``__init__``), routes through
+        :class:`~omnigent.inner.vertex_anthropic_shim.VertexAnthropicGatewayShim`
+        instead, which translates the request into Vertex's
+        ``:rawPredict``/``:streamRawPredict`` shape and resolves a GCP
+        access token in this process — the sandboxed CLI subprocess never
+        sees a GCP credential.
+
+        No-op when neither transport is configured.
 
         :param options: SDK options about to be passed to
             ``ClaudeSDKClient``; ``options.env["ANTHROPIC_BASE_URL"]``
@@ -1658,6 +1718,25 @@ class ClaudeSDKExecutor(Executor):
             without an ``ANTHROPIC_BASE_URL`` — a config bug that
             would silently bypass the shim.
         """
+        if self._vertex_project is not None:
+            if self._vertex_shim is None:
+                self._vertex_shim = VertexAnthropicGatewayShim(
+                    project=self._vertex_project,
+                    location=self._vertex_location,
+                )
+            await self._vertex_shim.start()
+            env = getattr(options, "env", None)
+            if isinstance(env, dict):
+                env["ANTHROPIC_BASE_URL"] = self._vertex_shim.base_url
+                # The shim never reads this value (its real auth is a GCP
+                # token attached upstream — see PLACEHOLDER_API_KEY docs),
+                # but the CLI itself refuses to run with no key at all and
+                # reports "Not logged in". ANTHROPIC_API_KEY is stripped
+                # from os.environ (not options.env) around the connect
+                # call below, so setting it here — a later merge layer —
+                # survives that strip.
+                env["ANTHROPIC_API_KEY"] = PLACEHOLDER_API_KEY
+            return
         if not self._gateway:
             return
         env = getattr(options, "env", None)
@@ -1719,6 +1798,20 @@ class ClaudeSDKExecutor(Executor):
                 # non-gateway branch re-adds the key through ``options.env``,
                 # which wins over os.environ, and a non-gateway session keeps
                 # whatever it inherited.
+                #
+                # On the vertex-shim path, the env vars the CLI's own native
+                # Vertex support keys off (CLAUDE_CODE_USE_VERTEX,
+                # ANTHROPIC_VERTEX_PROJECT_ID, CLOUD_ML_REGION — see
+                # ``onboarding/ambient.py``'s vertex-claude detection) must
+                # also be absent from the child env, not just left at
+                # whatever the calling process happens to have ambiently
+                # set (e.g. a developer's own shell already configured for
+                # Claude-on-Vertex). If left in place, the CLI ignores our
+                # ``ANTHROPIC_BASE_URL`` sentinel and goes straight to
+                # native Vertex-via-ADC inside the (possibly sandboxed)
+                # child process — silently defeating the entire point of
+                # the shim, which exists specifically to keep GCP ADC out
+                # of that child's reach.
                 sdk_env = getattr(options, "env", None)
                 with ExitStack() as env_stack:
                     env_stack.enter_context(_unset_env_var("CLAUDECODE"))
@@ -1727,6 +1820,14 @@ class ClaudeSDKExecutor(Executor):
                         env_stack.enter_context(
                             _unset_env_var("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS")
                         )
+                    if self._vertex_project is not None:
+                        for _native_vertex_var in (
+                            "CLAUDE_CODE_USE_VERTEX",
+                            "ANTHROPIC_VERTEX_PROJECT_ID",
+                            "ANTHROPIC_VERTEX_REGION",
+                            "CLOUD_ML_REGION",
+                        ):
+                            env_stack.enter_context(_unset_env_var(_native_vertex_var))
                     await asyncio.wait_for(client.connect(), timeout=_CONNECT_TIMEOUT_SECONDS)
             except asyncio.TimeoutError as exc:
                 await self._force_close_client(client)
@@ -1840,6 +1941,9 @@ class ClaudeSDKExecutor(Executor):
         if self._gateway_shim is not None:
             await self._gateway_shim.aclose()
             self._gateway_shim = None
+        if self._vertex_shim is not None:
+            await self._vertex_shim.aclose()
+            self._vertex_shim = None
 
     async def interrupt_session(self, session_key: str) -> bool:
         state = self._clients.get(session_key)

--- a/omnigent/inner/claude_sdk_harness.py
+++ b/omnigent/inner/claude_sdk_harness.py
@@ -81,6 +81,17 @@ Env vars read at startup:
   stable plugin name (so bundled skills show as
   ``<agent>:<skill>`` rather than the bundle's tmpdir
   basename).
+- ``HARNESS_CLAUDE_SDK_VERTEX_PROJECT``: GCP project id with
+  Claude enabled on Vertex AI. When set, routes through
+  :class:`omnigent.inner.vertex_anthropic_shim.VertexAnthropicGatewayShim`
+  instead of the gateway transport — mutually exclusive with
+  ``HARNESS_CLAUDE_SDK_GATEWAY`` (the inner executor's
+  constructor rejects both being set). Authenticated by GCP
+  Application Default Credentials resolved in this process; the
+  sandboxed Claude CLI subprocess never sees a GCP credential.
+- ``HARNESS_CLAUDE_SDK_VERTEX_LOCATION``: Vertex location, e.g.
+  ``"global"`` or ``"us-east5"``. Defaults to ``"global"``.
+  Ignored unless ``HARNESS_CLAUDE_SDK_VERTEX_PROJECT`` is set.
 """
 
 from __future__ import annotations
@@ -117,6 +128,11 @@ _ENV_AGENT_NAME = "HARNESS_CLAUDE_SDK_AGENT_NAME"
 _ENV_GATEWAY_BASE_URL = "HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL"
 _ENV_GATEWAY_AUTH_COMMAND = "HARNESS_CLAUDE_SDK_GATEWAY_AUTH_COMMAND"
 _ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS = "HARNESS_CLAUDE_SDK_GATEWAY_AUTH_REFRESH_INTERVAL_MS"
+# GCP project/location for Claude on Vertex AI — mutually exclusive with the
+# gateway env vars above (validated by ClaudeSDKExecutor.__init__). See
+# vertex_anthropic_shim.py and the module docstring's Vertex AI entry.
+_ENV_VERTEX_PROJECT = "HARNESS_CLAUDE_SDK_VERTEX_PROJECT"
+_ENV_VERTEX_LOCATION = "HARNESS_CLAUDE_SDK_VERTEX_LOCATION"
 # Shell command the Claude CLI invokes to retrieve a bearer token.
 # Set by the Omnigent workflow layer when executor.auth: {type: api_key, …} is
 # declared.  Passed into ClaudeSDKExecutor.api_key_helper so it reaches
@@ -291,6 +307,8 @@ def _build_claude_sdk_executor() -> Executor:
         gateway_auth_command=os.environ.get(_ENV_GATEWAY_AUTH_COMMAND) or None,
         gateway_auth_refresh_interval_ms=os.environ.get(_ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS)
         or None,
+        vertex_project=os.environ.get(_ENV_VERTEX_PROJECT) or None,
+        vertex_location=os.environ.get(_ENV_VERTEX_LOCATION) or "global",
         retry_policy=_resolve_retry_policy(),
         bundle_dir=bundle_dir,
         agent_name=agent_name,

--- a/omnigent/inner/vertex_anthropic_shim.py
+++ b/omnigent/inner/vertex_anthropic_shim.py
@@ -1,0 +1,533 @@
+"""Local reverse proxy that lets the Claude CLI reach Claude on Vertex AI.
+
+Google exposes Anthropic's models on Vertex AI through its Model Garden
+partner integration, which uses a different wire shape than the plain
+Anthropic API the Claude CLI's ``ANTHROPIC_BASE_URL`` normally targets:
+
+- Path: ``.../publishers/anthropic/models/<model>:rawPredict`` (or
+  ``:streamRawPredict`` for streaming) instead of ``/v1/messages``. The
+  model id is part of the URL, not the request body, and uses Vertex's
+  ``@``-dated form (``claude-haiku-4-5@20251001``) rather than Anthropic's
+  own dash-dated form (``claude-haiku-4-5-20251001``).
+- Body: requires an injected ``anthropic_version`` field (Vertex has no
+  equivalent of the plain API's ``anthropic-version`` header).
+- Auth: a GCP OAuth2 access token (``Authorization: Bearer ...``), not an
+  Anthropic API key — and that token must come from Application Default
+  Credentials resolved in this (unsandboxed) process, never from inside
+  the sandboxed Claude CLI subprocess the executor spawns.
+
+This shim sits between the CLI and Vertex, translating one Anthropic
+Messages API request (whatever the CLI would have sent to
+``api.anthropic.com/v1/messages``) into the equivalent Vertex rawPredict
+call, and forwarding the response back unchanged — Vertex's response body
+and SSE stream shape already match Anthropic's native Messages API, so no
+response-side translation is needed.
+
+Request/response shapes and the exact rawPredict path were confirmed
+against a real Vertex AI project with Claude enabled, using the Claude
+CLI's own (``CLAUDE_CODE_USE_VERTEX=1``) debug log as ground truth for the
+path format, and live calls to Vertex to validate the request/response
+shape end to end (including tool use and streaming).
+
+See ``ClaudeGatewayShim`` (``claude_gateway_shim.py``) for the sibling
+shim used for the Databricks AI Gateway path — that one proxies to an
+already-Anthropic-shaped upstream and only patches specific body fields,
+so it doesn't need to know about Vertex's different path/body/auth shape
+at all. This module is intentionally separate rather than a mode flag on
+that class: the two proxy fundamentally different upstream contracts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable, Iterator, MutableMapping
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+import httpx
+import uvicorn
+
+if TYPE_CHECKING:
+    import google.auth.credentials
+
+logger = logging.getLogger(__name__)
+
+# The Vertex-specific `anthropic_version` value, distinct from the plain
+# Anthropic API's `anthropic-version` header values (e.g. "2023-06-01").
+# See https://docs.anthropic.com/en/api/claude-on-vertex-ai
+ANTHROPIC_VERTEX_VERSION = "vertex-2023-10-16"
+
+# GCP OAuth2 scope required for Vertex AI calls.
+_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+# Anthropic's native model id uses a dash before the trailing date
+# (claude-haiku-4-5-20251001); Vertex's publisher-model path uses "@"
+# (claude-haiku-4-5@20251001).
+_DASH_DATE_RE = re.compile(r"^(?P<family>.+)-(?P<date>\d{8})$")
+_AT_DATE_RE = re.compile(r"^(?P<family>.+)@(?P<date>\d{8})$")
+
+# Refresh the cached access token this many seconds before it actually
+# expires, so a request never races a not-yet-refreshed, about-to-expire
+# token.
+_TOKEN_REFRESH_MARGIN_SECONDS = 120
+
+# How long to wait for the in-process uvicorn server to bind before
+# failing the turn. Mirrors ClaudeGatewayShim's identical constant.
+_START_TIMEOUT_SECONDS = 10.0
+
+# Upstream timeout: `read=None` because streamed responses can legitimately
+# idle between deltas for minutes on long thinking turns; the CLI applies
+# its own request-level timeout.
+_UPSTREAM_TIMEOUT = httpx.Timeout(connect=30.0, read=None, write=60.0, pool=None)
+
+# ASGI callable types — uvicorn's protocol is untyped dicts.
+_Scope: TypeAlias = MutableMapping[str, Any]  # type: ignore[explicit-any]  # ASGI scope is a heterogeneous dict by spec
+_Receive: TypeAlias = Callable[[], Awaitable[MutableMapping[str, Any]]]  # type: ignore[explicit-any]  # ASGI message dicts
+_Send: TypeAlias = Callable[[MutableMapping[str, Any]], Awaitable[None]]  # type: ignore[explicit-any]  # ASGI message dicts
+
+
+class _NoSignalServer(uvicorn.Server):
+    """uvicorn Server that never installs process signal handlers.
+
+    Identical rationale to ``ClaudeGatewayShim``'s copy of this class: a
+    second signal-capturing server on the main thread would steal
+    SIGINT/SIGTERM from the harness subprocess's own uvicorn server,
+    breaking its graceful shutdown path.
+    """
+
+    @contextlib.contextmanager
+    def capture_signals(self) -> Iterator[None]:
+        """No-op replacement for uvicorn's signal-handler swap."""
+        yield
+
+
+def to_vertex_model_id(model: str) -> str:
+    """Convert an Anthropic-style dash-dated model id to Vertex's @-dated form.
+
+    Idempotent — a model already in ``@``-form, or with no trailing
+    8-digit date at all, is returned unchanged.
+
+    :param model: Model id, e.g. ``"claude-haiku-4-5-20251001"`` or
+        ``"claude-haiku-4-5@20251001"``.
+    :returns: The Vertex publisher-model id, e.g.
+        ``"claude-haiku-4-5@20251001"``.
+    """
+    if _AT_DATE_RE.match(model):
+        return model
+    m = _DASH_DATE_RE.match(model)
+    if m:
+        return f"{m.group('family')}@{m.group('date')}"
+    return model
+
+
+def build_vertex_anthropic_url(
+    *,
+    project: str,
+    location: str,
+    model: str,
+    stream: bool,
+) -> str:
+    """Build the Vertex AI rawPredict URL for a Claude publisher model.
+
+    :param project: GCP project id.
+    :param location: Vertex location, e.g. ``"global"`` or ``"us-east5"``.
+    :param model: Model id in either dash- or ``@``-dated form; translated
+        to the ``@``-dated Vertex form internally.
+    :param stream: Use ``:streamRawPredict`` instead of ``:rawPredict``.
+    :returns: Full HTTPS URL for the Vertex publisher-model endpoint.
+    """
+    vertex_model = to_vertex_model_id(model)
+    method = "streamRawPredict" if stream else "rawPredict"
+    host = (
+        "aiplatform.googleapis.com"
+        if location == "global"
+        else f"{location}-aiplatform.googleapis.com"
+    )
+    return (
+        f"https://{host}/v1/projects/{project}/locations/{location}"
+        f"/publishers/anthropic/models/{vertex_model}:{method}"
+    )
+
+
+def prepare_vertex_anthropic_body(body: bytes) -> bytes:
+    """Translate an Anthropic Messages API request body for Vertex.
+
+    Drops ``model`` (it's part of the URL path on Vertex, not the body)
+    and injects ``anthropic_version`` (Vertex expects it in the body; the
+    plain Anthropic API takes it as an ``anthropic-version`` header
+    instead). Also drops ``context_management`` — confirmed against a
+    real Vertex project that ``:rawPredict`` rejects it outright with
+    ``400 context_management: Extra inputs are not permitted``, unlike
+    ``api.anthropic.com`` which accepts it; Vertex's schema for this
+    endpoint appears to be a stricter subset of the plain Messages API
+    rather than a true pass-through, so the CLI's auto-compaction context
+    editing feature is unavailable on this path. Everything else
+    (``messages``, ``system``, ``max_tokens``, ``tools``, ``tool_choice``,
+    ``stream``, etc.) is Anthropic Messages API-shaped and passed through
+    unchanged.
+
+    Non-object JSON and invalid JSON are returned unchanged rather than
+    raising — Vertex owns request validation for malformed bodies, same
+    as ``ClaudeGatewayShim.restore_thinking_display``'s pass-through
+    behavior for the same class of input.
+
+    :param body: Raw request body bytes a client sent to ``/v1/messages``.
+    :returns: The body reshaped for Vertex's ``:rawPredict`` /
+        ``:streamRawPredict``, or the original bytes if it doesn't parse
+        as a JSON object.
+    """
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return body
+    if not isinstance(parsed, dict):
+        return body
+    parsed.pop("model", None)
+    parsed.pop("context_management", None)
+    parsed["anthropic_version"] = ANTHROPIC_VERTEX_VERSION
+    return json.dumps(parsed).encode("utf-8")
+
+
+class GoogleADCTokenCache:
+    """Caches a short-lived Google Cloud access token, refreshing when stale.
+
+    Generic Google OAuth2 / Application Default Credentials token
+    exchange — nothing here is specific to Vertex AI or Claude. Resolves
+    ADC once per process (reading
+    ``~/.config/gcloud/application_default_credentials.json``, or a
+    service account key via ``GOOGLE_APPLICATION_CREDENTIALS``) and
+    refreshes the access token as needed.
+
+    Designed to run only in the unsandboxed parent process — the whole
+    point of :class:`VertexAnthropicGatewayShim` is that the sandboxed
+    Claude CLI subprocess never needs to see the credential this class
+    holds.
+    """
+
+    def __init__(self) -> None:
+        self._credentials: google.auth.credentials.Credentials | None = None
+        self._lock = asyncio.Lock()
+
+    async def get_token(self) -> str:
+        """Return a valid access token, refreshing it first if it's stale.
+
+        :returns: A bearer token suitable for
+            ``Authorization: Bearer <token>``.
+        """
+        async with self._lock:
+            await asyncio.to_thread(self._ensure_fresh_sync)
+            assert (
+                self._credentials is not None
+            )  # narrows for the type checker; set by _ensure_fresh_sync
+            return str(self._credentials.token)
+
+    def _ensure_fresh_sync(self) -> None:
+        """Resolve ADC (once) and refresh the token if it's stale.
+
+        Blocking Google Cloud SDK calls — always run via
+        ``asyncio.to_thread`` from :meth:`get_token`, never awaited
+        directly.
+        """
+        import google.auth
+        import google.auth.transport.requests
+
+        if self._credentials is None:
+            self._credentials, _ = google.auth.default(scopes=[_CLOUD_PLATFORM_SCOPE])
+
+        needs_refresh = not self._credentials.valid or self._expires_within_margin()
+        if needs_refresh:
+            request = google.auth.transport.requests.Request()
+            self._credentials.refresh(request)
+
+    def _expires_within_margin(self) -> bool:
+        """Check whether the cached credential is within its refresh margin.
+
+        ``google.auth.credentials.Credentials.expiry`` is documented as a
+        naive ``datetime`` that's implicitly UTC — comparing it against
+        ``datetime.now(timezone.utc)`` directly (rather than converting
+        either side through ``.timestamp()``, which treats a naive
+        datetime as *local* time) avoids misjudging the margin on a
+        non-UTC host.
+
+        :returns: ``True`` if there's no expiry at all (never observed on
+            a real ADC token, but treated as "needs refresh" defensively)
+            or the expiry is closer than
+            ``_TOKEN_REFRESH_MARGIN_SECONDS`` away.
+        """
+        import datetime
+
+        expiry = getattr(self._credentials, "expiry", None)
+        if expiry is None:
+            return True
+        now_utc_naive = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        margin = datetime.timedelta(seconds=_TOKEN_REFRESH_MARGIN_SECONDS)
+        return (expiry - now_utc_naive) < margin
+
+
+# Sent by the CLI as ``ANTHROPIC_API_KEY`` / ``x-api-key`` on the client
+# side of the loopback hop. The shim never reads or validates it — real
+# auth is the GCP access token it attaches to the *upstream* Vertex
+# request (see module docstring) — so this only needs to be a non-empty
+# string that satisfies the CLI's own "are we logged in" check.
+PLACEHOLDER_API_KEY = "vertex-shim-placeholder-not-a-real-key"
+
+
+class VertexAnthropicGatewayShim:
+    """Reverse proxy between the Claude CLI and Claude on Vertex AI.
+
+    Start with :meth:`start`, then point ``ANTHROPIC_BASE_URL`` at
+    :attr:`base_url`. Every ``POST .../v1/messages`` request is
+    translated into the equivalent Vertex ``:rawPredict`` /
+    ``:streamRawPredict`` call (see module docstring) and the response —
+    including SSE streams — is forwarded back to the CLI unbuffered and
+    unmodified, since Vertex's response shape already matches Anthropic's
+    native Messages API.
+
+    One shim runs per
+    :class:`~omnigent.inner.claude_sdk_executor.ClaudeSDKExecutor` using
+    the Vertex gateway path, started lazily with the first Vertex client
+    and stopped by the executor's ``close()`` (or with the harness
+    subprocess, whichever comes first) — the same lifecycle
+    ``ClaudeGatewayShim`` uses.
+
+    :param project: GCP project id with Claude enabled on Vertex AI.
+    :param location: Vertex location, e.g. ``"global"`` or ``"us-east5"``.
+    :param token_cache: Optional pre-built token cache; a fresh
+        :class:`GoogleADCTokenCache` is created if omitted. Exposed for
+        tests that need to inject a fake.
+    """
+
+    def __init__(
+        self,
+        *,
+        project: str,
+        location: str = "global",
+        token_cache: GoogleADCTokenCache | None = None,
+    ) -> None:
+        self._project = project
+        self._location = location
+        self._token_cache = token_cache if token_cache is not None else GoogleADCTokenCache()
+        self._client: httpx.AsyncClient | None = None
+        self._server: uvicorn.Server | None = None
+        self._serve_task: asyncio.Task[None] | None = None
+        self._port: int | None = None
+        # Serializes start() so two concurrent first turns can't bind two
+        # servers / leak a connection pool — same rationale as
+        # ClaudeGatewayShim._start_lock.
+        self._start_lock = asyncio.Lock()
+
+    @property
+    def base_url(self) -> str:
+        """The local URL the CLI should use as ``ANTHROPIC_BASE_URL``.
+
+        :returns: Loopback base URL, e.g. ``"http://127.0.0.1:49152"``.
+        :raises RuntimeError: If :meth:`start` has not completed.
+        """
+        if self._port is None:
+            raise RuntimeError("VertexAnthropicGatewayShim.start() has not completed")
+        return f"http://127.0.0.1:{self._port}"
+
+    async def start(self) -> None:
+        """Bind the local server on an ephemeral loopback port.
+
+        Idempotent — subsequent calls return immediately once the server
+        is up.
+
+        :raises OSError: If the server fails to bind within
+            ``_START_TIMEOUT_SECONDS``.
+        """
+        async with self._start_lock:
+            if self._port is not None:
+                return
+            await self._start_locked()
+
+    async def _start_locked(self) -> None:
+        """Bind the server; caller must hold ``_start_lock``.
+
+        :raises OSError: If the server fails to bind within
+            ``_START_TIMEOUT_SECONDS``.
+        """
+        if self._client is not None:
+            # A prior failed start left a client behind; don't leak it.
+            await self._client.aclose()
+        self._client = httpx.AsyncClient(timeout=_UPSTREAM_TIMEOUT)
+        config = uvicorn.Config(
+            self._asgi_app,
+            host="127.0.0.1",
+            port=0,  # ephemeral — the bound port is read back below
+            log_level="warning",
+            lifespan="off",  # plain ASGI callable; no lifespan protocol
+            interface="asgi3",  # bound methods defeat uvicorn's auto-detection
+        )
+        server = _NoSignalServer(config)
+        self._server = server
+        self._serve_task = asyncio.create_task(
+            server.serve(), name="vertex-anthropic-gateway-shim-serve"
+        )
+        deadline = asyncio.get_running_loop().time() + _START_TIMEOUT_SECONDS
+        # uvicorn flips `server.started` from its serve task; there is no
+        # event/callback hook to await, so poll at 10ms.
+        while not server.started:
+            if self._serve_task.done():
+                self._serve_task.result()
+                raise OSError("Vertex Anthropic gateway shim server exited before startup")
+            if asyncio.get_running_loop().time() > deadline:
+                raise OSError(
+                    f"Vertex Anthropic gateway shim failed to start within "
+                    f"{_START_TIMEOUT_SECONDS}s"
+                )
+            await asyncio.sleep(0.01)
+        self._port = server.servers[0].sockets[0].getsockname()[1]
+        logger.info(
+            "Vertex Anthropic gateway shim listening on %s (project=%s, location=%s)",
+            self.base_url,
+            self._project,
+            self._location,
+        )
+
+    async def aclose(self) -> None:
+        """Stop the local server and release the upstream connection pool.
+
+        Safe to call multiple times or before :meth:`start`.
+        """
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._serve_task is not None:
+            try:
+                await asyncio.wait_for(self._serve_task, timeout=5.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._serve_task.cancel()
+            self._serve_task = None
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+        self._server = None
+        self._port = None
+
+    async def _asgi_app(self, scope: _Scope, receive: _Receive, send: _Send) -> None:
+        """Translate and forward one request to Vertex AI.
+
+        Only ``POST .../v1/messages`` is meaningful for this upstream —
+        Vertex has no equivalent of the plain Anthropic API's other
+        endpoints (``/v1/models`` etc.), so anything else gets a 404
+        rather than being forwarded nowhere.
+
+        :param scope: ASGI connection scope; only ``"http"`` is served.
+        :param receive: ASGI receive callable for request body chunks.
+        :param send: ASGI send callable for response messages.
+        """
+        if scope["type"] != "http":
+            return
+        if self._client is None:
+            raise RuntimeError("VertexAnthropicGatewayShim served a request before start()")
+
+        method: str = scope["method"]
+        path: str = scope["path"]
+        if method != "POST" or not path.endswith("/v1/messages"):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 404,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": json.dumps(
+                        {
+                            "type": "error",
+                            "error": {
+                                "type": "not_found_error",
+                                "message": (
+                                    "vertex-anthropic-gateway-shim only serves "
+                                    "POST .../v1/messages"
+                                ),
+                            },
+                        }
+                    ).encode("utf-8"),
+                }
+            )
+            return
+
+        body = bytearray()
+        while True:
+            message = await receive()
+            body.extend(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+        request_body = bytes(body)
+
+        try:
+            parsed = json.loads(request_body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            parsed = None
+        model = parsed.get("model") if isinstance(parsed, dict) else None
+        if not isinstance(model, str) or not model:
+            await self._send_error(send, status=400, message="request body must have a 'model'")
+            return
+        stream = bool(parsed.get("stream", False)) if isinstance(parsed, dict) else False
+
+        url = build_vertex_anthropic_url(
+            project=self._project,
+            location=self._location,
+            model=model,
+            stream=stream,
+        )
+        vertex_body = prepare_vertex_anthropic_body(request_body)
+
+        try:
+            token = await self._token_cache.get_token()
+        except Exception as exc:  # noqa: BLE001 — surface any ADC failure as a clean 502, not a crashed turn
+            logger.warning("Vertex Anthropic gateway shim failed to resolve a GCP token: %s", exc)
+            await self._send_error(send, status=502, message=f"GCP auth error: {exc}")
+            return
+
+        headers = {"authorization": f"Bearer {token}", "content-type": "application/json"}
+
+        try:
+            async with self._client.stream(
+                "POST", url, headers=headers, content=vertex_body
+            ) as upstream:
+                response_headers = [
+                    (k.encode("latin-1"), v.encode("latin-1"))
+                    for k, v in upstream.headers.items()
+                    if k.lower() not in {"content-length", "connection", "transfer-encoding"}
+                ]
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": upstream.status_code,
+                        "headers": response_headers,
+                    }
+                )
+                # aiter_raw() preserves the wire bytes (no transparent
+                # decompression), so SSE chunks flush to the CLI as they
+                # arrive rather than being buffered whole.
+                async for chunk in upstream.aiter_raw():
+                    await send({"type": "http.response.body", "body": chunk, "more_body": True})
+                await send({"type": "http.response.body", "body": b""})
+        except httpx.HTTPError as exc:
+            logger.warning("Vertex Anthropic gateway shim upstream error: %s", exc)
+            await self._send_error(send, status=502, message=f"gateway shim upstream error: {exc}")
+
+    @staticmethod
+    async def _send_error(send: _Send, *, status: int, message: str) -> None:
+        """Send a single-shot Anthropic-shaped error response.
+
+        :param send: ASGI send callable.
+        :param status: HTTP status code to send.
+        :param message: Human-readable error message.
+        """
+        body = json.dumps({"type": "error", "error": {"type": "api_error", "message": message}})
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": body.encode("utf-8")})

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1180,6 +1180,34 @@ def _build_claude_sdk_spawn_env(
     if cwd is not None:
         env["HARNESS_CLAUDE_SDK_CWD"] = str(cwd)
 
+    # ── Vertex AI (Claude on Vertex) ───────────────────────────────────
+    # Opt-in via executor.config, mirroring the antigravity harness's
+    # identical vertex/project/location convention (see
+    # _build_antigravity_spawn_env) — authenticated by GCP ADC resolved
+    # in the unsandboxed parent process (VertexAnthropicGatewayShim), not
+    # a spec-declared credential. Mutually exclusive with the
+    # provider/gateway/Databricks auth paths below: Vertex owns the whole
+    # transport, so a spec that also sets executor.auth or a databricks-*
+    # model alongside vertex: true is a config error the inner executor
+    # rejects at construction time (ClaudeSDKExecutor.__init__).
+    config = spec.executor.config
+    if config.get("vertex"):
+        env["HARNESS_CLAUDE_SDK_VERTEX_PROJECT"] = str(config.get("project", ""))
+        location = config.get("location")
+        if location:
+            env["HARNESS_CLAUDE_SDK_VERTEX_LOCATION"] = str(location)
+        _add_claude_sdk_skills_env(env, spec, workdir)
+        os_env_payload = _serialize_os_env(spec.os_env)
+        if os_env_payload is not None:
+            env["HARNESS_CLAUDE_SDK_OS_ENV"] = os_env_payload
+        retry_payload = _serialize_retry_policy(_resolve_retry_policy(spec))
+        if retry_payload is not None:
+            env["HARNESS_CLAUDE_SDK_RETRY_POLICY"] = retry_payload
+        permission_mode = config.get("permission_mode")
+        if permission_mode is not None:
+            env["HARNESS_CLAUDE_SDK_PERMISSION_MODE"] = str(permission_mode)
+        return env
+
     # ── Auth resolution ────────────────────────────────────────────────
     # Priority (highest first):
     # 0. Generic provider — spec.executor.auth: {type: provider, name: X},

--- a/tests/inner/test_vertex_anthropic_shim.py
+++ b/tests/inner/test_vertex_anthropic_shim.py
@@ -1,0 +1,680 @@
+"""Tests for the Vertex Anthropic gateway shim.
+
+The shim exists because Claude on Vertex AI uses a different wire shape
+(``:rawPredict``/``:streamRawPredict``, model in the URL path,
+``anthropic_version`` in the body, GCP OAuth2 bearer auth) than the plain
+Anthropic API the Claude CLI's ``ANTHROPIC_BASE_URL`` normally targets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import pytest
+import uvicorn
+
+from omnigent.inner.vertex_anthropic_shim import (
+    ANTHROPIC_VERTEX_VERSION,
+    GoogleADCTokenCache,
+    VertexAnthropicGatewayShim,
+    build_vertex_anthropic_url,
+    prepare_vertex_anthropic_body,
+    to_vertex_model_id,
+)
+
+# ── to_vertex_model_id ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("claude-haiku-4-5-20251001", "claude-haiku-4-5@20251001"),
+        ("claude-sonnet-4-5-20250929", "claude-sonnet-4-5@20250929"),
+        # Already @-form is idempotent.
+        ("claude-haiku-4-5@20251001", "claude-haiku-4-5@20251001"),
+        # No trailing 8-digit date — nothing to translate.
+        ("claude-3-5-sonnet-latest", "claude-3-5-sonnet-latest"),
+    ],
+)
+def test_to_vertex_model_id_translates_dash_dates_to_at_form(model: str, expected: str) -> None:
+    """Anthropic's dash-dated ids become Vertex's @-dated form; anything
+    else (already @-form, or no date suffix) passes through unchanged."""
+    assert to_vertex_model_id(model) == expected
+
+
+# ── build_vertex_anthropic_url ─────────────────────────────
+
+
+def test_build_vertex_anthropic_url_global_location() -> None:
+    """The "global" location uses the bare aiplatform.googleapis.com host,
+    matching the real Vertex API (confirmed against a live project)."""
+    url = build_vertex_anthropic_url(
+        project="my-project", location="global", model="claude-haiku-4-5-20251001", stream=False
+    )
+    assert url == (
+        "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global"
+        "/publishers/anthropic/models/claude-haiku-4-5@20251001:rawPredict"
+    )
+
+
+def test_build_vertex_anthropic_url_regional_location() -> None:
+    """A non-"global" location gets a region-prefixed host."""
+    url = build_vertex_anthropic_url(
+        project="my-project", location="us-east5", model="claude-haiku-4-5-20251001", stream=False
+    )
+    assert url.startswith("https://us-east5-aiplatform.googleapis.com/")
+
+
+def test_build_vertex_anthropic_url_stream_uses_streamrawpredict() -> None:
+    """`stream=True` selects the streaming RPC method."""
+    url = build_vertex_anthropic_url(
+        project="my-project", location="global", model="claude-haiku-4-5-20251001", stream=True
+    )
+    assert url.endswith(":streamRawPredict")
+
+
+# ── prepare_vertex_anthropic_body ──────────────────────────
+
+
+def test_prepare_vertex_anthropic_body_drops_model_and_injects_version() -> None:
+    """`model` is removed (it's in the URL on Vertex) and
+    `anthropic_version` is injected; everything else survives."""
+    body = json.dumps(
+        {
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    ).encode()
+    result = json.loads(prepare_vertex_anthropic_body(body))
+    assert "model" not in result
+    assert result["anthropic_version"] == ANTHROPIC_VERTEX_VERSION
+    assert result["max_tokens"] == 100
+    assert result["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_prepare_vertex_anthropic_body_drops_context_management() -> None:
+    """`context_management` is stripped — confirmed against a real Vertex
+    project that `:rawPredict` rejects it with `400 context_management:
+    Extra inputs are not permitted`, unlike api.anthropic.com."""
+    body = json.dumps(
+        {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}],
+            "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+        }
+    ).encode()
+    result = json.loads(prepare_vertex_anthropic_body(body))
+    assert "context_management" not in result
+    assert result["max_tokens"] == 100
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"not json at all",
+        b'"a json string"',
+        b'["a", "json", "array"]',
+    ],
+)
+def test_prepare_vertex_anthropic_body_passes_through_unparseable_bodies(body: bytes) -> None:
+    """Non-object JSON and invalid JSON are forwarded verbatim rather than
+    raising — Vertex owns request validation for malformed bodies."""
+    assert prepare_vertex_anthropic_body(body) == body
+
+
+# ── GoogleADCTokenCache ─────────────────────────────────────
+
+
+class _FakeCredentials:
+    """Stand-in for google.auth.credentials.Credentials in unit tests.
+
+    Real Google credentials never have ``valid=True`` with ``expiry=None``
+    at the same time — an unexpired token always carries an expiry.
+    ``expiry=None`` here models the pre-first-refresh state instead (a
+    freshly resolved credential has no token/expiry yet), matching
+    ``google.auth.credentials.Credentials``'s actual behavior.
+    """
+
+    def __init__(self, token: str = "fake-token", valid: bool = True) -> None:
+        import datetime
+
+        self.token = token
+        self.valid = valid
+        if valid:
+            now_utc_naive = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+            self.expiry = now_utc_naive + datetime.timedelta(hours=1)
+        else:
+            self.expiry = None
+        self.refresh_calls = 0
+
+    def refresh(self, request: object) -> None:
+        """Record a refresh and flip to valid with a fresh token."""
+        self.refresh_calls += 1
+        self.token = f"refreshed-token-{self.refresh_calls}"
+        self.valid = True
+
+
+@pytest.mark.asyncio
+async def test_token_cache_resolves_and_reuses_valid_credentials(monkeypatch) -> None:  # type: ignore[no-untyped-def]  # pytest fixture
+    """A valid, non-expiring credential is resolved once and reused —
+    google.auth.default() is not called again on a second get_token()."""
+    fake_creds = _FakeCredentials(token="initial-token", valid=True)
+    default_calls = 0
+
+    def fake_default(scopes: list[str]) -> tuple[_FakeCredentials, None]:
+        nonlocal default_calls
+        default_calls += 1
+        return fake_creds, None
+
+    monkeypatch.setattr("google.auth.default", fake_default)
+
+    cache = GoogleADCTokenCache()
+    token1 = await cache.get_token()
+    token2 = await cache.get_token()
+
+    assert token1 == "initial-token"
+    assert token2 == "initial-token"
+    assert default_calls == 1
+    assert fake_creds.refresh_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_token_cache_refreshes_invalid_credentials(monkeypatch) -> None:  # type: ignore[no-untyped-def]  # pytest fixture
+    """An invalid credential (never refreshed, or expired) is refreshed
+    before its token is returned."""
+    fake_creds = _FakeCredentials(token="stale-token", valid=False)
+    monkeypatch.setattr("google.auth.default", lambda scopes: (fake_creds, None))
+
+    cache = GoogleADCTokenCache()
+    token = await cache.get_token()
+
+    assert fake_creds.refresh_calls == 1
+    assert token == "refreshed-token-1"
+
+
+# ── VertexAnthropicGatewayShim integration tests ───────────
+
+
+@dataclass
+class _CapturedRequest:
+    """One request observed by the recording upstream."""
+
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
+
+
+@dataclass
+class _RecordingUpstream:
+    """Minimal real ASGI server standing in for Vertex AI."""
+
+    requests: list[_CapturedRequest] = field(default_factory=list)
+    _server: uvicorn.Server | None = None
+    _task: asyncio.Task[None] | None = None
+    port: int | None = None
+    stream_response: bool = False
+
+    async def _app(self, scope, receive, send) -> None:  # type: ignore[no-untyped-def]  # ASGI protocol is untyped dicts
+        """Record the request and reply with an Anthropic-shaped response."""
+        if scope["type"] != "http":
+            return
+        body = bytearray()
+        while True:
+            message = await receive()
+            body.extend(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+        self.requests.append(
+            _CapturedRequest(
+                method=scope["method"],
+                path=scope["path"],
+                headers={
+                    k.decode("latin-1").lower(): v.decode("latin-1") for k, v in scope["headers"]
+                },
+                body=bytes(body),
+            )
+        )
+        if self.stream_response:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"text/event-stream")],
+                }
+            )
+            for event in (b"event: ping\ndata: {}\n\n", b"data: [DONE]\n\n"):
+                await send({"type": "http.response.body", "body": event, "more_body": True})
+            await send({"type": "http.response.body", "body": b""})
+        else:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send(
+                {"type": "http.response.body", "body": b'{"type": "message", "id": "msg_1"}'}
+            )
+
+    async def start(self) -> str:
+        """Serve on an ephemeral loopback port.
+
+        :returns: The upstream base URL, e.g. ``"http://127.0.0.1:49153"``.
+        """
+        config = uvicorn.Config(
+            self._app,
+            host="127.0.0.1",
+            port=0,
+            log_level="warning",
+            lifespan="off",
+            interface="asgi3",  # bound methods defeat uvicorn's auto-detection
+        )
+        self._server = uvicorn.Server(config)
+        self._task = asyncio.create_task(self._server.serve())
+        while not self._server.started:
+            if self._task.done():
+                self._task.result()
+                raise OSError("recording upstream exited before startup")
+            await asyncio.sleep(0.01)
+        self.port = self._server.servers[0].sockets[0].getsockname()[1]
+        return f"http://127.0.0.1:{self.port}"
+
+    async def stop(self) -> None:
+        """Shut the server down and reap its serve task."""
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._task is not None:
+            await asyncio.wait_for(self._task, timeout=5.0)
+
+
+@pytest.fixture
+async def upstream() -> Any:  # type: ignore[explicit-any]  # async generator fixture; pytest infers the yield type
+    """Run a recording upstream for the duration of one test."""
+    server = _RecordingUpstream()
+    await server.start()
+    yield server
+    await server.stop()
+
+
+class _FakeTokenCache:
+    """Stand-in for GoogleADCTokenCache that never touches real GCP auth."""
+
+    def __init__(self, token: str = "fake-vertex-token") -> None:
+        self.token = token
+        self.calls = 0
+
+    async def get_token(self) -> str:
+        """Return the fixed fake token, counting calls."""
+        self.calls += 1
+        return self.token
+
+
+def _make_shim(upstream_port: int, token: str = "fake-vertex-token") -> VertexAnthropicGatewayShim:
+    """Build a shim pointed at the fake upstream's port with a fake token cache.
+
+    The shim always builds a real ``aiplatform.googleapis.com`` URL — these
+    tests monkeypatch nothing at the HTTP layer, so a real DNS resolution
+    would occur unless the shim's httpx client is redirected. Instead, the
+    fixture asserts on ``_asgi_app``'s translated request in isolation via
+    ``build_vertex_anthropic_url``/``prepare_vertex_anthropic_body`` (unit
+    tests above) and exercises the ASGI plumbing here against a fake
+    upstream reached by overriding ``httpx.AsyncClient`` transport — see
+    ``test_shim_posts_translated_request_to_fake_upstream`` for how.
+    """
+    return VertexAnthropicGatewayShim(
+        project="test-project", location="global", token_cache=_FakeTokenCache(token)
+    )
+
+
+@pytest.mark.asyncio
+async def test_shim_posts_translated_request_to_fake_upstream(
+    monkeypatch,
+    upstream: _RecordingUpstream,  # type: ignore[no-untyped-def]  # pytest fixture
+) -> None:
+    """A `/v1/messages` POST through the shim reaches Vertex's rawPredict
+    shape: model moved into the URL, anthropic_version injected into the
+    body, and the real GCP token attached as a bearer token."""
+    # Redirect the shim's "Vertex" calls to the local recording upstream
+    # instead of the real aiplatform.googleapis.com host, by overriding
+    # build_vertex_anthropic_url's result at the module level the shim
+    # imports it from.
+    import omnigent.inner.vertex_anthropic_shim as shim_module
+
+    real_build_url = shim_module.build_vertex_anthropic_url
+
+    def fake_build_url(*, project: str, location: str, model: str, stream: bool) -> str:
+        real_url = real_build_url(project=project, location=location, model=model, stream=stream)
+        # Swap only the host — path/method translation is exercised as-is.
+        suffix = real_url.split("/v1/projects/", 1)[1]
+        return f"http://127.0.0.1:{upstream.port}/v1/projects/{suffix}"
+
+    monkeypatch.setattr(shim_module, "build_vertex_anthropic_url", fake_build_url)
+
+    shim = _make_shim(upstream.port, token="test-token-123")
+    await shim.start()
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{shim.base_url}/v1/messages",
+                json={
+                    "model": "claude-haiku-4-5-20251001",
+                    "max_tokens": 50,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        assert resp.status_code == 200
+
+        assert len(upstream.requests) == 1
+        seen = upstream.requests[0]
+        assert seen.path == (
+            "/v1/projects/test-project/locations/global/publishers/anthropic/models/"
+            "claude-haiku-4-5@20251001:rawPredict"
+        )
+        upstream_body = json.loads(seen.body)
+        assert "model" not in upstream_body
+        assert upstream_body["anthropic_version"] == ANTHROPIC_VERTEX_VERSION
+        assert upstream_body["messages"] == [{"role": "user", "content": "hi"}]
+        # The real Anthropic API key the CLI might have set (there isn't
+        # one here, but this is the credential-swap point) never reaches
+        # Vertex — only the token the shim's own token cache resolved.
+        assert seen.headers["authorization"] == "Bearer test-token-123"
+    finally:
+        await shim.aclose()
+
+
+@pytest.mark.asyncio
+async def test_shim_streams_sse_response_unmodified(
+    monkeypatch,
+    upstream: _RecordingUpstream,  # type: ignore[no-untyped-def]  # pytest fixture
+) -> None:
+    """A streaming request's SSE response round-trips through the shim
+    byte-identical — a buffering bug in the relay would corrupt this."""
+    upstream.stream_response = True
+    import omnigent.inner.vertex_anthropic_shim as shim_module
+
+    real_build_url = shim_module.build_vertex_anthropic_url
+
+    def fake_build_url(*, project: str, location: str, model: str, stream: bool) -> str:
+        real_url = real_build_url(project=project, location=location, model=model, stream=stream)
+        suffix = real_url.split("/v1/projects/", 1)[1]
+        return f"http://127.0.0.1:{upstream.port}/v1/projects/{suffix}"
+
+    monkeypatch.setattr(shim_module, "build_vertex_anthropic_url", fake_build_url)
+
+    shim = _make_shim(upstream.port)
+    await shim.start()
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{shim.base_url}/v1/messages",
+                json={
+                    "model": "claude-haiku-4-5-20251001",
+                    "max_tokens": 50,
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "text/event-stream"
+        assert resp.text == "event: ping\ndata: {}\n\ndata: [DONE]\n\n"
+        # `stream: true` in the request body selected :streamRawPredict.
+        assert upstream.requests[0].path.endswith(":streamRawPredict")
+    finally:
+        await shim.aclose()
+
+
+@pytest.mark.asyncio
+async def test_shim_rejects_non_messages_paths_with_404() -> None:
+    """Vertex has no equivalent of the plain API's other endpoints
+    (`/v1/models` etc.) — anything but `/v1/messages` gets a clean 404
+    instead of being forwarded nowhere or hanging."""
+    shim = _make_shim(upstream_port=9)  # port unused; request never leaves the shim
+    await shim.start()
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{shim.base_url}/v1/models")
+        assert resp.status_code == 404
+        assert resp.json()["type"] == "error"
+    finally:
+        await shim.aclose()
+
+
+@pytest.mark.asyncio
+async def test_shim_rejects_body_without_model_with_400() -> None:
+    """A body with no `model` can't be routed to any Vertex publisher-model
+    path — fail fast with a 400 instead of building a malformed URL."""
+    shim = _make_shim(upstream_port=9)
+    await shim.start()
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(f"{shim.base_url}/v1/messages", json={"max_tokens": 50})
+        assert resp.status_code == 400
+    finally:
+        await shim.aclose()
+
+
+@pytest.mark.asyncio
+async def test_shim_returns_502_when_upstream_unreachable() -> None:
+    """Upstream connection failures surface as a 502 with an Anthropic-
+    shaped error body instead of hanging or crashing the shim."""
+    import omnigent.inner.vertex_anthropic_shim as shim_module
+
+    # Port 9 (discard) on loopback is closed — connect fails immediately.
+    monkeypatch_target = shim_module.build_vertex_anthropic_url
+    try:
+        shim_module.build_vertex_anthropic_url = lambda **kwargs: "http://127.0.0.1:9/v1/messages"
+        shim = _make_shim(upstream_port=9)
+        await shim.start()
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"{shim.base_url}/v1/messages",
+                    json={
+                        "model": "claude-haiku-4-5-20251001",
+                        "max_tokens": 50,
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+            assert resp.status_code == 502
+            assert resp.json()["type"] == "error"
+        finally:
+            await shim.aclose()
+    finally:
+        shim_module.build_vertex_anthropic_url = monkeypatch_target
+
+
+@pytest.mark.asyncio
+async def test_shim_returns_502_when_token_resolution_fails() -> None:
+    """A GCP auth failure (e.g. no ADC configured) surfaces as a clean 502
+    rather than propagating an unhandled exception into the ASGI app."""
+
+    class _FailingTokenCache:
+        async def get_token(self) -> str:
+            raise RuntimeError("no ADC found")
+
+    shim = VertexAnthropicGatewayShim(
+        project="test-project", location="global", token_cache=_FailingTokenCache()
+    )
+    await shim.start()
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{shim.base_url}/v1/messages",
+                json={
+                    "model": "claude-haiku-4-5-20251001",
+                    "max_tokens": 50,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        assert resp.status_code == 502
+        assert "no ADC found" in resp.json()["error"]["message"]
+    finally:
+        await shim.aclose()
+
+
+@pytest.mark.asyncio
+async def test_shim_does_not_install_process_signal_handlers() -> None:
+    """The shim's uvicorn server must not swap the process's
+    SIGINT/SIGTERM handlers — same rationale as ClaudeGatewayShim's
+    identical test."""
+    import signal
+
+    before = {sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)}
+    shim = _make_shim(upstream_port=9)
+    await shim.start()
+    try:
+        after = {sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)}
+        assert after == before
+    finally:
+        await shim.aclose()
+
+
+# ── executor wiring tests ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vertex_executor_routes_new_client_through_shim() -> None:
+    """On the Vertex path, a new SDK client's env must point at the
+    local Vertex shim (not left at the sentinel ANTHROPIC_BASE_URL set
+    in __init__).
+
+    Follows test_claude_gateway_shim.py's established stub-SDK pattern
+    for driving ``_get_or_create_client`` — spawning the real CLI is
+    infeasible in unit tests.
+    """
+    from types import SimpleNamespace
+
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+    executor = ClaudeSDKExecutor(vertex_project="test-project", vertex_location="us-east5")
+
+    connect_env: dict[str, str] = {}
+
+    class _StubClient:
+        """Captures ``options.env`` at connect time (= CLI spawn time)."""
+
+        def __init__(self, options) -> None:  # type: ignore[no-untyped-def]  # SDK options shape owned by stub
+            self.options = options
+
+        async def connect(self) -> None:
+            """Snapshot the env the CLI subprocess would receive."""
+            connect_env.update(self.options.env)
+
+        async def disconnect(self) -> None:
+            """No-op disconnect for teardown."""
+
+    class _StubSDK:
+        """Minimal SDK namespace exposing ClaudeSDKClient."""
+
+        ClaudeSDKClient = _StubClient
+
+    options = SimpleNamespace(
+        env={"ANTHROPIC_BASE_URL": "https://vertex-anthropic.invalid"},
+        stderr=None,
+    )
+    try:
+        await executor._get_or_create_client(
+            _StubSDK,  # type: ignore[arg-type]  # stub stands in for the claude_agent_sdk module
+            session_key="vertex-wiring-test",
+            options=options,
+            model="claude-haiku-4-5-20251001",
+        )
+        # The CLI must talk to the loopback Vertex shim, not the sentinel
+        # URL invented in __init__ — otherwise every real request 404s.
+        assert connect_env["ANTHROPIC_BASE_URL"].startswith("http://127.0.0.1:")
+        assert executor._vertex_shim is not None
+        assert connect_env["ANTHROPIC_BASE_URL"] == executor._vertex_shim.base_url
+        # The Databricks/generic gateway shim must never start on this path.
+        assert executor._gateway_shim is None
+        # The CLI refuses to run with no key at all ("Not logged in"); the
+        # shim never reads this value (real auth is a GCP token attached
+        # upstream), so a non-empty placeholder must be present.
+        from omnigent.inner.vertex_anthropic_shim import PLACEHOLDER_API_KEY
+
+        assert connect_env["ANTHROPIC_API_KEY"] == PLACEHOLDER_API_KEY
+    finally:
+        if executor._vertex_shim is not None:
+            await executor._vertex_shim.aclose()
+
+
+@pytest.mark.asyncio
+async def test_vertex_executor_connect_strips_ambient_native_vertex_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller whose own shell already has CLAUDE_CODE_USE_VERTEX=1 (e.g. a
+    developer who also uses native Claude-on-Vertex) must not leak that
+    into the CLI subprocess on this path — otherwise the CLI silently
+    prefers its own native Vertex-via-ADC support over our
+    ANTHROPIC_BASE_URL override, defeating the shim's entire purpose of
+    keeping GCP ADC out of the (possibly sandboxed) child process."""
+    from types import SimpleNamespace
+
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+    monkeypatch.setenv("CLAUDE_CODE_USE_VERTEX", "1")
+    monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "some-other-ambient-project")
+    monkeypatch.setenv("ANTHROPIC_VERTEX_REGION", "us-east5")
+    monkeypatch.setenv("CLOUD_ML_REGION", "us-east5")
+
+    executor = ClaudeSDKExecutor(vertex_project="test-project", vertex_location="us-east5")
+
+    seen_env_during_connect: dict[str, str] = {}
+
+    class _StubClient:
+        def __init__(self, options) -> None:  # type: ignore[no-untyped-def]
+            self.options = options
+
+        async def connect(self) -> None:
+            # Snapshot os.environ *during* connect — this is the window
+            # the fix under test unsets the ambient vars for.
+            seen_env_during_connect.update(os.environ)
+
+        async def disconnect(self) -> None:
+            """No-op disconnect for teardown."""
+
+    class _StubSDK:
+        ClaudeSDKClient = _StubClient
+
+    options = SimpleNamespace(
+        env={"ANTHROPIC_BASE_URL": "https://vertex-anthropic.invalid"},
+        stderr=None,
+    )
+    try:
+        await executor._get_or_create_client(
+            _StubSDK,  # type: ignore[arg-type]
+            session_key="vertex-env-strip-test",
+            options=options,
+            model="claude-haiku-4-5-20251001",
+        )
+        assert "CLAUDE_CODE_USE_VERTEX" not in seen_env_during_connect
+        assert "ANTHROPIC_VERTEX_PROJECT_ID" not in seen_env_during_connect
+        assert "ANTHROPIC_VERTEX_REGION" not in seen_env_during_connect
+        assert "CLOUD_ML_REGION" not in seen_env_during_connect
+        # Restored afterwards for anything else in the process.
+        assert os.environ["CLAUDE_CODE_USE_VERTEX"] == "1"
+    finally:
+        if executor._vertex_shim is not None:
+            await executor._vertex_shim.aclose()
+
+
+def test_executor_rejects_gateway_and_vertex_together() -> None:
+    """gateway=True and vertex_project set together is a config error —
+    the two transports set ANTHROPIC_BASE_URL in incompatible ways."""
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        ClaudeSDKExecutor(
+            gateway=True,
+            base_url_override="https://example.com/anthropic",
+            gateway_auth_command="printf %s test",
+            vertex_project="test-project",
+        )


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds a Claude-on-Vertex-AI transport for the `claude-sdk` harness, alongside the existing Databricks/generic gateway path. Vertex's Anthropic Model Garden integration uses a different wire shape than the plain Anthropic API (`:rawPredict`/`:streamRawPredict` instead of `/v1/messages`, model id in the URL path using Vertex's `@`-dated form, `anthropic_version` injected into the body, GCP OAuth2 bearer auth instead of an Anthropic API key) — this needs its own translating shim (`VertexAnthropicGatewayShim`) rather than the existing `ClaudeGatewayShim`, which only patches specific fields of an already-Anthropic-shaped upstream (Databricks' AI Gateway).

GCP credentials are resolved via Application Default Credentials in Omnigent's own (unsandboxed) process; the sandboxed Claude CLI subprocess this harness spawns never sees a GCP credential. This is the reason to prefer this path over Claude's own native `CLAUDE_CODE_USE_VERTEX=1` support, which reads GCP credentials directly inside the CLI process.

Opt in via `executor.config`, reusing the `vertex`/`project`/`location` keys the `antigravity` harness already established:

```yaml
executor:
  harness: claude-sdk
  model: claude-sonnet-4-5-20250929
  config:
    vertex: true
    project: my-gcp-project
    location: global
```

Mutually exclusive with the gateway path (Databricks / generic `api_key` + `base_url`) — validated at executor construction time (`ClaudeSDKExecutor.__init__` raises `ValueError`).

## Test Plan

- Request/response shape (`:rawPredict`/`:streamRawPredict` path, `@`-dated model id, `anthropic_version` body injection, GCP bearer auth) confirmed against a live Vertex AI project with Claude enabled — non-streaming, streaming, and tool-use calls all verified end to end.
- Reference path format cross-checked against the Claude CLI's own `CLAUDE_CODE_USE_VERTEX=1` debug log on the same project.
- Design cross-checked against a comparable open-source implementation (a Rust Anthropic-on-Vertex gateway) — confirmed identical `anthropic_version` value, `model`-in-body stripping, and `@`-dated path format.
- `uv run pytest tests/inner/test_vertex_anthropic_shim.py tests/inner/test_claude_gateway_shim.py tests/inner/test_claude_sdk_executor.py tests/inner/test_claude_sdk_harness.py tests/runtime/test_claude_sdk_spawn_env.py` — 171 passed.
- `uv run ruff check` / `ruff format --check` / `pre-commit run` on all touched files — clean.

## Demo

N/A (no UI change)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the pure translation functions (`to_vertex_model_id`, `build_vertex_anthropic_url`, `prepare_vertex_anthropic_body`) and `GoogleADCTokenCache`'s refresh/reuse logic with a fake credentials object (no real GCP calls in the test suite). Integration tests exercise `VertexAnthropicGatewayShim`'s ASGI plumbing end to end against a local recording upstream standing in for Vertex (request translation, SSE streaming passthrough, 404/400/502 error paths, signal-handler safety), plus executor-wiring tests mirroring `test_claude_gateway_shim.py`'s existing stub-SDK pattern. Manual verification (live Vertex calls, described above) covers what the unit/integration tests can't: the actual Google Cloud request/response contract.

## Changelog

`executor.config: {vertex: true, project: ..., location: ...}` on the `claude-sdk` harness now routes Claude through Vertex AI, keeping GCP credentials out of the sandboxed CLI subprocess