### PR TITLE
Add SandboxLauncher.materialize_workspace override seam

### DIFF
--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -244,12 +244,16 @@ class SandboxLauncher(ABC):
         Start ``omnigent host`` in the sandbox and return the workspace path.
 
         The default is the EXEC model: probe ``$HOME``, create
-        ``<HOME>/workspace``, optionally clone the repository into it, and start
-        the host detached (``setsid``-backgrounded, identity + token in the
-        process environment) — all driven through :meth:`run` /
-        :meth:`run_background`. It is shared by every provider whose sandbox is a
-        bare box the server execs into (Modal, Daytona, …); entrypoint-as-host
-        providers (e.g. Kubernetes, whose Pod boots running the host) override it.
+        ``<HOME>/workspace``, optionally materialize the repository into it (via
+        :meth:`materialize_workspace`, which clones by default), and start the
+        host detached (``setsid``-backgrounded, identity + token in the process
+        environment) — all driven through :meth:`run` / :meth:`run_background`.
+        It is shared by every provider whose sandbox is a bare box the server
+        execs into (Modal, Daytona, …); entrypoint-as-host providers (e.g.
+        Kubernetes, whose Pod boots running the host) override it. A provider
+        that only needs to change how the repository is obtained (resolve a local
+        checkout instead of cloning) overrides :meth:`materialize_workspace`
+        alone.
 
         The launch token is registered before this call, so the host
         authenticates the moment it dials back. The ``repo_*`` arguments arrive
@@ -287,28 +291,14 @@ class SandboxLauncher(ABC):
         workspace = f"{home}/workspace"
         self.run(sandbox_id, f"mkdir -p {shlex.quote(workspace)}")
         if repo_url is not None:
-            if on_stage is not None:
-                on_stage("cloning")
-            clone_dir = f"{workspace}/{repo_name}"
-            branch_args = (
-                f"--branch {shlex.quote(repo_branch)} --single-branch "
-                if repo_branch is not None
-                else ""
+            workspace = self.materialize_workspace(
+                sandbox_id,
+                workspace=workspace,
+                repo_url=repo_url,
+                repo_branch=repo_branch,
+                repo_name=repo_name,
+                on_stage=on_stage,
             )
-            try:
-                self.run(
-                    sandbox_id,
-                    f"git clone {branch_args}-- {shlex.quote(repo_url)} {shlex.quote(clone_dir)}",
-                )
-            except click.ClickException as exc:
-                # Provider boundary: re-raise with the repository named so the
-                # create-session 502 says WHAT failed to clone, not just that a
-                # sandbox command exited non-zero.
-                raise click.ClickException(
-                    f"failed to clone repository '{repo_url}'"
-                    f"{f' (branch {repo_branch!r})' if repo_branch else ''}: {exc.message}"
-                ) from exc
-            workspace = clone_dir
         # "starting" covers from here through host registration — the caller's
         # online poll resolves it.
         if on_stage is not None:
@@ -326,6 +316,77 @@ class SandboxLauncher(ABC):
             f"{env_prefix} omnigent host --server {shlex.quote(server_url)}",
         )
         return workspace
