### PR TITLE
feat(web): add a code font weight setting for the editor and terminal

### DIFF
--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -408,10 +408,11 @@ describe("TerminalSession", () => {
     const { socket, session } = makeSession();
     const { term } = session as unknown as { term: Terminal };
 
-    // Socket-down (pre-open): setFont still applies the size and must not throw
-    // or send — sendResize no-ops until the WS opens, and the reconnect re-fits.
-    session.setFont(16, "");
+    // Socket-down (pre-open): setFont still applies the size/weight and must not
+    // throw or send — sendResize no-ops until the WS opens, reconnect re-fits.
+    session.setFont(16, "", 500);
     expect(term.options.fontSize).toBe(16);
+    expect(term.options.fontWeight).toBe(500);
     expect(socket.sent).toHaveLength(0);
 
     // Once open, setFont refits the grid (sendResize) so the new glyph cell size
@@ -420,10 +421,13 @@ describe("TerminalSession", () => {
     socket.open();
     const before = socket;
     const sendResize = vi.spyOn(session as unknown as { sendResize: () => void }, "sendResize");
-    session.setFont(18, "Fira Code");
+    session.setFont(18, "Fira Code", 700);
     expect(sendResize).toHaveBeenCalledTimes(1);
     expect(term.options.fontSize).toBe(18);
     expect(term.options.fontFamily).toContain("Fira Code");
+    // The normal weight applies, and the bold weight is derived (+300, capped).
+    expect(term.options.fontWeight).toBe(700);
+    expect(term.options.fontWeightBold).toBe(900);
     // Same socket instance, still open — a re-font never reconnects.
     expect(socket).toBe(before);
     expect(socket.closed).toBe(false);

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -12,9 +12,13 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
-import { type ITheme, Terminal } from "@xterm/xterm";
+import { type FontWeight, type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import { codeFontFamilyForEditor, readCodeFont } from "@/lib/codeFontPreferences";
+import {
+  codeFontBoldWeight,
+  codeFontFamilyForEditor,
+  readCodeFont,
+} from "@/lib/codeFontPreferences";
 
 // Card background colors derived from the app's CSS palette.
 // Light: --card: oklch(1.000 0 0) = pure white.
@@ -341,10 +345,15 @@ export class TerminalSession {
     // construction; a mid-session change is applied live via setFont(). The
     // xterm.js defaults (15px, no theme) feel out of place inside the app
     // chrome, so an unset family falls back to the shared mono stack.
-    const { sizePx, family } = readCodeFont();
+    const { sizePx, family, weight } = readCodeFont();
     this.term = new Terminal({
       fontFamily: codeFontFamilyForEditor(family),
       fontSize: sizePx,
+      // xterm renders bold cells (e.g. prompts, ANSI bold) at a heavier weight
+      // derived from the chosen normal weight so the two stay proportional. The
+      // stored weight is a stepped 100–900 numeric, all valid FontWeight values.
+      fontWeight: weight as FontWeight,
+      fontWeightBold: codeFontBoldWeight(weight) as FontWeight,
       scrollback: 20000,
       cursorBlink: true,
       theme: terminalTheme(isDark),
@@ -506,12 +515,15 @@ export class TerminalSession {
    * changes the character-cell dimensions, so this re-fits the grid to the
    * container and pushes the resulting cols×rows to tmux via {@link sendResize}
    * (which no-ops the send while the socket is down; the reconnect re-fits on
-   * open). An empty family falls back to the shared mono stack. Safe to call at
-   * any point after construction.
+   * open). An empty family falls back to the shared mono stack. A weight change
+   * also re-fits — glyph advance can shift with weight. Safe to call at any
+   * point after construction.
    */
-  setFont(sizePx: number, family: string): void {
+  setFont(sizePx: number, family: string, weight: number): void {
     this.term.options.fontFamily = codeFontFamilyForEditor(family);
     this.term.options.fontSize = sizePx;
+    this.term.options.fontWeight = weight as FontWeight;
+    this.term.options.fontWeightBold = codeFontBoldWeight(weight) as FontWeight;
     this.sendResize();
   }
 

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -237,7 +237,7 @@ export function TerminalView({
   // disconnected still lands on reconnect.
   useEffect(() => {
     return subscribeCodeFont((font) => {
-      sessionRef.current?.setFont(font.sizePx, font.family);
+      sessionRef.current?.setFont(font.sizePx, font.family, font.weight);
     });
   }, []);
 

--- a/web/src/lib/codeFontPreferences.test.ts
+++ b/web/src/lib/codeFontPreferences.test.ts
@@ -5,17 +5,24 @@ import {
   CODE_FONT_SIZE_DEFAULT,
   CODE_FONT_SIZE_MAX,
   CODE_FONT_SIZE_MIN,
+  CODE_FONT_WEIGHT_DEFAULT,
+  CODE_FONT_WEIGHT_MAX,
+  CODE_FONT_WEIGHT_MIN,
+  codeFontBoldWeight,
   codeFontFamilyForEditor,
   readCodeFont,
   readCodeFontFamily,
   readCodeFontSizePx,
+  readCodeFontWeight,
   subscribeCodeFont,
   writeCodeFontFamily,
   writeCodeFontSizePx,
+  writeCodeFontWeight,
 } from "./codeFontPreferences";
 
 const SIZE_STORAGE_KEY = "omnigent:code-font-size";
 const FAMILY_STORAGE_KEY = "omnigent:code-font-family";
+const WEIGHT_STORAGE_KEY = "omnigent:code-font-weight";
 
 afterEach(() => {
   localStorage.clear();
@@ -145,7 +152,7 @@ describe("codeFontPreferences — pub/sub", () => {
     writeCodeFontSizePx(20);
     // The callback receives the freshly persisted font so a mounted editor can
     // re-apply it live without re-reading storage itself.
-    expect(cb).toHaveBeenCalledWith({ sizePx: 20, family: "" });
+    expect(cb).toHaveBeenCalledWith({ sizePx: 20, family: "", weight: CODE_FONT_WEIGHT_DEFAULT });
 
     unsubscribe();
   });
@@ -155,7 +162,11 @@ describe("codeFontPreferences — pub/sub", () => {
     const unsubscribe = subscribeCodeFont(cb);
 
     writeCodeFontFamily("Fira Code");
-    expect(cb).toHaveBeenCalledWith({ sizePx: CODE_FONT_SIZE_DEFAULT, family: "Fira Code" });
+    expect(cb).toHaveBeenCalledWith({
+      sizePx: CODE_FONT_SIZE_DEFAULT,
+      family: "Fira Code",
+      weight: CODE_FONT_WEIGHT_DEFAULT,
+    });
 
     unsubscribe();
   });
@@ -178,7 +189,11 @@ describe("codeFontPreferences — pub/sub", () => {
     writeCodeFontSizePx(999);
     // Subscribers see the same clamped value that was persisted, so the live
     // widget and a later reload agree.
-    expect(cb).toHaveBeenCalledWith({ sizePx: CODE_FONT_SIZE_MAX, family: "" });
+    expect(cb).toHaveBeenCalledWith({
+      sizePx: CODE_FONT_SIZE_MAX,
+      family: "",
+      weight: CODE_FONT_WEIGHT_DEFAULT,
+    });
 
     unsubscribe();
   });
@@ -193,7 +208,7 @@ describe("codeFontPreferences — pub/sub", () => {
     });
     try {
       writeCodeFontSizePx(19);
-      expect(cb).toHaveBeenCalledWith({ sizePx: 19, family: "" });
+      expect(cb).toHaveBeenCalledWith({ sizePx: 19, family: "", weight: CODE_FONT_WEIGHT_DEFAULT });
     } finally {
       setItem.mockRestore();
     }
@@ -208,7 +223,11 @@ describe("codeFontPreferences — pub/sub", () => {
     });
     try {
       writeCodeFontFamily("Fira Code");
-      expect(cb).toHaveBeenCalledWith({ sizePx: CODE_FONT_SIZE_DEFAULT, family: "Fira Code" });
+      expect(cb).toHaveBeenCalledWith({
+        sizePx: CODE_FONT_SIZE_DEFAULT,
+        family: "Fira Code",
+        weight: CODE_FONT_WEIGHT_DEFAULT,
+      });
     } finally {
       setItem.mockRestore();
     }
@@ -216,10 +235,94 @@ describe("codeFontPreferences — pub/sub", () => {
   });
 });
 
+describe("codeFontPreferences — weight", () => {
+  it("returns the default when nothing is stored", () => {
+    expect(readCodeFontWeight()).toBe(CODE_FONT_WEIGHT_DEFAULT);
+  });
+
+  it("round-trips a valid weight", () => {
+    writeCodeFontWeight(600);
+    expect(readCodeFontWeight()).toBe(600);
+    expect(localStorage.getItem(WEIGHT_STORAGE_KEY)).toBe(JSON.stringify(600));
+  });
+
+  it("clamps a stored value above the range", () => {
+    localStorage.setItem(WEIGHT_STORAGE_KEY, JSON.stringify(1500));
+    expect(readCodeFontWeight()).toBe(CODE_FONT_WEIGHT_MAX);
+  });
+
+  it("clamps a stored value below the range", () => {
+    localStorage.setItem(WEIGHT_STORAGE_KEY, JSON.stringify(10));
+    expect(readCodeFontWeight()).toBe(CODE_FONT_WEIGHT_MIN);
+  });
+
+  it("clamps out-of-range values on write", () => {
+    writeCodeFontWeight(2000);
+    expect(readCodeFontWeight()).toBe(CODE_FONT_WEIGHT_MAX);
+    writeCodeFontWeight(0);
+    expect(readCodeFontWeight()).toBe(CODE_FONT_WEIGHT_MIN);
+  });
+
+  it("snaps an off-step value to the nearest step", () => {
+    // Weights are stepped by 100; a stray 440 rounds to 400, 460 to 500.
+    localStorage.setItem(WEIGHT_STORAGE_KEY, JSON.stringify(440));
+    expect(readCodeFontWeight()).toBe(400);
+    writeCodeFontWeight(460);
+    expect(readCodeFontWeight()).toBe(500);
+  });
+
+  it("falls back to the default on malformed JSON", () => {
+    localStorage.setItem(WEIGHT_STORAGE_KEY, "}{not json");
+    expect(readCodeFontWeight()).toBe(CODE_FONT_WEIGHT_DEFAULT);
+  });
+
+  it("falls back to the default on a non-numeric value", () => {
+    localStorage.setItem(WEIGHT_STORAGE_KEY, JSON.stringify("bold"));
+    expect(readCodeFontWeight()).toBe(CODE_FONT_WEIGHT_DEFAULT);
+  });
+
+  it("notifies subscribers with the new font when the weight is written", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeCodeFont(cb);
+
+    writeCodeFontWeight(700);
+    expect(cb).toHaveBeenCalledWith({ sizePx: CODE_FONT_SIZE_DEFAULT, family: "", weight: 700 });
+
+    unsubscribe();
+  });
+
+  it("emits the intended weight even when the storage write throws", () => {
+    const cb = vi.fn();
+    const unsubscribe = subscribeCodeFont(cb);
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    try {
+      writeCodeFontWeight(500);
+      expect(cb).toHaveBeenCalledWith({ sizePx: CODE_FONT_SIZE_DEFAULT, family: "", weight: 500 });
+    } finally {
+      setItem.mockRestore();
+    }
+    unsubscribe();
+  });
+});
+
+describe("codeFontBoldWeight", () => {
+  it("derives a heavier weight (+300) from the normal weight", () => {
+    expect(codeFontBoldWeight(400)).toBe(700);
+  });
+
+  it("caps the derived bold weight at the max", () => {
+    expect(codeFontBoldWeight(700)).toBe(CODE_FONT_WEIGHT_MAX);
+    expect(codeFontBoldWeight(CODE_FONT_WEIGHT_MAX)).toBe(CODE_FONT_WEIGHT_MAX);
+  });
+});
+
 describe("readCodeFont", () => {
-  it("reads size and family together", () => {
+  it("reads size, family and weight together", () => {
     writeCodeFontSizePx(15);
     writeCodeFontFamily("Menlo");
-    expect(readCodeFont()).toEqual({ sizePx: 15, family: "Menlo" });
+    writeCodeFontWeight(600);
+    expect(readCodeFont()).toEqual({ sizePx: 15, family: "Menlo", weight: 600 });
   });
 });

--- a/web/src/lib/codeFontPreferences.ts
+++ b/web/src/lib/codeFontPreferences.ts
@@ -14,6 +14,7 @@
 
 const SIZE_STORAGE_KEY = "omnigent:code-font-size";
 const FAMILY_STORAGE_KEY = "omnigent:code-font-family";
+const WEIGHT_STORAGE_KEY = "omnigent:code-font-weight";
 
 // Code widgets read smaller than the chrome by convention, and a monospaced
 // grid tolerates a wider useful range than body text — hence bounds distinct
@@ -22,6 +23,15 @@ export const CODE_FONT_SIZE_DEFAULT = 13;
 export const CODE_FONT_SIZE_MIN = 10;
 export const CODE_FONT_SIZE_MAX = 24;
 export const CODE_FONT_SIZE_STEP = 1;
+
+// Normal-text weight for code widgets, stored as a CSS numeric weight (100–900
+// in steps of 100). 400 is the effective default — xterm's own default normal
+// weight is 'normal' (≈400) and Monaco's is likewise 400 — so an unset pref
+// leaves both widgets rendering exactly as they do today.
+export const CODE_FONT_WEIGHT_DEFAULT = 400;
+export const CODE_FONT_WEIGHT_MIN = 100;
+export const CODE_FONT_WEIGHT_MAX = 900;
+export const CODE_FONT_WEIGHT_STEP = 100;
 
 /** Empty string = "editor default": no override, falls back to the mono stack. */
 export const CODE_FONT_FAMILY_DEFAULT = "";
@@ -40,6 +50,20 @@ export const CODE_FONT_FAMILY_FALLBACK =
 /** Clamp an arbitrary number into the supported px range. */
 export function clampCodeFontSizePx(px: number): number {
   return Math.min(CODE_FONT_SIZE_MAX, Math.max(CODE_FONT_SIZE_MIN, Math.round(px)));
+}
+
+/**
+ * Clamp an arbitrary number into the supported weight range and snap it to the
+ * nearest step, so a stored/typed value is always a valid CSS numeric weight.
+ */
+export function clampCodeFontWeight(weight: number): number {
+  const snapped = Math.round(weight / CODE_FONT_WEIGHT_STEP) * CODE_FONT_WEIGHT_STEP;
+  return Math.min(CODE_FONT_WEIGHT_MAX, Math.max(CODE_FONT_WEIGHT_MIN, snapped));
+}
+
+/** Bold weight derived from the normal weight: +300, capped at the max. */
+export function codeFontBoldWeight(weight: number): number {
+  return Math.min(CODE_FONT_WEIGHT_MAX, weight + 300);
 }
 
 function isValidPx(value: unknown): value is number {
@@ -83,7 +107,47 @@ export function writeCodeFontSizePx(px: number): void {
   // Broadcast the intended value, not a storage re-read: if the write above
   // failed (quota/denied), mounted editors/terminals must still re-font to the
   // new size now rather than snapping back to the stale/default stored value.
-  emit({ sizePx, family: readCodeFontFamily() });
+  emit({ sizePx, family: readCodeFontFamily(), weight: readCodeFontWeight() });
+}
+
+/**
+ * Read the persisted code font weight (CSS numeric, 100–900).
+ *
+ * Returns the default when nothing is stored, on a server render (no `window`),
+ * or when the stored value is missing/malformed — never throws, so a corrupt
+ * entry can't break app boot. A stored value outside the range is clamped and
+ * snapped to the nearest step.
+ */
+export function readCodeFontWeight(): number {
+  if (typeof window === "undefined") return CODE_FONT_WEIGHT_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(WEIGHT_STORAGE_KEY);
+    if (!raw) return CODE_FONT_WEIGHT_DEFAULT;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidPx(parsed)) return CODE_FONT_WEIGHT_DEFAULT;
+    return clampCodeFontWeight(parsed);
+  } catch {
+    return CODE_FONT_WEIGHT_DEFAULT;
+  }
+}
+
+/**
+ * Persist the code font weight, clamped/snapped to the supported range, then
+ * notify subscribers so mounted editors/terminals re-apply it live. Swallows
+ * quota/access errors so a failed write can't break the app.
+ */
+export function writeCodeFontWeight(weight: number): void {
+  const clamped = clampCodeFontWeight(weight);
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(WEIGHT_STORAGE_KEY, JSON.stringify(clamped));
+    } catch {
+      // localStorage quota or access errors shouldn't break the app.
+    }
+  }
+  // Broadcast the intended value, not a storage re-read: a failed write must
+  // still live-apply the new weight to mounted editors/terminals.
+  emit({ sizePx: readCodeFontSizePx(), family: readCodeFontFamily(), weight: clamped });
 }
 
 /**
@@ -143,7 +207,7 @@ export function writeCodeFontFamily(name: string): void {
   }
   // Broadcast the intended value, not a storage re-read: a failed write must
   // still live-apply the new family to mounted editors/terminals.
-  emit({ sizePx: readCodeFontSizePx(), family });
+  emit({ sizePx: readCodeFontSizePx(), family, weight: readCodeFontWeight() });
 }
 
 /**
@@ -159,17 +223,23 @@ export function codeFontFamilyForEditor(family: string): string {
   return normalized ? `${normalized}, ${CODE_FONT_FAMILY_FALLBACK}` : CODE_FONT_FAMILY_FALLBACK;
 }
 
-/** The current code font size + family, read together for widget construction. */
+/** The current code font size + family + weight, read together for widget construction. */
 export interface CodeFont {
   /** Font size in px, already clamped to the supported range. */
   sizePx: number;
   /** Custom family, or "" for the editor/terminal default. */
   family: string;
+  /** Normal-text weight (CSS numeric 100–900), already clamped. */
+  weight: number;
 }
 
-/** Read both code font preferences at once. Handy on editor/terminal mount. */
+/** Read all code font preferences at once. Handy on editor/terminal mount. */
 export function readCodeFont(): CodeFont {
-  return { sizePx: readCodeFontSizePx(), family: readCodeFontFamily() };
+  return {
+    sizePx: readCodeFontSizePx(),
+    family: readCodeFontFamily(),
+    weight: readCodeFontWeight(),
+  };
 }
 
 type CodeFontListener = (font: CodeFont) => void;

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -403,6 +403,35 @@ describe("SettingsPage", () => {
     expect(localStorage.getItem("omnigent:code-font-family")).toBeNull();
   });
 
+  it("shows the default code font weight and steps it up, persisting the choice", () => {
+    localStorage.clear();
+    renderPage("/settings/appearance");
+    const value = screen.getByTestId("code-font-weight-value");
+    // No stored preference → 400 (normal) default, matching the widget defaults.
+    expect(value.textContent).toBe("400");
+
+    fireEvent.click(screen.getByTestId("code-font-weight-inc"));
+    expect(value.textContent).toBe("500");
+    // Persisted under the code-font weight key so it survives a refresh and
+    // reaches the editor/terminal imperatively via the pub/sub.
+    expect(localStorage.getItem("omnigent:code-font-weight")).toBe("500");
+  });
+
+  it("disables the code font weight steppers at the min and max bounds", () => {
+    localStorage.setItem("omnigent:code-font-weight", "900");
+    renderPage("/settings/appearance");
+    // At the 900 max, only the increase button is disabled.
+    expect(screen.getByTestId("code-font-weight-inc")).toBeDisabled();
+    expect(screen.getByTestId("code-font-weight-dec")).not.toBeDisabled();
+
+    cleanup();
+    localStorage.setItem("omnigent:code-font-weight", "100");
+    renderPage("/settings/appearance");
+    // At the 100 min, only the decrease button is disabled.
+    expect(screen.getByTestId("code-font-weight-dec")).toBeDisabled();
+    expect(screen.getByTestId("code-font-weight-inc")).not.toBeDisabled();
+  });
+
   it("defaults bare /settings to Account when a login session exists, else Appearance", async () => {
     // Login session (accounts OR OIDC) → Account leads, so /settings lands on it.
     renderPage("/settings");

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -105,14 +105,20 @@ import {
 } from "@/lib/uiFontPreferences";
 import {
   clampCodeFontSizePx,
+  clampCodeFontWeight,
   CODE_FONT_FAMILY_DEFAULT,
   CODE_FONT_SIZE_MAX,
   CODE_FONT_SIZE_MIN,
   CODE_FONT_SIZE_STEP,
+  CODE_FONT_WEIGHT_MAX,
+  CODE_FONT_WEIGHT_MIN,
+  CODE_FONT_WEIGHT_STEP,
   readCodeFontFamily,
   readCodeFontSizePx,
+  readCodeFontWeight,
   writeCodeFontFamily,
   writeCodeFontSizePx,
+  writeCodeFontWeight,
 } from "@/lib/codeFontPreferences";
 import {
   readTerminalThemeMode,
@@ -605,6 +611,8 @@ function AppearanceSection() {
         <UiCodeFontSizeControl />
 
         <UiCodeFontFamilyControl />
+
+        <UiCodeFontWeightControl />
       </div>
     </Section>
   );
@@ -979,6 +987,76 @@ function UiCodeFontFamilyControl() {
           value={family}
           onChange={(e) => update(e.target.value)}
         />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Code font weight stepper. Sets the normal-text weight (CSS numeric 100–900)
+ * of the code editor (Monaco) and terminal (xterm) via the code-font pub/sub
+ * (see lib/codeFontPreferences.ts). Values snap to steps of 100, so — unlike
+ * the size control — there's no free-text draft: each step commits a valid,
+ * clamped weight directly.
+ */
+function UiCodeFontWeightControl() {
+  const [weight, setWeight] = useState(() => readCodeFontWeight());
+
+  const commit = useCallback((next: number) => {
+    const clamped = clampCodeFontWeight(next);
+    setWeight(clamped);
+    writeCodeFontWeight(clamped);
+  }, []);
+
+  const atMin = weight <= CODE_FONT_WEIGHT_MIN;
+  const atMax = weight >= CODE_FONT_WEIGHT_MAX;
+
+  return (
+    <div
+      className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3"
+      data-testid="code-font-weight-control"
+    >
+      <div className="flex flex-col">
+        <span className="text-sm font-medium">Code font weight</span>
+        <span className="text-sm text-muted-foreground">
+          Weight of code in the editor and terminal.
+        </span>
+      </div>
+      {/* One cohesive pill: [ −  | value |  + ] — same shell as the code
+          font-size control, but the value is read-only (weights snap to 100s). */}
+      <div
+        role="group"
+        aria-label="Code font weight"
+        className={cn(
+          "inline-flex h-9 items-stretch overflow-hidden rounded-lg border border-input bg-background transition-colors dark:bg-input/30",
+          "focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50",
+        )}
+      >
+        <StepperButton
+          label="Decrease code font weight"
+          testId="code-font-weight-dec"
+          disabled={atMin}
+          onClick={() => commit(weight - CODE_FONT_WEIGHT_STEP)}
+        >
+          <MinusIcon className="size-4" />
+        </StepperButton>
+        <div className="flex items-center border-x border-input px-2 tabular-nums">
+          <span
+            aria-label="Code font weight"
+            data-testid="code-font-weight-value"
+            className="w-8 text-center text-sm font-medium tabular-nums"
+          >
+            {weight}
+          </span>
+        </div>
+        <StepperButton
+          label="Increase code font weight"
+          testId="code-font-weight-inc"
+          disabled={atMax}
+          onClick={() => commit(weight + CODE_FONT_WEIGHT_STEP)}
+        >
+          <PlusIcon className="size-4" />
+        </StepperButton>
       </div>
     </div>
   );

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -24,6 +24,7 @@ import {
   codeFontFamilyForEditor,
   readCodeFontFamily,
   readCodeFontSizePx,
+  readCodeFontWeight,
   subscribeCodeFont,
 } from "@/lib/codeFontPreferences";
 import type { Comment } from "@/hooks/useComments";
@@ -404,6 +405,8 @@ function MonacoCodeEditorInner({
       // rather than falling back to Monaco's own platform default.
       fontSize: readCodeFontSizePx(),
       fontFamily: codeFontFamilyForEditor(readCodeFontFamily()),
+      // Monaco's fontWeight takes a string; the stored numeric weight maps 1:1.
+      fontWeight: String(readCodeFontWeight()),
       automaticLayout: true,
       renderLineHighlight: canEdit ? "line" : "none",
       // Read-only buffers still allow selection + copy; just hide the caret.
@@ -421,6 +424,7 @@ function MonacoCodeEditorInner({
       editorInstanceRef.current?.updateOptions({
         fontSize: font.sizePx,
         fontFamily: codeFontFamilyForEditor(font.family),
+        fontWeight: String(font.weight),
       });
     });
   }, []);


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The Appearance settings already expose a **Code font** group (size + family) that drives both the Monaco editor and the xterm terminal. This adds a third control to that group: a **Code font weight** stepper, so code surfaces can be made lighter or heavier to taste.
- Weight is persisted as a CSS numeric weight (100–900, stepped by 100) under a new `omnigent:code-font-weight` key, defaulting to **400** — matching both widgets' current normal weight, so an unset preference renders exactly as today.
- Both widgets re-apply the weight live via the existing code-font pub/sub (no new state library). xterm's bold weight is derived from the chosen normal weight (`+300`, capped at 900) so bold cells stay proportional, and a weight change re-fits the terminal grid since glyph advance can shift with weight.

## Test Plan

Ran from `web/`:

- `npm run type-check` → **pass** (`tsc -b`, no errors).
- `npm run lint` (`oxlint .`) → no new findings; the 10 pre-existing errors (in `agentBundle.test.ts` and `TerminalSession.test.ts:293`) are unchanged from the base branch and unrelated to this change.
- `npx vitest run` → **pass** (214 files, 3809 tests passed, 3 expected-fail, 2 skipped).
- `pre-commit run --files <changed files>` → **pass** (prettier, whitespace, EOF, etc.).

New/extended unit tests:
- `codeFontPreferences.test.ts`: weight default, round-trip, clamp above/below range, step-snapping, malformed/non-numeric fallback, pub/sub emission (incl. quota-throw path), `codeFontBoldWeight` derivation + cap, and `readCodeFont` reading all three prefs together. Existing pub/sub expectations updated to include `weight`.
- `SettingsPage.test.tsx`: default weight display + step-up persistence, and min/max stepper disabling.
- `TerminalSession.test.ts`: `setFont(...)` now asserts `fontWeight`/`fontWeightBold` are applied and derived.

## Demo

N/A — screenshots/video are not capturable by an automated agent. Manual verification instead: the new **Code font weight** row renders in Settings → Appearance under the existing Code font size/family rows, as a `[ − | value | + ]` pill matching the size stepper. Stepping it writes `omnigent:code-font-weight` and, via the code-font pub/sub, live-updates a mounted Monaco editor's `fontWeight` and the xterm terminal's `fontWeight`/`fontWeightBold` (with a re-fit). This behaviour is covered by the unit tests listed above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Weight preference logic (clamp/snap/read/write/pub-sub/bold-derivation) and the settings stepper are covered by the new unit tests above. Manual verification: confirmed the control renders in the Code font group and that the weight flows through to Monaco (`fontWeight`) and xterm (`fontWeight` + derived `fontWeightBold`) live via the pub/sub; the terminal path re-fits on change. Rendering the actual glyph weight in a live browser could not be automated in this environment.

## Changelog

Added a Code font weight setting in Appearance that adjusts the editor and terminal font weight
