### PR TITLE
fix(web): hide embedded browser on desktop shells that lack it

### DIFF
--- a/web/src/components/BrowserPane/BrowserPane.test.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.test.tsx
@@ -2,10 +2,11 @@ import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserPane } from "./BrowserPane";
 
-// isElectronShell gates the whole pane. Force it true so the pane renders; the
-// plain-browser (returns null) path is covered by reading the early return.
+// supportsBrowser gates the whole pane. Force it true so the pane renders; the
+// unsupported-shell (returns null) path is covered by reading the early return.
 vi.mock("@/lib/nativeBridge", () => ({
   isElectronShell: () => true,
+  supportsBrowser: () => true,
 }));
 
 /**

--- a/web/src/components/BrowserPane/BrowserPane.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.tsx
@@ -23,7 +23,7 @@ import {
   WrenchIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { isElectronShell } from "@/lib/nativeBridge";
+import { supportsBrowser } from "@/lib/nativeBridge";
 import { normalizeTypedUrl } from "@/lib/normalizeTypedUrl";
 import { cn } from "@/lib/utils";
 
@@ -87,7 +87,7 @@ interface BrowserPaneBridge {
 }
 
 function getBridge(): BrowserPaneBridge | null {
-  if (!isElectronShell()) return null;
+  if (!supportsBrowser()) return null;
   const w = window as unknown as { omnigentDesktop?: BrowserPaneBridge };
   return w.omnigentDesktop ?? null;
 }
@@ -106,7 +106,7 @@ export interface BrowserPaneProps {
 export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const lastBoundsRef = useRef<Bounds | null>(null);
-  const electron = isElectronShell();
+  const browserSupported = supportsBrowser();
   // Whether a native view is attached for THIS conversation — drives when the
   // measuring placeholder mounts (no empty pane on an idle conversation).
   const [viewActive, setViewActive] = useState(false);
@@ -130,7 +130,7 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
   // probe on re-mount; (3) host-active-changed for later attach/detach.
   // browser-view-closed flips it false.
   useEffect(() => {
-    if (!electron) return;
+    if (!browserSupported) return;
     const bridge = getBridge();
     if (!bridge) return;
     let cancelled = false;
@@ -159,13 +159,13 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
       unsubActive?.();
       unsubClosed?.();
     };
-  }, [conversationId, electron]);
+  }, [conversationId, browserSupported]);
 
   // Live-track the real URL + back/forward via did-navigate listeners (redirects,
   // link clicks, agent nav all keep the bar honest), but never stomp the input
   // while the user is editing it (urlEditingRef).
   useEffect(() => {
-    if (!electron) return;
+    if (!browserSupported) return;
     const bridge = getBridge();
     if (!bridge) return;
     const unsubUrl = bridge.onBrowserUrlChanged?.((payload) => {
@@ -182,7 +182,7 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
       unsubUrl?.();
       unsubNav?.();
     };
-  }, [conversationId, electron]);
+  }, [conversationId, browserSupported]);
 
   // ── Toolbar handlers ─────────────────────────────────────────────────────
 
@@ -285,7 +285,7 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
   // present; DETACH (not destroy) on unmount so a background agent's page keeps
   // running when the user switches away. A later mount re-attaches.
   useEffect(() => {
-    if (!electron || !viewActive) return;
+    if (!browserSupported || !viewActive) return;
     const bridge = getBridge();
     if (!bridge?.browserSetActive) return;
     void bridge.browserSetActive(conversationId);
@@ -313,7 +313,7 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
         /* swallow — window may be tearing down */
       }
     };
-  }, [conversationId, electron, viewActive, syncBounds]);
+  }, [conversationId, browserSupported, viewActive, syncBounds]);
 
   // Reconcile bounds every frame while shown (cheap: same-rect setBounds is a
   // no-op + we dedupe via lastBoundsRef). Catches position-only shifts that
@@ -321,7 +321,7 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
   // teardown still schedules the next frame — else the rAF chain dies and the
   // overlay strands.
   useEffect(() => {
-    if (!electron || !viewActive) return;
+    if (!browserSupported || !viewActive) return;
     let rafId = 0;
     const tick = () => {
       try {
@@ -333,13 +333,13 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
     };
     rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
-  }, [electron, viewActive, syncBounds]);
+  }, [browserSupported, viewActive, syncBounds]);
 
   // Defense-in-depth against a hung rAF chain: ResizeObserver (size), window
   // resize, and visibilitychange (tab-back, where rAFs were throttled) each
   // recover bounds on the next interaction.
   useEffect(() => {
-    if (!electron || !viewActive || !containerRef.current) return;
+    if (!browserSupported || !viewActive || !containerRef.current) return;
     const el = containerRef.current;
     const ro = new ResizeObserver(() => syncBounds());
     ro.observe(el);
@@ -354,11 +354,12 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
       window.removeEventListener("resize", onResize);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [electron, viewActive, syncBounds]);
+  }, [browserSupported, viewActive, syncBounds]);
 
