### PR TITLE
fix(electron): repair the Electron Build workflow

### DIFF
--- a/web/electron/package-lock.json
+++ b/web/electron/package-lock.json
@@ -17,7 +17,7 @@
     },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@electron/asar/-/asar-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
       "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
       "dev": true,
       "license": "MIT",
@@ -35,14 +35,14 @@
     },
     "node_modules/@electron/asar/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
       "version": "1.1.15",
-      "resolved": "https://npm-proxy.cloud.databricks.com/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
@@ -53,7 +53,7 @@
     },
     "node_modules/@electron/asar/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
@@ -66,7 +66,7 @@
     },
     "node_modules/@electron/fuses": {
       "version": "1.8.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@electron/fuses/-/fuses-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
@@ -81,7 +81,7 @@
     },
     "node_modules/@electron/fuses/node_modules/fs-extra": {
       "version": "9.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs-extra/-/fs-extra-9.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "license": "MIT",
@@ -97,7 +97,7 @@
     },
     "node_modules/@electron/get": {
       "version": "5.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@electron/get/-/get-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
       "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
@@ -118,7 +118,7 @@
     },
     "node_modules/@electron/notarize": {
       "version": "2.5.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@electron/notarize/-/notarize-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
       "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
       "dev": true,
       "license": "MIT",
@@ -133,7 +133,7 @@
     },
     "node_modules/@electron/notarize/node_modules/fs-extra": {
       "version": "9.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs-extra/-/fs-extra-9.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "license": "MIT",
@@ -149,7 +149,7 @@
     },
     "node_modules/@electron/osx-sign": {
       "version": "1.3.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
       "integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -171,7 +171,7 @@
     },
     "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
       "version": "4.0.10",
-      "resolved": "https://npm-proxy.cloud.databricks.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
       "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
       "dev": true,
       "license": "MIT",
@@ -184,7 +184,7 @@
     },
     "node_modules/@electron/rebuild": {
       "version": "4.0.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@electron/rebuild/-/rebuild-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
       "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
       "dev": true,
       "license": "MIT",
@@ -205,7 +205,7 @@
     },
     "node_modules/@electron/universal": {
       "version": "2.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@electron/universal/-/universal-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
       "integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
       "dev": true,
       "license": "MIT",
@@ -224,14 +224,14 @@
     },
     "node_modules/@electron/universal/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
       "version": "2.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
       "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
@@ -241,7 +241,7 @@
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
       "version": "11.3.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs-extra/-/fs-extra-11.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
       "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
@@ -256,7 +256,7 @@
     },
     "node_modules/@electron/universal/node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
