### PR TITLE
fix(runtime): drop parallel tool-call batches atomically in Layer-3 compaction

### DIFF
--- a/omnigent/runtime/compaction.py
+++ b/omnigent/runtime/compaction.py
@@ -324,23 +324,27 @@ def _pair_aware_drop_count(messages: list[dict[str, Any]]) -> int:
     Return how many items to drop from the front to avoid
     orphaning a tool call pair.
 
-    If the first item is a ``function_call`` and the second is its
-    matching ``function_call_output``, both are dropped together.
-    Otherwise, a single item is dropped.
+    Recognizes a leading run of ``function_call`` items immediately
+    followed by a matching run of ``function_call_output`` items
+    (same call_ids) and drops the whole batch together, covering
+    parallel tool calls in one turn, not just a single pair.
+    Otherwise, drops a single item.
 
     :param messages: The messages list (must be non-empty).
-    :returns: Number of items to drop (1 or 2), or 0 if the list
-        is empty.
+    :returns: Number of items to drop, or 0 if the list is empty.
     """
     if not messages:
         return 0
-    if (
-        len(messages) >= 2
-        and messages[0].get("type") == "function_call"
-        and messages[1].get("type") == "function_call_output"
-        and messages[0].get("call_id") == messages[1].get("call_id")
-    ):
-        return 2
+    call_count = 0
+    while call_count < len(messages) and messages[call_count].get("type") == "function_call":
+        call_count += 1
+    if call_count == 0:
+        return 1
+    call_ids = {m.get("call_id") for m in messages[:call_count]}
+    outputs = messages[call_count : call_count * 2]
+    output_ids = {m.get("call_id") for m in outputs if m.get("type") == "function_call_output"}
+    if len(outputs) == call_count and output_ids == call_ids:
+        return call_count * 2
     return 1
 
 

--- a/tests/runtime/test_compaction.py
+++ b/tests/runtime/test_compaction.py
@@ -1269,6 +1269,44 @@ def test_pair_aware_drop_count_returns_zero_for_empty() -> None:
     assert _pair_aware_drop_count([]) == 0
 
 
+def test_pair_aware_drop_count_drops_parallel_call_batch_together() -> None:
+    """
+    Parallel tool calls (two function_calls before either output
+    arrives) must be dropped as one atomic batch.
+
+    If only the first function_call were dropped, the surviving
+    function_call_output for that call_id would be orphaned, which
+    mainstream LLM APIs reject.
+    """
+    messages = [
+        {"type": "function_call", "call_id": "c1", "name": "read_file", "arguments": "{}"},
+        {"type": "function_call", "call_id": "c2", "name": "read_file", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "c1", "output": "contents 1"},
+        {"type": "function_call_output", "call_id": "c2", "output": "contents 2"},
+        _user_msg_dict("after the batch"),
+    ]
+    assert _pair_aware_drop_count(messages) == 4, (
+        "Expected 4 (drop both calls and both outputs together). "
+        "A smaller count would orphan a function_call_output."
+    )
+
+
+def test_pair_aware_drop_count_falls_back_when_batch_incomplete() -> None:
+    """
+    A leading run of function_calls not immediately followed by a
+    matching run of outputs (same call_ids) falls back to dropping
+    just one item, same as any other unrecognized shape.
+    """
+    messages = [
+        {"type": "function_call", "call_id": "c1", "name": "grep", "arguments": "{}"},
+        {"type": "function_call", "call_id": "c2", "name": "grep", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "c1", "output": "result"},
+        _user_msg_dict("interrupts before c2's output"),
+        {"type": "function_call_output", "call_id": "c2", "output": "result"},
+    ]
+    assert _pair_aware_drop_count(messages) == 1
+
+
 def test_truncate_oldest_preserves_tool_call_pairs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1321,6 +1359,44 @@ def test_truncate_oldest_preserves_tool_call_pairs(
         f"Expected the surviving message to be the user message, "
         f"got type={result[0].get('type')!r} role={result[0].get('role')!r}."
     )
+
+
+def test_truncate_oldest_preserves_parallel_tool_call_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    _truncate_oldest drops an entire parallel tool-call batch
+    (two function_calls + their two outputs) together, never
+    leaving an orphaned function_call_output.
+    """
+    call_count = [0]
+
+    def mock_count_tokens(msgs: list[dict[str, Any]], model: str) -> int:
+        call_count[0] += 1
+        # Above budget first, then below budget once the batch is dropped.
+        return 10000 if call_count[0] == 1 else 50
+
+    monkeypatch.setattr(
+        "omnigent.runtime.compaction.count_tokens",
+        mock_count_tokens,
+    )
+
+    messages = [
+        {"type": "function_call", "call_id": "c1", "name": "read_file", "arguments": "{}"},
+        {"type": "function_call", "call_id": "c2", "name": "read_file", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "c1", "output": "contents 1"},
+        {"type": "function_call_output", "call_id": "c2", "output": "contents 2"},
+        _user_msg_dict("kept message"),
+    ]
+
+    result = _truncate_oldest(messages, budget=100, model="test")
+
+    assert len(result) == 1, (
+        f"Expected 1 message after dropping the parallel-call batch, "
+        f"got {len(result)}. A partial drop would orphan a "
+        f"function_call_output."
+    )
+    assert result[0]["role"] == "user"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #2448 

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
- `_pair_aware_drop_count()` (Layer-3 emergency compaction) only recognized a single `function_call` + `function_call_output` pair at positions 0/1, so it failed to keep parallel tool calls (multiple `function_call`s before either output arrives, a normal agent pattern) together as one unit.
- When compaction dropped just the first `function_call` of such a batch, the matching `function_call_output` was left orphaned in history, which mainstream LLM APIs reject, breaking the next LLM call for that session outright.
- Generalized the check to recognize a leading contiguous run of N `function_call`s immediately followed by a contiguous run of N matching `function_call_output`s (same call_ids), dropping the whole batch atomically. Falls back to dropping 1 item for any other shape, unchanged from before.

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->
- Added 3 new tests in `tests/runtime/test_compaction.py`: parallel-batch drop and an incomplete-batch fallback at the `_pair_aware_drop_count` level, plus an end-to-end `_truncate_oldest` version.
- All 4 pre-existing tests for this function still pass unchanged.
- Full `pytest tests/runtime/test_compaction.py`. 32/32 pass.
- Manually reproduced the original bug before the fix (`drop == 1`, orphaned `function_call_output`) and confirmed the corrected output after (`drop == 4`, whole batch dropped, no orphan).

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->
```
python3 -c "
from omnigent.runtime.compaction import _pair_aware_drop_count
messages = [
    {'type': 'function_call', 'call_id': 'call_A', 'name': 'read_file'},
    {'type': 'function_call', 'call_id': 'call_B', 'name': 'read_file'},
    {'type': 'function_call_output', 'call_id': 'call_A', 'output': 'contents A'},
    {'type': 'function_call_output', 'call_id': 'call_B', 'output': 'contents B'},
    {'type': 'message', 'role': 'user', 'content': 'thanks'},
]
drop = _pair_aware_drop_count(messages)
print(drop, [m['type'] for m in messages[drop:]])
"
4 ['message']
```

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [X] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->
Manually confirmed the bug via direct repro (`_pair_aware_drop_count` on a constructed parallel-tool-call message list returned `drop == 1` and left an orphaned `function_call_output` before the fix; returns `drop == 4` and drops the whole batch after). New unit tests cover the fix at both the `_pair_aware_drop_count` and `_truncate_oldest` levels.

