### PR TITLE
fix(codex-native): reuse plugin cache on cold starts

### DIFF
--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -57,7 +57,12 @@ from omnigent.codex_native_bridge import (
     socket_path_for_bridge_dir,
     write_bridge_state,
 )
-from omnigent.codex_native_forwarder import supervise_forwarder
+from omnigent.codex_native_forwarder import (
+    _THREAD_START_TIMEOUT_SECONDS as _CODEX_THREAD_START_TIMEOUT_SECONDS,
+)
+from omnigent.codex_native_forwarder import (
+    supervise_forwarder,
+)
 from omnigent.codex_native_state import read_launch_state, write_launch_state
 from omnigent.conversation_browser import conversation_url, open_conversation_link_if_enabled
 from omnigent.entities.session_resources import terminal_resource_id
@@ -91,7 +96,6 @@ _DEFAULT_CODEX_COMMAND = "codex"
 _TERMINAL_NAME = "codex"
 _TERMINAL_SESSION_KEY = "main"
 _CODEX_TERMINAL_SCROLLBACK_LINES = 100_000
-_CODEX_THREAD_START_TIMEOUT_SECONDS = 15.0
 _SESSION_LABELS = {
     "omnigent.ui": "terminal",
     _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -62,9 +62,10 @@ _logger = logging.getLogger(__name__)
 _AGENT_NAME = "codex-native-ui"
 _SUBSCRIBE_RETRY_DELAY_SECONDS = 0.2
 # How long to wait for a freshly launched Codex TUI to create its
-# app-server thread (emit ``thread/started``) before giving up. Generous
-# because a host-spawned TUI cold-starts over the runner.
-_THREAD_START_TIMEOUT_SECONDS = 30.0
+# app-server thread (emit ``thread/started``) before giving up. A first launch
+# can populate remote plugin caches on a slow or recently reconnected network,
+# so this must cover more than the app-server's own lightweight startup.
+_THREAD_START_TIMEOUT_SECONDS = 120.0
 _NO_ROLLOUT_FRAGMENT = "no rollout found for thread id"
 # A freshly created thread passes through a second transient state: its rollout
 # file exists but is still empty (the TUI created the thread but no turn has

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -110,6 +110,12 @@ _DATABRICKS_CODEX_DEFAULT_MODEL = "databricks-gpt-5-5"
 # to running sessions without any action from Omnigent.
 _CODEX_HOME_SYMLINK_FILES = ("auth.json",)
 
+# Cache directories shared with the real CODEX_HOME. Codex's plugin cache is
+# designed for concurrent CLI processes that use one home, while Omnigent's
+# private homes otherwise force every session to clone remote plugins again.
+# Keep session-local plugin metadata private; only the reusable cache is shared.
+_CODEX_HOME_SYMLINK_DIRS = (Path("plugins/cache"),)
+
 # Files copied (not symlinked) from the real CODEX_HOME into the per-session
 # temp home. config.toml is intentionally copied so that an in-TUI ``/model``
 # command writes only to the session's own private copy and never touches the
@@ -699,6 +705,8 @@ def _populate_codex_home_config(target_dir: Path, source_dir: Path) -> None:
 
     - ``auth.json`` is **symlinked** so OAuth token refreshes written to
       the real home propagate to running sessions without delay.
+    - ``plugins/cache`` is **symlinked** so each private session reuses the
+      shared Codex plugin cache instead of cloning remote plugins at startup.
     - ``config.toml`` is **copied** so an in-TUI ``/model`` command writes
       only to the session's own private copy and never mutates the shared
       ``~/.codex/config.toml``. This keeps model selection and cost-policy
@@ -730,6 +738,24 @@ def _populate_codex_home_config(target_dir: Path, source_dir: Path) -> None:
                 exc,
             )
             shutil.copy2(source_file, link_path)
+
+    for relative_path in _CODEX_HOME_SYMLINK_DIRS:
+        source_path = source_dir / relative_path
+        if not source_path.is_dir():
+            continue
+        link_path = target_dir / relative_path
+        if link_path.exists() or link_path.is_symlink():
+            continue
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            link_path.symlink_to(source_path.resolve(), target_is_directory=True)
+        except OSError as exc:
+            logger.warning(
+                "could not symlink %r into %s (%s); using a private cache",
+                str(relative_path),
+                target_dir,
+                exc,
+            )
 
     for filename in _CODEX_HOME_COPY_FILES:
         source_file = source_dir / filename

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2158,6 +2158,26 @@ def test_populate_codex_home_config_symlinks_auth_and_config(tmp_path: Path) -> 
     assert (target / "config.toml").read_text() == '[default]\nmodel = "gpt-5.4"'
 
 
+def test_populate_codex_home_config_shares_only_plugin_cache(tmp_path: Path) -> None:
+    """Private homes reuse plugin downloads but keep plugin runtime state local."""
+    from omnigent.inner.codex_executor import _populate_codex_home_config
+
+    source = tmp_path / "real_codex_home"
+    source_cache = source / "plugins" / "cache"
+    source_cache.mkdir(parents=True)
+    (source_cache / "cached-plugin").mkdir()
+    target = tmp_path / "temp_codex_home"
+    target.mkdir()
+
+    _populate_codex_home_config(target, source)
+
+    target_cache = target / "plugins" / "cache"
+    assert target_cache.is_symlink()
+    assert target_cache.resolve() == source_cache.resolve()
+    assert (target_cache / "cached-plugin").is_dir()
+    assert not (target / "plugins" / ".plugin-appserver").exists()
+
+
 def test_populate_codex_home_config_config_toml_copy_is_isolated(tmp_path: Path) -> None:
     """Writing to the session's ``config.toml`` copy does not affect the source.
 


### PR DESCRIPTION
## Summary
- Reuse Codex's shared plugin cache from private session homes so post-restart sessions do not clone remote plugins on every launch.
- Align native Codex thread-start timeouts around the forwarder's longer cold-start budget.

## Test plan
- `uv run pytest -q tests/inner/test_codex_executor.py -k populate_codex_home_config tests/test_codex_native_app_server.py tests/test_codex_native.py -k 'thread or timeout'`

Made with [Cursor](https://cursor.com)

## Demo

N/A — no UI change. Codex-native cold starts reuse the plugin cache instead of reinstalling; covered by unit tests.
