### PR TITLE
fix(spec): stop parser from globally clobbering yaml.SafeLoader booleans

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -124,8 +124,13 @@ def _read_terminal_transport_config() -> str | None:
     """Read ``terminal.transport`` from the global config, or ``None``.
 
     Best-effort: any failure (missing/unreadable file, non-mapping YAML,
-    absent table/key, non-string value) returns ``None`` so the caller uses
-    the control default. Never raises.
+    absent table/key, non-string/bool value) returns ``None`` so the caller
+    uses the control default. Never raises.
+
+    An unquoted YAML ``true``/``false`` parses as a real bool rather than a
+    string, so a bool value is normalized to its lowercase string spelling
+    before returning — ``terminal.transport: false`` still selects the PTY
+    alias in :data:`_TRANSPORT_PTY_ALIASES`.
 
     :returns: The raw configured transport string, or ``None`` when unset.
     """
@@ -146,6 +151,8 @@ def _read_terminal_transport_config() -> str | None:
     if not isinstance(table, dict):
         return None
     value = table.get(_TERMINAL_TRANSPORT_CONFIG_KEY)
+    if isinstance(value, bool):
+        return "true" if value else "false"
     return value if isinstance(value, str) else None
 
 

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -373,11 +373,10 @@ def load_omnigent_yaml(
     # ``match_tools``, ``action``, ``reason``, ``set_labels``).
     # Non-mapping roots are tolerated as an empty dict — the
     # omnigent loader would already have rejected them above.
-    # Use _OmnigentYamlLoader (not yaml.safe_load) so that
-    # booleans parse consistently — importing load_agent_def
-    # mutates yaml.SafeLoader's implicit resolvers as a side
-    # effect, causing yaml.safe_load to return string "false"
-    # for unquoted ``false`` values (e.g. use_responses: false).
+    # Use _OmnigentYamlLoader (not yaml.safe_load) so this raw
+    # read resolves booleans the same way load_agent_def's YAML
+    # parsing did — both loaders keep on/off as plain strings
+    # instead of the YAML 1.1 bool aliases.
     raw = _yaml.load(path.read_text(), Loader=_OmnigentYamlLoader) or {}
     if not isinstance(raw, dict):
         raw = {}

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -90,6 +90,13 @@ _YAML_1_2_BOOL_RE = re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$")
 # ``executor.config`` keys kept as their nested YAML structure instead of
 # string-coerced — their consumers read the nested mapping/list shape.
 _STRUCTURED_EXECUTOR_CONFIG_KEYS: frozenset[str] = frozenset()
+
+# Copy the resolver dict onto the subclass before mutating — it's inherited
+# from SafeLoader by reference, so in-place edits below would strip
+# SafeLoader's bool resolver process-wide.
+_ConfigYamlLoader.yaml_implicit_resolvers = {
+    key: value[:] for key, value in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
 for _ch in list(_ConfigYamlLoader.yaml_implicit_resolvers.keys()):
     _ConfigYamlLoader.yaml_implicit_resolvers[_ch] = [
         (tag, regexp)

--- a/tests/spec/test_load.py
+++ b/tests/spec/test_load.py
@@ -338,12 +338,10 @@ def test_load_omnigent_yaml_preserves_use_responses_bool(tmp_path: Path) -> None
     ``HARNESS_OPENAI_AGENTS_USE_RESPONSES=true``, causing silent API failures for
     models that require ``use_responses=False`` (e.g. Kimi K2 via Databricks).
 
-    Root cause guarded: ``_omnigent_compat.load_omnigent_yaml`` previously used
-    ``yaml.safe_load`` to read the raw YAML, but importing ``load_agent_def`` mutates
-    ``yaml.SafeLoader``'s implicit resolvers as a side effect, causing ``safe_load`` to
-    return string ``"false"`` for unquoted ``false`` values.  The fix is to use
-    ``_OmnigentYamlLoader`` directly (which owns its resolvers and is unaffected by
-    the mutation).
+    How it's guarded: ``_omnigent_compat.load_omnigent_yaml`` reads the raw YAML
+    with ``_OmnigentYamlLoader`` (not ``yaml.safe_load``) so this raw read resolves
+    booleans the same way ``load_agent_def``'s own parsing does — both loaders keep
+    ``on``/``off`` as plain strings and parse unquoted ``false`` as bool ``False``.
     """
     yaml_text = textwrap.dedent("""\
         name: kimi-test

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -3487,3 +3487,30 @@ def test_parse_credential_proxy_https_primitive_allowed_on_macos(tmp_path: Path)
     proxy = spec.os_env.sandbox.credential_proxy
     assert proxy is not None
     assert proxy.entries[0].scheme == "bearer"
+
+
+def test_config_loader_does_not_mutate_shared_safeloader_resolvers() -> None:
+    """``_ConfigYamlLoader`` must not corrupt ``yaml.SafeLoader`` process-wide.
+
+    The loader narrows the YAML 1.1 bool resolver to YAML-1.2 spellings, but it
+    must do so on its OWN copy of ``yaml_implicit_resolvers``. If it mutated the
+    dict it inherits from ``SafeLoader`` by reference, every plain
+    ``yaml.safe_load`` caller in the process would lose bool parsing — e.g.
+    ``safe_load("false")`` would return the string ``"false"``.
+    """
+    import omnigent.spec.parser as parser
+
+    # Importing the module must leave SafeLoader's bool resolver intact.
+    assert yaml.safe_load("false") is False
+    assert yaml.safe_load("true") is True
+    # SafeLoader keeps its own YAML 1.1 behavior (``on`` -> True) untouched.
+    assert yaml.safe_load("on") is True
+
+    # Sharpest guard: the subclass must own a distinct resolver dict. This
+    # fails the instant someone drops the copy, regardless of import order.
+    loader = parser._ConfigYamlLoader
+    assert loader.yaml_implicit_resolvers is not yaml.SafeLoader.yaml_implicit_resolvers
+
+    # The subclass still narrows bools: ``on`` is a plain string, ``false`` a bool.
+    assert yaml.load("on", loader) == "on"
+    assert yaml.load("false", loader) is False


### PR DESCRIPTION
## Related issue

Closes #2312

## Summary

Importing `omnigent.spec.parser` (pulled in by any agent-YAML load) **globally mutated `yaml.SafeLoader`'s implicit resolvers**, so after the import `yaml.safe_load("false")` returned the *string* `"false"` process-wide — breaking every plain `yaml.safe_load` caller in the server.

- **Root cause:** `_ConfigYamlLoader(yaml.SafeLoader)` narrowed the YAML 1.1 bool resolver to YAML-1.2 spellings via **item assignment** on `yaml_implicit_resolvers` *without first copying* the dict it inherits from `SafeLoader` by reference. That stripped the bool resolver from `SafeLoader` itself; the later copy-on-write `add_implicit_resolver` re-added the narrowed resolver only to the subclass — leaving `SafeLoader` with no bool resolver at all.
- **Fix:** copy the resolver dict onto the subclass *before* mutating, mirroring the already-correct pattern in `omnigent/inner/loader.py`. One-line root cause; the rest is fallout cleanup.
- **Fallout:** `_read_terminal_transport_config` had come to rely on the mutation delivering a string, so with a healed loader `terminal.transport: false` would have silently flipped from PTY to control — now it normalizes a bool value explicitly. Corrected the now-stale workaround comment in `_omnigent_compat.py` (and the matching test docstring). Added a regression test.

Most visible operator impact this unblocks: `omnigent server` no longer rejects the documented boolean at startup —

```yaml
sandbox:
  provider: kubernetes
  kubernetes:
    in_cluster: false   # previously: Error: server config 'sandbox.kubernetes.in_cluster' must be a boolean
```

## Test Plan

- New regression test `tests/spec/test_parser.py::test_config_loader_does_not_mutate_shared_safeloader_resolvers` asserts, after `import omnigent.spec.parser`: `yaml.safe_load("false") is False`, `yaml.safe_load("true") is True`, `yaml.safe_load("on") is True` (SafeLoader's own YAML 1.1 behavior untouched), and the sharpest guard `_ConfigYamlLoader.yaml_implicit_resolvers is not yaml.SafeLoader.yaml_implicit_resolvers`. **Verified it fails** (`assert 'false' is False`) when the copy-block is removed, and passes with the fix.
- `uv run --extra dev python -m pytest tests/spec tests/inner/test_terminal.py -q` → **540 passed**, 1 unrelated failure (`test_server_survives_inner_process_exit_real_tmux`: macOS AF_UNIX socket path-length limit in the pytest tmpdir; fails identically on unmodified `main`).
- `pre-commit run --files ...` on all five touched files → all hooks pass.
- Manual repro confirmed: `python -c "import omnigent.spec.parser; import yaml; print(repr(yaml.safe_load('false')))"` now prints `False` (was `'false'` on `main`).

## Demo

Before/after on the same repro script — `main` rejects the documented boolean at startup; this PR parses it correctly:

![before/after: safe_load('false') and parse_sandbox_config on main vs this PR](https://raw.githubusercontent.com/btli/omnigent/demo-assets/pr-2314-safeloader-fix-demo.gif)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a targeted regression test that isolates this exact bug (the pre-existing suite passed identically with or without the fix, so the regression was previously invisible). Manual verification: reproduced the string-vs-bool behavior before/after the fix in a fresh interpreter, and confirmed the `terminal.transport: false` PTY opt-out still resolves correctly with the healed loader.

## Changelog

`omnigent server` now accepts documented boolean server-config values like `sandbox.kubernetes.in_cluster: false` instead of rejecting them at startup.
