### PR TITLE
feat(harness-bench): probe native policy actions

### DIFF
--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -286,7 +286,6 @@ The bench on `main` includes:
 
 ### Not yet wired
 
-- Policy ALLOW and ASK on `native-tui`.
 - Registry-driven server seeding for community native UI agents.
 - Steering, live queue, resume/fork, reasoning, images, and compaction probes.
 - Automatic provisioning of vendor login/provider configuration for native
@@ -353,13 +352,13 @@ stream, the bench flags a real drift on the next run, rather than a false
 | Basic turn, Streaming, Model override, Interrupt | Wrap-level observation | End-to-end server/runner observation | End-to-end server/runner/vendor observation |
 | Tool calling | Request-level wrap tool | Server-dispatched builtin | Vendor tool mirrored into session items |
 | Policy DENY | Not observable | Fixed policy blocks the builtin | Session CEL policy triggers the native policy hook |
-| Policy ALLOW / ASK | Not observable | Fixed policy; ASK observes and resolves an elicitation | Not implemented |
+| Policy ALLOW / ASK | Not observable | Fixed policy; ASK observes and resolves an elicitation | Temporary session CEL policy; ASK observes and resolves an elicitation |
 | Cost tracking | Completed-response usage when forwarded | Session snapshot usage/cost | Session snapshot when the vendor forwards usage |
 
 `full-server` remains the SDK default because it covers the deployed server
 path and all three policy actions. `--fast` trades that policy coverage for
-lower startup cost. `native-tui` now has real Tool calling and Policy DENY
-coverage; its remaining policy gap is ALLOW/ASK.
+lower startup cost. `native-tui` now has real Tool calling and all three policy
+action probes through the native hook path.
 
 ## Plugin seamlessness: where it is and isn't
 
@@ -415,8 +414,6 @@ agree with it.
 - **Registry-driven native-agent seeding** — replace the hardcoded server
   seeding list with registry iteration so community native harnesses work end
   to end after plugin installation.
-- **Policy ALLOW / ASK on `native-tui`** — attach and observe native allow/ask
-  policies with the same rigor as the shipped native DENY probe.
 - **Per-harness native provisioning** — some vendors require login or provider
   configuration that the bench deliberately cannot create. Improve diagnostics
   where possible while retaining clean skips.

--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -205,7 +205,7 @@ Validated for presence and shape only: `Owner`, `Transport`, `Implementation`,
 | Streaming (P0) | count output-text deltas; repeated single-delta output is `PARTIAL` |
 | Tool calling (P0) | provoke the transport's tool mechanism and require a surfaced call |
 | Policy DENY (P0) | apply a tool-call deny and require a blocked-call signal |
-| Policy ALLOW (P1) | apply an explicit allow and require a non-blocked tool output |
+| Policy ALLOW (P1) | attach an explicit allow and require a non-blocked tool output; native hooks expose no positive ALLOW event |
 | Policy ASK (P1) | apply ask and require an elicitation/approval request |
 | Model override (P0) | validate the requested harness/model pair and complete a turn |
 | Cost tracking (P1) | read priced cost or token usage from the turn/session |

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -84,7 +84,7 @@ A profile's `transport` is a harness-family marker. The resolved driver is:
 | **Streaming** | More than one output-text delta is emitted; a repeated single delta is `PARTIAL`. | P0 |
 | **Tool calling** | A tool call is surfaced and the turn closes after its result. | P0 |
 | **Policy DENY** | A tool-call policy blocks the call. | P0 |
-| **Policy ALLOW** | An explicit allow policy lets the call proceed. | P1 |
+| **Policy ALLOW** | A tool call proceeds while an explicit allow policy is attached. | P1 |
 | **Policy ASK** | An ask policy raises an approval elicitation. | P1 |
 | **Model override** | The harness accepts and completes with the requested model. | P0 |
 | **Cost tracking** | A completed turn reports priced cost (`SUPPORTED`) or tokens only (`PARTIAL`). | P1 |

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -102,7 +102,7 @@ transport; it does not claim the harness lacks the capability.
 | Basic turn, Streaming, Model override, Interrupt | End-to-end through server + runner | End-to-end through server + runner + vendor CLI | Wrap boundary only |
 | Tool calling | Server-dispatched builtin | Vendor tool mirrored as a session item | Request-level wrap tool |
 | Policy DENY | Fixed policy in the agent spec | Session CEL policy + native policy hook | Not observable |
