### PR TITLE
ci(release-notes): always append the community thanks note

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -409,13 +409,38 @@ jobs:
           RELEASE_ID: ${{ steps.release.outputs.release_id }}
         run: |
           set -euo pipefail
+          # Always end the notes with the community thanks. The AI drafter curates
+          # freely (and can drop a hand-added line), so this is appended here rather
+          # than via the prompt — every release, AI-drafted or mechanical fallback,
+          # gets it. Idempotent, and placed just before the trailing "Full Changelog:"
+          # link to match the layout of prior releases.
+          python3 - <<'PYEOF'
+          import pathlib
+          NOTE = (
+              "### 💜 Thanks to our community\n\n"
+              "This release was shaped by the people who filed issues, opened PRs, and "
+              "talked through feature requests with us on our Discord! Thank you for "
+              "building omnigent with us, keep the bug reports, ideas and contributions "
+              "coming :)"
+          )
+          path = pathlib.Path("/tmp/release_notes.md")
+          text = path.read_text(encoding="utf-8").rstrip("\n")
+          if "Thanks to our community" not in text:
+              idx = text.find("\nFull Changelog:")
+              if idx != -1:
+                  head, tail = text[:idx].rstrip("\n"), text[idx:].lstrip("\n")
+                  text = f"{head}\n\n{NOTE}\n\n{tail}"
+              else:
+                  text = f"{text}\n\n{NOTE}"
+              path.write_text(text + "\n", encoding="utf-8")
+          PYEOF
           # github-release.yml seeds only a short placeholder body (no
           # auto-generated notes), so replace it wholesale with the curated notes.
           # Edit by release ID: a draft release can't be addressed by tag (the
           # get/edit-by-tag REST endpoint 404s until the release is published).
           gh api --method PATCH "repos/${SOURCE_REPO}/releases/${RELEASE_ID}" \
             --field body=@/tmp/release_notes.md > /dev/null
-          echo "Enriched the ${TAG} release draft with curated notes." \
+          echo "Enriched the ${TAG} release draft with curated notes + community note." \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
       # ::add-mask:: redacts rendered logs, not artifact files — scrub the key


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The release-notes drafter is an LLM that curates the GitHub Release body freely, so a "Thanks to our community" note added via the prompt (or the mechanical scaffold) can be reworded or dropped — v0.5.0 shipped without it until it was added by hand.
- Append the note **deterministically** in the `Enrich the release draft body` step (after the drafter, before the `PATCH`), so every drafted release ends with it — AI-drafted or mechanical fallback.
- Idempotent, and inserted just before the trailing `Full Changelog:` link to match the layout of v0.2.0–v0.4.0. `release_to_mdx.py` copies the release body verbatim, so the website `/releases` post inherits the note too.

## Test Plan

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/draft-release-notes.yml'))"` — parses clean.
- Ran the exact injected snippet against sample notes: (a) inserts the note immediately before `Full Changelog:` and keeps that link last; (b) re-running adds nothing (idempotent); (c) appends at the end when there is no `Full Changelog:` line.
- Applied the same note to the live v0.5.0 GitHub Release and `/releases/0.5.0` site post this cycle by hand (this workflow change lands after v0.5.0 was cut).

## Demo

N/A — CI workflow change, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Workflow-YAML change; there is no harness that unit-tests workflow steps. Verified by parsing the YAML and running the injected Python against representative release-notes inputs (Full-Changelog-present and absent) plus a re-run to confirm idempotency.

This pull request and its description were written by Isaac.