### PR TITLE
feat(harness-bench): add policy_allow + policy_ask probes

### DIFF
--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -113,6 +113,8 @@ Each probe drives one real turn and watches what the harness does:
 | **Streaming** | Does the answer arrive incrementally (word-by-word) or all at once at the end? Counts the token-level chunks. |
 | **Tool calling** | Can it use a tool (run a command, read a file) mid-answer, not just chat? |
 | **Policy DENY** | If a policy says "block that tool", does the harness actually enforce it? |
+| **Policy ALLOW** | If a policy explicitly allows the tool, does the call actually go through (not just "wasn't blocked")? |
+| **Policy ASK** | If a policy says "ask first", does the tool call pause for an approval prompt (an elicitation) the way the web UI would show? |
 | **Model override** | If you ask for a specific model, does it actually run that one? |
 | **Cost tracking** | Does a completed turn report what it spent? `✓` a priced USD cost, `~` tokens only (unpriced model), `·` no usage surfaced. Gates any future cost *policy* -- a cost budget is a no-op without this. |
 | **Interrupt** | If you stop it mid-answer, does it actually stop? |
@@ -158,6 +160,8 @@ it was observed at the harness-wrap boundary, below the server.
 | **Streaming** | ✓ = token deltas seen on the server SSE stream | ✓ = token deltas seen on the server SSE stream | ✓ = deltas seen on the wrap SSE (no server) |
 | **Tool calling** | ✓ = a server-dispatched builtin call was made + turn closed | ✓ = the vendor's own tool call surfaced as a server `function_call` item | ✓ = a request-level tool call surfaced at the wrap |
 | **Policy DENY** | ✓ = a spec-baked `tool_call` deny policy blocked the call | ✓ = a session-attached CEL deny fired `response.policy_denied` | `·` = the wrap path has no server-side policy hook |
+| **Policy ALLOW** | ✓ = a spec-baked `allow` policy let the call proceed (non-blocked output) | `·` = CEL allow/ask attach is a follow-up | `·` = no server-side policy hook |
+| **Policy ASK** | ✓ = a spec-baked `ask` policy raised `response.elicitation_request` (then resolved) | `·` = follow-up | `·` = no elicitation surface |
 | **Model override** | ✓ = the requested model was the one used | ✓ = the requested model was the one used | ✓ = the requested model was the one used |
 | **Cost tracking** | ✓/~ = usage read from the session snapshot (`total_cost_usd` / `last_total_tokens`) | ✓/~ = usage from the snapshot (native `session.usage`) | ✓/~ if the wrap forwards `usage` on `response.completed`, else `·` |
 | **Interrupt** | ✓ = a mid-turn cancel stopped the turn (server marker) | ✓ = a mid-turn cancel surfaced `session.interrupted` | ✓ = a mid-turn cancel stopped the wrap turn |
@@ -165,8 +169,11 @@ it was observed at the harness-wrap boundary, below the server.
 So for the harnesses users actually reach through the web UI (SDK on
 `full-server`, natives on `native-tui`), **a ✓ does mean the capability works
 end-to-end through the server API the UI relies on** -- minus the browser render
-layer. The only cell that reads `·` purely for a transport reason is Policy DENY
-under `--fast`; drop `--fast` (the default) and it becomes a real `✓`.
+layer. The cells that read `·` purely for a transport reason are the policy
+verdicts where a transport has no server-side policy surface: Policy DENY under
+`--fast`, and Policy ALLOW / ASK anywhere but `full-server` (their `native-tui`
+attach is a follow-up). On the default SDK run (`full-server`) all three policy
+verdicts are real `✓`.
 
 ### Why a `·` appears
 
@@ -218,10 +225,13 @@ harness-agnostic -- they only call the driver's semantic methods.
 
 ## Scope
 
-Live today: the dimensions in the table above (including `cost_tracking`); all
-three transports (`sdk-inproc`, `full-server`, `native-tui`); the four official
-SDK harnesses (claude-sdk, codex, pi, openai-agents) plus every registered
-native. Tool calling and Policy DENY are observed on `native-tui` too (landed
-separately). Not yet wired (see the design doc's open items): registry-driven
-server-side native-agent seeding, and further dimensions (policy ALLOW/ASK,
-steering, live-queue, resume/fork, elicitation, reasoning, images, compaction).
+Live today: the dimensions in the table above (including `cost_tracking` and
+Policy ALLOW / ASK on `full-server`); all three transports (`sdk-inproc`,
+`full-server`, `native-tui`); the four official SDK harnesses (claude-sdk,
+codex, pi, openai-agents) plus every registered native. Tool calling and Policy
+DENY are observed on `native-tui` too (landed separately). Not yet wired (see
+the design doc's open items): Policy ALLOW / ASK on `native-tui` (a CEL
+allow/ask attach, the way native DENY works), registry-driven server-side
+native-agent seeding, the MCP-tool vs harness-native-tool distinction, and
+further dimensions (steering, live-queue, resume/fork, elicitation, reasoning,
+images, compaction).

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -221,10 +221,12 @@ class TurnResult:
         turn — the signal an ASK policy fired (server publishes
         ``response.elicitation_request`` / lands a pending elicitation on the
         snapshot). The policy_ask probe keys on this.
-    :param tool_call_allowed: Whether a surfaced tool call actually proceeded
-        (dispatched + a result delivered) rather than being blocked — the
-        signal an ALLOW policy let the call through. The policy_allow probe
-        keys on this.
+    :param tool_call_allowed: Whether a surfaced tool call produced a
+        non-blocked ``function_call_output`` — i.e. the call proceeded. This is
+        set for *any* non-blocked tool output, not only under an ALLOW policy;
+        the policy_allow probe's correctness comes from driving a real
+        ``action=allow`` session (``_ensure_policy_session("allow")``), so a set
+        flag there means the ALLOW policy let the call through.
     """
 
     events: list[dict[str, Any]] = field(default_factory=list)

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -217,6 +217,14 @@ class TurnResult:
         (``None`` when unobserved or the model is unpriced). Read from
         ``SessionResponse.total_cost_usd`` / ``session.usage`` /
         ``response.completed`` usage.
+    :param elicitation_requested: Whether an elicitation was raised during the
+        turn — the signal an ASK policy fired (server publishes
+        ``response.elicitation_request`` / lands a pending elicitation on the
+        snapshot). The policy_ask probe keys on this.
+    :param tool_call_allowed: Whether a surfaced tool call actually proceeded
+        (dispatched + a result delivered) rather than being blocked — the
+        signal an ALLOW policy let the call through. The policy_allow probe
+        keys on this.
     """
 
     events: list[dict[str, Any]] = field(default_factory=list)
@@ -233,6 +241,8 @@ class TurnResult:
     timed_out: bool = False
     total_tokens: int | None = None
     total_cost_usd: float | None = None
+    elicitation_requested: bool = False
+    tool_call_allowed: bool = False
 
     @property
     def reached_terminal(self) -> bool:
@@ -438,6 +448,13 @@ class SdkInprocDriver:
             auto_tool_output="bench-tool-ok",
             timeout=150.0,
         )