-| Policy ALLOW / ASK | Fixed policy; ASK observes and resolves an elicitation | Not implemented | Not observable |
+| Policy ALLOW / ASK | Fixed policy; ASK observes and resolves an elicitation | Temporary session CEL policy; ASK observes and resolves an elicitation | Not observable |
 | Cost tracking | Session snapshot | Session snapshot when the vendor forwards usage | Completed-response usage when forwarded |
 
 The bench is a headless client of the server API. It verifies the contract the
@@ -155,7 +155,6 @@ inside drivers so probes remain harness-agnostic.
 
 ## Current gaps
 
-- Policy ALLOW and ASK are not yet observable on `native-tui`.
 - Native agent seeding in the server is still hardcoded rather than driven by
   the harness registry, which limits community-native end-to-end execution.
 - Some native harnesses require vendor login/provider setup that the bench

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -566,7 +566,12 @@ class NativeTuiDriver:
         return result
 
     def _drive_policy_turn(self, *, action: str) -> TurnResult:
-        """Provoke a native tool under an explicit ALLOW or ASK policy."""
+        """Provoke a native tool under an explicit ALLOW or ASK policy.
+
+        ALLOW proves that a tool proceeds while an explicit policy is attached;
+        the native hook emits no positive signal that distinguishes an evaluated
+        ALLOW from its default no-op behavior.
+        """
         if action not in {"allow", "ask"}:
             raise ValueError(f"unsupported native policy action: {action!r}")
         assert self._client is not None and self._vendor is not None
@@ -592,6 +597,7 @@ class NativeTuiDriver:
 
         def _read() -> None:
             assert self._client is not None
+            event_type: str | None = None
             try:
                 with self._client.stream(
                     "GET",
@@ -600,16 +606,22 @@ class NativeTuiDriver:
                 ) as resp:
                     ready.set()
                     for line in resp.iter_lines():
+                        if line.startswith("event:"):
+                            event_type = line[len("event:") :].strip()
+                            if action == "allow" and event_type in _READER_TERMINAL:
+                                return
                         if line.startswith("data:"):
                             try:
                                 frame = json.loads(line[len("data:") :].strip())
                             except (TypeError, ValueError):
                                 continue
-                            if frame.get("type") == _ELICITATION_EVENT:
-                                result.elicitation_requested = True
+                            if frame.get("type") == _ELICITATION_EVENT or (
+                                event_type == _ELICITATION_EVENT
+                            ):
                                 value = frame.get("elicitation_id")
                                 if isinstance(value, str):
                                     elicitation_id.append(value)
+                                result.elicitation_requested = True
                                 return
                         if stop.is_set():
                             return

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import shutil
 import signal
 import subprocess
@@ -62,9 +63,10 @@ _IN_PROGRESS_EVENT = "response.in_progress"
 _FAILED_EVENT = "response.failed"
 _INTERRUPTED_EVENT = "session.interrupted"
 _POLICY_DENIED_EVENT = "response.policy_denied"
+_ELICITATION_EVENT = "response.elicitation_request"
 
 _CEL_POLICY_HANDLER = "omnigent.policies.builtins.cel.cel_policy"
-_NATIVE_DENY_REASON = "bench-native-tool-deny"
+_NATIVE_POLICY_REASON = "bench-native-tool-policy"
 _TOOL_TURN_TIMEOUT_S = 60.0
 # policy_denied may arrive after output_item.done.
 _DENY_OBSERVE_S = 15.0
@@ -223,8 +225,7 @@ class NativeTuiDriver:
         return await asyncio.to_thread(self._drive_tool_turn, deny=deny)
 
     async def run_policy_turn(self, *, action: str) -> TurnResult:
-        """Return unmeasured until native ALLOW/ASK observation is implemented."""
-        return TurnResult()
+        return await asyncio.to_thread(self._drive_policy_turn, action=action)
 
     async def run_interrupt_turn(self) -> TurnResult:
         return await asyncio.to_thread(self._drive_interrupt_turn)
@@ -504,10 +505,12 @@ class NativeTuiDriver:
                     "cannot exercise tool-call DENY"
                 )
                 return result
