### PR TITLE
feat(omnidev): give each dev pod its own isolated config.yaml

### DIFF
--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -56,12 +56,19 @@ Open the UI at the `ui` URL shown in the header (the Vite dev server).
 ## Isolation
 
 Only Omnigent's own state is isolated per pod — enough that concurrent pods
-never share a database or server pidfile — via `OMNIGENT_DATA_DIR`,
-`OMNIGENT_DATABASE_URI`, and `OMNIGENT_URL`. Everything else (your real
-`HOME`, credentials, config, and uv/npm caches) is inherited, because the
-agents Omnigent runs need it. This is deliberately lighter than the hermetic
-`scripts/backend-smoke.sh` sandbox, which repoints `HOME`/`XDG_*` to touch
-nothing real.
+never share a database, server pidfile, or `config.yaml` — via
+`OMNIGENT_DATA_DIR`, `OMNIGENT_DATABASE_URI`, `OMNIGENT_URL`, and
+`OMNIGENT_CONFIG_HOME`. Everything else (your real `HOME`, credentials, and
+uv/npm caches) is inherited, because the agents Omnigent runs need it. This is
+deliberately lighter than the hermetic `scripts/backend-smoke.sh` sandbox,
+which repoints `HOME`/`XDG_*` to touch nothing real.
+
+Each pod gets its own `config.yaml` under `<pod>/config/`, pointed to by
+`OMNIGENT_CONFIG_HOME`. On first create it's **seeded** from your real
+`~/.omnigent/config.yaml` (if present) so the pod works out of the box — it
+keeps your providers — after which the two are independent: server-config edits
+inside a pod (via the UI or `omnigent config`) don't touch your real config.
+`--clean` wipes the pod dir, so the next run re-seeds from your real config.
 
 The pod dir defaults to
 `${XDG_CACHE_HOME:-~/.cache}/omnidev/<repo-name>-<hash>/`, keyed to the