+
+    def materialize_workspace(
+        self,
+        sandbox_id: str,
+        *,
+        workspace: str,
+        repo_url: str,
+        repo_branch: str | None,
+        repo_name: str | None,
+        on_stage: Callable[[str], None] | None = None,
+    ) -> str:
+        """
+        Materialize the requested repository into the sandbox and return the
+        working directory the host should start in.
+
+        Override point for how a repository *identity* becomes an on-disk
+        checkout. The default is the EXEC model — ``git clone`` the URL into
+        ``<workspace>/<repo_name>`` via :meth:`run` — shared by every provider
+        whose sandbox is a bare box with outbound git access (Modal, Daytona,
+        E2B, …). Providers whose sandbox already carries the repository (a
+        pre-provisioned checkout, a local mirror, a cached worktree) override
+        this to *resolve* the identity to that local path instead of cloning,
+        without having to reimplement :meth:`start_host`. Called by
+        :meth:`start_host` only when ``repo_url`` is set, after ``<workspace>``
+        has been created and before the host launches.
+
+        The ``repo_*`` arguments are the same repository identity
+        :meth:`start_host` received (the server's ``RepoWorkspace`` unpacked into
+        primitives, so this onboarding-layer method carries no server
+        dependency). An override is free to interpret ``repo_url`` as an identity
+        to map to a local checkout rather than a URL to fetch.
+
+        :param sandbox_id: The sandbox from :meth:`provision`.
+        :param workspace: The already-created workspace root, e.g.
+            ``"/root/workspace"``.
+        :param repo_url: Repository clone URL (or, for a resolving override, the
+            repository identity), e.g. ``"https://github.com/org/repo"``.
+        :param repo_branch: Branch to check out, or ``None`` for the default
+            branch.
+        :param repo_name: Directory the checkout lands in under *workspace*, or
+            ``None``.
+        :param on_stage: Progress observer; the default invokes it with
+            ``"cloning"`` before the clone. Runs on this (worker) thread, so it
+            must be thread-safe. ``None`` disables progress reporting.
+        :returns: The absolute in-sandbox path the host should start in (the
+            checkout directory).
+        :raises click.ClickException: If materialization fails (e.g. the clone
+            fails).
+        """
+        if on_stage is not None:
+            on_stage("cloning")
+        clone_dir = f"{workspace}/{repo_name}"
+        branch_args = (
+            f"--branch {shlex.quote(repo_branch)} --single-branch "
+            if repo_branch is not None
+            else ""
+        )
+        try:
+            self.run(
+                sandbox_id,
+                f"git clone {branch_args}-- {shlex.quote(repo_url)} {shlex.quote(clone_dir)}",
+            )
+        except click.ClickException as exc:
+            # Provider boundary: re-raise with the repository named so the
+            # create-session 502 says WHAT failed to clone, not just that a
+            # sandbox command exited non-zero.
+            raise click.ClickException(
+                f"failed to clone repository '{repo_url}'"
+                f"{f' (branch {repo_branch!r})' if repo_branch else ''}: {exc.message}"
+            ) from exc
+        return clone_dir
 
     def attach(self, sandbox_id: str) -> None:
         """

--- a/tests/onboarding/sandboxes/test_base.py
+++ b/tests/onboarding/sandboxes/test_base.py
@@ -99,3 +99,79 @@ def test_start_host_env_prefix_is_honored_by_a_real_shell() -> None:
         ["sh", "-c", probe], capture_output=True, text=True, check=True
     ).stdout.strip()
     assert out == "tok-123:host_abc:managed-abc"
+
+
+def test_start_host_default_materialize_clones_repo() -> None:
+    """
+    With a ``repo_url``, the default :meth:`materialize_workspace` clones into
+    ``<workspace>/<repo_name>`` and ``start_host`` returns that checkout dir —
+    the exec-model behavior every default provider (Modal/Daytona/E2B/…)
+    inherits, unchanged by the extraction of the clone into its own method.
+    """
+    launcher = _RecordingLauncher()
+
+    workspace = launcher.start_host(
+        "sb-1",
+        token="tok-123",
+        host_id="host_abc",
+        host_name="managed-abc",
+        server_url="https://srv",
+        repo_url="https://github.com/org/repo",
+        repo_branch="release-1.2",
+        repo_name="repo",
+    )
+
+    assert workspace == "/root/workspace/repo"
+    assert (
+        "git clone --branch release-1.2 --single-branch -- "
+        "https://github.com/org/repo /root/workspace/repo"
+    ) in launcher.commands
+
+
+def test_materialize_workspace_override_resolves_local_checkout_without_cloning() -> None:
+    """
+    A provider whose sandbox already carries the repository overrides
+    :meth:`materialize_workspace` to resolve the identity to a local path and
+    performs NO clone. ``start_host`` must use the override's returned path and
+    still launch the host — proving the seam lets a provider swap repo
+    materialization without reimplementing ``start_host``.
+    """
+
+    class _LocalCheckoutLauncher(_RecordingLauncher):
+        def materialize_workspace(
+            self,
+            sandbox_id: str,
+            *,
+            workspace: str,
+            repo_url: str,
+            repo_branch,
+            repo_name,
+            on_stage=None,
+        ) -> str:
+            # Resolve the repo identity to a pre-provisioned local checkout;
+            # fetch the branch into it rather than cloning the URL.
+            local = f"/checkouts/{repo_name}"
+            if repo_branch is not None:
+                self.run(sandbox_id, f"git -C {local} checkout {repo_branch}")
+            return local
+
+    launcher = _LocalCheckoutLauncher()
+
+    workspace = launcher.start_host(
+        "sb-1",
+        token="tok-123",
+        host_id="host_abc",
+        host_name="managed-abc",
+        server_url="https://srv",
+        repo_url="https://github.com/org/repo",
+        repo_branch="main",
+        repo_name="repo",
+    )
+
+    assert workspace == "/checkouts/repo"
+    # No clone happened; the override resolved a local checkout instead.
+    assert not any(cmd.startswith("git clone") for cmd in launcher.commands)
+    assert "git -C /checkouts/repo checkout main" in launcher.commands
+    # The host still launched, in the resolved workspace.
+    [raw] = launcher.backgrounded
+    assert raw.endswith("omnigent host --server https://srv")


### PR DESCRIPTION
## Related issue

N/A — enabling refactor (no behavior change to existing providers).

## Summary

- Extracts the repository-materialization step of the exec-model `start_host` (the `git clone` into `<workspace>/<repo_name>`) into a new overridable `SandboxLauncher.materialize_workspace()` method.
- The default implementation is the existing clone **verbatim**, so every provider inheriting the exec-model `start_host` (Modal, Daytona, E2B, Boxlite, Islo, …) is behavior-identical. The Kubernetes provider overrides `start_host` entirely (init-container clone) and is untouched.
- This lets a provider whose sandbox already carries the repository (a pre-provisioned checkout, a local mirror, a cached worktree) resolve the repo **identity** to a local path instead of cloning the URL — by overriding `materialize_workspace()` alone, not reimplementing `start_host`. The `repo_*` arguments are unchanged, so `repo_url` can be treated as a clone URL (default) or as an identity to resolve (override) with no signature or grammar change.

### ELI5

`start_host` used to do "make a workspace dir → `git clone` the repo into it → launch the host." Some sandboxes already *have* the repo on disk (a warm checkout or a local mirror), so cloning from a git URL is wrong for them. This splits out just the "get the repo onto disk" step so those providers can say "it's already here at this path" without rewriting the whole host-start flow. Everyone else keeps cloning exactly as before.

```
start_host(...)
  ├─ mkdir <workspace>
  ├─ if repo_url: workspace = materialize_workspace(...)   ← new seam
  │       default impl == today's `git clone` (unchanged)
  │       override      == resolve identity → local checkout (no clone)
  └─ run_background("… omnigent host --server …")
```

## Test Plan

```
uv run pytest tests/onboarding/sandboxes/ tests/server/test_managed_hosts.py
# 342 passed — every existing provider is behavior-identical.

uv run pytest tests/onboarding/sandboxes/test_base.py
# 4 passed (2 existing + 2 new)
```

New tests in `tests/onboarding/sandboxes/test_base.py`:
- `test_start_host_default_materialize_clones_repo` — the default still issues the exact `git clone --branch … --single-branch -- <url> <workspace>/<repo_name>` and `start_host` returns that checkout dir.
- `test_materialize_workspace_override_resolves_local_checkout_without_cloning` — an override resolves the identity to a local path, performs **no** clone, and `start_host` launches the host in the resolved workspace.

Also ran `uv run pre-commit run --files …` (ruff format + check, DCO, misc hooks) and `uv run mypy` on the changed file — all clean.

### End-to-end verification (managed Databricks sandbox)

Beyond the unit suites, this change was verified **end-to-end against a real managed Databricks sandbox launch** (default exec-model launcher, which inherits `start_host` and therefore exercises the new `materialize_workspace` seam):

- Created a managed session with a git-URL workspace (`host_type="managed"`, `workspace=https://github.com/octocat/Hello-World`).
- The launch ran through the seam: sandbox provisioned → `start_host` → `materialize_workspace` issued the `git clone` → host started and came online (`host_online: true`).
- Confirmed the checkout is real by running a shell inside the sandbox: workspace root `.../workspace/Hello-World`, `git remote -v` → `origin https://github.com/octocat/Hello-World`, `git log -1` → the real upstream HEAD.

This confirms the extraction is behavior-preserving on the live managed-launch path, not just in unit tests.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = (1) the full `tests/onboarding/sandboxes/` + `tests/server/test_managed_hosts.py` suites (342 passed) confirm the extraction is behavior-identical for all existing providers, and the two new base tests cover the default clone and the override path; (2) a live end-to-end managed Databricks sandbox launch with a git-URL workspace, which cloned the repo through the new `materialize_workspace` seam, brought the host online, and produced a verified real checkout inside the sandbox (see End-to-end verification above).

