### PR TITLE
fix(ci): pin rotation workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/discord-watch-rotation.yml
+++ b/.github/workflows/discord-watch-rotation.yml
@@ -22,8 +22,8 @@ jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12" # for zoneinfo in the stdlib
       - name: Send rotation ping


### PR DESCRIPTION
## Related issue

N/A

## Summary

The Discord watch rotation workflow failed on its first scheduled run ([run 29083842707](https://github.com/omnigent-ai/omnigent/actions/runs/29083842707/job/86332769570)):

> The actions actions/checkout@v4 and actions/setup-python@v5 are not allowed in omnigent-ai/omnigent because all actions must be pinned to a full-length commit SHA.

The org enforces SHA-pinned actions. This pins both to the same commit SHAs the repo's other workflows already use:

- `actions/checkout` → `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` (v7.0.0)
- `actions/setup-python` → `a309ff8b426b58ec0e2a45f0f869d46889d02405` (v6.2.0)

## Test Plan

- `pre-commit run check-yaml` passes on the workflow file.
- SHAs verified against the pins used by other workflows in `.github/workflows/` (grep).
- Confirmed via the run log that the two unpinned actions were the only cause of the failure (the job failed at "Set up job", before running the script).

## Demo

N/A — non-visual CI fix.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by matching the pinned SHAs to those used by other workflows in the repo and by reading the failing run log, which showed the unpinned actions were rejected at job setup. No code paths changed.

This pull request and its description were written by Isaac.