### PR TITLE
fix(web): prevent editor crash on list items with a block-first child

### DIFF
--- a/web/src/shell/MarkdownRichTextViewer.listItemCrash.test.ts
+++ b/web/src/shell/MarkdownRichTextViewer.listItemCrash.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression test: opening a markdown file whose list contains a block-first
+ * item — a nested list (`- - x`), a fenced code block, a blockquote, a heading,
+ * or a table as the item's first child — used to crash the whole editor panel.
+ *
+ * `@tiptap/markdown` (beta) parses those into a `listItem` whose first child is
+ * a non-paragraph block. The stock TipTap `listItem` content model is
+ * `paragraph block*` (it must START with a paragraph), so the parsed document
+ * is schema-invalid. ProseMirror builds the initial doc via `nodeFromJSON`,
+ * which does NOT validate content, so the bad doc loads silently — then the
+ * first transaction that touches the list item (a user edit, or StarterKit's
+ * TrailingNode appendTransaction that runs on load) calls `contentMatchAt` on
+ * it and throws ("Called contentMatchAt on a node with invalid content"). The
+ * viewer's React panel boundary catches the throw and renders a crash instead
+ * of the file. (Same failure family as the blockquote crash fixed in #2004,
+ * but for list items — which agent-authored markdown hits constantly.)
+ *
+ * Fix: relax the list item's content model to `block+` (SafeListItem) so a
+ * non-paragraph first child is schema-valid. These tests use the EXACT
+ * extension stack from MarkdownRichTextViewer so a regression fails here.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
+import { ListItem, TaskItem, TaskList } from "@tiptap/extension-list";
+import { Markdown } from "@tiptap/markdown";
+import { createWorkspaceImageExtension, ImageAwareLink } from "./TipTapWorkspaceImage";
+import { GitHubAlertBlockquote } from "./TipTapGitHubAlert";
+import { HtmlPassthrough } from "./TipTapHtmlPassthrough";
+
+// The fix under test — must match MarkdownRichTextViewer's SafeListItem.
+const SafeListItem = ListItem.extend({ content: "block+" });
+
+vi.mock("@/hooks/useFileContent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/useFileContent")>();
+  return { ...actual, fetchFileContent: vi.fn().mockResolvedValue(undefined) };
+});
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+beforeEach(() => {
+  URL.createObjectURL = vi.fn(() => "blob:mock");
+  URL.revokeObjectURL = vi.fn();
+});
+
+let editor: Editor | null = null;
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  vi.clearAllMocks();
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+function makeEditor(markdown: string): Editor {
+  return new Editor({
+    element: document.createElement("div"),
+    extensions: [
+      StarterKit.configure({ link: false, blockquote: false, listItem: false }),
+      SafeListItem,
+      TaskList,
+      TaskItem.configure({ nested: true }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableCell,
+      TableHeader,
+      ImageAwareLink.configure({ openOnClick: false, autolink: false }),
+      GitHubAlertBlockquote,
+      HtmlPassthrough,
+      Markdown,
+      createWorkspaceImageExtension("conv_test", "README.md"),
+    ],
+    content: markdown,
+    contentType: "markdown",
+  });
+}
+
+/** Dispatch an edit inside the first node — the transaction that tripped the crash. */
+function typeInsideFirstNode(ed: Editor): void {
+  ed.view.dispatch(ed.state.tr.insertText("a", 2));
+}
+
+describe("list-item block-first crash", () => {
+  // Inputs that previously crashed the editor: a list item whose first (or only)
+  // child is a non-paragraph block.
+  const CRASHERS = [
+    "- - nested",
+    "- ```\n  code\n  ```",
+    "- > quote",
+    "- # heading",
+    "- | a | b |\n  |---|---|\n  | 1 | 2 |",
+    "> - > ![x](y.png)",
+  ];
+
+  it.each(CRASHERS)("parses %j into a schema-valid document", (md) => {
+    editor = makeEditor(md);
+    // Node.check() recurses the whole tree and throws on invalid content;
+    // before the fix this threw for the list item.
+    expect(() => editor!.state.doc.check()).not.toThrow();
+  });
+
+  it.each(CRASHERS)("survives an edit transaction without crashing: %j", (md) => {
+    editor = makeEditor(md);
+    expect(() => typeInsideFirstNode(editor!)).not.toThrow();
+  });
+
+  it("keeps a nested list schema-valid with the list as the item's first child", () => {
+    editor = makeEditor("- - nested");
+    const outerItem = editor.state.doc.child(0).child(0); // bulletList > listItem
+    expect(outerItem.type.name).toBe("listItem");
+    expect(outerItem.child(0).type.name).toBe("bulletList");
+  });
+});

--- a/web/src/shell/MarkdownRichTextViewer.test.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@tiptap/extension-table", () => ({
   TableHeader: {},
 }));
 vi.mock("@tiptap/extension-list", () => ({
+  ListItem: { extend: vi.fn().mockReturnValue({}) },
   TaskList: {},
   TaskItem: { configure: vi.fn().mockReturnValue({}) },
 }));

--- a/web/src/shell/MarkdownRichTextViewer.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.tsx
@@ -21,7 +21,7 @@ import { AlertTriangleIcon, Check, Copy, MessageSquareOffIcon } from "lucide-rea
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
-import { TaskItem, TaskList } from "@tiptap/extension-list";
+import { ListItem, TaskItem, TaskList } from "@tiptap/extension-list";
 import { Markdown } from "@tiptap/markdown";
 import type { Comment } from "@/hooks/useComments";
 import type { ActiveSelection } from "./codeViewerHelpers";
