### PR TITLE
fix(harness-bench): stop the live --rich table flickering / cursor jumps

### DIFF
--- a/tests/harness_bench/richreport.py
+++ b/tests/harness_bench/richreport.py
@@ -79,9 +79,17 @@ class _RichLiveSink:
         self._dim_by_name = {p.name: p.title for p in ALL_PROBES}
         # harness → {dim_title: markup}; insertion order = display order.
         self._rows: dict[str, dict[str, str]] = {}
-        self._notes: dict[str, str] = {}
         self._transport: dict[str, str] = {}  # harness → resolved transport label
-        self._live = Live(self._render(), console=console, refresh_per_second=8)
+        # vertical_overflow="visible": let a grid taller than the viewport print
+        # in full instead of rich clipping/repositioning it each frame (the
+        # "pointer jumps around" thrash). refresh_per_second=4 + our own
+        # update() per event is smooth without high-rate flicker.
+        self._live = Live(
+            self._render(),
+            console=console,
+            refresh_per_second=4,
+            vertical_overflow="visible",
+        )
         self._live.start()
 
     def _blank_row(self) -> dict[str, str]:
@@ -95,13 +103,10 @@ class _RichLiveSink:
         for dim in self._dimensions:
             table.add_column(dim, justify="center")
         for harness, cells in self._rows.items():
-            note = self._notes.get(harness)
             transport = self._transport.get(harness)
             label = harness
             if transport:
                 label += f" [dim]\\[{_TRANSPORT_LABEL.get(transport, transport)}][/dim]"
-            if note:
-                label += f"  [dim]({note})[/dim]"
             table.add_row(label, *(cells[dim] for dim in self._dimensions))
         return table
 
@@ -110,9 +115,10 @@ class _RichLiveSink:
             self._rows.setdefault(event.harness, self._blank_row())
             self._transport[event.harness] = event.transport
         elif isinstance(event, HarnessSkipped):
+            # A whole-harness skip leaves every dimension ·; the reason prints in
+            # the stdout Notes section after the run (from the matrix), not on the
+            # live row — keeping rows one line high avoids reflow/flicker.
             self._rows.setdefault(event.harness, self._blank_row())
-            # A whole-harness skip: every dimension is ·, reason on the label.
-            self._notes[event.harness] = event.reason.split(";")[0][:60]
             if event.transport:
                 self._transport[event.harness] = event.transport
         elif isinstance(event, ProbeStarted):


### PR DESCRIPTION
## Summary

The `--rich` live progress table flickered and made the terminal cursor jump
around during a bench run. It was cosmetic (the final table was always correct)
but distracting. Three causes, all in `tests/harness_bench/richreport.py`:

- **`refresh_per_second` 8 -> 4** — fewer full repaints of a table whose height
  grows as harness rows appear.
- **`vertical_overflow="visible"`** — a grid taller than the viewport now prints
  in full instead of rich clipping and repositioning it every frame (the
  cursor-jump thrash).
- **Whole-harness skip reason removed from the row label** — a long reason (up
  to 60 chars) plus the transport tag could wrap the Harness cell, changing a
  row's height mid-run and forcing a reflow. Rows are now always one line high.
  The reason is unchanged in the output: it still prints in the stdout Notes
  section after the run (sourced from the matrix, not this live sink), so nothing
  is lost.

Also drops the now-dead `self._notes` state.

Separate from the policy-probe PR (#2313) -- this only touches the live
renderer, off `main`.

## Test Plan

- `python -m pytest tests/harness_bench/` -> green (91 passed / 18 skipped),
  including the rich-sink smoke test.
- Built the sink with `force=True` and confirmed it renders + closes cleanly.
- `ruff check` clean; no `uv.lock` drift.
- Manual: a `--rich` run no longer flickers and the cursor stays put (the
  reporter can confirm on their terminal, which surfaced the issue).

## Demo

N/A -- terminal progress rendering; the fix is the absence of flicker. Reporter
to confirm on their terminal.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI / frontend change

## Test coverage

- [ ] Added or updated automated tests
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Flicker is a live-terminal rendering property that the existing rich-sink test
can't assert (it exercises build/render/close, which still pass). The fix is
config + a one-line-per-row invariant; verified manually against the terminal
that reported the issue.
