### PR TITLE
docs(readme): point to the harness test bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,9 +453,7 @@ Contributions are welcome. See [CONTRIBUTING.md](https://github.com/omnigent-ai/
 
 Adding or changing support for a harness (Claude, Codex, Cursor, OpenCode,
 Hermes, Pi, ...)? Run the [harness test bench](https://github.com/omnigent-ai/omnigent/tree/main/tests/harness_bench)
-to check its capability matrix against observed behavior — see
-[`docs/harness-bench-design.md`](https://github.com/omnigent-ai/omnigent/blob/main/docs/harness-bench-design.md)
-for the design and rationale.
+to check its capability matrix against observed behavior.
 
 
 ### Contributors

--- a/README.md
+++ b/README.md
@@ -451,6 +451,12 @@ Polly at [`examples/polly/`](https://github.com/omnigent-ai/omnigent/tree/main/e
 
 Contributions are welcome. See [CONTRIBUTING.md](https://github.com/omnigent-ai/omnigent/blob/main/CONTRIBUTING.md) for how to set up your environment, run the checks, and open a pull request.
 
+Adding or changing support for a harness (Claude, Codex, Cursor, OpenCode,
+Hermes, Pi, ...)? Run the [harness test bench](https://github.com/omnigent-ai/omnigent/tree/main/tests/harness_bench)
+to check its capability matrix against observed behavior — see
+[`docs/harness-bench-design.md`](https://github.com/omnigent-ai/omnigent/blob/main/docs/harness-bench-design.md)
+for the design and rationale.
+
 
 ### Contributors
 


### PR DESCRIPTION
## Related issue

Closes N/A

## Summary

The harness test bench (`tests/harness_bench/`) is a standardized conformance
suite for checking a harness's capability matrix against observed behavior,
but the root README never mentioned it, so a contributor adding or changing
harness support could easily miss it. Add a pointer to it from the
Contributing section, alongside the existing design-doc link.

## Test Plan

Read through the rendered README section to confirm the links resolve to the
right paths (`tests/harness_bench/` and `docs/harness-bench-design.md`) and
that the addition reads naturally next to the existing CONTRIBUTING.md
pointer.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Docs-only change (a README link addition); no behavior changed, so no test
coverage applies.
