### PR TITLE
feat(benchmarks): add MySQL as a third backend leg

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,12 +63,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: [sqlite, postgres]
+        backend: [sqlite, postgres, mysql]
     services:
-      # A Postgres service is defined unconditionally (GitHub Actions has no
-      # per-matrix-value service gating), but only the postgres leg connects to
-      # it — the sqlite leg simply ignores it. postgres:16 mirrors Lakebase's
-      # major version.
+      # The Postgres and MySQL services are defined unconditionally (GitHub
+      # Actions has no per-matrix-value service gating); each leg connects only
+      # to its own backend and ignores the others. postgres:16 mirrors
+      # Lakebase's major version; mysql:8.0 matches the stores-mysql CI lane.
       postgres:
         image: postgres:16
         env:
@@ -78,6 +78,18 @@ jobs:
           - 5432:5432
         options: >-
           --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: bench
+          MYSQL_DATABASE: benchdb
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -u root -pbench"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
@@ -101,17 +113,30 @@ jobs:
         # `databricks` extra carries psycopg[binary] for the Postgres backend.
         run: uv sync --extra dev --extra databricks
 
+      - name: Install MySQL driver
+        # mysqlclient (mysql+mysqldb://) needs the system client library and is
+        # not in any extra, so install it only on the mysql leg. Matches the
+        # stores-mysql lane in ci.yml.
+        if: matrix.backend == 'mysql'
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -q libmysqlclient-dev
+          uv pip install mysqlclient
+
       # Resolve the DB URI + a stable seed-cache key for this backend. The
       # cache key binds the DB schema head + seed.py contents + corpus config,
       # so a schema change or seed edit busts the cache and forces a reseed —
       # the "you changed the schema, refresh the seed" contract (SQLite only;
-      # the Postgres service is fresh each run so its DB is never cached).
+      # the Postgres/MySQL services are fresh each run so their DB is never
+      # cached).
       - name: Resolve DB target
         id: db
         run: |
           HEAD="$(uv run --no-sync dev/benchmarks/omnigent/seed.py --print-head)"
           if [[ "${{ matrix.backend }}" == "postgres" ]]; then
             echo "uri=postgresql+psycopg://postgres:bench@localhost:5432/benchdb" >> "$GITHUB_OUTPUT"
+            echo "cache_path=" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ matrix.backend }}" == "mysql" ]]; then
+            echo "uri=mysql+mysqldb://root:bench@127.0.0.1:3306/benchdb" >> "$GITHUB_OUTPUT"
             echo "cache_path=" >> "$GITHUB_OUTPUT"
           else
             echo "uri=sqlite:///$PWD/bench.db" >> "$GITHUB_OUTPUT"
@@ -120,7 +145,7 @@ jobs:
           echo "cache_key=benchdb-${{ matrix.backend }}-$HEAD-${SESSIONS}x${ITEMS}-${{ hashFiles('dev/benchmarks/omnigent/seed.py') }}" >> "$GITHUB_OUTPUT"
 
       # Reuse a previously-seeded SQLite corpus when schema + seed + config are
-      # unchanged. No-op for the postgres leg (empty path).
+      # unchanged. No-op for the server-backed legs (empty path).
       - name: Restore seeded SQLite corpus
         if: matrix.backend == 'sqlite'
         id: seedcache
@@ -130,9 +155,10 @@ jobs:
           key: ${{ steps.db.outputs.cache_key }}
 
       - name: Seed corpus
-        # Postgres always seeds (fresh service each run); SQLite seeds only on a
-        # cache miss. seed.py is itself idempotent, so a stray hit is harmless.
-        if: matrix.backend == 'postgres' || steps.seedcache.outputs.cache-hit != 'true'
+        # The fresh-service backends (postgres, mysql) always seed; SQLite seeds
+        # only on a cache miss. seed.py is itself idempotent, so a stray hit is
+        # harmless.
+        if: matrix.backend != 'sqlite' || steps.seedcache.outputs.cache-hit != 'true'
         run: |
           uv run --no-sync dev/benchmarks/omnigent/seed.py \
             --database-uri "${{ steps.db.outputs.uri }}" \