+
+    async def run_policy_turn(self, *, action: str) -> TurnResult:
+        """The wrap-direct path has no server-side policy/elicitation surface, so
+        an explicit ALLOW/ASK verdict cannot be observed here. Return an
+        unmeasured result so the policy_allow / policy_ask probes SKIP (never a
+        false verdict), mirroring how Policy DENY reports on this transport."""
+        return TurnResult()
 
     async def run_interrupt_turn(self) -> TurnResult:
         return await self.run_turn(_LONG_PROMPT, interrupt_on_first_delta=True, timeout=120.0)

--- a/tests/harness_bench/full_server.py
+++ b/tests/harness_bench/full_server.py
@@ -142,15 +142,20 @@ def _wait_server_runner_ready(base_url: str, runner_id: str) -> None:
 
 
 def _build_bench_agent_config(
-    profile: BenchProfile, db_profile: str | None, *, deny: bool
+    profile: BenchProfile, db_profile: str | None, *, policy_action: str | None = None
 ) -> dict[str, Any]:
     """The agent spec for a bench harness: the harness + the read-only builtin,
-    plus (when *deny*) a baked tool_call-phase deny on that builtin."""
+    plus (when *policy_action* is set) a baked tool_call-phase policy with that
+    fixed action (``"allow"`` / ``"deny"`` / ``"ask"``) on that builtin.
+
+    ``make_fixed_action_callable`` is not on the REST policy allowlist, so the
+    policy must ride in the agent spec (this path) rather than a live
+    ``POST /policies`` attach."""
     # The agent name must match [a-zA-Z0-9_-]+, but a harness id can contain a
     # colon (acp:<slug>). Sanitize it for the name only; config.harness keeps
     # the real id so the runner resolves the right ACP agent at spawn.
     safe_harness = profile.harness.replace(":", "-")
-    name = f"bench-{safe_harness}" + ("-deny" if deny else "")
+    name = f"bench-{safe_harness}" + (f"-{policy_action}" if policy_action else "")
     executor: dict[str, Any] = {
         "type": "omnigent",
         "model": profile.model,
@@ -171,15 +176,15 @@ def _build_bench_agent_config(
         # turns (the model just won't call it).
         "tools": {"builtins": [_TOOL_NAME]},
     }
-    if deny:
+    if policy_action:
         config["guardrails"] = {
             "policies": {
-                "deny_tool": {
+                f"{policy_action}_tool": {
                     "type": "function",
                     "function": {
                         "path": "omnigent.policies.function.make_fixed_action_callable",
                         "arguments": {
-                            "action": "deny",
+                            "action": policy_action,
                             "reason": _DENY_REASON,
                             "on_phases": ["tool_call"],
                             "on_tools": [_TOOL_NAME],
@@ -262,10 +267,14 @@ class SharedFullServer:
                     proc.kill()
         shutil.rmtree(self._tmp, ignore_errors=True)
 
-    def register_agent(self, profile: BenchProfile, *, deny: bool) -> str:
-        """Register a bench agent for *profile*; return its agent name."""
+    def register_agent(self, profile: BenchProfile, *, policy_action: str | None = None) -> str:
+        """Register a bench agent for *profile*; return its agent name.
+
+        *policy_action* (``"allow"`` / ``"deny"`` / ``"ask"`` or ``None``) bakes a
+        fixed-action tool_call policy into the agent spec so the policy probes can
+        force each verdict deterministically."""
         assert self.client is not None
-        config = _build_bench_agent_config(profile, self._db_profile, deny=deny)
+        config = _build_bench_agent_config(profile, self._db_profile, policy_action=policy_action)
         resp = self.client.post(
             "/v1/sessions",
             data={"metadata": json.dumps({})},

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -228,17 +228,13 @@ class FullServerDriver:
     # ── policy ALLOW / ASK probe ─────────────────────────────
 
     def policy_probe_turn(self, *, action: str, timeout: float = 180.0) -> TurnResult:
-        """Drive a tool turn under an explicit tool_call policy *action*.
+        """Drive a tool turn under a fixed tool_call policy *action*.
 
-        - ``"allow"``: the agent bakes a fixed ALLOW on the builtin, so the
-          call proceeds; ``_scan_tool_items`` sets ``tool_call_allowed`` from the
-          (non-blocked) ``function_call_output``.
-        - ``"ask"``: the agent bakes a fixed ASK, so the tool_call parks on an
-          elicitation. A background reader watches the SSE stream for
-          ``response.elicitation_request`` (sets ``elicitation_requested`` and
-          captures the ``elicitation_id``), then this method resolves it with an
-          ``approval`` ``accept`` event so the turn can settle rather than park
-          for the (1-day) ASK timeout.
+        ``"allow"``: the call proceeds (``tool_call_allowed`` from the non-blocked
+        output). ``"ask"``: it parks on an elicitation; a background reader sets
+        ``elicitation_requested`` off ``response.elicitation_request`` and this
+        method resolves it (approval accept) so the turn settles instead of
+        parking for the ASK timeout.
         """
         assert self._client is not None
         sid = self._ensure_policy_session(action)
@@ -265,9 +261,13 @@ class FullServerDriver:
                                     if isinstance(eid, str):
                                         elicitation_id["id"] = eid
                                 except (ValueError, TypeError):
