### PR TITLE
refactor(harness-bench): reuse shared runtime helpers

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -34,6 +34,7 @@ from omnigent._startup_profile import StartupProfiler
 from omnigent.cli_sandbox import lakebox as _lakebox_alias_group
 from omnigent.cli_sandbox import sandbox as _sandbox_group
 from omnigent.config import (
+    global_config_path,
     load_global_config,
     load_local_config,
 )
@@ -303,9 +304,7 @@ def _effective_global_config_path() -> Path:
     :returns: ``$OMNIGENT_CONFIG_HOME/config.yaml`` when the env
         override is set, otherwise :data:`_GLOBAL_CONFIG_PATH`.
     """
-    if config_home := os.environ.get(_CONFIG_HOME_ENV_VAR):
-        return Path(config_home) / "config.yaml"
-    return _GLOBAL_CONFIG_PATH
+    return global_config_path(_GLOBAL_CONFIG_PATH)
 
 
 def _display_path(path: Path) -> str:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -33,6 +33,10 @@ from omnigent._platform import IS_WINDOWS, resolve_repo_symlink
 from omnigent._startup_profile import StartupProfiler
 from omnigent.cli_sandbox import lakebox as _lakebox_alias_group
 from omnigent.cli_sandbox import sandbox as _sandbox_group
+from omnigent.config import (
+    load_global_config,
+    load_local_config,
+)
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.host.local_server import (
     _DEFAULT_LOCAL_PORT,
@@ -360,12 +364,7 @@ def _load_global_config() -> dict[str, Any]:  # type: ignore[explicit-any]
         ``{"default_agent": "examples/hello_world.yaml",
         "auth": {"type": "databricks", "profile": "oss"}}``.
     """
-    path = _effective_global_config_path()
-    if not path.exists():
-        return {}
-    with open(path) as f:
-        raw: dict[str, Any] = yaml.safe_load(f) or {}  # type: ignore[explicit-any]
-        return raw
+    return load_global_config(_effective_global_config_path())
 
 
 def _load_local_config() -> dict[str, Any]:  # type: ignore[explicit-any]
@@ -376,12 +375,7 @@ def _load_local_config() -> dict[str, Any]:  # type: ignore[explicit-any]
 
     :returns: Parsed YAML as a dict.
     """
-    path = Path.cwd() / _LOCAL_CONFIG_RELPATH
-    if not path.exists():
-        return {}
-    with open(path) as f:
-        raw: dict[str, Any] = yaml.safe_load(f) or {}  # type: ignore[explicit-any]
-        return raw
+    return load_local_config(Path.cwd() / _LOCAL_CONFIG_RELPATH)
 
 
 def _load_effective_config() -> dict[str, Any]:  # type: ignore[explicit-any]

--- a/omnigent/config.py
+++ b/omnigent/config.py
@@ -13,11 +13,11 @@ _GLOBAL_CONFIG_PATH = Path.home() / ".omnigent" / "config.yaml"
 _LOCAL_CONFIG_RELPATH = Path(".omnigent") / "config.yaml"
 
 
-def global_config_path() -> Path:
+def global_config_path(default_path: Path | None = None) -> Path:
     """Return the effective user-level config path."""
     if config_home := os.environ.get(_CONFIG_HOME_ENV_VAR):
         return Path(config_home) / "config.yaml"
-    return _GLOBAL_CONFIG_PATH
+    return default_path or _GLOBAL_CONFIG_PATH
 
 
 def load_global_config(path: Path | None = None) -> dict[str, Any]:  # type: ignore[explicit-any]

--- a/omnigent/config.py
+++ b/omnigent/config.py
@@ -1,0 +1,53 @@
+"""Read Omnigent's user and project configuration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_CONFIG_HOME_ENV_VAR = "OMNIGENT_CONFIG_HOME"
+_GLOBAL_CONFIG_PATH = Path.home() / ".omnigent" / "config.yaml"
+_LOCAL_CONFIG_RELPATH = Path(".omnigent") / "config.yaml"
+
+
+def global_config_path() -> Path:
+    """Return the effective user-level config path."""
+    if config_home := os.environ.get(_CONFIG_HOME_ENV_VAR):
+        return Path(config_home) / "config.yaml"
+    return _GLOBAL_CONFIG_PATH
+
+
+def load_global_config(path: Path | None = None) -> dict[str, Any]:  # type: ignore[explicit-any]
+    """Load the user-level config, returning an empty mapping when absent."""
+    resolved_path = path or global_config_path()
+    if not resolved_path.exists():
+        return {}
+    with resolved_path.open() as config_file:
+        raw: dict[str, Any] = yaml.safe_load(config_file) or {}  # type: ignore[explicit-any]
+        return raw
+
+
+def load_local_config(path: Path | None = None) -> dict[str, Any]:  # type: ignore[explicit-any]
+    """Load the project-level config, returning an empty mapping when absent."""
+    resolved_path = path or Path.cwd() / _LOCAL_CONFIG_RELPATH
+    if not resolved_path.exists():
+        return {}
+    with resolved_path.open() as config_file:
+        raw: dict[str, Any] = yaml.safe_load(config_file) or {}  # type: ignore[explicit-any]
+        return raw
+
+
+def load_effective_config() -> dict[str, Any]:  # type: ignore[explicit-any]
+    """Merge user and project config, with project values taking precedence."""
+    return {**load_global_config(), **load_local_config()}
+
+
+__all__ = [
+    "global_config_path",
+    "load_effective_config",
+    "load_global_config",
+    "load_local_config",
+]

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -1,27 +1,4 @@
-"""CLI: render the harness capability matrix.
-
-Examples::
-
-    # List official harnesses.
-    python -m tests.harness_bench --list
-
-    # Dry (offline) render — declared matrix, no turns, no creds.
-    python -m tests.harness_bench
-
-    # Live probe one harness against a gateway profile (SDK → full-server,
-    # the default: covers Tool calling + Policy DENY).
-    python -m tests.harness_bench --harness codex --profile my-profile
-
-    # Quicker run: SDK harnesses on sdk-inproc (skips the server boot; no
-    # Tool calling / Policy DENY coverage).
-    python -m tests.harness_bench --harness codex --profile my-profile --fast
-
-    # Live probe all official harnesses, JSON out.
-    python -m tests.harness_bench --profile my-profile --json
-
-    # A community harness that ships its own BenchProfile.
-    python -m tests.harness_bench --harness mypkg.harness:PROFILE --profile my-profile
-"""
+"""Command-line entry point for the harness bench."""
 
 from __future__ import annotations
 
@@ -146,8 +123,6 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv if argv is not None else sys.argv[1:])
 
     if args.list:
-        # Show the transport a default run would pick (SDK family → full-server),
-        # not the raw family marker, so --list matches what actually runs.
         for name, profile in sorted(OFFICIAL_PROFILES.items()):
             transport = resolve_transport_name(profile, override=None, fast=False)
             print(f"{name}\t{transport}\t{profile.model}")
@@ -159,8 +134,6 @@ def main(argv: list[str] | None = None) -> int:
         print(str(exc), file=sys.stderr)
         return 2
 
