### PR TITLE
Nest sub-agent telemetry spans under dispatch tools

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7580,6 +7580,37 @@ def unregister_child_session(child_session_id: str) -> None:
     :param child_session_id: Child session id to forget.
     """
     _child_session_parents.pop(child_session_id, None)
+    _pending_child_turn_traceparents.pop(child_session_id, None)
+
+
+# child_session_id → W3C traceparent of the parent's dispatching tool span.
+# One entry per pending child turn; a re-send overwrites before the child
+# message is posted and then popped while building the harness payload.
+_pending_child_turn_traceparents: dict[str, str] = {}
+
+
+def stash_child_turn_traceparent(child_session_id: str, traceparent: str) -> None:
+    """
+    Record the parent tool span traceparent for a child's next turn.
+
+    :param child_session_id: Child session id, e.g. ``"conv_child123"``.
+    :param traceparent: W3C traceparent of the dispatching
+        ``tool:sys_session_send`` span,
+        e.g. ``"00-<32 hex>-<16 hex>-01"``.
+    """
+    _pending_child_turn_traceparents[child_session_id] = traceparent
+
+
+def pop_child_turn_traceparent(child_session_id: str) -> str | None:
+    """
+    Consume the stashed parent tool span traceparent for a child turn.
+
+    :param child_session_id: Child session id, e.g. ``"conv_child123"``.
+    :returns: The traceparent, or ``None`` when the turn was not
+        dispatched via ``sys_session_send`` (or the parent ran
+        without tracing).
+    """
+    return _pending_child_turn_traceparents.pop(child_session_id, None)
 
 
 def _session_status_to_task_status(status: object) -> str | None:
@@ -13555,6 +13586,13 @@ def create_runner_app(
             "role": "user",
             "model": msg_body.get("model", ""),
         }
+        # Sub-agent telemetry: nest the child agent span under the
+        # parent tool span, and use the sub-agent name for span naming.
+        _parent_tool_traceparent = pop_child_turn_traceparent(conv)
+        if _parent_tool_traceparent:
+            harness_body["parent_tool_traceparent"] = _parent_tool_traceparent
+        if _sa_name:
+            harness_body["agent_name"] = _sa_name
         if _session_histories[conv]:
             harness_body["content"] = _session_histories[conv]
         else:
@@ -14140,6 +14178,7 @@ def create_runner_app(
                 dispatch_tool_locally,
                 get_arguments,
                 get_call_id,
+                get_item_traceparent,
                 get_tool_name,
                 is_action_required,
                 should_dispatch_locally,
@@ -14517,6 +14556,7 @@ def create_runner_app(
                                                     ),
                                                     publish_event=_publish_event,
                                                     filesystem_registry=filesystem_registry,
+                                                    tool_traceparent=get_item_traceparent(event),
                                                 )
                                             )
                                         )

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -511,6 +511,21 @@ def get_arguments(event: dict[str, Any]) -> str:
     return (event.get("item") or {}).get("arguments", "{}")
 
 
+def get_item_traceparent(event: dict[str, Any]) -> str | None:
+    """
+    Extract the dispatching tool span's W3C traceparent, when present.
+
+    The harness stamps ``traceparent`` on ``sys_session_send``
+    action_required items (see ``TurnContext.dispatch_tool``) so the
+    child session's agent span can nest under the parent's tool span.
+
+    :param event: An action_required SSE event dict.
+    :returns: The traceparent string, or ``None`` when absent/invalid.
+    """
+    value = (event.get("item") or {}).get("traceparent")
+    return value if isinstance(value, str) and value else None
+
+
 def should_dispatch_locally(tool_name: str) -> bool:
     """Return True if this tool should be dispatched by the runner locally.
 
@@ -1363,6 +1378,7 @@ async def _execute_subagent_tool(
     agent_spec: Any | None = None,
     publish_event: Callable[[str, dict[str, Any]], None] | None = None,
     session_inbox: asyncio.Queue[dict[str, Any]] | None = None,
+    tool_traceparent: str | None = None,
 ) -> str:
     """
     Dispatch a sub-agent tool call (``sys_session_send``).
@@ -1388,6 +1404,11 @@ async def _execute_subagent_tool(
         discovery events to the parent stream.
     :param session_inbox: Parent session's inbox queue for async
         completion delivery.
+    :param tool_traceparent: W3C traceparent of the parent's dispatching
+        ``tool:sys_session_send`` span. Stashed on the runner so the
+        child turn's harness payload carries it as
+        ``parent_tool_traceparent`` and the child agent span nests under
+        the parent's tool span.
     :returns: JSON child-session handle, or an error string.
     """
     # Lazy import to avoid circular dependency at module load.
@@ -1470,6 +1491,7 @@ async def _execute_subagent_tool(
             server_client=server_client,
             conversation_id=conversation_id,
             publish_event=publish_event,
+            tool_traceparent=tool_traceparent,
         )
 
     # Named mode: (agent, title) spawn-or-continue.
