### PR TITLE
fix(cursor-native): honor yolo: true as --yolo for piloted workers

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -559,6 +559,7 @@ _CLAUDE_NATIVE_MODEL = CLAUDE_NATIVE_CODING_AGENT.agent_name
 _CODEX_NATIVE_WRAPPER_LABEL_VALUE = CODEX_NATIVE_CODING_AGENT.wrapper_label
 _CODEX_NATIVE_HARNESS = CODEX_NATIVE_CODING_AGENT.harness
 _CODEX_NATIVE_MODEL = CODEX_NATIVE_CODING_AGENT.agent_name
+_CURSOR_NATIVE_HARNESS = CURSOR_NATIVE_CODING_AGENT.harness
 _CURSOR_NATIVE_WRAPPER_LABEL_VALUE = CURSOR_NATIVE_CODING_AGENT.wrapper_label
 _KIRO_NATIVE_WRAPPER_LABEL_VALUE = KIRO_NATIVE_CODING_AGENT.wrapper_label
 _CLAUDE_NATIVE_MESSAGE_TIMEOUT_S = 30.0
@@ -11917,16 +11918,37 @@ def _spec_config_flag_explicitly_disabled(spec: AgentSpec, key: str) -> bool:
     return isinstance(value, str) and value.strip().lower() == "false"
 
 
+def _spec_config_flag_explicitly_enabled(spec: AgentSpec, key: str) -> bool:
+    """
+    Return whether an ``executor.config`` flag is explicitly set true.
+
+    Mirror of :func:`_spec_config_flag_explicitly_disabled` for opt-IN
+    semantics (see the cursor-native branch of
+    :func:`_derive_terminal_launch_args_from_spec`). The spec parser
+    stringifies config values, so ``yolo: true`` arrives as ``"True"``.
+
+    :param spec: A parsed sub-agent spec.
+    :param key: The ``executor.config`` key to read, e.g. ``"yolo"``.
+    :returns: ``True`` only when the value is the boolean ``True`` or the
+        string ``"true"`` (case-insensitive); ``False`` otherwise
+        (including when the key is absent).
+    """
+    value = spec.executor.config.get(key)
+    if isinstance(value, bool):
+        return value is True
+    return isinstance(value, str) and value.strip().lower() == "true"
+
+
 def _derive_terminal_launch_args_from_spec(sub_spec: AgentSpec) -> list[str] | None:
     """
     Derive native-terminal YOLO pass-through args from a trusted sub-spec.
 
-    polly's native workers (claude-native / codex-native) launch in a
-    headless pane where no human can answer an ApprovalCard, so every
-    Edit/Write/Bash that prompts stalls the worker. This translates a
+    polly's native workers (claude-native / codex-native / cursor-native)
+    launch in a headless pane where no human can answer an ApprovalCard, so
+    every Edit/Write/Bash that prompts stalls the worker. This translates a
     worker bundle's declared full-bypass intent into the per-session
     ``terminal_launch_args`` the runner already appends to the claude /
-    codex argv:
+    codex / cursor argv:
 
     - claude-native + ``executor.config.permission_mode`` set ->
       ``["--permission-mode", "<value>"]``. The value is passed through
@@ -11943,12 +11965,17 @@ def _derive_terminal_launch_args_from_spec(sub_spec: AgentSpec) -> list[str] | N
       and the codex-sdk executor's ``approvalPolicy="never"``). An explicit
       ``executor.config.yolo: false`` opts back out for a read-only / must
       -keep-prompting sub-agent. See issue #171.
+    - cursor-native + ``executor.config.yolo: true`` -> ``["--yolo"]``
+      (alias for ``cursor-agent --force`` / Run Everything). Opt-in, not a
+      default: cursor's own approval gate is the source of truth unless the
+      worker bundle explicitly asks to bypass it. Without the flag, Omnigent
+      mirrors cursor's pending tool calls as ApprovalCards.
 
-    Only the two native harnesses are translated; for any other harness
-    (e.g. ``claude-sdk``, whose bypass is set via the SDK ``permissionMode``
-    spawn env, not a terminal flag) this returns ``None`` so no terminal
-    args are set. ``None`` is also returned when the relevant field is
-    absent / falsey.
+    Only the three native harnesses above are translated; for any other
+    harness (e.g. ``claude-sdk``, whose bypass is set via the SDK
+    ``permissionMode`` spawn env, not a terminal flag) this returns ``None``
+    so no terminal args are set. ``None`` is also returned when the relevant
+    field is absent / falsey.
 
     :param sub_spec: The trusted child sub-agent spec, resolved from the
         server-loaded parent bundle via :func:`_resolve_subagent_spec`.
@@ -11975,6 +12002,16 @@ def _derive_terminal_launch_args_from_spec(sub_spec: AgentSpec) -> list[str] | N
         if _spec_config_flag_explicitly_disabled(sub_spec, "yolo"):
             return None
         return _validate_terminal_launch_args(["--dangerously-bypass-approvals-and-sandbox"])
+    if harness == _CURSOR_NATIVE_HARNESS:
+        # Opt-in full bypass. cursor-agent gates tools in its own TUI;
+        # Omnigent mirrors those gates as ApprovalCards unless --yolo /
+        # --force is on the launch argv. A piloted worker cannot answer
+        # those cards, so worker bundles that need unattended runs must
+        # declare ``yolo: true``. Absent / false keeps the default
+        # prompting stance (matches the web UI's Cursor "Default" mode).
+        if not _spec_config_flag_explicitly_enabled(sub_spec, "yolo"):
+            return None
+        return _validate_terminal_launch_args(["--yolo"])
     return None
 
 
@@ -12311,12 +12348,13 @@ async def _create_session_from_existing_agent(
     # from the trusted, server-loaded sub-spec only — any caller-supplied
     # ``body.terminal_launch_args`` is ignored. This is the YOLO seam:
     # claude-native maps ``permission_mode`` to ``--permission-mode``,
-    # while codex-native defaults to full bypass
+    # codex-native defaults to full bypass
     # (``--dangerously-bypass-approvals-and-sandbox``) so a headless
     # codex worker can edit/run unattended without stalling on codex's
-    # on-request approval default (opt out with ``yolo: false``). A
-    # caller cannot inject launch wiring by smuggling args through the
-    # spawn body.
+    # on-request approval default (opt out with ``yolo: false``), and
+    # cursor-native maps ``yolo: true`` to ``--yolo`` (opt-in; absent
+    # keeps cursor's own approval prompts). A caller cannot inject
+    # launch wiring by smuggling args through the spawn body.
     #
     # Sessions that resolve their own agent (top-level sessions and the
     # manual Add Agent child flow where ``sub_agent_name`` is null) keep

--- a/tests/server/routes/test_sessions_yolo_launch_args.py
+++ b/tests/server/routes/test_sessions_yolo_launch_args.py
@@ -1,12 +1,13 @@
 """Unit tests for native-worker YOLO ``terminal_launch_args`` derivation.
 
