### PR TITLE
docs(deploy): keep a local workstation server running (launchd / systemd)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -76,6 +76,9 @@ deploy/
 ├── tailscale/         ← Tailscale (private access from phone/tablet/laptop
 │   └── README.md         via tailnet; Funnel for cloud sandbox dial-back)
 │
+├── local/             ← keep a LOCAL workstation server running across
+│   └── README.md         crashes/reboots (launchd / systemd); not a deploy target
+│
 ├── daytona/           ← Daytona sandbox-provider guide + the Cloudflare
 │   ├── wrangler.toml     Worker egress relay for its free tier; NOT a
 │   ├── src/index.js      server deploy target. See its README.md.
@@ -118,6 +121,7 @@ deploy/
 | Stand up a quick demo (no DB to provision) | HF Spaces | [`hf-spaces/README.md`](hf-spaces/README.md): Docker Space, SQLite |
 | Share a server running on your **laptop**: demo it to teammates, or let remote runners & cloud sandboxes connect back to it (nothing to deploy) | Cloudflare quick tunnel | `cloudflared tunnel --url http://localhost:6767` |
 | Access your server privately from **your phone, tablet, or other personal devices** without exposing it to the internet | Tailscale | [`tailscale/README.md`](tailscale/README.md): `tailscale serve https / http://localhost:8000` |
+| Keep the **local** server on your workstation running — start at login, restart on crash (nothing to deploy) | launchd / systemd | [`local/README.md`](local/README.md): supervise the foreground `omnigent server` |
 | Cloud Run / Kubernetes / other | Docker image | [`docker/README.md`](docker/README.md), then point your platform at the image |
 | Deploy on a Databricks workspace (Lakebase + UC Volumes), self-managed | Databricks Apps | [`databricks/README.md`](databricks/README.md): uses Asset Bundles |
 

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -27,11 +27,51 @@ the tooling won't find it and will spawn a competing second server.
 The defaults are already what you want (`127.0.0.1:6767`, shared
 `chat.db` and artifacts under the data dir).
 
+## The wrapper script (both platforms)
+
+One wrinkle: when the supervisor replaces a running server, the new
+process can start while the old one is still draining connections (or
+its sockets sit in `TIME_WAIT`). The server's port probe then finds 6767
+busy and silently binds a free port instead. Discovery still works —
+everything finds the server through the pidfile, not the port — but
+anything of yours that hardcodes `http://127.0.0.1:6767` breaks until
+the next restart. In practice this happens on *most* restarts once the
+desktop app or web UI holds long-lived WebSocket connections.
+
+The fix is a short wait before the server starts. Save this as
+`~/.omnigent/omnigent-server-wrapper.sh` and `chmod +x` it; both
+recipes below run the server through it:
+
+```sh
+#!/bin/sh
+# Wait (max 60s) for the previous server to release port 6767, then exec
+# the foreground server so it reclaims its preferred port instead of
+# falling back to a random one. The bind probe matches the one the
+# server itself uses. exec keeps the server as the supervisor's direct
+# child, so restart-on-failure still works.
+python3 - <<'EOF'
+import socket, time
+for _ in range(60):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", 6767))
+        s.close()
+        break
+    except OSError:
+        s.close()
+        time.sleep(1)
+EOF
+exec "$HOME/.local/bin/omnigent" server
+```
+
+Adjust the `omnigent` path to `which omnigent` on your machine. Any
+Python 3 works for the probe; omnigent installs one you can point at if
+`python3` isn't on the service's PATH.
+
 ## macOS: launchd
 
 Save as `~/Library/LaunchAgents/ai.omnigent.server.plist`, replacing
-`YOU` with your username (find your `omnigent` path with
-`which omnigent`):
+`YOU` with your username:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -42,8 +82,8 @@ Save as `~/Library/LaunchAgents/ai.omnigent.server.plist`, replacing
     <string>ai.omnigent.server</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/YOU/.local/bin/omnigent</string>
-        <string>server</string>
+        <string>/bin/sh</string>
+        <string>/Users/YOU/.omnigent/omnigent-server-wrapper.sh</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>
@@ -78,7 +118,7 @@ omnigent server stop
 
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.omnigent.server.plist
 