@@ -272,7 +272,7 @@
     },
     "node_modules/@electron/windows-sign": {
       "version": "1.2.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
       "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -294,7 +294,7 @@
     },
     "node_modules/@electron/windows-sign/node_modules/fs-extra": {
       "version": "11.3.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs-extra/-/fs-extra-11.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
       "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
@@ -311,7 +311,7 @@
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
       "license": "ISC",
@@ -324,7 +324,7 @@
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
       "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
       "dev": true,
       "funding": [
@@ -347,7 +347,7 @@
     },
     "node_modules/@malept/flatpak-bundler": {
       "version": "0.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
       "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
       "dev": true,
       "license": "MIT",
@@ -363,7 +363,7 @@
     },
     "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
       "version": "9.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs-extra/-/fs-extra-9.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "license": "MIT",
@@ -379,7 +379,7 @@
     },
     "node_modules/@noble/hashes": {
       "version": "2.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@noble/hashes/-/hashes-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "dev": true,
       "license": "MIT",
@@ -392,7 +392,7 @@
     },
     "node_modules/@peculiar/asn1-schema": {
       "version": "2.7.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
       "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
       "dev": true,
       "license": "MIT",
@@ -404,7 +404,7 @@
     },
     "node_modules/@peculiar/json-schema": {
       "version": "1.1.12",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
       "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
       "dev": true,
       "license": "MIT",
@@ -417,7 +417,7 @@
     },
     "node_modules/@peculiar/utils": {
       "version": "2.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@peculiar/utils/-/utils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
       "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
       "dev": true,
       "license": "MIT",
@@ -427,7 +427,7 @@
     },
     "node_modules/@peculiar/webcrypto": {
       "version": "1.7.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
       "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
       "dev": true,
       "license": "MIT",
@@ -444,7 +444,7 @@
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@sindresorhus/is/-/is-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
       "license": "MIT",
@@ -457,7 +457,7 @@
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "dev": true,
       "license": "MIT",
@@ -470,7 +470,7 @@
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "dev": true,
       "license": "MIT",
@@ -483,7 +483,7 @@
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@types/debug/-/debug-4.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "dev": true,
       "license": "MIT",
@@ -493,7 +493,7 @@
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
       "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
       "dev": true,
       "license": "MIT",
@@ -503,14 +503,14 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@types/keyv/-/keyv-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dev": true,
       "license": "MIT",
@@ -520,14 +520,14 @@
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@types/ms/-/ms-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.13.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@types/node/-/node-24.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
       "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
       "dev": true,
       "license": "MIT",
@@ -537,7 +537,7 @@
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@types/responselike/-/responselike-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
       "license": "MIT",
@@ -547,7 +547,7 @@
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
       "license": "MIT",
@@ -558,7 +558,7 @@
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
       "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
@@ -568,7 +568,7 @@
     },
     "node_modules/abbrev": {
       "version": "4.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/abbrev/-/abbrev-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
       "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
       "license": "ISC",
@@ -578,7 +578,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/agent-base/-/agent-base-7.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
@@ -588,7 +588,7 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
@@ -605,7 +605,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
@@ -615,7 +615,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
@@ -631,7 +631,7 @@
     },
     "node_modules/app-builder-lib": {
       "version": "26.15.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/app-builder-lib/-/app-builder-lib-26.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.2.tgz",
       "integrity": "sha512-3mYfKOjr/ZY7gFESOcq8kylBMgGPpmlQYnpBVit4p6zIg0t/8bkWBILdMMtnjFyN2jllyBf225T8dLlz3D6oBQ==",
       "dev": true,
       "license": "MIT",
@@ -688,7 +688,7 @@
     },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
       "version": "3.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@electron/get/-/get-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
       "integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
       "dev": true,
       "license": "MIT",
@@ -710,7 +710,7 @@
     },
     "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs-extra/-/fs-extra-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "license": "MIT",
@@ -725,7 +725,7 @@
     },
     "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -735,7 +735,7 @@
     },
     "node_modules/app-builder-lib/node_modules/ci-info": {
       "version": "4.3.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/ci-info/-/ci-info-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
       "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
       "dev": true,
       "funding": [
@@ -751,7 +751,7 @@
     },
     "node_modules/app-builder-lib/node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/env-paths/-/env-paths-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
@@ -761,7 +761,7 @@
     },
     "node_modules/app-builder-lib/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
@@ -771,7 +771,7 @@
     },
     "node_modules/app-builder-lib/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -784,7 +784,7 @@
     },
     "node_modules/app-builder-lib/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