-  // Plain browser (non-Electron): render nothing so the web build has no empty
-  // split pane. The relay is a no-op there anyway.
-  if (!electron) return null;
+  // No browser-capable shell (plain web build, or a desktop build too old for
+  // the embedded browser): render nothing so there's no empty split pane. The
+  // relay is a no-op there anyway.
+  if (!browserSupported) return null;
 
   // Flex column: the toolbar (shrink-0) is ALWAYS the first child so the URL bar
   // is reachable from a cold start (typing a URL creates the view on demand →

--- a/web/src/hooks/useBrowserAgentRelay.test.tsx
+++ b/web/src/hooks/useBrowserAgentRelay.test.tsx
@@ -1,9 +1,10 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// isElectronShell gates the whole relay; force it true so the hook registers.
+// supportsBrowser gates the whole relay; force it true so the hook registers.
 vi.mock("@/lib/nativeBridge", () => ({
   isElectronShell: () => true,
+  supportsBrowser: () => true,
 }));
 
 // The relay POSTs claim + result through authenticatedFetch; mock it so we can

--- a/web/src/hooks/useBrowserAgentRelay.ts
+++ b/web/src/hooks/useBrowserAgentRelay.ts
@@ -4,12 +4,14 @@
  *  (atomic CAS on the server), and only the `{claimed:true, claim_token}` winner
  *  dispatches to `window.omnigentDesktop.browser*` and POSTs the result back
  *  with its token — so multiple windows can't double-execute.
- *  Gated on `isElectronShell()`: without a WebContentsView the hook registers
- *  nothing and actions time out cleanly (no headless fallback). */
+ *  Gated on `supportsBrowser()`: without a WebContentsView the hook registers
+ *  nothing and actions time out cleanly (no headless fallback). An older
+ *  desktop build that predates the `browser*` bridge is treated as unsupported,
+ *  so the relay never claims an action it couldn't fulfill. */
 import { useEffect } from "react";
 import { onBrowserActionRequest } from "@/lib/browserActionBus";
 import type { BrowserActionRequestEvent } from "@/lib/events";
-import { isElectronShell } from "@/lib/nativeBridge";
+import { supportsBrowser } from "@/lib/nativeBridge";
 import { authenticatedFetch } from "@/lib/identity";
 
 /** Subset of `window.omnigentDesktop` the relay calls (typed locally, not via
@@ -32,7 +34,7 @@ interface BrowserDesktopBridge {
 }
 
 function getBrowserDesktop(): BrowserDesktopBridge | null {
-  if (!isElectronShell()) return null;
+  if (!supportsBrowser()) return null;
   const w = window as unknown as { omnigentDesktop?: BrowserDesktopBridge };
   return w.omnigentDesktop ?? null;
 }
@@ -344,11 +346,11 @@ async function postResult(
 export function useBrowserAgentRelay(conversationId: string | null | undefined): void {
   useEffect(() => {
     if (!conversationId) return;
-    if (!isElectronShell()) return;
+    if (!supportsBrowser()) return;
 
     const handler = async (evt: BrowserActionRequestEvent) => {
       const desktop = getBrowserDesktop();
-      if (!desktop) return; // not the Electron shell — nothing to claim
+      if (!desktop) return; // no browser-capable shell — nothing to claim
       // Claim FIRST — only the winner proceeds, so two windows can't double-execute.
       const claimToken = await claimAction(conversationId, evt.actionId);
       if (!claimToken) return;

--- a/web/src/lib/nativeBridge.test.ts
+++ b/web/src/lib/nativeBridge.test.ts
@@ -10,6 +10,7 @@ import {
   onNativeSidebarDrag,
   setBadgeCount as bridgeSetBadge,
   setNativeServerSwitcherHidden,
+  supportsBrowser,
 } from "./nativeBridge";
 
 // The Electron preload bridge mock, installed on window.omnigentDesktop.
@@ -40,8 +41,11 @@ const androidOnNotificationActivated = vi.fn().mockReturnValue(androidUnsubscrib
  * Simulate running inside / outside the Electron shell via the preload key.
  * `withClickRouting` toggles the optional `onNotificationActivated` method so
  * tests can also exercise a shell too old to support click routing.
+ * `withBrowser` toggles the optional `browserOpenOrNavigate` method — the
+ * capability marker `supportsBrowser()` probes; off by default so it stands in
+ * for a desktop build that predates the embedded browser feature.
  */
