### PR TITLE
fix(spec): stop the YAML bool override leaking into global loaders

### DIFF
--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -90,6 +90,17 @@ _YAML_1_2_BOOL_RE = re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$")
 # ``executor.config`` keys kept as their nested YAML structure instead of
 # string-coerced — their consumers read the nested mapping/list shape.
 _STRUCTURED_EXECUTOR_CONFIG_KEYS: frozenset[str] = frozenset()
+# ``yaml_implicit_resolvers`` is inherited by reference from PyYAML's base
+# ``Resolver``, so stripping entries in place rewrites the resolver tables
+# of ``yaml.SafeLoader`` (and every other loader) process-wide — after this
+# module was imported, plain ``yaml.safe_load`` returned the string
+# ``"false"`` for an unquoted ``false`` anywhere in the process. Give the
+# subclass its own copy (dict and per-character lists) first, so the
+# override stays scoped to ``_ConfigYamlLoader``.
+_ConfigYamlLoader.yaml_implicit_resolvers = {
+    _ch: _resolvers[:]
+    for _ch, _resolvers in _ConfigYamlLoader.yaml_implicit_resolvers.items()
+}
 for _ch in list(_ConfigYamlLoader.yaml_implicit_resolvers.keys()):
     _ConfigYamlLoader.yaml_implicit_resolvers[_ch] = [
         (tag, regexp)

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 
 from omnigent.errors import OmnigentError
-from omnigent.spec.parser import discover_host_skills, parse
+from omnigent.spec.parser import _ConfigYamlLoader, discover_host_skills, parse
 from omnigent.spec.types import ApiKeyAuth, DatabricksAuth, ProviderAuth, SharePolicy
 
 
@@ -3587,3 +3587,23 @@ def test_parse_credential_proxy_https_primitive_allowed_on_macos(tmp_path: Path)
     proxy = spec.os_env.sandbox.credential_proxy
     assert proxy is not None
     assert proxy.entries[0].scheme == "bearer"
+
+
+def test_yaml_bool_override_does_not_leak_into_global_loaders() -> None:
+    """
+    Importing this module's parser must not rewrite the resolver tables of
+    ``yaml.SafeLoader``: ``yaml_implicit_resolvers`` is inherited by reference
+    from PyYAML's base ``Resolver``, so stripping entries in place leaks the
+    YAML-1.2 bool override into every ``yaml.safe_load`` call in the process.
+    A plain ``safe_load`` must keep full YAML 1.1 bool semantics, while
+    ``_ConfigYamlLoader`` keeps its narrowed ones.
+    """
+    # Global loaders keep YAML 1.1 semantics (parser.py is imported above).
+    assert yaml.safe_load("in_cluster: false") == {"in_cluster": False}
+    assert yaml.safe_load("enabled: true") == {"enabled": True}
+    assert yaml.safe_load("switch: on") == {"switch": True}
+
+    # The narrowed semantics stay scoped to _ConfigYamlLoader.
+    assert yaml.load("on: [request]", Loader=_ConfigYamlLoader) == {"on": ["request"]}
+    assert yaml.load("flag: false", Loader=_ConfigYamlLoader) == {"flag": False}
+    assert yaml.load("flag: no", Loader=_ConfigYamlLoader) == {"flag": "no"}


### PR DESCRIPTION
Fixes #2312

Importing `omnigent.spec.parser` rewrote `yaml.SafeLoader`'s resolver tables process-wide. `_ConfigYamlLoader` inherits `yaml_implicit_resolvers` by reference from PyYAML's base `Resolver`, and the module-level loop that strips the bool entries mutated that shared dict in place. From then on, plain `yaml.safe_load` returned the string `'false'` for an unquoted `false` anywhere in the process, which is what rejected the documented `sandbox.kubernetes.in_cluster: false` at server startup.

The fix gives the subclass its own copy of the table (the dict and the per-character lists) before the strip, so the YAML 1.2 bool override stays scoped to `_ConfigYamlLoader`. The config loader's own semantics are unchanged.

Added a regression test that pins both sides after the import: `yaml.safe_load` keeps real booleans (`false`, `true`, `on`), and `_ConfigYamlLoader` keeps its narrowed behavior (`on` stays a string key, `no` stays a plain string, `false` still parses as a boolean).

Tests: `tests/spec/test_parser.py` passes 207/207 and `tests/spec/test_load.py` passes, run with `uv sync --frozen --extra dev` in a python:3.13 container (`OMNIGENT_SKIP_WEB_UI=true`, non-root so the chmod-based unreadable-skill test exercises real permissions). `test_load_omnigent_yaml_preserves_use_responses_bool`, whose docstring documents a downstream workaround for this leak, still passes.