### PR TITLE
fix(host): non-editable install sibling SDKs

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -334,7 +334,8 @@ RUN set -eu; \
 # site-packages and imports no longer require /build at runtime.
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /build /build
-RUN pip install --no-cache-dir /build
+RUN pip install --no-cache-dir /build /build/sdks/python-client /build/sdks/ui \
+ && ! grep -R --include='*.pth' --include='*.egg-link' -nE '/build(/|$)' /opt/venv/lib/python*/site-packages
 
 # Sandbox launchers exec commands through `bash -lc`, and Debian's
 # /etc/profile unconditionally resets PATH for login shells — the ENV


### PR DESCRIPTION
## Related issue

Follow-up to #2034 and #2107.

## Summary

The host image already reinstalled the root `omnigent` package non-editably to avoid Landlock-denied imports through `/build`, but the sibling SDKs still came from editable path dependencies. This updates the host-stage reinstall to also install `/build/sdks/python-client` and `/build/sdks/ui` non-editably, then fails the image build if any `.pth` or `.egg-link` in the venv still points at `/build`.

## Test Plan

- `npm_config_package_lock=false pre-commit run --all-files`
- Confirmed the host Dockerfile keeps the existing `/build` root reinstall and adds both sibling SDK package directories to the same non-editable `pip install` layer.
- Confirmed the Dockerfile now includes a build-time grep check over `/opt/venv/lib/python*/site-packages` for `.pth` / `.egg-link` entries that still reference `/build`.
- Could not run a full Docker image build locally because Docker Desktop/daemon is unavailable: `failed to connect to the docker API at unix:///Users/pat.sukprasert/.docker/run/docker.sock`.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is a Docker packaging fix, so there is no unit-level behavior to cover. Manual verification checked the Dockerfile install command and added an in-image assertion that no editable `.pth` / `.egg-link` path still references `/build`; a full runtime Landlock verification still requires building and running the host image in a Kubernetes/OpenShift sandbox environment.
