### PR TITLE
fix(runner): resolve os_env cwd against the session workspace, not the daemon cwd

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2685,6 +2685,10 @@ def _start_cli_runner_process(
             stderr=log_fh,
             **_proc.spawn_kwargs(),
         )
+    except OSError as exc:
+        # E.g. the workspace vanished between the is_dir check and the
+        # spawn; surface a CLI error instead of a raw traceback.
+        raise click.ClickException(f"Failed to spawn runner: {exc}") from exc
     finally:
         if log_fh is not None:
             log_fh.close()

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2589,7 +2589,9 @@ def _start_cli_runner_process(
         to runner-local filesystem tools when a spec uses the
         placeholder cwd ``"."``. Remote ``run/attach --server``
         passes the CLI launch cwd so local runner tools operate
-        in the user's project checkout.
+        in the user's project checkout. Also becomes the runner
+        subprocess's cwd so relative path resolution never depends
+        on the parent process's cwd.
     :param capture_logs: When True, redirect the runner
         subprocess's stdout/stderr to a per-run temp log file
         instead of inheriting the parent's stdio. The attach-remote
@@ -2645,8 +2647,14 @@ def _start_cli_runner_process(
         RUNNER_PARENT_PID_ENV_VAR: str(os.getpid()),
     }
     env[RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR] = binding_token
+    resolved_workspace: str | None = None
     if workspace_cwd is not None:
-        env[RUNNER_WORKSPACE_ENV_VAR] = str(Path(workspace_cwd).expanduser().resolve())
+        resolved_workspace = str(Path(workspace_cwd).expanduser().resolve())
+        # The workspace becomes the runner's cwd below; fail with a clear
+        # message rather than an uncaught FileNotFoundError from Popen.
+        if not Path(resolved_workspace).is_dir():
+            raise click.ClickException(f"Runner workspace does not exist: {resolved_workspace}")
+        env[RUNNER_WORKSPACE_ENV_VAR] = resolved_workspace
     if isolate_session:
         env[RUNNER_ISOLATE_SESSION_ENV_VAR] = "1"
     if prewarm_spec_path is not None:
@@ -2669,6 +2677,10 @@ def _start_cli_runner_process(
         runner_proc = subprocess.Popen(
             [sys.executable, "-m", "omnigent.runner._entry"],
             env=env,
+            # Anchor the runner in the workspace so relative os_env cwd
+            # values resolve there instead of wherever the CLI happened
+            # to be launched from.
+            cwd=resolved_workspace,
             stdout=log_fh,
             stderr=log_fh,
             **_proc.spawn_kwargs(),

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1034,7 +1034,10 @@ class HostProcess:
                 error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
             )
 
-        workspace = Path(frame.workspace).expanduser()
+        # Resolve before the is_dir check and the spawn: a relative or
+        # symlinked workspace must not be interpreted against the
+        # daemon's own (possibly deleted) cwd.
+        workspace = Path(frame.workspace).expanduser().resolve(strict=False)
         if not workspace.is_dir():
             return HostLaunchRunnerResultFrame(
                 request_id=frame.request_id,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1074,6 +1074,11 @@ class HostProcess:
             proc = subprocess.Popen(
                 [sys.executable, "-m", "omnigent.runner._entry"],
                 env=env,
+                # Anchor the runner in the session workspace. Inheriting the
+                # long-lived daemon's cwd makes relative os_env cwd values
+                # resolve against the wrong directory — and os.getcwd()
+                # crashes outright if the daemon's cwd has been deleted.
+                cwd=str(workspace),
                 # Runners are WS-tunnel clients with no interactive input.
                 # Give them a clean /dev/null stdin instead of inheriting the
                 # daemon's: a long-lived daemon (e.g. backgrounded / nohup'd)

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -880,14 +880,33 @@ class CallerProcessOSEnvironment(OSEnvironment):
         self.close()
 
 
-def create_os_environment(spec: OSEnvSpec | None) -> OSEnvironment | None:
-    """Instantiate the configured OS environment."""
+def create_os_environment(
+    spec: OSEnvSpec | None,
+    base_cwd: Path | None = None,
+) -> OSEnvironment | None:
+    """Instantiate the configured OS environment.
+
+    :param spec: The environment spec, or ``None`` for no environment.
+    :param base_cwd: Base directory a relative (or unset) ``spec.cwd``
+        resolves against — typically the session/runner workspace. Pass
+        an absolute path: a relative ``base_cwd`` still resolves via the
+        process cwd. When ``None``, falls back to the process cwd, which
+        is only safe when the caller controls it.
+    """
     if spec is None:
         return None
     if spec.type != "caller_process":
         raise NotImplementedError(f"os_env type '{spec.type}' is not implemented")
 
-    cwd = Path(spec.cwd or os.getcwd()).resolve(strict=False)
+    if spec.cwd:
+        raw_cwd = Path(spec.cwd)
+        if not raw_cwd.is_absolute() and base_cwd is not None:
+            raw_cwd = base_cwd / raw_cwd
+        cwd = raw_cwd.resolve(strict=False)
+    elif base_cwd is not None:
+        cwd = base_cwd.resolve(strict=False)
+    else:
+        cwd = Path(os.getcwd()).resolve(strict=False)
     fork_dir: Path | None = None
     if spec.fork:
         fork_dir = Path(tempfile.mkdtemp(prefix="omnigent-fork-"))

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -13594,6 +13594,9 @@ def create_runner_app(
                     _tmgr = ToolManager(
                         cached_spec,
                         workdir=cached_spec_workdir or runner_workspace,
+                        # Anchor os_env cwd resolution to the session
+                        # workspace, not the agent image dir in workdir.
+                        os_env_base_cwd=runner_workspace,
                     )
                     all_tools.extend(_tmgr.get_tool_schemas())
                 except (

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -529,7 +529,10 @@ class ToolManager:
         When a pre-resolved :class:`OSEnvironment` was provided to
         the constructor (from ``SessionResourceRegistry``), that
         shared instance is used directly. Otherwise, falls back to
-        creating a new instance via ``create_os_environment()``.
+        creating a new instance via ``create_os_environment()``,
+        resolving a relative ``os_env.cwd`` against ``workdir`` so it
+        never depends on the process cwd (which for runner subprocesses
+        historically inherited the host daemon's cwd).
 
         When the spec declares no os_env and no pre-resolved env
         was provided, this is a no-op.
@@ -546,7 +549,7 @@ class ToolManager:
             os_env_spec_obj = self._spec.os_env
             if os_env_spec_obj is None:
                 return
-            os_env = create_os_environment(os_env_spec_obj)
+            os_env = create_os_environment(os_env_spec_obj, base_cwd=self._workdir)
             if os_env is None:
                 return
 

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -109,6 +109,7 @@ class ToolManager:
         workdir: Path | None = None,
         sandbox_enabled: bool = True,
         os_env: OSEnvironment | None = None,
+        os_env_base_cwd: Path | None = None,
     ) -> None:
         """
         Initialize the tool manager and register built-in,
@@ -135,9 +136,15 @@ class ToolManager:
             tools use this shared instance instead of creating their
             own. ``None`` falls back to per-call creation via
             ``create_os_environment()``.
+        :param os_env_base_cwd: Base directory relative ``os_env.cwd``
+            values resolve against — the session/runner workspace when
+            the caller knows it. ``None`` falls back to ``workdir``,
+            which is the agent image directory and may differ from the
+            workspace.
         """
         self._spec = spec
         self._workdir = workdir
+        self._os_env_base_cwd = os_env_base_cwd
         self._sandbox_enabled = sandbox_enabled
         self._pre_resolved_os_env = os_env
         self._started = False
@@ -530,9 +537,10 @@ class ToolManager:
         the constructor (from ``SessionResourceRegistry``), that
         shared instance is used directly. Otherwise, falls back to
         creating a new instance via ``create_os_environment()``,
-        resolving a relative ``os_env.cwd`` against ``workdir`` so it
-        never depends on the process cwd (which for runner subprocesses
-        historically inherited the host daemon's cwd).
+        resolving a relative ``os_env.cwd`` against ``os_env_base_cwd``
+        (the workspace) or ``workdir`` so it never depends on the
+        process cwd (which for runner subprocesses historically
+        inherited the host daemon's cwd).
 
         When the spec declares no os_env and no pre-resolved env
         was provided, this is a no-op.
@@ -549,7 +557,10 @@ class ToolManager:
             os_env_spec_obj = self._spec.os_env
             if os_env_spec_obj is None:
                 return
-            os_env = create_os_environment(os_env_spec_obj, base_cwd=self._workdir)
+            os_env = create_os_environment(
+                os_env_spec_obj,
+                base_cwd=self._os_env_base_cwd or self._workdir,
+            )
             if os_env is None:
                 return
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -995,6 +995,7 @@ def test_start_cli_runner_process_uses_token_bound_runner_id(
         def __init__(self, args: list[str], *, env: dict[str, str], **_kwargs: object) -> None:
             captured["args"] = args
             captured["env"] = env
+            captured["cwd"] = _kwargs.get("cwd")
 
         def poll(self) -> None:
             """Report the runner process as still alive.
@@ -1022,6 +1023,38 @@ def test_start_cli_runner_process_uses_token_bound_runner_id(
     assert env[RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR] == "bind-token"
     assert env[RUNNER_PARENT_PID_ENV_VAR] == str(os.getpid())
     assert env[RUNNER_WORKSPACE_ENV_VAR] == str(workspace.resolve())
+    # The runner must start inside the workspace so relative os_env cwd
+    # values never resolve against the parent process's cwd.
+    assert captured["cwd"] == str(workspace.resolve())
+
+
+def test_start_cli_runner_process_rejects_missing_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A missing workspace fails with a clear error before spawning.
+
+    The workspace becomes the runner subprocess's cwd, so spawning
+    would otherwise die with an uncaught FileNotFoundError from Popen.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary directory fixture.
+    :returns: None.
+    """
+    spawned: list[object] = []
+    monkeypatch.setattr(
+        "omnigent.cli.subprocess.Popen",
+        lambda *args, **kwargs: spawned.append((args, kwargs)),
+    )
+
+    with pytest.raises(ClickException) as excinfo:
+        _start_cli_runner_process(
+            server_url="http://127.0.0.1:8000",
+            workspace_cwd=tmp_path / "gone",
+        )
+
+    assert "Runner workspace does not exist" in excinfo.value.message
+    assert not spawned, "Popen must not be called for a missing workspace"
 
 
 def test_start_cli_runner_process_binds_stable_local_runner_to_generated_token(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1086,6 +1086,7 @@ def test_start_cli_runner_process_binds_stable_local_runner_to_generated_token(
         def __init__(self, args: list[str], *, env: dict[str, str], **_kwargs: object) -> None:
             captured["args"] = args
             captured["env"] = env
+            captured["cwd"] = _kwargs.get("cwd")
 
         def poll(self) -> None:
             """Report the runner process as still alive.
@@ -1110,6 +1111,8 @@ def test_start_cli_runner_process_binds_stable_local_runner_to_generated_token(
     assert env[RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR] == "local-bind-token"
     assert env[RUNNER_PARENT_PID_ENV_VAR] == str(os.getpid())
     assert "OMNIGENT_RUNNER_TUNNEL_TOKEN" not in env
+    # No workspace_cwd → the runner inherits the CLI's cwd (unchanged).
+    assert captured["cwd"] is None
 
 
 def test_start_cli_runner_process_reports_captured_log_path(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -150,6 +150,14 @@ async def test_handle_launch_spawns_subprocess(
         "runner subprocess must be spawned with stdin=subprocess.DEVNULL"
     )
 
+    # The runner must start inside the session workspace. Inheriting the
+    # long-lived daemon's cwd resolves relative os_env cwd values against
+    # the wrong directory, and crashes os.getcwd() during turn setup when
+    # the daemon's cwd has since been deleted.
+    assert spawned_kwargs.get("cwd") == str(workspace), (
+        "runner subprocess must be spawned with cwd=<session workspace>"
+    )
+
     # Clean up the spawned sleep process (and its exit watcher).
     _cleanup_host(host)
 

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -4,10 +4,19 @@ from __future__ import annotations
 
 import base64
 import shutil
+import sys
 import tracemalloc
 from pathlib import Path
 
-from omnigent.inner.os_env import _read_impl, _shell_impl, build_helper_env
+import pytest
+
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.os_env import (
+    _read_impl,
+    _shell_impl,
+    build_helper_env,
+    create_os_environment,
+)
 from omnigent.inner.sandbox import SandboxPolicy
 from omnigent.runner.identity import (
     OMNIGENT_SESSION_ENV_VALUE,
@@ -294,3 +303,109 @@ def test_read_impl_nul_byte_file_classified_binary(tmp_path: Path) -> None:
 
     assert result["encoding"] == "base64"
     assert result["total_bytes"] == 10
+
+
+def _caller_process_spec(cwd: str | None) -> OSEnvSpec:
+    """A minimal unsandboxed caller_process spec for cwd-resolution tests.
+
+    :param cwd: The spec's ``cwd`` value, e.g. ``"."`` or ``None``.
+    :returns: An :class:`OSEnvSpec` with ``sandbox.type: none``.
+    """
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=cwd,
+        sandbox=OSEnvSandboxSpec(type="none"),
+    )
+
+
+def _created_cwd(spec: OSEnvSpec, base_cwd: Path | None) -> Path:
+    """Create an environment and return its resolved cwd.
+
+    :param spec: The environment spec under test.
+    :param base_cwd: The base directory passed to
+        :func:`create_os_environment`.
+    :returns: The environment's resolved ``cwd``.
+    """
+    env = create_os_environment(spec, base_cwd=base_cwd)
+    assert env is not None
+    try:
+        return env.cwd
+    finally:
+        env.close()
+
+
+def test_create_os_environment_placeholder_cwd_uses_base_cwd(tmp_path: Path) -> None:
+    """``os_env.cwd: "."`` resolves to the base cwd, not the process cwd.
+
+    Agent configs use ``cwd: .`` as a workspace placeholder; it must
+    anchor to the session/runner workspace the caller passes in.
+
+    :returns: None.
+    """
+    assert _created_cwd(_caller_process_spec("."), tmp_path) == tmp_path.resolve()
+
+
+def test_create_os_environment_relative_cwd_joins_base_cwd(tmp_path: Path) -> None:
+    """A relative ``os_env.cwd`` resolves under the base cwd.
+
+    :returns: None.
+    """
+    expected = (tmp_path / "sub").resolve()
+    assert _created_cwd(_caller_process_spec("sub"), tmp_path) == expected
+
+
+def test_create_os_environment_absolute_cwd_ignores_base_cwd(tmp_path: Path) -> None:
+    """An absolute ``os_env.cwd`` wins over the base cwd.
+
+    :returns: None.
+    """
+    absolute = tmp_path / "explicit"
+    absolute.mkdir()
+    base = tmp_path / "base"
+    base.mkdir()
+    assert _created_cwd(_caller_process_spec(str(absolute)), base) == absolute.resolve()
+
+
+def test_create_os_environment_unset_cwd_uses_base_cwd(tmp_path: Path) -> None:
+    """An unset ``os_env.cwd`` falls back to the base cwd when given.
+
+    :returns: None.
+    """
+    assert _created_cwd(_caller_process_spec(None), tmp_path) == tmp_path.resolve()
+
+
+def test_create_os_environment_without_base_cwd_uses_process_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a base cwd the process cwd remains the fallback.
+
+    :returns: None.
+    """
+    monkeypatch.chdir(tmp_path)
+    assert _created_cwd(_caller_process_spec("."), None) == tmp_path.resolve()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="cannot delete the cwd on Windows")
+def test_create_os_environment_survives_deleted_process_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deleted process cwd must not break base-cwd resolution.
+
+    Runner subprocesses historically inherited the host daemon's cwd;
+    when that directory had been deleted, ``os.getcwd()`` raised
+    ``FileNotFoundError`` during turn setup even though the session
+    workspace existed. With a base cwd supplied, resolution must never
+    consult the process cwd.
+
+    :returns: None.
+    """
+    doomed = tmp_path / "doomed"
+    doomed.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(doomed)
+    doomed.rmdir()
+
+    assert _created_cwd(_caller_process_spec("."), workspace) == workspace.resolve()

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -386,6 +386,52 @@ def test_create_os_environment_without_base_cwd_uses_process_cwd(
     assert _created_cwd(_caller_process_spec("."), None) == tmp_path.resolve()
 
 
+def test_create_os_environment_empty_cwd_uses_base_cwd(tmp_path: Path) -> None:
+    """An empty-string ``os_env.cwd`` is a placeholder, like unset.
+
+    Matches the placeholder set the runner dispatch layer treats as
+    "use the workspace" (``None``, ``""``, ``"."``, ``"./"``).
+
+    :returns: None.
+    """
+    assert _created_cwd(_caller_process_spec(""), tmp_path) == tmp_path.resolve()
+
+
+def test_create_os_environment_empty_cwd_without_base_uses_process_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a base cwd, empty-string ``cwd`` keeps the old fallback.
+
+    :returns: None.
+    """
+    monkeypatch.chdir(tmp_path)
+    assert _created_cwd(_caller_process_spec(""), None) == tmp_path.resolve()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="cannot delete the cwd on Windows")
+def test_create_os_environment_absolute_cwd_survives_deleted_process_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absolute ``os_env.cwd`` never consults the process cwd.
+
+    Callers without a ``base_cwd`` (resource registry, runner dispatch)
+    always pass an absolute cwd; they must stay immune to a deleted
+    process cwd.
+
+    :returns: None.
+    """
+    doomed = tmp_path / "doomed"
+    doomed.mkdir()
+    target = tmp_path / "target"
+    target.mkdir()
+    monkeypatch.chdir(doomed)
+    doomed.rmdir()
+
+    assert _created_cwd(_caller_process_spec(str(target)), None) == target.resolve()
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="cannot delete the cwd on Windows")
 def test_create_os_environment_survives_deleted_process_cwd(
     tmp_path: Path,

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -1165,3 +1165,63 @@ def test_web_search_does_not_emit_web_search_preview_for_databricks_model() -> N
         f"databricks-gpt-5-4 — Databricks does not support this tool type "
         f"and rejects the request with HTTP 400. Got schema: {schema!r}"
     )
+
+
+# ── os_env cwd anchoring ──────────────────────────────────────────────
+
+
+def _os_env_spec(cwd: str) -> AgentSpec:
+    """An AgentSpec declaring an unsandboxed os_env with the given cwd.
+
+    :param cwd: The ``os_env.cwd`` value, e.g. ``"."``.
+    :returns: An ``AgentSpec`` with ``spec_version=1``.
+    """
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+
+    return AgentSpec(
+        spec_version=1,
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=cwd,
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+    )
+
+
+def _manager_os_env_cwd(mgr: ToolManager) -> Path:
+    """Return the manager's os_env cwd, shutting the manager down.
+
+    :param mgr: A manager built from a spec that declares ``os_env``.
+    :returns: The resolved cwd of the environment the manager created.
+    """
+    try:
+        assert mgr._os_env is not None, "spec declares os_env; expected an environment"
+        return mgr._os_env.cwd
+    finally:
+        mgr.shutdown()
+
+
+def test_os_env_relative_cwd_resolves_against_workdir(tmp_path: Path) -> None:
+    """``os_env.cwd: "."`` anchors to ``workdir``, not the process cwd.
+
+    Runner subprocesses historically inherited the host daemon's cwd;
+    resolving against the process cwd pointed OS tools at an unrelated
+    (possibly deleted) directory.
+    """
+    mgr = ToolManager(_os_env_spec("."), workdir=tmp_path)
+    assert _manager_os_env_cwd(mgr) == tmp_path.resolve()
+
+
+def test_os_env_base_cwd_wins_over_workdir(tmp_path: Path) -> None:
+    """``os_env_base_cwd`` (the workspace) beats ``workdir`` (agent image).
+
+    The schema-building path passes both; the os_env must anchor to the
+    session workspace, not the extracted agent image directory.
+    """
+    image_dir = tmp_path / "image"
+    image_dir.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    mgr = ToolManager(_os_env_spec("."), workdir=image_dir, os_env_base_cwd=workspace)
+    assert _manager_os_env_cwd(mgr) == workspace.resolve()


### PR DESCRIPTION
## Related issue

Closes #2304

## Summary

- Runner subprocesses inherited the host daemon's cwd, so with `os_env.cwd: "."` (or unset) `create_os_environment()` resolved the OS-tool cwd via `os.getcwd()` — silently targeting whatever directory the long-lived daemon was started from, and crashing every turn with `FileNotFoundError` during `ToolManager` setup when that directory had since been deleted.
- Host-daemon (`HostProcess._handle_launch`) and CLI (`_start_cli_runner_process`) runner spawns now pass `cwd=<session workspace>` to `subprocess.Popen`.
- `create_os_environment()` gains an optional `base_cwd`; a relative (or unset) `spec.cwd` resolves against it, and `ToolManager._register_os_env_tools()` passes its workdir — so os_env cwd resolution never depends on the process cwd.

**ELI5:** the daemon that launches runners lives for a long time and remembers the folder it was started in. Runners used to "wake up" in that old folder instead of the project you opened — and if that folder had been deleted, they crashed before doing anything. Now every runner wakes up inside the session's workspace.

```mermaid
flowchart LR
    D["host daemon<br/>(cwd = wherever it was started, may be deleted)"] -- "before: Popen(env only) → inherits daemon cwd" --> R1["runner ❌<br/>os_env cwd '.' → os.getcwd() → wrong dir / FileNotFoundError"]
    D -- "after: Popen(cwd=workspace)" --> R2["runner ✅<br/>os_env cwd '.' → session workspace"]
```

## Test Plan

- New unit tests for `create_os_environment(base_cwd=...)`: placeholder `"."`, relative, absolute, and unset cwd values, the no-`base_cwd` process-cwd fallback, and a regression test that deletes the process cwd and verifies environment creation still succeeds.
- Extended `test_handle_launch_spawns_subprocess` (host) and `test_start_cli_runner_process_uses_token_bound_runner_id` (CLI) to assert the runner is spawned with `cwd=<workspace>`.
- `uv run pytest tests/inner/test_os_env.py tests/host/test_connect.py tests/runner/test_file_tool_dispatch.py tests/runner/test_environment_filesystem.py` → 165 passed.
- `uv run pytest tests/cli/test_cli.py -k start_cli_runner_process` → 4 passed.
- `uv run pre-commit run --files <changed files>` → clean.
- End-to-end verification against `main` vs this branch (real subprocesses, no mocks), simulating a daemon whose cwd was deleted:
  - Turn-setup path (`ToolManager` with `os_env.cwd: "."`): `main` crashes with `FileNotFoundError: [Errno 2] No such file or directory` (the exact field failure); this branch builds 20 tool schemas with the os_env cwd resolved to the session workspace.
  - Real spawn via `HostProcess._handle_launch` (`python -m omnigent.runner._entry`): on `main`, `lsof` shows the live runner's cwd is the deleted daemon directory; on this branch it is the session workspace.

## Follow-ups (out of scope)

A few other spots still resolve paths via the process cwd and could use the same anchoring in a separate PR: the native-relay schema extraction in `tool_dispatch.py` (`cwd=str(Path.cwd())`), the `os.getcwd()` fallbacks in `inner/terminal.py`, and `~`-expansion for `os_env.cwd` values (never expanded today).

## Demo

Terminal E2E (same scenario as the Test Plan): deleted host-daemon cwd → turn-setup crash vs fix, then real runner spawn cwd via `lsof`.

https://github.com/hellocybernetics/omnigent/releases/download/pr2305-demo/pr2305-demo.mp4

- **Before:** `create_os_environment(cwd='.', base_cwd=None)` raises `FileNotFoundError`; a child spawned without `cwd=` inherits the deleted daemon directory (`lsof`).
- **After:** `ToolManager(workdir=session workspace)` builds 20 tool schemas with os_env cwd = session workspace; `Popen(..., cwd=workspace)` shows the session workspace in `lsof`.


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The deleted-cwd regression test reproduces the exact failure from the field report (`turn setup failed: [Errno 2] No such file or directory`); the host/CLI spawn tests pin the new `cwd=` contract. Manual verification: the two `main`-vs-branch end-to-end checks in the Test Plan (turn-setup repro and a real `_handle_launch` runner spawn inspected with `lsof`) confirm the bug reproduces on `main` and is fixed here.

## Changelog

Sessions no longer fail turn setup (or point OS tools at the wrong directory) when the host daemon was started from a different — possibly deleted — directory; runners and `os_env.cwd: "."` now anchor to the session workspace.

This pull request and its description were written by Claude Code.

