### PR TITLE
fix(pi): list full Databricks model catalog in native pi /model picker

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -50,7 +50,10 @@ from urllib.parse import urlparse as _urlparse
 
 from omnigent.inner.native_attachments import parse_data_uri
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
-from omnigent.onboarding.databricks_config import DATABRICKS_CLAUDE_DEFAULT_MODEL
+from omnigent.onboarding.databricks_config import (
+    DATABRICKS_ANTHROPIC_MODELS,
+    DATABRICKS_CLAUDE_DEFAULT_MODEL,
+)
 from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
 from omnigent.spec.types import RetryPolicy
 
@@ -594,31 +597,9 @@ _DATABRICKS_RESPONSES_MODELS = [
     },
 ]
 
-_DATABRICKS_ANTHROPIC_MODELS = [
-    {
-        "id": "databricks-claude-opus-4-8",
-        "name": "Claude Opus 4.8",
-        # Gateway-verified caps: >1000000 input rejects, 128001+ output rejects.
-        "contextWindow": 1000000,
-        "maxTokens": 128000,
-        "input": ["text", "image"],
-    },
-    {
-        "id": "databricks-claude-sonnet-4-6",
-        "name": "Claude Sonnet 4.6",
-        "contextWindow": 1000000,
-        "maxTokens": 128000,
-        "input": ["text", "image"],
-    },
-    {
-        "id": "databricks-claude-sonnet-4-5",
-        "name": "Claude Sonnet 4.5",
-        # Gateway rejects this model past ~200k input.
-        "contextWindow": 200000,
-        "maxTokens": 16384,
-        "input": ["text", "image"],
-    },
-]
+# Claude endpoints (``DATABRICKS_ANTHROPIC_MODELS``, imported above) live in
+# ``onboarding.databricks_config`` so the interactive ``omnigent pi`` path shares
+# the same catalog this harness advertises.
 
 # Empty: the only listed endpoint (meta-llama-3.3-70b) no longer exists on
 # the gateway. The provider stays so non-Claude/GPT ids keep a routing home.
