### PR TITLE
feat(bench): distinguish Omnigent MCP tool calls

### DIFF
--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -413,6 +413,10 @@ agree with it.
 
 ## Open items
 
+- **Declarative native tool-relay mechanism** — extend the harness capability
+  model to distinguish generated MCP, native registration, and no relay. Derive
+  the Omnigent MCP probe's applicability from that declaration instead of the
+  bench's temporary `_NATIVE_OMNIGENT_MCP_HARNESSES` list.
 - **Registry-driven native-agent seeding** — replace the hardcoded server
   seeding list with registry iteration so community native harnesses work end
   to end after plugin installation.

--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -7,7 +7,7 @@ instead of a human hand-maintaining a spreadsheet and hoping it still reflects
 reality.
 
 > **Status:** shipped and in use. The bench on `main` has three transport
-> drivers, six P0 probes, three report-only P1 probes, automatic live/offline
+> drivers, six P0 probes, four report-only P1 probes, automatic live/offline
 > selection, and a capability-derived matrix that has already caught and
 > corrected real declaration drift. See
 > [Current state](#current-state-shipped) for what is live vs. still open. The
@@ -204,6 +204,7 @@ Validated for presence and shape only: `Owner`, `Transport`, `Implementation`,
 | Basic turn (P0 prerequisite) | complete a marker-echo turn and require assistant text |
 | Streaming (P0) | count output-text deltas; repeated single-delta output is `PARTIAL` |
 | Tool calling (P0) | provoke the transport's tool mechanism and require a surfaced call |
+| Omnigent MCP (P1, native only) | call read-only `sys_session_list` through the generated `omnigent` MCP relay and require a matching function-call item |
 | Policy DENY (P0) | apply a tool-call deny and require a blocked-call signal |
 | Policy ALLOW (P1) | attach an explicit allow and require a non-blocked tool output; native hooks expose no positive ALLOW event |
 | Policy ASK (P1) | apply ask and require an elicitation/approval request |
@@ -266,7 +267,7 @@ The bench on `main` includes:
 
 - **Six P0 probes:** Basic turn, Streaming, Tool calling, Policy DENY, Model
   override, and Interrupt.
-- **Three P1 probes:** Policy ALLOW, Policy ASK, and Cost tracking. P1 verdicts
+- **Four P1 probes:** Omnigent MCP, Policy ALLOW, Policy ASK, and Cost tracking. P1 verdicts
   are report-only and do not gate the same way as P0 declarations.
 - **Three transport drivers:** `full-server`, `native-tui`, and `sdk-inproc`,
   selected by harness family with `--transport` and `--fast` overrides.
@@ -351,6 +352,7 @@ stream, the bench flags a real drift on the next run, rather than a false
 |---|---|---|---|
 | Basic turn, Streaming, Model override, Interrupt | Wrap-level observation | End-to-end server/runner observation | End-to-end server/runner/vendor observation |
 | Tool calling | Request-level wrap tool | Server-dispatched builtin | Vendor tool mirrored into session items |
+| Omnigent MCP | Not applicable | Not applicable | Generated `omnigent` MCP relay when supported by the vendor |
 | Policy DENY | Not observable | Fixed policy blocks the builtin | Session CEL policy triggers the native policy hook |
 | Policy ALLOW / ASK | Not observable | Fixed policy; ASK observes and resolves an elicitation | Temporary session CEL policy; ASK observes and resolves an elicitation |
 | Cost tracking | Completed-response usage when forwarded | Session snapshot usage/cost | Session snapshot when the vendor forwards usage |

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -83,6 +83,7 @@ A profile's `transport` is a harness-family marker. The resolved driver is:
 | **Basic turn** | A turn completes and returns assistant text. | P0 |
 | **Streaming** | More than one output-text delta is emitted; a repeated single delta is `PARTIAL`. | P0 |
 | **Tool calling** | A tool call is surfaced and the turn closes after its result. | P0 |
+| **Omnigent MCP** | A native harness calls the read-only `sys_session_list` relay tool through its generated `omnigent` MCP server. | P1 |
 | **Policy DENY** | A tool-call policy blocks the call. | P0 |
 | **Policy ALLOW** | A tool call proceeds while an explicit allow policy is attached. | P1 |
 | **Policy ASK** | An ask policy raises an approval elicitation. | P1 |
@@ -101,6 +102,7 @@ transport; it does not claim the harness lacks the capability.
 | --- | --- | --- | --- |
 | Basic turn, Streaming, Model override, Interrupt | End-to-end through server + runner | End-to-end through server + runner + vendor CLI | Wrap boundary only |
 | Tool calling | Server-dispatched builtin | Vendor tool mirrored as a session item | Request-level wrap tool |
+| Omnigent MCP | Not applicable | Generated `omnigent` MCP relay when supported by the vendor | Not applicable |
 | Policy DENY | Fixed policy in the agent spec | Session CEL policy + native policy hook | Not observable |
 | Policy ALLOW / ASK | Fixed policy; ASK observes and resolves an elicitation | Temporary session CEL policy; ASK observes and resolves an elicitation | Not observable |
 | Cost tracking | Session snapshot | Session snapshot when the vendor forwards usage | Completed-response usage when forwarded |

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -185,9 +185,9 @@ async def run_harness(
     :param probes: Probes to run; defaults to :data:`ALL_PROBES`.
     :param databricks_profile: Gateway profile for live turns. Required
         for ``live=True``; its absence skips the whole harness.
-    :param live: When ``False``, produce a declared-only report (every
-        cell ``SKIPPED`` with an "offline" note) without spawning
-        anything — used for a fast ``--list``/dry render.
+    :param live: When ``False``, produce a declared-only report (applicable
+        cells ``SKIPPED`` with an "offline" note; others ``NOT_APPLICABLE``)
+        without spawning anything — used for a fast ``--list``/dry render.
     :param transport: ``--transport`` override; wins over the profile's
         family default (see :func:`resolve_driver_class`).
     :param fast: ``--fast`` — downgrade the SDK family to sdk-inproc (skip the

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -284,6 +284,9 @@ class SdkInprocDriver:
             timeout=150.0,
         )
 
+    async def run_mcp_tool_turn(self) -> TurnResult:
+        return TurnResult(error="Omnigent MCP relay is not observable on sdk-inproc")
+
     async def run_policy_turn(self, *, action: str) -> TurnResult:
         """Return unmeasured because wrap-direct cannot observe ALLOW or ASK."""
         return TurnResult()

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -113,6 +113,9 @@ class FullServerDriver:
     async def run_tool_turn(self, *, deny: bool) -> TurnResult:
         return await asyncio.to_thread(lambda: self.tool_probe_turn(deny=deny))
 
+    async def run_mcp_tool_turn(self) -> TurnResult:
+        return TurnResult(error="Omnigent MCP relay is a native-harness dimension")
+
     async def run_policy_turn(self, *, action: str) -> TurnResult:
         return await asyncio.to_thread(lambda: self.policy_probe_turn(action=action))
 

--- a/tests/harness_bench/mcp_tools.py
+++ b/tests/harness_bench/mcp_tools.py
@@ -1,0 +1,16 @@
+"""Shared Omnigent-MCP tool-name helpers for the harness bench."""
+
+from __future__ import annotations
+
+TARGET_OMNIGENT_MCP_TOOL = "sys_session_list"
+_TARGET_TOOL_NAMES = frozenset(
+    {
+        TARGET_OMNIGENT_MCP_TOOL,
+        f"mcp__omnigent__{TARGET_OMNIGENT_MCP_TOOL}",
+    }
+)
+
+
+def is_target_omnigent_mcp_tool(name: object) -> bool:
+    """Return whether *name* is the target relay tool's bare or wire name."""
+    return isinstance(name, str) and name in _TARGET_TOOL_NAMES

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -34,6 +34,7 @@ from tests._helpers.live_server import find_free_port
 from tests.e2e._harness_probes import cli_unavailable_reason
 from tests.harness_bench.driver import ProvisioningError, TurnResult, fill_snapshot_cost
 from tests.harness_bench.full_server import spawn_omnigent_server
+from tests.harness_bench.mcp_tools import is_target_omnigent_mcp_tool
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.runtime_env import (
     BenchRuntimeEnv,
@@ -149,7 +150,6 @@ _NATIVE_OMNIGENT_MCP_HARNESSES = frozenset(
         "qwen-native",
     }
 )
-_MCP_TOOL_NAME = "sys_session_list"
 _MCP_TOOL_PROMPT = (
     "You must call the omnigent MCP tool mcp__omnigent__sys_session_list exactly once. "
     "It may be displayed as sys_session_list by your client. Do not use a shell or any "
@@ -607,9 +607,7 @@ class NativeTuiDriver:
             calls_before = len(result.tool_calls)
             self._post_message(prompt)
             self._poll_new_tool_calls(baseline, result, timeout=timeout)
-            if any(
-                str(call.get("name") or "").endswith(_MCP_TOOL_NAME) for call in result.tool_calls
-            ):
+            if any(is_target_omnigent_mcp_tool(call.get("name")) for call in result.tool_calls):
                 result.completed = True
                 break
             baseline += len(result.tool_calls) - calls_before

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -137,6 +137,29 @@ _NATIVE_TOOL_PROVOCATION: dict[str, tuple[str, str]] = {
     "kimi-native": ("Bash", "Use the Bash tool to run this exact command: echo omnigent-bench-ok"),
 }
 
+_NATIVE_OMNIGENT_MCP_HARNESSES = frozenset(
+    {
+        "antigravity-native",
+        "claude-native",
+        "codex-native",
+        "cursor-native",
+        "goose-native",
+        "hermes-native",
+        "kiro-native",
+        "qwen-native",
+    }
+)
+_MCP_TOOL_NAME = "sys_session_list"
+_MCP_TOOL_PROMPT = (
+    "You must call the omnigent MCP tool mcp__omnigent__sys_session_list exactly once. "
+    "It may be displayed as sys_session_list by your client. Do not use a shell or any "
+    "other tool. After the tool returns, reply with done."
+)
+_MCP_TOOL_RETRY_PROMPT = (
+    "Call the available tool named sys_session_list now with an empty argument object. "
+    "This is required; do not answer from memory and do not use any other tool."
+)
+
 
 def native_vendor(harness: str) -> NativeVendor | None:
     """Derive the :class:`NativeVendor` for *harness* from its capabilities.
@@ -223,6 +246,9 @@ class NativeTuiDriver:
 
     async def run_tool_turn(self, *, deny: bool) -> TurnResult:
         return await asyncio.to_thread(self._drive_tool_turn, deny=deny)
+
+    async def run_mcp_tool_turn(self) -> TurnResult:
+        return await asyncio.to_thread(self._drive_mcp_tool_turn)
 
     async def run_policy_turn(self, *, action: str) -> TurnResult:
         return await asyncio.to_thread(self._drive_policy_turn, action=action)
@@ -563,6 +589,30 @@ class NativeTuiDriver:
             self._delete_tool_policy(policy_id)
 
         result.completed = _OUTPUT_DONE_EVENT in events or bool(result.tool_calls)
+        return result
+
+    def _drive_mcp_tool_turn(self, *, timeout: float = _TOOL_TURN_TIMEOUT_S) -> TurnResult:
+        """Call the read-only Omnigent MCP relay tool for this native harness."""
+        assert self._vendor is not None
+        result = TurnResult()
+        if self._vendor.harness not in _NATIVE_OMNIGENT_MCP_HARNESSES:
+            result.error = (
+                f"{self._vendor.harness!r} has no Omnigent MCP bridge; "
+                "its relayed tools use another native mechanism"
+            )
+            return result
+
+        baseline = self._tool_item_count()
+        for prompt in (_MCP_TOOL_PROMPT, _MCP_TOOL_RETRY_PROMPT):
+            calls_before = len(result.tool_calls)
+            self._post_message(prompt)
+            self._poll_new_tool_calls(baseline, result, timeout=timeout)
+            if any(
+                str(call.get("name") or "").endswith(_MCP_TOOL_NAME) for call in result.tool_calls
+            ):
+                result.completed = True
+                break
+            baseline += len(result.tool_calls) - calls_before
         return result
 
     def _drive_policy_turn(self, *, action: str) -> TurnResult:

--- a/tests/harness_bench/probes/__init__.py
+++ b/tests/harness_bench/probes/__init__.py
@@ -7,6 +7,7 @@ from tests.harness_bench.probes.basic_turn import BasicTurnProbe
 from tests.harness_bench.probes.cost_tracking import CostTrackingProbe
 from tests.harness_bench.probes.interrupt import InterruptProbe
 from tests.harness_bench.probes.model_override import ModelOverrideProbe
+from tests.harness_bench.probes.omnigent_mcp import OmnigentMcpProbe
 from tests.harness_bench.probes.policy_allow import PolicyAllowProbe
 from tests.harness_bench.probes.policy_ask import PolicyAskProbe
 from tests.harness_bench.probes.policy_deny import PolicyDenyProbe
@@ -18,6 +19,7 @@ ALL_PROBES: list[CapabilityProbe] = [
     BasicTurnProbe(),
     StreamingProbe(),
     ToolCallingProbe(),
+    OmnigentMcpProbe(),
     PolicyDenyProbe(),
     PolicyAllowProbe(),
     PolicyAskProbe(),

--- a/tests/harness_bench/probes/omnigent_mcp.py
+++ b/tests/harness_bench/probes/omnigent_mcp.py
@@ -9,12 +9,14 @@ through the generated ``omnigent`` MCP server.
 from __future__ import annotations
 
 from tests.harness_bench.driver import infra_failure_reason
+from tests.harness_bench.mcp_tools import (
+    TARGET_OMNIGENT_MCP_TOOL,
+    is_target_omnigent_mcp_tool,
+)
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.transport import Driver
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
-
-_TARGET_TOOL = "sys_session_list"
 
 
 class OmnigentMcpProbe(CapabilityProbe):
@@ -26,13 +28,13 @@ class OmnigentMcpProbe(CapabilityProbe):
     async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
         result = await driver.run_mcp_tool_turn()
         names = [str(call.get("name") or "") for call in result.tool_calls]
-        matched = [name for name in names if name.endswith(_TARGET_TOOL)]
+        matched = [name for name in names if is_target_omnigent_mcp_tool(name)]
         detail = {"tool_calls": names, "matched_calls": matched, "completed": result.completed}
 
         if matched:
             return ProbeResult(
                 Verdict.SUPPORTED,
-                note=f"called {_TARGET_TOOL} through the Omnigent MCP relay",
+                note=f"called {TARGET_OMNIGENT_MCP_TOOL} through the Omnigent MCP relay",
                 detail=detail,
             )
         infra = infra_failure_reason(result)
@@ -43,11 +45,11 @@ class OmnigentMcpProbe(CapabilityProbe):
         if result.timed_out:
             return ProbeResult(
                 Verdict.SKIPPED,
-                note=f"timed out before calling {_TARGET_TOOL} through Omnigent MCP",
+                note=(f"timed out before calling {TARGET_OMNIGENT_MCP_TOOL} through Omnigent MCP"),
                 detail=detail,
             )
         return ProbeResult(
             Verdict.SKIPPED,
-            note=f"model did not call {_TARGET_TOOL} through the Omnigent MCP relay",
+            note=(f"model did not call {TARGET_OMNIGENT_MCP_TOOL} through the Omnigent MCP relay"),
             detail=detail,
         )

--- a/tests/harness_bench/probes/omnigent_mcp.py
+++ b/tests/harness_bench/probes/omnigent_mcp.py
@@ -1,0 +1,53 @@
+"""Omnigent-MCP probe — can a native harness call the Omnigent relay?
+
+This is intentionally separate from ``ToolCallingProbe``: that probe exercises
+whatever tool mechanism is native to the transport (for example Bash in Claude
+Code), while this probe targets the read-only ``sys_session_list`` tool exposed
+through the generated ``omnigent`` MCP server.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import infra_failure_reason
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+_TARGET_TOOL = "sys_session_list"
+
+
+class OmnigentMcpProbe(CapabilityProbe):
+    name = "omnigent_mcp"
+    title = "Omnigent MCP"
+    priority = Priority.P1
+    applies_to = Applicability.NATIVE
+
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_mcp_tool_turn()
+        names = [str(call.get("name") or "") for call in result.tool_calls]
+        matched = [name for name in names if name.endswith(_TARGET_TOOL)]
+        detail = {"tool_calls": names, "matched_calls": matched, "completed": result.completed}
+
+        if matched:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note=f"called {_TARGET_TOOL} through the Omnigent MCP relay",
+                detail=detail,
+            )
+        infra = infra_failure_reason(result)
+        if infra is not None:
+            return ProbeResult(Verdict.SKIPPED, note=infra, detail=detail)
+        if result.error:
+            return ProbeResult(Verdict.SKIPPED, note=str(result.error), detail=detail)
+        if result.timed_out:
+            return ProbeResult(
+                Verdict.SKIPPED,
+                note=f"timed out before calling {_TARGET_TOOL} through Omnigent MCP",
+                detail=detail,
+            )
+        return ProbeResult(
+            Verdict.SKIPPED,
+            note=f"model did not call {_TARGET_TOOL} through the Omnigent MCP relay",
+            detail=detail,
+        )

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -234,7 +234,9 @@ async def test_offline_render_produces_matrix() -> None:
     matrix = await run_bench(_OFFICIAL, live=False)
     assert not matrix.has_drift
     assert all(
-        cell.observed is Verdict.SKIPPED for report in matrix.reports for cell in report.cells
+        cell.observed in {Verdict.SKIPPED, Verdict.NOT_APPLICABLE}
+        for report in matrix.reports
+        for cell in report.cells
     )
     md = render_markdown(matrix)
     assert "Harness capability matrix" in md
@@ -635,7 +637,7 @@ async def test_provisioning_failure_skips_and_tears_down(monkeypatch: pytest.Mon
     report = await run_harness(profile, databricks_profile="oss", live=True)
 
     assert report.skipped_reason is not None and "provisioning failed" in report.skipped_reason
-    assert all(c.observed is Verdict.SKIPPED for c in report.cells)
+    assert all(c.observed in {Verdict.SKIPPED, Verdict.NOT_APPLICABLE} for c in report.cells)
     assert torn_down == [True], "provisioning-failure path must tear down the driver"
 
 

--- a/tests/harness_bench/test_native_tui_driver.py
+++ b/tests/harness_bench/test_native_tui_driver.py
@@ -314,6 +314,16 @@ def test_mcp_tool_turn_observes_prefixed_omnigent_tool() -> None:
     assert "mcp__omnigent__sys_session_list" in str(client.posted_events[-1])
 
 
+def test_mcp_tool_turn_rejects_unrelated_suffix_match() -> None:
+    client = _FakeClient(items=[_function_call_item("other_sys_session_list")])
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_mcp_tool_turn(timeout=0.01)
+
+    assert not result.completed
+    assert [call["name"] for call in result.tool_calls] == ["other_sys_session_list"]
+
+
 def test_mcp_tool_turn_retries_when_first_prompt_has_no_call() -> None:
     client = _FakeClient(items=[])
     driver = _driver_with_fake("claude-native", client)

--- a/tests/harness_bench/test_native_tui_driver.py
+++ b/tests/harness_bench/test_native_tui_driver.py
@@ -16,6 +16,7 @@ import pytest
 
 from tests.harness_bench.driver import TurnResult
 from tests.harness_bench.native_tui_driver import NativeTuiDriver, native_vendor
+from tests.harness_bench.probes.omnigent_mcp import OmnigentMcpProbe
 from tests.harness_bench.probes.policy_allow import PolicyAllowProbe
 from tests.harness_bench.probes.policy_ask import PolicyAskProbe
 from tests.harness_bench.probes.policy_deny import PolicyDenyProbe
@@ -302,6 +303,59 @@ def test_tool_turn_skips_vendor_without_tool_mapping() -> None:
     assert not result.tool_calls
 
 
+def test_mcp_tool_turn_observes_prefixed_omnigent_tool() -> None:
+    client = _FakeClient(items=[_function_call_item("mcp__omnigent__sys_session_list")])
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_mcp_tool_turn()
+
+    assert result.completed
+    assert [call["name"] for call in result.tool_calls] == ["mcp__omnigent__sys_session_list"]
+    assert "mcp__omnigent__sys_session_list" in str(client.posted_events[-1])
+
+
+def test_mcp_tool_turn_retries_when_first_prompt_has_no_call() -> None:
+    client = _FakeClient(items=[])
+    driver = _driver_with_fake("claude-native", client)
+
+    result = driver._drive_mcp_tool_turn(timeout=0.01)
+
+    assert not result.completed
+    messages = [event for event in client.posted_events if event.get("type") == "message"]
+    assert len(messages) == 2
+    assert "empty argument object" in str(messages[-1])
+
+
+def test_mcp_tool_turn_advances_baseline_after_wrong_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient()
+    driver = _driver_with_fake("claude-native", client)
+    baselines: list[int] = []
+
+    def _poll(baseline: int, result: TurnResult, timeout: float) -> None:
+        baselines.append(baseline)
+        name = "Bash" if len(baselines) == 1 else "mcp__omnigent__sys_session_list"
+        result.tool_calls.append({"name": name})
+
+    monkeypatch.setattr(driver, "_poll_new_tool_calls", _poll)
+
+    result = driver._drive_mcp_tool_turn(timeout=0.01)
+
+    assert result.completed
+    assert baselines == [0, 1]
+
+
+def test_mcp_tool_turn_skips_non_mcp_native_relay() -> None:
+    client = _FakeClient()
+    driver = _driver_with_fake("pi-native", client)
+
+    result = driver._drive_mcp_tool_turn()
+
+    assert result.error and "no Omnigent MCP bridge" in result.error
+    assert client.posted_events == []
+
+
 async def test_probes_read_native_tool_result_as_supported() -> None:
     """The transport-agnostic probes turn the native TurnResults into verdicts."""
     profile = BenchProfile(
@@ -329,6 +383,12 @@ async def test_probes_read_native_tool_result_as_supported() -> None:
                 )
             return TurnResult(elicitation_requested=True)
 
+        async def run_mcp_tool_turn(self) -> TurnResult:
+            return TurnResult(
+                completed=True,
+                tool_calls=[{"name": "mcp__omnigent__sys_session_list"}],
+            )
+
     tool_result = await ToolCallingProbe().run(_Driver(), profile)
     assert tool_result.verdict is Verdict.SUPPORTED
     deny_result = await PolicyDenyProbe().run(_Driver(), profile)
@@ -337,6 +397,8 @@ async def test_probes_read_native_tool_result_as_supported() -> None:
     assert allow_result.verdict is Verdict.SUPPORTED
     ask_result = await PolicyAskProbe().run(_Driver(), profile)
     assert ask_result.verdict is Verdict.SUPPORTED
+    mcp_result = await OmnigentMcpProbe().run(_Driver(), profile)
+    assert mcp_result.verdict is Verdict.SUPPORTED
 
 
 def test_format_matches_server_wire_name() -> None:

--- a/tests/harness_bench/test_omnigent_mcp.py
+++ b/tests/harness_bench/test_omnigent_mcp.py
@@ -33,6 +33,24 @@ async def test_supported_for_prefixed_omnigent_tool_call() -> None:
     assert result.verdict is Verdict.SUPPORTED
 
 
+async def test_supported_for_bare_omnigent_tool_call() -> None:
+    result = await OmnigentMcpProbe().run(
+        _Driver(TurnResult(tool_calls=[{"name": "sys_session_list"}])),
+        _PROFILE,
+    )
+
+    assert result.verdict is Verdict.SUPPORTED
+
+
+async def test_skipped_for_unrelated_suffix_match() -> None:
+    result = await OmnigentMcpProbe().run(
+        _Driver(TurnResult(tool_calls=[{"name": "other_sys_session_list"}])),
+        _PROFILE,
+    )
+
+    assert result.verdict is Verdict.SKIPPED
+
+
 async def test_skipped_when_native_has_no_mcp_bridge() -> None:
     result = await OmnigentMcpProbe().run(
         _Driver(TurnResult(error="'pi-native' has no Omnigent MCP bridge")),

--- a/tests/harness_bench/test_omnigent_mcp.py
+++ b/tests/harness_bench/test_omnigent_mcp.py
@@ -1,0 +1,60 @@
+"""Verdict tests for the native Omnigent-MCP probe."""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.probes.omnigent_mcp import OmnigentMcpProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Applicability, Priority, Verdict
+
+_PROFILE = BenchProfile(
+    harness="claude-native",
+    model="m",
+    env_prefix="HARNESS_X_",
+    marker="X",
+    transport="native-tui",
+)
+
+
+class _Driver:
+    def __init__(self, result: TurnResult) -> None:
+        self._result = result
+
+    async def run_mcp_tool_turn(self) -> TurnResult:
+        return self._result
+
+
+async def test_supported_for_prefixed_omnigent_tool_call() -> None:
+    result = await OmnigentMcpProbe().run(
+        _Driver(TurnResult(tool_calls=[{"name": "mcp__omnigent__sys_session_list"}])),
+        _PROFILE,
+    )
+
+    assert result.verdict is Verdict.SUPPORTED
+
+
+async def test_skipped_when_native_has_no_mcp_bridge() -> None:
+    result = await OmnigentMcpProbe().run(
+        _Driver(TurnResult(error="'pi-native' has no Omnigent MCP bridge")),
+        _PROFILE,
+    )
+
+    assert result.verdict is Verdict.SKIPPED
+    assert "no Omnigent MCP bridge" in result.note
+
+
+async def test_skipped_when_model_calls_another_tool() -> None:
+    result = await OmnigentMcpProbe().run(
+        _Driver(TurnResult(completed=True, tool_calls=[{"name": "Bash"}])),
+        _PROFILE,
+    )
+
+    assert result.verdict is Verdict.SKIPPED
+    assert "did not call sys_session_list" in result.note
+
+
+def test_probe_is_native_p1() -> None:
+    probe = OmnigentMcpProbe()
+
+    assert probe.priority is Priority.P1
+    assert probe.applies_to is Applicability.NATIVE

--- a/tests/harness_bench/transport.py
+++ b/tests/harness_bench/transport.py
@@ -44,6 +44,14 @@ class Driver(Protocol):
         force so the call should be blocked (``tool_call_denied``); otherwise
         the call is dispatched and answered (``tool_calls`` populated)."""
 
+    async def run_mcp_tool_turn(self) -> TurnResult:
+        """Provoke an Omnigent MCP relay tool call.
+
+        Native transports use this to distinguish the Omnigent MCP bridge from
+        the vendor's own shell/tool surface. Unsupported transports return an
+        unmeasured result so the probe SKIPs.
+        """
+
     async def run_policy_turn(self, *, action: str) -> TurnResult:
         """Provoke a tool call under an explicit tool-call policy *action*
         (``"allow"`` or ``"ask"``), for the policy_allow / policy_ask probes.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Distinguish generated Omnigent MCP relay calls from each harness's vendor-native tool mechanism in the live capability matrix.
- Add a native-only, report-only P1 probe that requests the read-only `sys_session_list` relay and verifies the persisted function-call item.
- Treat missing MCP bridges and model non-invocation as `SKIPPED`, avoiding false unsupported verdicts, and document the new dimension.

**ELI5:** the bench previously had one "can use tools" check. It now separately checks whether a native harness can use its own tools and whether it can reach tools supplied by Omnigent through MCP.

```text
Native harness
  |-- vendor tool (Bash/shell/etc.) --> Tool calling
  `-- omnigent MCP: sys_session_list --> Omnigent MCP
```

## Test Plan

- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync ruff check tests/harness_bench`
- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync pytest -q -p no:rerunfailures tests/harness_bench` — 127 passed, 19 skipped
- `pre-commit run --files docs/harness-bench-design.md tests/harness_bench/README.md tests/harness_bench/bench.py tests/harness_bench/driver.py tests/harness_bench/full_server_driver.py tests/harness_bench/native_tui_driver.py tests/harness_bench/probes/__init__.py tests/harness_bench/probes/omnigent_mcp.py tests/harness_bench/test_bench.py tests/harness_bench/test_native_tui_driver.py tests/harness_bench/test_omnigent_mcp.py tests/harness_bench/transport.py`
- Ran the live matrix for `claude-native`, `codex-native`, and `pi-native`; Pi cleanly skipped with its non-MCP native mechanism, while model non-invocation remained a neutral skip.

## Demo

N/A — command-line capability matrix and test infrastructure only.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover probe verdicts, prefixed relay names, retry behavior, wrong-tool baseline advancement, and native harnesses without an MCP bridge. Manual verification exercised the live native matrix; individual model decisions remain nondeterministic and intentionally produce `SKIPPED` rather than a capability verdict when the requested relay is not called.

## Changelog

Harness bench now reports Omnigent MCP relay support separately from vendor-native tool calling.
