### PR TITLE
feat(sandbox): operator-configured PVC mounts for Kubernetes runners (+ fix global YAML bool-resolver leak)

### DIFF
--- a/deploy/kubernetes/overlays/sandbox-runners/README.md
+++ b/deploy/kubernetes/overlays/sandbox-runners/README.md
@@ -151,7 +151,9 @@ output directories) mount pre-created PersistentVolumeClaims:
    (NFS/SMB CSI drivers, SAN, cloud disks). Omnigent only references the claim;
    it never creates volumes, so the server RBAC stays unchanged.
 2. List the claims under `sandbox.kubernetes.pvc_mounts` (see
-   `sandbox-config.yaml`). Mount paths must sit outside `/home/omnigent`.
+   `sandbox-config.yaml`). Mount paths may not overlap `/home/omnigent`, the
+   OS directories, or their ancestors (e.g. `/home`, `/var`) — the server
+   rejects such config at startup.
 
 Caveats:
 

--- a/deploy/kubernetes/overlays/sandbox-runners/README.md
+++ b/deploy/kubernetes/overlays/sandbox-runners/README.md
@@ -138,6 +138,36 @@ writing nothing to disk — use HTTPS repository URLs. Details by provider match
 | `resources` | Optional `requests` / `limits` (`cpu` / `memory`) override. |
 | `in_cluster` | Optional cluster-config source: `true` (in-cluster SA only), `false` (kubeconfig only), omit (try in-cluster, then kubeconfig). |
 | `kubeconfig` | Optional kubeconfig path for the out-of-cluster fallback (env: `OMNIGENT_KUBERNETES_KUBECONFIG`). |
