### PR TITLE
Hide dismissed harnesses from picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,15 @@ omnigent host           # (separate terminal) register this machine as a host
 In the web UI, hit **New Chat**, pick your machine, and go. Check status with
 `omnigent server status`; stop everything with `omnigent stop`.
 
+If the harness picker shows runtimes you cannot use, hide them from the web UI
+without changing the underlying harness registry:
+
+```bash
+omnigent harness list
+omnigent harness hide claude-sdk
+omnigent harness unhide claude-sdk
+```
+
 ### 3. Choose & switch models
 
 ```bash

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -39,6 +39,12 @@ from omnigent.config import (
     load_local_config,
 )
 from omnigent.harness_aliases import canonicalize_harness
+from omnigent.harness_plugins import harness_catalog
+from omnigent.harness_visibility import (
+    DISMISSED_HARNESSES_CONFIG_KEY,
+    dismissed_harness_ids,
+    resolve_catalog_harness_id,
+)
 from omnigent.host.local_server import (
     _DEFAULT_LOCAL_PORT,
     _pid_alive,
@@ -1178,6 +1184,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "debby",
         "debug",
         "goose",
+        "harness",
         "hermes",
         "host",
         "kimi",
@@ -8150,6 +8157,67 @@ def config_unset(is_global: bool, keys: tuple[str, ...]) -> None:
         _save_local_config({}, tuple(validated))
         config_path = Path.cwd() / _LOCAL_CONFIG_RELPATH
     click.echo(f"Unset {len(validated)} key(s) from {config_path}")
+
+
+@cli.group("harness")
+def harness_grp() -> None:
+    """List and configure web UI harness picker visibility."""
+
+
+@harness_grp.command("list")
+def harness_list() -> None:
+    """List harness catalog rows and their web UI visibility status."""
+    rows = harness_catalog()
+    dismissed = dismissed_harness_ids(_load_global_config(), rows)
+    table = Table(title="Harnesses", box=box.SIMPLE)
+    table.add_column("ID")
+    table.add_column("Visibility")
+    table.add_column("Label")
+    for row in rows:
+        harness_id = str(row["id"])
+        status = "dismissed" if harness_id in dismissed else "visible"
+        table.add_row(harness_id, status, str(row.get("label", "")))
+    Console().print(table)
+
+
+def _resolve_visible_harness_or_raise(harness_id: str) -> str:
+    """Resolve a CLI harness id/alias to a web-catalog row id."""
+    resolved = resolve_catalog_harness_id(harness_id, harness_catalog())
+    if resolved is None:
+        raise click.ClickException(
+            f"Unknown harness id {harness_id!r}. Run `omnigent harness list` to see "
+            "harnesses that can be hidden from the web UI picker."
+        )
+    return resolved
+
+
+@harness_grp.command("hide")
+@click.argument("harness_id")
+def harness_hide(harness_id: str) -> None:
+    """Hide a harness id from the web UI harness picker."""
+    resolved = _resolve_visible_harness_or_raise(harness_id)
+    rows = harness_catalog()
+    cfg = _load_global_config()
+    dismissed = set(dismissed_harness_ids(cfg, rows))
+    dismissed.add(resolved)
+    _save_global_config({DISMISSED_HARNESSES_CONFIG_KEY: sorted(dismissed)})
+    click.echo(f"Hidden {resolved} in {_effective_global_config_path()}")
+
+
+@harness_grp.command("unhide")
+@click.argument("harness_id")
+def harness_unhide(harness_id: str) -> None:
+    """Restore a hidden harness id to the web UI harness picker."""
+    resolved = _resolve_visible_harness_or_raise(harness_id)
+    rows = harness_catalog()
+    cfg = _load_global_config()
+    dismissed = set(dismissed_harness_ids(cfg, rows))
+    dismissed.discard(resolved)
+    if dismissed:
+        _save_global_config({DISMISSED_HARNESSES_CONFIG_KEY: sorted(dismissed)})
+    else:
+        _save_global_config({}, unset_keys=(DISMISSED_HARNESSES_CONFIG_KEY,))
+    click.echo(f"Visible {resolved} in {_effective_global_config_path()}")
 
 
 # Node version hint shared by the preflight problem messages and surfaced

--- a/omnigent/harness_visibility.py
+++ b/omnigent/harness_visibility.py
@@ -1,0 +1,85 @@
+"""User-configurable visibility filtering for harness catalog rows."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from omnigent.config import load_global_config
+from omnigent.harness_aliases import canonicalize_harness
+from omnigent.harness_plugins import harness_catalog
+
+DISMISSED_HARNESSES_CONFIG_KEY = "dismissed_harnesses"
+
+
+def _as_str_list(value: Any) -> list[str]:  # type: ignore[explicit-any]
+    """Coerce a YAML scalar/list into stripped string values."""
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def catalog_harness_ids(rows: Sequence[Mapping[str, Any]] | None = None) -> frozenset[str]:  # type: ignore[explicit-any]
+    """Return the harness ids currently present in the web catalog."""
+    catalog_rows = rows if rows is not None else harness_catalog()
+    return frozenset(str(row.get("id", "")).strip() for row in catalog_rows if row.get("id"))
+
+
+def resolve_catalog_harness_id(
+    harness_id: str,
+    rows: Sequence[Mapping[str, Any]] | None = None,  # type: ignore[explicit-any]
+) -> str | None:
+    """Resolve a user-supplied harness id/alias to a visible catalog id.
+
+    :param harness_id: Harness id or accepted alias, e.g. ``"claude"``.
+    :param rows: Optional catalog rows to validate against.
+    :returns: The catalog id to persist, or ``None`` if the value is not a
+        known web-catalog harness.
+    """
+    requested = harness_id.strip()
+    if not requested:
+        return None
+    ids = catalog_harness_ids(rows)
+    if requested in ids:
+        return requested
+    canonical = canonicalize_harness(requested)
+    if canonical in ids:
+        return canonical
+    return None
+
+
+def dismissed_harness_ids(
+    config: Mapping[str, Any] | None = None,  # type: ignore[explicit-any]
+    rows: Sequence[Mapping[str, Any]] | None = None,  # type: ignore[explicit-any]
+) -> frozenset[str]:
+    """Return valid dismissed harness catalog ids from config.
+
+    Unknown config entries are ignored so a typo or stale value never breaks the
+    ``GET /v1/harnesses`` response.
+    """
+    cfg = load_global_config() if config is None else config
+    resolved: set[str] = set()
+    for value in _as_str_list(cfg.get(DISMISSED_HARNESSES_CONFIG_KEY)):
+        catalog_id = resolve_catalog_harness_id(value, rows)
+        if catalog_id is not None:
+            resolved.add(catalog_id)
+    return frozenset(resolved)
+
+
+def filtered_harness_catalog(config: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:  # type: ignore[explicit-any]
+    """Return web-catalog rows after applying ``dismissed_harnesses``."""
+    rows = harness_catalog()
+    dismissed = dismissed_harness_ids(config, rows)
+    if not dismissed:
+        return rows
+    return [row for row in rows if row.get("id") not in dismissed]
+
+
+__all__ = [
+    "DISMISSED_HARNESSES_CONFIG_KEY",
+    "catalog_harness_ids",
+    "dismissed_harness_ids",
+    "filtered_harness_catalog",
+    "resolve_catalog_harness_id",
+]

--- a/omnigent/server/routes/harnesses.py
+++ b/omnigent/server/routes/harnesses.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi import APIRouter, Request
 
-from omnigent.harness_plugins import harness_catalog
+from omnigent.harness_visibility import filtered_harness_catalog
 from omnigent.server.auth import AuthProvider
 from omnigent.server.routes._auth_helpers import require_user
 
@@ -18,6 +18,6 @@ def create_harnesses_router(*, auth_provider: AuthProvider | None = None) -> API
     @router.get("/harnesses")
     async def list_harnesses(request: Request) -> dict[str, list[dict[str, Any]]]:
         require_user(request, auth_provider)
-        return {"data": harness_catalog()}
+        return {"data": filtered_harness_catalog()}
 
     return router

--- a/openspec/changes/hide-unavailable-harnesses/.openspec.yaml
+++ b/openspec/changes/hide-unavailable-harnesses/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+createdAt: "2026-07-10T15:17:16Z"

--- a/openspec/changes/hide-unavailable-harnesses/proposal.md
+++ b/openspec/changes/hide-unavailable-harnesses/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+Add a user-configurable way to hide unusable or unwanted harnesses from the web UI harness picker without changing the underlying harness registry.
+
+## What Changes
+
+- Create the `hide-unavailable-harnesses` OpenSpec change scaffold for review and refinement.
+
+## Capabilities
+
+### New Capabilities
+- `hide-unavailable-harnesses`: Initial capability placeholder. Refine before implementation.
+
+### Modified Capabilities
+- None yet.
+
+## Impact
+
+- TBD: Fill in affected code, APIs, dependencies, or systems before implementation.

--- a/openspec/changes/hide-unavailable-harnesses/specs/harness-catalog-visibility/spec.md
+++ b/openspec/changes/hide-unavailable-harnesses/specs/harness-catalog-visibility/spec.md
@@ -1,0 +1,49 @@
+# Harness Catalog Visibility
+
+## ADDED Requirements
+
+### Requirement: Harness catalog visibility filter
+The system SHALL support a persisted `dismissed_harnesses` configuration list that hides matching harness ids from the web UI harness catalog response without mutating the underlying harness registry.
+
+#### Scenario: No dismissed harnesses preserves current catalog
+- **GIVEN** the global Omnigent config has no `dismissed_harnesses` key
+- **WHEN** an authenticated client requests `GET /v1/harnesses`
+- **THEN** the response includes the same harness rows produced by `harness_catalog()` today
+
+#### Scenario: Dismissed harness is omitted from API response
+- **GIVEN** the global Omnigent config contains `dismissed_harnesses: ["claude-sdk"]`
+- **WHEN** an authenticated client requests `GET /v1/harnesses`
+- **THEN** the response does not include a row whose id is `claude-sdk`
+- **AND** all non-dismissed harness rows remain present and unchanged
+
+#### Scenario: Unknown dismissed harness entries are ignored safely
+- **GIVEN** the global Omnigent config contains a `dismissed_harnesses` entry that is not a valid harness id
+- **WHEN** an authenticated client requests `GET /v1/harnesses`
+- **THEN** the server does not fail the request
+- **AND** valid harness rows are filtered only by valid dismissed ids
+
+### Requirement: Headless harness visibility CLI
+The CLI SHALL expose commands to list, hide, and unhide harness ids so users can configure web UI visibility without editing YAML by hand.
+
+#### Scenario: List reports visible and dismissed harnesses
+- **GIVEN** the global Omnigent config has zero or more `dismissed_harnesses` entries
+- **WHEN** the user runs `omni harness list`
+- **THEN** the CLI displays known harness ids with whether each is visible or dismissed
+
+#### Scenario: Hide persists a valid harness id
+- **GIVEN** `claude-sdk` is a known harness id
+- **WHEN** the user runs `omni harness hide claude-sdk`
+- **THEN** `claude-sdk` is stored in `dismissed_harnesses` in the global config
+- **AND** subsequent `GET /v1/harnesses` responses omit `claude-sdk`
+
+#### Scenario: Unhide restores a dismissed harness id
+- **GIVEN** `claude-sdk` is present in `dismissed_harnesses`
+- **WHEN** the user runs `omni harness unhide claude-sdk`
+- **THEN** `claude-sdk` is removed from `dismissed_harnesses` in the global config
+- **AND** subsequent `GET /v1/harnesses` responses include `claude-sdk` when it is present in `harness_catalog()`
+
+#### Scenario: Invalid harness id is rejected by CLI
+- **GIVEN** `not-a-harness` is not a known harness id or alias accepted for visibility configuration
+- **WHEN** the user runs `omni harness hide not-a-harness`
+- **THEN** the command fails with a clear error
+- **AND** the global config is not modified

--- a/openspec/changes/hide-unavailable-harnesses/tasks.md
+++ b/openspec/changes/hide-unavailable-harnesses/tasks.md
@@ -1,0 +1,7 @@
+## 1. Tasks
+
+- [x] 1.1 Add a dismissed_harnesses config reader/writer that validates harness ids against the harness catalog.
+- [x] 1.2 Filter GET /v1/harnesses server-side using dismissed_harnesses while preserving current behavior when the key is absent.
+- [x] 1.3 Add CLI commands to list, hide, and unhide harnesses for headless configuration.
+- [x] 1.4 Add unit tests for default catalog behavior, filtered catalog behavior, CLI hide/unhide, and invalid harness handling.
+- [x] 1.5 Update user-facing docs/help text for the new harness visibility controls.

--- a/tests/cli/test_harness_cli.py
+++ b/tests/cli/test_harness_cli.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from omnigent.cli import cli
+
+
+def _config_path(config_home: Path) -> Path:
+    return config_home / "config.yaml"
+
+
+def test_harness_list_reports_visible_and_dismissed(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    _config_path(tmp_path).write_text("dismissed_harnesses:\n- claude-sdk\n", encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["harness", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "claude-sdk" in result.output
+    assert "dismissed" in result.output
+    assert "codex" in result.output
+    assert "visible" in result.output
+
+
+def test_harness_hide_persists_canonical_alias(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["harness", "hide", "claude"])
+
+    assert result.exit_code == 0, result.output
+    assert yaml.safe_load(_config_path(tmp_path).read_text())["dismissed_harnesses"] == [
+        "claude-sdk"
+    ]
+
+
+def test_harness_unhide_removes_harness_from_config(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    _config_path(tmp_path).write_text(
+        "dismissed_harnesses:\n- claude-sdk\n- codex\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli, ["harness", "unhide", "claude"])
+
+    assert result.exit_code == 0, result.output
+    assert yaml.safe_load(_config_path(tmp_path).read_text())["dismissed_harnesses"] == ["codex"]
+
+
+def test_harness_hide_rejects_invalid_id_without_modifying_config(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    before = "model: gpt-5\n"
+    _config_path(tmp_path).write_text(before, encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["harness", "hide", "not-a-harness"])
+
+    assert result.exit_code != 0
+    assert "Unknown harness id" in result.output
+    assert _config_path(tmp_path).read_text(encoding="utf-8") == before

--- a/tests/server/routes/test_harnesses_route.py
+++ b/tests/server/routes/test_harnesses_route.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from omnigent.server.routes.harnesses import create_harnesses_router
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(create_harnesses_router(), prefix="/v1")
+    return TestClient(app)
+
+
+def test_harnesses_route_preserves_catalog_without_dismissed_config(monkeypatch) -> None:
+    monkeypatch.setattr("omnigent.harness_visibility.load_global_config", dict)
+
+    response = _client().get("/v1/harnesses")
+
+    assert response.status_code == 200
+    ids = {row["id"] for row in response.json()["data"]}
+    assert "claude-sdk" in ids
+    assert "codex" in ids
+
+
+def test_harnesses_route_filters_dismissed_harnesses(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "omnigent.harness_visibility.load_global_config",
+        lambda: {"dismissed_harnesses": ["claude-sdk", "not-a-harness"]},
+    )
+
+    response = _client().get("/v1/harnesses")
+
+    assert response.status_code == 200
+    ids = {row["id"] for row in response.json()["data"]}
+    assert "claude-sdk" not in ids
+    assert "codex" in ids

--- a/tests/test_harness_visibility.py
+++ b/tests/test_harness_visibility.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from omnigent.harness_visibility import (
+    dismissed_harness_ids,
+    filtered_harness_catalog,
+    resolve_catalog_harness_id,
+)
+
+
+def test_dismissed_harness_ids_resolves_aliases_and_ignores_unknown() -> None:
+    rows = [
+        {"id": "claude-sdk", "label": "Claude SDK"},
+        {"id": "codex", "label": "Codex"},
+    ]
+
+    dismissed = dismissed_harness_ids(
+        {"dismissed_harnesses": ["claude", "not-a-harness"]},
+        rows,
+    )
+
+    assert dismissed == frozenset({"claude-sdk"})
+
+
+def test_filtered_harness_catalog_preserves_default_catalog() -> None:
+    rows = filtered_harness_catalog({})
+
+    assert any(row["id"] == "claude-sdk" for row in rows)
+    assert any(row["id"] == "codex" for row in rows)
+
+
+def test_filtered_harness_catalog_omits_valid_dismissed_entries() -> None:
+    rows = filtered_harness_catalog({"dismissed_harnesses": ["claude-sdk"]})
+
+    ids = {row["id"] for row in rows}
+    assert "claude-sdk" not in ids
+    assert "codex" in ids
+
+
+def test_resolve_catalog_harness_id_accepts_aliases() -> None:
+    rows = [{"id": "claude-sdk", "label": "Claude SDK"}]
+
+    assert resolve_catalog_harness_id("claude", rows) == "claude-sdk"
+    assert resolve_catalog_harness_id("not-a-harness", rows) is None

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -35,7 +35,9 @@ async function fetchHarnessLabels(): Promise<Record<string, string>> {
   const res = await authenticatedFetch("/v1/harnesses");
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = (await res.json()) as HarnessCatalogWire;
-  const labels: Record<string, string> = { ...BRAIN_HARNESS_LABELS };
+  // Start empty — only expose harnesses the server actually returns.
+  // A missing catalog response must not reintroduce dismissed harnesses.
+  const labels: Record<string, string> = {};
   for (const row of body.data ?? []) {
     if (typeof row.id === "string" && typeof row.label === "string") {
       labels[row.id] = row.label;
@@ -50,7 +52,9 @@ export function useBrainHarnessLabels(): Record<string, string> {
     queryFn: fetchHarnessLabels,
     staleTime: 30_000,
   });
-  return data ?? BRAIN_HARNESS_LABELS;
+  // Fail closed: a static fallback would reintroduce dismissed harnesses
+  // while the catalog query is loading or unavailable.
+  return data ?? {};
 }
 
 /**

--- a/web/src/lib/nativeCodingAgents.test.ts
+++ b/web/src/lib/nativeCodingAgents.test.ts
@@ -3,6 +3,7 @@ import {
   UI_MODE_LABEL_KEY,
   UI_MODE_TERMINAL_VALUE,
   WRAPPER_LABEL_KEY,
+  catalogHarnessIdForNativeCodingAgent,
   nativeCodingAgentForHarness,
   nativeWrapperLabelsForAgent,
 } from "./nativeCodingAgents";
@@ -70,6 +71,23 @@ describe("nativeCodingAgentForHarness", () => {
     expect(nativeCodingAgentForHarness("antigravity")).toBeUndefined();
     expect(nativeCodingAgentForHarness(null)).toBeUndefined();
     expect(nativeCodingAgentForHarness(undefined)).toBeUndefined();
+  });
+});
+
+describe("catalogHarnessIdForNativeCodingAgent", () => {
+  it("maps native wrappers to their web-catalog ids", () => {
+    expect(
+      catalogHarnessIdForNativeCodingAgent({ name: "codex-native-ui", harness: "codex-native" }),
+    ).toBe("codex");
+    expect(
+      catalogHarnessIdForNativeCodingAgent({ name: "claude-native-ui", harness: "claude-native" }),
+    ).toBe("claude-sdk");
+  });
+
+  it("does not expose native-only wrappers through the web catalog", () => {
+    expect(
+      catalogHarnessIdForNativeCodingAgent({ name: "goose-native-ui", harness: "goose-native" }),
+    ).toBeUndefined();
   });
 });
 

--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -167,6 +167,17 @@ const BY_WRAPPER: Map<string, NativeCodingAgentSpec> = new Map(
   NATIVE_CODING_AGENTS.map((agent) => [agent.wrapperLabel, agent]),
 );
 
+// Native terminal wrappers are distinct executor harnesses, while the web
+// catalog uses the corresponding user-configurable harness ids. Native-only
+// wrappers without a catalog entry intentionally return undefined.
+const CATALOG_HARNESS_ID_BY_NATIVE_KEY: Partial<Record<NativeCodingAgentIconKind, string>> = {
+  claude: "claude-sdk",
+  codex: "codex",
+  cursor: "cursor",
+  pi: "pi",
+  antigravity: "antigravity",
+};
+
 // Reversed harness spellings that fold to a canonical native `harness`.
 // Mirrors omnigent.harness_aliases.NATIVE_HARNESSES on the server, which
 // accepts both the canonical and reversed native spellings (claude/codex
@@ -213,6 +224,14 @@ export function isNativeCodingAgent(
   agent: Pick<AvailableAgent, "name" | "harness"> | null | undefined,
 ): boolean {
   return nativeCodingAgentForAvailableAgent(agent) !== undefined;
+}
+
+/** Return the web catalog id that controls visibility of a native wrapper. */
+export function catalogHarnessIdForNativeCodingAgent(
+  agent: Pick<AvailableAgent, "name" | "harness"> | null | undefined,
+): string | undefined {
+  const nativeAgent = nativeCodingAgentForAvailableAgent(agent);
+  return nativeAgent == null ? undefined : CATALOG_HARNESS_ID_BY_NATIVE_KEY[nativeAgent.key];
 }
 
 export function isNativeWrapper(wrapper: string | null | undefined): boolean {

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -65,18 +65,23 @@ vi.mock("@/hooks/useConversations", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/hooks/useConversations")>()),
   useProjects: () => ({ data: [] }),
 }));
-// The harness-label catalog is not under test here. Keep it synchronous so
-// create-session fetch assertions only observe the POST/PATCH calls they own.
-vi.mock("@/lib/agentLabels", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
-  useBrainHarnessLabels: () => ({
+const brainHarnessLabels = vi.hoisted(() => {
+  const defaults = {
     "claude-sdk": "Claude SDK",
     codex: "Codex",
     cursor: "Cursor",
     pi: "Pi",
     antigravity: "Antigravity",
     copilot: "Copilot",
-  }),
+  } as Record<string, string>;
+  return { defaults, current: defaults };
+});
+
+// The harness-label catalog is not under test here. Keep it synchronous so
+// create-session fetch assertions only observe the POST/PATCH calls they own.
+vi.mock("@/lib/agentLabels", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
+  useBrainHarnessLabels: () => brainHarnessLabels.current,
 }));
 // Partial mock: only spy on the first-message handoff so the "@"-mention
 // tests can assert the prepended attachment marker. Everything else
@@ -573,6 +578,7 @@ function mockAgents(agents: AvailableAgent[]) {
 // directory-session / runner-health / filesystem stubs, and a persisted
 // recent workspace so the working-directory field seeds to a known path.
 function setupLandingMocks() {
+  brainHarnessLabels.current = { ...brainHarnessLabels.defaults };
   authenticatedFetchMock.mockReset();
   useHostsMock.mockReset();
   useAvailableAgentsMock.mockReset();
@@ -746,7 +752,8 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByText("No agents")).toBeTruthy();
   });
 
-  it("orders native built-ins together in the agent picker", () => {
+  it("filters native built-ins to the configured catalog in the agent picker", () => {
+    brainHarnessLabels.current = { codex: "Codex", pi: "Pi" };
     mockAgents([
       {
         id: "a_pi",
@@ -799,13 +806,14 @@ describe("NewChatLandingScreen", () => {
     ]);
     renderLanding();
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    const cursor = screen.getByTestId("new-chat-landing-agent-a_cursor");
+    const codex = screen.getByTestId("new-chat-landing-agent-a_codex");
     const pi = screen.getByTestId("new-chat-landing-agent-a_pi");
-    const kiro = screen.getByTestId("new-chat-landing-agent-a_kiro");
     const polly = screen.getByTestId("new-chat-landing-agent-a_polly");
-    expect(cursor.compareDocumentPosition(pi) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(pi.compareDocumentPosition(kiro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(kiro.compareDocumentPosition(polly) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-agent-a_cursor")).toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-agent-a_kiro")).toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-agent-a_claude")).toBeNull();
+    expect(codex.compareDocumentPosition(pi) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(pi.compareDocumentPosition(polly) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("seeds the working directory from the host's most-recent path", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -75,6 +75,7 @@ import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { sortAgentsForDisplay } from "@/lib/agentGrouping";
 import { cn } from "@/lib/utils";
 import {
+  catalogHarnessIdForNativeCodingAgent,
   isNativeCodingAgent,
   nativeAgentHasCapability,
   nativeCodingAgentForAvailableAgent,
@@ -1736,8 +1737,12 @@ export function NewChatLandingScreen() {
   // builtins/customs split: Polly & Debby are built-ins but belong under
   // "Agents", not "Harnesses".
   const harnessEntries = useMemo(
-    () => agentList.filter((a) => isNativeCodingAgent(a)),
-    [agentList],
+    () =>
+      agentList.filter((a) => {
+        const catalogHarnessId = catalogHarnessIdForNativeCodingAgent(a);
+        return catalogHarnessId != null && catalogHarnessId in brainHarnessLabels;
+      }),
+    [agentList, brainHarnessLabels],
   );
   const agentEntries = useMemo(() => agentList.filter((a) => !isNativeCodingAgent(a)), [agentList]);
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds `dismissed_harnesses` config support so unavailable harnesses can be hidden from the web UI picker without removing them from the registry.
- Adds `omnigent harness list`, `omnigent harness hide <id>`, and `omnigent harness unhide <id>` for headless configuration.
- **Fixes the New Chat picker leak**: the prior backend-only filtering left native wrapper agents (e.g. `antigravity-native-ui`, `cursor-native-ui`) visible in the top-level "Harnesses" group on the New Chat landing screen because those rows come from `/v1/agents`, not `/v1/harnesses`. The frontend now filters native wrappers using a catalog-harness mapping against the server-driven label map, so dismissed harnesses are hidden there too.
- Changes `useBrainHarnessLabels` to fail-closed (returns `{}`) when the catalog is unavailable, preventing stale static fallback data from reintroducing dismissed entries.

```mermaid
flowchart LR
    C[config.yaml dismissed_harnesses] --> F[filtered_harness_catalog]
    H[harness_catalog] --> F
    F --> A[GET /v1/harnesses]
    A --> U[web UI picker]
    CLI[omnigent harness hide/unhide] --> C
    C2[dismissed_harnesses] --> N[catalogHarnessId mapping]
    N --> P[New Chat picker filter]
    A -.-> P
