### PR TITLE
fix(web): don't switch sessions on Cmd+Arrow while editing the composer

### DIFF
--- a/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
+++ b/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
@@ -1,24 +1,27 @@
-"""E2E: Cmd/Ctrl+↑/↓ switches sessions even while the composer is focused.
+"""E2E: Cmd/Ctrl+Arrow switches sessions from the page body, but not the composer.
 
-Covers the composer fix in ``web/src/pages/ChatPage.tsx``: the composer's
-ArrowUp/ArrowDown draft-recall handler used to intercept *any* arrow keydown,
-so the global session-switch hotkey (``useSessionSwitchHotkey``, Cmd/Ctrl+↑/↓)
-appeared dead while typing — recall swallowed the keystroke and replaced the
-draft instead of switching sessions. The fix gates recall to UNmodified arrows
-(``!metaKey && !ctrlKey && !altKey``), letting the modified chord bubble to the
-window-level hotkey.
+``useSessionSwitchHotkey`` (window keydown) steps the sidebar's ordered
+sessions on Cmd/Ctrl+Up/Down. It bails when the keydown target is inside an
+editable field (``textarea``, ``input``, ``[contenteditable="true"]``) so
+typing in the composer keeps its native caret-to-start/end and the user isn't
+yanked to another session mid-edit. The chord still navigates when focus is
+outside an editable field.
 
-The regression is specifically "composer has focus". So this test puts focus
-in the composer (types a draft), then presses Ctrl+ArrowDown (the Win/Linux
-chord; CI runs Linux chromium — the hook also accepts Cmd via metaKey on
-macOS) and asserts the route navigates to a different session. Pre-fix, recall
-ate the chord and the route never changed.
+This exercises both halves of that contract through the real chain the unit
+tests mock out: live session list -> sidebar render order -> window keydown
+handler -> client-side navigation to ``/c/{id}``.
 
