### PR TITLE
feat(web): file new sessions under the active project by default

### DIFF
--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1446,13 +1446,15 @@ describe("NewChatLandingScreen", () => {
     await waitFor(() => expect(screen.queryByTestId("new-chat-landing-error")).toBeNull());
   });
 
-  it("hides the project chip in the normal new-session flow (no project pre-selected)", async () => {
-    // Without a `?project=` param the session is unfiled, so the chip is
-    // hidden entirely — the fresh new-session flow stays project-free.
+  it("shows the project chip as 'No project' in the normal new-session flow", async () => {
+    // Without a `?project=` param the session is unfiled, but the chip is still
+    // visible (defaulting to "No project") so the target project can be seen
+    // and set before creating.
     renderLanding();
 
     await screen.findByTestId("new-chat-landing-input");
-    expect(screen.queryByTestId("new-chat-landing-project-chip")).toBeNull();
+    const chip = screen.getByTestId("new-chat-landing-project-chip");
+    expect(chip.textContent).toContain("No project");
   });
 
   it("files a pre-filled project chip's selection, and invalidates project sessions", async () => {
@@ -1497,10 +1499,10 @@ describe("NewChatLandingScreen", () => {
     invalidateSpy.mockRestore();
   });
 
-  it("hides the chip again when a pre-filled project is cleared to 'No project'", async () => {
-    // When shown, the picker still lets the user clear the selection; doing so
-    // empties `selectedProject` and the chip disappears (consistent with the
-    // "only show when selected" rule).
+  it("resets a pre-filled project chip to 'No project' when cleared", async () => {
+    // The picker lets the user clear the selection; doing so empties
+    // `selectedProject` and the chip falls back to the "No project" label
+    // (the chip stays visible so the choice can be changed again).
     renderLanding({}, "/?project=docs");
 
     await waitFor(() =>
@@ -1510,7 +1512,11 @@ describe("NewChatLandingScreen", () => {
     fireEvent.click(screen.getByTestId("new-chat-landing-project-chip"));
     fireEvent.click(screen.getByText("No project"));
 
-    await waitFor(() => expect(screen.queryByTestId("new-chat-landing-project-chip")).toBeNull());
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-project-chip").textContent).toContain(
+        "No project",
+      ),
+    );
   });
 
   it("pre-fills the project chip from the ?project= query param", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3604,13 +3604,11 @@ export function NewChatLandingScreen() {
               )}
 
               {/* Project chip — files the session under a named project on
-                create. Sits after the worktree chip. Only shown when a project
-                is already selected (e.g. quick-starting from an existing
-                project's "new session" pencil, which passes `?project=`);
-                otherwise the new-session flow stays unfiled. */}
-              {selectedProject && (
-                <LandingProjectPicker value={selectedProject} onChange={setSelectedProject} />
-              )}
+                create. Sits after the worktree chip. Always shown (defaulting
+                to "No project") so the target project is visible and settable
+                before creating, whether arriving from a project's "new session"
+                pencil (which passes `?project=`) or the plain composer. */}
+              <LandingProjectPicker value={selectedProject} onChange={setSelectedProject} />
             </div>
             {/* The agent / harness picker moved out of the tray and into the
                 composer's right action cluster (next to Send) — see

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -423,6 +423,48 @@ describe("Sidebar tabs", () => {
     expect(screen.queryByText("conv_shared")).toBeNull();
   });
 
+  it("carries the active session's project into New session so the next lands there too", () => {
+    // Viewing a session filed under "Alpha": New session should pre-file the
+    // next one under Alpha (no manual move afterward).
+    projectsMock.push("Alpha");
+    mockConversations([conv("conv_filed", "Claude Code", { labels: { omni_project: "Alpha" } })]);
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_filed"]}>
+            <Routes>
+              <Route path="/c/:conversationId" element={<Sidebar open onClose={vi.fn()} />} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+    expect(screen.getByTestId("new-chat-button").closest("a")).toHaveAttribute(
+      "href",
+      "/?project=Alpha",
+    );
+  });
+
+  it("keeps New session unfiled when the active session has no project", () => {
+    mockConversations([conv("conv_unfiled", "Claude Code")]);
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_unfiled"]}>
+            <Routes>
+              <Route path="/c/:conversationId" element={<Sidebar open onClose={vi.fn()} />} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+    expect(screen.getByTestId("new-chat-button").closest("a")).toHaveAttribute("href", "/");
+  });
+
   it("hides the tabs on a single-user (local) server and shows only owned sessions", () => {
     // A loopback-only server can't share sessions with anyone, so the tab
     // split is meaningless — collapse to the plain owned-session list.

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -335,6 +335,17 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
     [conversationsQuery.data],
   );
   const pendingApprovals = useMemo(() => sumPendingApprovals(loadedRows), [loadedRows]);
+  // The project the active session is filed under, so "New session" defaults to
+  // creating the next session in the same project. Empty when the active
+  // session is unfiled, on a non-chat route, or not among the loaded rows
+  // (e.g. a sub-agent, which the list omits) — then New session stays unfiled.
+  const { conversationId: activeConversationId } = useParams<{ conversationId: string }>();
+  const activeProject = useMemo(() => {
+    if (!activeConversationId) return "";
+    const active = loadedRows.find((c) => c.id === activeConversationId);
+    return active?.labels?.[PROJECT_LABEL_KEY] ?? "";
+  }, [activeConversationId, loadedRows]);
+  const newSessionTo = activeProject ? `/?project=${encodeURIComponent(activeProject)}` : "/";
   // Plus unseen file comments — the badge counts everything the Inbox
   // page lists. Comment queries are shared with the page/FileViewer
   // (same ["comments", id] keys), so this adds no duplicate fetches.
@@ -542,9 +553,10 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
             >
               {/* New session always creates a session the viewer owns, which
               lands under "My sessions" — so snap the tab back there on click
-              (the button stays visible on both tabs). */}
+              (the button stays visible on both tabs). Carries the active
+              session's project so the next session is filed alongside it. */}
               <Link
-                to="/"
+                to={newSessionTo}
                 onClick={(e) => {
                   setActiveTab("mine");
                   onNavClick(e);


### PR DESCRIPTION
## Related issue

N/A

## Summary

Starting a session filed under a project only worked from a project row's "new session" pencil. The global **New session** button routed to `/` with no project, and the composer's project chip was hidden unless a project was already selected — so sessions started from the composer landed **unfiled**, with no visible control to file them, forcing a manual "move to project" afterward.

Two changes:
- The composer's project chip is now **always visible** (defaulting to "No project"), so the target project can be seen and set before creating. The picker already supported a "No project" reset; this just drops the `selectedProject &&` render guard.
- The sidebar's **New session** button now carries the active session's project (`/?project=<name>`), so the next session is filed alongside the one you're viewing. It falls back to unfiled (`/`) when the active session has no project or isn't a loaded top-level row (e.g. a sub-agent, which the list omits).

The attach mechanism itself was already correct (PATCH `omni_project` → invalidate `["projects"]` / `["project-sessions"]` → folder refetch); this only fixes the entry points that weren't reaching it.

## Test Plan

- `cd web && npm run test -- src/shell/Sidebar.test.tsx src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx` — 226 pass / 1 skipped. New/updated cases:
  - Sidebar: New session href carries the active session's project (`/?project=Alpha`); stays `/` when the active session is unfiled.
  - NewChatDialog: the project chip renders as "No project" in the normal flow; clearing a pre-filled project resets the chip to "No project" (instead of hiding it).
- `cd web && npm run build` — succeeds.
- `uv run pre-commit run --files ...` (the four changed files) — passes.

## Demo

_UI change — screenshot/recording to be added. With a project session open, the composer shows that project's chip and the sidebar's New session button files the next session into the same project; with no active project the chip shows "No project" and can be set before sending._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified in the running desktop app: clicking New session while viewing a project's session pre-selects that project in the composer, and the created session lands in the project folder without a manual move. The composer's project chip is always present and can be set/cleared before creating.

## Changelog

New sessions started from the composer now show and default to the project you're working in, so they file into it instead of landing unfiled
