### PR TITLE
feat(policies): add fallback model list for LLM-based policy

### DIFF
--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -360,6 +360,10 @@ class PolicyLLMClient:
         primary ``_model`` call fails. Same provider-prefixed
         format as ``_model``. Empty (the default) preserves
         single-model behaviour — one attempt, no fallback loop.
+        ``_connection``/``_request_timeout`` are shared across the
+        primary and every fallback, so same-provider fallbacks are
+        the reliable case (a cross-provider fallback only works when
+        ``_connection`` is ``None``).
     """
 
     _client: Any  # omnigent.llms.client.Client — Any to avoid import cycle
@@ -389,6 +393,11 @@ class PolicyLLMClient:
         re-raised only after every candidate has failed. A caller
         that passes an explicit ``model`` opts out of fallback — the
         single requested model is used as-is.
+
+        Candidates are tried serially, so the worst-case latency of
+        this call is ``(1 + len(_fallback_models)) * timeout``. On
+        the policy hot path this delays the fail-closed (DENY)
+        verdict, so keep the fallback list short.
 
         :param input: Messages in OpenAI Responses API format,
             e.g. ``[{"role": "user", "content": [{"type": "input_text",
@@ -441,6 +450,15 @@ class PolicyLLMClient:
                         exc_info=True,
                     )
         # Every candidate failed — surface the last error to the caller.
+        # This is the fail-closed (DENY) path and, because candidates are
+        # tried serially, the caller has now waited up to
+        # ``len(candidates) * timeout``; log it so the latency is visible.
+        _log.error(
+            "PolicyLLMClient: all %d candidate model(s) failed after "
+            "serial attempts (up to %ds each); surfacing last error",
+            len(candidates),
+            timeout,
+        )
         assert last_exc is not None
         raise last_exc
 

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -28,6 +28,7 @@ and :class:`PolicyResult` from here (or from the
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -35,6 +36,8 @@ from omnigent.spec.types import Phase, PolicyAction, StateUpdate
 
 if TYPE_CHECKING:
     from omnigent.entities import ConversationItem
+
+_log = logging.getLogger(__name__)
 
 
 # Proto-style phase wire strings (the ``type`` field on events that
@@ -353,12 +356,17 @@ class PolicyLLMClient:
         adapter defaults / env vars.
     :param _request_timeout: Request timeout in seconds from the
         server ``llm:`` config, e.g. ``300``.
+    :param _fallback_models: Ordered backup models tried when the
+        primary ``_model`` call fails. Same provider-prefixed
+        format as ``_model``. Empty (the default) preserves
+        single-model behaviour — one attempt, no fallback loop.
     """
 
     _client: Any  # omnigent.llms.client.Client — Any to avoid import cycle
     _model: str
     _connection: dict[str, str] | None
     _request_timeout: int