-            attached = self._attach_tool_deny_policy()
-            if attached is not None:
-                result.error = attached  # e.g. CEL handler unavailable -> SKIP
+            policy_id, attach_error = self._attach_tool_policy("deny")
+            if attach_error is not None:
+                result.error = attach_error
                 return result
+        else:
+            policy_id = None
 
         events: list[str] = []
         ready = threading.Event()
@@ -542,60 +545,153 @@ class NativeTuiDriver:
         token = "deny" if deny else "allow"
         prompt = self._vendor.tool_prompt.replace("omnigent-bench-ok", f"omnigent-bench-{token}")
 
-        baseline = self._tool_item_count()
         reader = threading.Thread(target=_read)
-        reader.start()
-        ready.wait(timeout=10.0)
-        self._post_message(prompt)
-        self._poll_new_tool_calls(baseline, result)
-        if deny and not result.tool_call_denied:
-            deadline = time.monotonic() + _DENY_OBSERVE_S
-            while reader.is_alive() and time.monotonic() < deadline:
-                reader.join(timeout=0.5)
-        stop.set()
-        reader.join(timeout=10.0)
+        try:
+            baseline = self._tool_item_count()
+            reader.start()
+            ready.wait(timeout=10.0)
+            self._post_message(prompt)
+            self._poll_new_tool_calls(baseline, result)
+            if deny and not result.tool_call_denied:
+                deadline = time.monotonic() + _DENY_OBSERVE_S
+                while reader.is_alive() and time.monotonic() < deadline:
+                    reader.join(timeout=0.5)
+        finally:
+            stop.set()
+            if reader.is_alive():
+                reader.join(timeout=10.0)
+            self._delete_tool_policy(policy_id)
 
         result.completed = _OUTPUT_DONE_EVENT in events or bool(result.tool_calls)
         return result
 
-    def _attach_tool_deny_policy(self) -> str | None:
-        """Attach a session policy that DENYs any tool call at the tool_call phase.
+    def _drive_policy_turn(self, *, action: str) -> TurnResult:
+        """Provoke a native tool under an explicit ALLOW or ASK policy."""
+        if action not in {"allow", "ask"}:
+            raise ValueError(f"unsupported native policy action: {action!r}")
+        assert self._client is not None and self._vendor is not None
+        result = TurnResult()
+        if not self._vendor.tool_name:
+            result.error = f"no tool-provocation mapping for {self._vendor.harness!r}; skipped"
+            return result
+        if self._policy_hook_disabled_reason:
+            result.error = (
+                f"native policy enforcement inactive ({self._policy_hook_disabled_reason}); "
+                f"cannot exercise tool-call {action.upper()}"
+            )
+            return result
 
-        Uses the registered CEL handler via ``POST /v1/sessions/{id}/policies``.
-        Denies on the *phase* alone rather than a specific tool name: the wire
-        ``event.data.name`` is the vendor's raw hook ``tool_name``, which varies
-        per vendor and is not always the item name the forwarder mirrors (codex
-        mirrors ``shell`` but its hook may report a different tool_name). Gating
-        on ``event.type == "tool_call"`` blocks whatever tool the model calls,
-        which is exactly what "is a tool-call DENY enforced?" asks. The session
-        is bench-owned, so denying every tool call in it is harmless.
+        policy_id, attach_error = self._attach_tool_policy(action)
+        if attach_error is not None:
+            result.error = attach_error
+            return result
 
-        Returns ``None`` on success (200/201/409); a skip-reason string when the
-        handler is unavailable (e.g. ``cel_expr_python`` not installed, so the
-        server rejects it as unregistered) — an environment gap, not a
-        capability gap.
-        """
+        ready = threading.Event()
+        stop = threading.Event()
+        elicitation_id: list[str] = []
+
+        def _read() -> None:
+            assert self._client is not None
+            try:
+                with self._client.stream(
+                    "GET",
+                    f"/v1/sessions/{self._session_id}/stream",
+                    timeout=_TOOL_TURN_TIMEOUT_S,
+                ) as resp:
+                    ready.set()
+                    for line in resp.iter_lines():
+                        if line.startswith("data:"):
+                            try:
+                                frame = json.loads(line[len("data:") :].strip())
+                            except (TypeError, ValueError):
+                                continue
+                            if frame.get("type") == _ELICITATION_EVENT:
+                                result.elicitation_requested = True
+                                value = frame.get("elicitation_id")
+                                if isinstance(value, str):
+                                    elicitation_id.append(value)
+                                return
+                        if stop.is_set():
+                            return
+            except httpx.HTTPError as exc:
+                result.error = repr(exc)
+
+        reader = threading.Thread(target=_read)
+        try:
+            baseline = self._tool_item_count()
+            reader.start()
+            ready.wait(timeout=10.0)
+            prompt = self._vendor.tool_prompt.replace(
+                "omnigent-bench-ok", f"omnigent-bench-{action}"
+            )
+            self._post_message(prompt)
+            deadline = time.monotonic() + _TOOL_TURN_TIMEOUT_S
+            while time.monotonic() < deadline:
+                if result.elicitation_requested:
+                    if elicitation_id:
+                        self._resolve_elicitation(elicitation_id[0])
+                    break
+                self._poll_new_tool_calls(
+                    baseline, result, timeout=min(1.0, deadline - time.monotonic())
+                )
+                if result.tool_calls:
+                    break
+            else:
+                result.timed_out = True
+        finally:
+            stop.set()
+            reader.join(timeout=10.0)
+            self._delete_tool_policy(policy_id)
+
+        result.completed = bool(result.tool_calls)
+        result.tool_call_allowed = action == "allow" and bool(result.tool_calls)
+        return result
+
+    def _attach_tool_policy(self, action: str) -> tuple[str | None, str | None]:
+        """Attach a temporary CEL policy for every native tool call."""
         assert self._client is not None