@@ -794,13 +794,13 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/argparse/-/argparse-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
     "node_modules/asn1js": {
       "version": "3.0.10",
-      "resolved": "https://npm-proxy.cloud.databricks.com/asn1js/-/asn1js-3.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
       "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -815,14 +815,14 @@
     },
     "node_modules/async": {
       "version": "3.2.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/async/-/async-3.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/async-exit-hook": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
       "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
       "dev": true,
       "license": "MIT",
@@ -832,14 +832,14 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/at-least-node/-/at-least-node-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true,
       "license": "ISC",
@@ -849,14 +849,14 @@
     },
     "node_modules/aws4": {
       "version": "1.13.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/aws4/-/aws4-1.13.2.tgz",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -866,7 +866,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true,
       "funding": [
@@ -887,14 +887,14 @@
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/bluebird/-/bluebird-3.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/boolean": {
       "version": "3.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/boolean/-/boolean-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
@@ -903,7 +903,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
@@ -916,7 +916,7 @@
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://npm-proxy.cloud.databricks.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
       "license": "MIT",
@@ -926,14 +926,14 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/buffer-from/-/buffer-from-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/builder-util": {
       "version": "26.15.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/builder-util/-/builder-util-26.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.0.tgz",
       "integrity": "sha512-dUx+HxVbiNsNQ4mGe1PyoC/tBmsHwBNDLdBuqWCj+rhHFE9lHgrXiGYKAM1uNlznhAaUSyMlms84VeSSr3gOBA==",
       "dev": true,
       "license": "MIT",
@@ -959,7 +959,7 @@
     },
     "node_modules/builder-util-runtime": {
       "version": "9.7.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
       "dev": true,
       "license": "MIT",
@@ -973,7 +973,7 @@
     },
     "node_modules/bytestreamjs": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
       "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -983,7 +983,7 @@
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "dev": true,
       "license": "MIT",
@@ -993,7 +993,7 @@
     },
     "node_modules/cacheable-request": {
       "version": "7.0.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dev": true,
       "license": "MIT",
@@ -1012,7 +1012,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
@@ -1026,7 +1026,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -1043,7 +1043,7 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/chownr/-/chownr-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -1053,14 +1053,14 @@
     },
     "node_modules/chromium-pickle-js": {
       "version": "0.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/ci-info/-/ci-info-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
       "funding": [
@@ -1076,7 +1076,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
@@ -1091,7 +1091,7 @@
     },
     "node_modules/clone-response": {
       "version": "1.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/clone-response/-/clone-response-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "dev": true,
       "license": "MIT",
@@ -1104,7 +1104,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
@@ -1117,14 +1117,14 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://npm-proxy.cloud.databricks.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "license": "MIT",
@@ -1137,7 +1137,7 @@
     },
     "node_modules/commander": {
       "version": "5.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/commander/-/commander-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true,
       "license": "MIT",
@@ -1147,7 +1147,7 @@
     },
     "node_modules/compare-version": {
       "version": "0.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/compare-version/-/compare-version-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
       "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
       "dev": true,
       "license": "MIT",
@@ -1157,21 +1157,21 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/core-util-is/-/core-util-is-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
@@ -1180,7 +1180,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -1195,14 +1195,14 @@
     },
     "node_modules/cross-spawn/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -1218,7 +1218,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -1236,7 +1236,7 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/decompress-response/-/decompress-response-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
       "license": "MIT",
@@ -1252,7 +1252,7 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/mimic-response/-/mimic-response-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
       "license": "MIT",
@@ -1265,7 +1265,7 @@
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true,
       "license": "MIT",
@@ -1275,7 +1275,7 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
@@ -1294,7 +1294,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/define-properties/-/define-properties-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "license": "MIT",
@@ -1313,7 +1313,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "license": "MIT",
@@ -1323,7 +1323,7 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/detect-node/-/detect-node-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT",
@@ -1331,7 +1331,7 @@
     },
     "node_modules/dir-compare": {
       "version": "4.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/dir-compare/-/dir-compare-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
       "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
       "dev": true,
       "license": "MIT",
@@ -1342,14 +1342,14 @@
     },
     "node_modules/dir-compare/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
       "version": "1.1.15",
-      "resolved": "https://npm-proxy.cloud.databricks.com/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
@@ -1360,7 +1360,7 @@
     },
     "node_modules/dir-compare/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
