### PR TITLE
fix: bound session stream subscriber queues

### DIFF
--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -1,13 +1,14 @@
 """Pure pub-sub in-process live stream for real-time SSE delivery.
 
 This module is a fan-out broadcaster keyed by ``conversation_id``.
-Every active call to :func:`subscribe` owns its own ephemeral
-``asyncio.Queue``; :func:`publish` fans the event out to all
-queues currently subscribed to that conversation_id. Events emitted
-before any subscriber is connected are LOST — there is no buffer
-and no replay. Clients that need to recover state across a
-disconnect fetch ``GET /v1/sessions/{id}`` for the persisted
-history and dedupe by item id.
+Every active call to :func:`subscribe` owns its own bounded ephemeral
+``asyncio.Queue``; :func:`publish` fans the event out to all queues
+currently subscribed to that conversation_id. A subscriber that falls
+behind past the bound is disconnected so it can recover through the
+snapshot + live-tail reconnect contract. Events emitted before any
+subscriber is connected are LOST — there is no buffer and no replay.
+Clients that need to recover state across a disconnect fetch
+``GET /v1/sessions/{id}`` for the persisted history and dedupe by item id.
 
 This module owns no per-conversation lifecycle. There is no
 ``register`` / ``unregister`` step: the first ``subscribe`` call
@@ -35,8 +36,17 @@ from omnigent.runtime import inflight_text, pending_elicitations
 
 _logger = logging.getLogger(__name__)
 
-# Sentinel object that signals end-of-stream to every subscriber.
+# A generous burst allowance that still bounds one stalled subscriber's memory.
+_SUBSCRIBER_QUEUE_MAX_EVENTS = 1024
+
+# Sentinel objects that signal terminal subscriber states.
 _DONE = object()
+_OVERFLOW = object()
+
+
+class SubscriberOverflowError(RuntimeError):
+    """Raised when a subscriber falls behind the bounded live-event queue."""
+
 
 # Subscriber registry: conversation_id -> set of
 # (queue, event_loop) pairs. The event_loop reference is needed
@@ -47,6 +57,25 @@ _subscribers: dict[
     set[tuple[asyncio.Queue[dict[str, Any] | object], asyncio.AbstractEventLoop]],
 ] = {}
 _lock = threading.Lock()
+
+
+def _enqueue_or_overflow(
+    queue: asyncio.Queue[dict[str, Any] | object],
+    item: dict[str, Any] | object,
+) -> None:
+    """Enqueue *item*, replacing a full backlog with an overflow signal."""
+    try:
+        queue.put_nowait(item)
+        return
+    except asyncio.QueueFull:
+        pass
+
+    while True:
+        try:
+            queue.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+    queue.put_nowait(_OVERFLOW)
 
 
 def publish(conversation_id: str, event: dict[str, Any]) -> None:
@@ -105,7 +134,7 @@ def publish(conversation_id: str, event: dict[str, Any]) -> None:
     with _lock:
         subs = list(_subscribers.get(conversation_id, ()))
     for queue, loop in subs:
-        loop.call_soon_threadsafe(queue.put_nowait, event)
+        loop.call_soon_threadsafe(_enqueue_or_overflow, queue, event)
 
 
 def close(conversation_id: str) -> None:
@@ -122,7 +151,7 @@ def close(conversation_id: str) -> None:
     with _lock:
         subs = list(_subscribers.get(conversation_id, ()))
     for queue, loop in subs:
-        loop.call_soon_threadsafe(queue.put_nowait, _DONE)
+        loop.call_soon_threadsafe(_enqueue_or_overflow, queue, _DONE)
 
 
 def shutdown_all() -> None:
@@ -139,7 +168,7 @@ def shutdown_all() -> None:
     with _lock:
         all_subs = [entry for subs in _subscribers.values() for entry in subs]
     for queue, _ in all_subs:
-        queue.put_nowait(_DONE)
+        _enqueue_or_overflow(queue, _DONE)
 
 
 async def subscribe(
@@ -153,13 +182,20 @@ async def subscribe(
     """
     Subscribe to live events for a conversation.
 
-    Creates a fresh ephemeral queue for this subscriber, registers
+    Creates a fresh bounded ephemeral queue for this subscriber, registers
     it under ``conversation_id``, and yields events as they arrive
     from :func:`publish`. Ends when :func:`close` broadcasts the
     end-of-stream sentinel or when the caller stops iterating
     (e.g. client disconnect cancels the generator). The
     ``finally`` block always unregisters this subscriber slot so
     a stale queue cannot keep accumulating events.
