### PR TITLE
fix(web): ignore IME composition Enter in rename and new-project inputs

### DIFF
--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -838,6 +838,9 @@ function LandingProjectPicker({
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
                 onKeyDown={(e) => {
+                  // Don't commit while an IME composition Enter is being
+                  // confirmed (e.g. Japanese conversion). Mirrors #132/#243.
+                  if (isImeCompositionKeyEvent(e)) return;
                   if (e.key === "Enter") {
                     e.preventDefault();
                     commitNew();

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -297,6 +297,43 @@ describe("double-click to rename", () => {
     expect(mocks.rename.mutate).toHaveBeenCalledWith({ id: "conv_1", title: "Renamed Session" });
   });
 
+  it("does not commit the rename when Enter confirms an active IME composition", () => {
+    renderSidebar();
+
+    const row = screen.getByRole("link", { name: /My Session/ });
+    fireEvent.dblClick(row);
+
+    const input = screen.getByTestId("rename-conversation-input") as HTMLInputElement;
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "名前変更" } });
+
+    // The Enter that confirms the conversion candidate must NOT commit.
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mocks.rename.mutate).not.toHaveBeenCalled();
+
+    // Once composition ends, a subsequent Enter commits as usual.
+    fireEvent.compositionEnd(input);
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mocks.rename.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.rename.mutate).toHaveBeenCalledWith({ id: "conv_1", title: "名前変更" });
+  });
+
+  it("does not commit the rename when Enter carries the IME keyCode 229 fallback", () => {
+    renderSidebar();
+
+    const row = screen.getByRole("link", { name: /My Session/ });
+    fireEvent.dblClick(row);
+
+    const input = screen.getByTestId("rename-conversation-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Renamed" } });
+    fireEvent.keyDown(input, { key: "Enter", keyCode: 229 });
+    expect(mocks.rename.mutate).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mocks.rename.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.rename.mutate).toHaveBeenCalledWith({ id: "conv_1", title: "Renamed" });
+  });
+
   it("does not enter rename on double-click for a viewer-only row", () => {
     // permission_level 1 is below the edit threshold (>= 2), so the kebab's
     // Rename item is disabled and double-click must be inert too. A viewer-only

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -121,6 +121,7 @@ import { useCommentInbox } from "@/hooks/useCommentInbox";
 import { sumPendingApprovals } from "@/lib/inbox";
 import { isSessionStoppable } from "@/lib/sessionStop";
 import { isOwnerLevel } from "@/lib/permissionsApi";
+import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { getSessionState, type SessionState } from "@/hooks/useSessionState";
 import {
   isConversationUnseen,
@@ -3440,6 +3441,10 @@ function ConversationEditRow({ initialTitle, onCommit, onCancel }: ConversationE
   // checks this so we don't double-fire onCommit with the unedited
   // value when the input loses focus as part of unmounting.
   const cancelledRef = useRef(false);
+  // Tracks an active IME composition (e.g. Japanese conversion) so the Enter
+  // that confirms a candidate doesn't commit the rename. Mirrors the chat
+  // composer guard (#132/#243).
+  const isComposingRef = useRef(false);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -3447,6 +3452,7 @@ function ConversationEditRow({ initialTitle, onCommit, onCancel }: ConversationE
   }, []);
 
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (isImeCompositionKeyEvent(e, isComposingRef.current)) return;
     if (e.key === "Enter") {
       e.preventDefault();
       onCommit(value);
@@ -3473,6 +3479,12 @@ function ConversationEditRow({ initialTitle, onCommit, onCancel }: ConversationE
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
+        onCompositionStart={() => {
+          isComposingRef.current = true;
+        }}
+        onCompositionEnd={() => {
+          isComposingRef.current = false;
+        }}
         onKeyDown={handleKeyDown}
         onBlur={handleBlur}
         data-testid="rename-conversation-input"


### PR DESCRIPTION
## Related issue

Closes #2458

## Summary

The IME-composition Enter fix that landed for the chat composer (PR #132 / #243, ref #433) was not applied to two other inline inputs, which still submit on the Enter used to confirm a Japanese IME conversion candidate:

- **Session rename field** (`web/src/shell/Sidebar.tsx`) — confirmed unguarded in both the latest `main` and the `v0.5.1` release.
- **"New project" name input** in the New Session dialog (`web/src/shell/NewChatDialog.tsx`).

Both now route their `keydown` through the existing `isImeCompositionKeyEvent()` helper (`web/src/lib/ime.ts`), matching the chat composer: the first Enter only confirms the composition; commit happens on a later Enter after `compositionend`. The rename field also tracks composition via `onCompositionStart`/`onCompositionEnd` refs (same pattern as the chat composer), so `fireEvent.compositionStart` is honored. Same root cause as #433, different components.

## Test Plan

```
cd web
npm install
npx vitest run src/shell/Sidebar.rowActions.test.tsx
```

- Added two regression tests to `Sidebar.rowActions.test.tsx`: a `compositionStart`/`compositionEnd` case and a `keyCode: 229` fallback case. Both assert no commit mid-composition and a normal commit afterwards. Both pass.
- Note: two pre-existing `pin` tests in that file fail in a bare jsdom sandbox with `localStorage.getItem is not a function` — this reproduces on `main` (HEAD~1) unchanged and is unrelated to this PR.

## Demo

N/A — behavioural fix in an inline text input; covered by the added component tests. Manual IME verification requires a running web build.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Component-level tests drive the rename input with `compositionStart` + Enter (and the `keyCode 229` fallback) and assert the rename mutation is not called mid-composition, then is called on a post-`compositionend` Enter. Full manual IME verification in a browser is not included because it requires a deployed web build; the guard is identical to the already-shipped chat composer fix (#132/#243).

## Changelog

[UI] Confirming a Japanese IME conversion with Enter no longer submits the session rename or new-project name inputs
