### PR TITLE
fix(cli): forward remote token to host daemon

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2456,13 +2456,18 @@ def _build_host_daemon_env(
     else:
         # Allowlist the remote daemon's environment (W8): pass process
         # essentials + TLS trust + the user's Databricks auth (the daemon
-        # authenticates to the server with it), but not unrelated provider
-        # secrets like ANTHROPIC_API_KEY / OPENAI_API_KEY.
+        # authenticates to the server with it), plus the explicit remote
+        # bearer accepted by the parent CLI. The daemon owns the long-lived
+        # host WebSocket, so dropping that bearer authenticates the HTTP
+        # setup calls but leaves the host tunnel anonymous. Do not broaden
+        # this to OMNIGENT_*: unrelated runtime/provider credentials remain
+        # outside the remote daemon.
         daemon_env_prefixes = (*_RUNNER_ENV_ALLOWLIST_PREFIXES, "DATABRICKS_")
         env = {
             key: value
             for key, value in os.environ.items()
-            if key in _RUNNER_ENV_ALLOWLIST or key.startswith(daemon_env_prefixes)
+            if key in (*_RUNNER_ENV_ALLOWLIST, "OMNIGENT_REMOTE_AUTH_TOKEN")
+            or key.startswith(daemon_env_prefixes)
         }
     return env
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -313,6 +313,12 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # cli._ensure_host_daemon), never to a (possibly hosted) runner.
         "OMNIGENT_CONFIG_HOME",
         "OMNIGENT_DATA_DIR",
+        # Explicit bearer for a user-launched remote host. The host daemon
+        # authenticates its own tunnel with this token; its spawned runners
+        # must present the same owner identity on their runner tunnels and
+        # HTTP callbacks. This is a deliberate auth credential, not a broad
+        # OMNIGENT_* passthrough. Provider and database secrets remain out.
+        "OMNIGENT_REMOTE_AUTH_TOKEN",
         # Auth provider selection. The env-unset default was flipped
         # to "accounts", so the whole CLI → daemon → local-server chain has
         # to agree on the mode. Without this, the daemon strips

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -291,9 +291,10 @@ def _make_auth_token_factory(
     """Build a callable that mints fresh auth tokens.
 
     Resolution order:
-      1. Stored OIDC token from ``~/.omnigent/auth_tokens.json``
+      1. Explicit ``OMNIGENT_REMOTE_AUTH_TOKEN`` from the invoking CLI.
+      2. Stored OIDC token from ``~/.omnigent/auth_tokens.json``
          (populated by ``omnigent login``), keyed by ``server_url``.
-      2. Databricks OAuth token (refreshed via the SDK) — host-keyed
+      3. Databricks OAuth token (refreshed via the SDK) — host-keyed
          when a Databricks Apps pointer record is stored for
          ``server_url`` (``omnigent login <apps-url>``), ambient
          otherwise.
@@ -325,6 +326,9 @@ def _make_auth_token_factory(
     )
 
     resolved_server_url = server_url or os.environ.get(_RUNNER_SERVER_URL_ENV_VAR)
+    explicit_remote_token = os.environ.get("OMNIGENT_REMOTE_AUTH_TOKEN")
+    if explicit_remote_token:
+        return lambda: explicit_remote_token
 
     # Reused Databricks SDK auth, resolved once on first use and cached
     # here for the life of the factory. Reusing one Config is the whole

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -261,6 +261,8 @@ def test_build_host_daemon_env_remote_strips_provider_credentials(
     monkeypatch.setenv("OPENAI_BASE_URL", "https://example.databricks.com/serving-endpoints")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
     monkeypatch.setenv("DATABRICKS_TOKEN", "test-databricks-token")
+    monkeypatch.setenv("OMNIGENT_REMOTE_AUTH_TOKEN", "test-remote-token")
+    monkeypatch.setenv("OMNIGENT_DATABASE_URI", "unrelated-database-secret")
 
     env = _build_host_daemon_env(server_url="https://example.databricksapps.com")
 
@@ -270,6 +272,9 @@ def test_build_host_daemon_env_remote_strips_provider_credentials(
     assert "ANTHROPIC_API_KEY" not in env
     # Databricks auth is intentionally preserved for the daemon's server auth.
     assert env["DATABRICKS_TOKEN"] == "test-databricks-token"
+    # The explicit remote bearer authenticates the daemon-owned host tunnel.
+    assert env["OMNIGENT_REMOTE_AUTH_TOKEN"] == "test-remote-token"
+    assert "OMNIGENT_DATABASE_URI" not in env
 
 
 def test_ensure_host_daemon_reuses_same_target(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1239,6 +1239,7 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "OMNIGENT_LOG_LEVEL": "DEBUG",
         "OMNIGENT_LOG_TO_STDERR": "1",
         "OMNIGENT_LOG_TTY_FD": "9",
+        "OMNIGENT_REMOTE_AUTH_TOKEN": "remote-owner-token",
     }
 
     env = _build_runner_env(
@@ -1293,6 +1294,9 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     assert env["OMNIGENT_LOG_LEVEL"] == "DEBUG"
     assert env["OMNIGENT_LOG_TO_STDERR"] == "1"
     assert env["OMNIGENT_LOG_TTY_FD"] == "9"
+    # The runner tunnel and callbacks must authenticate as the same owner as
+    # the user-launched remote host daemon.
+    assert env["OMNIGENT_REMOTE_AUTH_TOKEN"] == "remote-owner-token"
     # Non-harness secrets are stripped — the point of the allowlist.
     assert "DATABRICKS_TOKEN" not in env
     assert "AWS_SECRET_ACCESS_KEY" not in env

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -159,6 +159,26 @@ def test_make_auth_token_factory_returns_factory_when_databricks_creds_available
     assert factory() == "fresh-token"
 
 
+def test_make_auth_token_factory_prefers_explicit_remote_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The daemon/runner uses the explicit bearer supplied by its parent CLI."""
+    monkeypatch.setenv("OMNIGENT_REMOTE_AUTH_TOKEN", "explicit-remote-token")
+    monkeypatch.setattr(
+        "omnigent.cli_auth.load_token",
+        lambda _server_url: pytest.fail("stored token should not be consulted"),
+    )
+    monkeypatch.setattr(
+        "omnigent.inner.databricks_executor._resolve_databricks_auth",
+        lambda **_kwargs: pytest.fail("Databricks auth should not be consulted"),
+    )
+
+    factory = _make_auth_token_factory(server_url="https://server.test")
+
+    assert factory is not None
+    assert factory() == "explicit-remote-token"
+
+
 def test_make_auth_token_factory_returns_none_without_databricks_creds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #2446

## Summary

- Forward `OMNIGENT_REMOTE_AUTH_TOKEN` from a remote CLI invocation to its host daemon and host-spawned runner.
- Prefer that explicit bearer when the connector builds its token factory.
- Keep the existing environment allowlists so unrelated provider, database, and cloud secrets remain excluded.

## Test Plan

`uv run pytest -o addopts='' tests/cli/test_backend.py tests/host/test_connect.py tests/runner/test_runner_entry.py -q` (`208 passed`). The three changed boundary tests fail on pristine main and pass on this commit. Applicable changed-file hooks pass. Pristine upstream `npm ci` is currently blocked by the web lockfile tracked in #693; upstream CI remains authoritative for the all-files check.

## Demo

Deterministic proof of the three token boundaries after rebasing onto current `main`:

![Remote token forwarding boundary tests](https://raw.githubusercontent.com/dosenr/omnigent/demo-assets-2447/demo/remote-token-forwarding-tests.png)

The checks cover CLI-to-daemon forwarding, daemon-to-runner allowlisting, and explicit bearer precedence in the runner. All three pass. The end-to-end symptom remains the same: before the fix, the runner reports `runner tunnel rejected by server (HTTP 403)`; after the fix, the native terminal connects without a server or proxy change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the CLI-to-daemon, daemon-to-runner, and runner-to-server token boundaries independently. A live remote native session connected without changing the server or proxy.

## Changelog

Remote native sessions now reuse the CLI's explicit bearer when connecting their host daemon and runner.
