### PR TITLE
fix(smart-routing): choose model and effort together

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4007,6 +4007,7 @@ def _build_native_terminal_message_event(
     conv: Conversation,
     body: SessionEventInput,
     model_override: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> dict[str, Any]:
     """
     Build the runner event that delivers a web message to a native TUI.
@@ -4020,6 +4021,7 @@ def _build_native_terminal_message_event(
         so the claude-native executor applies ``/model`` and injects the
         message under one lock (no separate racing ``model_change``
         event). ``None`` when routing did not pick a model.
+    :param reasoning_effort: Routed effort to apply with *model_override*.
     :returns: Harness ``MessageEvent`` body for the runner-local
         native terminal harness, including ``agent_id`` so the runner
         can resolve the harness spec on the first message.
@@ -4053,6 +4055,8 @@ def _build_native_terminal_message_event(
     # inject as ONE locked step, so the switch can't race the message.
     if model_override is not None:
         event["model_override"] = model_override
+    if reasoning_effort is not None:
+        event["reasoning"] = {"effort": reasoning_effort}
     return event
 
 
@@ -4064,6 +4068,7 @@ async def _forward_native_terminal_message(
     file_store: FileStore | None = None,
     artifact_store: ArtifactStore | None = None,
     model_override: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> None:
     """
     Forward one Omnigent web-chat message to the native terminal harness.
@@ -4087,12 +4092,18 @@ async def _forward_native_terminal_message(
         in-band on the message so the executor applies ``/model`` and the
         inject under one lock (no separate racing ``model_change``).
         ``None`` when routing did not pick a model.
+    :param reasoning_effort: Routed effort carried in the same message.
     :returns: None.
     :raises HTTPException: 502 when the runner or harness rejects
         the injection request.
     """
     display_name, _, _ = _native_terminal_runtime(conv)
-    event = _build_native_terminal_message_event(conv, body, model_override=model_override)
+    event = _build_native_terminal_message_event(
+        conv,
+        body,
+        model_override=model_override,
+        reasoning_effort=reasoning_effort,
+    )
     _logger.info(
         "%s terminal message forward starting: session=%s block_types=%s model_override=%s",
         display_name,
@@ -5428,6 +5439,7 @@ async def _dispatch_session_event_to_runner_impl(
             conv.cost_control_mode_override == "on" and conv.parent_conversation_id is None
         ) or _native_parent_routing_on
         _native_routed_model: str | None = None
+        _native_routed_effort: str | None = None
         _native_verdict: dict[str, Any] | None = None
         # Set when nothing was routed — the call failed, or the family rule
         # below refused a cross-family spawn. The chip then carries the
@@ -5502,13 +5514,32 @@ async def _dispatch_session_event_to_runner_impl(
                         else _native_routed_model
                     )
                 if _native_applied_model is not None:
+                    _native_effort_owned = "reasoning_effort" in (_native_verdict or {})
+                    _effort_update: dict[str, Any] = {}
+                    if _native_effort_owned:
+                        raw_effort = (_native_verdict or {}).get("reasoning_effort")
+                        _native_routed_effort = raw_effort if isinstance(raw_effort, str) else None
+                        _effort_update = {
+                            "reasoning_effort": _native_routed_effort,
+                            "_unset_reasoning_effort": _native_routed_effort is None,
+                        }
                     try:
                         await asyncio.to_thread(
                             conversation_store.update_conversation,
                             session_id,
                             model_override=_native_routed_model,
+                            **_effort_update,
                         )
                         _publish_routed_model(session_id, _native_applied_model)
+                        if _native_effort_owned:
+                            session_stream.publish(
+                                session_id,
+                                {
+                                    "type": "session.reasoning_effort",
+                                    "conversation_id": session_id,
+                                    "reasoning_effort": _native_routed_effort,
+                                },
+                            )
                     except (OSError, ValueError):
                         _logger.warning(
                             "smart_routing: persist failed for native session=%s",
@@ -5536,6 +5567,9 @@ async def _dispatch_session_event_to_runner_impl(
                 # routed id; ``None`` when the pane has no spelling for it.
                 model_override=(
                     _native_routed_model if _native_applied_model is not None else None
+                ),
+                reasoning_effort=(
+                    _native_routed_effort if _native_applied_model is not None else None
                 ),
             )
             forwarded = True

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -1619,6 +1619,7 @@ def register_hooks_routes(
                 prompt,
                 session_id=session_id,
                 runner_client=runner_client,
+                discover_efforts=False,
                 catalog=catalog,
                 gateway_backed=turn_gateway_backed,
                 allow_static_fallback=turn_gateway_backed,

--- a/omnigent/server/routing_backend.py
+++ b/omnigent/server/routing_backend.py
@@ -132,6 +132,7 @@ async def route_with_fallback(
     available_models: dict[str, list[str]],
     *,
     gateway_backed: bool,
+    model_efforts: dict[str, list[str]] | None = None,
 ) -> RoutedCall | None:
     """Call the deployment's router, falling back to the judge when it fails.
 
@@ -144,6 +145,7 @@ async def route_with_fallback(
     :param backends: The deployment's configured clients.
     :param message: The task text to route on.
     :param available_models: Harness id → candidate model ids.
+    :param model_efforts: Optional model id → supported effort values.
     :param gateway_backed: Whether every harness family involved resolves
         AI-Gateway-backed inference (see :func:`select_router`).
     :returns: The answer, or ``None`` when no backend is configured at all.
@@ -154,14 +156,20 @@ async def route_with_fallback(
     choice = select_router(backends, gateway_backed=gateway_backed)
     if choice is None:
         return None
+
+    async def _route(client: RoutingClient) -> RoutingResult | None:
+        if model_efforts is None:
+            return await client.route(message, available_models)
+        return await client.route(message, available_models, model_efforts)
+
     if choice.source != "databricks-aigw" or backends.local is None:
         return RoutedCall(
-            result=await choice.client.route(message, available_models),
+            result=await _route(choice.client),
             source=choice.source,
             client=choice.client,
         )
     try:
-        result = await choice.client.route(message, available_models)
+        result = await _route(choice.client)
     except Exception:  # noqa: BLE001 — the judge is the fallback for any failure
         _logger.warning(
             "routing: the external router raised; falling back to the built-in judge",
@@ -176,7 +184,7 @@ async def route_with_fallback(
             getattr(choice.client, "last_error", None),
         )
     return RoutedCall(
-        result=await backends.local.route(message, available_models),
+        result=await _route(backends.local),
         source="oss-llm",
         client=backends.local,
     )

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -67,6 +67,8 @@ ROUTES_SELECT_PATH = "routes:select"
 #: stall, and falling open onto the harness's own model is the better answer.
 ROUTING_REQUEST_TIMEOUT_S = 9.0
 
+_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S = (0.25, 0.5, 1.0)
+
 # ── Model lists per harness family ──────────────────────────────────────────
 #
 # Ordered cheapest → most powerful within each family. Live per-session catalogs
@@ -236,6 +238,7 @@ class RoutingResult:
     rationale: str
     harness: str | None = None
     raw_model: str | None = None
+    reasoning_effort: str | None = None
 
 
 class RoutingClient(Protocol):
@@ -250,6 +253,7 @@ class RoutingClient(Protocol):
         self,
         message: str,
         available_models: dict[str, list[str]],
+        model_efforts: dict[str, list[str]] | None = None,
     ) -> RoutingResult | None:
         """Pick the best model for a session's initial message.
 
@@ -259,6 +263,7 @@ class RoutingClient(Protocol):
             a one-entry dict; multi-agent fan-out passes one entry per
             harness.  Implementations that only need the flat model list can
             call :func:`_flatten_models` to get a deduped ordered sequence.
+        :param model_efforts: Optional model id → supported effort values.
         :returns: A :class:`RoutingResult`, or ``None`` to skip routing.
         """
         ...
@@ -462,6 +467,51 @@ async def fetch_runner_models(
     return {worker: [model.id for model in models] for worker, models in catalog.items()}
 
 
+async def fetch_codex_model_efforts(
+    session_id: str,
+    runner_client: httpx.AsyncClient,
+) -> dict[str, list[str]] | None:
+    """Return the canonical effort menu advertised by Codex's live model list."""
+    import httpx as _httpx
+
+    from omnigent.reasoning_effort import CODEX_EFFORTS, validate_effort
+
+    try:
+        for delay in (*_CODEX_MODEL_OPTIONS_RETRY_DELAYS_S, None):
+            resp = await runner_client.get(
+                f"/v1/sessions/{session_id}/codex-model-options", timeout=5.0
+            )
+            if resp.status_code != 503 or delay is None:
+                break
+            await asyncio.sleep(delay)
+        resp.raise_for_status()
+        rows = resp.json().get("models", [])
+        result: dict[str, list[str]] = {}
+        for row in rows:
+            if not isinstance(row, dict) or not isinstance(row.get("id"), str):
+                continue
+            efforts: list[str] = []
+            for item in row.get("supportedReasoningEfforts", []):
+                if not isinstance(item, dict):
+                    continue
+                try:
+                    effort = validate_effort(item.get("reasoningEffort"), "codex", CODEX_EFFORTS)
+                except ValueError:
+                    continue
+                if effort is not None and effort not in efforts:
+                    efforts.append(effort)
+            if efforts:
+                result[row["id"]] = efforts
+        return result or None
+    except (_httpx.HTTPError, AttributeError, TypeError, ValueError):
+        _logger.debug(
+            "fetch_codex_model_efforts: runner request failed for session=%s",
+            session_id,
+            exc_info=True,
+        )
+        return None
+
+
 def _flatten_models(available_models: dict[str, list[str]]) -> list[str]:
     """Return a deduped, ordered flat model list from a harness → models map.
 
@@ -521,11 +571,19 @@ Return **strict JSON only**:
 """
 
 
-def _build_rubric(available_models: dict[str, list[str]]) -> str:
+def _build_rubric(
+    available_models: dict[str, list[str]],
+    model_efforts: dict[str, list[str]] | None = None,
+) -> str:
     """Format the judge prompt with the harness → models structure."""
     sections: list[str] = []
     for harness, models in available_models.items():
-        model_lines = "\n".join(f"    - {m}" for m in models)
+        model_lines = "\n".join(
+            f"    - {model} (efforts: {', '.join(model_efforts[model])})"
+            if model_efforts and model_efforts.get(model)
+            else f"    - {model}"
+            for model in models
+        )
         sections.append(f"  harness: {harness}\n{model_lines}")
     return _JUDGE_SYSTEM_TEMPLATE.format(
         harness_menu="\n".join(sections),
@@ -543,6 +601,18 @@ _VERDICT_SCHEMA: dict[str, object] = {
         "rationale": {"type": "string"},
     },
     "required": ["harness", "model", "rationale"],
+    "additionalProperties": False,
+}
+
+_EFFORT_VERDICT_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "properties": {
+        "harness": {"type": "string"},
+        "model": {"type": "string"},
+        "reasoning_effort": {"type": "string"},
+        "rationale": {"type": "string"},
+    },
+    "required": ["harness", "model", "reasoning_effort", "rationale"],
     "additionalProperties": False,
 }
 
@@ -567,11 +637,14 @@ class LLMRoutingClient:
         self,
         message: str,
         available_models: dict[str, list[str]],
+        model_efforts: dict[str, list[str]] | None = None,
     ) -> RoutingResult | None:
         import asyncio
 
         flat = _flatten_models(available_models)
-        rubric = _build_rubric(available_models)
+        rubric = _build_rubric(available_models, model_efforts)
+        if model_efforts:
+            rubric += "\nChoose a listed reasoning effort for the selected model."
         _logger.info(
             "LLMRoutingClient: available_models=%s prompt_chars=%d",
             dict(available_models),
@@ -596,7 +669,7 @@ class LLMRoutingClient:
                             "type": "json_schema",
                             "name": "routing_verdict",
                             "strict": True,
-                            "schema": _VERDICT_SCHEMA,
+                            "schema": _EFFORT_VERDICT_SCHEMA if model_efforts else _VERDICT_SCHEMA,
                         }
                     },
                     timeout=ROUTING_REQUEST_TIMEOUT_S,
@@ -653,7 +726,16 @@ class LLMRoutingClient:
                 None,
             )
 
-        return RoutingResult(model=model, rationale=str(rationale), harness=chosen_harness)
+        reasoning_effort = verdict.get("reasoning_effort")
+        if model_efforts is not None and reasoning_effort not in model_efforts.get(model, []):
+            self.last_error = "routing judge returned an unsupported effort"
+            return None
+        return RoutingResult(
+            model=model,
+            rationale=str(rationale),
+            harness=chosen_harness,
+            reasoning_effort=reasoning_effort,
+        )
 
 
 def _bearer_auth(token: str) -> httpx.Auth:
@@ -1802,7 +1884,9 @@ class ExternalRoutingClient:
         self,
         message: str,
         available_models: dict[str, list[str]],
+        model_efforts: dict[str, list[str]] | None = None,
     ) -> RoutingResult | None:
