### PR TITLE
fix(cli): scope native resume picker to current host

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -460,6 +460,7 @@ def _resolve_session_id_for_resume(
     headers: dict[str, str],
     session_id: str | None,
     resume_picker: bool,
+    host_id: str | None = None,
 ) -> str | None:
     """
     Translate the CLI's resume inputs into a concrete session id.
@@ -487,7 +488,10 @@ def _resolve_session_id_for_resume(
             base_url=base_url, headers=headers if headers else None
         ) as client:
             return await pick_conversation_by_wrapper_label_from_sdk(
-                client, wrapper_value=_WRAPPER_LABEL_VALUE, agent_name=_AGENT_NAME
+                client,
+                wrapper_value=_WRAPPER_LABEL_VALUE,
+                agent_name=_AGENT_NAME,
+                host_id=host_id,
             )
 
     return asyncio.run(_drive())
@@ -2885,11 +2889,13 @@ def _run_with_remote_server(
     should_print_resume_hint = False
     try:
         startup_profiler.mark("resolving remote session")
+        host_id = load_or_create_host_identity().host_id
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
             headers=headers,
             session_id=session_id,
             resume_picker=resume_picker,
+            host_id=host_id,
         )
         startup_profiler.mark(
             "remote session resolved",
@@ -2930,7 +2936,6 @@ def _run_with_remote_server(
                 "host daemon ready",
                 startup_progress=progress,
             )
-            host_id = load_or_create_host_identity().host_id
             _mark_startup_step(
                 startup_profiler,
                 "host identity loaded",

--- a/omnigent/repl/_resume_picker.py
+++ b/omnigent/repl/_resume_picker.py
@@ -31,8 +31,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import IO, Any, Protocol
 
-import click
-
 from omnigent._terminal_picker_theme import (
     PICKER_ACCENT as _ACCENT,
 )
@@ -875,27 +873,6 @@ def _page_start_for_selection(selected_index: int) -> int:
     return (selected_index // _PAGE_SIZE) * _PAGE_SIZE
 
 
-async def _list_sessions_with_rate_limit_retry(client: Any, **kwargs: Any) -> list[Any]:
-    """List sessions with a short bounded retry for an edge 429."""
-    for attempt in range(3):
-        try:
-            return await client.sessions.list(**kwargs)
-        except Exception as exc:
-            if getattr(exc, "status_code", None) != 429:
-                raise
-            if attempt == 2:
-                raise click.ClickException(
-                    "Session listing is temporarily rate-limited; retry shortly."
-                ) from None
-            await _sleep(float(2**attempt))
-    raise AssertionError("unreachable")
-
-
-async def _sleep(seconds: float) -> None:
-    """Sleep indirection kept local so tests never patch global asyncio state."""
-    await asyncio.sleep(seconds)
-
-
 async def pick_conversation_from_sdk(
     # ``Any`` to avoid coupling the repl package to the client's load order.
     client: Any,
@@ -917,8 +894,7 @@ async def pick_conversation_from_sdk(
         has this name. Used for session-scoped agents that share a
         YAML name but intentionally do not share ``agent_id``.
     """