+| `pvc_mounts` | Optional pre-created PersistentVolumeClaims mounted into every runner Pod — see [Persistent storage mounts](#persistent-storage-mounts-pvc_mounts). |
+
+## Persistent storage mounts (`pvc_mounts`)
+
+Runner Pods are ephemeral by design — the workspace lives on an `emptyDir` and
+dies with the Pod. To expose durable data (datasets, model caches, shared
+output directories) mount pre-created PersistentVolumeClaims:
+
+1. Create the PV/PVC **in the runner namespace** (`omnigent-sandboxes`) out of
+   band — via your GitOps repo, with whatever backend your cluster provides
+   (NFS/SMB CSI drivers, SAN, cloud disks). Omnigent only references the claim;
+   it never creates volumes, so the server RBAC stays unchanged.
+2. List the claims under `sandbox.kubernetes.pvc_mounts` (see
+   `sandbox-config.yaml`). Mount paths must sit outside `/home/omnigent`.
+
+Caveats:
+
+- **Multiple runners share writable claims concurrently** — use a
+  `ReadWriteMany`-capable backend (NFS/SMB/CephFS) for anything writable, and
+  prefer `read_only: true` (the default) everywhere else: a writable shared
+  mount lets one session's agent read and modify what another session wrote,
+  and anything written there outlives the Pod and its launch token.
+- Runner Pods run as uid/gid 1000660000 with `fsGroup`. NFS `root_squash` and
+  SMB ownership mapping must permit that identity (export to the uid, or use
+  CSI mount options like `uid=`/`gid=` for SMB); `fsGroupChangePolicy:
+  OnRootMismatch` avoids re-chowning large exports on every start.
+- `ReadWriteOnce` claims pin all runners to one node — combine with
+  `node_selector` deliberately, or the second Pod sits `Pending`.
+- A mount visible in the Pod is not automatically visible to a harness's own
+  OS-level sandbox (OmniBox path grants are separate).
 
 To verify `host_config` end to end against a live cluster, run
 `python tests/e2e/integrations/deploy/kubernetes/e2e_managed_host_config.py

--- a/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
+++ b/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
@@ -45,5 +45,9 @@ data:
         # resources:                 # runner Pod sizing (defaults: 0.5-2 cpu / 1-4Gi)
         #   requests: {cpu: "500m", memory: "1Gi"}
         #   limits: {cpu: "2", memory: "4Gi"}
+        # pvc_mounts:                # pre-created PVCs (in the runner namespace) mounted into every runner Pod
+        #   - claim_name: omnigent-datasets
+        #     mount_path: /mnt/datasets
+        #     read_only: true        # default true; set false only for claims meant as shared scratch
         # in_cluster: true           # config source: true=in-cluster SA only, false=kubeconfig only, omit=try both
         # kubeconfig: /path/to/config  # out-of-cluster kubeconfig (env: OMNIGENT_KUBERNETES_KUBECONFIG)

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -875,7 +875,7 @@ class KubernetesSandboxLauncher(SandboxLauncher):
         self._kubeconfig = kubeconfig
         self._in_cluster = in_cluster
         self._resources = resources
-        self._pvc_mounts = [dict(m) for m in pvc_mounts] if pvc_mounts else None
+        self._pvc_mounts = list(pvc_mounts) if pvc_mounts else None
         self._core: k8s_client.CoreV1Api | None = None
         self._api_client: k8s_client.ApiClient | None = None
 

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -838,6 +838,7 @@ class KubernetesSandboxLauncher(SandboxLauncher):
         kubeconfig: str | None = None,
         in_cluster: bool | None = None,
         resources: dict[str, object] | None = None,
+        pvc_mounts: Sequence[Mapping[str, object]] | None = None,
     ) -> None:
         """
         Initialize the launcher.
@@ -862,6 +863,8 @@ class KubernetesSandboxLauncher(SandboxLauncher):
             ``False`` kubeconfig only, ``None`` to try in-cluster then fall back.
         :param resources: ``sandbox.kubernetes.resources`` block, or ``None``
             for the built-in defaults.
+        :param pvc_mounts: Normalized ``sandbox.kubernetes.pvc_mounts`` entries
+            (validated at parse time), or ``None`` for none.
         """
         self._image_ref = image
         self._namespace = namespace
@@ -872,6 +875,7 @@ class KubernetesSandboxLauncher(SandboxLauncher):
         self._kubeconfig = kubeconfig
         self._in_cluster = in_cluster
         self._resources = resources
+        self._pvc_mounts = [dict(m) for m in pvc_mounts] if pvc_mounts else None
         self._core: k8s_client.CoreV1Api | None = None
         self._api_client: k8s_client.ApiClient | None = None
 
@@ -1167,6 +1171,7 @@ class KubernetesSandboxLauncher(SandboxLauncher):
                     repo_branch=repo_branch,
                     host_config=host_config,
                     resources=self._resources,
+                    pvc_mounts=self._pvc_mounts,
                 )
                 # Secret before Pod so the Pod's secretKeyRef resolves
                 # immediately — a Pod referencing a missing Secret would sit in

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -54,7 +54,7 @@ import re
 import shlex
 import time
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, ClassVar, Literal
 
 import click
@@ -475,6 +475,7 @@ def build_pod_manifest(
     repo_branch: str | None = None,
     host_config: dict[str, object] | None = None,
     resources: dict[str, object] | None = None,
+    pvc_mounts: Sequence[Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
     """
     Build the sandbox Pod manifest as a plain dict.
@@ -502,6 +503,9 @@ def build_pod_manifest(
       root filesystem stays writable (the host writes ``/tmp`` + ``~/.omnigent``).
     - ``kubernetes.io/arch: amd64`` is the default; a *node_selector* entry for
       that key overrides it (e.g. ``arm64`` — the host image is multi-arch).
+    - Operator *pvc_mounts* become ``persistentVolumeClaim`` volumes mounted on
+      the **host container only** (read-only unless opted out); the init
+      container sees only HOME, so nothing external is exposed at clone time.
 
     :param pod_name: DNS-label-safe Pod name (see :func:`_new_pod_name`).
     :param namespace: Namespace the Pod is created in.
@@ -530,6 +534,9 @@ def build_pod_manifest(
         the sandbox against the ``envFrom`` harness Secret), so embedding the
         content in the init container's command is as safe as the clone URL.
     :param resources: Configured resources block, or ``None`` for the defaults.
+    :param pvc_mounts: Normalized PVC mounts (``{claim_name, mount_path,
+        read_only}``) added as ``persistentVolumeClaim`` volumes on the host
+        container only, or ``None``.
     :returns: The Pod manifest dict.
     """
     pod_resources = _resolve_pod_resources(resources)
@@ -538,6 +545,23 @@ def build_pod_manifest(
         "capabilities": {"drop": ["ALL"]},
     }
     home_mount = [{"name": "home", "mountPath": _HOME_DIR}]
+    pvc_volumes: list[dict[str, object]] = []
+    pvc_volume_mounts: list[dict[str, object]] = []
+    for i, mount in enumerate(pvc_mounts or ()):
+        # Index-based names sidestep DNS-label collisions between similar claim
+        # names and with the reserved "home" volume.
+        claim_source: dict[str, object] = {"claimName": mount["claim_name"]}
+        volume_mount: dict[str, object] = {
+            "name": f"pvc-{i}",
+            "mountPath": mount["mount_path"],
+        }
+        if mount["read_only"]:
+            # readOnly on the volume source too, so even a future second mount
+            # of the same volume cannot write through it.
+            claim_source["readOnly"] = True
+            volume_mount["readOnly"] = True
+        pvc_volumes.append({"name": f"pvc-{i}", "persistentVolumeClaim": claim_source})
+        pvc_volume_mounts.append(volume_mount)
 
     init_env = [{"name": "HOME", "value": _HOME_DIR}]
     config_home = env_literals.get("OMNIGENT_CONFIG_HOME")
@@ -603,7 +627,7 @@ def build_pod_manifest(
         "env": host_env,
         "resources": pod_resources,
         "securityContext": container_security,
-        "volumeMounts": home_mount,
+        "volumeMounts": [*home_mount, *pvc_volume_mounts],
     }
     if harness_secret:
         host_container["envFrom"] = [{"secretRef": {"name": harness_secret}}]
@@ -624,7 +648,7 @@ def build_pod_manifest(
             "fsGroupChangePolicy": "OnRootMismatch",
             "seccompProfile": {"type": "RuntimeDefault"},
         },
-        "volumes": [{"name": "home", "emptyDir": {}}],
+        "volumes": [{"name": "home", "emptyDir": {}}, *pvc_volumes],
         "initContainers": [init_container],
         "containers": [host_container],
     }

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1869,8 +1869,7 @@ def _parse_kubernetes_pvc_mounts(raw: dict[str, object]) -> list[dict[str, objec
                 f"path (no '..', '.', doubled or trailing slashes): {mount!r}"
             )
         if mount == "/" or any(
-            mount == p or mount.startswith(p + "/")
-            for p in _KUBERNETES_RESERVED_MOUNT_PREFIXES
+            mount == p or mount.startswith(p + "/") for p in _KUBERNETES_RESERVED_MOUNT_PREFIXES
         ):
             raise ValueError(
                 f"server config '{path_prefix}.mount_path' is a reserved path: "
@@ -1885,8 +1884,7 @@ def _parse_kubernetes_pvc_mounts(raw: dict[str, object]) -> list[dict[str, objec
         pa, pb = str(a["mount_path"]), str(b["mount_path"])
         if pa == pb:
             raise ValueError(
-                "server config 'sandbox.kubernetes.pvc_mounts' has a duplicate "
-                f"mount_path: {pa!r}"
+                f"server config 'sandbox.kubernetes.pvc_mounts' has a duplicate mount_path: {pa!r}"
             )
         low, high = sorted((pa, pb), key=len)
         if high.startswith(low + "/"):

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -123,7 +123,9 @@ stores into ``create_app``):
 from __future__ import annotations
 
 import asyncio
+import itertools
 import logging
+import posixpath
 import re
 import secrets
 import time
@@ -831,6 +833,7 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
             kubeconfig=_parse_provider_string(raw, "kubernetes", "kubeconfig"),
             in_cluster=_parse_provider_bool(raw, "kubernetes", "in_cluster"),
             resources=_parse_kubernetes_resources(raw),
+            pvc_mounts=_parse_kubernetes_pvc_mounts(raw),
         )
         token_ttl_s = KUBERNETES_MANAGED_TOKEN_TTL_S
     else:
@@ -1785,6 +1788,115 @@ def _parse_kubernetes_resources(raw: dict[str, object]) -> dict[str, object] | N
     return normalized
 
 
+# Absolute path prefixes a pvc_mounts mount_path may not land on or under:
+# "/home/omnigent" is the runner's writable-HOME emptyDir (mirrors _HOME_DIR in
+# omnigent.onboarding.sandboxes.kubernetes — fixed by design, like the RFC 1123
+# regexes above); "/var/run/secrets" is where Kubernetes projects Secrets; the
+# rest would shadow the image's OS or the host's scratch space.
+_KUBERNETES_RESERVED_MOUNT_PREFIXES: tuple[str, ...] = (
+    "/home/omnigent",
+    "/var/run/secrets",
+    "/tmp",
+    "/etc",
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/proc",
+    "/sys",
+    "/dev",
+)
+
+
+def _parse_kubernetes_pvc_mounts(raw: dict[str, object]) -> list[dict[str, object]] | None:
+    """
+    Extract and validate the optional ``sandbox.kubernetes.pvc_mounts`` list.
+
+    Each entry references a PersistentVolumeClaim the operator pre-created in
+    the runner namespace: ``{claim_name, mount_path, read_only?}`` with
+    ``read_only`` defaulting to ``True``. Validated at parse time so an
+    operator typo fails server startup instead of the first managed launch.
+
+    :param raw: The raw ``sandbox`` mapping.
+    :returns: Normalized entries, or ``None`` when omitted or empty.
+    :raises ValueError: When the list or any entry has the wrong shape, a name
+        or path is malformed, a path is reserved, or paths collide.
+    """
+    section = _parse_provider_section(raw, "kubernetes")
+    if section is None:
+        return None
+    value = section.get("pvc_mounts")
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError(
+            "server config 'sandbox.kubernetes.pvc_mounts' must be a list of "
+            "{claim_name, mount_path, read_only?} entries"
+        )
+    normalized: list[dict[str, object]] = []
+    for i, entry in enumerate(value):
+        path_prefix = f"sandbox.kubernetes.pvc_mounts[{i}]"
+        if not isinstance(entry, dict):
+            raise ValueError(f"server config '{path_prefix}' must be a mapping")
+        unknown = sorted(set(entry) - {"claim_name", "mount_path", "read_only"})
+        if unknown:
+            raise ValueError(
+                f"server config '{path_prefix}' has unknown key(s): "
+                f"{', '.join(unknown)} (expected claim_name, mount_path, read_only)"
+            )
+        claim = entry.get("claim_name")
+        if not isinstance(claim, str) or not claim.strip():
+            raise ValueError(
+                f"server config '{path_prefix}.claim_name' must name a "
+                "PersistentVolumeClaim pre-created in the runner namespace"
+            )
+        claim = claim.strip()
+        if len(claim) > 253 or not _DNS1123_SUBDOMAIN_RE.fullmatch(claim):
+            raise ValueError(
+                f"server config '{path_prefix}.claim_name' is not a valid "
+                f"Kubernetes name (RFC 1123 DNS subdomain): {claim!r}"
+            )
+        mount = entry.get("mount_path")
+        if not isinstance(mount, str) or not mount.startswith("/"):
+            raise ValueError(
+                f"server config '{path_prefix}.mount_path' must be an absolute "
+                "in-Pod path, e.g. '/mnt/datasets'"
+            )
+        if mount != posixpath.normpath(mount):
+            raise ValueError(
+                f"server config '{path_prefix}.mount_path' must be a normalized "
+                f"path (no '..', '.', doubled or trailing slashes): {mount!r}"
+            )
+        if mount == "/" or any(
+            mount == p or mount.startswith(p + "/")
+            for p in _KUBERNETES_RESERVED_MOUNT_PREFIXES
+        ):
+            raise ValueError(
+                f"server config '{path_prefix}.mount_path' is a reserved path: "
+                f"{mount!r} (the runner's HOME, Secret projections, and OS "
+                "directories cannot be shadowed)"
+            )
+        read_only = entry.get("read_only", True)
+        if not isinstance(read_only, bool):
+            raise ValueError(f"server config '{path_prefix}.read_only' must be a boolean")
+        normalized.append({"claim_name": claim, "mount_path": mount, "read_only": read_only})
+    for a, b in itertools.combinations(normalized, 2):
+        pa, pb = str(a["mount_path"]), str(b["mount_path"])
+        if pa == pb:
+            raise ValueError(
+                "server config 'sandbox.kubernetes.pvc_mounts' has a duplicate "
+                f"mount_path: {pa!r}"
+            )
+        low, high = sorted((pa, pb), key=len)
+        if high.startswith(low + "/"):
+            raise ValueError(
+                "server config 'sandbox.kubernetes.pvc_mounts' has nested "
+                f"mount_paths: {low!r} contains {high!r}"
+            )
+    return normalized or None
+
+
 def _kubernetes_launcher_factory(
     *,
     image: str | None,
@@ -1796,6 +1908,7 @@ def _kubernetes_launcher_factory(
     kubeconfig: str | None,
     in_cluster: bool | None,
     resources: dict[str, object] | None,
+    pvc_mounts: list[dict[str, object]] | None,
 ) -> Callable[[], SandboxLauncher]:
     """
     Build the launcher factory for the YAML ``provider: kubernetes`` path.
@@ -1817,6 +1930,8 @@ def _kubernetes_launcher_factory(
     :param in_cluster: Force the cluster-config source, or ``None`` to try
         in-cluster then fall back to kubeconfig.
     :param resources: Validated ``resources`` block, or ``None`` for defaults.
+    :param pvc_mounts: Normalized PVC mount entries added to every runner Pod,
+        or ``None``.
     :returns: A factory producing parameterized Kubernetes launchers.
     :raises ValueError: When a name or node-selector label is malformed.
     """
@@ -1836,6 +1951,7 @@ def _kubernetes_launcher_factory(
             kubeconfig=kubeconfig,
             in_cluster=in_cluster,
             resources=resources,
+            pvc_mounts=pvc_mounts,
         )
 
     return _build

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1806,7 +1806,8 @@ def _parse_kubernetes_resources(raw: dict[str, object]) -> dict[str, object] | N
 
 # Path prefixes a pvc_mounts mount_path may not shadow: the runner's
 # writable-HOME emptyDir (mirrors the launcher's _HOME_DIR — pinned by test),
-# Kubernetes Secret projections, and the image's OS / scratch directories.
+# Kubernetes Secret projections, the image's OS / scratch directories, and
+# /opt (the host image's omnigent venv lives at /opt/venv).
 _KUBERNETES_RESERVED_MOUNT_PREFIXES: tuple[str, ...] = (
     "/home/omnigent",
     "/var/run/secrets",
@@ -1817,6 +1818,7 @@ _KUBERNETES_RESERVED_MOUNT_PREFIXES: tuple[str, ...] = (
     "/sbin",
     "/lib",
     "/lib64",
+    "/opt",
     "/proc",
     "/sys",
     "/dev",
@@ -1868,7 +1870,10 @@ def _parse_kubernetes_pvc_mounts(raw: dict[str, object]) -> list[dict[str, objec
                 f"server config '{path_prefix}.mount_path' must be an absolute "
                 "in-Pod path, e.g. '/mnt/datasets'"
             )
-        if mount != posixpath.normpath(mount):
+        # normpath preserves exactly two leading slashes (POSIX), but the
+        # kernel collapses them at mount time — reject them explicitly so
+        # '//home/omnigent' cannot slip past the reserved-prefix check.
+        if mount.startswith("//") or mount != posixpath.normpath(mount):
             raise ValueError(
                 f"server config '{path_prefix}.mount_path' must be a normalized "
                 f"path (no '..', '.', doubled or trailing slashes): {mount!r}"

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -770,9 +770,7 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
         token_ttl_s = DAYTONA_MANAGED_TOKEN_TTL_S
     elif provider == "boxlite":
         section = _boxlite_section(raw)
-        _reject_unknown_boxlite_keys(
-            section, {"image", "env", "local", "cloud"}, "sandbox.boxlite"
-        )
+        _reject_unknown_keys(section, {"image", "env", "local", "cloud"}, "sandbox.boxlite")
         endpoint, home_dir, registry = _parse_boxlite_mode(section)
         launcher_factory = _boxlite_launcher_factory(
             endpoint,
@@ -823,6 +821,24 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
         )
         token_ttl_s = OPENSHELL_MANAGED_TOKEN_TTL_S
     elif provider == "kubernetes":
+        kubernetes_section = _parse_provider_section(raw, "kubernetes")
+        if kubernetes_section is not None:
+            _reject_unknown_keys(
+                kubernetes_section,
+                {
+                    "image",
+                    "env",
+                    "namespace",
+                    "secret_name",
+                    "service_account",
+                    "node_selector",
+                    "kubeconfig",
+                    "in_cluster",
+                    "resources",
+                    "pvc_mounts",
+                },
+                "sandbox.kubernetes",
+            )
         launcher_factory = _kubernetes_launcher_factory(
             image=_parse_provider_image(raw, "kubernetes"),
             env=_parse_provider_env(raw, "kubernetes"),
@@ -1079,7 +1095,7 @@ def _boxlite_section(raw: dict[str, object]) -> dict[str, object]:
     return section
 
 
-def _reject_unknown_boxlite_keys(mapping: dict[str, object], allowed: set[str], path: str) -> None:
+def _reject_unknown_keys(mapping: dict[str, object], allowed: set[str], path: str) -> None:
     """
     Fail loud on any key outside *allowed* — catches typos and misplaced keys
     (e.g. ``endpoint`` at the section level instead of under ``cloud:``, or a
@@ -1130,7 +1146,7 @@ def _parse_boxlite_mode(
     if cloud_present:
         if not isinstance(cloud_block, dict):
             raise ValueError("server config 'sandbox.boxlite.cloud' must be a mapping")
-        _reject_unknown_boxlite_keys(cloud_block, {"endpoint"}, "sandbox.boxlite.cloud")
+        _reject_unknown_keys(cloud_block, {"endpoint"}, "sandbox.boxlite.cloud")
         endpoint = cloud_block.get("endpoint")
         if not isinstance(endpoint, str) or not endpoint.strip():
             raise ValueError(
@@ -1143,7 +1159,7 @@ def _parse_boxlite_mode(
         return None, None, None
     if not isinstance(local_block, dict):
         raise ValueError("server config 'sandbox.boxlite.local' must be a mapping")
-    _reject_unknown_boxlite_keys(local_block, {"home_dir", "registry"}, "sandbox.boxlite.local")
+    _reject_unknown_keys(local_block, {"home_dir", "registry"}, "sandbox.boxlite.local")
     return None, _parse_boxlite_home_dir(local_block), _parse_boxlite_registry(local_block)
 
 
@@ -1224,7 +1240,7 @@ def _parse_boxlite_registry(local: dict[str, object]) -> dict[str, object] | Non
         return None
     if not isinstance(registry, dict):
         raise ValueError("server config 'sandbox.boxlite.local.registry' must be a mapping")
-    _reject_unknown_boxlite_keys(
+    _reject_unknown_keys(
         registry,
         {"host", "transport", "skip_verify", "username_env", "password_env", "token_env"},
         "sandbox.boxlite.local.registry",

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1804,11 +1804,9 @@ def _parse_kubernetes_resources(raw: dict[str, object]) -> dict[str, object] | N
     return normalized
 
 
-# Absolute path prefixes a pvc_mounts mount_path may not land on or under:
-# "/home/omnigent" is the runner's writable-HOME emptyDir (mirrors _HOME_DIR in
-# omnigent.onboarding.sandboxes.kubernetes — fixed by design, like the RFC 1123
-# regexes above); "/var/run/secrets" is where Kubernetes projects Secrets; the
-# rest would shadow the image's OS or the host's scratch space.
+# Path prefixes a pvc_mounts mount_path may not shadow: the runner's
+# writable-HOME emptyDir (mirrors the launcher's _HOME_DIR — pinned by test),
+# Kubernetes Secret projections, and the image's OS / scratch directories.
 _KUBERNETES_RESERVED_MOUNT_PREFIXES: tuple[str, ...] = (
     "/home/omnigent",
     "/var/run/secrets",
@@ -1855,12 +1853,7 @@ def _parse_kubernetes_pvc_mounts(raw: dict[str, object]) -> list[dict[str, objec
         path_prefix = f"sandbox.kubernetes.pvc_mounts[{i}]"
         if not isinstance(entry, dict):
             raise ValueError(f"server config '{path_prefix}' must be a mapping")
-        unknown = sorted(set(entry) - {"claim_name", "mount_path", "read_only"})
-        if unknown:
-            raise ValueError(
-                f"server config '{path_prefix}' has unknown key(s): "
-                f"{', '.join(unknown)} (expected claim_name, mount_path, read_only)"
-            )
+        _reject_unknown_keys(entry, {"claim_name", "mount_path", "read_only"}, path_prefix)
         claim = entry.get("claim_name")
         if not isinstance(claim, str) or not claim.strip():
             raise ValueError(
@@ -1868,11 +1861,7 @@ def _parse_kubernetes_pvc_mounts(raw: dict[str, object]) -> list[dict[str, objec
                 "PersistentVolumeClaim pre-created in the runner namespace"
             )
         claim = claim.strip()
-        if len(claim) > 253 or not _DNS1123_SUBDOMAIN_RE.fullmatch(claim):
-            raise ValueError(
-                f"server config '{path_prefix}.claim_name' is not a valid "
-                f"Kubernetes name (RFC 1123 DNS subdomain): {claim!r}"
-            )
+        _validate_dns1123_subdomain(claim, f"pvc_mounts[{i}].claim_name")
         mount = entry.get("mount_path")
         if not isinstance(mount, str) or not mount.startswith("/"):
             raise ValueError(

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1804,13 +1804,21 @@ def _parse_kubernetes_resources(raw: dict[str, object]) -> dict[str, object] | N
     return normalized
 
 
-# Path prefixes a pvc_mounts mount_path may not shadow: the runner's
-# writable-HOME emptyDir (mirrors the launcher's _HOME_DIR — pinned by test),
-# Kubernetes Secret projections, the image's OS / scratch directories, and
-# /opt (the host image's omnigent venv lives at /opt/venv).
+# Path prefixes a pvc_mounts mount_path may not overlap — neither sitting at
+# or under one, nor mounting over one from an ancestor (a PVC at /home would
+# shadow the /home/omnigent mountpoint): the runner's writable-HOME emptyDir
+# (mirrors the launcher's _HOME_DIR — pinned by test), Kubernetes Secret
+# projections, the image's OS / scratch directories, and /opt (the host
+# image's omnigent venv lives at /opt/venv).
 _KUBERNETES_RESERVED_MOUNT_PREFIXES: tuple[str, ...] = (
     "/home/omnigent",
-    "/var/run/secrets",
+    # Secret projections live under /var/run/secrets; the Debian-based host
+    # image symlinks /var/run -> /run and /var/lock -> /run/lock, so every
+    # spelling is reserved in full to keep the lexical check consistent
+    # across the aliases.
+    "/var/run",
+    "/var/lock",
+    "/run",
     "/tmp",
     "/etc",
     "/usr",
@@ -1879,12 +1887,13 @@ def _parse_kubernetes_pvc_mounts(raw: dict[str, object]) -> list[dict[str, objec
                 f"path (no '..', '.', doubled or trailing slashes): {mount!r}"
             )
         if mount == "/" or any(
-            mount == p or mount.startswith(p + "/") for p in _KUBERNETES_RESERVED_MOUNT_PREFIXES
+            mount == p or mount.startswith(p + "/") or p.startswith(mount + "/")
+            for p in _KUBERNETES_RESERVED_MOUNT_PREFIXES
         ):
             raise ValueError(
-                f"server config '{path_prefix}.mount_path' is a reserved path: "
-                f"{mount!r} (the runner's HOME, Secret projections, and OS "
-                "directories cannot be shadowed)"
+                f"server config '{path_prefix}.mount_path' overlaps a reserved "
+                f"path: {mount!r} (the runner's HOME, Secret projections, and OS "
+                "directories cannot be shadowed or mounted over)"
             )
         read_only = entry.get("read_only", True)
         if not isinstance(read_only, bool):

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -252,6 +252,41 @@ def test_build_pod_manifest_node_selector_can_override_arch() -> None:
     assert selector["disktype"] == "ssd"
 
 
+def test_build_pod_manifest_pvc_mounts_land_on_host_container_only() -> None:
+    """Each pvc_mounts entry becomes a persistentVolumeClaim volume mounted on host only."""
+    manifest = build_pod_manifest(
+        **_MANIFEST_KW,
+        pvc_mounts=[
+            {"claim_name": "omnigent-datasets", "mount_path": "/mnt/datasets", "read_only": True},
+            {"claim_name": "scratch", "mount_path": "/mnt/scratch", "read_only": False},
+        ],
+    )
+    spec = manifest["spec"]
+    volumes = {v["name"]: v for v in spec["volumes"]}
+    assert volumes["home"] == {"name": "home", "emptyDir": {}}
+    assert volumes["pvc-0"]["persistentVolumeClaim"] == {
+        "claimName": "omnigent-datasets",
+        "readOnly": True,
+    }
+    assert volumes["pvc-1"]["persistentVolumeClaim"] == {"claimName": "scratch"}
+    host_mounts = {m["name"]: m for m in spec["containers"][0]["volumeMounts"]}
+    assert host_mounts["pvc-0"] == {"name": "pvc-0", "mountPath": "/mnt/datasets", "readOnly": True}
+    assert host_mounts["pvc-1"] == {"name": "pvc-1", "mountPath": "/mnt/scratch"}
+    # The init container keeps exactly its HOME emptyDir — no dataset exposure at clone time.
+    assert spec["initContainers"][0]["volumeMounts"] == [
+        {"name": "home", "mountPath": "/home/omnigent"}
+    ]
+
+
+def test_build_pod_manifest_without_pvc_mounts_is_unchanged() -> None:
+    """No pvc_mounts → the single home emptyDir, exactly as before."""
+    manifest = build_pod_manifest(**_MANIFEST_KW)
+    assert manifest["spec"]["volumes"] == [{"name": "home", "emptyDir": {}}]
+    assert manifest["spec"]["containers"][0]["volumeMounts"] == [
+        {"name": "home", "mountPath": "/home/omnigent"}
+    ]
+
+
 def test_build_pod_manifest_is_restricted_and_least_privilege() -> None:
     """The Pod satisfies Pod Security 'restricted' and mounts no SA token."""
     manifest = build_pod_manifest(**_MANIFEST_KW)

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -270,7 +270,11 @@ def test_build_pod_manifest_pvc_mounts_land_on_host_container_only() -> None:
     }
     assert volumes["pvc-1"]["persistentVolumeClaim"] == {"claimName": "scratch"}
     host_mounts = {m["name"]: m for m in spec["containers"][0]["volumeMounts"]}
-    assert host_mounts["pvc-0"] == {"name": "pvc-0", "mountPath": "/mnt/datasets", "readOnly": True}
+    assert host_mounts["pvc-0"] == {
+        "name": "pvc-0",
+        "mountPath": "/mnt/datasets",
+        "readOnly": True,
+    }
     assert host_mounts["pvc-1"] == {"name": "pvc-1", "mountPath": "/mnt/scratch"}
     # The init container keeps exactly its HOME emptyDir — no dataset exposure at clone time.
     assert spec["initContainers"][0]["volumeMounts"] == [

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -516,6 +516,31 @@ def test_launch_host_creates_secret_then_pod_and_returns_workspace(
     assert fake_core.deleted_pods == []
 
 
+def test_launch_host_threads_pvc_mounts_into_the_pod(fake_core: _FakeCore) -> None:
+    """A launcher built with pvc_mounts creates Pods carrying the PVC volume."""
+    fake_core.read_queue = [_pod(phase="Running")]
+    launcher = KubernetesSandboxLauncher(
+        in_cluster=True,
+        namespace="omnigent-sandboxes",
+        secret_name="omnigent-creds",
+        env=(),
+        pvc_mounts=[
+            {"claim_name": "omnigent-datasets", "mount_path": "/mnt/datasets", "read_only": True}
+        ],
+    )
+    launcher.start_host(
+        "omnigent-pod-1",
+        token=_TOKEN,
+        host_id="host_1",
+        host_name="managed-1",
+        server_url="http://srv.example.com",
+    )
+    assert {
+        "name": "pvc-0",
+        "persistentVolumeClaim": {"claimName": "omnigent-datasets", "readOnly": True},
+    } in fake_core.created_pods[0]["spec"]["volumes"]
+
+
 def test_launch_host_with_repo_returns_clone_dir(fake_core: _FakeCore) -> None:
     """With a repo, the returned workspace is the cloned directory under the workspace."""
     fake_core.read_queue = [_pod(phase="Running")]

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -211,6 +211,7 @@ class FakeSandboxLauncher(SandboxLauncher):
         self.kubeconfig: str | None = None
         self.in_cluster: bool | None = None
         self.resources: dict[str, object] | None = None
+        self.pvc_mounts: list[dict[str, object]] | None = None
         self.prepared = False
         self.provisioned_names: list[str] = []
         self.commands: list[str] = []
@@ -518,7 +519,7 @@ def install_fake_kubernetes_launcher(
 
     The managed flow constructs ``KubernetesSandboxLauncher(image=…, env=…,
     namespace=…, secret_name=…, service_account=…, node_selector=…,
-    kubeconfig=…, in_cluster=…, resources=…)``; the shim records those
+    kubeconfig=…, in_cluster=…, resources=…, pvc_mounts=…)``; the shim records those
     constructor args on the fake and hands it back, so production code runs
     unmodified against it.
 
@@ -538,6 +539,7 @@ def install_fake_kubernetes_launcher(
         kubeconfig: str | None = None,
         in_cluster: bool | None = None,
         resources: dict[str, object] | None = None,
+        pvc_mounts: list[dict[str, object]] | None = None,
     ) -> FakeSandboxLauncher:
         """Stand-in constructor recording the construction wiring."""
         fake.image = image
@@ -549,6 +551,7 @@ def install_fake_kubernetes_launcher(
         fake.kubeconfig = kubeconfig
         fake.in_cluster = in_cluster
         fake.resources = resources
+        fake.pvc_mounts = pvc_mounts
         return fake
 
     monkeypatch.setattr(kubernetes_mod, "KubernetesSandboxLauncher", _ctor)

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -764,11 +764,18 @@ def test_parse_kubernetes_without_pvc_mounts_is_none(monkeypatch: pytest.MonkeyP
         ([{"claim_name": "c", "mount_path": "mnt/x"}], "absolute"),
         ([{"claim_name": "c", "mount_path": "/mnt/../etc"}], "normalized"),
         ([{"claim_name": "c", "mount_path": "/mnt/x/"}], "normalized"),
+        # Exactly two leading slashes survive posixpath.normpath (POSIX) but
+        # the kernel collapses them, so '//home/omnigent' would shadow HOME.
+        ([{"claim_name": "c", "mount_path": "//home/omnigent"}], "normalized"),
+        ([{"claim_name": "c", "mount_path": "//mnt/x"}], "normalized"),
         ([{"claim_name": "c", "mount_path": "/"}], "reserved"),
         ([{"claim_name": "c", "mount_path": "/home/omnigent/data"}], "reserved"),
         ([{"claim_name": "c", "mount_path": "/var/run/secrets/x"}], "reserved"),
         ([{"claim_name": "c", "mount_path": "/tmp"}], "reserved"),
         ([{"claim_name": "c", "mount_path": "/etc"}], "reserved"),
+        # /opt hosts the image's omnigent venv (/opt/venv).
+        ([{"claim_name": "c", "mount_path": "/opt"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/opt/venv"}], "reserved"),
         # read_only must be a boolean, not a truthy string.
         ([{"claim_name": "c", "mount_path": "/mnt/x", "read_only": "yes"}], "boolean"),
         # Duplicates / nesting between entries.

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -764,6 +764,8 @@ def test_parse_kubernetes_without_pvc_mounts_is_none(monkeypatch: pytest.MonkeyP
         ([{"claim_name": "c", "mount_path": "mnt/x"}], "absolute"),
         ([{"claim_name": "c", "mount_path": "/mnt/../etc"}], "normalized"),
         ([{"claim_name": "c", "mount_path": "/mnt/x/"}], "normalized"),
+        ([{"claim_name": "c", "mount_path": "/home//omnigent"}], "normalized"),
+        ([{"claim_name": "c", "mount_path": "/home/./omnigent"}], "normalized"),
         # Exactly two leading slashes survive posixpath.normpath (POSIX) but
         # the kernel collapses them, so '//home/omnigent' would shadow HOME.
         ([{"claim_name": "c", "mount_path": "//home/omnigent"}], "normalized"),
@@ -771,6 +773,21 @@ def test_parse_kubernetes_without_pvc_mounts_is_none(monkeypatch: pytest.MonkeyP
         ([{"claim_name": "c", "mount_path": "/"}], "reserved"),
         ([{"claim_name": "c", "mount_path": "/home/omnigent/data"}], "reserved"),
         ([{"claim_name": "c", "mount_path": "/var/run/secrets/x"}], "reserved"),
+        # Ancestors of reserved paths: a PVC at /home would mount over the
+        # HOME emptyDir's /home/omnigent mountpoint (likewise /var, /var/run
+        # over the Secret projections).
+        ([{"claim_name": "c", "mount_path": "/home"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/var"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/var/run"}], "reserved"),
+        # /var/run -> /run and /var/lock -> /run/lock on the Debian-based
+        # host image: every spelling of any path under them must be
+        # rejected, not just the secrets subtree.
+        ([{"claim_name": "c", "mount_path": "/run"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/run/secrets"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/run/cache"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/var/run/cache"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/var/lock"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/var/lock/cache"}], "reserved"),
         ([{"claim_name": "c", "mount_path": "/tmp"}], "reserved"),
         ([{"claim_name": "c", "mount_path": "/etc"}], "reserved"),
         # /opt hosts the image's omnigent venv (/opt/venv).
@@ -807,6 +824,21 @@ def test_parse_kubernetes_pvc_mounts_invalid_fails_loud(
                 "kubernetes": {"pvc_mounts": pvc_mounts},
             }
         )
+
+
+@pytest.mark.parametrize(
+    "mount_path", ["/home/other", "/home/omnigent-data", "/var/lib", "/runway"]
+)
+def test_parse_kubernetes_pvc_mounts_reserved_check_is_segment_aware(mount_path: str) -> None:
+    """Siblings sharing a string prefix with a reserved path (or its parent) are allowed."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "kubernetes",
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": {"pvc_mounts": [{"claim_name": "c", "mount_path": mount_path}]},
+        }
+    )
+    assert cfg is not None
 
 
 def test_parse_kubernetes_pvc_mounts_sibling_prefix_is_not_nested() -> None:

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -819,6 +819,55 @@ def test_parse_kubernetes_pvc_mounts_sibling_prefix_is_not_nested() -> None:
     assert cfg is not None
 
 
+def test_parse_kubernetes_pvc_mounts_nesting_is_rejected_regardless_of_order() -> None:
+    """The pairwise collision check catches nesting anywhere in a 3-entry list."""
+    with pytest.raises(ValueError, match="nested"):
+        parse_sandbox_config(
+            {
+                "provider": "kubernetes",
+                "server_url": "http://s.svc.cluster.local",
+                "kubernetes": {
+                    "pvc_mounts": [
+                        {"claim_name": "a", "mount_path": "/mnt/x/sub"},
+                        {"claim_name": "b", "mount_path": "/mnt/y"},
+                        {"claim_name": "c", "mount_path": "/mnt/x"},
+                    ]
+                },
+            }
+        )
+
+
+def test_parse_kubernetes_pvc_mounts_rejects_explicit_null_read_only() -> None:
+    """An explicit YAML `read_only: null` is rejected, not silently defaulted."""
+    with pytest.raises(ValueError, match="boolean"):
+        parse_sandbox_config(
+            {
+                "provider": "kubernetes",
+                "server_url": "http://s.svc.cluster.local",
+                "kubernetes": {
+                    "pvc_mounts": [{"claim_name": "c", "mount_path": "/mnt/x", "read_only": None}]
+                },
+            }
+        )
+
+
+def test_parse_kubernetes_pvc_mounts_allows_same_claim_at_two_paths() -> None:
+    """One claim may be mounted at two paths (e.g. RO datasets + RW scratch subtrees)."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "kubernetes",
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": {
+                "pvc_mounts": [
+                    {"claim_name": "shared", "mount_path": "/mnt/a"},
+                    {"claim_name": "shared", "mount_path": "/mnt/b", "read_only": False},
+                ]
+            },
+        }
+    )
+    assert cfg is not None
+
+
 @pytest.mark.parametrize(
     ("raw", "expected_fragment"),
     [

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -851,6 +851,15 @@ def test_parse_kubernetes_pvc_mounts_rejects_explicit_null_read_only() -> None:
         )
 
 
+def test_reserved_mount_prefixes_pin_the_launcher_home_dir() -> None:
+    """The mirrored HOME prefix must track the launcher's _HOME_DIR — a rename
+    there without updating the reserved list would let a mount shadow HOME."""
+    from omnigent.onboarding.sandboxes.kubernetes import _HOME_DIR
+    from omnigent.server.managed_hosts import _KUBERNETES_RESERVED_MOUNT_PREFIXES
+
+    assert _HOME_DIR in _KUBERNETES_RESERVED_MOUNT_PREFIXES
+
+
 def test_parse_kubernetes_pvc_mounts_allows_same_claim_at_two_paths() -> None:
     """One claim may be mounted at two paths (e.g. RO datasets + RW scratch subtrees)."""
     cfg = parse_sandbox_config(

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -702,6 +702,119 @@ def test_parse_kubernetes_invalid_block_fails_loud(
         )
 
 
+def test_parse_kubernetes_pvc_mounts_normalizes_and_reaches_launcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pvc_mounts parse into normalized entries (read_only defaults True) on the launcher."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "kubernetes",
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": {
+                "pvc_mounts": [
+                    {"claim_name": "omnigent-datasets", "mount_path": "/mnt/datasets"},
+                    {"claim_name": "scratch", "mount_path": "/mnt/scratch", "read_only": False},
+                ]
+            },
+        }
+    )
+    assert cfg is not None
+    fake = FakeSandboxLauncher()
+    install_fake_kubernetes_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.pvc_mounts == [
+        {"claim_name": "omnigent-datasets", "mount_path": "/mnt/datasets", "read_only": True},
+        {"claim_name": "scratch", "mount_path": "/mnt/scratch", "read_only": False},
+    ]
+
+
+def test_parse_kubernetes_without_pvc_mounts_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Omitted (or empty) pvc_mounts reach the launcher as None — no volumes added."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "kubernetes",
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": {"pvc_mounts": []},
+        }
+    )
+    assert cfg is not None
+    fake = FakeSandboxLauncher()
+    install_fake_kubernetes_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.pvc_mounts is None
+
+
+@pytest.mark.parametrize(
+    ("pvc_mounts", "expected_fragment"),
+    [
+        # Wrong container shapes.
+        ("nfs-share", "must be a list"),
+        ([["claim"]], "must be a mapping"),
+        # Unknown / missing keys.
+        ([{"claim_name": "c", "mount_path": "/mnt/x", "sub_path": "y"}], "unknown key"),
+        ([{"mount_path": "/mnt/x"}], "claim_name"),
+        ([{"claim_name": "c"}], "mount_path"),
+        # Bad claim names (PVC names are DNS-1123 subdomains).
+        ([{"claim_name": "Bad_Claim", "mount_path": "/mnt/x"}], "claim_name"),
+        # Bad mount paths: relative, unnormalized, root, reserved.
+        ([{"claim_name": "c", "mount_path": "mnt/x"}], "absolute"),
+        ([{"claim_name": "c", "mount_path": "/mnt/../etc"}], "normalized"),
+        ([{"claim_name": "c", "mount_path": "/mnt/x/"}], "normalized"),
+        ([{"claim_name": "c", "mount_path": "/"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/home/omnigent/data"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/var/run/secrets/x"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/tmp"}], "reserved"),
+        ([{"claim_name": "c", "mount_path": "/etc"}], "reserved"),
+        # read_only must be a boolean, not a truthy string.
+        ([{"claim_name": "c", "mount_path": "/mnt/x", "read_only": "yes"}], "boolean"),
+        # Duplicates / nesting between entries.
+        (
+            [
+                {"claim_name": "a", "mount_path": "/mnt/x"},
+                {"claim_name": "b", "mount_path": "/mnt/x"},
+            ],
+            "duplicate",
+        ),
+        (
+            [
+                {"claim_name": "a", "mount_path": "/mnt/x"},
+                {"claim_name": "b", "mount_path": "/mnt/x/sub"},
+            ],
+            "nested",
+        ),
+    ],
+)
+def test_parse_kubernetes_pvc_mounts_invalid_fails_loud(
+    pvc_mounts: object, expected_fragment: str
+) -> None:
+    """An operator typo in pvc_mounts fails at parse (server startup), not at launch."""
+    with pytest.raises(ValueError, match=expected_fragment):
+        parse_sandbox_config(
+            {
+                "provider": "kubernetes",
+                "server_url": "http://s.svc.cluster.local",
+                "kubernetes": {"pvc_mounts": pvc_mounts},
+            }
+        )
+
+
+def test_parse_kubernetes_pvc_mounts_sibling_prefix_is_not_nested() -> None:
+    """/mnt/data vs /mnt/database share a string prefix but are distinct mounts."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "kubernetes",
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": {
+                "pvc_mounts": [
+                    {"claim_name": "a", "mount_path": "/mnt/data"},
+                    {"claim_name": "b", "mount_path": "/mnt/database"},
+                ]
+            },
+        }
+    )
+    assert cfg is not None
+
+
 @pytest.mark.parametrize(
     ("raw", "expected_fragment"),
     [

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -556,6 +556,7 @@ def test_parse_kubernetes_without_section_defaults(monkeypatch: pytest.MonkeyPat
     assert fake.secret_name is None
     assert fake.in_cluster is None
     assert fake.resources is None
+    assert fake.pvc_mounts is None
 
 
 def test_parse_host_config_threads_verbatim_without_resolving_secrets(
@@ -686,6 +687,9 @@ def test_parse_host_config_lossy_json_key_collision_fails_loud() -> None:
         ({"resources": {"requests": {"cpu": "not a quantity!"}}}, "valid Kubernetes quantity"),
         ({"resources": {"requests": {"disk": "1Gi"}}}, "unknown key"),
         ({"in_cluster": "yes"}, "must be a boolean"),
+        # A misspelled section key would silently no-op (e.g. no PVCs mounted)
+        # without the allowlist check.
+        ({"pvc_mount": [{"claim_name": "c", "mount_path": "/mnt/x"}]}, "unknown key"),
     ],
 )
 def test_parse_kubernetes_invalid_block_fails_loud(


### PR DESCRIPTION
## Related issue

Closes #2434

**Depends on #2314** — the global YAML bool-resolver leak that PR fixes also breaks this feature's boolean config fields (`in_cluster`, `pvc_mounts[].read_only`) on the `--config` path. This branch carries an equivalent interim fix (commit `9b896a81`) so it works standalone; once #2314 merges, that commit will be dropped on rebase.

## Summary

- Kubernetes sandbox runners can now mount operator-provided persistent storage: a new `sandbox.kubernetes.pvc_mounts` config lists pre-created PersistentVolumeClaims (`claim_name`, `mount_path`, `read_only` — default `true`) that become `persistentVolumeClaim` volumes on every runner Pod. NFS/SMB/SAN backends stay an operator concern (CSI/PV/PVC created out of band in the runner namespace); omnigent only references the claim, so server RBAC is unchanged and Pods stay Pod Security "restricted"-compliant.
- The mounts land on the **host container only** — the init container keeps just the HOME `emptyDir`, so nothing external is exposed at clone time, and the ephemeral workspace model is untouched. Validation is parse-time fail-loud (DNS-1123 claim names, absolute normalized paths, reserved-path rejection for HOME/`/var/run/secrets`/OS dirs, duplicate + nested mount rejection), and the whole `sandbox.kubernetes` block now rejects unknown keys (previously a typo like `pvc_mount:` silently no-oped).
- Interim fix surfaced by live validation (same bug as #2314, which this PR depends on): `omnigent/spec/parser.py` stripped PyYAML's bool resolver from the resolver dict it inherits from the shared `Resolver`, so importing the spec parser broke `yaml.safe_load` bool parsing process-wide — any boolean in the server's `--config` (e.g. `sandbox.kubernetes.in_cluster: false`) was read as a string and rejected. The override now copies the dict onto the subclass first (as `omnigent/inner/loader.py` already does). This commit will be dropped in favor of #2314 once it lands.

ELI5: your cluster admin can now plug a shared network drive into every sandbox, read-only by default — like handing each sandbox a reference library card instead of letting it redecorate the library.

```
sandbox-config.yaml            managed_hosts.py                    kubernetes.py
pvc_mounts:            ──►  _parse_kubernetes_pvc_mounts  ──►  build_pod_manifest
  - claim_name: data         (fail-loud validation at            volumes: home emptyDir
    mount_path: /mnt/data     server startup)                    + pvc-0 (claimName, readOnly)
    read_only: true                                              host container mounts /mnt/data
                                                                 init container: HOME only
```

## Test Plan

- Unit: new manifest tests (`tests/onboarding/sandboxes/test_kubernetes.py` — volumes/mounts on host container only, no-`pvc_mounts` manifest byte-identical to before, `start_host` threading) and parse tests (`tests/server/test_managed_hosts.py` — normalization, `read_only` default, 17 invalid-shape cases, unknown-key allowlist, collision order-independence). Regression test for the YAML resolver leak (`tests/spec/test_parser.py`).
- `uv run pytest tests/server tests/onboarding` — 2849 passed (one pre-existing, environment-dependent failure: `test_boxlite.py::test_prepare_requires_sdk` fails only when the optional boxlite SDK is installed, e.g. after `uv sync --all-extras`; unrelated to this diff). `pre-commit run --all-files` clean.
- Three independent review passes over the diff (two external engines + one Claude reviewer), all approving; findings that surfaced (three extra test cases, the unknown-key gap) are folded into the branch.
- Live E2E on a real k3s cluster: NFS-backed RWX PVC pre-created and seeded in the runner namespace, server launched with the config below, session started from the web UI on the Kubernetes Sandbox host. Verified the Pod spec carries the volume, and from inside the session (transcript in Demo) that the data is readable and writes are blocked. The namespace enforces `restricted` Pod Security admission, confirming PSA compliance live.

```yaml
sandbox:
  provider: kubernetes
  kubernetes:
    pvc_mounts:
      - claim_name: omnigent-test-datasets
        mount_path: /mnt/datasets
```

## Demo

Live recording — session started on the Kubernetes Sandbox host, agent inside the runner Pod reads the mounted NFS dataset and shows the read-only mount rejecting a write:

![pvc_mounts live demo](https://raw.githubusercontent.com/btli/omnigent/demo-assets/pr-2435-pvc-mounts-demo.gif)

In-session output from the live E2E (agent running inside the runner Pod; NFS server redacted):

```
$ cat /mnt/datasets/hello.txt
hello from the persistent PVC mount (seeded 2026-07-12)

$ ls -la /mnt/datasets
-rw-r--r-- 1 sandbox sandbox  56 Jul 12 14:37 hello.txt

$ touch /mnt/datasets/write-test 2>&1 || echo WRITE_BLOCKED
touch: cannot touch '/mnt/datasets/write-test': Read-only file system
WRITE_BLOCKED

$ mount | grep datasets
<nfs-server>:/<export>/omnigent-sandboxes-omnigent-test-datasets-pvc-… on /mnt/datasets type nfs4 (ro,…)
```

Pod spec created by the launcher (via `kubectl get pod … -o jsonpath`):

```json
"volumes": [
  {"name": "home", "emptyDir": {}},
  {"name": "pvc-0", "persistentVolumeClaim": {"claimName": "omnigent-test-datasets", "readOnly": true}}
]
```

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the live cluster E2E described in the Test Plan: real NFS-backed PVC on k3s, session launched through the web UI, mount contents and read-only enforcement verified from inside the runner Pod. The Pod-manifest and config-parse behavior that E2E exercised is also covered by the new unit tests; the cluster-side pieces (CSI attach, PSA admission, NFS export permissions) are operator infrastructure that unit tests cannot reach.

## Changelog

Operators can mount pre-created PersistentVolumeClaims (NFS/SMB/SAN) into Kubernetes sandbox runners via `sandbox.kubernetes.pvc_mounts` (read-only by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
