### PR TITLE
docs(harness-bench): update shipped status

### DIFF
--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -6,9 +6,10 @@ available", "is steering possible", "does policy DENY actually block a call" —
 instead of a human hand-maintaining a spreadsheet and hoping it still reflects
 reality.
 
-> **Status:** shipped and in use. The MVP plus most of phase-2 is on `main` —
-> three transport drivers, the six P0 probes, and a capability-derived matrix
-> that has already caught and corrected real declaration drift. See
+> **Status:** shipped and in use. The bench on `main` has three transport
+> drivers, six P0 probes, three report-only P1 probes, automatic live/offline
+> selection, and a capability-derived matrix that has already caught and
+> corrected real declaration drift. See
 > [Current state](#current-state-shipped) for what is live vs. still open. The
 > sections before it describe the design and the decisions behind it.
 
@@ -125,48 +126,42 @@ list" to "discover"; probes, profiles, and reports are untouched.
 
 ## Architecture
 
-Three layers plus a report step.
+The implementation has three layers plus reporting:
 
 ```
 tests/harness_bench/
-  profile.py         # BenchProfile: per-harness self-declared facts
-  manifest.py        # registry of official BenchProfiles (the spreadsheet as data)
-  verdict.py         # Verdict enum, ProbeResult, priority (P0/P1)
-  transports/        # transport drivers keyed by class
-    _base.py         #   TransportDriver: launch/session/turn against a harness
-    sdk_inproc.py    #   in-proc HTTP (reuses existing e2e server helpers)
-    tmux_tui.py      #   (phase 2)
-    app_server.py    #   (phase 2)
-    http_sse.py      #   (phase 2)
-  probes/            # one module per dimension
-    _base.py         #   CapabilityProbe: name, priority, applies_to, declared(), run()
-    basic_turn.py
-    streaming.py
-    tool_calling.py  #   incl. "connects to Omnigent MCP"
-    interrupt.py
-    policy_deny.py
-    model_override.py
-    ...              #   (phase 2: steering, live_queue, resume_fork, elicitation,
-                     #    reasoning, images, cost, compaction)
-  bench.py           # driver: iterate probes x harnesses -> matrix
-  report.py          # render Markdown + JSON, with a DRIFT column
-  test_bench.py      # pytest wrapper (parametrized) for CI
+  profile.py             # BenchProfile and profile-name resolution
+  manifest.py            # official profiles derived from capabilities + e2e metadata
+  verdict.py             # verdict vocabulary, priority, and drift reconciliation
+  transport.py           # semantic Driver protocol and transport resolution
+  driver.py              # sdk-inproc driver + shared TurnResult/usage helpers
+  full_server.py         # shared server/runner lifecycle and registration
+  full_server_driver.py  # full-server driver and session polling
+  native_tui_driver.py   # native vendor CLI + host-daemon/tmux driver
+  session_items.py       # shared session-item envelope parsing
+  runtime_env.py         # config/credential resolution matching `omni run`
+  probes/                # one module per capability dimension
+  events.py              # structured progress events and plain sink
+  richreport.py          # optional live Rich matrix
+  bench.py               # orchestration, concurrency, and shared-server wiring
+  report.py              # terminal, Markdown, and JSON rendering
 ```
 
-- **Layer 0 — Profile / manifest.** The spreadsheet, as data. Source of truth
-  for the static columns and the *expected* verdicts for behavioral ones.
-- **Layer 1 — Offline conformance** (no network, always in CI). Harness
-  registers, `create_app()` builds, required routes exist, `Executor` flags are
-  internally consistent, a `BenchProfile` exists. Fast, catches structural
-  regressions.
-- **Layer 2 — Live probes** (gated on CLI + creds; reuses
-  `skip_if_harness_cli_missing`). Runs the behavioral table against a live
-  server, exactly like the existing e2e tests
-  (`/v1/sessions` + `send_user_message_to_session` +
-  `poll_session_until_terminal` + `final_assistant_text`).
-- **Report.** `python -m tests.harness_bench --harness codex` prints one
-  harness's matrix; no filter regenerates the whole sheet with a `DRIFT` column
-  diffing declared vs observed.
+Reusable configuration and runtime primitives live in production modules such
+as `omnigent.config`, `find_free_port`, and the harness registry rather than
+being reimplemented under tests.
+
+- **Layer 0 — Profile / manifest.** Static facts and declared verdicts are
+  derived from `harness_capabilities()` plus the existing e2e harness metadata.
+- **Layer 1 — Offline conformance.** No network or credentials. It validates
+  registration, profile shape, capability derivation, transport resolution,
+  rendering, and orchestration behavior in normal CI.
+- **Layer 2 — Live probes.** Drivers execute behavioral probes through the
+  wrap boundary or the real server/runner session API. Missing credentials,
+  vendor binaries, or vendor login produce capability-neutral skips.
+- **Report.** The CLI renders the declared matrix offline or reconciles live
+  observations into terminal, Markdown, and JSON reports. `DRIFT` produces a
+  non-zero exit status.
 
 ### Build on `HarnessProbe`, don't reinvent it
 
@@ -206,20 +201,18 @@ Validated for presence and shape only: `Owner`, `Transport`, `Implementation`,
 
 | Dimension | How the probe proves it |
 |---|---|
-| Basic turn (prereq) | ask model to reply with `<marker>`, assert marker in final text |
-| Connects to Omnigent MCP | expose an Omnigent tool, ask model to call it, assert `ToolCallRequest` dispatched through the relay |
-| Streaming | count `TextChunk` events: >1 delta = `deltas`, single blob = `complete-only` |
-| Model override | launch with a chosen model, assert routing (gateway request / `TurnComplete` usage model); cross-family reject verified via `model_family_mismatch` |
-| Policy: DENY | set DENY on a tool, ask model to call it, assert the call is blocked + surfaced |
-| Policy: ASK -> Elicitation | set ASK, assert an elicitation event is emitted upstream (web-surfaceable) |
-| Interrupt | start a long turn, call `interrupt_session`, assert it stops promptly |
-| Live queue (concurrent) | `enqueue_session_message` mid-turn, assert accepted (not rejected) |
-| Tool-boundary steer | inject steering text at a tool boundary, assert the next turn reflects it |
-| Resume/fork from transcript | run a convo, resume in a fresh session, assert prior context present; fork = branch diverges |
-| Compaction | assert `CompactionComplete` surfaced when triggered |
-| Reasoning | reasoning-heavy prompt, assert `ReasoningChunk` emitted |
-| Images | send an image, assert the model describes it |
-| Cost tracking | assert `TurnComplete` carries usage / cost |
+| Basic turn (P0 prerequisite) | complete a marker-echo turn and require assistant text |
+| Streaming (P0) | count output-text deltas; repeated single-delta output is `PARTIAL` |
+| Tool calling (P0) | provoke the transport's tool mechanism and require a surfaced call |
+| Policy DENY (P0) | apply a tool-call deny and require a blocked-call signal |
+| Policy ALLOW (P1) | apply an explicit allow and require a non-blocked tool output |
+| Policy ASK (P1) | apply ask and require an elicitation/approval request |
+| Model override (P0) | validate the requested harness/model pair and complete a turn |
+| Cost tracking (P1) | read priced cost or token usage from the turn/session |
+| Interrupt (P0) | interrupt a long turn and require cancellation or early termination |
+
+Planned dimensions are steering, live queue, resume/fork, reasoning, images,
+and compaction.
 
 Every behavioral probe also reads the corresponding declared flag and returns
 `DRIFT` when observed disagrees with declared.
@@ -247,80 +240,57 @@ class StreamingProbe(CapabilityProbe):
 
 ## Transport drivers: the real ceiling on "all dimensions"
 
-Behavioral probes run through a **transport driver** resolved from the
-harness *family* plus flags: SDK harnesses default to `full-server` (`--fast`
-picks `sdk-inproc`), natives use `native-tui`, and `--transport NAME` overrides
-the family for any harness. A probe calls
-*semantic* methods on the driver (`run_basic_turn`, `run_streaming_turn`,
-`run_tool_turn(deny=...)`, `run_interrupt_turn`); the driver owns the
-*mechanism* and the probe owns the *interpretation*, so one probe runs across
-transports that reach the same capability by different means.
+Behavioral probes call semantic driver methods such as `run_basic_turn`,
+`run_tool_turn`, `run_policy_turn`, and `run_interrupt_turn`. Drivers own the
+transport-specific mechanism; probes interpret a common `TurnResult`.
 
-Three drivers exist today (see "Current state" above): `sdk-inproc`,
-`full-server`, `native-tui`. Two consequences fall out of this design:
+Three drivers exist:
 
-- A dimension is only observable where a driver exercises it. Tool calling and
-  Policy DENY need `full-server`; on `sdk-inproc`/`native-tui` they report `·`.
-  A `·` therefore often means "this transport can't exercise it here," not "the
-  harness lacks it" (see "Which transport exercises which dimension").
-- A harness that invents a *novel* transport (neither wrap-subprocess, full
-  server, nor native tmux) would degrade its transport-dependent probes to
-  `SKIPPED`/`UNKNOWN` until a driver for that class exists.
+- `full-server` is the SDK-family default. It drives a real server and runner,
+  uses a server-dispatched builtin for tool probes, and observes fixed
+  ALLOW/ASK/DENY policies.
+- `native-tui` drives a resident vendor CLI in a runner-owned tmux pane through
+  the server session API. It observes vendor tool calls and tool-call DENY via
+  the native policy hook. ALLOW/ASK are not yet implemented.
+- `sdk-inproc` drives the harness wrap directly. It is selected by `--fast` and
+  provides cheaper wrap-level coverage, but no server-side policy surface.
 
-So "run the bench, see all verdicts, zero code" is true *for any harness
-reusing a known transport class*, and honest about the cases where a dimension
-or a transport is not yet wired.
+A `SKIPPED` verdict therefore means the behavior was not measurable in that
+transport or environment, not that the harness lacks the capability. A novel
+transport class still requires a driver, but harnesses reusing one of these
+families flow through the existing probes without per-harness probe code.
 
 ## Current state (shipped)
 
-The MVP and most of phase-2 are landed. What exists on `main` today:
+The bench on `main` includes:
 
-- **Layer 0/1/2** — profile/manifest, offline conformance (runs in CI via the
-  `misc` pytest group), and the six P0 live probes (basic turn, streaming,
-  tool calling, policy DENY, model override, interrupt) with the `DRIFT`
-  column.
-- **Three transport drivers**, selected by harness *family* with flag overrides:
-  - `sdk-inproc` — drives a harness wrap subprocess directly (the four P0 SDK
-    harnesses: claude-sdk, codex, pi, openai-agents).
-  - `full-server` — a real server + runner; the only transport that exercises
-    **Tool calling** and **Policy DENY** as server-dispatched, policy-gated
-    calls (SDK harnesses only — it registers via an agent bundle).
-  - `native-tui` — a resident vendor CLI in a runner-owned tmux pane, driven
-    over the session HTTP surface via a host daemon.
-
-  SDK harnesses default to **`full-server`** — the fullest coverage, and a
-  strict superset of what `sdk-inproc` observes (everything sdk-inproc does,
-  *plus* Tool calling + Policy DENY). `--fast` opts the SDK family down to
-  `sdk-inproc` when you want to skip the server boot (those two dimensions then
-  report `·`). Native harnesses have a single transport `--fast` does not touch.
-  An explicit `--transport NAME` overrides the family default for any harness
-  and is mutually exclusive with `--fast`.
-- **Capability-derived matrix** — descriptive columns and declared verdicts
-  come from `harness_capabilities()` (the seam; see
-  `designs/harness-capabilities-bench-seam.md`), so a harness added to the
-  registry — in-repo *or* a community plugin — flows into the bench with no
-  bench edit.
-- **Native harnesses auto-derived** — every `NATIVE_TUI` harness is registered
-  and drivable by name; `native_vendor()` derives what the driver needs from
-  capabilities, with no per-vendor table.
+- **Six P0 probes:** Basic turn, Streaming, Tool calling, Policy DENY, Model
+  override, and Interrupt.
+- **Three P1 probes:** Policy ALLOW, Policy ASK, and Cost tracking. P1 verdicts
+  are report-only and do not gate the same way as P0 declarations.
+- **Three transport drivers:** `full-server`, `native-tui`, and `sdk-inproc`,
+  selected by harness family with `--transport` and `--fast` overrides.
+- **Automatic live selection:** without an explicit mode, the CLI runs live
+  when credentials are resolvable and otherwise renders the declared matrix.
+  `--live` and `--no-live` force either mode. Credentials are derived like
+  `omni run`; `--profile` is only an override.
+- **Concurrent execution and shared infrastructure:** `--jobs` runs harnesses
+  concurrently while preserving report order, and full-server harnesses share
+  one server/runner pair within a run.
+- **Structured progress and reports:** plain or Rich live progress plus terminal,
+  Markdown, JSON, and optional report-file output.
+- **Capability-derived registration:** official SDK and native profiles derive
+  from `harness_capabilities()` and existing e2e metadata. Session-item parsing,
+  config loading, free-port selection, and polling helpers are shared rather
+  than duplicated.
 
 ### Not yet wired
 
-- **Bench observation of Tool calling / Policy DENY on `native-tui`** — a
-  *driver gap, not a native-harness limitation*. Native harnesses do call tools
-  and enforce permissions; the bench cannot yet observe it on this transport.
-  A native tool call is the vendor's own tool (Bash/Read/...), not a
-  server-dispatched `function_call_output` the bench can force, and a native
-  deny is a vendor permission decision, not a server-side policy evaluation the
-  probe can assert against. So both cells show `·` (not measured), never `✗`.
-  Wiring the observation needs new driver work. (SDK harnesses get these via
-  `full-server`.)
-- **P1 dimensions** — steering, live-queue, resume/fork, elicitation ASK,
-  reasoning, images, cost, compaction. Probes not written yet (report
-  `UNKNOWN`).
-- **Server-side native-agent seeding is a hardcoded list** — see the
-  plugin-seamlessness note below; this is the main gap between "the bench is
-  plugin-ready" and "a plugged-in native harness just works end to end".
+- Policy ALLOW and ASK on `native-tui`.
+- Registry-driven server seeding for community native UI agents.
+- Steering, live queue, resume/fork, reasoning, images, and compaction probes.
+- Automatic provisioning of vendor login/provider configuration for native
+  harnesses; unavailable environments skip cleanly.
 
 ## CI integration
 
@@ -332,37 +302,29 @@ The MVP and most of phase-2 are landed. What exists on `main` today:
 ## Running the bench and reading the result
 
 ```
-# Offline: the declared matrix, no creds, every harness. Fast.
-python -m tests.harness_bench
+# Declared matrix only, with no credentials.
+python -m tests.harness_bench --no-live
 
-# Live: probe one harness against a gateway profile.
-python -m tests.harness_bench --harness codex-native --profile oss
+# Auto-live when configured or ambient credentials are available.
+python -m tests.harness_bench --harness codex
 
-# Live: probe every official harness (SDK + native) sequentially.
-python -m tests.harness_bench --profile oss
+# Force a named profile and probe several harnesses concurrently.
+python -m tests.harness_bench --profile oss --jobs 4 --rich
 
 # A community harness that ships its own BenchProfile.
-python -m tests.harness_bench --harness mypkg.harness:PROFILE --profile oss
+python -m tests.harness_bench --harness mypkg.harness:PROFILE --live
 ```
 
-**You do not need to live-probe every harness on every host — and you cannot.**
-Each native harness needs its own vendor CLI logged in (a login the bench
-cannot provision), so no single host has them all. The two layers split the
-work:
+Without `--live` or `--no-live`, resolvable credentials select live mode and
+missing credentials select the offline declared matrix. Native harnesses also
+need their vendor CLI installed and logged in; the bench cannot provision those
+accounts, so unavailable harnesses skip without aborting the run.
 
-- **Offline conformance** already covers every harness in CI — registration,
-  the declared matrix, capability derivation. No host access needed.
-- **Live probes** only answer "does observed behavior match the declaration?"
-  You get value from live-probing a harness where the declaration is unverified
-  or might be wrong — not from chasing 100% coverage on one box.
-
-Run the full set on whatever host you have (`--profile oss`); harnesses whose
-vendor CLI is absent or logged out **skip cleanly** (they do not fail or abort
-the run). Read two signals only: any `!!` DRIFT, and any harness you *can* run
-that shows an unexpected `✗` / `·`. A single live run is a spot-check, not a
-gate — live probes are non-deterministic (model behavior, timing), so re-run
-before treating one `·`/timeout as a regression. Drift coverage is cumulative:
-each host that has harness X logged in contributes a live check for X.
+Offline conformance covers every registered harness in CI. Live runs are
+spot-checks of observed behavior and can vary with model behavior and timing;
+re-run an isolated timeout or skip before treating it as a regression. The
+signals that matter most are `DRIFT` and repeatable unexpected
+`UNSUPPORTED`/`PARTIAL` verdicts on a runnable harness.
 
 ## Streaming is a binary declared capability
 
@@ -386,46 +348,18 @@ stream, the bench flags a real drift on the next run, rather than a false
 
 ## Which transport exercises which dimension
 
-Not every dimension is observable on every transport, so a `·` (SKIPPED) in a
-run always means "the bench did not measure this here," never "the harness
-lacks it." Two dimensions in particular only get a real verdict on the
-`full-server` transport:
-
-| Dimension | sdk-inproc (`--fast`) | full-server (default) | native-tui |
+| Dimension | `sdk-inproc` (`--fast`) | `full-server` (SDK default) | `native-tui` |
 |---|---|---|---|
-| Basic turn, Streaming, Model override, Interrupt | ✓ | ✓ | ✓ |
-| **Tool calling** | · (harness dispatches tools internally) | ✓ (server-dispatched builtin) | · (bench can't observe vendor tools yet) |
-| **Policy DENY** | · (wrap-direct: no tool-call policy hook) | ✓ (spec-baked deny, enforced) | · (bench can't observe vendor deny yet) |
+| Basic turn, Streaming, Model override, Interrupt | Wrap-level observation | End-to-end server/runner observation | End-to-end server/runner/vendor observation |
+| Tool calling | Request-level wrap tool | Server-dispatched builtin | Vendor tool mirrored into session items |
+| Policy DENY | Not observable | Fixed policy blocks the builtin | Session CEL policy triggers the native policy hook |
+| Policy ALLOW / ASK | Not observable | Fixed policy; ASK observes and resolves an elicitation | Not implemented |
+| Cost tracking | Completed-response usage when forwarded | Session snapshot usage/cost | Session snapshot when the vendor forwards usage |
 
-The `native-tui` `·` is a *bench observation gap, not a native-harness
-limitation*: native harnesses do call tools and enforce permissions, but a
-native tool call is the vendor's own (Bash/Read/...) and a native deny is a
-vendor permission decision, neither of which is the server-dispatched,
-policy-gated call the probe watches for. Giving those cells a real verdict
-needs new driver work, not a change to the harnesses.
-
-Because `full-server` sees everything `sdk-inproc` does *plus* these two, it is
-the **default** for SDK harnesses — a plain live run proves Tool calling and
-Policy DENY out of the box:
-
-```
-python -m tests.harness_bench --harness claude-sdk --profile oss
-```
-
-Live-verified: `claude-sdk` completes the full matrix on `full-server` —
-Tool calling `✓` and Policy DENY `✓` (the deny is delivered and the blocked
-call does not stall the turn). Add `--fast` to trade that coverage for a quicker
-run on `sdk-inproc`; those two columns then show `·`, since neither `sdk-inproc`
-nor `native-tui` (for natives) routes a tool call through a server policy
-evaluation.
-
-`full-server` covers **SDK harnesses only** — it registers the harness via an
-agent bundle, which is the SDK-wrap path; native harnesses need the host-daemon
-provisioning the `native-tui` driver owns. So Tool calling / Policy DENY on
-native harnesses are not observed by *any* transport yet — a bench follow-up,
-not a native-harness gap — distinct from the `--fast` (sdk-inproc) `·`, which
-is a transport limitation the default `full-server` run already answers for SDK
-harnesses.
+`full-server` remains the SDK default because it covers the deployed server
+path and all three policy actions. `--fast` trades that policy coverage for
+lower startup cost. `native-tui` now has real Tool calling and Policy DENY
+coverage; its remaining policy gap is ALLOW/ASK.
 
 ## Plugin seamlessness: where it is and isn't
 
@@ -478,25 +412,13 @@ agree with it.
 
 ## Open items
 
-- **Registry-driven native-agent seeding** (highest leverage) — replace the
-  hardcoded `_ensure_default_*_agent()` list in `server/app.py` with a loop over
-  `native_agents()`, so any native harness (in-repo or plugin) registers
-  automatically. This is the fix for the plugin-seamlessness seam above.
-- **Bench observation of Tool calling / Policy DENY on `native-tui`** — a
-  driver gap, not a native-harness limitation: native harnesses call tools and
-  enforce permissions, but a native tool call is the vendor's own and a native
-  deny is a vendor permission decision, not the server-dispatched
-  `function_call_output` the probe watches for. The cells show `·` (not
-  measured), never `✗`. Needs new driver work. (SDK harnesses get these via
-  `full-server`.)
-- **Per-harness native provisioning gaps** the bench has surfaced but not yet
-  resolved: goose-native returns a 500 on the terminal-ensure endpoint;
-  hermes-native's forwarder does not wire up (a lazy-chat / first-turn gate to
-  confirm); kimi-native and own-auth natives need a vendor provider setup the
-  bench cannot provision (kimi in particular has no gateway path — it routes
-  via `kimi provider add`, out of band).
-- **P1 dimensions + their probes** — steering, live-queue, resume/fork,
-  elicitation ASK, reasoning, images, cost, compaction.
-- Exact `BenchProfile` field set and whether it subsumes `HarnessProbe` or wraps
-  it; whether the manifest fully retires the spreadsheet or diffs against an
-  exported CSV during transition.
+- **Registry-driven native-agent seeding** — replace the hardcoded server
+  seeding list with registry iteration so community native harnesses work end
+  to end after plugin installation.
+- **Policy ALLOW / ASK on `native-tui`** — attach and observe native allow/ask
+  policies with the same rigor as the shipped native DENY probe.
+- **Per-harness native provisioning** — some vendors require login or provider
+  configuration that the bench deliberately cannot create. Improve diagnostics
+  where possible while retaining clean skips.
+- **Additional dimensions** — steering, live queue, resume/fork, reasoning,
+  images, and compaction.

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -1,9 +1,8 @@
 # Harness test bench
 
-A standardized, pluggable conformance suite that probes a harness and
-reports a verdict per capability dimension, reconciling observed behavior
-against a self-declared profile to surface drift. Design and rationale:
-[`docs/harness-bench-design.md`](../../docs/harness-bench-design.md).
+A pluggable conformance suite that probes harness behavior and reconciles the
+observed verdicts with the capability model to surface drift. Design and
+rationale: [`docs/harness-bench-design.md`](../../docs/harness-bench-design.md).
 
 ## Run it
 
@@ -11,227 +10,155 @@ against a self-declared profile to surface drift. Design and rationale:
 # List official harnesses (name, resolved transport, model).
 python -m tests.harness_bench --list
 
-# Offline (declared) matrix -- no turns, no creds.
-python -m tests.harness_bench
+# Force the declared-only matrix: no turns and no credentials required.
+python -m tests.harness_bench --no-live
 
-# Live probe one harness against a gateway profile.
+# Probe one harness. Credentials are resolved like `omni run`.
+python -m tests.harness_bench --harness codex
+
+# Override the configured/ambient Databricks profile.
 python -m tests.harness_bench --harness codex --profile my-profile
 
-# Live probe every official harness, several at a time, with a live table.
-python -m tests.harness_bench --profile my-profile --jobs 4 --rich
+# Probe several harnesses concurrently with the live table.
+python -m tests.harness_bench --jobs 4 --rich
 ```
 
-A non-zero exit means a `DRIFT` cell was found (observed behavior disagrees
-with the declared matrix).
+Without `--live` or `--no-live`, the CLI runs live when gateway credentials are
+resolvable and otherwise renders the declared matrix offline. Credential
+resolution follows `omni run`: existing ambient `OPENAI_*` routing is
+preserved; otherwise `--profile` overrides the configured profile. A
+non-zero exit means at least one `DRIFT` cell was found.
 
 ### Flags
 
-- `--profile NAME` -- Databricks gateway profile. Enables the live layer;
-  without it the bench renders the declared matrix offline.
-- `--harness NAME` -- probe one harness (repeatable). An official name, or a
-  `module:attr` / `module.ATTR` reference to a community `BenchProfile`.
+- `--live` / `--no-live` -- force live probing or the declared-only matrix.
+  `--live` requires resolvable gateway credentials.
+- `--profile NAME` -- optional Databricks profile override; it is not required
+  when config or ambient `OPENAI_*` already supplies credentials.
+- `--harness NAME` -- probe one harness (repeatable). Accepts an official name
+  or a `module:attr` / `module.ATTR` reference to a community `BenchProfile`.
   Defaults to every official harness.
 - `--fast` -- run SDK harnesses on `sdk-inproc` instead of the `full-server`
-  default: skips the server boot for a quicker run, at the cost of the Tool
-  calling + Policy DENY dimensions (they report `·`). No effect on natives.
-  Mutually exclusive with `--transport`.
-- `--transport NAME` -- force a specific transport driver (`sdk-inproc`,
-  `full-server`, `native-tui`), overriding the family default.
+  default. This skips server startup, but policy ALLOW/ASK/DENY are not
+  observable and tool/cost verdicts are limited to what the wrap forwards.
+  It has no effect on native harnesses and is mutually exclusive with
+  `--transport`.
+- `--transport NAME` -- force `sdk-inproc`, `full-server`, or `native-tui`,
+  overriding the harness-family default.
 - `--jobs N` / `-j N` -- run up to N harnesses concurrently (default 1).
-  Probes within a harness stay sequential; 3-4 is a reasonable ceiling on one
-  host. Report order always matches input order.
-- `--rich` / `--no-rich` -- force / disable the live progress table (auto: rich
-  on a TTY, plain per-line output otherwise).
-- `--report PATH` -- also write the final matrix to PATH; format follows
-  `--json` / `--markdown`, else inferred from the extension.
+  Probes within one harness remain sequential and report order is stable.
+- `--rich` / `--no-rich` -- force or disable the live progress table. Auto mode
+  uses Rich on a TTY and plain per-line output otherwise.
+- `--report PATH` -- also write the final matrix. Format follows `--json` or
+  `--markdown`, then the filename extension.
 
-### Output formats (mutually exclusive)
+### Output formats
 
-- default: an aligned, ANSI-colored terminal table (color auto-disables when
-  piped or with `--no-color`), followed by a Notes section explaining every
-  non-supported cell so a `·` is never opaque.
-- `--markdown`: the GitHub-flavored table for docs / PRs.
-- `--json`: machine-readable, for diffing runs or regenerating docs.
+- Default: aligned terminal table plus Notes for every non-supported cell.
+  Color disables automatically when piped or with `--no-color`.
+- `--markdown`: GitHub-flavored table for docs and pull requests.
+- `--json`: machine-readable output for diffing runs or regenerating docs.
 
-Each row is labelled with the transport that actually ran it, e.g.
-`claude-sdk [full-server]`, `kimi-native [native]`.
-
-Under `--rich`, the live table (on stderr) already shows the grid, so the
-stdout report drops the grid and prints only the legend + notes -- no duplicate
-table. When stdout is redirected to a file, the report keeps the full grid so
-the file is self-contained.
-
-### Example output
-
-A live `--rich` run of the four SDK harnesses on the `oss` profile:
-
-```console
-$ uv run --no-sync python -m tests.harness_bench --profile oss --rich \
-    --harness claude-sdk --harness codex --harness pi --harness openai-agents
-
-                              Harness capability matrix (live)
-┌───────────────────────────┬────────────┬───────────┬──────────────┬─────────────┬────────────────┬───────────┐
-│ Harness                   │ Basic turn │ Streaming │ Tool calling │ Policy DENY │ Model override │ Interrupt │
-├───────────────────────────┼────────────┼───────────┼──────────────┼─────────────┼────────────────┼───────────┤
-│ claude-sdk  [full-server] │     ✓      │     ✓     │      ✓       │     ✓       │       ✓        │     ✓     │
-│ codex       [full-server] │     ✓      │     ✓     │      ✓       │     ·       │       ✓        │     ✓     │
-│ pi          [full-server] │     ✓      │     ✓     │      ✓       │     ✓       │       ✓        │     ✓     │
-│ openai-agents [full-server] │   ✓      │     ✓     │      ✓       │     ✓       │       ✓        │     ✓     │
-└───────────────────────────┴────────────┴───────────┴──────────────┴─────────────┴────────────────┴───────────┘
-Legend: `✓` SUPPORTED · `~` PARTIAL · `✗` UNSUPPORTED · `—` NOT_APPLICABLE · `?` UNKNOWN · `·` SKIPPED · `!!` DRIFT
-
-Notes:
-- codex / Policy DENY: · model never attempted the tool; tool-call DENY path not exercised
-```
-
-The `·` in codex / Policy DENY is a clean SKIP, not a failure: the model simply
-never reached for the gated tool, so the deny path had nothing to block (see the
-Notes line). Every non-`✓` cell gets a matching Notes entry.
+Each row includes the transport that actually ran it, such as
+`claude-sdk [full-server]` or `kimi-native [native]`. Under `--rich`, the live
+table is rendered on stderr; the stdout report avoids printing the grid twice,
+but redirected output remains self-contained.
 
 ## Transport selection
 
-A profile's `transport` field is the harness *family* marker, not the literal
-driver the run uses:
+A profile's `transport` is a harness-family marker. The resolved driver is:
 
-- **SDK-family** harnesses default to **`full-server`** -- the fullest
-  coverage, and a superset of what `sdk-inproc` observes: it drives every
-  dimension through the real server API the web UI uses, and adds Policy DENY
-  (a server-dispatched builtin under a spec-baked deny policy), which the
-  wrap-direct `sdk-inproc` path cannot see. `--fast` opts them down to
-  `sdk-inproc` (Policy DENY then reports `·`; see "What a ✓ actually means").
-- **native** harnesses use `native-tui` (a resident vendor CLI in a
-  runner-owned tmux pane); `--fast` does not apply.
-- `--transport NAME` overrides the family default for any harness.
+- **SDK family:** `full-server` by default. This runs through a real server and
+  runner and observes server-dispatched tools plus fixed ALLOW/ASK/DENY policy
+  behavior. `--fast` selects the cheaper wrap-direct `sdk-inproc` driver.
+- **Native family:** `native-tui`, which drives a resident vendor CLI in a
+  runner-owned tmux pane through the server session API.
+- `--transport NAME` overrides the family default when the driver supports the
+  selected harness.
 
-## What it reports (dimensions)
+## Dimensions
 
-Each probe drives one real turn and watches what the harness does:
+| Probe | What it verifies | Priority |
+| --- | --- | --- |
+| **Basic turn** | A turn completes and returns assistant text. | P0 |
+| **Streaming** | More than one output-text delta is emitted; a repeated single delta is `PARTIAL`. | P0 |
+| **Tool calling** | A tool call is surfaced and the turn closes after its result. | P0 |
+| **Policy DENY** | A tool-call policy blocks the call. | P0 |
+| **Policy ALLOW** | An explicit allow policy lets the call proceed. | P1 |
+| **Policy ASK** | An ask policy raises an approval elicitation. | P1 |
+| **Model override** | The harness accepts and completes with the requested model. | P0 |
+| **Cost tracking** | A completed turn reports priced cost (`SUPPORTED`) or tokens only (`PARTIAL`). | P1 |
+| **Interrupt** | A running turn stops after interruption. | P0 |
 
-| Probe | In plain terms |
-| --- | --- |
-| **Basic turn** | Can it hold a conversation at all? Asks it to echo a marker and checks the marker comes back -- the "is it alive" test. |
-| **Streaming** | Does the answer arrive incrementally (word-by-word) or all at once at the end? Counts the token-level chunks. |
-| **Tool calling** | Can it use a tool (run a command, read a file) mid-answer, not just chat? |
-| **Policy DENY** | If a policy says "block that tool", does the harness actually enforce it? |
-| **Policy ALLOW** | If a policy explicitly allows the tool, does the call actually go through (not just "wasn't blocked")? |
-| **Policy ASK** | If a policy says "ask first", does the tool call pause for an approval prompt (an elicitation) the way the web UI would show? |
-| **Model override** | If you ask for a specific model, does it actually run that one? |
-| **Cost tracking** | Does a completed turn report what it spent? `✓` a priced USD cost, `~` tokens only (unpriced model), `·` no usage surfaced. Gates any future cost *policy* -- a cost budget is a no-op without this. |
-| **Interrupt** | If you stop it mid-answer, does it actually stop? |
+Verdicts are `SUPPORTED` (`✓`), `PARTIAL` (`~`), `UNSUPPORTED` (`✗`),
+`NOT_APPLICABLE` (`—`), `UNKNOWN` (`?`), `SKIPPED` (`·`), and `DRIFT` (`!!`).
+A skip means the bench could not measure the behavior in that environment or
+transport; it does not claim the harness lacks the capability.
 
-Each cell is a verdict: **✓** works, **✗** doesn't, **·** couldn't be tested
-here (see below), **!!** the harness *declared* it works but the probe observed
-otherwise (drift).
+### Coverage by transport
 
-## What a ✓ actually means (read before trusting a green cell)
-
-A ✓ is only as strong as the *layer the probe drove it through*, and that layer
-depends on the transport. There are three:
-
-- **`full-server`** (SDK-family default) and **`native-tui`** (native default)
-  both drive a turn through a **real Omnigent server + runner over the same HTTP
-  API the web UI uses** -- `POST /v1/sessions/{id}/events` to send and
-  `GET /v1/sessions/{id}/stream` (SSE) to observe. So a ✓ here means the
-  capability works end-to-end through the **exact server contract the browser
-  depends on** -- real server, real runner, real harness subprocess.
-- **`sdk-inproc`** (only under `--fast`) drives the **harness *wrap* subprocess
-  directly**, bypassing the server + runner. A ✓ here means "the harness wrap
-  can do it", *not* "it works through the deployed server path the web UI hits".
-  This is the documented trade-off of `--fast`, and why full-server is the SDK
-  default.
-
-**The one caveat that applies to every transport:** the bench is a *headless
-HTTP client* of that API. It validates the server-side contract the web UI
-consumes (endpoints accept the turn, the harness runs it, the right SSE events
-flow) -- it does **not** run the browser / React layer, so it cannot catch a UI
-that mis-*renders* a correct event. For "does the pixel show up", that is the
-Playwright `tests/e2e_ui/` suite, not this bench.
-
-### Per-dimension, per-transport: what a ✓ verifies
-
-Rows are the dimensions; columns are the three transports. "server API"
-(full-server / native-tui) means the ✓ was observed over the same
-`/v1/sessions/...` surface the web UI uses; "wrap" (sdk-inproc, `--fast`) means
-it was observed at the harness-wrap boundary, below the server.
-
-| Dimension | `full-server` (SDK default) | `native-tui` (native default) | `sdk-inproc` (`--fast`) |
+| Dimension | `full-server` | `native-tui` | `sdk-inproc` (`--fast`) |
 | --- | --- | --- | --- |
-| **Basic turn** | ✓ = turn completes over the server API | ✓ = turn completes over the server API | ✓ = turn completes at the wrap (no server) |
-| **Streaming** | ✓ = token deltas seen on the server SSE stream | ✓ = token deltas seen on the server SSE stream | ✓ = deltas seen on the wrap SSE (no server) |
-| **Tool calling** | ✓ = a server-dispatched builtin call was made + turn closed | ✓ = the vendor's own tool call surfaced as a server `function_call` item | ✓ = a request-level tool call surfaced at the wrap |
-| **Policy DENY** | ✓ = a spec-baked `tool_call` deny policy blocked the call | ✓ = a session-attached CEL deny fired `response.policy_denied` | `·` = the wrap path has no server-side policy hook |
-| **Policy ALLOW** | ✓ = a spec-baked `allow` policy let the call proceed (non-blocked output) | `·` = CEL allow/ask attach is a follow-up | `·` = no server-side policy hook |
-| **Policy ASK** | ✓ = a spec-baked `ask` policy raised `response.elicitation_request` (then resolved) | `·` = follow-up | `·` = no elicitation surface |
-| **Model override** | ✓ = the requested model was the one used | ✓ = the requested model was the one used | ✓ = the requested model was the one used |
-| **Cost tracking** | ✓/~ = usage read from the session snapshot (`total_cost_usd` / `last_total_tokens`) | ✓/~ = usage from the snapshot (native `session.usage`) | ✓/~ if the wrap forwards `usage` on `response.completed`, else `·` |
-| **Interrupt** | ✓ = a mid-turn cancel stopped the turn (server marker) | ✓ = a mid-turn cancel surfaced `session.interrupted` | ✓ = a mid-turn cancel stopped the wrap turn |
+| Basic turn, Streaming, Model override, Interrupt | End-to-end through server + runner | End-to-end through server + runner + vendor CLI | Wrap boundary only |
+| Tool calling | Server-dispatched builtin | Vendor tool mirrored as a session item | Request-level wrap tool |
+| Policy DENY | Fixed policy in the agent spec | Session CEL policy + native policy hook | Not observable |
+| Policy ALLOW / ASK | Fixed policy; ASK observes and resolves an elicitation | Not implemented | Not observable |
+| Cost tracking | Session snapshot | Session snapshot when the vendor forwards usage | Completed-response usage when forwarded |
 
-So for the harnesses users actually reach through the web UI (SDK on
-`full-server`, natives on `native-tui`), **a ✓ does mean the capability works
-end-to-end through the server API the UI relies on** -- minus the browser render
-layer. The cells that read `·` purely for a transport reason are the policy
-verdicts where a transport has no server-side policy surface: Policy DENY under
-`--fast`, and Policy ALLOW / ASK anywhere but `full-server` (their `native-tui`
-attach is a follow-up). On the default SDK run (`full-server`) all three policy
-verdicts are real `✓`.
-
-### Why a `·` appears
-
-A `·` always means "the bench did not measure this *here*", never "the harness
-lacks it". Two causes:
-
-- **Transport can't observe it** -- Policy DENY under `--fast` (the wrap path has
-  no server-side policy hook). Run without `--fast` for a real verdict.
-- **The run diagnosed a clean skip** -- e.g. the model never reached for the
-  offered tool (Tool calling / Policy DENY can't be judged if no call happened),
-  a vendor CLI is not installed / not logged in, or creds could not be resolved.
-  Every `·` gets a matching Notes line explaining which.
+The bench is a headless client of the server API. It verifies the contract the
+web application consumes, not browser rendering; UI presentation belongs in
+`tests/e2e_ui/`.
 
 ## Layout
 
 | File | Role |
 | --- | --- |
-| `verdict.py` | `Verdict` / `Priority` / `ProbeResult` and the `reconcile` drift check |
-| `profile.py` | `BenchProfile` (per-harness self-declaration) + name resolution |
-| `manifest.py` | Official profiles, derived from the capability model + `tests/e2e/_harness_probes.py` |
-| `transport.py` | `Driver` protocol, driver registry, family/flag transport resolution |
-| `driver.py` | `SdkInprocDriver` (harness wrap over SSE) + `ProvisioningError` |
-| `full_server.py` | `SharedFullServer` -- real server+runner lifecycle + agent/session registration |
-| `full_server_driver.py` | `FullServerDriver` -- runs probes against a (owned or shared) full server |
-| `native_tui_driver.py` | `NativeTuiDriver` -- vendor CLI in tmux via a host daemon; native vendor auto-derivation |
-| `probes/` | One module per dimension; `ALL_PROBES` is the registry |
-| `events.py` | Structured `BenchEvent`s + `ProgressSink` / `LineSink` |
-| `richreport.py` | `rich.Live` progress table (optional-dep; falls back to `LineSink`) |
-| `bench.py` | Orchestrator: probes x harnesses -> `BenchMatrix`, `--jobs`, shared-server wiring |
-| `report.py` | Terminal / Markdown / JSON renderers |
-| `test_bench.py` | Offline conformance (always) + live layer (gated on `--profile`) |
+| `verdict.py` | Verdicts, priorities, probe results, and drift reconciliation |
+| `profile.py` | `BenchProfile` and profile-name resolution |
+| `manifest.py` | Official profiles derived from the capability registry and e2e probe metadata |
+| `transport.py` | Driver protocol, registry, and transport resolution |
+| `driver.py` | `SdkInprocDriver`, shared `TurnResult`, and usage helpers |
+| `full_server.py` | Shared server/runner lifecycle and agent/session registration |
+| `full_server_driver.py` | Full-server probe implementation and shared polling |
+| `native_tui_driver.py` | Native vendor CLI provisioning and native probe implementation |
+| `session_items.py` | Shared parsing for session-item envelope shapes |
+| `runtime_env.py` | Credential/config resolution shared with the normal runtime behavior |
+| `probes/` | One module per dimension; `ALL_PROBES` defines display and run order |
+| `events.py` / `richreport.py` | Structured progress events and optional Rich rendering |
+| `bench.py` | Orchestration, concurrency, prerequisite handling, and shared-server wiring |
+| `report.py` | Terminal, Markdown, and JSON renderers |
 
-## Add a harness
+Reusable production helpers live in `omnigent.config` and the existing runtime
+utility modules rather than being duplicated in the bench.
 
-- **Official SDK:** add a `BenchProfile` to `manifest.py` (base fields come
-  from `_harness_probes.HARNESS_PROBES`). No probe or driver edits.
-- **Native:** nothing to add -- every harness the capability model marks
-  `NATIVE_TUI` (in-repo or a community plugin) is auto-derived into the matrix
-  and drivable by name; `native_vendor()` derives what the driver needs.
-- **Community / out-of-repo:** ship a `BenchProfile` and select it by
-  reference: `--harness mypkg.harness:PROFILE`. No bench edits.
+## Extending the bench
 
-## Add a dimension
+### Add a harness
 
-Add a `CapabilityProbe` subclass under `probes/`, list it in
-`probes/__init__.py:ALL_PROBES`, and add its declared verdict to the profiles
-(or derive it from the capability model in `manifest.py`). Probes are
-harness-agnostic -- they only call the driver's semantic methods.
+- **Official SDK:** register the harness normally; base probe metadata and
+  capabilities flow into the manifest without a new driver.
+- **Native:** every harness marked `NATIVE_TUI` is derived automatically;
+  `native_vendor()` derives its launch metadata from capabilities.
+- **Community:** ship a `BenchProfile` and select it with
+  `--harness mypkg.harness:PROFILE`.
 
-## Scope
+A community native harness is recognized by the bench, but the server still
+needs a seeded native UI agent. Registry-driven native-agent seeding remains an
+open platform item.
 
-Live today: the dimensions in the table above (including `cost_tracking` and
-Policy ALLOW / ASK on `full-server`); all three transports (`sdk-inproc`,
-`full-server`, `native-tui`); the four official SDK harnesses (claude-sdk,
-codex, pi, openai-agents) plus every registered native. Tool calling and Policy
-DENY are observed on `native-tui` too (landed separately). Not yet wired (see
-the design doc's open items): Policy ALLOW / ASK on `native-tui` (a CEL
-allow/ask attach, the way native DENY works), registry-driven server-side
-native-agent seeding, the MCP-tool vs harness-native-tool distinction, and
-further dimensions (steering, live-queue, resume/fork, elicitation, reasoning,
-images, compaction).
+### Add a dimension
+
+Add a `CapabilityProbe` under `probes/`, register it in
+`probes/__init__.py:ALL_PROBES`, add a semantic method to the driver protocol,
+and derive or declare the expected verdict. Keep transport-specific mechanics
+inside drivers so probes remain harness-agnostic.
+
+## Current gaps
+
+- Policy ALLOW and ASK are not yet observable on `native-tui`.
+- Native agent seeding in the server is still hardcoded rather than driven by
+  the harness registry, which limits community-native end-to-end execution.
+- Some native harnesses require vendor login/provider setup that the bench
+  cannot provision and therefore skip cleanly.
+- Steering, live queue, resume/fork, reasoning, images, and compaction do not
+  yet have probes.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Refresh the harness bench README and design document after the transport/refactor work landed.
- Document automatic live/offline selection, all current P0/P1 probes, native Tool/DENY coverage, shared runtime helpers, and the remaining gaps.
- Remove stale phase-2 plans and examples that no longer match the CLI or drivers.

**ELI5:** The bench documentation described an older version with fewer checks and different command behavior. This update makes the instructions match what the bench currently runs.

```text
CLI mode + credentials
        |
        v
transport resolver --> semantic probes --> declared/observed reconciliation
        |                                      |
        +-- full-server / native / fast -------+--> terminal / Markdown / JSON
```

## Test Plan

- Ran applicable pre-commit checks for both Markdown files.
- Ran `uv run --no-sync python -m tests.harness_bench --no-live --harness codex --json` and verified it produced the declared JSON matrix.
- Scanned both documents for stale phase/status claims.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Documentation-only change. Manually verified the documented offline command and checked the content against the current CLI, probe registry, and transport drivers.
