### PR TITLE
feat(harness-bench): derive creds like omni run; --profile optional

### DIFF
--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -54,15 +54,18 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         "--profile",
         metavar="NAME",
         default=None,
-        help="Databricks gateway profile. Enables the live layer; without "
-        "it the bench renders the declared matrix offline.",
+        help="Databricks gateway profile override. Optional: without it the "
+        "bench derives creds the way `omni run` does (a configured "
+        "~/.omnigent profile or ambient OPENAI_*). The live layer turns on "
+        "whenever creds are resolvable; use --no-live for the offline matrix.",
     )
     parser.add_argument(
         "--live",
         dest="live",
         action="store_true",
         default=None,
-        help="Force the live layer (requires --profile).",
+        help="Force the live layer (needs resolvable creds: --profile, a "
+        "configured ~/.omnigent profile, or ambient OPENAI_*).",
     )
     parser.add_argument(
         "--no-live",
@@ -169,10 +172,15 @@ def main(argv: list[str] | None = None) -> int:
         print("--jobs must be >= 1", file=sys.stderr)
         return 2
 
-    # Live if explicitly forced, or implied by a supplied profile.
-    live = args.live if args.live is not None else bool(args.profile)
-    if live and not args.profile:
-        print("--live requires --profile <name>", file=sys.stderr)
+    # Live layer: derive creds the way `omni run` does — a --profile, a
+    # configured ~/.omnigent profile, or ambient OPENAI_*. So a live run no
+    # longer requires --profile; it is implied whenever creds are resolvable.
+    from tests.harness_bench.runtime_env import bench_creds_skip_reason
+
+    creds_skip = bench_creds_skip_reason(args.profile)
+    live = args.live if args.live is not None else creds_skip is None
+    if live and creds_skip is not None:
+        print(f"--live needs resolvable gateway creds: {creds_skip}", file=sys.stderr)
         return 2
 
     # Progress sink: only for a live run (offline is instant). Prefer the rich

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -29,6 +29,7 @@ from tests.harness_bench.events import (
 from tests.harness_bench.full_server import SharedFullServer
 from tests.harness_bench.probes import ALL_PROBES, CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.runtime_env import bench_creds_skip_reason, resolve_bench_env
 from tests.harness_bench.transport import resolve_driver_class, resolve_transport_name
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict, reconcile
 
@@ -229,7 +230,9 @@ async def run_harness(
             transport=resolved_transport,
         )
 
-    assert databricks_profile is not None  # guaranteed by the unavailable() check
+    # databricks_profile may be None here — the driver derives creds like
+    # `omni run` (config profile / ambient OPENAI_*); the unavailable() check
+    # above already confirmed creds are resolvable.
     _emit(sink, HarnessStarted(profile.harness, driver_cls.transport, profile.model))
     cells: list[CellResult] = []
     # Only the full-server driver accepts a shared server; pass it through when
@@ -394,14 +397,17 @@ async def _maybe_shared_full_server(
     run still owns its own server, unchanged).
     """
     shared = None
-    if live and jobs > 1 and databricks_profile is not None:
+    if live and jobs > 1:
         full = [
             p
             for p in profiles
             if resolve_driver_class(p, override=transport, fast=fast).transport == "full-server"
         ]
-        if len(full) > 1:
-            shared = SharedFullServer(databricks_profile)
+        # Only stand one up when creds are actually resolvable (a --profile, a
+        # configured ~/.omnigent profile, or ambient OPENAI_*); otherwise let
+        # each harness's unavailable() report the clean no-creds skip.
+        if len(full) > 1 and bench_creds_skip_reason(databricks_profile) is None:
+            shared = SharedFullServer(resolve_bench_env(databricks_profile))
             await asyncio.to_thread(shared.__enter__)
     try:
         yield shared

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -28,6 +28,7 @@ import httpx
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 from tests.e2e._harness_probes import cli_unavailable_reason
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.runtime_env import bench_creds_skip_reason, resolve_bench_env
 
 
 class ProvisioningError(RuntimeError):
@@ -248,7 +249,7 @@ class SdkInprocDriver:
 
     transport = "sdk-inproc"
 
-    def __init__(self, profile: BenchProfile, *, databricks_profile: str) -> None:
+    def __init__(self, profile: BenchProfile, *, databricks_profile: str | None) -> None:
         self._profile = profile
         self._databricks_profile = databricks_profile
         self._pm: HarnessProcessManager | None = None
@@ -259,20 +260,22 @@ class SdkInprocDriver:
     def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
         """Return a skip reason if this driver cannot run *profile*, else ``None``.
 
-        Checks, in order: the profile's transport matches this driver, a
-        supplied Databricks profile (no gateway route without one), and a
-        runnable harness CLI binary. Mirrors the e2e suite's gating so the
-        bench skips — rather than errors — in environments missing creds or
-        a vendor CLI, or when a profile declares a transport this driver
-        does not implement (e.g. a native/community harness).
+        Checks, in order: the profile's transport matches this driver,
+        resolvable gateway credentials (``--profile``, a configured
+        ``~/.omnigent`` profile, or ambient ``OPENAI_*`` — like ``omni run``),
+        and a runnable harness CLI binary. Mirrors the e2e suite's gating so the
+        bench skips — rather than errors — in environments missing creds or a
+        vendor CLI, or when a profile declares a transport this driver does not
+        implement (e.g. a native/community harness).
         """
         if profile.transport != SdkInprocDriver.transport:
             return (
                 f"transport {profile.transport!r} not supported by the "
                 f"{SdkInprocDriver.transport!r} driver"
             )
-        if not databricks_profile:
-            return "no --profile / databricks profile provided; live probes need a gateway route"
+        creds_skip = bench_creds_skip_reason(databricks_profile)
+        if creds_skip is not None:
+            return creds_skip
         if profile.cli_binary is not None:
             reason = cli_unavailable_reason(profile.cli_binary)
             if reason is not None:
@@ -285,15 +288,17 @@ class SdkInprocDriver:
         self._pm = HarnessProcessManager(tmp_parent=self._tmp_parent)
         await self._pm.start()
         p = self._profile
-        self._client = await self._pm.get_client(
-            _CONV_ID,
-            p.harness,
-            env={
-                f"{p.env_prefix}GATEWAY": "true",
-                f"{p.env_prefix}DATABRICKS_PROFILE": self._databricks_profile,
-                f"{p.env_prefix}MODEL": p.model,
-            },
-        )
+        # Resolve the effective profile the way `omni run` does (the --profile
+        # override, else the config-derived one). May be None when auth comes
+        # from ambient OPENAI_*, in which case the wrap inherits that env.
+        resolved = resolve_bench_env(self._databricks_profile)
+        wrap_env = {
+            f"{p.env_prefix}GATEWAY": "true",
+            f"{p.env_prefix}MODEL": p.model,
+        }
+        if resolved.db_profile:
+            wrap_env[f"{p.env_prefix}DATABRICKS_PROFILE"] = resolved.db_profile
+        self._client = await self._pm.get_client(_CONV_ID, p.harness, env=wrap_env)
         return self
 
     async def __aexit__(self, *exc: object) -> None:

--- a/tests/harness_bench/full_server.py
+++ b/tests/harness_bench/full_server.py
@@ -1,16 +1,17 @@
 """Shared full-server infrastructure: spawn a real Omnigent server + runner.
 
 Split from :mod:`tests.harness_bench.full_server_driver` so the *server
-lifecycle* (spawning the server/runner, minting a bearer, registering bench
-agents + sessions) lives apart from the *driver* that runs probes against it.
-Two consumers use this:
+lifecycle* (spawning the server/runner, registering bench agents + sessions)
+lives apart from the *driver* that runs probes against it. Credentials come from
+:func:`tests.harness_bench.runtime_env.resolve_bench_env` (the same layering
+``omni run`` uses), not a bench-local bearer mint. Two consumers use this:
 
 - :class:`~tests.harness_bench.full_server_driver.FullServerDriver` — one
   harness per :class:`SharedFullServer` (solo run), or several harnesses on one
   shared server (parallel run; see ``bench.run_bench``).
 - :mod:`tests.harness_bench.native_tui_driver` reuses the lower-level spawn
-  helpers (:func:`spawn_omnigent_server`, :func:`_mint_bearer`,
-  :func:`_find_free_port`) for its own server + host-daemon topology.
+  helpers (:func:`spawn_omnigent_server`, :func:`_find_free_port`) for its own
+  server + host-daemon topology.
 """
 
 from __future__ import annotations
@@ -40,8 +41,8 @@ from tests._helpers.compat import (
     runner_executable,
     server_executable,
 )
-from tests.e2e.helpers import lookup_databricks_host
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.runtime_env import BenchRuntimeEnv
 
 _REPO_ROOT = str(Path(__file__).resolve().parents[2])
 _HEALTH_TIMEOUT_S = 90.0
@@ -58,27 +59,6 @@ def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return int(s.getsockname()[1])
-
-
-def _mint_bearer(profile: str) -> str:
-    """Mint a Databricks bearer for *profile* via the CLI (isolated from ambient token env).
-
-    ``env -u DATABRICKS_TOKEN -u DATABRICKS_BEARER`` guards against a stale
-    ambient credential shadowing profile auth (see omnigent issue #1781).
-    """
-    proc = subprocess.run(
-        ["databricks", "auth", "token", "--profile", profile, "--output", "json"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=True,
-        env={
-            k: v
-            for k, v in os.environ.items()
-            if k not in ("DATABRICKS_TOKEN", "DATABRICKS_BEARER")
-        },
-    )
-    return str(json.loads(proc.stdout)["access_token"])
 
 
 def spawn_omnigent_server(
@@ -162,7 +142,7 @@ def _wait_server_runner_ready(base_url: str, runner_id: str) -> None:
 
 
 def _build_bench_agent_config(
-    profile: BenchProfile, db_profile: str, *, deny: bool
+    profile: BenchProfile, db_profile: str | None, *, deny: bool
 ) -> dict[str, Any]:
     """The agent spec for a bench harness: the harness + the read-only builtin,
     plus (when *deny*) a baked tool_call-phase deny on that builtin."""
@@ -171,16 +151,21 @@ def _build_bench_agent_config(
     # the real id so the runner resolves the right ACP agent at spawn.
     safe_harness = profile.harness.replace(":", "-")
     name = f"bench-{safe_harness}" + ("-deny" if deny else "")
+    executor: dict[str, Any] = {
+        "type": "omnigent",
+        "model": profile.model,
+        "config": {"harness": profile.harness},
+    }
+    # Omit executor.profile when auth comes from the ambient env (no derived
+    # profile), so the runner uses the OPENAI_* already in its env instead of
+    # trying to resolve a profile that may not exist.
+    if db_profile:
+        executor["profile"] = db_profile
     config: dict[str, Any] = {
         "spec_version": 1,
         "name": name,
         "prompt": "You are a helpful assistant used for capability testing.",
-        "executor": {
-            "type": "omnigent",
-            "model": profile.model,
-            "profile": db_profile,
-            "config": {"harness": profile.harness},
-        },
+        "executor": executor,
         # A read-only builtin the server dispatches (and gates at the tool_call
         # phase). The tool/policy probes drive a call to it; harmless for basic
         # turns (the model just won't call it).
@@ -233,8 +218,9 @@ class SharedFullServer:
     are the per-harness operations a ``FullServerDriver`` calls against it.
     """
 
-    def __init__(self, db_profile: str) -> None:
-        self._db_profile = db_profile
+    def __init__(self, env: BenchRuntimeEnv) -> None:
+        self._env = env
+        self._db_profile = env.db_profile
         self._proc: subprocess.Popen[bytes] | None = None
         self._runner: subprocess.Popen[bytes] | None = None
         self.client: httpx.Client | None = None
@@ -244,19 +230,13 @@ class SharedFullServer:
 
     def __enter__(self) -> SharedFullServer:
         self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)
-        host = lookup_databricks_host(self._db_profile)
-        assert host is not None
-        bearer = _mint_bearer(self._db_profile)
         port = _find_free_port()
         self.base_url = f"http://localhost:{port}"
         binding_token = uuid.uuid4().hex
         self.runner_id = token_bound_runner_id(binding_token)
-        base_env = {
-            **os.environ,
-            "OPENAI_API_KEY": bearer,
-            "OPENAI_BASE_URL": f"{host}/serving-endpoints",
-            "DATABRICKS_CONFIG_PROFILE": self._db_profile,
-        }
+        # Credentials/profile were derived the way ``omni run`` does (ambient
+        # OPENAI_* wins, else resolve_databricks_workspace) in resolve_bench_env.
+        base_env = dict(self._env.base_env)
         apply_server_env(base_env, _REPO_ROOT)
         self._proc = spawn_omnigent_server(self._tmp, port, base_env, binding_token)
         self._runner = _spawn_bench_runner(

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -36,7 +36,6 @@ from typing import Any
 import httpx
 
 from tests.e2e._harness_probes import cli_unavailable_reason
-from tests.e2e.helpers import lookup_databricks_host
 from tests.harness_bench.driver import TurnResult
 from tests.harness_bench.full_server import (
     _DENY_REASON,
@@ -45,6 +44,7 @@ from tests.harness_bench.full_server import (
     SharedFullServer,
 )
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.runtime_env import bench_creds_skip_reason, resolve_bench_env
 
 _TOOL_PROMPT = f"List the files using the {_TOOL_NAME} tool, then tell me how many there are."
 
@@ -77,7 +77,7 @@ class FullServerDriver:
         self,
         profile: BenchProfile,
         *,
-        databricks_profile: str,
+        databricks_profile: str | None,
         shared: SharedFullServer | None = None,
     ) -> None:
         self._profile = profile
@@ -111,12 +111,9 @@ class FullServerDriver:
                 f"{profile.harness!r} is a native-tui harness; the full-server transport "
                 "registers via an agent bundle and cannot drive it (use --transport native-tui)"
             )
-        if not databricks_profile:
-            return "no --profile / databricks profile provided; full-server needs a gateway route"
-        if lookup_databricks_host(databricks_profile) is None:
-            return (
-                f"databricks profile {databricks_profile!r} missing/hostless in ~/.databrickscfg"
-            )
+        creds_skip = bench_creds_skip_reason(databricks_profile)
+        if creds_skip is not None:
+            return creds_skip
         # Same CLI gate as the wrap driver (same binary requirement), but skip
         # its transport check — that is sdk-inproc-specific and would misreport
         # the driver name; the native case is already handled above.
@@ -126,7 +123,7 @@ class FullServerDriver:
 
     def __enter__(self) -> FullServerDriver:
         if self._shared is None:
-            self._shared = SharedFullServer(self._db_profile)
+            self._shared = SharedFullServer(resolve_bench_env(self._db_profile))
             self._shared.__enter__()
         agent_name = self._shared.register_agent(self._profile, deny=False)
         self._session_id = self._shared.create_session(agent_name)

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -50,7 +50,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import os
 import shutil
 import signal
 import subprocess
@@ -74,14 +73,17 @@ from omnigent.native_terminal import bind_session_runner
 from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e._harness_probes import cli_unavailable_reason
-from tests.e2e.helpers import lookup_databricks_host
 from tests.harness_bench.driver import ProvisioningError, TurnResult
 from tests.harness_bench.full_server import (
     _find_free_port,
-    _mint_bearer,
     spawn_omnigent_server,
 )
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.runtime_env import (
+    BenchRuntimeEnv,
+    bench_creds_skip_reason,
+    resolve_bench_env,
+)
 
 _HEALTH_TIMEOUT_S = 90.0
 _HOST_ONLINE_TIMEOUT_S = 45.0
@@ -257,9 +259,10 @@ class NativeTuiDriver:
 
     transport = "native-tui"
 
-    def __init__(self, profile: BenchProfile, *, databricks_profile: str) -> None:
+    def __init__(self, profile: BenchProfile, *, databricks_profile: str | None) -> None:
         self._profile = profile
         self._db_profile = databricks_profile
+        self._resolved_env: BenchRuntimeEnv | None = None
         self._vendor = native_vendor(profile.harness)
         self._proc: subprocess.Popen[bytes] | None = None
         self._daemon: subprocess.Popen[bytes] | None = None
@@ -278,12 +281,9 @@ class NativeTuiDriver:
         vendor = native_vendor(profile.harness)
         if vendor is None:
             return f"{profile.harness!r} is not a native-tui harness"
-        if not databricks_profile:
-            return "no --profile / databricks profile provided; native-tui needs a gateway route"
-        if lookup_databricks_host(databricks_profile) is None:
-            return (
-                f"databricks profile {databricks_profile!r} missing/hostless in ~/.databrickscfg"
-            )
+        creds_skip = bench_creds_skip_reason(databricks_profile)
+        if creds_skip is not None:
+            return creds_skip
         # The vendor CLI must exist AND be interactively logged in on this
         # host; the bench cannot provision a login. Presence on PATH is the
         # cheapest precondition we can check — a missing login still fails the
@@ -333,17 +333,15 @@ class NativeTuiDriver:
     def _provision(self) -> None:
         self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)
         assert self._vendor is not None
-        host = lookup_databricks_host(self._db_profile)
-        assert host is not None
         port = _find_free_port()
         self._base_url = f"http://localhost:{port}"
         binding_token = uuid.uuid4().hex
 
+        # Credentials derived the way `omni run` does (ambient OPENAI_* wins,
+        # else resolve_databricks_workspace); plus the native tunnel token.
+        self._resolved_env = resolve_bench_env(self._db_profile)
         base_env = {
-            **os.environ,
-            "OPENAI_API_KEY": _mint_bearer(self._db_profile),
-            "OPENAI_BASE_URL": f"{host}/serving-endpoints",
-            "DATABRICKS_CONFIG_PROFILE": self._db_profile,
+            **self._resolved_env.base_env,
             "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token,
         }
         # An omnigent-credential native resolves its provider from omnigent's
@@ -378,13 +376,17 @@ class NativeTuiDriver:
 
     def _write_provider_config(self) -> Path:
         """Write the ``OMNIGENT_CONFIG_HOME`` config that routes the vendor's
-        LLM provider through this run's Databricks profile; return its dir."""
+        LLM provider through this run's Databricks profile; return its dir.
+
+        Uses the profile resolved by :func:`resolve_bench_env` (``--profile`` or
+        the config-derived one). When auth came from the ambient env (no
+        profile), the vendor inherits the ambient ``OPENAI_*`` already in
+        ``base_env``, so no ``auth:`` block is written."""
         config_home = self._tmp / "omnigent-config"
         config_home.mkdir(exist_ok=True)
-        (config_home / "config.yaml").write_text(
-            f"auth:\n  type: databricks\n  profile: {self._db_profile}\n",
-            encoding="utf-8",
-        )
+        profile = self._resolved_env.db_profile if self._resolved_env is not None else None
+        body = f"auth:\n  type: databricks\n  profile: {profile}\n" if profile else "auth: {}\n"
+        (config_home / "config.yaml").write_text(body, encoding="utf-8")
         return config_home
 
     def _wire_native_forwarder(self, host_id: str, workspace: Path) -> None:

--- a/tests/harness_bench/runtime_env.py
+++ b/tests/harness_bench/runtime_env.py
@@ -36,9 +36,19 @@ class BenchRuntimeEnv:
 def _profile_from_config() -> str | None:
     """Return the Databricks profile ``omni run`` would use, or ``None``.
 
-    Reads the user-level ``auth:`` block first (what ``omni run`` consults), then
-    a top-level ``profile:`` key. Imported lazily so importing this module never
-    drags in ``omnigent.cli`` at load time.
+    Mirrors ``omni run``'s profile sources, in the same precedence:
+
+    1. the user-level ``auth:`` block (``omni setup`` writes this);
+    2. a top-level ``profile:`` key;
+    3. the default ``providers:`` entry of ``kind: databricks`` — the common
+       case for a machine configured through the provider wizard rather than
+       ``auth:`` (e.g. ``providers.databricks {default: true, profile: DEFAULT}``).
+       ``omni run`` resolves creds from this entry's ``profile`` (see
+       ``runtime/workflow.py`` ``DATABRICKS_KIND`` branch), so the bench must too
+       or a no-flag run would go offline where ``omni run`` goes live.
+
+    All imports are lazy so importing this module never drags in ``omnigent.cli``
+    at load time.
     """
     try:
         from omnigent.runtime.workflow import _load_global_auth
@@ -53,10 +63,34 @@ def _profile_from_config() -> str | None:
     try:
         from omnigent.cli import _load_effective_config
 
-        cfg_profile = _load_effective_config().get("profile")
+        config = _load_effective_config()
     except Exception:
-        cfg_profile = None
-    return str(cfg_profile) if cfg_profile else None
+        return None
+
+    cfg_profile = config.get("profile")
+    if cfg_profile:
+        return str(cfg_profile)
+
+    # Tier 3: the configured ``providers:`` block. Reuse ``omni``'s own resolver
+    # (``default_provider_for_harness`` — the same call ``resolve_credential``
+    # and the runtime spawn-env builder use) so the bench picks exactly the
+    # provider a launch would, with no reinvented selection logic. When that
+    # provider is a Databricks profile, its ``profile`` is the gateway route.
+    try:
+        from omnigent.onboarding.provider_config import (
+            DATABRICKS_KIND,
+            default_provider_for_harness,
+        )
+
+        # claude-sdk is a representative gateway harness; the databricks
+        # provider is auth-only (serves every family), so the harness choice
+        # only decides which family's default is consulted, not the profile.
+        provider = default_provider_for_harness(config, "claude-sdk")
+    except Exception:
+        provider = None
+    if provider is not None and provider.kind == DATABRICKS_KIND and provider.profile:
+        return str(provider.profile)
+    return None
 
 
 def resolve_bench_env(explicit_profile: str | None) -> BenchRuntimeEnv:

--- a/tests/harness_bench/runtime_env.py
+++ b/tests/harness_bench/runtime_env.py
@@ -1,0 +1,134 @@
+"""Derive the bench's server+runner environment the way ``omni run`` does.
+
+``omni run`` resolves credentials through the canonical
+:func:`omnigent.runtime.credentials.databricks.resolve_databricks_workspace`,
+takes its profile from ``~/.omnigent/config.yaml``'s ``auth:``/``profile`` block,
+and lets an ambient ``OPENAI_*`` env win when present. This module mirrors that
+layering for the bench so a no-flag run behaves like ``omni run``, while an
+explicit ``--profile`` overrides the config-derived profile.
+
+The old bench path always minted its own bearer via a ``databricks auth token``
+subprocess (which did not handle OAuth profiles) and required ``--profile``;
+this replaces it.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BenchRuntimeEnv:
+    """The environment a bench server/runner/host-daemon is spawned with.
+
+    :param base_env: The full env dict (``os.environ`` plus any derived
+        ``OPENAI_*`` / ``DATABRICKS_CONFIG_PROFILE``).
+    :param db_profile: The resolved Databricks profile name (for
+        ``spec.executor.profile`` / skip-gating), or ``None`` when auth came
+        from the ambient env or the SDK default.
+    """
+
+    base_env: dict[str, str]
+    db_profile: str | None
+
+
+def _profile_from_config() -> str | None:
+    """Return the Databricks profile ``omni run`` would use, or ``None``.
+
+    Reads the user-level ``auth:`` block first (what ``omni run`` consults), then
+    a top-level ``profile:`` key. Imported lazily so importing this module never
+    drags in ``omnigent.cli`` at load time.
+    """
+    try:
+        from omnigent.runtime.workflow import _load_global_auth
+
+        auth = _load_global_auth()
+    except Exception:
+        auth = None
+    profile = getattr(auth, "profile", None)
+    if profile:
+        return str(profile)
+
+    try:
+        from omnigent.cli import _load_effective_config
+
+        cfg_profile = _load_effective_config().get("profile")
+    except Exception:
+        cfg_profile = None
+    return str(cfg_profile) if cfg_profile else None
+
+
+def resolve_bench_env(explicit_profile: str | None) -> BenchRuntimeEnv:
+    """Build the bench runtime env, mirroring ``omni run``'s credential layering.
+
+    Precedence:
+
+    1. **Ambient wins.** If both ``OPENAI_BASE_URL`` and ``OPENAI_API_KEY`` are
+       already in the environment, use them and skip credential resolution
+       entirely — the same short-circuit ``omni run`` has
+       (``inner/databricks_executor.py``). This also lets a run with an
+       exported gateway token work with no profile configured.
+    2. **Profile.** ``explicit_profile`` (the ``--profile`` flag) wins; else the
+       config-derived profile (``auth:``/``profile`` in
+       ``~/.omnigent/config.yaml``). May be ``None`` (the resolver then uses the
+       SDK / ``[DEFAULT]`` path, as ``omni run`` does).
+    3. **Compose** ``OPENAI_*`` from
+       :func:`resolve_databricks_workspace` — OAuth-profile aware, fails loud on
+       a typo'd named profile — filling in only the vars not already ambient.
+
+    :param explicit_profile: The ``--profile`` value, or ``None`` to derive.
+    :returns: A :class:`BenchRuntimeEnv`.
+    :raises OSError: When credentials cannot be resolved and no ambient
+        ``OPENAI_*`` covers auth (surfaced by the caller as a clean skip).
+    """
+    base = dict(os.environ)
+    have_ambient = bool(base.get("OPENAI_BASE_URL")) and bool(base.get("OPENAI_API_KEY"))
+    profile = explicit_profile or _profile_from_config()
+
+    if have_ambient:
+        # Ambient OPENAI_* already routes the gateway; don't mint. Still stamp
+        # the profile so the runner's DATABRICKS_CONFIG_PROFILE matches.
+        if profile:
+            base["DATABRICKS_CONFIG_PROFILE"] = profile
+        return BenchRuntimeEnv(base_env=base, db_profile=profile)
+
+    from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
+
+    creds = resolve_databricks_workspace(profile)
+    base["OPENAI_BASE_URL"] = f"{creds.host}/serving-endpoints"
+    base["OPENAI_API_KEY"] = creds.token
+    if profile:
+        base["DATABRICKS_CONFIG_PROFILE"] = profile
+    return BenchRuntimeEnv(base_env=base, db_profile=profile)
+
+
+def bench_creds_skip_reason(explicit_profile: str | None) -> str | None:
+    """Cheap gate: why the bench cannot get gateway creds, or ``None`` if it can.
+
+    Mirrors :func:`resolve_bench_env`'s precedence without minting a token, so a
+    driver's ``unavailable()`` can skip a live run cleanly (no creds) rather than
+    fail mid-provision. A ``--profile`` is no longer required: an ambient
+    ``OPENAI_*`` or a configured ``~/.omnigent`` profile is enough, matching
+    ``omni run``.
+
+    :param explicit_profile: The ``--profile`` value, or ``None`` to derive.
+    :returns: A skip reason, or ``None`` when creds are resolvable.
+    """
+    if os.environ.get("OPENAI_BASE_URL") and os.environ.get("OPENAI_API_KEY"):
+        return None
+    profile = explicit_profile or _profile_from_config()
+    if not profile:
+        return (
+            "no gateway creds: pass --profile, configure a profile in "
+            "~/.omnigent/config.yaml (like `omni run`), or export OPENAI_API_KEY + "
+            "OPENAI_BASE_URL"
+        )
+    from tests.e2e.helpers import lookup_databricks_host
+
+    if lookup_databricks_host(profile) is None:
+        return f"databricks profile {profile!r} missing/hostless in ~/.databrickscfg"
+    return None
+
+
+__all__ = ["BenchRuntimeEnv", "bench_creds_skip_reason", "resolve_bench_env"]

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -473,7 +473,7 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
     built: list[object] = []
 
     class _FakeShared:
