### PR TITLE
fix(anthropic): keep a genuine zero total_tokens as 0, not None

### DIFF
--- a/omnigent/llms/adapters/anthropic.py
+++ b/omnigent/llms/adapters/anthropic.py
@@ -432,9 +432,13 @@ def _anthropic_to_chat(resp: dict[str, Any]) -> dict[str, Any]:
         "usage": {
             "prompt_tokens": usage.get("input_tokens"),
             "completion_tokens": usage.get("output_tokens"),
-            "total_tokens": (
-                (usage.get("input_tokens") or 0) + (usage.get("output_tokens") or 0) or None
-            ),
+            # NB: no trailing ``or None``. Precedence makes
+            # ``(a or 0) + (b or 0) or None`` collapse a genuine zero total to
+            # ``None`` (yielding an inconsistent ``prompt=0, completion=0,
+            # total=None``), and it disagrees with the streaming path, which
+            # reports ``input + output`` directly. Keep the per-operand ``or 0``
+            # guards so a missing count is treated as zero.
+            "total_tokens": (usage.get("input_tokens") or 0) + (usage.get("output_tokens") or 0),
         },
     }
 

--- a/tests/llms/test_anthropic_adapter.py
+++ b/tests/llms/test_anthropic_adapter.py
@@ -141,6 +141,33 @@ def test_anthropic_text_response_to_chat() -> None:
     assert chat["choices"][0]["finish_reason"] == "stop"
     assert chat["usage"]["prompt_tokens"] == 10
     assert chat["usage"]["completion_tokens"] == 5
+    assert chat["usage"]["total_tokens"] == 15
+
+
+def test_anthropic_zero_usage_total_is_zero_not_none() -> None:
+    """A genuine zero token total stays ``0``, not ``None``.
+
+    The non-streaming usage builder used ``(a or 0) + (b or 0) or None``, whose
+    precedence collapses a real ``0`` total to ``None`` — yielding an
+    inconsistent ``prompt=0, completion=0, total=None`` and disagreeing with the
+    streaming path, which reports ``input + output`` directly.
+
+    Regression guard: pre-fix ``total_tokens`` is ``None`` here.
+    """
+    resp = {
+        "id": "msg_0",
+        "model": "claude-test",
+        "content": [{"type": "text", "text": ""}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+    chat = _anthropic_to_chat(resp)
+    assert chat["usage"]["prompt_tokens"] == 0
+    assert chat["usage"]["completion_tokens"] == 0
+    assert chat["usage"]["total_tokens"] == 0, (
+        f"total_tokens is {chat['usage']['total_tokens']!r}, expected 0 — a real "
+        "zero total must not collapse to None."
+    )
 
 
 def test_anthropic_tool_use_response_to_chat() -> None:

--- a/tests/llms/test_anthropic_adapter.py
+++ b/tests/llms/test_anthropic_adapter.py
@@ -170,6 +170,25 @@ def test_anthropic_zero_usage_total_is_zero_not_none() -> None:
     )
 
 
+def test_anthropic_missing_usage_counts_are_treated_as_zero() -> None:
+    """Missing non-streaming usage counts normalize to zero."""
+    resp = {
+        "id": "msg_missing_usage",
+        "model": "claude-test",
+        "content": [{"type": "text", "text": ""}],
+        "stop_reason": "end_turn",
+        "usage": {},
+    }
+
+    chat = _anthropic_to_chat(resp)
+
+    assert chat["usage"] == {
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "total_tokens": 0,
+    }
+
+
 def test_anthropic_tool_use_response_to_chat() -> None:
     resp = {
         "id": "msg_456",


### PR DESCRIPTION
## Related issue

Closes #2409

## Summary

- The non-streaming Anthropic usage builder in `_anthropic_to_chat` used `(a or 0) + (b or 0) or None`, whose precedence collapses a genuine zero total to `None`, yielding an inconsistent `prompt=0, completion=0, total=None`.
- It also disagreed with the streaming path in the same file, which reports `input + output` directly (keeping a zero total as `0`).
- Fix: drop the trailing `or None` so a real zero total stays `0`, keeping the per-operand `or 0` guards for missing counts.

## Demo

No UI surface. Before/after for `_anthropic_to_chat({..., "usage": {"input_tokens": 0, "output_tokens": 0}})["usage"]`:

- Before: `{"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": None}`
- After:  `{"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}`

## Test Plan

- New `test_anthropic_zero_usage_total_is_zero_not_none`: asserts `total_tokens == 0` for a zero-token usage. Verified it **fails before the fix** (`None`).
- Strengthened `test_anthropic_text_response_to_chat` to assert `total_tokens == 15`.
- `uv run pytest tests/llms/test_anthropic_adapter.py` -> 39 passed.
- `ruff check` / `ruff format --check` clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Reproduced the collapse (a `0/0` usage yields `total_tokens=None`), applied the one-line fix, and confirmed the new test passes and fails without the fix. The fix aligns the non-streaming path with the streaming path in the same module. No secrets involved.