@@ -44,6 +44,20 @@ import { installMarkdownSerializerPatch } from "./tiptapMarkdownPatches";
 // Minimal-escaping serialiser override (see tiptapMarkdownPatches.ts) —
 // installed once at module load, before any editor instance is created.
 installMarkdownSerializerPatch();
+
+// @tiptap/markdown parses a list item whose first child is a non-paragraph
+// block — a nested list, a fenced code block, a blockquote, a heading, or a
+// table — into a `listItem` that violates the stock `paragraph block*` content
+// model. ProseMirror builds the initial doc via `nodeFromJSON`, which does NOT
+// validate content, so the invalid doc loads silently; the first transaction
+// that touches it (a user edit, or StarterKit's TrailingNode plugin on load)
+// then calls `contentMatchAt` and throws ("Called contentMatchAt on a node
+// with invalid content"), which the viewer's panel boundary catches — the
+// whole file view crashes instead of rendering. Relaxing the content model to
+// `block+` accepts a non-paragraph first child, keeping the parsed doc
+// schema-valid. Same class as the blockquote fix in #2004 (see toBlockContent),
+// for list items.
+const SafeListItem = ListItem.extend({ content: "block+" });
 
 // ---------------------------------------------------------------------------
 // MarkdownRichTextViewer — outer shell manages the editor key for remounting
@@ -265,7 +279,11 @@ function MarkdownRichTextViewerInner({
       // link/blockquote: false — StarterKit bundles its own versions whose
       // markdown handlers would shadow the GitHub-flavored replacements
       // below (duplicate extension names: first wins).
-      StarterKit.configure({ link: false, blockquote: false }),
+      // listItem: false — replaced by SafeListItem (content: block+) so a list
+      // item whose first child is a non-paragraph block doesn't build a
+      // schema-invalid doc that crashes the panel. See SafeListItem above.
+      StarterKit.configure({ link: false, blockquote: false, listItem: false }),
+      SafeListItem,
       // Task lists (GitHub `- [ ]` / `- [x]`). StarterKit ships
       // BulletList/OrderedList/ListItem but NOT TaskList/TaskItem, so without
       // these two the markdown parser drops the checkbox and renders a plain


### PR DESCRIPTION
## What & why

Opening a markdown file whose list has an item that **starts with a non-paragraph block** — a nested list (`- - x`), a fenced code block, a blockquote, a heading, or a table — crashes the entire markdown editor panel: the `omnigent_page` route falls to its React `PanelBoundary` and renders a crash instead of the file.

### Root cause

TipTap's `listItem` content model is `paragraph block*` — a list item **must start with a paragraph**. `@tiptap/markdown` (beta) parses a block-first list item into a `listItem` whose first child is that block, which violates the model. ProseMirror builds the initial document via `nodeFromJSON`, which does **not** validate content, so the invalid doc loads silently — then the first transaction that touches the list item (a user edit, or StarterKit's `TrailingNode` `appendTransaction`, which runs on load) calls `contentMatchAt` on it and throws _"Called contentMatchAt on a node with invalid content"_. The panel boundary catches the throw and crashes the view.

This is the **same crash family as #2004** ("prevent editor crash on blockquote with inline-only content"), which normalized only `GitHubAlertBlockquote`. List items were left unguarded — and nested lists / code-blocks-in-lists are exactly what agent-authored markdown emits constantly, so it fired across multiple workspaces (surfaced as a `RouteLevelPanelBoundaryAvailabilityBurnRateSLO` page for `omnigent_page`).

### Fix

Relax the list item's content model to `block+` (`SafeListItem = ListItem.extend({ content: "block+" })`) so a non-paragraph first child is schema-valid, registered via `StarterKit.configure({ listItem: false })` + `SafeListItem`. Purely more-permissive; no serialization change.

## How verified

New `MarkdownRichTextViewer.listItemCrash.test.ts`, mirroring #2004's `MarkdownRichTextViewer.blockquoteCrash.test.ts` and using the **exact** viewer extension stack: every block-first shape (nested list, code block, blockquote, heading, table, deep-nested) now parses to a schema-valid document and survives an edit transaction without throwing. 13/13 green against `@tiptap/*@3.23.4` (the pinned version).

## Related

- **#2004** — sibling fix for the blockquote variant of this exact crash (`@tiptap/markdown` → schema-invalid `nodeFromJSON` doc → `contentMatchAt` throws on first edit). This PR extends the same idea from blockquotes to list items, and its regression test is modeled on that PR's `blockquoteCrash.test.ts`.
- **#1333** — `ap-web/` → `web/` rename; the affected file now lives at `web/src/shell/MarkdownRichTextViewer.tsx`.

## Known residual (follow-up)

A **bare inline image not wrapped in a paragraph** — at list-item (`1. ![x](y)`) or document (`---` then a lone image) level — is the other half of #2004's class and is _not_ covered by `block+` (an inline node can't sit directly in a `block+` container). Much rarer than block-first list items; the fast-follow is to generalize #2004's `toBlockContent` helper to wrap loose inline runs at parse time.

This pull request and its description were written by Isaac.
