### PR TITLE
feat(web): show and copy the session working directory

### DIFF
--- a/web/src/components/AgentInfo.test.tsx
+++ b/web/src/components/AgentInfo.test.tsx
@@ -54,6 +54,12 @@ vi.mock("@/lib/identity", async (importOriginal) => ({
   getCurrentUserId: () => viewerData.current,
 }));
 vi.mock("@/lib/clipboard", () => ({ copyText: copyTextMock }));
+// Session snapshot, controllable per test. Feeds the working-directory row;
+// default null workspace keeps the row hidden so unrelated cases are untouched.
+const sessionData = { current: { workspace: null as string | null } };
+vi.mock("@/hooks/useSession", () => ({
+  useSession: () => ({ session: sessionData.current, isLoading: false, error: null }),
+}));
 // The codex-only "Restart with model…" dialog mounts (closed) inside
 // AgentInfoContent for codex sessions; stub its routing + fork deps so it
 // renders without a Router/network in jsdom.
@@ -87,6 +93,7 @@ afterEach(() => {
   ownerData.current = null;
   viewerData.current = null;
   grantsData.current = undefined;
+  sessionData.current = { workspace: null };
 });
 
 function renderButton(agent: Agent | undefined) {
@@ -273,6 +280,35 @@ describe("AgentInfoButton session id row", () => {
     expect(copyTextMock).toHaveBeenCalledTimes(1);
     expect(copyTextMock).toHaveBeenCalledWith("conv_info123");
     expect(await screen.findByRole("button", { name: "Copied session ID" })).toBeInTheDocument();
+  });
+});
+
+describe("AgentInfoButton working directory row", () => {
+  it("shows and copies the session's working directory in the popover", async () => {
+    sessionData.current = { workspace: "/Users/me/projects/app" };
+    renderButtonWithSession(AGENT_WITH_BOTH, "conv_ws");
+
+    fireEvent.click(screen.getByTestId("agent-info-trigger"));
+
+    expect(screen.getByTestId("agent-info-workspace")).toHaveTextContent("/Users/me/projects/app");
+    fireEvent.click(screen.getByTestId("agent-info-copy-workspace"));
+
+    expect(copyTextMock).toHaveBeenCalledTimes(1);
+    expect(copyTextMock).toHaveBeenCalledWith("/Users/me/projects/app");
+    expect(
+      await screen.findByRole("button", { name: "Copied working directory" }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the working directory row when the session has no workspace", () => {
+    sessionData.current = { workspace: null };
+    renderButtonWithSession(AGENT_WITH_BOTH, "conv_ws_none");
+
+    fireEvent.click(screen.getByTestId("agent-info-trigger"));
+
+    // Popover still opens (agent name proves it) — just no working-dir row.
+    expect(screen.getByText("Databricks_coding_agent")).toBeInTheDocument();
+    expect(screen.queryByTestId("agent-info-workspace")).toBeNull();
   });
 });
 

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -6,6 +6,7 @@ import {
   CheckIcon,
   CopyIcon,
   AlertTriangleIcon,
+  FolderIcon,
   PencilIcon,
   InfoIcon,
   PlusIcon,
@@ -56,6 +57,7 @@ import { copyText } from "@/lib/clipboard";
 import { useChatStore } from "@/store/chatStore";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { useSessionHostVersion } from "@/hooks/RunnerHealthProvider";
+import { useSession } from "@/hooks/useSession";
 
 /**
  * Display label for an agent name: the wrapper alias when mapped, else
@@ -1174,7 +1176,14 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
   const mcpEditable = agent?.mcp_servers_editable === true;
   const displayName = agent ? agentDisplayLabel(agent.name) : null;
   const [sessionIdCopied, setSessionIdCopied] = useState(false);
+  const [workspaceCopied, setWorkspaceCopied] = useState(false);
   const copyResetTimeoutRef = useRef<number | null>(null);
+  const workspaceCopyResetTimeoutRef = useRef<number | null>(null);
+  // The session's working directory, so a viewer can see and copy the cwd
+  // (e.g. to paste into the chat). ``null`` for sandbox sessions or while the
+  // snapshot loads, in which case the row is omitted.
+  const { session } = useSession(sessionId ?? null);
+  const workspace = session?.workspace ?? null;
   // Cumulative session spend, live from the store (seeded on bind, updated
   // by SSE ``session_usage``). ``null`` when the session is unpriced (no
   // turn priced yet) — omit the row rather than show "$0.00" / "—".
@@ -1215,6 +1224,8 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
   useEffect(() => {
     return () => {
       if (copyResetTimeoutRef.current !== null) window.clearTimeout(copyResetTimeoutRef.current);
+      if (workspaceCopyResetTimeoutRef.current !== null)
+        window.clearTimeout(workspaceCopyResetTimeoutRef.current);
     };
   }, []);
 
@@ -1229,6 +1240,20 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
     setSessionIdCopied(true);
     if (copyResetTimeoutRef.current !== null) window.clearTimeout(copyResetTimeoutRef.current);
     copyResetTimeoutRef.current = window.setTimeout(() => setSessionIdCopied(false), 2000);
+  }
+
+  async function copyWorkspace() {
+    if (!workspace) return;
+    try {
+      await copyText(workspace);
+    } catch (err) {
+      console.warn("Failed to copy working directory", err);
+      return;
+    }
+    setWorkspaceCopied(true);
+    if (workspaceCopyResetTimeoutRef.current !== null)
+      window.clearTimeout(workspaceCopyResetTimeoutRef.current);
+    workspaceCopyResetTimeoutRef.current = window.setTimeout(() => setWorkspaceCopied(false), 2000);
   }
 
   return (
@@ -1275,6 +1300,36 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
               className="shrink-0"
             >
               {sessionIdCopied ? (
+                <CheckIcon className="size-3.5" />
+              ) : (
+                <CopyIcon className="size-3.5" />
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+      {workspace && (
+        <div className="flex flex-col gap-1.5 py-3">
+          <SectionLabel>Working directory</SectionLabel>
+          <div className="flex items-center gap-2">
+            <code
+              className="flex min-w-0 flex-1 items-center gap-1.5 py-1 font-mono text-xs text-muted-foreground"
+              data-testid="agent-info-workspace"
+              title={workspace}
+            >
+              <FolderIcon className="size-3.5 shrink-0" />
+              <span className="min-w-0 truncate">{workspace}</span>
+            </code>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={workspaceCopied ? "Copied working directory" : "Copy working directory"}
+              data-testid="agent-info-copy-workspace"
+              onClick={copyWorkspace}
+              className="shrink-0"
+            >
+              {workspaceCopied ? (
                 <CheckIcon className="size-3.5" />
               ) : (
                 <CopyIcon className="size-3.5" />


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The session's working directory (cwd) wasn't surfaced anywhere in the active chat, so there was no way to see it or copy it (e.g. to paste a path into the conversation).
- Adds a **Working directory** row to the agent-info popover, right after the Session ID row, with a folder icon and a copy button — mirroring the existing session-id copy affordance.
- The row reads `session.workspace` via `useSession` and is omitted for sandbox sessions that have no workspace.

## Test Plan

- `cd web && npm run lint` — clean (no new findings).
- `cd web && npm run test -- src/components/AgentInfo.test.tsx` — 41 pass, including 2 new cases: copy calls `copyText(session.workspace)` and shows the "Copied working directory" state; the row is absent when `workspace` is null.
- `cd web && npm run build` — succeeds.
- `uv run pre-commit run --files web/src/components/AgentInfo.tsx web/src/components/AgentInfo.test.tsx` — passes.

## Demo

_UI change — screenshot/recording to be added. The new "Working directory" row appears in the session info popover (the header info icon) beneath "Session ID", showing the cwd with a copy button._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified in the running desktop app: opening the session info popover shows the working directory, and the copy button places the path on the clipboard (confirmed by pasting into the composer). Sandbox sessions with no workspace omit the row.

## Changelog

The session info popover now shows the working directory with a button to copy its path
