### PR TITLE
[runtime] Configure git status timeout

### DIFF
--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -878,7 +878,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 ["git", "show", f"HEAD:{git_path}"],
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=5,
+                timeout=self._git_status_timeout_s,
             )
             if result.returncode == 0:
                 return result.stdout.decode("utf-8", errors="replace")

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import dataclasses
 import fnmatch
 import logging
+import os
 import subprocess
 import threading
 import time
@@ -34,6 +35,8 @@ from pathlib import Path
 from typing import Any
 
 _logger = logging.getLogger(__name__)
+
+_GIT_STATUS_TIMEOUT_ENV = "OMNIGENT_GIT_STATUS_TIMEOUT_S"
 
 
 class GitStatusUnavailable(RuntimeError):
@@ -677,6 +680,10 @@ class GitFilesystemRegistry(FilesystemRegistry):
         ``Path("/home/user/project")``.
     :param git_root: The repository root (directory containing ``.git/``),
         as returned by :func:`_find_git_root`.
+
+    ``git status`` calls time out after five seconds by default. Set
+    :envvar:`OMNIGENT_GIT_STATUS_TIMEOUT_S` to a positive integer of seconds for
+    repositories that need a larger budget.
     """
 
     def __init__(self, watch_path: Path, git_root: Path) -> None:
@@ -687,6 +694,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
         """
         super().__init__(watch_path)
         self._git_root = git_root
+        self._git_status_timeout_s = int(os.environ.get(_GIT_STATUS_TIMEOUT_ENV, 5))
 
     def list_changed_files(self, conversation_id: str, *, limit: int) -> list[dict[str, Any]]:
         """Return all uncommitted changes in the working tree, newest first.
@@ -711,7 +719,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 argv,
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=5,
+                timeout=self._git_status_timeout_s,
             )
         except subprocess.TimeoutExpired as exc:
             elapsed = time.monotonic() - started
@@ -802,7 +810,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 argv,
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=5,
+                timeout=self._git_status_timeout_s,
             )
         except subprocess.TimeoutExpired as exc:
             elapsed = time.monotonic() - started

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from omnigent.runtime.filesystem_registry import (
+    _GIT_STATUS_TIMEOUT_ENV,
     AgentEditFilesystemRegistry,
     GitFilesystemRegistry,
     GitStatusUnavailable,
@@ -542,6 +543,13 @@ def test_git_list_changed_files_raises_on_timeout(tmp_path: Path, monkeypatch) -
     reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
     with pytest.raises(GitStatusUnavailable, match="timed out"):
         reg.list_changed_files("any-conv", limit=100)
+
+
+def test_git_status_timeout_env_override(tmp_path: Path, monkeypatch) -> None:
+    """The git status timeout can be overridden for large repositories."""
+    monkeypatch.setenv(_GIT_STATUS_TIMEOUT_ENV, "50")
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    assert reg._git_status_timeout_s == 50
 
 
 def test_git_list_changed_files_raises_on_nonzero_exit(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Large monorepos can take longer than five seconds to run `git status --porcelain --untracked-files=all`, causing the Files panel's changed-files request to fail. This change lets users increase the Git subprocess budget with `OMNIGENT_GIT_STATUS_TIMEOUT_S` while preserving the existing five-second default.

- Apply the configured timeout to changed-file listing, individual-file lookup, and baseline retrieval.
- Add focused unit coverage for a 50-second environment override.

## Test Plan

- `.venv/bin/pytest tests/runtime/test_filesystem_registry.py -q` — 56 passed.
- `.venv/bin/ruff format omnigent/runtime/filesystem_registry.py tests/runtime/test_filesystem_registry.py`.
- `.venv/bin/ruff check omnigent/runtime/filesystem_registry.py tests/runtime/test_filesystem_registry.py`.
- `PIP_INDEX_URL=https://pypi-proxy.cloud.databricks.com/simple .venv/bin/pre-commit run --all-files` — all hooks passed.

## Demo

N/A — backend configuration change with no visual UI changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test verifies that `OMNIGENT_GIT_STATUS_TIMEOUT_S=50` is read by `GitFilesystemRegistry`; the existing registry suite covers Git status and baseline retrieval.

## Changelog

The Files panel Git status timeout can now be increased with `OMNIGENT_GIT_STATUS_TIMEOUT_S` for large repositories.
