### PR TITLE
fix: skip model-change respawn check for the "any" harness sentinel

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -724,14 +724,22 @@ class HarnessProcessManager:
                 )
                 await self._close_entry(entry)
                 entry = None
-            if entry is not None:
+            if entry is not None and harness != "any":
                 # The model is baked into the subprocess env at spawn time;
                 # a later turn requesting a different model (e.g. after the
                 # user runs ``/model``) must respawn, otherwise the cached
                 # process keeps serving the old model. Only respawn when a
                 # concrete different model is requested — a turn that sets no
                 # model env (``None``) keeps the running process.
-                requested_model = (env or {}).get(_model_env_key(harness))
+                #
+                # ``"any"`` is excluded for the same reason as the harness
+                # mismatch check above: it is the harness-agnostic sentinel
+                # steering / cancel / interrupt pass to reuse the live
+                # subprocess. It has no real harness of its own, so there is no
+                # model env key to look up, and letting this check run on it
+                # could drop the entry and then raise ``NoLiveHarnessError``,
+                # turning a harmless reuse call into a mid-turn crash.
+                requested_model = (env or {}).get(_model_env_key(entry.harness))
                 if requested_model is not None and requested_model != entry.model:
                     _logger.info(
                         "harness %s for conversation %s: model changed %r -> %r; respawning",

--- a/tests/runtime/test_process_manager.py
+++ b/tests/runtime/test_process_manager.py
@@ -98,6 +98,66 @@ async def test_get_client_respawns_only_when_model_changes(
         await final.client.aclose()
 
 
+@pytest.mark.asyncio
+async def test_get_client_any_sentinel_never_respawns_on_model_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``"any"`` sentinel reuses the live subprocess, model env or not.
+
+    ``"any"`` is the harness-agnostic key steering / cancel / interrupt pass
+    to reach an already-running subprocess without knowing its real harness.
+    It carries no harness of its own, so the model-change check must skip it:
+    if that check ever ran a real key lookup and saw a mismatch it would drop
+    the entry and then raise ``NoLiveHarnessError`` on the ``"any"`` branch,
+    turning a harmless reuse call into a mid-turn crash. This drives exactly
+    that shape (a live entry plus an ``"any"`` call whose env carries the
+    running harness's model key set to a *different* model) and asserts it
+    stays a plain cache hit.
+
+    :param monkeypatch: Pytest monkeypatch fixture used to mock the
+        subprocess-spawn boundary.
+    """
+    pm = HarnessProcessManager()
+    pm._started = True
+
+    spawns: list[str | None] = []
+    closes: list[str | None] = []
+
+    async def _fake_spawn(conv: str, harness: str, env: dict[str, str] | None) -> _SubprocessEntry:
+        model = (env or {}).get(_model_env_key(harness))
+        spawns.append(model)
+        return _SubprocessEntry(
+            process=_AliveProc(),  # type: ignore[arg-type]  # stand-in process
+            client=httpx.AsyncClient(),
+            endpoint=_HarnessEndpoint(socket_path=Path("/tmp/fake.sock")),
+            harness=harness,
+            model=model,
+        )
+
+    async def _fake_close(entry: _SubprocessEntry) -> None:
+        closes.append(entry.model)
+        await entry.client.aclose()
+
+    monkeypatch.setattr(pm, "_spawn_entry", _fake_spawn)
+    monkeypatch.setattr(pm, "_close_entry", _fake_close)
+
+    conv, harness = "conv_any", "claude-sdk"
+    key = _model_env_key(harness)  # HARNESS_CLAUDE_SDK_MODEL
+
+    first = await pm.get_client(conv, harness, env={key: "claude-opus-4-6"})  # spawn opus
+    # ``"any"`` reuse whose env carries a DIFFERENT model for the running
+    # harness. This must not respawn and must not raise NoLiveHarnessError.
+    reused = await pm.get_client(conv, "any", env={key: "claude-sonnet-4-6"})
+
+    assert spawns == ["claude-opus-4-6"], spawns  # no second spawn
+    assert closes == [], closes  # nothing torn down
+    assert reused is first  # same live client handed back
+
+    final = pm._entries.get(conv)
+    if final is not None:
+        await final.client.aclose()
+
+
 def test_build_harness_spawn_env_strips_binding_token_with_overrides(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #2224

## Summary

`get_client`'s model-change respawn check built its env key from the raw `harness` argument, but that argument can be the `"any"` sentinel that steering / cancel / interrupt callers pass to reach a live subprocess without knowing its real harness. `_model_env_key("any")` resolves to `HARNESS_ANY_MODEL`, a key no spawn env ever sets, so the lookup always missed and the check got skipped by accident.

That skip is the behavior we actually want (`"any"` has no harness of its own to respawn into), but nothing guarded it. If that key lookup ever turned into a real one and saw a mismatch, it would drop the entry and then fall into the `NoLiveHarnessError` branch, turning a harmless reuse call into a mid-turn crash. This makes the exclusion explicit, mirroring the harness-mismatch check right above it, and reads the key from `entry.harness` now that `"any"` is filtered out first.

## Test Plan

`uv run pytest tests/runtime/test_process_manager.py` (4 passed).

Added `test_get_client_any_sentinel_never_respawns_on_model_env`, which spawns a `claude-sdk` entry and then makes an `"any"` call whose env carries a different model for that harness, asserting it stays a plain cache hit (no second spawn, no teardown, no `NoLiveHarnessError`). I confirmed the test fails on the unguarded version (raises `NoLiveHarnessError`) and passes with the fix. There was no coverage for this path before.

## Demo

There is no UI or user-visible surface for this change, it is an internal guard in `get_client`'s respawn path, so a screenshot does not apply here. The observable behavior is captured by the new unit test instead:

```
$ uv run pytest tests/runtime/test_process_manager.py -k any_sentinel -q
```

On the unguarded code the `"any"` call raises `NoLiveHarnessError` mid turn, and with the fix it stays a plain cache hit (no second spawn, no teardown). Test passes on the fix and fails without it, which is the before/after evidence for this one.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

