### PR TITLE
feat(web): remember a per-project default working directory

### DIFF
--- a/web/src/hooks/useProjectWorkspaces.test.ts
+++ b/web/src/hooks/useProjectWorkspaces.test.ts
@@ -1,0 +1,81 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useProjectWorkspaces } from "./useProjectWorkspaces";
+
+const PROJECT_KEY = "omnigent:project-workspaces";
+
+describe("useProjectWorkspaces", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("returns the project's persisted default workspace", () => {
+    localStorage.setItem(PROJECT_KEY, JSON.stringify({ Alpha: "/repos/alpha" }));
+    const { result } = renderHook(() => useProjectWorkspaces("Alpha"));
+    expect(result.current.projectWorkspace).toBe("/repos/alpha");
+  });
+
+  it("returns null for a project with no stored default", () => {
+    localStorage.setItem(PROJECT_KEY, JSON.stringify({ Alpha: "/repos/alpha" }));
+    const { result } = renderHook(() => useProjectWorkspaces("Beta"));
+    expect(result.current.projectWorkspace).toBeNull();
+  });
+
+  it("returns null for the unfiled (empty) project", () => {
+    localStorage.setItem(PROJECT_KEY, JSON.stringify({ Alpha: "/repos/alpha" }));
+    const { result } = renderHook(() => useProjectWorkspaces(""));
+    expect(result.current.projectWorkspace).toBeNull();
+  });
+
+  it("never exposes the previous project's default after a project switch", () => {
+    // Synchronous read (not effect-based) so the render right after a project
+    // change already reflects the new project — no stale frame that could seed
+    // the wrong directory into the composer's prefill.
+    localStorage.setItem(
+      PROJECT_KEY,
+      JSON.stringify({ Alpha: "/repos/alpha", Beta: "/repos/beta" }),
+    );
+    const renders: { project: string; workspace: string | null }[] = [];
+    const { rerender } = renderHook(
+      ({ project }) => {
+        const { projectWorkspace } = useProjectWorkspaces(project);
+        renders.push({ project, workspace: projectWorkspace });
+      },
+      { initialProps: { project: "Alpha" } },
+    );
+    rerender({ project: "Beta" });
+
+    const betaRenders = renders.filter((r) => r.project === "Beta");
+    expect(betaRenders.length).toBeGreaterThan(0);
+    for (const r of betaRenders) {
+      expect(r.workspace).toBe("/repos/beta");
+    }
+  });
+
+  it("setProjectWorkspace persists and reflects the write synchronously", () => {
+    const { result } = renderHook(() => useProjectWorkspaces("Alpha"));
+    act(() => result.current.setProjectWorkspace("/repos/alpha"));
+    expect(result.current.projectWorkspace).toBe("/repos/alpha");
+    // A later session in the same project overwrites the default.
+    act(() => result.current.setProjectWorkspace("/repos/alpha-v2"));
+    expect(result.current.projectWorkspace).toBe("/repos/alpha-v2");
+    expect(JSON.parse(localStorage.getItem(PROJECT_KEY)!)).toEqual({ Alpha: "/repos/alpha-v2" });
+  });
+
+  it("setProjectWorkspace is a no-op for the unfiled (empty) project", () => {
+    const { result } = renderHook(() => useProjectWorkspaces(""));
+    act(() => result.current.setProjectWorkspace("/repos/alpha"));
+    expect(result.current.projectWorkspace).toBeNull();
+    expect(localStorage.getItem(PROJECT_KEY)).toBeNull();
+  });
+
+  it("setProjectWorkspace ignores a blank path", () => {
+    const { result } = renderHook(() => useProjectWorkspaces("Alpha"));
+    act(() => result.current.setProjectWorkspace("   "));
+    expect(result.current.projectWorkspace).toBeNull();
+    expect(localStorage.getItem(PROJECT_KEY)).toBeNull();
+  });
+});

--- a/web/src/hooks/useProjectWorkspaces.ts
+++ b/web/src/hooks/useProjectWorkspaces.ts
@@ -1,0 +1,83 @@
+// localStorage-backed default workspace directory per project. Lets a new
+// session started under a project pre-fill the working directory to the one
+// last used for that project, instead of the host-wide most-recent path.
+
+import { useCallback, useMemo, useState } from "react";
+
+const STORAGE_KEY = "omnigent:project-workspaces";
+
+// Map of project name -> the last-used absolute workspace path for it.
+type ProjectMap = Record<string, string>;
+
+function readAll(): ProjectMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object") return {};
+    // Keep only string values; drop anything malformed so a corrupted
+    // entry can't crash the picker.
+    const out: ProjectMap = {};
+    for (const [project, path] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof path === "string") out[project] = path;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(map: ProjectMap): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // Quota exceeded or storage disabled — non-fatal; the default just
+    // stops persisting until the next successful write.
+  }
+}
+
+export interface ProjectWorkspaces {
+  /** The stored default workspace for the current project, or ``null``. */
+  projectWorkspace: string | null;
+  /**
+   * Record ``path`` as the default workspace for the current project.
+   * No-op when ``project`` is empty or the path is blank.
+   */
+  setProjectWorkspace: (path: string) => void;
+}
+
+/**
+ * Track the default workspace directory for one project.
+ *
+ * @param project Project name whose default to read/write. ``""`` (unfiled)
+ *   yields a ``null`` default and a no-op setter.
+ * @returns The project's stored workspace plus a recorder.
+ */
+export function useProjectWorkspaces(project: string): ProjectWorkspaces {
+  // Bumped by the setter to recompute after a write; the map is read
+  // synchronously below, not hydrated via an effect.
+  const [revision, setRevision] = useState(0);
+
+  const projectWorkspace = useMemo(
+    () => (project === "" ? null : (readAll()[project] ?? null)),
+    [project, revision],
+  );
+
+  const setProjectWorkspace = useCallback(
+    (path: string) => {
+      if (project === "") return;
+      const trimmed = path.trim();
+      if (!trimmed) return;
+      const all = readAll();
+      if (all[project] === trimmed) return;
+      all[project] = trimmed;
+      writeAll(all);
+      setRevision((r) => r + 1);
+    },
+    [project],
+  );
+
+  return { projectWorkspace, setProjectWorkspace };
+}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -91,6 +91,7 @@ import {
 import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
+import { useProjectWorkspaces } from "@/hooks/useProjectWorkspaces";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFilesystem";
@@ -1988,6 +1989,9 @@ export function NewChatLandingScreen() {
   }, []);
 
   const { recent, addRecent } = useRecentWorkspaces(selectedHostId);
