### PR TITLE
perf(search): keep snippet fetch on the conversation_items index

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -456,7 +456,12 @@ def _fetch_search_snippets(
     if not conversation_ids or not query:
         return {}
     pattern = f"%{query.lower()}%"
+    workspace_id = current_workspace_id()
+    # workspace_id leads the (workspace_id, conversation_id, position) index.
+    # Both the aggregate and the join-back below must include it or Postgres
+    # can't use that index and falls back to a full table scan of every item.
     match_pred = and_(
+        SqlConversationItem.workspace_id == workspace_id,
         SqlConversationItem.conversation_id.in_(conversation_ids),
         func.lower(SqlConversationItem.search_text).like(pattern),
     )
@@ -471,7 +476,8 @@ def _fetch_search_snippets(
         .group_by(SqlConversationItem.conversation_id)
         .subquery()
     )
-    # Join back to pull exactly one search_text body per conversation.
+    # Join back to pull exactly one search_text body per conversation. The
+    # workspace_id predicate keeps this on the composite index.
     rows = session.execute(
         select(
             SqlConversationItem.conversation_id,
@@ -479,6 +485,7 @@ def _fetch_search_snippets(
         ).join(
             earliest,
             and_(
+                SqlConversationItem.workspace_id == workspace_id,
                 SqlConversationItem.conversation_id == earliest.c.cid,
                 SqlConversationItem.position == earliest.c.pos,
             ),


### PR DESCRIPTION
## Related issue

N/A

## Summary

`GET /v1/sessions?search_query=` got slower after the matched-content preview landed (#2162). The cause is in `_fetch_search_snippets`, the second query that builds the snippet excerpts.

That helper filtered and joined on `conversation_id` + `position` but **omitted `workspace_id`** — the *leading* column of the only covering index `(workspace_id, conversation_id, position)`. A B-tree can't be used if you skip its leading column, so Postgres fell back to a **full `Seq Scan` of every `conversation_item`** just to fetch the ~20 snippet bodies for a search page. The scan cost grows with the whole corpus, so it roughly doubled search latency.

Adding `workspace_id` to both the `MIN(position)` aggregate and the join-back keeps both on the composite index.

```
snippet query (Query B):   430–680ms (Seq Scan)  →  ~7ms (Index Scan)
```

No behavior change — same rows, same earliest-match snippet text.

## Test Plan

Measured on a local Postgres corpus (5,002 sessions, 1,000,014 items) via `dev/benchmarks/omnigent/run.py --journeys search_sessions`:

| | P50 | Mean |
|---|---|---|
| `origin/main` | 571 ms | 607 ms |
| this PR | **315 ms** | **324 ms** |

- `EXPLAIN ANALYZE` confirms the snippet join-back switches from `Seq Scan on conversation_items (rows=1,000,014)` to `Index Scan using ix_conversation_items_conversation_id_position`.
- `pytest tests/stores/test_conversation_store.py -k "snippet or search"` → 8 passed (existing coverage; earliest-match, title-only, absent-without-query all still hold).
- Verified on the real corpus that every returned snippet contains the query term and the earliest matching item wins.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is a query-plan optimization with no behavioral change, so existing snippet tests (`test_list_conversations_search_snippet_*`) fully cover correctness. Manual verification was the benchmark + `EXPLAIN ANALYZE` before/after on a realistic Postgres corpus, since the index effect only shows against a large dataset that the unit tests (SQLite, tiny) don't exercise.

## Changelog

Session search returns matched-content previews faster on large histories.