-                                    pass
+                                    # Verdict already recorded; unparseable id
+                                    # just means we can't resolve, so the turn
+                                    # parks to the deadline. Note it.
+                                    result.error = "elicitation_request frame had no parseable id"
                                 return
             except httpx.HTTPError:
+                # Best-effort watcher; an SSE read error must not fail the turn.
                 pass
 
         watcher = None
@@ -285,8 +285,6 @@ class FullServerDriver:
         deadline = time.monotonic() + timeout
         seen_running = False
         while time.monotonic() < deadline:
-            # For ASK: once the elicitation is seen, resolve it so the turn
-            # settles instead of parking on the day-long ASK timeout.
             if action == "ask" and result.elicitation_requested and "id" in elicitation_id:
                 self._resolve_elicitation(sid, elicitation_id.pop("id"))
             snap = self._client.get(f"/v1/sessions/{sid}").json()

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -227,14 +227,18 @@ class FullServerDriver:
 
     # ── policy ALLOW / ASK probe ─────────────────────────────
 
-    def policy_probe_turn(self, *, action: str, timeout: float = 180.0) -> TurnResult:
+    def policy_probe_turn(self, *, action: str, timeout: float = 90.0) -> TurnResult:
         """Drive a tool turn under a fixed tool_call policy *action*.
 
         ``"allow"``: the call proceeds (``tool_call_allowed`` from the non-blocked
         output). ``"ask"``: it parks on an elicitation; a background reader sets
-        ``elicitation_requested`` off ``response.elicitation_request`` and this
-        method resolves it (approval accept) so the turn settles instead of
-        parking for the ASK timeout.
+        ``elicitation_requested`` off ``response.elicitation_request``. The ASK
+        verdict is decided the moment that fires, so we resolve the elicitation
+        (approval accept, to leave no dangling park) and return immediately
+        rather than polling the turn to a terminal state.
+
+        The timeout bounds the *worst* case (the model never calls the tool, so
+        no elicitation fires): a bounded SKIP, not a 3-minute stall.
         """
         assert self._client is not None
         sid = self._ensure_policy_session(action)
@@ -285,8 +289,12 @@ class FullServerDriver:
         deadline = time.monotonic() + timeout
         seen_running = False
         while time.monotonic() < deadline:
-            if action == "ask" and result.elicitation_requested and "id" in elicitation_id:
-                self._resolve_elicitation(sid, elicitation_id.pop("id"))
+            # ASK verdict is decided once the elicitation fires: resolve it (so
+            # no park dangles) and stop — no need to poll the turn to idle.
+            if action == "ask" and result.elicitation_requested:
+                if "id" in elicitation_id:
+                    self._resolve_elicitation(sid, elicitation_id.pop("id"))
+                break
             snap = self._client.get(f"/v1/sessions/{sid}").json()
             status = snap.get("status")
             items = snap.get("items", [])

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -256,20 +256,22 @@ class FullServerDriver:
                         if stop.is_set():
                             return
                         line = raw.strip()
-                        if line.startswith("data:"):
-                            payload = line[len("data:") :].strip()
-                            if '"response.elicitation_request"' in payload:
-                                result.elicitation_requested = True
-                                try:
-                                    eid = json.loads(payload).get("elicitation_id")
-                                    if isinstance(eid, str):
-                                        elicitation_id["id"] = eid
-                                except (ValueError, TypeError):
-                                    # Verdict already recorded; unparseable id
-                                    # just means we can't resolve, so the turn
-                                    # parks to the deadline. Note it.
-                                    result.error = "elicitation_request frame had no parseable id"
-                                return
+                        if not line.startswith("data:"):
+                            continue
+                        try:
+                            frame = json.loads(line[len("data:") :].strip())
+                        except (ValueError, TypeError):
+                            continue
+                        if frame.get("type") == "response.elicitation_request":
+                            result.elicitation_requested = True
+                            eid = frame.get("elicitation_id")
+                            if isinstance(eid, str):
+                                elicitation_id["id"] = eid
+                            else:
+                                # No parseable id: verdict is recorded, but we
+                                # can't resolve, so the turn parks to the deadline.
+                                result.error = "elicitation_request frame had no parseable id"
+                            return
             except httpx.HTTPError:
                 # Best-effort watcher; an SSE read error must not fail the turn.
                 pass

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -321,13 +321,15 @@ class FullServerDriver:
         """Accept an outstanding elicitation via an ``approval`` event so an ASK
         turn settles (best-effort; a raced resolve is harmless)."""
         assert self._client is not None
+        # The server reads the id from inside `data` (SessionEventInput has no
+        # top-level elicitation_id field), so it must be nested there or the
+        # resolve is a silent no-op and the park dangles.
         with contextlib.suppress(httpx.HTTPError):
             self._client.post(
                 f"/v1/sessions/{sid}/events",
                 json={
                     "type": "approval",
-                    "elicitation_id": elicitation_id,
-                    "data": {"action": "accept"},
+                    "data": {"elicitation_id": elicitation_id, "action": "accept"},
                 },
             )
 

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -29,6 +29,8 @@ bench's probes run through this driver, not just its gated tests.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
 import threading
 import time
 from typing import Any
@@ -88,11 +90,11 @@ class FullServerDriver:
         # for back-compat with the original one-server-per-harness behavior.
         self._shared = shared
         self._owns_shared = shared is None
-        # A second agent+session whose spec bakes a tool_call deny policy,
-        # created lazily for the policy probe (the REST policy endpoint's
-        # handler allowlist excludes make_fixed_action_callable, so the deny
-        # must ride in the agent spec instead).
-        self._deny_session_id: str | None = None
+        # Per-action agent+session cache for the policy probes. Each bakes a
+        # fixed-action tool_call policy into its agent spec (the REST policy
+        # endpoint's allowlist excludes make_fixed_action_callable, so the
+        # policy must ride in the spec). Created lazily, keyed by action.
+        self._policy_session_ids: dict[str, str] = {}
         self._session_id: str | None = None
 
     @property
@@ -125,7 +127,7 @@ class FullServerDriver:
         if self._shared is None:
             self._shared = SharedFullServer(resolve_bench_env(self._db_profile))
             self._shared.__enter__()
