### PR TITLE
perf(search): scope content-search item scan to the caller's ACL

### DIFF
--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -858,6 +858,55 @@ def strip_nul_bytes(value: str) -> str:
     return value.replace("\x00", "")
 
 
+def build_search_snippet(
+    text: str,
+    query: str,
+    *,
+    context: int = 60,
+    max_len: int = 160,
+) -> str | None:
+    """
+    Build a short excerpt of ``text`` centered on the first ``query`` match.
+
+    Powers the session-search preview: the sidebar/palette matches on chat
+    content, so a hit is often invisible in the session title. This returns
+    the matching span plus a little surrounding context, with ``…`` marking
+    elided ends, so the UI can show *where* a session matched.
+
+    Matching is case-insensitive substring (mirrors the ``LIKE`` filter that
+    selected the row). Whitespace in ``text`` is collapsed first so a match
+    inside a multi-line tool output renders as one clean line.
+
+    :param text: The item's plain search text to excerpt from.
+    :param query: The user's search string, e.g. ``"deploy error"``.
+    :param context: Characters of context to keep on each side of the match.
+    :param max_len: Hard cap on the returned snippet length (excluding the
+        ``…`` markers) so a giant match term can't blow up the row.
+    :returns: The excerpt, or ``None`` when ``query`` is empty or does not
+        occur in ``text`` (caller then falls back to no preview).
+    """
+    if not query:
+        return None
+    collapsed = " ".join(text.split())
+    idx = collapsed.lower().find(query.lower())
+    if idx == -1:
+        return None
+    match_end = idx + len(query)
+    start = max(0, idx - context)
+    end = min(len(collapsed), match_end + context)
+    # Keep the total under max_len, but never clamp the matched term itself out
+    # of the window — otherwise the UI would highlight nothing. A pathologically
+    # long match term overflows max_len rather than being cut mid-term.
+    if end - start > max_len:
+        end = max(start + max_len, match_end)
+    snippet = collapsed[start:end]
+    if start > 0:
+        snippet = f"…{snippet}"
+    if end < len(collapsed):
+        snippet = f"{snippet}…"
+    return snippet
+
+
 # ── Timestamp ──────────────────────────────────────────
 
 

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -180,6 +180,12 @@ class Conversation:
         listing (and the sidebar), surfacing only when the caller
         passes ``include_archived=True``. ``False`` for normal
         sessions; toggled via ``PATCH /v1/sessions/{id}``.
+    :param search_snippet: Transient, list-only excerpt of the chat
+        content that matched a ``search_query`` — set by
+        ``list_conversations`` whenever the query hit an item's body (even
+        if the title also matched), so the search UI can show *where* the
+        session matched. Never persisted (not a DB column) and ``None`` on
+        every non-search read path and title-only matches.
     """
 
     id: str
@@ -205,6 +211,9 @@ class Conversation:
     workspace: str | None = None
     git_branch: str | None = None
     archived: bool = False
+    # Transient: populated only by list_conversations on a content search;
+    # never read from or written to the DB.
+    search_snippet: str | None = None
 
 
 # ── Conversation item data types ───────────────────────

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -2157,6 +2157,9 @@ def _build_session_list_item(
         ),
         viewer_last_seen=viewer_last_seen,
         viewer_unread=viewer_unread,
+        # Transient; set by the store only on a content search. The WS
+        # push-stream path leaves it None (no query in flight there).
+        search_snippet=conv.search_snippet,
     )
 
 

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -14883,7 +14883,14 @@ def create_sessions_router(
         # ``permission_level === null`` full-access sentinel in the web sidebar
         # is never tripped by a streamed null. The GET list endpoint keeps
         # exclude_none — it replaces whole pages, so it has nothing to clear.
-        return [item.model_dump() for item in items]
+        #
+        # search_snippet is excluded: it is search-only (populated just by
+        # GET /v1/sessions?search_query=), so this no-query path always has it
+        # None. Dumping it as an explicit null would overwrite a snippet the
+        # search response put in the client cache, making the palette's match
+        # preview flicker away on the next stream tick. Omitting the key leaves
+        # the cached snippet untouched.
+        return [item.model_dump(exclude={"search_snippet"}) for item in items]
 
     @router.websocket("/sessions/updates")
     async def session_updates(websocket: WebSocket) -> None:

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2186,6 +2186,12 @@ class SessionListItem(BaseModel):
     :param viewer_unread: Whether the *requesting user* explicitly
         marked this session unread. Per-viewer; lifts the active-row
         dot suppression on the client. ``False`` by default.
+    :param search_snippet: Excerpt of the chat content that matched the
+        request's ``search_query``, centered on the match with ``…``
+        marking elided ends, so the search UI can show *where* a session
+        matched in its body. Present whenever the query hit an item body
+        (even if the title also matched); ``None`` on non-search reads and
+        when only the title matched.
     """
 
     id: str
