### PR TITLE
fix(runner): reap terminals after orphan runner teardown

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -792,7 +792,7 @@ def reap_orphaned_terminals() -> int:
             continue
         socket_path = entry / "tmux.sock"
         if socket_path.exists():
-            with contextlib.suppress(OSError, subprocess.TimeoutExpired):
+            try:
                 subprocess.run(
                     ["tmux", "-S", str(socket_path), "kill-server"],
                     # kill-server on an already-dead server exits non-zero;
@@ -801,6 +801,17 @@ def reap_orphaned_terminals() -> int:
                     capture_output=True,
                     timeout=_REAP_KILL_TIMEOUT_S,
                 )
+            except (OSError, subprocess.TimeoutExpired):
+                # Keep the socket path and owner marker so a later startup can
+                # retry. Removing them here would leave a wedged tmux server
+                # alive but permanently unreachable by the orphan sweep.
+                logger.warning(
+                    "Failed to stop orphaned terminal tmux server at %s; "
+                    "retaining instance metadata for retry",
+                    socket_path,
+                    exc_info=True,
+                )
+                continue
         shutil.rmtree(entry, ignore_errors=True)
         reaped += 1
     return reaped

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -979,18 +979,6 @@ def create_app(
     from omnigent.terminals import TerminalRegistry
 
     _terminal_registry = TerminalRegistry(conversation_link_base_url=server_url)
-    # Reap terminal tmux servers leaked by a previous runner that died
-    # without graceful shutdown (SIGKILL / harness teardown). Detached
-    # tmux outlives its supervisor, and runner-bound SDK sessions now
-    # auto-create the embedded REPL terminal — without this sweep every
-    # ungraceful exit leaks one tmux server per session (enough to
-    # starve CI hosts running many short-lived runners).
-    _reaped_terminals = reap_orphaned_terminals()
-    if _reaped_terminals:
-        _logger.info(
-            "Reaped %d orphaned terminal tmux server(s) from prior runs",
-            _reaped_terminals,
-        )
 
     # Reuse the tunnel binding token for runner-side request auth.
     # The same secret is already shared between the
@@ -1011,6 +999,16 @@ def create_app(
     async def _start_pm() -> None:
         """Start harness process manager; register MCP prewarm metadata if requested."""
         await pm.start()
+        # Process-manager startup first terminates orphan runners from prior
+        # instances. Only after that can their detached tmux owners read as
+        # dead; sweeping before pm.start() misses them and no later startup
+        # pass revisits the newly orphaned terminals.
+        _reaped_terminals = reap_orphaned_terminals()
+        if _reaped_terminals:
+            _logger.info(
+                "Reaped %d orphaned terminal tmux server(s) from prior runs",
+                _reaped_terminals,
+            )
         prewarm_path = os.environ.get(_RUNNER_PREWARM_SPEC_PATH_ENV_VAR)
         if prewarm_path and mcp_manager is not None:
             try:

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -1259,6 +1259,35 @@ def test_reap_orphaned_terminals_kills_server_for_dead_owner_socket(
     assert kill_calls == [["tmux", "-S", str(socket_path), "kill-server"]]
 
 
+def test_reap_orphaned_terminals_retains_metadata_when_kill_times_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timed-out tmux server remains reachable for a later cleanup retry."""
+
+    def _time_out(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise TimeoutError
+
+    monkeypatch.setattr(terminal_mod, "_terminals_tmp_root", lambda: tmp_path)
+    monkeypatch.setattr(terminal_mod, "_tmux_available", lambda: True)
+    monkeypatch.setattr(
+        terminal_mod,
+        "subprocess",
+        SimpleNamespace(run=_time_out, TimeoutExpired=TimeoutError),
+    )
+    dead_dir = _write_instance_dir(tmp_path, "omnigent-terminal-wedged", _dead_pid())
+    socket_path = dead_dir / "tmux.sock"
+    socket_path.touch()
+
+    reaped = terminal_mod.reap_orphaned_terminals()
+
+    assert reaped == 0
+    assert dead_dir.exists()
+    assert socket_path.exists()
+    assert (dead_dir / "owner.pid").exists()
+
+
 @pytest.mark.skipif(
     sys.platform not in ("linux", "darwin"),
     reason="sandbox backends only resolve on Linux (bwrap) or macOS (seatbelt)",

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -1144,6 +1144,7 @@ async def test_runner_shutdown_closes_terminal_registry(
     mcp_managers: list[_TrackingMcpManager] = []
     async_clients: list[_TrackingAsyncClient] = []
     sync_clients: list[_TrackingSyncClient] = []
+    startup_events: list[str] = []
 
     class _FakeProcessManager:
         def __init__(self) -> None:
@@ -1153,6 +1154,7 @@ async def test_runner_shutdown_closes_terminal_registry(
 
         async def start(self) -> None:
             self.started = True
+            startup_events.append("process_manager_started")
 
         async def shutdown(self) -> None:
             self.shutdown_called = True
@@ -1197,6 +1199,10 @@ async def test_runner_shutdown_closes_terminal_registry(
     monkeypatch.setattr(entry_mod.httpx, "Client", _sync_client_factory)
     monkeypatch.setattr(entry_mod, "_make_auth_token_factory", lambda: None)
     monkeypatch.setattr(
+        "omnigent.inner.terminal.reap_orphaned_terminals",
+        lambda: startup_events.append("terminals_reaped") or 1,
+    )
+    monkeypatch.setattr(
         "omnigent.runner.identity.get_stable_runner_id",
         lambda: "runner-test-id",
     )
@@ -1207,6 +1213,7 @@ async def test_runner_shutdown_closes_terminal_registry(
         pass
 
     assert process_managers and process_managers[0].shutdown_called
+    assert startup_events == ["process_manager_started", "terminals_reaped"]
     assert terminal_registries and terminal_registries[0].shutdown_called
     assert terminal_registries[0].conversation_link_base_url == "http://runner.test"
     # In Omnigent mode (P1) the entry point passes mcp_manager=None; MCP calls are


### PR DESCRIPTION
## Summary
- run the terminal orphan sweep after process-manager startup has terminated prior runner owners
- retain tmux socket and owner metadata when teardown times out so a later startup can retry
- cover startup ordering and retry preservation with focused regressions

## Test plan
- [x] `uv run pytest tests/inner/test_terminal.py::test_reap_orphaned_terminals_reaps_only_dead_owner_dirs tests/inner/test_terminal.py::test_reap_orphaned_terminals_kills_server_for_dead_owner_socket tests/inner/test_terminal.py::test_reap_orphaned_terminals_retains_metadata_when_kill_times_out tests/runner/test_runner_entry.py::test_runner_shutdown_closes_terminal_registry`
- [x] `uv run ruff check omnigent/runner/_entry.py omnigent/inner/terminal.py tests/runner/test_runner_entry.py tests/inner/test_terminal.py`
- [x] `uv run ruff format --check omnigent/runner/_entry.py omnigent/inner/terminal.py tests/runner/test_runner_entry.py tests/inner/test_terminal.py`


Made with [Cursor](https://cursor.com)

## Demo

N/A — no UI change. Orphan runner teardown now reaps leftover terminals; behaviour covered by the regression tests in this PR.
