### PR TITLE
fix(inner): default the terminal pane to a UTF-8 locale for native TUI harnesses (#2427)

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -650,6 +650,60 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
 
 
+def _is_utf8_locale_value(value: str | None) -> bool:
+    """Whether a locale string names a UTF-8 codeset.
+
+    A POSIX locale looks like ``language[_TERRITORY][.codeset][@modifier]``;
+    the codeset after the dot is what selects the encoding (``en_US.UTF-8``,
+    ``C.UTF-8``). Bare ``C`` / ``POSIX`` and empty values are not UTF-8.
+    Matching is case- and separator-insensitive (``utf8`` == ``UTF-8``).
+
+    :param value: A locale string such as ``"C.UTF-8"``, or ``None``.
+    :returns: ``True`` when the codeset is UTF-8.
+    """
+    if not value:
+        return False
+    codeset = value.split("@", 1)[0]
+    codeset = codeset.rsplit(".", 1)[-1] if "." in codeset else ""
+    return codeset.replace("-", "").lower() == "utf8"
+
+
+def _has_utf8_locale(env: dict[str, str]) -> bool:
+    """Whether the env already carries a UTF-8 signal the TUI CLIs honor.
+
+    The CLIs that mis-decode (opencode/pi/hermes) read ``LC_ALL`` / ``LANG``
+    directly rather than calling ``setlocale``, so only those two vars count
+    here; a UTF-8 ``LC_CTYPE`` alone does not help them. Per POSIX precedence
+    a non-empty ``LC_ALL`` overrides ``LANG``.
+
+    :param env: The prospective terminal spawn environment.
+    :returns: ``True`` when the effective ``LC_ALL``/``LANG`` names UTF-8.
+    """
+    lc_all = env.get("LC_ALL")
+    if lc_all:
+        return _is_utf8_locale_value(lc_all)
+    return _is_utf8_locale_value(env.get("LANG"))
+
+
+def _apply_utf8_locale_default(env: dict[str, str]) -> None:
+    """Force ``LANG=LC_ALL=C.UTF-8`` when the env lacks a UTF-8 locale signal.
+
+    Mutates ``env`` in place. No-op on Windows (tmux terminals are POSIX-only)
+    and when the operator already supplied a UTF-8 ``LC_ALL``/``LANG`` (that
+    value is preserved). A pinned non-UTF-8 ``LC_ALL`` (e.g. ``C``) is
+    corrected. ``C.UTF-8`` is chosen because it needs no locale archive and so
+    is present on minimal container images where ``en_US.UTF-8`` is not.
+
+    :param env: The terminal spawn environment to normalize.
+    """
+    if IS_WINDOWS:
+        return
+    if _has_utf8_locale(env):
+        return
+    env["LANG"] = "C.UTF-8"
+    env["LC_ALL"] = "C.UTF-8"
+
+
 def _tmux_available() -> bool:
     """Check if tmux is installed."""
     return shutil.which("tmux") is not None
@@ -1052,6 +1106,13 @@ class TerminalInstance:
         # this tmux pane, so the binding token must never reach it.
         # After ``env.update`` so ``self.env`` can't re-admit it.
         env = strip_runner_auth_secrets(env)
+        # Force a UTF-8 locale into the pane env when the inherited env
+        # carries no UTF-8 signal in the vars the native TUI CLIs actually
+        # read (LC_ALL/LANG). Without it, CLIs that read LC_ALL/LANG directly
+        # (opencode/pi/hermes) instead of calling setlocale fall back to an
+        # ASCII/Latin-1 codeset and re-encode their UTF-8 output byte-by-byte,
+        # rendering multibyte characters as mojibake in the pane (issue #2427).
+        _apply_utf8_locale_default(env)
 
         # Build the command to run inside tmux. If a sandbox policy
         # is configured, wrap the command in the sandbox launcher so

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -19,6 +19,9 @@ from omnigent.inner.terminal import (
     TERMINAL_TRANSPORT_CONTROL,
     TERMINAL_TRANSPORT_PTY,
     TerminalInstance,
+    _apply_utf8_locale_default,
+    _has_utf8_locale,
+    _is_utf8_locale_value,
     create_terminal_instance,
     resolve_terminal_transport,
 )
@@ -1320,3 +1323,90 @@ def test_create_terminal_instance_denies_control_socket_but_keeps_private_dir_wr
         )
     finally:
         shutil.rmtree(instance.private_dir, ignore_errors=True)