@@ -2212,6 +2218,7 @@ class SessionListItem(BaseModel):
     comments_updated_at: int | None = None
     viewer_last_seen: int | None = None
     viewer_unread: bool = False
+    search_snippet: str | None = None
 
 
 class SessionList(BaseModel):

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -47,6 +47,7 @@ from omnigent.db.enum_codecs import (
 )
 from omnigent.db.utils import (
     _supports_fts5,
+    build_search_snippet,
     delete_fts_by_conversation,
     ensure_fts_table,
     extract_search_text,
@@ -421,6 +422,75 @@ def _fetch_labels_bulk(
     out: dict[str, dict[str, str]] = {}
     for conv_id, key, value in rows:
         out.setdefault(conv_id, {})[key] = value
+    return out
+
+
+def _fetch_search_snippets(
+    session: Session,
+    conversation_ids: list[str],
+    query: str,
+) -> dict[str, str]:
+    """
+    Build a per-conversation preview excerpt of matching chat content.
+
+    For each conversation whose body matched ``query`` (case-insensitive
+    substring on ``search_text``), returns a short snippet centered on the
+    match so the search UI can show *where* the session matched. The
+    earliest matching item per conversation wins.
+
+    Bulk (no N+1) *and* bounded to one row per conversation: a grouped
+    subquery finds the min matching ``position`` per conversation, then the
+    outer query materializes only those rows. Without the ``MIN(position)``
+    join, the plain ``LIKE`` would stream every matching item's full
+    ``search_text`` body — potentially thousands per long conversation —
+    just to keep the first.
+
+    :param session: The active SQLAlchemy session.
+    :param conversation_ids: Conversation IDs to build snippets for,
+        e.g. ``["conv_a", "conv_b"]``.
+    :param query: The user's search string.
+    :returns: Mapping ``{conversation_id: snippet}``. Conversations whose
+        only match was the title (no item body match) are absent — the
+        caller leaves their ``search_snippet`` as ``None``.
+    """
+    if not conversation_ids or not query:
+        return {}
+    pattern = f"%{query.lower()}%"
+    match_pred = and_(
+        SqlConversationItem.conversation_id.in_(conversation_ids),
+        func.lower(SqlConversationItem.search_text).like(pattern),
+    )
+    # Earliest matching position per conversation — a small (conv_id, position)
+    # aggregate, no bodies materialized.
+    earliest = (
+        select(
+            SqlConversationItem.conversation_id.label("cid"),
+            func.min(SqlConversationItem.position).label("pos"),
+        )
+        .where(match_pred)
+        .group_by(SqlConversationItem.conversation_id)
+        .subquery()
+    )
+    # Join back to pull exactly one search_text body per conversation.
+    rows = session.execute(
+        select(
+            SqlConversationItem.conversation_id,
+            SqlConversationItem.search_text,
+        ).join(
+            earliest,
+            and_(
+                SqlConversationItem.conversation_id == earliest.c.cid,
+                SqlConversationItem.position == earliest.c.pos,
+            ),
+        )
+    ).all()
+    out: dict[str, str] = {}
+    for conv_id, search_text in rows:
+        if not search_text:
+            continue
+        snippet = build_search_snippet(search_text, query)
+        if snippet is not None:
+            out[conv_id] = snippet
     return out
 
 
@@ -1881,6 +1951,18 @@ class SqlAlchemyConversationStore(ConversationStore):
                 [r.id for r in rows],
             )
             convs = [_to_conversation(r, labels_by_conv.get(r.id, {})) for r in rows]
+            # On a content search, attach a preview excerpt of the matching
+            # chat text so the UI can show *where* each session matched (the
+            # match is often invisible in the title). Title-only matches keep
+            # search_snippet=None — the title already shows the hit.
+            if search_query:
+                snippets = _fetch_search_snippets(
+                    session,
+                    [r.id for r in rows],
+                    search_query,
+                )
+                for conv in convs:
+                    conv.search_snippet = snippets.get(conv.id)
             return PagedList(
                 data=convs,
                 first_id=convs[0].id if convs else None,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1867,12 +1867,17 @@ class SqlAlchemyConversationStore(ConversationStore):
                 stmt = stmt.where(SqlConversation.agent_id == agent_id)
             if title is not None:
                 stmt = stmt.where(SqlConversation.title == title)
+            # ACL id-scopes, reused for both the outer conversation filter and
+            # (below) the content-search item scan so the LIKE never sweeps
+            # items in sessions the caller can't see.
+            accessible_ids = None
             if accessible_by is not None:
                 accessible_ids = select(SqlSessionPermission.conversation_id).where(
                     SqlSessionPermission.workspace_id == current_workspace_id(),
                     SqlSessionPermission.user_id == accessible_by,
                 )
                 stmt = stmt.where(SqlConversation.id.in_(accessible_ids))
+            owned_ids = None
             if owned_by is not None:
                 owned_ids = select(SqlSessionPermission.conversation_id).where(
                     SqlSessionPermission.workspace_id == current_workspace_id(),
@@ -1883,14 +1888,23 @@ class SqlAlchemyConversationStore(ConversationStore):
             if search_query:
                 pattern = f"%{search_query.lower()}%"
                 title_match = func.lower(SqlConversation.title).like(pattern)
-                content_match = SqlConversation.id.in_(
-                    select(SqlConversationItem.conversation_id)
-                    .where(
-                        SqlConversationItem.workspace_id == current_workspace_id(),
-                        func.lower(SqlConversationItem.search_text).like(pattern),
-                    )
-                    .distinct()
+                content_scan = select(SqlConversationItem.conversation_id).where(
+                    SqlConversationItem.workspace_id == current_workspace_id(),
+                    func.lower(SqlConversationItem.search_text).like(pattern),
                 )
+                # Scope the item scan to the caller's visible sessions. The
+                # outer query already ANDs these same id-sets, so this changes
+                # no results — it just stops the LIKE from scanning items in
+                # sessions the caller can't access.
+                if accessible_ids is not None:
+                    content_scan = content_scan.where(
+                        SqlConversationItem.conversation_id.in_(accessible_ids)
+                    )
+                if owned_ids is not None:
+                    content_scan = content_scan.where(
+                        SqlConversationItem.conversation_id.in_(owned_ids)
+                    )
+                content_match = SqlConversation.id.in_(content_scan.distinct())
                 stmt = stmt.where(or_(title_match, content_match))
             if project is not None:
                 if project == "":

--- a/openapi.json
+++ b/openapi.json
@@ -3905,6 +3905,18 @@
             "description": "Strict runner liveness \u2014 `True` iff a runner tunnel is currently registered for this session. Matches `GET /health`'s `runner_online` value. Strict: a dead runner on a live host reads `False` here (no host-relaunch optimism folded in), unlike the legacy conflated value. `None` when the server has no runner liveness lookup wired.",
             "title": "Runner Online"
           },
+          "search_snippet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Excerpt of the chat content that matched the request's `search_query`, centered on the match with `\u2026` marking elided ends, so the search UI can show *where* a session matched in its body. Present whenever the query hit an item body (even if the title also matched); `None` on non-search reads and when only the title matched.",
+            "title": "Search Snippet"
+          },
           "status": {
             "description": "Derived session lifecycle status.",
             "enum": [

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -20,6 +20,7 @@ from omnigent.db.utils import (
     _initialize_or_verify_schema,
     _install_lakebase_token_refresh,
     _resolve_lakebase_token_provider,
+    build_search_snippet,
     builtin_agent_id,
     clear_engine_cache,
     extract_search_text,
@@ -637,3 +638,51 @@ def test_extract_search_text_routing_decision() -> None:
         }
     )
     assert extract_search_text(item) == "databricks-claude-opus-4-8 Deep design work."
+
+
+def test_build_search_snippet_short_text_returned_whole() -> None:
+    """A match within a short line yields the whole (collapsed) line, no ellipsis."""
+    assert (
+        build_search_snippet("Hello what model are you using?", "what")
+        == "Hello what model are you using?"
+    )
+
+
+def test_build_search_snippet_is_case_insensitive() -> None:
+    """Matching mirrors the store's case-insensitive LIKE filter."""
+    assert build_search_snippet("Deploy the SERVICE now", "service") is not None
+
+
+def test_build_search_snippet_windows_long_text_with_ellipses() -> None:
+    """A match buried in long text is windowed with … on both elided ends."""
+    text = "a" * 200 + " deploy error " + "b" * 200
+    snippet = build_search_snippet(text, "deploy error")
+    assert snippet is not None
+    assert "deploy error" in snippet
+    assert snippet.startswith("…") and snippet.endswith("…")
+    # Kept short enough for a single UI row.
+    assert len(snippet) <= 160 + 2
+
+
+def test_build_search_snippet_collapses_whitespace() -> None:
+    """Multi-line / repeated whitespace collapses so the snippet is one clean line."""
+    snippet = build_search_snippet("line one\n\n   line two matches here", "matches")
+    assert snippet == "line one line two matches here"
+
+
+def test_build_search_snippet_never_clamps_out_the_match() -> None:
+    """A query term longer than max_len still appears in the snippet.
+
+    The length cap must not truncate the window before the matched span
+    ends — otherwise the UI would have nothing to highlight.
+    """
+    term = "x" * 300
+    snippet = build_search_snippet(f"prefix {term} suffix", term)
+    assert snippet is not None
+    assert term in snippet
+
+
+def test_build_search_snippet_no_match_returns_none() -> None:
+    """No occurrence (or empty query) yields None so the caller shows no preview."""
+    assert build_search_snippet("no match here", "xyz") is None
+    assert build_search_snippet("anything", "") is None

--- a/tests/server/integration/test_routes_sessions_aliases.py
+++ b/tests/server/integration/test_routes_sessions_aliases.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from omnigent.entities.conversation import MessageData, NewConversationItem
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 from tests.server.helpers import (
     create_test_session,
 )
@@ -135,6 +137,56 @@ async def test_list_sessions_search_query_excludes_null_titles(
     # Only the titled match returns. If conv_b appears, the NULL
     # filter is misbehaving.
     assert ids == [conv_a]
+
+
+async def test_list_sessions_search_snippet_on_content_match(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A content match returns a ``search_snippet``; a title match omits it.
+
+    The palette uses ``search_snippet`` to show *where* a session matched
+    when the hit is in the chat body (invisible in the title). Seed one
+    session whose body — not title — contains the query, and one whose
+    title matches, then assert only the content match carries the snippet.
+
+    :param client: HTTP client wired to the test app.
+    :param db_uri: Per-test SQLite database URI (same DB the app uses),
+        so an item can be appended directly through a store.
+    """
+    conv_content = await _create_session(
+        client,
+        name="snippet-content-agent",
+        title="General chat",
+    )
+    conv_title = await _create_session(
+        client,
+        name="snippet-title-agent",
+        title="deployment runbook",
+    )
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    conv_store.append(
+        conv_content,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_snip",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "please fix the deployment pipeline"}],
+                ),
+            ),
+        ],
+    )
+
+    resp = await client.get("/v1/sessions", params={"search_query": "deployment"})
+    assert resp.status_code == 200
+    by_id = {c["id"]: c for c in resp.json()["data"]}
+    # Content match carries the excerpt with the matched term.
+    assert "deployment" in by_id[conv_content]["search_snippet"].lower()
+    # Title-only match: exclude_none drops the null field entirely.
+    assert "search_snippet" not in by_id[conv_title]
 
 
 # ── DELETE /v1/sessions/{conversation_id} ─────────────────────

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1111,6 +1111,114 @@ def test_list_conversations_search_query_content_only(
     assert page.data[0].id == conv.id
 
 
+def test_list_conversations_search_snippet_on_content_match(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    A content match carries a ``search_snippet`` excerpt of the matching
+    text; a title-only match leaves it ``None``.
+
+    :param conversation_store: The conversation store fixture.
+    """
+    conv_content = conversation_store.create_conversation()
+    conversation_store.update_conversation(conv_content.id, title="General chat")
+    conversation_store.append(
+        conv_content.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_snip1",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "please fix the deployment pipeline"}],
+                ),
+            ),
+        ],
+    )
+
+    conv_title = conversation_store.create_conversation()
+    conversation_store.update_conversation(conv_title.id, title="deployment runbook")
+
+    by_id = {
+        c.id: c for c in conversation_store.list_conversations(search_query="deployment").data
+    }
+    # Content match: snippet present and contains the query term.
+    assert by_id[conv_content.id].search_snippet is not None
+    assert "deployment" in by_id[conv_content.id].search_snippet.lower()
+    # Title-only match: no snippet (the title already shows the hit).
+    assert by_id[conv_title.id].search_snippet is None
+
+
+def test_list_conversations_search_snippet_absent_without_query(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    Non-search listings never populate ``search_snippet``.
+
+    :param conversation_store: The conversation store fixture.
+    """
+    conv = conversation_store.create_conversation()
+    conversation_store.append(
+        conv.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_snip2",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "hello world"}],
+                ),
+            ),
+        ],
+    )
+    page = conversation_store.list_conversations()
+    assert all(c.search_snippet is None for c in page.data)
+
+
+def test_list_conversations_search_snippet_uses_earliest_match(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    With multiple matching turns, the snippet comes from the earliest one.
+
+    Exercises the ``MIN(position)`` join path: two turns match the query;
+    the snippet must be built from the first turn's text, not a later one.
+
+    :param conversation_store: The conversation store fixture.
+    """
+    conv = conversation_store.create_conversation()
+    conversation_store.append(
+        conv.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_early",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "deployment first mention"}],
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="resp_late",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "deployment second mention"}],
+                    agent="test-agent",
+                ),
+            ),
+        ],
+    )
+
+    by_id = {
+        c.id: c for c in conversation_store.list_conversations(search_query="deployment").data
+    }
+    snippet = by_id[conv.id].search_snippet
+    assert snippet is not None
+    assert "first mention" in snippet
+    assert "second mention" not in snippet
+
+
 def test_list_conversations_excludes_archived_by_default(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1111,6 +1111,50 @@ def test_list_conversations_search_query_content_only(
     assert page.data[0].id == conv.id
 
 
+def test_list_conversations_search_content_scoped_to_accessible(
+    conversation_store: SqlAlchemyConversationStore,
+    db_uri: str,
+) -> None:
+    """A content search scoped by ``accessible_by`` must not surface a session
+    the caller can't see, even when its body matches — the item scan is scoped
+    to the caller's visible sessions, matching the outer ACL filter."""
+    from omnigent.stores.permission_store.sqlalchemy_store import (
+        SqlAlchemyPermissionStore,
+    )
+
+    mine = conversation_store.create_conversation()
+    theirs = conversation_store.create_conversation()
+    for conv in (mine, theirs):
+        conversation_store.append(
+            conv.id,
+            [
+                NewConversationItem(
+                    type="message",
+                    response_id=f"resp_{conv.id}",
+                    data=MessageData(
+                        role="user",
+                        content=[{"type": "input_text", "text": "fix the deployment pipeline"}],
+                    ),
+                ),
+            ],
+        )
+
+    perms = SqlAlchemyPermissionStore(db_uri)
+    for user in ("alice@example.com", "bob@example.com"):
+        perms.ensure_user(user)
+    perms.grant("alice@example.com", mine.id, 4)
+    perms.grant("bob@example.com", theirs.id, 4)
+
+    ids = {
+        c.id
+        for c in conversation_store.list_conversations(
+            search_query="deployment", accessible_by="alice@example.com"
+        ).data
+    }
+    # Bob's session matches on content but isn't accessible to Alice.
+    assert ids == {mine.id}
+
+
 def test_list_conversations_search_snippet_on_content_match(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -132,6 +132,14 @@ export interface Conversation {
    * Per-viewer; lifts the active-row dot suppression on the client.
    */
   viewer_unread?: boolean;
+  /**
+   * Excerpt of the chat content that matched the current `search_query`,
+   * centered on the match with `…` marking elided ends. Present only on
+   * search responses where the query hit a message body rather than the
+   * title, so the search UI (command palette) can show *where* a session
+   * matched. Absent on non-search fetches and title-only matches.
+   */
+  search_snippet?: string | null;
 }
 
 export interface ConversationsPage {

--- a/web/src/lib/sessionListCache.test.ts
+++ b/web/src/lib/sessionListCache.test.ts
@@ -82,6 +82,21 @@ describe("mergeItemsIntoPages", () => {
     expect(found).toEqual(new Set(["a"]));
   });
 
+  it("leaves a cached search_snippet intact when the wire omits the key", () => {
+    // search_snippet is search-only: the WS stream excludes it from its dump,
+    // so a changed/snapshot frame never carries the key. A key-absent overlay
+    // must NOT touch the snippet the search response put in the cache — this is
+    // what stops the palette's match preview from flickering away on a tick.
+    const before = data([conv("a", { search_snippet: "…setup.py test…" })]);
+    const items = new Map<string, SessionListWireItem>([["a", { id: "a", status: "running" }]]);
+
+    const { data: after } = mergeItemsIntoPages(before, items, DEFAULT_FILTERS, NO_ACTIVE);
+
+    // Snippet survives; only the field the frame carried is applied.
+    expect(after!.pages[0].data[0].search_snippet).toBe("…setup.py test…");
+    expect(after!.pages[0].data[0].status).toBe("running");
+  });
+
   it("returns the same data reference when nothing actually changed", () => {
     const before = data([conv("a", { status: "running" })]);
     // Wire item restates the current values — an idempotent snapshot replay.

--- a/web/src/shell/CommandPalette.test.tsx
+++ b/web/src/shell/CommandPalette.test.tsx
@@ -14,12 +14,23 @@ vi.mock("@/hooks/useConversations", () => ({
   useConversations: (...args: unknown[]) => useConversations(...args),
 }));
 
-function conv(id: string, title: string | null, agent_name: string | null = null) {
-  return { id, title, agent_name, archived: false };
+function conv(
+  id: string,
+  title: string | null,
+  agent_name: string | null = null,
+  search_snippet: string | null = null,
+) {
+  return { id, title, agent_name, archived: false, search_snippet };
 }
 
 function setSessions(sessions: ReturnType<typeof conv>[], isFetching = false) {
   useConversations.mockReturnValue({ data: { pages: [{ data: sessions }] }, isFetching });
+}
+
+/** Find a session row by its full label text even when the highlighter has
+    split it around a <mark> (so the text lives across several nodes). */
+function labelRow(text: string) {
+  return screen.getByText((_content, el) => el?.tagName === "SPAN" && el.textContent === text);
 }
 
 function renderPalette(overrides: Partial<ComponentProps<typeof CommandPalette>> = {}) {
@@ -119,8 +130,10 @@ describe("CommandPalette — sessions", () => {
       act(() => {
         vi.advanceTimersByTime(300);
       });
-      expect(screen.getByText("Session 5")).toBeTruthy();
-      expect(screen.getByText("Session 7")).toBeTruthy();
+      // The label is now split around the highlighted query term
+      // (`<mark>Session</mark> 5`), so match on the row's combined text.
+      expect(labelRow("Session 5")).toBeTruthy();
+      expect(labelRow("Session 7")).toBeTruthy();
     } finally {
       vi.useRealTimers();
     }
@@ -148,6 +161,50 @@ describe("CommandPalette — sessions", () => {
     // silently regress.
     const item = screen.getByText("Fix the parser").closest("[data-slot=command-item]");
     expect(item?.className).toContain("pl-6");
+  });
+});
+
+describe("CommandPalette — match preview", () => {
+  // Drive a debounced query through so the palette highlights against it.
+  function search(term: string) {
+    fireEvent.change(screen.getByTestId("command-palette-input"), { target: { value: term } });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+  }
+
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("shows the content snippet as a second line when the match is in the body", () => {
+    setSessions([conv("c1", "Hello", "cursor", "…can you fix the what if I switch…")]);
+    renderPalette();
+    search("what");
+
+    // The title stays as the primary line; the snippet shows where it matched.
+    expect(screen.getByText("Hello")).toBeTruthy();
+    expect(screen.getByText(/can you fix the/)).toBeTruthy();
+  });
+
+  it("highlights the query term in both the title and the snippet", () => {
+    setSessions([conv("c1", "what model", "cursor", "Hello what model are you using?")]);
+    renderPalette();
+    search("what");
+
+    // Every occurrence of the query renders inside a <mark> (title + snippet).
+    const marks = document.querySelectorAll("mark");
+    expect(marks.length).toBeGreaterThanOrEqual(2);
+    for (const m of marks) expect(m.textContent?.toLowerCase()).toBe("what");
+  });
+
+  it("omits the snippet line for a title-only match (no search_snippet)", () => {
+    setSessions([conv("c1", "deploy runbook", "agent", null)]);
+    renderPalette();
+    search("deploy");
+
+    expect(screen.getByText(/deploy/)).toBeTruthy();
+    // No second line: only the single title row is present.
+    expect(screen.queryByText(/runbook.*\n/)).toBeNull();
   });
 });
 

--- a/web/src/shell/CommandPalette.tsx
+++ b/web/src/shell/CommandPalette.tsx
@@ -16,6 +16,7 @@
 // sessions, and we filter the (tiny, static) action list ourselves so both
 // groups react to the same input.
 
+import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import {
   InboxIcon,
@@ -59,6 +60,34 @@ interface ActionCommand {
 
 /** Debounce matches the sidebar search (300ms) so keystrokes don't each fetch. */
 const SEARCH_DEBOUNCE_MS = 300;
+
+/** Split `text` on case-insensitive occurrences of `query`, bolding the matches
+    so a search hit is visible in the title / content snippet. Returns the raw
+    text unchanged when the query is empty or doesn't occur (e.g. the snippet
+    matched a stemmed form). */
+function HighlightedText({ text, query }: { text: string; query: string }): React.ReactNode {
+  const q = query.trim();
+  if (!q) return text;
+  // Escape regex metacharacters so a query like "a.b" matches literally.
+  const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const parts = text.split(new RegExp(`(${escaped})`, "gi"));
+  const lower = q.toLowerCase();
+  // Non-matches stay raw strings (React needs no key for those); each match is
+  // keyed by its running offset so repeated terms get stable, unique keys
+  // without leaning on the bare array index.
+  let offset = 0;
+  return parts.map((part) => {
+    const at = offset;
+    offset += part.length;
+    return part.toLowerCase() === lower ? (
+      <mark key={at} className="bg-transparent font-semibold text-foreground">
+        {part}
+      </mark>
+    ) : (
+      part
+    );
+  });
+}
 
 /** How many recent sessions to show before the user types, so the Actions
     group stays visible without scrolling. Typing lifts the cap. */
@@ -146,7 +175,7 @@ export function CommandPalette({
 
   const sessions = useMemo(() => {
     const seen = new Set<string>();
-    const out: { id: string; label: string; agent: string }[] = [];
+    const out: { id: string; label: string; agent: string; snippet: string | null }[] = [];
     for (const page of data?.pages ?? []) {
       for (const c of page.data) {
         if (seen.has(c.id)) continue;
@@ -155,6 +184,9 @@ export function CommandPalette({
           id: c.id,
           label: conversationDisplayLabel(c),
           agent: getConversationAgentType(c),
+          // Present only when the match was in chat content (not the title);
+          // the server omits it otherwise. Shown as a dimmed second line.
+          snippet: c.search_snippet ?? null,
         });
       }
     }
@@ -207,9 +239,20 @@ export function CommandPalette({
                     key={s.id}
                     value={s.id}
                     onSelect={() => goToSession(s.id)}
-                    className="pl-6"
+                    className="items-start pl-6"
                   >
-                    <span className="flex-1 truncate text-left">{s.label}</span>
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="truncate text-left">
+                        <HighlightedText text={s.label} query={debouncedQuery} />
+                      </span>
+                      {s.snippet && (
+                        // Where the match was found in the chat body — the
+                        // session is often unidentifiable from the title alone.
+                        <span className="truncate text-left text-muted-foreground text-xs">
+                          <HighlightedText text={s.snippet} query={debouncedQuery} />
+                        </span>
+                      )}
+                    </div>
                     <span className="ml-2 shrink-0 text-xs text-muted-foreground">{s.agent}</span>
                   </CommandItem>
                 ))}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Stacked on `improve_search` (the match-preview PR #2162). Cuts the cost of the content-search item scan added there.

- The `content_match` subquery in `list_conversations` ran the `search_text` `LIKE` over **every item in the workspace**, then the outer query discarded matches from sessions the caller can't see via `accessible_by` / `owned_by`.
- This pushes the same ACL id-scopes into the item scan, so the `LIKE` only sweeps items in sessions the caller can actually access.
- **No result change** — the outer query already ANDs these exact id-sets; this only restricts how much the scan reads. On the palette/sidebar search path `accessible_by` is always set, so this is the common path.

```
Before:  LIKE scans ALL workspace items → outer ACL filter drops the invisible ones
After:   LIKE scans only the caller's accessible sessions' items
```

## Test Plan

- `pytest tests/stores/test_conversation_store.py -k "search or snippet or accessible or owned or shared"` → all pass.
- Added `test_list_conversations_search_content_scoped_to_accessible`: a session that matches on content but belongs to another user does **not** leak into the caller's search — proving the scoping preserves ACL correctness.
- `ruff format` + `ruff check` clean.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

This pull request and its description were written by Isaac.
