### PR TITLE
fix: exclude native TUI wrappers from brainHarnessLabels

### DIFF
--- a/web/src/lib/agentLabels.test.ts
+++ b/web/src/lib/agentLabels.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NATIVE_CODING_AGENTS } from "@/lib/nativeCodingAgents";
+
+// Mock the fetch used by fetchHarnessLabels.
+const mockFetch = vi.fn();
+vi.mock("@/lib/identity", () => ({
+  authenticatedFetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+// Import after mocking so the mock is in place.
+const { useBrainHarnessLabels } = await import("@/lib/agentLabels");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useBrainHarnessLabels", () => {
+  it("excludes native TUI wrapper harnesses from the server catalog", async () => {
+    // Simulate the server returning every harness, including native ones.
+    const nativeHarnessRows = NATIVE_CODING_AGENTS.map((a) => ({
+      id: a.harness as string,
+      label: `Native ${a.displayName}`,
+    }));
+    const brainHarnessRow = { id: "my-community-harness", label: "My Harness" };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [...nativeHarnessRows, brainHarnessRow] }),
+    });
+
+    // Render the hook via React Query.
+    const { renderHook } = await import("@testing-library/react");
+    const { QueryClient, QueryClientProvider } = await import("@tanstack/react-query");
+    const React = await import("react");
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result, unmount } = renderHook(() => useBrainHarnessLabels(), { wrapper });
+
+    // Wait for the query to resolve.
+    await vi.waitFor(() => {
+      expect(result.current).toHaveProperty("my-community-harness");
+    });
+
+    const labels = result.current;
+
+    // Brain harness (non-native) should be present.
+    expect(labels["my-community-harness"]).toBe("My Harness");
+
+    // All static BRAIN_HARNESS_LABELS should still be present.
+    expect(labels["claude-sdk"]).toBe("Claude SDK");
+    expect(labels["codex"]).toBe("Codex");
+    expect(labels["cursor"]).toBe("Cursor");
+    expect(labels["pi"]).toBe("Pi");
+    expect(labels["antigravity"]).toBe("Antigravity");
+    expect(labels["copilot"]).toBe("Copilot");
+
+    // No native TUI wrapper should leak in.
+    for (const agent of NATIVE_CODING_AGENTS) {
+      expect(labels[agent.harness as string]).toBeUndefined();
+    }
+
+    unmount();
+  });
+});

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
+import { NATIVE_CODING_AGENTS } from "@/lib/nativeCodingAgents";
 
 /**
  * Shared display-name helpers for agents and brain harnesses, used by
@@ -36,8 +37,17 @@ async function fetchHarnessLabels(): Promise<Record<string, string>> {
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = (await res.json()) as HarnessCatalogWire;
   const labels: Record<string, string> = { ...BRAIN_HARNESS_LABELS };
+  // Exclude native TUI wrappers — they are not brain harnesses and should
+  // not offer a harness-override flyout. The harness catalog includes them
+  // (the server knows they exist), but the picker only wants non-native
+  // harnesses that a bundle agent can be switched to at runtime.
+  const nativeHarnesses = new Set<string>(NATIVE_CODING_AGENTS.map((a) => a.harness as string));
   for (const row of body.data ?? []) {
-    if (typeof row.id === "string" && typeof row.label === "string") {
+    if (
+      typeof row.id === "string" &&
+      typeof row.label === "string" &&
+      !nativeHarnesses.has(row.id)
+    ) {
       labels[row.id] = row.label;
     }
   }


### PR DESCRIPTION
## Problem

`fetchHarnessLabels()` in `web/src/lib/agentLabels.ts` unconditionally merges every harness from `GET /v1/harnesses` into `brainHarnessLabels`, including native TUI wrappers (hermes-native, claude-native, etc.).

The `BRAIN_HARNESS_LABELS` constant correctly excludes native wrappers — the comment says:

> Native terminal wrappers (claude-native / codex-native) are deliberately absent: an agent whose declared harness isn't in this map gets no harness options or pill suffix at all.

But the dynamic merge undoes this intent by adding all server catalog entries, including native harnesses.

This causes native agents without `permissionMode`/`approvalMode`/`cursorMode` capabilities (currently Hermes) to show a spurious harness-override flyout, since `hasKnobs()` in the NewChatDialog checks `brainHarnessLabels` as a fallback.

## Fix

Filter out native coding agent harnesses (from `NATIVE_CODING_AGENTS`) before merging server catalog entries into the labels map.

## Impact

- **Hermes** no longer shows a harness-override flyout (Claude SDK, Codex, Cursor, etc.) in the New Session picker — matching all other native harnesses.
- Any future native agent without those three capability flags would also be protected.
- No behavioral change for bundle/custom agents (Polly, Debby, etc.) — their brain harness flyouts are unaffected.