-        # Ternary so the expression returns a map (a bare comparison returns a
-        # bool, which the CEL policy treats as abstain -> ALLOW).
+        verdict = action.upper()
         expression = (
             'event.type == "tool_call" '
-            f'? {{"result": "DENY", "reason": "{_NATIVE_DENY_REASON}"}} '
+            f'? {{"result": "{verdict}", "reason": "{_NATIVE_POLICY_REASON}"}} '
             ': {"result": "ALLOW"}'
         )
         resp = self._client.post(
             f"/v1/sessions/{self._session_id}/policies",
             json={
-                "name": "bench_tool_deny",
+                "name": f"bench_tool_{action}_{uuid.uuid4().hex[:8]}",
                 "type": "python",
                 "handler": _CEL_POLICY_HANDLER,
-                "factory_params": {"expression": expression, "reason": _NATIVE_DENY_REASON},
+                "factory_params": {"expression": expression, "reason": _NATIVE_POLICY_REASON},
             },
             timeout=30.0,
         )
-        if resp.status_code in (200, 201, 409):  # 409: already attached (reused session)
-            return None
-        return f"could not attach tool-call deny policy (status {resp.status_code}); skipped"
+        if resp.status_code not in (200, 201):
+            return None, (
+                f"could not attach tool-call {action} policy (status {resp.status_code}); skipped"
+            )
+        policy_id = resp.json().get("id")
+        return (policy_id if isinstance(policy_id, str) else None), None
+
+    def _delete_tool_policy(self, policy_id: str | None) -> None:
+        if policy_id is None:
+            return
+        assert self._client is not None
+        with contextlib.suppress(httpx.HTTPError):
+            self._client.delete(
+                f"/v1/sessions/{self._session_id}/policies/{policy_id}", timeout=30.0
+            )
+
+    def _resolve_elicitation(self, elicitation_id: str) -> None:
+        assert self._client is not None
+        with contextlib.suppress(httpx.HTTPError):
+            self._client.post(
+                f"/v1/sessions/{self._session_id}/events",
+                json={
+                    "type": "approval",
+                    "data": {"elicitation_id": elicitation_id, "action": "accept"},
+                },
+            )
 
     def _tool_item_count(self) -> int:
         """Current number of function_call items in the session (pre-turn baseline)."""