-function setElectron(on: boolean, withClickRouting = true): void {
+function setElectron(on: boolean, withClickRouting = true, withBrowser = false): void {
   if (on) {
     (window as unknown as Record<string, unknown>).omnigentDesktop = {
       kind: "electron",
@@ -53,6 +57,7 @@ function setElectron(on: boolean, withClickRouting = true): void {
               electronOnNotificationActivated(...args),
           }
         : {}),
+      ...(withBrowser ? { browserOpenOrNavigate: () => Promise.resolve({ ok: true }) } : {}),
     };
   } else {
     delete (window as unknown as Record<string, unknown>).omnigentDesktop;
@@ -164,6 +169,31 @@ describe("isNativeShell / isElectronShell", () => {
     expect(isNativeShell()).toBe(false);
     delete (window as unknown as Record<string, unknown>).omnigentDesktop;
     delete (window as unknown as Record<string, unknown>).omnigentNative;
+  });
+});
+
+describe("supportsBrowser", () => {
+  it("is false in a plain browser (no preload bridge)", () => {
+    setElectron(false);
+    expect(supportsBrowser()).toBe(false);
+  });
+
+  it("is false on an Electron shell too old for the browser bridge", () => {
+    // Electron shell present, but no `browserOpenOrNavigate` method — mirrors an
+    // installed desktop build that predates the embedded browser feature.
+    setElectron(true, true, false);
+    expect(isElectronShell()).toBe(true);
+    expect(supportsBrowser()).toBe(false);
+  });
+
+  it("is true when the shell exposes the browser bridge", () => {
+    setElectron(true, true, true);
+    expect(supportsBrowser()).toBe(true);
+  });
+
+  it("is false under a non-Electron native shell (iOS)", () => {
+    setIOS(true);
+    expect(supportsBrowser()).toBe(false);
   });
 });
 

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -130,6 +130,17 @@ interface ElectronDesktopApi extends NativeShellApi {
   getCliStatus?: () => Promise<CliStatus | null>;
   /** Clear the CLI-path override (revert to auto-detection); resolves status. */
   resetCliPath?: () => Promise<CliStatus | null>;
+  /**
+   * Open/navigate a conversation's embedded browser view. Present only on
+   * desktop shells new enough to ship the embedded browser feature — its
+   * presence is the capability marker the whole `browser*` suite ships with.
+   */
+  browserOpenOrNavigate?: (
+    conversationId: string,
+    url: string,
+    bounds?: unknown,
+    opts?: { force?: boolean; agent?: boolean },
+  ) => Promise<{ ok: boolean; created?: boolean; error?: string }>;
 }
 
 /** A lifecycle action for the host daemon. */
