### PR TITLE
fix(windows): replace os.getuid() with stable_user_id() in 4 native b…

### DIFF
--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -39,12 +39,16 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from omnigent._platform import stable_user_id
+
 _logger = logging.getLogger(__name__)
 
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_HERMES_NATIVE_BRIDGE_DIR"
 
-_BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}" / "hermes-native"
+_BRIDGE_ROOT = (
+    Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{stable_user_id()}" / "hermes-native"
+)
 _TMUX_FILE = "tmux.json"
 _TMUX_READY_TIMEOUT_S = 30.0
 _TMUX_SEND_TIMEOUT_S = 10.0

--- a/omnigent/kimi_native_bridge.py
+++ b/omnigent/kimi_native_bridge.py
@@ -21,10 +21,14 @@ import time
 from pathlib import Path
 from typing import Any
 
+from omnigent._platform import stable_user_id
+
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_KIMI_NATIVE_BRIDGE_DIR"
 
-_BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}" / "kimi-native"
+_BRIDGE_ROOT = (
+    Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{stable_user_id()}" / "kimi-native"
+)
 _TMUX_FILE = "tmux.json"
 # Omnigent routing details the kimi hook subprocess reads to reach the server.
 # Mirrors claude-native's ``permission_hook.json`` (server URL + auth headers +

--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -14,10 +14,14 @@ import time
 from pathlib import Path
 from typing import Any
 
+from omnigent._platform import stable_user_id
+
 KIRO_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_KIRO_NATIVE_BRIDGE_DIR"
 KIRO_ACP_RECORD_PATH_ENV_VAR = "KIRO_ACP_RECORD_PATH"
 
-_BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}" / "kiro-native"
+_BRIDGE_ROOT = (
+    Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{stable_user_id()}" / "kiro-native"
+)
 _TMUX_FILE = "tmux.json"
 _FORWARDER_READY_FILE = "kiro_session_forwarder_ready.json"
 _ACP_RECORD_FILE = "kiro_acp_record.jsonl"

--- a/omnigent/qwen_native_bridge.py
+++ b/omnigent/qwen_native_bridge.py
@@ -41,6 +41,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from omnigent._platform import stable_user_id
+
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_QWEN_NATIVE_BRIDGE_DIR"
 
@@ -49,7 +51,9 @@ BRIDGE_DIR_ENV_VAR = "HARNESS_QWEN_NATIVE_BRIDGE_DIR"
 #: qwen recording (resume would mint a new id and lose history).
 _QWEN_SESSION_NAMESPACE = uuid.UUID("6b6f3d2e-9a1c-5e84-bf0a-1d7c5a2e9f43")
 
-_BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}" / "qwen-native"
+_BRIDGE_ROOT = (
+    Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{stable_user_id()}" / "qwen-native"
+)
 _TMUX_FILE = "tmux.json"
 #: JSONL command file qwen watches (``--input-file``); we append to it.
 _INPUT_FILE = "qwen_in.jsonl"


### PR DESCRIPTION
## Summary

`omnigent server start` crashes on Windows because 4 native bridge modules call `os.getuid()` at module top level — a POSIX-only function that raises `AttributeError` on import. The codebase already ships `omnigent._platform.stable_user_id()` for this; `claude_native_bridge`, `cursor_native_bridge`, and `goose_native_bridge` already use it. These 4 files were missed.

Fixes #2340

## Changes

Replaced `os.getuid()` with `stable_user_id()` (imported from `omnigent._platform`) in:

- `omnigent/kiro_native_bridge.py`
- `omnigent/hermes_native_bridge.py`
- `omnigent/kimi_native_bridge.py`
- `omnigent/qwen_native_bridge.py`

POSIX behavior is unchanged (`stable_user_id()` returns `str(os.getuid())` on POSIX). Windows gains a stable 12-char SHA-256 digest of the login name instead of crashing.

## Verification

```bash
# Before fix: all 4 crash on Windows
python -c "import omnigent.kiro_native_bridge"    # AttributeError: os.getuid

# After fix: all 4 import cleanly
python -c "import omnigent.kiro_native_bridge"    # OK
python -c "import omnigent.hermes_native_bridge"  # OK
python -c "import omnigent.kimi_native_bridge"    # OK
python -c "import omnigent.qwen_native_bridge"    # OK

# Server now starts
omnigent server start
# Started background server at http://127.0.0.1:6767