### PR TITLE
fix: derive sub-agent snapshot metadata from child spec

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -22468,6 +22468,12 @@ async def _get_session_snapshot(
                         agent_cache.load, agent.id, agent.bundle_location
                     )
                     spec = loaded.spec
+                    if conv.sub_agent_name:
+                        from omnigent.runtime.workflow import _find_spec_by_name
+
+                        child_spec = _find_spec_by_name(spec, conv.sub_agent_name)
+                        if child_spec is not None:
+                            spec = child_spec
                     # Prefer the spec's name over the agent row's: a
                     # switch-created session-scoped clone is named
                     # "<builtin> (switch ag_…)" for row disambiguation,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -97,6 +97,7 @@ from omnigent.harness_plugins import (
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE as _HARNESS_NOT_CONFIGURED_ERROR_CODE,
 )
+from omnigent.llms.context_window import resolve_effective_context_window
 from omnigent.model_override import validate_model_override
 from omnigent.native_coding_agents import (
     native_coding_agent_for_agent_name,
@@ -144,6 +145,7 @@ from omnigent.runtime.policies.builder import (
 )
 from omnigent.runtime.policies.engine import PolicyEngine
 from omnigent.runtime.tool_output import cap_tool_output
+from omnigent.runtime.workflow import _find_spec_by_name
 from omnigent.server import presence, session_live_state
 from omnigent.server._elicitation_registry import (
     _harness_elicitation_owners,
@@ -22469,8 +22471,6 @@ async def _get_session_snapshot(
                     )
                     spec = loaded.spec
                     if conv.sub_agent_name:
-                        from omnigent.runtime.workflow import _find_spec_by_name
-
                         child_spec = _find_spec_by_name(spec, conv.sub_agent_name)
                         if child_spec is not None:
                             spec = child_spec
@@ -22482,9 +22482,6 @@ async def _get_session_snapshot(
                     if spec.name:
                         agent_name = spec.name
                     llm_model = spec.executor.model
-                    from omnigent.llms.context_window import (
-                        resolve_effective_context_window,
-                    )
 
                     # Size the context ring against whatever the next turn will
                     # actually run, using the SAME resolver the runner uses to

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -18,6 +18,7 @@ from omnigent.server.routes.sessions import (
     _publish_subtree_cost_to_ancestors,
     _truncate_label,
 )
+from omnigent.spec.types import AgentSpec, ExecutorSpec
 
 
 async def _drain_runner_skills(session_id: str) -> None:
@@ -181,6 +182,91 @@ async def test_session_snapshot_reads_latest_items_then_returns_chronological() 
     assert [item.id for item in snapshot.items] == ["item_103", "item_104", "item_105"]
     assert snapshot.agent_id == "087b7cb7ac30abf4debfaa578d052ec6"
     assert snapshot.status == "idle"
+
+
+@pytest.mark.asyncio
+async def test_session_snapshot_uses_child_spec_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Child snapshots expose their selected spec while parents keep the root spec."""
+    child_spec = AgentSpec(
+        spec_version=1,
+        name="executor",
+        executor=ExecutorSpec(
+            config={"harness": "codex"},
+            model="openai-codex/gpt-5.6-sol:medium",
+            context_window=100_000,
+        ),
+    )
+    parent_spec = AgentSpec(
+        spec_version=1,
+        name="advisor",
+        executor=ExecutorSpec(
+            config={"harness": "codex"},
+            model="openai-codex/gpt-5.6-sol:high",
+            context_window=200_000,
+        ),
+        sub_agents=[child_spec],
+    )
+    conversations = {
+        "conv_parent": Conversation(
+            id="conv_parent",
+            created_at=1,
+            updated_at=1,
+            root_conversation_id="conv_parent",
+            agent_id="ag_advisor",
+        ),
+        "conv_child": Conversation(
+            id="conv_child",
+            created_at=1,
+            updated_at=1,
+            root_conversation_id="conv_parent",
+            parent_conversation_id="conv_parent",
+            agent_id="ag_advisor",
+            kind="sub_agent",
+            sub_agent_name="executor",
+        ),
+    }
+    conv_store = _ConversationStore([], conversations=conversations)
+
+    class _AgentStore:
+        @staticmethod
+        def get(agent_id: str) -> Any:
+            assert agent_id == "ag_advisor"
+            return type(
+                "StoredAgent",
+                (),
+                {"id": agent_id, "name": "advisor-row", "bundle_location": "bundle"},
+            )()
+
+    class _AgentCache:
+        @staticmethod
+        def load(agent_id: str, bundle_location: str) -> Any:
+            assert (agent_id, bundle_location) == ("ag_advisor", "bundle")
+            return type("LoadedAgent", (), {"spec": parent_spec})()
+
+    monkeypatch.setattr("omnigent.runtime.get_runner_client", lambda: None)
+    monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
+
+    parent = await _get_session_snapshot(
+        conv_store,  # type: ignore[arg-type]
+        "conv_parent",
+        agent_store=_AgentStore(),  # type: ignore[arg-type]
+        agent_cache=_AgentCache(),  # type: ignore[arg-type]
+    )
+    child = await _get_session_snapshot(
+        conv_store,  # type: ignore[arg-type]
+        "conv_child",
+        agent_store=_AgentStore(),  # type: ignore[arg-type]
+        agent_cache=_AgentCache(),  # type: ignore[arg-type]
+    )
+
+    assert parent.agent_name == "advisor"
+    assert parent.llm_model == "openai-codex/gpt-5.6-sol:high"
+    assert parent.context_window == 200_000
+    assert child.agent_name == "executor"
+    assert child.llm_model == "openai-codex/gpt-5.6-sol:medium"
+    assert child.context_window == 100_000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix session metadata for bundled sub-agents so the UI displays the model and context information from the selected child specification rather than from the parent agent.

## Problem

A bundled agent can define different models for its parent and child agents. For example:

- Advisor: `openai-codex/gpt-5.6-sol:high`
- Executor: `openai-codex/gpt-5.6-sol:medium`

The runner correctly resolves the executor’s child specification and runs it using `medium`. However, opening the executor session in the Omnigent UI incorrectly shows `high`.

This happens because the session snapshot loads metadata from the parent bundle specification referenced by `conv.agent_id`, without resolving `conv.sub_agent_name`.

As a result, runtime behavior and displayed metadata disagree:

- Actual executor model: `medium`
- Model displayed for the executor session: `high`

## Root cause

The runner already resolves the matching child specification before starting a sub-agent turn.

The server-side session snapshot did not perform the equivalent resolution before deriving:

- `agent_name`
- `llm_model`
- context window

It therefore returned metadata from the parent specification for child sessions.

## Fix

When a session has `conv.sub_agent_name`, resolve that name against the loaded parent specification using the existing `_find_spec_by_name` helper.

When the child specification is found, use it to derive the session’s:

- agent name
- LLM model
- context window

Top-level sessions remain unchanged. If a child specification cannot be resolved, snapshot construction safely falls back to the parent specification as before.

This change does not modify model routing or agent execution. It only makes the session metadata accurately reflect the specification that the runner already uses.

## Test coverage

Added a regression test with:

- Parent advisor using `openai-codex/gpt-5.6-sol:high`
- Executor child using `openai-codex/gpt-5.6-sol:medium`

The test verifies that:

- The parent snapshot continues to report `high`
- The child snapshot reports `medium`
- The parent and child expose their respective agent names
- Each snapshot uses the context window from its corresponding specification

## Verification

```bash
uv run --extra dev python -m pytest \
  tests/server/routes/test_sessions_snapshot.py \
  tests/runtime/test_workflow_subagent_resolution.py \
  tests/runner/test_native_subagent_harness_resolution.py -q
