### PR TITLE
fix(runtime): orphan sweep honors best-effort on unreadable entries

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1465,13 +1465,35 @@ class HarnessProcessManager:
         """
         if not self._tmp_parent.exists():
             return
-        for child in self._tmp_parent.iterdir():
-            if not child.is_dir() or not child.name.startswith("ap-"):
-                continue
-            sentinel = child / _AP_PID_FILE
-            if not sentinel.exists():
-                # No sentinel — directory either pre-dates the
-                # convention or is mid-creation. Leave alone.
+        try:
+            children = list(self._tmp_parent.iterdir())
+        except OSError as exc:
+            # Multi-tenant same-host case: the parent can belong to
+            # another user and be unreadable. Boot proceeds without a
+            # sweep rather than crashing the runner.
+            _logger.warning(
+                "cannot enumerate %s for the orphan sweep: %s; skipping sweep",
+                self._tmp_parent,
+                exc,
+            )
+            return
+        for child in children:
+            try:
+                if not child.is_dir() or not child.name.startswith("ap-"):
+                    continue
+                sentinel = child / _AP_PID_FILE
+                if not sentinel.exists():
+                    # No sentinel — directory either pre-dates the
+                    # convention or is mid-creation. Leave alone.
+                    continue
+            except OSError as exc:
+                # A foreign sibling stats as EACCES; a dir vanishing
+                # mid-inspection as ENOENT. Skip it, keep sweeping.
+                _logger.warning(
+                    "cannot inspect %s during the orphan sweep: %s; skipping",
+                    child,
+                    exc,
+                )
                 continue
             try:
                 pid_str = sentinel.read_text(encoding="utf-8").strip()

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1463,14 +1463,21 @@ class HarnessProcessManager:
         Best-effort throughout — a permission error or unreadable
         sentinel logs and skips the dir rather than aborting boot.
         """
-        if not self._tmp_parent.exists():
+        try:
+            if not self._tmp_parent.exists():
+                return
+        except OSError as exc:
+            _logger.warning(
+                "cannot access %s for the orphan sweep: %s; skipping sweep",
+                self._tmp_parent,
+                exc,
+            )
             return
         try:
             children = list(self._tmp_parent.iterdir())
         except OSError as exc:
-            # Multi-tenant same-host case: the parent can belong to
-            # another user and be unreadable. Boot proceeds without a
-            # sweep rather than crashing the runner.
+            # A configured shared parent can be unreadable. Boot proceeds
+            # without a sweep rather than crashing the runner.
             _logger.warning(
                 "cannot enumerate %s for the orphan sweep: %s; skipping sweep",
                 self._tmp_parent,
@@ -1483,11 +1490,11 @@ class HarnessProcessManager:
                     continue
                 sentinel = child / _AP_PID_FILE
                 if not sentinel.exists():
-                    # No sentinel — directory either pre-dates the
+                    # No sentinel: directory either pre-dates the
                     # convention or is mid-creation. Leave alone.
                     continue
             except OSError as exc:
-                # A foreign sibling stats as EACCES; a dir vanishing
+                # An inaccessible sibling stats as EACCES; a dir vanishing
                 # mid-inspection as ENOENT. Skip it, keep sweeping.
                 _logger.warning(
                     "cannot inspect %s during the orphan sweep: %s; skipping",

--- a/tests/e2e/test_orphan_sweep_unreadable_tmp_parent_e2e.py
+++ b/tests/e2e/test_orphan_sweep_unreadable_tmp_parent_e2e.py
@@ -1,0 +1,265 @@
+"""
+End-to-end regression: the boot-time orphan sweep must not abort
+``omnigent server`` startup when the harness tmp parent (or an entry
+inside it) is unreadable.
+
+``HarnessProcessManager._sweep_orphans()`` documents best-effort cleanup:
+an inaccessible path should log and skip rather than abort runner boot.
+Without ``OSError`` guards on the metadata operations around the sentinel
+read — ``self._tmp_parent.exists()`` / ``iterdir()`` and ``child.is_dir()``
+/ ``sentinel.exists()`` — a ``PermissionError`` propagates straight out of
+``start()``, which the server lifespan awaits, so uvicorn logs
+"Application startup failed. Exiting." and the whole ``omnigent server``
+process dies.
+
+The user journey guarded here (both facets):
+
+1. operator points ``OMNIGENT_HARNESS_TMP_PARENT`` at a shared directory
+   whose contents they cannot fully read (another Unix user's entries, a
+   broken ACL, a filesystem race);
+2. operator runs ``omnigent server``;
+3. boot crashes with ``PermissionError`` from ``_sweep_orphans`` instead
+   of warning, skipping the unreadable scope, and serving.
+
+Two staged filesystem shapes cover the two unguarded surfaces:
+
+- **unlistable parent** — the parent is mode ``0o333`` (creatable but not
+  listable, exactly what a non-owner sees on a ``0o700``-style shared
+  parent); ``iterdir()`` raises.
+- **inaccessible child** — the parent is listable but contains a mode
+  ``0o000`` ``ap-*`` sibling; ``(child / "AP_PID").exists()`` raises.
+
+Each test boots a REAL ``omnigent server`` subprocess through the CLI (the
+same command a user runs) and asserts the server reaches ``/health``.
+Without the sweep's ``OSError`` guards both tests fail with the process
+exiting early and the ``PermissionError`` traceback in its log. The
+child-facet test additionally asserts that a readable dead orphan sibling
+still gets swept, guarding the "readable dead-orphan cleanup remains
+unchanged" clause of the expected behavior.
+
+Permission-bit staging is meaningless as root or on Windows, hence the
+skips.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A failing boot dies in a few seconds; a healthy boot serves /health well
+# under this ceiling even on a contended CI box.
+_HEALTH_TIMEOUT_S = 60.0
+_POLL_INTERVAL_S = 0.2
+
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX permission-bit staging; Windows ACLs need a different setup.",
+    ),
+    pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses permission bits, so the unreadable staging is inert.",
+    ),
+]
+
+
+def _find_free_port() -> int:
+    """Pick a free TCP port for the server subprocess to bind."""
+    s = socket.socket()
+    s.bind(("", 0))
+    port: int = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _server_env(tmp_parent: Path, home: Path) -> dict[str, str]:
+    """
+    Environment for the ``omnigent server`` subprocess.
+
+    Points the harness tmp parent at the staged directory, forces imports
+    from this worktree, and strips every ambient ``OMNIGENT_*`` var so a
+    test run that is itself hosted inside an Omnigent runner doesn't leak
+    zygote fds, tunnel tokens, or log/config/data paths into the child
+    server. ``HOME`` is redirected to a scratch dir so the child's default
+    config and log locations stay test-local.
+
+    :param tmp_parent: Value for ``OMNIGENT_HARNESS_TMP_PARENT``.
+    :param home: Scratch ``HOME`` for the child server.
+    :returns: The subprocess environment mapping.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OMNIGENT_")}
+    env.pop("RUNNER_SERVER_URL", None)
+    for var in ("DATABRICKS_TOKEN", "ANTHROPIC_API_KEY", "CODEX", "CLAUDE_CODE"):
+        env.pop(var, None)
+    env["HOME"] = str(home)
+    env["PYTHONPATH"] = f"{_REPO_ROOT}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    # Startup constructs an LLM client; a stub satisfies the env check.
+    env["OPENAI_API_KEY"] = "stub-not-used"
+    env["OMNIGENT_HARNESS_TMP_PARENT"] = str(tmp_parent)
+    return env
+
+
+def _boot_server_and_wait_health(
+    tmp_parent: Path, tmp_path: Path
+) -> Iterator[tuple[subprocess.Popen[bytes], str, Path]]:
+    """
+    Start ``omnigent server`` with *tmp_parent* configured and wait for
+    ``/health``.
+
+    Yields once with ``(proc, outcome, log_path)`` where *outcome* is
+    ``"healthy"``, ``"exited"`` (the startup abort this bug produces), or
+    ``"timeout"``. Generator form so callers get teardown via ``finally``.
+
+    :param tmp_parent: The staged harness tmp parent.
+    :param tmp_path: Per-test scratch dir for db/artifacts/log.
+    """
+    port = _find_free_port()
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    log_path = tmp_path / "server.log"
+    log_handle = open(log_path, "w")  # noqa: SIM115 — subprocess holds the FD
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omnigent.cli",
+            "server",
+            "--port",
+            str(port),
+            "--database-uri",
+            f"sqlite:///{tmp_path / 'e2e.db'}",
+            "--artifact-location",
+            str(artifact_dir),
+        ],
+        env=_server_env(tmp_parent, home_dir),
+        cwd=str(_REPO_ROOT),
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+    )
+    outcome = "timeout"
+    try:
+        deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                outcome = "exited"
+                break
+            try:
+                # trust_env=False: CI shells force an HTTP proxy that
+                # intercepts even localhost, failing the probe spuriously.
+                resp = httpx.get(
+                    f"http://127.0.0.1:{port}/health",
+                    timeout=2.0,
+                    trust_env=False,
+                )
+                if resp.status_code == 200:
+                    outcome = "healthy"
+                    break
+            except httpx.HTTPError:
+                pass
+            time.sleep(_POLL_INTERVAL_S)
+        yield proc, outcome, log_path
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5.0)
+        log_handle.close()
+
+
+def _assert_boot_survived(outcome: str, log_path: Path) -> None:
+    """
+    Fail with the server log's abort evidence when boot did not survive.
+
+    :param outcome: ``"healthy"`` / ``"exited"`` / ``"timeout"`` from
+        :func:`_boot_server_and_wait_health`.
+    :param log_path: The captured server stdout/stderr log.
+    """
+    if outcome == "healthy":
+        return
+    log_text = log_path.read_text() if log_path.exists() else ""
+    pytest.fail(
+        "omnigent server boot did not survive the orphan sweep over an "
+        f"unreadable harness tmp parent scope (outcome={outcome}). The sweep "
+        "must warn and skip inaccessible entries, not abort startup.\n"
+        f"Server log tail:\n{log_text[-4000:]}"
+    )
+
+
+def test_server_boot_survives_unlistable_tmp_parent(tmp_path: Path) -> None:
+    """
+    Facet 1 — parent enumeration: an ``OMNIGENT_HARNESS_TMP_PARENT`` that
+    exists but cannot be listed (mode ``0o333``, the non-owner view of a
+    shared parent) must not abort ``omnigent server`` startup.
+
+    Without the guard, ``_sweep_orphans``'s ``self._tmp_parent.iterdir()``
+    raises ``PermissionError``, the server lifespan aborts, and the
+    process exits before ever serving ``/health``.
+    """
+    parent = tmp_path / "shared"
+    parent.mkdir(mode=0o700)
+    (parent / "ap-foreign").mkdir(mode=0o700)
+    parent.chmod(0o333)  # creatable but not listable
+    boot = _boot_server_and_wait_health(parent, tmp_path)
+    try:
+        _proc, outcome, log_path = next(boot)
+        _assert_boot_survived(outcome, log_path)
+    finally:
+        boot.close()
+        # Restore modes so pytest's tmp_path cleanup can remove the tree.
+        parent.chmod(0o700)
+
+
+def test_server_boot_survives_inaccessible_ap_sibling(tmp_path: Path) -> None:
+    """
+    Facet 2 — child inspection: a listable parent containing a mode
+    ``0o000`` ``ap-*`` sibling (another user's instance dir, a broken ACL)
+    must not abort startup, and a READABLE dead orphan alongside it must
+    still get swept.
+
+    Without the guard, ``(child / "AP_PID").exists()`` raises
+    ``PermissionError`` on the inaccessible sibling and boot dies before
+    the readable orphan is even considered.
+    """
+    parent = tmp_path / "shared"
+    parent.mkdir(mode=0o700)
+    blocked = parent / "ap-foreign"
+    blocked.mkdir(mode=0o700)
+    (blocked / "AP_PID").write_text("999999", encoding="utf-8")
+    blocked.chmod(0o000)  # inaccessible sibling: sentinel probes raise
+    # A readable dead orphan: sorts after "ap-foreign" so the sweep hits the
+    # blocked sibling first on ordered filesystems; PID 2**22+5 is above
+    # every real pid_max default, so it is reliably not alive.
+    dead = parent / "ap-orphan-dead"
+    dead.mkdir(mode=0o700)
+    (dead / "AP_PID").write_text(str(2**22 + 5), encoding="utf-8")
+    boot = _boot_server_and_wait_health(parent, tmp_path)
+    try:
+        _proc, outcome, log_path = next(boot)
+        _assert_boot_survived(outcome, log_path)
+        # Best-effort contract's other half: the readable dead orphan was
+        # cleaned even though a sibling was unreadable.
+        assert not dead.exists(), (
+            "readable dead orphan dir survived the sweep; skipping the "
+            "unreadable sibling must not skip readable cleanup"
+        )
+        # The unreadable sibling itself is preserved (we cannot prove it is
+        # dead), not clobbered.
+        assert blocked.exists()
+    finally:
+        boot.close()
+        blocked.chmod(0o700)

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -936,10 +936,9 @@ async def test_orphan_sweep_survives_unreadable_tmp_parent(
 ) -> None:
     """An unreadable tmp_parent must not abort manager startup.
 
-    Multi-tenant same-host case: the shared parent can belong to
-    another user and be unreadable to us. ``iterdir()`` then raises
-    PermissionError -- the documented best-effort contract is to log
-    and proceed with boot, not crash the runner.
+    A configured shared parent can be unreadable. ``iterdir()`` then
+    raises PermissionError; the documented best-effort contract is to
+    log and proceed with boot instead of crashing the runner.
     """
     if os.geteuid() == 0:
         pytest.skip("permission checks do not apply to root")
