### PR TITLE
feat: add MiniMax provider compatibility

### DIFF
--- a/omnigent/llms/LLMCLIENT.md
+++ b/omnigent/llms/LLMCLIENT.md
@@ -228,6 +228,9 @@ compatible global endpoint is the default. Use `connection_params["base_url"]`
 for another region or use the `anthropic` model prefix with an Anthropic base
 URL to select the Messages protocol:
 
+`MiniMax-M3` accepts text, image, and video input. Both protocols also accept
+`service_tier="priority"`; omitting it uses the standard admission tier.
+
 | Region | Protocol | Model prefix | Base URL |
 |--------|----------|--------------|----------|
 | Global | OpenAI compatible | `minimax/` | `https://api.minimax.io/v1` |

--- a/omnigent/llms/LLMCLIENT.md
+++ b/omnigent/llms/LLMCLIENT.md
@@ -216,8 +216,50 @@ Chat Completions IS the native format. Minimal translation (add model to payload
 | `xai` | `https://api.x.ai/v1` | `XAI_API_KEY` |
 | `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
 | `ollama` | `http://localhost:11434/v1` | (none) |
+| `minimax` | `https://api.minimax.io/v1` | (none) |
 
 HTTP via sync `httpx` (already a project dependency).
+
+#### MiniMax
+
+The `minimax` provider supports `MiniMax-M3` with a 1,000,000-token context
+window and `MiniMax-M2.7` with a 204,800-token context window. The OpenAI
+compatible global endpoint is the default. Use `connection_params["base_url"]`
+for another region or use the `anthropic` model prefix with an Anthropic base
+URL to select the Messages protocol:
+
+| Region | Protocol | Model prefix | Base URL |
+|--------|----------|--------------|----------|
+| Global | OpenAI compatible | `minimax/` | `https://api.minimax.io/v1` |
+| China | OpenAI compatible | `minimax/` | `https://api.minimaxi.com/v1` |
+| Global | Anthropic compatible | `anthropic/` | `https://api.minimax.io/anthropic` |
+| China | Anthropic compatible | `anthropic/` | `https://api.minimaxi.com/anthropic` |
+
+```python
+from omnigent.llms import Client
+
+client = Client()
+
+response = await client.responses.create(
+    input=[{"role": "user", "content": "Hello"}],
+    model="minimax/MiniMax-M3",
+    connection_params={"api_key": "..."},
+    thinking={"type": "disabled"},
+)
+
+response = await client.responses.create(
+    input=[{"role": "user", "content": "Hello"}],
+    model="anthropic/MiniMax-M3",
+    connection_params={
+        "api_key": "...",
+        "base_url": "https://api.minimax.io/anthropic",
+    },
+    thinking={"type": "adaptive"},
+)
+```
+
+The Anthropic base URLs intentionally end in `/anthropic`. The adapter derives
+the `/v1/messages` request path internally.
 
 ### Anthropic — `adapters/anthropic.py`
 

--- a/omnigent/llms/LLMCLIENT.md
+++ b/omnigent/llms/LLMCLIENT.md
@@ -228,8 +228,23 @@ compatible global endpoint is the default. Use `connection_params["base_url"]`
 for another region or use the `anthropic` model prefix with an Anthropic base
 URL to select the Messages protocol:
 
-`MiniMax-M3` accepts text, image, and video input. Both protocols also accept
-`service_tier="priority"`; omitting it uses the standard admission tier.
+`MiniMax-M3` accepts text, image, and video input. OpenAI-compatible requests
+enable thinking by default, while Anthropic-compatible requests disable it by
+default. Use `thinking={"type": "adaptive"}` or
+`thinking={"type": "disabled"}` to select the behavior explicitly.
+`MiniMax-M2.7` accepts text input and always uses thinking.
+
+Both protocols also accept `service_tier="priority"` for `MiniMax-M3`;
+omitting it uses the standard admission tier. Published prices are in USD per
+million tokens:
+
+| Model | Service tier | Input length | Input | Output | Cache read | Cache write |
+|-------|--------------|--------------|-------|--------|------------|-------------|
+| `MiniMax-M3` | Standard | Up to 512,000 | $0.30 | $1.20 | $0.06 | N/A |
+| `MiniMax-M3` | Standard | Above 512,000 | $0.60 | $2.40 | $0.12 | N/A |
+| `MiniMax-M3` | Priority | Up to 512,000 | $0.45 | $1.80 | $0.09 | N/A |
+| `MiniMax-M3` | Priority | Above 512,000 | $0.90 | $3.60 | $0.18 | N/A |
+| `MiniMax-M2.7` | Standard | Any | $0.30 | $1.20 | $0.06 | $0.375 |
 
 | Region | Protocol | Model prefix | Base URL |
 |--------|----------|--------------|----------|

--- a/omnigent/llms/adapters/__init__.py
+++ b/omnigent/llms/adapters/__init__.py
@@ -57,6 +57,7 @@ def _create_adapter(provider: str, **kwargs: Any) -> BaseAdapter:
         "openrouter": "https://openrouter.ai/api/v1",
         "ollama": "http://localhost:11434/v1",
         "moonshot": "https://api.moonshot.cn/v1",
+        "minimax": "https://api.minimax.io/v1",
     }
 
     if provider in openai_compat_providers:

