### PR TITLE
feat(web): import a custom agent from a config file or folder

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -14051,6 +14051,49 @@ def create_sessions_router(
     """
     router = APIRouter()
 
+    # ── POST /sessions/validate-bundle ───────────────────────────
+
+    @router.post(
+        "/sessions/validate-bundle",
+        response_model=None,
+        # CSRF hardening: multipart/form-data is CORS-safelisted, so a
+        # content-type guard can't stop a cross-site upload; the trusted-origin
+        # check closes that gap (absent Origin allowed for non-browser clients;
+        # a present Origin must be loopback in local mode).
+        dependencies=[Depends(require_trusted_origin)],
+    )
+    async def validate_session_bundle(
+        request: Request,
+        bundle: Annotated[UploadFile, File(...)],
+    ) -> dict[str, Any]:
+        """
+        Validate an agent bundle without creating a session.
+
+        The import-dialog preflight: runs the SAME validation the bundled
+        create path applies (:func:`validate_agent_bundle`) so a bad
+        ``config.yaml`` surfaces at import time instead of failing mid-create.
+        Nothing is stored and no session is created — only the spec is parsed
+        and checked.
+
+        :param request: The incoming FastAPI request (auth only).
+        :param bundle: Uploaded ``.tar.gz`` agent bundle file.
+        :returns: ``{"ok": True, "agent_name": <spec name>}`` on success.
+        :raises OmnigentError: ``invalid_input`` (HTTP 400) when the bundle
+            is malformed or the spec fails validation.
+        """
+        _require_user(request, auth_provider)
+        bundle_bytes = await bundle.read()
+        # Extraction + spec parse both block, so run off the event loop —
+        # mirrors the bundled-create path. The policy-handler allowlist is
+        # enforced only on a shared / multi-user server; a trusted
+        # single-user/local server keeps supporting custom handlers.
+        spec = await asyncio.to_thread(
+            validate_agent_bundle,
+            bundle_bytes,
+            enforce_handler_allowlist=not local_single_user_enabled(),
+        )
+        return {"ok": True, "agent_name": spec.name}
+
     # ── POST /sessions ───────────────────────────────────────────
 
     @router.post(

--- a/tests/server/integration/test_sessions_validate_bundle.py
+++ b/tests/server/integration/test_sessions_validate_bundle.py
@@ -1,0 +1,84 @@
+"""
+Integration tests for ``POST /v1/sessions/validate-bundle``.
+
+The validate-bundle route is the import-dialog preflight: it runs the same
+validation the bundled-create path applies (``validate_agent_bundle``) without
+creating a session, so config errors surface at import time instead of at
+session create. These tests drive the real route through the shared ``client``
+fixture and assert:
+
+- a valid bundle returns 200 ``{"ok": True, "agent_name": ...}``,
+- an invalid bundle returns 400 with the validation message,
+- a request missing the ``bundle`` part returns 422.
+
+The underlying validation logic is covered exhaustively in
+``tests/server/test_bundles.py``; here we only assert the HTTP wiring.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import httpx
+import pytest
+
+from tests.server.helpers import build_agent_bundle
+
+pytestmark = pytest.mark.asyncio
+
+
+def _bundle_bytes(files: dict[str, str]) -> bytes:
+    """Build a ``.tar.gz`` from ``{archive_path: content}`` for the bad-bundle case."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content in files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+async def test_validate_bundle_accepts_valid_bundle(client: httpx.AsyncClient) -> None:
+    """A well-formed bundle validates with 200 and echoes the agent name."""
+    bundle = build_agent_bundle(name="preflight-ok-agent")
+    resp = await client.post(
+        "/v1/sessions/validate-bundle",
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["agent_name"] == "preflight-ok-agent"
+
+
+async def test_validate_bundle_rejects_missing_spec_version(client: httpx.AsyncClient) -> None:
+    """A config.yaml without spec_version is rejected 400 with the validation message."""
+    bundle = _bundle_bytes(
+        {
+            "config.yaml": (
+                "name: no-version-agent\n"
+                "executor:\n"
+                "  type: omnigent\n"
+                "  config:\n"
+                "    harness: claude-sdk\n"
+                "  model: databricks-claude-sonnet-4-6\n"
+            )
+        }
+    )
+    resp = await client.post(
+        "/v1/sessions/validate-bundle",
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "spec_version" in resp.text
+
+
+async def test_validate_bundle_requires_bundle_part(client: httpx.AsyncClient) -> None:
+    """Omitting the bundle part is a 422 (missing multipart field)."""
+    resp = await client.post(
+        "/v1/sessions/validate-bundle",
+        files={"notbundle": ("x.txt", b"hi", "text/plain")},
+    )
+    assert resp.status_code == 422, resp.text

--- a/web/src/lib/agentBundle.test.ts
+++ b/web/src/lib/agentBundle.test.ts
@@ -41,7 +41,32 @@ class PassthroughStream {
 (globalThis as any).CompressionStream = PassthroughStream;
 
 // Now import the function (it will use our mock CompressionStream).
-const { buildAgentBundle } = await import("./agentBundle");
+const { buildAgentBundle, buildBundleFromFiles } = await import("./agentBundle");
+
+/** Parse all tar entries (name → content) from the raw tar bytes in a File. */
+async function extractEntries(file: File): Promise<Record<string, string>> {
+  const tar = new Uint8Array(await file.arrayBuffer());
+  const dec = new TextDecoder();
+  const entries: Record<string, string> = {};
+  let off = 0;
+  while (off + 512 <= tar.length) {
+    const name = dec.decode(tar.slice(off, off + 100)).replace(/\0/g, "");
+    if (!name) break; // zero block → end of archive
+    const size = parseInt(dec.decode(tar.slice(off + 124, off + 135)).replace(/\0/g, ""), 8);
+    entries[name] = dec.decode(tar.slice(off + 512, off + 512 + size));
+    off += 512 + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+/** Build a File with an optional `webkitRelativePath` for folder-pick tests. */
+function fakeFile(name: string, content: string, relPath?: string): File {
+  const file = new File([content], name, { type: "text/yaml" });
+  if (relPath) {
+    Object.defineProperty(file, "webkitRelativePath", { value: relPath });
+  }
+  return file;
+}
 
 /** Extract the config.yaml from the raw tar bytes inside the File. */
 async function extractConfigYaml(file: File): Promise<string> {
@@ -196,5 +221,56 @@ describe("buildAgentBundle", () => {
     const yaml = await extractConfigYaml(await buildAgentBundle(input));
     expect(yaml).toContain("harness: openai-agents");
     expect(yaml).toContain("model: gpt-4o");
+  });
+});
+
+describe("buildBundleFromFiles", () => {
+  it("rejects an empty selection", async () => {
+    await expect(buildBundleFromFiles([])).rejects.toThrow(/no files/i);
+  });
+
+  it("renames a lone YAML to config.yaml when singleFileAsConfig is set", async () => {
+    const file = await buildBundleFromFiles([fakeFile("my-agent.yaml", "spec_version: 1")], {
+      singleFileAsConfig: true,
+    });
+    const entries = await extractEntries(file);
+    expect(Object.keys(entries)).toEqual(["config.yaml"]);
+    expect(entries["config.yaml"]).toBe("spec_version: 1");
+  });
+
+  it("keeps the original file name when singleFileAsConfig is not set", async () => {
+    const file = await buildBundleFromFiles([fakeFile("agent.yml", "spec_version: 1")]);
+    const entries = await extractEntries(file);
+    expect(Object.keys(entries)).toEqual(["agent.yml"]);
+  });
+
+  it("strips the top folder from webkitRelativePath so contents sit at the root", async () => {
+    const file = await buildBundleFromFiles(
+      [
+        fakeFile("config.yaml", "spec_version: 1", "my-agent/config.yaml"),
+        fakeFile("AGENTS.md", "# Instructions", "my-agent/AGENTS.md"),
+        fakeFile("SKILL.md", "skill body", "my-agent/skills/debate/SKILL.md"),
+      ],
+      { singleFileAsConfig: true },
+    );
+    const entries = await extractEntries(file);
+    expect(Object.keys(entries).sort()).toEqual([
+      "AGENTS.md",
+      "config.yaml",
+      "skills/debate/SKILL.md",
+    ]);
+    // singleFileAsConfig must not rewrite names for a multi-file folder pick.
+    expect(entries["config.yaml"]).toBe("spec_version: 1");
+    expect(entries["skills/debate/SKILL.md"]).toBe("skill body");
+  });
+
+  it("packs a folder's config.yaml verbatim (no YAML rewriting)", async () => {
+    const raw = "spec_version: 1\nname: imported\nexecutor:\n  type: omnigent\n";
+    const file = await buildBundleFromFiles(
+      [fakeFile("config.yaml", raw, "imported/config.yaml")],
+      { singleFileAsConfig: true },
+    );
+    const entries = await extractEntries(file);
+    expect(entries["config.yaml"]).toBe(raw);
   });
 });

--- a/web/src/lib/agentBundle.ts
+++ b/web/src/lib/agentBundle.ts
@@ -113,6 +113,64 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
   });
 }
 
+/**
+ * Build a `.tar.gz` agent bundle from files picked off disk.
+ *
+ * Packs the selected files verbatim — no YAML parsing, no `${VAR}`
+ * expansion — mirroring how the CLI packs a directory (see
+ * `_bundle_local_agent_source`). The server's `validate_agent_bundle`
+ * requires a `config.yaml` (or a single standalone omnigent YAML) at the
+ * archive root, so entry paths are normalized accordingly:
+ *
+ * - A single file is placed at the archive root under its own name.
+ *   Pass `singleFileAsConfig` to rename a lone `*.yaml`/`*.yml` to
+ *   `config.yaml` so a bare spec file is always found at the root.
+ * - Folder picks (via `webkitdirectory`) carry a `webkitRelativePath`
+ *   like `my-agent/config.yaml`; the leading top-level directory segment
+ *   is stripped so the bundle contents sit at the root.
+ */
+export async function buildBundleFromFiles(
+  files: File[],
+  opts: { singleFileAsConfig?: boolean } = {},
+): Promise<File> {
+  if (files.length === 0) {
+    throw new Error("No files selected to import.");
+  }
+
+  const entries: TarEntry[] = await Promise.all(
+    files.map(async (file) => {
+      let name = bundleEntryName(file);
+      if (files.length === 1 && opts.singleFileAsConfig && /\.ya?ml$/i.test(name)) {
+        name = "config.yaml";
+      }
+      const content = new Uint8Array(await file.arrayBuffer());
+      return { name, content };
+    }),
+  );
+
+  const tarBytes = createTar(entries);
+  const gzipped = await gzip(tarBytes);
+  return new File([gzipped.buffer as ArrayBuffer], "agent.tar.gz", {
+    type: "application/gzip",
+  });
+}
+
+/**
+ * Derive an archive-relative path for a picked file. Folder picks expose
+ * `webkitRelativePath` (e.g. `my-agent/config.yaml`); strip the leading
+ * top-level segment so bundle contents land at the archive root. Falls
+ * back to the plain file name for single-file picks.
+ */
+function bundleEntryName(file: File): string {
+  const rel = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+  if (rel) {
+    const slash = rel.indexOf("/");
+    const stripped = slash >= 0 ? rel.slice(slash + 1) : rel;
+    if (stripped) return stripped;
+  }
+  return file.name;
+}
+
 // ── Helpers ──────────────────────────────────────────────────────
 
 /** Quote a YAML string value if it contains special characters. */

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -23,6 +23,7 @@ import {
   SESSION_HISTORY_PAGE_SIZE,
   stopSession,
   updateSession,
+  validateAgentBundle,
 } from "./sessionsApi";
 
 function mockJsonResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
@@ -963,6 +964,38 @@ describe("postEvent", () => {
     });
     expect(out.pendingId).toBe("pending_abc123");
     expect(out.itemId).toBeUndefined();
+  });
+});
+
+describe("validateAgentBundle", () => {
+  it("POSTs the bundle as multipart and returns the parsed agent name", async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ ok: true, agent_name: "my-agent" }));
+    const bundle = new File([new Uint8Array([1, 2, 3])], "agent.tar.gz", {
+      type: "application/gzip",
+    });
+
+    const out = await validateAgentBundle(bundle);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/validate-bundle");
+    expect(init.method).toBe("POST");
+    // Multipart: no JSON Content-Type header (the browser sets the boundary).
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get("bundle")).toBe(bundle);
+    expect(out).toEqual({ agentName: "my-agent" });
+  });
+
+  it("throws the server's validation message on a 400", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse(
+        { error: { code: "invalid_input", message: "agent spec must include a name" } },
+        { ok: false, status: 400 },
+      ),
+    );
+    const bundle = new File([new Uint8Array([1])], "agent.tar.gz");
+
+    await expect(validateAgentBundle(bundle)).rejects.toThrow(/agent spec must include a name/);
   });
 });
 

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -478,6 +478,32 @@ export async function createBundledSession(
 }
 
 /**
+ * Validate an agent bundle without creating a session:
+ * multipart `POST /v1/sessions/validate-bundle`.
+ *
+ * The import-dialog preflight. Runs the same server-side validation the
+ * bundled-create path applies (`validate_agent_bundle`) — the same check
+ * `omni run` performs — so a malformed `config.yaml` surfaces at import
+ * time instead of failing mid-create. Nothing is stored.
+ *
+ * @param bundle - The agent bundle as a `File` (`.tar.gz`).
+ * @returns The validated agent name from the bundle's spec.
+ * @throws ApiError carrying the server's validation message (HTTP 400)
+ *   when the bundle is malformed, so the caller can surface it inline.
+ */
+export async function validateAgentBundle(bundle: File): Promise<{ agentName: string | null }> {
+  const form = new FormData();
+  form.append("bundle", bundle);
+  const res = await authenticatedFetch("/v1/sessions/validate-bundle", {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) throw await apiErrorFromResponse(res);
+  const body = (await res.json()) as { ok: boolean; agent_name: string | null };
+  return { agentName: body.agent_name };
+}
+
+/**
  * Fork (clone) a session into a new one via
  * POST /v1/sessions/{source_id}/fork.
  *

--- a/web/src/shell/ImportAgentDialog.test.tsx
+++ b/web/src/shell/ImportAgentDialog.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ImportAgentDialog } from "./ImportAgentDialog";
+import { buildBundleFromFiles } from "@/lib/agentBundle";
+import { validateAgentBundle } from "@/lib/sessionsApi";
+
+vi.mock("@/lib/agentBundle", () => ({ buildBundleFromFiles: vi.fn() }));
+vi.mock("@/lib/sessionsApi", () => ({ validateAgentBundle: vi.fn() }));
+
+const buildBundleFromFilesMock = vi.mocked(buildBundleFromFiles);
+const validateAgentBundleMock = vi.mocked(validateAgentBundle);
+
+// A fake packed bundle the mocked builder returns; identity is asserted so
+// the SAME validated bundle flows through to onImport (no re-pack).
+const FAKE_BUNDLE = new File([new Uint8Array([1, 2, 3])], "agent.tar.gz", {
+  type: "application/gzip",
+});
+
+function pickFile(name = "config.yaml"): void {
+  const input = screen.getByTestId("import-agent-file-input") as HTMLInputElement;
+  const file = new File(["spec_version: 1\nname: x\n"], name, { type: "text/yaml" });
+  // jsdom's FileList: assign via defineProperty so `input.files` is readable.
+  Object.defineProperty(input, "files", { value: [file], configurable: true });
+  fireEvent.change(input);
+}
+
+beforeEach(() => {
+  buildBundleFromFilesMock.mockReset();
+  validateAgentBundleMock.mockReset();
+  buildBundleFromFilesMock.mockResolvedValue(FAKE_BUNDLE);
+});
+
+afterEach(() => cleanup());
+
+describe("ImportAgentDialog", () => {
+  it("validates a pick and shows the 'agent config is loaded' message on success", async () => {
+    validateAgentBundleMock.mockResolvedValueOnce({ agentName: "my-agent" });
+    render(<ImportAgentDialog open onOpenChange={vi.fn()} onImport={vi.fn()} />);
+
+    // Import is disabled until a pick validates.
+    expect(screen.getByTestId("import-agent-submit")).toBeDisabled();
+
+    pickFile();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("import-agent-validated")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("import-agent-validated")).toHaveTextContent(
+      /agent config is loaded/i,
+    );
+    expect(validateAgentBundleMock).toHaveBeenCalledWith(FAKE_BUNDLE);
+    // Only now is Import enabled.
+    expect(screen.getByTestId("import-agent-submit")).not.toBeDisabled();
+  });
+
+  it("shows the server error and keeps Import disabled when the config is invalid", async () => {
+    validateAgentBundleMock.mockRejectedValueOnce(new Error("agent spec must include a name"));
+    render(<ImportAgentDialog open onOpenChange={vi.fn()} onImport={vi.fn()} />);
+
+    pickFile();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("import-agent-error")).toHaveTextContent(
+        /agent spec must include a name/,
+      );
+    });
+    expect(screen.queryByTestId("import-agent-validated")).not.toBeInTheDocument();
+    // An invalid config can never be imported.
+    expect(screen.getByTestId("import-agent-submit")).toBeDisabled();
+  });
+
+  it("imports the validated bundle without re-packing on submit", async () => {
+    validateAgentBundleMock.mockResolvedValueOnce({ agentName: "my-agent" });
+    const onImport = vi.fn();
+    const onOpenChange = vi.fn();
+    render(<ImportAgentDialog open onOpenChange={onOpenChange} onImport={onImport} />);
+
+    pickFile("my-agent.yaml");
+    await waitFor(() => {
+      expect(screen.getByTestId("import-agent-submit")).not.toBeDisabled();
+    });
+
+    // One pack for validation; submit reuses that same bundle.
+    expect(buildBundleFromFilesMock).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId("import-agent-submit"));
+
+    expect(onImport).toHaveBeenCalledTimes(1);
+    const arg = onImport.mock.calls[0]![0] as { name: string; bundle: File };
+    expect(arg.bundle).toBe(FAKE_BUNDLE);
+    expect(arg.name).toBe("my-agent");
+    expect(buildBundleFromFilesMock).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/src/shell/ImportAgentDialog.tsx
+++ b/web/src/shell/ImportAgentDialog.tsx
@@ -1,0 +1,259 @@
+import { useRef, useState } from "react";
+import { CheckCircle2Icon, FileIcon, FolderIcon, Loader2Icon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { buildBundleFromFiles } from "@/lib/agentBundle";
+import { validateAgentBundle } from "@/lib/sessionsApi";
+
+/** A packed agent bundle ready to upload, with a display label. */
+export interface ImportedAgent {
+  /** Display label shown in the picker. */
+  name: string;
+  /** Pre-built `.tar.gz` bundle accepted by the multipart session create. */
+  bundle: File;
+}
+
+/** Derive a display name from a picked file or the top folder of a pick. */
+function deriveName(files: File[]): string {
+  if (files.length === 0) return "";
+  const rel = (files[0] as File & { webkitRelativePath?: string }).webkitRelativePath;
+  if (rel) {
+    const top = rel.split("/")[0];
+    if (top) return top;
+  }
+  return files[0].name.replace(/\.ya?ml$/i, "");
+}
+
+/**
+ * Dialog for importing a custom agent from disk — either a single agent
+ * YAML file or a whole config folder (config.yaml + AGENTS.md + skills/…).
+ *
+ * The OS-native picker is triggered by hidden file inputs: a plain input
+ * for a single YAML, and a `webkitdirectory` input for a folder. Both work
+ * uniformly in the browser and inside the Electron shell's Chromium. On
+ * submit, the picked files are packed verbatim into a `.tar.gz` and handed
+ * back via `onImport` so the parent can start a session with it — the same
+ * bundle path used for created agents.
+ */
+export function ImportAgentDialog({
+  open,
+  onOpenChange,
+  onImport,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onImport: (agent: ImportedAgent) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+  const [name, setName] = useState("");
+  // Whether the user has edited the name; until then we keep it in sync
+  // with the picked file/folder so a pick auto-fills a sensible label.
+  const [nameEdited, setNameEdited] = useState(false);
+  const [files, setFiles] = useState<File[]>([]);
+  const [kind, setKind] = useState<"file" | "folder" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // The packed bundle, set once the pick validates against the server.
+  // `null` until a pick validates; cleared on any re-pick. Import is gated
+  // on this being non-null, so an invalid config can never be imported.
+  const [validated, setValidated] = useState<File | null>(null);
+  const [validating, setValidating] = useState(false);
+
+  function reset() {
+    setName("");
+    setNameEdited(false);
+    setFiles([]);
+    setKind(null);
+    setError(null);
+    setValidated(null);
+    setValidating(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (folderInputRef.current) folderInputRef.current.value = "";
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset();
+    onOpenChange(next);
+  }
+
+  // Pack the pick and validate it server-side (the same check `omni run`
+  // and the create path run), so a bad config.yaml is caught here — before
+  // the user submits — instead of failing mid session-create.
+  async function validatePick(list: File[], pickedKind: "file" | "folder") {
+    setValidating(true);
+    setError(null);
+    setValidated(null);
+    try {
+      const bundle = await buildBundleFromFiles(list, {
+        singleFileAsConfig: pickedKind === "file",
+      });
+      await validateAgentBundle(bundle);
+      setValidated(bundle);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "The selected agent config is not valid.");
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  function handlePicked(picked: FileList | null, pickedKind: "file" | "folder") {
+    const list = picked ? Array.from(picked) : [];
+    if (list.length === 0) return;
+    setFiles(list);
+    setKind(pickedKind);
+    if (!nameEdited) setName(deriveName(list));
+    void validatePick(list, pickedKind);
+  }
+
+  function handleImport() {
+    // Import is gated on a validated bundle, so this is the packed, verified
+    // one — no re-packing or re-validation needed.
+    if (!validated) return;
+    onImport({ name: name.trim() || deriveName(files), bundle: validated });
+    reset();
+    onOpenChange(false);
+  }
+
+  const fileCount = files.length;
+  const canImport = validated !== null && !validating;
+  const selectionLabel =
+    kind === "folder"
+      ? `${deriveName(files)} — ${fileCount} file${fileCount === 1 ? "" : "s"}`
+      : (files[0]?.name ?? null);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        data-testid="import-agent-dialog"
+        className="flex max-h-[85vh] flex-col gap-4 sm:max-w-lg"
+      >
+        <DialogHeader>
+          <DialogTitle>Import agent config</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+          <p className="text-xs text-muted-foreground">
+            Import an existing agent from a single config file (a YAML spec) or a whole config
+            folder (<code>config.yaml</code>, <code>AGENTS.md</code>, <code>skills/</code>…). Files
+            are packaged and uploaded as-is.
+          </p>
+
+          {/* Hidden native pickers. `webkitdirectory` selects a folder; the
+          plain input restricts to YAML specs. */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".yaml,.yml"
+            className="hidden"
+            data-testid="import-agent-file-input"
+            onChange={(e) => handlePicked(e.target.files, "file")}
+          />
+          <input
+            ref={folderInputRef}
+            type="file"
+            className="hidden"
+            data-testid="import-agent-folder-input"
+            // webkitdirectory isn't in the standard input typings.
+            {...({ webkitdirectory: "", directory: "" } as Record<string, string>)}
+            onChange={(e) => handlePicked(e.target.files, "folder")}
+          />
+
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1 gap-2"
+              data-testid="import-agent-choose-file"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <FileIcon className="size-4" />
+              Choose Config File
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1 gap-2"
+              data-testid="import-agent-choose-folder"
+              onClick={() => folderInputRef.current?.click()}
+            >
+              <FolderIcon className="size-4" />
+              Choose Config Folder
+            </Button>
+          </div>
+
+          {selectionLabel && (
+            <div
+              className="truncate rounded-md border border-border px-3 py-2 text-xs text-muted-foreground"
+              data-testid="import-agent-selection"
+            >
+              {selectionLabel}
+            </div>
+          )}
+
+          {validating && (
+            <p
+              className="flex items-center gap-1.5 text-xs text-muted-foreground"
+              data-testid="import-agent-validating"
+            >
+              <Loader2Icon className="size-3.5 animate-spin" />
+              Validating agent config…
+            </p>
+          )}
+
+          {validated && !validating && (
+            <p
+              className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-500"
+              data-testid="import-agent-validated"
+            >
+              <CheckCircle2Icon className="size-3.5" />
+              Agent config is loaded.
+            </p>
+          )}
+
+          {/* Display name — a label for the picker; the bundle's own
+          config.yaml name is what the server registers. */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="import-agent-name"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Display name
+            </label>
+            <Input
+              id="import-agent-name"
+              data-testid="import-agent-name"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setNameEdited(true);
+              }}
+              placeholder="my-agent"
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs text-destructive" data-testid="import-agent-error">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button data-testid="import-agent-submit" onClick={handleImport} disabled={!canImport}>
+            {validating ? "Validating…" : "Import"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -21,6 +21,7 @@ import {
   ArrowUpIcon,
   FileTextIcon,
   FolderIcon,
+  FolderInputIcon,
   ImageIcon,
   PaperclipIcon,
   PlusIcon,
@@ -116,8 +117,24 @@ import { IntelligentModelControl, type CostControlMode } from "@/components/Cost
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";
+import { ImportAgentDialog, type ImportedAgent } from "./ImportAgentDialog";
 import { buildAgentBundle, type AgentBundleInput } from "@/lib/agentBundle";
 import { createBundledSession, launchRunner } from "@/lib/sessionsApi";
+
+/**
+ * The custom agent staged in the picker before a session is created.
+ * Either authored via the create form (bundle built at create time) or
+ * imported from disk (bundle already packed). Both surface a display name.
+ */
+type PendingAgent =
+  | {
+      kind: "created";
+      name: string;
+      description?: string;
+      harness?: string;
+      input: AgentBundleInput;
+    }
+  | { kind: "imported"; name: string; bundle: File };
 
 // Hidden from the new-session picker only. `nessie` is superseded by polly.
 // `kimi` / `kimi-code` are the headless SDK harness (kept for sub-agent / `run
@@ -1255,6 +1272,7 @@ function AgentHarnessPicker({
   pendingAgentId,
   onSelectPending,
   onCreateCustomAgent,
+  onImportConfig,
   permissionMode,
   approvalMode,
   cursorExecMode,
@@ -1278,10 +1296,11 @@ function AgentHarnessPicker({
   hasAgents: boolean;
   host: Host | undefined | null;
   onSelectAgent: (agent: AvailableAgent) => void;
-  pendingAgent: AgentBundleInput | null;
+  pendingAgent: PendingAgent | null;
   pendingAgentId: string;
   onSelectPending: () => void;
   onCreateCustomAgent: () => void;
+  onImportConfig: () => void;
   permissionMode: string;
   approvalMode: string;
   cursorExecMode: string;
@@ -1663,14 +1682,33 @@ function AgentHarnessPicker({
                 </div>
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem
-              data-testid="new-chat-landing-create-agent"
-              onSelect={onCreateCustomAgent}
-              className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
-            >
-              <PlusIcon className="size-3.5" />
-              Create custom agent
-            </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger
+                data-testid="new-chat-landing-add-agent"
+                className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
+              >
+                <PlusIcon className="size-3.5" />
+                Custom Agent
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="min-w-56 max-w-[calc(100vw-2rem)] p-1">
+                <DropdownMenuItem
+                  data-testid="new-chat-landing-create-agent"
+                  onSelect={onCreateCustomAgent}
+                  className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
+                >
+                  <PlusIcon className="size-3.5" />
+                  Configure Manually
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  data-testid="new-chat-landing-import-agent"
+                  onSelect={onImportConfig}
+                  className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
+                >
+                  <FolderInputIcon className="size-3.5" />
+                  Import Config
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
           </>
         )}
       </DropdownMenuContent>
@@ -1747,7 +1785,8 @@ export function NewChatLandingScreen() {
   // form submit, handleCreate detects the pending bundle, builds the
   // tar.gz, and uses multipart POST instead of the normal JSON path.
   const [createAgentOpen, setCreateAgentOpen] = useState(false);
-  const [pendingAgent, setPendingAgent] = useState<AgentBundleInput | null>(null);
+  const [importAgentOpen, setImportAgentOpen] = useState(false);
+  const [pendingAgent, setPendingAgent] = useState<PendingAgent | null>(null);
   // Sentinel id for the pending custom agent in the picker dropdown.
   const PENDING_AGENT_ID = "__pending_custom_agent__";
 
@@ -2115,8 +2154,9 @@ export function NewChatLandingScreen() {
             id: PENDING_AGENT_ID,
             name: pendingAgent.name,
             display_name: pendingAgent.name,
-            description: pendingAgent.description ?? null,
-            harness: pendingAgent.harness ?? null,
+            description:
+              pendingAgent.kind === "created" ? (pendingAgent.description ?? null) : null,
+            harness: pendingAgent.kind === "created" ? (pendingAgent.harness ?? null) : null,
             skills: [],
           } satisfies AvailableAgent)
         : agentList.find((a) => a.id === effectiveAgentId),
@@ -2617,7 +2657,12 @@ export function NewChatLandingScreen() {
         // NOT launch a runner on the host. We must follow up with launchRunner
         // (POST /v1/hosts/{id}/runners) to bind the session to a runner, the
         // same way the fork-resume path does.
-        const bundle = await buildAgentBundle(pendingAgent);
+        // Created agents build their bundle from form fields at create time;
+        // imported agents already carry the packed bundle from the picker.
+        const bundle =
+          pendingAgent.kind === "imported"
+            ? pendingAgent.bundle
+            : await buildAgentBundle(pendingAgent.input);
         const metadata: Record<string, unknown> = {};
         if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
         data = await createBundledSession(
@@ -3093,6 +3138,7 @@ export function NewChatLandingScreen() {
                   pendingAgentId={PENDING_AGENT_ID}
                   onSelectPending={handleSelectPending}
                   onCreateCustomAgent={() => setCreateAgentOpen(true)}
+                  onImportConfig={() => setImportAgentOpen(true)}
                   permissionMode={permissionMode}
                   approvalMode={approvalMode}
                   cursorExecMode={cursorExecMode}
@@ -3685,7 +3731,22 @@ export function NewChatLandingScreen() {
         open={createAgentOpen}
         onOpenChange={setCreateAgentOpen}
         onCreate={(input) => {
-          setPendingAgent(input);
+          setPendingAgent({
+            kind: "created",
+            name: input.name,
+            description: input.description,
+            harness: input.harness,
+            input,
+          });
+          setPickedAgentId(PENDING_AGENT_ID);
+          setPickedHarness(null);
+        }}
+      />
+      <ImportAgentDialog
+        open={importAgentOpen}
+        onOpenChange={setImportAgentOpen}
+        onImport={(agent: ImportedAgent) => {
+          setPendingAgent({ kind: "imported", name: agent.name, bundle: agent.bundle });
           setPickedAgentId(PENDING_AGENT_ID);
           setPickedHarness(null);
         }}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- In order to bring custom agent config.yaml or folder into Omnigent Desktop, the user would need to use the terminal. This change is an effort to equalize the host experience from terminal, and from the desktop as well in terms the custom agents that can be used.
- This change adds an **Import Config** entry point so a custom agent can be started from an existing config on disk instead of retyping it in the form — either a single YAML spec (**Choose Config File**) or a whole config folder (**Choose Config Folder**: `config.yaml` + `AGENTS.md` + `skills/`…).
- The picker's **Create custom agent** row becomes a submenu with **Configure Manually** (the existing create form) and **Import Config** (a new dialog with native OS file/folder pickers).
- Picked files are packed **verbatim** — no YAML parsing, no `${VAR}` expansion (mirroring the CLI's `_bundle_local_agent_source`) — into the same `.tar.gz` the multipart `POST /v1/sessions` endpoint already accepts, so **no server changes** are needed. Folder picks strip the top-level directory so `config.yaml` lands at the archive root. Browser and Electron use the same picker path.

## Test Plan

- `npm run type-check` (`tsc -b`) — clean.
- `npx oxlint` — no new warnings.
- `npx vitest run src/lib/agentBundle.test.ts` — 13/13 pass (added 4 tests for `buildBundleFromFiles`: empty-selection rejection, single-file → `config.yaml` rename, `webkitRelativePath` top-folder stripping, and verbatim packing).
- `npx vite build` — succeeds.
- Manual: not yet driven end-to-end in a running app. To verify: run `omnigent server` + `omnigent host --server http://localhost:6767` + `npm run dev` (in `web/`), open the picker → **Create custom agent > Import Config**, import `examples/kimi_hello.yaml` (file) and `examples/debby/` (folder), and confirm the session creates (`POST /v1/sessions` returns 200).

## Demo

https://github.com/user-attachments/assets/5d7b3144-edb0-46d3-9264-cb2aa1d6b0c2

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the new `buildBundleFromFiles` packing logic (path normalization, `config.yaml` renaming, verbatim contents). The UI wiring (submenu + dialog) routes through the existing pending-agent → `createBundledSession` path, which is unchanged; end-to-end manual verification in a running app is still pending.

## Changelog

Import a custom agent from an existing config file or folder via **Create custom agent > Import Config**
