### PR TITLE
fix(tests): make subagent resolution tests pass on hosts without bwrap

### DIFF
--- a/tests/runtime/test_workflow_subagent_resolution.py
+++ b/tests/runtime/test_workflow_subagent_resolution.py
@@ -21,6 +21,10 @@ the child boots as the intended ``max_iterations=5`` curl helper instead.
 
 from __future__ import annotations
 
+import shutil
+
+import pytest
+
 from omnigent.runtime.workflow import _find_spec_by_name
 from omnigent.spec.types import (
     AgentSpec,
@@ -30,6 +34,21 @@ from omnigent.spec.types import (
     ToolsConfig,
 )
 from omnigent.tools.builtins.web_fetch import RESEARCHER_NAME, build_researcher_spec
+
+
+@pytest.fixture(autouse=True)
+def _default_sandbox_binary_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Keep the seed-time sandbox probe host-independent for the suite.
+
+    ``build_researcher_spec`` calls ``shutil.which`` against the real host
+    PATH for a no-``os_env`` parent (``_ensure_default_sandbox_runnable``).
+    These tests exercise resolution, not the probe, so default it to
+    "binary present" (same fixture as
+    ``tests/tools/builtins/test_web_fetch.py``, which owns the
+    probe-specific coverage).
+    """
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
 
 
 def _coordinator_parent(*, web_fetch: bool = True) -> AgentSpec:


### PR DESCRIPTION
## Related issue

N/A. Test-only follow-up to [#2097](https://github.com/omnigent-ai/omnigent/pull/2097), fixing the breakage flagged in its [post-merge review comment](https://github.com/omnigent-ai/omnigent/pull/2097#issuecomment-4932162039).

## Summary

[#2097](https://github.com/omnigent-ai/omnigent/pull/2097) made `build_researcher_spec` probe the real host for the platform-default sandbox binary when the parent has no `os_env`. The workflow subagent resolution tests reach that probe (directly and via `_find_spec_by_name`), so on a Linux host without `bwrap` three of them fail with `OmnigentError`. This adds the same autouse `shutil.which` stub that [#2097](https://github.com/omnigent-ai/omnigent/pull/2097) added to `tests/tools/builtins/test_web_fetch.py`; the probe itself keeps its dedicated coverage there.

## Test Plan

- `pytest tests/runtime/test_workflow_subagent_resolution.py -q`: 6 passed.
- `ruff check` and `ruff format --check` pass on the changed file.
- The breakage is Linux-only: the probe is a no-op on Windows and only fires when `bwrap` is off `PATH`. The [post-merge review comment on #2097](https://github.com/omnigent-ai/omnigent/pull/2097#issuecomment-4932162039) reported the same three tests failing on hosts without `bwrap`, CI included.

## Demo

N/A: test-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Test-only change; the sandbox probe's own behavior keeps its dedicated coverage in `tests/tools/builtins/test_web_fetch.py`.
