### PR TITLE
fix(cli): create fresh remote registered-agent sessions

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -498,12 +498,14 @@ def run_prompt(
                 "agent paths. The remote server controls its own agent registrations."
             )
         base_url = target.rstrip("/")
-        agent_name = _pick_agent(base_url, quiet=True)
-        _run_headless_prompt(
-            base_url,
-            agent_name,
-            tool_handler,
+        choice = _pick_remote_agent(base_url, quiet=True)
+        session_id = _create_remote_registered_session(base_url, choice)
+        _run_one_shot(
+            base_url=base_url,
+            agent_name=choice.name,
+            tool_handler=tool_handler,
             prompt=prompt,
+            resume_conversation_id=session_id,
         )
         return
 
@@ -964,7 +966,23 @@ def _chat_with_server(
     ):
         return
 
-    selected_agent = agent_name or _pick_agent(base_url)
+    remote_choice = (
+        _pick_remote_agent(base_url, quiet=initial_message is not None)
+        if agent_name is None
+        else None
+    )
+    selected_agent = remote_choice.name if remote_choice is not None else agent_name
+    if selected_agent is None:
+        raise click.ClickException("No agent selected")
+    if (
+        remote_choice is not None
+        and resume_conversation_id is None
+        and fork_session_id is None
+        and session_bundle is None
+        and runner_id is None
+    ):
+        resume_conversation_id = _create_remote_registered_session(base_url, remote_choice)
+        attach_only = True
 
     # Bring-up is done — clear the spinner the instant before we produce
     # terminal output (the one-shot reply or the REPL's first paint), so it
@@ -1480,21 +1498,19 @@ def _attach_session_info(
     )
 
 
-def _pick_agent(base_url: str, *, quiet: bool = False) -> str:
-    """
-    Discover agent names from existing sessions and let the user pick.
+@dataclass(frozen=True)
+class _RemoteAgentChoice:
+    """Registered-agent launch facts recovered from a prior session."""
 
-    If only one agent name is found, selects it automatically.
-    Falls back to requiring the user to specify ``--agent`` if no
-    sessions exist yet.
+    name: str
+    agent_id: str
+    host_id: str
+    workspace: str
 
-    :param base_url: Server base URL.
-    :param quiet: When ``True``, suppress interactive prompts and
-        auto-select the first available agent.
-    :returns: The chosen agent name.
-    :raises click.ClickException: If no sessions exist or no
-        agent name can be discovered.
-    """
+
+def _remote_agent_choices(base_url: str) -> list[_RemoteAgentChoice]:
+    """Return launchable registered agents from recent remote sessions."""
+
     resp = httpx.get(
         f"{base_url}/v1/sessions",
         headers=_remote_headers(server_url=base_url),
@@ -1502,42 +1518,89 @@ def _pick_agent(base_url: str, *, quiet: bool = False) -> str:
         timeout=10.0,
     )
     resp.raise_for_status()
-    sessions = resp.json()["data"]
-
-    # Collect unique agent names from sessions.
-    names: list[str] = []
+    choices: list[_RemoteAgentChoice] = []
     seen: set[str] = set()
-    for s in sessions:
-        name = s.get("agent_name")
-        if name and name not in seen:
-            names.append(name)
+    for session in resp.json()["data"]:
+        name = session.get("agent_name")
+        agent_id = session.get("agent_id")
+        host_id = session.get("host_id")
+        workspace = session.get("workspace")
+        if (
+            isinstance(name, str)
+            and name
+            and name not in seen
+            and isinstance(agent_id, str)
+            and agent_id
+            and isinstance(host_id, str)
+            and host_id
+            and isinstance(workspace, str)
+            and workspace
+        ):
+            choices.append(
+                _RemoteAgentChoice(
+                    name=name,
+                    agent_id=agent_id,
+                    host_id=host_id,
+                    workspace=workspace,
+                )
+            )
             seen.add(name)
+    return choices
 
-    if not names:
+
+def _pick_remote_agent(base_url: str, *, quiet: bool = False) -> _RemoteAgentChoice:
+    """Pick a launchable registered agent for a fresh remote session."""
+
+    choices = _remote_agent_choices(base_url)
+    if not choices:
         raise click.ClickException(
-            "No sessions found on the server. Start a session first "
-            "or specify the agent with --agent."
+            "No launchable agents found on the server. Start a host-bound "
+            "session in the web UI first."
+        )
+    if len(choices) == 1:
+        if not quiet:
+            click.echo(f"\n  Agent: {choices[0].name}")
+        return choices[0]
+    if quiet:
+        raise click.ClickException(
+            "Multiple remote agents are available. Run without -p to choose one interactively."
         )
 
-    if len(names) == 1:
-        if not quiet:
-            click.echo(f"\n  Agent: {names[0]}")
-        return names[0]
-
     click.echo("\n  Available agents:\n")
-    for i, name in enumerate(names, 1):
-        click.echo(f"    {i}. {name}")
-
+    for index, choice in enumerate(choices, 1):
+        click.echo(f"    {index}. {choice.name}")
     while True:
         raw = str(click.prompt("\n  Agent", default="1"))
         try:
-            choice = int(raw)
-            if 1 <= choice <= len(names):
-                return names[choice - 1]
+            index = int(raw)
+            if 1 <= index <= len(choices):
+                return choices[index - 1]
         except ValueError:
-            if raw.strip() in seen:
-                return raw.strip()
-        click.echo(f"  Enter a number between 1 and {len(names)}.")
+            for choice in choices:
+                if raw.strip() == choice.name:
+                    return choice
+        click.echo(f"  Enter a number between 1 and {len(choices)}.")
+
+
+def _create_remote_registered_session(
+    base_url: str,
+    choice: _RemoteAgentChoice,
+) -> str:
+    """Create and host-launch one fresh registered-agent session."""
+
+    async def _main() -> str:
+        async with OmnigentClient(
+            base_url=base_url,
+            auth=_server_auth(server_url=base_url),
+        ) as client:
+            session = await client.sessions.create_registered(
+                choice.agent_id,
+                host_id=choice.host_id,
+                workspace=choice.workspace,
+            )
+            return session.id
+
+    return asyncio.run(_main())
 
 
 # ---------------------------------------------------------------------------
@@ -2320,7 +2383,7 @@ async def _query_sessions_once(
     agent_name: str,
     tool_handler: ToolHandler | None,
     prompt: str,
-    session_bundle: bytes,
+    session_bundle: bytes | None,
     session_bundle_filename: str,
     runner_id: str | None,
     resume_conversation_id: str | None = None,
@@ -2334,7 +2397,8 @@ async def _query_sessions_once(
         Used only for tool-handler validation messages.
     :param tool_handler: Optional client-side tool handler.
     :param prompt: User prompt for the single turn.
-    :param session_bundle: Gzipped agent tarball bytes.
+    :param session_bundle: Gzipped agent tarball bytes. May be ``None``
+        only when resuming a server-created session.
     :param session_bundle_filename: Multipart filename, e.g.
         ``"agent.tar.gz"``.
     :param runner_id: Registered runner id, e.g.
@@ -2350,17 +2414,22 @@ async def _query_sessions_once(
     """
     from omnigent_client import SessionsChat
 
-    if runner_id is None:
-        raise RuntimeError(
-            "Sessions API headless prompt requires a registered runner id. "
-            "Start through `omnigent run <agent>` or pass --server so the CLI "
-            "can launch and bind a runner."
-        )
     tool_callables = _sessions_tool_callables(tool_handler, agent_name)
     if resume_conversation_id is not None:
         bound = await client.sessions.get(resume_conversation_id)
-        await client.sessions.bind_runner(resume_conversation_id, runner_id=runner_id)
+        if runner_id is not None:
+            bound = await client.sessions.bind_runner(resume_conversation_id, runner_id=runner_id)
+        elif bound.runner_id is None:
+            raise RuntimeError("The remote session has no bound runner")
     else:
+        if runner_id is None:
+            raise RuntimeError(
+                "Sessions API headless prompt requires a registered runner id. "
+                "Start through `omnigent run <agent>` or pass --server so the CLI "
+                "can launch and bind a runner."
+            )
+        if session_bundle is None:
+            raise RuntimeError("Fresh local sessions require an agent bundle")
         created = await client.sessions.create(
             session_bundle,
             filename=session_bundle_filename,
@@ -4070,7 +4139,7 @@ def _run_one_shot(
             headers=_server_headers(runner_id=runner_id),
             auth=_server_auth(server_url=base_url),
         ) as client:
-            if session_bundle is not None:
+            if session_bundle is not None or resume_conversation_id is not None:
                 text = await _query_sessions_once(
                     client=client,
                     agent_name=agent_name,

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -308,12 +308,10 @@ class SessionsNamespace:
     """
     Client namespace for ``/v1/sessions`` endpoints.
 
-    Provides the four operations the route module exposes: create a
-    session from an uploaded agent bundle, bind it to a runner, fetch
-    a snapshot, post an event into the session's input queue (or an
-    interrupt that bypasses it), and live-tail the SSE stream. There
-    is no replay; see the module docstring for the snapshot +
-    live-tail reconnect contract.
+    Creates sessions from either an uploaded bundle or an existing
+    registered agent, binds caller-managed runners, fetches snapshots,
+    posts inputs, and live-tails the SSE stream. There is no replay;
+    see the module docstring for the snapshot + live-tail contract.
 
     :param http: Pre-built ``httpx.AsyncClient`` shared with the
         parent :class:`OmnigentClient`. Owned by the parent;
@@ -390,6 +388,35 @@ class SessionsNamespace:
         created = require_json_object(resp, "POST /v1/sessions")
         session_id = str(created["session_id"])
         return await self.get(session_id)
+
+    async def create_registered(
+        self,
+        agent_id: str,
+        *,
+        host_id: str | None = None,
+        workspace: str | None = None,
+    ) -> Session:
+        """Create a fresh session from an already-registered agent.
+
+        Calls JSON ``POST /v1/sessions`` with the same agent/host/workspace
+        contract used by the web new-chat flow. The server launches and binds
+        the host runner before returning the session snapshot.
+
+        :param agent_id: Durable registered-agent id, e.g. ``"ag_abc123"``.
+        :param host_id: Optional host that should launch the runner.
+        :param workspace: Absolute workspace on that host. Required with
+            ``host_id`` and invalid without it.
+        :returns: The newly created and host-bound session snapshot.
+        :raises OmnigentError: If the server returns a non-2xx status.
+        """
+        if (host_id is None) != (workspace is None):
+            raise ValueError("host_id and workspace must be provided together")
+        body = {"agent_id": agent_id}
+        if host_id is not None and workspace is not None:
+            body.update({"host_id": host_id, "workspace": workspace})
+        resp = await self._http.post(f"{self._base}/v1/sessions", json=body)
+        raise_for_status(resp.status_code, response_body(resp))
+        return Session.from_dict(require_json_object(resp, "POST /v1/sessions"))
 
     async def list(
         self,

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -399,14 +399,14 @@ class SessionsNamespace:
         """Create a fresh session from an already-registered agent.
 
         Calls JSON ``POST /v1/sessions`` with the same agent/host/workspace
-        contract used by the web new-chat flow. The server launches and binds
-        the host runner before returning the session snapshot.
+        contract used by the web new-chat flow. When host fields are supplied,
+        the server launches and binds the runner before returning.
 
         :param agent_id: Durable registered-agent id, e.g. ``"ag_abc123"``.
         :param host_id: Optional host that should launch the runner.
         :param workspace: Absolute workspace on that host. Required with
             ``host_id`` and invalid without it.
-        :returns: The newly created and host-bound session snapshot.
+        :returns: The newly created session snapshot.
         :raises OmnigentError: If the server returns a non-2xx status.
         """
         if (host_id is None) != (workspace is None):

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import click
 import httpx
 import pytest
+from click.testing import CliRunner
 from omnigent_client import OmnigentError as ClientOmnigentError
 from omnigent_client import QueryResult
 
@@ -2420,6 +2421,235 @@ def test_run_chat_remote_dispatches_without_profile_plumbing(
     assert "profile" not in kwargs, kwargs
 
 
+def test_remote_agent_choices_keep_latest_complete_launch_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fresh remote chat needs durable agent, host, and workspace facts."""
+
+    response = httpx.Response(
+        200,
+        request=httpx.Request("GET", "https://server.test/v1/sessions"),
+        json={
+            "data": [
+                {
+                    "agent_name": "Eric",
+                    "agent_id": "ag_eric_new",
+                    "host_id": "host_hermes",
+                    "workspace": "/srv/current",
+                },
+                {
+                    "agent_name": "Eric",
+                    "agent_id": "ag_eric_old",
+                    "host_id": "host_old",
+                    "workspace": "/srv/old",
+                },
+                {"agent_name": "No host", "agent_id": "ag_unbound"},
+            ]
+        },
+    )
+    monkeypatch.setattr(chat_module.httpx, "get", lambda *_a, **_k: response)
+
+    assert chat_module._remote_agent_choices("https://server.test") == [
+        chat_module._RemoteAgentChoice(
+            name="Eric",
+            agent_id="ag_eric_new",
+            host_id="host_hermes",
+            workspace="/srv/current",
+        )
+    ]
+
+
+def test_pick_remote_agent_headless_rejects_ambiguous_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headless mode never silently launches the first remote agent."""
+
+    monkeypatch.setattr(
+        chat_module,
+        "_remote_agent_choices",
+        lambda _url: [
+            chat_module._RemoteAgentChoice("Eric", "ag_eric", "host_h", "/srv/e"),
+            chat_module._RemoteAgentChoice("Codex", "ag_codex", "host_c", "/srv/c"),
+        ],
+    )
+
+    with pytest.raises(click.ClickException, match="Multiple remote agents"):
+        chat_module._pick_remote_agent("https://server.test", quiet=True)
+
+
+def test_chat_remote_creates_fresh_registered_session_before_repl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """URL chat creates a fresh server-hosted session, never a stale attach."""
+
+    choice = chat_module._RemoteAgentChoice(
+        "Eric",
+        "ag_eric",
+        "host_hermes",
+        "/srv/current",
+    )
+    monkeypatch.setattr(
+        chat_module,
+        "_pick_remote_agent",
+        lambda _url, *, quiet: choice if quiet is False else pytest.fail(),
+    )
+    monkeypatch.setattr(
+        chat_module,
+        "_create_remote_registered_session",
+        lambda _url, selected: "conv_fresh" if selected == choice else pytest.fail(),
+    )
+    captured: dict[str, object] = {}
+
+    def _capture_repl(*args: object, **kwargs: object) -> None:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(chat_module, "_run_repl", _capture_repl)
+
+    chat_module._chat_with_server("https://server.test", None)
+
+    assert captured["args"][:2] == ("https://server.test", "Eric")
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["resume_conversation_id"] == "conv_fresh"
+    assert kwargs["attach_only"] is True
+
+
+def test_run_prompt_remote_creates_fresh_session_before_one_shot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headless URL mode launches one unambiguous registered agent."""
+
+    choice = chat_module._RemoteAgentChoice(
+        "Eric",
+        "ag_eric",
+        "host_hermes",
+        "/srv/current",
+    )
+    monkeypatch.setattr(chat_module, "_pick_remote_agent", lambda _url, quiet: choice)
+    monkeypatch.setattr(
+        chat_module,
+        "_create_remote_registered_session",
+        lambda _url, _choice: "conv_fresh",
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        chat_module,
+        "_run_one_shot",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    chat_module.run_prompt(
+        "https://server.test",
+        None,
+        prompt="say hi",
+    )
+
+    assert captured["agent_name"] == "Eric"
+    assert captured["prompt"] == "say hi"
+    assert captured["resume_conversation_id"] == "conv_fresh"
+
+
+def test_cli_remote_prompt_rejects_ambiguous_agents_without_creating_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real ``run --server ... -p`` route fails before any launch side effect."""
+
+    from omnigent.cli import cli
+
+    monkeypatch.setattr(
+        chat_module,
+        "_remote_agent_choices",
+        lambda _url: [
+            chat_module._RemoteAgentChoice("Eric", "ag_eric", "host_h", "/srv/e"),
+            chat_module._RemoteAgentChoice("Codex", "ag_codex", "host_c", "/srv/c"),
+        ],
+    )
+    monkeypatch.setattr(
+        chat_module,
+        "_create_remote_registered_session",
+        lambda *_a, **_k: pytest.fail("ambiguous headless mode created a session"),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "--server", "https://server.test", "-p", "say hi"],
+    )
+
+    assert result.exit_code != 0
+    assert "Multiple remote agents are available" in result.output
+    assert "Run without -p" in result.output
+    assert "Available agents" not in result.output
+
+
+def test_cli_remote_prompt_with_one_agent_creates_session_and_runs_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real ``-p`` route proceeds when remote selection is unambiguous."""
+
+    from omnigent.cli import cli
+
+    choice = chat_module._RemoteAgentChoice("Eric", "ag_eric", "host_h", "/srv/e")
+    monkeypatch.setattr(chat_module, "_remote_agent_choices", lambda _url: [choice])
+    monkeypatch.setattr(
+        chat_module,
+        "_create_remote_registered_session",
+        lambda _url, selected: "conv_fresh" if selected == choice else pytest.fail(),
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        chat_module,
+        "_run_one_shot",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "--server", "https://server.test", "-p", "say hi"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["agent_name"] == "Eric"
+    assert captured["prompt"] == "say hi"
+    assert captured["resume_conversation_id"] == "conv_fresh"
+
+
+def test_cli_remote_interactive_keeps_agent_picker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive direct-server mode still lets the operator choose an agent."""
+
+    from omnigent.cli import cli
+
+    choices = [
+        chat_module._RemoteAgentChoice("Eric", "ag_eric", "host_h", "/srv/e"),
+        chat_module._RemoteAgentChoice("Codex", "ag_codex", "host_c", "/srv/c"),
+    ]
+    monkeypatch.setattr(chat_module, "_remote_agent_choices", lambda _url: choices)
+    monkeypatch.setattr(
+        chat_module,
+        "_create_remote_registered_session",
+        lambda _url, selected: f"conv_{selected.name.lower()}",
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        chat_module,
+        "_run_repl",
+        lambda *args, **kwargs: captured.update(args=args, kwargs=kwargs),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "--server", "https://server.test"],
+        input="2\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Available agents" in result.output
+    assert captured["args"][:2] == ("https://server.test", "Codex")
+    assert captured["kwargs"]["resume_conversation_id"] == "conv_codex"
+
+
 def test_run_repl_auto_opens_conversation_when_session_starts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3325,6 +3555,7 @@ class _FakeSessionsNamespace:
         self._items = items
         self._forbid_list_items = list_items_must_not_be_called
         self.list_items_calls = 0
+        self.bind_runner_calls = 0
 
     async def create(self, bundle: bytes, *, filename: str, workspace: str) -> SimpleNamespace:
         """Pretend to create a session; return an object with an ``id``."""
@@ -3332,7 +3563,12 @@ class _FakeSessionsNamespace:
 
     async def bind_runner(self, session_id: str, *, runner_id: str) -> SimpleNamespace:
         """Pretend to bind a runner; echo back the session id."""
+        self.bind_runner_calls += 1
         return SimpleNamespace(id=session_id)
+
+    async def get(self, session_id: str) -> SimpleNamespace:
+        """Return an existing session already bound by its remote host."""
+        return SimpleNamespace(id=session_id, runner_id="runner_remote")
 
     async def list_items(
         self, session_id: str, *, limit: int, order: str
@@ -3575,6 +3811,29 @@ async def test_query_sessions_once_returns_text_without_reconcile_on_success(
     result = await _run_one_shot(client, _return_text, monkeypatch)
     assert result == "direct answer"
     assert client.sessions.list_items_calls == 0  # no reconcile on success
+
+
+async def test_query_sessions_once_uses_existing_remote_runner_without_rebinding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server-hosted fresh session is queried without client affinity writes."""
+
+    client = _FakeAPClient([], list_items_must_not_be_called=True)
+    monkeypatch.setattr("omnigent_client.SessionsChat", _fake_sessions_chat_cls(_return_text))
+
+    result = await _query_sessions_once(
+        client=client,
+        agent_name="Eric",
+        tool_handler=None,
+        prompt="say hi",
+        session_bundle=None,
+        session_bundle_filename="agent.tar.gz",
+        runner_id=None,
+        resume_conversation_id="conv_fresh",
+    )
+
+    assert result == "direct answer"
+    assert client.sessions.bind_runner_calls == 0
 
 
 async def test_query_sessions_once_multi_turn_async_orchestrator(
@@ -3853,11 +4112,11 @@ def test_cursor_native_resume_never_drives_an_omnigent_turn(
 
     monkeypatch.setattr(chat_module, "_run_repl", _fail_repl)
     monkeypatch.setattr(chat_module, "_run_one_shot", _fail_one_shot)
-    # _pick_agent runs only on the non-redirect path; tripping it also signals
-    # the redirect failed to short-circuit.
+    # _pick_remote_agent runs only on the non-redirect path; tripping it also
+    # signals the redirect failed to short-circuit.
     monkeypatch.setattr(
         chat_module,
-        "_pick_agent",
+        "_pick_remote_agent",
         lambda *_a, **_k: pytest.fail("reached the non-redirect path"),
     )
 

--- a/tests/e2e/test_chat_e2e.py
+++ b/tests/e2e/test_chat_e2e.py
@@ -14,10 +14,12 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
 import uuid
 from pathlib import Path
 
 import httpx
+import pytest
 import yaml as _yaml
 from omnigent_client import OmnigentClient
 
@@ -373,4 +375,96 @@ def test_sdk_creates_registered_agent_session(
         assert session_id.startswith("conv_")
         assert runner_id == server.runner_id
     finally:
+        _stop_local_server(server)
+
+
+def test_remote_prompt_creates_fresh_host_bound_session(
+    mock_llm_server_url: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Remote headless chat discovers an agent and completes in a fresh session."""
+    from omnigent.chat import (
+        _start_local_server,
+        _stop_local_server,
+        _wait_for_server,
+        run_prompt,
+    )
+    from tests.e2e.test_host_e2e import _spawn_host_daemon, _wait_for_host_online
+
+    marker = f"REMOTE_FRESH_OK_{uuid.uuid4().hex[:6]}"
+    model = f"mock-remote-fresh-{uuid.uuid4().hex[:6]}"
+    agent_name = f"remote-fresh-probe-{uuid.uuid4().hex[:6]}"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    host_home = tmp_path / "host-home"
+    host_home.mkdir()
+
+    yaml_path = _make_inline_agent_yaml(
+        tmp_path,
+        agent_name=agent_name,
+        model=model,
+        mock_llm_server_url=mock_llm_server_url,
+    )
+    os.environ["OPENAI_API_KEY"] = "mock-key"
+    os.environ["OPENAI_BASE_URL"] = f"{mock_llm_server_url}/v1"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(mock_llm_server_url, [{"text": marker}], key=model)
+
+    port = find_free_port()
+    server = _start_local_server(yaml_path, port, ephemeral=True)
+    base_url = f"http://127.0.0.1:{port}"
+    daemon = None
+    try:
+        _wait_for_server(port, server)
+        client = httpx.Client(
+            base_url=base_url,
+            timeout=60.0,
+            headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+        )
+        agent_id = _lookup_builtin_agent_id(client, agent_name)
+        daemon = _spawn_host_daemon(
+            tmp_path=host_home,
+            live_server=base_url,
+            mock_llm_server_url=mock_llm_server_url,
+        )
+        _wait_for_host_online(client, daemon.host_id)
+
+        seed = client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "host_id": daemon.host_id,
+                "workspace": str(workspace),
+            },
+        )
+        seed.raise_for_status()
+        seed_id = str(seed.json()["id"])
+        client.post(
+            f"/v1/sessions/{seed_id}/events",
+            json={"type": "stop_session", "data": {}},
+        ).raise_for_status()
+
+        run_prompt(base_url, None, prompt="Reply with the configured marker.")
+
+        assert marker in capsys.readouterr().out
+        sessions = client.get(
+            "/v1/sessions",
+            params={"agent_id": agent_id, "limit": 10, "order": "desc"},
+        )
+        sessions.raise_for_status()
+        rows = sessions.json()["data"]
+        assert len(rows) == 2
+        fresh = next(row for row in rows if row["id"] != seed_id)
+        assert fresh["host_id"] == daemon.host_id
+        assert fresh["workspace"] == str(workspace)
+        assert fresh["runner_id"]
+    finally:
+        if daemon is not None:
+            daemon.proc.terminate()
+            try:
+                daemon.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                daemon.proc.kill()
+                daemon.proc.wait()
         _stop_local_server(server)

--- a/tests/e2e/test_chat_e2e.py
+++ b/tests/e2e/test_chat_e2e.py
@@ -12,12 +12,14 @@ Runs entirely against the mock LLM server — no real API key needed::
 
 from __future__ import annotations
 
+import asyncio
 import os
 import uuid
 from pathlib import Path
 
 import httpx
 import yaml as _yaml
+from omnigent_client import OmnigentClient
 
 from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from tests.e2e.conftest import (
@@ -316,22 +318,21 @@ def test_chat_local_accepts_omnigent_yaml_file(
         _stop_local_server(server)
 
 
-def test_chat_remote_pick_agent(
+def test_sdk_creates_registered_agent_session(
     mock_llm_server_url: str | None,
     tmp_path: Path,
 ) -> None:
     """
-    Remote chat can list and identify agents on a server.
+    The SDK can create a session from a server-registered agent.
 
-    Tests the remote mode's agent discovery by starting a server with
-    an inline agent and verifying ``_pick_agent`` finds it.
+    Starts a real server with an inline agent, resolves its durable id,
+    and exercises the SDK's JSON session-creation contract.
 
     **What breaks if this fails:**
-    - _pick_agent can't parse server agent listing response.
-    - Agent name extraction broken.
+    - The SDK's registered-agent request no longer matches the server route.
+    - The returned session cannot be bound to a runner through the SDK.
     """
     from omnigent.chat import (
-        _pick_agent,
         _start_local_server,
         _stop_local_server,
         _wait_for_server,
@@ -356,19 +357,20 @@ def test_chat_remote_pick_agent(
     try:
         _wait_for_server(port, server)
 
-        # Create a session so _pick_agent can discover the agent name
-        # from GET /v1/sessions (which it uses to list agent names).
-        client = httpx.Client(base_url=base_url, timeout=30.0)
-        _create_runner_bound_session_for_builtin(
-            client,
-            agent_name=agent_name,
-            runner_id=server.runner_id or "",
-        )
+        http_client = httpx.Client(base_url=base_url, timeout=30.0)
+        agent_id = _lookup_builtin_agent_id(http_client, agent_name)
 
-        # _pick_agent auto-selects when there's only one agent.
-        picked = _pick_agent(base_url)
-        assert picked == agent_name, (
-            f"Expected _pick_agent to return {agent_name!r}, got {picked!r}."
-        )
+        async def _create_and_bind() -> tuple[str, str | None]:
+            async with OmnigentClient(base_url=base_url) as client:
+                session = await client.sessions.create_registered(agent_id)
+                bound = await client.sessions.bind_runner(
+                    session.id,
+                    runner_id=server.runner_id or "",
+                )
+                return bound.id, bound.runner_id
+
+        session_id, runner_id = asyncio.run(_create_and_bind())
+        assert session_id.startswith("conv_")
+        assert runner_id == server.runner_id
     finally:
         _stop_local_server(server)

--- a/tests/frontends/sdk/test_sessions_namespace.py
+++ b/tests/frontends/sdk/test_sessions_namespace.py
@@ -218,6 +218,100 @@ async def test_create_404_raises_omnigent_error() -> None:
     assert "no such agent" in str(exc_info.value)
 
 
+@pytest.mark.asyncio
+async def test_create_registered_posts_json_launch_contract() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["content_type"] = request.headers.get("content-type")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            201,
+            json=_session_response_body(items=[]) | {"runner_id": "runner_local_test"},
+        )
+
+    ns, client = _make_namespace(handler)
+    try:
+        session = await ns.create_registered(
+            "ag_eric",
+            host_id="host_hermes",
+            workspace="/srv/project",
+        )
+    finally:
+        await client.aclose()
+
+    assert captured == {
+        "method": "POST",
+        "content_type": "application/json",
+        "body": {
+            "agent_id": "ag_eric",
+            "host_id": "host_hermes",
+            "workspace": "/srv/project",
+        },
+    }
+    assert session.agent_id == "ag_abc"
+    assert session.runner_id == "runner_local_test"
+
+
+@pytest.mark.asyncio
+async def test_create_registered_allows_agent_only_contract() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(201, json=_session_response_body(items=[]))
+
+    ns, client = _make_namespace(handler)
+    try:
+        await ns.create_registered("ag_eric")
+    finally:
+        await client.aclose()
+
+    assert captured["body"] == {"agent_id": "ag_eric"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("host_id", "workspace"),
+    [("host_hermes", None), (None, "/srv/project")],
+)
+async def test_create_registered_rejects_partial_host_binding(
+    host_id: str | None,
+    workspace: str | None,
+) -> None:
+    ns, client = _make_namespace(lambda _request: pytest.fail("request sent"))
+    try:
+        with pytest.raises(ValueError, match="must be provided together"):
+            await ns.create_registered(
+                "ag_eric",
+                host_id=host_id,
+                workspace=workspace,
+            )
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_registered_propagates_server_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={"error": {"code": "forbidden", "message": "host not owned"}},
+        )
+
+    ns, client = _make_namespace(handler)
+    try:
+        with pytest.raises(OmnigentError, match="host not owned"):
+            await ns.create_registered(
+                "ag_eric",
+                host_id="host_other",
+                workspace="/srv/project",
+            )
+    finally:
+        await client.aclose()
+
+
 # ── get() ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Closes #2437

## Summary

Remote URL chat could select a previously used agent but could not create a fresh session from that registered agent. The SDK exposed only multipart bundle creation.

This change adds the server's existing registered-agent JSON create contract to `SessionsNamespace`, retains the agent, host, and workspace launch fields from the latest session containing those fields, and creates a fresh host-bound session before starting the REPL or one-shot turn. Explicit resume, fork, and attach paths are unchanged. Headless mode fails clearly when more than one agent is available.

ELI5: the CLI now keeps enough information to start a new copy of a remote agent instead of reusing an old conversation.

```text
recent sessions
  -> select {agent_id, host_id, workspace}
  -> POST /v1/sessions
  -> attach CLI to the fresh host-bound session
```

## Test Plan

- `uv run --extra dev pytest tests/frontends/sdk/test_sessions_namespace.py tests/cli/test_chat.py tests/e2e/test_chat_e2e.py -q` (`156 passed`)
- `uv run --extra dev ruff check omnigent/chat.py sdks/python-client/omnigent_client/_sessions.py tests/cli/test_chat.py tests/frontends/sdk/test_sessions_namespace.py tests/e2e/test_chat_e2e.py`
- `uv run --extra dev ruff format --check omnigent/chat.py sdks/python-client/omnigent_client/_sessions.py tests/cli/test_chat.py tests/frontends/sdk/test_sessions_namespace.py tests/e2e/test_chat_e2e.py`

Manual verification created a fresh registered-agent session, observed the host-bound runner come online, sent a turn over the sessions API, and received the terminal response.

## Demo

The first image shows the registered-agent picker. The second shows the selected agent completing its first turn in a fresh session.

![Remote registered-agent picker](https://raw.githubusercontent.com/dosenr/omnigent/assets/remote-registered-agent-chat-demo/remote-agent-picker.png)

![Fresh remote registered-agent session](https://raw.githubusercontent.com/dosenr/omnigent/assets/remote-registered-agent-chat-demo/remote-fresh-session.png)

```text
Agents: beacon, atlas
Selected: atlas
Prompt: Reply with exactly: LOCAL FRESH SESSION OK
Reply: LOCAL FRESH SESSION OK
Runner bound: True
Host preserved: True
```

This first slice discovers launch fields from recent host-bound sessions. An agent with no session history is not yet discoverable from the CLI and must be started once through the web UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests cover the SDK request, ambiguous and unambiguous selection, fresh-session handoff, and a real host-daemon-backed one-shot turn. Discovery of agents without session history remains outside this change.

## Changelog

Remote URL chat starts a fresh session for the selected registered agent.
