### PR TITLE
fix(harnesses): flow Anthropic gateway creds host→runner→Claude Code launch

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -323,9 +323,8 @@ def build_native_claude_terminal_env(
         terminal_env[_CLAUDE_CODE_ENABLE_TOOL_SEARCH_ENV] = "true"
         terminal_env[_CLAUDE_CODE_DISABLE_AGENT_VIEW_ENV] = "1"
     # On the apiKeyHelper path the credential reaches Claude Code via the
-    # helper; a raw ANTHROPIC_API_KEY in the terminal env re-triggers Claude
-    # Code's "Detected a custom API key" menu, which hangs the tmux delivery
-    # path. Fail loud if a future change ever emits the raw key here.
+    # helper; a raw ANTHROPIC_API_KEY here re-triggers Claude Code's "Detected a
+    # custom API key" menu, which hangs tmux delivery. Fail loud if one leaks.
     if claude_config is not None and claude_config.api_key_helper:
         if _ANTHROPIC_API_KEY_ENV in terminal_env:
             raise RuntimeError(

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -322,6 +322,17 @@ def build_native_claude_terminal_env(
         terminal_env.update(claude_config.env)
         terminal_env[_CLAUDE_CODE_ENABLE_TOOL_SEARCH_ENV] = "true"
         terminal_env[_CLAUDE_CODE_DISABLE_AGENT_VIEW_ENV] = "1"
+    # On the apiKeyHelper path the credential reaches Claude Code via the
+    # helper; a raw ANTHROPIC_API_KEY in the terminal env re-triggers Claude
+    # Code's "Detected a custom API key" menu, which hangs the tmux delivery
+    # path. Fail loud if a future change ever emits the raw key here.
+    if claude_config is not None and claude_config.api_key_helper:
+        if _ANTHROPIC_API_KEY_ENV in terminal_env:
+            raise RuntimeError(
+                "native-claude: apiKeyHelper is configured but the terminal env "
+                f"carries a raw {_ANTHROPIC_API_KEY_ENV}; the credential must reach "
+                "Claude Code via the helper, not the environment."
+            )
     return terminal_env
 
 

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2933,18 +2933,24 @@ def _claude_prompt_rendered(pane: str) -> bool:
     it's framed by a box rule — the ``────`` closing line the live input
     box always renders below ``❯`` but a bare echoed prompt never has.
 
-    A ``❯`` on a selected numbered menu row is not the chat input and is
-    excluded from both scans (see :func:`_is_selected_menu_row`).
+    A bare ``❯`` on a selected numbered menu row is not the chat input. A
+    numbered line with an input-box rule below it still counts, however: the
+    readiness gate runs before every injection, so a restored composer draft
+    may legitimately begin with text such as ``2. buy milk``.
 
     :param pane: Captured pane text from :func:`_capture_pane`.
     :returns: ``True`` when the input box appears mounted.
     """
     non_empty = [line for line in pane.splitlines() if line.strip()]
-    if any(
-        _CLAUDE_PROMPT_GLYPH in line and not _is_selected_menu_row(line)
-        for line in non_empty[-_PROMPT_SCAN_TAIL_LINES:]
-    ):
-        return True
+    tail_start = max(0, len(non_empty) - _PROMPT_SCAN_TAIL_LINES)
+    for idx in range(tail_start, len(non_empty)):
+        line = non_empty[idx]
+        if _CLAUDE_PROMPT_GLYPH not in line:
+            continue
+        if not _is_selected_menu_row(line) or any(
+            _is_box_rule(rule) for rule in non_empty[idx + 1 :]
+        ):
+            return True
     # Above that window, trust the glyph only when a box rule sits below
     # it — the live input box's closing frame, absent from scrollback.
     # The footer height scales with concurrent subagents (a fan-out of
@@ -2952,7 +2958,7 @@ def _claude_prompt_rendered(pane: str) -> bool:
     # is a reliable structural signal at any depth, and `capture-pane -p`
     # returns only the visible pane, so this stays within one screen.
     for idx, line in enumerate(non_empty):
-        if _CLAUDE_PROMPT_GLYPH not in line or _is_selected_menu_row(line):
+        if _CLAUDE_PROMPT_GLYPH not in line:
             continue
         if any(_is_box_rule(rule) for rule in non_empty[idx + 1 :]):
             return True

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -124,10 +124,9 @@ _TMUX_SEND_TIMEOUT_S = 5.0
 # The glyph persists while Claude is busy responding, so its presence
 # means "input box mounted" (not "idle"), which is what injection needs.
 _CLAUDE_PROMPT_GLYPH = "❯"
-# A selected numbered menu row, e.g. ``❯ 2. No (recommended)`` in Claude
-# Code's startup "Detected a custom API key" confirmation. The glyph is the
-# same one the chat input uses, so the readiness scan must exclude these rows
-# — a chat prompt never renders a numbered choice after the glyph.
+# Matches a selected numbered menu row (``❯ 2. No (recommended)``): the glyph
+# followed by a numbered choice, which the chat input never renders. Used to
+# exclude startup menus from the readiness scan (see ``_is_selected_menu_row``).
 _SELECTED_MENU_ROW_RE = re.compile(rf"{_CLAUDE_PROMPT_GLYPH}\s*\d+\.\s")
 # Box-drawing glyphs Claude Code's input-box frame is made of. A line of
 # these below ``❯`` marks the live input box (see ``_is_box_rule``),
@@ -2934,10 +2933,8 @@ def _claude_prompt_rendered(pane: str) -> bool:
     it's framed by a box rule — the ``────`` closing line the live input
     box always renders below ``❯`` but a bare echoed prompt never has.
 
-    A ``❯`` on a selected numbered menu row (``❯ 2. No (recommended)`` in
-    Claude Code's startup "Detected a custom API key" menu) is NOT the chat
-    input — treating it as ready pastes the first message into the menu. Such
-    rows are excluded from both scans.
+    A ``❯`` on a selected numbered menu row is not the chat input and is
+    excluded from both scans (see :func:`_is_selected_menu_row`).
 
     :param pane: Captured pane text from :func:`_capture_pane`.
     :returns: ``True`` when the input box appears mounted.
@@ -2968,11 +2965,10 @@ def _is_selected_menu_row(line: str) -> bool:
 
     Claude Code's startup menus (e.g. the "Detected a custom API key"
     confirmation) mark the highlighted choice with the same ``❯`` glyph the
-    chat input uses, as ``❯ 1. Yes`` / ``❯ 2. No (recommended)``. The
-    readiness scan must not treat such a row as the chat composer, or the
-    first message gets typed into the menu. A chat prompt never renders a
-    numbered choice after the glyph, so the ``<glyph> <digit>.`` shape
-    distinguishes them.
+    chat input uses (``❯ 2. No (recommended)``). The readiness scan must not
+    treat such a row as the chat composer, or the first message gets typed
+    into the menu. A chat prompt never renders a numbered choice after the
+    glyph, so the ``<glyph> <digit>.`` shape distinguishes them.
 
     :param line: A single pane line, e.g. ``"❯ 2. No (recommended)"``.
     :returns: ``True`` when the line is a selected numbered menu choice.

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -124,6 +124,11 @@ _TMUX_SEND_TIMEOUT_S = 5.0
 # The glyph persists while Claude is busy responding, so its presence
 # means "input box mounted" (not "idle"), which is what injection needs.
 _CLAUDE_PROMPT_GLYPH = "❯"
+# A selected numbered menu row, e.g. ``❯ 2. No (recommended)`` in Claude
+# Code's startup "Detected a custom API key" confirmation. The glyph is the
+# same one the chat input uses, so the readiness scan must exclude these rows
+# — a chat prompt never renders a numbered choice after the glyph.
+_SELECTED_MENU_ROW_RE = re.compile(rf"{_CLAUDE_PROMPT_GLYPH}\s*\d+\.\s")
 # Box-drawing glyphs Claude Code's input-box frame is made of. A line of
 # these below ``❯`` marks the live input box (see ``_is_box_rule``),
 # distinguishing it from a bare prompt echoed into scrollback.
@@ -2929,11 +2934,19 @@ def _claude_prompt_rendered(pane: str) -> bool:
     it's framed by a box rule — the ``────`` closing line the live input
     box always renders below ``❯`` but a bare echoed prompt never has.
 
+    A ``❯`` on a selected numbered menu row (``❯ 2. No (recommended)`` in
+    Claude Code's startup "Detected a custom API key" menu) is NOT the chat
+    input — treating it as ready pastes the first message into the menu. Such
+    rows are excluded from both scans.
+
     :param pane: Captured pane text from :func:`_capture_pane`.
     :returns: ``True`` when the input box appears mounted.
     """
     non_empty = [line for line in pane.splitlines() if line.strip()]
-    if any(_CLAUDE_PROMPT_GLYPH in line for line in non_empty[-_PROMPT_SCAN_TAIL_LINES:]):
+    if any(
+        _CLAUDE_PROMPT_GLYPH in line and not _is_selected_menu_row(line)
+        for line in non_empty[-_PROMPT_SCAN_TAIL_LINES:]
+    ):
         return True
     # Above that window, trust the glyph only when a box rule sits below
     # it — the live input box's closing frame, absent from scrollback.
@@ -2942,11 +2955,29 @@ def _claude_prompt_rendered(pane: str) -> bool:
     # is a reliable structural signal at any depth, and `capture-pane -p`
     # returns only the visible pane, so this stays within one screen.
     for idx, line in enumerate(non_empty):
-        if _CLAUDE_PROMPT_GLYPH not in line:
+        if _CLAUDE_PROMPT_GLYPH not in line or _is_selected_menu_row(line):
             continue
         if any(_is_box_rule(rule) for rule in non_empty[idx + 1 :]):
             return True
     return False
+
+
+def _is_selected_menu_row(line: str) -> bool:
+    """
+    Return whether a ``❯`` line is a selected numbered menu row.
+
+    Claude Code's startup menus (e.g. the "Detected a custom API key"
+    confirmation) mark the highlighted choice with the same ``❯`` glyph the
+    chat input uses, as ``❯ 1. Yes`` / ``❯ 2. No (recommended)``. The
+    readiness scan must not treat such a row as the chat composer, or the
+    first message gets typed into the menu. A chat prompt never renders a
+    numbered choice after the glyph, so the ``<glyph> <digit>.`` shape
+    distinguishes them.
+
+    :param line: A single pane line, e.g. ``"❯ 2. No (recommended)"``.
+    :returns: ``True`` when the line is a selected numbered menu choice.
+    """
+    return bool(_SELECTED_MENU_ROW_RE.match(line.strip()))
 
 
 def _is_box_rule(line: str) -> bool:

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -404,10 +404,9 @@ _RUNNER_ENV_ALLOWLIST_PREFIXES: tuple[str, ...] = ("LC_", "MLFLOW_", "OTEL_", "O
 # present. These are the names the harnesses themselves resolve —
 # ANTHROPIC_* for claude-sdk / pi (claude-code also honors
 # ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL for gateways, and
-# ANTHROPIC_MODEL to pin the gateway-served model — a gateway that does
-# not serve Claude Code's own default model needs the pin, so it must
-# travel with the key/endpoint or native Claude launches model-less,
-# AWS_BEARER_TOKEN_BEDROCK + ANTHROPIC_BEDROCK_BASE_URL for Bedrock mode,
+# ANTHROPIC_MODEL to pin a gateway-served model (must travel with the
+# key/endpoint, else native Claude launches with a default the gateway
+# rejects), AWS_BEARER_TOKEN_BEDROCK + ANTHROPIC_BEDROCK_BASE_URL for Bedrock mode,
 # and CLAUDE_CODE_OAUTH_TOKEN for `claude setup-token` subscription auth),
 # OPENAI_* for codex / openai-agents (CODEX_ACCESS_TOKEN is the codex
 # CLI's headless ChatGPT-workspace credential, minted in the ChatGPT

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -403,7 +403,10 @@ _RUNNER_ENV_ALLOWLIST_PREFIXES: tuple[str, ...] = ("LC_", "MLFLOW_", "OTEL_", "O
 # Harness credential / endpoint env vars forwarded host→runner when
 # present. These are the names the harnesses themselves resolve —
 # ANTHROPIC_* for claude-sdk / pi (claude-code also honors
-# ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL for gateways,
+# ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL for gateways, and
+# ANTHROPIC_MODEL to pin the gateway-served model — a gateway that does
+# not serve Claude Code's own default model needs the pin, so it must
+# travel with the key/endpoint or native Claude launches model-less,
 # AWS_BEARER_TOKEN_BEDROCK + ANTHROPIC_BEDROCK_BASE_URL for Bedrock mode,
 # and CLAUDE_CODE_OAUTH_TOKEN for `claude setup-token` subscription auth),
 # OPENAI_* for codex / openai-agents (CODEX_ACCESS_TOKEN is the codex
@@ -423,6 +426,7 @@ _BASE_HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_AUTH_TOKEN",
         "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
         "ANTHROPIC_BEDROCK_BASE_URL",
         "AWS_BEARER_TOKEN_BEDROCK",
         "CLAUDE_CODE_OAUTH_TOKEN",

--- a/omnigent/onboarding/detected.py
+++ b/omnigent/onboarding/detected.py
@@ -181,12 +181,11 @@ def _synthesize_entry(det: DetectedProvider) -> dict[str, object] | None:
                 if env_base_url is not None:
                     base_url = env_base_url[1]
             # An ``ANTHROPIC_API_KEY`` detection honors companion
-            # ``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_MODEL`` the same way. An
+            # ``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_MODEL`` the same way: an
             # Anthropic-compatible gateway (LiteLLM, …) issues a gateway-scoped
-            # key that 401s against ``api.anthropic.com``, and serves a model
-            # id that is not Claude Code's own default — so both the endpoint
-            # and the model pin must ride the synthesized provider, else native
-            # Claude routes to the real API or launches without ``--model``.
+            # key that 401s against ``api.anthropic.com`` and serves a non-default
+            # model, so both the endpoint and the model pin must ride the entry —
+            # else native Claude routes to the real API or launches model-less.
             elif det.family == ANTHROPIC_FAMILY and env_var in (
                 "ANTHROPIC_API_KEY",
                 "OMNIGENT_ANTHROPIC_API_KEY",

--- a/omnigent/onboarding/detected.py
+++ b/omnigent/onboarding/detected.py
@@ -154,6 +154,10 @@ def _synthesize_entry(det: DetectedProvider) -> dict[str, object] | None:
         env_var = det.source[1:] if det.source.startswith("$") else det.source
         api_key_ref = f"env:{env_var}"
         vendor = key_provider_endpoint(det.name)
+        # No pinned model by default — the spec / catalog default picks it;
+        # /model then shows "(no model pinned)" rather than a fabricated one.
+        # A companion gateway ``*_MODEL`` env var overrides it below.
+        default_model: str | None = None
         if vendor is not None:
             # A third-party OpenAI-compatible vendor (OpenRouter, …): its
             # OWN base_url + Chat wire, not api.openai.com.
@@ -176,9 +180,26 @@ def _synthesize_entry(det: DetectedProvider) -> dict[str, object] | None:
                 env_base_url = getenv_nonempty_with_omnigent_prefix("OPENAI_BASE_URL")
                 if env_base_url is not None:
                     base_url = env_base_url[1]
-        # No pinned model — the spec / catalog default picks it; /model then
-        # shows "(no model pinned)" rather than a fabricated one.
-        return build_key_provider_entry(det.family, base_url, api_key_ref, None, wire_api=wire_api)
+            # An ``ANTHROPIC_API_KEY`` detection honors companion
+            # ``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_MODEL`` the same way. An
+            # Anthropic-compatible gateway (LiteLLM, …) issues a gateway-scoped
+            # key that 401s against ``api.anthropic.com``, and serves a model
+            # id that is not Claude Code's own default — so both the endpoint
+            # and the model pin must ride the synthesized provider, else native
+            # Claude routes to the real API or launches without ``--model``.
+            elif det.family == ANTHROPIC_FAMILY and env_var in (
+                "ANTHROPIC_API_KEY",
+                "OMNIGENT_ANTHROPIC_API_KEY",
+            ):
+                env_base_url = getenv_nonempty_with_omnigent_prefix("ANTHROPIC_BASE_URL")
+                if env_base_url is not None:
+                    base_url = env_base_url[1]
+                env_model = getenv_nonempty_with_omnigent_prefix("ANTHROPIC_MODEL")
+                if env_model is not None:
+                    default_model = env_model[1]
+        return build_key_provider_entry(
+            det.family, base_url, api_key_ref, default_model, wire_api=wire_api
+        )
 
     if det.kind == "local":
         # A self-hosted OpenAI-compatible server (Ollama). ``det.source`` is

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5102,22 +5102,21 @@ def _claude_terminal_env_unset(
     servers don't inherit the runner's ambient Databricks profile and
     resolve auth against the wrong workspace.
 
-    When the launch config carries an ``apiKeyHelper``, also drops the raw
-    ``ANTHROPIC_API_KEY`` and ``CLAUDECODE``. Claude Code — seeing both a raw
-    key and the helper — opens its "Detected a custom API key" menu, whose
-    selected row uses the same ``❯`` glyph the tmux delivery path waits for, so
-    the first web message is typed into the menu and no turn starts.
-    ``CLAUDECODE`` is stripped alongside it to avoid a nested-session error,
-    mirroring the claude-sdk executor's spawn.
+    Always drops ``CLAUDECODE`` because Claude Code rejects any child launch
+    carrying that nested-session marker, regardless of its auth mode. When the
+    launch config carries an ``apiKeyHelper``, also drops the raw
+    ``ANTHROPIC_API_KEY``: seeing both opens Claude Code's "Detected a custom
+    API key" menu, whose selected row uses the same ``❯`` glyph the tmux
+    delivery path waits for, so the first web message is typed into the menu.
 
     :param claude_config: The resolved native launch config, or ``None``
-        (Claude's own login) — which strips only the Databricks profile.
+        (Claude's own login) — which still strips the nested-session marker.
     :returns: The env var names to unset, e.g.
-        ``["DATABRICKS_CONFIG_PROFILE", "ANTHROPIC_API_KEY", "CLAUDECODE"]``.
+        ``["DATABRICKS_CONFIG_PROFILE", "CLAUDECODE", "ANTHROPIC_API_KEY"]``.
     """
-    env_unset = ["DATABRICKS_CONFIG_PROFILE"]
+    env_unset = ["DATABRICKS_CONFIG_PROFILE", "CLAUDECODE"]
     if claude_config is not None and claude_config.api_key_helper:
-        env_unset.extend(("ANTHROPIC_API_KEY", "CLAUDECODE"))
+        env_unset.append("ANTHROPIC_API_KEY")
     return env_unset
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5103,14 +5103,12 @@ def _claude_terminal_env_unset(
     resolve auth against the wrong workspace.
 
     When the launch config carries an ``apiKeyHelper``, also drops the raw
-    ``ANTHROPIC_API_KEY`` and ``CLAUDECODE``: the runner forwards the key as
-    a harness credential, and Claude Code — seeing both a raw key and the
-    helper — opens its "Detected a custom API key" confirmation menu, whose
-    selected row uses the same ``❯`` glyph the tmux delivery path waits for.
-    The first web message is then typed into the menu, not the chat
-    composer, so no turn starts. ``CLAUDECODE`` is stripped alongside it so
-    the child doesn't report a nested-session error, mirroring the
-    claude-sdk executor's spawn.
+    ``ANTHROPIC_API_KEY`` and ``CLAUDECODE``. Claude Code — seeing both a raw
+    key and the helper — opens its "Detected a custom API key" menu, whose
+    selected row uses the same ``❯`` glyph the tmux delivery path waits for, so
+    the first web message is typed into the menu and no turn starts.
+    ``CLAUDECODE`` is stripped alongside it to avoid a nested-session error,
+    mirroring the claude-sdk executor's spawn.
 
     :param claude_config: The resolved native launch config, or ``None``
         (Claude's own login) — which strips only the Databricks profile.
@@ -5772,19 +5770,14 @@ async def _auto_create_claude_terminal(
         # etc.) when derived. Empty provider config still forces
         # ENABLE_TOOL_SEARCH=true so MCP schemas are loaded on demand.
         env=build_native_claude_terminal_env(claude_config),
-        # Strip the ambient Databricks-SDK profile selection (and, on the
-        # apiKeyHelper path, the raw Anthropic key / nested-session marker —
-        # see above). Claude's MCP servers inherit this env, and several
-        # construct ``WorkspaceClient`` without pinning ``auth_type``; when
-        # ``DATABRICKS_CONFIG_PROFILE`` is set, the SDK's auth resolver picks
-        # up that profile's cached OAuth token and ignores the explicit token
-        # the MCP was configured with — sending a bearer minted for the wrong
-        # workspace and getting back a 400 ``Invalid Token`` from the right
-        # one. Claude itself doesn't read this env var (provider routing is
-        # via ``ANTHROPIC_BASE_URL`` / ``apiKeyHelper``), so dropping it from
-        # the terminal env affects only the leak path. MCPs that genuinely
-        # need a specific profile must declare it in their own per-MCP env
-        # configuration rather than inheriting it from the runner.
+        # Names to strip (see ``_claude_terminal_env_unset``). Dropping
+        # ``DATABRICKS_CONFIG_PROFILE`` matters because Claude's MCP servers
+        # inherit this env and several build ``WorkspaceClient`` without pinning
+        # ``auth_type``: a set profile makes the SDK prefer that profile's cached
+        # OAuth token over the MCP's explicit token, 400ing against the wrong
+        # workspace. Claude itself ignores the var (routing is
+        # ``ANTHROPIC_BASE_URL`` / ``apiKeyHelper``), so this affects only MCPs;
+        # ones needing a specific profile must set it in their own per-MCP env.
         env_unset=claude_terminal_env_unset,
         scrollback=50000,
         # Keep the private tmux server alive if the `claude` CLI exits (e.g. a

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     # Type-only import: the runner keeps codex deps out of its runtime import
     # graph (they are imported lazily inside the codex-native helpers).
+    from omnigent.claude_native import ClaudeNativeUcodeConfig
     from omnigent.codex_native_app_server import CodexAppServerClient
     from omnigent.terminals.registry import TerminalListEntry
 
@@ -5091,6 +5092,37 @@ def _build_claude_native_base_args(
     return tuple(args)
 
 
+def _claude_terminal_env_unset(
+    claude_config: ClaudeNativeUcodeConfig | None,
+) -> list[str]:
+    """
+    Env vars to strip from a native Claude terminal child.
+
+    Always drops ``DATABRICKS_CONFIG_PROFILE`` so the terminal's MCP
+    servers don't inherit the runner's ambient Databricks profile and
+    resolve auth against the wrong workspace.
+
+    When the launch config carries an ``apiKeyHelper``, also drops the raw
+    ``ANTHROPIC_API_KEY`` and ``CLAUDECODE``: the runner forwards the key as
+    a harness credential, and Claude Code — seeing both a raw key and the
+    helper — opens its "Detected a custom API key" confirmation menu, whose
+    selected row uses the same ``❯`` glyph the tmux delivery path waits for.
+    The first web message is then typed into the menu, not the chat
+    composer, so no turn starts. ``CLAUDECODE`` is stripped alongside it so
+    the child doesn't report a nested-session error, mirroring the
+    claude-sdk executor's spawn.
+
+    :param claude_config: The resolved native launch config, or ``None``
+        (Claude's own login) — which strips only the Databricks profile.
+    :returns: The env var names to unset, e.g.
+        ``["DATABRICKS_CONFIG_PROFILE", "ANTHROPIC_API_KEY", "CLAUDECODE"]``.
+    """
+    env_unset = ["DATABRICKS_CONFIG_PROFILE"]
+    if claude_config is not None and claude_config.api_key_helper:
+        env_unset.extend(("ANTHROPIC_API_KEY", "CLAUDECODE"))
+    return env_unset
+
+
 def _publish_terminal_pending(
     publish_event: Callable[[str, dict[str, Any]], None],
     session_id: str,
@@ -5424,7 +5456,6 @@ async def _auto_create_claude_terminal(
 
     from omnigent.claude_launcher import resolve_claude_launch
     from omnigent.claude_native import (
-        ClaudeNativeUcodeConfig,
         augment_claude_args,
         build_native_claude_terminal_env,
         resolve_native_claude_config,
@@ -5657,10 +5688,7 @@ async def _auto_create_claude_terminal(
     # the CLI injects this in ``_claude_terminal_request``; on this path
     # the runner must, since it (not the CLI) launches the terminal.
     # Best-effort: no profile / no ucode state / malformed state falls
-    # back to Claude's own native config (empty env). The runner env is
-    # an allowlist that excludes ``ANTHROPIC_API_KEY`` /
-    # ``CLAUDE_CODE_*``, so — unlike the CLI — there are no stray
-    # provider/session vars to unset before the gateway env applies.
+    # back to Claude's own native config (empty env).
     # See designs/NATIVE_RUNNER_SERVER_LAUNCH.md.
     # Resolve the launch config across all offerings — a configured provider
     # (omnigent setup), a Databricks ucode profile from provider config, or
@@ -5725,6 +5753,8 @@ async def _auto_create_claude_terminal(
     # managed-host path. Identity by default. See omnigent.claude_launcher.
     launch_command, launch_args = resolve_claude_launch("claude", list(claude_args))
 
+    claude_terminal_env_unset = _claude_terminal_env_unset(claude_config)
+
     # Inherit the agent's os_env so its sandbox (e.g. ``type: none``),
     # egress_rules and env_passthrough are honoured. Without ``sandbox`` here
     # and ``parent_os_env`` below, launch_terminal falls back to
@@ -5742,21 +5772,20 @@ async def _auto_create_claude_terminal(
         # etc.) when derived. Empty provider config still forces
         # ENABLE_TOOL_SEARCH=true so MCP schemas are loaded on demand.
         env=build_native_claude_terminal_env(claude_config),
-        # Strip the ambient Databricks-SDK profile selection from
-        # the Claude tmux env. Claude's MCP servers inherit this env,
-        # and several construct ``WorkspaceClient`` without pinning
-        # ``auth_type``; when ``DATABRICKS_CONFIG_PROFILE`` is set,
-        # the SDK's auth resolver picks up that profile's cached
-        # OAuth token and ignores the explicit token the MCP was
-        # configured with — sending a bearer minted for the wrong
-        # workspace and getting back a 400 ``Invalid Token`` from
-        # the right one. Claude itself doesn't read this env var
-        # (provider routing is via ``ANTHROPIC_BASE_URL`` /
-        # ``apiKeyHelper``), so dropping it from the terminal env
-        # affects only the leak path. MCPs that genuinely need a
-        # specific profile must declare it in their own per-MCP env
+        # Strip the ambient Databricks-SDK profile selection (and, on the
+        # apiKeyHelper path, the raw Anthropic key / nested-session marker —
+        # see above). Claude's MCP servers inherit this env, and several
+        # construct ``WorkspaceClient`` without pinning ``auth_type``; when
+        # ``DATABRICKS_CONFIG_PROFILE`` is set, the SDK's auth resolver picks
+        # up that profile's cached OAuth token and ignores the explicit token
+        # the MCP was configured with — sending a bearer minted for the wrong
+        # workspace and getting back a 400 ``Invalid Token`` from the right
+        # one. Claude itself doesn't read this env var (provider routing is
+        # via ``ANTHROPIC_BASE_URL`` / ``apiKeyHelper``), so dropping it from
+        # the terminal env affects only the leak path. MCPs that genuinely
+        # need a specific profile must declare it in their own per-MCP env
         # configuration rather than inheriting it from the runner.
-        env_unset=["DATABRICKS_CONFIG_PROFILE"],
+        env_unset=claude_terminal_env_unset,
         scrollback=50000,
         # Keep the private tmux server alive if the `claude` CLI exits (e.g. a
         # sub-agent worker whose CLI exits right after rendering its prompt on

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1312,6 +1312,7 @@ def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
         "HOME": "/root",
         "ANTHROPIC_API_KEY": "sk-a",
         "ANTHROPIC_BASE_URL": "https://gateway.example.com/anthropic",
+        "ANTHROPIC_MODEL": "gateway-served-claude",
         "CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat-sub",
         "CODEX_ACCESS_TOKEN": "codex-workspace-token",
         "OPENAI_API_KEY": "sk-o",
@@ -1319,6 +1320,8 @@ def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
         "GEMINI_API_KEY": "g-key",
         "AWS_BEARER_TOKEN_BEDROCK": "absk-fwd",
         "ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        # An unrelated secret must never ride the credential set.
+        "MY_UNRELATED_SECRET": "leak-me-not",
     }
 
     env = _build_runner_env(
@@ -1333,6 +1336,10 @@ def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
     for name in (
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_BASE_URL",
+        # The gateway model pin travels with the key/endpoint — without it a
+        # LiteLLM-style gateway session launches Claude Code model-less and
+        # the gateway rejects Claude Code's own default model.
+        "ANTHROPIC_MODEL",
         "CLAUDE_CODE_OAUTH_TOKEN",
         "CODEX_ACCESS_TOKEN",
         "OPENAI_API_KEY",
@@ -1349,6 +1356,8 @@ def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
     # but never invented into the env.
     assert "ANTHROPIC_AUTH_TOKEN" in HARNESS_CREDENTIAL_ENV_VARS
     assert "ANTHROPIC_AUTH_TOKEN" not in env
+    # A secret not on the credential set / allowlist is not forwarded.
+    assert "MY_UNRELATED_SECRET" not in env
 
 
 def test_build_runner_env_forwards_omnigent_prefixed_harness_credentials() -> None:

--- a/tests/onboarding/test_detected.py
+++ b/tests/onboarding/test_detected.py
@@ -139,11 +139,10 @@ def test_synthesize_env_key_anthropic_honors_base_url_and_model(
     """A detected ``ANTHROPIC_API_KEY`` adopts companion base URL + model.
 
     An Anthropic-compatible gateway (LiteLLM, …) issues a gateway-scoped key
-    that 401s against ``api.anthropic.com`` and serves a model id that is not
-    Claude Code's own default. Both the endpoint and the model pin must ride
-    the synthesized provider; otherwise native Claude routes to the real API
-    (auth fail) or launches without ``--model`` (invalid-model). This is the
-    regression guard for that gateway path.
+    that 401s against ``api.anthropic.com`` and serves a non-default model.
+    Both the endpoint and the model pin must ride the synthesized provider;
+    otherwise native Claude routes to the real API (auth fail) or launches
+    without ``--model`` (invalid-model).
     """
     gateway = "https://gateway.example/anthropic"
     monkeypatch.setenv("ANTHROPIC_BASE_URL", gateway)

--- a/tests/onboarding/test_detected.py
+++ b/tests/onboarding/test_detected.py
@@ -48,12 +48,16 @@ def _codex_login() -> DetectedProvider:
     )
 
 
-def test_synthesize_env_key_anthropic() -> None:
+def test_synthesize_env_key_anthropic(monkeypatch: pytest.MonkeyPatch) -> None:
     """An anthropic env key becomes a ``key`` entry with an ``env:`` ref.
 
     Failure means the detected key wouldn't route (wrong kind/family) or
-    would leak as an inline secret instead of an env reference.
+    would leak as an inline secret instead of an env reference. Clears the
+    companion gateway env so the assertion pins the vendor default rather
+    than an ambient ``ANTHROPIC_BASE_URL`` from the surrounding shell.
     """
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
     entries = synthesize_detected_entries([_anthropic_key()])
     assert set(entries) == {"anthropic"}
     parsed = load_providers({"providers": entries})["anthropic"]
@@ -127,6 +131,47 @@ def test_synthesize_env_key_openai_without_base_url_uses_default(
     )
     entries = synthesize_detected_entries([det])
     assert entries["openai"]["openai"]["base_url"] == "https://api.openai.com/v1"
+
+
+def test_synthesize_env_key_anthropic_honors_base_url_and_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A detected ``ANTHROPIC_API_KEY`` adopts companion base URL + model.
+
+    An Anthropic-compatible gateway (LiteLLM, …) issues a gateway-scoped key
+    that 401s against ``api.anthropic.com`` and serves a model id that is not
+    Claude Code's own default. Both the endpoint and the model pin must ride
+    the synthesized provider; otherwise native Claude routes to the real API
+    (auth fail) or launches without ``--model`` (invalid-model). This is the
+    regression guard for that gateway path.
+    """
+    gateway = "https://gateway.example/anthropic"
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", gateway)
+    monkeypatch.setenv("ANTHROPIC_MODEL", "gateway-served-claude")
+    entries = synthesize_detected_entries([_anthropic_key()])
+    anthropic_block = entries["anthropic"]["anthropic"]
+    assert anthropic_block["base_url"] == gateway
+    assert anthropic_block["api_key_ref"] == "env:ANTHROPIC_API_KEY"
+    # The model pin lands as the family default so the launch gets ``--model``.
+    assert anthropic_block["models"] == {"default": "gateway-served-claude"}
+
+
+def test_synthesize_env_key_anthropic_without_overrides_uses_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Absent overrides, a detected Anthropic key keeps the vendor default.
+
+    No ``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_MODEL`` means the canonical
+    ``https://api.anthropic.com`` endpoint and no pinned model (the spec /
+    catalog default picks the model).
+    """
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
+    entries = synthesize_detected_entries([_anthropic_key()])
+    anthropic_block = entries["anthropic"]["anthropic"]
+    assert anthropic_block["base_url"] == "https://api.anthropic.com"
+    # No model pinned — the block carries no ``models`` key.
+    assert "models" not in anthropic_block
 
 
 def test_synthesize_subscription_cli() -> None:

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -255,9 +255,8 @@ def test_claude_terminal_env_databricks_gateway_helper_path() -> None:
     assert "CLAUDECODE" in env_unset
 
     # The built terminal env preserves the gateway endpoint and never emits a
-    # raw key (routing is via ANTHROPIC_BASE_URL + apiKeyHelper). The Databricks
-    # profile is intentionally absent from the child: it's dropped via
-    # env_unset, not the built env, and Claude routes without it.
+    # raw key (routing is via ANTHROPIC_BASE_URL + apiKeyHelper); the Databricks
+    # profile is dropped via env_unset, not the built env.
     terminal_env = build_native_claude_terminal_env(config)
     assert terminal_env["ANTHROPIC_BASE_URL"] == (
         "https://dbc-example.cloud.databricks.com/anthropic"

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -166,21 +166,26 @@ def test_claude_terminal_env_unset_masks_key_with_api_key_helper() -> None:
     assert "DATABRICKS_CONFIG_PROFILE" in env_unset
 
 
-def test_claude_terminal_env_unset_without_helper_keeps_only_profile() -> None:
-    """No apiKeyHelper → only the Databricks profile is stripped.
+def test_claude_terminal_env_unset_without_helper_keeps_key() -> None:
+    """No apiKeyHelper preserves the raw key but strips nested-session state.
 
-    Claude's own-login path (``None`` config) and a Bedrock-style config
-    (credential via env, no ``apiKeyHelper``) carry no raw key to shadow,
-    so the key/nested-session strip must not apply — dropping ``CLAUDECODE``
-    there would be gratuitous.
+    Claude's own-login path (``None`` config) and a Bedrock-style config have
+    no ``apiKeyHelper``, so this helper does not strip ``ANTHROPIC_API_KEY``.
+    ``CLAUDECODE`` must still be absent because Claude Code rejects nested
+    launches in every auth mode.
     """
-    assert _claude_terminal_env_unset(None) == ["DATABRICKS_CONFIG_PROFILE"]
+    expected = ["DATABRICKS_CONFIG_PROFILE", "CLAUDECODE"]
+    own_login_env_unset = _claude_terminal_env_unset(None)
+    assert own_login_env_unset == expected
+    assert "ANTHROPIC_API_KEY" not in own_login_env_unset
     bedrock_like = ClaudeNativeUcodeConfig(
         env={"ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock.example"},
         api_key_helper=None,
         model="us.anthropic.claude-opus-4-5-20251101-v1:0",
     )
-    assert _claude_terminal_env_unset(bedrock_like) == ["DATABRICKS_CONFIG_PROFILE"]
+    bedrock_env_unset = _claude_terminal_env_unset(bedrock_like)
+    assert bedrock_env_unset == expected
+    assert "ANTHROPIC_API_KEY" not in bedrock_env_unset
 
 
 def test_native_launch_passes_synthesized_model_as_flag() -> None:

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 import pytest
 
-from omnigent.runner.app import _build_claude_native_base_args
+from omnigent.claude_native import ClaudeNativeUcodeConfig
+from omnigent.runner.app import _build_claude_native_base_args, _claude_terminal_env_unset
 
 
 @pytest.mark.parametrize(
@@ -139,3 +140,65 @@ def test_build_claude_native_base_args_resume_prefix(
         )
         == expected
     )
+
+
+def test_claude_terminal_env_unset_masks_key_with_api_key_helper() -> None:
+    """An apiKeyHelper launch strips the raw key + nested-session marker.
+
+    When the credential reaches Claude Code via an ``apiKeyHelper``, a raw
+    ``ANTHROPIC_API_KEY`` in the child env makes Claude open its custom-API-
+    key confirmation menu, and the first web message is typed into that menu
+    instead of the chat composer. The key must not leak into the terminal
+    child; ``CLAUDECODE`` is stripped alongside it to avoid a nested-session
+    error. ``DATABRICKS_CONFIG_PROFILE`` is always dropped.
+    """
+    config = ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"},
+        api_key_helper="printf %s sk-gateway",
+        model="gateway-served-claude",
+    )
+    env_unset = _claude_terminal_env_unset(config)
+    assert "ANTHROPIC_API_KEY" in env_unset
+    assert "CLAUDECODE" in env_unset
+    assert "DATABRICKS_CONFIG_PROFILE" in env_unset
+
+
+def test_claude_terminal_env_unset_without_helper_keeps_only_profile() -> None:
+    """No apiKeyHelper → only the Databricks profile is stripped.
+
+    Claude's own-login path (``None`` config) and a Bedrock-style config
+    (credential via env, no ``apiKeyHelper``) carry no raw key to shadow,
+    so the key/nested-session strip must not apply — dropping ``CLAUDECODE``
+    there would be gratuitous.
+    """
+    assert _claude_terminal_env_unset(None) == ["DATABRICKS_CONFIG_PROFILE"]
+    bedrock_like = ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock.example"},
+        api_key_helper=None,
+        model="us.anthropic.claude-opus-4-5-20251101-v1:0",
+    )
+    assert _claude_terminal_env_unset(bedrock_like) == ["DATABRICKS_CONFIG_PROFILE"]
+
+
+def test_native_launch_passes_synthesized_model_as_flag() -> None:
+    """A synthesized gateway model reaches the launch as ``--model``.
+
+    ``_auto_create_claude_terminal`` feeds ``claude_config.model`` (populated
+    by ambient Anthropic synthesis from ``ANTHROPIC_MODEL``) into the base
+    args as the model default. This pins the end-to-end contract: a gateway
+    model resolves to ``--model <id>`` so Claude Code doesn't launch with its
+    own default that the gateway rejects.
+    """
+    config = ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"},
+        api_key_helper="printf %s sk-gateway",
+        model="gateway-served-claude",
+    )
+    # Mirrors the runner's precedence: session override wins, else the
+    # provider/ucode gateway model becomes the --model default.
+    args = _build_claude_native_base_args(
+        reasoning_effort=None,
+        model_override=None or config.model,
+        terminal_launch_args=None,
+    )
+    assert args == ("--model", "gateway-served-claude")

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -227,3 +227,51 @@ def test_build_native_claude_terminal_env_rejects_raw_key_on_helper_path() -> No
     )
     with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
         build_native_claude_terminal_env(leaking)
+
+
+def test_claude_terminal_env_databricks_gateway_helper_path() -> None:
+    """The Databricks ucode/profile gateway session, end to end through the env seams.
+
+    A Databricks-gateway session has an ``apiKeyHelper`` (the Databricks auth
+    command), ``ANTHROPIC_BASE_URL`` at the Databricks endpoint, a ucode model,
+    and NO raw ``ANTHROPIC_API_KEY``; the runner also carries an ambient
+    ``DATABRICKS_CONFIG_PROFILE``. This pins the real-user shape (not just a
+    generic gateway): the terminal child must drop the Databricks profile and
+    the raw key / nested-session marker, while ``apiKeyHelper`` +
+    ``ANTHROPIC_BASE_URL`` + the model override survive so Claude Code still
+    authenticates against Databricks via the helper.
+    """
+    config = ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://dbc-example.cloud.databricks.com/anthropic"},
+        api_key_helper="databricks auth token --host https://dbc-example.cloud.databricks.com",
+        model="databricks-claude-opus-4-8",
+    )
+
+    # The terminal child strips the ambient Databricks profile plus the raw
+    # key / nested-session marker on the helper path.
+    env_unset = _claude_terminal_env_unset(config)
+    assert "DATABRICKS_CONFIG_PROFILE" in env_unset
+    assert "ANTHROPIC_API_KEY" in env_unset
+    assert "CLAUDECODE" in env_unset
+
+    # The built terminal env preserves the gateway endpoint and never emits a
+    # raw key (routing is via ANTHROPIC_BASE_URL + apiKeyHelper). The Databricks
+    # profile is intentionally absent from the child: it's dropped via
+    # env_unset, not the built env, and Claude routes without it.
+    terminal_env = build_native_claude_terminal_env(config)
+    assert terminal_env["ANTHROPIC_BASE_URL"] == (
+        "https://dbc-example.cloud.databricks.com/anthropic"
+    )
+    assert "ANTHROPIC_API_KEY" not in terminal_env
+    assert "DATABRICKS_CONFIG_PROFILE" not in terminal_env
+
+    # The gateway model reaches the launch as ``--model`` so Claude Code
+    # doesn't start on an Anthropic-direct default the gateway rejects; the
+    # apiKeyHelper survives on the config for augment_claude_args to register.
+    args = _build_claude_native_base_args(
+        reasoning_effort=None,
+        model_override=config.model,
+        terminal_launch_args=None,
+    )
+    assert args == ("--model", "databricks-claude-opus-4-8")
+    assert config.api_key_helper

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 
 import pytest
 
-from omnigent.claude_native import ClaudeNativeUcodeConfig
+from omnigent.claude_native import (
+    ClaudeNativeUcodeConfig,
+    build_native_claude_terminal_env,
+)
 from omnigent.runner.app import _build_claude_native_base_args, _claude_terminal_env_unset
 
 
@@ -202,3 +205,25 @@ def test_native_launch_passes_synthesized_model_as_flag() -> None:
         terminal_launch_args=None,
     )
     assert args == ("--model", "gateway-served-claude")
+
+
+def test_build_native_claude_terminal_env_rejects_raw_key_on_helper_path() -> None:
+    """The env-build seam fails loud if a raw key rides the apiKeyHelper path.
+
+    ``_claude_terminal_env_unset`` strips the raw key from the terminal child
+    only because ``build_native_claude_terminal_env`` never emits one on the
+    helper path. Pin that invariant mechanically: if a future config injects a
+    raw ``ANTHROPIC_API_KEY`` into the terminal env while an ``apiKeyHelper`` is
+    configured, the build must raise rather than silently reintroduce Claude
+    Code's custom-API-key menu hang.
+    """
+    leaking = ClaudeNativeUcodeConfig(
+        env={
+            "ANTHROPIC_BASE_URL": "https://gateway.example/anthropic",
+            "ANTHROPIC_API_KEY": "sk-leaked",
+        },
+        api_key_helper="printf %s sk-gateway",
+        model="gateway-served-claude",
+    )
+    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+        build_native_claude_terminal_env(leaking)

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -5039,6 +5039,19 @@ def test_claude_prompt_rendered_sees_chat_input_below_menu_glyph() -> None:
     assert _claude_prompt_rendered(pane) is True
 
 
+def test_claude_prompt_rendered_sees_numbered_draft_in_framed_input() -> None:
+    """A numbered composer draft is distinguished from an unframed menu row."""
+    pane = "\n".join(
+        [
+            "────────────────────────────────────────",
+            "❯ 2. buy milk",
+            "────────────────────────────────────────",
+            "  Opus 4.8 (1M context) | effort:high",
+        ]
+    )
+    assert _claude_prompt_rendered(pane) is True
+
+
 def _write_deltas_lines(bridge_dir: Path, lines: list[str]) -> None:
     """
     Append raw JSONL lines to the bridge deltas file.

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4999,6 +4999,46 @@ def test_claude_prompt_rendered_ignores_unframed_glyph_deep_in_tail() -> None:
     assert _claude_prompt_rendered(pane) is False
 
 
+def test_claude_prompt_rendered_ignores_custom_api_key_menu() -> None:
+    """The custom-API-key menu's selected row is not the chat input.
+
+    Claude Code's startup "Detected a custom API key" confirmation renders
+    its highlighted choice with the same ``❯`` glyph the chat composer uses
+    (``❯ 2. No (recommended)``). Treating it as ready pastes the first web
+    message into the menu, so no turn starts — the tmux delivery false
+    positive this guards against.
+    """
+    pane = "\n".join(
+        [
+            "Detected a custom API key in your environment",
+            "Do you want to use this API key?",
+            "  1. Yes",
+            "❯ 2. No (recommended)",  # selected menu row, NOT the chat input
+        ]
+    )
+    assert _claude_prompt_rendered(pane) is False
+
+
+def test_claude_prompt_rendered_sees_chat_input_below_menu_glyph() -> None:
+    """A real chat prompt still reads ready even past a menu-shaped echo.
+
+    A numbered ``❯`` choice echoed into scrollback must not suppress the
+    live input box below it: the chat ``❯`` row (no numbered choice after
+    the glyph) is the one that marks readiness.
+    """
+    pane = "\n".join(
+        [
+            "❯ 2. No (recommended)",  # scrollback echo of a prior menu row
+            "output",
+            "────────────────────────────────────────",  # input box top rule
+            "❯ ",  # the live chat prompt
+            "────────────────────────────────────────",  # box closing rule
+            "  Opus 4.8 (1M context) | effort:high",
+        ]
+    )
+    assert _claude_prompt_rendered(pane) is True
+
+
 def _write_deltas_lines(bridge_dir: Path, lines: list[str]) -> None:
     """
     Append raw JSONL lines to the bridge deltas file.


### PR DESCRIPTION
## Related issue

Closes #2332
Closes #2331
Closes #2330

These three are one scenario split across the data-flow, so they ship as one PR: a browser-created managed sandbox running a claude-native harness against an Anthropic-compatible gateway (e.g. LiteLLM), where `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` / `ANTHROPIC_MODEL` must flow host → runner env → provider synthesis → Claude Code launch. Fixing one without the others leaves the path broken, so they're delivered and tested together.

## ELI5

A managed session hands Claude Code its gateway credentials by passing them through **three doors** in a row: host → runner → the Claude Code launch. Each door was dropping one of the three things Claude needs — the **model name**, the **gateway URL**, or a stray copy of the **API key** getting typed into the wrong box. Drop any one and the session either talks to the wrong server, launches with no model (which the gateway rejects), or freezes on Claude Code's "Detected a custom API key" pop-up because the first chat message got typed into that menu instead of the composer. This PR makes all three doors pass the right things through — and adds a tripwire so a future change can't silently reopen the "key in the wrong box" bug.

## Data flow

```
                ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL / ANTHROPIC_MODEL
                                     │
   host  ──(#2332)──▶  runner env  ──(#2331)──▶  provider synthesis  ──(#2330)──▶  Claude Code launch
   _build_runner_env   allowlist        detected.py                    _claude_terminal_env_unset
   forwards all 3      now carries       synthesizes provider          + tmux readiness scan
   (was dropping        MODEL            from base_url + model         (masks raw key, skips menu row)
    MODEL)
```

## Summary

A gateway-backed managed claude-native session needs all three Anthropic env knobs to survive three hops. Each hop dropped or ignored the model / gateway wiring, so sessions failed with an invalid-model or auth error, or hung on Claude Code's custom-key menu. Fixed in data-flow order:

- **#2332 (host→runner env):** `_build_runner_env()` forwards a harness-credential allowlist that carried `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` but dropped `ANTHROPIC_MODEL`, so the runner resolved `model=None` and launched Claude Code with no `--model`. Added `ANTHROPIC_MODEL` to `_BASE_HARNESS_CREDENTIAL_ENV_VARS` (`omnigent/host/connect.py:429`).
- **#2331 (ambient provider synthesis):** ambient `ANTHROPIC_API_KEY` detection synthesized an Anthropic provider but ignored companion `ANTHROPIC_BASE_URL` / `ANTHROPIC_MODEL` — routing a gateway key to `api.anthropic.com` and/or launching model-less. Mirrored the existing OpenAI branch: read both via `getenv_nonempty_with_omnigent_prefix` and pass `base_url` + `default_model` to `build_key_provider_entry` (`omnigent/onboarding/detected.py:172-187`).
- **#2330 (launch + tmux delivery):** two coupled bugs. (a) The runner forwards the raw `ANTHROPIC_API_KEY`, so with an `apiKeyHelper` configured Claude Code opened its "Detected a custom API key" menu; its selected row uses the same `❯` glyph the tmux delivery scans for, so the first web message was typed into the menu. Now strip `ANTHROPIC_API_KEY` + `CLAUDECODE` from the terminal child on the apiKeyHelper path (`omnigent/runner/app.py`, `_claude_terminal_env_unset`). (b) The readiness scan now ignores selected numbered menu rows (`_is_selected_menu_row` in `omnigent/claude_native_bridge.py`). The `--model` launch wiring itself already existed (`_build_claude_native_base_args` feeds `claude_config.model`); it was model-less only because #2331 wasn't populating the model — now it is.

**Already partly fixed on main:** the `--model` launch path (#2330 part b's "missing --model") was already wired runner-side via `_build_claude_native_base_args(model_override=… or claude_config.model)`. The real gap was upstream: `claude_config.model` was `None` because ambient synthesis (#2331) never set a default model. No duplicate launch-side plumbing was added; a regression test now pins that the synthesized model reaches the launch as `--model`.

### Hardening (added after review)

Two follow-up commits from the automated + cross-vendor review pass:

- **Fail-loud `apiKeyHelper` invariant** (`omnigent/claude_native.py`, `build_native_claude_terminal_env`): the #2330 strip of the raw key relies on the env-build seam *never itself* emitting a raw `ANTHROPIC_API_KEY` on the helper path. That was an unpinned assumption. The build now raises `RuntimeError` (chosen over `assert` so it survives `python -O`; the message names only the var, never the secret value) if a future change ever puts a raw key in the terminal env while an `apiKeyHelper` is configured — so the "key in the wrong box" hang can't silently regress. The guard is gated on `api_key_helper` being set, so legitimate raw-key gateways (e.g. LiteLLM without a helper) are unaffected.
- **Databricks-gateway regression test**: existing helper-path coverage was "generic gateway-shaped"; this pins the real Databricks ucode/profile shape end-to-end (see next section).

## Databricks gateway (deployment note)

This fix was written for a LiteLLM-style gateway (raw `ANTHROPIC_API_KEY` + `ANTHROPIC_BASE_URL`), but Databricks-hosted Claude is a first-class deployment target and resolves differently — worth stating explicitly since operators run both:

- **Auth is via a config profile + `apiKeyHelper`, not a raw key.** A Databricks provider routes through `DATABRICKS_CONFIG_PROFILE` → workspace → ucode state, which builds the terminal env with `ANTHROPIC_BASE_URL` (Databricks endpoint), an `apiKeyHelper` (the Databricks auth command), and a model from ucode / `DATABRICKS_CLAUDE_DEFAULT_MODEL` (`omnigent/claude_native.py:1432-1473`).
- **#2332 is inert** for Databricks (model comes from ucode, not ambient `ANTHROPIC_MODEL`); the Databricks profile selectors (`DATABRICKS_CONFIG_PROFILE` / `_FILE` / `_AUTH_STORAGE`) are still forwarded host→runner and used to resolve creds.
- **#2331 does not fire** for Databricks — ambient synthesis is gated on a raw `ANTHROPIC_API_KEY`, which the Databricks path doesn't use, so it can't hijack or mis-synthesize the provider.
- **#2330 is a net-positive safety change**: the terminal child intentionally drops `DATABRICKS_CONFIG_PROFILE` (so the SDK can't route to the wrong workspace — Claude routes via `ANTHROPIC_BASE_URL` + `apiKeyHelper`) while keeping it host→runner where creds are resolved; it also strips any stray raw key that would trigger the menu hang.

Net: for a Databricks gateway this PR is a no-op plus one defensive improvement — no auth regression on the intended path. (Pre-existing, not touched here: if a Databricks setup lacks provider config / ucode state, `resolve_native_claude_config` returns `None` and Claude falls back to its own login.)

## Test Plan

All run in the worktree against the touched modules.

- `pre-commit run --all-files` — **green** (ruff format, ruff check, asyncio-monkeypatch lint, skipped-tests lint, prettier/ktlint/swift-format, uv.lock normalize, whitespace/newline/merge-conflict checks).
- `python -m pytest tests/host/test_connect.py tests/onboarding/test_detected.py tests/runner/test_app_claude_native_launch_args.py` — **107 passed** (base) / **16 passed** in the launch-args module including the two new hardening tests.
- `python -m pytest tests/test_claude_native_bridge.py -k "prompt_rendered or custom_api_key or chat_input_below"` — **6 passed**.

Tests added / extended:

- `test_build_runner_env_forwards_harness_credentials_and_endpoints` — extended to assert `ANTHROPIC_MODEL` forwards and an unrelated secret does not.
- `test_synthesize_env_key_anthropic_honors_base_url_and_model` / `…_without_overrides_uses_default` — ambient Anthropic synthesis consumes gateway base_url + model, preserves the `api.anthropic.com` default otherwise (mirrors the OpenAI-branch tests). Hardened the pre-existing `test_synthesize_env_key_anthropic` to clear ambient env.
- `test_claude_terminal_env_unset_masks_key_with_api_key_helper` / `…_without_helper_keeps_only_profile` — the raw key + `CLAUDECODE` are stripped only on the apiKeyHelper path.
- `test_native_launch_passes_synthesized_model_as_flag` — the synthesized gateway model reaches the launch as `--model`.
- `test_claude_prompt_rendered_ignores_custom_api_key_menu` / `…_sees_chat_input_below_menu_glyph` — the readiness scan ignores selected menu rows but still finds the real chat input.
- **`test_build_native_claude_terminal_env_rejects_raw_key_on_helper_path`** *(new)* — the env-build seam raises if a raw key rides the apiKeyHelper path (pins the fail-loud invariant).
- **`test_claude_terminal_env_databricks_gateway_helper_path`** *(new)* — the Databricks ucode/profile shape end-to-end: terminal child drops `DATABRICKS_CONFIG_PROFILE` / `ANTHROPIC_API_KEY` / `CLAUDECODE`, built env preserves `ANTHROPIC_BASE_URL` and emits no raw key, and the ucode model reaches launch as `--model databricks-claude-opus-4-8`.

Note: three subprocess-spawning MCP-relay tests in `tests/test_claude_native_bridge.py` (`test_channel_server_relays_active_omnigent_tools`, `test_mcp_server_initialize_omits_blocked_channel_capability`, `test_serve_mcp_survives_handler_exception_and_keeps_serving`) fail in this local sandbox with a subprocess-JSON timeout; confirmed they fail identically on the unmodified baseline (`git stash`), so they're pre-existing and unrelated to this change. Two ambient-key tests in `tests/test_claude_native.py` likewise fail only from local-machine env leakage (a real gateway URL in ambient config) and reproduce on the unmodified branch.

## Demo

No live capture. The user-visible symptom (the stuck "Detected a custom API key" menu → a clean first turn) only reproduces inside a **full managed sandbox against a live gateway (LiteLLM / Databricks) with a real tmux-delivered Claude Code session** — the exact environment that isn't stand-up-able in unit tests or locally without a gateway + credentials. Rather than a synthetic capture that wouldn't exercise the real tmux-delivery path, the fix is pinned at each of the three seams by the regression tests above, including the `❯`-menu readiness scan (`test_claude_prompt_rendered_ignores_custom_api_key_menu`) that is the direct proxy for the stuck-menu behaviour. The full image build + E2E run on CI exercises the real launch path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Each layer has a dedicated unit test at its seam: env-forwarding in `tests/host/test_connect.py`, ambient synthesis in `tests/onboarding/test_detected.py`, and launch key-masking + `--model` + readiness in `tests/runner/test_app_claude_native_launch_args.py` and `tests/test_claude_native_bridge.py`. The fail-loud `apiKeyHelper` invariant and the Databricks ucode/profile gateway shape are each pinned by a dedicated test. The end-to-end managed-sandbox-against-a-gateway flow isn't reproducible in unit tests (needs a live gateway + tmux), but the seams it depends on are each pinned; the CI image build + E2E covers the real launch path.

## Changelog

Managed claude-native sessions against an Anthropic-compatible gateway (e.g. LiteLLM or Databricks) now pass through the gateway model and don't stall on Claude Code's custom-API-key menu.
