### PR TITLE
feat(harness-bench): add cost_tracking probe

### DIFF
--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -103,11 +103,9 @@ driver the run uses:
   runner-owned tmux pane); `--fast` does not apply.
 - `--transport NAME` overrides the family default for any harness.
 
-## What it reports (P0 dimensions)
+## What it reports (dimensions)
 
-The six P0 dimensions are `basic_turn`, `streaming`, `tool_calling`,
-`policy_deny`, `model_override`, `interrupt`. Each probe drives one real turn
-and watches what the harness does:
+Each probe drives one real turn and watches what the harness does:
 
 | Probe | In plain terms |
 | --- | --- |
@@ -116,6 +114,7 @@ and watches what the harness does:
 | **Tool calling** | Can it use a tool (run a command, read a file) mid-answer, not just chat? |
 | **Policy DENY** | If a policy says "block that tool", does the harness actually enforce it? |
 | **Model override** | If you ask for a specific model, does it actually run that one? |
+| **Cost tracking** | Does a completed turn report what it spent? `✓` a priced USD cost, `~` tokens only (unpriced model), `·` no usage surfaced. Gates any future cost *policy* -- a cost budget is a no-op without this. |
 | **Interrupt** | If you stop it mid-answer, does it actually stop? |
 
 Each cell is a verdict: **✓** works, **✗** doesn't, **·** couldn't be tested
@@ -148,7 +147,7 @@ Playwright `tests/e2e_ui/` suite, not this bench.
 
 ### Per-dimension, per-transport: what a ✓ verifies
 
-Rows are the P0 dimensions; columns are the three transports. "server API"
+Rows are the dimensions; columns are the three transports. "server API"
 (full-server / native-tui) means the ✓ was observed over the same
 `/v1/sessions/...` surface the web UI uses; "wrap" (sdk-inproc, `--fast`) means
 it was observed at the harness-wrap boundary, below the server.
@@ -160,6 +159,7 @@ it was observed at the harness-wrap boundary, below the server.
 | **Tool calling** | ✓ = a server-dispatched builtin call was made + turn closed | ✓ = the vendor's own tool call surfaced as a server `function_call` item | ✓ = a request-level tool call surfaced at the wrap |
 | **Policy DENY** | ✓ = a spec-baked `tool_call` deny policy blocked the call | ✓ = a session-attached CEL deny fired `response.policy_denied` | `·` = the wrap path has no server-side policy hook |
 | **Model override** | ✓ = the requested model was the one used | ✓ = the requested model was the one used | ✓ = the requested model was the one used |