@@ -1373,7 +1373,7 @@
     },
     "node_modules/dmg-builder": {
       "version": "26.15.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/dmg-builder/-/dmg-builder-26.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.2.tgz",
       "integrity": "sha512-fMkjRqKyPtsz4Kzu/qGP0BGjqzMCIgp+/7kw/u6YH6lvn/8hvL3c0TXhoFayBoYdpPCnEinnCHztd4bW7/jetA==",
       "dev": true,
       "license": "MIT",
@@ -1386,7 +1386,7 @@
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/dotenv/-/dotenv-16.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1399,7 +1399,7 @@
     },
     "node_modules/dotenv-expand": {
       "version": "11.0.7",
-      "resolved": "https://npm-proxy.cloud.databricks.com/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
       "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1415,7 +1415,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
@@ -1430,7 +1430,7 @@
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1440,7 +1440,7 @@
     },
     "node_modules/ejs": {
       "version": "3.1.10",
-      "resolved": "https://npm-proxy.cloud.databricks.com/ejs/-/ejs-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
       "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1456,7 +1456,7 @@
     },
     "node_modules/electron": {
       "version": "42.3.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/electron/-/electron-42.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.3.3.tgz",
       "integrity": "sha512-0MwYp9wTb7TrtTalOYqeW+suqd9T/Znstr/nDLKqFGIjHdBZX339guo3mQqTPURRZ/UQmYM4uMpzKpI5wLptfQ==",
       "dev": true,
       "license": "MIT",
@@ -1475,7 +1475,7 @@
     },
     "node_modules/electron-builder": {
       "version": "26.15.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/electron-builder/-/electron-builder-26.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.2.tgz",
       "integrity": "sha512-veKM9+dCljaC5A74Pwc0ZWQ9arOHREXWh9hUIf8NGg49ch7x+IB4QhbMzIrV5ONZIXM2OEkaxW11cAPjPtoi4A==",
       "dev": true,
       "license": "MIT",
@@ -1501,7 +1501,7 @@
     },
     "node_modules/electron-builder-squirrel-windows": {
       "version": "26.15.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.2.tgz",
       "integrity": "sha512-PNl+SSRoma9mXhxycNGxutZPgvmK19v41mn8F9oecpAU2QNAldpB4HfMuA1LwFC2j8aRzzV5M9HKlKe6dfpvNw==",
       "dev": true,
       "license": "MIT",
@@ -1514,7 +1514,7 @@
     },
     "node_modules/electron-publish": {
       "version": "26.15.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/electron-publish/-/electron-publish-26.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.1.tgz",
       "integrity": "sha512-BMgMHOyexWn0UnOC+Afffw0DMrr0yfLp4U8YsLXwoJ3Da7LS7WUnz21teYZqO0gaApE1KgsjREWmbPqvF5JcPg==",
       "dev": true,
       "license": "MIT",
@@ -1532,7 +1532,7 @@
     },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
       "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
       "dev": true,
       "hasInstallScript": true,
@@ -1554,7 +1554,7 @@
     },
     "node_modules/electron-winstaller/node_modules/fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs-extra/-/fs-extra-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
@@ -1570,7 +1570,7 @@
     },
     "node_modules/electron-winstaller/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
@@ -1581,7 +1581,7 @@
     },
     "node_modules/electron-winstaller/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
@@ -1592,14 +1592,14 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "license": "MIT",
@@ -1609,7 +1609,7 @@
     },
     "node_modules/env-paths": {
       "version": "3.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/env-paths/-/env-paths-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
       "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "dev": true,
       "license": "MIT",
@@ -1622,14 +1622,14 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/err-code/-/err-code-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
@@ -1639,7 +1639,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
@@ -1649,7 +1649,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
@@ -1662,7 +1662,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
@@ -1678,7 +1678,7 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/es6-error/-/es6-error-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "license": "MIT",
@@ -1686,7 +1686,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
@@ -1696,7 +1696,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -1710,14 +1710,14 @@
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/extract-zip/-/extract-zip-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1738,14 +1738,14 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fast-uri/-/fast-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
@@ -1762,7 +1762,7 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "license": "MIT",
@@ -1772,7 +1772,7 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -1790,7 +1790,7 @@
     },
     "node_modules/filelist": {
       "version": "1.0.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/filelist/-/filelist-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
       "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1800,14 +1800,14 @@
     },
     "node_modules/filelist/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
       "version": "2.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
       "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