-        agent_name = self._shared.register_agent(self._profile, deny=False)
+        agent_name = self._shared.register_agent(self._profile, policy_action=None)
         self._session_id = self._shared.create_session(agent_name)
         return self
 
@@ -157,6 +159,9 @@ class FullServerDriver:
     async def run_tool_turn(self, *, deny: bool) -> TurnResult:
         return await asyncio.to_thread(lambda: self.tool_probe_turn(deny=deny))
 
+    async def run_policy_turn(self, *, action: str) -> TurnResult:
+        return await asyncio.to_thread(lambda: self.policy_probe_turn(action=action))
+
     async def run_interrupt_turn(self) -> TurnResult:
         return await asyncio.to_thread(self.interrupt_probe_turn)
 
@@ -165,13 +170,14 @@ class FullServerDriver:
     # SharedFullServer now; this driver delegates so a solo run and a parallel
     # (shared-server) run go through the same path.
 
-    def _ensure_deny_session(self) -> str:
-        """Lazily register the deny agent and its session; return the session id."""
+    def _ensure_policy_session(self, action: str) -> str:
+        """Lazily register a session whose agent bakes a fixed *action* tool_call
+        policy (``"allow"`` / ``"deny"`` / ``"ask"``); return the session id."""
         assert self._shared is not None
-        if self._deny_session_id is None:
-            name = self._shared.register_agent(self._profile, deny=True)
-            self._deny_session_id = self._shared.create_session(name)
-        return self._deny_session_id
+        if action not in self._policy_session_ids:
+            name = self._shared.register_agent(self._profile, policy_action=action)
+            self._policy_session_ids[action] = self._shared.create_session(name)
+        return self._policy_session_ids[action]
 
     # ── tool / policy probe ──────────────────────────────────
 
