### PR TITLE
feat(desktop): nickname recent servers on the connect screen and title-bar picker

### DIFF
--- a/tests/e2e_ui/desktop/test_setup_recents_rename.py
+++ b/tests/e2e_ui/desktop/test_setup_recents_rename.py
@@ -1,0 +1,132 @@
+"""Desktop setup-page recent-servers nicknames (Electron shell).
+
+The setup page (``web/electron/setup/index.html``) lists recently-connected
+servers and lets the user give each one an optional nickname, so a list of
+near-identical URLs can be told apart. This exercises the rename flow in a real
+browser: entries render their nickname (with the host trailing) or the bare
+URL, the pencil opens an inline field, Enter saves through the shell bridge,
+Escape cancels, and a blank value clears the nickname.
+
+Like ``test_setup_connect``, these drive only the static page plus its shared
+modules (``web/electron/src/url.js`` + ``src/recents.js``) with the Electron
+preload bridge (``window.omnigentSetup``) stubbed — no ``live_server`` backend.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from playwright.sync_api import Page, expect
+
+_SETUP_PAGE = Path(__file__).resolve().parents[3] / "web" / "electron" / "setup" / "index.html"
+
+# Stub the preload bridge. getRecentServers seeds a labelled + an unlabelled
+# entry; setRecentServerLabel records the call and mutates an in-page store the
+# way the main process mutates settings.json, returning the updated list so the
+# page re-renders — mirroring the real IPC contract.
+_PRELOAD_STUB = """
+  window.__connectCalls = [];
+  window.__labelCalls = [];
+  window.__recents = [
+    { url: "https://prod-abc.example.com/ml/omnigent", label: "Prod (west)" },
+    { url: "http://localhost:6767", label: "" },
+  ];
+  window.omnigentSetup = {
+    getServerUrl: () => Promise.resolve(""),
+    getRecentServers: () => Promise.resolve(window.__recents.map((e) => ({ ...e }))),
+    setServerUrl: (value) => { window.__connectCalls.push(value); return Promise.resolve(); },
+    setRecentServerLabel: (url, label) => {
+      window.__labelCalls.push([url, label]);
+      const trimmed = (label || "").trim();
+      window.__recents = window.__recents.map(
+        (e) => (e.url === url ? { url: e.url, label: trimmed } : e),
+      );
+      return Promise.resolve(window.__recents.map((e) => ({ ...e })));
+    },
+  };
+"""
+
+_DEFAULT_PREFILL = "http://localhost:6767"
+
+
+def _open_setup_page(page: Page) -> None:
+    """Load the setup page with the preload bridge stubbed and prefill settled.
+
+    :param page: Playwright page fixture.
+    """
+    page.add_init_script(_PRELOAD_STUB)
+    page.goto(_SETUP_PAGE.as_uri())
+    expect(page.locator("#url")).to_have_value(_DEFAULT_PREFILL)
+
+
+def test_recents_render_nickname_and_bare_url(page: Page) -> None:
+    """A labelled entry shows its nickname + host; an unlabelled one, its URL."""
+    _open_setup_page(page)
+
+    rows = page.locator(".recent-row")
+    expect(rows).to_have_count(2)
+
+    # Labelled entry: nickname leads, host trails.
+    expect(rows.nth(0).locator(".rb-label")).to_have_text("Prod (west)")
+    expect(rows.nth(0).locator(".rb-url")).to_have_text("prod-abc.example.com")
+
+    # Unlabelled entry: the bare URL, no nickname span.
+    expect(rows.nth(1).locator(".recent-btn")).to_have_text("http://localhost:6767")
+    expect(rows.nth(1).locator(".rb-label")).to_have_count(0)
+
+
+def test_rename_saves_nickname_and_rerenders(page: Page) -> None:
+    """The pencil opens an inline field; Enter saves through the bridge."""
+    _open_setup_page(page)
+
+    # Rename the unlabelled localhost entry (row 2).
+    page.locator(".recent-row").nth(1).locator(".recent-rename").click()
+    field = page.locator(".recent-edit input")
+    expect(field).to_be_focused()
+    field.fill("Local dev")
+    field.press("Enter")
+
+    # The bridge was called with the exact url + new nickname.
+    page.wait_for_function("() => window.__labelCalls.length === 1")
+    assert page.evaluate("() => window.__labelCalls") == [["http://localhost:6767", "Local dev"]]
+
+    # The row now renders the nickname + host instead of the bare URL.
+    row = page.locator(".recent-row").nth(1)
+    expect(row.locator(".rb-label")).to_have_text("Local dev")
+    expect(row.locator(".rb-url")).to_have_text("localhost:6767")
+
+
+def test_rename_escape_cancels_without_saving(page: Page) -> None:
+    """Escape leaves edit mode without calling the bridge or changing the row."""
+    _open_setup_page(page)
+
+    page.locator(".recent-row").nth(1).locator(".recent-rename").click()
+    field = page.locator(".recent-edit input")
+    field.fill("Discarded")
+    field.press("Escape")
+
+    expect(page.locator(".recent-edit")).to_have_count(0)
+    assert page.evaluate("() => window.__labelCalls") == []
+    expect(page.locator(".recent-row").nth(1).locator(".recent-btn")).to_have_text(
+        "http://localhost:6767"
+    )
+
+
+def test_blank_value_clears_the_nickname(page: Page) -> None:
+    """Saving a blank value clears the nickname, reverting to the bare URL."""
+    _open_setup_page(page)
+
+    # Clear the nickname on the labelled entry (row 1).
+    page.locator(".recent-row").nth(0).locator(".recent-rename").click()
+    field = page.locator(".recent-edit input")
+    field.fill("")
+    field.press("Enter")
+
+    page.wait_for_function("() => window.__labelCalls.length === 1")
+    assert page.evaluate("() => window.__labelCalls") == [
+        ["https://prod-abc.example.com/ml/omnigent", ""]
+    ]
+
+    row = page.locator(".recent-row").nth(0)
+    expect(row.locator(".rb-label")).to_have_count(0)
+    expect(row.locator(".recent-btn")).to_have_text("https://prod-abc.example.com/ml/omnigent")

--- a/tests/e2e_ui/desktop/test_setup_recents_rename.py
+++ b/tests/e2e_ui/desktop/test_setup_recents_rename.py
@@ -115,6 +115,37 @@ def test_rename_escape_cancels_without_saving(page: Page) -> None:
     )
 
 
+def test_switching_rows_mid_edit_moves_edit_on_first_click(page: Page) -> None:
+    """Clicking another row's pencil mid-edit switches editors on the first click.
+
+    The open field cancels on blur; without preempting that blur, clicking a
+    different row's pencil tears the pencil down before its click lands, so the
+    first click is swallowed and edit mode never moves. This asserts the switch
+    happens on a single click and discards the in-progress (unsaved) edit.
+    """
+    _open_setup_page(page)
+
+    # Start editing the labelled entry (row 1) and type an unsaved value.
+    page.locator(".recent-row").nth(0).locator(".recent-rename").click()
+    field = page.locator(".recent-edit input")
+    expect(field).to_be_focused()
+    field.fill("Unsaved edit")
+
+    # One click on row 2's pencil must move edit mode there.
+    page.locator(".recent-row").nth(1).locator(".recent-rename").click()
+
+    # Exactly one editor, on row 2, seeded from its stored (blank) label — the
+    # unsaved row-1 text did not leak across, and nothing was persisted.
+    expect(page.locator(".recent-edit")).to_have_count(1)
+    moved = page.locator(".recent-row").nth(1).locator(".recent-edit input")
+    expect(moved).to_be_focused()
+    expect(moved).to_have_value("")
+    assert page.evaluate("() => window.__labelCalls") == []
+
+    # Row 1 reverted to its unchanged nickname.
+    expect(page.locator(".recent-row").nth(0).locator(".rb-label")).to_have_text("Prod (west)")
+
+
 def test_blank_value_clears_the_nickname(page: Page) -> None:
     """Saving a blank value clears the nickname, reverting to the bare URL."""
     _open_setup_page(page)

--- a/tests/e2e_ui/desktop/test_setup_recents_rename.py
+++ b/tests/e2e_ui/desktop/test_setup_recents_rename.py
@@ -83,6 +83,9 @@ def test_rename_saves_nickname_and_rerenders(page: Page) -> None:
     page.locator(".recent-row").nth(1).locator(".recent-rename").click()
     field = page.locator(".recent-edit input")
     expect(field).to_be_focused()
+    # A nickname is a display label, so any characters are allowed — only the
+    # length is capped, to protect the stored file and the list layout.
+    expect(field).to_have_attribute("maxlength", "60")
     field.fill("Local dev")
     field.press("Enter")
 

--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -571,6 +571,9 @@
         btn.title = "Rename this server";
         btn.setAttribute("aria-label", `Rename ${entry.label || hostOf(entry.url)}`);
         btn.appendChild(renameIcon.content.cloneNode(true));
+        // Keep focus on any open editor so its blur→cancel doesn't tear this
+        // pencil down before the click lands and swallow a row switch.
+        btn.addEventListener("mousedown", (e) => e.preventDefault());
         btn.addEventListener("click", () => {
           editingUrl = entry.url;
           renderRecents();
@@ -597,7 +600,8 @@
         function cancel() {
           if (settled) return;
           settled = true;
-          editingUrl = null;
+          // Don't clobber a switch to another row: only exit if still ours.
+          if (editingUrl === entry.url) editingUrl = null;
           renderRecents();
         }
         async function save() {

--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -127,8 +127,18 @@
         font-weight: 500;
         color: var(--muted-foreground);
       }
-      .recent-btn {
+      /* Each recent server is a row: the quick-pick button (fill + connect on
+         click) and a rename control that swaps it for an inline field. */
+      .recent-row {
+        display: flex;
+        align-items: stretch;
+        gap: 6px;
         margin-top: 6px;
+      }
+      .recent-btn {
+        flex: 1 1 auto;
+        min-width: 0;
+        width: auto;
         padding: 8px 12px;
         text-align: left;
         border: 1px solid var(--border);
@@ -140,6 +150,41 @@
       }
       .recent-btn:hover {
         background: color-mix(in srgb, var(--foreground) 5%, transparent);
+      }
+      /* When a nickname is set the label leads; the host trails muted + small. */
+      .rb-label {
+        font-weight: 500;
+      }
+      .rb-url {
+        margin-left: 8px;
+        font-size: 12px;
+        color: var(--muted-foreground);
+      }
+      /* Rename control — the same quiet icon-button treatment as the gear. */
+      .recent-rename {
+        flex: 0 0 auto;
+        width: 34px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        border: 1px solid var(--border);
+        background: transparent;
+        color: var(--muted-foreground);
+      }
+      .recent-rename:hover {
+        color: var(--foreground);
+        background: color-mix(in srgb, var(--foreground) 5%, transparent);
+      }
+      /* Inline edit: the label field replaces the button, sharing the row. */
+      .recent-edit {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .edit-hint {
+        margin: 4px 0 0;
+        font-size: 11px;
+        color: var(--muted-foreground);
       }
       .err {
         margin-top: 12px;
@@ -372,6 +417,25 @@
         <p class="recents-title">Recent servers</p>
         <div id="recents-list"></div>
       </div>
+
+      <!-- Cloned per row for the rename control (avoids innerHTML on the list). -->
+      <template id="rename-icon">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 20h9" />
+          <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+        </svg>
+      </template>
     </div>
 
     <!-- Omnigent CLI settings, opened from the gear. Hidden by default. -->
@@ -407,10 +471,14 @@
       </div>
     </div>
     <script src="../src/url.js"></script>
+    <script src="../src/recents.js"></script>
     <script>
       // Shared URL helpers (electron/src/url.js), exposed as window.omnigentUrl
       // — the same module the main process uses, so the two never drift.
       const { isPlainHttpRemote } = window.omnigentUrl;
+      // Shared recent-servers helpers (electron/src/recents.js) — hostOf here is
+      // the same one the main process uses.
+      const { hostOf } = window.omnigentRecents;
       // Uses the Electron preload bridge (electron/src/preload.js).
       const setup = window.omnigentSetup;
       const input = document.getElementById("url");
@@ -460,24 +528,121 @@
       // form works without it.
       const recentsSection = document.getElementById("recents");
       const recentsList = document.getElementById("recents-list");
+      const renameIcon = document.getElementById("rename-icon");
+      // Whether the shell supports renaming; older shells lack the IPC, in
+      // which case rows render read-only (no pencil).
+      const canRename = typeof setup.setRecentServerLabel === "function";
+      // Loaded { url, label } entries, and the url currently in inline edit.
+      let recentServers = [];
+      let editingUrl = null;
+
+      // The fill+connect button: nickname (bold) with the host trailing muted,
+      // or the bare URL when there's no nickname. textContent, never innerHTML —
+      // the values come from disk and must render as inert text.
+      function recentButton(entry) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "recent-btn";
+        btn.title = entry.url; // full URL on hover, even when a nickname shows
+        if (entry.label) {
+          const label = document.createElement("span");
+          label.className = "rb-label";
+          label.textContent = entry.label;
+          const host = document.createElement("span");
+          host.className = "rb-url";
+          host.textContent = hostOf(entry.url);
+          btn.append(label, host);
+        } else {
+          btn.textContent = entry.url;
+        }
+        btn.addEventListener("click", () => {
+          input.value = entry.url;
+          connect();
+        });
+        return btn;
+      }
+
+      // The pencil that switches a row into inline-edit mode.
+      function renameButton(entry) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "recent-rename";
+        btn.title = "Rename this server";
+        btn.setAttribute("aria-label", `Rename ${entry.label || hostOf(entry.url)}`);
+        btn.appendChild(renameIcon.content.cloneNode(true));
+        btn.addEventListener("click", () => {
+          editingUrl = entry.url;
+          renderRecents();
+        });
+        return btn;
+      }
+
+      // The inline label editor: Enter saves, Escape or blur cancels.
+      function recentEditor(entry) {
+        const wrap = document.createElement("div");
+        wrap.className = "recent-edit";
+        const field = document.createElement("input");
+        field.type = "text";
+        field.value = entry.label;
+        field.placeholder = `${hostOf(entry.url)} — leave blank to clear`;
+        field.setAttribute("aria-label", "Server nickname");
+        const hint = document.createElement("p");
+        hint.className = "edit-hint";
+        hint.textContent = "Enter to save · Esc to cancel";
+
+        // Enter/Escape and blur can race; the first outcome wins.
+        let settled = false;
+        function cancel() {
+          if (settled) return;
+          settled = true;
+          editingUrl = null;
+          renderRecents();
+        }
+        async function save() {
+          if (settled) return;
+          settled = true;
+          const value = field.value;
+          editingUrl = null;
+          try {
+            recentServers = await setup.setRecentServerLabel(entry.url, value);
+          } catch {
+            // Keep the last-known list on failure; just leave edit mode.
+          }
+          renderRecents();
+        }
+        field.addEventListener("keydown", (e) => {
+          if (e.key === "Enter") save();
+          else if (e.key === "Escape") cancel();
+        });
+        field.addEventListener("blur", cancel);
+        wrap.append(field, hint);
+        // Focus once it's in the DOM (renderRecents appends synchronously).
+        setTimeout(() => field.focus(), 0);
+        return wrap;
+      }
+
+      function renderRecents() {
+        recentsList.textContent = "";
+        for (const entry of recentServers) {
+          const row = document.createElement("div");
+          row.className = "recent-row";
+          if (canRename && entry.url === editingUrl) {
+            row.appendChild(recentEditor(entry));
+          } else {
+            row.appendChild(recentButton(entry));
+            if (canRename) row.appendChild(renameButton(entry));
+          }
+          recentsList.appendChild(row);
+        }
+        recentsSection.hidden = recentServers.length === 0;
+      }
+
       setup
         .getRecentServers()
         .then((recents) => {
-          if (!Array.isArray(recents) || recents.length === 0) return;
-          for (const url of recents) {
-            const btn = document.createElement("button");
-            btn.type = "button";
-            btn.className = "recent-btn";
-            // textContent, never innerHTML: the URL comes from disk and must
-            // be rendered as inert text.
-            btn.textContent = url;
-            btn.addEventListener("click", () => {
-              input.value = url;
-              connect();
-            });
-            recentsList.appendChild(btn);
-          }
-          recentsSection.hidden = false;
+          if (!Array.isArray(recents)) return;
+          recentServers = recents;
+          renderRecents();
         })
         .catch(() => {});
 

--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -477,8 +477,9 @@
       // — the same module the main process uses, so the two never drift.
       const { isPlainHttpRemote } = window.omnigentUrl;
       // Shared recent-servers helpers (electron/src/recents.js) — hostOf here is
-      // the same one the main process uses.
-      const { hostOf } = window.omnigentRecents;
+      // the same one the main process uses, and MAX_LABEL_LENGTH keeps the
+      // field's cap in sync with the store's.
+      const { hostOf, MAX_LABEL_LENGTH } = window.omnigentRecents;
       // Uses the Electron preload bridge (electron/src/preload.js).
       const setup = window.omnigentSetup;
       const input = document.getElementById("url");
@@ -584,6 +585,7 @@
         const field = document.createElement("input");
         field.type = "text";
         field.value = entry.label;
+        field.maxLength = MAX_LABEL_LENGTH;
         field.placeholder = `${hostOf(entry.url)} — leave blank to clear`;
         field.setAttribute("aria-label", "Server nickname");
         const hint = document.createElement("p");

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -2095,7 +2095,8 @@ function registerIpc() {
     return {
       // isPinnedOriginSender guarantees the sender window is tracked.
       currentOrigin: windows.get(win).origin,
-      recentServers: normalizeRecents(loadSettings().recent_servers).map((e) => e.url),
+      // Each { url, label }; the picker shows the nickname when one is set.
+      recentServers: normalizeRecents(loadSettings().recent_servers),
     };
   });
 

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -41,7 +41,7 @@ const { createBrowserViewBoundsController } = require("./browserViewBounds");
 const { registerBrowserIpc } = require("./browserIpc");
 const { registerSessionExpiryReload } = require("./session-expiry");
 const { decideWindowOpen, stripCrossOriginOpenerHeaders, WEB_SCHEMES } = require("./popupPolicy");
-const { normalizeRecents, rememberRecent, serializeRecents } = require("./recents");
+const { normalizeRecents, rememberRecent, setLabel, serializeRecents } = require("./recents");
 const omnigentCli = require("./omnigent_cli");
 const serverManager = require("./server_manager");
 
@@ -2064,8 +2064,23 @@ function registerIpc() {
     if (!isSetupPageSender(event)) {
       throw new Error("get-recent-servers is only available to the setup page");
     }
-    // Bare URLs, most recent first; junk entries dropped (see normalizeRecents).
-    return normalizeRecents(loadSettings().recent_servers).map((e) => e.url);
+    // Recent servers, most recent first, each { url, label } (label is "" when
+    // no nickname is set); junk entries dropped (see normalizeRecents).
+    return normalizeRecents(loadSettings().recent_servers);
+  });
+
+  // Setup page → set or clear a recent server's nickname. Only a url already in
+  // the list can be labelled (setLabel is a no-op otherwise). Returns the
+  // updated { url, label } list so the page can re-render without a reload.
+  ipcMain.handle("omnigent:set-recent-server-label", (event, url, label) => {
+    if (!isSetupPageSender(event)) {
+      throw new Error("set-recent-server-label is only available to the setup page");
+    }
+    const settings = loadSettings();
+    const list = setLabel(normalizeRecents(settings.recent_servers), url, label);
+    settings.recent_servers = serializeRecents(list);
+    saveSettings(settings);
+    return list;
   });
 
   // SPA title-bar server picker → the sender window's pinned origin plus the

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -41,6 +41,7 @@ const { createBrowserViewBoundsController } = require("./browserViewBounds");
 const { registerBrowserIpc } = require("./browserIpc");
 const { registerSessionExpiryReload } = require("./session-expiry");
 const { decideWindowOpen, stripCrossOriginOpenerHeaders, WEB_SCHEMES } = require("./popupPolicy");
+const { normalizeRecents, rememberRecent, serializeRecents } = require("./recents");
 const omnigentCli = require("./omnigent_cli");
 const serverManager = require("./server_manager");
 
@@ -797,13 +798,12 @@ async function clearCliPath() {
   return omnigentCli.getCliStatus(null);
 }
 
-/** Maximum number of entries kept in the persisted recent-servers list. */
-const MAX_RECENT_SERVERS = 5;
-
 /**
  * Record a successfully-connected server URL at the head of the persisted
- * recent-servers list: most recent first, deduplicated, capped at
- * MAX_RECENT_SERVERS. Mutates `settings` in place; the caller saves it.
+ * recent-servers list: most recent first, deduplicated, capped, preserving any
+ * nickname the url already carries. Mutates `settings` in place; the caller
+ * saves it. The list model and its hand-edited/corrupt tolerance live in
+ * src/recents.js.
  *
  * @param {Record<string, unknown>} settings Settings object from
  *   loadSettings().
@@ -811,13 +811,8 @@ const MAX_RECENT_SERVERS = 5;
  *   e.g. ``"http://localhost:8000/"``.
  */
 function rememberRecentServer(settings, url) {
-  // Tolerate a hand-edited/corrupt settings.json (non-array, junk entries)
-  // by rebuilding the list from whatever string entries survive.
-  const existing = Array.isArray(settings.recent_servers) ? settings.recent_servers : [];
-  settings.recent_servers = [
-    url,
-    ...existing.filter((u) => typeof u === "string" && u !== url),
-  ].slice(0, MAX_RECENT_SERVERS);
+  const list = rememberRecent(normalizeRecents(settings.recent_servers), url);
+  settings.recent_servers = serializeRecents(list);
 }
 
 // ---------------------------------------------------------------------------
@@ -2069,9 +2064,8 @@ function registerIpc() {
     if (!isSetupPageSender(event)) {
       throw new Error("get-recent-servers is only available to the setup page");
     }
-    const recents = loadSettings().recent_servers;
-    // Same hand-edited-settings tolerance as rememberRecentServer.
-    return Array.isArray(recents) ? recents.filter((u) => typeof u === "string") : [];
+    // Bare URLs, most recent first; junk entries dropped (see normalizeRecents).
+    return normalizeRecents(loadSettings().recent_servers).map((e) => e.url);
   });
 
   // SPA title-bar server picker → the sender window's pinned origin plus the
@@ -2083,11 +2077,10 @@ function registerIpc() {
       return null;
     }
     const win = BrowserWindow.fromWebContents(event.sender);
-    const recents = loadSettings().recent_servers;
     return {
       // isPinnedOriginSender guarantees the sender window is tracked.
       currentOrigin: windows.get(win).origin,
-      recentServers: Array.isArray(recents) ? recents.filter((u) => typeof u === "string") : [],
+      recentServers: normalizeRecents(loadSettings().recent_servers).map((e) => e.url),
     };
   });
 
@@ -2101,8 +2094,7 @@ function registerIpc() {
     if (!isPinnedOriginSender(event)) {
       throw new Error("switch-server is only available to a connected server page");
     }
-    const recents = loadSettings().recent_servers;
-    const known = Array.isArray(recents) && recents.includes(url);
+    const known = normalizeRecents(loadSettings().recent_servers).some((e) => e.url === url);
     if (!known) {
       throw new Error("switch-server target must be a previously-connected server");
     }

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -357,8 +357,16 @@ contextBridge.exposeInMainWorld("omnigentSetup", {
    * @param {string} url
    */
   setServerUrl: (url) => ipcRenderer.invoke("omnigent:set-server-url", url),
-  /** Recently-connected server URLs, most recent first. */
+  /** Recently-connected servers, most recent first, each `{ url, label }`. */
   getRecentServers: () => ipcRenderer.invoke("omnigent:get-recent-servers"),
+  /**
+   * Set or clear a recent server's nickname (blank/whitespace clears it).
+   * Resolves the updated recent-servers list (`{ url, label }[]`).
+   * @param {string} url
+   * @param {string} label
+   */
+  setRecentServerLabel: (url, label) =>
+    ipcRenderer.invoke("omnigent:set-recent-server-label", url, label),
   /**
    * Whether the `omnigent` CLI is installed/runnable, e.g.
    * `{installed, path, version, source, installCommand}`.

--- a/web/electron/src/recents.js
+++ b/web/electron/src/recents.js
@@ -1,0 +1,126 @@
+// Recent-servers list logic for the desktop shell.
+//
+// The connect screen and the title-bar switcher both show the servers the user
+// has connected to before. Each entry is a URL that may carry an optional
+// user-set nickname, so a list of near-identical URLs (same host, differing
+// only by a long path or random-looking subdomain) can be told apart at a
+// glance.
+//
+// Stored in the Electron `userData/settings.json` under `recent_servers`. To
+// stay backward- and forward-compatible, an entry on disk is EITHER a bare URL
+// string (the historical format, still written when no nickname is set) OR a
+// `{ url, label }` object (written only once a nickname exists). A plain string
+// read back is treated as an unlabelled entry, and an older shell that only
+// understands strings keeps working for the unlabelled entries it wrote.
+//
+// Only web/Node globals (URL) are used, so the same source runs unchanged under
+// CommonJS (main process, `require("./recents")`) and in the renderer (the
+// setup page, as `window.omnigentRecents`) — one copy keeps the two from
+// drifting, mirroring `src/url.js`.
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  } else {
+    root.omnigentRecents = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  /** Maximum number of entries kept in the persisted recent-servers list. */
+  const MAX_RECENT_SERVERS = 5;
+
+  /** Short display label for a server URL — its host, e.g. "localhost:8000". */
+  function hostOf(url) {
+    try {
+      return new URL(url).host;
+    } catch {
+      return url;
+    }
+  }
+
+  /**
+   * Read a raw `recent_servers` value from disk into a clean, deduplicated list
+   * of `{ url, label }` entries (most recent first). Tolerates a hand-edited or
+   * corrupt file: a non-array yields `[]`, and junk entries (non-string urls,
+   * empty urls) are dropped rather than throwing. A bare string becomes an
+   * unlabelled entry; a duplicate url keeps its first (most recent) occurrence.
+   *
+   * @param {unknown} raw The stored `settings.recent_servers` value.
+   * @returns {Array<{ url: string, label: string }>}
+   */
+  function normalizeRecents(raw) {
+    if (!Array.isArray(raw)) return [];
+    const out = [];
+    const seen = new Set();
+    for (const entry of raw) {
+      let url;
+      let label = "";
+      if (typeof entry === "string") {
+        url = entry;
+      } else if (entry && typeof entry === "object" && typeof entry.url === "string") {
+        url = entry.url;
+        if (typeof entry.label === "string") label = entry.label;
+      } else {
+        continue; // junk entry — drop it
+      }
+      if (!url || seen.has(url)) continue;
+      seen.add(url);
+      out.push({ url, label });
+    }
+    return out;
+  }
+
+  /**
+   * Record a connected server URL at the head of the list: most recent first,
+   * deduplicated, capped at MAX_RECENT_SERVERS. A url already in the list keeps
+   * its existing nickname when it bumps to the head — re-connecting must never
+   * silently drop a label the user set.
+   *
+   * @param {Array<{ url: string, label: string }>} list Normalized list.
+   * @param {string} url Connected server URL (already normalizeUrl()'d).
+   * @returns {Array<{ url: string, label: string }>} A new list.
+   */
+  function rememberRecent(list, url) {
+    const existing = list.find((e) => e.url === url);
+    const head = { url, label: existing ? existing.label : "" };
+    return [head, ...list.filter((e) => e.url !== url)].slice(0, MAX_RECENT_SERVERS);
+  }
+
+  /**
+   * Set (or clear) the nickname for a url already in the list. A blank/whitespace
+   * label clears it, reverting the entry to showing its URL. A url not in the
+   * list is a no-op — you can only label a server you've connected to.
+   *
+   * @param {Array<{ url: string, label: string }>} list Normalized list.
+   * @param {string} url Target server URL.
+   * @param {string} label New nickname; empty/whitespace clears it.
+   * @returns {Array<{ url: string, label: string }>} A new list.
+   */
+  function setLabel(list, url, label) {
+    const trimmed = typeof label === "string" ? label.trim() : "";
+    return list.map((e) => (e.url === url ? { url: e.url, label: trimmed } : e));
+  }
+
+  /**
+   * Serialize a normalized list for disk: an entry with a nickname is written as
+   * a `{ url, label }` object, one without stays a bare string. Keeping the
+   * historical string shape for unlabelled entries means an older shell (which
+   * only reads strings) still sees them, and the file stays readable.
+   *
+   * @param {Array<{ url: string, label: string }>} list Normalized list.
+   * @returns {Array<string | { url: string, label: string }>}
+   */
+  function serializeRecents(list) {
+    return list.map((e) => (e.label ? { url: e.url, label: e.label } : e.url));
+  }
+
+  return {
+    MAX_RECENT_SERVERS,
+    hostOf,
+    normalizeRecents,
+    rememberRecent,
+    setLabel,
+    serializeRecents,
+  };
+});

--- a/web/electron/src/recents.js
+++ b/web/electron/src/recents.js
@@ -30,6 +30,13 @@
   /** Maximum number of entries kept in the persisted recent-servers list. */
   const MAX_RECENT_SERVERS = 5;
 
+  /**
+   * Maximum length of a server nickname. A nickname is a display label, not an
+   * identifier — any characters are allowed (spaces, punctuation, emoji); only
+   * the length is bounded, to protect the stored file and the list layout.
+   */
+  const MAX_LABEL_LENGTH = 60;
+
   /** Short display label for a server URL — its host, e.g. "localhost:8000". */
   function hostOf(url) {
     try {
@@ -98,7 +105,7 @@
    * @returns {Array<{ url: string, label: string }>} A new list.
    */
   function setLabel(list, url, label) {
-    const trimmed = typeof label === "string" ? label.trim() : "";
+    const trimmed = (typeof label === "string" ? label.trim() : "").slice(0, MAX_LABEL_LENGTH);
     return list.map((e) => (e.url === url ? { url: e.url, label: trimmed } : e));
   }
 
@@ -117,6 +124,7 @@
 
   return {
     MAX_RECENT_SERVERS,
+    MAX_LABEL_LENGTH,
     hostOf,
     normalizeRecents,
     rememberRecent,

--- a/web/electron/test/recents.test.js
+++ b/web/electron/test/recents.test.js
@@ -9,6 +9,7 @@ const assert = require("node:assert/strict");
 
 const {
   MAX_RECENT_SERVERS,
+  MAX_LABEL_LENGTH,
   hostOf,
   normalizeRecents,
   rememberRecent,
@@ -136,6 +137,11 @@ describe("setLabel", () => {
 
   it("is a no-op for a url not in the list", () => {
     assert.deepEqual(setLabel(base, "https://unknown.example.com", "X"), base);
+  });
+
+  it("caps the nickname at MAX_LABEL_LENGTH", () => {
+    const long = "x".repeat(MAX_LABEL_LENGTH + 20);
+    assert.equal(setLabel(base, "https://a.example.com", long)[0].label.length, MAX_LABEL_LENGTH);
   });
 });
 

--- a/web/electron/test/recents.test.js
+++ b/web/electron/test/recents.test.js
@@ -1,0 +1,173 @@
+// Tests for the recent-servers list helpers (src/recents.js), run with
+// `node --test` (no extra deps). Covers the legacy-string tolerance, the
+// nickname-preserving bump on re-connect, label set/clear, and the
+// string-when-unlabelled serialization that keeps the on-disk format
+// backward-compatible.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  MAX_RECENT_SERVERS,
+  hostOf,
+  normalizeRecents,
+  rememberRecent,
+  setLabel,
+  serializeRecents,
+} = require("../src/recents");
+
+describe("normalizeRecents", () => {
+  it("returns [] for a non-array (missing/corrupt settings)", () => {
+    assert.deepEqual(normalizeRecents(undefined), []);
+    assert.deepEqual(normalizeRecents(null), []);
+    assert.deepEqual(normalizeRecents("nope"), []);
+  });
+
+  it("reads a legacy string entry as an unlabelled server", () => {
+    assert.deepEqual(normalizeRecents(["http://localhost:6767"]), [
+      { url: "http://localhost:6767", label: "" },
+    ]);
+  });
+
+  it("reads a { url, label } object entry as-is", () => {
+    assert.deepEqual(normalizeRecents([{ url: "https://a.example.com", label: "Prod" }]), [
+      { url: "https://a.example.com", label: "Prod" },
+    ]);
+  });
+
+  it("tolerates a mix of strings and objects", () => {
+    assert.deepEqual(
+      normalizeRecents([{ url: "https://a.example.com", label: "Prod" }, "http://localhost:6767"]),
+      [
+        { url: "https://a.example.com", label: "Prod" },
+        { url: "http://localhost:6767", label: "" },
+      ],
+    );
+  });
+
+  it("drops junk entries (non-string url, empty url, non-string label)", () => {
+    assert.deepEqual(
+      normalizeRecents([
+        42,
+        null,
+        {},
+        { url: 5 },
+        { url: "" },
+        { url: "https://ok.example.com", label: 7 },
+      ]),
+      [{ url: "https://ok.example.com", label: "" }],
+    );
+  });
+
+  it("deduplicates by url, keeping the first (most recent) occurrence", () => {
+    assert.deepEqual(
+      normalizeRecents([
+        { url: "https://a.example.com", label: "First" },
+        { url: "https://a.example.com", label: "Later dup" },
+      ]),
+      [{ url: "https://a.example.com", label: "First" }],
+    );
+  });
+});
+
+describe("rememberRecent", () => {
+  it("puts a new url at the head", () => {
+    const list = [{ url: "https://a.example.com", label: "" }];
+    assert.deepEqual(rememberRecent(list, "http://localhost:6767"), [
+      { url: "http://localhost:6767", label: "" },
+      { url: "https://a.example.com", label: "" },
+    ]);
+  });
+
+  it("bumps an existing url to the head without duplicating it", () => {
+    const list = [
+      { url: "https://a.example.com", label: "" },
+      { url: "http://localhost:6767", label: "" },
+    ];
+    assert.deepEqual(rememberRecent(list, "http://localhost:6767"), [
+      { url: "http://localhost:6767", label: "" },
+      { url: "https://a.example.com", label: "" },
+    ]);
+  });
+
+  it("preserves an existing nickname when a url bumps to the head", () => {
+    const list = [
+      { url: "https://a.example.com", label: "" },
+      { url: "http://localhost:6767", label: "Local dev" },
+    ];
+    assert.deepEqual(rememberRecent(list, "http://localhost:6767"), [
+      { url: "http://localhost:6767", label: "Local dev" },
+      { url: "https://a.example.com", label: "" },
+    ]);
+  });
+
+  it("caps the list at MAX_RECENT_SERVERS", () => {
+    let list = [];
+    for (let i = 0; i < MAX_RECENT_SERVERS + 3; i += 1) {
+      list = rememberRecent(list, `https://s${i}.example.com`);
+    }
+    assert.equal(list.length, MAX_RECENT_SERVERS);
+    // The most recently remembered url leads the list.
+    assert.equal(list[0].url, `https://s${MAX_RECENT_SERVERS + 2}.example.com`);
+  });
+});
+
+describe("setLabel", () => {
+  const base = [
+    { url: "https://a.example.com", label: "" },
+    { url: "http://localhost:6767", label: "old" },
+  ];
+
+  it("sets a nickname on the matching url only", () => {
+    assert.deepEqual(setLabel(base, "https://a.example.com", "Prod"), [
+      { url: "https://a.example.com", label: "Prod" },
+      { url: "http://localhost:6767", label: "old" },
+    ]);
+  });
+
+  it("trims surrounding whitespace", () => {
+    assert.equal(setLabel(base, "https://a.example.com", "  Prod  ")[0].label, "Prod");
+  });
+
+  it("clears the nickname when given a blank/whitespace label", () => {
+    assert.equal(setLabel(base, "http://localhost:6767", "   ")[1].label, "");
+    assert.equal(setLabel(base, "http://localhost:6767", "")[1].label, "");
+  });
+
+  it("is a no-op for a url not in the list", () => {
+    assert.deepEqual(setLabel(base, "https://unknown.example.com", "X"), base);
+  });
+});
+
+describe("serializeRecents", () => {
+  it("writes an unlabelled entry as a bare string", () => {
+    assert.deepEqual(serializeRecents([{ url: "http://localhost:6767", label: "" }]), [
+      "http://localhost:6767",
+    ]);
+  });
+
+  it("writes a labelled entry as a { url, label } object", () => {
+    assert.deepEqual(serializeRecents([{ url: "https://a.example.com", label: "Prod" }]), [
+      { url: "https://a.example.com", label: "Prod" },
+    ]);
+  });
+
+  it("round-trips through normalizeRecents", () => {
+    const list = [
+      { url: "https://a.example.com", label: "Prod" },
+      { url: "http://localhost:6767", label: "" },
+    ];
+    assert.deepEqual(normalizeRecents(serializeRecents(list)), list);
+  });
+});
+
+describe("hostOf", () => {
+  it("returns the host for a valid URL", () => {
+    assert.equal(hostOf("https://a.example.com/ml/omnigent"), "a.example.com");
+    assert.equal(hostOf("http://localhost:6767"), "localhost:6767");
+  });
+
+  it("falls back to the raw input when unparseable", () => {
+    assert.equal(hostOf("not a url"), "not a url");
+  });
+});

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -205,12 +205,20 @@ export interface HostActionResult {
   error?: string;
 }
 
+/** A recently-connected server: its URL and an optional user-set nickname. */
+export interface RecentServer {
+  /** Full server URL, e.g. `"https://a.example.com/ml/omnigent"`. */
+  url: string;
+  /** User-set nickname shown instead of the host, or `""` when none. */
+  label: string;
+}
+
 /** Data backing the title-bar server picker, from the Electron shell. */
 export interface ServerPickerInfo {
   /** Origin this window is connected to, e.g. `"http://localhost:8000"`. */
   currentOrigin: string;
-  /** Recently-connected server URLs, most recent first. */
-  recentServers: string[];
+  /** Recently-connected servers, most recent first. */
+  recentServers: RecentServer[];
 }
 
 /** The Electron preload bridge, or undefined outside the Electron shell. */

--- a/web/src/shell/TitleBarServerPicker.test.tsx
+++ b/web/src/shell/TitleBarServerPicker.test.tsx
@@ -1,0 +1,73 @@
+// Tests for the title-bar server picker: it shows the current server's
+// nickname (falling back to its host) and lists the other recent servers by
+// nickname/host, switching to one on select. See TitleBarServerPicker.tsx.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ServerPickerInfo } from "@/lib/nativeBridge";
+
+const mocks = vi.hoisted(() => ({
+  getServerPicker: vi.fn(),
+  switchServer: vi.fn(),
+  openServerSetup: vi.fn(),
+}));
+
+vi.mock("@/lib/nativeBridge", () => ({
+  getServerPicker: mocks.getServerPicker,
+  switchServer: mocks.switchServer,
+  openServerSetup: mocks.openServerSetup,
+}));
+
+import { TitleBarServerPicker } from "./TitleBarServerPicker";
+
+const INFO: ServerPickerInfo = {
+  currentOrigin: "https://prod.example.com",
+  recentServers: [
+    { url: "https://prod.example.com/ml/omnigent", label: "Prod (west)" },
+    { url: "http://localhost:6767", label: "Local dev" },
+    { url: "https://other.example.com", label: "" },
+  ],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TitleBarServerPicker", () => {
+  it("labels the trigger with the current server's nickname", async () => {
+    mocks.getServerPicker.mockResolvedValue(INFO);
+
+    render(<TitleBarServerPicker />);
+
+    // Falls back through null until getServerPicker resolves.
+    expect(await screen.findByText("Omnigent — Prod (west)")).toBeInTheDocument();
+  });
+
+  it("renders nothing outside the Electron shell (null picker)", async () => {
+    mocks.getServerPicker.mockResolvedValue(null);
+
+    const { container } = render(<TitleBarServerPicker />);
+
+    // Give the resolved-null effect a tick; the component stays empty.
+    await Promise.resolve();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("lists other servers by nickname/host and switches on select", async () => {
+    mocks.getServerPicker.mockResolvedValue(INFO);
+
+    render(<TitleBarServerPicker />);
+    const trigger = await screen.findByText("Omnigent — Prod (west)");
+
+    // Radix DropdownMenu opens on pointerdown, not click.
+    fireEvent.pointerDown(trigger, { button: 0 });
+
+    // The labelled other server shows its nickname; the unlabelled one, its host.
+    expect(screen.getByText("Local dev")).toBeInTheDocument();
+    expect(screen.getByText("other.example.com")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Local dev"));
+    expect(mocks.switchServer).toHaveBeenCalledWith("http://localhost:6767");
+  });
+});

--- a/web/src/shell/TitleBarServerPicker.tsx
+++ b/web/src/shell/TitleBarServerPicker.tsx
@@ -74,7 +74,10 @@ export function TitleBarServerPicker({
 
   // The current server leads the list even when the recents file was edited
   // out from under us; recents matching the current origin collapse into it.
-  const others = info.recentServers.filter((url) => originOf(url) !== info.currentOrigin);
+  const others = info.recentServers.filter((s) => originOf(s.url) !== info.currentOrigin);
+  // Show the current server's nickname too when a recents entry carries one.
+  const current = info.recentServers.find((s) => originOf(s.url) === info.currentOrigin);
+  const currentName = current?.label || hostOf(info.currentOrigin);
 
   return (
     /* Sits over the drag strip; the button itself is no-drag via the blanket
@@ -90,20 +93,24 @@ export function TitleBarServerPicker({
           title="Switch server"
         >
           <span className="truncate font-medium">
-            {threadTitle || "Omnigent"} — {hostOf(info.currentOrigin)}
+            {threadTitle || "Omnigent"} — {currentName}
           </span>
           <ChevronDownIcon className="size-3 shrink-0" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="center" className="min-w-56">
           <DropdownMenuItem disabled className="gap-2 opacity-100">
             <CheckIcon className="size-4 shrink-0" />
-            <span className="truncate">{hostOf(info.currentOrigin)}</span>
+            <span className="truncate">{currentName}</span>
           </DropdownMenuItem>
-          {others.map((url) => (
-            <DropdownMenuItem key={url} className="gap-2" onSelect={() => void switchServer(url)}>
-              {/* Spacer aligns hosts under the current-server check. */}
+          {others.map((s) => (
+            <DropdownMenuItem
+              key={s.url}
+              className="gap-2"
+              onSelect={() => void switchServer(s.url)}
+            >
+              {/* Spacer aligns names under the current-server check. */}
               <span className="size-4 shrink-0" aria-hidden="true" />
-              <span className="truncate">{hostOf(url)}</span>
+              <span className="truncate">{s.label || hostOf(s.url)}</span>
             </DropdownMenuItem>
           ))}
           <DropdownMenuSeparator />


### PR DESCRIPTION
## Related issue

Closes #2372

## Summary

Recent servers on the desktop connect screen all rendered as raw URLs, which is
hard to scan when several share a host and differ only by a long path or a
random-looking subdomain. This lets you give each recent server an optional
**nickname**:

- **Connect screen** — a labelled entry shows its nickname with the host
  trailing; an unlabelled one still shows the URL. A pencil on each row opens an
  inline field (Enter saves, Esc/blur cancels, blank clears).
- **Title-bar picker** — shows the nickname when set, falling back to the host,
  for both the current server and the other recent servers.
- **Storage** — the `recent_servers` entry is promoted from a bare string to
  `{ url, label }`, but only written as an object once a nickname exists; an
  unlabelled entry stays a bare string, so the on-disk format and older shells
  remain compatible. Nicknames are display-only labels (the URL stays the
  identity), so any characters are allowed — only the length is capped
  (`MAX_LABEL_LENGTH`).

**ELI5:** your saved servers can now have a friendly name instead of a wall of
identical-looking URLs, like renaming a browser bookmark.

Data flow (single choke point, `web/electron/src/recents.js`):

```
settings.json ──normalizeRecents──▶ [{url,label}] ──▶ get-recent-servers ──▶ connect screen
     ▲                                    │                get-server-picker ─▶ title-bar picker
     └──serializeRecents◀──setLabel / rememberRecent◀── set-recent-server-label (rename)
```

## Test Plan

- `cd web/electron && node --test` → **159/159** pass (incl. 20 new `recents.test.js` cases: legacy-string tolerance, nickname-preserving bump, set/clear/trim/truncate, string-when-unlabelled round-trip).
- `cd web && npx vitest run src/shell/TitleBarServerPicker.test.tsx` → **3/3** pass.
- `cd web && npx tsc -b` → clean.
- Added `tests/e2e_ui/desktop/test_setup_recents_rename.py` (Playwright, 4 cases: render, save, Esc-cancel, blank-clears, `maxlength`).
- Manual: drove the real `setup/index.html` end-to-end (rename → persist → reload, Esc, blank-clears, `maxlength=60`, no console errors), and launched the Electron shell against an isolated `--user-data-dir` to confirm rename + persistence in the real binary.

## Demo

Renaming a recent server on the connect screen (dark mode):

1. **Recent servers with nicknames** — labelled entries lead with the name and
   trail the host; the unlabelled entry keeps its raw URL. Each row has a rename
   pencil.
2. **Inline rename** — the pencil swaps the row for a field (Enter to save, Esc
   to cancel, blank to clear).

<img width="2400" height="1708" alt="image" src="https://github.com/user-attachments/assets/15bb5edf-6298-402c-b750-c6772a85b135" />
<img width="2400" height="1708" alt="image" src="https://github.com/user-attachments/assets/54e97c91-90e6-4574-98f7-c20465d0d33f" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The recents model logic is extracted into a pure `web/electron/src/recents.js`
covered by `node --test`; the React picker by Vitest; the connect-screen rename
flow by a Playwright `tests/e2e_ui/` test. The Playwright test was validated by
driving the same real page via DevTools but not executed under pytest locally
(the pinned `uv` version wasn't available on the dev machine) — CI runs the
suite. Node/Vitest/tsc were run and are green.

## Changelog

Recent servers on the desktop connect screen and title-bar picker can be given a nickname.
