### PR TITLE
fix(ci): skip heavy CI workflows for changelog-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore: ['web/**', 'tests/e2e_ui/**']
+    paths-ignore: ['web/**', 'tests/e2e_ui/**', 'CHANGELOG.md']
   push:
     branches:
       - main
-    paths-ignore: ['web/**', 'tests/e2e_ui/**']
+    paths-ignore: ['web/**', 'tests/e2e_ui/**', 'CHANGELOG.md']
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -18,6 +18,7 @@ on:
     # Security Gate via rerun-security-gate.yml, so label churn need not re-run
     # the heavy Playwright suite. (#399 added these for the gate; superseded.)
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore: ['CHANGELOG.md']
   schedule:
     - cron: "0 9 * * *"
   workflow_dispatch:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ on:
     # (rerun-security-gate-run.yml falls back to this trigger). The concurrency
     # group key isolates label events so they never cancel a code-push run.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    paths-ignore: ['web/**', 'tests/e2e_ui/**']
+    paths-ignore: ['web/**', 'tests/e2e_ui/**', 'CHANGELOG.md']
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
## Related issue

#2395 is not getting auto-merged due to a failing check.


## Summary

Changelog-generation PRs (touching only `CHANGELOG.md`) currently trigger all CI workflows, including the heavy Playwright E2E UI suite. A flaky shard failure can block merge even though the change is just a markdown file.

Add `CHANGELOG.md` to `paths-ignore` in `ci.yml`, `e2e.yml`, and `e2e-ui.yml` so these workflows skip entirely for changelog-only PRs. The merge-ready gate already handles this correctly — all affected checks are in `ALLOW_SKIP`, so path-ignored workflows are classified as legitimate skips.

## Test Plan

- Verified that all E2E UI, E2E, and Pytest checks are in `ALLOW_SKIP` in `required.sh`, so the merge-ready gate will accept missing checks when workflows are path-ignored.
- Confirmed `evaluate-checks.sh` classifies a missing `ALLOW_SKIP` check with no workflow run (`outcome=none`) as "OK (skipped: path-ignored)".

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This is a CI workflow configuration change. The existing `evaluate-checks.sh` + `required.sh` gate logic already handles path-ignored workflows correctly — no new test coverage needed.