-No LLM turn is needed — this exercises pure client-side keyboard + routing —
-so it skips the nightly/real-agent markers the approval suites carry. Two
-runner-bound sessions come from the ``seeded_session_pair`` fixture; both
-render under the sidebar's "Sessions" group, so both are in the hotkey's ordered
-list.
+- ``test_ctrl_arrow_does_not_switch_session_from_focused_composer``: focus the
+  composer, leave a draft, press Ctrl+Down, and assert the route stays put.
+  A regression that drops the editable-field guard would route away here.
+- ``test_ctrl_arrow_still_switches_session_from_body_focus``: blur the
+  composer so the keydown targets the body, press Ctrl+Down, and assert the
+  route leaves the current session — the happy path the guard must preserve.
+
+No LLM turn is needed — pure client-side keyboard + routing — so this skips the
+nightly/real-agent markers the approval suites carry. Two runner-bound
+sessions come from the ``seeded_session_pair`` fixture; both render under the
+sidebar's "Sessions" group, so both are in the hotkey's ordered list.
 """
 
 from __future__ import annotations
@@ -39,38 +42,71 @@ def _set_title(base_url: str, session_id: str, title: str) -> None:
     resp.raise_for_status()
 
 
-def test_ctrl_arrow_switches_session_from_focused_composer(
+def test_ctrl_arrow_does_not_switch_session_from_focused_composer(
     page: Page,
     seeded_session_pair: tuple[str, str, str],
 ) -> None:
-    """Typing in the composer, then Ctrl+↓, navigates off the current session."""
+    """Typing in the composer, then Ctrl+↓, stays on the current session."""
     base_url, session_a, session_b = seeded_session_pair
     _set_title(base_url, session_a, "e2e-switch-a")
     _set_title(base_url, session_b, "e2e-switch-b")
 
     page.goto(f"{base_url}/c/{session_a}")
 
-    # Both sessions must be present in the sidebar for the hotkey to step
-    # between them.
+    # Both sessions must be present in the sidebar for the hotkey to have a
+    # step target — guaranteeing that staying put is the guard's doing, not an
+    # empty list.
     expect(page.locator(f'a[href="/c/{session_a}"]')).to_be_visible(timeout=30_000)
     expect(page.locator(f'a[href="/c/{session_b}"]')).to_be_visible()
 
     # Put focus in the composer and leave an unsent draft — this is the exact
-    # condition under which the recall handler used to swallow the chord.
+    # condition under which the editable-field guard must suppress the chord.
     composer = page.get_by_placeholder(_COMPOSER)
     expect(composer).to_be_visible()
     composer.click()
-    composer.fill("an unsent draft that recall must not intercept")
+    composer.fill("an unsent draft that must not trigger a session switch")
 
-    # Cmd/Ctrl+↓ steps to the adjacent sidebar session. With the bug, recall
-    # consumes ArrowDown and the route stays put; with the fix, the chord
-    # bubbles to the window hotkey and we navigate away from session_a.
-    page.keyboard.press("Control+ArrowDown")
+    # ControlOrMeta maps to the real platform modifier (Cmd on macOS, Ctrl
+    # elsewhere); CI runs Linux chromium, so this is Ctrl+Down. The keydown
+    # targets the focused composer, so the guard returns early.
+    page.keyboard.press("ControlOrMeta+ArrowDown")
 
-    # Assert we left the composing session for another /c/ route. We check
-    # "switched away" rather than a hard-coded target id: the suite shares one
-    # server across tests, so the sidebar may hold sessions beyond this pair —
-    # but navigating at all from a focused composer is precisely the regression.
+    # The SPA navigates synchronously in the keydown handler; with the guard,
+    # it never fires. Wait long enough that an unguarded chord would have
+    # routed, then confirm we stayed on session_a.
+    page.wait_for_timeout(500)
+    expect(page).to_have_url(f"{base_url}/c/{session_a}")
+
+
+def test_ctrl_arrow_still_switches_session_from_body_focus(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """With focus outside the composer, Ctrl+↓ still steps to a neighbor."""
+    base_url, session_a, session_b = seeded_session_pair
+    _set_title(base_url, session_a, "e2e-switch-a")
+    _set_title(base_url, session_b, "e2e-switch-b")
+
+    page.goto(f"{base_url}/c/{session_a}")
+
+    expect(page.locator(f'a[href="/c/{session_a}"]')).to_be_visible(timeout=30_000)
+    expect(page.locator(f'a[href="/c/{session_b}"]')).to_be_visible()
+
+    # Move focus off the composer so the editable-field guard doesn't swallow
+    # the chord (the session page autofocuses the composer on load).
+    page.evaluate(
+        "() => { const el = document.activeElement; "
+        "if (el && typeof el.blur === 'function') el.blur(); }"
+    )
+
+    # Dispatch the chord at the body; the keydown bubbles to the window hook,
+    # the guard sees a non-editable target, and we navigate to a neighbor.
+    page.locator("body").press("ControlOrMeta+ArrowDown")
+
+    # Assert we left session_a for another /c/ route. We check "switched away"
+    # rather than a hard-coded target id: the suite shares one server across
+    # tests, so the sidebar may hold sessions beyond this pair — but
+    # navigating at all from body focus is the behavior the guard preserves.
     expect(page).not_to_have_url(f"{base_url}/c/{session_a}", timeout=10_000)
     assert "/c/" in page.url and session_a not in page.url, (
         f"expected to switch to another session, still at {page.url}"

--- a/web/src/hooks/useSessionSwitchHotkey.test.tsx
+++ b/web/src/hooks/useSessionSwitchHotkey.test.tsx
@@ -1,6 +1,6 @@
 // Cmd/Ctrl+↓/↑ steps next/prev with wrap; off-list ↓ enters at top, ↑ at
-// bottom; fires inside text fields but ignores Alt/Shift/bare arrows; a no-op
-// step (same id) doesn't navigate.
+// bottom; suppressed inside editable fields; ignores Alt/Shift/bare arrows; a
+// no-op step (same id) doesn't navigate.
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -93,12 +93,20 @@ describe("useSessionSwitchHotkey", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it("still switches while a text field is focused (no click-out needed)", () => {
+  it("does not switch while a textarea is focused (composer editing)", () => {
     renderHook(() => useSessionSwitchHotkey(ids, "a"));
     const ta = document.createElement("textarea");
     document.body.appendChild(ta);
     press("ArrowDown", { metaKey: true }, ta);
-    expect(navigate).toHaveBeenCalledWith("/c/b");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not switch while an input is focused", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    press("ArrowDown", { metaKey: true }, input);
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   it("does nothing when the list is empty", () => {

--- a/web/src/hooks/useSessionSwitchHotkey.ts
+++ b/web/src/hooks/useSessionSwitchHotkey.ts
@@ -1,7 +1,7 @@
 // Cmd+↑/↓ (Ctrl+↑/↓ on Win/Linux) opens the previous / next sidebar session,
 // wrapping at the ends. Sibling to ChatPage's Cmd+Alt+↑/↓ message nav; they
-// don't collide (that one requires Alt, this one requires Alt up). Fires even
-// in a focused text field so you can switch mid-compose. Bind ONCE.
+// don't collide (that one requires Alt, this one requires Alt up). Suppressed
+// inside editable fields so typing in the composer isn't interrupted. Bind ONCE.
 
 import { useEffect, useRef } from "react";
 import { useNavigate } from "@/lib/routing";
@@ -26,6 +26,16 @@ export function useSessionSwitchHotkey(
       // Cmd/Ctrl, not Alt (Alt+arrow is the message hotkey); Shift left to selection.
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+
+      // Leave the chord alone while editing so the composer keeps its native
+      // caret-to-start/end and the user isn't yanked to another session.
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest('textarea, input, [contenteditable="true"]')
+      ) {
+        return;
+      }
 
       const { orderedIds: ids, activeId: active } = latest.current;
       if (ids.length === 0) return;


### PR DESCRIPTION
## Related issue

N/A

## Summary

Cmd+↑/↓ (Ctrl+↑/↓ on Windows/Linux) switched sidebar sessions even while the user was typing in the message composer, disrupting editing and clobbering the native caret-to-line-start/end behavior.

`useSessionSwitchHotkey` is a global `window` keydown listener that only checked the modifier + arrow keys — it never inspected the event target, so it fired regardless of focus. This change guards it to bail early when the keydown originates inside a `textarea`, `input`, or `[contenteditable="true"]`, mirroring the existing guard on ChatPage's sibling Cmd+Alt+Arrow message-nav handler. Session switching still works when focus is outside an editable field.

## Test Plan

- `cd web && npx vitest run src/hooks/useSessionSwitchHotkey.test.tsx` — 12 passing.
- Flipped the textarea test to assert no navigation while editing, and added an `input` companion case.
- Manual: focused the composer and pressed Cmd+↑/↓ (caret moves, no session switch); focused the page body and pressed Cmd+↑/↓ (switches with wrap).

## Demo


https://github.com/user-attachments/assets/29d58e8e-8346-4f87-b444-a57800c9c92d

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the guard (textarea and input focus bail out; body-focused Cmd+Arrow still navigates). Manually verified in the web app that composer editing is uninterrupted and session switching still works from outside editable fields.