### PR TITLE
feat(web): add tree view toggle for the changed files list (#2240)

### DIFF
--- a/tests/e2e_ui/files/test_changed_files_tree_toggle.py
+++ b/tests/e2e_ui/files/test_changed_files_tree_toggle.py
@@ -1,0 +1,132 @@
+"""E2E: the Changed scope toggles between a flat list and a folder tree.
+
+The Files panel's "Changed" scope renders changed files as a flat list by
+default; a list/tree toggle in its toolbar switches to a collapsible folder
+tree (``ChangedFileTree``), grouping the changed files under their directories
+VS Code Source Control–style and starting fully expanded.
+
+Driving real changed files needs an agent-run git workspace (the seeded PUT
+files land in the web-visible ``default`` environment and don't show as
+*changed*), so — like ``test_changed_files_git_status_error`` — this intercepts
+the ``/changes`` endpoint and fulfils it with a fixed set of changed files
+across nested folders. Everything else (environment availability, liveness)
+stays real so the changed-files query actually fires and the panel renders.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from playwright.sync_api import Locator, Page, Route, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# Changed files spanning two nested folders plus a root file, so the tree has
+# something to group (``src/app/``) and the flat list has a directory to show.
+_CHANGES = [
+    {
+        "path": "src/app/main.ts",
+        "name": "main.ts",
+        "status": "modified",
+        "bytes": 120,
+        "modified_at": 1_700_000_300,
+        "lines_added": 3,
+        "lines_removed": 1,
+    },
+    {
+        "path": "src/app/util.ts",
+        "name": "util.ts",
+        "status": "created",
+        "bytes": 64,
+        "modified_at": 1_700_000_200,
+        "lines_added": 8,
+        "lines_removed": 0,
+    },
+    {
+        "path": "README.md",
+        "name": "README.md",
+        "status": "modified",
+        "bytes": 42,
+        "modified_at": 1_700_000_100,
+        "lines_added": 1,
+        "lines_removed": 1,
+    },
+]
+
+
+def _row(rail: Locator, text: str) -> Locator:
+    """A file row is the button whose visible text contains *text*.
+
+    Matches on ``has_text`` rather than the accessible name so that text
+    containing ``/`` (e.g. the ``src/app`` directory chip) doesn't get turned
+    into a Playwright role-name *regex* — the slashes break its selector parser.
+    """
+    return rail.get_by_role("button").filter(has_text=text)
+
+
+def _folder(rail: Locator, name: str) -> Locator:
+    """A tree folder header button, matched on its exact ``name/`` label.
+
+    ``exact=True`` keeps it from colliding with a flat-list row whose full path
+    merely *contains* the folder name (e.g. ``src/`` inside ``src/app/main.ts``).
+    """
+    return rail.get_by_role("button", name=f"{name}/", exact=True)
+
+
+def test_changed_scope_toggles_between_list_and_tree(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The list/tree toggle groups the changed files into folders and back."""
+    base_url, session_id = seeded_session
+
+    def _serve_changes(route: Route) -> None:
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=json.dumps({"object": "list", "data": _CHANGES, "has_more": False}),
+        )
+
+    # Intercept ONLY the changed-files endpoint, before navigation, so the very
+    # first fetch returns our fixed set.
+    page.route(
+        re.compile(
+            rf"/v1/sessions/{re.escape(session_id)}/resources/environments/[^/]+/changes(\?|$)"
+        ),
+        _serve_changes,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+
+    # Files is the default rail tab, and Changed the default scope — but a prior
+    # session's remembered state could differ, so select both explicitly.
+    rail.get_by_role("tab", name=re.compile("^Files")).click()
+    rail.get_by_role("radio", name="Changed").click()
+
+    # List mode (the default): each row shows the file name plus its directory
+    # (two separate spans since #4150), and there is no folder row yet.
+    expect(_row(rail, "main.ts")).to_be_visible(timeout=30_000)
+    expect(_row(rail, "src/app")).to_have_count(2)
+    expect(_folder(rail, "src")).to_have_count(0)
+
+    # Flip to the tree.
+    rail.get_by_role("button", name="Switch to tree view").click()
+
+    # Tree mode: changed files are grouped under their folders (fully expanded),
+    # leaves show the filename only, and the toggle now offers the reverse.
+    expect(_folder(rail, "src")).to_be_visible()
+    expect(_folder(rail, "app")).to_be_visible()
+    expect(_row(rail, "main.ts")).to_be_visible()
+    # The folder is now a header row, so no leaf carries the directory text.
+    expect(_row(rail, "src/app")).to_have_count(0)
+    expect(rail.get_by_role("button", name="Switch to list view")).to_be_visible()
+
+    # Collapsing a folder hides its descendants; re-expanding brings them back.
+    _folder(rail, "app").click()
+    expect(_row(rail, "main.ts")).to_have_count(0)
+    _folder(rail, "app").click()
+    expect(_row(rail, "main.ts")).to_be_visible()

--- a/web/src/lib/filesPanelPreferences.test.ts
+++ b/web/src/lib/filesPanelPreferences.test.ts
@@ -19,12 +19,25 @@ describe("filesPanelPreferences", () => {
     expect(DEFAULT_FILES_PANEL_PREFERENCES.changedOnly).toBe(false);
   });
 
+  it("defaults the Changed scope to its flat list (changedTreeView false)", () => {
+    // The Changed scope opens as a flat list; the tree layout is opt-in.
+    expect(DEFAULT_FILES_PANEL_PREFERENCES.changedTreeView).toBe(false);
+  });
+
   it("round-trips a written preference", () => {
-    writeFilesPanelPreferences({ changedOnly: true, sort: "alpha" });
+    writeFilesPanelPreferences({ changedOnly: true, sort: "alpha", changedTreeView: true });
     expect(readFilesPanelPreferences()).toEqual({
       changedOnly: true,
       sort: "alpha",
+      changedTreeView: true,
     });
+  });
+
+  it("defaults changedTreeView when the stored field has the wrong type", () => {
+    // A record present but with a non-boolean changedTreeView must default the
+    // field rather than pass a garbage value through to the panel.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ changedTreeView: "yes" }));
+    expect(readFilesPanelPreferences().changedTreeView).toBe(false);
   });
 
   it("falls back to defaults on malformed JSON", () => {
@@ -47,6 +60,7 @@ describe("filesPanelPreferences", () => {
     expect(readFilesPanelPreferences()).toEqual({
       changedOnly: false,
       sort: "recent",
+      changedTreeView: false,
     });
   });
 
@@ -55,6 +69,7 @@ describe("filesPanelPreferences", () => {
     expect(readFilesPanelPreferences()).toEqual({
       changedOnly: true,
       sort: "recent",
+      changedTreeView: false,
     });
   });
 });

--- a/web/src/lib/filesPanelPreferences.ts
+++ b/web/src/lib/filesPanelPreferences.ts
@@ -20,15 +20,24 @@ export interface FilesPanelPreferences {
   changedOnly: boolean;
   /** Sort order for the changed-files flat list. */
   sort: ChangedSort;
+  /**
+   * Layout of the "Changed" scope: false = flat list (default), true = the
+   * changed files grouped into a collapsible folder tree. Independent of the
+   * scope switch — the "All" scope is always a tree — so a user can prefer the
+   * flat changed list while still folding changes by directory when they like.
+   */
+  changedTreeView: boolean;
 }
 
 const STORAGE_KEY = "omnigent:files-panel-preferences";
 
 // Default to the full folder tree ("All") — the panel opens on every file in
-// the working folder, not just the changed subset.
+// the working folder, not just the changed subset. The Changed scope defaults
+// to its flat list (changedTreeView false) to preserve the prior behaviour.
 export const DEFAULT_FILES_PANEL_PREFERENCES: FilesPanelPreferences = {
   changedOnly: false,
   sort: "recent",
+  changedTreeView: false,
 };
 
 /**
@@ -55,6 +64,10 @@ export function readFilesPanelPreferences(): FilesPanelPreferences {
         typeof p.sort === "string" && isValidSort(p.sort)
           ? p.sort
           : DEFAULT_FILES_PANEL_PREFERENCES.sort,
+      changedTreeView:
+        typeof p.changedTreeView === "boolean"
+          ? p.changedTreeView
+          : DEFAULT_FILES_PANEL_PREFERENCES.changedTreeView,
     };
   } catch {
     return DEFAULT_FILES_PANEL_PREFERENCES;

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -2486,7 +2486,7 @@ describe("Files scope default and persistence", () => {
     expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
     // The choice was written to localStorage — that's what makes it sticky.
     expect(localStorage.getItem(PREF_KEY)).toBe(
-      JSON.stringify({ changedOnly: true, sort: "recent" }),
+      JSON.stringify({ changedOnly: true, sort: "recent", changedTreeView: false }),
     );
 
     // Re-enter a *different* session fresh: it must open on the remembered

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -247,6 +247,12 @@ export function AppShell() {
   const [filesPanelSort, setFilesPanelSort] = useState<ChangedSort>(
     () => readFilesPanelPreferences().sort,
   );
+  // Changed-scope layout: false = flat list, true = collapsible folder tree.
+  // Seeded from the persisted preference; a manual toggle writes it back so the
+  // choice sticks across session switches and refreshes (like scope and sort).
+  const [filesPanelChangedTreeView, setFilesPanelChangedTreeView] = useState(
+    () => readFilesPanelPreferences().changedTreeView,
+  );
   const [panelInitialKey, setPanelInitialKeyState] = useState<string | null>(null);
   const [executionLogsKey, setExecutionLogsKey] = useState<string | null>(null);
   const [filesPanelOpen, setFilesPanelOpen] = useState(false);
@@ -862,6 +868,11 @@ export function AppShell() {
   const handleFilesSortChange = useCallback((s: ChangedSort) => {
     setFilesPanelSort(s);
     writeFilesPanelPreferences({ ...readFilesPanelPreferences(), sort: s });
+  }, []);
+
+  const handleFilesChangedTreeViewChange = useCallback((treeView: boolean) => {
+    setFilesPanelChangedTreeView(treeView);
+    writeFilesPanelPreferences({ ...readFilesPanelPreferences(), changedTreeView: treeView });
   }, []);
 
   const openFileViewer = useCallback(
@@ -1526,6 +1537,8 @@ export function AppShell() {
                     onSortChange={handleFilesSortChange}
                     filesPanelFlatView={filesPanelFlatView}
                     onFlatViewChange={handleFilesFlatViewChange}
+                    filesPanelChangedTreeView={filesPanelChangedTreeView}
+                    onChangedTreeViewChange={handleFilesChangedTreeViewChange}
                     filesPanelShowHidden={filesPanelShowHidden}
                     onShowHiddenChange={setFilesPanelShowHidden}
                     liveness={liveness}
@@ -1565,6 +1578,8 @@ export function AppShell() {
                   onFileSelect={openFileViewer}
                   flatView={filesPanelFlatView}
                   onFlatViewChange={handleFilesFlatViewChange}
+                  changedTreeView={filesPanelChangedTreeView}
+                  onChangedTreeViewChange={handleFilesChangedTreeViewChange}
                   showHidden={filesPanelShowHidden}
                   onShowHiddenChange={setFilesPanelShowHidden}
                   sort={filesPanelSort}

--- a/web/src/shell/ChangedFileTree.test.tsx
+++ b/web/src/shell/ChangedFileTree.test.tsx
@@ -1,0 +1,150 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RunnerOfflineError, type WorkspaceChangedFile } from "@/hooks/useWorkspaceChangedFiles";
+import { ChangedFileTree } from "./ChangedFileTree";
+
+afterEach(cleanup);
+
+function changedFile(
+  path: string,
+  status: WorkspaceChangedFile["status"] = "modified",
+): WorkspaceChangedFile {
+  return {
+    bytes: 10,
+    modified_at: null,
+    name: path.split("/").at(-1) ?? path,
+    path,
+    status,
+    // Required since main added per-file diff stats; the tree doesn't show them.
+    lines_added: null,
+    lines_removed: null,
+  };
+}
+
+/** Render ChangedFileTree with defaults; the rows mount FileDownloadButton
+ *  (imperative, no query on render) so a QueryClientProvider isn't required,
+ *  but we wrap in one anyway to stay robust to future row dependencies. */
+function renderTree(props: Partial<Parameters<typeof ChangedFileTree>[0]> = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ChangedFileTree
+        files={[]}
+        isLoading={false}
+        isError={false}
+        error={null}
+        onFileSelect={vi.fn()}
+        showHidden={false}
+        onShowHidden={vi.fn()}
+        searchQuery=""
+        sort="alpha"
+        conversationId="conv_abc"
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ChangedFileTree grouping", () => {
+  it("groups changed files under their folders, fully expanded by default", () => {
+    renderTree({
+      files: [changedFile("src/a.ts"), changedFile("src/nested/b.ts"), changedFile("README.md")],
+    });
+
+    // Folder rows for each directory segment.
+    expect(screen.getByRole("button", { name: "src/" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "nested/" })).toBeInTheDocument();
+    // Leaf rows use the filename only (not the full path) and are visible
+    // because folders start expanded.
+    expect(screen.getByText("a.ts")).toBeInTheDocument();
+    expect(screen.getByText("b.ts")).toBeInTheDocument();
+    expect(screen.getByText("README.md")).toBeInTheDocument();
+  });
+
+  it("collapses and re-expands a folder on click", () => {
+    renderTree({ files: [changedFile("src/a.ts"), changedFile("src/b.ts")] });
+
+    const folder = screen.getByRole("button", { name: "src/" });
+    expect(folder).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("a.ts")).toBeInTheDocument();
+
+    fireEvent.click(folder);
+    expect(folder).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("a.ts")).not.toBeInTheDocument();
+
+    fireEvent.click(folder);
+    expect(screen.getByText("a.ts")).toBeInTheDocument();
+  });
+
+  it("selects a file when its row is clicked", () => {
+    const onFileSelect = vi.fn();
+    renderTree({ files: [changedFile("src/a.ts")], onFileSelect });
+
+    fireEvent.click(screen.getByText("a.ts"));
+    expect(onFileSelect).toHaveBeenCalledWith("src/a.ts");
+  });
+});
+
+describe("ChangedFileTree hidden files", () => {
+  it("hides dot-directory files and offers to reveal them", () => {
+    const onShowHidden = vi.fn();
+    renderTree({
+      files: [changedFile("visible.ts"), changedFile(".config/secret.ts")],
+      onShowHidden,
+    });
+
+    expect(screen.getByText("visible.ts")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: ".config/" })).not.toBeInTheDocument();
+    expect(screen.getByText(/1 file hidden/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /click to show/i }));
+    expect(onShowHidden).toHaveBeenCalled();
+  });
+
+  it("shows hidden files when showHidden is set", () => {
+    renderTree({
+      files: [changedFile("visible.ts"), changedFile(".config/secret.ts")],
+      showHidden: true,
+    });
+
+    expect(screen.getByRole("button", { name: ".config/" })).toBeInTheDocument();
+    expect(screen.getByText("secret.ts")).toBeInTheDocument();
+  });
+});
+
+describe("ChangedFileTree search", () => {
+  it("filters to matching files and keeps their folders", () => {
+    renderTree({
+      files: [changedFile("src/alpha.ts"), changedFile("src/beta.ts")],
+      searchQuery: "alpha",
+    });
+
+    expect(screen.getByText("alpha.ts")).toBeInTheDocument();
+    expect(screen.queryByText("beta.ts")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "src/" })).toBeInTheDocument();
+  });
+
+  it("shows a no-match message when nothing matches", () => {
+    renderTree({ files: [changedFile("src/alpha.ts")], searchQuery: "zzz" });
+    expect(screen.getByText(/no changed files match/i)).toBeInTheDocument();
+  });
+});
+
+describe("ChangedFileTree empty and error states", () => {
+  it("shows the empty state with no changes", () => {
+    renderTree({ files: [] });
+    expect(screen.getByText(/no workspace changes yet/i)).toBeInTheDocument();
+  });
+
+  it("shows the reconnect hint when the runner went offline", () => {
+    renderTree({ isError: true, error: new RunnerOfflineError(), runnerWentOffline: true });
+    expect(screen.getByText(/agent is asleep/i)).toBeInTheDocument();
+  });
+
+  it("shows the empty state (not the asleep hint) for a session that hasn't started", () => {
+    renderTree({ isError: true, error: new RunnerOfflineError(), runnerWentOffline: false });
+    expect(screen.getByText(/no workspace changes yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/agent is asleep/i)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/shell/ChangedFileTree.tsx
+++ b/web/src/shell/ChangedFileTree.tsx
@@ -1,0 +1,300 @@
+import { ChevronRightIcon } from "lucide-react";
+import { useCallback, useState } from "react";
+import { RunnerOfflineError, type WorkspaceChangedFile } from "@/hooks/useWorkspaceChangedFiles";
+import { cn } from "@/lib/utils";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { RunnerAsleepHint } from "./RunnerAsleepHint";
+import { type ChangedSort, compareChangedFiles, type SortableFile } from "./FlatFileList";
+import { FileRowItem, IndentGuides, indentFor } from "./FolderTree";
+
+// ---------------------------------------------------------------------------
+// Tree data model — the changed set is fully known up front (no lazy loading),
+// so the whole tree is built synchronously from the flat file list.
+// ---------------------------------------------------------------------------
+
+interface ChangedFileNode {
+  type: "file";
+  name: string;
+  file: WorkspaceChangedFile;
+}
+
+interface ChangedDirNode {
+  type: "dir";
+  name: string;
+  /** Full path from workspace root, e.g. "src/utils" — the toggle key. */
+  path: string;
+  children: ChangedTreeNode[];
+}
+
+type ChangedTreeNode = ChangedFileNode | ChangedDirNode;
+
+/** Project a node onto the shape the shared comparator sorts by. Directories
+ *  in the changed tree carry neither size nor mtime, so under those sorts they
+ *  fall back to name among themselves. */
+function nodeSortable(node: ChangedTreeNode): SortableFile {
+  if (node.type === "file") return node.file;
+  return { name: node.name, path: node.path, bytes: null, modified_at: null };
+}
+
+/** Sibling comparator: directories group ahead of files (explorer default),
+ *  then entries order by the active sort via the shared comparator — so the
+ *  tree and the flat Changed list agree on ordering. */
+function compareChangedNodes(sort: ChangedSort) {
+  const compareFiles = compareChangedFiles(sort);
+  return (a: ChangedTreeNode, b: ChangedTreeNode): number => {
+    if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+    return compareFiles(nodeSortable(a), nodeSortable(b));
+  };
+}
+
+function buildChangedTree(files: WorkspaceChangedFile[], sort: ChangedSort): ChangedTreeNode[] {
+  const root: ChangedDirNode = { type: "dir", name: "", path: "", children: [] };
+  for (const file of files) {
+    const parts = file.path.split("/");
+    let node = root;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      let dir = node.children.find((c): c is ChangedDirNode => c.type === "dir" && c.name === part);
+      if (!dir) {
+        dir = { type: "dir", name: part, path: parts.slice(0, i + 1).join("/"), children: [] };
+        node.children.push(dir);
+      }
+      node = dir;
+    }
+    node.children.push({ type: "file", name: parts[parts.length - 1], file });
+  }
+
+  const compare = compareChangedNodes(sort);
+  function sortTree(node: ChangedDirNode) {
+    node.children.sort(compare);
+    for (const child of node.children) {
+      if (child.type === "dir") sortTree(child);
+    }
+  }
+  sortTree(root);
+  return root.children;
+}
+
+function normalizeSearchQuery(query: string): string {
+  return query.trim().toLowerCase();
+}
+
+function isHidden(path: string): boolean {
+  return path.split("/").some((seg) => seg.startsWith("."));
+}
+
+// ---------------------------------------------------------------------------
+// ChangedFileTree — the "Changed" scope rendered as a collapsible folder tree.
+// Mirrors FlatFileList's loading / error / empty / hidden-files states so the
+// list and tree layouts of the Changed scope behave identically apart from
+// their arrangement. Folders start fully expanded (VS Code Source Control
+// style); the toggle tracks an explicit *collapsed* set, so folders that
+// appear as new changes land stay expanded by default.
+// ---------------------------------------------------------------------------
+
+export function ChangedFileTree({
+  files,
+  isLoading,
+  isError,
+  error,
+  onFileSelect,
+  showHidden,
+  onShowHidden,
+  searchQuery,
+  sort,
+  conversationId,
+  runnerWentOffline = false,
+}: {
+  files: WorkspaceChangedFile[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  onFileSelect: (path: string) => void;
+  showHidden: boolean;
+  onShowHidden: () => void;
+  searchQuery: string;
+  sort: ChangedSort;
+  conversationId: string | undefined;
+  /** Runner went offline after connecting (session "failed") — show the
+   *  reconnect hint instead of the generic empty state. */
+  runnerWentOffline?: boolean;
+}) {
+  // Folders the user has explicitly collapsed. Empty = everything expanded,
+  // which is the required "fully expanded initially" default and keeps newly
+  // arriving changed folders open without a recompute effect.
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+  const togglePath = useCallback((path: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  if (isLoading) {
+    return <p className="px-2 py-1 text-muted-foreground text-xs">Loading…</p>;
+  }
+  if (isError) {
+    // Runner not connected. Distinguish "went offline after being up" (show the
+    // reconnect hint) from "hasn't started yet" (normal empty state), matching
+    // FlatFileList so the two layouts read identically.
+    if (error instanceof RunnerOfflineError) {
+      if (runnerWentOffline) return <RunnerAsleepHint />;
+      return <p className="px-2 py-1 text-muted-foreground text-xs">No workspace changes yet</p>;
+    }
+    return (
+      <p className="px-2 py-1 text-destructive text-xs">
+        Failed to load: {error instanceof Error ? error.message : String(error)}
+      </p>
+    );
+  }
+  if (!files || files.length === 0) {
+    return <p className="px-2 py-1 text-muted-foreground text-xs">No workspace changes yet</p>;
+  }
+
+  const visibleFiles = showHidden ? files : files.filter((f) => !isHidden(f.path));
+  const hiddenCount = files.length - visibleFiles.length;
+  if (visibleFiles.length === 0) {
+    return (
+      <p className="px-2 py-1 text-muted-foreground text-xs">
+        All changes are in hidden files.{" "}
+        <button
+          type="button"
+          className="cursor-pointer underline hover:text-foreground"
+          onClick={onShowHidden}
+        >
+          Click to show
+        </button>
+      </p>
+    );
+  }
+
+  const normalizedSearch = normalizeSearchQuery(searchQuery);
+  const searchActive = normalizedSearch.length > 0;
+  const matchedFiles = searchActive
+    ? visibleFiles.filter(
+        (f) =>
+          f.name.toLowerCase().includes(normalizedSearch) ||
+          f.path.toLowerCase().includes(normalizedSearch),
+      )
+    : visibleFiles;
+  if (matchedFiles.length === 0) {
+    return (
+      <p className="px-2 py-1 text-muted-foreground text-xs">
+        No changed files match "{searchQuery.trim()}"
+      </p>
+    );
+  }
+
+  const tree = buildChangedTree(matchedFiles, sort);
+
+  return (
+    <>
+      {hiddenCount > 0 && (
+        <p className="px-2 py-1 text-muted-foreground text-xs">
+          {hiddenCount} file{hiddenCount === 1 ? "" : "s"} hidden.{" "}
+          <button
+            type="button"
+            className="cursor-pointer underline hover:text-foreground"
+            onClick={onShowHidden}
+          >
+            Click to show
+          </button>
+        </p>
+      )}
+      <TooltipProvider>
+        <ul className="flex flex-col gap-0.5">
+          {tree.map((node) => (
+            <ChangedTreeNodeRow
+              key={node.type === "file" ? node.file.path : node.path}
+              node={node}
+              depth={0}
+              onFileSelect={onFileSelect}
+              conversationId={conversationId}
+              collapsed={collapsed}
+              onTogglePath={togglePath}
+              // A search forces every branch open so matches deep in a
+              // collapsed folder still surface.
+              forceExpanded={searchActive}
+            />
+          ))}
+        </ul>
+      </TooltipProvider>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChangedTreeNodeRow
+// ---------------------------------------------------------------------------
+
+function ChangedTreeNodeRow({
+  node,
+  depth,
+  onFileSelect,
+  conversationId,
+  collapsed,
+  onTogglePath,
+  forceExpanded,
+}: {
+  node: ChangedTreeNode;
+  depth: number;
+  onFileSelect: (path: string) => void;
+  conversationId: string | undefined;
+  collapsed: Set<string>;
+  onTogglePath: (path: string) => void;
+  forceExpanded: boolean;
+}) {
+  if (node.type === "file") {
+    return (
+      <FileRowItem
+        path={node.file.path}
+        displayLabel={node.name}
+        depth={depth}
+        fileStatus={node.file.status}
+        bytes={node.file.bytes}
+        onFileSelect={onFileSelect}
+        conversationId={conversationId}
+      />
+    );
+  }
+
+  const open = forceExpanded || !collapsed.has(node.path);
+  return (
+    <li>
+      <button
+        type="button"
+        className="group relative flex w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-muted"
+        style={{ paddingLeft: `${indentFor(depth)}px` }}
+        onClick={() => onTogglePath(node.path)}
+        aria-expanded={open}
+      >
+        <IndentGuides depth={depth} />
+        <ChevronRightIcon
+          className={cn(
+            "size-3.5 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-90",
+          )}
+        />
+        <span className="min-w-0 flex-1 truncate font-mono text-sm md:text-xs">{node.name}/</span>
+      </button>
+      {open && (
+        <ul className="flex flex-col gap-0.5">
+          {node.children.map((child) => (
+            <ChangedTreeNodeRow
+              key={child.type === "file" ? child.file.path : child.path}
+              node={child}
+              depth={depth + 1}
+              onFileSelect={onFileSelect}
+              conversationId={conversationId}
+              collapsed={collapsed}
+              onTogglePath={onTogglePath}
+              forceExpanded={forceExpanded}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -110,6 +110,8 @@ function searchResult(files: WorkspaceFile[] | undefined = undefined, isFetching
 function renderPanel({
   conversationId,
   flatView = false,
+  changedTreeView = false,
+  onChangedTreeViewChange = vi.fn(),
   showHidden = false,
   files,
   changedFiles = [],
@@ -120,6 +122,8 @@ function renderPanel({
 }: {
   conversationId: string;
   flatView?: boolean;
+  changedTreeView?: boolean;
+  onChangedTreeViewChange?: (treeView: boolean) => void;
   showHidden?: boolean;
   files: WorkspaceFile[];
   changedFiles?: WorkspaceChangedFile[];
@@ -146,6 +150,8 @@ function renderPanel({
               flatView={flatView}
               onFileSelect={vi.fn()}
               onFlatViewChange={vi.fn()}
+              changedTreeView={changedTreeView}
+              onChangedTreeViewChange={onChangedTreeViewChange}
               showHidden={showHidden}
               onShowHiddenChange={vi.fn()}
               onClose={onClose}
@@ -241,6 +247,8 @@ describe("FilesPanel working folder header role", () => {
                 flatView={false}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -322,6 +330,8 @@ describe("FilesPanel scope switch (Changed | All) visibility", () => {
                 flatView={false}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -372,6 +382,8 @@ describe("FilesPanel scope switch (Changed | All) visibility", () => {
                 flatView={false}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={onFlatViewChange}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -431,6 +443,8 @@ describe("FilesPanel changed files search", () => {
                 flatView={true}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -493,6 +507,8 @@ describe("FilesPanel changed files search", () => {
                 flatView={false}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -515,6 +531,8 @@ describe("FilesPanel changed files search", () => {
                 flatView={true}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -589,6 +607,8 @@ describe("FilesPanel changed files search", () => {
                     onFileSelect={vi.fn()}
                     flatView={false}
                     onFlatViewChange={vi.fn()}
+                    changedTreeView={false}
+                    onChangedTreeViewChange={vi.fn()}
                     showHidden={showHidden}
                     onShowHiddenChange={setShowHidden}
                   />
@@ -603,6 +623,8 @@ describe("FilesPanel changed files search", () => {
                         flatView={false}
                         onFileSelect={vi.fn()}
                         onFlatViewChange={vi.fn()}
+                        changedTreeView={false}
+                        onChangedTreeViewChange={vi.fn()}
                         showHidden={showHidden}
                         onShowHiddenChange={setShowHidden}
                       />
@@ -658,6 +680,8 @@ describe("FilesPanel changed files search", () => {
                     onFileSelect={vi.fn()}
                     flatView={false}
                     onFlatViewChange={vi.fn()}
+                    changedTreeView={false}
+                    onChangedTreeViewChange={vi.fn()}
                     showHidden={showHidden}
                     onShowHiddenChange={setShowHidden}
                   />
@@ -672,6 +696,8 @@ describe("FilesPanel changed files search", () => {
                         flatView={false}
                         onFileSelect={vi.fn()}
                         onFlatViewChange={vi.fn()}
+                        changedTreeView={false}
+                        onChangedTreeViewChange={vi.fn()}
                         showHidden={showHidden}
                         onShowHiddenChange={setShowHidden}
                       />
@@ -721,6 +747,8 @@ describe("FilesPanel changed files search", () => {
                   flatView={true}
                   onFileSelect={vi.fn()}
                   onFlatViewChange={vi.fn()}
+                  changedTreeView={false}
+                  onChangedTreeViewChange={vi.fn()}
                   showHidden={showHidden}
                   onShowHiddenChange={setShowHidden}
                 />
@@ -774,6 +802,8 @@ describe("FilesPanel tree (Explore) search", () => {
                 flatView={true}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -965,6 +995,8 @@ describe("FilesPanel tree (Explore) search", () => {
                 flatView={true}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -987,6 +1019,8 @@ describe("FilesPanel tree (Explore) search", () => {
                 flatView={false}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -1195,6 +1229,8 @@ describe("FilesPanel tree (Explore) search", () => {
                 flatView={true}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -1218,6 +1254,8 @@ describe("FilesPanel tree (Explore) search", () => {
                 flatView={false}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -1312,6 +1350,8 @@ describe("FilesPanel scroll position persistence", () => {
                 flatView={false}
                 onFileSelect={vi.fn()}
                 onFlatViewChange={vi.fn()}
+                changedTreeView={false}
+                onChangedTreeViewChange={vi.fn()}
                 showHidden={false}
                 onShowHiddenChange={vi.fn()}
               />
@@ -1390,5 +1430,75 @@ describe("FolderTree expanded state across conversation switches", () => {
     // Switch back to A in place: its collapsed state is restored.
     view.rerender(tree("conv_tree_resync_a"));
     expect(screen.queryByText("App.tsx")).toBeNull();
+  });
+});
+
+describe("FilesPanel changed list/tree layout toggle", () => {
+  it("offers the tree-view toggle in the Changed scope", () => {
+    renderPanel({
+      conversationId: "conv_toggle",
+      files: [],
+      flatView: true,
+      changedFiles: [changedFile("src/a.ts")],
+    });
+    expect(screen.getByRole("button", { name: "Switch to tree view" })).toBeInTheDocument();
+  });
+
+  it("does not show the layout toggle in the All scope", () => {
+    // The All scope is always a tree, so the list/tree toggle is meaningless
+    // there and must not render.
+    renderPanel({
+      conversationId: "conv_toggle_all",
+      files: [file("a.txt")],
+      flatView: false,
+    });
+    expect(screen.queryByRole("button", { name: /Switch to (tree|list) view/ })).toBeNull();
+  });
+
+  it("renders the changed files as a flat list by default", () => {
+    renderPanel({
+      conversationId: "conv_flat",
+      files: [],
+      flatView: true,
+      changedTreeView: false,
+      changedFiles: [changedFile("src/a.ts")],
+    });
+    // Flat list shows the file name with its directory alongside (two spans
+    // since #4150), not a folder row.
+    expect(screen.getByText("a.ts")).toBeInTheDocument();
+    expect(screen.getByText("src")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "src/" })).toBeNull();
+  });
+
+  it("renders the changed files as a folder tree when tree view is on", () => {
+    renderPanel({
+      conversationId: "conv_tree",
+      files: [],
+      flatView: true,
+      changedTreeView: true,
+      changedFiles: [changedFile("src/a.ts"), changedFile("src/nested/b.ts")],
+    });
+    expect(screen.getByRole("button", { name: "src/" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "nested/" })).toBeInTheDocument();
+    expect(screen.getByText("a.ts")).toBeInTheDocument();
+    // The toggle now reflects the active tree layout.
+    expect(screen.getByRole("button", { name: "Switch to list view" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("invokes the change handler when the toggle is clicked", () => {
+    const onChangedTreeViewChange = vi.fn();
+    renderPanel({
+      conversationId: "conv_toggle_click",
+      files: [],
+      flatView: true,
+      changedTreeView: false,
+      onChangedTreeViewChange,
+      changedFiles: [changedFile("src/a.ts")],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Switch to tree view" }));
+    expect(onChangedTreeViewChange).toHaveBeenCalledWith(true);
   });
 });

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -7,6 +7,7 @@ import {
   FileTypeIcon,
   FolderTreeIcon,
   ListIcon,
+  ListTreeIcon,
   MoonIcon,
   SearchIcon,
   SlidersHorizontalIcon,
@@ -33,12 +34,21 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { type ChangedSort, FlatFileList } from "./FlatFileList";
 import { FolderTree } from "./FolderTree";
+import { ChangedFileTree } from "./ChangedFileTree";
 import { useScrollRestore } from "./useScrollRestore";
 
 interface FilesPanelProps {
   onFileSelect: (path: string) => void;
   flatView: boolean;
   onFlatViewChange: (flatView: boolean) => void;
+  /**
+   * Layout of the "Changed" scope: false = flat list, true = collapsible
+   * folder tree of the changed files. Lifted to the parent (persisted) so the
+   * choice survives inline→drawer transitions and page refreshes. Only affects
+   * the Changed scope — the "All" scope is always a tree.
+   */
+  changedTreeView: boolean;
+  onChangedTreeViewChange: (changedTreeView: boolean) => void;
   /**
    * Whether hidden files (dot-prefixed paths) are visible. Lifted to
    * the parent so the state survives inline→drawer transitions.
@@ -160,6 +170,44 @@ function SortSelector({
 }
 
 // ---------------------------------------------------------------------------
+// ChangedLayoutToggle — flat list ⇄ folder tree for the Changed scope. A
+// single toggle button (like the hidden-files / filters toggles): the icon
+// reflects the active layout and the label states the action. Only rendered in
+// the Changed scope, since the All scope is always a tree.
+// ---------------------------------------------------------------------------
+
+function ChangedLayoutToggle({
+  treeView,
+  onChange,
+}: {
+  treeView: boolean;
+  onChange: (treeView: boolean) => void;
+}) {
+  const action = treeView ? "Switch to list view" : "Switch to tree view";
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={action}
+            aria-pressed={treeView}
+            className={cn(
+              "flex shrink-0 cursor-pointer items-center rounded-full px-2.5 py-[4px] hover:bg-muted",
+              treeView ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+            )}
+            onClick={() => onChange(!treeView)}
+          >
+            {treeView ? <ListTreeIcon className="size-3.5" /> : <ListIcon className="size-3.5" />}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{action}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // FileScopeSwitch — segmented Changed | All control that flips the whole Files
 // view between the changed-files-only flat list (Changed) and the full folder
 // tree (All). One control replaces the old separate Files / Changes rail tabs.
@@ -266,6 +314,8 @@ export function FilesPanel({
   onFileSelect,
   flatView,
   onFlatViewChange,
+  changedTreeView,
+  onChangedTreeViewChange,
   showHidden,
   onShowHiddenChange,
   sort: changedSort,
@@ -445,6 +495,7 @@ export function FilesPanel({
                 value={changedSearch}
               />
             </div>
+            <ChangedLayoutToggle treeView={changedTreeView} onChange={onChangedTreeViewChange} />
             <SortSelector sort={changedSort} onChange={onSortChange} />
           </div>
         </div>
@@ -514,19 +565,35 @@ export function FilesPanel({
         onScroll={handleScroll}
       >
         {flatView ? (
-          <FlatFileList
-            files={changedQuery.data?.data}
-            isLoading={changedQuery.isLoading}
-            isError={changedQuery.isError}
-            error={changedQuery.error}
-            onFileSelect={onFileSelect}
-            showHidden={showHidden}
-            onShowHidden={() => onShowHiddenChange(true)}
-            searchQuery={changedSearch}
-            sort={changedSort}
-            conversationId={conversationId}
-            runnerWentOffline={runnerWentOffline}
-          />
+          changedTreeView ? (
+            <ChangedFileTree
+              files={changedQuery.data?.data}
+              isLoading={changedQuery.isLoading}
+              isError={changedQuery.isError}
+              error={changedQuery.error}
+              onFileSelect={onFileSelect}
+              showHidden={showHidden}
+              onShowHidden={() => onShowHiddenChange(true)}
+              searchQuery={changedSearch}
+              sort={changedSort}
+              conversationId={conversationId}
+              runnerWentOffline={runnerWentOffline}
+            />
+          ) : (
+            <FlatFileList
+              files={changedQuery.data?.data}
+              isLoading={changedQuery.isLoading}
+              isError={changedQuery.isError}
+              error={changedQuery.error}
+              onFileSelect={onFileSelect}
+              showHidden={showHidden}
+              onShowHidden={() => onShowHiddenChange(true)}
+              searchQuery={changedSearch}
+              sort={changedSort}
+              conversationId={conversationId}
+              runnerWentOffline={runnerWentOffline}
+            />
+          )
         ) : (
           <FolderTree
             files={allFilesQuery.data?.data}

--- a/web/src/shell/FilesPanelDrawer.tsx
+++ b/web/src/shell/FilesPanelDrawer.tsx
@@ -35,6 +35,12 @@ interface FilesPanelDrawerProps {
   flatView: boolean;
   onFlatViewChange: (flatView: boolean) => void;
   /**
+   * Lifted Changed-scope layout (list vs folder tree). Lifted to AppShell
+   * (persisted) so the choice survives drawer open/close and page refreshes.
+   */
+  changedTreeView: boolean;
+  onChangedTreeViewChange: (changedTreeView: boolean) => void;
+  /**
    * Lifted hidden-files toggle state. Lifted to AppShell so the
    * eye-icon choice survives inline→drawer transitions.
    */
@@ -54,6 +60,8 @@ export function FilesPanelDrawer({
   onFileSelect,
   flatView,
   onFlatViewChange,
+  changedTreeView,
+  onChangedTreeViewChange,
   showHidden,
   onShowHiddenChange,
   sort,
@@ -112,6 +120,8 @@ export function FilesPanelDrawer({
           onFileSelect={onFileSelect}
           flatView={flatView}
           onFlatViewChange={onFlatViewChange}
+          changedTreeView={changedTreeView}
+          onChangedTreeViewChange={onChangedTreeViewChange}
           showHidden={showHidden}
           onShowHiddenChange={onShowHiddenChange}
           sort={sort}

--- a/web/src/shell/FolderTree.tsx
+++ b/web/src/shell/FolderTree.tsx
@@ -19,10 +19,10 @@ import { useCursorTooltip } from "./useCursorTooltip";
 const INDENT_STEP = 16;
 const BASE_PAD = 8;
 const GUIDE_OFFSET = 7;
-const indentFor = (depth: number) => depth * INDENT_STEP + BASE_PAD;
+export const indentFor = (depth: number) => depth * INDENT_STEP + BASE_PAD;
 
 // One vertical guide line per ancestor level; the row must be `relative`.
-function IndentGuides({ depth }: { depth: number }) {
+export function IndentGuides({ depth }: { depth: number }) {
   if (depth <= 0) return null;
   return (
     <>
@@ -423,7 +423,7 @@ export function FolderTree({
  * with depth-based indentation).  Keeping the DOM structure in one place
  * prevents the two views from drifting apart over time.
  */
-function FileRowItem({
+export function FileRowItem({
   path,
   displayLabel,
   labelIsPath = false,

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -131,6 +131,8 @@ function renderWorkspace(
         onSortChange={vi.fn()}
         filesPanelFlatView={false}
         onFlatViewChange={vi.fn()}
+        filesPanelChangedTreeView={false}
+        onChangedTreeViewChange={vi.fn()}
         filesPanelShowHidden={false}
         onShowHiddenChange={vi.fn()}
         liveness={overrides.liveness}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -586,6 +586,10 @@ interface WorkspacePanelProps {
   filesPanelFlatView: boolean;
   /** Toggle the Files view scope (persisted by AppShell). */
   onFlatViewChange: (flat: boolean) => void;
+  /** Changed-scope layout: false = flat list, true = folder tree. */
+  filesPanelChangedTreeView: boolean;
+  /** Toggle the Changed-scope layout (persisted by AppShell). */
+  onChangedTreeViewChange: (treeView: boolean) => void;
   /** Whether the Files panel shows dotfiles/hidden entries. */
   filesPanelShowHidden: boolean;
   /** Toggle hidden-file visibility in the Files panel. */
@@ -646,6 +650,8 @@ export function WorkspacePanel({
   onSortChange,
   filesPanelFlatView,
   onFlatViewChange,
+  filesPanelChangedTreeView,
+  onChangedTreeViewChange,
   filesPanelShowHidden,
   onShowHiddenChange,
   liveness,
@@ -925,6 +931,8 @@ export function WorkspacePanel({
               onFileSelect={openFileViewer}
               flatView={filesPanelFlatView}
               onFlatViewChange={onFlatViewChange}
+              changedTreeView={filesPanelChangedTreeView}
+              onChangedTreeViewChange={onChangedTreeViewChange}
               showHidden={filesPanelShowHidden}
               onShowHiddenChange={onShowHiddenChange}
               sort={filesPanelSort}


### PR DESCRIPTION
## Related issue

Closes #2240

## Summary

The Files panel's **Changed** scope only rendered changed files as a flat
list, which gets noisy when edits span many subdirectories. This adds a
**list ⇄ tree layout toggle** to that scope:

- **Tree mode** groups the changed files into collapsible folders (VS Code
  Source Control style), fully expanded initially.
- **List mode** is the existing flat list and remains the default, so current
  behaviour is unchanged.
- The choice persists (localStorage, alongside the existing scope/sort
  preferences) and survives session switches, the inline↔drawer transition,
  and page refreshes.

The toggle only appears in the **Changed** scope — the **All** scope is already
a full folder tree, so the toggle would be redundant there.

### ELI5

The list of files you changed used to be one long flat list. Now there's a
little button to fold those files into their folders instead, like the file
tree in VS Code, so a change touching ten folders is easy to scan and collapse.

```
Files panel
  ├─ scope: [ Changed | All ]
  │
  ├─ Changed ──► layout: [ list | tree ]   ← new toggle
  │                 ├─ list : flat changed files            (default, unchanged)
  │                 └─ tree : changed files grouped by folder, expanded initially
  │
  └─ All ─────► full workspace folder tree                  (unchanged)
```

The tree reuses the existing row/indent primitives from `FolderTree`
(`FileRowItem`, `IndentGuides`, `indentFor`, now exported) and the shared
`compareChangedFiles` sort, so the two layouts stay visually and behaviourally
consistent (status badges, sizes, download button, hidden-file handling,
search, offline/empty states).

## Test Plan

```bash
cd web
npm ci
npm run type-check   # tsc -b — clean
npm run test         # vitest — 78 passed
npm run lint         # oxlint — no new findings
```

- New `ChangedFileTree.test.tsx` (10 tests): folder grouping, initial expansion,
  collapse/re-expand, file selection, hidden-file filtering + reveal, search
  filtering + no-match, and empty / runner-offline states.
- `FilesPanel.test.tsx`: toggle present only in the Changed scope, flat list vs
  folder tree rendering, `aria-pressed` state, and the change handler firing.
- `filesPanelPreferences.test.ts`: round-trip + defaulting for the new
  `changedTreeView` field.
- Manual: in the Changed scope, toggled list ⇄ tree; confirmed folders start
  expanded, collapse/expand works, the search box and hidden-files banner behave
  as in the list, the list/tree choice sticks across a refresh, and the toggle
  is absent in the All scope.

## Demo
<img width="521" height="641" alt="image" src="https://github.com/user-attachments/assets/de983e22-97ec-47ce-9173-08e5d72fc904" />

<img width="522" height="657" alt="image" src="https://github.com/user-attachments/assets/f5b9db4b-8315-4d26-86c7-31e03b44fb61" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tree building, expansion/collapse, selection, hidden-file and search behaviour,
and empty/offline states are unit-tested in `ChangedFileTree.test.tsx`; the
toggle wiring and layout switch are covered in `FilesPanel.test.tsx`; the new
persisted preference is covered in `filesPanelPreferences.test.ts`. Manual
verification covered the visual layout and the cross-refresh persistence, which
aren't exercised by jsdom.

## Changelog

The changed-files list can switch between a flat list and a collapsible folder tree.