### PR TITLE
fix(db): drop FKs referencing a table before widening its primary key

### DIFF
--- a/omnigent/db/migrations/versions/r1a2b3c4d5e6_add_workspace_id_to_all_tables.py
+++ b/omnigent/db/migrations/versions/r1a2b3c4d5e6_add_workspace_id_to_all_tables.py
@@ -63,6 +63,30 @@ def _existing_pk_name(table: str) -> str | None:
     return sa.inspect(op.get_bind()).get_pk_constraint(table).get("name")
 
 
+def _drop_fks_referencing(tables: list[str]) -> None:
+    """Drop every FK that references any of ``tables`` (PostgreSQL).
+
+    The PK of a table cannot be dropped while another table's FK still
+    references it. Migration ``p1a2b3c4d5e6`` was meant to strip all FKs, but
+    it predates tables added later (e.g. ``host_permissions``), so surviving
+    FKs like ``host_permissions_user_id_fkey`` still block the PK rebuild here.
+    Drop whatever FKs actually reference these tables, by their real reflected
+    name, so the widening below is the "purely local" op the module assumes.
+    """
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT con.conname, con.conrelid::regclass::text AS child "
+            "FROM pg_constraint con "
+            "WHERE con.contype = 'f' "
+            "AND con.confrelid::regclass::text = ANY(:tables)"
+        ),
+        {"tables": tables},
+    ).fetchall()
+    for conname, child in rows:
+        op.execute(sa.text(f'ALTER TABLE "{child}" DROP CONSTRAINT "{conname}"'))
+
+
 @contextlib.contextmanager
 def _quiet_pk_override() -> Iterator[None]:
     """
@@ -86,6 +110,10 @@ def upgrade() -> None:
         op.execute(sa.text("PRAGMA foreign_keys = OFF"))
 
     is_mysql = op.get_bind().dialect.name == "mysql"
+    # PostgreSQL blocks dropping a PK while any FK still references it. Strip
+    # surviving FKs (incl. ones from tables added after p1a2b3c4d5e6) first.
+    if not sqlite and not is_mysql:
+        _drop_fks_referencing(list(_TABLE_PKS.keys()))
     for table, pk_cols in _TABLE_PKS.items():
         if is_mysql:
             # Use raw DDL on MySQL to avoid batch_alter_table reading ORM


### PR DESCRIPTION
## Related issue

Closes #2355

## Summary

Migration `r1a2b3c4d5e6_add_workspace_id_to_all_tables` widens every primary key to `(workspace_id, id)` by dropping the old PK and adding the wider one. On PostgreSQL a PK cannot be dropped while another table's foreign key still references it, so any FK that survives into this migration crash-loops the server on startup with `DependentObjectsStillExist` (e.g. `cannot drop constraint users_pkey`). The migration assumes `p1a2b3c4d5e6` already stripped all FKs, but that migration drops a hardcoded set by convention name and misses FKs named by the Postgres default (`<table>_<col>_fkey`) or on tables added later.

- Before the widening loop on PostgreSQL, reflect and drop every FK that actually references any table being widened (by real name from `pg_constraint`), so the rebuild is the "purely local" operation the migration already assumes.
- No re-add: the intended steady state has no DB-level FKs (per the R032 rationale in `p1a2b3c4d5e6`).
- Only bites a **populated** Postgres DB with live FK relationships; fresh DB / SQLite never hit it, which is why it passes CI and fresh deploys but crashes an upgrade of an existing environment.

## Test Plan

Verified against a byte-exact copy of a live, populated Postgres database (234 conversations / 61.5k conversation_items) that reproduced the crash:

1. `pg_dump -Fc` the affected DB → restore into a throwaway `postgres:16` container.
2. Re-stamp `alembic_version` to the pre-`r` revision.
3. `alembic -c omnigent/db/alembic.ini upgrade head` — **without** the fix: fails `DependentObjectsStillExist` on `users_pkey`; **with** the fix: reaches head, `users` PK widened to `(workspace_id, id)`, 0 FKs remaining, all rows preserved.

`ruff check` clean on the changed file.

## Demo

N/A — migration / non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Verified manually via a restore-and-migrate of a real populated Postgres DB (see Test Plan) — the failure only reproduces against populated data with live FK relationships, which the in-repo migration tests (fresh DB / SQLite) don't exercise. Existing migration tests continue to pass on a fresh DB (the new FK-drop is a no-op when there are no surviving FKs). A dedicated populated-Postgres migration test would be the ideal follow-up but requires DB fixtures the suite doesn't currently have.