@@ -1817,7 +1817,7 @@
     },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-5.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
@@ -1847,7 +1847,7 @@
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs-extra/-/fs-extra-10.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
@@ -1862,14 +1862,14 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
@@ -1879,7 +1879,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
@@ -1889,7 +1889,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
@@ -1914,7 +1914,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
@@ -1928,7 +1928,7 @@
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/get-stream/-/get-stream-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
       "license": "MIT",
@@ -1944,7 +1944,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/glob/-/glob-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
@@ -1966,14 +1966,14 @@
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.15",
-      "resolved": "https://npm-proxy.cloud.databricks.com/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
@@ -1984,7 +1984,7 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
@@ -1997,7 +1997,7 @@
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/global-agent/-/global-agent-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2016,7 +2016,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/globalthis/-/globalthis-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "license": "MIT",
@@ -2034,7 +2034,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
@@ -2047,7 +2047,7 @@
     },
     "node_modules/got": {
       "version": "11.8.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/got/-/got-11.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "dev": true,
       "license": "MIT",
@@ -2073,14 +2073,14 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://npm-proxy.cloud.databricks.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
@@ -2090,7 +2090,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
@@ -2104,7 +2104,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
@@ -2117,7 +2117,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
@@ -2133,7 +2133,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
@@ -2146,7 +2146,7 @@
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
       "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
       "license": "ISC",
@@ -2159,14 +2159,14 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
@@ -2180,7 +2180,7 @@
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dev": true,
       "license": "MIT",
@@ -2194,7 +2194,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
@@ -2208,7 +2208,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
@@ -2220,14 +2220,14 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
@@ -2237,14 +2237,14 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
-      "resolved": "https://npm-proxy.cloud.databricks.com/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
       "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
       "dev": true,
       "license": "MIT",
@@ -2257,7 +2257,7 @@
     },
     "node_modules/isexe": {
       "version": "3.1.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/isexe/-/isexe-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
       "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2267,7 +2267,7 @@
     },
     "node_modules/jake": {
       "version": "10.9.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/jake/-/jake-10.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
       "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2285,7 +2285,7 @@
     },
     "node_modules/jiti": {
       "version": "2.7.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/jiti/-/jiti-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
@@ -2295,7 +2295,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/js-yaml/-/js-yaml-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "funding": [
         {
@@ -2317,21 +2317,21 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "license": "ISC",
@@ -2339,7 +2339,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
@@ -2352,7 +2352,7 @@
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/jsonfile/-/jsonfile-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
@@ -2365,7 +2365,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -2375,21 +2375,21 @@
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/lazy-val/-/lazy-val-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/lodash/-/lodash-4.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true,
       "license": "MIT",
@@ -2399,7 +2399,7 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/lru-cache/-/lru-cache-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "license": "ISC",
@@ -2412,7 +2412,7 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/matcher/-/matcher-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
       "license": "MIT",
@@ -2426,7 +2426,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
@@ -2436,7 +2436,7 @@
     },
     "node_modules/mime": {
       "version": "2.6.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/mime/-/mime-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
       "license": "MIT",
@@ -2449,7 +2449,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
@@ -2459,7 +2459,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://npm-proxy.cloud.databricks.com/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
@@ -2472,7 +2472,7 @@
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/mimic-response/-/mimic-response-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true,
       "license": "MIT",
@@ -2482,7 +2482,7 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-10.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2498,7 +2498,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
@@ -2508,7 +2508,7 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minipass/-/minipass-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2518,7 +2518,7 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minizlib/-/minizlib-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "license": "MIT",
@@ -2531,7 +2531,7 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/mkdirp/-/mkdirp-0.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
@@ -2545,14 +2545,14 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
       "version": "4.31.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/node-abi/-/node-abi-4.31.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
       "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
       "dev": true,
       "license": "MIT",
@@ -2565,7 +2565,7 @@
     },
     "node_modules/node-api-version": {
       "version": "0.2.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/node-api-version/-/node-api-version-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
       "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
       "dev": true,
       "license": "MIT",
@@ -2575,7 +2575,7 @@
     },
     "node_modules/node-gyp": {
       "version": "12.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/node-gyp/-/node-gyp-12.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
       "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
       "dev": true,
       "license": "MIT",
@@ -2600,7 +2600,7 @@
     },
     "node_modules/node-gyp/node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/env-paths/-/env-paths-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
@@ -2610,7 +2610,7 @@
     },
     "node_modules/node-gyp/node_modules/isexe": {
       "version": "4.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/isexe/-/isexe-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
       "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2630,7 +2630,7 @@
     },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/which/-/which-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
       "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dev": true,
       "license": "ISC",
@@ -2646,14 +2646,14 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
       "version": "9.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/nopt/-/nopt-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
       "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "license": "ISC",
@@ -2669,7 +2669,7 @@
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/normalize-url/-/normalize-url-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true,
       "license": "MIT",
@@ -2682,7 +2682,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
       "license": "MIT",
@@ -2693,7 +2693,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
@@ -2703,7 +2703,7 @@
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true,
       "license": "MIT",
@@ -2713,7 +2713,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -2729,7 +2729,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "license": "MIT",
@@ -2739,7 +2739,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -2749,7 +2749,7 @@
     },
     "node_modules/pe-library": {
       "version": "0.4.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/pe-library/-/pe-library-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
       "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
       "dev": true,
       "license": "MIT",
@@ -2764,21 +2764,21 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -2791,7 +2791,7 @@
     },
     "node_modules/pkijs": {
       "version": "3.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/pkijs/-/pkijs-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
       "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2809,7 +2809,7 @@
     },
     "node_modules/pkijs/node_modules/@noble/hashes": {
       "version": "1.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/@noble/hashes/-/hashes-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "dev": true,
       "license": "MIT",
@@ -2822,7 +2822,7 @@
     },
     "node_modules/plist": {
       "version": "3.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/plist/-/plist-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
       "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
       "dev": true,
       "license": "MIT",
@@ -2837,7 +2837,7 @@
     },
     "node_modules/postject": {
       "version": "1.0.0-alpha.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/postject/-/postject-1.0.0-alpha.6.tgz",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
       "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
       "dev": true,
       "license": "MIT",
@@ -2855,7 +2855,7 @@
     },
     "node_modules/postject/node_modules/commander": {
       "version": "9.5.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/commander/-/commander-9.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true,
       "license": "MIT",
@@ -2867,7 +2867,7 @@
     },
     "node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