@@ -188,7 +194,7 @@ class FullServerDriver:
         plus ``completed`` / ``failed`` / ``text``.
         """
         assert self._client is not None
-        sid = self._ensure_deny_session() if deny else self._session_id
+        sid = self._ensure_policy_session("deny") if deny else self._session_id
         assert sid is not None
         result = TurnResult()
         body = {
@@ -218,6 +224,106 @@ class FullServerDriver:
         else:
             result.timed_out = True
         return result
+
+    # ── policy ALLOW / ASK probe ─────────────────────────────
+
+    def policy_probe_turn(self, *, action: str, timeout: float = 180.0) -> TurnResult:
+        """Drive a tool turn under an explicit tool_call policy *action*.
+
+        - ``"allow"``: the agent bakes a fixed ALLOW on the builtin, so the
+          call proceeds; ``_scan_tool_items`` sets ``tool_call_allowed`` from the
+          (non-blocked) ``function_call_output``.
+        - ``"ask"``: the agent bakes a fixed ASK, so the tool_call parks on an
+          elicitation. A background reader watches the SSE stream for
+          ``response.elicitation_request`` (sets ``elicitation_requested`` and
+          captures the ``elicitation_id``), then this method resolves it with an
+          ``approval`` ``accept`` event so the turn can settle rather than park
+          for the (1-day) ASK timeout.
+        """
+        assert self._client is not None
+        sid = self._ensure_policy_session(action)
+        result = TurnResult()
+
+        elicitation_id: dict[str, str] = {}
+        stop = threading.Event()
+
+        def _watch() -> None:
+            try:
+                with self._client.stream(  # type: ignore[union-attr]
+                    "GET", f"/v1/sessions/{sid}/stream", timeout=timeout
+                ) as resp:
+                    for raw in resp.iter_lines():
+                        if stop.is_set():
+                            return
+                        line = raw.strip()
+                        if line.startswith("data:"):
+                            payload = line[len("data:") :].strip()
+                            if '"response.elicitation_request"' in payload:
+                                result.elicitation_requested = True
+                                try:
+                                    eid = json.loads(payload).get("elicitation_id")
+                                    if isinstance(eid, str):
+                                        elicitation_id["id"] = eid
+                                except (ValueError, TypeError):
+                                    pass
+                                return
+            except httpx.HTTPError:
+                pass
+
+        watcher = None
+        if action == "ask":
+            watcher = threading.Thread(target=_watch, daemon=True)
+            watcher.start()
+            time.sleep(1.0)  # register the subscription before the turn starts
+
+        body = {
+            "type": "message",
+            "data": {"role": "user", "content": [{"type": "input_text", "text": _TOOL_PROMPT}]},
+        }
+        self._client.post(f"/v1/sessions/{sid}/events", json=body).raise_for_status()
+
+        deadline = time.monotonic() + timeout
+        seen_running = False
+        while time.monotonic() < deadline:
+            # For ASK: once the elicitation is seen, resolve it so the turn
+            # settles instead of parking on the day-long ASK timeout.
+            if action == "ask" and result.elicitation_requested and "id" in elicitation_id:
+                self._resolve_elicitation(sid, elicitation_id.pop("id"))
+            snap = self._client.get(f"/v1/sessions/{sid}").json()
+            status = snap.get("status")
+            items = snap.get("items", [])
+            _scan_tool_items(items, result)
+            if status in ("running", "waiting"):
+                seen_running = True
+            if status == "failed":
+                result.failed = True
+                result.error = snap.get("last_task_error") or snap.get("error")
+                break
+            if status == "idle" and seen_running:
+                result.completed = True
+                result.text = _assistant_text(items)
+                break
+            time.sleep(_POLL_INTERVAL_S)
+        else:
+            result.timed_out = True
+        stop.set()
+        if watcher is not None:
+            watcher.join(timeout=5.0)
+        return result
+
+    def _resolve_elicitation(self, sid: str, elicitation_id: str) -> None:
+        """Accept an outstanding elicitation via an ``approval`` event so an ASK
+        turn settles (best-effort; a raced resolve is harmless)."""
+        assert self._client is not None
+        with contextlib.suppress(httpx.HTTPError):
+            self._client.post(
+                f"/v1/sessions/{sid}/events",
+                json={
+                    "type": "approval",
+                    "elicitation_id": elicitation_id,
+                    "data": {"action": "accept"},
+                },
+            )
 
     # ── streaming probe ──────────────────────────────────────
 
@@ -385,6 +491,10 @@ def _scan_tool_items(items: list[dict], result: TurnResult) -> None:
             out = str(data.get("output", ""))
             if data.get("status") == "blocked" or _DENY_REASON in out:
                 result.tool_call_denied = True
+            else:
+                # The call produced a real (non-blocked) output — it proceeded,
+                # the signal an ALLOW policy let it through.
+                result.tool_call_allowed = True
 
 
 def _has_cancellation_marker(items: list[dict]) -> bool:

--- a/tests/harness_bench/manifest.py
+++ b/tests/harness_bench/manifest.py
@@ -80,13 +80,15 @@ _AUTH_PROSE: dict[AuthModel, str] = {
 # CEL unavailable) reports SKIPPED, so SUPPORTED here only ever drifts on a
 # genuine capability gap.
 #
-# cost_tracking is deliberately NOT declared here (left UNKNOWN). It is a P1
-# probe with no backing capability axis, and its observed verdict legitimately
-# varies — SUPPORTED (priced cost), PARTIAL (unpriced model: tokens only), or
-# SKIPPED (transport surfaced no usage). Declaring it SUPPORTED would manufacture
-# false DRIFT against a legitimate PARTIAL; leaving it UNKNOWN lets reconcile pass
-# the observed cell through unchanged (UNKNOWN is not concrete). The P0-coverage
-# test only requires declared verdicts for P0 dimensions, so this is allowed.
+# cost_tracking, policy_allow, and policy_ask are deliberately NOT declared here
+# (left UNKNOWN). Each is a P1 probe with no backing capability axis whose
+# observed verdict legitimately varies by transport / pricing — e.g. cost is
+# SUPPORTED (priced) / PARTIAL (unpriced) / SKIPPED (no usage), and ALLOW/ASK are
+# SUPPORTED only on full-server and SKIPPED where a transport has no policy
+# surface. Declaring any of them SUPPORTED would manufacture false DRIFT against
+# a legitimate PARTIAL/SKIP; leaving them UNKNOWN lets reconcile pass the observed
+# cell through unchanged (UNKNOWN is not concrete). The P0-coverage test only
+# requires declared verdicts for P0 dimensions, so this is allowed.
 _PROBE_ONLY_DECLARED: dict[str, Verdict] = {
     "basic_turn": Verdict.SUPPORTED,
     "tool_calling": Verdict.SUPPORTED,

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -325,6 +325,14 @@ class NativeTuiDriver:
     async def run_tool_turn(self, *, deny: bool) -> TurnResult:
         return await asyncio.to_thread(self._drive_tool_turn, deny=deny)
 
+    async def run_policy_turn(self, *, action: str) -> TurnResult:
+        """Native ALLOW/ASK observation is a follow-up (would attach a CEL
+        ALLOW/ASK policy the way the DENY path attaches its CEL deny, and watch
+        for the tool proceeding / an elicitation). Not wired yet, so return an
+        unmeasured result and let the probe SKIP rather than report a false
+        verdict. Native Policy DENY remains covered by run_tool_turn(deny=True)."""
+        return TurnResult()
+
     async def run_interrupt_turn(self) -> TurnResult:
         return await asyncio.to_thread(self._drive_interrupt_turn)
 

--- a/tests/harness_bench/probes/__init__.py
+++ b/tests/harness_bench/probes/__init__.py
@@ -12,6 +12,8 @@ from tests.harness_bench.probes.basic_turn import BasicTurnProbe
 from tests.harness_bench.probes.cost_tracking import CostTrackingProbe
 from tests.harness_bench.probes.interrupt import InterruptProbe
 from tests.harness_bench.probes.model_override import ModelOverrideProbe
+from tests.harness_bench.probes.policy_allow import PolicyAllowProbe
+from tests.harness_bench.probes.policy_ask import PolicyAskProbe
 from tests.harness_bench.probes.policy_deny import PolicyDenyProbe
 from tests.harness_bench.probes.streaming import StreamingProbe
 from tests.harness_bench.probes.tool_calling import ToolCallingProbe
@@ -26,6 +28,8 @@ ALL_PROBES: list[CapabilityProbe] = [
     StreamingProbe(),
     ToolCallingProbe(),
     PolicyDenyProbe(),
+    PolicyAllowProbe(),
+    PolicyAskProbe(),
     ModelOverrideProbe(),
     CostTrackingProbe(),
     InterruptProbe(),

--- a/tests/harness_bench/probes/policy_allow.py
+++ b/tests/harness_bench/probes/policy_allow.py
@@ -1,16 +1,8 @@
 """Policy-ALLOW probe — does an explicit ALLOW policy let a tool call through?
 