+
+
+# ── UTF-8 locale default for native TUI panes (issue #2427) ──────────────────
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("C.UTF-8", True),
+        ("en_US.UTF-8", True),
+        ("en_US.utf8", True),
+        ("en_US.UTF8", True),
+        ("de_DE.UTF-8@euro", True),
+        ("C", False),
+        ("POSIX", False),
+        ("en_US", False),
+        ("en_US.ISO-8859-1", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_utf8_locale_value(value: str | None, expected: bool) -> None:
+    """Only a UTF-8 codeset (after the dot) counts, case/separator-insensitive."""
+    assert _is_utf8_locale_value(value) is expected
+
+
+def test_has_utf8_locale_lc_all_overrides_lang() -> None:
+    """A non-empty LC_ALL wins over LANG per POSIX precedence."""
+    # LC_ALL UTF-8 beats a non-UTF-8 LANG.
+    assert _has_utf8_locale({"LC_ALL": "C.UTF-8", "LANG": "C"}) is True
+    # A pinned non-UTF-8 LC_ALL shadows an otherwise-UTF-8 LANG.
+    assert _has_utf8_locale({"LC_ALL": "C", "LANG": "en_US.UTF-8"}) is False
+    # Empty LC_ALL falls through to LANG.
+    assert _has_utf8_locale({"LC_ALL": "", "LANG": "en_US.UTF-8"}) is True
+
+
+def test_has_utf8_locale_ignores_lc_ctype() -> None:
+    """The affected CLIs read LC_ALL/LANG directly; a UTF-8 LC_CTYPE alone
+    (the CoDA container repro: empty LANG, unset LC_ALL) is not a signal."""
+    assert _has_utf8_locale({"LC_CTYPE": "C.UTF-8", "LANG": ""}) is False
+
+
+def test_apply_utf8_locale_default_fixes_repro_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The repro env (LC_CTYPE=C.UTF-8, empty LANG, no LC_ALL) gets C.UTF-8."""
+    monkeypatch.setattr(terminal_mod, "IS_WINDOWS", False)
+    env = {"LC_CTYPE": "C.UTF-8", "LANG": ""}
+    _apply_utf8_locale_default(env)
+    assert env["LANG"] == "C.UTF-8"
+    assert env["LC_ALL"] == "C.UTF-8"
+    # LC_CTYPE is left untouched.
+    assert env["LC_CTYPE"] == "C.UTF-8"
+
+
+def test_apply_utf8_locale_default_preserves_operator_locale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator-provided UTF-8 locale is left exactly as-is."""
+    monkeypatch.setattr(terminal_mod, "IS_WINDOWS", False)
+    env = {"LANG": "en_US.UTF-8"}
+    _apply_utf8_locale_default(env)
+    assert env["LANG"] == "en_US.UTF-8"
+    assert "LC_ALL" not in env
+
+
+def test_apply_utf8_locale_default_corrects_pinned_non_utf8_lc_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pinned non-UTF-8 LC_ALL is corrected to C.UTF-8."""
+    monkeypatch.setattr(terminal_mod, "IS_WINDOWS", False)
+    env = {"LC_ALL": "C", "LANG": "C"}
+    _apply_utf8_locale_default(env)
+    assert env["LANG"] == "C.UTF-8"
+    assert env["LC_ALL"] == "C.UTF-8"
+
+
+def test_apply_utf8_locale_default_noop_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No-op on Windows: tmux panes are POSIX-only, and forcing a locale onto
+    a Windows operator's env would be wrong."""
+    monkeypatch.setattr(terminal_mod, "IS_WINDOWS", True)
+    env = {"LANG": ""}
+    _apply_utf8_locale_default(env)
+    assert "LC_ALL" not in env
+    assert env["LANG"] == ""


### PR DESCRIPTION
## Related issue

Closes #2427

## Summary

Native TUI harnesses (opencode, pi, hermes) render multibyte UTF-8 as cascading mojibake in both the chat view and the raw terminal view when the deployment env has an **empty `LANG` and no `LC_ALL`** (only a UTF-8 `LC_CTYPE`, as in a minimal container).

- Those CLIs read `LC_ALL` / `LANG` **directly** rather than calling POSIX `setlocale` (which would honor `LC_CTYPE`). With no UTF-8 signal in the vars they read, they fall back to an ASCII/Latin-1 codeset and re-encode their own UTF-8 output byte-by-byte. Because the corrupt bytes are what the CLI physically writes to the tmux pane, the garbling appears in the raw terminal view too (tmux `%output` is byte-transparent). CLIs that call `setlocale` (claude, codex) are unaffected.
- `TerminalInstance.launch` now forces `LANG=LC_ALL=C.UTF-8` into the pane spawn env when the inherited env carries no UTF-8 signal in `LC_ALL`/`LANG`. A UTF-8 `LC_CTYPE` alone is **not** treated as a signal (it doesn't help these CLIs). Operator-provided UTF-8 locales are preserved; a pinned non-UTF-8 `LC_ALL` is corrected; no-op on Windows (tmux panes are POSIX-only). `C.UTF-8` needs no locale archive, so it's present on minimal images where `en_US.UTF-8` is not.

Scope note (from the issue): there's a *separate* consumer-side mojibake bug (a PTY reader decoding each `os.read` chunk independently, splitting multibyte chars across chunk boundaries) fixed in the downstream repo. This PR is only the omnigent-side locale fix.

## Test Plan

Added to `tests/inner/test_terminal.py` — pure, platform-independent unit tests for the three new helpers:

- `_is_utf8_locale_value`: codeset parsing, case/separator-insensitive (`utf8` == `UTF-8`), `@modifier` handling, bare `C`/`POSIX`/empty/`None` rejected
- `_has_utf8_locale`: POSIX `LC_ALL`-over-`LANG` precedence, and that a UTF-8 `LC_CTYPE` alone is ignored (the exact repro config)
- `_apply_utf8_locale_default`: fixes the `LC_CTYPE=C.UTF-8` + empty-`LANG` repro, preserves an operator's `en_US.UTF-8`, corrects a pinned non-UTF-8 `LC_ALL`, and is a no-op on Windows

```
OMNIGENT_SKIP_WEB_UI=true uv run pytest tests/inner/test_terminal.py -k "utf8 or locale" -q
# 17 passed
```

`ruff check` + `ruff format` clean. (Three unrelated `test_terminal.py` failures — idle-watcher / keep-alive — reproduce on clean `main` in this Windows dev env and are not touched by this change.)

## Demo

Before/after in a terminal with multibyte characters, in a real POSIX shell with the exact repro env from the issue (UTF-8 `LC_CTYPE`, empty `LANG`, no `LC_ALL`). BEFORE is `main` passing the env through as-is; AFTER is the same env after `TerminalInstance.launch` calls `_apply_utf8_locale_default`, which pins `LANG=LC_ALL=C.UTF-8`. The `agent ->` line is emitted by a stand-in that reads `LC_ALL`/`LANG` directly like the native CLIs (opencode/pi/hermes) do.

![before and after terminal with multibyte characters](https://raw.githubusercontent.com/abhay-codes07/omnigent/pr2440-demo-assets/pr2440_terminal.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: the helper unit tests are new code that implements the fix, so they exercise the exact locale-precedence and platform-guard logic; they pass with the change and cannot import without it. The `launch()` call site is a single guarded line inserted after the env is finalized (post secret-strip), so the pane inherits the normalized locale.

## Changelog

Native TUI harnesses (opencode, pi, hermes) no longer render multibyte UTF-8 as mojibake on deployments whose environment lacks a UTF-8 `LANG`/`LC_ALL`.

