### PR TITLE
fix(host): bypass proxies for loopback health checks

### DIFF
--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -189,7 +189,7 @@ def local_server_url_if_healthy() -> str | None:
         return None
     base_url = f"http://127.0.0.1:{port}"
     try:
-        resp = httpx.get(f"{base_url}/health", timeout=2.0)
+        resp = httpx.get(f"{base_url}/health", timeout=2.0, trust_env=False)
     except httpx.HTTPError:
         return None
     if resp.status_code == 200:
@@ -760,7 +760,7 @@ def _local_server_health_ok(base_url: str) -> bool:
     import httpx
 
     try:
-        resp = httpx.get(f"{base_url}/health", timeout=2.0)
+        resp = httpx.get(f"{base_url}/health", timeout=2.0, trust_env=False)
     except httpx.HTTPError:
         return False
     if resp.status_code != 200:
@@ -864,7 +864,7 @@ def _wait_for_local_omnigent_server(
         if proc.poll() is not None:
             _raise_local_server_failed(base_url, log_path)
         try:
-            resp = httpx.get(f"{base_url}/health", timeout=2.0)
+            resp = httpx.get(f"{base_url}/health", timeout=2.0, trust_env=False)
             if resp.status_code == 200:
                 return
         except httpx.TransportError:

--- a/tests/host/test_local_server.py
+++ b/tests/host/test_local_server.py
@@ -32,13 +32,13 @@ def test_local_server_url_if_healthy_returns_url_when_alive_and_healthy(
     monkeypatch.setattr(local_server, "_LOCAL_SERVER_PID_PATH", pid_file)
     monkeypatch.setattr(local_server, "_pid_alive", lambda pid: pid == 4242)
 
-    health_targets: list[str] = []
+    health_targets: list[tuple[str, bool]] = []
 
     class _Resp:
         status_code = 200
 
-    def _fake_get(url: str, *, timeout: float) -> _Resp:
-        health_targets.append(url)
+    def _fake_get(url: str, *, timeout: float, trust_env: bool) -> _Resp:
+        health_targets.append((url, trust_env))
         return _Resp()
 
     monkeypatch.setattr("httpx.get", _fake_get)
@@ -46,7 +46,36 @@ def test_local_server_url_if_healthy_returns_url_when_alive_and_healthy(
     assert local_server.local_server_url_if_healthy() == "http://127.0.0.1:8123"
     # The probe must hit the recorded port's /health, proving the port from
     # the pidfile (not a hardcoded default) was used.
-    assert health_targets == ["http://127.0.0.1:8123/health"]
+    assert health_targets == [("http://127.0.0.1:8123/health", False)]
+
+
+def test_wait_for_local_server_bypasses_environment_proxies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The readiness poll must connect to loopback without system proxies."""
+
+    class _Proc:
+        @staticmethod
+        def poll() -> None:
+            return None
+
+    class _Resp:
+        status_code = 200
+
+    health_targets: list[tuple[str, bool]] = []
+
+    def _fake_get(url: str, *, timeout: float, trust_env: bool) -> _Resp:
+        health_targets.append((url, trust_env))
+        return _Resp()
+
+    monkeypatch.setattr("httpx.get", _fake_get)
+
+    local_server._wait_for_local_omnigent_server(
+        "http://127.0.0.1:8123", _Proc(), tmp_path / "server.log"
+    )
+
+    assert health_targets == [("http://127.0.0.1:8123/health", False)]
 
 
 def test_local_server_url_if_healthy_none_when_pid_dead(
@@ -752,9 +781,12 @@ def test_stop_untracked_local_server_kills_orphan_on_default_port(
     confirm it's our server via ``/health``, resolve its PID via lsof, and
     terminate it — returning the PID so the off-switch can report it.
     """
-    monkeypatch.setattr(
-        "httpx.get", lambda url, *, timeout: _FakeHealthResp(200, {"status": "ok"})
-    )
+
+    def _healthy(url: str, *, timeout: float, trust_env: bool) -> _FakeHealthResp:
+        assert trust_env is False
+        return _FakeHealthResp(200, {"status": "ok"})
+
+    monkeypatch.setattr("httpx.get", _healthy)
     monkeypatch.setattr(local_server, "subprocess", _fake_subprocess(stdout="93359\n93360\n"))
     monkeypatch.setattr(local_server, "_pid_alive", lambda pid: True)
     terminated: list[int] = []
@@ -777,7 +809,8 @@ def test_stop_untracked_local_server_noop_when_nothing_listening(
     """
     import httpx
 
-    def _refused(url: str, *, timeout: float) -> Any:
+    def _refused(url: str, *, timeout: float, trust_env: bool) -> Any:
+        assert trust_env is False
         raise httpx.ConnectError("connection refused")
 
     monkeypatch.setattr("httpx.get", _refused)
@@ -795,9 +828,12 @@ def test_stop_untracked_local_server_noop_on_non_omnigent_listener(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A 200 that isn't ``{"status": "ok"}`` is some other app — never killed."""
-    monkeypatch.setattr(
-        "httpx.get", lambda url, *, timeout: _FakeHealthResp(200, {"hello": "world"})
-    )
+
+    def _foreign(url: str, *, timeout: float, trust_env: bool) -> _FakeHealthResp:
+        assert trust_env is False
+        return _FakeHealthResp(200, {"hello": "world"})
+
+    monkeypatch.setattr("httpx.get", _foreign)
     monkeypatch.setattr(local_server, "_terminate_pid", _raise_if_called)
 
     assert local_server.stop_untracked_local_server(port=8000) is None
@@ -811,9 +847,12 @@ def test_stop_untracked_local_server_noop_when_lsof_unavailable(
     Without a PID we can't terminate, so the sweep returns ``None`` rather
     than crashing — the off-switch then leaves a manual hint to the user.
     """
-    monkeypatch.setattr(
-        "httpx.get", lambda url, *, timeout: _FakeHealthResp(200, {"status": "ok"})
-    )
+
+    def _healthy(url: str, *, timeout: float, trust_env: bool) -> _FakeHealthResp:
+        assert trust_env is False
+        return _FakeHealthResp(200, {"status": "ok"})
+
+    monkeypatch.setattr("httpx.get", _healthy)
     monkeypatch.setattr(
         local_server, "subprocess", _fake_subprocess(raises=FileNotFoundError("lsof"))
     )


### PR DESCRIPTION
## Related issue

Closes #1977

## Summary

- Bypass environment and system proxies for the three loopback health probes used by local server discovery, startup, and orphan cleanup.
- Cover each probe path so future local health checks cannot silently re-enable proxy discovery.

## Test Plan

- `pytest tests/host/test_local_server.py -q` — 29 passed in the isolated host-test environment
- `pre-commit run --files omnigent/host/local_server.py tests/host/test_local_server.py` — passed
- Fake-proxy socket smoke: default HTTPX received 502 from the configured proxy; all three patched loopback probes reached the local health server with 200

## Demo

![Loopback proxy smoke](https://raw.githubusercontent.com/ychampion/omnigent/pr-2433-demo/pr-demos/2433-loopback-proxy.svg)

The configured fake proxy intercepts default HTTPX traffic, while each daemon health probe connects directly to loopback.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Ran a local health server and a fake 502 proxy with `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY` set and `NO_PROXY` cleared. Default HTTPX was intercepted; the reuse, readiness, and orphan-detection probes all connected directly.

## Changelog

Local server startup now works when a system proxy intercepts loopback traffic.