-Nessie's native sub-agent workers (claude-native / codex-native) launch
-in a headless pane where no human can answer an approval prompt. The
-server translates a worker's bypass stance into the per-session
-``terminal_launch_args`` the runner appends to the claude / codex argv:
-claude-native opts in via ``permission_mode``, while codex-native
-defaults to full bypass (issue #171) because the headless seam has no
-safe non-bypass default, with ``yolo: false`` as the opt-out.
+Nessie's native sub-agent workers (claude-native / codex-native /
+cursor-native) launch in a headless pane where no human can answer an
+approval prompt. The server translates a worker's bypass stance into the
+per-session ``terminal_launch_args`` the runner appends to the claude /
+codex / cursor argv: claude-native opts in via ``permission_mode``,
+codex-native defaults to full bypass (issue #171) because the headless
+seam has no safe non-bypass default, with ``yolo: false`` as the
+opt-out, and cursor-native opts in via ``yolo: true`` -> ``--yolo``.
 
 These tests exercise the pure translation helper
 ``_derive_terminal_launch_args_from_spec`` directly with real
@@ -139,6 +140,45 @@ def test_codex_native_yolo_false_string_opts_out_of_bypass() -> None:
     assert _derive_terminal_launch_args_from_spec(spec) is None
 
 
+def test_cursor_native_yolo_string_true_translates_to_yolo_flag() -> None:
+    """
+    cursor-native + ``yolo`` (string ``"True"``) -> ``--yolo``.
+
+    The spec parser stringifies ``yolo: true`` into ``"True"``, so this is
+    the value the server actually sees in production. A failure means a
+    piloted cursor worker would launch without ``--yolo`` / ``--force`` and
+    stall on cursor-agent's own approval prompts (mirrored as Omnigent
+    ApprovalCards).
+    """
+    spec = _spec_with_config({"harness": "cursor-native", "yolo": "True"})
+    assert _derive_terminal_launch_args_from_spec(spec) == ["--yolo"]
+
+
+def test_cursor_native_without_yolo_field_returns_none() -> None:
+    """
+    cursor-native without ``yolo`` keeps the default prompting stance.
+
+    Unlike codex-native, cursor bypass is opt-in: absent ``yolo`` must not
+    emit ``--yolo``, so interactive / web-launched cursor sessions still
+    surface ApprovalCards unless the worker bundle explicitly asks for
+    full bypass.
+    """
+    cursor = _spec_with_config({"harness": "cursor-native"})
+    assert _derive_terminal_launch_args_from_spec(cursor) is None
+
+
+def test_cursor_native_yolo_false_string_returns_none() -> None:
+    """
+    ``yolo: false`` on cursor-native must not emit ``--yolo``.
+
+    Guards the same ``bool("False") is True`` trap as the codex opt-out:
+    a naive truthiness check would incorrectly treat the stringified
+    ``"False"`` as enabled and launch with full bypass.
+    """
+    spec = _spec_with_config({"harness": "cursor-native", "yolo": "False"})
+    assert _derive_terminal_launch_args_from_spec(spec) is None
+
+
 @pytest.mark.parametrize(
     "harness",
     ["claude-sdk", "codex", "openai-agents"],
@@ -147,7 +187,7 @@ def test_non_native_harness_with_bypass_fields_is_ignored(harness: str) -> None:
     """
     Non-native harnesses never get terminal args, even with bypass fields.
 
-    ``terminal_launch_args`` is a native-terminal (claude/codex TUI)
+    ``terminal_launch_args`` is a native-terminal (claude/codex/cursor TUI)
     concept; a claude-sdk worker sets bypass via the SDK ``permissionMode``
     spawn env, not a CLI flag. Translating these fields for a non-native
     harness would emit a flag the runner has no terminal to apply it to.


### PR DESCRIPTION
## Related issue

N/A (pilot workflow stall; no tracking issue).

## Summary

- Named sub-agent creates derive `terminal_launch_args` from the trusted worker spec only — caller-supplied args are ignored. That YOLO seam already mapped claude-native (`permission_mode`) and codex-native (`--dangerously-bypass-approvals-and-sandbox`, default-on with `yolo: false` opt-out).
- **cursor-native was missing**: a piloted Cursor worker with no launch args kept `cursor-agent`'s default approval prompts, which Omnigent mirrors as ApprovalCards. A headless pilot cannot answer those cards, so the worker stalled on the first gated tool call.
- `executor.config.yolo: true` on a cursor-native sub-agent now becomes `["--yolo"]` (alias for `cursor-agent --force` / Run Everything). Opt-in, not a default — absent / `false` keeps the prompting stance (matches the web UI's Cursor "Default" mode).

ELI5: Codex workers already got a "don't ask, just do it" launch flag from the bundle. Cursor workers didn't, so they kept raising their hand for every shell/edit and the pilot had no way to click Approve. Now `yolo: true` on the Cursor worker bundle means "don't ask."

```
_derive_terminal_launch_args_from_spec(sub_spec)
  ├─ claude-native + permission_mode ──► --permission-mode <value>     (unchanged)
  ├─ codex-native (default; yolo:false opts out) ──► --dangerously-bypass-…  (unchanged)
  └─ cursor-native + yolo: true ───────► --yolo                        [was: None]
```

## Test Plan

- [x] `uv run pytest tests/server/routes/test_sessions_yolo_launch_args.py` — 12 passed (3 new: cursor `yolo: true` → `--yolo`, absent → `None`, `yolo: false` → `None`).
- [ ] Manual: register a parent agent whose `agents/cursor` (or equivalent) sub-spec has `harness: cursor-native` + `yolo: true`, dispatch a Cursor sub-agent, confirm the child session's `terminal_launch_args` include `--yolo` and a gated shell/edit does **not** surface an ApprovalCard. Existing Cursor sessions keep old launch args — only new creates pick this up.

## Demo

N/A — no UI change. `executor.config.yolo: true` on cursor-native sub-agents now maps to `cursor-agent --yolo` launch args (parity with claude/codex YOLO seams); covered by unit tests.


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests pin the three cursor-native cases (enabled / absent / false) against the same string-coerced config values the spec parser produces (`"True"` / `"False"`). Live pilot verification: after host restart with an updated cursor worker bundle, a fresh Cursor conversation should launch with `--yolo` and stop mirroring tool-approval cards.

## Changelog

Piloted cursor-native workers can opt into full tool-approval bypass via `executor.config.yolo: true`, which now launches `cursor-agent` with `--yolo`.

This pull request and its description were written by Isaac.

Made with [Cursor](https://cursor.com)