### PR TITLE
fix(openai-agents): don't route an unpinned model to Databricks auth (#377)

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -396,6 +396,27 @@ def _ensure_agents_sdk() -> ModuleType:
         ) from exc
 
 
+def _has_ambient_databricks_config() -> bool:
+    """True when the environment carries a Databricks auth signal.
+
+    Used to decide whether an unpinned model (no OpenAI credentials, no
+    explicit profile) should fall back to ambient Databricks authentication or
+    fail with a clear OpenAI-credentials error. Checks the standard Databricks
+    SDK environment variables and the ``~/.databrickscfg`` config file.
+    """
+    if any(
+        os.environ.get(var)
+        for var in (
+            "DATABRICKS_HOST",
+            "DATABRICKS_TOKEN",
+            "DATABRICKS_CONFIG_PROFILE",
+            "DATABRICKS_CLIENT_ID",
+        )
+    ):
+        return True
+    return os.path.isfile(os.path.expanduser("~/.databrickscfg"))
+
+
 def _get_openai_async_client(
     profile: str | None = None,
     api_key: str | None = None,
@@ -547,17 +568,29 @@ def _get_openai_async_client(
     if api_key:
         return AsyncOpenAI(api_key=api_key, **retry_kwargs)
 
-    # Non-Databricks model with no OpenAI credentials — fail loudly rather
-    # than silently routing to the Databricks AI Gateway, which will 404.
-    if not is_databricks_model:
+    # No OpenAI credentials. Only fall back to ambient Databricks auth when
+    # there is an actual Databricks signal: an explicit ``databricks-`` model,
+    # a spec profile, or ambient Databricks config in the environment. Without
+    # any such signal, an unpinned model (``model is None``) is an OpenAI/gpt
+    # sub-agent that never wanted Databricks, so fail with a clear
+    # OpenAI-credentials error instead of routing into Databricks auth and
+    # surfacing a misleading "install databricks-sdk" / "databricks auth login"
+    # error (#377).
+    databricks_intent = (
+        (model is not None and model.startswith("databricks-"))
+        or profile is not None
+        or _has_ambient_databricks_config()
+    )
+    if not databricks_intent:
+        pinned = f"for model {model!r}" if model else "and no model is pinned"
         raise ValueError(
-            f"Model {model!r} is not a Databricks-hosted model but no OpenAI "
-            "credentials were found. Set OPENAI_API_KEY (and optionally "
-            "OPENAI_BASE_URL) to use this model, or use a 'databricks-' "
-            "prefixed model name to route through Databricks."
+            f"No OpenAI credentials found {pinned}. Set OPENAI_API_KEY (and "
+            "optionally OPENAI_BASE_URL) to use an OpenAI model, or use a "
+            "'databricks-' prefixed model name or a Databricks profile to route "
+            "through Databricks."
         )
 
-    # No profile, no env — final fallback via ambient Databricks credentials.
+    # Databricks intent with no profile/env — resolve ambient Databricks creds.
     try:
         from .databricks_executor import _resolve_databricks_auth
 
@@ -565,10 +598,9 @@ def _get_openai_async_client(
     except ImportError as exc:
         raise ImportError(
             "The 'databricks-sdk' package is required for Databricks "
-            "authentication but is not installed, and no OPENAI_API_KEY or "
-            "OPENAI_BASE_URL environment variables are set. Either install "
-            "the package (`pip install 'omnigent[databricks]'`) or set "
-            "OPENAI_API_KEY/OPENAI_BASE_URL for non-Databricks OpenAI access."
+            "authentication but is not installed. Install it with "
+            "`pip install 'omnigent[databricks]'`, or set OPENAI_API_KEY / "
+            "OPENAI_BASE_URL for OpenAI access."
         ) from exc
     return AsyncOpenAI(
         base_url=base_url_override or _databricks_openai_base_url(host),

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -1528,6 +1528,61 @@ def test_get_openai_client_profile_uses_callback_auth(monkeypatch):
     assert isinstance(captured["http_client"], httpx.AsyncClient)
 
 
+def test_get_openai_client_unpinned_model_no_databricks_signal_raises_openai_error(monkeypatch):
+    """Unpinned model, no OpenAI creds, no Databricks signal -> clear OpenAI error (#377).
+
+    A gpt / openai-agents sub-agent whose model is left unpinned used to be
+    treated as Databricks-hosted (``is_databricks_model = model is None``) and
+    routed into ambient Databricks auth, surfacing "install databricks-sdk" /
+    "databricks auth login" even though nobody configured Databricks. It must
+    now fail with an OpenAI-credentials error that names the real problem.
+    """
+    from omnigent.inner import openai_agents_sdk_executor as mod
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    for var in ("OPENAI_API_KEY", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(mod, "_has_ambient_databricks_config", lambda: False)
+
+    with pytest.raises(ValueError, match=r"No OpenAI credentials found and no model is pinned"):
+        _get_openai_async_client(model=None)
+
+
+def test_get_openai_client_unpinned_model_with_databricks_signal_routes_to_databricks(monkeypatch):
+    """Unpinned model WITH an ambient Databricks signal still routes to Databricks.
+
+    Guards the #377 fix against over-reach: a real Databricks deployment (which
+    always carries a Databricks signal) must keep resolving an unpinned model
+    through Databricks auth, not hit the new OpenAI-credentials error.
+    """
+    import httpx
+
+    from omnigent.inner import openai_agents_sdk_executor as mod
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    for var in ("OPENAI_API_KEY", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(mod, "_has_ambient_databricks_config", lambda: True)
+    monkeypatch.setattr(
+        "omnigent.inner.databricks_executor._resolve_databricks_auth",
+        lambda profile: (httpx.BasicAuth("u", "p"), "https://workspace.example.com"),
+    )
+
+    captured: dict[str, Any] = {}
+
+    class _StubAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    import openai as _openai_mod
+
+    with patch.object(_openai_mod, "AsyncOpenAI", _StubAsyncOpenAI, create=True):
+        _get_openai_async_client(model=None)
+
+    # Routed to Databricks: base_url derives from the workspace host (no raise).
+    assert "workspace.example.com" in captured["base_url"]
+
+
 def test_get_openai_client_host_override_uses_ucode_auth_command(monkeypatch):
     """ucode host override uses ucode auth command without profile lookup.
 


### PR DESCRIPTION
## Related issue

Closes #377

## Summary

Root cause of #377 (full trace in the #1310 thread): `_get_openai_async_client` used `is_databricks_model = model is None or model.startswith("databricks-")`, so an **unpinned** model was assumed Databricks-hosted. A `gpt` / openai-agents sub-agent with no `OPENAI_API_KEY` in the worker env fell through to the ambient Databricks fallback and crashed with the misleading `"The 'databricks-sdk' package is required..."` / `"databricks auth login"` error, even though nobody configured Databricks.

- Gate the ambient-Databricks fallback behind an actual **Databricks signal**: an explicit `databricks-` model, a spec `profile`, or ambient Databricks config (`DATABRICKS_*` env or `~/.databrickscfg`).
- Without any such signal and without OpenAI credentials, raise a clear OpenAI-credentials error that names the real problem instead of blaming Databricks.
- Real Databricks deployments always carry a signal, so an unpinned model there still resolves through Databricks auth (unchanged).

This implements the issue's own "fail gracefully when not using Databricks" resolution: the crash becomes an actionable "set OPENAI_API_KEY" message. (Making a `gpt` sub-agent run with zero config — defaulting a model and/or propagating `OPENAI_API_KEY` into the worker — is a separate config decision I flagged to @TomeHirata in the #1310 thread; not in scope here.)

## Demo

No UI surface. Before/after for `_get_openai_async_client(model=None)` with no `OPENAI_API_KEY` / `OPENAI_BASE_URL` and no Databricks signal:

- Before: `ImportError: The 'databricks-sdk' package is required...` (or `DatabricksAuthError: ... databricks auth login` when the package is installed)
- After:  `ValueError: No OpenAI credentials found and no model is pinned. Set OPENAI_API_KEY ...`

With a Databricks signal present (`DATABRICKS_HOST` etc.), `model=None` still routes to Databricks, unchanged.

## Test Plan

- `test_get_openai_client_unpinned_model_no_databricks_signal_raises_openai_error`: unpinned model, no creds, no signal -> clear OpenAI `ValueError`.
- `test_get_openai_client_unpinned_model_with_databricks_signal_routes_to_databricks`: unpinned model + ambient signal -> still routes to Databricks (guards against over-reach).
- Verified manually with a cleaned env: `model=None` now raises the OpenAI error, `model="gpt-4o"` unchanged, `model="databricks-*"` still routes to Databricks.
- `uv run pytest tests/inner/test_openai_agents_sdk_executor.py` -> 72 passed (incl. the existing `test_databricks_client_default_model_uses_databricks_model`).
- `ruff check` / `ruff format --check` clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The ambient-Databricks path is preserved for genuine Databricks use (explicit `databricks-` model, a profile, or `DATABRICKS_*` / `~/.databrickscfg` present); only the no-signal case changes, turning a misleading Databricks error into a clear OpenAI-credentials one. No secrets involved (tests use dummy auth and stub `AsyncOpenAI`; no network calls).