@@ -191,6 +202,17 @@ function nativeApi(): NativeShellApi | undefined {
 /** True when running inside the Electron desktop shell. */
 export function isElectronShell(): boolean {
   return electronApi() !== undefined;
+}
+
+/**
+ * True when the desktop shell is new enough to host the embedded browser pane.
+ * Older installed builds expose `omnigentDesktop` but predate the `browser*`
+ * bridge, so `isElectronShell()` alone would surface a dead Browser tab whose
+ * calls no-op. Probes the foundational browser method (the suite ships
+ * together); false in a plain browser and on shells without the feature.
+ */
+export function supportsBrowser(): boolean {
+  return typeof electronApi()?.browserOpenOrNavigate === "function";
 }
 
 /**

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -14,11 +14,11 @@ import { useIOSViewportLock } from "@/hooks/useIOSViewportLock";
 import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/filesPanelPreferences";
 import { derivePermissionLevel, isOwnerLevel } from "@/lib/permissionsApi";
 import {
-  isElectronShell,
   isAndroidShell,
   isIOSShell,
   isMacElectronShell,
   onNativeSidebarDrag,
+  supportsBrowser,
 } from "@/lib/nativeBridge";
 import { onBrowserActionRequest } from "@/lib/browserActionBus";
 import {
@@ -471,10 +471,12 @@ export function AppShell() {
     () =>
       ({
         files: showFilesPanel,
-        // Browser tab: Electron shell only — that's where the embedded
-        // WebContentsView lives. A plain web build has no embedded browser, so
-        // the tab is hidden entirely (isElectronShell() is constant per load).
-        browser: isElectronShell(),
+        // Browser tab: shown only when the desktop shell hosts the embedded
+        // WebContentsView. A plain web build has no embedded browser, and an
+        // older desktop build predates the `browser*` bridge — both hide the
+        // tab entirely (supportsBrowser() is constant per load) so we never
+        // surface a dead tab whose calls no-op.
+        browser: supportsBrowser(),
         // Agents tab is unconditional: the panel always lists at least
         // the main agent (its "main" row), so there's never a dead end.
         subagents: true,
@@ -525,9 +527,9 @@ export function AppShell() {
 
   // Auto-surface the Browser tab on a `navigate` action, so a browser_navigate
   // fired while another tab is selected doesn't load into a hidden pane.
-  // Electron-only; no-op elsewhere (the bus never fires without a relay).
+  // Browser-capable shells only; no-op elsewhere (the bus never fires without a relay).
   useEffect(() => {
-    if (!isElectronShell()) return;
+    if (!supportsBrowser()) return;
     return onBrowserActionRequest((evt) => {
       if (evt.action !== "navigate") return;
       setRightRailTab("browser");
@@ -546,7 +548,7 @@ export function AppShell() {
   const designShotRef = useRef<Map<string, string>>(new Map());
   const boundAgentId = boundAgent?.id ?? null;
   useEffect(() => {
-    if (!isElectronShell()) return;
+    if (!supportsBrowser()) return;
     const w = window as unknown as {
       omnigentDesktop?: {
         onBrowserElementSelected?: (


### PR DESCRIPTION
## Related issue

N/A

## Summary

The web app gated the embedded-browser feature purely on `isElectronShell()` — "am I inside *any* Electron shell?". Older, already-installed desktop builds whose preload predates the `browser*` bridge return `true` there, so they surfaced a **Browser tab that did nothing**: the pane and agent relay called `browserOpenOrNavigate` on a bridge lacking that method and silently no-op'd.

- Add `supportsBrowser()` to `web/src/lib/nativeBridge.ts`, which probes for the `browserOpenOrNavigate` capability marker (the whole `browser*` suite ships together). This follows the module's established feature-based detection idiom and is the only approach that works retroactively for shells already in the field, since they expose no version number.
- Swap the browser-feature gates from `isElectronShell()` → `supportsBrowser()`: the `railTabsAvailable.browser` tab gate plus the auto-surface / design-mode effects in `AppShell.tsx`, both relay gates in `useBrowserAgentRelay.ts` (so an old shell never *claims* a browser action it can't fulfill), and the `BrowserPane` bridge + self-gate.
- Leave the non-browser `isElectronShell()` sites (host status, Local CLI settings) untouched.

## Test Plan

- `cd web && npx vitest run` on the affected suites (`nativeBridge`, `BrowserPane`, `useBrowserAgentRelay`): 70/70 pass.
- Full single-threaded `vitest run`: 3951 pass; the only 2 failures are in `ChatPage.composer.test.tsx`, confirmed pre-existing on the clean base (identical with and without this change).
- `tsc -p tsconfig.app.json --noEmit`: clean for the touched files (the `@xyflow/react` errors are a pre-existing missing-dep in an untouched file).
- Manual: verified the Browser tab shows on the current desktop build, and hides when the browser bridge is absent (simulated an old shell by deleting `window.omnigentDesktop.browserOpenOrNavigate` and reloading).

## Demo

Behavioural change (no new visual element): on a current desktop build the **Browser** tab in the workspace rail appears as before; on a desktop build without the `browser*` bridge (or a plain web tab) the tab, pane, and agent relay are absent instead of showing a dead tab. Verified manually per the Test Plan — screen recording can be attached here.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `supportsBrowser` unit cases in `nativeBridge.test.ts` (false in a plain browser, false on an Electron shell lacking the browser method, true when present, false under iOS) and updated the `BrowserPane` / relay test mocks to export it. Manually verified end-to-end: the Browser tab appears on a current desktop build and disappears when the `browserOpenOrNavigate` bridge method is absent.

## Changelog

The desktop Browser tab is now hidden on older desktop builds that don't support the embedded browser, instead of showing a tab that does nothing

This pull request and its description were written by Isaac.
