### PR TITLE
docs(DBSPEC): remove stale DBOS/tasks references

### DIFF
--- a/omnigent/server/DBSPEC.md
+++ b/omnigent/server/DBSPEC.md
@@ -1,17 +1,26 @@
 # Database Schema Design
 
-Four tables in the default schema: agents, files, conversations, conversation_items.
+This doc covers four core tables: agents, files, conversations,
+conversation_items. They are part of a larger schema — 17 tables in all, also
+including conversation labels, comments, policies, session permissions,
+conversation metadata, projects, hosts, users, and scheduled tasks. No model
+sets an explicit schema, so every table lives in the default one.
 
 Schema is managed by Alembic migrations in `alembic/`. SQLAlchemy models live
-in `omnigent/db/db_models.py`.
+in `omnigent/db/db_models.py`, which is the source of truth for the full table
+list.
 
 A `tasks` table existed in an earlier design — DBOS-backed workflow execution,
 with a `try_deliver`/`close_inbox` steering handshake requiring transactional
 atomicity with `conversation_items`. It was never populated by production code
 and was dropped in migration `b9c1d2e3f4a5_drop_tasks_table`; DBOS itself has
-been removed as a dependency. Turn/steering state today lives entirely
+been removed as a dependency. The authoritative turn/steering state today lives
 in-memory in the runner process (`_active_turns`, `_session_message_buffers` in
-`omnigent/runner/app.py`) and is not persisted to this schema at all.
+`omnigent/runner/app.py`) and is never written to the DB. Only a coarse mirror
+is persisted — `omnigent_conversation_metadata.live_status` /
+`pending_elicitation_count`, written by the relay via
+`session_live_state.persist_live_status` so any replica can render session
+status.
 
 ---
 
@@ -106,12 +115,15 @@ is solely responsible for cascading deletes and referential cleanup.
 `conversation_items.conversation_id` references `conversations.id` by
 convention only.
 
-Deletion order is therefore an explicit application-code responsibility:
+Deletion order is therefore an explicit application-code responsibility.
 `ConversationStore.delete_conversation` collects the conversation's full
-subtree, then deletes items, labels, comments, policies, and FTS rows before
-deleting the conversation rows themselves — children before parent. Do not
-remove that cleanup logic on the assumption a DB cascade covers it; none
-does.
+subtree, then in one transaction deletes FTS rows, items, and labels before the
+conversation rows themselves — children before parent. A second transaction
+then cleans up the Omnigent-side rows: comments, policies, session permissions,
+conversation metadata, and session-scoped agents. That transaction runs after
+the conversation is already gone and is best-effort — if it fails, orphaned
+Omnigent rows survive a conversation that no longer exists. Do not remove any
+of this cleanup logic on the assumption a DB cascade covers it; none does.
 
 `conversation_items.response_id` references no table at all — it's a
 turn/response grouping id (see the `tasks (removed)` note above) with no
@@ -126,8 +138,10 @@ schema changes.
 
 ### position for item ordering
 
-App-managed integer, assigned via `SELECT MAX(position) + 1` within the same
-transaction as the INSERT. Guarantees strict, gapless ordering within each conversation.
+App-managed integer, allocated from the `conversations.next_position` counter,
+read and advanced under `_lock_conversation` in the same transaction as the
+INSERT (a one-time `MAX(position)` scan backfills the counter for conversations
+created before it existed). Guarantees strict, gapless ordering within each conversation.
 
 Why not alternatives:
 - **Autoincrement**: global, not per-conversation — creates gaps and arbitrary numbers across conversations.
@@ -135,8 +149,8 @@ Why not alternatives:
 - **Time-sortable IDs (ULID/UUIDv7)**: our type-prefixed IDs (`msg_`, `fc_`) break lexicographic sorting.
 - **Compute on read** (`ROW_NUMBER()`): slower reads, makes cursor pagination ugly.
 
-The SELECT + INSERT already runs inside `ConversationStore.append()`'s own
-transaction, so the extra cost is negligible. Cursor pagination is clean:
+Allocation is O(1) under the conversation row lock `ConversationStore.append()`
+already holds, so it costs nothing extra. Cursor pagination is clean:
 `WHERE conversation_id = ? AND position > ?`.
 
 ### TEXT for JSON, Integer for booleans
@@ -250,7 +264,7 @@ in `omnigent/runner/app.py`; none of it is a DB operation.
 | `get_conversation_id(response_id)` | SELECT conversation_id FROM conversation_items WHERE response_id = ? LIMIT 1 |
 | `get_latest_response_id(conversation_id)` | SELECT response_id FROM conversation_items WHERE conversation_id = ? ORDER BY position DESC LIMIT 1 |
 | `search_messages(conversation_id, after, ...)` | SELECT FROM conversation_items WHERE conversation_id = ? [AND position > ?] ORDER BY position LIMIT ? |