--- a/omnigent/llms/adapters/anthropic.py
+++ b/omnigent/llms/adapters/anthropic.py
@@ -159,6 +159,10 @@ def _chat_to_anthropic(
     if tool_choice := extra.pop("tool_choice", None):
         payload["tool_choice"] = _convert_tool_choice(tool_choice)
 
+    # Provider-compatible admission tier.
+    if service_tier := extra.pop("service_tier", None):
+        payload["service_tier"] = service_tier
+
     # Explicit provider-native thinking configuration takes precedence over
     # the generic reasoning-effort translation.
     if thinking := extra.pop("thinking", None):
@@ -246,6 +250,7 @@ def _translate_part_to_anthropic(part: dict[str, Any]) -> dict[str, Any]:
       {"type": "base64", "media_type": "...", "data": "..."}}``
     - ``image_url`` with external URL → ``{"type": "image", "source":
       {"type": "url", "url": "..."}}``
+    - ``video_url`` -> ``{"type": "video", "source": ...}``
     - ``input_file`` with file_data → ``{"type": "document", "source":
       {"type": "base64", "media_type": "...", "data": "..."}}``
     - Unrecognized → passed through as-is.
@@ -276,6 +281,23 @@ def _translate_part_to_anthropic(part: dict[str, Any]) -> dict[str, Any]:
             "type": "image",
             "source": {"type": "url", "url": url},
         }
+
+    if part_type == "video_url":
+        video_url = part["video_url"]
+        url = video_url["url"]
+        parsed = parse_data_uri(url)
+        if parsed is not None:
+            source: dict[str, Any] = {
+                "type": "base64",
+                "media_type": parsed.media_type,
+                "data": parsed.data,
+            }
+        else:
+            source = {"type": "url", "url": url}
+        for key in ("detail", "fps", "max_long_side_pixel"):
+            if key in video_url:
+                source[key] = video_url[key]
+        return {"type": "video", "source": source}
 
     if part_type == "input_file":
         # file_data is a data: URI (e.g. "data:application/pdf;base64,...").

--- a/omnigent/llms/adapters/anthropic.py
+++ b/omnigent/llms/adapters/anthropic.py
@@ -21,6 +21,10 @@ from omnigent.llms.adapters.base import BaseAdapter
 from omnigent.reasoning_effort import ANTHROPIC_EFFORTS, validate_effort_or_llm_error
 
 _BASE_URL = "https://api.anthropic.com/v1"
+_MINIMAX_BASE_URLS = {
+    "https://api.minimax.io/anthropic",
+    "https://api.minimaxi.com/anthropic",
+}
 _API_VERSION = "2023-06-01"
 _DEFAULT_MAX_TOKENS = 16384
 _REQUEST_TIMEOUT = 120
@@ -66,8 +70,7 @@ class AnthropicAdapter(BaseAdapter):
         headers = _build_headers(
             api_key_override=params.get("api_key"),
         )
-        override_base = params.get("base_url")
-        effective_base = override_base.rstrip("/") if override_base else _BASE_URL
+        effective_base = _resolve_base_url(params.get("base_url"))
 
         if stream:
             payload["stream"] = True
