### PR TITLE
Add Context7 and ponytail style to polly

### DIFF
--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -43,6 +43,12 @@ prompt: |
   (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
   Note anything that did not fit the task.
 
+tools:
+  context7:
+    type: mcp
+    command: npx
+    args: ["-y", "@upstash/context7-mcp"]
+
 os_env:
   type: caller_process
   cwd: .

--- a/examples/polly/agents/codex/config.yaml
+++ b/examples/polly/agents/codex/config.yaml
@@ -43,6 +43,12 @@ prompt: |
   (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
   Note anything that did not fit the task.
 
+tools:
+  context7:
+    type: mcp
+    command: npx
+    args: ["-y", "@upstash/context7-mcp"]
+
 os_env:
   type: caller_process
   cwd: .

--- a/examples/polly/agents/cursor/config.yaml
+++ b/examples/polly/agents/cursor/config.yaml
@@ -44,6 +44,12 @@ prompt: |
   (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
   Note anything that did not fit the task.
 
+tools:
+  context7:
+    type: mcp
+    command: npx
+    args: ["-y", "@upstash/context7-mcp"]
+
 os_env:
   type: caller_process
   cwd: .

--- a/examples/polly/agents/hermes/config.yaml
+++ b/examples/polly/agents/hermes/config.yaml
@@ -43,6 +43,12 @@ prompt: |
   (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
   Note anything that did not fit the task.
 
+tools:
+  context7:
+    type: mcp
+    command: npx
+    args: ["-y", "@upstash/context7-mcp"]
+
 os_env:
   type: caller_process
   cwd: .

--- a/examples/polly/agents/opencode/config.yaml
+++ b/examples/polly/agents/opencode/config.yaml
@@ -44,6 +44,12 @@ prompt: |
   (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
   Note anything that did not fit the task.
 
+tools:
+  context7:
+    type: mcp
+    command: npx
+    args: ["-y", "@upstash/context7-mcp"]
+
 os_env:
   type: caller_process
   cwd: .

--- a/examples/polly/agents/pi/config.yaml
+++ b/examples/polly/agents/pi/config.yaml
@@ -42,6 +42,12 @@ prompt: |
   (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
   Note anything that did not fit the task.
 
+tools:
+  context7:
+    type: mcp
+    command: npx
+    args: ["-y", "@upstash/context7-mcp"]
+
 os_env:
   type: caller_process
   cwd: .

--- a/examples/polly/skills/ponytail-style/SKILL.md
+++ b/examples/polly/skills/ponytail-style/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ponytail-style
+description: Keep implementation dispatches narrowly scoped, minimal, and free of speculative code.
+when-to-use: Use for implementation tasks where a sub-agent may over-engineer or add code outside the request, especially refactors and bug fixes in established code.
+---
+
+# ponytail-style — minimal implementation discipline
+
+When dispatching an implementation task, extend the sub-agent's task packet
+with the following constraints. Keep the original acceptance contract intact;
+these constraints govern how the agent satisfies it.
+
+- Apply YAGNI: do not write code for hypothetical future needs.
+- Produce the smallest diff that satisfies the acceptance criteria.
+- Do not expand the scope. If the task says to fix X, do not also address Y.
+- Leave no dead code, TODOs, placeholders, or unused compatibility paths.
+- Avoid premature abstractions. Extract shared code only when a third concrete
+  use warrants it.
+- Add tests only for behavior introduced or changed by this task.
+- Prefer self-explanatory code. Add comments sparingly, and explain why rather
+  than what.
+
+Tell the implementer to call out any requested outcome that cannot be achieved
+within these constraints instead of silently broadening the task. Apply the
+same constraints when routing review fixes back to the implementer.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add Context7 MCP to all six polly coding workers while keeping its API key optional.
- Add a `ponytail-style` orchestration skill for minimal, scope-disciplined implementation dispatches.

## Test Plan

- `uv run pytest -q tests/spec/test_parser.py -k 'inline_mcp'` (`11 passed`)
- `uv run pre-commit run --files examples/polly/agents/claude_code/config.yaml examples/polly/agents/codex/config.yaml examples/polly/agents/cursor/config.yaml examples/polly/agents/hermes/config.yaml examples/polly/agents/opencode/config.yaml examples/polly/agents/pi/config.yaml examples/polly/skills/ponytail-style/SKILL.md`
- Booted Context7 with `CONTEXT7_API_KEY` unset and discovered `resolve-library-id` and `query-docs`.

## Demo

N/A — configuration and prose-only change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified that all six worker configs parse with the Context7 stdio server and that the real MCP server boots without an API key and exposes its tools.

## Changelog

Polly workers can use Context7 documentation tools and opt into minimal ponytail-style implementation guidance.
