### PR TITLE
chore(ci): Update Discord watch rotation

### DIFF
--- a/.github/scripts/rotation.py
+++ b/.github/scripts/rotation.py
@@ -65,7 +65,6 @@ PEOPLE: list[Person] = [
     Person("Daniel Lok", "U060CNWNHSQ", "Asia/Singapore"),
     Person("Dhruv Gupta", "U0A76097E1F", "America/Los_Angeles"),
     Person("Edwin He", "U077B1V6WQJ", "America/Los_Angeles"),
-    Person("Kecheng Cao", "U03NKUCH5HP", "America/Los_Angeles"),
     Person("Pat Sukprasert", "U05HRKWFY81", "Asia/Singapore"),
     Person("Sabhya Chhabria", "U07A1KQDXAB", "America/Los_Angeles"),
     Person("Serena Ruan", "U0571L5KNLR", "Asia/Singapore"),


### PR DESCRIPTION
## Related issue

N/A

## Summary

Removes Kecheng Cao from the Discord watch rotation roster in `.github/scripts/rotation.py`. The rotation now cycles through 11 people; because assignment is a pure function of the workday index modulo the roster size, the cycle simply shortens — no other change needed.

## Test Plan

- `ruff check` passes.
- Ran the script: asserted Kecheng is no longer in `PEOPLE`, confirmed 11 people remain in order, and the dry-run output is unchanged in behavior.

## Demo

N/A — non-visual change (roster edit).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually by running the script after the edit: the roster no longer contains Kecheng, the remaining 11 people are intact and in order, and rotation selection still works (dry-run executes without error).

This pull request and its description were written by Isaac.