### PR TITLE
fix(smart-routing): enforce rationale consistency with selected model tier

### DIFF
--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -196,24 +196,29 @@ Harness descriptions:
 - pi: Multi-model headless harness; can run both Claude and GPT models;
   best for read-only exploration, review, and cross-vendor verification.
 
-Model naming conventions — use these to judge cost and capability:
-- Claude family (cheapest → most capable): haiku < sonnet < opus.
-- GPT family: a -nano or -mini suffix always means cheaper and faster
-  than any base model (no suffix), regardless of version number. Tier
-  order: *-nano < *-mini < base. A newer base version (e.g. X.5) is
-  more capable and expensive than an older one (e.g. X.4), but a mini
-  or nano variant of any version is still cheaper than any base model.
+Model tiers (cheapest → most capable within each family):
+- Claude: haiku < sonnet < opus
+- GPT: *-nano < *-mini < base (e.g. gpt-5-4-nano < gpt-5-4-mini < gpt-5-4 < gpt-5-5)
 
-Trade-off guidance:
-- Simple tasks (greetings, quick lookups, one-line fixes) → cheapest model
-  (nano or mini if available, else haiku).
-- Moderately complex tasks (single-file edits, debugging, explanation)
-  → mid-range model.
-- Deeply complex tasks (multi-file refactors, architecture decisions,
-  security analysis, long reasoning chains) → most capable model.
+Classify the task as one of three complexity tiers and pick the corresponding model:
+
+  SIMPLE   → cheapest available model (haiku for Claude; nano for GPT)
+             Examples: greetings, quick lookups, one-line fixes, trivial Q&A.
+
+  MODERATE → mid-range model (sonnet for Claude; mini for GPT)
+             Examples: single-file edits, debugging a known issue, brief explanations.
+
+  COMPLEX  → most capable model (opus for Claude; newest base GPT)
+             Examples: multi-file refactors, architecture decisions, security analysis,
+             long reasoning chains, tasks requiring high accuracy or broad context.
+
+The rationale field must follow this exact pattern so the explanation is consistent
+with the model chosen:
+  "This is a [SIMPLE/MODERATE/COMPLEX] task ([brief reason]); \
+selected [cheapest/mid-range/most capable] model [model-id]."
 
 Return **strict JSON only**:
-{{"harness": "<harness-id>", "model": "<model-id>", "rationale": "<one sentence>"}}
+{{"harness": "<harness-id>", "model": "<model-id>", "rationale": "<sentence>"}}
 """
 
 

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -200,7 +200,7 @@ Model tiers (cheapest → most capable within each family):
 - Claude: haiku < sonnet < opus
 - GPT: *-nano < *-mini < base (e.g. gpt-5-4-nano < gpt-5-4-mini < gpt-5-4 < gpt-5-5)
 
-Classify the task as one of three complexity tiers and pick the corresponding model:
+Trade-off guidance — classify the task and pick the corresponding model:
 
   SIMPLE   → cheapest available model (haiku for Claude; nano for GPT)
              Examples: greetings, quick lookups, one-line fixes, trivial Q&A.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The smart routing judge prompt previously let the LLM write any free-form rationale, leading to mismatches where the reasoning said "high capability / comprehensive task" but Sonnet was still selected every time (self-reference bias: the router itself runs on Sonnet).
- Replaces the vague "trade-off guidance" block with an explicit **SIMPLE / MODERATE / COMPLEX** 3-tier classification, each tier hard-mapped to the corresponding model tier (haiku/sonnet/opus for Claude; nano/mini/base for GPT).
- Adds a required rationale template (`"This is a [SIMPLE/MODERATE/COMPLEX] task ([reason]); selected [tier] model [id]."`) so the explanation is structurally forced to match the chosen model.

## Test Plan

- Manually verified the prompt renders correctly via `_build_rubric`.
- Pre-commit (ruff format + ruff check) passes.
- Prompt logic change — no code path changes; existing routing tests still apply.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Prompt-only change to `_JUDGE_SYSTEM_TEMPLATE`. The routing logic and JSON schema are unchanged; existing unit tests for `LLMRoutingClient` still cover the parsing and clamping paths.

## Changelog

<Delete this section — prompt-only fix with no user-visible API change>