### PR TITLE
feat(kimi-native): live tool-call cards + session-status edges

### DIFF
--- a/omnigent/kimi_native_forwarder.py
+++ b/omnigent/kimi_native_forwarder.py
@@ -14,18 +14,39 @@ native harness points ``KIMI_CODE_HOME`` at ``<bridge_dir>/kimi-code-home`` whos
 sessions share the tree; we disambiguate by ``workDir`` (via ``session_index.jsonl``)
 and recency. Relevant wire events:
 
-- ``{"type": "turn.prompt", "input": [{"type":"text","text":…}], "origin": {"kind":"user"}}``
-  → a user message.
-- ``{"type": "context.append_loop_event", "event": {"type": "content.part",
-  "part": {"type": "text", "text": …}, "uuid": …}}`` → an assistant message.
-  (``part.type == "think"`` is reasoning, mirrored as a transient
-  ``external_output_reasoning_delta`` from ``part["think"]``; ``tool.call`` /
-  ``tool.result`` events are still skipped — the embedded terminal shows them.)
+- ``turn.prompt`` (``origin.kind == "user"``) → a user message.
+- ``context.append_loop_event`` wraps the streamed turn. Its ``event.type`` is
+  one of: ``step.begin`` / ``step.end`` (step boundaries, carrying ``turnId`` and
+  a terminal ``finishReason``); ``content.part`` where ``part.type == "text"`` is
+  an assistant message and ``part.type == "think"`` is reasoning (mirrored as a
+  transient ``external_output_reasoning_delta`` from ``part["think"]``);
+  ``tool.call`` and ``tool.result`` (a built-in tool invocation and its output).
+- ``turn.cancel`` → the turn was interrupted.
 