-The DENY probe proves a policy can *block* a call; this proves the other side of
-the verdict axis: with an explicit ``allow`` policy baked on the tool_call phase,
-a provoked tool call should *proceed* (dispatched + a result delivered), not be
-blocked. Absence of a deny is not the same as an asserted ALLOW — this drives a
-real ``action=allow`` policy so the allow path is exercised, not merely defaulted.
-
-Observability mirrors the DENY probe: full-server bakes the policy in the agent
-spec and observes a non-blocked ``function_call_output`` (``tool_call_allowed``);
-the wrap-direct and native transports have no server-side policy surface for this
-yet, so they return an unmeasured result and the probe SKIPs — never a false
-verdict.
+Drives a real ``action=allow`` tool_call policy (not mere absence of a deny) and
+checks the call proceeded. Full-server observes a non-blocked output; transports
+with no server-side policy surface return unmeasured and the probe SKIPs.
 """
 
 from __future__ import annotations
@@ -49,9 +41,6 @@ class PolicyAllowProbe(CapabilityProbe):
         if result.timed_out:
             return ProbeResult(Verdict.SKIPPED, note="allow-policy turn timed out", detail=detail)
         if not result.tool_calls and not result.completed:
-            # An unmeasured result (transport with no server-side policy surface
-            # for ALLOW) or a turn where the model never called the tool: the
-            # ALLOW path was not exercised here, so SKIP rather than fail.
             return ProbeResult(
                 Verdict.SKIPPED,
                 note=(
@@ -60,8 +49,6 @@ class PolicyAllowProbe(CapabilityProbe):
                 ),
                 detail=detail,
             )
-        # The turn completed but the tool call did not visibly proceed — not a
-        # clean ALLOW observation; SKIP rather than assert a false UNSUPPORTED.
         return ProbeResult(
             Verdict.SKIPPED,
             note="tool call did not visibly proceed under the ALLOW policy",

--- a/tests/harness_bench/probes/policy_allow.py
+++ b/tests/harness_bench/probes/policy_allow.py
@@ -1,0 +1,69 @@
+"""Policy-ALLOW probe — does an explicit ALLOW policy let a tool call through?
+
+The DENY probe proves a policy can *block* a call; this proves the other side of
+the verdict axis: with an explicit ``allow`` policy baked on the tool_call phase,
+a provoked tool call should *proceed* (dispatched + a result delivered), not be
+blocked. Absence of a deny is not the same as an asserted ALLOW — this drives a
+real ``action=allow`` policy so the allow path is exercised, not merely defaulted.
+
+Observability mirrors the DENY probe: full-server bakes the policy in the agent
+spec and observes a non-blocked ``function_call_output`` (``tool_call_allowed``);
+the wrap-direct and native transports have no server-side policy surface for this
+yet, so they return an unmeasured result and the probe SKIPs — never a false
+verdict.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import infra_failure_reason
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+
+class PolicyAllowProbe(CapabilityProbe):
+    name = "policy_allow"
+    title = "Policy ALLOW"
+    priority = Priority.P1
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_policy_turn(action="allow")
+        detail = {
+            "tool_call_allowed": result.tool_call_allowed,
+            "tool_calls": [tc.get("name") for tc in result.tool_calls],
+            "completed": result.completed,
+        }
+
+        if result.tool_call_allowed:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note="tool call proceeded under an explicit ALLOW policy",
+                detail=detail,
+            )
+
+        infra = infra_failure_reason(result)
+        if infra is not None:
+            return ProbeResult(Verdict.SKIPPED, note=infra, detail=detail)
+        if result.timed_out:
+            return ProbeResult(Verdict.SKIPPED, note="allow-policy turn timed out", detail=detail)
+        if not result.tool_calls and not result.completed:
+            # An unmeasured result (transport with no server-side policy surface
+            # for ALLOW) or a turn where the model never called the tool: the
+            # ALLOW path was not exercised here, so SKIP rather than fail.
+            return ProbeResult(
+                Verdict.SKIPPED,
+                note=(
+                    "ALLOW policy not observable on this transport "
+                    "(or the model never attempted the tool)"
+                ),
+                detail=detail,
+            )
+        # The turn completed but the tool call did not visibly proceed — not a
+        # clean ALLOW observation; SKIP rather than assert a false UNSUPPORTED.
+        return ProbeResult(
+            Verdict.SKIPPED,
+            note="tool call did not visibly proceed under the ALLOW policy",
+            detail=detail,
+        )

--- a/tests/harness_bench/probes/policy_ask.py
+++ b/tests/harness_bench/probes/policy_ask.py
@@ -1,17 +1,9 @@
 """Policy-ASK probe — does an ASK policy raise an elicitation for approval?
 
-The third verdict on the policy axis. With an ``ask`` policy on the tool_call
-phase, a provoked tool call should park for user approval, which omnigent
-surfaces as an elicitation (SSE ``response.elicitation_request`` /
-``pending_elicitations``) — the same signal the web UI renders an approval
-prompt from. The probe drives the ask policy, observes that an elicitation was
-raised (``elicitation_requested``), and the driver resolves it so the turn
-settles instead of parking for the (day-long) ASK timeout.
-
-Observability: full-server bakes the ASK policy in the agent spec and watches
-the session stream for the elicitation request. The wrap-direct and native
-transports have no elicitation surface wired here yet, so they return an
-unmeasured result and the probe SKIPs — never a false verdict.
+Drives an ``action=ask`` tool_call policy and checks the call parked on an
+elicitation (SSE ``response.elicitation_request`` — the same signal the web UI's
+approval prompt uses); the driver resolves it so the turn settles. Full-server
+observes it; transports with no elicitation surface return unmeasured and SKIP.
 """
 
 from __future__ import annotations
@@ -50,8 +42,6 @@ class PolicyAskProbe(CapabilityProbe):
         if result.timed_out:
             return ProbeResult(Verdict.SKIPPED, note="ask-policy turn timed out", detail=detail)
         if not result.tool_calls and not result.completed:
-            # Unmeasured (no elicitation surface on this transport) or the model
-            # never called the tool: the ASK path was not exercised here.
             return ProbeResult(
                 Verdict.SKIPPED,
                 note=(
@@ -60,8 +50,6 @@ class PolicyAskProbe(CapabilityProbe):
                 ),
                 detail=detail,
             )