@@ -947,8 +946,7 @@ async def test_orphan_sweep_survives_unreadable_tmp_parent(
     locked_parent.mkdir(mode=0o700)
     (locked_parent / "ap-unreachable").mkdir(mode=0o700)
     # Write+search without read: our own instance dir can be created,
-    # but the sweep cannot enumerate the parent (EACCES on iterdir) --
-    # the shape of a shared parent owned by another user.
+    # but the sweep cannot enumerate the configured shared parent.
     locked_parent.chmod(0o333)
     manager = HarnessProcessManager(tmp_parent=locked_parent)
     try:
@@ -964,12 +962,42 @@ async def test_orphan_sweep_survives_unreadable_tmp_parent(
             await manager.shutdown()
 
 
+async def test_orphan_sweep_survives_tmp_parent_stat_error(
+    short_tmp_parent: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A tmp-parent stat race must not abort manager startup."""
+    real_exists = Path.exists
+    raised = False
+
+    def _racy_exists(self: Path) -> bool:
+        nonlocal raised
+        if self == short_tmp_parent and not raised:
+            raised = True
+            raise OSError("tmp parent changed during sweep")
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", _racy_exists)
+    manager = HarnessProcessManager(tmp_parent=short_tmp_parent)
+    try:
+        await manager.start()
+        assert manager.instance_dir.exists()
+        assert any(
+            "cannot access" in record.getMessage() and str(short_tmp_parent) in record.getMessage()
+            for record in caplog.records
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            await manager.shutdown()
+
+
 @pytest.mark.posix_only
 async def test_orphan_sweep_skips_unreadable_sibling_and_still_sweeps(
     short_tmp_parent: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A foreign, unreadable ``ap-*`` sibling is skipped, not fatal.
+    """An inaccessible ``ap-*`` sibling is skipped, not fatal.
 
     Plants one mode-0000 sibling (stat of its sentinel raises
     PermissionError) and one readable dead-PID orphan. The sweep must
@@ -978,10 +1006,10 @@ async def test_orphan_sweep_skips_unreadable_sibling_and_still_sweeps(
     """
     if os.geteuid() == 0:
         pytest.skip("permission checks do not apply to root")
-    foreign = short_tmp_parent / "ap-foreignuser"
-    foreign.mkdir(mode=0o700)
-    (foreign / _AP_PID_FILE).write_text("99999999", encoding="utf-8")
-    foreign.chmod(0o000)
+    inaccessible = short_tmp_parent / "ap-inaccessible"
+    inaccessible.mkdir(mode=0o700)
+    (inaccessible / _AP_PID_FILE).write_text("99999999", encoding="utf-8")
+    inaccessible.chmod(0o000)
 
     dead = short_tmp_parent / "ap-deadsibling"
     dead.mkdir(mode=0o700)
@@ -994,15 +1022,15 @@ async def test_orphan_sweep_skips_unreadable_sibling_and_still_sweeps(
     manager = HarnessProcessManager(tmp_parent=short_tmp_parent)
     try:
         await manager.start()
-        assert foreign.exists(), "unreadable sibling must be skipped, not removed"
+        assert inaccessible.exists(), "unreadable sibling must be skipped, not removed"
         assert not dead.exists(), "readable dead orphan must still be swept"
         assert live.exists(), "live sibling must remain untouched"
         assert any(
-            "cannot inspect" in record.getMessage() and str(foreign) in record.getMessage()
+            "cannot inspect" in record.getMessage() and str(inaccessible) in record.getMessage()
             for record in caplog.records
         )
     finally:
-        foreign.chmod(0o700)
+        inaccessible.chmod(0o700)
         with contextlib.suppress(Exception):
             await manager.shutdown()
 

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -932,6 +932,7 @@ async def test_orphan_sweep_preserves_live_omnigent_dirs(
 @pytest.mark.posix_only
 async def test_orphan_sweep_survives_unreadable_tmp_parent(
     short_tmp_parent: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """An unreadable tmp_parent must not abort manager startup.
 
@@ -953,6 +954,10 @@ async def test_orphan_sweep_survives_unreadable_tmp_parent(
     try:
         # Before the fix this raised PermissionError out of start().
         await manager.start()
+        assert any(
+            "cannot enumerate" in record.getMessage() and str(locked_parent) in record.getMessage()
+            for record in caplog.records
+        )
     finally:
         locked_parent.chmod(0o700)
         with contextlib.suppress(Exception):
@@ -962,6 +967,7 @@ async def test_orphan_sweep_survives_unreadable_tmp_parent(
 @pytest.mark.posix_only
 async def test_orphan_sweep_skips_unreadable_sibling_and_still_sweeps(
     short_tmp_parent: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A foreign, unreadable ``ap-*`` sibling is skipped, not fatal.
 
@@ -991,6 +997,10 @@ async def test_orphan_sweep_skips_unreadable_sibling_and_still_sweeps(
         assert foreign.exists(), "unreadable sibling must be skipped, not removed"
         assert not dead.exists(), "readable dead orphan must still be swept"
         assert live.exists(), "live sibling must remain untouched"
+        assert any(
+            "cannot inspect" in record.getMessage() and str(foreign) in record.getMessage()
+            for record in caplog.records
+        )
     finally:
         foreign.chmod(0o700)
         with contextlib.suppress(Exception):

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -929,6 +929,109 @@ async def test_orphan_sweep_preserves_live_omnigent_dirs(
         await fresh.shutdown()
 
 
+@pytest.mark.posix_only
+async def test_orphan_sweep_survives_unreadable_tmp_parent(
+    short_tmp_parent: Path,
+) -> None:
+    """An unreadable tmp_parent must not abort manager startup.
+
+    Multi-tenant same-host case: the shared parent can belong to
+    another user and be unreadable to us. ``iterdir()`` then raises
+    PermissionError -- the documented best-effort contract is to log
+    and proceed with boot, not crash the runner.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("permission checks do not apply to root")
+    locked_parent = short_tmp_parent / "fp"
+    locked_parent.mkdir(mode=0o700)
+    (locked_parent / "ap-unreachable").mkdir(mode=0o700)
+    # Write+search without read: our own instance dir can be created,
+    # but the sweep cannot enumerate the parent (EACCES on iterdir) --
+    # the shape of a shared parent owned by another user.
+    locked_parent.chmod(0o333)
+    manager = HarnessProcessManager(tmp_parent=locked_parent)
+    try:
+        # Before the fix this raised PermissionError out of start().
+        await manager.start()
+    finally:
+        locked_parent.chmod(0o700)
+        with contextlib.suppress(Exception):
+            await manager.shutdown()
+
+
+@pytest.mark.posix_only
+async def test_orphan_sweep_skips_unreadable_sibling_and_still_sweeps(
+    short_tmp_parent: Path,
+) -> None:
+    """A foreign, unreadable ``ap-*`` sibling is skipped, not fatal.
+
+    Plants one mode-0000 sibling (stat of its sentinel raises
+    PermissionError) and one readable dead-PID orphan. The sweep must
+    skip the former, still remove the latter, and leave a live
+    sibling untouched.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("permission checks do not apply to root")
+    foreign = short_tmp_parent / "ap-foreignuser"
+    foreign.mkdir(mode=0o700)
+    (foreign / _AP_PID_FILE).write_text("99999999", encoding="utf-8")
+    foreign.chmod(0o000)
+
+    dead = short_tmp_parent / "ap-deadsibling"
+    dead.mkdir(mode=0o700)
+    (dead / _AP_PID_FILE).write_text("99999999", encoding="utf-8")
+
+    live = short_tmp_parent / "ap-livesibling"
+    live.mkdir(mode=0o700)
+    (live / _AP_PID_FILE).write_text(str(os.getpid()), encoding="utf-8")
+
+    manager = HarnessProcessManager(tmp_parent=short_tmp_parent)
+    try:
+        await manager.start()
+        assert foreign.exists(), "unreadable sibling must be skipped, not removed"
+        assert not dead.exists(), "readable dead orphan must still be swept"
+        assert live.exists(), "live sibling must remain untouched"
+    finally:
+        foreign.chmod(0o700)
+        with contextlib.suppress(Exception):
+            await manager.shutdown()
+
+
+async def test_orphan_sweep_treats_vanishing_child_as_benign_race(
+    short_tmp_parent: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A child that disappears mid-inspection does not abort the sweep.
+
+    Simulates the vanish race by making ``is_dir`` raise
+    FileNotFoundError for one planted child; the sweep must continue
+    and still remove a later dead orphan.
+    """
+    vanishing = short_tmp_parent / "ap-avanishing"
+    vanishing.mkdir(mode=0o700)
+    (vanishing / _AP_PID_FILE).write_text("99999999", encoding="utf-8")
+    dead = short_tmp_parent / "ap-zzdead"
+    dead.mkdir(mode=0o700)
+    (dead / _AP_PID_FILE).write_text("99999999", encoding="utf-8")
+
+    real_is_dir = Path.is_dir
+
+    def _racy_is_dir(self: Path, **kwargs: object) -> bool:
+        if self.name == "ap-avanishing":
+            raise FileNotFoundError(2, "vanished mid-sweep", str(self))
+        return real_is_dir(self, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "is_dir", _racy_is_dir)
+    manager = HarnessProcessManager(tmp_parent=short_tmp_parent)
+    try:
+        await manager.start()
+        assert not dead.exists(), "sweep must continue past the racy child"
+    finally:
+        monkeypatch.undo()
+        with contextlib.suppress(Exception):
+            await manager.shutdown()
+
+
 # ── Helper-level tests (small, fast) ───────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Fixes #2404

## Summary

- `HarnessProcessManager._sweep_orphans()` now treats `OSError` from checking or enumerating the temporary parent, inspecting a child, and reading its sentinel as best-effort failures. It logs and skips the inaccessible scope instead of aborting runner startup.
- Merged PR #1923 made `/tmp/omnigent-<uid>` the normal POSIX default. The remaining surfaces are an explicitly shared `OMNIGENT_HARNESS_TMP_PARENT`, inaccessible entries within one UID's parent, and filesystem races where the parent or a child changes during inspection.
- Readable dead orphans are still removed, while live siblings and entries without a readable sentinel are still preserved.

## Test Plan

Failing first on the rebased candidate before the new parent-stat guard:

- `test_orphan_sweep_survives_tmp_parent_stat_error`: `1 failed in 0.14s` because `self._tmp_parent.exists()` propagated `OSError` from `start()`.

Current focused results:

- `pytest tests/runtime/harnesses/test_process_manager.py -k orphan_sweep -q`: `7 passed, 36 deselected in 0.50s`.
- `pytest tests/runtime/harnesses/test_process_manager.py -q`: `43 passed in 25.12s`.
- `pre-commit run --all-files`: all hooks passed.

## Demo

N/A - non-visual runtime change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused suite covers parent existence and enumeration failures, inaccessible child inspection, child disappearance races, dead-orphan removal, live-sibling preservation, and SIGTERM-to-SIGKILL escalation.

## Changelog

A runner now continues starting when its orphan sweep cannot inspect the harness temporary parent or one of its entries.

## Issues

Resolves [OMNI-1508](https://linear.app/omnigent/issue/OMNI-1508/fixruntime-orphan-sweep-can-abort-startup-on-unreadable-shared-host)