-Each mirrored turn is POSTed as an ``external_conversation_item`` to
-``/v1/sessions/{id}/events`` (the same shape :mod:`omnigent.kimi_native_hook`
-uses for its read-only approval surface). A per-session line offset is persisted
-in ``<bridge_dir>/kimi_forwarder.json`` so restarts resume without double-posting.
+Each turn is mirrored so the web chat matches the TUI: user/assistant text and
+tool calls are :class:`_MirrorItem`s POSTed as ``external_conversation_item`` /
+``external_output_reasoning_delta``, and the turn is bracketed by ``running`` /
+``idle`` ``external_session_status`` edges (posted via :func:`_post_status_edge`,
+mirroring claude-native's item/status split — status is not a conversation item).
+All of a turn's assistant-side items and its status edges share one ``response_id``
+(``kimi:turn:<turnId>``) so the web renders in-flight tools as *live* cards
+(spinner + ticking timer) rather than static ones.
+
+kimi's wire has no ``turn.end`` event, and ``tool.result`` carries no ``turnId``,
+so the forwarder is a *stateful* tailer: it remembers the active turn across
+lines (:class:`_TurnState`) and treats a ``step.end`` whose ``finishReason`` is
+not ``tool_use`` (or a ``turn.cancel``) as the turn's end. A per-session line
+offset is persisted in ``<bridge_dir>/kimi_forwarder.json`` so restarts resume
+without double-posting.
+
+The ``idle`` edge is also the terminal-status report a parent orchestrator waits
+on, so it carries the turn's final assistant text as ``output`` — the runner
+delivers an empty result when an idle edge forwards none (#3166).
+
+Row translation is shared with the offline importer: :func:`read_kimi_wire_items`
+replays a whole wire log into :class:`KimiWireItem`s (see
+:mod:`omnigent.session_import.local`), so live mirroring and import agree on
+parsing and ids.
 """
 
 from __future__ import annotations
@@ -34,8 +55,9 @@ import asyncio
 import contextlib
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import NamedTuple
 
 import httpx
 
@@ -51,6 +73,38 @@ _DISCOVER_SKEW_MS = 10_000
 _BACKOFF_INITIAL_S = 1.0
 _BACKOFF_MAX_S = 30.0
 
+#: Omnigent session-event types (must match the server ingestion route; shared
+#: with the codex-/opencode-native forwarders).
+_EXTERNAL_ITEM = "external_conversation_item"
+_EXTERNAL_STATUS = "external_session_status"
+_EXTERNAL_REASONING_DELTA = "external_output_reasoning_delta"
+_STATUS_RUNNING = "running"
+_STATUS_IDLE = "idle"
+
+#: kimi ``step.end.finishReason`` meaning "paused this step to run a tool, more
+#: steps follow" — the one non-terminal reason. Anything else (``end_turn`` …)
+#: ends the turn.
+_FINISH_TOOL_USE = "tool_use"
+
+
+class _StatusEdge(NamedTuple):
+    """A ``running`` / ``idle`` status edge to POST.
+
+    ``response_id`` names the turn so the server records it as
+    ``active_response_id`` — that is what keeps a mid-turn reconnect rendering
+    the forwarded tool cards LIVE (the turn-start edge is not replayed on the SSE
+    stream). Not modeled as a conversation item, mirroring claude-native.
+
+    ``output`` carries the turn's final assistant text on the ``idle`` edge: for
+    a sub-agent conversation the server maps that edge to a terminal completion
+    that wakes the parent orchestrator's inbox, and the runner delivers an empty
+    result when an idle edge forwards none (#3166).
+    """
+
+    status: str
+    response_id: str | None = None
+    output: str = ""
+
 
 @dataclass
 class _ForwardState:
@@ -61,20 +115,69 @@ class _ForwardState:
 
 
 @dataclass
+class _TurnState:
+    """In-memory turn tracking for the stateful tail.
+
+    kimi emits no ``turn.end`` event and its ``tool.result`` carries no
+    ``turnId``, so the active turn must be remembered across lines. ``turn_id``
+    is kimi's ``turnId`` for the live turn (e.g. ``"3"``); ``running`` records
+    whether a ``running`` status edge has already been posted for it, so it
+    fires once per turn rather than once per step; ``last_text`` is the newest
+    assistant text seen in the turn, forwarded as the ``idle`` edge's ``output``
+    so a parent orchestrator's inbox gets the real result instead of an empty
+    one (#3166).
+    """
+
+    turn_id: str | None = None
+    running: bool = False
+    last_text: str = ""
+
+
+@dataclass
 class KimiWireItem:
-    """Stable parsed-wire contract shared by forwarding and offline import."""
+    """Stable parsed-wire contract shared by forwarding and offline import.
+
+    One conversation item to POST, plus the line index it came from.
+
+    ``kind`` selects the wire shape (all but ``reasoning`` post as
+    ``external_conversation_item``):
+
+    - ``message`` → user/assistant text (``role`` + ``text``)
+    - ``reasoning`` → a think block, posted as ``external_output_reasoning_delta``
+      from ``text``
+    - ``function_call`` → a tool invocation (``call_id`` + ``name`` + ``arguments``)
+    - ``function_call_output`` → its result (``call_id`` + ``output``)
+
+    Fields not relevant to a given ``kind`` stay ``None``.
+    """
 
     line_no: int
-    role: str
-    text: str
-    response_id: str
-    # "message" (a user/assistant turn → external_conversation_item),
-    # "reasoning" (a think block → external_output_reasoning_delta), or
-    # "turn_end" (an ``end_turn`` step → external_session_status: idle).
     kind: str = "message"
+    response_id: str = ""
+    role: str | None = None
+    text: str | None = None
+    call_id: str | None = None
+    name: str | None = None
+    arguments: str | None = None
+    output: str | None = None
 
 
+#: Historical in-module name, kept so the forwarder reads as before while
+#: :class:`KimiWireItem` is the name the offline importer depends on (#3032).
 _MirrorItem = KimiWireItem
+
+
+class _WireLine(NamedTuple):
+    """One tailed wire-log line: its 0-based index and the parsed JSON object."""
+
+    line_no: int
+    row: dict[str, object]
+
+
+#: What ``_translate_row`` produces for one wire line: the conversation items to
+#: POST, an optional ``running`` / ``idle`` status edge, and the next turn state.
+#: A row yields items *or* a status, never both.
+_RowResult = tuple[list[_MirrorItem], "_StatusEdge | None", _TurnState]
 
 
 def clear_kimi_bridge_state(bridge_dir: Path) -> None:
@@ -142,9 +245,6 @@ def workdirs_for_kimi_sessions(kimi_home: Path) -> dict[str, str]:
     return mapping
 
 
-_workdirs_for_sessions = workdirs_for_kimi_sessions
-
-
 def _discover_wire(kimi_home: Path, workspace: str, launch_epoch_ms: int) -> Path | None:
     """Locate the wire log for *workspace*'s newest session created at/after launch.
 
@@ -192,88 +292,178 @@ def _input_text(blocks: object) -> str:
     return "".join(parts)
 
 
-def _row_to_item(line_no: int, row: dict[str, object]) -> KimiWireItem | None:
-    """Map one wire-log row to a conversation item, or ``None`` to skip it."""
-    row_type = row.get("type")
-    if row_type == "turn.prompt":
-        origin = row.get("origin")
-        if isinstance(origin, dict) and origin.get("kind") != "user":
-            return None
-        text = _input_text(row.get("input"))
-        if not text:
-            return None
-        return KimiWireItem(
-            line_no=line_no,
-            role="user",
-            text=text,
-            response_id=f"kimi:turn:{line_no}",
-        )
-    if row_type == "context.append_loop_event":
-        event = row.get("event")
-        if not isinstance(event, dict):
-            return None
-        event_type = event.get("type")
-        if event_type == "step.end":
-            # kimi's agent loop keeps stepping while a step stops for ``tool_use``;
-            # ``end_turn`` is the only finish reason that ends the turn. Without
-            # this edge a native sub-agent never reports terminal status, so a
-            # parent orchestrator waits on it forever.
-            if event.get("finishReason") != "end_turn":
-                return None
-            return KimiWireItem(
-                line_no=line_no,
-                role="assistant",
-                text="",
-                response_id=f"kimi:turn_end:{line_no}",
-                kind="turn_end",
-            )
-        if event_type != "content.part":
-            return None
-        part = event.get("part")
-        if not isinstance(part, dict):
-            return None
-        uuid = event.get("uuid")
-        response_id = f"kimi:{uuid}" if isinstance(uuid, str) and uuid else f"kimi:line:{line_no}"
-        part_type = part.get("type")
-        if part_type == "text":
-            part_text = part.get("text")
-            if not isinstance(part_text, str) or not part_text:
-                return None
-            return KimiWireItem(
-                line_no=line_no,
-                role="assistant",
-                text=part_text,
-                response_id=response_id,
-            )
-        if part_type == "think":
-            # Reasoning lives in ``part["think"]`` (not ``part["text"]``). Mirror it
-            # as a transient reasoning event so the web UI paints a thinking block —
-            # the kimi analogue of codex-native's #1254 reasoning fix.
-            think = part.get("think")
-            if not isinstance(think, str) or not think:
-                return None
-            return KimiWireItem(
-                line_no=line_no,
-                role="assistant",
-                text=think,
-                response_id=response_id,
-                kind="reasoning",
-            )
-        return None
+def _event_turn_id(event: dict[str, object]) -> str | None:
+    """Return the event's ``turnId`` as a string, or ``None`` when absent."""
+    turn_id = event.get("turnId")
+    if isinstance(turn_id, str) and turn_id:
+        return turn_id
+    if isinstance(turn_id, int):
+        return str(turn_id)
     return None
 
 
-def read_kimi_wire_items(wire_path: Path, last_line: int) -> list[KimiWireItem]:
-    """Parse wire-log lines beyond *last_line* into the stable shared contract.
+def _turn_response_id(turn_id: str) -> str:
+    """The shared per-turn response id (groups a turn's items + status edges)."""
+    return f"kimi:turn:{turn_id}"
+
+
+def _response_id(state: _TurnState, event: dict[str, object], line_no: int) -> str:
+    """Per-turn response id, or a per-event fallback when no turn is known.
+
+    Assistant text and tool events group under ``kimi:turn:<turnId>`` so they
+    share the turn's ``running`` edge and render as one live response. A
+    ``tool.result`` has no ``turnId`` and leans on the remembered turn; if even
+    that is missing (e.g. a mid-turn restart resumed past ``step.begin``), fall
+    back to a per-event id so the item still posts, just ungrouped.
+    """
+    if state.turn_id is not None:
+        return _turn_response_id(state.turn_id)
+    uuid = event.get("uuid")
+    if isinstance(uuid, str) and uuid:
+        return f"kimi:{uuid}"
+    return f"kimi:line:{line_no}"
+
+
+def _tool_output_text(result: object) -> str:
+    """Extract the mirrored text from a ``tool.result`` ``result`` payload."""
+    if isinstance(result, str):
+        return result
+    if isinstance(result, dict):
+        output = result.get("output")
+        if isinstance(output, str):
+            return output
+        return json.dumps(result, ensure_ascii=True)
+    return ""
+
+
+def _idle_edge(state: _TurnState) -> _StatusEdge:
+    """The ``idle`` edge closing the active turn (id names the released turn).
+
+    Carries the turn's final assistant text so a sub-agent's parent orchestrator
+    is woken with the real result (#3166), not an empty one.
+    """
+    rid = _turn_response_id(state.turn_id) if state.turn_id is not None else None
+    return _StatusEdge(_STATUS_IDLE, rid, state.last_text)
+
+
+def _translate_row(line_no: int, row: dict[str, object], state: _TurnState) -> _RowResult:
+    """Translate one wire row into ``(items, status_edge, next_state)``.
+
+    Pure: any given row yields *either* conversation items *or* a status edge
+    (never both). The caller commits the returned state only after the posts
+    land, so a POST failure that retries the row cannot lose a ``running`` edge
+    or double-advance the turn.
+    """
+    row_type = row.get("type")
+
+    if row_type == "turn.prompt":
+        origin = row.get("origin")
+        if isinstance(origin, dict) and origin.get("kind") != "user":
+            return [], None, state
+        text = _input_text(row.get("input"))
+        if not text:
+            return [], None, state
+        # The user bubble keeps its own per-line id: turn.prompt carries no
+        # turnId, and the message need not join the turn's response group — it
+        # only has to precede the assistant items, which wire order guarantees.
+        item = _MirrorItem(line_no, "message", f"kimi:turn:{line_no}", role="user", text=text)
+        return [item], None, state
+
+    if row_type == "turn.cancel":
+        if state.running:
+            return [], _idle_edge(state), _TurnState()
+        return [], None, state
+
+    if row_type != "context.append_loop_event":
+        return [], None, state
+
+    event = row.get("event")
+    if not isinstance(event, dict):
+        return [], None, state
+    etype = event.get("type")
+
+    # Any event carrying turnId (re-)establishes the active turn — this also
+    # recovers the turn after a mid-turn restart resumed past ``step.begin``.
+    turn_id = _event_turn_id(event)
+    if turn_id is not None:
+        state = replace(state, turn_id=turn_id)
+
+    if etype == "step.begin":
+        if state.turn_id is not None and not state.running:
+            edge = _StatusEdge(_STATUS_RUNNING, _turn_response_id(state.turn_id))
+            return [], edge, replace(state, running=True)
+        return [], None, state
+
+    if etype == "step.end":
+        if event.get("finishReason") == _FINISH_TOOL_USE:
+            return [], None, state  # paused for a tool; the turn continues
+        # Unconditional, even when no ``running`` edge was posted for this turn
+        # (a restart can resume past ``step.begin``): the terminal edge is what
+        # wakes a parent orchestrator, so skipping it strands the parent (#3166).
+        return [], _idle_edge(state), _TurnState()
+
+    if etype == "content.part":
+        part = event.get("part")
+        if not isinstance(part, dict):
+            return [], None, state
+        part_type = part.get("type")
+        if part_type == "text":
+            text = part.get("text")
+            if not isinstance(text, str) or not text:
+                return [], None, state
+            rid = _response_id(state, event, line_no)
+            item = _MirrorItem(line_no, "message", rid, role="assistant", text=text)
+            # Remember it for the turn's ``idle`` edge output (#3166).
+            return [item], None, replace(state, last_text=text)
+        if part_type == "think":
+            # Reasoning lives in ``part["think"]`` (not ``part["text"]``); mirror
+            # it as a transient reasoning delta so the web UI paints a thinking
+            # block — the kimi analogue of codex-native's #1254 reasoning fix.
+            think = part.get("think")
+            if not isinstance(think, str) or not think:
+                return [], None, state
+            rid = _response_id(state, event, line_no)
+            item = _MirrorItem(line_no, "reasoning", rid, role="assistant", text=think)
+            return [item], None, state
+        return [], None, state
+
+    if etype == "tool.call":
+        call_id = event.get("toolCallId") or event.get("uuid")
+        name = event.get("name")
+        if not isinstance(call_id, str) or not isinstance(name, str):
+            return [], None, state
+        args = event.get("args")
+        arguments = json.dumps(args if isinstance(args, dict) else {}, ensure_ascii=True)
+        rid = _response_id(state, event, line_no)
+        item = _MirrorItem(
+            line_no, "function_call", rid, call_id=call_id, name=name, arguments=arguments
+        )
+        return [item], None, state
+
+    if etype == "tool.result":
+        call_id = event.get("toolCallId") or event.get("parentUuid")
+        if not isinstance(call_id, str):
+            return [], None, state
+        output = _tool_output_text(event.get("result"))
+        rid = _response_id(state, event, line_no)
+        item = _MirrorItem(line_no, "function_call_output", rid, call_id=call_id, output=output)
+        return [item], None, state
+
+    return [], None, state
+
+
+def _read_new_rows(wire_path: Path, last_line: int) -> list[_WireLine]:
+    """Parse wire-log lines beyond *last_line* into :class:`_WireLine`s.
 
     The wire log is append-only JSONL, so a line count is a stable high-water
-    mark. Non-JSON / unrecognized lines advance the cursor without emitting.
+    mark. Non-JSON / non-object lines are dropped (they carry no line number
+    forward on their own — the cursor advances as later rows are processed).
     """
     try:
         lines = wire_path.read_text(encoding="utf-8").splitlines()
     except OSError:
         return []
-    items: list[KimiWireItem] = []
+    rows: list[_WireLine] = []
     for idx in range(last_line, len(lines)):
         line = lines[idx].strip()
         if not line or not line.startswith("{"):
@@ -282,15 +472,64 @@ def read_kimi_wire_items(wire_path: Path, last_line: int) -> list[KimiWireItem]:
             row = json.loads(line)
         except ValueError:
             continue
-        if not isinstance(row, dict):
-            continue
-        item = _row_to_item(idx, row)
-        if item is not None:
-            items.append(item)
+        if isinstance(row, dict):
+            rows.append(_WireLine(idx, row))
+    return rows
+
+
+def read_kimi_wire_items(wire_path: Path, last_line: int) -> list[KimiWireItem]:
+    """Parse wire-log lines beyond *last_line* into the stable shared contract.
+
+    The offline importer (:mod:`omnigent.session_import.local`) replays a whole
+    wire log through this and keeps the ``message`` items, so it goes through the
+    same translation the live tail uses — one parser, one set of ids. Status
+    edges are a forwarding-only concern and are dropped here.
+    """
+    items: list[KimiWireItem] = []
+    turn = _TurnState()
+    for line_no, row in _read_new_rows(wire_path, last_line):
+        row_items, _status, turn = _translate_row(line_no, row, turn)
+        items.extend(row_items)
     return items
 
 
-_read_new_items = read_kimi_wire_items
+def _conversation_item_data(item: _MirrorItem, agent_name: str) -> dict[str, object]:
+    """Build the ``external_conversation_item`` ``data`` for one item."""
+    if item.kind == "function_call":
+        return {
+            "item_type": "function_call",
+            "item_data": {
+                "agent": agent_name,
+                "name": item.name,
+                "arguments": item.arguments,
+                "call_id": item.call_id,
+            },
+            "response_id": item.response_id,
+        }
+    if item.kind == "function_call_output":
+        return {
+            "item_type": "function_call_output",
+            "item_data": {"call_id": item.call_id, "output": item.output},
+            "response_id": item.response_id,
+        }
+    content_type = "input_text" if item.role == "user" else "output_text"
+    item_data: dict[str, object] = {
+        "role": item.role,
+        "content": [{"type": content_type, "text": item.text}],
+    }
+    if item.role == "assistant":
+        item_data["agent"] = agent_name
+    return {"item_type": "message", "item_data": item_data, "response_id": item.response_id}
+
+
+def _status_edge_data(edge: _StatusEdge) -> dict[str, object]:
+    """Build the ``external_session_status`` ``data`` for one edge."""
+    data: dict[str, object] = {"status": edge.status}
+    if edge.response_id is not None:
+        data["response_id"] = edge.response_id
+    if edge.output:
+        data["output"] = edge.output
+    return data
 
 
 async def _post_conversation_item(
@@ -299,55 +538,13 @@ async def _post_conversation_item(
     base_url: str,
     headers: dict[str, str],
     session_id: str,
-    item: KimiWireItem,
+    item: _MirrorItem,
     agent_name: str,
 ) -> None:
-    """POST one mirrored turn as an external conversation item."""
-    content_type = "input_text" if item.role == "user" else "output_text"
-    item_data: dict[str, object] = {
-        "role": item.role,
-        "content": [{"type": content_type, "text": item.text}],
-    }
-    if item.role == "assistant":
-        item_data["agent"] = agent_name
-    body = {
-        "type": "external_conversation_item",
-        "data": {
-            "item_type": "message",
-            "item_data": item_data,
-            "response_id": item.response_id,
-        },
-    }
+    """POST one mirrored message / function-call item."""
+    body = {"type": _EXTERNAL_ITEM, "data": _conversation_item_data(item, agent_name)}
     url = f"{base_url.rstrip('/')}/v1/sessions/{session_id}/events"
     resp = await client.post(url, headers=headers, json=body)
-    resp.raise_for_status()
-
-
-async def _post_external_session_status(
-    client: httpx.AsyncClient,
-    *,
-    base_url: str,
-    headers: dict[str, str],
-    session_id: str,
-    status: str,
-    output: str,
-) -> None:
-    """POST one ``external_session_status`` event to the Sessions API.
-
-    For a sub-agent conversation the server maps an ``idle`` edge to a terminal
-    completion that wakes the parent orchestrator's inbox — the SAME contract
-    claude-/codex-/opencode-/cursor-native use. ``output`` carries the turn's
-    final assistant text, since the runner delivers an empty result when an idle
-    edge forwards none.
-
-    :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
-    """
-    url = f"{base_url.rstrip('/')}/v1/sessions/{session_id}/events"
-    resp = await client.post(
-        url,
-        headers=headers,
-        json={"type": "external_session_status", "data": {"status": status, "output": output}},
-    )
     resp.raise_for_status()
 
 
@@ -357,21 +554,68 @@ async def _post_reasoning_item(
     base_url: str,
     headers: dict[str, str],
     session_id: str,
-    item: KimiWireItem,
+    item: _MirrorItem,
 ) -> None:
     """POST one mirrored think block as a transient reasoning event.
 
-    Mirrors codex-native (#1254): a one-shot ``external_output_reasoning_delta``
-    with ``started: true`` opens a reasoning block in the web UI. Kimi persists
-    completed think parts (not streamed deltas), so one delta per part is correct.
+    A one-shot ``external_output_reasoning_delta`` with ``started: true`` opens a
+    reasoning block in the web UI. Kimi persists completed think parts (not
+    streamed deltas), so one delta per part is correct.
     """
-    body = {
-        "type": "external_output_reasoning_delta",
-        "data": {"delta": item.text, "started": True},
-    }
+    body = {"type": _EXTERNAL_REASONING_DELTA, "data": {"delta": item.text, "started": True}}
     url = f"{base_url.rstrip('/')}/v1/sessions/{session_id}/events"
     resp = await client.post(url, headers=headers, json=body)
     resp.raise_for_status()
+
+
+async def _post_status_edge(
+    client: httpx.AsyncClient,
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    edge: _StatusEdge,
+) -> None:
+    """POST one ``running`` / ``idle`` session-status edge."""
+    body = {"type": _EXTERNAL_STATUS, "data": _status_edge_data(edge)}
+    url = f"{base_url.rstrip('/')}/v1/sessions/{session_id}/events"
+    resp = await client.post(url, headers=headers, json=body)
+    resp.raise_for_status()
+
+
+async def _deliver_row(
+    client: httpx.AsyncClient,
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    items: list[_MirrorItem],
+    status: _StatusEdge | None,
+    agent_name: str,
+) -> None:
+    """POST one row's items (then its status edge, if any) to ``/events``."""
+    for item in items:
+        if item.kind == "reasoning":
+            await _post_reasoning_item(
+                client, base_url=base_url, headers=headers, session_id=session_id, item=item
+            )
+        else:
+            await _post_conversation_item(
+                client,
+                base_url=base_url,
+                headers=headers,
+                session_id=session_id,
+                item=item,
+                agent_name=agent_name,
+            )
+    if status is not None:
+        await _post_status_edge(
+            client,
+            base_url=base_url,
+            headers=headers,
+            session_id=session_id,
+            edge=status,
+        )
 
 
 async def forward_kimi_wire_to_session(
@@ -388,15 +632,14 @@ async def forward_kimi_wire_to_session(
     """Poll the kimi session wire log and mirror new turns into the chat.
 
     Runs until cancelled. Discovers the wire log lazily (kimi writes it after the
-    first turn), then tails it, POSTing each new user/assistant turn and
-    persisting the line offset after every post.
+    first turn), then tails it, translating each new row into conversation items
+    and ``running`` / ``idle`` status edges and persisting the line offset after
+    every processed row.
     """
     state = _read_state(bridge_dir)
     wire_path = Path(state.wire_path) if state is not None else None
     last_line = state.last_line if state is not None else 0
-    # Final assistant text of the turn in flight, forwarded on the ``end_turn``
-    # edge so the parent's inbox gets the real result instead of an empty one.
-    last_assistant_text = ""
+    turn = _TurnState()
     async with httpx.AsyncClient(timeout=15.0) as client:
         while True:
             if wire_path is None or not wire_path.exists():
@@ -406,44 +649,29 @@ async def forward_kimi_wire_to_session(
                 if discovered is not None and discovered != wire_path:
                     wire_path = discovered
                     last_line = 0
+                    turn = _TurnState()
                     _write_state(bridge_dir, _ForwardState(str(wire_path), last_line))
             if wire_path is not None and wire_path.exists():
-                items = await asyncio.to_thread(read_kimi_wire_items, wire_path, last_line)
-                for item in items:
+                rows = await asyncio.to_thread(_read_new_rows, wire_path, last_line)
+                for line_no, row in rows:
+                    items, status, next_turn = _translate_row(line_no, row, turn)
                     try:
-                        if item.kind == "turn_end":
-                            await _post_external_session_status(
-                                client,
-                                base_url=base_url,
-                                headers=headers,
-                                session_id=session_id,
-                                status="idle",
-                                output=last_assistant_text,
-                            )
-                            last_assistant_text = ""
-                        elif item.kind == "reasoning":
-                            await _post_reasoning_item(
-                                client,
-                                base_url=base_url,
-                                headers=headers,
-                                session_id=session_id,
-                                item=item,
-                            )
-                        else:
-                            await _post_conversation_item(
-                                client,
-                                base_url=base_url,
-                                headers=headers,
-                                session_id=session_id,
-                                item=item,
-                                agent_name=agent_name,
-                            )
-                            if item.role == "assistant":
-                                last_assistant_text = item.text
+                        await _deliver_row(
+                            client,
+                            base_url=base_url,
+                            headers=headers,
+                            session_id=session_id,
+                            items=items,
+                            status=status,
+                            agent_name=agent_name,
+                        )
                     except httpx.HTTPError as exc:
                         _logger.warning("kimi forwarder: POST failed (will retry): %s", exc)
                         break
-                    last_line = item.line_no + 1
+                    # Commit turn state only after the row's posts land, so a
+                    # retried row re-translates against unchanged state.
+                    turn = next_turn
+                    last_line = line_no + 1
                     _write_state(bridge_dir, _ForwardState(str(wire_path), last_line))
             await asyncio.sleep(_POLL_INTERVAL_S)
 

--- a/tests/test_kimi_native_forwarder.py
+++ b/tests/test_kimi_native_forwarder.py
@@ -1,9 +1,10 @@
 """Unit tests for the kimi-native transcript forwarder.
 
-Covers the pure parsing/discovery helpers against kimi's real ``wire.jsonl``
-event schema (turn.prompt + content.part), the line-offset state round-trip,
-and workspace/recency-based session discovery. The live POST loop is exercised
-by the e2e gate, not here.
+Covers the stateful row translator against kimi's real ``wire.jsonl`` event
+schema (turn.prompt, step.begin/end, content.part text/think, tool.call/
+tool.result, turn.cancel), the ``/events`` body shapes, the line-offset state
+round-trip, and workspace/recency session discovery. The live POST loop is
+exercised by the e2e gate, not here.
 """
 
 from __future__ import annotations
@@ -12,145 +13,398 @@ import json
 from pathlib import Path
 
 from omnigent.kimi_native_forwarder import (
+    _conversation_item_data,
     _discover_wire,
     _ForwardState,
+    _MirrorItem,
+    _read_new_rows,
     _read_state,
-    _row_to_item,
+    _status_edge_data,
+    _StatusEdge,
+    _translate_row,
+    _TurnState,
     _write_state,
     clear_kimi_bridge_state,
     read_kimi_wire_items,
 )
 
+_AGENT = "kimi-native-ui"
 
-class TestRowToItem:
-    def test_turn_prompt_is_user(self) -> None:
-        row = {
-            "type": "turn.prompt",
-            "input": [{"type": "text", "text": "what is in this repo?"}],
-            "origin": {"kind": "user"},
-        }
-        item = _row_to_item(4, row)
-        assert item is not None
-        assert item.role == "user"
-        assert item.text == "what is in this repo?"
-        assert item.response_id == "kimi:turn:4"
+# --- wire-row builders (mirror the shapes seen in a real wire.jsonl) ---------
 
-    def test_content_part_text_is_assistant(self) -> None:
-        row = {
-            "type": "context.append_loop_event",
-            "event": {
-                "type": "content.part",
-                "uuid": "67ce67f7",
-                "part": {"type": "text", "text": "This is **Omnigent**."},
-            },
-        }
-        item = _row_to_item(9, row)
-        assert item is not None
-        assert item.role == "assistant"
-        assert item.text == "This is **Omnigent**."
-        assert item.response_id == "kimi:67ce67f7"
 
-    def test_think_part_is_reasoning(self) -> None:
-        # Reasoning lives in part["think"] (not part["text"]) and is mirrored as a
-        # reasoning item, not skipped — the kimi analogue of codex-native #1254.
-        row = {
-            "type": "context.append_loop_event",
-            "event": {
-                "type": "content.part",
-                "uuid": "abc123",
-                "part": {"type": "think", "think": "Let me reason about this."},
-            },
-        }
-        item = _row_to_item(5, row)
-        assert item is not None
-        assert item.kind == "reasoning"
-        assert item.role == "assistant"
-        assert item.text == "Let me reason about this."
-        assert item.response_id == "kimi:abc123"
+def _loop(etype: str, **fields: object) -> dict[str, object]:
+    return {"type": "context.append_loop_event", "event": {"type": etype, **fields}}
 
-    def test_tool_call_and_metadata_skipped(self) -> None:
-        for row in (
-            {"type": "context.append_loop_event", "event": {"type": "tool.call", "name": "Read"}},
-            {"type": "metadata", "protocol_version": 1},
-            {"type": "usage.record", "usage": {}},
-            {"type": "context.append_message", "message": {"role": "user", "content": []}},
-        ):
-            assert _row_to_item(0, row) is None
 
-    def test_step_end_with_end_turn_is_turn_end(self) -> None:
-        """``end_turn`` is the edge that reports terminal status to the parent."""
-        row = {
-            "type": "context.append_loop_event",
-            "event": {
-                "type": "step.end",
-                "turnId": "0",
-                "step": 3,
-                "finishReason": "end_turn",
-            },
-        }
-        item = _row_to_item(28, row)
-        assert item is not None
-        assert item.kind == "turn_end"
-        assert item.response_id == "kimi:turn_end:28"
+def _part(turn_id: str | None, part_type: str, text: str, uuid: str = "u") -> dict[str, object]:
+    event: dict[str, object] = {
+        "type": "content.part",
+        "uuid": uuid,
+        "part": {"type": part_type, "text": text},
+    }
+    if turn_id is not None:
+        event["turnId"] = turn_id
+    return {"type": "context.append_loop_event", "event": event}
 
-    def test_step_end_with_tool_use_is_skipped(self) -> None:
-        """A step that stopped to call a tool is mid-turn, not a completion."""
-        row = {
-            "type": "context.append_loop_event",
-            "event": {
-                "type": "step.end",
-                "turnId": "0",
-                "step": 1,
-                "finishReason": "tool_use",
-            },
-        }
-        assert _row_to_item(12, row) is None
 
-    def test_non_user_turn_prompt_skipped(self) -> None:
+def _think(turn_id: str | None, think: str, uuid: str = "u") -> dict[str, object]:
+    event: dict[str, object] = {
+        "type": "content.part",
+        "uuid": uuid,
+        "part": {"type": "think", "think": think},
+    }
+    if turn_id is not None:
+        event["turnId"] = turn_id
+    return {"type": "context.append_loop_event", "event": event}
+
+
+def _tool_call(
+    turn_id: str, call_id: str, name: str, args: dict[str, object]
+) -> dict[str, object]:
+    return _loop(
+        "tool.call", turnId=turn_id, toolCallId=call_id, uuid=call_id, name=name, args=args
+    )
+
+
+def _tool_result(call_id: str, output: str) -> dict[str, object]:
+    # tool.result carries no turnId — only the call id and the output.
+    return _loop("tool.result", toolCallId=call_id, parentUuid=call_id, result={"output": output})
+
+
+def _user_prompt(text: str) -> dict[str, object]:
+    return {
+        "type": "turn.prompt",
+        "input": [{"type": "text", "text": text}],
+        "origin": {"kind": "user"},
+    }
+
+
+def _run(line_no: int, row: dict[str, object], state: _TurnState | None = None):
+    return _translate_row(line_no, row, state or _TurnState())
+
+
+class TestTranslateRowMessages:
+    def test_user_prompt_keeps_own_line_id(self) -> None:
+        items, status, state = _run(4, _user_prompt("what is in this repo?"))
+        assert items == [
+            _MirrorItem(4, "message", "kimi:turn:4", role="user", text="what is in this repo?")
+        ]
+        assert status is None
+        assert state == _TurnState()  # user prompt carries no turnId → no turn state
+
+    def test_non_user_prompt_skipped(self) -> None:
         row = {
             "type": "turn.prompt",
             "input": [{"type": "text", "text": "x"}],
             "origin": {"kind": "system"},
         }
-        assert _row_to_item(0, row) is None
+        assert _run(0, row) == ([], None, _TurnState())
+
+    def test_assistant_text_uses_turn_id(self) -> None:
+        items, status, state = _run(30, _part("3", "text", "hello"), _TurnState("3", True))
+        assert items == [_MirrorItem(30, "message", "kimi:turn:3", role="assistant", text="hello")]
+        assert status is None
+        assert state.turn_id == "3"
+        # Remembered so the turn's idle edge can carry it as ``output`` (#3166).
+        assert state.last_text == "hello"
+
+    def test_assistant_text_falls_back_to_uuid_without_turn(self) -> None:
+        # A content.part with no turnId and no carried turn → per-event id.
+        items, _, _ = _run(9, _part(None, "text", "hi", uuid="67ce67f7"))
+        assert items == [_MirrorItem(9, "message", "kimi:67ce67f7", role="assistant", text="hi")]
+
+    def test_think_part_becomes_reasoning(self) -> None:
+        items, status, state = _run(30, _think("3", "let me think"), _TurnState("3", True))
+        assert items == [
+            _MirrorItem(30, "reasoning", "kimi:turn:3", role="assistant", text="let me think")
+        ]
+        assert status is None
+        assert state.turn_id == "3"
+
+    def test_noise_rows_skipped(self) -> None:
+        for row in (
+            {"type": "metadata", "protocol_version": 1},
+            {"type": "usage.record", "usage": {}},
+            {"type": "llm.request"},
+            {"type": "context.append_message", "message": {"role": "user", "content": []}},
+        ):
+            assert _run(0, row) == ([], None, _TurnState())
 
 
-class TestReadNewItems:
+class TestTranslateRowStatus:
+    def test_step_begin_posts_running_with_id_once(self) -> None:
+        items, status, state = _run(28, _loop("step.begin", turnId="3", step=1))
+        assert items == []
+        assert status == _StatusEdge("running", "kimi:turn:3")
+        assert state == _TurnState(turn_id="3", running=True)
+        # A second step.begin in the same turn does not re-post running.
+        again = _loop("step.begin", turnId="3", step=2)
+        items2, status2, state2 = _translate_row(35, again, state)
+        assert (items2, status2, state2) == ([], None, _TurnState(turn_id="3", running=True))
+
+    def test_step_end_tool_use_keeps_running(self) -> None:
+        row = _loop("step.end", turnId="3", step=1, finishReason="tool_use")
+        assert _translate_row(33, row, _TurnState("3", True)) == (
+            [],
+            None,
+            _TurnState(turn_id="3", running=True),
+        )
+
+    def test_step_end_end_turn_posts_idle_and_resets(self) -> None:
+        row = _loop("step.end", turnId="3", step=2, finishReason="end_turn")
+        state = _TurnState("3", True, last_text="the answer")
+        assert _translate_row(38, row, state) == (
+            [],
+            _StatusEdge("idle", "kimi:turn:3", "the answer"),
+            _TurnState(),
+        )
+
+    def test_step_end_posts_idle_even_without_a_running_edge(self) -> None:
+        """A restart can resume past ``step.begin``; the terminal edge still fires.
+
+        The ``idle`` edge is what wakes a parent orchestrator's inbox (#3166), so
+        suppressing it when this process never saw the turn start would strand
+        the parent forever.
+        """
+        row = _loop("step.end", turnId="0", step=1, finishReason="end_turn")
+        assert _translate_row(10, row, _TurnState("0", False)) == (
+            [],
+            _StatusEdge("idle", "kimi:turn:0", ""),
+            _TurnState(),
+        )
+
+    def test_turn_cancel_posts_idle_when_running(self) -> None:
+        assert _translate_row(18, {"type": "turn.cancel"}, _TurnState("1", True)) == (
+            [],
+            _StatusEdge("idle", "kimi:turn:1", ""),
+            _TurnState(),
+        )
+
+    def test_turn_cancel_noop_when_idle(self) -> None:
+        assert _run(18, {"type": "turn.cancel"}) == ([], None, _TurnState())
+
+
+class TestTranslateRowTools:
+    def test_tool_call_becomes_function_call(self) -> None:
+        row = _tool_call("3", "Agent:0", "Agent", {"q": "x"})
+        items, status, state = _translate_row(31, row, _TurnState("3", True))
+        args = json.dumps({"q": "x"}, ensure_ascii=True)
+        assert items == [
+            _MirrorItem(
+                31, "function_call", "kimi:turn:3", call_id="Agent:0", name="Agent", arguments=args
+            )
+        ]
+        assert status is None
+        assert state.turn_id == "3"
+
+    def test_tool_result_uses_carried_turn_id(self) -> None:
+        # tool.result has no turnId; it must inherit the remembered turn.
+        items, _, _ = _translate_row(32, _tool_result("Agent:0", "22:00"), _TurnState("3", True))
+        assert items == [
+            _MirrorItem(
+                32, "function_call_output", "kimi:turn:3", call_id="Agent:0", output="22:00"
+            )
+        ]
+
+
+# --- golden replay of a real multi-step, tool-using turn (turn 3) ------------
+
+_GOLDEN_TURN = [
+    (26, _user_prompt("help me find when norway and england quarter final starts")),
+    (27, {"type": "context.append_message", "message": {"role": "user", "content": []}}),
+    (28, _loop("step.begin", turnId="3", step=1)),
+    (29, {"type": "llm.request"}),
+    (30, _part("3", "text", "I will perform a web search.")),
+    (31, _tool_call("3", "Agent:0", "Agent", {"description": "web search"})),
+    (32, _tool_result("Agent:0", "starts at 22:00 on Sat 11 Jul")),
+    (33, _loop("step.end", turnId="3", step=1, finishReason="tool_use")),
+    (34, {"type": "usage.record", "usage": {}}),
+    (35, _loop("step.begin", turnId="3", step=2)),
+    (36, {"type": "llm.request"}),
+    (37, _part("3", "text", "The match starts at 22:00 on Sat 11 Jul.")),
+    (38, _loop("step.end", turnId="3", step=2, finishReason="end_turn")),
+    (39, {"type": "usage.record", "usage": {}}),
+]
+
+
+class TestGoldenTurn:
+    def _replay(self):
+        """Replay the turn into a flat ``(kind, payload)`` sequence of posts."""
+        state = _TurnState()
+        seq: list[tuple[str, object]] = []
+        for line_no, row in _GOLDEN_TURN:
+            items, status, state = _translate_row(line_no, row, state)
+            seq.extend(("item", it) for it in items)
+            if status is not None:
+                seq.append(("status", status))
+        return seq, state
+
+    def test_emits_expected_sequence(self) -> None:
+        seq, state = self._replay()
+        descriptors = []
+        for kind, payload in seq:
+            if kind == "status":
+                descriptors.append(f"status:{payload[0]}")
+            else:
+                descriptors.append(payload.kind)
+        assert descriptors == [
+            "message",  # user prompt
+            "status:running",
+            "message",  # assistant narration
+            "function_call",  # Agent call
+            "function_call_output",  # Agent result
+            "message",  # final answer
+            "status:idle",
+        ]
+        assert state == _TurnState()  # turn fully released
+
+    def test_assistant_side_shares_one_response_id(self) -> None:
+        seq, _ = self._replay()
+        ids: set[str] = set()
+        for kind, payload in seq:
+            if kind == "status" and payload[1] is not None:
+                ids.add(payload[1])
+            elif kind == "item" and (
+                payload.kind in ("function_call", "function_call_output")
+                or payload.role == "assistant"
+            ):
+                ids.add(payload.response_id)
+        assert ids == {"kimi:turn:3"}
+
+    def test_tool_call_and_output_share_call_id(self) -> None:
+        seq, _ = self._replay()
+        items = [p for k, p in seq if k == "item"]
+        call = next(i for i in items if i.kind == "function_call")
+        out = next(i for i in items if i.kind == "function_call_output")
+        assert call.call_id == out.call_id == "Agent:0"
+
+
+class TestBodyData:
+    def test_running_status_carries_response_id(self) -> None:
+        assert _status_edge_data(_StatusEdge("running", "kimi:turn:3")) == {
+            "status": "running",
+            "response_id": "kimi:turn:3",
+        }
+
+    def test_status_without_response_id_omits_it(self) -> None:
+        assert _status_edge_data(_StatusEdge("idle", None)) == {"status": "idle"}
+
+    def test_idle_status_carries_final_assistant_text(self) -> None:
+        """The parent orchestrator's inbox gets the turn's result, not an empty
+        one (#3166)."""
+        assert _status_edge_data(_StatusEdge("idle", "kimi:turn:3", "the answer")) == {
+            "status": "idle",
+            "response_id": "kimi:turn:3",
+            "output": "the answer",
+        }
+
+    def test_user_message_body(self) -> None:
+        item = _MirrorItem(4, "message", "kimi:turn:4", role="user", text="hi")
+        assert _conversation_item_data(item, _AGENT) == {
+            "item_type": "message",
+            "item_data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+            "response_id": "kimi:turn:4",
+        }
+
+    def test_assistant_message_carries_agent(self) -> None:
+        item = _MirrorItem(30, "message", "kimi:turn:3", role="assistant", text="yo")
+        assert _conversation_item_data(item, _AGENT)["item_data"] == {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "yo"}],
+            "agent": _AGENT,
+        }
+
+    def test_function_call_body(self) -> None:
+        item = _MirrorItem(
+            31,
+            "function_call",
+            "kimi:turn:3",
+            call_id="Agent:0",
+            name="Agent",
+            arguments='{"q": "x"}',
+        )
+        assert _conversation_item_data(item, _AGENT) == {
+            "item_type": "function_call",
+            "item_data": {
+                "agent": _AGENT,
+                "name": "Agent",
+                "arguments": '{"q": "x"}',
+                "call_id": "Agent:0",
+            },
+            "response_id": "kimi:turn:3",
+        }
+
+    def test_function_output_body(self) -> None:
+        item = _MirrorItem(
+            32, "function_call_output", "kimi:turn:3", call_id="Agent:0", output="done"
+        )
+        assert _conversation_item_data(item, _AGENT) == {
+            "item_type": "function_call_output",
+            "item_data": {"call_id": "Agent:0", "output": "done"},
+            "response_id": "kimi:turn:3",
+        }
+
+
+class TestReadNewRows:
     def _wire(self, tmp_path: Path) -> Path:
-        def _part(uuid: str, part_type: str, text: str) -> dict[str, object]:
-            return {
-                "type": "context.append_loop_event",
-                "event": {
-                    "type": "content.part",
-                    "uuid": uuid,
-                    "part": {"type": part_type, "text": text},
-                },
-            }
-
         rows = [
             {"type": "metadata", "protocol_version": 1},
-            {
-                "type": "turn.prompt",
-                "input": [{"type": "text", "text": "hi"}],
-                "origin": {"kind": "user"},
-            },
-            _part("u1", "think", "…"),
-            _part("u2", "text", "hello!"),
+            _user_prompt("hi"),
+            _think("0", "…"),
+            _part("0", "text", "hello!"),
         ]
         p = tmp_path / "wire.jsonl"
         p.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
         return p
 
-    def test_parses_user_and_assistant_only(self, tmp_path: Path) -> None:
-        items = read_kimi_wire_items(self._wire(tmp_path), 0)
-        assert [(i.role, i.text) for i in items] == [("user", "hi"), ("assistant", "hello!")]
+    def test_returns_line_indexed_rows(self, tmp_path: Path) -> None:
+        rows = _read_new_rows(self._wire(tmp_path), 0)
+        assert [(w.line_no, w.row["type"]) for w in rows] == [
+            (0, "metadata"),
+            (1, "turn.prompt"),
+            (2, "context.append_loop_event"),
+            (3, "context.append_loop_event"),
+        ]
 
     def test_offset_skips_already_seen(self, tmp_path: Path) -> None:
-        wire = self._wire(tmp_path)
-        # last_line past the user prompt (line 1) → only the assistant text (line 3).
-        items = read_kimi_wire_items(wire, 2)
-        assert [(i.role, i.text) for i in items] == [("assistant", "hello!")]
-        assert items[0].line_no == 3
+        rows = _read_new_rows(self._wire(tmp_path), 2)
+        assert [w.line_no for w in rows] == [2, 3]
+
+    def test_missing_file_is_empty(self, tmp_path: Path) -> None:
+        assert _read_new_rows(tmp_path / "nope.jsonl", 0) == []
+
+
+class TestReadKimiWireItems:
+    """The stable contract the offline session importer replays (#3032)."""
+
+    def _wire(self, tmp_path: Path) -> Path:
+        rows = [
+            {"type": "metadata", "protocol_version": 1},
+            _user_prompt("hi"),
+            _loop("step.begin", turnId="0", step=1),
+            _part("0", "text", "hello!"),
+            _loop("step.end", turnId="0", step=1, finishReason="end_turn"),
+        ]
+        p = tmp_path / "wire.jsonl"
+        p.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+        return p
+
+    def test_parses_user_and_assistant_messages(self, tmp_path: Path) -> None:
+        items = read_kimi_wire_items(self._wire(tmp_path), 0)
+        assert [(i.kind, i.role, i.text) for i in items] == [
+            ("message", "user", "hi"),
+            ("message", "assistant", "hello!"),
+        ]
+
+    def test_status_edges_are_forwarding_only(self, tmp_path: Path) -> None:
+        # step.begin / step.end yield edges, never importable items.
+        items = read_kimi_wire_items(self._wire(tmp_path), 0)
+        assert all(i.kind in ("message", "reasoning") for i in items)
+
+    def test_offset_skips_already_seen(self, tmp_path: Path) -> None:
+        items = read_kimi_wire_items(self._wire(tmp_path), 2)
+        assert [(i.line_no, i.role, i.text) for i in items] == [(3, "assistant", "hello!")]
 
     def test_missing_file_is_empty(self, tmp_path: Path) -> None:
         assert read_kimi_wire_items(tmp_path / "nope.jsonl", 0) == []
@@ -178,7 +432,6 @@ class TestDiscoverWire:
         import os
 
         os.utime(wire, (mtime, mtime))
-        # session_index keys on the session dir (…/<wd_…>/<session_…>).
         idx = home / "session_index.jsonl"
         index_row = {"sessionDir": str(wire.parent.parent.parent), "workDir": work_dir}
         with idx.open("a", encoding="utf-8") as fh:
@@ -191,8 +444,7 @@ class TestDiscoverWire:
         self._make_session(home, "session_old", "/ws", mtime=1000.0)
         newest = self._make_session(home, "session_new", "/ws", mtime=2000.0)
         self._make_session(home, "session_other", "/different", mtime=3000.0)
-        found = _discover_wire(home, "/ws", launch_epoch_ms=0)
-        assert found == newest
+        assert _discover_wire(home, "/ws", launch_epoch_ms=0) == newest
 
     def test_none_before_any_session(self, tmp_path: Path) -> None:
         home = tmp_path / "kimi-code-home"
@@ -203,5 +455,4 @@ class TestDiscoverWire:
         home = tmp_path / "kimi-code-home"
         home.mkdir()
         self._make_session(home, "session_stale", "/ws", mtime=1000.0)
-        # launch far in the future (ms) → the 1000s-mtime session is below the floor.
         assert _discover_wire(home, "/ws", launch_epoch_ms=9_000_000_000_000) is None


### PR DESCRIPTION
## Related issue

Closes #1877

## Summary

Extends live tool-call cards (spinner + ticking elapsed timer while a tool runs) to
**kimi-native** sessions, matching claude-native (#1499) and opencode-native (#1872).

**ELI5:** the kimi TUI shows its own tool calls, but Omnigent's web chat only mirrored
text bubbles. The forwarder now also mirrors each tool call/result and brackets the turn
with `running`/`idle` status edges, so in-flight kimi tools render as **live** cards in the
web chat (and stay live across a mid-turn reconnect) instead of not appearing at all.

`omnigent/kimi_native_forwarder.py` becomes a small **stateful tailer** of kimi's
`wire.jsonl` (it previously mirrored only user/assistant text and dropped tool events):

- `tool.call` → `function_call`, `tool.result` → `function_call_output`, paired by `toolCallId`.
- `step.begin` posts `running`; a `step.end` whose `finishReason != tool_use` (or a
  `turn.cancel`) posts `idle`. A turn can span several steps, so `running` fires once.
- All assistant-side items and the status edges share `response_id = kimi:turn:<turnId>`.
  The `running` edge carries that id in its `data`, so the server records `active_response_id`
  and the cards keep rendering live after an SSE reconnect (the turn-start edge isn't replayed).
- kimi's wire has no `turn.end` event and its `tool.result` carries no `turnId`, so the active
  turn is remembered across lines (`_TurnState`) rather than parsed per-row.

## Test Plan

- `uv run pytest tests/test_kimi_native_forwarder.py` — rewritten unit tests covering the
  stateful planner per event type, a golden replay of a real multi-step, tool-using turn
  (asserts the exact post sequence, one shared `response_id`, matching `call_id`), the
  `/events` request-body shapes, the line-offset state round-trip, and session discovery.
- Manual web-UI verification (pending): launch `omnigent kimi`, drive a tool-using turn
  (e.g. a web search), and confirm the tool card renders live (spinner + ticking timer)
  during execution, then freezes to a static card on completion.

## Demo
<img width="712" height="304" alt="image" src="https://github.com/user-attachments/assets/0d804900-6268-439c-839e-795ef409996e" />


<img width="1410" height="1208" alt="image" src="https://github.com/user-attachments/assets/2bfb339f-2f2d-4523-b4af-60f34efe4bb6" />

<img width="1352" height="755" alt="image" src="https://github.com/user-attachments/assets/982f4ebd-e038-4808-9e5e-d09c2e1c129c" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the pure planner and request-body helpers, including a golden replay of a
real turn. The live POST loop and web rendering are verified manually — recording to be
attached and the "Manual verification completed" box ticked before marking ready for review.

## Changelog

kimi-native sessions now show live tool-call cards in the web chat