--- a/dev/omnidev/src/pod.rs
+++ b/dev/omnidev/src/pod.rs
@@ -19,8 +19,8 @@ pub struct Pod {
 
 impl Pod {
     /// Create the pod directory tree (idempotent) and return the pod handle.
-    /// Only omnigent's own state is isolated (DB, artifacts, logs); the pod
-    /// otherwise inherits your real home, credentials, config, and caches.
+    /// Only omnigent's own state is isolated (DB, artifacts, logs, config); the
+    /// pod inherits your real home, credentials, and caches.
     pub fn create(
         repo_root: PathBuf,
         dir: PathBuf,
@@ -28,18 +28,28 @@ impl Pod {
         vite_host: String,
         trusted_origins: Vec<String>,
     ) -> Result<Pod> {
-        for sub in ["data/omnigent", "artifacts", "logs"] {
+        for sub in ["data/omnigent", "artifacts", "logs", "config"] {
             let p = dir.join(sub);
             std::fs::create_dir_all(&p)
                 .with_context(|| format!("creating pod dir {}", p.display()))?;
         }
-        Ok(Pod {
+        let pod = Pod {
             repo_root,
             dir,
             ports,
             vite_host,
             trusted_origins,
-        })
+        };
+        // Seed the pod's config from the developer's real one so it works out
+        // of the box (keeps their providers). Best-effort: a copy failure just
+        // starts the pod with an empty config, so warn rather than abort.
+        if let Some(src) = real_config_path() {
+            let dest = pod.config_dir().join("config.yaml");
+            if let Err(e) = seed_config_file(&src, &dest) {
+                eprintln!("omnidev: could not seed pod config: {e:#}");
+            }
+        }
+        Ok(pod)
     }
 
     pub fn db_uri(&self) -> String {
@@ -51,6 +61,13 @@ impl Pod {
 
     pub fn artifacts_dir(&self) -> PathBuf {
         self.dir.join("artifacts")
+    }
+
+    /// The pod's isolated config home, exposed to children as
+    /// `OMNIGENT_CONFIG_HOME` so its `config.yaml` is separate from the
+    /// developer's real `~/.omnigent/config.yaml`.
+    pub fn config_dir(&self) -> PathBuf {
+        self.dir.join("config")
     }
 
     pub fn server_url(&self) -> String {
@@ -104,17 +121,22 @@ impl Pod {
     }
 
     /// The env overrides applied on top of the inherited parent env for every
-    /// child. We isolate only omnigent's own state — the DB and data dir — so
-    /// concurrent pods don't share a database or pidfile. Everything else
-    /// (real `HOME`, credentials, config, uv/npm caches) is inherited, since
-    /// the agents omnigent runs need it. `OMNIGENT_URL` is the seam
-    /// `web/vite.config.ts` reads to point its proxy at this pod's backend.
+    /// child. We isolate omnigent's own state — the DB, data dir, and config
+    /// home — so concurrent pods don't share a database, pidfile, or
+    /// `config.yaml`. The rest (real `HOME`, credentials, uv/npm caches) is
+    /// inherited, since the agents omnigent runs need it. `OMNIGENT_URL` is the
+    /// seam `web/vite.config.ts` reads to point its proxy at this pod's backend;
+    /// `OMNIGENT_CONFIG_HOME` is where the server/host/runner read `config.yaml`.
     pub fn env(&self) -> Vec<(String, String)> {
         let d = |p: &str| self.dir.join(p).display().to_string();
         let mut env = vec![
             ("OMNIGENT_DATA_DIR".into(), d("data/omnigent")),
             ("OMNIGENT_DATABASE_URI".into(), self.db_uri()),
             ("OMNIGENT_URL".into(), self.server_url()),
+            (
+                "OMNIGENT_CONFIG_HOME".into(),
+                self.config_dir().display().to_string(),
+            ),
         ];
         if let Some(allowed) = self.allowed_origins_env() {
             env.push(("OMNIGENT_WS_ALLOWED_ORIGINS".into(), allowed));
@@ -155,4 +177,172 @@ pub fn clean(dir: &Path) -> Result<()> {
             .with_context(|| format!("removing pod dir {}", dir.display()))?;
     }
     Ok(())
+}
+
+/// The developer's real omnigent `config.yaml` to seed a fresh pod from.
+///
+/// Honors `OMNIGENT_CONFIG_HOME` if the parent env sets it (nested/test
+/// setups), else `~/.omnigent/config.yaml` via `HOME`. Returns `None` when the
+/// file does not exist — a fresh pod then starts with an empty config, just
+/// like a first-run user.
+fn real_config_path() -> Option<PathBuf> {
+    let home = match std::env::var_os("OMNIGENT_CONFIG_HOME") {
+        Some(h) if !h.is_empty() => PathBuf::from(h),
+        _ => PathBuf::from(std::env::var_os("HOME")?).join(".omnigent"),
+    };
+    let path = home.join("config.yaml");
+    path.exists().then_some(path)
+}
+
+/// Copy `src` to `dest`, but only when `dest` does not already exist — a normal
+/// pod restart must not clobber config the developer edited inside the pod.
+/// After `--clean` the whole pod dir is gone, so `dest` is absent and this
+/// re-seeds.
+fn seed_config_file(src: &Path, dest: &Path) -> Result<()> {
+    if dest.exists() {
+        return Ok(());
+    }
+    std::fs::copy(src, dest)
+        .with_context(|| format!("seeding {} from {}", dest.display(), src.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // `real_config_path` reads process-global env; serialize the tests that
+    // set it so parallel runs don't observe each other's overrides.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn tempdir() -> PathBuf {
+        let unique = format!(
+            "omnidev-pod-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let dir = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn make_pod(pod_dir: PathBuf) -> Pod {
+        Pod::create(
+            tempdir(),
+            pod_dir,
+            Ports {
+                server: 19191,
+                vite: 19292,
+            },
+            "127.0.0.1".into(),
+            Vec::new(),
+        )
+        .unwrap()
+    }
+
+    /// Point `OMNIGENT_CONFIG_HOME` at `home` for the duration of `f`, restoring
+    /// the previous value afterwards. Serialized against other env-touching
+    /// tests via `ENV_LOCK`.
+    fn with_config_home<T>(home: &Path, f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var_os("OMNIGENT_CONFIG_HOME");
+        std::env::set_var("OMNIGENT_CONFIG_HOME", home);
+        let out = f();
+        match prev {
+            Some(v) => std::env::set_var("OMNIGENT_CONFIG_HOME", v),
+            None => std::env::remove_var("OMNIGENT_CONFIG_HOME"),
+        }
+        out
+    }
+
+    #[test]
+    fn create_makes_config_dir() {
+        let real = tempdir(); // empty config home -> nothing to seed
+        let pod = with_config_home(&real, || make_pod(tempdir()));
+        assert!(pod.config_dir().is_dir());
+    }
+
+    #[test]
+    fn env_includes_config_home() {
+        let real = tempdir();
+        let pod = with_config_home(&real, || make_pod(tempdir()));
+        let env = pod.env();
+        let got = env
+            .iter()
+            .find(|(k, _)| k == "OMNIGENT_CONFIG_HOME")
+            .map(|(_, v)| v.clone());
+        assert_eq!(got, Some(pod.config_dir().display().to_string()));
+    }
+
+    #[test]
+    fn create_seeds_pod_config_from_real() {
+        let real = tempdir();
+        std::fs::write(real.join("config.yaml"), "providers:\n  seeded: true\n").unwrap();
+
+        let pod = with_config_home(&real, || make_pod(tempdir()));
+
+        let seeded = std::fs::read_to_string(pod.config_dir().join("config.yaml")).unwrap();
+        assert_eq!(seeded, "providers:\n  seeded: true\n");
+    }
+
+    #[test]
+    fn create_skips_seed_when_real_config_absent() {
+        let real = tempdir(); // no config.yaml inside
+        let pod = with_config_home(&real, || make_pod(tempdir()));
+        assert!(!pod.config_dir().join("config.yaml").exists());
+    }
+
+    #[test]
+    fn seed_does_not_overwrite_existing() {
+        let dir = tempdir();
+        let src = dir.join("src.yaml");
+        let dest = dir.join("dest.yaml");
+        std::fs::write(&src, "from: real\n").unwrap();
+        std::fs::write(&dest, "edited: in-pod\n").unwrap();
+
+        seed_config_file(&src, &dest).unwrap();
+
+        // Existing pod-local edits survive; the real config does not clobber them.
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "edited: in-pod\n");
+    }
+
+    #[test]
+    fn real_config_path_honors_config_home() {
+        let real = tempdir();
+        std::fs::write(real.join("config.yaml"), "x: 1\n").unwrap();
+        let got = with_config_home(&real, real_config_path);
+        assert_eq!(got, Some(real.join("config.yaml")));
+    }
+
+    #[test]
+    fn real_config_path_falls_back_to_home_dot_omnigent() {
+        // With no OMNIGENT_CONFIG_HOME, the real config resolves under
+        // `$HOME/.omnigent/` — the path a normal pod run seeds from.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_cfg = std::env::var_os("OMNIGENT_CONFIG_HOME");
+        let prev_home = std::env::var_os("HOME");
+
+        let home = tempdir();
+        std::fs::create_dir_all(home.join(".omnigent")).unwrap();
+        std::fs::write(home.join(".omnigent/config.yaml"), "y: 2\n").unwrap();
+
+        std::env::remove_var("OMNIGENT_CONFIG_HOME");
+        std::env::set_var("HOME", &home);
+        let got = real_config_path();
+
+        match prev_cfg {
+            Some(v) => std::env::set_var("OMNIGENT_CONFIG_HOME", v),
+            None => std::env::remove_var("OMNIGENT_CONFIG_HOME"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+
+        assert_eq!(got, Some(home.join(".omnigent/config.yaml")));
+    }
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Each omnidev dev pod now gets its **own** `config.yaml` under `<pod>/config/`, exposed to the server/host/runner via `OMNIGENT_CONFIG_HOME` (which omnigent already honors everywhere). Previously the pod deliberately read the developer's real `~/.omnigent/config.yaml`, so server-config edits made while testing in a pod (providers, host, server, tui blocks) leaked into — and were polluted by — the real user config, and every pod shared one config surface.
- On first create the pod's config is **seeded** from the real `~/.omnigent/config.yaml` (when present) so the pod works out of the box and keeps your providers; thereafter the two are independent. Seeding is copy-if-absent, so a normal restart never clobbers in-pod edits. `--clean` wipes the pod dir, so the next run re-seeds.
- This is a new default (no flag). The only behavioral change on the omnigent side is one extra env var in `Pod::env()`; no Python changes.

## Test Plan

- `cd dev/omnidev && cargo test` — 36 tests pass, including 7 new `pod::tests` covering: config dir creation, `OMNIGENT_CONFIG_HOME` injection in `env()`, seed-from-real, skip-when-real-config-absent, copy-if-absent (no overwrite of in-pod edits), and both branches of `real_config_path()` (`OMNIGENT_CONFIG_HOME` override and `$HOME/.omnigent` fallback).
- `cargo clippy --all-targets -- -D warnings` — clean.
- Live run: launched the release binary into a throwaway `--pod-dir`; the pod's `config/config.yaml` came out byte-identical (482 B) to the real config, in the right place, and the real `~/.omnigent/config.yaml` was untouched (mtime unchanged).

## Demo

N/A — non-visual (dev tooling / no UI change).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests in `dev/omnidev/src/pod.rs` cover the seeding logic and env injection (env-touching tests are serialized behind a `Mutex` and restore prior env). Manual verification: ran the real `omnidev` binary into a throwaway pod dir and confirmed the pod-local `config.yaml` was seeded byte-for-byte from the real config, landed under `<pod>/config/`, and left the real `~/.omnigent/config.yaml` untouched.

## Changelog

omnidev dev pods now get their own isolated `config.yaml` (seeded from `~/.omnigent/config.yaml`), so server-config edits while testing in a pod no longer touch your real config

This pull request and its description were written by Isaac.