@@ -777,7 +758,7 @@ def _build_models_json(
                 "apiKey": token,
                 "api": "anthropic-messages",
                 "authHeader": True,
-                "models": _DATABRICKS_ANTHROPIC_MODELS,
+                "models": DATABRICKS_ANTHROPIC_MODELS,
             },
             # Everything else (Llama, etc.) → same endpoint, same API
             "databricks-completions": {

--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -84,6 +84,42 @@ def databricks_sdk_installed() -> bool:
 # own ``opus[1m]`` default.
 DATABRICKS_CLAUDE_DEFAULT_MODEL = "databricks-claude-opus-4-8"
 
+# Known Claude endpoints on the Databricks AI gateway's Anthropic Messages
+# surface. Shared so every surface that renders a Pi ``models.json`` for that
+# gateway (the spawned harness in ``inner.pi_executor`` and the interactive
+# ``omnigent pi`` path in ``pi_native_credentials``) advertises the same set —
+# otherwise a picker built from one surface silently lists fewer models than
+# the gateway actually serves.
+#
+# Each entry declares ``input: ["text", "image"]``: Pi's transformMessages
+# strips image blocks unless the model entry advertises image input, so a
+# registered model missing this would silently drop attached images.
+DATABRICKS_ANTHROPIC_MODELS: list[dict[str, str | int | list[str]]] = [
+    {
+        "id": "databricks-claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        # Gateway-verified caps: >1000000 input rejects, 128001+ output rejects.
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "input": ["text", "image"],
+    },
+    {
+        "id": "databricks-claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "input": ["text", "image"],
+    },
+    {
+        "id": "databricks-claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5",
+        # Gateway rejects this model past ~200k input.
+        "contextWindow": 200000,
+        "maxTokens": 16384,
+        "input": ["text", "image"],
+    },
+]
+
 
 def list_databricks_profiles() -> list[str]:
     """Return the profile section names declared in ``~/.databrickscfg``.

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from omnigent.model_override import normalize_model_for_provider
+from omnigent.onboarding.databricks_config import DATABRICKS_ANTHROPIC_MODELS
 from omnigent.onboarding.provider_config import (
     CHAT_WIRE_API,
     CLI_CONFIG_KIND,
@@ -137,6 +138,13 @@ class PiProviderConfig:
         request time, used for short-lived gateway tokens).
     :param auth_header: When ``True``, Pi sends ``Authorization: Bearer
         <apiKey>`` (gateways) instead of a provider-native key header.
+    :param catalog: Extra model entries to advertise alongside ``model`` so
+        Pi's ``/model`` picker lists every model the endpoint serves, not just
+        the launch default. Each entry is a Pi ``models.json`` model dict (at
+        least ``{"id": ...}``). Empty for providers without a known catalog
+        (e.g. arbitrary key/local endpoints), which keeps the prior
+        single-model behavior. ``model`` is always registered even when absent
+        here — see :meth:`to_models_config`.
     """
 
     provider_id: str
@@ -145,14 +153,28 @@ class PiProviderConfig:
     model: str
     api_key: str
     auth_header: bool
+    catalog: tuple[dict[str, Any], ...] = ()
 
     def to_models_config(self) -> dict[str, Any]:
-        """Render this provider as a Pi ``models.json`` mapping."""
+        """Render this provider as a Pi ``models.json`` mapping.
+
+        Registers the full :attr:`catalog` so Pi's ``/model`` picker (and
+        manual model entry, which Pi validates against registered ids) offers
+        every model the endpoint serves. The launch default (:attr:`model`,
+        passed to Pi via ``--model``) is guaranteed present: if it isn't in the
+        catalog it's appended as a bare ``{"id": ...}`` entry — matching the
+        prior single-model shape for providers that ship no catalog (arbitrary
+        key/local endpoints, where advertising image input on a text-only
+        model would turn silent drops into request errors).
+        """
+        models: list[dict[str, Any]] = [dict(entry) for entry in self.catalog]
+        if not any(entry.get("id") == self.model for entry in models):
+            models.append({"id": self.model})
         provider: dict[str, Any] = {
             "baseUrl": self.base_url,
             "api": self.api,
             "apiKey": self.api_key,
-            "models": [{"id": self.model}],
+            "models": models,
         }
         if self.auth_header:
             provider["authHeader"] = True
@@ -187,6 +209,7 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # force-refreshes), matching codex-native's refresh semantics.
         api_key=f"!{auth_command}",
         auth_header=True,
+        catalog=tuple(DATABRICKS_ANTHROPIC_MODELS),
     )
 
 
@@ -328,6 +351,7 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # request — matching codex-native's refresh semantics.
         api_key=f"!{transport.auth_command}",
         auth_header=True,
