### PR TITLE
feat(spec): per-turn context_providers hook (additive system-instruction augmentation)

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -13608,13 +13608,24 @@ def create_runner_app(
                 # readout). Forwarded by the Omnigent server in the message body.
                 model_override=msg_body.get("model_override"),
             )
+            from omnigent.runtime.context_providers import (
+                input_from_turn,
+                run_context_providers,
+            )
             from omnigent.runtime.prompt import (
                 build_instructions,
             )
 
+            # Per-turn context providers (e.g. memory recall) append to the
+            # system instructions via the existing per_request_instructions
+            # slot. Returns None when the spec declares none — identical to the
+            # prior behavior, so this is a no-op unless an agent opts in.
+            provider_text = await run_context_providers(
+                cached_spec, input_from_turn(conv, msg_body)
+            )
             instructions = build_instructions(
                 cached_spec,
-                None,
+                provider_text,
                 [],
             )
 

--- a/omnigent/runtime/context_providers.py
+++ b/omnigent/runtime/context_providers.py
@@ -1,0 +1,98 @@
+"""Per-turn context providers.
+
+A *context provider* is a dotted-path callable declared in an agent spec's
+``context_providers:`` block. It is resolved and invoked on every turn; the text
+it returns is **appended** to the system instructions (additive — it never
+replaces the agent's prompt). Providers are read-only and best-effort: one that
+raises, or returns nothing, is logged and skipped, and never blocks the turn.
+
+Provider contract::
+
+    async def provider(ctx: ContextProviderInput) -> str | None: ...
+
+A synchronous callable returning ``str | None`` is also accepted. The ``path``
+may name the provider directly, or a factory (when ``arguments`` are given in
+the spec, it is called with those kwargs to produce the provider).
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from omnigent.policies.function import _resolve_dotted_path
+from omnigent.spec.types import AgentSpec
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ContextProviderInput:
+    """Read-only turn context handed to each provider.
+
+    :param conversation_id: The owning session/conversation id, or ``None``.
+    :param last_user_message: The latest user message text for this turn, or
+        ``None`` when it could not be extracted.
+    """
+
+    conversation_id: str | None = None
+    last_user_message: str | None = None
+
+
+def _last_user_text(msg_body: dict[str, Any]) -> str | None:
+    """Best-effort extraction of the latest user text from a turn message body.
+
+    Handles the shapes the runner uses: a bare string, a list of content blocks
+    (``{"type": "input_text", "text": ...}``), or message items
+    (``{"type": "message", "role": "user", "content": [...]}``).
+    """
+    content = msg_body.get("content")
+    if isinstance(content, str):
+        return content or None
+    if not isinstance(content, list):
+        return None
+    texts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        inner = block.get("content")
+        if isinstance(inner, list):
+            texts.extend(str(b["text"]) for b in inner if isinstance(b, dict) and b.get("text"))
+        elif block.get("text"):
+            texts.append(str(block["text"]))
+    return "\n".join(texts) or None
+
+
+def input_from_turn(conversation_id: str | None, msg_body: dict[str, Any]) -> ContextProviderInput:
+    """Build a :class:`ContextProviderInput` from a runner turn message body."""
+    return ContextProviderInput(
+        conversation_id=conversation_id,
+        last_user_message=_last_user_text(msg_body),
+    )
+
+
+async def run_context_providers(spec: AgentSpec, ctx: ContextProviderInput) -> str | None:
+    """Invoke each declared context provider for this turn.
+
+    :returns: The providers' outputs joined by blank lines, or ``None`` when the
+        spec declares no providers or none produced text. Best-effort — a
+        provider that errors is logged and skipped so memory never breaks a turn.
+    """
+    refs = getattr(spec, "context_providers", None)
+    if not refs:
+        return None
+    parts: list[str] = []
+    for ref in refs:
+        try:
+            target = _resolve_dotted_path(ref.path)
+            provider = target(**ref.arguments) if ref.arguments is not None else target
+            result = provider(ctx)
+            if inspect.isawaitable(result):
+                result = await result
+            if result:
+                parts.append(str(result).strip())
+        except Exception:
+            _logger.exception("context provider %r failed; skipping", ref.path)
+    return "\n\n".join(p for p in parts if p) or None

--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -1140,6 +1140,15 @@ def agent_def_to_agent_spec(
     # error regardless of which spec format the user is on.
     skills_filter = _translate_skills_filter_from_yaml(raw_yaml)
 
+    # Top-level ``context_providers:`` — same shape and parser as the
+    # canonical spec path. Needs the raw YAML (like guardrails above); the
+    # omnigent loader doesn't carry this field on ``AgentDef``.
+    context_providers = None
+    if raw_yaml is not None:
+        from omnigent.spec.parser import _parse_context_providers
+
+        context_providers = _parse_context_providers(raw_yaml.get("context_providers"))
+
     return AgentSpec(
         spec_version=_SYNTHETIC_SPEC_VERSION,
         name=name,
@@ -1160,6 +1169,7 @@ def agent_def_to_agent_spec(
         # AgentSpec expects.
         agent_session_sharing=SharePolicy(agent_def.agent_session_sharing),
         skills_filter=skills_filter,
+        context_providers=context_providers,
     )
 
 

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -231,6 +231,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
     guardrails = _parse_guardrails(raw.get("guardrails"), expand_env=expand_env)
     os_env = _parse_os_env(raw.get("os_env"))
     terminals = _parse_terminals(raw.get("terminals"))
+    context_providers = _parse_context_providers(raw.get("context_providers"))
     params = raw.get("params", {})
     # Top-level ``async:`` flag gates the LLM-callable async-dispatch
     # builtins (``sys_call_async``, ``sys_read_inbox``,
@@ -300,6 +301,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
         timers=timers,
         spawn=spawn,
         agent_session_sharing=agent_session_sharing,
+        context_providers=context_providers,
     )
 
 
@@ -3272,6 +3274,64 @@ def _parse_function_ref(
             code=ErrorCode.INVALID_INPUT,
         )
     return FunctionRef(path=path, arguments=args)
+
+
+def _parse_context_providers(raw: Any) -> list[FunctionRef] | None:
+    """
+    Parse the top-level ``context_providers:`` block into FunctionRefs.
+
+    Each entry is a function reference — the same shape as a function
+    policy's ``function:`` — accepted as a bare dotted-path string, a
+    ``{path, arguments}`` mapping, or a ``{type: function, function:
+    {path, arguments}}`` mapping (so the block reads like ``policies``).
+    Providers are resolved once at load and invoked on every turn; each
+    returns text appended to the system instructions.
+
+    :param raw: The raw ``context_providers:`` value from YAML.
+    :returns: A list of :class:`FunctionRef`, or ``None`` when the block
+        is absent or an empty list.
+    :raises OmnigentError: If the value isn't a list, or an entry is
+        malformed (non-string path, bad ``arguments``, wrong type).
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise OmnigentError(
+            f"context_providers: must be a list, got {type(raw).__name__}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    providers: list[FunctionRef] = []
+    for i, item in enumerate(raw):
+        label = f"context_providers[{i}]"
+        ref = item.get("function", item) if isinstance(item, dict) else item
+        if isinstance(ref, str):
+            if not ref:
+                raise OmnigentError(
+                    f"{label}: provider path must be a non-empty dotted-path string",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            providers.append(FunctionRef(path=ref, arguments=None))
+            continue
+        if not isinstance(ref, dict):
+            raise OmnigentError(
+                f"{label}: must be a dotted-path string or a mapping with "
+                f"{{path, arguments}}, got {type(ref).__name__}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        path = ref.get("path")
+        if not isinstance(path, str) or not path:
+            raise OmnigentError(
+                f"{label}: `path` must be a non-empty dotted-path string",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        args = ref.get("arguments")
+        if args is not None and not isinstance(args, dict):
+            raise OmnigentError(
+                f"{label}: `arguments` must be a mapping (or omitted), got {type(args).__name__}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        providers.append(FunctionRef(path=path, arguments=args))
+    return providers or None
 
 
 def _parse_policy_ask_timeout(

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -1481,6 +1481,13 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
         ``non-public`` (grant named users only), or ``public`` (also
         allow ``__public__`` anonymous read). **Defaults to
         ``SharePolicy.NONE``.**
+    :param context_providers: Per-turn context providers — dotted-path
+        callables (same ``FunctionRef`` shape as function policies)
+        resolved once at load and invoked on every turn. Each returns
+        text that is **appended** to the system instructions (additive;
+        it never replaces the agent prompt). ``None`` means no
+        ``context_providers:`` block was declared. See
+        ``runtime/prompt.py::build_instructions``.
     """
 
     spec_version: int
@@ -1527,3 +1534,4 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
     timers: bool = False
     spawn: bool = False
     agent_session_sharing: SharePolicy = SharePolicy.NONE
+    context_providers: list[FunctionRef] | None = None

--- a/tests/e2e/omnigent/test_yaml_context_providers.py
+++ b/tests/e2e/omnigent/test_yaml_context_providers.py
@@ -1,0 +1,118 @@
+"""E2E — per-turn ``context_providers`` injection.
+
+Runs ``tests/resources/examples/agent_with_context_provider.yaml`` through
+``omnigent run`` and asserts the sentinel passphrase a declared context provider
+injects into the system instructions appears in the model's reply — proving the
+``context_providers`` hook augments the prompt on a real turn.
+
+**What this proves:** the provider
+(``tests.resources.examples._shared.context_provider_probe.remember_passphrase``)
+returns a ``REMEMBER:`` line each turn; the runtime appends it to the system
+instructions via ``build_instructions``'s ``per_request_instructions`` slot
+(fed from ``AgentSpec.context_providers`` at the per-turn setup in
+``runner/app.py``). The agent is told to echo the passphrase, so the sentinel in
+stdout is end-to-end evidence the injection reached the model.
+
+**What breaks if this fails:** the ``context_providers`` spec field / parser, the
+single-file passthrough, ``runtime.context_providers.run_context_providers``, or
+the per-turn wiring regressed — or the provider output stopped being appended.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from shutil import which
+
+import pytest
+
+from tests.e2e._harness_probes import HARNESS_HARNESS_MODELS, HARNESS_IDS
+from tests.resources.examples._shared.context_provider_probe import SENTINEL
+
+_PROMPT = "What is the passphrase? Reply with it exactly and nothing else."
+_RUN_TIMEOUT_SEC = 240
+
+
+def _check_harness_available(harness: str, omnigent_python: Path) -> None:
+    """Fail loud (don't silently skip) if the parametrized harness is missing."""
+    if harness == "claude-sdk":
+        probe = subprocess.run(
+            [
+                str(omnigent_python),
+                "-c",
+                "import importlib.util, sys; "
+                "sys.exit(0 if importlib.util.find_spec('claude_agent_sdk') else 1)",
+            ],
+            capture_output=True,
+        )
+        if probe.returncode != 0 or which("claude") is None:
+            pytest.fail(
+                "claude-sdk harness prerequisites missing: both the "
+                "'claude_agent_sdk' Python package and the 'claude' CLI binary "
+                "must be present on PATH."
+            )
+    elif harness == "codex":
+        if which("codex") is None:
+            pytest.fail(
+                "codex harness prerequisite missing: the 'codex' CLI binary must "
+                "be installed on PATH (npm i -g @openai/codex)."
+            )
+
+
+@pytest.mark.parametrize("harness,model", HARNESS_HARNESS_MODELS, ids=HARNESS_IDS)
+def test_yaml_context_provider_injects_passphrase(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    omnigent_credentials_env: dict[str, str],
+    patched_databrickscfg: None,
+    harness: str,
+    model: str,
+) -> None:
+    """The injected REMEMBER line reaches the model: the reply contains the sentinel.
+
+    cwd is the repo root so the YAML's ``context_providers`` dotted path
+    (``tests.resources.examples._shared.context_provider_probe.remember_passphrase``)
+    resolves on ``sys.path``.
+    """
+    _check_harness_available(harness, omnigent_python)
+    yaml_path = (
+        omnigent_repo_root
+        / "tests"
+        / "resources"
+        / "examples"
+        / "agent_with_context_provider.yaml"
+    )
+
+    result = subprocess.run(
+        [
+            str(omnigent_python),
+            "-m",
+            "omnigent",
+            "run",
+            str(yaml_path),
+            "--harness",
+            harness,
+            "--model",
+            model,
+            "-p",
+            _PROMPT,
+            "--no-log",
+            "--no-session",
+        ],
+        env=omnigent_credentials_env,
+        cwd=str(omnigent_repo_root),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+        stdin=subprocess.DEVNULL,
+    )
+
+    assert result.returncode == 0, (
+        f"omnigent run exited {result.returncode}.\n\n"
+        f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+    )
+    assert SENTINEL in result.stdout, (
+        f"Expected the context-provider sentinel {SENTINEL!r} in stdout — the "
+        f"context_providers hook should have injected the REMEMBER line into the "
+        f"system prompt.\n\nstdout:\n{result.stdout!r}"
+    )

--- a/tests/resources/examples/_shared/context_provider_probe.py
+++ b/tests/resources/examples/_shared/context_provider_probe.py
@@ -1,0 +1,20 @@
+"""Context-provider probe used by the per-turn injection e2e test.
+
+A deterministic provider: it injects a ``REMEMBER:`` line carrying an
+unmistakable sentinel on every turn. The e2e agent is told to echo the
+passphrase, so the sentinel appearing in the model's reply proves the
+``context_providers`` hook injected this text into the system prompt.
+"""
+
+from __future__ import annotations
+
+# Unmistakable, unlikely-to-occur-by-chance sentinel.
+SENTINEL = "GALACTIC-OTTER-7"
+
+
+def remember_passphrase(ctx: object) -> str:
+    """Return a REMEMBER line; ``ctx`` is the per-turn ContextProviderInput."""
+    return (
+        f"REMEMBER: the passphrase is {SENTINEL}. "
+        f"When asked for the passphrase, reply with it exactly."
+    )

--- a/tests/resources/examples/agent_with_context_provider.yaml
+++ b/tests/resources/examples/agent_with_context_provider.yaml
@@ -1,0 +1,18 @@
+# E2E fixture: an agent with a per-turn context provider.
+#
+# The provider injects a "REMEMBER:" line containing a sentinel passphrase into
+# the system instructions on every turn. The prompt tells the agent to obey it,
+# so the sentinel appearing in the reply proves the context_providers hook
+# augmented the system prompt (and did not replace the agent's own prompt).
+#
+# Run (harness/model supplied by flags):
+#   omnigent run tests/resources/examples/agent_with_context_provider.yaml \
+#     --harness claude-sdk -p "What is the passphrase?"
+
+name: agent_with_context_provider
+prompt: |
+  You are a terse assistant. If your instructions contain a "REMEMBER:" line,
+  obey it. When asked for the passphrase, reply with it exactly and nothing else.
+
+context_providers:
+  - tests.resources.examples._shared.context_provider_probe.remember_passphrase

--- a/tests/runtime/test_context_providers.py
+++ b/tests/runtime/test_context_providers.py
@@ -1,0 +1,141 @@
+"""Unit tests for per-turn context providers (omnigent.runtime.context_providers)."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from omnigent.runtime.context_providers import (
+    ContextProviderInput,
+    _last_user_text,
+    input_from_turn,
+    run_context_providers,
+)
+from omnigent.spec.types import AgentSpec, FunctionRef
+
+
+def _spec(refs: list[FunctionRef] | None) -> AgentSpec:
+    return AgentSpec(spec_version=1, context_providers=refs)
+
+
+# Register provider callables in a throwaway module so dotted-path resolution
+# (importlib) can find them by string, exactly as a real spec would.
+_MOD = types.ModuleType("ctxprov_test_mod")
+
+
+def _sync_provider(ctx: ContextProviderInput) -> str:
+    return f"sync:{ctx.last_user_message}"
+
+
+async def _async_provider(ctx: ContextProviderInput) -> str:
+    return f"async:{ctx.conversation_id}"
+
+
+def _empty_provider(ctx: ContextProviderInput) -> None:
+    return None
+
+
+def _boom_provider(ctx: ContextProviderInput) -> str:
+    raise RuntimeError("boom")
+
+
+def _factory(prefix: str):
+    def provider(ctx: ContextProviderInput) -> str:
+        return f"{prefix}:{ctx.last_user_message}"
+
+    return provider
+
+
+for _name in (
+    "_sync_provider",
+    "_async_provider",
+    "_empty_provider",
+    "_boom_provider",
+    "_factory",
+):
+    setattr(_MOD, _name, globals()[_name])
+sys.modules["ctxprov_test_mod"] = _MOD
+
+
+async def test_no_providers_returns_none() -> None:
+    assert await run_context_providers(_spec(None), ContextProviderInput()) is None
+    assert await run_context_providers(_spec([]), ContextProviderInput()) is None
+
+
+async def test_sync_provider() -> None:
+    out = await run_context_providers(
+        _spec([FunctionRef(path="ctxprov_test_mod._sync_provider")]),
+        ContextProviderInput(last_user_message="hi"),
+    )
+    assert out == "sync:hi"
+
+
+async def test_async_provider() -> None:
+    out = await run_context_providers(
+        _spec([FunctionRef(path="ctxprov_test_mod._async_provider")]),
+        ContextProviderInput(conversation_id="conv_1"),
+    )
+    assert out == "async:conv_1"
+
+
+async def test_factory_with_arguments() -> None:
+    out = await run_context_providers(
+        _spec([FunctionRef(path="ctxprov_test_mod._factory", arguments={"prefix": "P"})]),
+        ContextProviderInput(last_user_message="q"),
+    )
+    assert out == "P:q"
+
+
+async def test_errors_and_empties_are_skipped() -> None:
+    out = await run_context_providers(
+        _spec(
+            [
+                FunctionRef(path="ctxprov_test_mod._boom_provider"),
+                FunctionRef(path="ctxprov_test_mod._empty_provider"),
+                FunctionRef(path="ctxprov_test_mod._sync_provider"),
+            ]
+        ),
+        ContextProviderInput(last_user_message="x"),
+    )
+    assert out == "sync:x"
+
+
+async def test_multiple_outputs_joined() -> None:
+    out = await run_context_providers(
+        _spec(
+            [
+                FunctionRef(path="ctxprov_test_mod._sync_provider"),
+                FunctionRef(path="ctxprov_test_mod._async_provider"),
+            ]
+        ),
+        ContextProviderInput(conversation_id="c", last_user_message="m"),
+    )
+    assert out == "sync:m\n\nasync:c"
+
+
+def test_last_user_text_string() -> None:
+    assert _last_user_text({"content": "hello"}) == "hello"
+
+
+def test_last_user_text_blocks() -> None:
+    body = {"content": [{"type": "input_text", "text": "a"}, {"type": "input_text", "text": "b"}]}
+    assert _last_user_text(body) == "a\nb"
+
+
+def test_last_user_text_message_items() -> None:
+    body = {
+        "content": [
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+        ]
+    }
+    assert _last_user_text(body) == "hi"
+
+
+def test_last_user_text_missing() -> None:
+    assert _last_user_text({}) is None
+
+
+def test_input_from_turn() -> None:
+    ci = input_from_turn("conv_9", {"content": "yo"})
+    assert ci.conversation_id == "conv_9"
+    assert ci.last_user_message == "yo"

--- a/tests/spec/test_context_providers.py
+++ b/tests/spec/test_context_providers.py
@@ -1,0 +1,90 @@
+"""Tests for the top-level ``context_providers:`` spec block."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.errors import OmnigentError
+from omnigent.spec.parser import _parse_context_providers, parse
+from omnigent.spec.types import FunctionRef
+
+
+def _agent_dir(tmp_path: Path, config: dict) -> Path:
+    config.setdefault("spec_version", 1)
+    config.setdefault("name", "ctx-test")
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    return tmp_path
+
+
+# ── via the public parser (integration) ──────────────────────────────────────
+
+
+def test_absent_block_is_none(tmp_path: Path) -> None:
+    spec = parse(_agent_dir(tmp_path, {}))
+    assert spec.context_providers is None
+
+
+def test_parse_full_spec(tmp_path: Path) -> None:
+    config = {
+        "context_providers": [
+            "pkg.mod.recall",
+            {
+                "type": "function",
+                "function": {"path": "pkg.mod.facts", "arguments": {"k": 1}},
+            },
+        ],
+    }
+    spec = parse(_agent_dir(tmp_path, config))
+    assert spec.context_providers == [
+        FunctionRef(path="pkg.mod.recall", arguments=None),
+        FunctionRef(path="pkg.mod.facts", arguments={"k": 1}),
+    ]
+
+
+# ── the parser helper directly ───────────────────────────────────────────────
+
+
+def test_bare_string() -> None:
+    assert _parse_context_providers(["pkg.mod.recall"]) == [
+        FunctionRef(path="pkg.mod.recall", arguments=None)
+    ]
+
+
+def test_path_arguments_dict() -> None:
+    assert _parse_context_providers([{"path": "pkg.mod.recall", "arguments": {"d": "ops"}}]) == [
+        FunctionRef(path="pkg.mod.recall", arguments={"d": "ops"})
+    ]
+
+
+def test_function_wrapper() -> None:
+    assert _parse_context_providers(
+        [{"type": "function", "function": {"path": "pkg.mod.recall"}}]
+    ) == [FunctionRef(path="pkg.mod.recall", arguments=None)]
+
+
+def test_none_and_empty_are_none() -> None:
+    assert _parse_context_providers(None) is None
+    assert _parse_context_providers([]) is None
+
+
+def test_non_list_rejected() -> None:
+    with pytest.raises(OmnigentError, match=r"must be a list"):
+        _parse_context_providers("pkg.mod.recall")
+
+
+def test_empty_path_rejected() -> None:
+    with pytest.raises(OmnigentError, match=r"non-empty"):
+        _parse_context_providers([""])
+
+
+def test_missing_path_rejected() -> None:
+    with pytest.raises(OmnigentError, match=r"`path`"):
+        _parse_context_providers([{"arguments": {"k": 1}}])
+
+
+def test_bad_arguments_rejected() -> None:
+    with pytest.raises(OmnigentError, match=r"`arguments`"):
+        _parse_context_providers([{"path": "pkg.mod.recall", "arguments": "nope"}])


### PR DESCRIPTION
Closes #2374.

Adds a declarative `context_providers:` block whose callables run each turn; their output is **appended** to the system instructions via the existing `per_request_instructions` slot — additive, it never replaces the agent's prompt. This gives agent-memory / RAG / dynamic-context integrations a first-class seam instead of forking or shell-wrapping the CLI.

### Config

```yaml
context_providers:
  - my_pkg.providers.recall                 # bare dotted-path
  - type: function                          # …or the full function-ref form
    function:
      path: my_pkg.providers.facts
      arguments: { domain: "ops" }
```

Same `FunctionRef` shape as a function policy — bare string, `{path, arguments}`, or `{type: function, function: {...}}`. Providers are read-only and best-effort (one that raises is logged + skipped, never breaking a turn).

### Change surface (+575 / −1)

| File | Change |
|------|--------|
| `spec/types.py` | `AgentSpec.context_providers` field |
| `spec/parser.py` | `_parse_context_providers` helper |
| `spec/omnigent.py` | single-file spec passthrough |
| `runtime/context_providers.py` | **new** — resolver + per-turn runner |
| `runner/app.py` | one line: `None` → `await run_context_providers(...)` |

`build_instructions` is unchanged — it already appends `per_request_instructions`; this PR just supplies it.

### Tests

- `tests/spec/test_context_providers.py` + `tests/runtime/test_context_providers.py` — 21 unit tests (parser shapes, resolver, sync/async, fail-open, join). Green on Python 3.10–3.12.
- `tests/e2e/omnigent/test_yaml_context_providers.py` — runs an agent through `omnigent run` and asserts a sentinel a provider injects reaches the model across turns (proves per-turn injection, not once).
- `ruff check` / `ruff format --check` clean.

### Notes

- Scoped to the turn path; the compaction call site (`runtime/workflow.py`) can follow later if wanted.
- Open questions (naming, async-only vs sync, error policy, ordering, caching) are in #2374 — happy to adjust to your preference.

Signed off per DCO.
