### PR TITLE
perf(harness-bench): tighten native timeouts so broken harnesses fail fast

### DIFF
--- a/tests/harness_bench/full_server.py
+++ b/tests/harness_bench/full_server.py
@@ -45,7 +45,9 @@ from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.runtime_env import BenchRuntimeEnv
 
 _REPO_ROOT = str(Path(__file__).resolve().parents[2])
-_HEALTH_TIMEOUT_S = 90.0
+# Server+runner boot is local; 45s is a "clearly failed to start" ceiling with
+# cold-start headroom, not an expected wait (a healthy boot is a few seconds).
+_HEALTH_TIMEOUT_S = 45.0
 _POLL_INTERVAL_S = 0.2
 
 # The builtin the tool/policy probes drive: read-only, zero setup, server-

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -41,11 +41,16 @@ from tests.harness_bench.runtime_env import (
 )
 from tests.harness_bench.session_items import assistant_text, function_calls, item_role, item_type
 
-_HEALTH_TIMEOUT_S = 90.0
-_HOST_ONLINE_TIMEOUT_S = 45.0
+# Timeouts are "clearly stuck" ceilings, not expected durations: provisioning is
+# local (server/runner/host/forwarder boot, no model call) and a healthy native
+# turn streams within seconds. A run that blows these is a cold-start on a slow
+# CLI or a connection/network problem, not normal latency — so keep them tight
+# enough that a broken harness fails fast, with cold-start headroom.
+_HEALTH_TIMEOUT_S = 45.0
+_HOST_ONLINE_TIMEOUT_S = 30.0
 _POLL_INTERVAL_S = 0.3
-_TURN_TIMEOUT_S = 180.0
-_FORWARDER_READY_TIMEOUT_S = 90.0
+_TURN_TIMEOUT_S = 60.0
+_FORWARDER_READY_TIMEOUT_S = 45.0
 
 _STREAM_PROMPT = "Count from 1 to 20 in words, one per line."
 _LONG_PROMPT = "Write a detailed 500-word essay about the history of computing."
@@ -60,9 +65,9 @@ _POLICY_DENIED_EVENT = "response.policy_denied"
 
 _CEL_POLICY_HANDLER = "omnigent.policies.builtins.cel.cel_policy"
 _NATIVE_DENY_REASON = "bench-native-tool-deny"
-_TOOL_TURN_TIMEOUT_S = 180.0
+_TOOL_TURN_TIMEOUT_S = 60.0
 # policy_denied may arrive after output_item.done.
-_DENY_OBSERVE_S = 30.0
+_DENY_OBSERVE_S = 15.0
 
 _INTERRUPT_HOLD_S = 2.0
 _READER_TERMINAL = frozenset({_OUTPUT_DONE_EVENT, _FAILED_EVENT, _INTERRUPTED_EVENT})
@@ -282,7 +287,7 @@ class NativeTuiDriver:
                 "session_key": "main",
                 "ensure_native_terminal": True,
             },
-            timeout=90.0,
+            timeout=_FORWARDER_READY_TIMEOUT_S,
         )
         ensure.raise_for_status()
         with contextlib.suppress(Exception):


### PR DESCRIPTION
## Summary

A full-matrix native run spent minutes in dead waits, which read as "the policy
parts are slow" but were actually the native provisioning/turn timeouts being
far too generous. Two dominant sinks:

- A broken vendor forwarder burned the full **90s** `_FORWARDER_READY_TIMEOUT_S`
  before SKIPping (e.g. `kimi-native`, `hermes-native` in a recent run).
- A model that stalled a turn burned the full **180s** `_TURN_TIMEOUT_S` /
  `_TOOL_TURN_TIMEOUT_S` (e.g. `cursor-native` basic turn, `kiro`/`qwen` tool /
  cost turns).

These are "clearly stuck" ceilings, not expected durations. Native provisioning
is local (server / runner / host-daemon / forwarder boot, no model call), and a
healthy native turn streams within seconds. A run that blows these is a
cold-start on a slow CLI or a connection/network issue, not normal latency -- so
they can be tight, with cold-start headroom.

Changes (native driver + full_server):

- `_TURN_TIMEOUT_S` / `_TOOL_TURN_TIMEOUT_S` 180 -> 60
- `_FORWARDER_READY_TIMEOUT_S` 90 -> 45 (and the terminal-ensure HTTP `timeout`
  now references it instead of a separate hardcoded 90)
- `_HEALTH_TIMEOUT_S` 90 -> 45 (native + full_server; same server+runner boot)
- `_HOST_ONLINE_TIMEOUT_S` 45 -> 30
- `_DENY_OBSERVE_S` 30 -> 15 (post-tool-call grace window for `response.policy_denied`)

Worst case for a broken/stalled harness drops from ~90-180s to ~45-60s per
stall; a whole-harness provisioning failure now fails in ~45s instead of 90s.
Healthy runs are unaffected -- they finish well under the new ceilings. The live
gated full-server tests keep their explicit `timeout=180` (real gateway turns
against a live model, a different budget).

Note on the policy cells specifically: native Policy ALLOW / ASK are instant `·`
(the driver returns unmeasured -- not wired on native yet), so they were never
the slow part; the wall-clock was provisioning + turn timeouts, which this
targets.

## Test Plan

- `python -m pytest tests/harness_bench/` -> 114 passed, 18 skipped.
- `ruff check` clean; no `uv.lock` drift.
- The reduction is verifiable on a native run: a broken/absent-forwarder harness
  now SKIPs in ~45s instead of 90s, and a stalled turn caps at 60s instead of
  180s. Healthy natives (claude/codex/pi) are well under the new ceilings.

## Demo

N/A -- timeout tuning; the effect is faster failure on the sad path.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance / internal change
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] UI / frontend change

## Test coverage

- [ ] Added or updated automated tests
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Pure constant tuning -- no new behavior to unit-test; the existing bench suite
(114 passed) confirms nothing regressed. The wall-clock improvement is a live-run
property (broken harness fails in ~45s not 90s); the numbers keep cold-start
headroom so healthy runs are unaffected.