+    _fallback_models: list[str] = field(default_factory=list)
 
     async def create(
         self,
@@ -375,6 +383,13 @@ class PolicyLLMClient:
         from the server config. Callers can override any of these
         via kwargs.
 
+        When ``_fallback_models`` is non-empty and the caller does
+        not override ``model``, the primary model is tried first and
+        each fallback in turn on failure; the last exception is
+        re-raised only after every candidate has failed. A caller
+        that passes an explicit ``model`` opts out of fallback — the
+        single requested model is used as-is.
+
         :param input: Messages in OpenAI Responses API format,
             e.g. ``[{"role": "user", "content": [{"type": "input_text",
             "text": "..."}]}]``.
@@ -382,15 +397,52 @@ class PolicyLLMClient:
         :param kwargs: Additional kwargs forwarded to
             ``client.responses.create()``.
         :returns: A :class:`~omnigent.llms.types.Response`.
+        :raises Exception: The last error encountered when every
+            candidate model fails. Propagates the primary model's
+            exception when no fallbacks are configured.
         """
-        return await self._client.responses.create(
-            input=input,
-            model=kwargs.pop("model", self._model),
-            connection_params=kwargs.pop("connection_params", self._connection),
-            timeout=kwargs.pop("timeout", self._request_timeout),
-            instructions=instructions,
-            **kwargs,
-        )
+        connection_params = kwargs.pop("connection_params", self._connection)
+        timeout = kwargs.pop("timeout", self._request_timeout)
+
+        # An explicit model override opts out of the fallback chain —
+        # honour exactly what the caller asked for.
+        if "model" in kwargs:
+            return await self._client.responses.create(
+                input=input,
+                model=kwargs.pop("model"),
+                connection_params=connection_params,
+                timeout=timeout,
+                instructions=instructions,
+                **kwargs,
+            )
+
+        candidates = [self._model, *self._fallback_models]
+        last_exc: Exception | None = None
+        for index, model in enumerate(candidates):
+            try:
+                return await self._client.responses.create(
+                    input=input,
+                    model=model,
+                    connection_params=connection_params,
+                    timeout=timeout,
+                    instructions=instructions,
+                    **kwargs,
+                )
+            except Exception as exc:  # noqa: BLE001 — retry next model on any failure
+                last_exc = exc
+                remaining = len(candidates) - index - 1
+                if remaining:
+                    _log.warning(
+                        "PolicyLLMClient: model %r failed (%s); "
+                        "falling back to next of %d remaining",
+                        model,
+                        exc,
+                        remaining,
+                        exc_info=True,
+                    )
+        # Every candidate failed — surface the last error to the caller.
+        assert last_exc is not None
+        raise last_exc
 
 
 __all__ = [

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -429,7 +429,7 @@ class PolicyLLMClient:
         last_exc: Exception | None = None
         for index, model in enumerate(candidates):
             try:
-                return await self._client.responses.create(
+                response = await self._client.responses.create(
                     input=input,
                     model=model,
                     connection_params=connection_params,
@@ -449,6 +449,18 @@ class PolicyLLMClient:
                         remaining,
                         exc_info=True,
                     )
+                continue
+            # A non-primary candidate succeeded — record which fallback
+            # recovered the call so the fallback path is visible in logs.
+            if index > 0:
+                _log.warning(
+                    "PolicyLLMClient: recovered on fallback model %r "
+                    "(candidate %d of %d) after primary failure",
+                    model,
+                    index + 1,
+                    len(candidates),
+                )
+            return response
         # Every candidate failed — surface the last error to the caller.
         # This is the fail-closed (DENY) path and, because candidates are
         # tried serially, the caller has now waited up to

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -468,12 +468,34 @@ def _build_policy_llm_client(
         return None
     from omnigent.llms.client import Client
 
+    primary = _normalize_policy_model(server_llm.model)
+    fallbacks = [_normalize_policy_model(m) for m in server_llm.fallback_models]
+
+    # The resolved ``connection`` (api_key / profile creds) is shared
+    # across the primary and every fallback. It is provider-specific,
+    # so a fallback on a different provider would be handed the wrong
+    # credentials. Warn at build time rather than failing mid-request.
+    if connection is not None:
+        primary_provider = _model_provider(primary)
+        mismatched = sorted(
+            {_model_provider(m) for m in fallbacks if _model_provider(m) != primary_provider}
+        )
+        if mismatched:
+            _logger.warning(
+                "Policy llm: connection is configured for provider %r but "
+                "fallback_models target %s; the shared connection likely "
+                "won't authenticate those providers. Use same-provider "
+                "fallbacks, or rely on environment defaults (no connection).",
+                primary_provider,
+                mismatched,
+            )
+
     return PolicyLLMClient(
         _client=Client(),
-        _model=_normalize_policy_model(server_llm.model),
+        _model=primary,
         _connection=connection,
         _request_timeout=server_llm.request_timeout,
-        _fallback_models=[_normalize_policy_model(m) for m in server_llm.fallback_models],
+        _fallback_models=fallbacks,
     )
 
 
@@ -498,6 +520,18 @@ def _normalize_policy_model(model: str) -> str:
     if "/" not in model and model.startswith("databricks-"):
         return f"databricks/{model}"
     return model
+
+
+def _model_provider(model: str) -> str:
+    """
+    Extract the provider prefix from a normalized model id.
+
+    :param model: A provider-prefixed model id, e.g.
+        ``"databricks/claude-sonnet-4"`` or ``"openai/gpt-4o-mini"``.
+    :returns: The provider segment before the first ``/`` (e.g.
+        ``"openai"``), or the whole string when unprefixed.
+    """
+    return model.split("/", 1)[0] if "/" in model else model
 
 
 def _resolve_databricks_connection(profile: str) -> dict[str, str]:

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -468,22 +468,36 @@ def _build_policy_llm_client(
         return None
     from omnigent.llms.client import Client
 
-    # Models prefixed with ``databricks-`` (e.g.
-    # ``databricks-claude-sonnet-4-6``) need the ``databricks/``
-    # provider prefix so the LLM adapter routes through
-    # DatabricksAdapter (Chat Completions) rather than
-    # OpenAIAdapter (Responses API). Without this, the request
-    # hits ``/responses`` on the Databricks gateway → 400.
-    model = server_llm.model
-    if "/" not in model and model.startswith("databricks-"):
-        model = f"databricks/{model}"
-
     return PolicyLLMClient(
         _client=Client(),
-        _model=model,
+        _model=_normalize_policy_model(server_llm.model),
         _connection=connection,
         _request_timeout=server_llm.request_timeout,
+        _fallback_models=[_normalize_policy_model(m) for m in server_llm.fallback_models],
     )
+
+
+def _normalize_policy_model(model: str) -> str:
+    """
+    Apply the ``databricks-`` → ``databricks/`` provider-prefix fixup.
+
+    Models prefixed with ``databricks-`` (e.g.
+    ``databricks-claude-sonnet-4-6``) need the ``databricks/``
+    provider prefix so the LLM adapter routes through
+    ``DatabricksAdapter`` (Chat Completions) rather than
+    ``OpenAIAdapter`` (Responses API). Without this, the request
+    hits ``/responses`` on the Databricks gateway → 400. Applied
+    uniformly to the primary model and every fallback so the
+    fallback path routes the same way as the primary.
+
+    :param model: A model id from the server ``llm:`` config,
+        possibly a bare ``databricks-`` name.
+    :returns: The model id with the ``databricks/`` prefix applied
+        when needed; otherwise unchanged.
+    """
+    if "/" not in model and model.startswith("databricks-"):
+        return f"databricks/{model}"
+    return model
 
 
 def _resolve_databricks_connection(profile: str) -> dict[str, str]:

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -348,7 +348,18 @@ def _parse_llm(
         else 300
     )
     retry = _parse_retry(raw.get("retry"))
-    reserved = {"model", "connection", "profile", "request_timeout", "retry"}
+    fallback_models_raw = raw.get("fallback_models")
+    fallback_models = (
+        [str(m) for m in fallback_models_raw] if isinstance(fallback_models_raw, list) else []
+    )
+    reserved = {
+        "model",
+        "connection",
+        "profile",
+        "request_timeout",
+        "retry",
+        "fallback_models",
+    }
     extra = {k: v for k, v in raw.items() if k not in reserved}
     return LLMConfig(
         model=str(model),
@@ -357,6 +368,7 @@ def _parse_llm(
         profile=profile,
         request_timeout=request_timeout,
         retry=retry,
+        fallback_models=fallback_models,
     )
 
 

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -349,9 +349,19 @@ def _parse_llm(
     )
     retry = _parse_retry(raw.get("retry"))
     fallback_models_raw = raw.get("fallback_models")
-    fallback_models = (
-        [str(m) for m in fallback_models_raw] if isinstance(fallback_models_raw, list) else []
-    )
+    if fallback_models_raw is None:
+        fallback_models = []
+    elif isinstance(fallback_models_raw, list):
+        fallback_models = [str(m) for m in fallback_models_raw]
+    else:
+        # A non-list value (e.g. a bare string) is almost certainly a
+        # config typo — a bare string would iterate per-character, so
+        # reject it loudly rather than silently dropping the fallbacks.
+        _log.warning(
+            "llm.fallback_models must be a list, got %s; ignoring it",
+            type(fallback_models_raw).__name__,
+        )
+        fallback_models = []
     reserved = {
         "model",
         "connection",

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -677,12 +677,16 @@ class LLMConfig:  # type: ignore[explicit-any]  # extra: dict[str, Any] field (s
     :param fallback_models: Ordered backup models tried, in order,
         when a call to ``model`` fails. Same provider-prefixed
         format as ``model``, e.g.
-        ``["anthropic/claude-3-5-haiku", "openai/gpt-4o-mini"]``.
+        ``["databricks/claude-3-5-haiku", "databricks/gpt-4o-mini"]``.
         Consumed today by the policy LLM client
         (:class:`~omnigent.policies.types.PolicyLLMClient`): a call
         advances to the next model on any failure and only surfaces
         an error once every candidate is exhausted. Empty (the
-        default) preserves single-model behaviour.
+        default) preserves single-model behaviour. The resolved
+        ``connection`` (or ``profile``) is shared across the primary
+        and every fallback, so prefer same-provider fallbacks; a
+        fallback on a different provider only works when credentials
+        come from environment defaults (no ``connection``/``profile``).
     """
 
     model: str

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -674,6 +674,15 @@ class LLMConfig:  # type: ignore[explicit-any]  # extra: dict[str, Any] field (s
         ``request_timeout`` to distinguish from the task-level
         ``executor.timeout``.
     :param retry: Retry policy for transient LLM failures.
+    :param fallback_models: Ordered backup models tried, in order,
+        when a call to ``model`` fails. Same provider-prefixed
+        format as ``model``, e.g.
+        ``["anthropic/claude-3-5-haiku", "openai/gpt-4o-mini"]``.
+        Consumed today by the policy LLM client
+        (:class:`~omnigent.policies.types.PolicyLLMClient`): a call
+        advances to the next model on any failure and only surfaces
+        an error once every candidate is exhausted. Empty (the
+        default) preserves single-model behaviour.
     """
 
     model: str
@@ -690,6 +699,9 @@ class LLMConfig:  # type: ignore[explicit-any]  # extra: dict[str, Any] field (s
     profile: str | None = None
     request_timeout: int = 300
     retry: RetryPolicy = field(default_factory=RetryPolicy)
+    # Ordered backup models tried when a call to ``model`` fails.
+    # Empty preserves single-model behaviour.
+    fallback_models: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/runtime/policies/test_policy_llm_client.py
+++ b/tests/runtime/policies/test_policy_llm_client.py
@@ -174,6 +174,40 @@ def test_parse_server_llm_parses_valid_block() -> None:
     assert result.request_timeout == 45
 
 
+def test_parse_server_llm_parses_fallback_models() -> None:
+    """
+    ``parse_server_llm`` parses a ``fallback_models:`` list into
+    ``LLMConfig.fallback_models`` and keeps it out of ``extra``.
+
+    What breaks if this fails: the fallback list is dropped or
+    leaks into SDK kwargs, so hosted never picks up fallback.
+    """
+    raw = {
+        "model": "databricks-claude-sonnet-4",
+        "fallback_models": ["databricks-claude-3-5-haiku", "openai/gpt-4o-mini"],
+    }
+    result = parse_server_llm(raw, expand_env=False)
+    assert result is not None
+    assert result.fallback_models == [
+        "databricks-claude-3-5-haiku",
+        "openai/gpt-4o-mini",
+    ]
+    assert "fallback_models" not in result.extra
+
+
+def test_parse_server_llm_fallback_models_defaults_empty() -> None:
+    """
+    Absent ``fallback_models:`` yields an empty list — the
+    default preserves single-model behaviour.
+
+    What breaks if this fails: configs without the key get a
+    non-empty or ``None`` fallback list, breaking existing specs.
+    """
+    result = parse_server_llm({"model": "openai/gpt-4o-mini"}, expand_env=False)
+    assert result is not None
+    assert result.fallback_models == []
+
+
 # ── PolicyLLMClient ─────────────────────────────────────────────────────────
 
 
@@ -246,6 +280,130 @@ async def test_policy_llm_client_create_allows_overrides() -> None:
     assert call_kwargs["model"] == "openai/gpt-4o"
     assert call_kwargs["connection_params"] == {"api_key": "sk-override"}
     assert call_kwargs["timeout"] == 120
+
+
+@pytest.mark.asyncio
+async def test_policy_llm_client_no_fallback_propagates_error() -> None:
+    """
+    With no fallbacks configured, a primary-model failure
+    propagates unchanged after a single attempt.
+
+    What breaks if this fails: the fallback loop swallows or
+    reshapes the primary error even when no fallback exists,
+    changing today's fail-closed behaviour in ``prompt_policy``.
+    """
+    fake_client = _FakeClient()
+    boom = RuntimeError("primary down")
+    fake_client.responses.create = AsyncMock(side_effect=boom)
+    policy_client = PolicyLLMClient(
+        _client=fake_client,
+        _model="openai/gpt-4o-mini",
+        _connection=None,
+        _request_timeout=60,
+    )
+
+    with pytest.raises(RuntimeError, match="primary down"):
+        await policy_client.create(input=[{"role": "user", "content": "hi"}])
+
+    # Exactly one attempt — the primary model, no retry.
+    assert fake_client.responses.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_policy_llm_client_falls_back_on_primary_failure() -> None:
+    """
+    When the primary model fails, ``create()`` advances to the
+    first fallback and returns its response.
+
+    What breaks if this fails: a transient primary-model failure
+    denies the request even though a healthy fallback was
+    configured.
+    """
+    fake_client = _FakeClient()
+    good = "fallback-response"
+    fake_client.responses.create = AsyncMock(side_effect=[RuntimeError("primary down"), good])
+    policy_client = PolicyLLMClient(
+        _client=fake_client,
+        _model="databricks/primary",
+        _connection={"api_key": "k"},
+        _request_timeout=60,
+        _fallback_models=["databricks/backup"],
+    )
+
+    result = await policy_client.create(input=[{"role": "user", "content": "hi"}])
+
+    assert result == good
+    assert fake_client.responses.create.await_count == 2
+    # Primary tried first, backup second — in order.
+    models = [c.kwargs["model"] for c in fake_client.responses.create.await_args_list]
+    assert models == ["databricks/primary", "databricks/backup"]
+    # The shared connection/timeout are reused across candidates.
+    for call in fake_client.responses.create.await_args_list:
+        assert call.kwargs["connection_params"] == {"api_key": "k"}
+        assert call.kwargs["timeout"] == 60
+
+
+@pytest.mark.asyncio
+async def test_policy_llm_client_all_models_fail_raises_last() -> None:
+    """
+    When the primary and every fallback fail, the last error is
+    re-raised after all candidates are exhausted.
+
+    What breaks if this fails: an exhausted fallback chain hides
+    the failure or raises the wrong (stale) error, breaking the
+    fail-closed contract in ``prompt_policy``.
+    """
+    fake_client = _FakeClient()
+    fake_client.responses.create = AsyncMock(
+        side_effect=[
+            RuntimeError("primary"),
+            RuntimeError("backup-1"),
+            RuntimeError("backup-2"),
+        ]
+    )
+    policy_client = PolicyLLMClient(
+        _client=fake_client,
+        _model="m0",
+        _connection=None,
+        _request_timeout=60,
+        _fallback_models=["m1", "m2"],
+    )
+
+    with pytest.raises(RuntimeError, match="backup-2"):
+        await policy_client.create(input=[{"role": "user", "content": "hi"}])
+
+    assert fake_client.responses.create.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_policy_llm_client_explicit_model_override_skips_fallback() -> None:
+    """
+    An explicit ``model=`` override opts out of the fallback
+    chain — only the requested model is tried, and its failure
+    propagates.
+
+    What breaks if this fails: a caller that deliberately targets
+    one model silently gets the fallback chain instead.
+    """
+    fake_client = _FakeClient()
+    fake_client.responses.create = AsyncMock(side_effect=RuntimeError("override down"))
+    policy_client = PolicyLLMClient(
+        _client=fake_client,
+        _model="m0",
+        _connection=None,
+        _request_timeout=60,
+        _fallback_models=["m1", "m2"],
+    )
+
+    with pytest.raises(RuntimeError, match="override down"):
+        await policy_client.create(
+            input=[{"role": "user", "content": "hi"}],
+            model="explicit",
+        )
+
+    # Only the explicit model was tried — fallbacks were skipped.
+    assert fake_client.responses.create.await_count == 1
+    assert fake_client.responses.create.await_args.kwargs["model"] == "explicit"
 
 
 # ── EvaluationContext.llm_client ────────────────────────────────────────────
@@ -413,6 +571,45 @@ def test_build_policy_llm_client_constructs_from_config() -> None:
     assert result._model == "openai/gpt-4o-mini"
     assert result._connection == {"api_key": "test-key", "base_url": "https://example.com"}
     assert result._request_timeout == 60
+
+
+def test_build_policy_llm_client_normalizes_databricks_prefix() -> None:
+    """
+    Bare ``databricks-`` model names get the ``databricks/``
+    provider prefix, on both the primary model and every fallback.
+
+    What breaks if this fails: hosted fallback calls route to
+    ``/responses`` on the Databricks gateway and 400 (the exact
+    bug the primary-model fixup already guards against).
+    """
+    llm_config = LLMConfig(
+        model="databricks-claude-sonnet-4",
+        fallback_models=["databricks-claude-3-5-haiku", "openai/gpt-4o-mini"],
+    )
+    result = _build_policy_llm_client(llm_config, None)
+
+    assert result is not None
+    assert result._model == "databricks/databricks-claude-sonnet-4"
+    # Fallbacks get the same fixup; already-prefixed ids pass through.
+    assert result._fallback_models == [
+        "databricks/databricks-claude-3-5-haiku",
+        "openai/gpt-4o-mini",
+    ]
+
+
+def test_build_policy_llm_client_empty_fallbacks_default() -> None:
+    """
+    A config with no ``fallback_models`` yields an empty fallback
+    list — single-model behaviour is preserved.
+
+    What breaks if this fails: the builder injects phantom
+    fallbacks, changing behaviour for every existing hosted
+    deployment that sets only ``model``.
+    """
+    result = _build_policy_llm_client(_make_server_llm(), None)
+
+    assert result is not None
+    assert result._fallback_models == []
 
 
 # ── build_policy_engine wiring ──────────────────────────────────────────────

--- a/tests/runtime/policies/test_policy_llm_client.py
+++ b/tests/runtime/policies/test_policy_llm_client.py
@@ -332,10 +332,12 @@ async def test_policy_llm_client_no_fallback_propagates_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_policy_llm_client_falls_back_on_primary_failure() -> None:
+async def test_policy_llm_client_falls_back_on_primary_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """
     When the primary model fails, ``create()`` advances to the
-    first fallback and returns its response.
+    first fallback, logs the recovery, and returns its response.
 
     What breaks if this fails: a transient primary-model failure
     denies the request even though a healthy fallback was
@@ -352,10 +354,13 @@ async def test_policy_llm_client_falls_back_on_primary_failure() -> None:
         _fallback_models=["databricks/backup"],
     )
 