@@ -2877,14 +2877,14 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "license": "MIT",
@@ -2894,7 +2894,7 @@
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/promise-retry/-/promise-retry-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
       "license": "MIT",
@@ -2908,7 +2908,7 @@
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
       "dev": true,
       "license": "MIT",
@@ -2920,7 +2920,7 @@
     },
     "node_modules/pump": {
       "version": "3.0.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/pump/-/pump-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
@@ -2931,7 +2931,7 @@
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
       "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
       "dev": true,
       "license": "MIT",
@@ -2941,7 +2941,7 @@
     },
     "node_modules/pvutils": {
       "version": "1.1.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/pvutils/-/pvutils-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
       "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
       "dev": true,
       "license": "MIT",
@@ -2951,7 +2951,7 @@
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/quick-lru/-/quick-lru-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
       "license": "MIT",
@@ -2964,7 +2964,7 @@
     },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
       "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
       "dev": true,
       "license": "MIT",
@@ -2977,7 +2977,7 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://npm-proxy.cloud.databricks.com/readable-stream/-/readable-stream-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
@@ -2993,7 +2993,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
@@ -3003,7 +3003,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
@@ -3013,7 +3013,7 @@
     },
     "node_modules/resedit": {
       "version": "1.7.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/resedit/-/resedit-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
       "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
       "dev": true,
       "license": "MIT",
@@ -3031,14 +3031,14 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/responselike": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/responselike/-/responselike-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "dev": true,
       "license": "MIT",
@@ -3051,7 +3051,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
       "license": "MIT",
@@ -3061,7 +3061,7 @@
     },
     "node_modules/rimraf": {
       "version": "2.6.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/rimraf/-/rimraf-2.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
@@ -3076,7 +3076,7 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/roarr/-/roarr-2.15.4.tgz",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3095,14 +3095,14 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
       "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "dev": true,
       "license": "WTFPL OR ISC",
@@ -3112,7 +3112,7 @@
     },
     "node_modules/sax": {
       "version": "1.6.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/sax/-/sax-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3122,7 +3122,7 @@
     },
     "node_modules/semver": {
       "version": "7.8.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/semver/-/semver-7.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
       "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "dev": true,
       "license": "ISC",
@@ -3135,7 +3135,7 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true,
       "license": "MIT",
@@ -3143,7 +3143,7 @@
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/serialize-error/-/serialize-error-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "dev": true,
       "license": "MIT",
@@ -3160,7 +3160,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -3173,7 +3173,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -3183,14 +3183,14 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://npm-proxy.cloud.databricks.com/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
       "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
       "dev": true,
       "license": "MIT",
@@ -3203,7 +3203,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3213,7 +3213,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
-      "resolved": "https://npm-proxy.cloud.databricks.com/source-map-support/-/source-map-support-0.5.21.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
@@ -3224,7 +3224,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3232,7 +3232,7 @@
     },
     "node_modules/stat-mode": {
       "version": "1.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/stat-mode/-/stat-mode-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
       "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
       "dev": true,
       "license": "MIT",
@@ -3242,7 +3242,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
@@ -3252,7 +3252,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
@@ -3267,7 +3267,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
@@ -3280,7 +3280,7 @@
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/sumchecker/-/sumchecker-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3293,7 +3293,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -3306,7 +3306,7 @@
     },
     "node_modules/tar": {
       "version": "7.5.16",
-      "resolved": "https://npm-proxy.cloud.databricks.com/tar/-/tar-7.5.16.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
       "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3323,7 +3323,7 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/yallist/-/yallist-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3333,7 +3333,7 @@
     },
     "node_modules/temp": {
       "version": "0.9.4",
-      "resolved": "https://npm-proxy.cloud.databricks.com/temp/-/temp-0.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
@@ -3348,7 +3348,7 @@
     },
     "node_modules/temp-file": {
       "version": "3.4.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/temp-file/-/temp-file-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
       "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
       "dev": true,
       "license": "MIT",
@@ -3359,7 +3359,7 @@
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
       "integrity": "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==",
       "dev": true,
       "license": "MIT",
@@ -3369,7 +3369,7 @@
     },
     "node_modules/tiny-async-pool/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/semver/-/semver-5.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "license": "ISC",