-| `append(conversation_id, messages)` | **Txn:** SELECT MAX(position); INSERT conversation_items (with search_text extracted from data) with incrementing position |
+| `append(conversation_id, messages)` | **Txn:** lock conversation, allocate from `next_position`; INSERT conversation_items (with search_text extracted from data) with incrementing position |
 | `search(query, conversation_id?, limit)` | FTS query against search_vector (Postgres) or conversation_items_fts (SQLite), optionally scoped to a conversation |
 
 ### API-Level (not in runtime stores)
@@ -260,7 +274,7 @@ in `omnigent/runner/app.py`; none of it is a DB operation.
 | List conversations | SELECT FROM conversations ORDER BY created_at with cursor pagination |
 | Delete conversation | Cancel any in-flight turn on the runner, DELETE conversation_items, DELETE conversation |
 | List agents | SELECT FROM agents ORDER BY created_at with cursor pagination |
-| Delete agent | Cancel any in-flight turns for the agent's live sessions, DELETE FROM agents |
+| Delete agent | `AgentStore.delete` → DELETE FROM agents. No API endpoint exposes this today; session-scoped agent rows are removed by `delete_conversation` |
 | CRUD files | TBD — may be backed by artifact store instead of DB |
 
 ---

--- a/omnigent/server/DBSPEC.md
+++ b/omnigent/server/DBSPEC.md
@@ -58,7 +58,8 @@ in-memory in the runner process (`_active_turns`, `_session_message_buffers` in
 
 Dropped in migration `b9c1d2e3f4a5_drop_tasks_table` — see the note at the top
 of this doc. `conversation_items.response_id` still exists as a plain
-app-generated grouping id (see below); it no longer references any table.
+turn/response grouping id (harness- or app-generated; see below); it no longer
+references any table.
 
 ---
 
@@ -70,8 +71,8 @@ Single table with a `type` discriminator and a JSON `data` blob for type-specifi
 | Column | Type | Notes |
 |---|---|---|
 | id | String(64) PK | Prefixed by type: msg_, fc_, fco_, rs_ |
-| conversation_id | String(64) NOT NULL | FK → conversations.id |
-| response_id | String(64) NOT NULL | App-generated id grouping items produced by one turn; no matching table since `tasks` was dropped |
+| conversation_id | String(64) NOT NULL | References conversations.id (by convention — no DB FK; see Foreign key strategy) |
+| response_id | String(64) NOT NULL | Turn/response grouping id (harness- or app-generated); no matching table since `tasks` was dropped |
 | created_at | Integer NOT NULL | |
 | status | String(32) NOT NULL | Default "completed" |
 | position | Integer NOT NULL | Ordering within conversation |
@@ -98,14 +99,23 @@ Single table with a `type` discriminator and a JSON `data` blob for type-specifi
 
 ### Foreign key strategy
 
-`conversation_items.conversation_id` has a FK to `conversations.id` (`ON DELETE
-CASCADE`), so deleting a conversation removes its items automatically — no
-separate deletion-order step is needed. The FK acts as a safety net against
-orphaned rows.
+There are no database-enforced foreign keys anywhere in the schema. Migration
+`p1a2b3c4d5e6_remove_all_fks` dropped every FK constraint (per internal DB
+standard Rule R032, which forbids DB-enforced foreign keys); the application
+is solely responsible for cascading deletes and referential cleanup.
+`conversation_items.conversation_id` references `conversations.id` by
+convention only.
 
-No FK for `conversation_items.response_id` — it's an app-generated grouping id
-with no backing table (see the `tasks (removed)` note above), so there's
-nothing to reference.
+Deletion order is therefore an explicit application-code responsibility:
+`ConversationStore.delete_conversation` collects the conversation's full
+subtree, then deletes items, labels, comments, policies, and FTS rows before
+deleting the conversation rows themselves — children before parent. Do not
+remove that cleanup logic on the assumption a DB cascade covers it; none
+does.
+
+`conversation_items.response_id` references no table at all — it's a
+turn/response grouping id (see the `tasks (removed)` note above) with no
+backing table since `tasks` was dropped.
 
 ### Single conversation_items table with JSON data column
 

--- a/omnigent/server/DBSPEC.md
+++ b/omnigent/server/DBSPEC.md
@@ -1,13 +1,17 @@
 # Database Schema Design
 
-Five tables in the default schema. DBOS manages its own tables (workflow_status,
-operation_outputs, streams, etc.) in a separate `dbos` schema within the same database.
-
-Tasks and conversation_items MUST share the same database — the steering handshake
-(try_deliver + close_inbox) requires single-transaction atomicity.
+Four tables in the default schema: agents, files, conversations, conversation_items.
 
 Schema is managed by Alembic migrations in `alembic/`. SQLAlchemy models live
 in `omnigent/db/db_models.py`.
+
+A `tasks` table existed in an earlier design — DBOS-backed workflow execution,
+with a `try_deliver`/`close_inbox` steering handshake requiring transactional
+atomicity with `conversation_items`. It was never populated by production code
+and was dropped in migration `b9c1d2e3f4a5_drop_tasks_table`; DBOS itself has
+been removed as a dependency. Turn/steering state today lives entirely
+in-memory in the runner process (`_active_turns`, `_session_message_buffers` in
+`omnigent/runner/app.py`) and is not persisted to this schema at all.
 
 ---
 
@@ -50,46 +54,11 @@ in `omnigent/db/db_models.py`.
 
 ---
 
-## tasks
+## tasks (removed)
 
-Responses. `task_id` = `response_id` = DBOS `workflow_uuid`.
-
-This table stores relationship/identity columns, display dimensions, and the steering
-handshake flag. All execution state — status, output, error, usage, etc. — lives in
-DBOS (workflow inputs for request params, workflow result for outcomes).
-`TaskStore.get()` assembles the full `Task` entity from both the DB row and DBOS state.
-If we later need to query by any DBOS-managed field (e.g. filter tasks by status), we
-can promote it to a column here.
-
-| Column | Type | Notes |
-|---|---|---|
-| id | String(64) PK | "resp_" + uuid4().hex (= DBOS workflow_uuid) |
-| agent_id | String(64) NOT NULL | FK → agents.id |
-| conversation_id | String(64) NOT NULL | FK → conversations.id |
-| previous_response_id | String(64) | No FK — allows dangling after mid-chain delete |
-| created_at | Integer NOT NULL | |
-| inbox_closed | Integer NOT NULL | Default 0 (0=open, 1=closed) |
-| agent_name | String(256) NOT NULL | Denormalized — stable model name even if agent is renamed/deleted |
-| background | Boolean NOT NULL | Default 0 — display dimension for API responses |
-
-**Stored in DBOS** (workflow inputs): `instructions`, `reasoning`
-
-**Stored in DBOS** (workflow result): `status`, `output`, `completed_at`, `error`,
-`incomplete_details`, `usage`
-
-**Indexes:** `ix_tasks_conversation_id`, `ix_tasks_agent_id` (for agent deletion cascade),
-`ix_tasks_created_at`
-
-### Task/workflow invariant
-
-For any task, both a `tasks` table row AND a DBOS `workflow_status` entry must exist,
-OR NEITHER. This is enforced by a compensating transaction in `TaskStore.start()`:
-
-1. `create()` writes the task row and commits.
-2. `start()` launches the DBOS workflow. On failure, it deletes the orphaned row.
-3. If the process crashes between `create()` committing and `start()` succeeding,
-   a reaper on startup can detect orphaned rows (rows with no matching DBOS workflow)
-   and clean them up.
+Dropped in migration `b9c1d2e3f4a5_drop_tasks_table` — see the note at the top
+of this doc. `conversation_items.response_id` still exists as a plain
+app-generated grouping id (see below); it no longer references any table.
 
 ---
 
@@ -102,13 +71,14 @@ Single table with a `type` discriminator and a JSON `data` blob for type-specifi
 |---|---|---|
 | id | String(64) PK | Prefixed by type: msg_, fc_, fco_, rs_ |
 | conversation_id | String(64) NOT NULL | FK → conversations.id |
-| response_id | String(64) NOT NULL | References tasks.id; no FK — must survive task deletion |
+| response_id | String(64) NOT NULL | App-generated id grouping items produced by one turn; no matching table since `tasks` was dropped |
 | created_at | Integer NOT NULL | |
 | status | String(32) NOT NULL | Default "completed" |
 | position | Integer NOT NULL | Ordering within conversation |
 | type | String(32) NOT NULL | message, function_call, function_call_output, reasoning |
 | data | Text NOT NULL | JSON blob — type-specific fields (see below) |
 | search_text | Text NOT NULL | Extracted plain text for full-text search (see below) |
+| created_by | String(128) | Nullable — identity of the human actor who authored the item; `None` for agent/tool/system items |
 
 **Indexes:** `ix_conversation_items_conversation_id_position` (composite), `ix_conversation_items_response_id`
 
@@ -128,17 +98,14 @@ Single table with a `type` discriminator and a JSON `data` blob for type-specifi
 
 ### Foreign key strategy
 
-`conversation_id` on both tasks and conversation_items has a FK to `conversations.id`.
-This is safe because the deletion order (tasks → conversation_items → conversation)
-always removes children before the parent. The FK acts as a safety net against
+`conversation_items.conversation_id` has a FK to `conversations.id` (`ON DELETE
+CASCADE`), so deleting a conversation removes its items automatically — no
+separate deletion-order step is needed. The FK acts as a safety net against
 orphaned rows.
 
-`tasks.agent_id → agents.id` — FK. Agent deletion handler cancels tasks,
-deletes task records, then deletes the agent row.
-
-No FK for these relationships:
-- `conversation_items.response_id → tasks.id` — items must survive task deletion
-- `tasks.previous_response_id → tasks.id` — dangling pointers are allowed after mid-chain delete
+No FK for `conversation_items.response_id` — it's an app-generated grouping id
+with no backing table (see the `tasks (removed)` note above), so there's
+nothing to reference.
 
 ### Single conversation_items table with JSON data column
 
@@ -158,8 +125,9 @@ Why not alternatives:
 - **Time-sortable IDs (ULID/UUIDv7)**: our type-prefixed IDs (`msg_`, `fc_`) break lexicographic sorting.
 - **Compute on read** (`ROW_NUMBER()`): slower reads, makes cursor pagination ugly.
 
-The SELECT + INSERT cost is negligible since the steering handshake already requires
-a transaction. Cursor pagination is clean: `WHERE conversation_id = ? AND position > ?`.
+The SELECT + INSERT already runs inside `ConversationStore.append()`'s own
+transaction, so the extra cost is negligible. Cursor pagination is clean:
+`WHERE conversation_id = ? AND position > ?`.
 
 ### TEXT for JSON, Integer for booleans
 
@@ -259,20 +227,10 @@ DDL event listener.
 
 ## Store Method → DB Operation Mapping
 
-### TaskStore
-
-| Method | DB Operation |
-|---|---|
-| `create(conversation_id, agent_id, agent_name, ...)` | INSERT INTO tasks (no instructions/reasoning — those are workflow inputs) |
-| `start(task_id, instructions, reasoning)` | Launch DBOS workflow; compensating delete of task row on failure |
-| `get(task_id)` | SELECT FROM tasks WHERE id = ?, then DBOS.retrieve_workflow() for status/output/etc. |
-| `wait(task_id)` | DBOS.retrieve_workflow().get_result(), then assemble Task from DB row + workflow result |
-| `stream(task_id)` | DBOS.read_stream(task_id, "output") |
-| `try_deliver(task_id, conversation_id, msg)` | **Txn:** SELECT tasks.inbox_closed FOR UPDATE; if open → INSERT INTO conversation_items, return True; if closed → return False |
-| `close_inbox(task_id, conversation_id, last_seen)` | **Txn:** SELECT conversation_items WHERE conversation_id = ? AND position > ?; if found → return them; if not → UPDATE tasks SET inbox_closed = 1, return [] |
-| `cancel(task_id)` | DBOS.cancel_workflow() (status lives in DBOS) |
-| `delete(task_id)` | Cancel if in-progress, then DELETE FROM tasks WHERE id = ? (items untouched) |
-| `list_tasks(conversation_id, agent_id)` | SELECT FROM tasks WHERE conversation_id = ? AND/OR agent_id = ? |
+`TaskStore` was removed along with the `tasks` table. Turn lifecycle (start,
+steering/injection, cancel, status) is runner-owned, in-memory state today —
+see `_active_turns` / `_session_message_buffers` / `_check_and_start_next_turn`
+in `omnigent/runner/app.py`; none of it is a DB operation.
 
 ### ConversationStore
 
@@ -290,9 +248,9 @@ DDL event listener.
 | Operation | DB Operation |
 |---|---|
 | List conversations | SELECT FROM conversations ORDER BY created_at with cursor pagination |
-| Delete conversation | Cancel in-flight tasks, DELETE tasks, DELETE conversation_items, DELETE conversation |
+| Delete conversation | Cancel any in-flight turn on the runner, DELETE conversation_items, DELETE conversation |
 | List agents | SELECT FROM agents ORDER BY created_at with cursor pagination |
-| Delete agent | Cancel in-flight tasks (by model), DELETE FROM agents |
+| Delete agent | Cancel any in-flight turns for the agent's live sessions, DELETE FROM agents |
 | CRUD files | TBD — may be backed by artifact store instead of DB |
 
 ---


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

The tasks table and DBOS were removed (migration b9c1d2e3f4a5_drop_tasks_table), but DBSPEC.md still described the
old DBOS-backed workflow design: the tasks table schema, the try_deliver/close_inbox steering handshake, and the TaskStore method mapping. Updated the doc to match current state — turn
state now lives in-memory in the runner (_active_turns, _session_message_buffers), and conversation_items.response_id is
just an app-generated grouping id with no backing table.

Also added the created_by column to conversation_items, which
existed in code but was missing from the doc.

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