+        catalog=tuple(DATABRICKS_ANTHROPIC_MODELS),
     )
 
 

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -47,6 +47,32 @@ def test_resolves_databricks_default_to_anthropic_gateway(monkeypatch: pytest.Mo
     assert "demo-staging" in provider.api_key
 
 
+def test_databricks_default_lists_full_model_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: Pi's ``/model`` must list every gateway Claude model.
+
+    Previously the rendered ``models.json`` carried only the launch default
+    (``databricks-claude-sonnet-4-6``), so ``omnigent pi`` → ``/model`` offered
+    a single choice and manual entry of another id was rejected. The resolver
+    now advertises the full Databricks Anthropic catalog.
+    """
+    from omnigent.inner import databricks_executor
+    from omnigent.onboarding.databricks_config import DATABRICKS_ANTHROPIC_MODELS
+
+    monkeypatch.setattr(
+        databricks_executor,
+        "_read_databrickscfg_host",
+        lambda profile: "https://wkspc.example.com/",
+    )
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    ids = [entry["id"] for entry in provider.to_models_config()["providers"]["omnigent"]["models"]]
+    assert ids == [entry["id"] for entry in DATABRICKS_ANTHROPIC_MODELS]
+    assert "databricks-claude-sonnet-4-6" in ids
+    assert "databricks-claude-opus-4-8" in ids
+
+
 def test_databricks_unresolvable_host_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """No host for the profile → fall back to Pi's own login (None)."""
     from omnigent.inner import databricks_executor
@@ -144,7 +170,48 @@ def test_to_models_config_shape() -> None:
     assert entry["api"] == "anthropic-messages"
     assert entry["apiKey"] == "!get-token"
     assert entry["authHeader"] is True
+    # No catalog supplied → prior single-model shape (bare id, no image caps).
     assert entry["models"] == [{"id": "databricks-claude-sonnet-4-6"}]
+
+
+def test_to_models_config_registers_full_catalog() -> None:
+    """A catalog is advertised in full, with the selected model deduped."""
+    catalog = (
+        {"id": "databricks-claude-opus-4-8", "input": ["text", "image"]},
+        {"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]},
+    )
+    provider = creds.PiProviderConfig(
+        provider_id="omnigent",
+        base_url="https://x/ai-gateway/anthropic",
+        api="anthropic-messages",
+        model="databricks-claude-sonnet-4-6",
+        api_key="!get-token",
+        auth_header=True,
+        catalog=catalog,
+    )
+    models = provider.to_models_config()["providers"]["omnigent"]["models"]
+    ids = [entry["id"] for entry in models]
+    # Every catalog model is offered, and the selected (in-catalog) model is
+    # not duplicated by the launch-default append.
+    assert ids == ["databricks-claude-opus-4-8", "databricks-claude-sonnet-4-6"]
+    assert ids.count("databricks-claude-sonnet-4-6") == 1
+
+
+def test_to_models_config_appends_selected_model_outside_catalog() -> None:
+    """A selected model absent from the catalog is appended so --model resolves."""
+    catalog = ({"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]},)
+    provider = creds.PiProviderConfig(
+        provider_id="omnigent",
+        base_url="https://x/ai-gateway/anthropic",
+        api="anthropic-messages",
+        model="databricks-claude-opus-4-7",
+        api_key="!get-token",
+        auth_header=True,
+        catalog=catalog,
+    )
+    models = provider.to_models_config()["providers"]["omnigent"]["models"]
+    ids = [entry["id"] for entry in models]
+    assert ids == ["databricks-claude-sonnet-4-6", "databricks-claude-opus-4-7"]
 
 
 def test_write_models_config_is_owner_only(tmp_path: Path) -> None:
@@ -697,9 +764,14 @@ def test_model_override_beats_databricks_default(monkeypatch: pytest.MonkeyPatch
 
     assert provider is not None
     assert provider.model == "databricks-claude-opus-4-7"
-    # The override flows all the way into the rendered models.json.
+    # The override flows all the way into the rendered models.json (an id
+    # outside the static catalog is appended), while the catalog stays
+    # advertised so /model still lists every gateway model.
     cfg = provider.to_models_config()
-    assert cfg["providers"]["omnigent"]["models"] == [{"id": "databricks-claude-opus-4-7"}]
+    model_ids = [entry["id"] for entry in cfg["providers"]["omnigent"]["models"]]
+    assert "databricks-claude-opus-4-7" in model_ids
+    assert "databricks-claude-sonnet-4-6" in model_ids
+    assert "databricks-claude-sonnet-4-5" in model_ids
 
 
 def test_model_override_beats_inline_family_default() -> None:


### PR DESCRIPTION
## Related issue

Closes #2369

## Summary

`omnigent pi` → `/model` only listed `databricks-claude-sonnet-4-6`, and manually
typing another id was rejected. The interactive pi path renders a per-session
`models.json` from `PiProviderConfig.to_models_config()`, which registered only the
single launch-default model. Pi's `/model` picker lists exactly what's registered.

This registers the full Databricks Anthropic catalog instead:
- Static Claude list moved to `onboarding.databricks_config` as shared
  `DATABRICKS_ANTHROPIC_MODELS`, reused by the harness (`inner.pi_executor`).
- `PiProviderConfig` gains a `catalog` field; `to_models_config()` advertises it
  alongside the launch default (still passed via `--model`, so unchanged).
- Providers with no known catalog keep the prior single-model behaviour.

## Test Plan

- `pytest tests/test_pi_native_credentials.py` → 48 passed.
- New tests cover the full-catalog listing, dedup of the selected model, and
  appending a selected id outside the catalog; updated the model-override test.
- Harness `_build_models_json` smoke-checked; `ruff check`/`format` clean.

## Demo

<img width="527" height="208" alt="image" src="https://github.com/user-attachments/assets/98069f1c-5951-4802-9b1d-39458f78ca8c" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises the resolver → `to_models_config()` path where the
bug lived. A live `omni pi` `/model` run against a real Databricks gateway wasn't
performed (no gateway credentials); the rendered `models.json` is asserted directly.

## Changelog

`omnigent pi` `/model` now lists every Databricks gateway Claude model, not just the default
