### PR TITLE
fix(web): repair AgentPicker composer tests broken on main

### DIFF
--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -528,6 +528,9 @@ describe("AgentPicker trigger label", () => {
       selectedModel: null,
       selectedEffort: null,
       llmModel: null,
+      // Reset the per-session override too: a test that sets it must not leak
+      // into the next, which now reads sessionModelOverride first for the label.
+      sessionModelOverride: null,
       codexModelOptions: [],
       nativeVendorOwnsModel: false,
     });
@@ -582,7 +585,11 @@ describe("AgentPicker trigger label", () => {
     const trigger = screen.getByTestId("agent-picker-trigger");
     expect(trigger).toHaveTextContent("Sonnet 4.6");
     expect(trigger).not.toHaveTextContent("Opus");
-    trigger.click();
+
+    // Open the picker via the bare-"/model" intercept — a synthetic click on the
+    // Radix trigger doesn't open the menu under jsdom, so the rows never mount.
+    fireEvent.change(textarea(), { target: { value: "/model " } });
+    fireEvent.keyDown(textarea(), { key: "Enter" });
 
     const sonnetRow = document.querySelector<HTMLElement>(
       '[data-testid="model-picker-item"][data-model-id="sonnet"]',
@@ -590,6 +597,8 @@ describe("AgentPicker trigger label", () => {
     const opusRow = document.querySelector<HTMLElement>(
       '[data-testid="model-picker-item"][data-model-id="opus"]',
     );
+    // The applied session override ("sonnet") is the active row, not the
+    // cross-session sticky ("opus").
     expect(sonnetRow).toHaveAttribute("data-active", "true");
     expect(opusRow).not.toHaveAttribute("data-active", "true");
   });


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two `AgentPicker trigger label` tests in `web/src/pages/ChatPage.composer.test.tsx` (added in #1513) fail on `main`, which also blocks the `npm test` required check on every open PR. Both are **test bugs, not product bugs** — #1513's shipped label logic is correct.

- *"prefers a claude session override over the cross-session sticky model"* opened the picker with `trigger.click()`. Radix's `DropdownMenuTrigger` doesn't open on a synthetic jsdom click, so no `model-picker-item` rows ever mounted and `sonnetRow` was `null`. Fixed by opening the picker via the bare-`/model` intercept — the same path the passing `/model ` test in the file already uses.
- *"still renders an enabled trigger when the model/effort label is unresolved"* inherited `sessionModelOverride: "sonnet"` from the previous test: the suite `beforeEach` reset `selectedModel`/`selectedEffort`/`llmModel` but **not** `sessionModelOverride`, which #1513 made the trigger label read first — so it showed "Sonnet 4.6" instead of the "Claude" fallback. Fixed by resetting `sessionModelOverride` in `beforeEach`.

Both tests keep asserting #1513's intended behavior (the applied session override wins over the cross-session sticky model).

## Test Plan

- `cd web && npx vitest run src/pages/ChatPage.composer.test.tsx`: **63/63 pass** (was 2 failed | 61 passed).
- Each repaired test also passes **in isolation** (`-t "prefers a claude session override"`, `-t "still renders an enabled trigger"`), proving the fix is order-independent and not just masking the leak.

## Demo

N/A — test-only change, no user-facing behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — this change only repairs existing unit tests; the assertions still cover #1513's session-override-priority behavior.

This pull request and its description were written by Isaac.