```

## Test Plan

- `uv run python -m pytest tests/test_harness_visibility.py tests/server/routes/test_harnesses_route.py tests/cli/test_harness_cli.py tests/test_harness_plugins.py tests/test_harness_capabilities.py -q` — 27 passed
- `npm test -- src/lib/nativeCodingAgents.test.ts src/shell/NewChatDialog.test.tsx` — 144 passed
- `npm run build` — production build succeeds
- `uv run pre-commit run --all-files` — all hooks pass
- Live server: `GET /v1/harnesses` returns only `codex`, `pi`
- Live server: `GET /v1/agents` still returns all agents (backend unchanged; filtering is at the picker level)
- Manual CLI smoke with isolated `OMNIGENT_CONFIG_HOME`: `harness hide claude`, `harness list`, `harness unhide claude`

## Demo

N/A — non-visual backend/CLI behavior plus filter-only UI change (no visual redesign). The New Chat picker now shows only Codex and Pi under "Harnesses" when the others are dismissed.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used a temporary config home to confirm `hide` persists the canonical harness id, `list` reports it as dismissed, and `unhide` removes the config key. Frontend tests verify that native wrappers are filtered to only those whose catalog harness id exists in the server-driven label map.

## Changelog

`dismissed_harnesses` config + `omnigent harness hide/unhide` CLI to hide unavailable harnesses from the web UI picker — both the harness catalog and the New Chat landing screen.