### PR TITLE
feat(web): import a custom agent from a config file or folder

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -14073,6 +14073,49 @@ def create_sessions_router(
     """
     router = APIRouter()
 
+    # ── POST /sessions/validate-bundle ───────────────────────────
+
+    @router.post(
+        "/sessions/validate-bundle",
+        response_model=None,
+        # CSRF hardening: multipart/form-data is CORS-safelisted, so a
+        # content-type guard can't stop a cross-site upload; the trusted-origin
+        # check closes that gap (absent Origin allowed for non-browser clients;
+        # a present Origin must be loopback in local mode).
+        dependencies=[Depends(require_trusted_origin)],
+    )
+    async def validate_session_bundle(
+        request: Request,
+        bundle: Annotated[UploadFile, File(...)],
+    ) -> dict[str, Any]:
+        """
+        Validate an agent bundle without creating a session.
+
+        The import-dialog preflight: runs the SAME validation the bundled
+        create path applies (:func:`validate_agent_bundle`) so a bad
+        ``config.yaml`` surfaces at import time instead of failing mid-create.
+        Nothing is stored and no session is created — only the spec is parsed
+        and checked.
+
+        :param request: The incoming FastAPI request (auth only).
+        :param bundle: Uploaded ``.tar.gz`` agent bundle file.
+        :returns: ``{"ok": True, "agent_name": <spec name>}`` on success.
+        :raises OmnigentError: ``invalid_input`` (HTTP 400) when the bundle
+            is malformed or the spec fails validation.
+        """
+        _require_user(request, auth_provider)
+        bundle_bytes = await bundle.read()
+        # Extraction + spec parse both block, so run off the event loop —
+        # mirrors the bundled-create path. The policy-handler allowlist is
+        # enforced only on a shared / multi-user server; a trusted
+        # single-user/local server keeps supporting custom handlers.
+        spec = await asyncio.to_thread(
+            validate_agent_bundle,
+            bundle_bytes,
+            enforce_handler_allowlist=not local_single_user_enabled(),
+        )
+        return {"ok": True, "agent_name": spec.name}
+
     # ── POST /sessions ───────────────────────────────────────────
 
     @router.post(

--- a/tests/server/integration/test_sessions_validate_bundle.py
+++ b/tests/server/integration/test_sessions_validate_bundle.py
@@ -1,0 +1,84 @@
+"""
+Integration tests for ``POST /v1/sessions/validate-bundle``.
+
+The validate-bundle route is the import-dialog preflight: it runs the same
+validation the bundled-create path applies (``validate_agent_bundle``) without
+creating a session, so config errors surface at import time instead of at
+session create. These tests drive the real route through the shared ``client``
+fixture and assert:
+
+- a valid bundle returns 200 ``{"ok": True, "agent_name": ...}``,
+- an invalid bundle returns 400 with the validation message,
+- a request missing the ``bundle`` part returns 422.
+
+The underlying validation logic is covered exhaustively in
+``tests/server/test_bundles.py``; here we only assert the HTTP wiring.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import httpx
+import pytest
+
+from tests.server.helpers import build_agent_bundle
+
+pytestmark = pytest.mark.asyncio
+
+
+def _bundle_bytes(files: dict[str, str]) -> bytes:
+    """Build a ``.tar.gz`` from ``{archive_path: content}`` for the bad-bundle case."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content in files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+async def test_validate_bundle_accepts_valid_bundle(client: httpx.AsyncClient) -> None:
+    """A well-formed bundle validates with 200 and echoes the agent name."""
+    bundle = build_agent_bundle(name="preflight-ok-agent")
+    resp = await client.post(
+        "/v1/sessions/validate-bundle",
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["agent_name"] == "preflight-ok-agent"
+
+
+async def test_validate_bundle_rejects_missing_spec_version(client: httpx.AsyncClient) -> None:
+    """A config.yaml without spec_version is rejected 400 with the validation message."""
+    bundle = _bundle_bytes(
+        {
+            "config.yaml": (
+                "name: no-version-agent\n"
+                "executor:\n"
+                "  type: omnigent\n"
+                "  config:\n"
+                "    harness: claude-sdk\n"
+                "  model: databricks-claude-sonnet-4-6\n"
+            )
+        }
+    )
+    resp = await client.post(
+        "/v1/sessions/validate-bundle",
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "spec_version" in resp.text
+
+
+async def test_validate_bundle_requires_bundle_part(client: httpx.AsyncClient) -> None:
+    """Omitting the bundle part is a 422 (missing multipart field)."""
+    resp = await client.post(
+        "/v1/sessions/validate-bundle",
+        files={"notbundle": ("x.txt", b"hi", "text/plain")},
+    )
+    assert resp.status_code == 422, resp.text

--- a/web/src/lib/agentBundle.test.ts
+++ b/web/src/lib/agentBundle.test.ts
@@ -41,7 +41,35 @@ class PassthroughStream {
 (globalThis as any).CompressionStream = PassthroughStream;
 
 // Now import the function (it will use our mock CompressionStream).
-const { buildAgentBundle } = await import("./agentBundle");
+const { buildAgentBundle, buildBundleFromFiles } = await import("./agentBundle");
+
+/** Parse all tar entries (name → content) from the raw tar bytes in a File. */
+async function extractEntries(file: File): Promise<Record<string, string>> {
+  const tar = new Uint8Array(await file.arrayBuffer());
+  const dec = new TextDecoder();
+  const entries: Record<string, string> = {};
+  let off = 0;
+  while (off + 512 <= tar.length) {
+    const name = dec.decode(tar.slice(off, off + 100)).split("\0")[0]!;
+    if (!name) break; // zero block → end of archive
+    // Rejoin the ustar prefix field (345..499) for long paths.
+    const prefix = dec.decode(tar.slice(off + 345, off + 500)).split("\0")[0]!;
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const size = parseInt(dec.decode(tar.slice(off + 124, off + 135)).split("\0")[0]!, 8);
+    entries[fullName] = dec.decode(tar.slice(off + 512, off + 512 + size));
+    off += 512 + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+/** Build a File with an optional `webkitRelativePath` for folder-pick tests. */
+function fakeFile(name: string, content: string, relPath?: string): File {
+  const file = new File([content], name, { type: "text/yaml" });
+  if (relPath) {
+    Object.defineProperty(file, "webkitRelativePath", { value: relPath });
+  }
+  return file;
+}
 
 /** Extract the config.yaml from the raw tar bytes inside the File. */
 async function extractConfigYaml(file: File): Promise<string> {
@@ -49,7 +77,7 @@ async function extractConfigYaml(file: File): Promise<string> {
   const tar = new Uint8Array(buf);
   // First tar entry: 512-byte header, then content.
   // File size is at offset 124, 12 bytes, octal null-terminated.
-  const sizeStr = new TextDecoder().decode(tar.slice(124, 135)).replace(/\0/g, "");
+  const sizeStr = new TextDecoder().decode(tar.slice(124, 135)).split("\0")[0]!;
   const size = parseInt(sizeStr, 8);
   return new TextDecoder().decode(tar.slice(512, 512 + size));
 }
@@ -58,18 +86,16 @@ async function extractConfigYaml(file: File): Promise<string> {
 async function extractAgentsMd(file: File): Promise<string | null> {
   const buf = await file.arrayBuffer();
   const tar = new Uint8Array(buf);
-  const size0Str = new TextDecoder().decode(tar.slice(124, 135)).replace(/\0/g, "");
+  const size0Str = new TextDecoder().decode(tar.slice(124, 135)).split("\0")[0]!;
   const size0 = parseInt(size0Str, 8);
   const blocks0 = Math.ceil(size0 / 512);
   const entry1Start = 512 + blocks0 * 512;
   if (entry1Start + 512 > tar.length) return null;
-  const name1 = new TextDecoder()
-    .decode(tar.slice(entry1Start, entry1Start + 100))
-    .replace(/\0/g, "");
+  const name1 = new TextDecoder().decode(tar.slice(entry1Start, entry1Start + 100)).split("\0")[0]!;
   if (!name1.startsWith("AGENTS.md")) return null;
   const size1Str = new TextDecoder()
     .decode(tar.slice(entry1Start + 124, entry1Start + 135))
-    .replace(/\0/g, "");
+    .split("\0")[0]!;
   const size1 = parseInt(size1Str, 8);
   return new TextDecoder().decode(tar.slice(entry1Start + 512, entry1Start + 512 + size1));
 }
@@ -196,5 +222,85 @@ describe("buildAgentBundle", () => {
     const yaml = await extractConfigYaml(await buildAgentBundle(input));
     expect(yaml).toContain("harness: openai-agents");
     expect(yaml).toContain("model: gpt-4o");
+  });
+});
+
+describe("buildBundleFromFiles", () => {
+  it("rejects an empty selection", async () => {
+    await expect(buildBundleFromFiles([])).rejects.toThrow(/no files/i);
+  });
+
+  it("renames a lone YAML to config.yaml when singleFileAsConfig is set", async () => {
+    const file = await buildBundleFromFiles([fakeFile("my-agent.yaml", "spec_version: 1")], {
+      singleFileAsConfig: true,
+    });
+    const entries = await extractEntries(file);
+    expect(Object.keys(entries)).toEqual(["config.yaml"]);
+    expect(entries["config.yaml"]).toBe("spec_version: 1");
+  });
+
+  it("keeps the original file name when singleFileAsConfig is not set", async () => {
+    const file = await buildBundleFromFiles([fakeFile("agent.yml", "spec_version: 1")]);
+    const entries = await extractEntries(file);
+    expect(Object.keys(entries)).toEqual(["agent.yml"]);
+  });
+
+  it("strips the top folder from webkitRelativePath so contents sit at the root", async () => {
+    const file = await buildBundleFromFiles(
+      [
+        fakeFile("config.yaml", "spec_version: 1", "my-agent/config.yaml"),
+        fakeFile("AGENTS.md", "# Instructions", "my-agent/AGENTS.md"),
+        fakeFile("SKILL.md", "skill body", "my-agent/skills/debate/SKILL.md"),
+      ],
+      { singleFileAsConfig: true },
+    );
+    const entries = await extractEntries(file);
+    expect(Object.keys(entries).sort()).toEqual([
+      "AGENTS.md",
+      "config.yaml",
+      "skills/debate/SKILL.md",
+    ]);
+    // singleFileAsConfig must not rewrite names for a multi-file folder pick.
+    expect(entries["config.yaml"]).toBe("spec_version: 1");
+    expect(entries["skills/debate/SKILL.md"]).toBe("skill body");
+  });
+
+  it("packs a folder's config.yaml verbatim (no YAML rewriting)", async () => {
+    const raw = "spec_version: 1\nname: imported\nexecutor:\n  type: omnigent\n";
+    const file = await buildBundleFromFiles(
+      [fakeFile("config.yaml", raw, "imported/config.yaml")],
+      { singleFileAsConfig: true },
+    );
+    const entries = await extractEntries(file);
+    expect(entries["config.yaml"]).toBe(raw);
+  });
+
+  it("packs an entry path over 100 bytes without truncation (ustar prefix)", async () => {
+    // A realistic deep skill path whose full length exceeds the 100-byte
+    // legacy name field, so the ustar prefix field must carry the head.
+    const skillDir = "a-really-quite-verbose-skill-directory-name-that-goes-on";
+    const longPath = `skills/${skillDir}/${skillDir}/SKILL.md`;
+    expect(new TextEncoder().encode(longPath).length).toBeGreaterThan(100);
+    const file = await buildBundleFromFiles(
+      [
+        fakeFile("config.yaml", "spec_version: 1", "agent/config.yaml"),
+        fakeFile("SKILL.md", "skill body", `agent/${longPath}`),
+      ],
+      { singleFileAsConfig: true },
+    );
+    const entries = await extractEntries(file);
+    expect(Object.keys(entries).sort()).toEqual(["config.yaml", longPath]);
+    expect(entries[longPath]).toBe("skill body");
+  });
+
+  it("throws rather than truncate when the file name exceeds 100 bytes", async () => {
+    // The final segment can't move into the prefix field, so a >100-byte
+    // file name has no valid split point and must fail loudly.
+    const hugeName = `${"x".repeat(120)}.md`;
+    await expect(
+      buildBundleFromFiles([fakeFile(hugeName, "body", `agent/skills/debate/${hugeName}`)], {
+        singleFileAsConfig: true,
+      }),
+    ).rejects.toThrow(/too long to archive/i);
   });
 });

--- a/web/src/lib/agentBundle.ts
+++ b/web/src/lib/agentBundle.ts
@@ -113,6 +113,64 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
   });
 }
 
+/**
+ * Build a `.tar.gz` agent bundle from files picked off disk.
+ *
+ * Packs the selected files verbatim — no YAML parsing, no `${VAR}`
+ * expansion — mirroring how the CLI packs a directory (see
+ * `_bundle_local_agent_source`). The server's `validate_agent_bundle`
+ * requires a `config.yaml` (or a single standalone omnigent YAML) at the
+ * archive root, so entry paths are normalized accordingly:
+ *
+ * - A single file is placed at the archive root under its own name.
+ *   Pass `singleFileAsConfig` to rename a lone `*.yaml`/`*.yml` to
+ *   `config.yaml` so a bare spec file is always found at the root.
+ * - Folder picks (via `webkitdirectory`) carry a `webkitRelativePath`
+ *   like `my-agent/config.yaml`; the leading top-level directory segment
+ *   is stripped so the bundle contents sit at the root.
+ */
+export async function buildBundleFromFiles(
+  files: File[],
+  opts: { singleFileAsConfig?: boolean } = {},
+): Promise<File> {
+  if (files.length === 0) {
+    throw new Error("No files selected to import.");
+  }
+
+  const entries: TarEntry[] = await Promise.all(
+    files.map(async (file) => {
+      let name = bundleEntryName(file);
+      if (files.length === 1 && opts.singleFileAsConfig && /\.ya?ml$/i.test(name)) {
+        name = "config.yaml";
+      }
+      const content = new Uint8Array(await file.arrayBuffer());
+      return { name, content };
+    }),
+  );
+
+  const tarBytes = createTar(entries);
+  const gzipped = await gzip(tarBytes);
+  return new File([gzipped.buffer as ArrayBuffer], "agent.tar.gz", {
+    type: "application/gzip",
+  });
+}
+
+/**
+ * Derive an archive-relative path for a picked file. Folder picks expose
+ * `webkitRelativePath` (e.g. `my-agent/config.yaml`); strip the leading
+ * top-level segment so bundle contents land at the archive root. Falls
+ * back to the plain file name for single-file picks.
+ */
+function bundleEntryName(file: File): string {
+  const rel = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+  if (rel) {
+    const slash = rel.indexOf("/");
+    const stripped = slash >= 0 ? rel.slice(slash + 1) : rel;
+    if (stripped) return stripped;
+  }
+  return file.name;
+}
+
 // ── Helpers ──────────────────────────────────────────────────────
 
 /** Quote a YAML string value if it contains special characters. */
@@ -140,9 +198,13 @@ function createTar(entries: TarEntry[]): Uint8Array {
     const header = new Uint8Array(512);
     const encoder = new TextEncoder();
 
-    // File name (0..99)
-    const nameBytes = encoder.encode(entry.name);
-    header.set(nameBytes.slice(0, 100), 0);
+    // File name (0..99), with the ustar 155-byte prefix field (345..499)
+    // for paths longer than 100 bytes. Folder picks can produce entries
+    // like `skills/<descriptive-name>/SKILL.md` that exceed the legacy
+    // name field, so split at a `/` boundary rather than truncating.
+    const { name, prefix } = splitTarName(entry.name);
+    header.set(encoder.encode(name), 0);
+    if (prefix) header.set(encoder.encode(prefix), 345);
 
     // File mode (100..107) — 0644
     writeOctal(header, 100, 8, 0o644);
@@ -189,6 +251,34 @@ function createTar(entries: TarEntry[]): Uint8Array {
     offset += block.length;
   }
   return result;
+}
+
+/**
+ * Split a tar entry path into the ustar `name` (≤100 bytes) and `prefix`
+ * (≤155 bytes) header fields. The extractor rejoins them as
+ * `prefix + "/" + name`. Short paths return an empty prefix.
+ *
+ * Throws when the path can't fit — a name segment over 100 bytes, or a
+ * total over 255 — so a bundle is never silently corrupted by truncation.
+ */
+function splitTarName(path: string): { name: string; prefix: string } {
+  const encoder = new TextEncoder();
+  if (encoder.encode(path).length <= 100) {
+    return { name: path, prefix: "" };
+  }
+  // Find the split point closest to the end that keeps name ≤100 bytes and
+  // prefix ≤155 bytes. Only `/` boundaries are valid ustar split points.
+  for (let i = path.indexOf("/"); i >= 0; i = path.indexOf("/", i + 1)) {
+    const prefix = path.slice(0, i);
+    const name = path.slice(i + 1);
+    if (encoder.encode(name).length <= 100 && encoder.encode(prefix).length <= 155) {
+      return { name, prefix };
+    }
+  }
+  throw new Error(
+    `Bundle entry path is too long to archive: ${path}. ` +
+      `Path segments must fit the tar name (100 bytes) and prefix (155 bytes) fields.`,
+  );
 }
 
 /** Write a number as null-terminated octal string into a tar header field. */

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -23,6 +23,7 @@ import {
   SESSION_HISTORY_PAGE_SIZE,
   stopSession,
   updateSession,
+  validateAgentBundle,
 } from "./sessionsApi";
 
 function mockJsonResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
@@ -963,6 +964,38 @@ describe("postEvent", () => {
     });
     expect(out.pendingId).toBe("pending_abc123");
     expect(out.itemId).toBeUndefined();
+  });
+});
+
+describe("validateAgentBundle", () => {
+  it("POSTs the bundle as multipart and returns the parsed agent name", async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ ok: true, agent_name: "my-agent" }));
+    const bundle = new File([new Uint8Array([1, 2, 3])], "agent.tar.gz", {
+      type: "application/gzip",
+    });
+
+    const out = await validateAgentBundle(bundle);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/validate-bundle");
+    expect(init.method).toBe("POST");
+    // Multipart: no JSON Content-Type header (the browser sets the boundary).
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get("bundle")).toBe(bundle);
+    expect(out).toEqual({ agentName: "my-agent" });
+  });
+
+  it("throws the server's validation message on a 400", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse(
+        { error: { code: "invalid_input", message: "agent spec must include a name" } },
+        { ok: false, status: 400 },
+      ),
+    );
+    const bundle = new File([new Uint8Array([1])], "agent.tar.gz");
+
+    await expect(validateAgentBundle(bundle)).rejects.toThrow(/agent spec must include a name/);
   });
 });
 

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -478,6 +478,32 @@ export async function createBundledSession(
 }
 
 /**
+ * Validate an agent bundle without creating a session:
+ * multipart `POST /v1/sessions/validate-bundle`.
+ *
+ * The import-dialog preflight. Runs the same server-side validation the
+ * bundled-create path applies (`validate_agent_bundle`) — the same check
+ * `omni run` performs — so a malformed `config.yaml` surfaces at import
+ * time instead of failing mid-create. Nothing is stored.
+ *
+ * @param bundle - The agent bundle as a `File` (`.tar.gz`).
+ * @returns The validated agent name from the bundle's spec.
+ * @throws ApiError carrying the server's validation message (HTTP 400)
+ *   when the bundle is malformed, so the caller can surface it inline.
+ */
+export async function validateAgentBundle(bundle: File): Promise<{ agentName: string | null }> {
+  const form = new FormData();
+  form.append("bundle", bundle);
+  const res = await authenticatedFetch("/v1/sessions/validate-bundle", {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) throw await apiErrorFromResponse(res);
+  const body = (await res.json()) as { ok: boolean; agent_name: string | null };
+  return { agentName: body.agent_name };
+}
+
+/**
  * Fork (clone) a session into a new one via
  * POST /v1/sessions/{source_id}/fork.
  *

--- a/web/src/shell/ImportAgentDialog.test.tsx
+++ b/web/src/shell/ImportAgentDialog.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ImportAgentDialog } from "./ImportAgentDialog";
+import { buildBundleFromFiles } from "@/lib/agentBundle";
+import { validateAgentBundle } from "@/lib/sessionsApi";
+
+vi.mock("@/lib/agentBundle", () => ({ buildBundleFromFiles: vi.fn() }));
+vi.mock("@/lib/sessionsApi", () => ({ validateAgentBundle: vi.fn() }));
+
+const buildBundleFromFilesMock = vi.mocked(buildBundleFromFiles);
+const validateAgentBundleMock = vi.mocked(validateAgentBundle);
+
+// A fake packed bundle the mocked builder returns; identity is asserted so
+// the SAME validated bundle flows through to onImport (no re-pack).
+const FAKE_BUNDLE = new File([new Uint8Array([1, 2, 3])], "agent.tar.gz", {
+  type: "application/gzip",
+});
+
+function pickFile(name = "config.yaml"): void {
+  const input = screen.getByTestId("import-agent-file-input") as HTMLInputElement;
+  const file = new File(["spec_version: 1\nname: x\n"], name, { type: "text/yaml" });
+  // jsdom's FileList: assign via defineProperty so `input.files` is readable.
+  Object.defineProperty(input, "files", { value: [file], configurable: true });
+  fireEvent.change(input);
+}
+
+/** A deferred promise whose resolve/reject can be triggered from a test. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  buildBundleFromFilesMock.mockReset();
+  validateAgentBundleMock.mockReset();
+  buildBundleFromFilesMock.mockResolvedValue(FAKE_BUNDLE);
+});
+
+afterEach(() => cleanup());
+
+describe("ImportAgentDialog", () => {
+  it("validates a pick and shows the 'agent config is loaded' message on success", async () => {
+    validateAgentBundleMock.mockResolvedValueOnce({ agentName: "my-agent" });
+    render(<ImportAgentDialog open onOpenChange={vi.fn()} onImport={vi.fn()} />);
+
+    // Import is disabled until a pick validates.
+    expect(screen.getByTestId("import-agent-submit")).toBeDisabled();
+
+    pickFile();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("import-agent-validated")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("import-agent-validated")).toHaveTextContent(
+      /agent config is loaded/i,
+    );
+    expect(validateAgentBundleMock).toHaveBeenCalledWith(FAKE_BUNDLE);
+    // Only now is Import enabled.
+    expect(screen.getByTestId("import-agent-submit")).not.toBeDisabled();
+  });
+
+  it("shows the server error and keeps Import disabled when the config is invalid", async () => {
+    validateAgentBundleMock.mockRejectedValueOnce(new Error("agent spec must include a name"));
+    render(<ImportAgentDialog open onOpenChange={vi.fn()} onImport={vi.fn()} />);
+
+    pickFile();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("import-agent-error")).toHaveTextContent(
+        /agent spec must include a name/,
+      );
+    });
+    expect(screen.queryByTestId("import-agent-validated")).not.toBeInTheDocument();
+    // An invalid config can never be imported.
+    expect(screen.getByTestId("import-agent-submit")).toBeDisabled();
+  });
+
+  it("imports the validated bundle without re-packing on submit", async () => {
+    validateAgentBundleMock.mockResolvedValueOnce({ agentName: "my-agent" });
+    const onImport = vi.fn();
+    const onOpenChange = vi.fn();
+    render(<ImportAgentDialog open onOpenChange={onOpenChange} onImport={onImport} />);
+
+    pickFile("my-agent.yaml");
+    await waitFor(() => {
+      expect(screen.getByTestId("import-agent-submit")).not.toBeDisabled();
+    });
+
+    // One pack for validation; submit reuses that same bundle.
+    expect(buildBundleFromFilesMock).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId("import-agent-submit"));
+
+    expect(onImport).toHaveBeenCalledTimes(1);
+    const arg = onImport.mock.calls[0]![0] as { name: string; bundle: File };
+    expect(arg.bundle).toBe(FAKE_BUNDLE);
+    expect(arg.name).toBe("my-agent");
+    expect(buildBundleFromFilesMock).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("ignores a stale validation when a newer pick supersedes it", async () => {
+    // First pick validates slowly; a second pick resolves first. The slow
+    // first result must not win and re-enable Import for the wrong pick.
+    const first = deferred<{ agentName: string }>();
+    validateAgentBundleMock.mockReturnValueOnce(first.promise);
+    validateAgentBundleMock.mockRejectedValueOnce(new Error("second pick is invalid"));
+    render(<ImportAgentDialog open onOpenChange={vi.fn()} onImport={vi.fn()} />);
+
+    pickFile("first.yaml");
+    pickFile("second.yaml");
+
+    // Second (rejected) pick settles → error shown, Import disabled.
+    await waitFor(() => {
+      expect(screen.getByTestId("import-agent-error")).toHaveTextContent(/second pick is invalid/);
+    });
+
+    // Now let the stale first pick resolve — it must not overwrite state.
+    first.resolve({ agentName: "first" });
+    await Promise.resolve();
+    expect(screen.queryByTestId("import-agent-validated")).not.toBeInTheDocument();
+    expect(screen.getByTestId("import-agent-submit")).toBeDisabled();
+  });
+
+  it("ignores a validation that resolves after the dialog is closed", async () => {
+    const pending = deferred<{ agentName: string }>();
+    validateAgentBundleMock.mockReturnValueOnce(pending.promise);
+    const onImport = vi.fn();
+    render(<ImportAgentDialog open onOpenChange={vi.fn()} onImport={onImport} />);
+
+    pickFile("config.yaml");
+    // Close the dialog (runs reset()) while validation is still in flight.
+    fireEvent.click(screen.getByText("Cancel"));
+
+    // The late-arriving success must not re-enable Import for the closed pick.
+    pending.resolve({ agentName: "late" });
+    await Promise.resolve();
+    expect(screen.queryByTestId("import-agent-validated")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/shell/ImportAgentDialog.tsx
+++ b/web/src/shell/ImportAgentDialog.tsx
@@ -1,0 +1,273 @@
+import { useRef, useState } from "react";
+import { CheckCircle2Icon, FileIcon, FolderIcon, Loader2Icon, XCircleIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { buildBundleFromFiles } from "@/lib/agentBundle";
+import { validateAgentBundle } from "@/lib/sessionsApi";
+
+/** A packed agent bundle ready to upload, with a display label. */
+export interface ImportedAgent {
+  /** Display label shown in the picker. */
+  name: string;
+  /** Pre-built `.tar.gz` bundle accepted by the multipart session create. */
+  bundle: File;
+}
+
+/** Derive a display name from a picked file or the top folder of a pick. */
+function deriveName(files: File[]): string {
+  if (files.length === 0) return "";
+  const rel = (files[0] as File & { webkitRelativePath?: string }).webkitRelativePath;
+  if (rel) {
+    const top = rel.split("/")[0];
+    if (top) return top;
+  }
+  return files[0].name.replace(/\.ya?ml$/i, "");
+}
+
+/**
+ * Dialog for importing a custom agent from disk — either a single agent
+ * YAML file or a whole config folder (config.yaml + AGENTS.md + skills/…).
+ *
+ * The OS-native picker is triggered by hidden file inputs: a plain input
+ * for a single YAML, and a `webkitdirectory` input for a folder. Both work
+ * uniformly in the browser and inside the Electron shell's Chromium. On
+ * submit, the picked files are packed verbatim into a `.tar.gz` and handed
+ * back via `onImport` so the parent can start a session with it — the same
+ * bundle path used for created agents.
+ */
+export function ImportAgentDialog({
+  open,
+  onOpenChange,
+  onImport,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onImport: (agent: ImportedAgent) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+  const [name, setName] = useState("");
+  // Whether the user has edited the name; until then we keep it in sync
+  // with the picked file/folder so a pick auto-fills a sensible label.
+  const [nameEdited, setNameEdited] = useState(false);
+  const [files, setFiles] = useState<File[]>([]);
+  const [kind, setKind] = useState<"file" | "folder" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // The packed bundle, set once the pick validates against the server.
+  // `null` until a pick validates; cleared on any re-pick. Import is gated
+  // on this being non-null, so an invalid config can never be imported.
+  const [validated, setValidated] = useState<File | null>(null);
+  const [validating, setValidating] = useState(false);
+  // Monotonic token identifying the most recent pick. A validation only
+  // writes state if its captured token still matches, so a slow pick that
+  // resolves after a newer pick — or after the dialog closed — can't apply
+  // a stale result (which would import the wrong config).
+  const pickIdRef = useRef(0);
+
+  function reset() {
+    setName("");
+    setNameEdited(false);
+    setFiles([]);
+    setKind(null);
+    setError(null);
+    setValidated(null);
+    setValidating(false);
+    // Supersede any in-flight validation so it can't mutate state after reset.
+    pickIdRef.current += 1;
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (folderInputRef.current) folderInputRef.current.value = "";
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset();
+    onOpenChange(next);
+  }
+
+  // Pack the pick and validate it server-side (the same check `omni run`
+  // and the create path run), so a bad config.yaml is caught here — before
+  // the user submits — instead of failing mid session-create.
+  async function validatePick(list: File[], pickedKind: "file" | "folder", pickId: number) {
+    setValidating(true);
+    setError(null);
+    setValidated(null);
+    try {
+      const bundle = await buildBundleFromFiles(list, {
+        singleFileAsConfig: pickedKind === "file",
+      });
+      await validateAgentBundle(bundle);
+      if (pickId !== pickIdRef.current) return;
+      setValidated(bundle);
+    } catch (err) {
+      if (pickId !== pickIdRef.current) return;
+      setError(err instanceof Error ? err.message : "The selected agent config is not valid.");
+    } finally {
+      if (pickId === pickIdRef.current) setValidating(false);
+    }
+  }
+
+  function handlePicked(picked: FileList | null, pickedKind: "file" | "folder") {
+    const list = picked ? Array.from(picked) : [];
+    if (list.length === 0) return;
+    const pickId = ++pickIdRef.current;
+    setFiles(list);
+    setKind(pickedKind);
+    if (!nameEdited) setName(deriveName(list));
+    void validatePick(list, pickedKind, pickId);
+  }
+
+  function handleImport() {
+    // Import is gated on a validated bundle, so this is the packed, verified
+    // one — no re-packing or re-validation needed.
+    if (!validated) return;
+    onImport({ name: name.trim() || deriveName(files), bundle: validated });
+    reset();
+    onOpenChange(false);
+  }
+
+  const fileCount = files.length;
+  const canImport = validated !== null && !validating;
+  const selectionLabel =
+    kind === "folder"
+      ? `${deriveName(files)} — ${fileCount} file${fileCount === 1 ? "" : "s"}`
+      : (files[0]?.name ?? null);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        data-testid="import-agent-dialog"
+        className="flex max-h-[85vh] flex-col gap-4 sm:max-w-lg"
+      >
+        <DialogHeader>
+          <DialogTitle>Import agent config</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+          <p className="text-xs text-muted-foreground">
+            Import an existing agent from a single config file (a YAML spec) or a whole config
+            folder (<code>config.yaml</code>, <code>AGENTS.md</code>, <code>skills/</code>…). Files
+            are packaged and uploaded as-is.
+          </p>
+
+          {/* Hidden native pickers. `webkitdirectory` selects a folder; the
+          plain input restricts to YAML specs. */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".yaml,.yml"
+            className="hidden"
+            data-testid="import-agent-file-input"
+            onChange={(e) => handlePicked(e.target.files, "file")}
+          />
+          <input
+            ref={folderInputRef}
+            type="file"
+            className="hidden"
+            data-testid="import-agent-folder-input"
+            // webkitdirectory isn't in the standard input typings.
+            {...({ webkitdirectory: "", directory: "" } as Record<string, string>)}
+            onChange={(e) => handlePicked(e.target.files, "folder")}
+          />
+
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1 gap-2"
+              data-testid="import-agent-choose-file"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <FileIcon className="size-4" />
+              Choose Config File
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1 gap-2"
+              data-testid="import-agent-choose-folder"
+              onClick={() => folderInputRef.current?.click()}
+            >
+              <FolderIcon className="size-4" />
+              Choose Config Folder
+            </Button>
+          </div>
+
+          {selectionLabel && (
+            <div
+              className="truncate rounded-md border border-border px-3 py-2 text-xs text-muted-foreground"
+              data-testid="import-agent-selection"
+            >
+              {selectionLabel}
+            </div>
+          )}
+
+          {validating && (
+            <p
+              className="flex items-center gap-1.5 text-xs text-muted-foreground"
+              data-testid="import-agent-validating"
+            >
+              <Loader2Icon className="size-3.5 animate-spin" />
+              Validating agent config…
+            </p>
+          )}
+
+          {validated && !validating && (
+            <p
+              className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-500"
+              data-testid="import-agent-validated"
+            >
+              <CheckCircle2Icon className="size-3.5" />
+              Agent config is loaded.
+            </p>
+          )}
+
+          {error && !validating && (
+            <p
+              className="flex items-center gap-1.5 text-xs text-destructive"
+              data-testid="import-agent-error"
+            >
+              <XCircleIcon className="size-3.5" />
+              {error}
+            </p>
+          )}
+
+          {/* Display name — a label for the picker; the bundle's own
+          config.yaml name is what the server registers. */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="import-agent-name"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Display name
+            </label>
+            <Input
+              id="import-agent-name"
+              data-testid="import-agent-name"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setNameEdited(true);
+              }}
+              placeholder="my-agent"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button data-testid="import-agent-submit" onClick={handleImport} disabled={!canImport}>
+            {validating ? "Validating…" : "Import"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -676,6 +676,7 @@ describe("NewChatLandingScreen", () => {
   afterEach(() => {
     cleanup();
     localStorage.clear();
+    delete (window as unknown as Record<string, unknown>).omnigentNative;
   });
 
   it("renders the inline composer with the prompt headline", () => {
@@ -744,6 +745,17 @@ describe("NewChatLandingScreen", () => {
       true,
     );
     expect(screen.getByText("No agents")).toBeTruthy();
+  });
+
+  it.each(["ios", "android"] as const)("hides config import in the %s native shell", (kind) => {
+    (window as unknown as Record<string, unknown>).omnigentNative = { kind };
+    renderLanding();
+
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.keyDown(screen.getByTestId("new-chat-landing-add-agent"), { key: "ArrowRight" });
+
+    expect(screen.getByTestId("new-chat-landing-create-agent")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-import-agent")).toBeNull();
   });
 
   it("orders native built-ins together in the agent picker", () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -84,8 +84,10 @@ import {
 import { useHosts, type Host } from "@/hooks/useHosts";
 import {
   controlHost,
+  isAndroidShell,
   getHostIdentity,
   isElectronShell,
+  isIOSShell,
   onHostStatusChanged,
   type HostIdentity,
 } from "@/lib/nativeBridge";
@@ -1316,6 +1318,8 @@ function AgentHarnessPicker({
   setPickedEffort: (effort: string) => void;
   setPickedHarness: (harness: string | null, agentId?: string) => void;
 }) {
+  const canImportAgentConfig = !isIOSShell() && !isAndroidShell();
+
   // Controlled so clicking a knobbed row can commit the pick and close the
   // menu (see the sub-trigger onClick below) without diving into the submenu.
   const [open, setOpen] = useState(false);
@@ -1699,14 +1703,16 @@ function AgentHarnessPicker({
                   <PlusIcon className="size-3.5" />
                   Configure Manually
                 </DropdownMenuItem>
-                <DropdownMenuItem
-                  data-testid="new-chat-landing-import-agent"
-                  onSelect={onImportConfig}
-                  className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
-                >
-                  <FolderInputIcon className="size-3.5" />
-                  Import Config
-                </DropdownMenuItem>
+                {canImportAgentConfig && (
+                  <DropdownMenuItem
+                    data-testid="new-chat-landing-import-agent"
+                    onSelect={onImportConfig}
+                    className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
+                  >
+                    <FolderInputIcon className="size-3.5" />
+                    Import Config
+                  </DropdownMenuItem>
+                )}
               </DropdownMenuSubContent>
             </DropdownMenuSub>
           </>
@@ -3746,15 +3752,17 @@ export function NewChatLandingScreen() {
           setPickedHarness(null);
         }}
       />
-      <ImportAgentDialog
-        open={importAgentOpen}
-        onOpenChange={setImportAgentOpen}
-        onImport={(agent: ImportedAgent) => {
-          setPendingAgent({ kind: "imported", name: agent.name, bundle: agent.bundle });
-          setPickedAgentId(PENDING_AGENT_ID);
-          setPickedHarness(null);
-        }}
-      />
+      {!isIOSShell() && !isAndroidShell() && (
+        <ImportAgentDialog
+          open={importAgentOpen}
+          onOpenChange={setImportAgentOpen}
+          onImport={(agent: ImportedAgent) => {
+            setPendingAgent({ kind: "imported", name: agent.name, bundle: agent.bundle });
+            setPickedAgentId(PENDING_AGENT_ID);
+            setPickedHarness(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -21,6 +21,7 @@ import {
   ArrowUpIcon,
   FileTextIcon,
   FolderIcon,
+  FolderInputIcon,
   ImageIcon,
   PaperclipIcon,
   PlusIcon,
@@ -116,8 +117,24 @@ import { IntelligentModelControl, type CostControlMode } from "@/components/Cost
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";
+import { ImportAgentDialog, type ImportedAgent } from "./ImportAgentDialog";
 import { buildAgentBundle, type AgentBundleInput } from "@/lib/agentBundle";
 import { createBundledSession, launchRunner } from "@/lib/sessionsApi";
+
+/**
+ * The custom agent staged in the picker before a session is created.
+ * Either authored via the create form (bundle built at create time) or
+ * imported from disk (bundle already packed). Both surface a display name.
+ */
+type PendingAgent =
+  | {
+      kind: "created";
+      name: string;
+      description?: string;
+      harness?: string;
+      input: AgentBundleInput;
+    }
+  | { kind: "imported"; name: string; bundle: File };
 
 // Hidden from the new-session picker only. `nessie` is superseded by polly.
 // `kimi` / `kimi-code` are the headless SDK harness (kept for sub-agent / `run
@@ -1255,6 +1272,7 @@ function AgentHarnessPicker({
   pendingAgentId,
   onSelectPending,
   onCreateCustomAgent,
+  onImportConfig,
   permissionMode,
   approvalMode,
   cursorExecMode,
@@ -1278,10 +1296,11 @@ function AgentHarnessPicker({
   hasAgents: boolean;
   host: Host | undefined | null;
   onSelectAgent: (agent: AvailableAgent) => void;
-  pendingAgent: AgentBundleInput | null;
+  pendingAgent: PendingAgent | null;
   pendingAgentId: string;
   onSelectPending: () => void;
   onCreateCustomAgent: () => void;
+  onImportConfig: () => void;
   permissionMode: string;
   approvalMode: string;
   cursorExecMode: string;
@@ -1663,14 +1682,33 @@ function AgentHarnessPicker({
                 </div>
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem
-              data-testid="new-chat-landing-create-agent"
-              onSelect={onCreateCustomAgent}
-              className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
-            >
-              <PlusIcon className="size-3.5" />
-              Create custom agent
-            </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger
+                data-testid="new-chat-landing-add-agent"
+                className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
+              >
+                <PlusIcon className="size-3.5" />
+                Custom Agent
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="min-w-56 max-w-[calc(100vw-2rem)] p-1">
+                <DropdownMenuItem
+                  data-testid="new-chat-landing-create-agent"
+                  onSelect={onCreateCustomAgent}
+                  className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
+                >
+                  <PlusIcon className="size-3.5" />
+                  Configure Manually
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  data-testid="new-chat-landing-import-agent"
+                  onSelect={onImportConfig}
+                  className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
+                >
+                  <FolderInputIcon className="size-3.5" />
+                  Import Config
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
           </>
         )}
       </DropdownMenuContent>
@@ -1747,7 +1785,8 @@ export function NewChatLandingScreen() {
   // form submit, handleCreate detects the pending bundle, builds the
   // tar.gz, and uses multipart POST instead of the normal JSON path.
   const [createAgentOpen, setCreateAgentOpen] = useState(false);
-  const [pendingAgent, setPendingAgent] = useState<AgentBundleInput | null>(null);
+  const [importAgentOpen, setImportAgentOpen] = useState(false);
+  const [pendingAgent, setPendingAgent] = useState<PendingAgent | null>(null);
   // Sentinel id for the pending custom agent in the picker dropdown.
   const PENDING_AGENT_ID = "__pending_custom_agent__";
 
@@ -2115,8 +2154,9 @@ export function NewChatLandingScreen() {
             id: PENDING_AGENT_ID,
             name: pendingAgent.name,
             display_name: pendingAgent.name,
-            description: pendingAgent.description ?? null,
-            harness: pendingAgent.harness ?? null,
+            description:
+              pendingAgent.kind === "created" ? (pendingAgent.description ?? null) : null,
+            harness: pendingAgent.kind === "created" ? (pendingAgent.harness ?? null) : null,
             skills: [],
           } satisfies AvailableAgent)
         : agentList.find((a) => a.id === effectiveAgentId),
@@ -2617,7 +2657,12 @@ export function NewChatLandingScreen() {
         // NOT launch a runner on the host. We must follow up with launchRunner
         // (POST /v1/hosts/{id}/runners) to bind the session to a runner, the
         // same way the fork-resume path does.
-        const bundle = await buildAgentBundle(pendingAgent);
+        // Created agents build their bundle from form fields at create time;
+        // imported agents already carry the packed bundle from the picker.
+        const bundle =
+          pendingAgent.kind === "imported"
+            ? pendingAgent.bundle
+            : await buildAgentBundle(pendingAgent.input);
         const metadata: Record<string, unknown> = {};
         if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
         data = await createBundledSession(
@@ -2639,6 +2684,10 @@ export function NewChatLandingScreen() {
         }
         // Clear pending agent after successful creation.
         setPendingAgent(null);
+        // The picker discovers custom agents by scanning sessions; refresh
+        // that cache so the just-run agent appears without waiting out the
+        // query's staleTime.
+        void queryClient.invalidateQueries({ queryKey: ["available-agents"] });
       } else {
         // Normal path: bind to an existing registered agent.
         const res = await authenticatedFetch("/v1/sessions", {
@@ -3093,6 +3142,7 @@ export function NewChatLandingScreen() {
                   pendingAgentId={PENDING_AGENT_ID}
                   onSelectPending={handleSelectPending}
                   onCreateCustomAgent={() => setCreateAgentOpen(true)}
+                  onImportConfig={() => setImportAgentOpen(true)}
                   permissionMode={permissionMode}
                   approvalMode={approvalMode}
                   cursorExecMode={cursorExecMode}
@@ -3685,7 +3735,22 @@ export function NewChatLandingScreen() {
         open={createAgentOpen}
         onOpenChange={setCreateAgentOpen}
         onCreate={(input) => {
-          setPendingAgent(input);
+          setPendingAgent({
+            kind: "created",
+            name: input.name,
+            description: input.description,
+            harness: input.harness,
+            input,
+          });
+          setPickedAgentId(PENDING_AGENT_ID);
+          setPickedHarness(null);
+        }}
+      />
+      <ImportAgentDialog
+        open={importAgentOpen}
+        onOpenChange={setImportAgentOpen}
+        onImport={(agent: ImportedAgent) => {
+          setPendingAgent({ kind: "imported", name: agent.name, bundle: agent.bundle });
           setPickedAgentId(PENDING_AGENT_ID);
           setPickedHarness(null);
         }}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Change allows Omnigent user to import a custom agent config through the web UI and desktop app, bringing the desktop app customization more closer to the customization possible through the `omni run` terminal command
- Adds an **"Import Config"** entry point alongside the manual create form so users can start a custom agent from an existing YAML spec or a whole config folder (`config.yaml` + `AGENTS.md` + `skills/…`) instead of retyping it.
- The picker's "Create custom agent" row becomes a submenu: **Configure Manually** and **Import Config**. Import opens a dialog with native file/folder pickers; picked files are packed verbatim (no YAML parsing, no `${VAR}` expansion) into the same `.tar.gz` the multipart session-create endpoint already accepts. Browser and Electron share the picker path.
- Validation happens **on pick** via a server-side preflight, `POST /v1/sessions/validate-bundle`, that runs the same `validate_agent_bundle` as the bundled-create path (same `expand_env` / handler-allowlist flags) without storing anything — so "config is loaded" can never green-light a bundle that create would reject. Submit reuses the already-validated bundle (no re-pack, no re-validate).
- Feature is disabled for iOS and Android distribution of Omnigent

## Test Plan

- `web/src/shell/ImportAgentDialog.test.tsx` — dialog states: validating, success (Import enabled), failure (inline server message, Import disabled).
- `web/src/lib/agentBundle.test.ts` / `sessionsApi.test.ts` — bundle packing and the validate-bundle API client.
- `tests/server/integration/test_sessions_validate_bundle.py` — the preflight endpoint runs the same validation as bundled create and stores nothing.
- Manual: imported a valid config folder and a single YAML (both browser and Electron), plus an intentionally-invalid `config.yaml` to confirm Import stays disabled with the server's message inline.

## Demo

<!-- TODO: attach screen recording of the Import Config flow (submenu → dialog → validating → loaded → import). -->
Entry Point:
<img width="1768" height="742" alt="image" src="https://github.com/user-attachments/assets/e44ed279-eb0c-4459-bfb9-3ba8c26c9642" />
<img width="992" height="604" alt="image" src="https://github.com/user-attachments/assets/5cf6308c-4987-4cd1-a753-e55ba319860e" />

Upload examples using configs that DOES comply with AGENT_SPEC:
<img width="940" height="715" alt="image" src="https://github.com/user-attachments/assets/35b02aeb-2c48-4862-ac7e-c44a500fcc57" />
<img width="984" height="755" alt="image" src="https://github.com/user-attachments/assets/edd8c0ae-94cf-497d-807f-d9fc380df221" />

Upload examples using configs that DOES NOT comply with AGENT_SPEC (import button no longer clickable, user must fix the error first):
<img width="928" height="696" alt="image" src="https://github.com/user-attachments/assets/190e8c78-8708-4915-80b6-c2423b700f5d" />
<img width="926" height="716" alt="image" src="https://github.com/user-attachments/assets/e0452614-c927-4a88-92ef-6f1fe4061a92" />

Example of uploaded agent running, where upload with folder works:
<img width="1002" height="1159" alt="image" src="https://github.com/user-attachments/assets/629af83d-68d0-4e8c-af90-a02d159001c8" />

Agent uploaded is saved on the agent picker for future usage:
<img width="1118" height="520" alt="image" src="https://github.com/user-attachments/assets/808c4731-a594-469d-a95e-06bc8847c786" />

Polly agent configuration uploaded through the UI is also saved in the agent picker for future usage:
<img width="550" height="651" alt="image" src="https://github.com/user-attachments/assets/f2aabc1c-4c0d-4ab2-ab4b-10655e6cd595" />
 

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the full Import Config flow in both browser and Electron: valid folder import, single-YAML import, and an invalid `config.yaml` or folder content that keeps Import disabled with the server's validation message shown inline.