+        del model_efforts
         import httpx
         from google.protobuf import json_format
 
@@ -2247,6 +2331,7 @@ async def route_turn(
     *,
     session_id: str | None = None,
     runner_client: httpx.AsyncClient | None = None,
+    discover_efforts: bool = True,
     catalog: Sequence[str] | None = None,
     gateway_backed: bool = True,
     allow_static_fallback: bool = True,
@@ -2263,6 +2348,8 @@ async def route_turn(
         vocabulary. Authoritative: its gateway serves more models than the
         running CLI can be switched to, and offering those routes the turn
         onto a model the switch would silently drop.
+    :param discover_efforts: Whether Codex effort-aware routing is supported
+        by the caller's decision protocol.
     :param gateway_backed: Whether this session's harness resolves
         AI-Gateway-backed inference on its host. ``False`` takes the external
         router out of play and the built-in judge answers instead.
@@ -2296,11 +2383,17 @@ async def route_turn(
     # the number the timeout ladder above the hook has to cover.
     _prep_started = time.monotonic()
     _catalog_fetched = False
+    model_efforts: dict[str, list[str]] | None = None
     # Prefer the live runner catalog, but only its "self" row — the sub-agent
     # workers' models are not this session's. Key the map by harness id, not the
     # "self" label, so the seam infers the right single-harness scenario.
     available: dict[str, list[str]] | None = None
-    if catalog:
+    if discover_efforts and harness == "codex-native" and session_id and runner_client is not None:
+        _catalog_fetched = True
+        model_efforts = await fetch_codex_model_efforts(session_id, runner_client)
+        if model_efforts:
+            available = {harness: list(model_efforts)}
+    if available is None and catalog:
         in_vocabulary = models_in_family(harness, catalog)
         if in_vocabulary:
             available = {harness or "self": in_vocabulary}
@@ -2355,7 +2448,11 @@ async def route_turn(
     _prep_s = time.monotonic() - _prep_started
     _route_started = time.monotonic()
     call = await route_with_fallback(
-        backends, user_message, available, gateway_backed=gateway_backed
+        backends,
+        user_message,
+        available,
+        gateway_backed=gateway_backed,
+        model_efforts=model_efforts,
     )
     _logger.info(
         "smart_routing: session=%s prep=%.3fs router=%.3fs catalog_fetch=%s candidates=%d",
@@ -2401,6 +2498,12 @@ async def route_turn(
         "rationale": result.rationale,
         "router_source": call.source,
     }
+    # The external router currently owns only model selection. Preserve any
+    # existing effort unless the effort-aware local judge answered this call.
+    if model_efforts is not None and call.source == "oss-llm":
+        effort = result.reasoning_effort
+        if effort in model_efforts.get(model, []):
+            verdict["reasoning_effort"] = effort
     if raw_model and _bare_id(raw_model, prefixes) != _bare_id(model, prefixes):
         verdict["raw_model"] = raw_model
     return model, verdict

--- a/tests/e2e_ui/start_session/test_smart_routing.py
+++ b/tests/e2e_ui/start_session/test_smart_routing.py
@@ -254,12 +254,18 @@ async def _drive_smart_routing_model_option(base_url: str, session_id: str) -> N
             # Pin Claude Code, then open its run-config modal.
             await _open_entry_config(page, "ag_claude_e2e")
             model = page.get_by_test_id("new-chat-landing-config-model")
+            effort = page.get_by_test_id("new-chat-landing-config-effort")
             await expect(model).to_be_visible()
+            await effort.click()
+            await page.get_by_role("option", name="High", exact=True).click()
+            await expect(effort).to_contain_text("High")
             await model.click()
             await page.get_by_role("option", name="Smart Routing", exact=True).click()
             await expect(model).to_contain_text("Smart Routing")
             # The router picks the effort with the model, so the row is frozen.
-            await expect(page.get_by_test_id("new-chat-landing-config-effort")).to_be_disabled()
+            await expect(effort).to_be_disabled()
+            await expect(effort).to_contain_text("—")
+            await expect(effort).not_to_contain_text("High")
             await _save_config(page)
 
             await page.get_by_test_id("new-chat-landing-input").fill("fix the flaky test")
@@ -272,6 +278,7 @@ async def _drive_smart_routing_model_option(base_url: str, session_id: str) -> N
             # Per-turn routing owns the model, so nothing is pinned; the
             # harness itself stays the one the user picked.
             assert body.get("model_override") is None, body
+            assert body.get("reasoning_effort") is None, body
             assert body.get("harness_override") != "auto", body
         finally:
             await browser.close()

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -1018,14 +1018,19 @@ class FakeRoutingClient:
         self.last_error = last_error
         self.calls: list[tuple[str, dict[str, list[str]]]] = []
         self.offered: list[dict[str, list[str]]] = []
+        self.model_efforts: list[dict[str, list[str]] | None] = []
 
     async def route(
-        self, message: str, available_models: dict[str, list[str]]
+        self,
+        message: str,
+        available_models: dict[str, list[str]],
+        model_efforts: dict[str, list[str]] | None = None,
     ) -> RoutingResult | None:
         """Record the offer and return the canned verdict (or raise)."""
         offer = dict(available_models)
         self.calls.append((message, offer))
         self.offered.append(offer)
+        self.model_efforts.append(model_efforts)
         if self._error is not None:
             raise self._error
         return self._result

--- a/tests/server/integration/test_routing_integration.py
+++ b/tests/server/integration/test_routing_integration.py
@@ -1501,6 +1501,53 @@ async def _dispatch_native_turn(
     return _routing_decisions(conv_store, conv.id)[-1].data, forwarded
 
 
+async def test_native_route_forwards_an_effort_owned_by_the_local_judge(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    from omnigent.harness_plugins import CODEX_NATIVE_CODING_AGENT
+
+    conv, conv_store = await _claude_native_session(
+        client, db_uri, agent_name="routing-owned-effort"
+    )
+    conv_store.set_labels(conv.id, {"omnigent.wrapper": CODEX_NATIVE_CODING_AGENT.wrapper_label})
+    conv = conv_store.get_conversation(conv.id)
+    assert conv is not None
+
+    published: list[tuple[str, dict[str, Any]]] = []
+    with (
+        patch(
+            "omnigent.server.smart_routing.route_turn_or_decline",
+            new=AsyncMock(
+                return_value=(
+                    GPT_MODEL,
+                    {"rationale": "moderate", "reasoning_effort": "high"},
+                    None,
+                )
+            ),
+        ),
+        patch.object(
+            orchestration_module.session_stream,
+            "publish",
+            side_effect=lambda sid, payload: published.append((sid, payload)),
+        ),
+    ):
+        _decision, forwarded = await _dispatch_native_turn(conv, conv_store, model=GPT_MODEL)
+
+    refreshed = conv_store.get_conversation(conv.id)
+    assert refreshed is not None
+    assert (refreshed.model_override, refreshed.reasoning_effort) == (GPT_MODEL, "high")
+    assert (forwarded[0]["model_override"], forwarded[0]["reasoning"]) == (
+        GPT_MODEL,
+        {"effort": "high"},
+    )
+    assert [
+        payload["reasoning_effort"]
+        for sid, payload in published
+        if sid == conv.id and payload.get("type") == "session.reasoning_effort"
+    ] == ["high"]
+
+
 async def test_a_childs_second_spawn_cannot_pin_a_model_the_pane_rejects(
     client: httpx.AsyncClient,
     db_uri: str,
@@ -1514,6 +1561,8 @@ async def test_a_childs_second_spawn_cannot_pin_a_model_the_pane_rejects(
     spelling has to exist for it.
     """
     child, conv_store = await _native_child(client, db_uri, agent_name="routing-child-second")
+    child = conv_store.update_conversation(child.id, reasoning_effort="medium")
+    assert child is not None
     # The pane's vocabulary covers the first pick only.
     orchestration_module._model_options_cache[child.id] = [
         {"id": "opus", "model": ROUTED_MODEL},
@@ -1524,6 +1573,7 @@ async def test_a_childs_second_spawn_cannot_pin_a_model_the_pane_rejects(
         pinned = conv_store.get_conversation(child.id)
         assert pinned is not None
         assert pinned.model_override == ROUTED_MODEL
+        assert pinned.reasoning_effort == "medium"
         assert [f.get("model_override") for f in first_forwards] == [ROUTED_MODEL]
 
         # Second spawn, unspellable pick: recorded as not applied, and the

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -22,6 +22,7 @@ from omnigent.server.smart_routing import (
     LLMRoutingClient,
     RoutingResult,
     _build_rubric,
+    fetch_codex_model_efforts,
     fetch_runner_models,
     harness_bars_model,
     infer_models,
@@ -336,6 +337,9 @@ def test_build_rubric_shows_harness_names() -> None:
     assert "codex" in rubric
     assert "databricks-claude-haiku-4-5" in rubric
     assert "databricks-gpt-5-4-nano" in rubric
+    assert "gpt-5.6-terra (efforts: low, high)" in _build_rubric(
+        {"codex-native": ["gpt-5.6-terra"]}, {"gpt-5.6-terra": ["low", "high"]}
+    )
 
 
 # ── LLMRoutingClient ───────────────────────────────────────────────
@@ -385,6 +389,26 @@ async def test_llm_routing_client_clamps_hallucinated_model() -> None:
     result = await client.route("hard task", {"claude-sdk": models})
     assert result is not None
     assert result.model == models[0]  # clamped to cheapest
+
+
+@pytest.mark.asyncio
+async def test_llm_routing_client_accepts_only_an_effort_for_the_selected_model() -> None:
+    verdict = {
+        "harness": "codex-native",
+        "model": "gpt-5.6-terra",
+        "reasoning_effort": "high",
+        "rationale": "moderate",
+    }
+    client = LLMRoutingClient(_FakeLLMClient(verdict))
+    models = {"codex-native": ["gpt-5.6-terra"]}
+    efforts = {"gpt-5.6-terra": ["low", "high"]}
+
+    result = await client.route("task", models, efforts)
+    assert result is not None and result.reasoning_effort == "high"
+
+    verdict["reasoning_effort"] = "ultra"
+    result = await client.route("task", models, efforts)
+    assert result is None
 
 
 @pytest.mark.asyncio
@@ -501,6 +525,33 @@ async def test_fetch_runner_models_returns_none_on_empty_workers() -> None:
     assert result is None
 
 
+@pytest.mark.asyncio
+async def test_fetch_codex_model_efforts_normalizes_and_skips_empty_menus() -> None:
+    not_ready = MagicMock(status_code=503)
+    ready = MagicMock(status_code=200)
+    ready.json.return_value = {
+        "models": [
+            {
+                "id": "gpt-5.6-terra",
+                "supportedReasoningEfforts": [
+                    {"reasoningEffort": "low"},
+                    {"reasoningEffort": "max"},
+                    {"reasoningEffort": "ultra"},
+                ],
+            },
+            {"id": "gpt-no-effort", "supportedReasoningEfforts": []},
+        ]
+    }
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=[not_ready, ready])
+
+    with patch("omnigent.server.smart_routing._CODEX_MODEL_OPTIONS_RETRY_DELAYS_S", (0.0,)):
+        result = await fetch_codex_model_efforts("conv_123", client)
+
+    assert result == {"gpt-5.6-terra": ["low", "xhigh"]}
+    assert client.get.await_count == 2
+
+
 # ── route_turn (integration) ───────────────────────────────────────
 
 
@@ -525,6 +576,59 @@ async def test_route_turn_uses_caps_routing_client() -> None:
     assert model == "databricks-claude-haiku-4-5"
     assert v is not None
     assert "tier" not in v
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("gateway_backed", "external_answers", "expected_source"),
+    [(False, True, "oss-llm"), (True, True, "databricks-aigw"), (True, False, "oss-llm")],
+)
+async def test_route_turn_threads_effort_only_from_the_local_judge(
+    gateway_backed: bool,
+    external_answers: bool,
+    expected_source: str,
+) -> None:
+    result = RoutingResult(
+        model="gpt-5.6-terra",
+        rationale="moderate",
+        harness="codex-native",
+        reasoning_effort="high",
+    )
+    external, local = (
+        FakeRoutingClient(result if external_answers else None),
+        FakeRoutingClient(result),
+    )
+    response = MagicMock(status_code=200)
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {
+        "models": [
+            {
+                "id": "gpt-5.6-terra",
+                "supportedReasoningEfforts": [{"reasoningEffort": "high"}],
+            }
+        ]
+    }
+    runner_client = MagicMock()
+    runner_client.get = AsyncMock(return_value=response)
+    caps = FakeCaps(
+        routing_client=external,
+        routing_backends=RoutingBackends(external=external, local=local),
+    )
+
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        model, verdict = await route_turn(
+            "codex-native",
+            "task",
+            session_id="conv_123",
+            runner_client=runner_client,
+            gateway_backed=gateway_backed,
+        )
+
+    assert model == "gpt-5.6-terra"
+    assert verdict is not None and verdict["router_source"] == expected_source
+    assert verdict.get("reasoning_effort") == ("high" if expected_source == "oss-llm" else None)
+    selected = local if expected_source == "oss-llm" else external
+    assert selected.model_efforts == [{"gpt-5.6-terra": ["high"]}]
 
 
 @pytest.mark.asyncio
@@ -659,6 +763,7 @@ async def test_route_turn_drops_out_of_family_catalog_models() -> None:
             "narrow fix",
             session_id="conv_123",
             runner_client=mock_client,
+            discover_efforts=False,
         )
     assert model == "databricks-gpt-5-5"
     assert client.offered == [{"codex-native": ["databricks-gpt-5-5", "databricks-gpt-5-4-mini"]}]

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2394,7 +2394,10 @@ export function NewChatLandingScreen() {
   }, []);
   const setCostControlMode = useCallback((mode: CostControlMode) => {
     _setCostControlMode(mode);
-    if (mode === "on") _setPickedModel("");
+    if (mode === "on") {
+      _setPickedModel("");
+      setPickedEffort("");
+    }
   }, []);
   // Controls the working-directory popover so picking a directory closes it.
   const [workspacePopoverOpen, setWorkspacePopoverOpen] = useState(false);

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -4665,6 +4665,20 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       expect(useChatStore.getState().selectedEffort).toBe("high");
     });
 
+    it("keeps a routed effort session-scoped", () => {
+      bindConversationForTest("conv_routed", { costControlModeOverride: "on" });
+      useChatStore.setState({ selectedEffort: null });
+
+      handleSessionEvent({
+        type: "session_reasoning_effort",
+        conversationId: "conv_routed",
+        reasoningEffort: "high",
+      });
+
+      expect(useChatStore.getState().sessionReasoningEffort).toBe("high");
+      expect(useChatStore.getState().selectedEffort).toBeNull();
+    });
+
     it("records a backgrounded conversation's effort switch on that conversation", () => {
       // The session-scoped value always lands, background included: a live entry
       // is never re-bound on return, so discarding the event left the picker
@@ -6971,14 +6985,46 @@ describe("chatStore — bindStream sticky-pref handoff", () => {
       model_override: null,
     });
 
-    useChatStore.setState({ selectedModel: "claude-opus-4-7" });
+    useChatStore.setState({ selectedModel: "claude-opus-4-7", selectedEffort: "high" });
     await useChatStore.getState().switchTo("conv_routing");
 
     // No model_override PATCH fired (contrast the handoff test above).
     const patches = patchCallsFor("conv_routing");
     expect(patches.some((p) => "model_override" in p)).toBe(false);
+    expect(patches.some((p) => "reasoning_effort" in p)).toBe(false);
     // …and the session is not mislabeled as pinned to the sticky model.
     expect(useChatStore.getState().sessionModelOverride).toBeNull();
+    expect(useChatStore.getState().selectedEffort).toBeNull();
+  });
+
+  it("keeps a routed session effort without making it the sticky preference", async () => {
+    seedSession("conv_routed_effort", []);
+    withSnapshot("conv_routed_effort", {
+      labels: { "omnigent.wrapper": "codex-native-ui" },
+      cost_control_mode_override: "on",
+      reasoning_effort: "high",
+    });
+
+    useChatStore.setState({ selectedEffort: "medium" });
+    await useChatStore.getState().switchTo("conv_routed_effort");
+
+    expect(patchCallsFor("conv_routed_effort")).toEqual([]);
+    expect(useChatStore.getState().sessionReasoningEffort).toBe("high");
+    expect(useChatStore.getState().selectedEffort).toBeNull();
+  });
+
+  it("leaves sticky effort alone when a routed session has no effort control", async () => {
+    seedSession("conv_routed_custom", []);
+    withSnapshot("conv_routed_custom", {
+      labels: {},
+      cost_control_mode_override: "on",
+    });
+
+    useChatStore.setState({ selectedEffort: "medium" });
+    await useChatStore.getState().switchTo("conv_routed_custom");
+
+    expect(useChatStore.getState().sessionReasoningEffort).toBeNull();
+    expect(useChatStore.getState().selectedEffort).toBe("medium");
   });
 
   it("applies sticky effort but never the sticky model on a codex-native session", async () => {
@@ -9466,7 +9512,7 @@ describe("chatStore — setCostControlMode", () => {
     });
     expect(patchCall).toBeDefined();
     const body = JSON.parse((patchCall![1] as RequestInit).body as string);
-    expect(body).toEqual({ cost_control_mode_override: "on" });
+    expect(body).toEqual({ cost_control_mode_override: "on", reasoning_effort: "default" });
     // Settled state is the server echo, proving the canonical refresh ran.
     expect(useChatStore.getState().costControlModeOverride).toBe("on");
   });
@@ -9477,11 +9523,17 @@ describe("chatStore — setCostControlMode", () => {
     // judge never runs. The clear rides in the SAME PATCH as the toggle.
     seedSession("conv_cc_model", []);
     await useChatStore.getState().switchTo("conv_cc_model");
-    useChatStore.setState({ sessionModelOverride: "claude-opus-4-7" });
+    useChatStore.setState({
+      sessionModelOverride: "claude-opus-4-7",
+      selectedEffort: "high",
+      sessionReasoningEffort: "high",
+    });
 
     // The optimistic clear is visible before the PATCH resolves.
     const settled = useChatStore.getState().setCostControlMode("on");
     expect(useChatStore.getState().sessionModelOverride).toBeNull();
+    expect(useChatStore.getState().selectedEffort).toBeNull();
+    expect(useChatStore.getState().sessionReasoningEffort).toBeNull();
     await settled;
 
     const patchCall = fetchMock.mock.calls.find(([u, init]) => {
@@ -9496,6 +9548,7 @@ describe("chatStore — setCostControlMode", () => {
     expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({
       cost_control_mode_override: "on",
       model_override: "default",
+      reasoning_effort: "default",
     });
   });
 
@@ -9518,6 +9571,7 @@ describe("chatStore — setCostControlMode", () => {
     expect(patchCall).toBeDefined();
     expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({
       cost_control_mode_override: "on",
+      reasoning_effort: "default",
     });
   });
 
@@ -9547,6 +9601,7 @@ describe("chatStore — setCostControlMode", () => {
   it("rolls back the optimistic flip when the PATCH fails", async () => {
     seedSession("conv_cc3", []);
     await useChatStore.getState().switchTo("conv_cc3");
+    useChatStore.setState({ selectedEffort: "high", sessionReasoningEffort: "high" });
 
     fetchMock.mockImplementationOnce((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
@@ -9560,6 +9615,8 @@ describe("chatStore — setCostControlMode", () => {
     // Back to the pre-toggle value: the pill must not claim a state the
     // server never persisted (it would silently diverge from the snapshot).
     expect(useChatStore.getState().costControlModeOverride).toBeNull();
+    expect(useChatStore.getState().selectedEffort).toBe("high");
+    expect(useChatStore.getState().sessionReasoningEffort).toBe("high");
   });
 
   it("rolls back on the toggling conversation when the failure outlives a switch", async () => {
@@ -9570,6 +9627,8 @@ describe("chatStore — setCostControlMode", () => {
     seedSession("conv_cc_bg", []);
     seedSession("conv_cc_fg", []);
     await useChatStore.getState().switchTo("conv_cc_bg");
+    useChatStore.setState({ selectedEffort: "high", sessionReasoningEffort: "high" });
+    window.localStorage.setItem("omnigent.picker.effort", "high");
 
     let failPatch: (() => void) | null = null;
     fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -9593,8 +9652,39 @@ describe("chatStore — setCostControlMode", () => {
 
     // The rejected optimistic flip is gone from the conversation that owns it...
     expect(conversationRegistry.peek("conv_cc_bg")!.getState().costControlModeOverride).toBeNull();
+    expect(conversationRegistry.peek("conv_cc_bg")!.getState().sessionReasoningEffort).toBe("high");
     // ...and the visible conversation was never touched.
     expect(useChatStore.getState().costControlModeOverride).toBeNull();
+    expect(useChatStore.getState().selectedEffort).toBeNull();
+    expect(window.localStorage.getItem("omnigent.picker.effort")).toBe("high");
+  });
+
+  it("does not overwrite a newer effort when an older routing PATCH fails", async () => {
+    seedSession("conv_cc_race", []);
+    sessionLabels.set("conv_cc_race", { "omnigent.wrapper": "codex-native-ui" });
+    await useChatStore.getState().switchTo("conv_cc_race");
+    useChatStore.setState({ selectedEffort: "high", sessionReasoningEffort: "high" });
+
+    let failPatch: (() => void) | null = null;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_cc_race" && init?.method === "PATCH" && failPatch === null) {
+        return new Promise<Response>((resolve) => {
+          failPatch = () =>
+            resolve(mockResponse({ error: { message: "boom" } }, { ok: false, status: 500 }));
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const toggling = useChatStore.getState().setCostControlMode("on");
+    await tick();
+    await useChatStore.getState().setEffort("low");
+    failPatch!();
+    await expect(toggling).rejects.toThrow();
+
+    expect(useChatStore.getState().selectedEffort).toBe("low");
+    expect(useChatStore.getState().sessionReasoningEffort).toBe("low");
   });
 
   it("hydrates from the session snapshot on bind and resets on switch-away", async () => {

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1117,6 +1117,7 @@ function savePickerPref(key: string, value: string | null): void {
 // have A's slower PATCH land last — and two reordered picks WITHIN one
 // conversation share an id. Only the newest pick may settle the sticky pref.
 let modelPickRevision = 0;
+let effortPickRevision = 0;
 
 /**
  * Make `id` the live, active conversation and return setters bound to its entry.
@@ -2092,6 +2093,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
   setEffort: async (effort) => {
     // `selectedEffort` is the cross-session sticky pick; `sessionReasoningEffort`
     // is this conversation's effective value. An explicit pick sets both.
+    effortPickRevision += 1;
     setActive({ selectedEffort: effort, sessionReasoningEffort: effort });
     savePickerPref(PICKER_PREF_EFFORT_KEY, effort);
     const { conversationId } = get();
@@ -2186,6 +2188,10 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     // model-less (e.g. SDK) session doesn't emit a spurious model-cleared change.
     const previousModel = get().sessionModelOverride;
     const clearModel = mode === "on" && previousModel != null;
+    const clearEffort = mode === "on";
+    const previousEffort = get().sessionReasoningEffort;
+    const previousStickyEffort = get().selectedEffort;
+    let effortClearRevision: number | null = null;
     // Pin the target: these are this conversation's switches, and the PATCH can
     // outlive a switch away. Resolving the target afterwards would leave a
     // backgrounded conversation showing an optimistic value the server rejected,
@@ -2196,15 +2202,26 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     patchSet({
       costControlModeOverride: mode,
       ...(clearModel ? { sessionModelOverride: null } : {}),
+      ...(clearEffort ? { sessionReasoningEffort: null } : {}),
     });
+    if (clearEffort) {
+      effortPickRevision += 1;
+      effortClearRevision = effortPickRevision;
+      rootSetState({ selectedEffort: null });
+      savePickerPref(PICKER_PREF_EFFORT_KEY, null);
+    }
     try {
       const session = await updateSession(conversationId, {
         costControlModeOverride: mode,
         ...(clearModel ? { modelOverride: null } : {}),
+        ...(clearEffort ? { reasoningEffort: null } : {}),
       });
       patchSet({
         costControlModeOverride: session.costControlModeOverride ?? null,
         ...(clearModel ? { sessionModelOverride: session.modelOverride ?? null } : {}),
+        ...(clearEffort && effortClearRevision === effortPickRevision
+          ? { sessionReasoningEffort: session.reasoningEffort ?? null }
+          : {}),
       });
     } catch (err) {
       // Roll back so neither control claims a state the server never persisted.
@@ -2213,7 +2230,16 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       patchSet({
         costControlModeOverride: previous,
         ...(clearModel ? { sessionModelOverride: previousModel } : {}),
+        ...(clearEffort && effortClearRevision === effortPickRevision
+          ? { sessionReasoningEffort: previousEffort }
+          : {}),
       });
+      if (clearEffort && effortClearRevision === effortPickRevision) {
+        savePickerPref(PICKER_PREF_EFFORT_KEY, previousStickyEffort);
+        if (useChatStore.getState().conversationId === conversationId) {
+          rootSetState({ selectedEffort: previousStickyEffort });
+        }
+      }
       throw err;
     }
   },
@@ -3097,9 +3123,15 @@ async function bindStream(
     const canApplyEffort = supportsEffortControl(session);
     const stickyEffort = get().selectedEffort;
     const stickyModel = get().selectedModel;
+    const routingOn = session.costControlModeOverride === "on";
     // Apply sticky effort only where the Web UI control is meaningful.
-    const effectiveEffort = canApplyEffort
-      ? (session.reasoningEffort ?? stickyEffort ?? null)
+    const sessionEffort = canApplyEffort
+      ? (session.reasoningEffort ?? (routingOn ? null : stickyEffort) ?? null)
+      : null;
+    const effectiveStickyEffort = canApplyEffort
+      ? routingOn
+        ? null
+        : sessionEffort
       : stickyEffort;
     // The sticky model is a UI PREFERENCE only: it pre-fills pickers but is
     // never silently PATCHed onto a session and never rendered as the
@@ -3109,6 +3141,7 @@ async function bindStream(
     // to honor — removed with the reported-model semantics.)
     if (
       !isSubAgentSession &&
+      !routingOn &&
       canApplyEffort &&
       session.reasoningEffort == null &&
       stickyEffort != null &&
@@ -3298,7 +3331,7 @@ async function bindStream(
         //
         // This conversation's own effective effort, which is what a warm switch
         // back re-projects (it does not re-bind, so it cannot recompute it).
-        sessionReasoningEffort: effectiveEffort,
+        sessionReasoningEffort: sessionEffort,
         // Session truth for the `/model` readout — overrides the snapshot
         // value spread via `...bindingPatch` so the claude-native sticky
         // handoff (fired above, silent) shows immediately.
@@ -3318,7 +3351,10 @@ async function bindStream(
     // mid-fetch, or two cold binds racing) must hydrate its own conversation
     // without touching the visible conversation's picker.
     if (useChatStore.getState().conversationId === id) {
-      rootSetState({ selectedEffort: effectiveEffort, selectedModel: resolvedStickyModel });
+      rootSetState({
+        selectedEffort: effectiveStickyEffort,
+        selectedModel: resolvedStickyModel,
+      });
     }
     racedNativeModelOptions.delete(id);
   } catch (err) {
@@ -5163,7 +5199,13 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
         event.conversationId === sourceConversationId &&
         useChatStore.getState().conversationId === event.conversationId
       ) {
-        useChatStore.setState({ selectedEffort: event.reasoningEffort });
+        effortPickRevision += 1;
+        if (
+          conversationRegistry.peek(event.conversationId)?.getState().costControlModeOverride !==
+          "on"
+        ) {
+          useChatStore.setState({ selectedEffort: event.reasoningEffort });
+        }
       }
       return;
     case "session_permission_mode":


### PR DESCRIPTION
## Related issue

Closes #2397

## Summary

- Route a Codex model and supported reasoning effort as one local-judge decision using the live Codex capability menu.
- Thread the capability menu through the current routing fallback layer and carry the selected pair together on the native message.
- Clear manual model and effort state when Smart Routing is enabled while keeping session-scoped routed effort and rollback behavior correct.
- Preserve model-only external-router, direct-TUI, and #3273 child-effort semantics. #3590 remains the required runner-to-executor handoff and is intentionally not duplicated here.

ELI5: Smart Routing owns both knobs only when its effort-aware judge selects a compatible pair; model-only routers do not erase an effort chosen elsewhere.

## Test Plan

- `uv run --group dev --extra all pytest -q tests/server/test_smart_routing.py tests/server/test_routing_backend.py tests/server/integration/test_routing_integration.py tests/test_sessions_native_messages.py` (333 passed)
- `pnpm --dir web exec vitest run` (5,800 passed, 3 expected failures, 1 skipped)
- `pnpm --dir web exec vitest run src/store/chatStore.test.ts` (355 passed)
- `uv run --group dev --extra all pytest -q tests/e2e_ui/start_session/test_smart_routing.py` (3 passed)
- `uv run --group dev --extra all pre-commit run --all-files` (all hooks passed)
- Disposable combined validation with #3590 (16 focused tests passed)
- Fork validation PR ThomasHFWright/omnigent#3 (55 code-bearing checks passed; fork-only secret and approval gates excluded)

## Demo

| Before — incompatible pair fails | After — compatible pair succeeds |
| --- | --- |
| ![Before: Smart Routing selected GPT-5.5 but retained unsupported max effort, causing an invalid-value failure](https://raw.githubusercontent.com/ThomasHFWright/omnigent/pr-assets-2398/smart-routing-before-incompatible-effort.png) | ![After: Smart Routing selected GPT-5.5 with compatible xhigh effort and the turn completed](https://raw.githubusercontent.com/ThomasHFWright/omnigent/pr-assets-2398/smart-routing-after-compatible-effort.png) |

The browser E2E reproduces #2397's routed-turn outcome without external credentials. Before the fix, routing changes the model but leaves the incompatible `max` effort, so GPT-5.5 rejects the turn. After the fix, the router selects GPT-5.5 and its supported `xhigh` effort together, and the same turn completes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Capability validation, local/external fallback ownership, persistence, SSE and in-band forwarding, sticky/session state separation, rollback behavior, direct-TUI model discovery, and the visible effort reset are covered automatically.

## Changelog

Smart Routing now chooses a compatible Codex model and reasoning effort together.