+
+    If the subscriber falls more than
+    :data:`_SUBSCRIBER_QUEUE_MAX_EVENTS` events behind, its queued backlog
+    is replaced with an overflow signal and this iterator raises
+    :class:`SubscriberOverflowError`. HTTP/SSE callers treat that as a
+    dropped transport and reconnect through the persisted snapshot rather
+    than retaining an unbounded in-memory backlog.
 
     Live-tail only: events emitted before this call are NOT
     replayed. Multiple concurrent subscribers to the same
@@ -208,8 +244,12 @@ async def subscribe(
         yielded verbatim as it was passed to :func:`publish`,
         plus synthetic heartbeat dicts when *heartbeat_interval_s*
         is set.
+    :raises SubscriberOverflowError: If this subscriber falls behind the
+        bounded event queue.
     """
-    queue: asyncio.Queue[dict[str, Any] | object] = asyncio.Queue()
+    queue: asyncio.Queue[dict[str, Any] | object] = asyncio.Queue(
+        maxsize=_SUBSCRIBER_QUEUE_MAX_EVENTS
+    )
     loop = asyncio.get_running_loop()
     entry = (queue, loop)
     with _lock:
@@ -271,6 +311,11 @@ async def subscribe(
                     continue
             if item is _DONE:
                 return
+            if item is _OVERFLOW:
+                raise SubscriberOverflowError(
+                    f"session stream subscriber for {conversation_id!r} "
+                    f"exceeded {_SUBSCRIBER_QUEUE_MAX_EVENTS} queued events"
+                )
             assert isinstance(item, dict)
             yield item
     finally:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -11581,11 +11581,13 @@ async def _stream_live_events(
     reconcile pre-subscribe state via the snapshot endpoint
     (``GET /v1/sessions/{id}``) and dedupe by item id.
 
-    On client disconnect the subscribe loop breaks; the
-    ``finally`` block emits a ``[DONE]`` sentinel so well-behaved
-    SSE consumers see a clean stream termination. The pub-sub
-    layer auto-cleans this generator's subscriber slot in its own
-    ``finally`` when iteration exits.
+    On client disconnect the subscribe loop breaks; the ``finally`` block
+    emits a ``[DONE]`` sentinel so well-behaved SSE consumers see a clean
+    stream termination. A subscriber-queue overflow instead ends without
+    ``[DONE]`` so clients treat it as a dropped transport, reconnect, and
+    reconcile from the persisted snapshot. The pub-sub layer auto-cleans
+    this generator's subscriber slot in its own ``finally`` when iteration
+    exits.
 
     Each emitted dict is validated against
     :data:`ServerStreamEvent` at the wire boundary so a runtime
@@ -11645,6 +11647,7 @@ async def _stream_live_events(
         presence_token = presence.connect(
             presence_root_id, session_id, viewer_user_id, viewer_idle
         )
+    subscriber_overflowed = False
     try:
         async for event in session_stream.subscribe(
             session_id,
@@ -11667,6 +11670,12 @@ async def _stream_live_events(
                 )
             validated = _SERVER_STREAM_EVENT_ADAPTER.validate_python(event)
             yield _format_sse(event_type, validated.model_dump())
+    except session_stream.SubscriberOverflowError:
+        subscriber_overflowed = True
+        _logger.warning(
+            "session stream subscriber overflowed for %s; closing for snapshot reconnect",
+            session_id,
+        )
     finally:
         # The non-None checks besides presence_token's are type
         # narrowing only: a minted token implies both were set above.
@@ -11676,7 +11685,8 @@ async def _stream_live_events(
             and presence_root_id is not None
         ):
             presence.disconnect(presence_root_id, viewer_user_id, presence_token)
-        yield "data: [DONE]\n\n"
+        if not subscriber_overflowed:
+            yield "data: [DONE]\n\n"
 
 
 # Bounds for per-session native-terminal pass-through args

--- a/tests/runtime/test_session_stream.py
+++ b/tests/runtime/test_session_stream.py
@@ -254,6 +254,40 @@ async def test_subscriber_slot_cleaned_up_on_exit() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_slow_subscriber_overflow_is_bounded_and_disconnects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A subscriber that falls behind is disconnected instead of growing forever.
+
+    The ready event suspends the consumer while keeping its slot registered,
+    reproducing a backpressured SSE response. Once more events arrive than the
+    configured queue bound, the stale backlog is replaced by one overflow
+    signal. Consuming that signal raises and unregisters the slot so the route
+    can close the transport and let the client reconnect from its snapshot.
+    """
+    monkeypatch.setattr(session_stream, "_SUBSCRIBER_QUEUE_MAX_EVENTS", 2)
+    conv_id = "conv_slow"
+    gen = session_stream.subscribe(conv_id, ready_event={"type": "test.ready"})
+
+    ready = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert ready == {"type": "test.ready"}
+
+    session_stream.publish(conv_id, {"type": "test.event", "i": 1})
+    session_stream.publish(conv_id, {"type": "test.event", "i": 2})
+    session_stream.publish(conv_id, {"type": "test.event", "i": 3})
+    await asyncio.sleep(0)
+
+    ((queue, _loop),) = session_stream._subscribers[conv_id]
+    assert queue.maxsize == 2
+    assert queue.qsize() == 1, "overflow must replace the stale backlog with one signal"
+
+    with pytest.raises(session_stream.SubscriberOverflowError, match=conv_id):
+        await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert conv_id not in session_stream._subscribers
+
+
 # ── Side-channel: pending-elicitations index ─────────────────────────
 
 

--- a/tests/server/test_stream_events.py
+++ b/tests/server/test_stream_events.py
@@ -466,6 +466,34 @@ def test_policy_denied_format_sse_uses_response_prefixed_wire_name() -> None:
     assert sse.startswith("event: response.policy_denied\ndata: {")
 
 
+@pytest.mark.asyncio
+async def test_stream_overflow_closes_without_done_for_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Subscriber overflow ends as a reconnectable drop, not a clean close."""
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes.sessions import _stream_live_events
+
+    async def overflowing_subscribe(*_args: Any, **_kwargs: Any):
+        yield {"type": "session.heartbeat"}
+        raise session_stream.SubscriberOverflowError("conv_slow overflowed")
+
+    class ConnectedRequest:
+        """Request stub that keeps the stream connected through its first event."""
+
+        async def is_disconnected(self) -> bool:
+            """Return ``False`` so overflow, not disconnect, ends the stream."""
+            return False
+
+    monkeypatch.setattr(session_stream, "subscribe", overflowing_subscribe)
+    request: Any = ConnectedRequest()
+    frames = [frame async for frame in _stream_live_events(request, "conv_slow")]
+
+    assert len(frames) == 1
+    assert frames[0].startswith("event: session.heartbeat\n")
+    assert all("[DONE]" not in frame for frame in frames)
+
+
 def test_publish_session_status_helper_uses_waiting_literal() -> None:
     """``workflow._publish_session_status`` publishes a typed waiting event.
 


### PR DESCRIPTION
## Summary

  - Bound each live-session subscriber queue to a 1,024-event burst allowance so a
  slow or stalled SSE client cannot grow server memory indefinitely.
  - When a subscriber overflows, discard its stale backlog and close that transport
  without `[DONE]`. The web client treats this as a dropped connection, reconnects,
  and reconciles from the persisted snapshot and in-flight text.
  - Add regression coverage for queue overflow, subscriber cleanup, and
  reconnectable SSE closure.

  ELI5: each connected viewer previously had a bottomless inbox. A viewer that
  stopped reading could make that inbox grow forever. The inbox now has a limit; if
  it fills, that viewer reconnects and catches up from the saved conversation.

  ```text
  producer → bounded queue → SSE client
                      │
                      └─ overflow → drop stale backlog
                                  → close without [DONE]
                                  → reconnect + snapshot

  The 1,024-event limit leaves a generous burst allowance while placing a firm
  bound on each stalled subscriber. Happy to adjust that threshold if there’s a
  preferred operational target.

  ## Test Plan

  - pytest tests/runtime/test_session_stream.py tests/server/test_stream_events.py
    -q
      - 37 passed

  - pre-commit run --all-files --show-diff-on-failure
      - all hooks passed

  - mypy omnigent/runtime/session_stream.py
      - passed

  - Full standard suite with four isolated workers:
      - 14,750 passed
      - 42 unrelated local platform/order-sensitive failures
      - interrupted during a hung final retry
      - the only sessions-route failure passed when rerun in isolation

  ## Demo

  N/A — non-visual server reliability fix.

  ## Type of change

  - [x] Bug fix
  - [ ] Feature
  - [ ] UI / frontend change
  - [ ] Test / CI
  - [ ] Breaking change

  ## Test coverage

  - [x] Unit tests added / updated
  - [ ] Integration tests added / updated
  - [ ] E2E tests added / updated
  - [ ] Manual verification completed
  - [x] Existing tests cover this change
  - [ ] Not applicable

  ## Coverage notes

  Added focused coverage that reproduces a backpressured subscriber with a small
  queue, verifies the backlog remains bounded, confirms the subscriber is
  unregistered, and ensures overflow closes the SSE stream without the clean [DONE]
  sentinel.