### PR TITLE
Fix TUI completions after deleting input

### DIFF
--- a/sdks/ui/omnigent_ui_sdk/terminal/_host.py
+++ b/sdks/ui/omnigent_ui_sdk/terminal/_host.py
@@ -30,6 +30,7 @@ from omnigent_client import TERMINAL_TASK_STATUSES, child_session_busy
 from prompt_toolkit import PromptSession
 from prompt_toolkit.application import Application
 from prompt_toolkit.application.current import get_app
+from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.completion import Completer
 from prompt_toolkit.data_structures import Point
 from prompt_toolkit.filters import Condition, is_searching
@@ -1222,6 +1223,17 @@ class TerminalHost:
             completer=completer,
             reserve_space_for_menu=0,
         )
+        previous_completion_text = ""
+
+        def _restart_completions_after_delete(buffer: Buffer) -> None:
+            nonlocal previous_completion_text
+            current_text = buffer.text
+            deleted = len(current_text) < len(previous_completion_text)
+            previous_completion_text = current_text
+            if deleted and current_text and completer is not None:
+                buffer.start_completion()
+
+        self._prompt.default_buffer.on_text_changed += _restart_completions_after_delete
 
         # ----------------------------------------------------------
         # Layout patches.

--- a/tests/frontends/sdk/test_terminal_host.py
+++ b/tests/frontends/sdk/test_terminal_host.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 import logging
 import sys
 from collections.abc import Iterable
+from unittest.mock import Mock
 
 import pytest
 from omnigent_client import child_summary_busy
 from omnigent_ui_sdk.terminal._formatter import StreamingText
 from omnigent_ui_sdk.terminal._host import TerminalHost
+from prompt_toolkit.completion import WordCompleter
+from prompt_toolkit.document import Document
 from prompt_toolkit.output import DummyOutput
 from rich.text import Text
 
@@ -30,6 +33,21 @@ def _formatted_text_plain(fragments: Iterable[tuple[str, str]]) -> str:
     :returns: Concatenated text payload without style names.
     """
     return "".join(text for _style, text in fragments)
+
+
+def test_deleting_input_restarts_available_completions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deleting a command prefix must reopen matching completions."""
+    monkeypatch.setattr("omnigent_ui_sdk.terminal._host.create_output", DummyOutput)
+    host = TerminalHost(model_name="test", completer=WordCompleter(["/help", "/history"]))
+    buffer = host._prompt.default_buffer
+    buffer.validator = None
+    buffer.set_document(Document("/hel", cursor_position=4))
+    start_completion = Mock()
+    buffer.start_completion = start_completion
+
+    buffer.delete_before_cursor(count=2)
+
+    start_completion.assert_called_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #2460

## Summary

- Restart terminal completions when an edit shortens a non-empty input buffer.
- Preserve the existing insertion-driven completion path and avoid scheduling completion for an empty reset.
- Add a regression test for deleting `/hel` back to `/h`.

ELI5: prompt-toolkit automatically rechecks suggestions when text is added, but not when text is removed. This adds the missing deletion-side refresh.

```text
delete input
    |
    v
text became shorter? -- no --> keep existing behavior
    |
   yes
    |
    v
non-empty + completer? -- no --> stop
    |
   yes
    |
    v
restart completion
```

## Test Plan

- `uv run pytest tests/frontends/sdk/test_terminal_host.py tests/repl/test_repl.py -q` — 169 passed on Ubuntu 24.04 under WSL2.
- `uv run ruff check sdks/ui/omnigent_ui_sdk/terminal/_host.py tests/frontends/sdk/test_terminal_host.py`
- `uv run ruff format --check sdks/ui/omnigent_ui_sdk/terminal/_host.py tests/frontends/sdk/test_terminal_host.py`
- Applicable pre-commit hooks passed for both changed files.
- Manual TUI verification on Ubuntu 24.04 under WSL2: type `/hel`, then delete back to `/h`; the menu refreshes from `/help` to `/help` and `/history`.

## Demo

Recorded on Ubuntu 24.04 under WSL2 using Omnigent's production slash-command completer.

Typing `/hel` shows `/help`; deleting back to `/h` refreshes the menu to show both `/help` and `/history`.

<img width="1214" height="479" alt="Omnigent TUI slash-command suggestions returning after deleting input" src="https://github.com/user-attachments/assets/004f843f-f9f1-48d1-ada7-4031bef0bab5" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test drives the real `prompt_toolkit` buffer deletion path and asserts that completion is restarted. Manual verification uses Omnigent's production slash-command completer and confirms that the visible menu refreshes after deletion. Existing REPL completer tests continue to pass.

## Changelog

Slash-command suggestions now return when you delete characters from a command prefix in the terminal.

## Issues

Resolves [OMNI-1542](https://linear.app/omnigent/issue/OMNI-1542/tui-slash-command-suggestions-do-not-reopen-after-deleting-input)
