### PR TITLE
fix(claude): back off failed cost forwarding

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -527,6 +527,11 @@ class _ForwardDedupeState:
     # ``state.current_response_id`` unadvanced). ``None`` until the first
     # turn-start edge. Reset on /clear and /fork like the other baselines.
     posted_running_response_id: str | None = None
+    # Failed cost posts are retried by this long-running poll loop. Without a
+    # retry gate, an edge 429 turns the poll interval into a request storm and
+    # prevents the limiter from recovering.
+    cost_retry_not_before: float = 0.0
+    cost_retry_failures: int = 0
 
 
 @dataclass(frozen=True)
@@ -1764,6 +1769,8 @@ async def _forward_session_cost(
         mutated in place.
     :returns: None.
     """
+    if time.monotonic() < dedupe.cost_retry_not_before:
+        return
     status_state = await asyncio.to_thread(read_claude_context_state, bridge_dir)
     status_cost = _cumulative_cost_from_status_state(status_state)
     active_subagents = [
@@ -1818,14 +1825,25 @@ async def _forward_session_cost(
             usage=payload,
         )
     except httpx.HTTPError as exc:
+        dedupe.cost_retry_failures += 1
+        delay = min(30.0, float(2 ** min(dedupe.cost_retry_failures - 1, 5)))
+        if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
+            raw_retry_after = exc.response.headers.get("retry-after")
+            with contextlib.suppress(ValueError):
+                delay = max(delay, float(raw_retry_after)) if raw_retry_after else delay
+        dedupe.cost_retry_not_before = time.monotonic() + delay
         _logger.warning(
-            "Failed to forward Claude session cost; session=%s bridge_dir=%s http_status=%s",
+            "Failed to forward Claude session cost; session=%s bridge_dir=%s "
+            "http_status=%s retry_in=%.1fs",
             session_id,
             bridge_dir,
             _http_status_for_log(exc),
+            delay,
             exc_info=True,
         )
         return
+    dedupe.cost_retry_failures = 0
+    dedupe.cost_retry_not_before = 0.0
     if "cumulative_cost_usd" in payload:
         dedupe.posted_cost = display_cost
     if "policy_cost_usd" in payload:

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -6070,6 +6070,57 @@ async def test_forward_session_cost_posts_status_when_no_subagents(
     assert dedupe.posted_policy_cost == pytest.approx(0.25)
 
 
+@pytest.mark.asyncio
+async def test_forward_session_cost_backs_off_after_rate_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    parent = tmp_path / "sess.jsonl"
+    parent.write_text("parent", encoding="utf-8")
+    monkeypatch.setattr(
+        forwarder, "read_claude_context_state", lambda _bridge: {"total_cost_usd": 0.25}
+    )
+    now = {"value": 100.0}
+    monkeypatch.setattr(forwarder.time, "monotonic", lambda: now["value"])
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(429, headers={"retry-after": "5"}, request=request)
+        return httpx.Response(200, json={}, request=request)
+
+    dedupe = forwarder._ForwardDedupeState()
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        kwargs = {
+            "client": client,
+            "session_id": "conv_parent",
+            "bridge_dir": bridge_dir,
+            "parent_transcript_path": parent,
+            "subagent_state": forwarder.SubagentForwardState(subagents={}),
+            "dedupe": dedupe,
+            "cost_cache": {},
+        }
+        await forwarder._forward_session_cost(**kwargs)
+        assert calls == 1
+        assert dedupe.cost_retry_failures == 1
+        assert dedupe.cost_retry_not_before == pytest.approx(105.0)
+
+        await forwarder._forward_session_cost(**kwargs)
+        assert calls == 1
+
+        now["value"] = 105.0
+        await forwarder._forward_session_cost(**kwargs)
+
+    assert calls == 2
+    assert dedupe.cost_retry_failures == 0
+    assert dedupe.cost_retry_not_before == 0.0
+    assert dedupe.posted_cost == pytest.approx(0.25)
+
+
 def test_parse_json_response_returns_value_on_valid_json() -> None:
     """
     A normal JSON body parses through ``_parse_json_response`` unchanged.


### PR DESCRIPTION
## Related issue

Closes #2452

## Summary

- Prevent the long-running Claude forwarder from retrying a failed cost event on every poll.
- Use bounded exponential backoff, honor a larger 429 `Retry-After`, and reset retry state after success.

## Test Plan

`uv run pytest -o addopts='' tests/test_claude_native_forwarder.py -q` (`113 passed`). The regression test fails on pristine main after the mocked 429 because no retry state exists, then passes on this commit. Applicable changed-file hooks pass. Pristine upstream `npm ci` is currently blocked by the web lockfile tracked in #693; upstream CI remains authoritative for the all-files check.

## Demo

Render of genuine deterministic output from the tested 429 scenario:

![Claude cost-forwarding retry timeline](https://raw.githubusercontent.com/dosenr/omnigent/demo-assets-2453/demo/cost-backoff.svg)

```text
t=100.0  POST -> 429 Retry-After: 5  next_attempt=105.0
t=100.0  next poll -> suppressed
t=105.0  POST -> 200  failures=0 next_attempt=0.0
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The test controls monotonic time and the HTTP transport, proving suppression before the retry deadline, `Retry-After` handling, retry after the deadline, and state reset after success.

## Changelog

Claude native sessions now back off rejected cost updates instead of retrying on every poll.