+  // Per-project default working directory: a session started under a project
+  // pre-fills its workspace to the one last used for that project.
+  const { projectWorkspace, setProjectWorkspace } = useProjectWorkspaces(selectedProject);
 
   const allHosts = hosts ?? [];
   const onlineHosts = allHosts.filter((h) => h.status === "online");
@@ -2088,17 +2092,18 @@ export function NewChatLandingScreen() {
   );
 
   // Seed the working directory once per host, into an empty field only, so an
-  // explicit pick isn't clobbered. Prefer the most-recent path; else the
-  // derived home (which can arrive a render later, hence the dep).
+  // explicit pick isn't clobbered. Prefer the active project's saved default,
+  // then the most-recent path, else the derived home (which can arrive a
+  // render later, hence the dep).
   const seededHostRef = useRef<string | null>(null);
   useEffect(() => {
     if (selectedHostId === null) return;
     if (seededHostRef.current === selectedHostId) return;
-    const candidate = recent[0] ?? derivedHome;
+    const candidate = projectWorkspace ?? recent[0] ?? derivedHome;
     if (!candidate) return;
     seededHostRef.current = selectedHostId;
     setWorkspace((cur) => (cur === "" ? candidate : cur));
-  }, [selectedHostId, recent, derivedHome]);
+  }, [selectedHostId, projectWorkspace, recent, derivedHome]);
 
   // A pick only wins while it exists in the list — a persisted id whose
   // agent has since been unregistered (or hidden) falls back to the default.
@@ -2727,7 +2732,11 @@ export function NewChatLandingScreen() {
         }
       }
       // Sandbox creates have no user-picked workspace to remember.
-      if (!sandboxSelected) addRecent(workspaceTrimmed);
+      if (!sandboxSelected) {
+        addRecent(workspaceTrimmed);
+        // Remember this directory as the project's default for next time.
+        if (selectedProject) setProjectWorkspace(workspaceTrimmed);
+      }
       // Fire-and-forget: don't block navigation on the sidebar list refresh.
       // The background refetch (or the WS session_added push) backfills the
       // new session's row within ~1s of landing in the chat; the chat itself


### PR DESCRIPTION
## Related issue

N/A

## Summary

The new-session working directory defaulted to the host-wide most-recent path, so every project showed the same directory — confusing when different projects live in different repos.

- Adds a `useProjectWorkspaces` hook that stores a `projectName -> path` map in localStorage (`omnigent:project-workspaces`), mirroring the existing `useRecentWorkspaces` hook.
- `NewChatDialog` seeds the workspace field from the active project's saved default **ahead of** the host recents, and records the chosen directory for that project on create.
- Purely client-side: projects are just `conversation_labels` rows with no backend metadata, so a localStorage map is the lightest place to remember this (same approach as recents).

## Test Plan

- `cd web && npm run test -- src/hooks/useProjectWorkspaces.test.ts src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx` — pass, including 8 new hook cases (read/write, per-project isolation, no-op for the unfiled/empty project and blank paths, synchronous read after a project switch).
- `cd web && npm run build` — succeeds.
- `uv run pre-commit run --files ...` — passes.

Lint note: `useProjectWorkspaces` uses the same `useState` "revision" bump + `useMemo([key, revision])` pattern as the sibling `useRecentWorkspaces` (so a write reflects synchronously). oxlint's `react-hooks/exhaustive-deps` flags `revision` as an "unnecessary dependency" here exactly as it already does on `useRecentWorkspaces.ts` — I mirrored the established convention rather than diverge. Happy to switch both to a different pattern if preferred.

## Demo

_UI change — screenshot/recording to be added. Setting a working directory for project A, then starting another session in A, pre-fills the workspace to A's last directory; a different project keeps its own default._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified in the running desktop app: choosing a directory for a project and creating the session, then starting a new session in the same project, pre-fills the workspace to that directory; switching to another project shows its own remembered directory (or the host recents when none is stored).

## Changelog

New sessions started under a project now remember and pre-fill that project's last-used working directory