-        # The tool call resolved without a visible elicitation — not a clean ASK
-        # observation; SKIP rather than assert a false UNSUPPORTED.
         return ProbeResult(
             Verdict.SKIPPED,
             note="tool call did not raise a visible elicitation under the ASK policy",

--- a/tests/harness_bench/probes/policy_ask.py
+++ b/tests/harness_bench/probes/policy_ask.py
@@ -1,0 +1,69 @@
+"""Policy-ASK probe — does an ASK policy raise an elicitation for approval?
+
+The third verdict on the policy axis. With an ``ask`` policy on the tool_call
+phase, a provoked tool call should park for user approval, which omnigent
+surfaces as an elicitation (SSE ``response.elicitation_request`` /
+``pending_elicitations``) — the same signal the web UI renders an approval
+prompt from. The probe drives the ask policy, observes that an elicitation was
+raised (``elicitation_requested``), and the driver resolves it so the turn
+settles instead of parking for the (day-long) ASK timeout.
+
+Observability: full-server bakes the ASK policy in the agent spec and watches
+the session stream for the elicitation request. The wrap-direct and native
+transports have no elicitation surface wired here yet, so they return an
+unmeasured result and the probe SKIPs — never a false verdict.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import infra_failure_reason
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+
+class PolicyAskProbe(CapabilityProbe):
+    name = "policy_ask"
+    title = "Policy ASK"
+    priority = Priority.P1
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_policy_turn(action="ask")
+        detail = {
+            "elicitation_requested": result.elicitation_requested,
+            "tool_calls": [tc.get("name") for tc in result.tool_calls],
+            "completed": result.completed,
+        }
+
+        if result.elicitation_requested:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note="ASK policy raised an elicitation (approval prompt) for the tool call",
+                detail=detail,
+            )
+
+        infra = infra_failure_reason(result)
+        if infra is not None:
+            return ProbeResult(Verdict.SKIPPED, note=infra, detail=detail)
+        if result.timed_out:
+            return ProbeResult(Verdict.SKIPPED, note="ask-policy turn timed out", detail=detail)
+        if not result.tool_calls and not result.completed:
+            # Unmeasured (no elicitation surface on this transport) or the model
+            # never called the tool: the ASK path was not exercised here.
+            return ProbeResult(
+                Verdict.SKIPPED,
+                note=(
+                    "ASK policy not observable on this transport "
+                    "(or the model never attempted the tool)"
+                ),
+                detail=detail,
+            )
+        # The tool call resolved without a visible elicitation — not a clean ASK
+        # observation; SKIP rather than assert a false UNSUPPORTED.
+        return ProbeResult(
+            Verdict.SKIPPED,
+            note="tool call did not raise a visible elicitation under the ASK policy",
+            detail=detail,
+        )

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -483,7 +483,7 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
         def __exit__(self, *exc: object) -> None:
             pass
 
-        def register_agent(self, profile, *, deny: bool) -> str:
+        def register_agent(self, profile, *, policy_action: str | None = None) -> str:
             self.registered.append(profile.harness)
             return f"bench-{profile.harness}"
 
@@ -504,7 +504,7 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
 
         async def __aenter__(self):
             assert self._shared is not None  # parallel run injected the shared server
-            self._shared.register_agent(self._profile, deny=False)
+            self._shared.register_agent(self._profile, policy_action=None)
             self._shared.create_session(f"bench-{self._profile.harness}")
             return self
 

--- a/tests/harness_bench/test_policy_matrix.py
+++ b/tests/harness_bench/test_policy_matrix.py
@@ -77,6 +77,13 @@ async def test_ask_supported_when_elicitation_raised() -> None:
     assert r.verdict is Verdict.SUPPORTED
 
 
+async def test_ask_supported_even_if_turn_not_settled() -> None:
+    # The driver returns early once the elicitation fires (verdict decided), so
+    # a real ASK success has elicitation_requested=True but completed=False.
+    r = await _ask(TurnResult(completed=False, elicitation_requested=True))
+    assert r.verdict is Verdict.SUPPORTED
+
+
 async def test_ask_passes_action_ask_to_driver() -> None:
     driver = _Driver(TurnResult(completed=True, elicitation_requested=True))
     await PolicyAskProbe().run(driver, _PROFILE)

--- a/tests/harness_bench/test_policy_matrix.py
+++ b/tests/harness_bench/test_policy_matrix.py
@@ -101,3 +101,28 @@ async def test_ask_skipped_when_no_elicitation_but_completed() -> None:
     # never a false UNSUPPORTED.
     r = await _ask(TurnResult(completed=True, tool_calls=[{"name": "list_files"}]))
     assert r.verdict is Verdict.SKIPPED
+
+
+def test_resolve_elicitation_nests_id_in_data() -> None:
+    """The approval event must carry elicitation_id INSIDE data (SessionEventInput
+    has no top-level elicitation_id field, so a top-level id is dropped and the
+    resolve is a silent no-op). Guards the payload shape the server reads."""
+    from tests.harness_bench.full_server_driver import FullServerDriver
+
+    posted: dict[str, object] = {}
+
+    class _Client:
+        def post(self, url, json):
+            posted["url"] = url
+            posted["json"] = json
+
+    class _Shared:
+        client = _Client()
+
+    driver = FullServerDriver(_PROFILE, databricks_profile=None, shared=_Shared())
+    driver._resolve_elicitation("sess-1", "elicit_abc")
+
+    body = posted["json"]
+    assert body["type"] == "approval"
+    assert "elicitation_id" not in body, "id must not be top-level (server ignores it there)"
+    assert body["data"] == {"elicitation_id": "elicit_abc", "action": "accept"}

--- a/tests/harness_bench/test_policy_matrix.py
+++ b/tests/harness_bench/test_policy_matrix.py
@@ -1,0 +1,96 @@
+"""Unit tests for the policy_allow / policy_ask probes.
+
+Network-free: a fake driver returns a canned TurnResult from run_policy_turn, so
+the verdict logic (allowed -> SUPPORTED, elicitation -> SUPPORTED, unmeasured /
+infra / timeout -> SKIPPED) is asserted without a live server.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.probes.policy_allow import PolicyAllowProbe
+from tests.harness_bench.probes.policy_ask import PolicyAskProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Priority, Verdict
+
+_PROFILE = BenchProfile(harness="fake", model="m", env_prefix="HARNESS_FAKE_", marker="MARK")
+
+
+class _Driver:
+    """Fake driver whose run_policy_turn returns a preset result per action."""
+
+    transport = "full-server"
+
+    def __init__(self, result: TurnResult) -> None:
+        self._result = result
+        self.seen_action: str | None = None
+
+    async def run_policy_turn(self, *, action: str) -> TurnResult:
+        self.seen_action = action
+        return self._result
+
+
+async def _allow(result: TurnResult):
+    return await PolicyAllowProbe().run(_Driver(result), _PROFILE)
+
+
+async def _ask(result: TurnResult):
+    return await PolicyAskProbe().run(_Driver(result), _PROFILE)
+
+
+def test_probes_are_p1() -> None:
+    assert PolicyAllowProbe().priority is Priority.P1
+    assert PolicyAskProbe().priority is Priority.P1
+
+
+# ── ALLOW ────────────────────────────────────────────────────────
+
+
+async def test_allow_supported_when_call_proceeds() -> None:
+    r = await _allow(TurnResult(completed=True, tool_call_allowed=True))
+    assert r.verdict is Verdict.SUPPORTED
+
+
+async def test_allow_passes_action_allow_to_driver() -> None:
+    driver = _Driver(TurnResult(completed=True, tool_call_allowed=True))
+    await PolicyAllowProbe().run(driver, _PROFILE)
+    assert driver.seen_action == "allow"
+
+
+async def test_allow_skipped_when_unmeasured() -> None:
+    # Wrap/native return an empty TurnResult -> no tool call, not completed.
+    r = await _allow(TurnResult())
+    assert r.verdict is Verdict.SKIPPED
+    assert "not observable" in r.note
+
+
+async def test_allow_skipped_on_infra_failure() -> None:
+    r = await _allow(TurnResult(failed=True, error={"message": "403 Forbidden"}))
+    assert r.verdict is Verdict.SKIPPED
+
+
+# ── ASK ──────────────────────────────────────────────────────────
+
+
+async def test_ask_supported_when_elicitation_raised() -> None:
+    r = await _ask(TurnResult(completed=True, elicitation_requested=True))
+    assert r.verdict is Verdict.SUPPORTED
+
+
+async def test_ask_passes_action_ask_to_driver() -> None:
+    driver = _Driver(TurnResult(completed=True, elicitation_requested=True))
+    await PolicyAskProbe().run(driver, _PROFILE)
+    assert driver.seen_action == "ask"
+
+
+async def test_ask_skipped_when_unmeasured() -> None:
+    r = await _ask(TurnResult())
+    assert r.verdict is Verdict.SKIPPED
+    assert "not observable" in r.note
+
+
+async def test_ask_skipped_when_no_elicitation_but_completed() -> None:
+    # Tool call happened and turn completed, but no elicitation surfaced -> SKIP,
+    # never a false UNSUPPORTED.
+    r = await _ask(TurnResult(completed=True, tool_calls=[{"name": "list_files"}]))
+    assert r.verdict is Verdict.SKIPPED

--- a/tests/harness_bench/transport.py
+++ b/tests/harness_bench/transport.py
@@ -78,6 +78,19 @@ class Driver(Protocol):
         force so the call should be blocked (``tool_call_denied``); otherwise
         the call is dispatched and answered (``tool_calls`` populated)."""
 
+    async def run_policy_turn(self, *, action: str) -> TurnResult:
+        """Provoke a tool call under an explicit tool-call policy *action*
+        (``"allow"`` or ``"ask"``), for the policy_allow / policy_ask probes.
+
+        - ``"allow"``: an explicit ALLOW policy is in force; the call should
+          proceed (``tool_call_allowed`` set once dispatched + answered).
+        - ``"ask"``: an ASK policy is in force; the call should raise an
+          elicitation (``elicitation_requested`` set), which the driver then
+          resolves so the turn can settle.
+
+        A transport that cannot surface the requested action returns an
+        unmeasured result so the probe SKIPs (never a false verdict)."""
+
     async def run_interrupt_turn(self) -> TurnResult:
         """Start a long turn and interrupt it mid-flight; ``cancelled``
         reflects whether the transport honored the interrupt."""


### PR DESCRIPTION
## Summary

Second probe-expansion PR (after cost, #2307). Extends the policy axis toward
Tomu's **ALLOW / DENY / ASK** matrix. The existing DENY probe proved a policy can
*block* a tool call; this adds the other two verdicts:

- **policy_allow** — an explicit `action=allow` tool_call policy lets the call
  *proceed* (`tool_call_allowed`, from a non-blocked `function_call_output`).
  Absence-of-deny is not an asserted ALLOW; this drives a real allow policy.
- **policy_ask** — an `action=ask` policy parks the call on an **elicitation**
  (SSE `response.elicitation_request` — the same signal the web UI renders an
  approval prompt from). The driver resolves it with an `approval` `accept`
  event so the turn settles instead of parking for the day-long ASK timeout.

**Mechanism** (full-server, where policy is observable): the spec-baked deny is
generalized into a fixed-action policy — `_build_bench_agent_config` /
`register_agent` take `policy_action` (`"allow"`/`"deny"`/`"ask"`), the driver
caches one session per action, and `run_policy_turn` / `policy_probe_turn` drive
it. (`make_fixed_action_callable` is not REST-allowlisted, so the policy rides in
the agent spec — same path the DENY probe already uses.)

**Honest SKIP elsewhere** (per the agreed coverage bar): sdk-inproc (wrap-only,
no policy surface) and native-tui (a CEL ALLOW/ASK attach is a follow-up) return
an unmeasured result, so the probes SKIP with a reason rather than assert a false
verdict. Native Policy DENY stays covered by `run_tool_turn(deny=True)`.

Both probes are **P1** and **undeclared** in the manifest (like `cost_tracking`):
no backing capability axis and the verdict varies by transport, so declaring
`SUPPORTED` would manufacture false `DRIFT`. `TurnResult` gains
`elicitation_requested` / `tool_call_allowed`.

**Deferred to PR-B3:** the MCP-tool vs harness-native-tool distinction (the other
dimension of Tomu's matrix). This PR is the ALLOW/DENY/ASK verdict axis.

Stacked on #2307 (cost probe) — both off `main`, in `tests/harness_bench/` (not
the parked package-move location, #2289).

## Test Plan

- New `tests/harness_bench/test_policy_matrix.py` (network-free): allow ->
  SUPPORTED, ask (elicitation) -> SUPPORTED, unmeasured/infra/timeout ->
  SKIPPED, and that each probe passes the right `action` to the driver.
- `python -m pytest tests/harness_bench/` -> 98 passed, 18 skipped.
- Offline render: **Policy ALLOW** / **Policy ASK** columns appear (`?` in the
  declared matrix, undeclared); Markdown carries them.
- `ruff check` + `ruff format` clean; no `uv.lock` drift.
- Remaining manual check: a live full-server run showing SUPPORTED for both on a
  harness that actually calls the tool (the SUPPORTED cell needs a real tool
  call + elicitation round-trip).

## Demo

N/A -- CLI/bench probe, no UI change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI / frontend change

## Test coverage

- [x] Added or updated automated tests
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

New unit tests cover both probes' verdict branches network-free via a fake
driver. Offline / Markdown renders were checked to carry the new columns. The
live SUPPORTED path (real tool call + elicitation resolve on full-server) is the
remaining manual check.
