### PR TITLE
fix: best-effort stop before session archive or delete

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -2044,17 +2044,17 @@ async def _best_effort_stop(
     :param runner_router: The ``RunnerRouter`` for runner-client
         resolution, or ``None`` in tests / in-process setups.
     """
-    child_ids_map = await asyncio.to_thread(
-        conversation_store.list_child_conversation_ids_by_parent,
-        [session_id],
-    )
-    child_ids = child_ids_map.get(session_id, [])
-    status = _session_status_with_child_rollup(session_id, child_ids)
-    if status != "running":
-        return
     try:
+        child_ids_map = await asyncio.to_thread(
+            conversation_store.list_child_conversation_ids_by_parent,
+            [session_id],
+        )
+        child_ids = child_ids_map.get(session_id, [])
+        status = _session_status_with_child_rollup(session_id, child_ids)
+        if status != "running":
+            return
         await _stop_session_via_runner(session_id, runner_router)
-    except Exception:
+    except Exception:  # noqa: BLE001 — best-effort; must not block archive/delete
         _logger.debug(
             "Best-effort stop failed for %s; proceeding anyway",
             session_id,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -2026,6 +2026,42 @@ def _session_status_with_child_rollup(
     return own_status
 
 
+async def _best_effort_stop(
+    session_id: str,
+    conversation_store: ConversationStore,
+    runner_router: Any,
+) -> None:
+    """Stop a running session before a destructive lifecycle action.
+
+    Mirrors the client-side stop-then-archive/delete pattern: if the
+    session (or any direct sub-agent child) is still running, attempt to
+    stop it via the runner. Failures are swallowed so the caller can
+    always proceed — the session must remain deletable/archivable even
+    when the runner is offline or unreachable.
+
+    :param session_id: Session/conversation identifier.
+    :param conversation_store: Store for child-id lookup.
+    :param runner_router: The ``RunnerRouter`` for runner-client
+        resolution, or ``None`` in tests / in-process setups.
+    """
+    child_ids_map = await asyncio.to_thread(
+        conversation_store.list_child_conversation_ids_by_parent,
+        [session_id],
+    )
+    child_ids = child_ids_map.get(session_id, [])
+    status = _session_status_with_child_rollup(session_id, child_ids)
+    if status != "running":
+        return
+    try:
+        await _stop_session_via_runner(session_id, runner_router)
+    except Exception:
+        _logger.debug(
+            "Best-effort stop failed for %s; proceeding anyway",
+            session_id,
+            exc_info=True,
+        )
+
+
 @dataclass(frozen=True)
 class SessionLiveness:
     """
@@ -15197,6 +15233,8 @@ def create_sessions_router(
         await _require_access(
             user_id, session_id, required_level, permission_store, conversation_store
         )
+        if body.archived is True:
+            await _best_effort_stop(session_id, conversation_store, runner_router)
         if body.runner_id is not None and permission_store is not None:
             if not check_session_access(
                 user_id, session_id, LEVEL_OWNER, permission_store, conversation_store
@@ -20021,6 +20059,7 @@ def create_sessions_router(
                 "Session not found",
                 code=ErrorCode.NOT_FOUND,
             )
+        await _best_effort_stop(session_id, conversation_store, runner_router)
         # Runner-side resource cleanup is best-effort: if the bound
         # runner is offline or unbound, the session must still be
         # deletable. Server-owned records (files and conversation row

--- a/tests/server/integration/test_sessions_archive.py
+++ b/tests/server/integration/test_sessions_archive.py
@@ -19,6 +19,7 @@ import tarfile
 import httpx
 import pytest
 
+from omnigent.server.routes import sessions as sessions_module
 from tests.server.helpers import create_test_session
 
 pytestmark = pytest.mark.asyncio
@@ -96,6 +97,66 @@ async def test_unarchive_restores_session_to_default_listing(
     assert listing.status_code == 200
     listed_ids = [s["id"] for s in listing.json()["data"]]
     assert session_id in listed_ids
+
+
+# ── Best-effort stop before archive ───────────────────────
+
+
+async def test_archive_running_session_succeeds_after_best_effort_stop(
+    client: httpx.AsyncClient,
+) -> None:
+    """Archiving a running session attempts a stop and proceeds."""
+    session = await create_test_session(client, name="archive-running")
+    session_id = session["id"]
+
+    sessions_module._session_status_cache[session_id] = "running"
+    try:
+        resp = await client.patch(
+            f"/v1/sessions/{session_id}",
+            json={"archived": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["archived"] is True
+    finally:
+        sessions_module._session_status_cache.pop(session_id, None)
+
+
+async def test_archive_idle_session(
+    client: httpx.AsyncClient,
+) -> None:
+    """An idle session can be archived normally (no stop needed)."""
+    session = await create_test_session(client, name="archive-idle")
+    session_id = session["id"]
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"archived": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["archived"] is True
+
+
+async def test_unarchive_skips_stop(
+    client: httpx.AsyncClient,
+) -> None:
+    """Unarchiving does not attempt a stop, even if the session is running."""
+    session = await create_test_session(client, name="unarchive-running")
+    session_id = session["id"]
+
+    # Archive it first (while idle).
+    await client.patch(f"/v1/sessions/{session_id}", json={"archived": True})
+
+    # Simulate it becoming running, then unarchive.
+    sessions_module._session_status_cache[session_id] = "running"
+    try:
+        resp = await client.patch(
+            f"/v1/sessions/{session_id}",
+            json={"archived": False},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["archived"] is False
+    finally:
+        sessions_module._session_status_cache.pop(session_id, None)
 
 
 # ── Agent contents download ──────────────────────────────

--- a/tests/server/integration/test_sessions_archive.py
+++ b/tests/server/integration/test_sessions_archive.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import gzip
 import io
 import tarfile
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -102,19 +103,78 @@ async def test_unarchive_restores_session_to_default_listing(
 # ── Best-effort stop before archive ───────────────────────
 
 
-async def test_archive_running_session_succeeds_after_best_effort_stop(
+async def test_archive_running_session_attempts_stop(
     client: httpx.AsyncClient,
 ) -> None:
-    """Archiving a running session attempts a stop and proceeds."""
+    """Archiving a running session calls ``_stop_session_via_runner``."""
     session = await create_test_session(client, name="archive-running")
+    session_id = session["id"]
+
+    mock_stop = AsyncMock(return_value=True)
+    sessions_module._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["archived"] is True
+        mock_stop.assert_awaited_once()
+    finally:
+        sessions_module._session_status_cache.pop(session_id, None)
+
+
+async def test_archive_proceeds_when_stop_fails(
+    client: httpx.AsyncClient,
+) -> None:
+    """Archive succeeds even when the runner stop raises."""
+    session = await create_test_session(client, name="archive-stop-fail")
+    session_id = session["id"]
+
+    mock_stop = AsyncMock(side_effect=ConnectionError("runner gone"))
+    sessions_module._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": True},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["archived"] is True
+    finally:
+        sessions_module._session_status_cache.pop(session_id, None)
+
+
+async def test_archive_proceeds_when_child_lookup_fails(
+    client: httpx.AsyncClient,
+) -> None:
+    """Archive succeeds even when the child-id DB lookup raises."""
+    session = await create_test_session(client, name="archive-db-fail")
     session_id = session["id"]
 
     sessions_module._session_status_cache[session_id] = "running"
     try:
-        resp = await client.patch(
-            f"/v1/sessions/{session_id}",
-            json={"archived": True},
-        )
+        with patch.object(
+            sessions_module,
+            "_best_effort_stop",
+            wraps=sessions_module._best_effort_stop,
+        ):
+            orig = sessions_module._best_effort_stop
+
+            async def _patched_stop(sid, cs, rr):
+                with patch.object(
+                    cs,
+                    "list_child_conversation_ids_by_parent",
+                    side_effect=RuntimeError("transient DB error"),
+                ):
+                    await orig(sid, cs, rr)
+
+            with patch.object(sessions_module, "_best_effort_stop", _patched_stop):
+                resp = await client.patch(
+                    f"/v1/sessions/{session_id}",
+                    json={"archived": True},
+                )
         assert resp.status_code == 200
         assert resp.json()["archived"] is True
     finally:
@@ -128,12 +188,15 @@ async def test_archive_idle_session(
     session = await create_test_session(client, name="archive-idle")
     session_id = session["id"]
 
-    resp = await client.patch(
-        f"/v1/sessions/{session_id}",
-        json={"archived": True},
-    )
+    mock_stop = AsyncMock()
+    with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+        resp = await client.patch(
+            f"/v1/sessions/{session_id}",
+            json={"archived": True},
+        )
     assert resp.status_code == 200
     assert resp.json()["archived"] is True
+    mock_stop.assert_not_awaited()
 
 
 async def test_unarchive_skips_stop(
@@ -143,18 +206,19 @@ async def test_unarchive_skips_stop(
     session = await create_test_session(client, name="unarchive-running")
     session_id = session["id"]
 
-    # Archive it first (while idle).
     await client.patch(f"/v1/sessions/{session_id}", json={"archived": True})
 
-    # Simulate it becoming running, then unarchive.
+    mock_stop = AsyncMock()
     sessions_module._session_status_cache[session_id] = "running"
     try:
-        resp = await client.patch(
-            f"/v1/sessions/{session_id}",
-            json={"archived": False},
-        )
+        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+            resp = await client.patch(
+                f"/v1/sessions/{session_id}",
+                json={"archived": False},
+            )
         assert resp.status_code == 200
         assert resp.json()["archived"] is False
+        mock_stop.assert_not_awaited()
     finally:
         sessions_module._session_status_cache.pop(session_id, None)
 

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -12,6 +12,7 @@ import httpx
 import pytest_asyncio
 
 from omnigent.db.utils import generate_agent_id
+from omnigent.server.routes import sessions as sessions_module
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
@@ -109,6 +110,20 @@ async def test_delete_session_not_found(client: httpx.AsyncClient) -> None:
     """Deleting a nonexistent session returns 404."""
     resp = await client.delete("/v1/sessions/conv_nonexistent_12345")
     assert resp.status_code == 404
+
+
+async def test_delete_running_session_succeeds_after_best_effort_stop(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> None:
+    """Deleting a running session attempts a stop and proceeds."""
+    sessions_module._session_status_cache[session_id] = "running"
+    try:
+        resp = await client.delete(f"/v1/sessions/{session_id}")
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] is True
+    finally:
+        sessions_module._session_status_cache.pop(session_id, None)
 
 
 # ── PATCH /v1/sessions/{id} ─────────────────────────────────────────

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -8,6 +8,8 @@ the stores.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import httpx
 import pytest_asyncio
 
@@ -112,14 +114,33 @@ async def test_delete_session_not_found(client: httpx.AsyncClient) -> None:
     assert resp.status_code == 404
 
 
-async def test_delete_running_session_succeeds_after_best_effort_stop(
+async def test_delete_running_session_attempts_stop(
     client: httpx.AsyncClient,
     session_id: str,
 ) -> None:
-    """Deleting a running session attempts a stop and proceeds."""
+    """Deleting a running session calls ``_stop_session_via_runner``."""
+    mock_stop = AsyncMock(return_value=True)
     sessions_module._session_status_cache[session_id] = "running"
     try:
-        resp = await client.delete(f"/v1/sessions/{session_id}")
+        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+            resp = await client.delete(f"/v1/sessions/{session_id}")
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] is True
+        mock_stop.assert_awaited_once()
+    finally:
+        sessions_module._session_status_cache.pop(session_id, None)
+
+
+async def test_delete_proceeds_when_stop_fails(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> None:
+    """Delete succeeds even when the runner stop raises."""
+    mock_stop = AsyncMock(side_effect=ConnectionError("runner gone"))
+    sessions_module._session_status_cache[session_id] = "running"
+    try:
+        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+            resp = await client.delete(f"/v1/sessions/{session_id}")
         assert resp.status_code == 200
         assert resp.json()["deleted"] is True
     finally:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The server previously had no guard against archiving or deleting a running session — the stop-before-mutate pattern lived entirely in the web client.
- Added a server-side `_best_effort_stop()` helper that checks session status (including child sub-agent rollup via `_session_status_with_child_rollup`) and attempts `_stop_session_via_runner()` before archive or delete. Failures are swallowed so the operation always proceeds, matching the existing client-side contract.
- The stop is only attempted on archive (`archived=True`), not unarchive.

## Test Plan

- `test_archive_running_session_succeeds_after_best_effort_stop` — sets status cache to `"running"`, archives, asserts 200.
- `test_archive_idle_session` — archives an idle session, asserts 200 (no stop attempted).
- `test_unarchive_skips_stop` — unarchives a running session, asserts 200 (stop not triggered).
- `test_delete_running_session_succeeds_after_best_effort_stop` — sets status cache to `"running"`, deletes, asserts 200.
- All existing archive and CRUD tests continue to pass (25 total).

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

Sessions are now stopped server-side before archive or delete, so SDK and API callers get the same stop-first behavior the web UI provides.