@@ -1786,6 +1808,12 @@ async def _execute_subagent_tool(
         return copy_result.error
     message_content = copy_result.content
 
+    # Stash the dispatching tool span's traceparent BEFORE posting the
+    # message — the server forwards it to the runner and starts the
+    # child turn, so a post-hoc stash could lose the race.
+    if tool_traceparent is not None:
+        _runner_app.stash_child_turn_traceparent(child_session_id, tool_traceparent)
+
     # Send the user message as a separate event so the server's
     # post_event forwards it to the runner and starts the child
     # turn.
@@ -1857,6 +1885,7 @@ async def _send_to_existing_session(
     server_client: httpx.AsyncClient,
     conversation_id: str,
     publish_event: Callable[[str, dict[str, Any]], None] | None = None,
+    tool_traceparent: str | None = None,
 ) -> str:
     """
     Post a message to an existing direct-child session, return a handle.
@@ -1878,6 +1907,9 @@ async def _send_to_existing_session(
     :param server_client: HTTP client pointed at the Omnigent server.
     :param conversation_id: The caller's own session id — the required
         parent of the target.
+    :param tool_traceparent: W3C traceparent of the caller's dispatching
+        ``tool:sys_session_send`` span; stashed for the target's next
+        turn so its agent span nests under this send's tool span.
     :returns: JSON handle on success; a JSON/text error otherwise.
     """
     from omnigent.runner import app as _runner_app
@@ -1947,6 +1979,10 @@ async def _send_to_existing_session(
         session_name=parsed.title or "",
         publish_event=publish_event,
     )
+
+    # Stash before posting — the post starts the child turn.
+    if tool_traceparent is not None:
+        _runner_app.stash_child_turn_traceparent(target_session_id, tool_traceparent)
 
     try:
         msg_resp = await server_client.post(
@@ -2439,6 +2475,7 @@ async def _execute_web_fetch_tool(
     task_id: str | None,
     publish_event: Callable[[str, dict[str, Any]], None] | None = None,
     session_inbox: asyncio.Queue[dict[str, Any]] | None = None,
+    tool_traceparent: str | None = None,
 ) -> str:
     """
     Dispatch a ``web_fetch`` tool call.
@@ -2494,6 +2531,7 @@ async def _execute_web_fetch_tool(
         agent_spec=agent_spec,
         publish_event=publish_event,
         session_inbox=session_inbox,
+        tool_traceparent=tool_traceparent,
     )
 
 
@@ -4307,6 +4345,7 @@ async def execute_tool(
     harness_client: httpx.AsyncClient | None = None,
     publish_event: Callable[[str, dict[str, Any]], None] | None = None,
     filesystem_registry: FilesystemRegistry | None = None,
+    tool_traceparent: str | None = None,
 ) -> str:
     """
     Execute a tool and return the output string.
@@ -4330,6 +4369,9 @@ async def execute_tool(
         so that ``sys_os_write`` and ``sys_os_edit`` calls record changed
         paths for the ``GET …/changes`` endpoint. ``sys_os_shell`` is
         not tracked — shell side-effects cannot be attributed to a session.
+    :param tool_traceparent: W3C traceparent of the harness-side tool
+        span dispatching this call. Forwarded to sub-agent spawning
+        tools so the child turn's agent span nests under it.
     :returns: Tool output string.
     """
     try:
@@ -4411,6 +4453,7 @@ async def execute_tool(
                 agent_spec=agent_spec,
                 publish_event=publish_event,
                 session_inbox=session_inbox,
+                tool_traceparent=tool_traceparent,
             )
         elif tool_name in _LIST_MODELS_TOOLS:
             output = await _execute_list_models_tool(agent_spec=agent_spec)
@@ -4440,6 +4483,7 @@ async def execute_tool(
                 task_id=task_id,
                 publish_event=publish_event,
                 session_inbox=session_inbox,
+                tool_traceparent=tool_traceparent,
             )
         elif tool_name in _WEB_SEARCH_TOOLS:
             output = await _execute_web_search_tool(
@@ -4603,6 +4647,7 @@ async def dispatch_tool_locally(
     session_async_tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] | None = None,
     publish_event: Callable[[str, dict[str, Any]], None] | None = None,
     filesystem_registry: FilesystemRegistry | None = None,
+    tool_traceparent: str | None = None,
 ) -> str:
     """Execute a tool locally and PATCH the result to the harness.
 
@@ -4624,6 +4669,10 @@ async def dispatch_tool_locally(
         for the ``GET …/changes`` endpoint.
     :param resource_registry: Optional session-resource registry used to
         observe tool-launched terminals.
+    :param tool_traceparent: W3C traceparent of the harness-side tool
+        span dispatching this call (from the action_required item's
+        ``traceparent`` field). Forwarded so sub-agent child turns can
+        nest their agent span under the dispatching tool span.
     :returns: The tool output string.
     """
     output = await execute_tool(
@@ -4644,6 +4693,7 @@ async def dispatch_tool_locally(
         harness_client=harness_client,
         filesystem_registry=filesystem_registry,
         publish_event=publish_event,
+        tool_traceparent=tool_traceparent,
     )
 
     # A file-mutating tool just ran — nudge the web to refetch the

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -109,6 +109,12 @@ _OBSERVED_TOOL_CALL_STATUS = "in_progress"
 #    paired output. Keeps the dedup story symmetric.
 _MCP_TOOL_NAME_PREFIX = "mcp__"
 
+# Runner tools that spawn or continue a child session. Their dispatches
+# carry the active tool span's traceparent so the child turn's agent span
+# nests under the dispatching tool span (same trace) instead of rooting a
+# fresh trace. See :meth:`ExecutorAdapter._dispatch_traceparent`.
+_CHILD_SPAWNING_TOOLS = frozenset({"sys_session_send", "web_fetch"})
+
 
 def _strip_mcp_tool_prefix(name: str) -> str:
     """
@@ -374,11 +380,16 @@ class ExecutorAdapter(HarnessApp):
             trace_cm: contextlib.AbstractContextManager[None] = contextlib.nullcontext()
             if tctx:
                 try:
-                    from omnigent.runtime.telemetry import trace_context_for_response
+                    if request.parent_tool_traceparent:
+                        from omnigent.runtime.telemetry import trace_context_from_traceparent
 
-                    trace_cm = trace_context_for_response(response_id=ctx.response_id)
+                        trace_cm = trace_context_from_traceparent(request.parent_tool_traceparent)
+                    else:
+                        from omnigent.runtime.telemetry import trace_context_for_response
+
+                        trace_cm = trace_context_for_response(response_id=ctx.response_id)
                 except Exception:
-                    _logger.debug("trace_context_for_response unavailable", exc_info=True)
+                    _logger.debug("trace context setup unavailable", exc_info=True)
             # Bind the session for the whole turn so every span the harness
             # creates (agent/LLM/tool, the native tmux inject, DB/httpx child
             # spans) is tagged with session.id by the span processor — no
@@ -386,7 +397,7 @@ class ExecutorAdapter(HarnessApp):
             with session_scope(turn_session_id), trace_cm:
                 if tctx is not None:
                     agent_span = tctx.start_agent_span(
-                        agent_name=request.model or "unknown",
+                        agent_name=request.agent_name or request.model or "unknown",
                         user_message=user_message,
                         model=request.model_override or request.model,
                     )
@@ -695,7 +706,39 @@ class ExecutorAdapter(HarnessApp):
             tool_name,
             args,
             call_id=dispatch_call_id,
+            traceparent=self._dispatch_traceparent(tool_name),
         )
+
+    def _dispatch_traceparent(self, tool_name: str) -> str | None:
+        """
+        Serialize the span a child-spawning dispatch should parent
+        remote children under.
+
+        Prefers the active ``tool:<name>`` span (started when the turn
+        loop translated the ToolCallRequest); when the dispatch races
+        ahead of that translation — or a parallel tool call moved the
+        cursor — falls back to the turn's agent span so the child still
+        joins this turn's trace one level up.
+
+        :param tool_name: Bare tool name from the dispatch callback,
+            e.g. ``"sys_session_send"``.
+        :returns: A W3C traceparent string, or ``None`` for
+            non-child-spawning tools and when tracing is inactive.
+        """
+        bare_name = _strip_mcp_tool_prefix(tool_name)
+        if bare_name not in _CHILD_SPAWNING_TOOLS:
+            return None
+        tctx = self._tracing_ctx
+        if tctx is None or not tctx.active:
+            return None
+        from omnigent.runtime.telemetry import traceparent_from_span
+
+        span = tctx._current_span
+        if span is None or getattr(span, "name", None) != f"tool:{bare_name}":
+            span = tctx._root_span
+        if span is None:
+            return None
+        return traceparent_from_span(span)
 
     async def _stable_elicitation_handler(
         self,
@@ -1432,6 +1475,7 @@ async def _bridge_one_dispatch(
     args: dict[str, Any],
     *,
     call_id: str | None = None,
+    traceparent: str | None = None,
 ) -> dict[str, Any]:
     """
     Round-trip one tool call through ``ctx.dispatch_tool``.
@@ -1456,6 +1500,10 @@ async def _bridge_one_dispatch(
         freshly-allocated uuid — the dispatch still works but the
         observed and action_required events render as separate
         ``⏵ tool_name`` lines.
+    :param traceparent: Optional W3C traceparent of the dispatching
+        tool span, forwarded onto the action_required item so remote
+        children can nest under it (see
+        :meth:`ExecutorAdapter._dispatch_traceparent`).
     :returns: A dict suitable as the MCP tool result.
     """
     import json
@@ -1468,6 +1516,7 @@ async def _bridge_one_dispatch(
             name=tool_name,
             arguments=json.dumps(args),
             agent=agent,
+            traceparent=traceparent,
         )
     except Exception as exc:
         _logger.exception("dispatch_tool failed for %s", tool_name)

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -446,7 +446,14 @@ class TurnContext:
             self._reset_idle_watchdog()
         self._event_queue.put_nowait(event)
 
-    async def dispatch_tool(self, call_id: str, name: str, arguments: str, agent: str) -> str:
+    async def dispatch_tool(
+        self,
+        call_id: str,
+        name: str,
+        arguments: str,
+        agent: str,
+        traceparent: str | None = None,
+    ) -> str:
         """
         Emit a server-dispatched tool call and park until the result.
 
@@ -468,6 +475,11 @@ class TurnContext:
         :param agent: Agent name that invoked the tool — required
             on the function_call item per
             :class:`omnigent.entities.conversation.FunctionCallData`.
+        :param traceparent: Optional W3C traceparent of the harness-side
+            span dispatching this call (the ``tool:<name>`` span). Rides
+            the action_required item so the runner can parent remote
+            children — e.g. a ``sys_session_send`` child agent span —
+            under the dispatching tool span. Not persisted.
         :returns: The tool's output string from
             :class:`omnigent.server.schemas.ToolResult`.
         :raises asyncio.CancelledError: If the turn is cancelled
@@ -489,6 +501,8 @@ class TurnContext:
             "call_id": call_id,
             "agent": agent,
         }
+        if traceparent is not None:
+            item["traceparent"] = traceparent
         self.emit(OutputItemDoneEvent(type="response.output_item.done", item=item))
         try:
             result = await future

--- a/omnigent/runtime/telemetry.py
+++ b/omnigent/runtime/telemetry.py
@@ -693,6 +693,58 @@ def get_traceparent_env() -> dict[str, str]:
     return result
 
 
+def traceparent_from_span(span: Span) -> str | None:
+    """
+    Serialize a span's :class:`SpanContext` as a W3C ``traceparent`` string.
+
+    Used to hand a specific span — not the ambient context — across a
+    process boundary as the parent for remote children. The sub-agent
+    dispatch path serializes the parent's ``tool:sys_session_send`` span
+    here so the child harness can parent its agent span under it even
+    after the tool span has ended (OTel permits children of ended
+    parents via a remote ``SpanContext``).
+
+    :param span: The span whose context to serialize, e.g. the active
+        TOOL span for a ``sys_session_send`` dispatch.
+    :returns: A ``"00-<trace_id>-<span_id>-<flags>"`` traceparent, or
+        ``None`` when the span has no valid context (e.g. a no-op span
+        from the default tracer provider).
+    """
+    ctx = span.get_span_context()
+    if ctx is None or not ctx.is_valid:
+        return None
+    return f"00-{ctx.trace_id:032x}-{ctx.span_id:016x}-{int(ctx.trace_flags):02x}"
+
+
+@contextmanager
+def trace_context_from_traceparent(traceparent: str) -> Iterator[None]:
+    """
+    Attach a remote W3C ``traceparent`` as the ambient trace context.
+
+    The receive-side counterpart to :func:`traceparent_from_span` for
+    in-process span creation (rather than frame handling — see
+    :func:`consume_frame_span` for that). Any span started inside the
+    context manager without an explicit parent becomes a child of the
+    remote span and shares its trace ID. The sub-agent child turn uses
+    this so its agent span nests under the parent's dispatching tool
+    span instead of rooting a fresh trace.
+
+    :param traceparent: A W3C traceparent string, e.g.
+        ``"00-<32 hex>-<16 hex>-01"``.
+    :raises ValueError: Never — an unparseable traceparent yields an
+        empty context, so spans simply root a new trace.
+    """
+    from opentelemetry import context
+    from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+    ctx = TraceContextTextMapPropagator().extract({"traceparent": traceparent})
+    token = context.attach(ctx)
+    try:
+        yield
+    finally:
+        context.detach(token)
+
+
 def inject_trace_context(carrier: dict[str, str]) -> dict[str, str]:
     """
     Inject the active W3C trace context into a dict carrier.

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -961,6 +961,19 @@ class CreateResponseRequest(BaseModel):
     # the message, so the runner can drop the buffered copy and not
     # re-deliver it in a continuation turn. ``None`` for fresh turns.
     injection_id: str | None = None
+    # W3C traceparent of the parent turn's dispatching tool span
+    # (``tool:sys_session_send``). Stamped by the runner on sub-agent
+    # child turns so the child harness parents its agent span under the
+    # parent's tool span (same trace) instead of rooting a fresh trace
+    # from the child response id. ``None`` for non-child turns and when
+    # the parent turn ran without tracing.
+    parent_tool_traceparent: str | None = None
+    # Display/telemetry agent name for this turn. For sub-agent child
+    # turns the runner stamps the SUB-agent's name here (``model``
+    # carries the value the server forwarded, which for child sessions
+    # is the root agent's name). Tracing prefers this over ``model``
+    # for ``gen_ai.agent.name`` / the ``agent:<name>`` span name.
+    agent_name: str | None = None
     conversation: ConversationRef | None = None
     # Reasoning config, e.g. {"effort": "low"|"medium"|"high"}
     reasoning: dict[str, str] | None = None

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -24,8 +24,12 @@ from typing import Any
 
 import httpx
 import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from omnigent.inner.executor import Executor
+from omnigent.inner.executor import Executor, ExecutorConfig, Message, ToolSpec
 from omnigent.runtime.harnesses import _HARNESS_MODULES
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 
@@ -813,6 +817,149 @@ class _StubExecutor(Executor):
     """
 
 
+@pytest.fixture
+def in_memory_span_exporter() -> Iterator[InMemorySpanExporter]:
+    """Install a fresh OTel provider for adapter tracing assertions."""
+    from omnigent.inner.tracing import disable_tracing, enable_tracing, is_tracing_enabled
+
+    previous = otel_trace._TRACER_PROVIDER  # type: ignore[attr-defined]
+    previous_done = otel_trace._TRACER_PROVIDER_SET_ONCE._done  # type: ignore[attr-defined]
+    tracing_was_enabled = is_tracing_enabled()
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    otel_trace._TRACER_PROVIDER = provider  # type: ignore[attr-defined]
+    otel_trace._TRACER_PROVIDER_SET_ONCE._done = True  # type: ignore[attr-defined]
+    try:
+        yield exporter
+    finally:
+        exporter.clear()
+        with contextlib.suppress(Exception):
+            provider.shutdown()
+        otel_trace._TRACER_PROVIDER = previous  # type: ignore[attr-defined]
+        otel_trace._TRACER_PROVIDER_SET_ONCE._done = previous_done  # type: ignore[attr-defined]
+        if tracing_was_enabled:
+            enable_tracing()
+        else:
+            disable_tracing()
+
+
+class _NoInjectionTurnContext:
+    """Recording turn context with the async surfaces ``run_turn`` needs."""
+
+    def __init__(self, response_id: str = "resp_child") -> None:
+        """Initialize a context that never receives mid-turn injections."""
+        import asyncio as _aio
+
+        self.response_id = response_id
+        self.cancelled = _aio.Event()
+        self.emitted: list[Any] = []
+
+    def emit(self, event: Any) -> None:
+        """Record an emitted event."""
+        self.emitted.append(event)
+
+    async def next_injection(self, timeout: float | None = None) -> Any:
+        """Block until the adapter's injection watcher is cancelled."""
+        import asyncio as _aio
+
+        del timeout
+        await _aio.sleep(3600)
+        return None
+
+
+class _NestedChildTraceExecutor(Executor):
+    """Executor script that keeps the child turn open around a nested tool."""
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[Any]:
+        """Yield one nested tool call and then complete with real output."""
+        import asyncio as _aio
+
+        from omnigent.inner.executor import ToolCallComplete, ToolCallRequest, TurnComplete
+
+        del messages, tools, system_prompt, config
+        yield ToolCallRequest(
+            name="child_tool",
+            args={"value": 1},
+            metadata={"call_id": "call_child_tool"},
+        )
+        await _aio.sleep(0.01)
+        yield ToolCallComplete(
+            name="child_tool",
+            result={"ok": True},
+            metadata={"call_id": "call_child_tool"},
+            duration_ms=17.0,
+        )
+        await _aio.sleep(0.01)
+        yield TurnComplete(response="child result")
+
+
+@pytest.mark.asyncio
+async def test_child_turn_agent_span_nests_under_parent_tool_traceparent(
+    in_memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A child turn uses the dispatching ``tool:sys_session_send`` span as
+    its remote parent and keeps its agent span open around real execution.
+    """
+    from omnigent.inner.tracing import TracingContext, enable_tracing
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.runtime.telemetry import traceparent_from_span
+    from omnigent.server.schemas import CreateResponseRequest
+
+    monkeypatch.setattr("omnigent.runtime.telemetry._capture_content", True)
+    enable_tracing()
+
+    parent_ctx = TracingContext(session_id="conv_parent")
+    parent_agent = parent_ctx.start_agent_span(agent_name="parent", user_message="dispatch")
+    parent_tool = parent_ctx.start_tool_span(
+        tool_name="sys_session_send",
+        tool_args={"agent": "worker", "input": "do work"},
+    )
+    traceparent = traceparent_from_span(parent_tool)
+    assert traceparent is not None
+    parent_ctx.end_tool_span(parent_tool, result={"status": "launching"})
+    parent_ctx.end_agent_span(parent_agent, response="launched")
+
+    adapter = ExecutorAdapter(
+        executor_factory=lambda: _NestedChildTraceExecutor(),
+        session_key="conv_child",
+    )
+    child_ctx = _NoInjectionTurnContext(response_id="resp_child_trace")
+    await adapter.run_turn(
+        CreateResponseRequest(
+            model="root-agent",
+            agent_name="worker",
+            input="child input",
+            parent_tool_traceparent=traceparent,
+        ),
+        child_ctx,  # type: ignore[arg-type]
+    )
+
+    spans = {span.name: span for span in in_memory_span_exporter.get_finished_spans()}
+    parent_tool_span = spans["tool:sys_session_send"]
+    child_agent_span = spans["agent:worker"]
+    child_tool_span = spans["tool:child_tool"]
+
+    assert child_agent_span.context.trace_id == parent_tool_span.context.trace_id
+    assert child_agent_span.parent is not None
+    assert child_agent_span.parent.span_id == parent_tool_span.context.span_id
+    assert child_tool_span.parent is not None
+    assert child_tool_span.parent.span_id == child_agent_span.context.span_id
+    assert child_agent_span.start_time < child_tool_span.start_time
+    assert child_agent_span.end_time > child_tool_span.end_time
+    attrs = dict(child_agent_span.attributes or {})
+    assert attrs["gen_ai.agent.name"] == "worker"
+    assert attrs["output.value"] == "child result"
+
+
 def test_translate_input_to_messages_reconstructs_full_history() -> None:
     """
     Role-keyed message items in ``input`` must round-trip back
@@ -1313,6 +1460,7 @@ async def test_stable_tool_executor_pops_queue_for_bare_tool_name() -> None:
             name: str,
             arguments: str,
             agent: str,
+            traceparent: str | None = None,
         ) -> str:
             """Record the call_id then return a benign payload.
 
@@ -1323,7 +1471,7 @@ async def test_stable_tool_executor_pops_queue_for_bare_tool_name() -> None:
             :returns: Empty JSON object so
                 ``_bridge_one_dispatch`` can decode.
             """
-            del name, arguments, agent
+            del name, arguments, agent, traceparent
             captured_call_ids.append(call_id)
             return "{}"
 
@@ -1437,6 +1585,7 @@ async def test_observed_and_dispatched_call_ids_match_for_openai_agents() -> Non
             name: str,
             arguments: str,
             agent: str,
+            traceparent: str | None = None,
         ) -> str:
             """
             Record the call_id and return a benign payload.
@@ -1452,7 +1601,7 @@ async def test_observed_and_dispatched_call_ids_match_for_openai_agents() -> Non
             :returns: ``"{}"`` so the inner SDK can decode it as
                 JSON without errors.
             """
-            del name, arguments, agent
+            del name, arguments, agent, traceparent
             captured_dispatched_call_ids.append(call_id)
             return "{}"
 
@@ -1476,7 +1625,7 @@ async def test_observed_and_dispatched_call_ids_match_for_openai_agents() -> Non
 @pytest.mark.asyncio
 async def test_executor_adapter_builds_config_from_request() -> None:
     """Forwards request controls but not agent name as executor model."""
-    from omnigent.inner.executor import Executor, ExecutorConfig, Message, ToolSpec, TurnComplete
+    from omnigent.inner.executor import Executor, TurnComplete
     from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
     from omnigent.runtime.harnesses._scaffold import TurnContext
     from omnigent.server.schemas import CreateResponseRequest
@@ -1527,7 +1676,7 @@ async def test_executor_adapter_forwards_model_override_to_config() -> None:
     Without this, every harness-backed agent silently ignores
     ``/model``.
     """
-    from omnigent.inner.executor import Executor, ExecutorConfig, Message, ToolSpec, TurnComplete
+    from omnigent.inner.executor import Executor, TurnComplete
     from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
     from omnigent.runtime.harnesses._scaffold import TurnContext
     from omnigent.server.schemas import CreateResponseRequest

--- a/tests/runtime/test_subagent_span_nesting.py
+++ b/tests/runtime/test_subagent_span_nesting.py
@@ -1,0 +1,398 @@
+"""
+Tests for sub-agent span nesting across the dispatch boundary.
+
+Covers the contract that a child session's agent span nests under the
+parent's dispatching ``tool:sys_session_send`` span (same trace) and
+survives the edge cases: parent completing before the child, tracing
+off, content capture off, and re-sends. Exercises the production
+pieces individually — the telemetry traceparent helpers, the executor
+adapter's dispatch-side capture, the scaffold's action_required item
+stamping, and the runner's per-child stash — plus the full nested
+export shape via an in-memory OTel exporter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from omnigent.inner.tracing import (
+    TracingContext,
+    disable_tracing,
+    enable_tracing,
+    is_tracing_enabled,
+)
+from omnigent.runtime.telemetry import (
+    trace_context_from_traceparent,
+    traceparent_from_span,
+)
+
+
+@pytest.fixture
+def exporter() -> Iterator[InMemorySpanExporter]:
+    """
+    Install a fresh TracerProvider with an in-memory exporter for one
+    test, restoring the previous provider on teardown (OTel's set-once
+    semantics would otherwise leak into later tests).
+    """
+    previous = otel_trace._TRACER_PROVIDER  # type: ignore[attr-defined]
+    previous_done = otel_trace._TRACER_PROVIDER_SET_ONCE._done  # type: ignore[attr-defined]
+    tracing_was_enabled = is_tracing_enabled()
+    in_mem = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(in_mem))
+    otel_trace._TRACER_PROVIDER = provider  # type: ignore[attr-defined]
+    otel_trace._TRACER_PROVIDER_SET_ONCE._done = True  # type: ignore[attr-defined]
+    enable_tracing()
+    try:
+        yield in_mem
+    finally:
+        in_mem.clear()
+        with contextlib.suppress(Exception):
+            provider.shutdown()
+        otel_trace._TRACER_PROVIDER = previous  # type: ignore[attr-defined]
+        otel_trace._TRACER_PROVIDER_SET_ONCE._done = previous_done  # type: ignore[attr-defined]
+        # Restore the global tracing flag — leaving it enabled would make
+        # unrelated tests in the same process build real trace contexts
+        # (and choke on non-hex response ids).
+        if tracing_was_enabled:
+            enable_tracing()
+        else:
+            disable_tracing()
+
+
+def _expected_traceparent(span_ctx) -> str:  # type: ignore[no-untyped-def]
+    """W3C traceparent for a SpanContext; flags come from the SDK (the
+    provider may set the random-trace-id bit, yielding 03 not 01)."""
+    return f"00-{span_ctx.trace_id:032x}-{span_ctx.span_id:016x}-{int(span_ctx.trace_flags):02x}"
+
+
+# ---
+# traceparent helpers
+# ---
+
+
+def test_traceparent_from_span_round_trips_ids(exporter: InMemorySpanExporter) -> None:
+    ctx = TracingContext()
+    span = ctx.start_agent_span(agent_name="a", user_message="hi")
+    tp = traceparent_from_span(span)
+    ctx.end_agent_span(span, response="done")
+
+    span_ctx = span.get_span_context()
+    assert tp == _expected_traceparent(span_ctx)
+
+
+def test_traceparent_from_span_invalid_context_returns_none() -> None:
+    from opentelemetry.trace import INVALID_SPAN
+
+    assert traceparent_from_span(INVALID_SPAN) is None
+
+
+def test_trace_context_from_traceparent_nests_new_spans(
+    exporter: InMemorySpanExporter,
+) -> None:
+    remote_trace_id = "0af7651916cd43dd8448eb211c80319c"
+    remote_span_id = "b7ad6b7169203331"
+    with trace_context_from_traceparent(f"00-{remote_trace_id}-{remote_span_id}-01"):
+        ctx = TracingContext()
+        span = ctx.start_agent_span(agent_name="child", user_message="go")
+        ctx.end_agent_span(span, response="ok")
+
+    (exported,) = exporter.get_finished_spans()
+    assert format(exported.context.trace_id, "032x") == remote_trace_id
+    assert exported.parent is not None
+    assert format(exported.parent.span_id, "016x") == remote_span_id
+
+
+def test_trace_context_from_traceparent_garbage_roots_fresh_trace(
+    exporter: InMemorySpanExporter,
+) -> None:
+    with trace_context_from_traceparent("not-a-traceparent"):
+        ctx = TracingContext()
+        span = ctx.start_agent_span(agent_name="child", user_message="go")
+        ctx.end_agent_span(span, response="ok")
+
+    (exported,) = exporter.get_finished_spans()
+    assert exported.context.trace_id != 0
+    assert exported.parent is None
+
+
+# ---
+# parent completes before the child
+# ---
+
+
+def test_parent_completion_before_child_still_exports_nested(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """
+    The tool span ends at launch and the parent agent span can end
+    before the child runs; the child agent span still exports with the
+    ended tool span as its remote parent (OTel allows children of
+    ended parents via a remote SpanContext).
+    """
+    parent_ctx = TracingContext(session_id="conv_parent")
+    parent_agent = parent_ctx.start_agent_span(agent_name="parent", user_message="dispatch")
+    parent_tool = parent_ctx.start_tool_span("sys_session_send", {"agent": "worker"})
+    tp = traceparent_from_span(parent_tool)
+    assert tp is not None
+    parent_ctx.end_tool_span(parent_tool, result="launching", parent_span=parent_agent)
+    parent_ctx.end_agent_span(parent_agent, response="dispatched")
+
+    # Parent's spans are fully exported before the child starts.
+    assert {s.name for s in exporter.get_finished_spans()} == {
+        "agent:parent",
+        "tool:sys_session_send",
+    }
+
+    with trace_context_from_traceparent(tp):
+        child_ctx = TracingContext(session_id="conv_child")
+        child_agent = child_ctx.start_agent_span(agent_name="worker", user_message="go")
+        child_tool = child_ctx.start_tool_span("child_tool", {"x": 1})
+        child_ctx.end_tool_span(child_tool, result="ok", parent_span=child_agent)
+        child_ctx.end_agent_span(child_agent, response="did work")
+
+    spans = {s.name: s for s in exporter.get_finished_spans()}
+    tool_span = spans["tool:sys_session_send"]
+    child_agent_span = spans["agent:worker"]
+    child_tool_span = spans["tool:child_tool"]
+    assert child_agent_span.context.trace_id == tool_span.context.trace_id
+    assert child_agent_span.parent is not None
+    assert child_agent_span.parent.span_id == tool_span.context.span_id
+    assert child_tool_span.parent is not None
+    assert child_tool_span.parent.span_id == child_agent_span.context.span_id
+    # The tool span closed at launch — before the child agent span —
+    # and there is exactly one child agent span (no second wrapper).
+    assert tool_span.end_time < child_agent_span.end_time
+    assert len([s for s in spans.values() if s.name == "agent:worker"]) == 1
+
+
+def test_resend_nests_each_child_turn_under_its_own_tool_span(
+    exporter: InMemorySpanExporter,
+) -> None:
+    parent_ctx = TracingContext(session_id="conv_parent")
+    parent_agent = parent_ctx.start_agent_span(agent_name="parent", user_message="dispatch")
+
+    traceparents: list[str] = []
+    for _ in range(2):
+        tool = parent_ctx.start_tool_span("sys_session_send", {"agent": "worker"})
+        tp = traceparent_from_span(tool)
+        assert tp is not None
+        traceparents.append(tp)
+        parent_ctx.end_tool_span(tool, result="launching", parent_span=parent_agent)
+    parent_ctx.end_agent_span(parent_agent, response="done")
+
+    for turn, tp in enumerate(traceparents):
+        with trace_context_from_traceparent(tp):
+            child_ctx = TracingContext(session_id="conv_child")
+            span = child_ctx.start_agent_span(agent_name="worker", user_message=f"turn {turn}")
+            child_ctx.end_agent_span(span, response=f"result {turn}")
+
+    tool_span_ids = [
+        s.context.span_id
+        for s in exporter.get_finished_spans()
+        if s.name == "tool:sys_session_send"
+    ]
+    child_parent_ids = [
+        s.parent.span_id
+        for s in exporter.get_finished_spans()
+        if s.name == "agent:worker" and s.parent is not None
+    ]
+    assert sorted(child_parent_ids) == sorted(tool_span_ids)
+
+
+# ---
+# content capture off
+# ---
+
+
+def test_content_capture_off_child_still_nests_without_payloads(
+    exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("omnigent.runtime.telemetry._capture_content", False)
+
+    parent_ctx = TracingContext()
+    parent_tool = parent_ctx.start_tool_span("sys_session_send", {"agent": "worker"})
+    tp = traceparent_from_span(parent_tool)
+    assert tp is not None
+    parent_ctx.end_tool_span(parent_tool, result="launching")
+
+    with trace_context_from_traceparent(tp):
+        child_ctx = TracingContext()
+        span = child_ctx.start_agent_span(agent_name="worker", user_message="secret")
+        child_ctx.end_agent_span(span, response="secret result")
+
+    spans = {s.name: s for s in exporter.get_finished_spans()}
+    child_agent_span = spans["agent:worker"]
+    tool_span = spans["tool:sys_session_send"]
+    assert child_agent_span.parent is not None
+    assert child_agent_span.parent.span_id == tool_span.context.span_id
+    attrs = dict(child_agent_span.attributes or {})
+    assert "input.value" not in attrs
+    assert "output.value" not in attrs
+
+
+# ---
+# adapter dispatch-side traceparent capture
+# ---
+
+
+def _adapter_with_tracing(tctx: TracingContext):  # type: ignore[no-untyped-def]
+    from omnigent.inner.executor import MockExecutor
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=MockExecutor)
+    adapter._tracing_ctx = tctx
+    return adapter
+
+
+def test_dispatch_traceparent_prefers_matching_tool_span(
+    exporter: InMemorySpanExporter,
+) -> None:
+    tctx = TracingContext()
+    agent = tctx.start_agent_span(agent_name="parent", user_message="hi")
+    tool = tctx.start_tool_span("sys_session_send", {"agent": "worker"})
+    adapter = _adapter_with_tracing(tctx)
+
+    tp = adapter._dispatch_traceparent("sys_session_send")
+
+    tool_ctx = tool.get_span_context()
+    assert tp == _expected_traceparent(tool_ctx)
+    tctx.end_tool_span(tool, result="ok", parent_span=agent)
+    tctx.end_agent_span(agent, response="done")
+
+
+def test_dispatch_traceparent_falls_back_to_agent_span(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """A mismatched current span (dispatch raced ahead, or a parallel
+    tool moved the cursor) falls back to the turn's agent span."""
+    tctx = TracingContext()
+    agent = tctx.start_agent_span(agent_name="parent", user_message="hi")
+    other_tool = tctx.start_tool_span("sys_os_shell", {"cmd": "ls"})
+    adapter = _adapter_with_tracing(tctx)
+
+    tp = adapter._dispatch_traceparent("sys_session_send")
+
+    agent_ctx = agent.get_span_context()
+    assert tp == _expected_traceparent(agent_ctx)
+    tctx.end_tool_span(other_tool, result="ok", parent_span=agent)
+    tctx.end_agent_span(agent, response="done")
+
+
+def test_dispatch_traceparent_none_for_non_spawning_tool(
+    exporter: InMemorySpanExporter,
+) -> None:
+    tctx = TracingContext()
+    agent = tctx.start_agent_span(agent_name="parent", user_message="hi")
+    adapter = _adapter_with_tracing(tctx)
+
+    assert adapter._dispatch_traceparent("sys_os_shell") is None
+    tctx.end_agent_span(agent, response="done")
+
+
+def test_dispatch_traceparent_none_when_tracing_inactive() -> None:
+    from omnigent.inner.executor import MockExecutor
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=MockExecutor)
+    assert adapter._dispatch_traceparent("sys_session_send") is None
+
+
+# ---
+# scaffold action_required item stamping
+# ---
+
+
+def _make_turn_context():  # type: ignore[no-untyped-def]
+    from omnigent.runtime.harnesses._scaffold import TurnContext
+
+    queue: asyncio.Queue = asyncio.Queue()
+    return TurnContext(
+        response_id="resp_test",
+        event_queue=queue,
+        cancelled=asyncio.Event(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_stamps_traceparent_on_action_required_item() -> None:
+    ctx = _make_turn_context()
+    task = asyncio.create_task(
+        ctx.dispatch_tool(
+            call_id="call_1",
+            name="sys_session_send",
+            arguments="{}",
+            agent="parent",
+            traceparent="00-" + "a" * 32 + "-" + "b" * 16 + "-01",
+        )
+    )
+    event = await asyncio.wait_for(ctx._event_queue.get(), timeout=2)
+    assert event.item["traceparent"] == "00-" + "a" * 32 + "-" + "b" * 16 + "-01"
+    ctx._pending_tool_calls["call_1"].set_result("ok")
+    assert await asyncio.wait_for(task, timeout=2) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_omits_traceparent_when_absent() -> None:
+    ctx = _make_turn_context()
+    task = asyncio.create_task(
+        ctx.dispatch_tool(call_id="call_2", name="sys_os_shell", arguments="{}", agent="parent")
+    )
+    event = await asyncio.wait_for(ctx._event_queue.get(), timeout=2)
+    assert "traceparent" not in event.item
+    ctx._pending_tool_calls["call_2"].set_result("ok")
+    await asyncio.wait_for(task, timeout=2)
+
+
+# ---
+# runner-side extraction + stash
+# ---
+
+
+def test_get_item_traceparent_extracts_string() -> None:
+    from omnigent.runner.tool_dispatch import get_item_traceparent
+
+    tp = "00-" + "a" * 32 + "-" + "b" * 16 + "-01"
+    assert get_item_traceparent({"item": {"traceparent": tp}}) == tp
+    assert get_item_traceparent({"item": {}}) is None
+    assert get_item_traceparent({"item": {"traceparent": ""}}) is None
+    assert get_item_traceparent({"item": {"traceparent": 42}}) is None
+    assert get_item_traceparent({}) is None
+
+
+def test_stash_and_pop_child_turn_traceparent() -> None:
+    from omnigent.runner import app as runner_app
+
+    tp = "00-" + "c" * 32 + "-" + "d" * 16 + "-01"
+    runner_app.stash_child_turn_traceparent("conv_child_x", tp)
+    assert runner_app.pop_child_turn_traceparent("conv_child_x") == tp
+    # Consumed — a second (non-dispatched) turn gets nothing.
+    assert runner_app.pop_child_turn_traceparent("conv_child_x") is None
+
+
+def test_restash_overwrites_previous_traceparent() -> None:
+    from omnigent.runner import app as runner_app
+
+    first = "00-" + "1" * 32 + "-" + "1" * 16 + "-01"
+    runner_app.stash_child_turn_traceparent("conv_child_y", first)
+    replacement = "00-" + "2" * 32 + "-" + "2" * 16 + "-01"
+    runner_app.stash_child_turn_traceparent("conv_child_y", replacement)
+    assert runner_app.pop_child_turn_traceparent("conv_child_y") == replacement
+
+
+def test_unregister_child_session_clears_pending_traceparent() -> None:
+    from omnigent.runner import app as runner_app
+
+    traceparent = "00-" + "3" * 32 + "-" + "3" * 16 + "-01"
+    runner_app.stash_child_turn_traceparent("conv_child_z", traceparent)
+    runner_app.unregister_child_session("conv_child_z")
+    assert runner_app.pop_child_turn_traceparent("conv_child_z") is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes the Omnigent telemetry gap where sub-agent turns rooted a separate trace instead of appearing under the parent `tool:sys_session_send` dispatch. The runner now carries the dispatching tool span's W3C traceparent through local tool dispatch into the child harness request, and the child adapter uses that remote parent context for its agent span while preserving real child execution duration and output capture.

ELI5: when a parent asks a child agent to do work, the trace now shows the child work inside that exact ask, even if the parent already moved on.

```mermaid
graph TD
  A[agent:parent] --> B[tool:sys_session_send]
  B --> C[agent:worker]
  C --> D[tool:child_tool]
```

## Test Plan

- `uv run pytest -q tests/runtime/test_subagent_span_nesting.py tests/runtime/harnesses/test_executor_adapter.py tests/inner/test_tracing_genai_semconv.py`
- `uv run pytest -q tests/runner/test_runner_dispatch.py -k "sys_session_send and (completion_drains or inbox_cleanup or reuses_existing_child_session or session_id_posts_to_direct_child or model_lands)"`
- `uv run pre-commit run --all-files`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

## Changelog

Sub-agent telemetry traces now nest child agent work under the parent dispatch tool.