### PR TITLE
Route out-of-process native posters (pi, opencode) through databricks_request_headers

### DIFF
--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -226,6 +226,37 @@ def load_databricks_org_id(server_url: str) -> str | None:
 DATABRICKS_ORG_ID_HEADER = "X-Databricks-Org-Id"
 
 
+# Opaque extra request headers for dev/test: a JSON object of header name→value
+# in :data:`DATABRICKS_EXTRA_HEADERS_ENV_VAR`. Databricks deployments use it to
+# carry request-routing selector headers so a request pins to a specific server
+# instance/replica instead of the default one. Folded into
+# :func:`databricks_request_headers` below so it travels with every
+# client→server connection built through that one helper — a per-call-site
+# bearer that skips this helper misses the selectors. Unset in prod.
+DATABRICKS_EXTRA_HEADERS_ENV_VAR = "OMNIGENT_DATABRICKS_EXTRA_HEADERS"
+
+
+def _databricks_extra_headers() -> dict[str, str]:
+    """Return the opaque extra request headers when configured, else ``{}``.
+
+    Reads :data:`DATABRICKS_EXTRA_HEADERS_ENV_VAR`, a JSON object of header
+    name→value. Missing or malformed (unset, not JSON, or not an object) →
+    ``{}``, so production and local runs are unaffected.
+
+    :returns: A header dict parsed from the env var, or an empty dict.
+    """
+    raw = os.environ.get(DATABRICKS_EXTRA_HEADERS_ENV_VAR, "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(key): str(value) for key, value in parsed.items()}
+
+
 def databricks_request_headers(
     server_url: str, *, bearer_token: str | None = None
 ) -> dict[str, str]:
@@ -243,12 +274,17 @@ def databricks_request_headers(
     Both values are omitted when absent, so single-workspace and
     local-unauthenticated callers get ``{}`` and are unaffected.
 
+    Also folds in any opaque dev/test headers from
+    :data:`DATABRICKS_EXTRA_HEADERS_ENV_VAR` (request-routing selectors set by
+    some Databricks deployments) so every chokepoint that builds headers through
+    this one helper carries them when set.
+
     :param server_url: The server URL, e.g.
         ``"https://example.databricks.com/api/2.0/omnigent"``.
     :param bearer_token: The workspace bearer token, or ``None`` when the
         credential is supplied by a separate mechanism (or there is none).
-    :returns: A header dict carrying ``Authorization`` and/or
-        ``X-Databricks-Org-Id`` as available, possibly empty.
+    :returns: A header dict carrying ``Authorization``, ``X-Databricks-Org-Id``,
+        and/or the configured extra headers as available, possibly empty.
     """
     headers: dict[str, str] = {}
     if bearer_token:
@@ -256,6 +292,9 @@ def databricks_request_headers(
     org_id = load_databricks_org_id(server_url)
     if org_id:
         headers[DATABRICKS_ORG_ID_HEADER] = org_id
+    # Opaque dev/test extra headers (request-routing selectors); no-op in prod
+    # (env unset).
+    headers.update(_databricks_extra_headers())
     return headers
 
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -380,6 +380,16 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # telemetry is opt-in. Not a secret (a boolean). The OMNIGENT_OTEL_*
         # knobs (capture-content, FastAPI toggle) ride the prefix allowlist below.
         "OMNIGENT_TELEMETRY_ENABLED",
+        # Opaque request-routing headers (dev/test): a JSON header map folded by
+        # cli_auth.databricks_request_headers into every client→server connection
+        # so a request pins to a specific server instance/replica. Must reach the
+        # spawned runner so its tunnel + server callbacks route to the SAME
+        # instance the host registered on — otherwise the host lands on the
+        # selected instance while its runners fall back to the default one.
+        # Routing config, not a secret; unset in prod. Allowlisting it forwards it
+        # host→runner intrinsically, so the setter need not also list it in
+        # OMNIGENT_RUNNER_ENV_PASSTHROUGH.
+        "OMNIGENT_DATABRICKS_EXTRA_HEADERS",
     }
     # Windows system / profile constants (SYSTEMROOT is mandatory for Winsock,
     # USERPROFILE for Path.home(), etc.); a no-op on POSIX. See _platform.

--- a/omnigent/inner/pi_native_executor.py
+++ b/omnigent/inner/pi_native_executor.py
@@ -120,12 +120,23 @@ class PiNativeExecutor(Executor):
         the pi terminal if that case ever bites.
         """
         try:
+            from omnigent.cli_auth import databricks_request_headers
             from omnigent.runner._entry import _make_auth_token_factory
 
             factory = _make_auth_token_factory()
             token = factory() if factory is not None else None
             if token:
-                refresh_config_auth_headers(self._bridge_dir, {"Authorization": f"Bearer {token}"})
+                # Rebuild the FULL routing header set (not just the bearer) so the
+                # per-turn refresh preserves the workspace / deployment routing
+                # selectors baked at launch (see runner/app.py). A bearer-only
+                # refresh would drop them and re-break routing after the first turn.
+                refresh_config_auth_headers(
+                    self._bridge_dir,
+                    databricks_request_headers(
+                        os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767").rstrip("/"),
+                        bearer_token=token,
+                    ),
+                )
         except Exception:  # noqa: BLE001 — best-effort refresh; never block a turn
             pass
 

--- a/omnigent/opencode_native_bridge.py
+++ b/omnigent/opencode_native_bridge.py
@@ -82,15 +82,22 @@ _OPENCODE_POLICY_PLUGIN_JS = r"""
 // phases the reactive permission.asked path cannot reach.
 const BASE = (process.env.OMNIGENT_POLICY_URL || "").replace(/\/+$/, "");
 const SESSION = process.env.OMNIGENT_SESSION_ID || "";
-const AUTH = process.env.OMNIGENT_POLICY_AUTH || "";
+// Full routing header map (Authorization + workspace / deployment routing
+// selectors) baked by the runner so this out-of-process plugin's POSTs reach the
+// SAME server instance as the runner.
+let POLICY_HEADERS = {};
+try {
+  POLICY_HEADERS = JSON.parse(process.env.OMNIGENT_POLICY_HEADERS || "{}") || {};
+} catch (e) {
+  POLICY_HEADERS = {};
+}
 const TIMEOUT_MS = 600000;
 
 async function evaluate(type, target, data) {
   // Returns {result, reason}. Not wired (no server/session) -> no-op allow.
   if (!BASE || !SESSION) return { result: "ALLOW" };
   const url = BASE + "/v1/sessions/" + encodeURIComponent(SESSION) + "/policies/evaluate";
-  const headers = { "content-type": "application/json" };
-  if (AUTH) headers["authorization"] = AUTH;
+  const headers = { "content-type": "application/json", ...POLICY_HEADERS };
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
@@ -168,9 +175,9 @@ def write_opencode_policy_plugin(bridge_dir: Path) -> Path:
 
     The runner registers the returned path in the synthesized ``opencode.json``
     ``plugin`` field and stamps ``OMNIGENT_POLICY_URL`` / ``OMNIGENT_SESSION_ID``
-    / ``OMNIGENT_POLICY_AUTH`` on the ``opencode serve`` process so the plugin
-    can reach ``/policies/evaluate``. Overwritten each launch so a code update
-    ships without stale plugin files.
+    / ``OMNIGENT_POLICY_HEADERS`` on the ``opencode serve`` process so the plugin
+    can reach ``/policies/evaluate`` with workspace / deployment routing.
+    Overwritten each launch so a code update ships without stale plugin files.
 
     :param bridge_dir: OpenCode-native bridge directory.
     :returns: The written plugin file path (absolute).

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1160,7 +1160,15 @@ async def _auto_create_opencode_terminal(
         _policy_factory = _make_auth_token_factory()
         _policy_token = _policy_factory() if _policy_factory is not None else None
         if _policy_token:
-            policy_env["OMNIGENT_POLICY_AUTH"] = f"Bearer {_policy_token}"
+            from omnigent.cli_auth import databricks_request_headers
+
+            # Bake the FULL routing header map (bearer + workspace / deployment
+            # selectors), not a bare bearer: the plugin POSTs /policies/evaluate
+            # to the omnigent server out-of-process, so without the selectors it
+            # could land on a different server instance than the runner's.
+            policy_env["OMNIGENT_POLICY_HEADERS"] = json.dumps(
+                databricks_request_headers(runner_server_url, bearer_token=_policy_token)
+            )
 
     # Merge the user's global provider definitions (e.g. OpenAI-compatible
     # endpoints with custom base URLs) into the synthesized config so the
@@ -1910,7 +1918,15 @@ async def _auto_create_pi_terminal(
     session_dir = pi_session_dir(bridge_dir)
     auth_factory = _make_auth_token_factory()
     auth_token = auth_factory() if auth_factory is not None else None
-    auth_headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
+    # Route the extension's out-of-process POSTs (/events, /mcp,
+    # /policies/evaluate) through the shared header builder so they carry the
+    # workspace / deployment routing selectors, not just a bare bearer. A bare
+    # bearer skips those selectors and can land on a different server instance
+    # than the one the runner (and the web UI) are on, so live-streamed items
+    # never reach the browser's in-process event stream (they only appear on reload).
+    from omnigent.cli_auth import databricks_request_headers
+
+    auth_headers = databricks_request_headers(launch_config.server_url, bearer_token=auth_token)
     # Build the Omnigent tool surface (sys_* tools) the Pi extension registers
     # via pi.registerTool. Reuses the same schema set the claude-native /
     # codex-native relay advertises, gated by the session's spec. Each tool's

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -282,6 +282,49 @@ def test_databricks_request_headers_pairs_bearer_and_org(token_dir) -> None:
     }
 
 
+def test_databricks_request_headers_folds_extra_headers(token_dir, monkeypatch) -> None:
+    """OMNIGENT_DATABRICKS_EXTRA_HEADERS rides every request built via the helper.
+
+    Databricks deployments set it to opaque request-routing selector headers so
+    a request pins to a specific server instance. Because it is folded into this
+    one helper, any caller that routes through it gets the selectors for free; a
+    caller that hand-rolls a bare bearer misses them. Malformed / unset input is
+    a no-op (prod-safe).
+    """
+    from omnigent.cli_auth import databricks_request_headers, store_databricks_auth
+
+    store_databricks_auth(
+        server_url="https://acme.databricks.com/api/2.0/omnigent",
+        workspace_host="https://acme.databricks.com",
+        org_id="2850744067564480",
+    )
+    recorded = "https://acme.databricks.com/api/2.0/omnigent"
+    monkeypatch.setenv(
+        "OMNIGENT_DATABRICKS_EXTRA_HEADERS",
+        '{"x-databricks-route-hint": "instance-abc"}',
+    )
+    # Extra header travels alongside the bearer + ?o= routing header.
+    assert databricks_request_headers(recorded, bearer_token="tok") == {
+        "Authorization": "Bearer tok",
+        "X-Databricks-Org-Id": "2850744067564480",
+        "x-databricks-route-hint": "instance-abc",
+    }
+    # It rides even for an unknown server with no token (routing-only request).
+    assert databricks_request_headers("https://other.example.com") == {
+        "x-databricks-route-hint": "instance-abc",
+    }
+    # Malformed JSON is ignored (no crash) so a bad value can't break requests.
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_EXTRA_HEADERS", "not-json")
+    assert databricks_request_headers("https://other.example.com", bearer_token="tok") == {
+        "Authorization": "Bearer tok",
+    }
+    # Unset (prod default) is a no-op.
+    monkeypatch.delenv("OMNIGENT_DATABRICKS_EXTRA_HEADERS", raising=False)
+    assert databricks_request_headers("https://other.example.com", bearer_token="tok") == {
+        "Authorization": "Bearer tok",
+    }
+
+
 def test_load_token_returns_none_for_databricks_record(token_dir) -> None:
     """A Databricks pointer record carries NO bearer — load_token must miss.
 

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1235,6 +1235,7 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "OMNIGENT_CLAUDE_SDK_NO_SANDBOX": "1",
         "KUBECONFIG": "/home/alice/.kube/config",
         "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
+        "OMNIGENT_DATABRICKS_EXTRA_HEADERS": '{"x-databricks-route-hint": "instance-abc"}',
     }
 
     env = _build_runner_env(
@@ -1278,6 +1279,12 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     # CLAUDE_CODE_SKIP_BEDROCK_AUTH disables AWS SigV4 auth for LiteLLM
     # proxies — a non-secret boolean, same rationale as CLAUDE_CODE_USE_BEDROCK.
     assert env["CLAUDE_CODE_SKIP_BEDROCK_AUTH"] == "1"
+    # Opaque request-routing headers forward host→runner so the runner's tunnel
+    # and server callbacks reach the same server instance the host registered on
+    # (without the operator also listing it in OMNIGENT_RUNNER_ENV_PASSTHROUGH).
+    assert (
+        env["OMNIGENT_DATABRICKS_EXTRA_HEADERS"] == '{"x-databricks-route-hint": "instance-abc"}'
+    )
     # Non-harness secrets are stripped — the point of the allowlist.
     assert "DATABRICKS_TOKEN" not in env
     assert "AWS_SECRET_ACCESS_KEY" not in env

--- a/tests/test_opencode_native_bridge.py
+++ b/tests/test_opencode_native_bridge.py
@@ -295,3 +295,19 @@ def test_user_opencode_config_path_prefers_jsonc(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "pref"))
     path = user_opencode_config_path()
     assert path is not None and path.name == "opencode.jsonc"
+
+
+def test_policy_plugin_merges_routing_headers(bridge_dir: Path) -> None:
+    """The generated policy plugin merges OMNIGENT_POLICY_HEADERS into its
+    /policies/evaluate POST.
+
+    The runner bakes the full routing header map (bearer + workspace / deployment
+    selectors) into that env var, so the out-of-process plugin's callbacks reach
+    the same server instance as the runner instead of a different one.
+    """
+    src = write_opencode_policy_plugin(bridge_dir).read_text(encoding="utf-8")
+    assert "OMNIGENT_POLICY_HEADERS" in src
+    # The routing map is spread into the request headers.
+    assert "...POLICY_HEADERS" in src
+    # The old bearer-only env var is fully removed.
+    assert "OMNIGENT_POLICY_AUTH" not in src


### PR DESCRIPTION
## Related issue

N/A

## Summary

The pi native harness (a JS extension) and the opencode policy plugin (a JS plugin) run **out of the runner process** and POST to the omnigent server with a hand-rolled `Authorization: Bearer` header, bypassing `cli_auth.databricks_request_headers()`. That helper is the single chokepoint that folds in the server-routing selectors — `X-Databricks-Org-Id` and the opaque `OMNIGENT_DATABRICKS_EXTRA_HEADERS` map (request-routing selectors set by some Databricks deployments to pin a request to a specific server instance). Every in-runner Python client already routes correctly because `_RunnerDatabricksAuth` / `_remote_headers` inject those headers automatically; these two out-of-process posters were the only gap.

Consequence on a multi-instance deployment: their POSTs can land on a different server instance than the one the runner and the web UI are bound to. For pi, streamed items are persisted but never delivered to the browser's in-process event stream, so **messages only appear on reload**; for opencode, policy evaluation is routed to a different instance (and fails open).

- `cli_auth`: fold `OMNIGENT_DATABRICKS_EXTRA_HEADERS` (opaque JSON header map, no-op when unset) into `databricks_request_headers`.
- **pi**: build the extension's `config.authHeaders` — at launch (`runner/app.py`) and on each per-turn refresh (`inner/pi_native_executor.py`) — via `databricks_request_headers`.
- **opencode**: bake the full routing header map as `OMNIGENT_POLICY_HEADERS` and merge it in the policy plugin, replacing the bearer-only `OMNIGENT_POLICY_AUTH`.
- **host**: allowlist `OMNIGENT_DATABRICKS_EXTRA_HEADERS` in the host→runner env builder (`_build_runner_env`) so a host forwards the routing selectors to the runners it spawns. Without it the host tunnel lands on the selected instance while its runners fall back to the default one — so the session's runner registers on a different instance than the one serving the UI, and the session reports `runner_failed_to_start`.

## Test Plan

- `uv run --extra dev --extra all pytest tests/cli/test_cli_auth.py tests/test_opencode_native_bridge.py tests/test_pi_native_bridge.py tests/host/test_connect.py` → all pass.
- `uvx ruff check` + `ruff format --check` on all changed files → clean.
- Tests: `test_databricks_request_headers_folds_extra_headers` (the chokepoint folds/ignores the env map correctly), `test_policy_plugin_merges_routing_headers` (the generated opencode plugin merges `OMNIGENT_POLICY_HEADERS`), and an extended `test_build_runner_env_allowlists_host_env_and_strips_secrets` asserting the host forwards `OMNIGENT_DATABRICKS_EXTRA_HEADERS` to spawned runners.

## Demo

N/A (non-visual — server request-routing).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The core mechanism (`databricks_request_headers` folding) and the opencode plugin generation are unit-tested. The two runner bake sites (`_auto_create_pi_terminal`, `_auto_create_opencode_terminal`) are thin calls into that now-tested helper, exercised end-to-end by the runner integration path. The root cause was confirmed on a multi-instance managed deployment — pi's `config.authHeaders` carried only `Authorization`, so `/events` POSTs reached a different instance than the browser's stream, matching "messages only appear on reload." End-to-end validation of the patched build there is still pending.

## Changelog

Fix pi (and opencode policy) losing live web-UI updates on multi-instance deployments by sending their out-of-process callbacks to the same server instance as the runner.

This pull request and its description were written by Isaac.
