### PR TITLE
fix(harness-bench): emit hardcoded per-journey needs_runner in report

### DIFF
--- a/dev/benchmarks/omnigent/README.md
+++ b/dev/benchmarks/omnigent/README.md
@@ -163,7 +163,7 @@ document without running the harness.
 
 ```jsonc
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "generated_at": "<ISO-8601 UTC>",
   "git_sha": "<HEAD sha>",
   "git_branch": "<branch>",
@@ -176,6 +176,7 @@ document without running the harness.
     "<journey name>": {
       "kind": "latency" | "throughput",
       "backend": "sqlite" | "postgres" | "mysql",
+      "needs_runner": false,          // hardcoded per journey: HTTP=false, full-turn=true
       "runs": [                       // one per --runs
         {"n_success": N, "n_failures": N, "failures": {"HTTP 500": 1},
          "wall_time_s": …, "mean_ms": …, "p50_ms": …, "p95_ms": …,

--- a/dev/benchmarks/omnigent/run.py
+++ b/dev/benchmarks/omnigent/run.py
@@ -135,6 +135,11 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, object], bo
             block = aggregate(results)
             block["kind"] = kind
             block["backend"] = backend
+            # Hardcoded per-journey mapping: HTTP journeys are False, full-turn
+            # journeys True. Sourced from the journey itself, not the run-level
+            # env, so it stays correct in a mixed selection (where with_runner
+            # is True for the whole run because *some* journey needs it).
+            block["needs_runner"] = journey.needs_runner
             journey_results[journey.name] = block
             if not check_thresholds(
                 results,

--- a/dev/benchmarks/omnigent/sample_output.json
+++ b/dev/benchmarks/omnigent/sample_output.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "generated_at": "2026-07-08T18:30:00+00:00",
   "git_sha": "0000000000000000000000000000000000000000",
   "git_branch": "main",
@@ -66,7 +66,8 @@
         "avg_rps": 162.7669557884957
       },
       "kind": "latency",
-      "backend": "sqlite"
+      "backend": "sqlite",
+      "needs_runner": false
     },
     "create_session": {
       "runs": [
@@ -115,7 +116,8 @@
         "avg_rps": 40.548671853654
       },
       "kind": "latency",
-      "backend": "sqlite"
+      "backend": "sqlite",
+      "needs_runner": false
     },
     "get_session": {
       "runs": [
@@ -164,7 +166,8 @@
         "avg_rps": 199.59858100569238
       },
       "kind": "latency",
-      "backend": "sqlite"
+      "backend": "sqlite",
+      "needs_runner": false
     },
     "load_conversation_history": {
       "runs": [
@@ -213,7 +216,8 @@
         "avg_rps": 503.8957501013986
       },
       "kind": "latency",
-      "backend": "sqlite"
+      "backend": "sqlite",
+      "needs_runner": false
     },
     "search_sessions": {
       "runs": [
@@ -262,7 +266,8 @@
         "avg_rps": 12.317410535217997
       },
       "kind": "latency",
-      "backend": "sqlite"
+      "backend": "sqlite",
+      "needs_runner": false
     }
   }
 }

--- a/dev/benchmarks/omnigent/schema.py
+++ b/dev/benchmarks/omnigent/schema.py
@@ -13,7 +13,7 @@ import platform
 import subprocess
 
 # Incremented on any breaking change to the report document shape below.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 def _git(*args: str) -> str:

--- a/tests/benchmarks/test_benchmark_smoke.py
+++ b/tests/benchmarks/test_benchmark_smoke.py
@@ -169,6 +169,9 @@ async def test_benchmark_smoke_end_to_end() -> None:
         block = _d(journeys[name])
         assert block["kind"] == "latency"
         assert block["backend"] == "sqlite"
+        # Hardcoded per-journey flag: HTTP journeys are always False, even in a
+        # run whose config.with_runner is True because a runner journey rode along.
+        assert block["needs_runner"] is False
         run_rows = cast(list[dict[str, object]], block["runs"])
         assert run_rows, f"{name} produced no runs"
         # Zero failures — a failure here means the HTTP path itself broke.
@@ -216,6 +219,8 @@ async def test_benchmark_smoke_runner_journeys() -> None:
     for name in _RUNNER_JOURNEYS:
         assert ALL_JOURNEYS[name].needs_runner
         block = _d(journeys[name])
+        # The hardcoded per-journey flag surfaces in the report block.
+        assert block["needs_runner"] is True
         run_rows = cast(list[dict[str, object]], block["runs"])
         assert run_rows, f"{name} produced no runs"
         # Zero failures — a failure here means the full-turn path broke.


### PR DESCRIPTION
## Related issue

N/A

## Summary

The benchmark report only carried a **run-level** `config.with_runner = any(j.needs_runner for j in journeys)`. The nightly workflow runs *all* journeys in one invocation, so that flag is `true` for the whole run as soon as a single full-turn journey is included — and any per-journey `needs_runner` column the workspace ETL derived from it wrongly marked the HTTP journeys `true` too.

- Emit `journey.needs_runner` straight into each per-journey report block, so the `needs_runner` column is a true hardcoded mapping: HTTP journeys → `false`, full-turn journeys → `true`, independent of what else ran alongside them.
- Bump `SCHEMA_VERSION` 1 → 2 (additive shape change to the JSON contract) and update the README schema block and `sample_output.json` to match.

Note: the `needs_runner` column itself materializes in the workspace Databricks ETL notebook (owned outside this repo). This change makes the field available per-journey in the JSON contract and bumps the schema version so the notebook can branch on it — the notebook still needs to be pointed at `journeys.<name>.needs_runner` instead of `config.with_runner`.

## Test Plan

`uv run --no-sync python -m pytest tests/benchmarks/test_benchmark_smoke.py` — all 11 pass. The HTTP end-to-end test now asserts `block["needs_runner"] is False` (even though that run's `config.with_runner` is `False`, this pins the per-journey field), and the runner-journeys smoke test asserts `is True`. `pre-commit` passes on all five files.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the updated smoke tests above.

This pull request and its description were written by Isaac.