@@ -3379,7 +3379,7 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://npm-proxy.cloud.databricks.com/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
@@ -3396,7 +3396,7 @@
     },
     "node_modules/tmp": {
       "version": "0.2.7",
-      "resolved": "https://npm-proxy.cloud.databricks.com/tmp/-/tmp-0.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
       "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
@@ -3406,7 +3406,7 @@
     },
     "node_modules/tmp-promise": {
       "version": "3.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
       "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "dev": true,
       "license": "MIT",
@@ -3416,7 +3416,7 @@
     },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "dev": true,
       "license": "WTFPL",
@@ -3426,14 +3426,14 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/type-fest/-/type-fest-0.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
@@ -3458,14 +3458,14 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/undici-types/-/undici-types-7.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/universalify/-/universalify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
@@ -3475,7 +3475,7 @@
     },
     "node_modules/unzipper": {
       "version": "0.12.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/unzipper/-/unzipper-0.12.3.tgz",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
       "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
       "dev": true,
       "license": "MIT",
@@ -3489,7 +3489,7 @@
     },
     "node_modules/unzipper/node_modules/fs-extra": {
       "version": "11.3.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/fs-extra/-/fs-extra-11.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
       "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
@@ -3504,21 +3504,21 @@
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "dev": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/webcrypto-core": {
       "version": "1.9.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
       "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
       "dev": true,
       "license": "MIT",
@@ -3532,7 +3532,7 @@
     },
     "node_modules/which": {
       "version": "5.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/which/-/which-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
       "license": "ISC",
@@ -3548,7 +3548,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
@@ -3566,14 +3566,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true,
       "license": "MIT",
@@ -3583,7 +3583,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://npm-proxy.cloud.databricks.com/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
@@ -3593,14 +3593,14 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/yallist/-/yallist-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/yargs/-/yargs-17.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
@@ -3619,7 +3619,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
@@ -3629,7 +3629,7 @@
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "license": "MIT",
@@ -3640,7 +3640,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -6,6 +6,10 @@
   "private": true,
   "main": "src/main.js",
   "homepage": "https://omnigent.ai",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/omnigent-ai/omnigent.git"
+  },
   "author": {
     "name": "Databricks, Inc.",
     "email": "support@omnigent.ai"
@@ -30,6 +34,13 @@
     "directories": {
       "output": "dist"
     },
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "omnigent-ai",
+        "repo": "omnigent"
+      }
+    ],
     "afterPack": "build/afterPack.js",
     "files": [
       "src/**/*",


### PR DESCRIPTION
## Related issue

N/A

## Summary

The manual **Electron Build** workflow failed on both Linux and Windows. Fixing it took two layers:

- **Install hang (the reported symptom):** `web/electron/package-lock.json` pinned 286 of its 290 `resolved` URLs to the internal `npm-proxy.cloud.databricks.com` mirror, which is unreachable from public GitHub runners. `npm ci` fetches each tarball from its exact `resolved` URL, so the install stalled ~8 minutes on the first fetch and died with `Exit handler never called!`. Rewrote those URLs to `registry.npmjs.org`, matching `web/package-lock.json` (already all-public) and the `uv.lock` normalization. The `integrity` hashes are content-based and unchanged, so they still validate against the public tarballs.
- **Post-package crash:** electron-builder 26.x packaged all artifacts, then threw `TypeError: Cannot read properties of null (reading 'channel')` in `computeChannelNames` because it computes auto-update channel metadata but found no `publish` provider and could not detect the repository (repeated `Cannot detect repository by .git/config` warnings). Added a `github` `publish` provider and a top-level `repository` field. Under `--publish never` the metadata is generated locally without uploading, so the build no longer throws.

The `electron-build.yml` workflow itself is unchanged.

## Test Plan

Triggered the workflow on this branch via `gh workflow run electron-build.yml --ref fix/electron-build-npm-hang`. The final run ([29059809297](https://github.com/omnigent-ai/omnigent/actions/runs/29059809297)) is green on both platforms, with both installer artifacts uploaded:

- `omnigent-desktop-linux` (~229 MB — AppImage + .deb)
- `omnigent-desktop-win` (~104 MB — nsis .exe)

Confirmed `Install dependencies`, `Build … app`, and `Upload installers` all succeed on `macos`/`ubuntu`/`windows` matrix legs.

## Demo

N/A — CI/build fix, no user-visible UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by running the Electron Build workflow end-to-end on this branch (run 29059809297) and confirming both Linux and Windows produced and uploaded installers. There is no automated test for this manually-dispatched packaging workflow; the workflow run itself is the verification.

This pull request and its description were written by Isaac.