@@ -156,8 +159,11 @@ def _chat_to_anthropic(
     if tool_choice := extra.pop("tool_choice", None):
         payload["tool_choice"] = _convert_tool_choice(tool_choice)
 
-    # Reasoning effort (for Claude extended thinking)
-    if reasoning_effort := extra.pop("reasoning_effort", None):
+    # Explicit provider-native thinking configuration takes precedence over
+    # the generic reasoning-effort translation.
+    if thinking := extra.pop("thinking", None):
+        payload["thinking"] = thinking
+    elif reasoning_effort := extra.pop("reasoning_effort", None):
         effort = validate_effort_or_llm_error(reasoning_effort, "Anthropic", ANTHROPIC_EFFORTS)
         if effort is not None:
             payload["thinking"] = {
@@ -568,6 +574,22 @@ def _make_chunk(
 
 
 # ── HTTP helpers ──────────────────────────────────────────
+
+
+def _resolve_base_url(override: str | None) -> str:
+    """Resolve an Anthropic-compatible base URL for the Messages endpoint.
+
+    MiniMax publishes a base URL ending in ``/anthropic`` while its Messages
+    endpoint lives under ``/anthropic/v1/messages``. Keep the public base URL
+    unchanged and derive the version segment inside the adapter.
+
+    :param override: Per-call base URL override, or ``None``.
+    :returns: Base URL to which ``/messages`` can be appended.
+    """
+    effective_base = override.rstrip("/") if override else _BASE_URL
+    if effective_base in _MINIMAX_BASE_URLS:
+        return f"{effective_base}/v1"
+    return effective_base
 
 
 def _build_headers(

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -67,9 +67,13 @@ _DEFAULT_CONTEXT_WINDOW: int = 128_000
 # Covered today:
 #  - Qwen models (absent from litellm + the MLflow catalog) — published Alibaba
 #    Cloud Model Studio / DashScope maxima.
+#  - MiniMax models whose catalog entries are absent or report input and output
+#    limits separately from the published total context window.
 #  - Anthropic 1M-context beta ids (the ``[1m]`` suffix) — handled by a rule in
 #    :func:`_registry_context_window` rather than enumerated per base model.
 _CONTEXT_WINDOW_REGISTRY: dict[str, int] = {
+    "minimax-m3": 1_000_000,
+    "minimax-m2.7": 204_800,
     "qwen3-coder-plus": 1_048_576,  # DashScope coding-plan default: 1M tokens
     "qwen3-coder-flash": 1_048_576,  # served flash variant: 1M tokens
     "qwen3-coder": 262_144,  # 480B open weights: 256K native (1M w/ YaRN)

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -411,17 +411,63 @@ class ModelPricing:
     :param cache_write_per_token: Price per cache-write (cache-creation)
         input token (typically ~1.25x input), or ``None`` when
         unpublished.
+    :param long_context_threshold_tokens: Input-token threshold above which
+        the long-context rates apply, or ``None`` for flat pricing.
+    :param long_context_input_per_token: Long-context input price per token.
+    :param long_context_output_per_token: Long-context output price per token.
+    :param long_context_cache_read_per_token: Long-context cache-read price
+        per token.
+    :param long_context_cache_write_per_token: Long-context cache-write price
+        per token.
     """
 
     input_per_token: float
     output_per_token: float
     cache_read_per_token: float | None = None
     cache_write_per_token: float | None = None
+    long_context_threshold_tokens: int | None = None
+    long_context_input_per_token: float | None = None
+    long_context_output_per_token: float | None = None
+    long_context_cache_read_per_token: float | None = None
+    long_context_cache_write_per_token: float | None = None
 
 
-def fetch_model_pricing(model: str) -> ModelPricing | None:
+_MODEL_PRICING_REGISTRY: dict[tuple[str, str], ModelPricing] = {
+    ("minimax-m3", "standard"): ModelPricing(
+        input_per_token=0.3e-6,
+        output_per_token=1.2e-6,
+        cache_read_per_token=0.06e-6,
+        long_context_threshold_tokens=512_000,
+        long_context_input_per_token=0.6e-6,
+        long_context_output_per_token=2.4e-6,
+        long_context_cache_read_per_token=0.12e-6,
+    ),
+    ("minimax-m3", "priority"): ModelPricing(
+        input_per_token=0.45e-6,
+        output_per_token=1.8e-6,
+        cache_read_per_token=0.09e-6,
+        long_context_threshold_tokens=512_000,
+        long_context_input_per_token=0.9e-6,
+        long_context_output_per_token=3.6e-6,
+        long_context_cache_read_per_token=0.18e-6,
+    ),
+    ("minimax-m2.7", "standard"): ModelPricing(
+        input_per_token=0.3e-6,
+        output_per_token=1.2e-6,
+        cache_read_per_token=0.06e-6,
+        cache_write_per_token=0.375e-6,
+    ),
+}
+_CURATED_PRICING_MODELS = frozenset(model for model, _tier in _MODEL_PRICING_REGISTRY)
+
+
+def fetch_model_pricing(
+    model: str,
+    *,
+    service_tier: str = "standard",
+) -> ModelPricing | None:
     """
-    Look up per-token pricing for *model* from the MLflow catalog.
+    Look up per-token pricing for *model* from the curated registry or catalog.
 
     Returns prices per token (not per million), including cache-read /
     cache-write rates when the catalog publishes them. Uses the same
@@ -431,19 +477,29 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
 
     :param model: Model identifier, e.g. ``"anthropic/claude-sonnet-4-6"``
         or ``"databricks-gpt-5-5"``.
+    :param service_tier: Provider service tier, such as ``"standard"`` or
+        ``"priority"``, used when curated pricing defines that tier.
     :returns: A :class:`ModelPricing`, or ``None`` when pricing is
         unavailable (network error, model not in catalog, or catalog
         entry lacks input/output pricing data).
     """
-    if os.environ.get("OMNIGENT_DISABLE_CATALOG_LOOKUP") == "1":
-        return None
-
     if "/" in model:
         _explicit_provider, bare = model.split("/", 1)
         provider = _explicit_provider
     else:
         bare = model
         provider = _infer_provider(bare)
+
+    normalized_model = bare.strip().lower()
+    normalized_tier = service_tier.strip().lower()
+    registered = _MODEL_PRICING_REGISTRY.get((normalized_model, normalized_tier))
+    if registered is not None:
+        return registered
+    if normalized_model in _CURATED_PRICING_MODELS:
+        return None
+
+    if os.environ.get("OMNIGENT_DISABLE_CATALOG_LOOKUP") == "1":
+        return None
 
     if provider is None:
         return None
@@ -503,7 +559,7 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
     if provider == "databricks" and bare.startswith("databricks-"):
         base = bare[len("databricks-") :]
         if base and base != bare:
-            return fetch_model_pricing(base)
+            return fetch_model_pricing(base, service_tier=service_tier)
 
     return None
 
@@ -545,25 +601,40 @@ def compute_llm_cost(usage: dict[str, Any], pricing: ModelPricing) -> float:
     output_tokens = usage.get("output_tokens") or 0
     cache_read = usage.get("cache_read_input_tokens") or 0
     cache_write = usage.get("cache_creation_input_tokens") or 0
+    input_rate = pricing.input_per_token
+    output_rate = pricing.output_per_token
+    cache_read_rate = pricing.cache_read_per_token
+    cache_write_rate = pricing.cache_write_per_token
+    total_input_tokens = input_tokens + cache_read + cache_write
+    if (
+        pricing.long_context_threshold_tokens is not None
+        and total_input_tokens > pricing.long_context_threshold_tokens
+    ):
+        if pricing.long_context_input_per_token is not None:
+            input_rate = pricing.long_context_input_per_token
+        if pricing.long_context_output_per_token is not None:
+            output_rate = pricing.long_context_output_per_token
+        cache_read_rate = pricing.long_context_cache_read_per_token
+        cache_write_rate = pricing.long_context_cache_write_per_token
     # No published cache rate → derive one from the input rate using the
     # industry-standard ratios (see _FALLBACK_CACHE_*_INPUT_RATIO). This keeps
     # cache reads at ~10% of input on models whose catalog entry omits cache
     # pricing (``databricks-*`` today) instead of billing them at full input
     # rate, which over-charged cache-heavy sessions ~10×. Never drop the
     # tokens — cache reads/writes still cost something.
-    cache_read_rate = (
-        pricing.cache_read_per_token
-        if pricing.cache_read_per_token is not None
-        else pricing.input_per_token * _FALLBACK_CACHE_READ_INPUT_RATIO
+    resolved_cache_read_rate = (
+        cache_read_rate
+        if cache_read_rate is not None
+        else input_rate * _FALLBACK_CACHE_READ_INPUT_RATIO
     )
-    cache_write_rate = (
-        pricing.cache_write_per_token
-        if pricing.cache_write_per_token is not None
-        else pricing.input_per_token * _FALLBACK_CACHE_WRITE_INPUT_RATIO
+    resolved_cache_write_rate = (
+        cache_write_rate
+        if cache_write_rate is not None
+        else input_rate * _FALLBACK_CACHE_WRITE_INPUT_RATIO
     )
     return (
-        input_tokens * pricing.input_per_token
-        + output_tokens * pricing.output_per_token
-        + cache_read * cache_read_rate
-        + cache_write * cache_write_rate
+        input_tokens * input_rate
+        + output_tokens * output_rate
+        + cache_read * resolved_cache_read_rate
+        + cache_write * resolved_cache_write_rate
     )

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -29,6 +29,7 @@ PROVIDER_CONFIGS: dict[str, str | None] = {
     "openrouter": "https://openrouter.ai/api/v1",
     "ollama": "http://localhost:11434/v1",
     "moonshot": "https://api.moonshot.cn/v1",
+    "minimax": "https://api.minimax.io/v1",
 }
 
 _DEFAULT_PROVIDER = "openai"

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -382,7 +382,15 @@ def build_policy_engine(
     initial_model = _resolve_session_model(conversation_id, conversation_store, spec)
     # Pass the full ModelPricing so the engine can price cache-read and
     # cache-write tokens at their own rates via compute_llm_cost().
-    token_pricing = fetch_model_pricing(spec.llm.model) if spec.llm else None
+    if spec.llm:
+        service_tier = spec.llm.extra.get("service_tier")
+        token_pricing = (
+            fetch_model_pricing(spec.llm.model, service_tier=service_tier)
+            if isinstance(service_tier, str)
+            else fetch_model_pricing(spec.llm.model)
+        )
+    else:
+        token_pricing = None
     server_connection = _resolve_server_llm_connection(server_llm)
     # host_connection carries the per-request caller token (billed to
     # the caller). It takes precedence over the static server-level

--- a/tests/llms/test_anthropic_adapter.py
+++ b/tests/llms/test_anthropic_adapter.py
@@ -231,6 +231,28 @@ def test_user_message_with_external_url() -> None:
     }
 
 
+def test_user_message_with_video_url() -> None:
+    """Video URLs translate to Anthropic-compatible video blocks."""
+    part = {
+        "type": "video_url",
+        "video_url": {
+            "url": "https://example.com/demo.mp4",
+            "detail": "high",
+            "fps": 2,
+        },
+    }
+    result = _translate_part_to_anthropic(part)
+    assert result == {
+        "type": "video",
+        "source": {
+            "type": "url",
+            "url": "https://example.com/demo.mp4",
+            "detail": "high",
+            "fps": 2,
+        },
+    }
+
+
 def test_user_message_with_file_data() -> None:
     """
     input_file with file_data translates to Anthropic document type.
@@ -404,9 +426,11 @@ async def test_minimax_anthropic_base_url_derives_messages_path(
 ) -> None:
     """The public MiniMax base URL resolves to ``/anthropic/v1/messages``."""
     requested_urls: list[str] = []
+    requested_bodies: list[dict] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requested_urls.append(str(request.url))
+        requested_bodies.append(json.loads(request.content))
         return httpx.Response(
             200,
             json={
@@ -427,15 +451,35 @@ async def test_minimax_anthropic_base_url_derives_messages_path(
 
     adapter = AnthropicAdapter()
     await adapter.chat_completions(
-        messages=[{"role": "user", "content": "Hello"}],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this video"},
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/demo.mp4"},
+                    },
+                ],
+            }
+        ],
         model="MiniMax-M3",
         tools=None,
         stream=False,
-        extra={"thinking": {"type": "adaptive"}},
+        extra={
+            "thinking": {"type": "adaptive"},
+            "service_tier": "priority",
+        },
         connection_params={"api_key": "test-key", "base_url": api_base_url},
     )
 
     assert requested_urls == [f"{api_base_url}/v1/messages"]
+    assert requested_bodies[0]["service_tier"] == "priority"
+    assert requested_bodies[0]["thinking"] == {"type": "adaptive"}
+    assert requested_bodies[0]["messages"][0]["content"][1] == {
+        "type": "video",
+        "source": {"type": "url", "url": "https://example.com/demo.mp4"},
+    }
 
 
 # ── Stop sequences ───────────────────────────────────────

--- a/tests/llms/test_anthropic_adapter.py
+++ b/tests/llms/test_anthropic_adapter.py
@@ -3,9 +3,11 @@
 import base64
 import json
 
+import httpx
 import pytest
 
 from omnigent.llms.adapters.anthropic import (
+    AnthropicAdapter,
     _anthropic_to_chat,
     _chat_to_anthropic,
     _convert_tool_choice,
@@ -374,6 +376,66 @@ def test_reasoning_effort_adds_thinking_to_payload() -> None:
     payload = _chat_to_anthropic(messages, "claude-test", None, {"reasoning_effort": "high"})
     assert payload["thinking"]["type"] == "enabled"
     assert payload["thinking"]["budget_tokens"] == 8192
+
+
+def test_explicit_thinking_configuration_takes_precedence() -> None:
+    """Provider-native thinking settings bypass reasoning-effort translation."""
+    messages = [{"role": "user", "content": "Hi"}]
+    payload = _chat_to_anthropic(
+        messages,
+        "MiniMax-M3",
+        None,
+        {"thinking": {"type": "adaptive"}, "reasoning_effort": "high"},
+    )
+    assert payload["thinking"] == {"type": "adaptive"}
+
+
+@pytest.mark.parametrize(
+    "api_base_url",
+    [
+        "https://api.minimax.io/anthropic",
+        "https://api.minimaxi.com/anthropic",
+    ],
+)
+@pytest.mark.asyncio
+async def test_minimax_anthropic_base_url_derives_messages_path(
+    monkeypatch: pytest.MonkeyPatch,
+    api_base_url: str,
+) -> None:
+    """The public MiniMax base URL resolves to ``/anthropic/v1/messages``."""
+    requested_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg-test",
+                "model": "MiniMax-M3",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        "omnigent.llms.adapters.anthropic.httpx.AsyncClient",
+        lambda **kwargs: real_async_client(transport=transport, **kwargs),
+    )
+
+    adapter = AnthropicAdapter()
+    await adapter.chat_completions(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="MiniMax-M3",
+        tools=None,
+        stream=False,
+        extra={"thinking": {"type": "adaptive"}},
+        connection_params={"api_key": "test-key", "base_url": api_base_url},
+    )
+
+    assert requested_urls == [f"{api_base_url}/v1/messages"]
 
 
 # ── Stop sequences ───────────────────────────────────────

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -175,6 +175,56 @@ def test_compute_llm_cost_without_cache_tokens_is_the_flat_formula() -> None:
     assert compute_llm_cost(usage, pricing) == pytest.approx(0.007)
 
 
+def test_fetch_model_pricing_preserves_minimax_published_tiers() -> None:
+    """Curated MiniMax pricing keeps service and long-context tiers distinct."""
+    standard = fetch_model_pricing("minimax/MiniMax-M3")
+    priority = fetch_model_pricing("anthropic/MiniMax-M3", service_tier="priority")
+    m27 = fetch_model_pricing("minimax/MiniMax-M2.7")
+
+    assert standard == ModelPricing(
+        input_per_token=0.3e-6,
+        output_per_token=1.2e-6,
+        cache_read_per_token=0.06e-6,
+        long_context_threshold_tokens=512_000,
+        long_context_input_per_token=0.6e-6,
+        long_context_output_per_token=2.4e-6,
+        long_context_cache_read_per_token=0.12e-6,
+    )
+    assert priority == ModelPricing(
+        input_per_token=0.45e-6,
+        output_per_token=1.8e-6,
+        cache_read_per_token=0.09e-6,
+        long_context_threshold_tokens=512_000,
+        long_context_input_per_token=0.9e-6,
+        long_context_output_per_token=3.6e-6,
+        long_context_cache_read_per_token=0.18e-6,
+    )
+    assert m27 == ModelPricing(
+        input_per_token=0.3e-6,
+        output_per_token=1.2e-6,
+        cache_read_per_token=0.06e-6,
+        cache_write_per_token=0.375e-6,
+    )
+
+
+def test_compute_llm_cost_switches_above_long_context_threshold() -> None:
+    """The published long-context rates apply only above 512,000 input tokens."""
+    pricing = fetch_model_pricing("minimax/MiniMax-M3")
+    assert pricing is not None
+
+    short_cost = compute_llm_cost(
+        {"input_tokens": 512_000, "output_tokens": 1_000},
+        pricing,
+    )
+    long_cost = compute_llm_cost(
+        {"input_tokens": 512_001, "output_tokens": 1_000},
+        pricing,
+    )
+
+    assert short_cost == pytest.approx(0.1548)
+    assert long_cost == pytest.approx(0.3096006)
+
+
 def test_fetch_model_pricing_parses_cache_rates(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     ``fetch_model_pricing`` surfaces catalog cache-read/write rates.

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -362,6 +362,10 @@ def test_provider_catalog_caches_fetch_failure(
 
 def test_registry_context_window_normalizes_id() -> None:
     """The registry strips provider prefixes and ``:tag`` suffixes before matching."""
+    assert _registry_context_window("MiniMax-M3") == 1_000_000
+    assert _registry_context_window("minimax/MiniMax-M3") == 1_000_000
+    assert _registry_context_window("anthropic/MiniMax-M3") == 1_000_000
+    assert _registry_context_window("minimax/MiniMax-M2.7") == 204_800
     assert _registry_context_window("qwen3-coder-plus") == 1_048_576
     assert _registry_context_window("qwen/qwen3-coder") == 262_144
     assert _registry_context_window("qwen3-coder:free") == 262_144
@@ -408,5 +412,8 @@ def test_get_model_context_window_uses_registry_first(monkeypatch: pytest.Monkey
     assert get_model_context_window("anthropic/claude-opus-4-8[1m]") == 1_000_000
     # Qwen: curated window, not the default.
     assert get_model_context_window("qwen3-coder-plus") == 1_048_576
+    # MiniMax: both current model ids resolve without catalog access.
+    assert get_model_context_window("minimax/MiniMax-M3") == 1_000_000
+    assert get_model_context_window("minimax/MiniMax-M2.7") == 204_800
     # A model the registry doesn't own still falls back to the conservative default.
     assert get_model_context_window("qwen-nonexistent-xyz") == 128_000

--- a/tests/llms/test_openai_adapter.py
+++ b/tests/llms/test_openai_adapter.py
@@ -116,9 +116,11 @@ async def test_minimax_openai_endpoints_use_default_and_override(
 ) -> None:
     """MiniMax uses the global default and accepts the China base URL override."""
     requested_urls: list[str] = []
+    requested_bodies: list[dict] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requested_urls.append(str(request.url))
+        requested_bodies.append(json.loads(request.content))
         return httpx.Response(
             200,
             json={
@@ -147,15 +149,35 @@ async def test_minimax_openai_endpoints_use_default_and_override(
         connection_params["base_url"] = api_base_url
 
     await adapter.chat_completions(
-        messages=[{"role": "user", "content": "Hello"}],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this video"},
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/demo.mp4"},
+                    },
+                ],
+            }
+        ],
         model="MiniMax-M3",
         tools=None,
         stream=False,
-        extra={},
+        extra={
+            "thinking": {"type": "adaptive"},
+            "service_tier": "priority",
+        },
         connection_params=connection_params,
     )
 
     assert requested_urls == [expected_url]
+    assert requested_bodies[0]["service_tier"] == "priority"
+    assert requested_bodies[0]["thinking"] == {"type": "adaptive"}
+    assert requested_bodies[0]["messages"][0]["content"][1] == {
+        "type": "video_url",
+        "video_url": {"url": "https://example.com/demo.mp4"},
+    }
 
 
 # ── Headers ──────────────────────────────────────────────

--- a/tests/llms/test_openai_adapter.py
+++ b/tests/llms/test_openai_adapter.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from omnigent.llms.adapters import _create_adapter
 from omnigent.llms.adapters.openai import (
     OpenAIAdapter,
     OpenAICompatibleAdapter,
@@ -98,6 +99,63 @@ def test_base_url_trailing_slash_stripped() -> None:
         api_key_env=None,
     )
     assert adapter._base_url == "https://api.openai.com/v1"
+
+
+@pytest.mark.parametrize(
+    ("api_base_url", "expected_url"),
+    [
+        (None, "https://api.minimax.io/v1/chat/completions"),
+        ("https://api.minimaxi.com/v1", "https://api.minimaxi.com/v1/chat/completions"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_minimax_openai_endpoints_use_default_and_override(
+    monkeypatch: pytest.MonkeyPatch,
+    api_base_url: str | None,
+    expected_url: str,
+) -> None:
+    """MiniMax uses the global default and accepts the China base URL override."""
+    requested_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "model": "MiniMax-M3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        "omnigent.llms.adapters.openai.httpx.AsyncClient",
+        lambda **kwargs: real_async_client(transport=transport, **kwargs),
+    )
+    adapter = _create_adapter("minimax")
+    connection_params = {"api_key": "test-key"}
+    if api_base_url is not None:
+        connection_params["base_url"] = api_base_url
+
+    await adapter.chat_completions(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="MiniMax-M3",
+        tools=None,
+        stream=False,
+        extra={},
+        connection_params=connection_params,
+    )
+
+    assert requested_urls == [expected_url]
 
 
 # ── Headers ──────────────────────────────────────────────

--- a/tests/llms/test_routing.py
+++ b/tests/llms/test_routing.py
@@ -60,6 +60,14 @@ from omnigent.llms.routing import RoutedModel, infer_harness_from_model, parse_m
             "moonshot/kimi-k2-instruct",
             RoutedModel(provider="moonshot", model="kimi-k2-instruct"),
         ),
+        (
+            "minimax/MiniMax-M3",
+            RoutedModel(provider="minimax", model="MiniMax-M3"),
+        ),
+        (
+            "minimax/MiniMax-M2.7",
+            RoutedModel(provider="minimax", model="MiniMax-M2.7"),
+        ),
     ],
 )
 def test_parse_with_provider_prefix(

--- a/tests/runtime/policies/test_builder.py
+++ b/tests/runtime/policies/test_builder.py
@@ -29,12 +29,14 @@ from pathlib import Path
 
 import pytest
 
+from omnigent.llms.context_window import ModelPricing
 from omnigent.runtime.policies.builder import build_policy_engine
 from omnigent.spec.parser import parse
 from omnigent.spec.types import (
     AgentSpec,
     GuardrailsSpec,
     LabelDef,
+    LLMConfig,
     Phase,
     PhaseSelector,
 )
@@ -122,6 +124,46 @@ guardrails: {}
     assert engine.policies[0].spec.name == "__ask_on_add_policy"
     assert engine.label_defs == {}
     assert engine.labels == {}
+
+
+def test_build_uses_llm_service_tier_for_model_pricing(
+    monkeypatch: pytest.MonkeyPatch,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The configured service tier selects the matching model prices."""
+    observed: dict[str, str] = {}
+    pricing = ModelPricing(input_per_token=1e-6, output_per_token=2e-6)
+
+    def _fetch_pricing(model: str, *, service_tier: str = "standard") -> ModelPricing:
+        observed["model"] = model
+        observed["service_tier"] = service_tier
+        return pricing
+
+    monkeypatch.setattr(
+        "omnigent.runtime.policies.builder.fetch_model_pricing",
+        _fetch_pricing,
+    )
+    spec = AgentSpec(
+        spec_version=1,
+        name="tiered-pricing",
+        llm=LLMConfig(
+            model="minimax/MiniMax-M3",
+            extra={"service_tier": "priority"},
+        ),
+    )
+    conv = conversation_store.create_conversation()
+
+    engine = build_policy_engine(
+        spec=spec,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+    )
+
+    assert observed == {
+        "model": "minimax/MiniMax-M3",
+        "service_tier": "priority",
+    }
+    assert engine._token_pricing is pricing
 
 
 # ── Declared policies + label seeding ──────────────────


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Register MiniMax as an OpenAI-compatible LLM provider with the global endpoint as its default.
- Support both published regions and protocol endpoints, including internal `/v1/messages` derivation from the Messages-compatible base URL.
- Register the published context windows for `MiniMax-M3` and `MiniMax-M2.7`, and document configuration.
- Preserve thinking controls, service-tier selection, and text, image, and video inputs across both protocol adapters.
- Preserve standard, priority, and long-context pricing tiers for cost tracking.

Request flow:

```text
MiniMax model -> selected protocol adapter -> global or China endpoint
```

## Test Plan

- `uv run pytest tests/llms/test_routing.py tests/llms/test_context_window.py tests/llms/test_openai_adapter.py tests/llms/test_anthropic_adapter.py tests/runtime/policies/test_builder.py`
- `uv run ruff check omnigent/llms/routing.py omnigent/llms/adapters/__init__.py omnigent/llms/adapters/anthropic.py omnigent/llms/context_window.py omnigent/runtime/policies/builder.py tests/llms/test_routing.py tests/llms/test_context_window.py tests/llms/test_openai_adapter.py tests/llms/test_anthropic_adapter.py tests/runtime/policies/test_builder.py`
- `uv run ruff format --check omnigent/llms/routing.py omnigent/llms/adapters/__init__.py omnigent/llms/adapters/anthropic.py omnigent/llms/context_window.py omnigent/runtime/policies/builder.py tests/llms/test_routing.py tests/llms/test_context_window.py tests/llms/test_openai_adapter.py tests/llms/test_anthropic_adapter.py tests/runtime/policies/test_builder.py`
- `uv run pre-commit run --files omnigent/llms/LLMCLIENT.md omnigent/llms/adapters/__init__.py omnigent/llms/adapters/anthropic.py omnigent/llms/context_window.py omnigent/llms/routing.py omnigent/runtime/policies/builder.py tests/llms/test_anthropic_adapter.py tests/llms/test_context_window.py tests/llms/test_openai_adapter.py tests/llms/test_routing.py tests/runtime/policies/test_builder.py`

## Demo

N/A. This is a backend-only provider integration with no UI or visual behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests capture final request URLs and payloads for both regions and protocols, verify thinking and multimodal fields, and cover service-tier and long-context pricing selection without making live API calls.

## Changelog

MiniMax models can now use both supported protocol endpoints in global and China regions with tier-aware cost tracking.