--- a/dev/benchmarks/omnigent/README.md
+++ b/dev/benchmarks/omnigent/README.md
@@ -128,7 +128,8 @@ that a schema change hasn't broken seeding.
 ## Backends
 
 `--database-uri` selects the DB; the report's `backend` field (`sqlite` /
-`postgres`) is derived from the URI scheme so results group by backend.
+`postgres` / `mysql`) is derived from the URI scheme so results group by
+backend.
 
 - **SQLite** (default) — in-process; fast, but not prod-representative.
 - **Postgres** — `postgresql+psycopg://user@host:5432/db` (the fully-qualified
@@ -136,6 +137,11 @@ that a schema change hasn't broken seeding.
   Requires `psycopg[binary]` (the `databricks` extra). Matches prod's
   round-trip/pooling profile. Stand up a local one with
   `docker run -e POSTGRES_PASSWORD=… -p 5432:5432 postgres:16`.
+- **MySQL** — `mysql+mysqldb://user@host:3306/db`. Requires the `mysqlclient`
+  driver (`pip install mysqlclient`, which needs the `libmysqlclient-dev`
+  system library) — it is not in any extra. A supported backend, though prod
+  runs on Postgres. Stand up a local one with
+  `docker run -e MYSQL_ROOT_PASSWORD=… -e MYSQL_DATABASE=benchdb -p 3306:3306 mysql:8.0`.
 
 ## Output → Databricks → dashboard
 
@@ -169,7 +175,7 @@ document without running the harness.
   "journeys": {
     "<journey name>": {
       "kind": "latency" | "throughput",
-      "backend": "sqlite" | "postgres",
+      "backend": "sqlite" | "postgres" | "mysql",
       "runs": [                       // one per --runs
         {"n_success": N, "n_failures": N, "failures": {"HTTP 500": 1},
          "wall_time_s": …, "mean_ms": …, "p50_ms": …, "p95_ms": …,
@@ -205,10 +211,11 @@ creds).
 ## CI
 
 `.github/workflows/benchmark.yml` runs nightly (and on dispatch) as a backend
-matrix — `sqlite` and `postgres` (a `postgres:16` service container). Each leg
-seeds a corpus (SQLite reuses a cache keyed on the schema head + `seed.py` +
-corpus config, so a migration busts the cache and forces a reseed; Postgres is
-fresh per run), runs the benchmark, and uploads
+matrix — `sqlite`, `postgres` (a `postgres:16` service container), and `mysql`
+(a `mysql:8.0` service container; the `mysqlclient` driver is installed on that
+leg only). Each leg seeds a corpus (SQLite reuses a cache keyed on the schema
+head + `seed.py` + corpus config, so a migration busts the cache and forces a
+reseed; Postgres and MySQL are fresh per run), runs the benchmark, and uploads
 `benchmark-results-<backend>-<run_id>.json`. The workspace notebook pulls those
 artifacts.
 

--- a/dev/benchmarks/omnigent/run.py
+++ b/dev/benchmarks/omnigent/run.py
@@ -64,6 +64,8 @@ def _backend_of(database_uri: str | None) -> str:
         return "sqlite"
     if database_uri.startswith("postgres"):
         return "postgres"
+    if database_uri.startswith("mysql"):
+        return "mysql"
     return "other"
 
 
@@ -178,10 +180,10 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         "--database-uri",
         default=None,
         metavar="URI",
-        help="DB the server boots against — a pre-seeded SQLite file or a "
-        "postgresql+psycopg://… instance (see seed.py). Default: a fresh "
-        "throwaway SQLite DB (empty — best-case numbers). The report's "
-        "`backend` field is derived from this.",
+        help="DB the server boots against — a pre-seeded SQLite file, a "
+        "postgresql+psycopg://… instance, or a mysql+mysqldb://… instance "
+        "(see seed.py). Default: a fresh throwaway SQLite DB (empty — "
+        "best-case numbers). The report's `backend` field is derived from this.",
     )
     parser.add_argument(
         "--iterations",

--- a/tests/benchmarks/test_benchmark_smoke.py
+++ b/tests/benchmarks/test_benchmark_smoke.py
@@ -60,6 +60,14 @@ def _smoke_args(**overrides: object) -> argparse.Namespace:
 # ── pure-layer unit checks (no server) ───────────────────────
 
 
+def test_backend_of_classifies_uri_schemes() -> None:
+    """The report's backend label is derived from the URI scheme."""
+    assert bench_run._backend_of(None) == "sqlite"
+    assert bench_run._backend_of("sqlite:////abs/bench.db") == "sqlite"
+    assert bench_run._backend_of("postgresql+psycopg://u@h:5432/db") == "postgres"
+    assert bench_run._backend_of("mysql+mysqldb://u@h:3306/db") == "mysql"
+
+
 def test_percentile_and_throughput() -> None:
     r = RunResult(latencies_ms=[10.0, 20.0, 30.0, 40.0], wall_time=2.0)
     assert r.n_success == 4


### PR DESCRIPTION
## Related issue

N/A

## Summary

MySQL/MariaDB is a supported database backend (the store + DB CI suites already run against `mysql:8.0`), but the perf benchmark harness only knew SQLite and Postgres. This adds MySQL as a first-class leg, mirroring the existing Postgres path:

- **`run.py`** — `_backend_of()` classifies `mysql://` URIs as `"mysql"` (previously fell into `"other"`), so the report's `backend` field groups correctly; `--database-uri` help mentions the `mysql+mysqldb://…` form.
- **`benchmark.yml`** — MySQL joins the nightly matrix with a `mysql:8.0` service container, a `mysql`-gated `mysqlclient` install step (`libmysqlclient-dev` + `uv pip install mysqlclient`; it's not in any extra), its own DB-target branch, and a seed condition widened from `== 'postgres'` to `!= 'sqlite'` so both fresh-service backends always seed.
- **README** — documents the MySQL backend, the CI leg, and the new schema `backend` value.
- **smoke test** — cred-free `test_backend_of_classifies_uri_schemes` covering every URI scheme.

The server passes `--database-uri` straight through `normalize_database_url` into the generic pooled-engine path (MySQL URIs pass through unchanged), so `environment.py`, `schema.py`, `seed.py`, and `sample_output.json` need no changes. `SCHEMA_VERSION` stays `1` (new `backend` *value*, no shape change).

## Test Plan

- `uv run --no-sync -m pytest tests/benchmarks/test_benchmark_smoke.py` → **12 passed**, including the new classifier test and both server-booting end-to-end tests.
- `benchmark.yml` validated as YAML (python + pre-commit `check-yaml`).
- `pre-commit run --files …` → all hooks pass (ruff format/check, yaml, etc.).
- The MySQL leg has not been run live locally (Docker is org-locked here, same as the Postgres leg) — CI's `mysql:8.0` service container is the first real exercise. The image + `mysql+mysqldb://` driver combo is already proven by the `stores-mysql` CI lane, so risk is low; the first nightly (or a `workflow_dispatch` on this branch) is the real confirmation.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `test_backend_of_classifies_uri_schemes` (cred-free) to cover the new `mysql` branch. Manual verification: ran the full `test_benchmark_smoke.py` suite (12 passed) and validated the workflow YAML + pre-commit hooks locally. The live MySQL leg runs first in CI, backed by the same `mysql:8.0` image and `mysql+mysqldb://` driver the `stores-mysql` lane already exercises.

This pull request and its description were written by Isaac.
