### PR TITLE
fix: advertise web_search on claude-sdk sessions (gate passthrough on harness) (#2071)

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -1,7 +1,9 @@
 # Fork-only workflow (bobbyhyam/omnigent). Builds + pushes the Omnigent
-# SERVER image to our fork's GHCR package on every push to a dev/* branch
-# (and on manual dispatch), so the homelab `omnigent-dev` stack can pin a
-# fork-built image to test upstream fix branches before we PR them upstream.
+# SERVER image to our fork's GHCR package on every push to `main` and to a
+# dev/* branch (and on manual dispatch), so the homelab `omnigent-dev` stack
+# can pin a fork-built image: `main` tracks current upstream (kept in sync by
+# the omni-ops #40 fork-sync timer), dev/* carries fix branches we test before
+# PRing them upstream.
 #
 #   ghcr.io/bobbyhyam/omnigent:sha-<short>   immutable per-commit pin
 #
@@ -25,6 +27,11 @@ name: Build dev server image (fork)
 on:
   push:
     branches:
+      # main: the fork-sync timer (omni-ops #40) force-pushes main = upstream
+      # main + this fork CI each day, so a current sha-<short> image always
+      # exists for the omnigent-dev stack to pin without a manual dispatch.
+      - main
+      # dev/**: fix branches under test before we PR them upstream.
       - 'dev/**'
   workflow_dispatch:
 

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -1,0 +1,79 @@
+# Fork-only workflow (bobbyhyam/omnigent). Builds + pushes the Omnigent
+# SERVER image to our fork's GHCR package on every push to a dev/* branch
+# (and on manual dispatch), so the homelab `omnigent-dev` stack can pin a
+# fork-built image to test upstream fix branches before we PR them upstream.
+#
+#   ghcr.io/bobbyhyam/omnigent:sha-<short>   immutable per-commit pin
+#
+# This mirrors how UPSTREAM builds the server image we run in prod
+# (.github/workflows/oss-publish-images.yml -> the default/final target of
+# deploy/docker/Dockerfile; the Dockerfile ARGs default to public registries,
+# so no build-args are needed). We build ONLY the server image (not the host
+# image or the openshell variant) and ONLY linux/amd64 (nas1 is amd64) to keep
+# fork builds fast and cheap.
+#
+# Auth to GHCR is the built-in GITHUB_TOKEN (same pattern as
+# bobbyhyam/omnigent-orchestrator's publish-image.yml). First run creates the
+# ghcr.io/bobbyhyam/omnigent package PRIVATE; nas1 pulls it via the existing
+# ghcr_pull_token docker_login in homelab's compose-deploy role (the same path
+# the private orchestrator image uses).
+#
+# Gated to the fork by `if: github.repository == 'bobbyhyam/omnigent'` so this
+# file is inert if it ever lands in an upstream PR.
+name: Build dev server image (fork)
+
+on:
+  push:
+    branches:
+      - 'dev/**'
+  workflow_dispatch:
+
+# Read-only at the top level; the job requests packages:write to push to GHCR.
+permissions:
+  contents: read
+
+concurrency:
+  # Key by SHA so back-to-back pushes each build; don't cancel mid-push.
+  group: dev-image-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    if: github.repository == 'bobbyhyam/omnigent'
+    permissions:
+      contents: read
+      packages: write # push the image to GHCR via GITHUB_TOKEN
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tag
+        id: tag
+        run: echo "tags=ghcr.io/bobbyhyam/omnigent:sha-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Server image only: the default/final target of the upstream Dockerfile
+      # (the FastAPI/WebSocket coordinator). amd64 only. No build-args: the
+      # Dockerfile ARGs default to public registries.
+      - name: Build and push server image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tag.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -33,6 +33,22 @@ PROVIDER_CONFIGS: dict[str, str | None] = {
 
 _DEFAULT_PROVIDER = "openai"
 
+# When a model string carries no ``provider/`` prefix, its provider is
+# inferred from a well-known model-name prefix (e.g. an unprefixed
+# ``claude-opus-4-8`` routes to ``anthropic``, not the ``_DEFAULT_PROVIDER``).
+# Without this, every unprefixed alias fell through to ``openai`` — which
+# mis-typed non-OpenAI models and, for example, made the OpenAI-native
+# ``web_search_preview`` passthrough leak onto a claude-sdk session (#2071).
+# Genuinely unprefixed ``gpt-*`` stays on ``openai`` via the trailing default.
+_UNPREFIXED_MODEL_PROVIDER: dict[str, str] = {
+    "claude-": "anthropic",
+    "gemini-": "gemini",
+    "grok-": "xai",
+    "deepseek-": "deepseek",
+    "databricks-": "databricks",
+    "gpt-": "openai",
+}
+
 
 @dataclass
 class RoutedModel:
@@ -52,8 +68,9 @@ def parse_model_string(model: str) -> RoutedModel:
     """
     Parse a ``"provider/model-name"`` string into its components.
 
-    If no ``"/"`` is present, the provider defaults to ``"openai"``
-    for backward compatibility.
+    If no ``"/"`` is present, the provider is inferred from a well-known
+    model-name prefix (e.g. ``"claude-"`` -> ``"anthropic"``) and otherwise
+    defaults to ``"openai"`` for backward compatibility.
 
     :param model: The model string, e.g.
         ``"anthropic/claude-sonnet-4-20250514"`` or ``"gpt-5.4"``.
@@ -64,6 +81,10 @@ def parse_model_string(model: str) -> RoutedModel:
         provider, model_name = model.split("/", 1)
     else:
         provider = _DEFAULT_PROVIDER
+        for prefix, inferred in _UNPREFIXED_MODEL_PROVIDER.items():
+            if model.startswith(prefix):
+                provider = inferred
+                break
         model_name = model
 
     if provider not in PROVIDER_CONFIGS:

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -220,6 +220,48 @@ def provider_family_for_harness(harness: str | None) -> str | None:
     return harness_family(canonical)
 
 
+# Harnesses that speak the OpenAI Responses/Assistants API and can therefore
+# honor the native ``{"type": "web_search_preview"}`` hosted-tool passthrough.
+# Deliberately narrower than the whole ``openai`` provider family: OpenAI-*wire*
+# harnesses that are not the Responses API (native CLIs, qwen, antigravity)
+# cannot consume ``web_search_preview`` and must get the function-tool schema.
+_OPENAI_WEB_SEARCH_HARNESSES: frozenset[str] = frozenset({"openai-agents", "codex"})
+
+
+def harness_supports_openai_web_search(harness: str | None, model: str | None = None) -> bool:
+    """Return whether *harness* can consume the OpenAI ``web_search_preview``.
+
+    The ``web_search`` builtin emits OpenAI's native
+    ``{"type": "web_search_preview"}`` passthrough only when the session's
+    harness actually speaks the OpenAI Responses API (``openai-agents`` or
+    ``codex``); on any other harness — notably ``claude-sdk`` — the passthrough
+    is meaningless (it carries no function name, so the model is never offered
+    a callable ``web_search``) and the tool must fall back to a function-tool
+    schema. Keying on the **harness** rather than a model-string-inferred
+    provider is the correct determinant: the provider inference mis-typed
+    unprefixed aliases (e.g. ``claude-opus-4-8`` -> ``openai``) and hid
+    ``web_search`` from claude-sdk sessions (#2071).
+
+    :param harness: The agent's harness, e.g. :attr:`ExecutorSpec.harness_kind`
+        (``"claude_sdk"``, ``"codex"``, ``"omnigent"`` ...); ``None`` returns
+        ``False``.
+    :param model: The agent's model string. Consulted only when *harness* is
+        absent or the generic in-process ``"omnigent"`` executor, to recover
+        the implied harness via
+        :func:`~omnigent.llms.routing.infer_harness_from_model`.
+    :returns: ``True`` only for OpenAI-Responses-capable harnesses.
+    """
+    if not harness or harness == "omnigent":
+        from omnigent.llms.routing import infer_harness_from_model
+
+        harness = infer_harness_from_model(model or "") or harness
+    if not harness:
+        return False
+    canonical = canonicalize_harness(harness) or harness
+    canonical = _EXECUTOR_TYPE_HARNESS_ALIASES.get(canonical, canonical)
+    return canonical in _OPENAI_WEB_SEARCH_HARNESSES
+
+
 @dataclass(frozen=True)
 class FamilyConfig:
     """One provider family (``anthropic`` or ``openai``) for a harness surface.

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2535,16 +2535,19 @@ async def _execute_web_search_tool(
     runs its synchronous ``invoke`` off the event loop (the backend makes a
     blocking HTTP call).
 
-    ``llm_provider`` is inferred exactly as ``ToolManager._create_web_search``
+    ``llm_provider`` is derived exactly as ``ToolManager._create_web_search``
     does, so the dispatch path preserves the same invariants as session setup:
 
-    - **OpenAI models** keep the native ``web_search_preview`` passthrough; if a
-      ``web_search`` function call ever reached this path, ``invoke()`` raises
-      (its built-in fence) and the third-party backend is never run. In normal
-      operation OpenAI models never emit a ``web_search`` function call, so this
-      is defensive — but it keeps the promise rather than silently weakening it.
-    - **``databricks-*`` models** skip provider inference (they don't support
-      ``web_search_preview``) and run in function-tool mode.
+    - **OpenAI-Responses harnesses** (``openai-agents`` / ``codex``) keep the
+      native ``web_search_preview`` passthrough; if a ``web_search`` function
+      call ever reached this path, ``invoke()`` raises (its built-in fence) and
+      the third-party backend is never run. In normal operation those harnesses
+      never emit a ``web_search`` function call, so this is defensive — but it
+      keeps the promise rather than silently weakening it.
+    - **Every other harness** (notably ``claude-sdk``) runs in function-tool
+      mode, so ``web_search`` is advertised and dispatched here (#2071).
+    - **``databricks-*`` models** skip the passthrough (they reject
+      ``web_search_preview`` with HTTP 400) and run in function-tool mode.
 
     :param args: Parsed LLM arguments — ``query`` (required).
     :param agent_spec: Parent agent's spec; carries the web_search config + model.
@@ -2557,14 +2560,22 @@ async def _execute_web_search_tool(
     from omnigent.tools.builtins.web_search import WebSearchTool
 
     config = _web_search_config_from_spec(agent_spec)
-    # Mirror ToolManager._create_web_search's provider inference (same skip for
-    # databricks-*, same OpenAI passthrough fence) so dispatch honors session-setup invariants.
+    # Mirror ToolManager._create_web_search's harness gate (same databricks-*
+    # skip, same OpenAI passthrough fence) so dispatch honors session-setup
+    # invariants: emit the OpenAI passthrough only for OpenAI-Responses harnesses.
     llm_provider: str | None = None
-    model = getattr(getattr(agent_spec, "executor", None), "model", None)
+    executor = getattr(agent_spec, "executor", None)
+    model = getattr(executor, "model", None)
+    harness = getattr(executor, "harness_kind", None)
     if model and not model.startswith("databricks-"):
-        from omnigent.llms.routing import parse_model_string
+        from omnigent.onboarding.provider_config import (
+            harness_supports_openai_web_search,
+        )
 
-        llm_provider = parse_model_string(model).provider
+        if harness_supports_openai_web_search(harness, model):
+            from omnigent.llms.routing import parse_model_string
+
+            llm_provider = parse_model_string(model).provider
     tool = WebSearchTool(config=config, llm_provider=llm_provider)
     ctx = ToolContext(
         task_id=task_id or "web_search",

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -340,22 +340,33 @@ class ToolManager:
         """
         Build a :class:`WebSearchTool` for the parent's LLM.
 
-        Uses ``parse_model_string`` to infer the provider, except for
-        ``databricks-*`` models which don't support the native
-        ``web_search_preview`` schema and fall back to function-tool mode.
+        Emits the OpenAI-native ``web_search_preview`` passthrough only when
+        the agent's harness speaks the OpenAI Responses API
+        (``openai-agents`` / ``codex``); every other harness — and every
+        ``databricks-*`` model — falls back to function-tool mode.
 
         :param config: Spec-level tool config dict, e.g.
             ``{"api_key": "...", "engine_id": "..."}``.
         :returns: A configured :class:`WebSearchTool`.
         """
+        from omnigent.onboarding.provider_config import (
+            harness_supports_openai_web_search,
+        )
         from omnigent.tools.builtins.web_search import WebSearchTool
 
         llm_provider = None
         if self._spec.executor.model:
             model = self._spec.executor.model
-            # Databricks doesn't support web_search_preview; skip
-            # OpenAI provider inference for all databricks-* models.
-            if not model.startswith("databricks-"):
+            # The OpenAI-native ``web_search_preview`` passthrough is emitted
+            # only when the harness actually speaks the OpenAI Responses API.
+            # Keying on the harness (not a model-string-inferred provider) keeps
+            # ``web_search`` visible on claude-sdk sessions whose unprefixed
+            # alias would otherwise mis-infer as OpenAI (#2071). Databricks is
+            # excluded up front: it rides the openai wire but rejects
+            # ``web_search_preview`` with HTTP 400.
+            if not model.startswith("databricks-") and harness_supports_openai_web_search(
+                self._spec.executor.harness_kind, model
+            ):
                 from omnigent.llms.routing import parse_model_string
 
                 llm_provider = parse_model_string(model).provider

--- a/tests/llms/test_routing.py
+++ b/tests/llms/test_routing.py
@@ -74,6 +74,34 @@ def test_parse_without_prefix_defaults_to_openai() -> None:
     assert result == RoutedModel(provider="openai", model="gpt-5.4")
 
 
+@pytest.mark.parametrize(
+    ("model_string", "expected_provider"),
+    [
+        # Unprefixed vendor aliases (the strings a subscription/gateway login
+        # exposes) must infer their real provider, not fall through to openai.
+        ("claude-opus-4-8", "anthropic"),
+        ("claude-sonnet-5", "anthropic"),
+        ("gemini-2.5-flash", "gemini"),
+        ("grok-2", "xai"),
+        ("deepseek-chat", "deepseek"),
+        ("databricks-claude-sonnet-4", "databricks"),
+        # A genuinely unprefixed gpt-* stays on openai (the backward-compatible
+        # default is preserved for the one family it was actually correct for).
+        ("gpt-5.4", "openai"),
+    ],
+)
+def test_parse_without_prefix_infers_provider_from_model_prefix(
+    model_string: str,
+    expected_provider: str,
+) -> None:
+    """
+    Regression for #2071: an unprefixed ``claude-*`` (and every other
+    well-known vendor alias) must not be mis-inferred as provider ``openai``.
+    """
+    result = parse_model_string(model_string)
+    assert result == RoutedModel(provider=expected_provider, model=model_string)
+
+
 def test_unknown_provider_raises() -> None:
     with pytest.raises(OmnigentError, match="Unknown provider 'foobar'"):
         parse_model_string("foobar/some-model")

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -14,6 +14,7 @@ from omnigent.onboarding.provider_config import (
     PI_SURFACE,
     default_provider_for_harness,
     harness_family,
+    harness_supports_openai_web_search,
     load_providers,
     provider_families,
     provider_family_for_harness,
@@ -94,6 +95,44 @@ def test_provider_family_for_harness_accepts_executor_type_spellings(
     same-family (anthropic) and carries history.
     """
     assert provider_family_for_harness(harness) == expected
+
+
+@pytest.mark.parametrize(
+    ("harness", "model", "expected"),
+    [
+        # OpenAI-Responses harnesses can honor the web_search_preview passthrough.
+        ("openai-agents", "gpt-5.4", True),
+        ("agents_sdk", "gpt-5.4", True),  # executor-type spelling
+        ("codex", "gpt-5.4", True),
+        # claude-sdk cannot — even with an unprefixed alias that used to
+        # mis-infer as provider openai (#2071).
+        ("claude-sdk", "claude-opus-4-8", False),
+        ("claude_sdk", "claude-opus-4-8", False),  # executor-type spelling
+        ("claude-native", "claude-opus-4-8", False),
+        # OpenAI-*wire* but not the Responses API: must NOT get the passthrough.
+        ("qwen", "qwen-max", False),
+        ("antigravity", "gemini-2.5-pro", False),
+        # Generic in-process executor with no explicit harness: recover the
+        # implied harness from the model prefix.
+        ("omnigent", "gpt-5.4", True),
+        ("omnigent", "claude-opus-4-8", False),
+        (None, "gpt-5.4", True),
+        (None, "claude-opus-4-8", False),
+        (None, None, False),
+    ],
+)
+def test_harness_supports_openai_web_search(
+    harness: str | None, model: str | None, expected: bool
+) -> None:
+    """Gate for the OpenAI ``web_search_preview`` passthrough (#2071).
+
+    Only OpenAI-Responses-capable harnesses (``openai-agents`` / ``codex``,
+    and their executor-type spellings) may emit the passthrough; every other
+    harness — including OpenAI-wire-but-not-Responses ones like ``qwen`` /
+    ``antigravity`` — falls back to the function-tool schema so ``web_search``
+    is actually advertised to the model.
+    """
+    assert harness_supports_openai_web_search(harness, model) is expected
 
 
 def test_resolve_secret_env_ref_accepts_omnigent_prefixed_alias(

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -13,6 +13,7 @@ from omnigent.errors import OmnigentError
 from omnigent.spec.types import (
     AgentSpec,
     BuiltinToolConfig,
+    ExecutorSpec,
     LLMConfig,
     LocalToolInfo,
     MCPServerConfig,
@@ -1164,4 +1165,80 @@ def test_web_search_does_not_emit_web_search_preview_for_databricks_model() -> N
         f'web_search emitted {{"type": "web_search_preview"}} for '
         f"databricks-gpt-5-4 — Databricks does not support this tool type "
         f"and rejects the request with HTTP 400. Got schema: {schema!r}"
+    )
+
+
+def test_web_search_emits_web_search_preview_for_openai_agents_harness() -> None:
+    """
+    An OpenAI-Responses harness (``agents_sdk`` -> ``openai-agents``) with a
+    gpt-* model keeps the native ``web_search_preview`` passthrough — the
+    harness gate must not over-correct and strip it from OpenAI sessions.
+    """
+    spec = AgentSpec(
+        spec_version=1,
+        llm=LLMConfig(model="gpt-5.4"),
+        executor=ExecutorSpec(type="agents_sdk", model="gpt-5.4"),
+        tools=ToolsConfig(builtins=[BuiltinToolConfig(name="web_search")]),
+    )
+    mgr = ToolManager(spec)
+    tool = mgr.get_tool("web_search")
+
+    assert tool is not None, "web_search should be registered"
+    assert tool.get_schema() == {"type": "web_search_preview"}, (
+        "web_search must keep the OpenAI passthrough on an openai-agents harness"
+    )
+
+
+def test_web_search_does_not_emit_web_search_preview_for_claude_sdk_harness() -> None:
+    """
+    Regression for #2071: on a ``claude_sdk`` harness the ``web_search``
+    builtin must NOT emit ``{"type": "web_search_preview"}`` — even though the
+    unprefixed model alias ``claude-opus-4-8`` used to mis-infer as provider
+    ``openai``. It must fall back to a named function schema so the model is
+    actually offered a callable ``web_search``.
+    """
+    spec = AgentSpec(
+        spec_version=1,
+        llm=LLMConfig(model="claude-opus-4-8"),
+        executor=ExecutorSpec(type="claude_sdk", model="claude-opus-4-8"),
+        tools=ToolsConfig(builtins=[BuiltinToolConfig(name="web_search")]),
+    )
+    mgr = ToolManager(spec)
+    tool = mgr.get_tool("web_search")
+
+    assert tool is not None, "web_search should be registered"
+    schema = tool.get_schema()
+    assert schema.get("type") != "web_search_preview", (
+        f"web_search leaked the OpenAI passthrough onto a claude_sdk harness. "
+        f"Got schema: {schema!r}"
+    )
+    assert schema.get("function", {}).get("name") == "web_search", (
+        f"web_search must advertise a named function schema on claude_sdk. Got schema: {schema!r}"
+    )
+
+
+def test_web_search_not_preview_for_omnigent_claude_sdk_harness() -> None:
+    """
+    Regression for #2071 in our exact production shape: an ``omnigent``
+    executor whose ``config.harness`` is ``claude-sdk`` (with an unprefixed
+    ``claude-opus-4-8``) must NOT emit ``{"type": "web_search_preview"}``.
+    """
+    spec = AgentSpec(
+        spec_version=1,
+        llm=LLMConfig(model="claude-opus-4-8"),
+        executor=ExecutorSpec(
+            type="omnigent",
+            model="claude-opus-4-8",
+            config={"harness": "claude-sdk"},
+        ),
+        tools=ToolsConfig(builtins=[BuiltinToolConfig(name="web_search")]),
+    )
+    mgr = ToolManager(spec)
+    tool = mgr.get_tool("web_search")
+
+    assert tool is not None, "web_search should be registered"
+    schema = tool.get_schema()
+    assert schema.get("type") != "web_search_preview", (
+        f"web_search leaked the OpenAI passthrough onto an omnigent/claude-sdk "
+        f"harness. Got schema: {schema!r}"
     )


### PR DESCRIPTION
## Related issue

Closes #2071

## Summary

`web_search` was configured, registered, and dispatchable on a `claude-sdk`
session yet **never advertised to the model** — the agent silently answered
without searching. Two coupled causes:

1. **Provider mis-inference.** `parse_model_string` defaulted *every* unprefixed
   model string to provider `openai`, so a bare `claude-opus-4-8` (the alias a
   subscription/gateway login exposes) resolved to `openai`.
2. **Wrong schema gate.** `web_search`'s schema shape was chosen from that
   mis-inferred provider — provider `openai` ⇒ the OpenAI-native
   `{"type": "web_search_preview"}` passthrough, which carries no function name
   and so can never be offered to a claude-sdk session as a callable tool.
   `web_fetch`, whose schema is always a named function, survived — hence the
   surface looked half-wired.

This PR fixes both, keying the passthrough on the **correct determinant — the
harness** rather than a model-string-inferred provider:

- **`omnigent/llms/routing.py`** — `parse_model_string` now infers the provider
  from well-known unprefixed model prefixes (`claude-`→anthropic,
  `gemini-`→gemini, `grok-`→xai, `deepseek-`→deepseek, `databricks-`→databricks),
  leaving a genuinely unprefixed `gpt-*` on `openai` (backward-compatible).
- **`omnigent/onboarding/provider_config.py`** — new
  `harness_supports_openai_web_search(harness, model)` helper. It returns `True`
  only for OpenAI-Responses harnesses (`openai-agents` / `codex`), reusing the
  existing `canonicalize_harness` + `_EXECUTOR_TYPE_HARNESS_ALIASES` +
  `infer_harness_from_model` seams. Deliberately **narrower than the whole
  `openai` provider family**: OpenAI-*wire* harnesses that are not the Responses
  API (native CLIs, `qwen`, `antigravity`) cannot consume `web_search_preview`
  and must get the function-tool schema.
- **`omnigent/tools/manager.py`** + **`omnigent/runner/tool_dispatch.py`** — both
  the session-setup path and the runner dispatch path now gate the passthrough
  on that helper. The `databricks-*` skip (Databricks rejects
  `web_search_preview` with HTTP 400) is preserved up front.

Net: on `claude-sdk` (and every non-Responses harness) `web_search` now emits a
named function schema and is advertised + dispatched; `openai-agents` / `codex`
keep the native passthrough unchanged.

### ELI5

The tool picked its shape by guessing the vendor from the model *name*. An
unprefixed Claude model name guessed "OpenAI", so Claude got handed OpenAI's
special built-in search button — which Claude can't press. Now the shape is
picked from the actual **engine** (harness) running the model, so Claude gets a
normal, pressable search tool and OpenAI keeps its built-in one.

```
              model="claude-opus-4-8"  (no "provider/" prefix)
before:  parse_model_string -> "openai"  -> {"type":"web_search_preview"}  -> not advertised on claude-sdk ✗
after:   harness = claude-sdk (not openai-agents/codex) -> function schema  -> web_search advertised ✓
```

## Test Plan

`uv run pytest` on the touched suites (all green):

- `tests/llms/test_routing.py` — parametrized `parse_model_string` inference for
  unprefixed `claude-/gemini-/grok-/deepseek-/databricks-` aliases, with
  `gpt-5.4` still `openai`.
- `tests/onboarding/test_provider_config.py` — `harness_supports_openai_web_search`
  across `openai-agents`/`agents_sdk`/`codex` (True), `claude-sdk`/`claude_sdk`/
  `claude-native`/`qwen`/`antigravity` (False), and the `omnigent`/`None`
  model-inferred fallbacks.
- `tests/tools/test_manager.py` — `web_search` **keeps** `web_search_preview` on
  an `openai-agents` harness; **does not** emit it on `claude_sdk` nor on
  `omnigent` + `config.harness: claude-sdk` (the exact production shape from
  #2071), advertising a named `web_search` function instead.
- `tests/runner/test_web_search_local_dispatch.py` + `tests/tools/builtins/test_web_search.py`
  — unchanged, still green (passthrough fence + databricks function-mode preserved).

## Demo

N/A — backend tool-advertisement gating; no user-visible UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified against the `v0.5.1` release tag we run and current `main` (identical
in the touched files). Beyond unit tests, this reproduces the live symptom from
an external deployment: two `claude-sdk` agents (`claude-opus-4-8`,
`claude-sonnet-5`) declaring `web_search` + `web_fetch` enumerated `web_fetch`
but not `web_search`; with this change `web_search` is advertised.

Credits the harness-family gate approach in #2095 (which was CI-blocked on an
unrelated flaky presence-timing E2E test and went idle); this PR additionally
closes the latent `parse_model_string` mis-inference maintainers pointed at in
https://github.com/omnigent-ai/omnigent/issues/2071#issuecomment-4903404679.

## Changelog

`web_search` now works on Claude (and other non-OpenAI) agents whose model
alias has no provider prefix, instead of being silently unavailable.