-# Verify
+# Verify (first boot takes ~10-15s)
 launchctl list | grep ai.omnigent.server   # shows a PID
 omnigent server status
 ```
@@ -92,7 +132,9 @@ launchctl bootout gui/$(id -u)/ai.omnigent.server        # stop for real (unload
 
 Note that `omnigent server stop` (and crashes, and plain `kill`) no
 longer stop the server for long — `KeepAlive` restarts it. To actually
-take it down, unload the job with `bootout`.
+take it down, unload the job with `bootout`. On restart, expect a pause
+while the wrapper waits for the previous instance to drain its
+connections and release the port.
 
 ## Linux: systemd user unit
 
@@ -104,7 +146,7 @@ Description=Omnigent local server
 After=network.target
 
 [Service]
-ExecStart=%h/.local/bin/omnigent server
+ExecStart=/bin/sh %h/.omnigent/omnigent-server-wrapper.sh
 Restart=always
 RestartSec=10
 
@@ -121,6 +163,11 @@ systemctl --user enable --now omnigent-server
 systemctl --user status omnigent-server
 ```
 
+(`systemctl --user restart` waits for the old process to exit before
+starting the new one, so the port race is narrower than on launchd —
+but `TIME_WAIT` sockets from a crashed instance can still trigger the
+fallback, and the wrapper costs nothing when the port is already free.)
+
 By default user units only run while you're logged in. To keep the
 server up across logouts (headless boxes, SSH targets):
 
@@ -128,14 +175,12 @@ server up across logouts (headless boxes, SSH targets):
 sudo loginctl enable-linger "$USER"
 ```
 
-## Crash-restart port fallback
+## If you skip the wrapper
 
-If the server is restarted within a second or two of a crash, the OS may
-not have released port 6767 yet, and the respawn logs
-`port 6767 is busy — using <other> instead.` and binds a free port. This
-is safe: discovery goes through the pidfile, not the port, so
-`omnigent run`, the daemon, and the desktop app still find it. Anything
-of yours that hardcodes `http://127.0.0.1:6767` won't, though — check
-`omnigent server status` for the live URL, and restart the service once
-the old socket is gone to get 6767 back. The 10-second restart delay in
-both recipes above makes this rare in practice.
+Running bare `omnigent server` as the supervised command still gives you
+crash recovery and start-at-login — rules 1 and 2 are what matter for
+correctness. You just lose the stable port: restarts that overlap the
+old instance log `port 6767 is busy — using <other> instead.` and bind a
+free port. That is safe by design (discovery goes through the pidfile;
+check `omnigent server status` for the live URL), but hardcoded-6767
+clients won't find the server until a later restart reclaims the port.

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -1,0 +1,141 @@
+# Keeping the local server running (launchd / systemd)
+
+The cloud recipes in [`deploy/`](../README.md) give you a hosted server.
+This page is for the other case: the **local** server on your own
+workstation — the one the desktop app, `omnigent run`, and the host
+daemon all talk to on `127.0.0.1:6767`. Out of the box it is started on
+demand and detached; if it crashes, or you log out and back in, nothing
+brings it back until something next asks for it. A user-level service
+manager (launchd on macOS, systemd on Linux) fixes that: start at login,
+restart on failure.
+
+## The two rules
+
+**1. Supervise the foreground command, not `server start`.**
+`omnigent server start` is a daemonizer: it spawns the real server
+detached and exits `0`. A supervisor pointed at it sees a process that
+exits immediately and has nothing to keep alive. Bare `omnigent server`
+runs in the foreground — that is the invocation a supervisor must own.
+
+**2. Don't pass `--port` / `--database-uri` / `--artifact-location`.**
+With no explicit flags the foreground server runs as the *canonical*
+local server: it registers itself in `~/.omnigent/local_server.pid`, and
+`omnigent run`, the host daemon, and the desktop app discover and reuse
+it through that pidfile. Passing any of those flags makes it a
+*dedicated* server that deliberately does **not** register — the rest of
+the tooling won't find it and will spawn a competing second server.
+The defaults are already what you want (`127.0.0.1:6767`, shared
+`chat.db` and artifacts under the data dir).
+
+## macOS: launchd
+
+Save as `~/Library/LaunchAgents/ai.omnigent.server.plist`, replacing
+`YOU` with your username (find your `omnigent` path with
+`which omnigent`):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.omnigent.server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOU/.local/bin/omnigent</string>
+        <string>server</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/YOU/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/YOU</string>
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>/Users/YOU</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/YOU/.omnigent/logs/launchd-server.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOU/.omnigent/logs/launchd-server.err.log</string>
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>
+```
+
+Then:
+
+```sh
+# Stop any detached server first so the supervised one can bind 6767
+omnigent server stop
+
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.omnigent.server.plist
+
+# Verify
+launchctl list | grep ai.omnigent.server   # shows a PID
+omnigent server status
+```
+
+Day-to-day:
+
+```sh
+launchctl kickstart -k gui/$(id -u)/ai.omnigent.server   # restart (e.g. after upgrade)
+launchctl bootout gui/$(id -u)/ai.omnigent.server        # stop for real (unload)
+```
+
+Note that `omnigent server stop` (and crashes, and plain `kill`) no
+longer stop the server for long — `KeepAlive` restarts it. To actually
+take it down, unload the job with `bootout`.
+
+## Linux: systemd user unit
+
+Save as `~/.config/systemd/user/omnigent-server.service`:
+
+```ini
+[Unit]
+Description=Omnigent local server
+After=network.target
+
+[Service]
+ExecStart=%h/.local/bin/omnigent server
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+```
+
+Then:
+
+```sh
+omnigent server stop        # stop any detached server first
+systemctl --user daemon-reload
+systemctl --user enable --now omnigent-server
+systemctl --user status omnigent-server
+```
+
+By default user units only run while you're logged in. To keep the
+server up across logouts (headless boxes, SSH targets):
+
+```sh
+sudo loginctl enable-linger "$USER"
+```
+
+## Crash-restart port fallback
+
+If the server is restarted within a second or two of a crash, the OS may
+not have released port 6767 yet, and the respawn logs
+`port 6767 is busy — using <other> instead.` and binds a free port. This
+is safe: discovery goes through the pidfile, not the port, so
+`omnigent run`, the daemon, and the desktop app still find it. Anything
+of yours that hardcodes `http://127.0.0.1:6767` won't, though — check
+`omnigent server status` for the live URL, and restart the service once
+the old socket is gone to get 6767 back. The 10-second restart delay in
+both recipes above makes this rare in practice.