-        def __init__(self, db_profile: str) -> None:
+        def __init__(self, env: object) -> None:
             built.append(self)
             self.registered: list[str] = []
 
@@ -529,6 +529,10 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
         "tests.harness_bench.bench.resolve_driver_class",
         lambda p, *, override=None, fast=False: _FSDriver,
     )
+    # Keep the shared-server gate cred-free: this test fakes the server + driver,
+    # so it must not depend on a resolvable Databricks profile (CI has none).
+    monkeypatch.setattr("tests.harness_bench.bench.bench_creds_skip_reason", lambda p: None)
+    monkeypatch.setattr("tests.harness_bench.bench.resolve_bench_env", lambda p: object())
 
     profiles = [
         BenchProfile(

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -754,7 +754,7 @@ async def test_expected_provisioning_error_logged_quietly(
 # ── native-tui transport (offline) ──────────────────────────────
 
 
-def test_native_tui_registered_and_gates() -> None:
+def test_native_tui_registered_and_gates(monkeypatch: pytest.MonkeyPatch) -> None:
     """native-tui is in the registry and derives any native-tui harness."""
     from tests.harness_bench.native_tui_driver import NativeTuiDriver, native_vendor
     from tests.harness_bench.transport import driver_registry, resolve_driver_class
@@ -781,7 +781,13 @@ def test_native_tui_registered_and_gates() -> None:
     codex_sdk = BenchProfile(harness="codex", model="m", env_prefix="X_", marker="X")
     assert NativeTuiDriver.unavailable(codex_sdk, databricks_profile="oss") is not None
 
-    # No profile → the same capability-neutral skip contract as other drivers.
+    # No creds anywhere (no --profile, no ambient OPENAI_*, no configured
+    # profile) → capability-neutral skip. Clear the ambient env and stub the
+    # config lookup so the contract is tested deterministically regardless of
+    # the host's environment.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setattr("tests.harness_bench.runtime_env._profile_from_config", lambda: None)
     assert NativeTuiDriver.unavailable(claude_native, databricks_profile=None) is not None
 
 

--- a/tests/harness_bench/test_runtime_env.py
+++ b/tests/harness_bench/test_runtime_env.py
@@ -16,6 +16,10 @@ from tests.harness_bench.runtime_env import (
     resolve_bench_env,
 )
 
+# Captured before the autouse _clean_env fixture stubs the module attribute, so
+# the tier-3 test can drive the real resolver.
+_REAL_PROFILE_FROM_CONFIG = runtime_env._profile_from_config
+
 
 class _Creds:
     """Stand-in for ``WorkspaceCreds`` (host + token)."""
@@ -97,6 +101,26 @@ def test_explicit_profile_overrides_config(monkeypatch: pytest.MonkeyPatch) -> N
     )
     resolve_bench_env("explicit")
     assert seen["profile"] == "explicit"  # flag wins over config
+
+
+def test_profile_from_providers_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 3: with no ``auth:`` / top-level ``profile:``, the default
+    ``providers:`` databricks entry supplies the profile — the common
+    provider-wizard config where ``omni run`` goes live with no ``--profile``.
+
+    Exercises the real ``_profile_from_config`` (captured before the autouse
+    stub) by monkeypatching the two upstream config sources it reads.
+    """
+    monkeypatch.setattr("omnigent.runtime.workflow._load_global_auth", lambda: None)
+    monkeypatch.setattr(
+        "omnigent.cli._load_effective_config",
+        lambda: {
+            "providers": {
+                "databricks": {"kind": "databricks", "default": True, "profile": "DEFAULT"}
+            }
+        },
+    )
+    assert _REAL_PROFILE_FROM_CONFIG() == "DEFAULT"
 
 
 def test_skip_reason_none_when_ambient(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/harness_bench/test_runtime_env.py
+++ b/tests/harness_bench/test_runtime_env.py
@@ -1,0 +1,119 @@
+"""Unit tests for the bench env resolver (derive creds like ``omni run``).
+
+Network-free: monkeypatches the config lookup and the canonical Databricks
+resolver, so these assert the *layering* (ambient wins, ``--profile`` overrides
+config, no-creds skips) without touching ``~/.databrickscfg`` or the gateway.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.harness_bench import runtime_env
+from tests.harness_bench.runtime_env import (
+    BenchRuntimeEnv,
+    bench_creds_skip_reason,
+    resolve_bench_env,
+)
+
+
+class _Creds:
+    """Stand-in for ``WorkspaceCreds`` (host + token)."""
+
+    def __init__(self, host: str, token: str) -> None:
+        self.host = host
+        self.token = token
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test from a known env: no ambient OPENAI_*, no config profile."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setattr(runtime_env, "_profile_from_config", lambda: None)
+
+
+def _stub_resolver(monkeypatch: pytest.MonkeyPatch, host: str, token: str) -> None:
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace",
+        lambda profile: _Creds(host, token),
+    )
+
+
+def test_explicit_profile_mints_via_canonical_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_resolver(monkeypatch, "https://ws.example.com", "tok-123")
+    env = resolve_bench_env("oss")
+    assert isinstance(env, BenchRuntimeEnv)
+    assert env.db_profile == "oss"
+    assert env.base_env["OPENAI_BASE_URL"] == "https://ws.example.com/serving-endpoints"
+    assert env.base_env["OPENAI_API_KEY"] == "tok-123"
+    assert env.base_env["DATABRICKS_CONFIG_PROFILE"] == "oss"
+
+
+def test_ambient_openai_wins_and_skips_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://ambient.example.com/serving-endpoints")
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-key")
+
+    def _boom(profile: str | None) -> _Creds:  # pragma: no cover - must not run
+        raise AssertionError("resolver must not be called when ambient OPENAI_* is set")
+
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace", _boom
+    )
+    env = resolve_bench_env(None)
+    assert env.base_env["OPENAI_API_KEY"] == "ambient-key"
+    assert env.base_env["OPENAI_BASE_URL"] == "https://ambient.example.com/serving-endpoints"
+
+
+def test_config_profile_used_when_no_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No --profile, but ~/.omnigent config yields a profile (like `omni run`).
+    monkeypatch.setattr(runtime_env, "_profile_from_config", lambda: "from-config")
+    seen: dict[str, str | None] = {}
+
+    def _resolver(profile: str | None) -> _Creds:
+        seen["profile"] = profile
+        return _Creds("https://cfg.example.com", "cfg-tok")
+
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace", _resolver
+    )
+    env = resolve_bench_env(None)
+    assert seen["profile"] == "from-config"
+    assert env.db_profile == "from-config"
+    assert env.base_env["OPENAI_API_KEY"] == "cfg-tok"
+
+
+def test_explicit_profile_overrides_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runtime_env, "_profile_from_config", lambda: "from-config")
+    seen: dict[str, str | None] = {}
+
+    def _resolver(profile: str | None) -> _Creds:
+        seen["profile"] = profile
+        return _Creds("https://x", "t")
+
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace", _resolver
+    )
+    resolve_bench_env("explicit")
+    assert seen["profile"] == "explicit"  # flag wins over config
+
+
+def test_skip_reason_none_when_ambient(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://a/serving-endpoints")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    assert bench_creds_skip_reason(None) is None
+
+
+def test_skip_reason_when_no_creds_anywhere() -> None:
+    # _clean_env stubbed _profile_from_config -> None and cleared OPENAI_*.
+    reason = bench_creds_skip_reason(None)
+    assert reason is not None
+    assert "--profile" in reason
+
+
+def test_skip_reason_when_profile_hostless(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("tests.e2e.helpers.lookup_databricks_host", lambda p: None)
+    reason = bench_creds_skip_reason("typo-profile")
+    assert reason is not None
+    assert "typo-profile" in reason


### PR DESCRIPTION
## Summary

Makes the harness bench derive its runtime environment the **same way `omni run`
does**, and makes `--profile` optional. Stands alone off `main` -- independent
of both open questions on the earlier stack (where the bench lives, and whether
`omni bench` should ship an alias), because it changes only credential
resolution and stays in `tests/harness_bench/`.

Before, the bench always minted its own bearer via a `databricks auth token`
subprocess (which does not handle OAuth `databricks-cli` profiles) and required
`--profile` for any live run -- a path entirely separate from how `omni run`
authenticates.

This adds `tests/harness_bench/runtime_env.py` with `resolve_bench_env()`,
mirroring `omni run`'s credential layering:

1. ambient `OPENAI_BASE_URL` + `OPENAI_API_KEY` win (resolution skipped
   entirely -- the same short-circuit `omni run` has);
2. else the profile from `--profile`, else the `~/.omnigent/config.yaml`
   `auth:`/`profile` block (exactly what `omni run` reads);
3. compose `OPENAI_*` via the canonical `resolve_databricks_workspace()`
   (OAuth-aware, fails loud on a typo'd profile) -- the resolver the runner
   already uses.

So a no-flag run now behaves like `omni run`, and `--profile` overrides. A new
`bench_creds_skip_reason()` gives every driver's `unavailable()` a cheap,
token-free gate, so a run **skips cleanly** when no creds are resolvable instead
of demanding a flag.

Threading changes (all in place, no file moves):

- `SharedFullServer` takes a `BenchRuntimeEnv` (was `db_profile: str`); its
  `__enter__` drops `_mint_bearer` + `lookup_databricks_host` and uses
  `env.base_env`.
- `FullServerDriver` / `NativeTuiDriver` / `SdkInprocDriver` resolve via
  `resolve_bench_env`; `databricks_profile` is now Optional throughout.
  `run_bench` keeps the kwarg for back-compat.
- The full-server agent spec and the native provider-config omit
  `executor.profile` / the `auth:` block when auth came from the ambient env.
- `__main__`: a live run no longer requires `--profile`; it turns on whenever
  creds are resolvable, and `--no-live` forces the offline declared matrix.

**Intentional behavior change:** this drops the bench-only #1781 stale-token
strip (`env -u DATABRICKS_TOKEN`). `omni run` uses the same resolver and does not
strip either; aligning with `omni` is the point. Flagged for reviewer
visibility -- if ambient-token shadowing is a real concern it is an omni-wide fix
in the resolver, not a bench special-case.

Relationship to the earlier work: this supersedes the credential part of the
`omni bench` stack (#2290). The package move (#2289) and the `omni bench` command
(#2292) stay open for the alias / user-facing discussion; when they rebase after
this lands, the now-redundant env commit drops out.

## Test Plan

- New `tests/harness_bench/test_runtime_env.py` (network-free) covers the
  layering: `--profile` mints via the canonical resolver, ambient `OPENAI_*`
  wins and skips the resolver, config-derived profile when no flag, `--profile`
  overrides config, no-creds -> skip reason, hostless profile -> skip reason.
- `python -m pytest tests/harness_bench/` -> 80 passed, 18 skipped.
- `python -m pytest tests/e2e --collect-only` -> 376 collected (no import
  breakage; `tests.e2e.helpers.lookup_databricks_host` still used).
- `python -m tests.harness_bench --list` still renders.
- `ruff check` + `ruff format` clean; no `uv.lock` drift.

## Demo

N/A -- no UI change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI / frontend change

## Test coverage

- [x] Added or updated automated tests
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

New unit tests cover the resolver's layering directly (network-free via
monkeypatched config + resolver). The existing bench suite exercises the driver
threading changes; `--list` and e2e collection confirm no import breakage.