-    result = await policy_client.create(input=[{"role": "user", "content": "hi"}])
+    with caplog.at_level("WARNING"):
+        result = await policy_client.create(input=[{"role": "user", "content": "hi"}])
 
     assert result == good
     assert fake_client.responses.create.await_count == 2
+    # The recovery is logged so the fallback path is visible in ops logs.
+    assert any("recovered on fallback model" in r.message for r in caplog.records)
     # Primary tried first, backup second — in order.
     models = [c.kwargs["model"] for c in fake_client.responses.create.await_args_list]
     assert models == ["databricks/primary", "databricks/backup"]

--- a/tests/runtime/policies/test_policy_llm_client.py
+++ b/tests/runtime/policies/test_policy_llm_client.py
@@ -208,6 +208,28 @@ def test_parse_server_llm_fallback_models_defaults_empty() -> None:
     assert result.fallback_models == []
 
 
+def test_parse_server_llm_fallback_models_non_list_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A non-list ``fallback_models:`` (e.g. a bare string typo) is
+    rejected with a warning and yields an empty list.
+
+    What breaks if this fails: a bare string is dropped silently
+    (or iterated per-character), so the operator's intended
+    fallback is lost with no hint.
+    """
+    with caplog.at_level("WARNING"):
+        result = parse_server_llm(
+            {"model": "openai/gpt-4o-mini", "fallback_models": "openai/gpt-4o"},
+            expand_env=False,
+        )
+
+    assert result is not None
+    assert result.fallback_models == []
+    assert any("fallback_models must be a list" in r.message for r in caplog.records)
+
+
 # ── PolicyLLMClient ─────────────────────────────────────────────────────────
 
 
@@ -610,6 +632,52 @@ def test_build_policy_llm_client_empty_fallbacks_default() -> None:
 
     assert result is not None
     assert result._fallback_models == []
+
+
+def test_build_policy_llm_client_warns_on_cross_provider_fallback_with_connection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A fallback on a different provider than the primary, combined
+    with a resolved connection, warns at build time.
+
+    What breaks if this fails: the shared connection is silently
+    handed to a fallback on another provider, so the fallback
+    request fails to authenticate mid-policy-evaluation with no
+    hint at startup.
+    """
+    llm_config = LLMConfig(
+        model="databricks/primary",
+        fallback_models=["openai/gpt-4o-mini"],
+    )
+    with caplog.at_level("WARNING"):
+        result = _build_policy_llm_client(llm_config, {"api_key": "k"})
+
+    assert result is not None
+    assert any(
+        "fallback_models target" in r.message and "openai" in r.message for r in caplog.records
+    )
+
+
+def test_build_policy_llm_client_no_warn_same_provider_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Same-provider fallbacks with a connection do not warn — the
+    shared connection is valid for every candidate.
+
+    What breaks if this fails: correct configs get spurious
+    warnings, training operators to ignore the real ones.
+    """
+    llm_config = LLMConfig(
+        model="databricks/primary",
+        fallback_models=["databricks/backup"],
+    )
+    with caplog.at_level("WARNING"):
+        result = _build_policy_llm_client(llm_config, {"api_key": "k"})
+
+    assert result is not None
+    assert not any("fallback_models target" in r.message for r in caplog.records)
 
 
 # ── build_policy_engine wiring ──────────────────────────────────────────────


### PR DESCRIPTION
The LLM-backed prompt classifier policy (and the smart-routing judge) resolve a single model from the server-level `llm:` config. A transient failure of that one model fails the policy closed (DENY), with no retry against an alternate model.

Add an optional `fallback_models` list to `LLMConfig`. `PolicyLLMClient` now tries the primary model first and each fallback in turn on any failure, only surfacing the last error once every candidate is exhausted. An explicit `model=` override opts out of the chain.

The `databricks-` -> `databricks/` provider-prefix fixup is factored into `_normalize_policy_model` and applied uniformly to the primary model and every fallback, so the fallback path routes through the same adapter as the primary. Empty `fallback_models` (the default) preserves today's single-model behaviour.

Follow-up hardening in this PR: warn at build time when a `fallback_models` entry targets a different provider than the primary while a `connection:` is set (the shared connection would not authenticate the other provider); reject a non-list `fallback_models:` with a warning instead of silently dropping it; log the accumulated `len(candidates) * timeout` latency before the fail-closed DENY; and log which fallback model recovered the call so the fallback path is observable in ops logs.

Co-authored-by: Isaac

## Related issue

Closes #

## Summary

- Add `fallback_models: list[str]` to the server-level `llm:` config; `PolicyLLMClient.create()` tries the primary then each fallback in order, re-raising the last error only once every candidate is exhausted. Empty list = today's single-model behaviour; an explicit `model=` override skips the chain.
- Apply the `databricks-` → `databricks/` prefix fixup uniformly to primary + fallbacks via `_normalize_policy_model`.
- Guardrails/observability: warn on cross-provider fallback with a shared connection, warn on a non-list `fallback_models:`, log fail-closed latency, and log fallback recovery.

## Test Plan

**Automated** — `pytest tests/runtime/policies/test_policy_llm_client.py` (33 passed). New cases cover: config parsing of `fallback_models` (incl. non-list warning + empty default), the `create()` fallback loop (no-fallback error propagation, recovery on primary failure + recovery log, all-candidates-fail raises last, explicit-`model=` skips the chain), `databricks-` prefix normalization on primary + fallbacks, and the cross-provider-with-connection build-time warning.

**Manual end-to-end** against a real Databricks AI gateway, exercising the full server → host → runner → policy-hook path:

1. Started a local server on `:8000` with a server config whose primary model is deliberately bogus (`databricks-this-model-does-not-exist-primary`) and whose `fallback_models` is a healthy `databricks-claude-haiku-4-5`, plus a server-level `prompt_policy` (LLM-backed classifier) so every request drives `PolicyLLMClient.create()`.
2. Registered this machine as a host against that server (`omnigent host http://127.0.0.1:8000`) and drove a session from the web UI.
3. Observed in the server app log, on a real request:
   - `PolicyLLMClient: model 'databricks/databricks-this-model-does-not-exist-primary' failed (404 Not Found); falling back to next of 1 remaining`
   - `PolicyLLMClient: recovered on fallback model 'databricks/databricks-claude-haiku-4-5' (candidate 2 of 2) after primary failure`
   - The policy then evaluated on the fallback model (a real ~1s LLM call) and the verdict (allow / deny) flowed back to the UI — i.e. the request no longer fails closed just because the primary model is down.
4. Confirmed the fail-closed path too: with a deliberately bad credential, both candidates 401 and the classifier correctly fails closed (`Policy classifier error (fail-closed)`) after logging the exhausted-chain latency — the intended safety behaviour.

## Demo

N/A — server-side / config change; the observable behaviour is the fallback + recovery log lines quoted in the Test Plan.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover config parsing, the `create()` fallback loop, prefix normalization, and the build-time warnings. Manual verification (above) exercised the full server → host → runner → policy-hook path against a live Databricks gateway, confirming both the recovery path (primary fails → fallback answers) and the fail-closed path (all candidates fail → DENY). No automated E2E was added because it would require live LLM credentials in CI.

## Changelog

Server `llm:` config accepts an optional `fallback_models:` list; LLM-backed policies now retry alternate models before failing closed.