--- a/tests/harness_bench/probes/policy_allow.py
+++ b/tests/harness_bench/probes/policy_allow.py
@@ -1,8 +1,9 @@
 """Policy-ALLOW probe — does an explicit ALLOW policy let a tool call through?
 
-Drives a real ``action=allow`` tool_call policy (not mere absence of a deny) and
-checks the call proceeded. Full-server observes a non-blocked output; transports
-with no server-side policy surface return unmeasured and the probe SKIPs.
+Drives a real ``action=allow`` tool_call policy and checks the call proceeded
+while that policy was attached. The native hook has no positive ALLOW event, so
+this measures non-blocking under an explicit policy rather than proving the hook
+evaluated it. Transports with no policy surface return unmeasured and SKIP.
 """
 
 from __future__ import annotations

--- a/tests/harness_bench/test_native_tui_driver.py
+++ b/tests/harness_bench/test_native_tui_driver.py
@@ -2,9 +2,8 @@
 
 Network-free: a fake HTTP client feeds the driver canned session items (the
 ``function_call`` a native tool call persists as) and a canned SSE stream (the
-``response.policy_denied`` a native tool-call DENY publishes). This exercises
-``_drive_tool_turn`` and its helpers without a server, host daemon, or vendor
-CLI. The live path is covered by the gated ``test_native_tui`` layer.
+policy and elicitation events native tool-call policies publish). This exercises
+the tool and policy turns without a server, host daemon, or vendor CLI.
 """
 
 from __future__ import annotations
@@ -12,8 +11,12 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import pytest
+
 from tests.harness_bench.driver import TurnResult
 from tests.harness_bench.native_tui_driver import NativeTuiDriver, native_vendor
+from tests.harness_bench.probes.policy_allow import PolicyAllowProbe
+from tests.harness_bench.probes.policy_ask import PolicyAskProbe
 from tests.harness_bench.probes.policy_deny import PolicyDenyProbe
 from tests.harness_bench.probes.tool_calling import ToolCallingProbe
 from tests.harness_bench.profile import BenchProfile
@@ -33,10 +36,15 @@ class _FakeResponse:
 
 
 class _FakeStream:
-    """Context manager yielding canned SSE ``event:`` lines via iter_lines."""
+    """Context manager yielding canned SSE lines via iter_lines."""
 
-    def __init__(self, event_names: list[str]) -> None:
-        self._lines = [f"event: {name}" for name in event_names]
+    def __init__(self, frames: list[str | dict]) -> None:
+        self._lines = []
+        for frame in frames:
+            if isinstance(frame, str):
+                self._lines.append(f"event: {frame}")
+            else:
+                self._lines.extend([f"event: {frame['type']}", f"data: {json.dumps(frame)}"])
 
     def __enter__(self) -> _FakeStream:
         return self
@@ -63,7 +71,7 @@ class _FakeClient:
         self,
         *,
         items: list[dict] | None = None,
-        stream_events: list[str] | None = None,
+        stream_events: list[str | dict] | None = None,
         policy_status: int = 200,
     ) -> None:
         self._items = items or []
@@ -72,6 +80,8 @@ class _FakeClient:
         ]
         self._policy_status = policy_status
         self.attached_policies: list[dict] = []
+        self.deleted_policies: list[str] = []
+        self.posted_events: list[dict] = []
         self._items_calls = 0
 
     def get(self, url: str, params: dict | None = None, timeout: float | None = None):
@@ -84,8 +94,14 @@ class _FakeClient:
     def post(self, url: str, json: dict | None = None, timeout: float | None = None):
         if url.endswith("/policies"):
             self.attached_policies.append(json or {})
-            return _FakeResponse(self._policy_status, {"name": "bench_tool_deny"})
+            return _FakeResponse(self._policy_status, {"id": "spol_test"})
+        if url.endswith("/events"):
+            self.posted_events.append(json or {})
         return _FakeResponse(202, {})
+
+    def delete(self, url: str, timeout: float | None = None):
+        self.deleted_policies.append(url.rsplit("/", 1)[-1])
+        return _FakeResponse(200, {"deleted": True})
 
     def stream(self, method: str, url: str, timeout: float | None = None):
         return _FakeStream(self._stream_events)
@@ -139,6 +155,7 @@ def test_tool_turn_deny_attaches_policy_and_observes_denied_event() -> None:
     expr = attached["factory_params"]["expression"]
     assert 'event.type == "tool_call"' in expr
     assert '"result": "DENY"' in expr
+    assert client.deleted_policies == ["spol_test"]
 
 
 def test_tool_turn_deny_observes_denied_event_after_terminal() -> None:
@@ -189,6 +206,69 @@ def test_tool_turn_deny_skips_when_cel_handler_unregistered() -> None:
     assert not result.tool_call_denied
 
 
+def test_policy_allow_attaches_policy_and_observes_tool_call() -> None:
+    client = _FakeClient(items=[_function_call_item("Bash")])
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_policy_turn(action="allow")
+
+    assert result.tool_call_allowed
+    assert [tc["name"] for tc in result.tool_calls] == ["Bash"]
+    assert '"result": "ALLOW"' in client.attached_policies[0]["factory_params"]["expression"]
+    assert client.deleted_policies == ["spol_test"]
+
+
+def test_policy_ask_observes_and_resolves_elicitation() -> None:
+    client = _FakeClient(
+        stream_events=[
+            {
+                "type": "response.elicitation_request",
+                "elicitation_id": "elicit_test",
+                "params": {},
+            }
+        ]
+    )
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_policy_turn(action="ask")
+
+    assert result.elicitation_requested
+    assert '"result": "ASK"' in client.attached_policies[0]["factory_params"]["expression"]
+    assert client.posted_events[-1] == {
+        "type": "approval",
+        "data": {"elicitation_id": "elicit_test", "action": "accept"},
+    }
+    assert client.deleted_policies == ["spol_test"]
+
+
+def test_policy_turn_skips_when_policy_enforcement_inactive() -> None:
+    client = _FakeClient()
+    driver = _driver_with_fake("claude-native", client)
+    driver._policy_hook_disabled_reason = "Codex CLI too old"
+
+    result = driver._drive_policy_turn(action="allow")
+
+    assert result.error and "inactive" in result.error
+    assert client.attached_policies == []
+
+
+def test_policy_turn_skips_when_cel_handler_unregistered() -> None:
+    client = _FakeClient(policy_status=400)
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_policy_turn(action="ask")
+
+    assert result.error and "ask policy" in result.error
+    assert not result.elicitation_requested
+
+
+def test_policy_turn_rejects_unknown_action() -> None:
+    driver = _driver_with_fake("claude-native", _FakeClient())
+
+    with pytest.raises(ValueError, match="unsupported native policy action"):
+        driver._drive_policy_turn(action="defer")
+
+
 def test_tool_turn_skips_vendor_without_tool_mapping() -> None:
     """A native with no tool-provocation entry (e.g. cursor) SKIPs cleanly."""
     client = _FakeClient()
@@ -219,10 +299,23 @@ async def test_probes_read_native_tool_result_as_supported() -> None:
                 )
             return TurnResult(completed=True, tool_calls=[{"name": "Bash"}])
 
+        async def run_policy_turn(self, *, action: str) -> TurnResult:
+            if action == "allow":
+                return TurnResult(
+                    completed=True,
+                    tool_calls=[{"name": "Bash"}],
+                    tool_call_allowed=True,
+                )
+            return TurnResult(elicitation_requested=True)
+
     tool_result = await ToolCallingProbe().run(_Driver(), profile)
     assert tool_result.verdict is Verdict.SUPPORTED
     deny_result = await PolicyDenyProbe().run(_Driver(), profile)
     assert deny_result.verdict is Verdict.SUPPORTED
+    allow_result = await PolicyAllowProbe().run(_Driver(), profile)
+    assert allow_result.verdict is Verdict.SUPPORTED
+    ask_result = await PolicyAskProbe().run(_Driver(), profile)
+    assert ask_result.verdict is Verdict.SUPPORTED
 
 
 def test_format_matches_server_wire_name() -> None:

--- a/tests/harness_bench/test_native_tui_driver.py
+++ b/tests/harness_bench/test_native_tui_driver.py
@@ -9,6 +9,7 @@ the tool and policy turns without a server, host daemon, or vendor CLI.
 from __future__ import annotations
 
 import json
+import time
 from typing import Any
 
 import pytest
@@ -38,8 +39,9 @@ class _FakeResponse:
 class _FakeStream:
     """Context manager yielding canned SSE lines via iter_lines."""
 
-    def __init__(self, frames: list[str | dict]) -> None:
+    def __init__(self, frames: list[str | dict], *, tail_delay: float = 0.0) -> None:
         self._lines = []
+        self._tail_delay = tail_delay
         for frame in frames:
             if isinstance(frame, str):
                 self._lines.append(f"event: {frame}")
@@ -54,6 +56,8 @@ class _FakeStream:
 
     def iter_lines(self):
         yield from self._lines
+        if self._tail_delay:
+            time.sleep(self._tail_delay)
 
 
 class _FakeClient:
@@ -72,12 +76,14 @@ class _FakeClient:
         *,
         items: list[dict] | None = None,
         stream_events: list[str | dict] | None = None,
+        stream_tail_delay: float = 0.0,
         policy_status: int = 200,
     ) -> None:
         self._items = items or []
         self._stream_events = stream_events or [
             "response.output_item.done",
         ]
+        self._stream_tail_delay = stream_tail_delay
         self._policy_status = policy_status
         self.attached_policies: list[dict] = []
         self.deleted_policies: list[str] = []
@@ -104,7 +110,7 @@ class _FakeClient:
         return _FakeResponse(200, {"deleted": True})
 
     def stream(self, method: str, url: str, timeout: float | None = None):
-        return _FakeStream(self._stream_events)
+        return _FakeStream(self._stream_events, tail_delay=self._stream_tail_delay)
 
 
 def _driver_with_fake(harness: str, client: _FakeClient) -> NativeTuiDriver:
@@ -216,6 +222,21 @@ def test_policy_allow_attaches_policy_and_observes_tool_call() -> None:
     assert [tc["name"] for tc in result.tool_calls] == ["Bash"]
     assert '"result": "ALLOW"' in client.attached_policies[0]["factory_params"]["expression"]
     assert client.deleted_policies == ["spol_test"]
+
+
+def test_policy_allow_reader_stops_on_terminal_event() -> None:
+    client = _FakeClient(
+        items=[_function_call_item("Bash")],
+        stream_events=["response.output_item.done"],
+        stream_tail_delay=1.0,
+    )
+    driver = _driver_with_fake("claude-native", client)
+
+    started = time.monotonic()
+    result = driver._drive_policy_turn(action="allow")
+
+    assert result.tool_call_allowed
+    assert time.monotonic() - started < 0.5
 
 
 def test_policy_ask_observes_and_resolves_elicitation() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Native harness rows could measure tool-call DENY, but Policy ALLOW and ASK remained unmeasured even though native hooks support both actions. This completes the native policy matrix by exercising explicit session-scoped CEL policies through the real hook path.

- Attach temporary ALLOW or ASK policies for native tool turns and remove them after each probe so policy state cannot leak between sequential probes.
- Observe ASK elicitations on the session stream and accept them to release the parked native hook request.
- Update the harness-bench README and design status to reflect native coverage for all three policy actions.

### ELI5

The bench now temporarily tells a native CLI to allow or ask before using its own tool, watches what happens, and removes that rule before testing the next behavior.

```text
bench -> attach temporary CEL policy -> native tool hook
                                      -> ALLOW: tool-call item appears
                                      -> ASK: elicitation appears -> approve
      <- record verdict <- session stream/items
bench -> delete temporary policy
```

## Test Plan

- `uv run --no-sync ruff check tests/harness_bench/native_tui_driver.py tests/harness_bench/test_native_tui_driver.py`
- `uv run --no-sync pytest -q -p no:rerunfailures tests/harness_bench/test_native_tui_driver.py tests/harness_bench/test_policy_matrix.py` (`24 passed`)
- `uv run --no-sync pytest -q -p no:rerunfailures tests/harness_bench` (`118 passed, 19 skipped`)
- `pre-commit run --files tests/harness_bench/native_tui_driver.py tests/harness_bench/test_native_tui_driver.py`
- `pre-commit run --files tests/harness_bench/README.md docs/harness-bench-design.md`
- Live matrix: `uv run --no-sync python -m tests.harness_bench --jobs 3 --rich`; Policy ALLOW and ASK reported supported for `claude-native`, `codex-native`, and `pi-native`.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The offline fake-client tests cover policy attachment, cleanup, ALLOW observation, ASK elicitation parsing and approval, unavailable policy enforcement, and CEL registration failures. The live matrix verified the native hook path against installed Claude, Codex, and Pi CLIs.

## Changelog

Harness Bench now measures Policy ALLOW and ASK through native CLI policy hooks.