-    # Validate the transport override up front so a typo is a clean CLI error
-    # (exit 2) rather than a KeyError traceback out of the async run.
     if args.transport is not None and args.transport not in driver_registry():
         known = ", ".join(sorted(driver_registry()))
         print(
@@ -172,9 +145,6 @@ def main(argv: list[str] | None = None) -> int:
         print("--jobs must be >= 1", file=sys.stderr)
         return 2
 
-    # Live layer: derive creds the way `omni run` does — a --profile, a
-    # configured ~/.omnigent profile, or ambient OPENAI_*. So a live run no
-    # longer requires --profile; it is implied whenever creds are resolvable.
     from tests.harness_bench.runtime_env import bench_creds_skip_reason
 
     creds_skip = bench_creds_skip_reason(args.profile)
@@ -183,9 +153,6 @@ def main(argv: list[str] | None = None) -> int:
         print(f"--live needs resolvable gateway creds: {creds_skip}", file=sys.stderr)
         return 2
 
-    # Progress sink: only for a live run (offline is instant). Prefer the rich
-    # live table when a TTY + rich are available (or --rich forces it), else
-    # fall back to plain per-line output on stderr (the report goes to stdout).
     sink = None
     if live:
         sink = _select_progress_sink(args.rich)
@@ -204,20 +171,14 @@ def main(argv: list[str] | None = None) -> int:
     if sink is not None:
         sink.close()
 
-    # Offline (not live) has nothing observed, so show the declared matrix.
     declared = not live
     if args.json:
         output = render_json(matrix)
     elif args.markdown:
         output = render_markdown(matrix, declared=declared)
     else:
-        # Default: terminal table. Color only when stdout is a real TTY and
-        # not suppressed, so piping to a file / pager stays plain.
         color = sys.stdout.isatty() and not args.no_color
-        # If the rich live table already painted the grid to this same terminal,
-        # drop the grid from the stdout report (keep the legend + notes) so the
-        # matrix is not printed twice. When stdout is redirected, print it in
-        # full -- the file needs the grid the on-screen table did not capture.
+        # Avoid duplicating a live grid, but preserve it in redirected output.
         grid = not (_grid_already_shown(sink) and sys.stdout.isatty())
         output = render_table(matrix, color=color, declared=declared, grid=grid)
     print(output, end="")
@@ -225,7 +186,6 @@ def main(argv: list[str] | None = None) -> int:
     if args.report:
         _write_report(args.report, matrix, json_flag=args.json, markdown_flag=args.markdown)
 
-    # A drift is a non-zero exit so CI / scripts notice without parsing output.
     return 1 if matrix.has_drift else 0
 
 
@@ -251,8 +211,6 @@ def _select_progress_sink(rich_flag: bool | None):
         print(msg, file=sys.stderr, flush=True)
 
     if rich_flag is not False:
-        # richreport is imported lazily: it is the only place that touches the
-        # optional `rich` dependency, so a plain/no-rich run never imports it.
         from tests.harness_bench.richreport import rich_sink_or_none
 
         rich_sink = rich_sink_or_none(force=bool(rich_flag))
@@ -274,7 +232,6 @@ def _write_report(path: str, matrix, *, json_flag: bool, markdown_flag: bool) ->
     elif path.endswith((".md", ".markdown")):
         content = render_markdown(matrix, declared=False)
     else:
-        # Plain, un-colored grid — a file should never carry ANSI codes.
         content = render_table(matrix, color=False, declared=False)
     with open(path, "w", encoding="utf-8") as fh:
         fh.write(content if content.endswith("\n") else content + "\n")

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -35,14 +35,9 @@ from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Ve
 
 _logger = logging.getLogger(__name__)
 
-# Back-compat: a plain per-line progress callback. The orchestrator now emits
-# structured events to a ProgressSink; callers that still pass a line callback
-# get it adapted to a LineSink. ``None`` stays silent (the pytest layer).
+# Backward-compatible line callback; new callers should use ProgressSink.
 Progress = Callable[[str], None]
 
-# The prerequisite probe: if it does not pass, the harness cannot be exercised
-# at all, so the remaining probes are skipped rather than run against a dead
-# turn (which would otherwise emit misleading UNSUPPORTED/DRIFT noise).
 _PREREQ_PROBE = "basic_turn"
 
 
@@ -210,8 +205,6 @@ async def run_harness(
     sink = _as_sink(progress)
 
     if not live:
-        # Offline: still resolve the transport a live run *would* pick, so the
-        # declared matrix labels each row with its effective transport.
         resolved = resolve_transport_name(profile, override=transport, fast=fast)
         return _uniform_report(
             profile, probes, ProbeResult.skipped("offline (declared shown)"), transport=resolved
@@ -230,13 +223,8 @@ async def run_harness(
             transport=resolved_transport,
         )
 
-    # databricks_profile may be None here — the driver derives creds like
-    # `omni run` (config profile / ambient OPENAI_*); the unavailable() check
-    # above already confirmed creds are resolvable.
     _emit(sink, HarnessStarted(profile.harness, driver_cls.transport, profile.model))
     cells: list[CellResult] = []
-    # Only the full-server driver accepts a shared server; pass it through when
-    # this harness resolved to that transport, else construct plainly.
     if shared_full_server is not None and driver_cls.transport == "full-server":
         driver_cm = driver_cls(
             profile, databricks_profile=databricks_profile, shared=shared_full_server
@@ -246,20 +234,7 @@ async def run_harness(
     try:
         entered = await driver_cm.__aenter__()
     except Exception as exc:
-        # Provisioning failed (e.g. an own-auth native whose vendor CLI is
-        # installed but not logged in, so its terminal never wires up). Report
-        # a capability-neutral skip for this harness rather than aborting the
-        # whole run — a multi-harness run must survive one unrunnable harness.
-        #
-        # __aenter__ may have already spawned the server + daemon and opened a
-        # client before raising, so tear those down here or they leak for the
-        # rest of the run (_teardown null-checks each, so a half-provisioned
-        # driver is safe to tear down).
-        #
-        # An expected ProvisioningError (a known-unrunnable environment) logs
-        # only its reason — the matrix already shows the skip. Any *other*
-        # exception is a possible driver bug (e.g. an AssertionError), so keep
-        # its full traceback rather than letting it vanish behind a green skip.
+        # Provisioning failures skip one harness without aborting a matrix run.
         if isinstance(exc, ProvisioningError):
             _logger.info("skipping %s: %s", profile.harness, exc)
         else:
@@ -298,8 +273,6 @@ async def run_harness(
             )
             cell = _cell(probe, profile, observed)
             cells.append(cell)
-            # If the prerequisite turn did not pass, short-circuit the rest:
-            # they would only re-hit the same failure and pollute the matrix.
             if probe.name == _PREREQ_PROBE and cell.observed is not Verdict.SUPPORTED:
                 prereq_skip = f"prerequisite '{probe.title}' did not pass ({observed.note})"
     finally:
@@ -373,8 +346,6 @@ async def run_bench(
                     shared_full_server=shared,
                 )
 
-        # gather preserves input order, so the matrix stays in *profiles* order
-        # even though harnesses finish out of order.
         reports = await asyncio.gather(*(_one(p) for p in profiles))
         return BenchMatrix(reports=list(reports))
 
@@ -403,9 +374,6 @@ async def _maybe_shared_full_server(
             for p in profiles
             if resolve_driver_class(p, override=transport, fast=fast).transport == "full-server"
         ]
-        # Only stand one up when creds are actually resolvable (a --profile, a
-        # configured ~/.omnigent profile, or ambient OPENAI_*); otherwise let
-        # each harness's unavailable() report the clean no-creds skip.
         if len(full) > 1 and bench_creds_skip_reason(databricks_profile) is None:
             shared = SharedFullServer(resolve_bench_env(databricks_profile))
             await asyncio.to_thread(shared.__enter__)

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -1,17 +1,4 @@
-"""Transport drivers: launch a harness and drive turns for the probes.
-
-A driver hides the transport (how a turn is started and how events come
-back) behind a small harness-agnostic surface the probes call. The only
-driver today is :class:`SdkInprocDriver`, which spawns a single harness
-wrap subprocess via :class:`HarnessProcessManager` and drives turns over
-the wrap's ``POST /v1/sessions/{conv}/events`` SSE endpoint — the same
-path exercised by ``tests/e2e/test_harness_wrap_e2e.py``.
-
-Native transports (tmux TUI, app-server, HTTP/SSE) are phase-2 drivers
-keyed by :attr:`BenchProfile.transport`; a profile on a transport with no
-driver yields :meth:`unavailable`, and the bench renders its
-transport-dependent probes as ``SKIPPED``.
-"""
+"""SDK in-process transport driver and shared turn results."""
 
 from __future__ import annotations
 
@@ -32,34 +19,17 @@ from tests.harness_bench.runtime_env import bench_creds_skip_reason, resolve_ben
 
 
 class ProvisioningError(RuntimeError):
-    """An *expected* provisioning failure that should skip the harness quietly.
-
-    Raised by a driver's ``__aenter__`` when the environment cannot bring a
-    harness up through no fault of the bench — e.g. an own-auth native whose
-    vendor CLI is installed but not logged in, so its forwarder never wires up.
-    The orchestrator turns this into a capability-neutral skip and logs only the
-    reason (no traceback), reserving the full stack for *unexpected* exceptions
-    that signal a genuine driver bug.
-    """
+    """Expected environment failure that should skip one harness."""
 
 
-# Proto-style policy verdict strings the wrap's policy_verdict event accepts.
 POLICY_ALLOW = "POLICY_ACTION_ALLOW"
 POLICY_DENY = "POLICY_ACTION_DENY"
 
-# Proto-style policy evaluation phases (see _scaffold.evaluate_policy and
-# omnigent/native_policy_hook.py). A tool call is gated at PHASE_TOOL_CALL;
-# the request/result phases fire at other points in the turn. The policy
-# probe must scope its DENY to PHASE_TOOL_CALL so a DENY on the request
-# phase cannot masquerade as a tool-call guardrail pass.
+# Denying another phase does not prove tool-call enforcement.
 PHASE_TOOL_CALL = "PHASE_TOOL_CALL"
 
 _CONV_ID = "conv_bench"
 
-# Wrap-transport turn shapes for the semantic driver methods. The wrap path
-# provokes a tool call with a request-level function tool (unlike full-server,
-# which uses a builtin); prompts are long enough that a streaming harness
-# emits many deltas and an interrupted turn has visibly less output.
 _STREAM_PROMPT = (
     "Count from 1 to 30 in words, one number per line, and add a short note after each."
 )
@@ -83,11 +53,7 @@ _BENCH_TOOL_SPEC = [
     }
 ]
 
-# Substrings in a turn error that mean the *environment* is the problem
-# (auth, entitlement, gateway, connectivity) rather than a real capability
-# gap. Turns that fail this way are reported SKIPPED, never UNSUPPORTED, so
-# a bad token or an unentitled gateway route can never masquerade as
-# capability drift.
+# Infrastructure failures must not be reported as capability gaps.
 _INFRA_ERROR_MARKERS: tuple[str, ...] = (
     "403",
     "401",
@@ -102,22 +68,11 @@ _INFRA_ERROR_MARKERS: tuple[str, ...] = (
     "502",
     "503",
     "504",
-    # Sequencing, not capability: a prior turn on the shared session had not
-    # fully settled. Reported SKIPPED so it never reads as a capability gap.
     "already processing",
-    # Token provisioning failed before the harness could reach the model — an
-    # environment/auth gap (a missing/empty gateway token, a provider auth
-    # command that produced nothing), not a capability the harness lacks.
-    # Seen on full-server for codex ("provider auth command ... empty token")
-    # and pi ("could not fetch a gateway token").
     "could not fetch a gateway token",
     "provider auth command",
     "empty token",
     "Failed to resolve external API key auth",
-    # Own-auth harness whose vendor CLI is not installed / not logged in (e.g.
-    # an ACP harness like rovo: "Ensure `acli` is installed and you are logged
-    # in"). The vendor process exits before a turn can run — an environment/
-    # login gap, not a capability the harness lacks, so it must SKIP not drift.
     "are logged in",
     "AcpProcessExited",
     "ACP subprocess",
@@ -126,19 +81,13 @@ _INFRA_ERROR_MARKERS: tuple[str, ...] = (
 
 
 def _error_text(error: object) -> str:
-    """Flatten a turn error (dict or str) into searchable text."""
     if isinstance(error, dict):
         return f"{error.get('message', '')} {error.get('code', '')}"
     return str(error or "")
 
 
 def infra_failure_reason(result: TurnResult) -> str | None:
-    """Return a concise env-skip reason if a turn failed on infra/auth, else ``None``.
-
-    Lets probes distinguish "the gateway rejected us" (an environment
-    problem the operator must fix) from "the harness cannot do this" (a
-    capability fact). Only the latter should ever count as UNSUPPORTED.
-    """
+    """Return a skip reason when failure reflects infrastructure, not capability."""
     if not result.failed:
         return None
     text = _error_text(result.error)
@@ -146,9 +95,6 @@ def infra_failure_reason(result: TurnResult) -> str | None:
         return None
     for code in ("403", "401"):
         if code in text:
-            # Provider-neutral: any harness can hit this when its credential is
-            # expired or shadowed by an ambient env var (a stale bearer/API-key/
-            # token) that takes precedence over the configured auth source.
             return (
                 f"auth rejected ({code} Invalid/Forbidden token); the harness "
                 "credential is stale or shadowed by an ambient env var. Refresh "
@@ -184,50 +130,7 @@ def infra_failure_reason(result: TurnResult) -> str | None:
 
 @dataclass
 class TurnResult:
-    """Everything a probe needs to inspect after one turn.
-
-    :param events: Every decoded SSE event dict, in order.
-    :param text: Concatenation of all ``response.output_text.delta``
-        payloads.
-    :param text_delta_count: Number of ``response.output_text.delta``
-        events — the streaming signal (>1 = token-level deltas, 1 = a
-        single complete blob).
-    :param reasoning_delta_count: Number of reasoning-delta events, if the
-        harness forwards any.
-    :param tool_calls: The ``response.tool_call`` events observed, each a
-        raw event dict carrying ``call_id`` / ``name`` / ``arguments``.
-    :param policy_actions: ``(phase, action)`` pairs this driver posted back
-        (one per ``policy_evaluation.requested``), so a probe can tell which
-        verdict was delivered for which phase.
-    :param tool_call_denied: Whether a ``PHASE_TOOL_CALL`` evaluation was
-        answered DENY — the only signal that proves a tool-call guardrail
-        (not a request/result-phase DENY) was actually exercised.
-    :param completed: Whether a terminal ``response.completed`` was seen.
-    :param cancelled: Whether a terminal ``response.cancelled`` was seen
-        (the harness honored an interrupt).
-    :param failed: Whether a terminal ``response.failed`` was seen.
-    :param error: The error payload from ``response.failed``, if any.
-    :param timed_out: Whether the stream did not reach a terminal event
-        within the probe's timeout.
-    :param total_tokens: Cumulative token count the turn reported, if any
-        (``None`` when the transport surfaced no usage). Read from the session
-        snapshot (``SessionResponse.last_total_tokens``) or the completed
-        turn's ``usage``.
-    :param total_cost_usd: Cumulative USD cost the turn reported, if any
-        (``None`` when unobserved or the model is unpriced). Read from
-        ``SessionResponse.total_cost_usd`` / ``session.usage`` /
-        ``response.completed`` usage.
-    :param elicitation_requested: Whether an elicitation was raised during the
-        turn — the signal an ASK policy fired (server publishes
-        ``response.elicitation_request`` / lands a pending elicitation on the
-        snapshot). The policy_ask probe keys on this.
-    :param tool_call_allowed: Whether a surfaced tool call produced a
-        non-blocked ``function_call_output`` — i.e. the call proceeded. This is
-        set for *any* non-blocked tool output, not only under an ALLOW policy;
-        the policy_allow probe's correctness comes from driving a real
-        ``action=allow`` session (``_ensure_policy_session("allow")``), so a set
-        flag there means the ALLOW policy let the call through.
-    """
+    """Probe-observable state from one turn."""
 
     events: list[dict[str, Any]] = field(default_factory=list)
     text: str = ""
@@ -248,25 +151,15 @@ class TurnResult:
 
     @property
     def reached_terminal(self) -> bool:
-        """Whether the stream ended on any terminal event (done/cancelled/failed)."""
         return self.completed or self.cancelled or self.failed
 
     @property
     def event_types(self) -> list[str]:
-        """The ``type`` of every event, in order."""
         return [e.get("type", "") for e in self.events]
 
 
 def fill_snapshot_cost(result: TurnResult, snapshot: dict[str, Any]) -> None:
-    """Populate *result*'s usage/cost from a session snapshot (``SessionResponse``).
-
-    The server tracks cumulative usage on the conversation and exposes it on the
-    snapshot as ``total_cost_usd`` (priced spend; ``None`` for an unpriced model)
-    and ``last_total_tokens`` (token count). Both server-backed drivers poll the
-    snapshot to a terminal state, so this is the uniform cost read point. A
-    tokens-only snapshot (no price) leaves ``total_cost_usd`` ``None`` — the cost
-    probe reports that as PARTIAL, not a failure.
-    """
+    """Copy observed usage and cost from a session snapshot."""
     tokens = snapshot.get("last_total_tokens")
     if isinstance(tokens, int):
         result.total_tokens = tokens
@@ -276,16 +169,7 @@ def fill_snapshot_cost(result: TurnResult, snapshot: dict[str, Any]) -> None:
 
 
 class SdkInprocDriver:
-    """Drive turns through a single harness wrap subprocess.
-
-    Use as an async context manager::
-
-        async with SdkInprocDriver(profile, databricks_profile="prof") as d:
-            result = await d.run_turn("Reply with FOO.")
-
-    The context manager owns the :class:`HarnessProcessManager` lifecycle
-    and a short-pathed tmp parent (macOS ``AF_UNIX`` path limit).
-    """
+    """Drive turns through a harness wrap subprocess."""
 
     transport = "sdk-inproc"
 
@@ -298,16 +182,7 @@ class SdkInprocDriver:
 
     @staticmethod
     def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
-        """Return a skip reason if this driver cannot run *profile*, else ``None``.
-
-        Checks, in order: the profile's transport matches this driver,
-        resolvable gateway credentials (``--profile``, a configured
-        ``~/.omnigent`` profile, or ambient ``OPENAI_*`` — like ``omni run``),
-        and a runnable harness CLI binary. Mirrors the e2e suite's gating so the
-        bench skips — rather than errors — in environments missing creds or a
-        vendor CLI, or when a profile declares a transport this driver does not
-        implement (e.g. a native/community harness).
-        """
+        """Return why this driver cannot run the profile, if applicable."""
         if profile.transport != SdkInprocDriver.transport:
             return (
                 f"transport {profile.transport!r} not supported by the "
@@ -328,9 +203,6 @@ class SdkInprocDriver:
         self._pm = HarnessProcessManager(tmp_parent=self._tmp_parent)
         await self._pm.start()
         p = self._profile
-        # Resolve the effective profile the way `omni run` does (the --profile
-        # override, else the config-derived one). May be None when auth comes
-        # from ambient OPENAI_*, in which case the wrap inherits that env.
         resolved = resolve_bench_env(self._databricks_profile)
         wrap_env = {
             f"{p.env_prefix}GATEWAY": "true",
@@ -358,36 +230,7 @@ class SdkInprocDriver:
         interrupt_on_first_delta: bool = False,
         timeout: float = 120.0,
     ) -> TurnResult:
-        """Start one turn and drain its event stream into a :class:`TurnResult`.
-
-        Handles the three downward round-trips the wrap may need mid-turn:
-
-        - ``policy_evaluation.requested`` → posts a ``policy_verdict``,
-          answering DENY only for evaluations whose ``phase`` is in
-          *deny_phases* and ALLOW otherwise. Scoping the DENY by phase is
-          what lets the policy probe prove a *tool-call* guardrail rather
-          than accidentally denying the request phase.
-        - ``response.output_item.done`` (function_call, action_required) →
-          when *auto_tool_output* is set, posts a ``tool_result`` so a
-          tool-calling turn can complete.
-        - *interrupt_on_first_delta* → posts an ``interrupt`` event the
-          first time text streams, to exercise cancellation.
-
-        :param prompt: The user text for the turn.
-        :param tools: Optional tool specs forwarded verbatim as the wrap's
-            passthrough ``tools`` field (Chat-Completions shape:
-            ``[{"type": "function", "function": {...}}]``).
-        :param deny_phases: Policy phases to answer DENY (e.g.
-            ``{PHASE_TOOL_CALL}``); all other phases are answered ALLOW.
-            Empty (default) answers ALLOW to every phase.
-        :param policy_reason: Reason string sent with a DENY verdict.
-        :param auto_tool_output: Stringified output auto-returned for each
-            tool call; ``None`` leaves tool calls unanswered.
-        :param interrupt_on_first_delta: Post an interrupt once text starts.
-        :param timeout: Seconds to wait for a terminal event before marking
-            the result :attr:`TurnResult.timed_out`.
-        :returns: The drained :class:`TurnResult`.
-        """
+        """Start one turn and drain its event stream."""
         assert self._client is not None, "driver used outside its async context"
         body: dict[str, Any] = {
             "type": "message",
@@ -415,11 +258,6 @@ class SdkInprocDriver:
             result.timed_out = True
         return result
 
-    # ── semantic driver protocol ─────────────────────────────
-    # The probe-facing surface (see tests/harness_bench/transport.py). Each
-    # method wraps run_turn with the wrap-transport mechanism for one
-    # capability dimension, so probes stay transport-agnostic.
-
     async def run_basic_turn(self, marker: str) -> TurnResult:
         return await self.run_turn(
             f"Reply with exactly the literal string {marker} and nothing else."
@@ -429,12 +267,7 @@ class SdkInprocDriver:
         return await self.run_turn(_STREAM_PROMPT)
 
     async def run_tool_turn(self, *, deny: bool) -> TurnResult:
-        """Provoke a tool call via a request-level function tool.
-
-        With *deny*, answer the tool-call policy evaluation DENY (and post no
-        tool result, since a blocked call never runs); otherwise auto-answer
-        the call so the turn completes.
-        """
+        """Provoke a tool call and optionally deny its policy evaluation."""
         if deny:
             return await self.run_turn(
                 f"Call the {_BENCH_TOOL_NAME} tool with arg='go'. It is required.",
@@ -452,10 +285,7 @@ class SdkInprocDriver:
         )
 
     async def run_policy_turn(self, *, action: str) -> TurnResult:
-        """The wrap-direct path has no server-side policy/elicitation surface, so
-        an explicit ALLOW/ASK verdict cannot be observed here. Return an
-        unmeasured result so the policy_allow / policy_ask probes SKIP (never a
-        false verdict), mirroring how Policy DENY reports on this transport."""
+        """Return unmeasured because wrap-direct cannot observe ALLOW or ASK."""
         return TurnResult()
 
     async def run_interrupt_turn(self) -> TurnResult:
@@ -496,11 +326,7 @@ class SdkInprocDriver:
                     elif etype in _REASONING_DELTA_TYPES:
                         result.reasoning_delta_count += 1
                     elif etype == "response.output_item.done":
-                        # Server-dispatched tool calls arrive as an
-                        # output_item.done carrying a function_call item with
-                        # status "action_required" (see _scaffold.dispatch_tool).
-                        # We must answer with a tool_result or the turn parks
-                        # forever waiting on the dispatch future.
+                        # Action-required calls park until a tool result arrives.
                         item = event.get("item") or {}
                         if (
                             item.get("type") == "function_call"
@@ -517,10 +343,6 @@ class SdkInprocDriver:
                                     }
                                 )
                     elif etype == "policy_evaluation.requested":
-                        # Answer DENY only for phases the caller asked to deny
-                        # (e.g. PHASE_TOOL_CALL); ALLOW every other phase so a
-                        # request/result-phase evaluation cannot be mistaken
-                        # for a tool-call guardrail.
                         phase = str(event.get("phase", ""))
                         action = POLICY_DENY if phase in deny_phases else POLICY_ALLOW
                         verdict: dict[str, Any] = {
@@ -530,17 +352,13 @@ class SdkInprocDriver:
                         }
                         if action == POLICY_DENY and policy_reason is not None:
                             verdict["reason"] = policy_reason
-                        # Record only after a successful post, so a raced /
-                        # rejected verdict is not counted as delivered.
+                        # A raced or rejected verdict was not delivered.
                         if await self._post(verdict):
                             result.policy_actions.append((phase, action))
                             if action == POLICY_DENY and phase == PHASE_TOOL_CALL:
                                 result.tool_call_denied = True
                     elif etype == "response.completed":
                         result.completed = True
-                        # The wrap-direct path has no server snapshot; usage, if
-                        # the wrap forwards it, rides on the completed response.
-                        # Absent -> stays None and the cost probe SKIPs.
                         usage = (event.get("response") or {}).get("usage") or {}
                         tok = usage.get("total_tokens")
                         if isinstance(tok, int):
@@ -555,16 +373,7 @@ class SdkInprocDriver:
                         result.error = event.get("error") or event.get("response", {}).get("error")
 
     async def _post(self, payload: dict[str, Any]) -> bool:
-        """POST a downward event on the wrap's events endpoint (best-effort).
-
-        Downward events race the turn's terminal state (e.g. an interrupt
-        landing just as the turn ends). A failed post here is benign — the
-        probe reads the outcome from the stream — so the error is suppressed.
-
-        :returns: ``True`` if the post got a non-error response, else
-            ``False``. Callers that record a verdict as "delivered" gate on
-            this so a raced/rejected post is not counted.
-        """
+        """Post a downward event, tolerating races with turn completion."""
         assert self._client is not None
         try:
             resp = await self._client.post(f"/v1/sessions/{_CONV_ID}/events", json=payload)
@@ -573,15 +382,13 @@ class SdkInprocDriver:
         return not resp.is_error
 
 
-# Reasoning-delta event names vary across harness wraps; match the common
-# spellings so the reasoning signal is captured without per-harness code.
+# Harness wraps use both reasoning-delta spellings.
 _REASONING_DELTA_TYPES: frozenset[str] = frozenset(
     {"response.reasoning.delta", "response.reasoning_summary_text.delta"}
 )
 
 
 def _decode_frame(frame: str) -> dict[str, Any] | None:
-    """Decode one SSE frame's ``data:`` line into an event dict, or ``None``."""
     data_line = next(
         (line for line in frame.splitlines() if line.startswith("data:")),
         None,

--- a/tests/harness_bench/events.py
+++ b/tests/harness_bench/events.py
@@ -1,19 +1,4 @@
-"""Structured progress events for a bench run.
-
-The bench emits a small stream of typed events as it works — one harness
-starts, a probe starts, a probe finishes with a verdict, a harness finishes.
-A *sink* (``ProgressSink``) consumes them. This is the seam that lets the CLI
-render progress in more than one way without the orchestrator knowing how:
-
-- :class:`LineSink` prints the plain ``[harness] Probe: VERDICT`` lines to a
-  writer (the default; what CI / a piped run wants).
-- a rich live-table sink (see :mod:`tests.harness_bench.richreport`) draws one
-  row per harness with per-dimension cells that fill in as events arrive.
-
-Events carry structured fields (harness id, probe name/title, verdict, note),
-not pre-rendered strings, so a sink can lay them out however it likes and a
-parallel run can interleave multiple harnesses' events cleanly.
-"""
+"""Structured progress events and sinks for bench runs."""
 
 from __future__ import annotations
 

--- a/tests/harness_bench/full_server.py
+++ b/tests/harness_bench/full_server.py
@@ -9,9 +9,9 @@ lives apart from the *driver* that runs probes against it. Credentials come from
 - :class:`~tests.harness_bench.full_server_driver.FullServerDriver` — one
   harness per :class:`SharedFullServer` (solo run), or several harnesses on one
   shared server (parallel run; see ``bench.run_bench``).
-- :mod:`tests.harness_bench.native_tui_driver` reuses the lower-level spawn
-  helpers (:func:`spawn_omnigent_server`, :func:`_find_free_port`) for its own
-  server + host-daemon topology.
+- :mod:`tests.harness_bench.native_tui_driver` reuses the lower-level server
+  spawn helper and :func:`tests._helpers.live_server.find_free_port` for its
+  own server + host-daemon topology.
 """
 
 from __future__ import annotations
@@ -21,7 +21,6 @@ import json
 import os
 import shutil
 import signal
-import socket
 import subprocess
 import tarfile
 import time
@@ -41,6 +40,7 @@ from tests._helpers.compat import (
     runner_executable,
     server_executable,
 )
+from tests._helpers.live_server import find_free_port
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.runtime_env import BenchRuntimeEnv
 
@@ -53,12 +53,6 @@ _POLL_INTERVAL_S = 0.2
 # _DENY_REASON so a blocked call is unambiguous.
 _TOOL_NAME = "list_files"
 _DENY_REASON = "bench-policy-deny"
-
-
-def _find_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return int(s.getsockname()[1])
 
 
 def spawn_omnigent_server(
@@ -235,7 +229,7 @@ class SharedFullServer:
 
     def __enter__(self) -> SharedFullServer:
         self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)
-        port = _find_free_port()
+        port = find_free_port()
         self.base_url = f"http://localhost:{port}"
         binding_token = uuid.uuid4().hex
         self.runner_id = token_bound_runner_id(binding_token)

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -33,6 +33,7 @@ import contextlib
 import json
 import threading
 import time
+from collections.abc import Callable
 from typing import Any
 
 import httpx
@@ -47,6 +48,12 @@ from tests.harness_bench.full_server import (
 )
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.runtime_env import bench_creds_skip_reason, resolve_bench_env
+from tests.harness_bench.session_items import (
+    assistant_text,
+    contains_user_text,
+    function_calls,
+    tool_output_states,
+)
 
 _TOOL_PROMPT = f"List the files using the {_TOOL_NAME} tool, then tell me how many there are."
 
@@ -179,6 +186,46 @@ class FullServerDriver:
             self._policy_session_ids[action] = self._shared.create_session(name)
         return self._policy_session_ids[action]
 
+    def _poll_session(
+        self,
+        sid: str,
+        result: TurnResult,
+        *,
+        timeout: float,
+        scan_tools: bool = False,
+        fill_cost: bool = False,
+        stop_when: Callable[[], bool] | None = None,
+    ) -> TurnResult:
+        """Poll a session until it settles, fails, times out, or is stopped."""
+        assert self._client is not None
+        deadline = time.monotonic() + timeout
+        seen_running = False
+        while time.monotonic() < deadline:
+            if stop_when is not None and stop_when():
+                return result
+            response = self._client.get(f"/v1/sessions/{sid}")
+            response.raise_for_status()
+            snapshot = response.json()
+            status = snapshot.get("status")
+            items = snapshot.get("items", [])
+            if scan_tools:
+                _scan_tool_items(items, result)
+            if status in ("running", "waiting"):
+                seen_running = True
+            elif status == "failed":
+                result.failed = True
+                result.error = snapshot.get("last_task_error") or snapshot.get("error")
+                return result
+            elif status == "idle" and seen_running:
+                result.completed = True
+                result.text = assistant_text(items)
+                if fill_cost:
+                    fill_snapshot_cost(result, snapshot)
+                return result
+            time.sleep(_POLL_INTERVAL_S)
+        result.timed_out = True
+        return result
+
     # ── tool / policy probe ──────────────────────────────────
 
     def tool_probe_turn(self, *, deny: bool, timeout: float = 180.0) -> TurnResult:
@@ -203,27 +250,7 @@ class FullServerDriver:
         }
         self._client.post(f"/v1/sessions/{sid}/events", json=body).raise_for_status()
 
-        deadline = time.monotonic() + timeout
-        seen_running = False
-        while time.monotonic() < deadline:
-            snap = self._client.get(f"/v1/sessions/{sid}").json()
-            status = snap.get("status")
-            items = snap.get("items", [])
-            if status in ("running", "waiting"):
-                seen_running = True
-            if status == "failed":
-                result.failed = True
-                result.error = snap.get("last_task_error") or snap.get("error")
-                break
-            if status == "idle" and seen_running:
-                result.completed = True
-                _scan_tool_items(items, result)
-                result.text = _assistant_text(items)
-                break
-            time.sleep(_POLL_INTERVAL_S)
-        else:
-            result.timed_out = True
-        return result
+        return self._poll_session(sid, result, timeout=timeout, scan_tools=True)
 
     # ── policy ALLOW / ASK probe ─────────────────────────────
 
@@ -288,32 +315,20 @@ class FullServerDriver:
         }
         self._client.post(f"/v1/sessions/{sid}/events", json=body).raise_for_status()
 
-        deadline = time.monotonic() + timeout
-        seen_running = False
-        while time.monotonic() < deadline:
-            # ASK verdict is decided once the elicitation fires: resolve it (so
-            # no park dangles) and stop — no need to poll the turn to idle.
+        def _elicitation_observed() -> bool:
             if action == "ask" and result.elicitation_requested:
                 if "id" in elicitation_id:
                     self._resolve_elicitation(sid, elicitation_id.pop("id"))
-                break
-            snap = self._client.get(f"/v1/sessions/{sid}").json()
-            status = snap.get("status")
-            items = snap.get("items", [])
-            _scan_tool_items(items, result)
-            if status in ("running", "waiting"):
-                seen_running = True
-            if status == "failed":
-                result.failed = True
-                result.error = snap.get("last_task_error") or snap.get("error")
-                break
-            if status == "idle" and seen_running:
-                result.completed = True
-                result.text = _assistant_text(items)
-                break
-            time.sleep(_POLL_INTERVAL_S)
-        else:
-            result.timed_out = True
+                return True
+            return False
+
+        self._poll_session(
+            sid,
+            result,
+            timeout=timeout,
+            scan_tools=True,
+            stop_when=_elicitation_observed,
+        )
         stop.set()
         if watcher is not None:
             watcher.join(timeout=5.0)
@@ -420,12 +435,12 @@ class FullServerDriver:
                 interrupted = True
             if _has_cancellation_marker(items):
                 result.cancelled = True
-                result.text = _assistant_text(items)
+                result.text = assistant_text(items)
                 break
             if status == "idle" and interrupted:
                 # Settled after the interrupt; the marker lands just after.
                 result.cancelled = _has_cancellation_marker(items)
-                result.text = _assistant_text(items)
+                result.text = assistant_text(items)
                 break
             time.sleep(_POLL_INTERVAL_S)
         else:
@@ -437,15 +452,8 @@ class FullServerDriver:
     def run_turn(self, prompt: str, *, timeout: float = 180.0) -> TurnResult:
         """Drive one basic turn through the full server, return a :class:`TurnResult`.
 
-        Foundation scope: posts the user message and polls the session
-        snapshot to a terminal state, filling ``text`` / ``completed`` /
-        ``failed`` / ``timed_out``. A synchronous (request-phase) policy
-        DENY short-circuits to ``failed``.
-
-        The dimensions that motivated this transport — server-dispatched
-        tools, tool-call policy enforcement, delta streaming, interrupt —
-        are follow-ups (see the module docstring); they extend this
-        signature and are not implemented yet.
+        Posts the user message and polls the session snapshot to a terminal
+        state, filling text, completion, failure, timeout, and usage fields.
         """
         assert self._client is not None and self._session_id is not None
         result = TurnResult()
@@ -460,73 +468,22 @@ class FullServerDriver:
             return result
         posted.raise_for_status()
 
-        deadline = time.monotonic() + timeout
-        seen_running = False
-        while time.monotonic() < deadline:
-            snap = self._client.get(f"/v1/sessions/{self._session_id}")
-            snap.raise_for_status()
-            body = snap.json()
-            status = body.get("status")
-            if status in ("running", "waiting"):
-                seen_running = True
-            if status == "failed":
-                result.failed = True
-                result.error = body.get("last_task_error") or body.get("error")
-                break
-            if status == "idle" and seen_running:
-                result.completed = True
-                result.text = _assistant_text(body.get("items", []))
-                fill_snapshot_cost(result, body)
-                break
-            time.sleep(_POLL_INTERVAL_S)
-        else:
-            result.timed_out = True
-        return result
+        return self._poll_session(
+            self._session_id,
+            result,
+            timeout=timeout,
+            fill_cost=True,
+        )
 
 
-def _scan_tool_items(items: list[dict], result: TurnResult) -> None:
+def _scan_tool_items(items: list[dict[str, Any]], result: TurnResult) -> None:
     """Populate tool_calls and tool_call_denied from session items."""
-    for raw in items:
-        data = raw.get("data", raw)
-        itype = raw.get("type") or data.get("type")
-        if itype == "function_call":
-            result.tool_calls.append(
-                {
-                    "call_id": data.get("call_id"),
-                    "name": data.get("name"),
-                    "arguments": data.get("arguments"),
-                }
-            )
-        elif itype == "function_call_output":
-            out = str(data.get("output", ""))
-            if data.get("status") == "blocked" or _DENY_REASON in out:
-                result.tool_call_denied = True
-            else:
-                # The call produced a real (non-blocked) output — it proceeded,
-                # the signal an ALLOW policy let it through.
-                result.tool_call_allowed = True
+    result.tool_calls = function_calls(items)
+    result.tool_call_allowed, result.tool_call_denied = tool_output_states(
+        items, deny_marker=_DENY_REASON
+    )
 
 
-def _has_cancellation_marker(items: list[dict]) -> bool:
+def _has_cancellation_marker(items: list[dict[str, Any]]) -> bool:
     """Whether items include the synthetic 'interrupted' user message."""
-    for raw in items:
-        data = raw.get("data", raw)
-        if (raw.get("type") == "message") and (data.get("role") == "user"):
-            if any(
-                _CANCELLATION_MARKER in (b.get("text", "") or "")
-                for b in data.get("content", []) or []
-            ):
-                return True
-    return False
-
-
-def _assistant_text(items: list[dict]) -> str:
-    """Concatenate assistant output_text from session items."""
-    out: list[str] = []
-    for item in items:
-        data = item.get("data", item)
-        if data.get("role") == "assistant" or item.get("role") == "assistant":
-            for block in data.get("content", []) or []:
-                if block.get("type") in ("output_text", "text"):
-                    out.append(block.get("text", ""))
-    return "\n".join(t for t in out if t)
+    return contains_user_text(items, _CANCELLATION_MARKER)

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -1,30 +1,4 @@
-"""Full-server transport driver (phase-2).
-
-Unlike :class:`tests.harness_bench.driver.SdkInprocDriver` (which drives a
-harness wrap subprocess directly), this driver spins up a REAL Omnigent
-``server`` + ``runner`` pair, registers an agent, and drives turns through
-the full session path — so policy enforcement and server-dispatched tools
-are exercised the way production does, not simulated at the wrap boundary.
-
-It reuses the exact spawn recipe of the e2e ``live_server`` fixture
-(``tests/e2e/conftest.py``) via the shared compat helpers, but packaged as
-a plain async context manager so the bench CLI can drive it without pytest.
-
-Status (live-verified): server+runner lifecycle, a basic turn, and the
-payoff this transport exists for — a real **server-dispatched tool call**
-(a read-only builtin) and **tool-call policy enforcement** (a spec-baked
-``tool_call`` deny policy blocks the call the way production does). Ad-hoc
-request-level function tools are NOT used here: the SDK harnesses handle
-tools internally, so they never round-trip as a server-dispatched, policy-
-gated call — a builtin does.
-
-Interrupt/cancel is verified (a long turn is interrupted mid-flight and the
-server's cancellation marker confirms it stopped), and delta-level
-streaming is measured via the ``/v1/sessions/{id}/stream`` SSE subscribe.
-
-Follow-up (stacked PR): a ``--transport`` selector + driver registry so the
-bench's probes run through this driver, not just its gated tests.
-"""
+"""Full-server transport driver."""
 
 from __future__ import annotations
 
@@ -57,14 +31,12 @@ from tests.harness_bench.session_items import (
 
 _TOOL_PROMPT = f"List the files using the {_TOOL_NAME} tool, then tell me how many there are."
 
-# The server persists an interrupted turn as a synthetic user message whose
-# text contains this marker (see tests/e2e/test_cancel_history.py).
+# Interrupted turns persist this marker in session history.
 _CANCELLATION_MARKER = "interrupted"
 _LONG_PROMPT = (
     "Write a very detailed 600-word essay about the history of computing, in full paragraphs."
 )
 
-# Prompt long enough that a streaming harness emits clearly many deltas.
 _STREAM_PROMPT = (
     "Count from 1 to 30 in words, one number per line, and add a short note after each."
 )
@@ -72,13 +44,7 @@ _TERMINAL_EVENTS = frozenset({"response.completed", "response.failed", "response
 
 
 class FullServerDriver:
-    """Drive turns through a live Omnigent server + runner.
-
-    Async context manager: on enter it spawns the server and runner,
-    waits for both to report healthy, registers *profile*'s harness as an
-    agent, and creates a runner-bound session. ``run_turn`` drives one turn
-    through that session.
-    """
+    """Drive turns through a live Omnigent server and runner."""
 
     transport = "full-server"
 
@@ -91,16 +57,9 @@ class FullServerDriver:
     ) -> None:
         self._profile = profile
         self._db_profile = databricks_profile
-        # When *shared* is given (a parallel run), this driver registers its
-        # agent + session on that one server+runner and spawns nothing itself.
-        # When None (a solo / --jobs 1 run), it owns a private SharedFullServer
-        # for back-compat with the original one-server-per-harness behavior.
         self._shared = shared
         self._owns_shared = shared is None
-        # Per-action agent+session cache for the policy probes. Each bakes a
-        # fixed-action tool_call policy into its agent spec (the REST policy
-        # endpoint's allowlist excludes make_fixed_action_callable, so the
-        # policy must ride in the spec). Created lazily, keyed by action.
+        # Fixed-action policies must be baked into separate agent specs.
         self._policy_session_ids: dict[str, str] = {}
         self._session_id: str | None = None
 
@@ -110,11 +69,8 @@ class FullServerDriver:
 
     @staticmethod
     def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
-        """Return a skip reason if this driver cannot run *profile*, else ``None``."""
-        # full-server registers the harness via an agent bundle (the SDK-wrap
-        # path); a native harness needs the host-daemon/tmux provisioning only
-        # the native-tui driver does, so it cannot run here even under an
-        # explicit --transport full-server override.
+        """Return why this driver cannot run the profile, if applicable."""
+        # Native harnesses require host-daemon provisioning.
         if profile.transport == "native-tui":
             return (
                 f"{profile.harness!r} is a native-tui harness; the full-server transport "
@@ -123,9 +79,6 @@ class FullServerDriver:
         creds_skip = bench_creds_skip_reason(databricks_profile)
         if creds_skip is not None:
             return creds_skip
-        # Same CLI gate as the wrap driver (same binary requirement), but skip
-        # its transport check — that is sdk-inproc-specific and would misreport
-        # the driver name; the native case is already handled above.
         if profile.cli_binary is not None:
             return cli_unavailable_reason(profile.cli_binary)
         return None
@@ -139,16 +92,10 @@ class FullServerDriver:
         return self
 
     def __exit__(self, *exc: object) -> None:
-        # Only tear down the server we own; an injected shared server is the
-        # orchestrator's to close after all harnesses finish.
         if self._owns_shared and self._shared is not None:
             self._shared.__exit__(*exc)
 
-    # ── async driver protocol ────────────────────────────────
-    # This driver's provisioning and turns are synchronous (subprocess spawn,
-    # blocking snapshot polls, a threaded SSE reader). Bridge to the bench's
-    # async Driver protocol by running the blocking work in a worker thread so
-    # the event loop is never blocked.
+    # Blocking server operations run off the event loop.
 
     async def __aenter__(self) -> FullServerDriver:
         return await asyncio.to_thread(self.__enter__)
@@ -172,14 +119,8 @@ class FullServerDriver:
     async def run_interrupt_turn(self) -> TurnResult:
         return await asyncio.to_thread(self.interrupt_probe_turn)
 
-    # ── agent + session ──────────────────────────────────────
-    # The server/runner lifecycle and agent/session registration live on
-    # SharedFullServer now; this driver delegates so a solo run and a parallel
-    # (shared-server) run go through the same path.
-
     def _ensure_policy_session(self, action: str) -> str:
-        """Lazily register a session whose agent bakes a fixed *action* tool_call
-        policy (``"allow"`` / ``"deny"`` / ``"ask"``); return the session id."""
+        """Return a session whose agent bakes in the requested policy action."""
         assert self._shared is not None
         if action not in self._policy_session_ids:
             name = self._shared.register_agent(self._profile, policy_action=action)
@@ -226,8 +167,6 @@ class FullServerDriver:
         result.timed_out = True
         return result
 
-    # ── tool / policy probe ──────────────────────────────────
-
     def tool_probe_turn(self, *, deny: bool, timeout: float = 180.0) -> TurnResult:
         """Drive a turn that calls the builtin tool; return a :class:`TurnResult`.
 
@@ -251,8 +190,6 @@ class FullServerDriver:
         self._client.post(f"/v1/sessions/{sid}/events", json=body).raise_for_status()
 
         return self._poll_session(sid, result, timeout=timeout, scan_tools=True)
-
-    # ── policy ALLOW / ASK probe ─────────────────────────────
 
     def policy_probe_turn(self, *, action: str, timeout: float = 90.0) -> TurnResult:
         """Drive a tool turn under a fixed tool_call policy *action*.
@@ -350,8 +287,6 @@ class FullServerDriver:
                 },
             )
 
-    # ── streaming probe ──────────────────────────────────────
-
     def streaming_probe_turn(self, *, timeout: float = 120.0) -> TurnResult:
         """Measure token-level streaming via the session SSE subscribe stream.
 
@@ -403,8 +338,6 @@ class FullServerDriver:
             result.timed_out = True
         return result
 
-    # ── interrupt probe ──────────────────────────────────────
-
     def interrupt_probe_turn(self, *, timeout: float = 120.0) -> TurnResult:
         """Start a long turn, interrupt it mid-flight, and report the outcome.
 
@@ -446,8 +379,6 @@ class FullServerDriver:
         else:
             result.timed_out = True
         return result
-
-    # ── turn ─────────────────────────────────────────────────
 
     def run_turn(self, prompt: str, *, timeout: float = 180.0) -> TurnResult:
         """Drive one basic turn through the full server, return a :class:`TurnResult`.

--- a/tests/harness_bench/manifest.py
+++ b/tests/harness_bench/manifest.py
@@ -1,36 +1,4 @@
-"""The registry of official harness bench profiles.
-
-Each profile's descriptive columns and *declared* verdicts derive from the
-canonical capability model (:func:`omnigent.harness_plugins.harness_capabilities`),
-so there is a single source of truth for "what each harness supports". The
-base fields (model, env_prefix, marker, cli_binary) are reused from
-``tests.e2e._harness_probes.HARNESS_PROBES`` — a harness added to the e2e
-parametrize matrix flows into the bench without a second copy.
-
-The declared matrix is the harness's *published capability*; the bench's
-probes measure live behavior. When they disagree,
-:func:`tests.harness_bench.verdict.reconcile` flags ``DRIFT`` — which means a
-harness's capability declaration is false. That makes the capability table
-self-enforcing.
-
-Axis mapping (see ``designs/harness-capabilities-bench-seam.md``):
-
-- **Group A — descriptive columns** derive from capabilities:
-  ``implementation`` from ``integration_mode``, ``auth`` from ``auth``.
-- **Group B — declared verdicts** derive where a capability backs the probe:
-  ``interrupt`` from ``capabilities.interrupt``, ``streaming`` from
-  ``capabilities.streaming``, ``model_override`` from membership in
-  ``model_env_keys()`` (the SDK model-override registry).
-- **Group C — probe-only** dimensions have no backing capability axis and
-  stay explicit: ``basic_turn`` (every harness completes a turn),
-  ``tool_calling`` (not a modeled axis), and ``policy_deny`` (enforcement,
-  distinct from the elicitation ASK surface — deliberately NOT derived from
-  ``elicitation``).
-
-Non-P0 harnesses' ``interrupt``/``streaming`` are declared best-effort by
-integration mode and not yet probe-verified; the bench's live probes confirm
-or correct them as transport coverage lands.
-"""
+"""Build harness bench profiles from the canonical capability registry."""
 
 from __future__ import annotations
 
@@ -48,8 +16,6 @@ from tests.e2e._harness_probes import HARNESS_PROBES, HarnessProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.verdict import Verdict
 
-# ── Group A: enum → prose for the descriptive columns ────────────
-
 _INTEGRATION_MODE_PROSE: dict[IntegrationMode, str] = {
     IntegrationMode.SDK_IN_PROCESS: "SDK in-process",
     IntegrationMode.CLI_SUBPROCESS: "CLI subprocess",
@@ -65,30 +31,7 @@ _AUTH_PROSE: dict[AuthModel, str] = {
 }
 
 
-# ── Group C: probe-only dimensions with no backing capability ────
-#
-# These stay explicitly SUPPORTED for the official (P0) harnesses: every one
-# completes a turn, calls tools, and enforces a policy DENY. They are NOT
-# derived from any capability axis (see the module docstring / seam brief).
-#
-# tool_calling is now live-probed on BOTH transports: SDK harnesses via
-# full-server (server-dispatched builtin) and native harnesses via native-tui
-# (observing the vendor's own function_call item). policy_deny is live on
-# full-server (spec-baked deny) and wired on native-tui (a session-attached CEL
-# deny + the response.policy_denied stream signal), though native enforcement is
-# a follow-up. An environment gap (fail-open policy, no tool-provocation mapping,
-# CEL unavailable) reports SKIPPED, so SUPPORTED here only ever drifts on a
-# genuine capability gap.
-#
-# cost_tracking, policy_allow, and policy_ask are deliberately NOT declared here
-# (left UNKNOWN). Each is a P1 probe with no backing capability axis whose
-# observed verdict legitimately varies by transport / pricing — e.g. cost is
-# SUPPORTED (priced) / PARTIAL (unpriced) / SKIPPED (no usage), and ALLOW/ASK are
-# SUPPORTED only on full-server and SKIPPED where a transport has no policy
-# surface. Declaring any of them SUPPORTED would manufacture false DRIFT against
-# a legitimate PARTIAL/SKIP; leaving them UNKNOWN lets reconcile pass the observed
-# cell through unchanged (UNKNOWN is not concrete). The P0-coverage test only
-# requires declared verdicts for P0 dimensions, so this is allowed.
+# P1 probes stay UNKNOWN because their valid result varies by transport or pricing.
 _PROBE_ONLY_DECLARED: dict[str, Verdict] = {
     "basic_turn": Verdict.SUPPORTED,
     "tool_calling": Verdict.SUPPORTED,
@@ -97,48 +40,26 @@ _PROBE_ONLY_DECLARED: dict[str, Verdict] = {
 
 
 def _implementation_prose(caps: HarnessCapabilities | None) -> str:
-    """Group A: the ``implementation`` column from ``integration_mode``."""
     if caps is None:
         return ""
     return _INTEGRATION_MODE_PROSE.get(caps.integration_mode, caps.integration_mode.value)
 
 
 def _auth_prose(caps: HarnessCapabilities | None) -> str:
-    """Group A: the ``auth`` column from ``auth``."""
     if caps is None:
         return ""
     return _AUTH_PROSE.get(caps.auth, caps.auth.value)
 
 
 def _declared_from_capabilities(harness: str) -> dict[str, Verdict]:
-    """Build a harness's declared verdicts from the capability model.
-
-    Group B (capability-backed) plus group C (probe-only, explicit).
-    Tolerant of a harness with no declared capabilities (a sparse
-    ``harness_capabilities()`` — e.g. a community plugin): the
-    capability-backed dimensions are simply omitted (left ``UNKNOWN`` by
-    :meth:`BenchProfile.declared_for`) rather than raising.
-
-    :param harness: Harness id, e.g. ``"codex"``.
-    :returns: A ``{dimension: Verdict}`` map for this harness.
-    """
+    """Build declared verdicts, leaving unmodeled capabilities UNKNOWN."""
     declared: dict[str, Verdict] = dict(_PROBE_ONLY_DECLARED)
 
     caps = harness_capabilities().get(harness)
     if caps is not None:
-        # streaming is binary: True → SUPPORTED, False → UNSUPPORTED. PARTIAL is
-        # a probe observation (coalesced single delta), never a declared value —
-        # declaring False as PARTIAL would drift against a harness the probe
-        # reports UNSUPPORTED (0 deltas).
         declared["streaming"] = Verdict.SUPPORTED if caps.streaming else Verdict.UNSUPPORTED
-        # interrupt: True → SUPPORTED; False → UNSUPPORTED.
         declared["interrupt"] = Verdict.SUPPORTED if caps.interrupt else Verdict.UNSUPPORTED
 
-    # model_override is backed by the registry, not a capability field. An
-    # SDK harness takes it via a HARNESS_<H>_MODEL env key (model_env_keys);
-    # a native harness takes it as a launch --model argv element (see
-    # omnigent/model_override.py). Either path means the harness accepts a
-    # caller-specified model.
     if harness in model_env_keys() or is_native_harness(harness):
         declared["model_override"] = Verdict.SUPPORTED
 
@@ -146,11 +67,7 @@ def _declared_from_capabilities(harness: str) -> dict[str, Verdict]:
 
 
 def _profile_from_probe(probe: HarnessProbe) -> BenchProfile:
-    """Build an official :class:`BenchProfile` from an e2e ``HarnessProbe``.
-
-    Descriptive columns and declared verdicts derive from the capability
-    model; only the transport and the e2e base fields are bench-local.
-    """
+    """Build an official profile from the shared e2e probe metadata."""
     caps = harness_capabilities().get(probe.harness)
     return BenchProfile(
         harness=probe.harness,
@@ -166,9 +83,6 @@ def _profile_from_probe(probe: HarnessProbe) -> BenchProfile:
     )
 
 
-# Official harnesses the bench ships with: the P0 SDK harnesses the
-# sdk-inproc driver covers today. Built from HARNESS_PROBES so the e2e and
-# bench matrices never diverge.
 _OFFICIAL_HARNESSES = frozenset({"claude-sdk", "codex", "pi", "openai-agents"})
 
 OFFICIAL_PROFILES: dict[str, BenchProfile] = {
@@ -178,38 +92,12 @@ OFFICIAL_PROFILES: dict[str, BenchProfile] = {
 }
 
 
-# ── native-tui harnesses ─────────────────────────────────────────
-#
-# Native harnesses are not in HARNESS_PROBES (that matrix is the SDK-wrap
-# e2e set), so their profiles are derived here directly from the capability
-# model: every harness with integration_mode == NATIVE_TUI is registered, so
-# the shipped natives and any community-plugin native (harness_capabilities()
-# discovers plugins via entry points) are probeable by name with no bench edit.
-#
-# What the bench can actually *run* is a separate axis from what it registers.
-# OMNIGENT_CREDENTIAL natives (claude, codex) route through the run's Databricks
-# profile, so the bench runs them unattended. OWN_AUTH / session-scoped natives
-# need a vendor login the bench cannot provision; they are still registered
-# (visible, resolvable, honest declared matrix) but skip-gate at the driver's
-# unavailable() on a host without that login.
-#
-# model: an OMNIGENT_CREDENTIAL native routes its launch --model through the
-# gateway, so it takes a databricks-* model; an own-auth native's model lives
-# in the vendor's namespace the bench does not control, and is unused in
-# practice (the harness skip-gates before a turn). model_override still
-# declares UNKNOWN for all natives (absent from model_env_keys()), confirmed
-# live by the probe.
 _NATIVE_CREDENTIAL_MODELS: dict[str, str] = {
     "claude-native": "databricks-claude-sonnet-4-6",
     "codex-native": "databricks-gpt-5-4-mini",
 }
 _NATIVE_DEFAULT_MODEL = "databricks-claude-sonnet-4-6"
 
-# The vendor CLI the driver skip-gates on. Usually the harness id minus
-# "-native" (claude-native -> "claude"), but several vendors ship a
-# differently-named binary (the _DEFAULT_*_COMMAND in each omnigent/*_native.py),
-# so those are listed explicitly. A missing/unlisted native falls back to the
-# suffix convention.
 _NATIVE_CLI_BINARY: dict[str, str] = {
     "cursor-native": "cursor-agent",
     "kiro-native": "kiro-cli",
@@ -217,7 +105,6 @@ _NATIVE_CLI_BINARY: dict[str, str] = {
 
 
 def _native_profile(harness: str) -> BenchProfile:
-    """Build a native-tui :class:`BenchProfile`; all fields from convention/capabilities."""
     caps = harness_capabilities().get(harness)
     cli_binary = _NATIVE_CLI_BINARY.get(harness, harness.removesuffix("-native"))
     env_prefix = "HARNESS_" + harness.upper().replace("-", "_") + "_"
@@ -237,7 +124,6 @@ def _native_profile(harness: str) -> BenchProfile:
 
 
 def _native_tui_harnesses() -> list[str]:
-    """Every harness the capability model marks as native-tui (plugins included)."""
     return [
         harness
         for harness, caps in harness_capabilities().items()
@@ -249,21 +135,6 @@ for _h in _native_tui_harnesses():
     OFFICIAL_PROFILES[_h] = _native_profile(_h)
 
 
-# ── registry fallback: build a profile for ANY registered harness ─
-#
-# resolve_profile uses this so a harness passed by name (--harness acp,
-# --harness rovo) is runnable even though it is not an official profile and
-# ships no BenchProfile of its own. It covers the harnesses the auto-derivation
-# above misses: ACP / CLI-subprocess harnesses (in the capability model but not
-# NATIVE_TUI, e.g. the in-repo `acp`), and community-plugin harnesses that
-# register via entry point but declare no capabilities entry (e.g. `rovo-cli`
-# from omnigent-rovo, discovered through harness_modules()).
-
-# integration_mode -> bench transport family. SDK / CLI / ACP subprocess
-# harnesses all run through the SDK-wrap drivers (registered as an omnigent
-# agent, driven over the session HTTP surface); only NATIVE_TUI needs the
-# native driver. A harness with no capabilities entry defaults to the SDK
-# family (the common case for a plain subprocess plugin like rovo).
 _INTEGRATION_MODE_TRANSPORT: dict[IntegrationMode, str] = {
     IntegrationMode.SDK_IN_PROCESS: "sdk-inproc",
     IntegrationMode.CLI_SUBPROCESS: "sdk-inproc",
@@ -273,38 +144,19 @@ _INTEGRATION_MODE_TRANSPORT: dict[IntegrationMode, str] = {
 
 
 def _registry_cli_binary(canonical: str) -> str | None:
-    """The vendor binary to skip-gate on, from the harness's install spec.
-
-    e.g. rovo-cli -> ``acli`` (Atlassian CLI). ``None`` when the harness has no
-    install spec (e.g. the generic ``acp`` harness, whose command is supplied
-    at run time via ``HARNESS_ACP_COMMAND``), in which case there is no cheap
-    pre-flight gate and an unrunnable harness skips on the turn instead.
-    """
+    """Return the install spec's binary, if the harness has one."""
     install_key = harness_install_keys().get(canonical)
     spec = install_specs().get(install_key) if install_key else None
     return getattr(spec, "binary", None)
 
 
 def _registry_profile(name: str) -> BenchProfile | None:
-    """Build a :class:`BenchProfile` for a harness known to the omnigent registry.
-
-    Resolves aliases (``rovo`` -> ``rovo-cli``) and requires the canonical name
-    to be a registered harness (``harness_modules()``); returns ``None`` for an
-    unknown name so :func:`resolve_profile` can fall through to its error. The
-    transport family comes from the capability model's ``integration_mode``
-    (defaulting to the SDK family when a plugin declares no capabilities), so
-    the harness runs on the existing drivers with no bench edit.
-    """
+    """Build a profile for a registered harness, resolving aliases."""
     canonical = harness_aliases().get(name, name)
-    # ``acp:<slug>`` is a first-class harness id: the base ``acp`` harness is
-    # registered, and the slug selects a user-configured ACP agent at spawn
-    # (resolved from the ~/.omnigent config ``acp:`` block, see
-    # onboarding/acp_auth.py). Look up caps/module by the base ``acp`` but keep
-    # the full id as the profile harness so ``config.harness=acp:<slug>`` reaches
-    # the runner. Lets ``--harness acp:qwen`` bind to a specific ACP agent.
+    # ACP slugs use base-harness metadata but must reach the runner unchanged.
     if canonical.startswith("acp:"):
         if not canonical[len("acp:") :]:
-            return None  # empty slug ("acp:") — use bare "acp" instead
+            return None
         registry_key = "acp"
     else:
         registry_key = canonical
@@ -314,46 +166,24 @@ def _registry_profile(name: str) -> BenchProfile | None:
     caps = harness_capabilities().get(registry_key)
     mode = caps.integration_mode if caps is not None else None
     if mode is None:
-        # No capabilities entry (a plain subprocess plugin like rovo): the bench
-        # has no modeled transport, so assume the SDK-wrap family — the only
-        # thing a registered-but-unmodeled harness can plausibly run on.
         transport = "sdk-inproc"
     elif mode in _INTEGRATION_MODE_TRANSPORT:
         transport = _INTEGRATION_MODE_TRANSPORT[mode]
     else:
-        # A MODELED mode the bench has no driver for (e.g. NATIVE_SERVER /
-        # opencode-native). Refuse rather than silently degrade to the SDK
-        # family: return None so resolve_profile raises a clean KeyError. A
-        # bare "default to sdk-inproc" here would bind a native-server harness
-        # to the wrong driver and drop its skip-gate.
         return None
 
     if transport == "native-tui":
-        # A native-tui harness the auto-derivation would already cover; reuse
-        # its builder so the two paths agree.
         return _native_profile(canonical)
 
-    # env_prefix / marker sanitize non-word chars (an acp:<slug> id has a colon)
-    # to a valid env-var stem, e.g. acp:qwen -> HARNESS_ACP_QWEN_.
     stem = canonical.upper().replace("-", "_").replace(":", "_")
     env_prefix = "HARNESS_" + stem + "_"
     marker = stem + "_OK"
-    # A model is always required: the omnigent executor spec mandates one
-    # (spec/omnigent.py: "executor.type='omnigent' requires a model"), so an
-    # empty model fails agent registration ("llm.model must be present"). For an
-    # own-auth harness (e.g. ACP/rovo) the value is inert — the runner drops any
-    # databricks-* gateway model for it (ACP: workflow.py::_build_acp_spawn_env)
-    # and the agent authenticates + picks its own model — but it must still be a
-    # valid non-empty id to register. So stamp the databricks default in all
-    # cases: real for a gateway harness, an accepted-but-ignored placeholder for
-    # an own-auth one.
+    # Agent registration requires a model even when an own-auth harness ignores it.
     return BenchProfile(
         harness=canonical,
         model=_NATIVE_DEFAULT_MODEL,
         env_prefix=env_prefix,
         marker=marker,
-        # install-spec + declared caps are keyed by the base harness, not the
-        # acp:<slug> id, so look them up by registry_key.
         cli_binary=_registry_cli_binary(registry_key),
         transport=transport,
         owner="",

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -1,49 +1,7 @@
-"""Native-TUI transport driver (phase-2, walking skeleton).
+"""Drive native-TUI harnesses through a live server and host daemon.
 
-Drives a native-tui harness — a resident vendor CLI (``claude``, ``codex``,
-``pi``, ``cursor-agent``, ...) running in a runner-owned tmux pane — through
-the bench's :class:`~tests.harness_bench.transport.Driver` protocol.
-
-The research finding this is built on: a native-tui turn rides the *same*
-HTTP surface as the full server — ``POST /v1/sessions/{id}/events`` to send,
-``GET /v1/sessions/{id}/stream`` for ``response.output_text.delta`` events,
-``/v1/sessions/{id}/policies`` for a tool-call deny, and item polling for the
-assistant reply. So ~90% of this driver is shared with
-:class:`~tests.harness_bench.full_server_driver.FullServerDriver`. Three
-things genuinely diverge, and they are the entire reason this is a separate
-driver:
-
-1. **Provisioning** — instead of registering an agent tarball, a native
-   harness needs a **host daemon** (``omnigent host``) registered with the
-   server, the auto-registered ``<harness>-native-ui`` agent, and a session
-   created with ``{agent_id, host_id, workspace}``. The runner then launches
-   the vendor CLI in tmux itself.
-2. **Interrupt detection** — native turns do not persist an "interrupted"
-   user-message marker; cancellation surfaces as a ``session.interrupted``
-   event / status, so the interrupt probe keys off that.
-3. **Auth + login** — the vendor CLI must be interactively logged in on the
-   host. ``OMNIGENT_CREDENTIAL`` vendors (claude, codex) can take a minted
-   bearer; ``OWN_AUTH`` vendors (cursor, kiro, ...) must be pre-logged-in.
-   Either way the bench cannot provision a fresh login, so this transport is
-   only exercisable on a host with the vendor CLI already authenticated.
-
-Per-vendor differences beyond auth (tmux paste vs app-server RPC delivery,
-readiness signal, tool-deny surface) are captured in :class:`NativeVendor`
-records, so adding a harness is a config entry, not a new driver — until a
-vendor diverges in kind (codex-native is RPC-delivered; opencode-native is
-``native-server`` not ``native-tui``), which will want its own handling.
-
-Scope: this driver runs **any** native-tui harness — the two shipped
-(claude-native, codex-native) and any other in-repo or community-plugin native
-harness — with no per-vendor table. It derives what it needs (agent name,
-terminal name, whether the vendor self-authenticates) from the capability model
-via :func:`native_vendor`, and provisions every native uniformly: launch/bind a
-runner, ensure the native terminal, and wait for the runner-side forwarder to
-come live (all natives stamp ``external_session_id`` once their terminal thread
-starts) before driving turns on the shared observe path. An OMNIGENT_CREDENTIAL
-native (claude, codex) is routed through the run's Databricks profile via a
-written config home; an own-auth native runs only where its vendor CLI is
-already logged in.
+Native sessions use the standard session HTTP surface, but require host/runner
+provisioning and report cancellation through ``session.interrupted``.
 """
 
 from __future__ import annotations
@@ -87,53 +45,26 @@ _HEALTH_TIMEOUT_S = 90.0
 _HOST_ONLINE_TIMEOUT_S = 45.0
 _POLL_INTERVAL_S = 0.3
 _TURN_TIMEOUT_S = 180.0
-# How long to wait for the forwarder to come live (external_session_id stamped)
-# after the terminal ensure returns.
 _FORWARDER_READY_TIMEOUT_S = 90.0
 
-# Native turns take longer (terminal boot + a real interactive vendor turn),
-# so the prompts stay short and the timeouts generous.
 _STREAM_PROMPT = "Count from 1 to 20 in words, one per line."
 _LONG_PROMPT = "Write a detailed 500-word essay about the history of computing."
 
-# Session SSE event names (confirmed live against claude-native with a
-# per-event diagnostic). Critical native-tui quirk: ``response.completed``
-# fires EARLY — right after the turn is accepted, seconds before the
-# assistant's text deltas — so it marks the orchestration round, not the
-# reply. The real end-of-output is ``response.output_item.done``, which
-# arrives immediately after the final delta. Treating ``response.completed``
-# as terminal makes the SSE reader exit before any delta streams, so every
-# delta is lost (0 counted) and the interrupt probe never sees text to
-# interrupt. The reader therefore stops on ``response.output_item.done``.
+# ``response.completed`` precedes native text deltas; output_item.done is terminal.
 _DELTA_EVENT = "response.output_text.delta"
 _OUTPUT_DONE_EVENT = "response.output_item.done"
 _IN_PROGRESS_EVENT = "response.in_progress"
 _FAILED_EVENT = "response.failed"
 _INTERRUPTED_EVENT = "session.interrupted"
-# Published by the server when a native tool-call policy DENY is enforced (see
-# sessions.py::_publish_policy_denied). The positive signal the deny probe keys
-# on — a native deny is decided in the hook and otherwise leaves no stream trace.
 _POLICY_DENIED_EVENT = "response.policy_denied"
 
-# The registered CEL policy handler + a bench-owned deny reason. The deny probe
-# attaches a session policy that DENYs the provoked tool at the tool_call phase.
 _CEL_POLICY_HANDLER = "omnigent.policies.builtins.cel.cel_policy"
 _NATIVE_DENY_REASON = "bench-native-tool-deny"
-# How long to wait for the tool call / deny signal on a tool turn.
 _TOOL_TURN_TIMEOUT_S = 180.0
-# On a deny turn, how long to keep the SSE reader open after the tool call to
-# observe response.policy_denied. The PreToolUse hook publishes it when it
-# evaluates, whose timing relative to the turn's output_item.done is variable
-# (it can trail a second output_item.done and the session settle). The reader
-# returns the instant it sees the deny, so a real deny rarely waits the full
-# budget; this is the ceiling before the probe SKIPs "no deny observed".
+# policy_denied may arrive after output_item.done.
 _DENY_OBSERVE_S = 30.0
 
-# How long to let a turn run after it reports in-progress before firing the
-# interrupt, so the cancel lands mid-turn rather than racing turn setup.
 _INTERRUPT_HOLD_S = 2.0
-# The reader stops here: output finished, failed, or cancelled. Note the
-# deliberate absence of ``response.completed`` (see above).
 _READER_TERMINAL = frozenset({_OUTPUT_DONE_EVENT, _FAILED_EVENT, _INTERRUPTED_EVENT})
 
 
@@ -179,26 +110,10 @@ class NativeVendor:
     tool_prompt: str = ""
 
 
-# Vendors whose external_session_id is created by the first message, not at TUI
-# launch (see NativeVendor.lazy_chat). A delivery-mechanism fact not derivable
-# from the capability model, so it is an explicit set. cursor is confirmed
-# (its forwarder discovers the chat store written on the first message); others
-# are added only once live-verified to behave this way.
+# These vendors create external_session_id only after the first message.
 _LAZY_CHAT_HARNESSES: frozenset[str] = frozenset({"cursor-native"})
 
-# Per-harness tool provocation for the tool/policy probes:
-# ``harness -> (tool_name, prompt)``. The prompt asks the vendor to run a
-# harmless ``echo`` via its own shell/terminal tool (side-effect-free in the
-# ephemeral workspace); the tool call then surfaces as a ``function_call`` item
-# and (with a deny attached) trips the tool_call-phase policy.
-#
-# ``tool_name`` is the vendor's own tool for a shell command, for documentation
-# and as a non-empty gate — a harness absent here (or with an empty entry) has
-# its tool/policy probes SKIP, never a false UNSUPPORTED. The deny policy gates
-# on the tool_call *phase* alone (name-agnostic; see _attach_tool_deny_policy),
-# so ``tool_name`` no longer has to match the vendor's raw hook name exactly.
-# Names sourced from omnigent/policies/builtins/safety.py::ask_on_os_tools and
-# each vendor's native module.
+# Missing entries skip tool and policy probes.
 _SHELL_PROMPT = "Use your shell/terminal tool to run this exact command: echo omnigent-bench-ok"
 _NATIVE_TOOL_PROVOCATION: dict[str, tuple[str, str]] = {
     "claude-native": (
@@ -229,10 +144,6 @@ def native_vendor(harness: str) -> NativeVendor | None:
     caps = harness_capabilities().get(harness)
     if caps is None or caps.integration_mode is not IntegrationMode.NATIVE_TUI:
         return None
-    # agent_name and terminal_name are convention (``<harness>-ui`` and the
-    # vendor CLI name), which holds for every in-repo native. A community
-    # plugin whose registered terminal/agent name diverges would need an
-    # override map here, mirroring the manifest's _NATIVE_CLI_BINARY.
     tool_name, tool_prompt = _NATIVE_TOOL_PROVOCATION.get(harness, ("", ""))
     return NativeVendor(
         harness=harness,
@@ -268,9 +179,6 @@ class NativeTuiDriver:
         self._session_id: str | None = None
         self._base_url = ""
         self._tmp = Path("/tmp") / f"omni-bench-nt-{uuid.uuid4().hex[:8]}"
-        # Set from the terminal-ensure response when native policy enforcement
-        # is inactive (fail-open: codex too old / hook untrusted). The deny
-        # probe reads this to SKIP rather than report a false UNSUPPORTED.
         self._policy_hook_disabled_reason: str | None = None
 
     @staticmethod
@@ -282,10 +190,6 @@ class NativeTuiDriver:
         creds_skip = bench_creds_skip_reason(databricks_profile)
         if creds_skip is not None:
             return creds_skip
-        # The vendor CLI must exist AND be interactively logged in on this
-        # host; the bench cannot provision a login. Presence on PATH is the
-        # cheapest precondition we can check — a missing login still fails the
-        # live turn, reported as a capability-neutral skip by the probes.
         binary = profile.cli_binary
         if binary is not None:
             reason = cli_unavailable_reason(binary)
@@ -293,20 +197,10 @@ class NativeTuiDriver:
                 return reason
         return None
 
-    # ── async driver protocol ────────────────────────────────
-
     async def __aenter__(self) -> NativeTuiDriver:
         try:
             await asyncio.to_thread(self._provision)
         except httpx.HTTPError as exc:
-            # Native provisioning drives a live vendor CLI + a server-native
-            # terminal, so an HTTP failure here (e.g. a 500 from terminal-ensure
-            # when the vendor cannot start a thread) is an environment/server-
-            # state gap, not a bench bug. Re-raise as ProvisioningError so the
-            # orchestrator skips this harness quietly (reason shown in its row)
-            # instead of dumping a traceback. A programming error (AssertionError
-            # on a misconfigured profile, etc.) is not an HTTPError, so it still
-            # propagates loud.
             raise ProvisioningError(f"native provisioning HTTP error: {exc}") from exc
         return self
 
@@ -324,17 +218,11 @@ class NativeTuiDriver:
         return await asyncio.to_thread(self._drive_tool_turn, deny=deny)
 
     async def run_policy_turn(self, *, action: str) -> TurnResult:
-        """Native ALLOW/ASK observation is a follow-up (would attach a CEL
-        ALLOW/ASK policy the way the DENY path attaches its CEL deny, and watch
-        for the tool proceeding / an elicitation). Not wired yet, so return an
-        unmeasured result and let the probe SKIP rather than report a false
-        verdict. Native Policy DENY remains covered by run_tool_turn(deny=True)."""
+        """Return unmeasured until native ALLOW/ASK observation is implemented."""
         return TurnResult()
 
     async def run_interrupt_turn(self) -> TurnResult:
         return await asyncio.to_thread(self._drive_interrupt_turn)
-
-    # ── provisioning ─────────────────────────────────────────
 
     def _provision(self) -> None:
         self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -343,17 +231,12 @@ class NativeTuiDriver:
         self._base_url = f"http://localhost:{port}"
         binding_token = uuid.uuid4().hex
 
-        # Credentials derived the way `omni run` does (ambient OPENAI_* wins,
-        # else resolve_databricks_workspace); plus the native tunnel token.
         self._resolved_env = resolve_bench_env(self._db_profile)
         base_env = {
             **self._resolved_env.base_env,
             "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token,
         }
-        # An omnigent-credential native resolves its provider from omnigent's
-        # global config, not DATABRICKS_CONFIG_PROFILE; without it some vendors
-        # (codex) hit the login screen and never start a thread. Own-auth
-        # vendors use their own login and are left untouched.
+        # Omnigent-credential natives resolve their provider from global config.
         if not self._vendor.own_auth:
             base_env["OMNIGENT_CONFIG_HOME"] = str(self._write_provider_config())
         self._proc = spawn_omnigent_server(self._tmp, port, base_env, binding_token)
@@ -375,19 +258,10 @@ class NativeTuiDriver:
         )
         created.raise_for_status()
         self._session_id = str(created.json()["id"])
-        # Ensure the native terminal + wait for the forwarder for every
-        # native-tui harness: it is the uniform readiness protocol (all natives
-        # stamp external_session_id once their terminal thread starts).
         self._wire_native_forwarder(host_id, workspace)
 
     def _write_provider_config(self) -> Path:
-        """Write the ``OMNIGENT_CONFIG_HOME`` config that routes the vendor's
-        LLM provider through this run's Databricks profile; return its dir.
-
-        Uses the profile resolved by :func:`resolve_bench_env` (``--profile`` or
-        the config-derived one). When auth came from the ambient env (no
-        profile), the vendor inherits the ambient ``OPENAI_*`` already in
-        ``base_env``, so no ``auth:`` block is written."""
+        """Write config routing the native vendor through the resolved profile."""
         config_home = self._tmp / "omnigent-config"
         config_home.mkdir(exist_ok=True)
         profile = self._resolved_env.db_profile if self._resolved_env is not None else None
@@ -396,12 +270,7 @@ class NativeTuiDriver:
         return config_home
 
     def _wire_native_forwarder(self, host_id: str, workspace: Path) -> None:
-        """Launch/bind a runner, ensure the native terminal, and wait for the
-        forwarder to come live, so turns can drive on the shared observe path.
-
-        Readiness is the session's ``external_session_id`` being stamped (the
-        vendor thread id), which the forwarder sets once its thread starts.
-        """
+        """Launch the runner and wait for the native forwarder."""
         assert self._client is not None and self._session_id is not None
         assert self._vendor is not None
         session_id = self._session_id
@@ -416,19 +285,9 @@ class NativeTuiDriver:
             timeout=90.0,
         )
         ensure.raise_for_status()
-        # The terminal-ensure success body carries a one-shot
-        # ``policy_hook_disabled_reason`` when native tool-call policy
-        # enforcement is inactive (fail-open: codex too old / hook untrusted).
-        # Record it so the deny probe SKIPs rather than reading an unenforced
-        # deny as UNSUPPORTED.
         with contextlib.suppress(Exception):
             self._policy_hook_disabled_reason = ensure.json().get("policy_hook_disabled_reason")
-        # A lazy-chat vendor (cursor) does not create its external_session_id
-        # until the first message lands, so it cannot be gated on here — waiting
-        # pre-turn would deadlock. The terminal is ensured; the first probe turn
-        # triggers the chat, and the forwarder discovers it then. Thread-at-launch
-        # vendors (claude/codex) stamp external_session_id at TUI launch, so gate
-        # on it to avoid racing a turn ahead of the forwarder subscription.
+        # Waiting before the first message would deadlock lazy-chat vendors.
         if self._vendor.lazy_chat:
             return
         deadline = time.monotonic() + _FORWARDER_READY_TIMEOUT_S
@@ -470,8 +329,7 @@ class NativeTuiDriver:
         return asyncio.run(_run())
 
     def _spawn_host_daemon(self, base_env: dict[str, str]) -> subprocess.Popen[bytes]:
-        # Under the real $HOME so the vendor's interactive login is inherited
-        # (auth cannot be relocated for native harnesses).
+        # Keep the real HOME so the vendor login remains available.
         log = (self._tmp / "host-daemon.log").open("wb")
         return subprocess.Popen(
             [runner_executable(), "-m", "omnigent.host._daemon_entry", "--server", self._base_url],
@@ -488,7 +346,6 @@ class NativeTuiDriver:
                 if httpx.get(f"{self._base_url}/health", timeout=2).status_code == 200:
                     return
             except httpx.HTTPError:
-                # Connection refused while the server boots; keep polling.
                 pass
             time.sleep(_POLL_INTERVAL_S)
         raise ProvisioningError(
@@ -514,8 +371,6 @@ class NativeTuiDriver:
         for agent in resp.json()["data"]:
             if agent.get("name") == agent_name:
                 return str(agent["id"])
-        # A native agent the server did not seed (the hardcoded seeding seam):
-        # an environment gap, not a bench bug, so skip this harness quietly.
         raise ProvisioningError(f"{agent_name!r} not auto-registered on the server")
 
     def _teardown(self) -> None:
@@ -529,8 +384,6 @@ class NativeTuiDriver:
                 except subprocess.TimeoutExpired:
                     proc.kill()
         shutil.rmtree(self._tmp, ignore_errors=True)
-
-    # ── turns ────────────────────────────────────────────────
 
     def _post_message(self, prompt: str) -> None:
         assert self._client is not None
@@ -589,17 +442,11 @@ class NativeTuiDriver:
         ready.wait(timeout=10.0)  # subscribe before posting so no delta is lost
         self._post_message(prompt)
         text = self._poll_new_assistant_text(baseline)
-        # The item landed, so the turn's output is done; the reader stops on
-        # output_item.done, which coincides with the last delta.
         reader.join(timeout=10.0)
 
         result.text_delta_count = sum(1 for e in events if e == _DELTA_EVENT)
         result.text = text or ""
-        if text is not None:
-            result.completed = True
-        elif _OUTPUT_DONE_EVENT in events:
-            # Output finished but no new assistant item surfaced — treat as a
-            # completed-but-empty turn rather than a hang.
+        if text is not None or _OUTPUT_DONE_EVENT in events:
             result.completed = True
         else:
             result.timed_out = True
@@ -664,14 +511,7 @@ class NativeTuiDriver:
 
         def _read() -> None:
             assert self._client is not None
-            # response.policy_denied is published when the PreToolUse hook
-            # evaluates the tool call — its timing relative to the turn's
-            # output_item.done is highly variable (it can land after a SECOND
-            # output_item.done and the session settle). So on a deny turn the
-            # reader does NOT stop on the turn's terminal events; it reads until
-            # it sees policy_denied (the signal we want) or the caller signals
-            # stop() once the deny deadline elapses. On a non-deny turn it stops
-            # on the terminal event as before.
+            # A deny reader stays open because policy_denied can arrive after completion.
             try:
                 with self._client.stream(
                     "GET",
@@ -693,23 +533,16 @@ class NativeTuiDriver:
             except httpx.HTTPError as exc:
                 result.error = repr(exc)
 
-        # Vary the command per turn so a reused session can't treat the deny
-        # turn as already-satisfied by the allow turn's identical request (which
-        # would leave the model with nothing to call, and nothing to deny).
+        # Avoid satisfying the second probe from reused-session history.
         token = "deny" if deny else "allow"
         prompt = self._vendor.tool_prompt.replace("omnigent-bench-ok", f"omnigent-bench-{token}")
 
         baseline = self._tool_item_count()
         reader = threading.Thread(target=_read)
         reader.start()
-        ready.wait(timeout=10.0)  # subscribe before posting so no event is lost
+        ready.wait(timeout=10.0)
         self._post_message(prompt)
         self._poll_new_tool_calls(baseline, result)
-        # On a deny turn, give response.policy_denied a generous window to land
-        # (the hook round-trip can trail the tool call), then stop the reader.
-        # The reader returns early the moment it sees the deny, so a real deny
-        # rarely waits the full budget. On a non-deny turn the reader has already
-        # stopped on the terminal event, so this join returns immediately.
         if deny and not result.tool_call_denied:
             deadline = time.monotonic() + _DENY_OBSERVE_S
             while reader.is_alive() and time.monotonic() < deadline:
@@ -717,12 +550,6 @@ class NativeTuiDriver:
         stop.set()
         reader.join(timeout=10.0)
 
-        # Turn end. On a deny turn tool_call_denied is set from the observed
-        # response.policy_denied event (the server's positive signal when the
-        # PreToolUse policy hook returns DENY). Note the probe's SUPPORTED means
-        # "the tool call was routed through policy and a DENY verdict returned";
-        # whether the vendor CLI then hard-blocks the tool is a separate axis
-        # (claude-native evaluates the DENY but may still run the tool).
         result.completed = _OUTPUT_DONE_EVENT in events or bool(result.tool_calls)
         return result
 
@@ -793,8 +620,6 @@ class NativeTuiDriver:
                 if len(calls) > baseline:
                     result.tool_calls.extend(calls[baseline:])
                     return
-            # On a deny the tool never runs, so no new function_call item will
-            # appear — stop waiting once the stream already reported the block.
             if result.tool_call_denied:
                 return
             time.sleep(_POLL_INTERVAL_S)
@@ -871,9 +696,6 @@ class NativeTuiDriver:
                             result.cancelled = True
                             return
                         elif etype in (_OUTPUT_DONE_EVENT, _FAILED_EVENT):
-                            # Output finished (or failed) before the interrupt
-                            # landed. Stop on output_item.done, not the early
-                            # response.completed (see _READER_TERMINAL).
                             return
             except httpx.HTTPError as exc:
                 result.error = repr(exc)
@@ -882,8 +704,7 @@ class NativeTuiDriver:
         reader.start()
         ready.wait(timeout=10.0)
         self._post_message(_LONG_PROMPT)
-        # Interrupt once the turn is in flight, after a short hold so it lands
-        # mid-turn (the CLI is working; deltas have not burst yet).
+        # Native deltas arrive late, so interrupt from in-progress instead.
         if in_progress.wait(timeout=_TURN_TIMEOUT_S):
             time.sleep(_INTERRUPT_HOLD_S)
             try:

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -58,7 +58,6 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import httpx
 
@@ -72,18 +71,17 @@ from omnigent.host.daemon_launch import (
 from omnigent.native_terminal import bind_session_runner
 from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
+from tests._helpers.live_server import find_free_port
 from tests.e2e._harness_probes import cli_unavailable_reason
 from tests.harness_bench.driver import ProvisioningError, TurnResult, fill_snapshot_cost
-from tests.harness_bench.full_server import (
-    _find_free_port,
-    spawn_omnigent_server,
-)
+from tests.harness_bench.full_server import spawn_omnigent_server
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.runtime_env import (
     BenchRuntimeEnv,
     bench_creds_skip_reason,
     resolve_bench_env,
 )
+from tests.harness_bench.session_items import assistant_text, function_calls, item_role, item_type
 
 _HEALTH_TIMEOUT_S = 90.0
 _HOST_ONLINE_TIMEOUT_S = 45.0
@@ -341,7 +339,7 @@ class NativeTuiDriver:
     def _provision(self) -> None:
         self._tmp.mkdir(mode=0o700, parents=True, exist_ok=True)
         assert self._vendor is not None
-        port = _find_free_port()
+        port = find_free_port()
         self._base_url = f"http://localhost:{port}"
         binding_token = uuid.uuid4().hex
 
@@ -773,7 +771,7 @@ class NativeTuiDriver:
         resp = self._client.get(f"/v1/sessions/{self._session_id}/items", params={"order": "asc"})
         if resp.status_code != 200:
             return 0
-        return sum(1 for it in resp.json().get("data", []) if _item_type(it) == "function_call")
+        return sum(1 for it in resp.json().get("data", []) if item_type(it) == "function_call")
 
     def _poll_new_tool_calls(
         self, baseline: int, result: TurnResult, timeout: float = _TOOL_TURN_TIMEOUT_S
@@ -791,19 +789,9 @@ class NativeTuiDriver:
                 f"/v1/sessions/{self._session_id}/items", params={"order": "asc"}
             )
             if resp.status_code == 200:
-                calls = [
-                    it for it in resp.json().get("data", []) if _item_type(it) == "function_call"
-                ]
+                calls = function_calls(resp.json().get("data", []))
                 if len(calls) > baseline:
-                    for raw in calls[baseline:]:
-                        data = raw.get("data", raw)
-                        result.tool_calls.append(
-                            {
-                                "call_id": data.get("call_id"),
-                                "name": data.get("name"),
-                                "arguments": data.get("arguments"),
-                            }
-                        )
+                    result.tool_calls.extend(calls[baseline:])
                     return
             # On a deny the tool never runs, so no new function_call item will
             # appear — stop waiting once the stream already reported the block.
@@ -817,7 +805,7 @@ class NativeTuiDriver:
         resp = self._client.get(f"/v1/sessions/{self._session_id}/items", params={"order": "asc"})
         if resp.status_code != 200:
             return 0
-        return sum(1 for it in resp.json().get("data", []) if it.get("role") == "assistant")
+        return sum(1 for it in resp.json().get("data", []) if item_role(it) == "assistant")
 
     def _poll_new_assistant_text(
         self, baseline: int, timeout: float = _TURN_TIMEOUT_S
@@ -835,10 +823,10 @@ class NativeTuiDriver:
             )
             if resp.status_code == 200:
                 assistants = [
-                    it for it in resp.json().get("data", []) if it.get("role") == "assistant"
+                    it for it in resp.json().get("data", []) if item_role(it) == "assistant"
                 ]
                 if len(assistants) > baseline:
-                    return _assistant_text(assistants[-1])
+                    return assistant_text(assistants[-1], separator=" ")
             time.sleep(_POLL_INTERVAL_S)
         return None
 
@@ -908,26 +896,3 @@ class NativeTuiDriver:
                 result.error = repr(exc)
         reader.join(timeout=_TURN_TIMEOUT_S)
         return result
-
-
-def _assistant_text(item: dict[str, Any]) -> str:
-    """Concatenate assistant output_text blocks from a session item."""
-    content = item.get("content")
-    if not isinstance(content, list):
-        return ""
-    return " ".join(
-        block["text"]
-        for block in content
-        if isinstance(block, dict) and isinstance(block.get("text"), str)
-    )
-
-
-def _item_type(item: dict[str, Any]) -> str | None:
-    """The item's type, tolerant of a top-level or nested-``data`` shape.
-
-    A native ``function_call`` item may carry ``type`` at the top level or under
-    ``data`` depending on the items-endpoint serialization, so check both (mirrors
-    full_server_driver._scan_tool_items).
-    """
-    data = item.get("data", item)
-    return item.get("type") or (data.get("type") if isinstance(data, dict) else None)

--- a/tests/harness_bench/probes/__init__.py
+++ b/tests/harness_bench/probes/__init__.py
@@ -1,9 +1,4 @@
-"""Capability probes and their ordered registry.
-
-:data:`ALL_PROBES` is the single list the bench iterates; append a probe
-here to add a dimension. Order is the report's column order:
-``basic_turn`` first (the prerequisite), then the capabilities.
-"""
+"""Capability probes and their ordered registry."""
 
 from __future__ import annotations
 
@@ -18,11 +13,7 @@ from tests.harness_bench.probes.policy_deny import PolicyDenyProbe
 from tests.harness_bench.probes.streaming import StreamingProbe
 from tests.harness_bench.probes.tool_calling import ToolCallingProbe
 
-# Order is the report's column order AND the run order. basic_turn is first
-# (the prerequisite short-circuit). interrupt is LAST because cancelling a
-# turn can leave a harness's session mid-processing, which would contaminate
-# any probe that runs after it on the same shared session (e.g. pi rejecting
-# the next turn with "Agent is already processing").
+# Basic turn gates the run; interrupt stays last because cancellation can linger.
 ALL_PROBES: list[CapabilityProbe] = [
     BasicTurnProbe(),
     StreamingProbe(),

--- a/tests/harness_bench/probes/basic_turn.py
+++ b/tests/harness_bench/probes/basic_turn.py
@@ -1,9 +1,4 @@
-"""Basic-turn probe — the prerequisite: does a plain turn produce text?
-
-Every other behavioral probe presupposes this one passes. Its verdict
-also tells a reader whether a red row is "this harness is broken" versus
-"this one capability is missing".
-"""
+"""Basic-turn prerequisite probe."""
 
 from __future__ import annotations
 
@@ -23,16 +18,12 @@ class BasicTurnProbe(CapabilityProbe):
     async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
         result = await driver.run_basic_turn(profile.marker)
         if result.timed_out:
-            # A timeout on the prerequisite turn is almost always a hung
-            # environment, not a capability fact — do not call it UNSUPPORTED.
             return ProbeResult(
                 Verdict.SKIPPED,
                 note="turn did not complete within timeout; harness not exercisable",
             )
         infra = infra_failure_reason(result)
         if infra is not None:
-            # Auth / gateway / connectivity failure — an environment problem,
-            # reported as SKIPPED so it never shows up as capability drift.
             return ProbeResult(Verdict.SKIPPED, note=infra)
         if result.failed:
             return ProbeResult(Verdict.UNSUPPORTED, note=f"turn failed: {result.error}")
@@ -43,8 +34,6 @@ class BasicTurnProbe(CapabilityProbe):
                 detail={"chars": len(result.text)},
             )
         if result.text:
-            # Text came back but not the marker — the wire path works, the
-            # model just didn't follow instructions. Still a working turn.
             return ProbeResult(
                 Verdict.SUPPORTED,
                 note="text returned (marker not echoed; model drift)",

--- a/tests/harness_bench/probes/cost_tracking.py
+++ b/tests/harness_bench/probes/cost_tracking.py
@@ -33,8 +33,7 @@ from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Ve
 class CostTrackingProbe(CapabilityProbe):
     name = "cost_tracking"
     title = "Cost tracking"
-    # P1: reported, not merge-gating — a harness that doesn't surface cost is
-    # still usable; the operator just can't run a USD-cost policy against it.
+    # Missing cost data does not make a harness unusable.
     priority = Priority.P1
     applies_to = Applicability.BOTH
 
@@ -46,8 +45,6 @@ class CostTrackingProbe(CapabilityProbe):
             "completed": result.completed,
         }
 
-        # An env/auth failure or timeout means we never got a clean turn to
-        # measure — SKIP (never UNSUPPORTED), same contract as the other probes.
         infra = infra_failure_reason(result)
         if infra is not None:
             return ProbeResult(Verdict.SKIPPED, note=infra, detail=detail)
@@ -60,10 +57,7 @@ class CostTrackingProbe(CapabilityProbe):
                 detail=detail,
             )
 
-        # Require a POSITIVE value, not merely non-None: a completed turn always
-        # spends tokens, so a reported 0 cost / 0 tokens means the usage plumbing
-        # returned an empty default, not that tracking genuinely measured zero.
-        # Treating 0 as "supported" would be a false pass.
+        # Zero values may be empty defaults rather than measured usage.
         if result.total_cost_usd is not None and result.total_cost_usd > 0:
             return ProbeResult(
                 Verdict.SUPPORTED,
@@ -79,8 +73,6 @@ class CostTrackingProbe(CapabilityProbe):
                 ),
                 detail=detail,
             )
-        # Completed but no positive usage surfaced (absent, or a zero default) —
-        # not a capability gap we can assert, so SKIP with the reason.
         return ProbeResult(
             Verdict.SKIPPED,
             note="turn completed but the transport surfaced no usage/cost to observe",

--- a/tests/harness_bench/probes/interrupt.py
+++ b/tests/harness_bench/probes/interrupt.py
@@ -30,11 +30,7 @@ class InterruptProbe(CapabilityProbe):
             "failed": result.failed,
             "timed_out": result.timed_out,
         }
-        # The clearest signal: the transport confirmed a cancellation (an SSE
-        # response.cancelled, or the server's cancellation marker). This is
-        # checked first because a confirmed cancel proves the interrupt was
-        # honored regardless of how the transport surfaces streamed text — the
-        # full-server driver confirms via the marker, not a delta count.
+        # Explicit cancellation is transport-independent proof.
         if result.cancelled:
             return ProbeResult(
                 Verdict.SUPPORTED,
@@ -42,18 +38,7 @@ class InterruptProbe(CapabilityProbe):
                 detail=detail,
             )
 
-        # No confirmed cancel. The wrap path posts the interrupt on the FIRST
-        # text delta, so a turn that emitted no text and then terminated did
-        # not exercise the interrupt at all — unmeasurable, not a failure.
-        #
-        # Measurement gap: the full-server driver confirms an interrupt via the
-        # cancellation marker (handled above) and never populates
-        # text_delta_count, so a full-server harness that *ignores* an
-        # interrupt can only be caught as UNSUPPORTED via timed_out below —
-        # otherwise it settles here as SKIPPED (unmeasurable), not a negative
-        # result. Honored interrupts (the probe's goal) are measured on both
-        # transports; a full-server negative needs a delta signal on that
-        # transport to become UNSUPPORTED rather than SKIPPED.
+        # Without deltas, the transport cannot prove the interrupt was exercised.
         if result.text_delta_count == 0:
             infra = infra_failure_reason(result)
             note = infra or "turn produced no text before terminating; interrupt not exercised"
@@ -64,9 +49,7 @@ class InterruptProbe(CapabilityProbe):
                 note="turn kept running after interrupt (timed out)",
                 detail=detail,
             )
-        # No explicit cancel, but the turn reached a terminal event with only a
-        # fraction of the ~400-word target (a full essay is well over 1200
-        # chars) — the interrupt cut it short.
+        # A short terminal response indicates generation was cut off.
         if result.reached_terminal and len(result.text) < 800:
             return ProbeResult(
                 Verdict.SUPPORTED,
@@ -74,8 +57,6 @@ class InterruptProbe(CapabilityProbe):
                 detail=detail,
             )
         if result.reached_terminal:
-            # Terminated, but with a full-length body: the interrupt likely
-            # landed after generation had already finished. Inconclusive.
             return ProbeResult(
                 Verdict.PARTIAL,
                 note=(

--- a/tests/harness_bench/probes/policy_deny.py
+++ b/tests/harness_bench/probes/policy_deny.py
@@ -27,9 +27,6 @@ class PolicyDenyProbe(CapabilityProbe):
     applies_to = Applicability.BOTH
 
     async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
-        # The driver owns the deny mechanism (a tool_call-phase verdict on the
-        # wrap path, a spec-baked deny policy on full-server); the probe only
-        # cares whether a surfaced tool call was actually blocked.
         result = await driver.run_tool_turn(deny=True)
         detail = {
             "policy_actions": result.policy_actions,
@@ -38,13 +35,7 @@ class PolicyDenyProbe(CapabilityProbe):
             "completed": result.completed,
         }
 
-        # A confirmed tool-call DENY is enforcement, whether or not a
-        # ``function_call`` item persisted. On full-server the denied call still
-        # surfaces an item (with a blocked output); on native-tui the deny is
-        # decided at the vendor hook *before* the tool runs, so no item persists
-        # and the only signal is the server's ``response.policy_denied`` event.
-        # Check the deny signal first so the native path is not swallowed by the
-        # "no tool call" guard below.
+        # Native hooks can deny before a function-call item is persisted.
         if result.tool_call_denied:
             if result.completed or result.failed:
                 return ProbeResult(
@@ -65,20 +56,12 @@ class PolicyDenyProbe(CapabilityProbe):
             )
 
         if not result.tool_calls:
-            # No deny signal AND no tool call: the model never tried the tool, so
-            # the tool-call DENY path was never exercised. (On native this also
-            # covers a turn where the vendor simply didn't call the tool.)
             return ProbeResult(
                 Verdict.SKIPPED,
                 note="model never attempted the tool; tool-call DENY path not exercised",
                 detail=detail,
             )
-        # A tool call happened but no DENY was surfaced. Policy evaluation is
-        # normally driven by the server / runner; in the wrap-direct transport
-        # some harnesses (e.g. codex) dispatch the tool without a tool-call
-        # evaluation hook, so we cannot exercise DENY here. That is a transport
-        # limitation, not proof the harness ignores policy — report SKIPPED and
-        # let the full-server / native transport assert enforcement.
+        # Wrap-direct transports may dispatch tools without a policy hook.
         return ProbeResult(
             Verdict.SKIPPED,
             note=(

--- a/tests/harness_bench/probes/tool_calling.py
+++ b/tests/harness_bench/probes/tool_calling.py
@@ -26,9 +26,6 @@ class ToolCallingProbe(CapabilityProbe):
     applies_to = Applicability.BOTH
 
     async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
-        # The driver owns the tool mechanism (a request-level function tool on
-        # the wrap path, a builtin on full-server); the probe only cares that
-        # *a* tool call was dispatched and the turn closed.
         result = await driver.run_tool_turn(deny=False)
         called = list(result.tool_calls)
         detail = {
@@ -40,13 +37,7 @@ class ToolCallingProbe(CapabilityProbe):
                 Verdict.SKIPPED, note="timed out before any tool call", detail=detail
             )
         if not called:
-            # The turn ran without dispatching the offered tool. This is
-            # ambiguous: some harnesses (codex, openai-agents) accept a
-            # request-level tool and surface a server-dispatched call, while
-            # others (claude-sdk, pi) register tools via agent config / MCP
-            # and ignore the wire-level `tools` field. Not calling it here is
-            # therefore not proof the harness cannot call tools — report
-            # SKIPPED rather than a false UNSUPPORTED.
+            # Some harnesses ignore request-level tools and require config or MCP.
             return ProbeResult(
                 Verdict.SKIPPED,
                 note=(
@@ -61,8 +52,6 @@ class ToolCallingProbe(CapabilityProbe):
                 note="tool call dispatched; result delivered; turn completed",
                 detail=detail,
             )
-        # The tool call surfaced (the load-bearing signal) but the turn did
-        # not cleanly complete after the result — partial support.
         return ProbeResult(
             Verdict.PARTIAL,
             note="tool call surfaced but turn did not complete after result",

--- a/tests/harness_bench/report.py
+++ b/tests/harness_bench/report.py
@@ -1,18 +1,4 @@
-"""Render a :class:`BenchMatrix` as a terminal table, Markdown, or JSON.
-
-Three renderers for three audiences:
-
-- :func:`render_table` — an aligned, optionally ANSI-colored grid for
-  reading in a terminal (the CLI default). Pipes-and-dashes Markdown reads
-  as raw noise in a shell, so this is what a human sees.
-- :func:`render_markdown` — the GitHub-flavored table for docs / PRs,
-  reproducing the hand-maintained support matrix.
-- :func:`render_json` — the machine-readable form for regenerating docs or
-  diffing runs.
-
-Each verdict maps to a spreadsheet glyph plus a DRIFT callout the
-spreadsheet cannot express.
-"""
+"""Render bench matrices as terminal, Markdown, or JSON reports."""
 
 from __future__ import annotations
 

--- a/tests/harness_bench/richreport.py
+++ b/tests/harness_bench/richreport.py
@@ -1,15 +1,4 @@
-"""A rich live-progress sink for a bench run.
-
-Draws a table that updates in place as events arrive: one row per harness,
-one column per capability dimension, each cell showing the probe's live state
-(a spinner while running, then the verdict glyph). Under a parallel run
-(``--jobs`` > 1) several rows advance at once, which is exactly what the live
-table is for.
-
-Only usable on a TTY with ``rich`` installed. :func:`rich_sink_or_none`
-returns ``None`` when either precondition is missing, so the CLI falls back to
-the plain :class:`~tests.harness_bench.events.LineSink`.
-"""
+"""Rich live progress renderer for harness bench runs."""
 
 from __future__ import annotations
 
@@ -80,10 +69,7 @@ class _RichLiveSink:
         # harness → {dim_title: markup}; insertion order = display order.
         self._rows: dict[str, dict[str, str]] = {}
         self._transport: dict[str, str] = {}  # harness → resolved transport label
-        # vertical_overflow="visible": let a grid taller than the viewport print
-        # in full instead of rich clipping/repositioning it each frame (the
-        # "pointer jumps around" thrash). refresh_per_second=4 + our own
-        # update() per event is smooth without high-rate flicker.
+        # Visible overflow prevents Rich from repositioning tall grids each frame.
         self._live = Live(
             self._render(),
             console=console,

--- a/tests/harness_bench/runtime_env.py
+++ b/tests/harness_bench/runtime_env.py
@@ -38,14 +38,22 @@ def _profile_from_config() -> str | None:
     All imports are lazy so importing this module never drags in ``omnigent.cli``
     at load time.
     """
-    from omnigent.config import load_effective_config
+    from omnigent.config import load_effective_config, load_global_config
 
-    config = load_effective_config()
-    raw_auth = config.get("auth")
+    try:
+        global_config = load_global_config()
+    except Exception:
+        global_config = {}
+    raw_auth = global_config.get("auth")
     if isinstance(raw_auth, dict) and raw_auth.get("type") == "databricks":
         profile = raw_auth.get("profile")
         if profile:
             return str(profile)
+
+    try:
+        config = load_effective_config()
+    except Exception:
+        return None
 
     cfg_profile = config.get("profile")
     if cfg_profile:

--- a/tests/harness_bench/runtime_env.py
+++ b/tests/harness_bench/runtime_env.py
@@ -1,16 +1,4 @@
-"""Derive the bench's server+runner environment the way ``omni run`` does.
-
-``omni run`` resolves credentials through the canonical
-:func:`omnigent.runtime.credentials.databricks.resolve_databricks_workspace`,
-takes its profile from ``~/.omnigent/config.yaml``'s ``auth:``/``profile`` block,
-and lets an ambient ``OPENAI_*`` env win when present. This module mirrors that
-layering for the bench so a no-flag run behaves like ``omni run``, while an
-explicit ``--profile`` overrides the config-derived profile.
-
-The old bench path always minted its own bearer via a ``databricks auth token``
-subprocess (which did not handle OAuth profiles) and required ``--profile``;
-this replaces it.
-"""
+"""Resolve the runtime environment used by harness bench processes."""
 
 from __future__ import annotations
 
@@ -63,11 +51,7 @@ def _profile_from_config() -> str | None:
     if cfg_profile:
         return str(cfg_profile)
 
-    # Tier 3: the configured ``providers:`` block. Reuse ``omni``'s own resolver
-    # (``default_provider_for_harness`` — the same call ``resolve_credential``
-    # and the runtime spawn-env builder use) so the bench picks exactly the
-    # provider a launch would, with no reinvented selection logic. When that
-    # provider is a Databricks profile, its ``profile`` is the gateway route.
+    # Reuse the runtime resolver so bench and normal launches select identically.
     try:
         from omnigent.onboarding.provider_config import (
             DATABRICKS_KIND,

--- a/tests/harness_bench/runtime_env.py
+++ b/tests/harness_bench/runtime_env.py
@@ -50,22 +50,14 @@ def _profile_from_config() -> str | None:
     All imports are lazy so importing this module never drags in ``omnigent.cli``
     at load time.
     """
-    try:
-        from omnigent.runtime.workflow import _load_global_auth
+    from omnigent.config import load_effective_config
 
-        auth = _load_global_auth()
-    except Exception:
-        auth = None
-    profile = getattr(auth, "profile", None)
-    if profile:
-        return str(profile)
-
-    try:
-        from omnigent.cli import _load_effective_config
-
-        config = _load_effective_config()
-    except Exception:
-        return None
+    config = load_effective_config()
+    raw_auth = config.get("auth")
+    if isinstance(raw_auth, dict) and raw_auth.get("type") == "databricks":
+        profile = raw_auth.get("profile")
+        if profile:
+            return str(profile)
 
     cfg_profile = config.get("profile")
     if cfg_profile:

--- a/tests/harness_bench/session_items.py
+++ b/tests/harness_bench/session_items.py
@@ -1,0 +1,113 @@
+"""Helpers for reading session-item wire shapes used by bench drivers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def item_data(item: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the nested item payload when one is present."""
+    data = item.get("data")
+    return data if isinstance(data, Mapping) else item
+
+
+def item_type(item: Mapping[str, Any]) -> str | None:
+    """Return an item's type from either supported envelope shape."""
+    data = item_data(item)
+    value = item.get("type") or data.get("type")
+    return value if isinstance(value, str) else None
+
+
+def item_role(item: Mapping[str, Any]) -> str | None:
+    """Return an item's role from either supported envelope shape."""
+    data = item_data(item)
+    value = data.get("role") or item.get("role")
+    return value if isinstance(value, str) else None
+
+
+def assistant_text(
+    items: Mapping[str, Any] | Iterable[Mapping[str, Any]], *, separator: str = "\n"
+) -> str:
+    """Concatenate assistant text blocks from one item or an item collection."""
+    candidates = [items] if isinstance(items, Mapping) else items
+    output: list[str] = []
+    for item in candidates:
+        data = item_data(item)
+        if item_role(item) != "assistant":
+            continue
+        content = data.get("content")
+        if not isinstance(content, list):
+            continue
+        output.extend(
+            block["text"]
+            for block in content
+            if isinstance(block, Mapping)
+            and block.get("type") in (None, "output_text", "text")
+            and isinstance(block.get("text"), str)
+        )
+    return separator.join(text for text in output if text)
+
+
+def function_calls(items: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Return normalized function-call records from session items."""
+    calls: list[dict[str, Any]] = []
+    for item in items:
+        if item_type(item) != "function_call":
+            continue
+        data = item_data(item)
+        calls.append(
+            {
+                "call_id": data.get("call_id"),
+                "name": data.get("name"),
+                "arguments": data.get("arguments"),
+            }
+        )
+    return calls
+
+
+def tool_output_states(
+    items: Iterable[Mapping[str, Any]], *, deny_marker: str
+) -> tuple[bool, bool]:
+    """Return whether tool outputs show an allowed or denied call."""
+    allowed = False
+    denied = False
+    for item in items:
+        if item_type(item) != "function_call_output":
+            continue
+        data = item_data(item)
+        output = str(data.get("output", ""))
+        if data.get("status") == "blocked" or deny_marker in output:
+            denied = True
+        else:
+            allowed = True
+    return allowed, denied
+
+
+def contains_user_text(items: Iterable[Mapping[str, Any]], marker: str) -> bool:
+    """Return whether a user message contains *marker*."""
+    for item in items:
+        data = item_data(item)
+        if item_type(item) != "message" or data.get("role") != "user":
+            continue
+        content = data.get("content")
+        if not isinstance(content, list):
+            continue
+        if any(
+            marker in block.get("text", "")
+            for block in content
+            if isinstance(block, Mapping) and isinstance(block.get("text"), str)
+        ):
+            return True
+    return False
+
+
+__all__ = [
+    "assistant_text",
+    "contains_user_text",
+    "function_calls",
+    "item_data",
+    "item_role",
+    "item_type",
+    "tool_output_states",
+]

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -29,17 +29,12 @@ from tests.harness_bench.verdict import Priority, Verdict, reconcile
 _OFFICIAL = list(OFFICIAL_PROFILES.values())
 _OFFICIAL_IDS = [p.harness for p in _OFFICIAL]
 
-# A community-style profile used to prove name-based resolution of an
-# out-of-repo harness that ships its own BenchProfile.
 _FAKE_PROFILE = BenchProfile(
     harness="fake-community",
     model="databricks-claude-sonnet-4-6",
     env_prefix="HARNESS_FAKE_",
     marker="FAKE_OK",
 )
-
-
-# ── Offline layer ───────────────────────────────────────────────
 
 
 @pytest.mark.parametrize("profile", _OFFICIAL, ids=_OFFICIAL_IDS)
@@ -58,8 +53,6 @@ def test_profile_fields_wellformed(profile: BenchProfile) -> None:
 
 @pytest.mark.parametrize("profile", _OFFICIAL, ids=_OFFICIAL_IDS)
 def test_declared_covers_every_p0_dimension(profile: BenchProfile) -> None:
-    # Every P0 probe must have a declared verdict, or drift can never fire
-    # for that cell — the bench would silently under-report a regression.
     for probe in ALL_PROBES:
         if probe.priority is Priority.P0:
             assert profile.declared_for(probe.name) is not Verdict.UNKNOWN, (
@@ -68,8 +61,6 @@ def test_declared_covers_every_p0_dimension(profile: BenchProfile) -> None:
 
 
 def test_streaming_capability_declares_binary_verdict() -> None:
-    # Guards the kiro-native drift: streaming declares binary (True→SUPPORTED,
-    # False→UNSUPPORTED), never PARTIAL.
     from omnigent.harness_plugins import harness_capabilities
     from tests.harness_bench.manifest import _declared_from_capabilities
 
@@ -122,10 +113,6 @@ def test_resolve_registered_harness_by_name() -> None:
     assert profile.harness == "acp"
     assert profile.transport == "sdk-inproc"
 
-    # acp:<slug> is a first-class id: base `acp` is registered and the slug
-    # selects a configured ACP agent at spawn. It binds, keeping the full id as
-    # the harness (so config.harness=acp:qwen reaches the runner) and a valid
-    # env-prefix stem. An empty slug ("acp:") is refused.
     slug = resolve_profile("acp:qwen")
     assert slug.harness == "acp:qwen"
     assert slug.transport == "sdk-inproc"
@@ -153,8 +140,6 @@ def test_resolve_entry_point_plugin_and_alias() -> None:
     assert by_alias.harness == "rovo-cli" == by_name.harness
     assert by_alias.transport == "sdk-inproc"
     assert by_alias.cli_binary == "acli"  # skip-gates on the Atlassian CLI
-    # A model is always stamped (agent registration requires a non-empty one);
-    # it is inert for an own-auth harness, which uses its own.
     assert by_alias.model
 
 
@@ -174,8 +159,6 @@ def test_registry_profile_happy_path_no_plugin(monkeypatch: pytest.MonkeyPatch) 
     class _Spec:
         binary = "fakebin"
 
-    # A lightweight caps stand-in: _registry_profile + the prose/declared helpers
-    # only read integration_mode / auth / streaming / interrupt.
     caps = SimpleNamespace(
         integration_mode=IntegrationMode.CLI_SUBPROCESS,
         auth=AuthModel.OWN_AUTH,
@@ -224,7 +207,6 @@ def test_registry_refuses_native_server_mode(monkeypatch: pytest.MonkeyPatch) ->
 def test_infra_failure_reason_classifies_auth_and_ignores_capability_gaps() -> None:
     from tests.harness_bench.driver import TurnResult, infra_failure_reason
 
-    # A 403 gateway error is an environment problem -> yields a skip reason.
     auth = TurnResult(
         failed=True,
         error={
@@ -236,14 +218,9 @@ def test_infra_failure_reason_classifies_auth_and_ignores_capability_gaps() -> N
     assert reason is not None
     assert "403" in reason
 
-    # A plain failure with no infra marker is a real capability gap -> None.
     assert infra_failure_reason(TurnResult(failed=True, error="model refused the tool")) is None
-    # A successful turn is never an infra failure.
     assert infra_failure_reason(TurnResult(completed=True, text="ok")) is None
 
-    # Token-provisioning failures on full-server (codex/pi) are env/auth gaps,
-    # not capability gaps -> must yield a skip reason, never a false UNSUPPORTED
-    # that drifts against a SUPPORTED declaration.
     for msg in (
         "inner executor error: provider auth command `sh` produced an empty token",
         "PiExecutor(gateway=True) could not fetch a gateway token for the workspace host.",
@@ -255,7 +232,6 @@ def test_infra_failure_reason_classifies_auth_and_ignores_capability_gaps() -> N
 
 async def test_offline_render_produces_matrix() -> None:
     matrix = await run_bench(_OFFICIAL, live=False)
-    # Offline: nothing observed, so no drift and every cell is SKIPPED.
     assert not matrix.has_drift
     assert all(
         cell.observed is Verdict.SKIPPED for report in matrix.reports for cell in report.cells
@@ -264,12 +240,8 @@ async def test_offline_render_produces_matrix() -> None:
     assert "Harness capability matrix" in md
     for profile in _OFFICIAL:
         assert profile.harness in md
-    # The harness column is labelled with the *resolved* transport: an SDK
-    # harness shows its full-server default (not the sdk-inproc family marker),
-    # a native shows the short `native` label.
     assert "`claude-sdk [full-server]`" in md
     assert "`claude-native [native]`" in md
-    # JSON is well-formed and carries every harness, plus the resolved transport.
     payload = json.loads(render_json(matrix))
     assert {h["harness"] for h in payload["harnesses"]} == {p.harness for p in _OFFICIAL}
     by_harness = {h["harness"]: h for h in payload["harnesses"]}
@@ -304,19 +276,12 @@ async def test_render_table_grid_false_drops_grid_keeps_footer() -> None:
     full = render_table(matrix, declared=True, grid=True)
     footer = render_table(matrix, declared=True, grid=False)
 
-    # The full render has the heading + a harness row; the footer-only render
-    # has neither, but both carry the legend.
     assert "Harness capability matrix" in full
     assert "claude-sdk" in full
     assert "Harness capability matrix" not in footer
     assert "claude-sdk" not in footer
     assert "Legend:" in footer
-    # The offline note is suppressed, so a declared render's footer is just the
-    # legend -- no dangling "Notes:" header.
     assert footer.strip().startswith("Legend:")
-
-
-# ── Progress events / rich / parallel / report (offline) ─────────
 
 
 async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None:
@@ -393,12 +358,10 @@ async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None
     assert isinstance(sink.events[0], HarnessStarted)
     assert kinds[-1] == "HarnessFinished"
     assert isinstance(sink.events[-1], HarnessFinished)
-    # Every probe that ran emits a started+finished pair.
     assert any(isinstance(e, ProbeStarted) for e in sink.events)
     finished = [e for e in sink.events if isinstance(e, ProbeFinished)]
     assert {e.probe for e in finished} >= {"basic_turn", "streaming"}
 
-    # A bare callable is adapted to a LineSink (structured events → lines).
     lines: list[str] = []
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(
@@ -429,8 +392,6 @@ async def test_run_bench_jobs_preserves_order(monkeypatch: pytest.MonkeyPatch) -
             return None
 
         async def __aenter__(self):
-            # Reverse-stagger the delay so, without order preservation, finish
-            # order would differ from input order.
             await _asyncio.sleep(0.02 if self._h.endswith("1") else 0.01)
             return self
 
@@ -490,7 +451,6 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
         def create_session(self, agent_name: str) -> str:
             return f"sess-{agent_name}"
 
-    # A full-server driver that records which shared server it was handed.
     class _FSDriver:
         transport = "full-server"
 
@@ -523,14 +483,11 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
         async def run_interrupt_turn(self) -> TurnResult:
             return TurnResult(cancelled=True)
 
-    # bench imports SharedFullServer into its own namespace, so patch it there.
     monkeypatch.setattr("tests.harness_bench.bench.SharedFullServer", _FakeShared)
     monkeypatch.setattr(
         "tests.harness_bench.bench.resolve_driver_class",
         lambda p, *, override=None, fast=False: _FSDriver,
     )
-    # Keep the shared-server gate cred-free: this test fakes the server + driver,
-    # so it must not depend on a resolvable Databricks profile (CI has none).
     monkeypatch.setattr("tests.harness_bench.bench.bench_creds_skip_reason", lambda p: None)
     monkeypatch.setattr("tests.harness_bench.bench.resolve_bench_env", lambda p: object())
 
@@ -547,7 +504,6 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
     matrix = await run_bench(
         profiles, databricks_profile="oss", live=True, jobs=3, transport="full-server"
     )
-    # Exactly one shared server, and all three harnesses registered on it.
     assert len(built) == 1
     assert sorted(built[0].registered) == ["fs-0", "fs-1", "fs-2"]
     assert [r.profile.harness for r in matrix.reports] == ["fs-0", "fs-1", "fs-2"]
@@ -567,9 +523,6 @@ def test_cli_writes_report_file(tmp_path) -> None:
     main(["--no-live", "--report", str(js)])
     payload = json.loads(js.read_text())
     assert payload.get("harnesses")
-
-
-# ── Live layer (gated) ──────────────────────────────────────────
 
 
 @pytest.fixture
@@ -592,8 +545,6 @@ async def test_live_harness_matches_declared(
 
     basic = next(c for c in report.cells if c.probe_name == "basic_turn")
     if basic.observed is Verdict.SKIPPED:
-        # Auth / gateway / connectivity problem (not a capability fact) —
-        # the harness could not be exercised, so skip rather than fail.
         pytest.skip(f"{profile.harness}: {basic.note}")
     assert basic.observed is Verdict.SUPPORTED, (
         f"{profile.harness}: basic turn did not work ({basic.note}); "
@@ -607,9 +558,6 @@ async def test_live_harness_matches_declared(
             for c in drifted
         )
     )
-
-
-# ── full-server async shims (offline) ───────────────────────────
 
 
 async def test_full_server_async_shims_delegate_to_sync(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -671,8 +619,6 @@ async def test_provisioning_failure_skips_and_tears_down(monkeypatch: pytest.Mon
             return None
 
         async def __aenter__(self):
-            # Simulates _wire_native_forwarder raising after the server/daemon
-            # are already up.
             raise RuntimeError("native forwarder did not wire up within 90.0s")
 
         async def __aexit__(self, *exc: object) -> None:
@@ -728,7 +674,6 @@ async def test_expected_provisioning_error_logged_quietly(
 
     profile = BenchProfile(harness="stub", model="m", env_prefix="HARNESS_STUB_", marker="X")
 
-    # Expected failure → a single INFO record, no exception/traceback attached.
     monkeypatch.setattr(
         "tests.harness_bench.bench.resolve_driver_class",
         lambda p, *, override=None, fast=False: _driver_raising(
@@ -741,7 +686,6 @@ async def test_expected_provisioning_error_logged_quietly(
     assert provisioning_logs, "expected a log line for the skip"
     assert all(r.levelno == logging.INFO and r.exc_info is None for r in provisioning_logs)
 
-    # Unexpected failure → WARNING with the traceback attached.
     caplog.clear()
     monkeypatch.setattr(
         "tests.harness_bench.bench.resolve_driver_class",
@@ -755,9 +699,6 @@ async def test_expected_provisioning_error_logged_quietly(
     )
 
 
-# ── native-tui transport (offline) ──────────────────────────────
-
-
 def test_native_tui_registered_and_gates(monkeypatch: pytest.MonkeyPatch) -> None:
     """native-tui is in the registry and derives any native-tui harness."""
     from tests.harness_bench.native_tui_driver import NativeTuiDriver, native_vendor
@@ -765,30 +706,19 @@ def test_native_tui_registered_and_gates(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert driver_registry()["native-tui"] is NativeTuiDriver
 
-    # A --transport override routes any profile to the native driver.
     claude_native = BenchProfile(
         harness="claude-native", model="m", env_prefix="HARNESS_CLAUDE_NATIVE_", marker="X"
     )
     assert resolve_driver_class(claude_native, override="native-tui") is NativeTuiDriver
 
-    # Every native-tui harness derives a vendor from the capability model with
-    # no per-vendor table — an own-auth native (cursor) as much as a shipped
-    # credential one (claude). This is what lets a community-plugin native run
-    # by name with no bench edit.
     assert native_vendor("claude-native") is not None
     cursor = native_vendor("cursor-native")
     assert cursor is not None and cursor.own_auth is True
 
-    # A non-native-tui harness derives no vendor and gates cleanly: an SDK
-    # harness, or a native-server one (opencode-native), is not this driver's.
     assert native_vendor("claude-sdk") is None
     codex_sdk = BenchProfile(harness="codex", model="m", env_prefix="X_", marker="X")
     assert NativeTuiDriver.unavailable(codex_sdk, databricks_profile="oss") is not None
 
-    # No creds anywhere (no --profile, no ambient OPENAI_*, no configured
-    # profile) → capability-neutral skip. Clear the ambient env and stub the
-    # config lookup so the contract is tested deterministically regardless of
-    # the host's environment.
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     monkeypatch.setattr("tests.harness_bench.runtime_env._profile_from_config", lambda: None)
@@ -811,16 +741,12 @@ def test_transport_resolution_family_default_and_fast() -> None:
         harness="claude-native", model="m", env_prefix="X_", marker="X", transport="native-tui"
     )
 
-    # SDK family: full-server by default, sdk-inproc under --fast.
     assert resolve_transport_name(sdk, override=None, fast=False) == "full-server"
     assert resolve_transport_name(sdk, override=None, fast=True) == "sdk-inproc"
 
-    # native: a single transport --fast does not touch.
     assert resolve_transport_name(native, override=None, fast=False) == "native-tui"
     assert resolve_transport_name(native, override=None, fast=True) == "native-tui"
 
-    # An explicit --transport wins over both the default and --fast, for any
-    # family (the caller validates the name against the registry separately).
     assert resolve_transport_name(sdk, override="sdk-inproc", fast=False) == "sdk-inproc"
     assert resolve_transport_name(sdk, override="native-tui", fast=True) == "native-tui"
 
@@ -869,8 +795,6 @@ def test_full_server_skips_native_with_accurate_message() -> None:
     """
     from tests.harness_bench.full_server_driver import FullServerDriver
 
-    # Real native profiles carry transport="native-tui" (set in the manifest);
-    # that is what the full-server gate keys on.
     claude_native = BenchProfile(
         harness="claude-native",
         model="m",

--- a/tests/harness_bench/test_cost_tracking.py
+++ b/tests/harness_bench/test_cost_tracking.py
@@ -32,7 +32,6 @@ async def _run(result: TurnResult):
 
 
 def test_priority_is_p1() -> None:
-    # P1 = reported, not merge-gating; also why it needs no declared verdict.
     assert CostTrackingProbe().priority is Priority.P1
 
 
@@ -43,30 +42,23 @@ async def test_priced_cost_is_supported() -> None:
 
 
 async def test_tokens_only_is_partial() -> None:
-    # Unpriced model: usage visible, no USD cost -> PARTIAL (not a failure).
     r = await _run(TurnResult(completed=True, text="ok", total_cost_usd=None, total_tokens=900))
     assert r.verdict is Verdict.PARTIAL
     assert "900 tokens" in r.note
 
 
 async def test_no_usage_is_skipped() -> None:
-    # Completed but the transport surfaced nothing -> SKIP, never UNSUPPORTED.
     r = await _run(TurnResult(completed=True, text="ok"))
     assert r.verdict is Verdict.SKIPPED
     assert "no usage" in r.note
 
 
 async def test_zero_cost_and_tokens_is_skipped() -> None:
-    # A completed turn always spends tokens; a reported 0/0 means an empty
-    # default from the usage plumbing, not a genuine zero -> SKIP, not a false
-    # SUPPORTED/PARTIAL. Guards against the `is not None` false positive.
     r = await _run(TurnResult(completed=True, text="ok", total_cost_usd=0.0, total_tokens=0))
     assert r.verdict is Verdict.SKIPPED
 
 
 async def test_zero_cost_but_positive_tokens_is_partial() -> None:
-    # Cost defaulted to 0 (unpriced) but real tokens were counted -> PARTIAL,
-    # not a false SUPPORTED on the 0 cost.
     r = await _run(TurnResult(completed=True, text="ok", total_cost_usd=0.0, total_tokens=900))
     assert r.verdict is Verdict.PARTIAL
 

--- a/tests/harness_bench/test_full_server.py
+++ b/tests/harness_bench/test_full_server.py
@@ -52,13 +52,11 @@ async def test_full_server_tool_call_and_policy_deny(databricks_profile: str) ->
         allowed = driver.tool_probe_turn(deny=False, timeout=180)
         denied = driver.tool_probe_turn(deny=True, timeout=180)
 
-    # ALLOW: the server dispatches the builtin tool call and it is not blocked.
     assert [tc["name"] for tc in allowed.tool_calls] == ["list_files"], (
         f"expected a list_files call, got {allowed.tool_calls} ({allowed.error})"
     )
     assert not allowed.tool_call_denied, "tool call was blocked without a deny policy"
 
-    # DENY: the same call is blocked by the pre-baked tool_call deny policy.
     assert denied.tool_call_denied, (
         f"tool_call deny policy did not block the call: {denied.tool_calls} ({denied.error})"
     )

--- a/tests/harness_bench/test_full_server_driver.py
+++ b/tests/harness_bench/test_full_server_driver.py
@@ -1,0 +1,69 @@
+"""Unit tests for full-server session polling."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.full_server_driver import FullServerDriver
+from tests.harness_bench.profile import BenchProfile
+
+_PROFILE = BenchProfile(harness="fake", model="m", env_prefix="HARNESS_FAKE_", marker="MARK")
+
+
+class _Response:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _Client:
+    def __init__(self, snapshots: list[dict[str, Any]]) -> None:
+        self._snapshots = iter(snapshots)
+
+    def get(self, _url: str) -> _Response:
+        return _Response(next(self._snapshots))
+
+
+def _driver(snapshots: list[dict[str, Any]]) -> FullServerDriver:
+    class _Shared:
+        client = _Client(snapshots)
+
+    return FullServerDriver(_PROFILE, databricks_profile=None, shared=_Shared())
+
+
+def test_poll_session_collects_terminal_snapshot_once(monkeypatch) -> None:
+    monkeypatch.setattr("tests.harness_bench.full_server_driver.time.sleep", lambda _: None)
+    call = {"type": "function_call", "data": {"call_id": "c1", "name": "list_files"}}
+    output = {"type": "function_call_output", "data": {"output": "ok"}}
+    driver = _driver(
+        [
+            {"status": "running", "items": [call]},
+            {
+                "status": "idle",
+                "items": [call, output, {"role": "assistant", "content": [{"text": "done"}]}],
+            },
+        ]
+    )
+
+    result = driver._poll_session("sess", TurnResult(), timeout=1, scan_tools=True)
+
+    assert result.completed
+    assert result.text == "done"
+    assert result.tool_calls == [{"call_id": "c1", "name": "list_files", "arguments": None}]
+    assert result.tool_call_allowed
+
+
+def test_poll_session_reports_failure(monkeypatch) -> None:
+    monkeypatch.setattr("tests.harness_bench.full_server_driver.time.sleep", lambda _: None)
+    driver = _driver([{"status": "failed", "last_task_error": {"message": "boom"}}])
+
+    result = driver._poll_session("sess", TurnResult(), timeout=1)
+
+    assert result.failed
+    assert result.error == {"message": "boom"}

--- a/tests/harness_bench/test_native_tui_driver.py
+++ b/tests/harness_bench/test_native_tui_driver.py
@@ -76,8 +76,6 @@ class _FakeClient:
 
     def get(self, url: str, params: dict | None = None, timeout: float | None = None):
         if url.endswith("/items"):
-            # First call is the pre-turn baseline (empty); later calls see the
-            # item the turn produced.
             self._items_calls += 1
             data = [] if self._items_calls == 1 else self._items
             return _FakeResponse(200, {"data": data})
@@ -121,7 +119,6 @@ def test_tool_turn_observes_function_call_item() -> None:
     assert [tc["name"] for tc in result.tool_calls] == ["Bash"]
     assert result.completed
     assert not result.tool_call_denied
-    # No deny policy is attached on the allow path.
     assert client.attached_policies == []
 
 
@@ -136,8 +133,6 @@ def test_tool_turn_deny_attaches_policy_and_observes_denied_event() -> None:
     result = driver._drive_tool_turn(deny=True)
 
     assert result.tool_call_denied
-    # The attached policy denies at the tool_call phase (name-agnostic, so it
-    # blocks whatever tool the vendor calls regardless of its wire name).
     assert len(client.attached_policies) == 1
     attached = client.attached_policies[0]
     assert attached["handler"] == "omnigent.policies.builtins.cel.cel_policy"
@@ -180,7 +175,6 @@ def test_tool_turn_deny_skips_when_policy_enforcement_inactive() -> None:
     assert result.error and "inactive" in result.error
     assert not result.tool_call_denied
     assert not result.tool_calls
-    # No policy is attached when enforcement is known-inactive.
     assert client.attached_policies == []
 
 
@@ -237,6 +231,5 @@ def test_format_matches_server_wire_name() -> None:
     from tests.harness_bench.native_tui_driver import _POLICY_DENIED_EVENT
 
     sse = _format_sse(_POLICY_DENIED_EVENT, {"type": _POLICY_DENIED_EVENT})
-    # The reader parses `event: <name>`; assert the driver's key is that name.
     assert sse.startswith(f"event: {_POLICY_DENIED_EVENT}\n")
     assert json.loads(sse.split("data: ", 1)[1])["type"] == _POLICY_DENIED_EVENT

--- a/tests/harness_bench/test_policy_matrix.py
+++ b/tests/harness_bench/test_policy_matrix.py
@@ -43,9 +43,6 @@ def test_probes_are_p1() -> None:
     assert PolicyAskProbe().priority is Priority.P1
 
 
-# ── ALLOW ────────────────────────────────────────────────────────
-
-
 async def test_allow_supported_when_call_proceeds() -> None:
     r = await _allow(TurnResult(completed=True, tool_call_allowed=True))
     assert r.verdict is Verdict.SUPPORTED
@@ -58,7 +55,6 @@ async def test_allow_passes_action_allow_to_driver() -> None:
 
 
 async def test_allow_skipped_when_unmeasured() -> None:
-    # Wrap/native return an empty TurnResult -> no tool call, not completed.
     r = await _allow(TurnResult())
     assert r.verdict is Verdict.SKIPPED
     assert "not observable" in r.note
@@ -69,17 +65,12 @@ async def test_allow_skipped_on_infra_failure() -> None:
     assert r.verdict is Verdict.SKIPPED
 
 
-# ── ASK ──────────────────────────────────────────────────────────
-
-
 async def test_ask_supported_when_elicitation_raised() -> None:
     r = await _ask(TurnResult(completed=True, elicitation_requested=True))
     assert r.verdict is Verdict.SUPPORTED
 
 
 async def test_ask_supported_even_if_turn_not_settled() -> None:
-    # The driver returns early once the elicitation fires (verdict decided), so
-    # a real ASK success has elicitation_requested=True but completed=False.
     r = await _ask(TurnResult(completed=False, elicitation_requested=True))
     assert r.verdict is Verdict.SUPPORTED
 
@@ -97,8 +88,6 @@ async def test_ask_skipped_when_unmeasured() -> None:
 
 
 async def test_ask_skipped_when_no_elicitation_but_completed() -> None:
-    # Tool call happened and turn completed, but no elicitation surfaced -> SKIP,
-    # never a false UNSUPPORTED.
     r = await _ask(TurnResult(completed=True, tool_calls=[{"name": "list_files"}]))
     assert r.verdict is Verdict.SKIPPED
 

--- a/tests/harness_bench/test_runtime_env.py
+++ b/tests/harness_bench/test_runtime_env.py
@@ -108,6 +108,7 @@ def test_profile_from_providers_block(monkeypatch: pytest.MonkeyPatch) -> None:
     Exercises the real ``_profile_from_config`` (captured before the autouse
     stub) by monkeypatching the two upstream config sources it reads.
     """
+    monkeypatch.setattr("omnigent.config.load_global_config", dict)
     monkeypatch.setattr(
         "omnigent.config.load_effective_config",
         lambda: {
@@ -121,13 +122,44 @@ def test_profile_from_providers_block(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_profile_from_auth_block(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "omnigent.config.load_effective_config",
+        "omnigent.config.load_global_config",
         lambda: {"auth": {"type": "databricks", "profile": "AUTH_PROFILE"}},
     )
     assert _REAL_PROFILE_FROM_CONFIG() == "AUTH_PROFILE"
 
 
+def test_project_auth_does_not_override_global_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "omnigent.config.load_global_config",
+        lambda: {"auth": {"type": "databricks", "profile": "GLOBAL_AUTH"}},
+    )
+    monkeypatch.setattr(
+        "omnigent.config.load_effective_config",
+        lambda: {"auth": {"type": "databricks", "profile": "PROJECT_AUTH"}},
+    )
+    assert _REAL_PROFILE_FROM_CONFIG() == "GLOBAL_AUTH"
+
+
+def test_project_only_auth_is_not_used_for_tier_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("omnigent.config.load_global_config", dict)
+    monkeypatch.setattr(
+        "omnigent.config.load_effective_config",
+        lambda: {"auth": {"type": "databricks", "profile": "PROJECT_AUTH"}},
+    )
+    assert _REAL_PROFILE_FROM_CONFIG() is None
+
+
+def test_profile_from_config_tolerates_malformed_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _malformed() -> dict[str, object]:
+        raise ValueError("malformed yaml")
+
+    monkeypatch.setattr("omnigent.config.load_global_config", _malformed)
+    monkeypatch.setattr("omnigent.config.load_effective_config", _malformed)
+    assert _REAL_PROFILE_FROM_CONFIG() is None
+
+
 def test_top_level_profile_precedes_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("omnigent.config.load_global_config", dict)
     monkeypatch.setattr(
         "omnigent.config.load_effective_config",
         lambda: {

--- a/tests/harness_bench/test_runtime_env.py
+++ b/tests/harness_bench/test_runtime_env.py
@@ -16,8 +16,6 @@ from tests.harness_bench.runtime_env import (
     resolve_bench_env,
 )
 
-# Captured before the autouse _clean_env fixture stubs the module attribute, so
-# the tier-3 test can drive the real resolver.
 _REAL_PROFILE_FROM_CONFIG = runtime_env._profile_from_config
 
 
@@ -71,7 +69,6 @@ def test_ambient_openai_wins_and_skips_resolver(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_config_profile_used_when_no_flag(monkeypatch: pytest.MonkeyPatch) -> None:
-    # No --profile, but ~/.omnigent config yields a profile (like `omni run`).
     monkeypatch.setattr(runtime_env, "_profile_from_config", lambda: "from-config")
     seen: dict[str, str | None] = {}
 
@@ -150,7 +147,6 @@ def test_skip_reason_none_when_ambient(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_skip_reason_when_no_creds_anywhere() -> None:
-    # _clean_env stubbed _profile_from_config -> None and cleared OPENAI_*.
     reason = bench_creds_skip_reason(None)
     assert reason is not None
     assert "--profile" in reason

--- a/tests/harness_bench/test_runtime_env.py
+++ b/tests/harness_bench/test_runtime_env.py
@@ -111,9 +111,8 @@ def test_profile_from_providers_block(monkeypatch: pytest.MonkeyPatch) -> None:
     Exercises the real ``_profile_from_config`` (captured before the autouse
     stub) by monkeypatching the two upstream config sources it reads.
     """
-    monkeypatch.setattr("omnigent.runtime.workflow._load_global_auth", lambda: None)
     monkeypatch.setattr(
-        "omnigent.cli._load_effective_config",
+        "omnigent.config.load_effective_config",
         lambda: {
             "providers": {
                 "databricks": {"kind": "databricks", "default": True, "profile": "DEFAULT"}
@@ -121,6 +120,27 @@ def test_profile_from_providers_block(monkeypatch: pytest.MonkeyPatch) -> None:
         },
     )
     assert _REAL_PROFILE_FROM_CONFIG() == "DEFAULT"
+
+
+def test_profile_from_auth_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "omnigent.config.load_effective_config",
+        lambda: {"auth": {"type": "databricks", "profile": "AUTH_PROFILE"}},
+    )
+    assert _REAL_PROFILE_FROM_CONFIG() == "AUTH_PROFILE"
+
+
+def test_top_level_profile_precedes_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "omnigent.config.load_effective_config",
+        lambda: {
+            "profile": "TOP_LEVEL",
+            "providers": {
+                "databricks": {"kind": "databricks", "default": True, "profile": "PROVIDER"}
+            },
+        },
+    )
+    assert _REAL_PROFILE_FROM_CONFIG() == "TOP_LEVEL"
 
 
 def test_skip_reason_none_when_ambient(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/harness_bench/test_session_items.py
+++ b/tests/harness_bench/test_session_items.py
@@ -30,6 +30,18 @@ def test_assistant_text_reads_both_item_shapes() -> None:
     assert assistant_text(items, separator=" ") == "one two"
 
 
+def test_assistant_text_accepts_untyped_text_and_ignores_non_text_blocks() -> None:
+    item = {
+        "role": "assistant",
+        "content": [
+            {"text": "plain"},
+            {"type": "reasoning", "text": "internal"},
+            {"type": "image", "text": "metadata"},
+        ],
+    }
+    assert assistant_text(item) == "plain"
+
+
 def test_function_calls_and_output_states_are_normalized() -> None:
     items = [
         {"data": {"type": "function_call", "call_id": "c1", "name": "Bash"}},

--- a/tests/harness_bench/test_session_items.py
+++ b/tests/harness_bench/test_session_items.py
@@ -1,0 +1,50 @@
+"""Tests for shared harness-bench session-item parsing."""
+
+from tests.harness_bench.session_items import (
+    assistant_text,
+    contains_user_text,
+    function_calls,
+    item_role,
+    item_type,
+    tool_output_states,
+)
+
+
+def test_item_type_accepts_top_level_and_nested_shapes() -> None:
+    assert item_type({"type": "message"}) == "message"
+    assert item_type({"data": {"type": "function_call"}}) == "function_call"
+    assert item_role({"data": {"role": "assistant"}}) == "assistant"
+
+
+def test_assistant_text_reads_both_item_shapes() -> None:
+    items = [
+        {"role": "assistant", "content": [{"type": "text", "text": "one"}]},
+        {
+            "data": {
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "two"}],
+            }
+        },
+    ]
+    assert assistant_text(items) == "one\ntwo"
+    assert assistant_text(items, separator=" ") == "one two"
+
+
+def test_function_calls_and_output_states_are_normalized() -> None:
+    items = [
+        {"data": {"type": "function_call", "call_id": "c1", "name": "Bash"}},
+        {"type": "function_call_output", "data": {"output": "ok"}},
+        {"type": "function_call_output", "data": {"status": "blocked", "output": "no"}},
+    ]
+    assert function_calls(items) == [{"call_id": "c1", "name": "Bash", "arguments": None}]
+    assert tool_output_states(items, deny_marker="bench-deny") == (True, True)
+
+
+def test_contains_user_text_reads_message_blocks() -> None:
+    items = [
+        {
+            "type": "message",
+            "data": {"role": "user", "content": [{"type": "text", "text": "interrupted"}]},
+        }
+    ]
+    assert contains_user_text(items, "interrupt")

--- a/tests/harness_bench/transport.py
+++ b/tests/harness_bench/transport.py
@@ -1,38 +1,4 @@
-"""Transport drivers: the probe-facing contract and the registry.
-
-A probe measures one capability dimension by calling a small set of
-*semantic* methods on a driver — ``run_basic_turn``, ``run_streaming_turn``,
-``run_tool_turn``, ``run_interrupt_turn`` — each returning a
-:class:`~tests.harness_bench.driver.TurnResult`. The driver owns the
-*mechanism* (how a tool call is provoked, how a deny is enforced, how deltas
-are observed); the probe owns the *interpretation* (what verdict the result
-implies). This split is what lets one probe run over transports that reach
-the same capability by different means:
-
-- ``sdk-inproc`` (:class:`~tests.harness_bench.driver.SdkInprocDriver`)
-  drives a harness wrap subprocess directly, with request-level tools and
-  verdict-posted policy.
-- ``full-server``
-  (:class:`~tests.harness_bench.full_server_driver.FullServerDriver`) drives
-  a real server+runner, with a builtin tool and a spec-baked policy.
-
-A kwargs-carrying ``run_turn`` could not bridge these: e.g. streaming is only
-observable on full-server via a separate SSE subscription, so "basic turn"
-and "streaming turn" must be *distinct* calls, not one call with a flag.
-
-Transport selection (see :func:`resolve_driver_class`). A profile's
-``transport`` field is the harness *family* marker, not the literal driver:
-
-- **SDK-family** harnesses (``sdk-inproc``/``full-server``) default to
-  ``full-server`` — the fullest coverage, the only transport that exercises
-  Tool calling + Policy DENY, and a strict superset of what ``sdk-inproc``
-  observes. ``--fast`` downgrades them to ``sdk-inproc``, trading that
-  coverage for skipping the server boot.
-- **native** harnesses (``native-tui``) have exactly one transport; ``--fast``
-  does not apply to them.
-
-A ``--transport`` override wins over both, for any family.
-"""
+"""Transport-independent driver protocol and driver resolution."""
 
 from __future__ import annotations
 
@@ -117,10 +83,7 @@ def driver_registry() -> dict[str, type]:
     }
 
 
-# The SDK harness family: transports that drive an SDK-wrap harness. They
-# observe the same core dimensions; full-server additionally reaches Tool
-# calling + Policy DENY (server-dispatched) and is a strict coverage superset,
-# so it is the default. --fast picks the cheaper sdk-inproc within this family.
+# Full-server covers server-dispatched tools; --fast uses cheaper sdk-inproc.
 _SDK_FAMILY = frozenset({"sdk-inproc", "full-server"})
 _SDK_DEFAULT = "full-server"
 _SDK_FAST = "sdk-inproc"

--- a/tests/harness_bench/verdict.py
+++ b/tests/harness_bench/verdict.py
@@ -1,10 +1,4 @@
-"""Verdict vocabulary, priorities, and the observed-vs-declared reconciler.
-
-The verdicts map onto the glyphs of the hand-maintained harness support
-matrix so a rendered bench report reads like the spreadsheet it replaces,
-plus two operational states (``SKIPPED``) and the drift alarm (``DRIFT``)
-that the spreadsheet cannot express.
-"""
+"""Verdict types and observed-versus-declared reconciliation."""
 
 from __future__ import annotations
 
@@ -57,10 +51,7 @@ _GLYPHS: dict[Verdict, str] = {
     Verdict.DRIFT: "!!",
 }
 
-# Verdicts that assert a concrete, comparable fact. Reconciliation only
-# fires drift when BOTH sides are concrete — an UNKNOWN/SKIPPED on either
-# side means we never claimed or never observed, so there is nothing to
-# disagree about.
+# Unknown or skipped results cannot establish drift.
 _CONCRETE: frozenset[Verdict] = frozenset(
     {Verdict.SUPPORTED, Verdict.UNSUPPORTED, Verdict.PARTIAL, Verdict.NOT_APPLICABLE}
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+"""Tests for shared Omnigent config loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.config import global_config_path, load_effective_config
+
+
+def test_global_config_path_respects_config_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    assert global_config_path() == tmp_path / "config.yaml"
+
+
+def test_effective_config_merges_project_over_user(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_home = tmp_path / "home"
+    project = tmp_path / "project"
+    config_home.mkdir()
+    (project / ".omnigent").mkdir(parents=True)
+    (config_home / "config.yaml").write_text("profile: global\nmodel: global-model\n")
+    (project / ".omnigent" / "config.yaml").write_text("profile: local\n")
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(config_home))
+    monkeypatch.chdir(project)
+
+    assert load_effective_config() == {"profile": "local", "model": "global-model"}


### PR DESCRIPTION
## Related issue

N/A

## Summary

The harness bench had started duplicating runtime behavior at its integration boundaries: it imported private CLI/workflow config functions, decoded the same session-item envelopes in multiple drivers, and maintained separate full-server polling loops. That made protocol or configuration changes easy to apply inconsistently.

- Add a small public config-loading module while preserving the CLI's existing compatibility wrappers and global/project precedence.
- Centralize bench session-item parsing for assistant text, tool calls, tool outputs, roles, and cancellation markers.
- Consolidate full-server terminal-state polling, make tool snapshots idempotent, and reuse the existing live-server free-port helper.

**ELI5:** the bench now uses one shared reader for configuration, one shared translator for session messages, and one shared waiting loop instead of several slightly different copies.

```text
Before                              After
CLI private loaders <--- bench      omnigent.config <--- CLI wrappers
                                      ^
                                      +------------ bench

full-server parser ----\            session_items <--- full-server
native parser ----------+ copies                   <--- native

basic/tool/policy polls - copies     _poll_session <--- basic/tool/policy
```

## Test Plan

- `uv run --no-sync pytest -q -p no:rerunfailures tests/test_config.py tests/harness_bench tests/cli/test_cli.py tests/cli/test_opencode_setup.py`
  - 309 passed, 19 skipped
- `uv run --no-sync mypy omnigent/config.py tests/harness_bench/session_items.py tests/harness_bench/runtime_env.py tests/harness_bench/full_server_driver.py tests/harness_bench/native_tui_driver.py`
- `pre-commit run --files <all changed files>`

## Demo

N/A — internal refactor with no visual or user-facing behavior change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover config precedence, both session-item envelope shapes, normalized tool-call/output parsing, and full-server completion/failure polling. Existing CLI and harness-bench suites cover compatibility and orchestration behavior.