+| **Cost tracking** | ✓/~ = usage read from the session snapshot (`total_cost_usd` / `last_total_tokens`) | ✓/~ = usage from the snapshot (native `session.usage`) | ✓/~ if the wrap forwards `usage` on `response.completed`, else `·` |
 | **Interrupt** | ✓ = a mid-turn cancel stopped the turn (server marker) | ✓ = a mid-turn cancel surfaced `session.interrupted` | ✓ = a mid-turn cancel stopped the wrap turn |
 
 So for the harnesses users actually reach through the web UI (SDK on
@@ -218,11 +218,10 @@ harness-agnostic -- they only call the driver's semantic methods.
 
 ## Scope
 
-Live today: the six P0 dimensions above; all three transports (`sdk-inproc`,
-`full-server`, `native-tui`); the four official SDK harnesses (claude-sdk,
-codex, pi, openai-agents) plus every registered native. Not yet wired (see the
-design doc's open items): **bench observation** of Tool calling / Policy DENY
-on `native-tui` (a driver gap, not a native-harness limitation),
-registry-driven server-side native-agent seeding, and the P1 dimensions
-(steering, live-queue, resume/fork, elicitation, reasoning, images, cost,
-compaction).
+Live today: the dimensions in the table above (including `cost_tracking`); all
+three transports (`sdk-inproc`, `full-server`, `native-tui`); the four official
+SDK harnesses (claude-sdk, codex, pi, openai-agents) plus every registered
+native. Tool calling and Policy DENY are observed on `native-tui` too (landed
+separately). Not yet wired (see the design doc's open items): registry-driven
+server-side native-agent seeding, and further dimensions (policy ALLOW/ASK,
+steering, live-queue, resume/fork, elicitation, reasoning, images, compaction).

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -209,6 +209,14 @@ class TurnResult:
     :param error: The error payload from ``response.failed``, if any.
     :param timed_out: Whether the stream did not reach a terminal event
         within the probe's timeout.
+    :param total_tokens: Cumulative token count the turn reported, if any
+        (``None`` when the transport surfaced no usage). Read from the session
+        snapshot (``SessionResponse.last_total_tokens``) or the completed
+        turn's ``usage``.
+    :param total_cost_usd: Cumulative USD cost the turn reported, if any
+        (``None`` when unobserved or the model is unpriced). Read from
+        ``SessionResponse.total_cost_usd`` / ``session.usage`` /
+        ``response.completed`` usage.
     """
 
     events: list[dict[str, Any]] = field(default_factory=list)
@@ -223,6 +231,8 @@ class TurnResult:
     failed: bool = False
     error: Any = None
     timed_out: bool = False
+    total_tokens: int | None = None
+    total_cost_usd: float | None = None
 
     @property
     def reached_terminal(self) -> bool:
@@ -233,6 +243,24 @@ class TurnResult:
     def event_types(self) -> list[str]:
         """The ``type`` of every event, in order."""
         return [e.get("type", "") for e in self.events]
+
+
+def fill_snapshot_cost(result: TurnResult, snapshot: dict[str, Any]) -> None:
+    """Populate *result*'s usage/cost from a session snapshot (``SessionResponse``).
+
+    The server tracks cumulative usage on the conversation and exposes it on the
+    snapshot as ``total_cost_usd`` (priced spend; ``None`` for an unpriced model)
+    and ``last_total_tokens`` (token count). Both server-backed drivers poll the
+    snapshot to a terminal state, so this is the uniform cost read point. A
+    tokens-only snapshot (no price) leaves ``total_cost_usd`` ``None`` — the cost
+    probe reports that as PARTIAL, not a failure.
+    """
+    tokens = snapshot.get("last_total_tokens")
+    if isinstance(tokens, int):
+        result.total_tokens = tokens
+    cost = snapshot.get("total_cost_usd")
+    if isinstance(cost, (int, float)):
+        result.total_cost_usd = float(cost)
 
 
 class SdkInprocDriver:
@@ -491,6 +519,16 @@ class SdkInprocDriver:
                                 result.tool_call_denied = True
                     elif etype == "response.completed":
                         result.completed = True
+                        # The wrap-direct path has no server snapshot; usage, if
+                        # the wrap forwards it, rides on the completed response.
+                        # Absent -> stays None and the cost probe SKIPs.
+                        usage = (event.get("response") or {}).get("usage") or {}
+                        tok = usage.get("total_tokens")
+                        if isinstance(tok, int):
+                            result.total_tokens = tok
+                        cost = usage.get("cost_usd")
+                        if isinstance(cost, (int, float)):
+                            result.total_cost_usd = float(cost)
                     elif etype == "response.cancelled":
                         result.cancelled = True
                     elif etype == "response.failed":

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -36,7 +36,7 @@ from typing import Any
 import httpx
 
 from tests.e2e._harness_probes import cli_unavailable_reason
-from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.driver import TurnResult, fill_snapshot_cost
 from tests.harness_bench.full_server import (
     _DENY_REASON,
     _POLL_INTERVAL_S,
@@ -360,6 +360,7 @@ class FullServerDriver:
             if status == "idle" and seen_running:
                 result.completed = True
                 result.text = _assistant_text(body.get("items", []))
+                fill_snapshot_cost(result, body)
                 break
             time.sleep(_POLL_INTERVAL_S)
         else:

--- a/tests/harness_bench/manifest.py
+++ b/tests/harness_bench/manifest.py
@@ -79,6 +79,14 @@ _AUTH_PROSE: dict[AuthModel, str] = {
 # a follow-up. An environment gap (fail-open policy, no tool-provocation mapping,
 # CEL unavailable) reports SKIPPED, so SUPPORTED here only ever drifts on a
 # genuine capability gap.
+#
+# cost_tracking is deliberately NOT declared here (left UNKNOWN). It is a P1
+# probe with no backing capability axis, and its observed verdict legitimately
+# varies — SUPPORTED (priced cost), PARTIAL (unpriced model: tokens only), or
+# SKIPPED (transport surfaced no usage). Declaring it SUPPORTED would manufacture
+# false DRIFT against a legitimate PARTIAL; leaving it UNKNOWN lets reconcile pass
+# the observed cell through unchanged (UNKNOWN is not concrete). The P0-coverage
+# test only requires declared verdicts for P0 dimensions, so this is allowed.
 _PROBE_ONLY_DECLARED: dict[str, Verdict] = {
     "basic_turn": Verdict.SUPPORTED,
     "tool_calling": Verdict.SUPPORTED,

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -73,7 +73,7 @@ from omnigent.native_terminal import bind_session_runner
 from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e._harness_probes import cli_unavailable_reason
-from tests.harness_bench.driver import ProvisioningError, TurnResult
+from tests.harness_bench.driver import ProvisioningError, TurnResult, fill_snapshot_cost
 from tests.harness_bench.full_server import (
     _find_free_port,
     spawn_omnigent_server,
@@ -597,7 +597,26 @@ class NativeTuiDriver:
             result.completed = True
         else:
             result.timed_out = True
+        if result.completed:
+            self._fill_cost_from_snapshot(result)
         return result
+
+    def _fill_cost_from_snapshot(self, result: TurnResult) -> None:
+        """Read cumulative usage/cost off the session snapshot after a turn.
+
+        Native runtimes report usage via ``external_session_usage`` (published as
+        ``session.usage``); the cumulative totals also land on the session
+        snapshot (``total_cost_usd`` / ``last_total_tokens``), which is the same
+        read point the full-server driver uses. A vendor that forwards no usage
+        leaves both ``None`` and the cost probe SKIPs with that reason.
+        """
+        assert self._client is not None
+        try:
+            snap = self._client.get(f"/v1/sessions/{self._session_id}", timeout=15.0)
+            if snap.status_code == 200:
+                fill_snapshot_cost(result, snap.json())
+        except httpx.HTTPError:
+            pass  # cost is best-effort; absence -> probe SKIPs, never a false verdict
 
     def _drive_tool_turn(self, *, deny: bool) -> TurnResult:
         """Provoke the vendor's own tool, observe the call (and, with *deny*, the block).

--- a/tests/harness_bench/probes/__init__.py
+++ b/tests/harness_bench/probes/__init__.py
@@ -1,4 +1,4 @@
-"""P0 capability probes and their ordered registry.
+"""Capability probes and their ordered registry.
 
 :data:`ALL_PROBES` is the single list the bench iterates; append a probe
 here to add a dimension. Order is the report's column order:
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.probes.basic_turn import BasicTurnProbe
+from tests.harness_bench.probes.cost_tracking import CostTrackingProbe
 from tests.harness_bench.probes.interrupt import InterruptProbe
 from tests.harness_bench.probes.model_override import ModelOverrideProbe
 from tests.harness_bench.probes.policy_deny import PolicyDenyProbe
@@ -26,6 +27,7 @@ ALL_PROBES: list[CapabilityProbe] = [
     ToolCallingProbe(),
     PolicyDenyProbe(),
     ModelOverrideProbe(),
+    CostTrackingProbe(),
     InterruptProbe(),
 ]
 

--- a/tests/harness_bench/probes/cost_tracking.py
+++ b/tests/harness_bench/probes/cost_tracking.py
@@ -1,0 +1,84 @@
+"""Cost-tracking probe — does a completed turn report usage / cost?
+
+Cost tracking is the keystone for cost *policies*: a ``cost_budget`` guardrail
+(``omnigent/policies/builtins/cost.py``) is a no-op without usage to measure, so
+this probe answers "can the operator see what a turn spent?".
+
+It reads the cumulative usage the server records on the session: ``total_cost_usd``
+(priced spend) and ``last_total_tokens`` (token count), surfaced on the session
+snapshot (``SessionResponse``) and the ``session.usage`` SSE event. The bench
+observes it via ``TurnResult.total_cost_usd`` / ``total_tokens``, which the
+server-backed drivers fill from the snapshot after a turn and the wrap driver
+fills from the completed turn's ``usage`` when the wrap forwards it.
+
+Verdicts:
+- **SUPPORTED** — a USD cost was reported (full cost tracking).
+- **PARTIAL** — tokens reported but no priced cost (an unpriced model: usage is
+  visible, so a token/budget policy works, but a USD-cost policy cannot price
+  it). This matches omnigent's own behavior — an unpriced model makes the cost
+  policy fail to ASK/DENY rather than silently allow.
+- **SKIPPED** — the transport surfaced no usage at all (e.g. the wrap path when
+  the harness forwards none), with the reason; never a false UNSUPPORTED.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import infra_failure_reason
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+
+class CostTrackingProbe(CapabilityProbe):
+    name = "cost_tracking"
+    title = "Cost tracking"
+    # P1: reported, not merge-gating — a harness that doesn't surface cost is
+    # still usable; the operator just can't run a USD-cost policy against it.
+    priority = Priority.P1
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_basic_turn(profile.marker)
+        detail = {
+            "total_cost_usd": result.total_cost_usd,
+            "total_tokens": result.total_tokens,
+            "completed": result.completed,
+        }
+
+        # An env/auth failure or timeout means we never got a clean turn to
+        # measure — SKIP (never UNSUPPORTED), same contract as the other probes.
+        infra = infra_failure_reason(result)
+        if infra is not None:
+            return ProbeResult(Verdict.SKIPPED, note=infra, detail=detail)
+        if not result.completed:
+            if result.timed_out:
+                return ProbeResult(Verdict.SKIPPED, note="turn timed out", detail=detail)
+            return ProbeResult(
+                Verdict.SKIPPED,
+                note=f"turn did not complete: {result.error}",
+                detail=detail,
+            )
+
+        if result.total_cost_usd is not None:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note=f"turn reported cost ${result.total_cost_usd:.6f}",
+                detail=detail,
+            )
+        if result.total_tokens is not None:
+            return ProbeResult(
+                Verdict.PARTIAL,
+                note=(
+                    f"usage reported ({result.total_tokens} tokens) but no priced cost "
+                    "(unpriced model): token/budget policy works, USD-cost policy cannot price it"
+                ),
+                detail=detail,
+            )
+        # Completed but no usage surfaced on this transport — not a capability
+        # gap we can assert, so SKIP with the reason.
+        return ProbeResult(
+            Verdict.SKIPPED,
+            note="turn completed but the transport surfaced no usage/cost to observe",
+            detail=detail,
+        )

--- a/tests/harness_bench/probes/cost_tracking.py
+++ b/tests/harness_bench/probes/cost_tracking.py
@@ -60,13 +60,17 @@ class CostTrackingProbe(CapabilityProbe):
                 detail=detail,
             )
 
-        if result.total_cost_usd is not None:
+        # Require a POSITIVE value, not merely non-None: a completed turn always
+        # spends tokens, so a reported 0 cost / 0 tokens means the usage plumbing
+        # returned an empty default, not that tracking genuinely measured zero.
+        # Treating 0 as "supported" would be a false pass.
+        if result.total_cost_usd is not None and result.total_cost_usd > 0:
             return ProbeResult(
                 Verdict.SUPPORTED,
                 note=f"turn reported cost ${result.total_cost_usd:.6f}",
                 detail=detail,
             )
-        if result.total_tokens is not None:
+        if result.total_tokens is not None and result.total_tokens > 0:
             return ProbeResult(
                 Verdict.PARTIAL,
                 note=(
@@ -75,8 +79,8 @@ class CostTrackingProbe(CapabilityProbe):
                 ),
                 detail=detail,
             )
-        # Completed but no usage surfaced on this transport — not a capability
-        # gap we can assert, so SKIP with the reason.
+        # Completed but no positive usage surfaced (absent, or a zero default) —
+        # not a capability gap we can assert, so SKIP with the reason.
         return ProbeResult(
             Verdict.SKIPPED,
             note="turn completed but the transport surfaced no usage/cost to observe",

--- a/tests/harness_bench/test_cost_tracking.py
+++ b/tests/harness_bench/test_cost_tracking.py
@@ -1,0 +1,80 @@
+"""Unit tests for the cost_tracking probe + the shared snapshot-cost reader.
+
+Network-free: drives the probe with fake drivers returning canned TurnResults,
+so the verdict logic (priced -> SUPPORTED, unpriced -> PARTIAL, no usage / infra
+/ timeout -> SKIPPED) is asserted without a live gateway.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import TurnResult, fill_snapshot_cost
+from tests.harness_bench.probes.cost_tracking import CostTrackingProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Priority, Verdict
+
+_PROFILE = BenchProfile(harness="fake", model="m", env_prefix="HARNESS_FAKE_", marker="MARK")
+
+
+class _Driver:
+    """Fake driver whose run_basic_turn returns a preset TurnResult."""
+
+    transport = "full-server"
+
+    def __init__(self, result: TurnResult) -> None:
+        self._result = result
+
+    async def run_basic_turn(self, marker: str) -> TurnResult:
+        return self._result
+
+
+async def _run(result: TurnResult):
+    return await CostTrackingProbe().run(_Driver(result), _PROFILE)
+
+
+def test_priority_is_p1() -> None:
+    # P1 = reported, not merge-gating; also why it needs no declared verdict.
+    assert CostTrackingProbe().priority is Priority.P1
+
+
+async def test_priced_cost_is_supported() -> None:
+    r = await _run(TurnResult(completed=True, text="ok", total_cost_usd=0.0123, total_tokens=1500))
+    assert r.verdict is Verdict.SUPPORTED
+    assert "0.012" in r.note
+
+
+async def test_tokens_only_is_partial() -> None:
+    # Unpriced model: usage visible, no USD cost -> PARTIAL (not a failure).
+    r = await _run(TurnResult(completed=True, text="ok", total_cost_usd=None, total_tokens=900))
+    assert r.verdict is Verdict.PARTIAL
+    assert "900 tokens" in r.note
+
+
+async def test_no_usage_is_skipped() -> None:
+    # Completed but the transport surfaced nothing -> SKIP, never UNSUPPORTED.
+    r = await _run(TurnResult(completed=True, text="ok"))
+    assert r.verdict is Verdict.SKIPPED
+    assert "no usage" in r.note
+
+
+async def test_infra_failure_is_skipped() -> None:
+    r = await _run(TurnResult(failed=True, error={"message": "403 Forbidden"}))
+    assert r.verdict is Verdict.SKIPPED
+
+
+async def test_timeout_is_skipped() -> None:
+    r = await _run(TurnResult(timed_out=True))
+    assert r.verdict is Verdict.SKIPPED
+
+
+def test_fill_snapshot_cost_reads_session_fields() -> None:
+    r = TurnResult(completed=True)
+    fill_snapshot_cost(r, {"total_cost_usd": 0.5, "last_total_tokens": 4200})
+    assert r.total_cost_usd == 0.5
+    assert r.total_tokens == 4200
+
+
+def test_fill_snapshot_cost_tolerates_missing_and_null() -> None:
+    r = TurnResult(completed=True)
+    fill_snapshot_cost(r, {"total_cost_usd": None})  # unpriced snapshot
+    assert r.total_cost_usd is None
+    assert r.total_tokens is None

--- a/tests/harness_bench/test_cost_tracking.py
+++ b/tests/harness_bench/test_cost_tracking.py
@@ -56,6 +56,21 @@ async def test_no_usage_is_skipped() -> None:
     assert "no usage" in r.note
 
 
+async def test_zero_cost_and_tokens_is_skipped() -> None:
+    # A completed turn always spends tokens; a reported 0/0 means an empty
+    # default from the usage plumbing, not a genuine zero -> SKIP, not a false
+    # SUPPORTED/PARTIAL. Guards against the `is not None` false positive.
+    r = await _run(TurnResult(completed=True, text="ok", total_cost_usd=0.0, total_tokens=0))
+    assert r.verdict is Verdict.SKIPPED
+
+
+async def test_zero_cost_but_positive_tokens_is_partial() -> None:
+    # Cost defaulted to 0 (unpriced) but real tokens were counted -> PARTIAL,
+    # not a false SUPPORTED on the 0 cost.
+    r = await _run(TurnResult(completed=True, text="ok", total_cost_usd=0.0, total_tokens=900))
+    assert r.verdict is Verdict.PARTIAL
+
+
 async def test_infra_failure_is_skipped() -> None:
     r = await _run(TurnResult(failed=True, error={"message": "403 Forbidden"}))
     assert r.verdict is Verdict.SKIPPED


### PR DESCRIPTION
## Summary

First of two probe-expansion PRs reviewers asked for (Serena/Tomu). Adds a
**cost_tracking** capability probe — the keystone Tomu called out: a cost
*policy* (`cost_budget` guardrail) is a no-op without cost *tracking*, so the
bench should first prove the operator can see what a turn spent.

- **`TurnResult`** gains `total_tokens` / `total_cost_usd` (both Optional;
  `None` = the transport surfaced no usage).
- **`fill_snapshot_cost(result, snapshot)`** (`driver.py`) reads the cumulative
  totals the server records on the session snapshot (`SessionResponse`
  `total_cost_usd` / `last_total_tokens`) — the uniform read point both
  server-backed drivers already poll:
  - **full-server** fills it on turn completion (it already polls the snapshot);
  - **native-tui** reads the snapshot post-turn (native usage arrives via
    `external_session_usage` -> `session.usage`);
  - **sdk-inproc** (wrap-only, no server) fills from the completed turn's
    embedded `usage` when the wrap forwards it, else leaves it `None`.
- **Verdicts:** `SUPPORTED` (priced USD cost), `PARTIAL` (tokens but no price =
  unpriced model: usage is visible so a token/budget policy works, but a
  USD-cost policy can't price it — matching omnigent's own unpriced-model
  behavior), `SKIPPED` (no usage surfaced / infra failure / timeout). Never a
  false `UNSUPPORTED`.
- **Not declared in the manifest** (left `UNKNOWN`): there is no backing
  capability axis, and the observed verdict legitimately varies, so declaring
  `SUPPORTED` would manufacture false `DRIFT` against a legitimate `PARTIAL`.
  Leaving it `UNKNOWN` lets `reconcile` pass the observed cell through (UNKNOWN
  is not concrete). The P0-coverage test only requires declared verdicts for P0
  dimensions, so a P1 probe with no declaration is allowed.

Follow-up (PR-B, next): the ALLOW/DENY/ASK x MCP/native policy matrix. This PR
is scoped to cost tracking alone. Lands in `tests/harness_bench/` (not the
parked package-move location, #2289).

## Test Plan

- New `tests/harness_bench/test_cost_tracking.py` (network-free): priced ->
  SUPPORTED, tokens-only -> PARTIAL, no-usage/infra/timeout -> SKIPPED, plus
  `fill_snapshot_cost` reads/tolerates snapshot fields.
- `python -m pytest tests/harness_bench/` -> 89 passed, 18 skipped.
- Offline render: the new **Cost tracking** column appears (`?` in the declared
  matrix, since undeclared); JSON + Markdown renderers carry it.
- `ruff check` + `ruff format` clean; no `uv.lock` drift.

## Demo

N/A -- CLI/bench probe, no UI change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI / frontend change

## Test coverage

- [x] Added or updated automated tests
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

New unit tests cover the probe's verdict branches and the snapshot reader,
network-free via fake drivers. The offline matrix / JSON / Markdown renders were
manually checked to carry the new column. A live run against a priced profile is
the remaining manual check (SUPPORTED cell with a real cost); unpriced -> PARTIAL.