### PR DESCRIPTION
## Related issue

N/A — docs addition, no associated issue.

## Summary

- `deploy/` documents plenty of ways to host the server, but nothing about keeping the **local** workstation server (the one the desktop app, `omnigent run`, and the host daemon use on `127.0.0.1:6767`) running across crashes, logouts, and reboots.
- Adds `deploy/local/README.md` with supervision recipes for **launchd** (macOS) and a **systemd user unit** (Linux), and registers `local/` in this README's tree + "Pick your target" table.
- Documents two constraints that are easy to get wrong: supervisors must run the **foreground** `omnigent server` (`server start` daemonizes and exits `0`, so there is nothing to keep alive — with `RunAtLoad` only, nothing ever restarts the server), and the supervised invocation must stay **flagless** so it remains the canonical pidfile-registered server that the rest of the tooling discovers (explicit `--port`/`--database-uri` deliberately creates a dedicated, unregistered server).
- Both recipes run the server through a small **port-wait wrapper**: the supervisor spawns the replacement while the old instance is still draining WebSocket connections, so without the wait most restarts hit the `pick_local_port` fallback (probe without `SO_REUSEADDR`) and land on a random port. Pidfile discovery keeps that safe, but hardcoded-6767 clients lose the server; the doc covers both the wrapper and what you get if you skip it.

ELI5: `omnigent server start` is fire-and-forget — if the server dies, nothing notices. This guide shows how to hand the server to the OS's babysitter (launchd/systemd) so it comes back on its own, the one command shape the babysitter needs, and a tiny "wait for the old one to leave before taking the chair" script so the server keeps its well-known port.

## Test Plan

Verified the launchd recipe end-to-end on macOS 15 (Darwin 25.4), with a desktop app + web UI attached (33 live sessions):

- Loaded the plist with `launchctl bootstrap`; server bound `127.0.0.1:6767`, answered `/health` 200, and registered itself in `~/.omnigent/local_server.pid`.
- `kill -9` on the server PID → launchd respawned it automatically; clients reconnected.
- Reproduced the port fallback described in the doc: without the wrapper, `launchctl kickstart -k` restarts overlapped the old instance's graceful drain and logged `port 6767 is busy — using <other> instead.` on 2 of 3 restarts; pidfile discovery (`omnigent server status`) still found the server each time.
- With the wrapper: `kickstart -k` restarts deterministically reclaimed 6767 — the new job waited out the old instance's connection drain, then bound the preferred port and re-registered the pidfile.
- Confirmed the anti-pattern: the same plist pointed at `omnigent server start` exits `0` immediately and leaves nothing under supervision.

systemd unit is the direct translation (`Restart=always`, `RestartSec=10`, same wrapper via `ExecStart`); not exercised on a Linux box as part of this PR.

`pre-commit run` passes on both files.

## Demo

N/A — docs-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Docs-only change; no code paths modified. The launchd recipe was manually verified end-to-end on macOS as described in the Test Plan (bootstrap, crash-respawn via `kill -9`, port-fallback reproduction with and without the wrapper, restart/unload commands).

Possible code follow-up (out of scope here): `pick_local_port` could probe with `SO_REUSEADDR` so supervised respawns reclaim the preferred port without the wrapper.

## Changelog

New guide: keep the local `omnigent server` running across crashes and reboots with launchd / systemd (`deploy/local/README.md`)

---

This pull request and its description were written by Isaac.