-    convos = await _list_sessions_with_rate_limit_retry(
-        client,
+    convos = await client.sessions.list(
         limit=200,
         agent_id=agent_id,
         agent_name=agent_name_filter,
@@ -957,9 +933,7 @@ async def pick_conversation_by_wrapper_label_from_sdk(
     The cwd comes from the wrapper's client-side persistent state
     (``~/.omnigent/claude-native/``); sessions created on a
     different machine will show as having no recorded cwd."""
-    all_convos = await _list_sessions_with_rate_limit_retry(
-        client, limit=200, agent_id=None, order="desc"
-    )
+    all_convos = await client.sessions.list(limit=200, agent_id=None, order="desc")
     convos = [
         c
         for c in all_convos
@@ -987,9 +961,7 @@ async def pick_conversation_cross_agent_from_sdk(
     """Cross-agent variant: lists every session the caller can see
     via ``/v1/sessions`` and renders runtime metadata for
     ``omnigent resume``'s runtime-dispatch UX."""
-    convos = await _list_sessions_with_rate_limit_retry(
-        client, limit=200, agent_id=None, order="desc"
-    )
+    convos = await client.sessions.list(limit=200, agent_id=None, order="desc")
     previews = await _collect_previews_async(client, convos)
     # Header label is intentionally generic — "resume" describes the
     # action, not a single agent. Without overriding the legacy

--- a/omnigent/repl/_resume_picker.py
+++ b/omnigent/repl/_resume_picker.py
@@ -31,6 +31,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import IO, Any, Protocol
 
+import click
+
 from omnigent._terminal_picker_theme import (
     PICKER_ACCENT as _ACCENT,
 )
@@ -873,6 +875,27 @@ def _page_start_for_selection(selected_index: int) -> int:
     return (selected_index // _PAGE_SIZE) * _PAGE_SIZE
 
 
+async def _list_sessions_with_rate_limit_retry(client: Any, **kwargs: Any) -> list[Any]:
+    """List sessions with a short bounded retry for an edge 429."""
+    for attempt in range(3):
+        try:
+            return await client.sessions.list(**kwargs)
+        except Exception as exc:
+            if getattr(exc, "status_code", None) != 429:
+                raise
+            if attempt == 2:
+                raise click.ClickException(
+                    "Session listing is temporarily rate-limited; retry shortly."
+                ) from None
+            await _sleep(float(2**attempt))
+    raise AssertionError("unreachable")
+
+
+async def _sleep(seconds: float) -> None:
+    """Sleep indirection kept local so tests never patch global asyncio state."""
+    await asyncio.sleep(seconds)
+
+
 async def pick_conversation_from_sdk(
     # ``Any`` to avoid coupling the repl package to the client's load order.
     client: Any,
@@ -894,7 +917,8 @@ async def pick_conversation_from_sdk(
         has this name. Used for session-scoped agents that share a
         YAML name but intentionally do not share ``agent_id``.
     """
-    convos = await client.sessions.list(
+    convos = await _list_sessions_with_rate_limit_retry(
+        client,
         limit=200,
         agent_id=agent_id,
         agent_name=agent_name_filter,
@@ -909,6 +933,7 @@ async def pick_conversation_by_wrapper_label_from_sdk(
     *,
     wrapper_value: str,
     agent_name: str,
+    host_id: str | None = None,
     out: IO[str] | None = None,
     in_: IO[str] | None = None,
 ) -> str | None:
@@ -919,6 +944,12 @@ async def pick_conversation_by_wrapper_label_from_sdk(
     record — agent-id filtering can't be used. List every session the
     caller can see and filter by the wrapper label client-side.
 
+    When ``host_id`` is supplied, only sessions bound to that host are
+    offered. Native runtime state is host-local, so showing a session from
+    another machine would imply unsupported cross-host portability. An
+    explicit ``--resume <session-id>`` remains available to callers that
+    intentionally need to inspect or migrate a session.
+
     Renders workspace metadata so the user can see which cwd each
     session was launched from -- claude --resume requires cwd parity
     with the original session, and the row-level hint prepares the
@@ -926,12 +957,15 @@ async def pick_conversation_by_wrapper_label_from_sdk(
     The cwd comes from the wrapper's client-side persistent state
     (``~/.omnigent/claude-native/``); sessions created on a
     different machine will show as having no recorded cwd."""
-    all_convos = await client.sessions.list(limit=200, agent_id=None, order="desc")
+    all_convos = await _list_sessions_with_rate_limit_retry(
+        client, limit=200, agent_id=None, order="desc"
+    )
     convos = [
         c
         for c in all_convos
         if getattr(c, "labels", None)
         and c.labels.get(_CLAUDE_NATIVE_WRAPPER_LABEL_KEY) == wrapper_value
+        and (host_id is None or getattr(c, "host_id", None) == host_id)
     ]
     previews = await _collect_previews_async(client, convos)
     return pick_conversation(
@@ -953,7 +987,9 @@ async def pick_conversation_cross_agent_from_sdk(
     """Cross-agent variant: lists every session the caller can see
     via ``/v1/sessions`` and renders runtime metadata for
     ``omnigent resume``'s runtime-dispatch UX."""
-    convos = await client.sessions.list(limit=200, agent_id=None, order="desc")
+    convos = await _list_sessions_with_rate_limit_retry(
+        client, limit=200, agent_id=None, order="desc"
+    )
     previews = await _collect_previews_async(client, convos)
     # Header label is intentionally generic — "resume" describes the
     # action, not a single agent. Without overriding the legacy

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -247,6 +247,7 @@ class SessionListItem:
     :param title: Optional human-readable title.
     :param labels: Session-scoped guardrails labels.
     :param runner_id: Runner currently bound to the session.
+    :param host_id: Host the session is bound to, when host-managed.
     :param reasoning_effort: Per-session reasoning-effort hint.
     :param owner: User ID of the session owner.
     :param external_session_id: Runtime-native session id this
@@ -271,6 +272,7 @@ class SessionListItem:
     title: str | None = None
     labels: dict[str, str] = field(default_factory=dict)
     runner_id: str | None = None
+    host_id: str | None = None
     reasoning_effort: str | None = None
     owner: str | None = None
     external_session_id: str | None = None
@@ -296,6 +298,7 @@ class SessionListItem:
             title=raw.get("title"),
             labels=labels_raw if isinstance(labels_raw, dict) else {},
             runner_id=raw.get("runner_id"),
+            host_id=raw.get("host_id"),
             reasoning_effort=raw.get("reasoning_effort"),
             owner=raw.get("owner"),
             external_session_id=raw.get("external_session_id"),

--- a/tests/repl/test_resume_picker.py
+++ b/tests/repl/test_resume_picker.py
@@ -27,9 +27,7 @@ import io
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
 
-import click
 import pytest
 
 from omnigent.entities import ConversationItem, MessageData
@@ -37,7 +35,6 @@ from omnigent.repl._resume_picker import (
     _extract_text_from_content_blocks,
     _last_message_preview_from_dicts,
     _last_message_preview_from_entities,
-    _list_sessions_with_rate_limit_retry,
     _Preview,
     pick_conversation,
     pick_conversation_from_store,
@@ -74,53 +71,6 @@ class _TtyPickResult:
 
     selected: str | None
     rendered: str
-
-
-@pytest.mark.asyncio
-async def test_session_list_retries_two_rate_limits(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = 0
-    sleeps: list[float] = []
-
-    class RateLimited(Exception):
-        status_code = 429
-
-    async def list_sessions(**kwargs: object) -> list[str]:
-        nonlocal calls
-        calls += 1
-        assert kwargs == {"limit": 200}
-        if calls < 3:
-            raise RateLimited
-        return ["conv_ready"]
-
-    async def fake_sleep(delay: float) -> None:
-        sleeps.append(delay)
-
-    monkeypatch.setattr("omnigent.repl._resume_picker._sleep", fake_sleep)
-    client = SimpleNamespace(sessions=SimpleNamespace(list=list_sessions))
-
-    assert await _list_sessions_with_rate_limit_retry(client, limit=200) == ["conv_ready"]
-    assert calls == 3
-    assert sleeps == [1.0, 2.0]
-
-
-@pytest.mark.asyncio
-async def test_session_list_rate_limit_exhaustion_is_clean(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class RateLimited(Exception):
-        status_code = 429
-
-    async def list_sessions(**_kwargs: object) -> list[str]:
-        raise RateLimited
-
-    async def fake_sleep(_delay: float) -> None:
-        return None
-
-    monkeypatch.setattr("omnigent.repl._resume_picker._sleep", fake_sleep)
-    client = SimpleNamespace(sessions=SimpleNamespace(list=list_sessions))
-
-    with pytest.raises(click.ClickException, match="temporarily rate-limited"):
-        await _list_sessions_with_rate_limit_retry(client, limit=200)
 
 
 def _convs(n: int) -> list[_FakeConversation]:

--- a/tests/repl/test_resume_picker.py
+++ b/tests/repl/test_resume_picker.py
@@ -27,7 +27,9 @@ import io
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 
+import click
 import pytest
 
 from omnigent.entities import ConversationItem, MessageData
@@ -35,6 +37,7 @@ from omnigent.repl._resume_picker import (
     _extract_text_from_content_blocks,
     _last_message_preview_from_dicts,
     _last_message_preview_from_entities,
+    _list_sessions_with_rate_limit_retry,
     _Preview,
     pick_conversation,
     pick_conversation_from_store,
@@ -73,6 +76,53 @@ class _TtyPickResult:
     rendered: str
 
 
+@pytest.mark.asyncio
+async def test_session_list_retries_two_rate_limits(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+    sleeps: list[float] = []
+
+    class RateLimited(Exception):
+        status_code = 429
+
+    async def list_sessions(**kwargs: object) -> list[str]:
+        nonlocal calls
+        calls += 1
+        assert kwargs == {"limit": 200}
+        if calls < 3:
+            raise RateLimited
+        return ["conv_ready"]
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr("omnigent.repl._resume_picker._sleep", fake_sleep)
+    client = SimpleNamespace(sessions=SimpleNamespace(list=list_sessions))
+
+    assert await _list_sessions_with_rate_limit_retry(client, limit=200) == ["conv_ready"]
+    assert calls == 3
+    assert sleeps == [1.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_session_list_rate_limit_exhaustion_is_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RateLimited(Exception):
+        status_code = 429
+
+    async def list_sessions(**_kwargs: object) -> list[str]:
+        raise RateLimited
+
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("omnigent.repl._resume_picker._sleep", fake_sleep)
+    client = SimpleNamespace(sessions=SimpleNamespace(list=list_sessions))
+
+    with pytest.raises(click.ClickException, match="temporarily rate-limited"):
+        await _list_sessions_with_rate_limit_retry(client, limit=200)
+
+
 def _convs(n: int) -> list[_FakeConversation]:
     """
     Build *n* fake conversations with monotonically increasing
@@ -88,6 +138,23 @@ def _convs(n: int) -> list[_FakeConversation]:
         )
         for i in range(1, n + 1)
     ]
+
+
+def test_sdk_session_list_item_preserves_host_id() -> None:
+    from omnigent_client._sessions import SessionListItem
+
+    item = SessionListItem.from_dict(
+        {
+            "id": "conv_hosted",
+            "agent_id": "agent_1",
+            "status": "idle",
+            "created_at": 1,
+            "updated_at": 2,
+            "host_id": "host_this_mac",
+        }
+    )
+
+    assert item.host_id == "host_this_mac"
 
 
 # ── 1. Pure picker ───────────────────────────────────────
@@ -840,6 +907,7 @@ class _BadgeRow:
     title: str | None = "test"
     created_at: int = 0
     labels: dict[str, str] | None = None
+    host_id: str | None = None
 
 
 def test_runtime_badge_claude_native() -> None:
@@ -1021,12 +1089,20 @@ async def test_wrapper_label_picker_filters_and_lists_without_agent_filter(
             id="conv_claude_1",
             title="claude one",
             labels={"omnigent.wrapper": "claude-code-native-ui"},
+            host_id="host_this_mac",
         ),
         _BadgeRow(id="conv_chat", title="chat one", labels={}),
         _BadgeRow(
             id="conv_claude_2",
             title="claude two",
             labels={"omnigent.wrapper": "claude-code-native-ui"},
+            host_id="host_this_mac",
+        ),
+        _BadgeRow(
+            id="conv_claude_other_host",
+            title="claude elsewhere",
+            labels={"omnigent.wrapper": "claude-code-native-ui"},
+            host_id="host_other_machine",
         ),
     ]
     client = _FakeAPClient(rows=rows)
@@ -1037,6 +1113,7 @@ async def test_wrapper_label_picker_filters_and_lists_without_agent_filter(
         client,
         wrapper_value="claude-code-native-ui",
         agent_name="claude-native-ui",
+        host_id="host_this_mac",
         out=out,
         in_=io.StringIO("2\n"),
     )
@@ -1050,6 +1127,7 @@ async def test_wrapper_label_picker_filters_and_lists_without_agent_filter(
     assert "conv_claude_1" in rendered
     assert "conv_claude_2" in rendered
     assert "conv_chat" not in rendered
+    assert "conv_claude_other_host" not in rendered
     # No launch state was recorded for these fake rows, so the
     # picker should not render empty workspace placeholders.
     assert "Workspace" not in rendered

--- a/tests/test_claude_native_daemon.py
+++ b/tests/test_claude_native_daemon.py
@@ -225,11 +225,12 @@ def _install_daemon_seam_mocks(
         "omnigent.host.identity.load_or_create_host_identity",
         lambda *a, **k: SimpleNamespace(host_id="host_1", name="h"),
     )
-    monkeypatch.setattr(
-        claude_native,
-        "_resolve_session_id_for_resume",
-        lambda **k: k.get("session_id"),
-    )
+
+    def _resolve_session(**kwargs: Any) -> str | None:
+        captured["resume_host_id"] = kwargs.get("host_id")
+        return kwargs.get("session_id")
+
+    monkeypatch.setattr(claude_native, "_resolve_session_id_for_resume", _resolve_session)
     monkeypatch.setattr(
         claude_native, "_align_working_directory_with_session", lambda *a, **k: None
     )
@@ -294,6 +295,7 @@ def test_run_with_remote_server_routes_through_daemon(
     # The launch was routed through the daemon prepare with this host,
     # the cwd workspace, and the user's args.
     assert captured["host_id"] == "host_1"
+    assert captured["resume_host_id"] == "host_1"
     assert captured["workspace"] == str(tmp_path.resolve())
     assert captured["claude_args"] == ("--dangerously-skip-permissions",)
     assert captured["session_id"] is None


### PR DESCRIPTION
## Related issue

Closes #2450

## Summary

- Preserve `host_id` in Python SDK session-list rows.
- Scope bare Claude-native `--resume` to sessions bound to the invoking host.
- Leave explicit `--resume <session-id>` unchanged.

Native runtime state is host-local. Offering a session from another machine in the picker suggests a resume path that cannot work on the current host.

ELI5: the resume picker now shows only conversations stored on the machine running the native agent.

```text
session list + invoking host id
  -> keep rows bound to that host
  -> show resumable native sessions
```

## Test Plan

- `uv run --extra dev pytest tests/repl/test_resume_picker.py tests/test_claude_native_daemon.py -q` (`51 passed`)
- `uv run --extra dev ruff check omnigent/claude_native.py omnigent/repl/_resume_picker.py sdks/python-client/omnigent_client/_sessions.py tests/repl/test_resume_picker.py tests/test_claude_native_daemon.py`
- `uv run --extra dev ruff format --check omnigent/claude_native.py omnigent/repl/_resume_picker.py sdks/python-client/omnigent_client/_sessions.py tests/repl/test_resume_picker.py tests/test_claude_native_daemon.py`

The focused tests verify SDK decoding, host filtering, and propagation of the invoking host identity through remote startup to the resume resolver.

## Demo

Rendered from prompt-toolkit output captured against the local reproduction:

![Host-scoped native resume picker](https://raw.githubusercontent.com/dosenr/omnigent/demo-assets-2451/demo/native-resume-picker.svg)

```text
server rows: local=2 other-host=1 unbound=1
picker rows: local=2 other-host=0 unbound=0
explicit resume by id: unchanged
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Live verification showed only sessions with the invoking host's server-provided `host_id`. The public demo uses synthetic fixture data.

## Changelog

Native resume offers sessions that can be resumed on the current host.
