### PR TITLE
✨ feat(logging): Add process log routing

### DIFF
--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -42,8 +42,8 @@ Run it from anywhere inside the checkout — it walks up to the repo root
 
 | Process | Command | Notes |
 |---|---|---|
-| server | `uv run omnigent server --host 127.0.0.1 --port <p> --database-uri … --artifact-location …` | Waited on via `GET /health`. |
-| host   | `uv run omnigent host --server http://127.0.0.1:<p>` | Started once the server is healthy. |
+| server | `uv run omnigent --log-to-stderr server --host 127.0.0.1 --port <p> --database-uri … --artifact-location …` | Waited on via `GET /health`. |
+| host   | `uv run omnigent --log-to-stderr host --server http://127.0.0.1:<p>` | Started once the server is healthy. |
 | vite   | `npm run dev -- --host <host> --port <p> --strictPort` (cwd `web/`) | `OMNIGENT_URL` points its proxy at the pod's server. |
 
 Before Vite starts (and on a manual Vite restart), omnidev runs `npm install`

--- a/dev/omnidev/src/process.rs
+++ b/dev/omnidev/src/process.rs
@@ -5,22 +5,31 @@ use std::path::PathBuf;
 use crate::pod::Pod;
 
 /// A resolved command line + working dir for one process. Env is applied by the
-/// supervisor from `Pod::env()`, so it is not duplicated here.
+/// supervisor from `Pod::env()`, with per-process additions from `extra_env`.
 pub struct ProcSpec {
     pub program: String,
     pub args: Vec<String>,
     pub cwd: PathBuf,
+    pub extra_env: Vec<(String, String)>,
 }
 
 impl ProcSpec {
-    /// `uv run omnigent server --host 127.0.0.1 --port <p> --database-uri <db>
-    /// --artifact-location <dir>`, from the repo root.
+    fn omnigent_log_env() -> Vec<(String, String)> {
+        // Child stderr is a pipe that omnidev reads into its process panes.
+        // Let Omnigent's process logger mirror to that pipe despite it not
+        // being a terminal.
+        vec![("OMNIGENT_LOG_TTY_FD".into(), "2".into())]
+    }
+
+    /// `uv run omnigent --log-to-stderr server --host 127.0.0.1 --port <p>
+    /// --database-uri <db> --artifact-location <dir>`, from the repo root.
     pub fn server(pod: &Pod) -> ProcSpec {
         ProcSpec {
             program: "uv".into(),
             args: vec![
                 "run".into(),
                 "omnigent".into(),
+                "--log-to-stderr".into(),
                 "server".into(),
                 "--host".into(),
                 "127.0.0.1".into(),
@@ -32,21 +41,25 @@ impl ProcSpec {
                 pod.artifacts_dir().display().to_string(),
             ],
             cwd: pod.repo_root.clone(),
+            extra_env: Self::omnigent_log_env(),
         }
     }
 
-    /// `uv run omnigent host --server http://127.0.0.1:<p>`, from the repo root.
+    /// `uv run omnigent --log-to-stderr host --server http://127.0.0.1:<p>`,
+    /// from the repo root.
     pub fn host(pod: &Pod) -> ProcSpec {
         ProcSpec {
             program: "uv".into(),
             args: vec![
                 "run".into(),
                 "omnigent".into(),
+                "--log-to-stderr".into(),
                 "host".into(),
                 "--server".into(),
                 pod.server_url(),
             ],
             cwd: pod.repo_root.clone(),
+            extra_env: Self::omnigent_log_env(),
         }
     }
 
@@ -67,6 +80,7 @@ impl ProcSpec {
                 "http".into(),
             ],
             cwd: pod.web_dir(),
+            extra_env: Vec::new(),
         }
     }
 
@@ -86,6 +100,7 @@ impl ProcSpec {
                 "--strictPort".into(),
             ],
             cwd: pod.web_dir(),
+            extra_env: Vec::new(),
         }
     }
 }
@@ -115,6 +130,38 @@ mod tests {
         let host_flag = vite.args.iter().position(|arg| arg == "--host").unwrap();
         assert_eq!(vite.args[host_flag + 1], "0.0.0.0");
         assert_eq!(pod.server_url(), "http://127.0.0.1:19191");
+    }
+
+    #[test]
+    fn omnigent_processes_mirror_logs_to_omnidev_pipe() {
+        let repo = tempdir();
+        let pod_dir = tempdir();
+        let pod = Pod::create(
+            repo,
+            pod_dir,
+            Ports {
+                server: 19191,
+                vite: 19292,
+            },
+            "127.0.0.1".into(),
+            Vec::new(),
+        )
+        .unwrap();
+
+        for spec in [ProcSpec::server(&pod), ProcSpec::host(&pod)] {
+            assert!(
+                spec.args.iter().any(|arg| arg == "--log-to-stderr"),
+                "omnigent command should request stderr logging: {:?}",
+                spec.args
+            );
+            assert_eq!(
+                spec.extra_env
+                    .iter()
+                    .find(|(key, _)| key == "OMNIGENT_LOG_TTY_FD")
+                    .map(|(_, value)| value.as_str()),
+                Some("2")
+            );
+        }
     }
 
     fn tempdir() -> std::path::PathBuf {

--- a/dev/omnidev/src/supervisor.rs
+++ b/dev/omnidev/src/supervisor.rs
@@ -211,6 +211,7 @@ impl Supervisor {
         cmd.args(&spec.args)
             .current_dir(&spec.cwd)
             .envs(self.env.iter().cloned())
+            .envs(spec.extra_env.iter().cloned())
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -292,6 +293,7 @@ impl Supervisor {
         cmd.args(&spec.args)
             .current_dir(&spec.cwd)
             .envs(self.env.iter().cloned())
+            .envs(spec.extra_env.iter().cloned())
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3495,7 +3495,7 @@ def _start_local_server(
     :returns: The server handle bundling the subprocess and
         the path to its captured stdout/stderr log file.
     """
-    log_path, log_fh = open_process_log_file("server")
+    log_path, log_fh = open_process_log_file("server", root=_omnigent_log_dir())
     if ephemeral:
         data_tmpdir = tempfile.mkdtemp(prefix="ap-chat-data-")
         db_path = Path(data_tmpdir) / "chat.db"

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -58,6 +58,12 @@ from omnigent.harness_aliases import canonicalize_harness
 from omnigent.inner import _proc
 from omnigent.inner.databricks_executor import _DatabricksBearerAuth, _read_databrickscfg
 from omnigent.native_coding_agents import native_coding_agent_for_wrapper_label
+from omnigent.process_logging import (
+    PROCESS_LOG_FILE_ENV_VAR,
+    child_logging_popen_kwargs,
+    logs_root,
+    open_process_log_file,
+)
 from omnigent.spec import load as load_spec
 from omnigent.spec._omnigent_compat import OMNIGENT_EXECUTOR_TYPE
 from omnigent.spec.parser import discover_host_skills
@@ -3420,7 +3426,7 @@ def _omnigent_log_dir() -> Path:
 
     :returns: ``~/.omnigent/logs``, created if needed.
     """
-    log_dir = Path.home() / ".omnigent" / "logs"
+    log_dir = logs_root()
     log_dir.mkdir(parents=True, exist_ok=True)
     return log_dir
 
@@ -3489,11 +3495,7 @@ def _start_local_server(
     :returns: The server handle bundling the subprocess and
         the path to its captured stdout/stderr log file.
     """
-    log_dir = _omnigent_log_dir() / "server"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_fd, log_name = tempfile.mkstemp(prefix="server-", suffix=".log", dir=log_dir)
-    log_path = Path(log_name)
-    log_fh = os.fdopen(log_fd, "wb")
+    log_path, log_fh = open_process_log_file("server")
     if ephemeral:
         data_tmpdir = tempfile.mkdtemp(prefix="ap-chat-data-")
         db_path = Path(data_tmpdir) / "chat.db"
@@ -3534,6 +3536,7 @@ def _start_local_server(
     child_env = {
         **os.environ,
         "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token,
+        PROCESS_LOG_FILE_ENV_VAR: str(log_path),
         # Single-user loopback runtime — see ensure_local_omnigent_server for why
         # this lets the host tunnel re-own this machine's host_id across an
         # auth-mode flip without weakening the deployed multi-user boundary.
@@ -3566,28 +3569,30 @@ def _start_local_server(
             child_env["DATABRICKS_CONFIG_PROFILE"] = _spec.executor.profile
 
     try:
-        server_proc = subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "omnigent.cli",
-                "server",
-                "--host",
-                "127.0.0.1",
-                "--port",
-                str(port),
-                "--database-uri",
-                f"sqlite:///{db_path}",
-                "--artifact-location",
-                str(artifact_path),
-                "--agent",
-                str(agent_path),
-            ],
-            env=child_env,
-            stdout=log_fh,
-            stderr=log_fh,
-            **_proc.spawn_kwargs(),
-        )
+        with child_logging_popen_kwargs(child_env) as logging_kwargs:
+            server_proc = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "omnigent.cli",
+                    "server",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(port),
+                    "--database-uri",
+                    f"sqlite:///{db_path}",
+                    "--artifact-location",
+                    str(artifact_path),
+                    "--agent",
+                    str(agent_path),
+                ],
+                env=child_env,
+                stdout=log_fh,
+                stderr=log_fh,
+                **_proc.spawn_kwargs(),
+                **logging_kwargs,
+            )
     finally:
         log_fh.close()
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7,6 +7,7 @@ import contextlib
 import copy
 import hashlib
 import json
+import logging
 import os
 import secrets
 import shutil
@@ -56,6 +57,7 @@ from omnigent.onboarding.ucode_setup import (
     find_ucode_command,
     model_gateway_workspace_urls,
 )
+from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR
 
 if TYPE_CHECKING:
     import httpx
@@ -78,7 +80,11 @@ def _load_config(path: str | None) -> dict[str, Any]:  # type: ignore[explicit-a
         return yaml.safe_load(f) or {}
 
 
-def _server_uvicorn_log_config() -> dict[str, Any]:  # type: ignore[explicit-any]
+def _server_uvicorn_log_config(
+    log_path: Path | None = None,
+    *,
+    log_to_stderr: bool | None = None,
+) -> dict[str, Any]:  # type: ignore[explicit-any]
     """
     Return Uvicorn logging config with request-duration access logs.
 
@@ -86,14 +92,66 @@ def _server_uvicorn_log_config() -> dict[str, Any]:  # type: ignore[explicit-any
     only the access formatter while preserving Uvicorn's default
     handlers, levels, and server-log formatting.
 
+    :param log_path: Optional server process log file. When set, Uvicorn
+        default/error/access logs write there.
+    :param log_to_stderr: Optional override for terminal mirroring.
     :returns: Uvicorn ``log_config`` suitable for ``uvicorn.run``.
     """
     import uvicorn.config
+
+    from omnigent.process_logging import effective_log_level, should_log_to_stderr
 
     log_config = copy.deepcopy(uvicorn.config.LOGGING_CONFIG)
     log_config["formatters"]["access"]["()"] = (
         "omnigent.server.performance_metrics.RequestDurationAccessFormatter"
     )
+    if log_path is not None:
+        level_name = logging.getLevelName(effective_log_level())
+        if not isinstance(level_name, str):
+            level_name = "INFO"
+        mirror = should_log_to_stderr() if log_to_stderr is None else log_to_stderr
+        log_config["handlers"]["server_file"] = {
+            "class": "logging.FileHandler",
+            "formatter": "default",
+            "filename": str(log_path),
+            "encoding": "utf-8",
+        }
+        log_config["handlers"]["server_access_file"] = {
+            "class": "logging.FileHandler",
+            "formatter": "access",
+            "filename": str(log_path),
+            "encoding": "utf-8",
+        }
+        default_handlers: list[str] = []
+        access_handlers: list[str] = []
+        if mirror:
+            log_config["handlers"]["server_terminal"] = {
+                "()": "omnigent.process_logging.terminal_stream_handler",
+                "formatter": "default",
+                "level": level_name,
+            }
+            log_config["handlers"]["server_access_terminal"] = {
+                "()": "omnigent.process_logging.terminal_stream_handler",
+                "formatter": "access",
+                "level": level_name,
+            }
+            default_handlers.append("server_terminal")
+            access_handlers.append("server_access_terminal")
+        log_config["loggers"]["uvicorn"] = {
+            "handlers": [*default_handlers, "server_file"],
+            "level": level_name,
+            "propagate": False,
+        }
+        log_config["loggers"]["uvicorn.error"] = {
+            "handlers": [*default_handlers, "server_file"],
+            "level": level_name,
+            "propagate": False,
+        }
+        log_config["loggers"]["uvicorn.access"] = {
+            "handlers": [*access_handlers, "server_access_file"],
+            "level": level_name,
+            "propagate": False,
+        }
     return log_config
 
 
@@ -319,7 +377,7 @@ def _display_path(path: Path) -> str:
     its real location rather than a misleading ``~``.
 
     :param path: The path to display, e.g.
-        ``Path("/Users/alice/.omnigent/logs/server/local-server-ab12.log")``.
+        ``Path("/Users/alice/.omnigent/logs/server/server-ab12.log")``.
     :returns: ``"~/.omnigent/..."`` when *path* is under ``$HOME``,
         otherwise ``str(path)``.
     """
@@ -1150,7 +1208,63 @@ class _OmnigentCLI(click.Group):
         super().format_help(ctx, formatter)
 
 
+def _set_debug_logging(
+    _ctx: click.Context,
+    _param: click.Parameter,
+    value: bool,
+) -> bool:
+    if value:
+        os.environ[LOG_LEVEL_ENV_VAR] = "DEBUG"
+    return value
+
+
+def _set_log_to_stderr(
+    _ctx: click.Context,
+    _param: click.Parameter,
+    value: bool,
+) -> bool:
+    if value:
+        os.environ[LOG_TO_STDERR_ENV_VAR] = "1"
+    return value
+
+
+def _extract_global_logging_flags(argv: list[str]) -> tuple[list[str], bool, bool]:
+    """Remove global logging flags before run-shorthand rewriting."""
+    debug_logging = False
+    log_to_stderr = False
+    remaining: list[str] = []
+    passthrough = False
+    for token in argv:
+        if token == "--":
+            passthrough = True
+            remaining.append(token)
+        elif not passthrough and token == "--debug":
+            debug_logging = True
+        elif not passthrough and token == "--log-to-stderr":
+            log_to_stderr = True
+        else:
+            remaining.append(token)
+    return remaining, debug_logging, log_to_stderr
+
+
 @click.group(cls=_OmnigentCLI)
+@click.option(
+    "--debug",
+    "debug_logging",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_set_debug_logging,
+    help="Enable verbose DEBUG logging for Omnigent processes.",
+)
+@click.option(
+    "--log-to-stderr",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_set_log_to_stderr,
+    help="Mirror process logs to the terminal when stderr is interactive.",
+)
 @click.option(
     "--version",
     is_flag=True,
@@ -1260,7 +1374,11 @@ def main() -> None:
     # (update-check cache, diagnostics logs, config). No-op once migrated.
     _migrate_legacy_state_dir()
 
-    argv = sys.argv[1:]
+    argv, debug_logging, log_to_stderr = _extract_global_logging_flags(sys.argv[1:])
+    if debug_logging:
+        os.environ[LOG_LEVEL_ENV_VAR] = "DEBUG"
+    if log_to_stderr:
+        os.environ[LOG_TO_STDERR_ENV_VAR] = "1"
 
     # Bare ``omnigent`` with no args behaves like ``omnigent run`` on an
     # interactive terminal: ``run`` resolves the configured default agent /
@@ -1302,7 +1420,7 @@ def main() -> None:
         raise SystemExit(2)
 
     # Always-on diagnostics — captures exceptions, lifecycle events,
-    # and warnings to ~/.omnigent/logs/cli-*.log even when --log
+    # and warnings to ~/.omnigent/logs/cli/cli-*.log even when --log
     # (conversation JSON) and --debug-events (SSE tape) are off.
     # Skip for pure help/version so quick invocations don't create
     # log litter.
@@ -1473,7 +1591,7 @@ class _HostDaemonRecord:
         mode, e.g. ``"https://example.databricksapps.com"``. ``None``
         for local mode.
     :param log_path: Daemon log file path, e.g.
-        ``"/Users/me/.omnigent/logs/host-daemon/daemon-abc.log"``.
+        ``"/Users/me/.omnigent/logs/host/host-abc.log"``.
     :param started_at: Unix epoch seconds when the daemon was spawned,
         e.g. ``1710000000``.
     :param host_id: Local host id advertised to Omnigent servers, e.g.
@@ -1587,7 +1705,7 @@ class _SpawnedDaemonProcess:
 
     :param pid: Spawned process id, e.g. ``4242``.
     :param log_path: Daemon log path, e.g.
-        ``"/Users/me/.omnigent/logs/host-daemon/daemon-abc.log"``.
+        ``"/Users/me/.omnigent/logs/host/host-abc.log"``.
     """
 
     pid: int
@@ -2050,23 +2168,29 @@ def _spawn_host_daemon_process(
     :param env: Allowlisted daemon environment.
     :returns: Spawned process metadata, or ``None`` if spawn fails.
     """
-    log_dir = _HOST_PID_PATH.parent / "logs" / "host-daemon"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_fd, log_path = tempfile.mkstemp(prefix="daemon-", suffix=".log", dir=log_dir)
-    log_fh = os.fdopen(log_fd, "wb")
+    from omnigent.process_logging import (
+        PROCESS_LOG_FILE_ENV_VAR,
+        child_logging_popen_kwargs,
+        open_process_log_file,
+    )
+
+    log_path, log_fh = open_process_log_file("host")
+    env = {**env, PROCESS_LOG_FILE_ENV_VAR: str(log_path)}
     try:
-        proc = subprocess.Popen(
-            args,
-            env=env,
-            stdout=log_fh,
-            stderr=log_fh,
-            **_proc.spawn_kwargs(),
-        )
+        with child_logging_popen_kwargs(env) as logging_kwargs:
+            proc = subprocess.Popen(
+                args,
+                env=env,
+                stdout=log_fh,
+                stderr=log_fh,
+                **_proc.spawn_kwargs(),
+                **logging_kwargs,
+            )
     except OSError:
         return None
     finally:
         log_fh.close()
-    return _SpawnedDaemonProcess(pid=proc.pid, log_path=log_path)
+    return _SpawnedDaemonProcess(pid=proc.pid, log_path=str(log_path))
 
 
 def _persist_spawned_daemon(
@@ -2518,7 +2642,7 @@ def _discover_local_server_url(
         if not _host_daemon_alive():
             raise click.ClickException(
                 "The local daemon exited before its Omnigent server became ready. "
-                "See logs under ~/.omnigent/logs/host-daemon/ and "
+                "See logs under ~/.omnigent/logs/host/ and "
                 "~/.omnigent/logs/server/."
             )
         time.sleep(0.2)
@@ -2607,6 +2731,11 @@ def _start_cli_runner_process(
     :returns: The spawned runner process metadata.
     :raises click.ClickException: If the runner exits immediately.
     """
+    from omnigent.process_logging import (
+        PROCESS_LOG_FILE_ENV_VAR,
+        child_logging_popen_kwargs,
+        open_process_log_file,
+    )
     from omnigent.runner.identity import (
         RUNNER_ID_ENV_VAR,
         RUNNER_ISOLATE_SESSION_ENV_VAR,
@@ -2648,24 +2777,18 @@ def _start_cli_runner_process(
     log_path: Path | None = None
     log_fh: BinaryIO | None = None
     if capture_logs:
-        base_log_dir = (
-            Path(log_dir).expanduser()
-            if log_dir is not None
-            else Path.home() / ".omnigent" / "logs"
-        )
-        runner_log_dir = base_log_dir / "runner"
-        runner_log_dir.mkdir(parents=True, exist_ok=True)
-        log_fd, log_name = tempfile.mkstemp(prefix="runner-", suffix=".log", dir=runner_log_dir)
-        log_path = Path(log_name)
-        log_fh = os.fdopen(log_fd, "wb")
+        log_path, log_fh = open_process_log_file("runner", root=log_dir)
+        env[PROCESS_LOG_FILE_ENV_VAR] = str(log_path)
     try:
-        runner_proc = subprocess.Popen(
-            [sys.executable, "-m", "omnigent.runner._entry"],
-            env=env,
-            stdout=log_fh,
-            stderr=log_fh,
-            **_proc.spawn_kwargs(),
-        )
+        with child_logging_popen_kwargs(env) as logging_kwargs:
+            runner_proc = subprocess.Popen(
+                [sys.executable, "-m", "omnigent.runner._entry"],
+                env=env,
+                stdout=log_fh,
+                stderr=log_fh,
+                **_proc.spawn_kwargs(),
+                **logging_kwargs,
+            )
     finally:
         if log_fh is not None:
             log_fh.close()
@@ -3148,6 +3271,13 @@ def server(
 
         account_store = SqlAlchemyAccountStore(db_uri)
 
+    from omnigent.process_logging import configure_process_logging
+
+    server_log_path = configure_process_logging(
+        "server",
+        logger_names=("omnigent", "uvicorn", "uvicorn.error", "uvicorn.access"),
+    )
+
     app = create_app(
         agent_store=agent_store,
         file_store=file_store,
@@ -3170,17 +3300,7 @@ def server(
     click.echo(f"Starting omnigent server on {host}:{port}")
     click.echo(f"  database:  {db_uri}")
     click.echo(f"  artifacts: {art_loc}")
-    # A foreground server streams uvicorn logs to this terminal, but the
-    # always-on diagnostics (omnigent.* loggers, captured warnings) also land
-    # in a persistent per-invocation file — point at it so there's a concrete
-    # log to grep after the terminal scrolls. None only in the detached spawn
-    # path (`-m omnigent.cli server`, no setup_cli_logging), whose captured
-    # log `server start` already reports.
-    from omnigent.cli_diagnostics import current_cli_log_path
-
-    _cli_log = current_cli_log_path()
-    if _cli_log is not None:
-        click.echo(f"  log:       {_display_path(_cli_log)}")
+    click.echo(f"  log:       {_display_path(server_log_path)}")
 
     # First-run terminal setup: the FALLBACK entry point. Fires only on
     # an interactive TTY when no admin exists AND the browser isn't about
@@ -3254,7 +3374,7 @@ def server(
         app,
         host=host,
         port=port,
-        log_config=_server_uvicorn_log_config(),
+        log_config=_server_uvicorn_log_config(server_log_path),
         ws_max_size=RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
         # Server side of the runner/host tunnels' protocol keepalive, aligned
         # to the 90 s app-level budget instead of uvicorn's 20 s default that
@@ -11911,20 +12031,22 @@ def debug_migrate_accounts_to_oidc(
 @click.option(
     "--type",
     "log_type",
-    type=click.Choice(["runner", "host-runner", "server", "cli"], case_sensitive=False),
+    type=click.Choice(
+        ["runner", "host", "server", "cli", "host-runner", "host-daemon"],
+        case_sensitive=False,
+    ),
     default="runner",
     show_default=True,
-    help="Log category: runner (local CLI runner via omnigent run), "
-    "host-runner (runner spawned by a host daemon), "
-    "server (local server), or cli (CLI diagnostics).",
+    help="Log category: runner, host, server, or cli. "
+    "Legacy aliases host-runner and host-daemon are still accepted.",
 )
 @click.option(
     "--session",
     "session_id",
     default=None,
     metavar="SESSION_ID",
-    help="Filter host-runner logs by session id, e.g. conv_abc123. "
-    "Only applies to --type host-runner. Shows all log files for the "
+    help="Filter runner logs by session id, e.g. conv_abc123. "
+    "Only applies to --type runner/host-runner. Shows all log files for the "
     "session, oldest first.",
 )
 @click.option(
@@ -11962,15 +12084,15 @@ def debug_logs(
     Use ``--list`` to see all available files, or ``--follow`` to stream
     new output as it is written.
 
-    Pass ``--session SESSION_ID`` (``--type host-runner`` only) to scope
+    Pass ``--session SESSION_ID`` (``--type runner`` only) to scope
     output to all log files produced for a specific session across relaunches.
 
     \b
     Log locations (relative to ~/.omnigent or $OMNIGENT_DATA_DIR):
       runner       logs/runner/runner-*.log
-      host-runner  logs/host-runner/runner-*.log
-      server       logs/server/*server*.log
-      cli          logs/cli-*.log
+      host         logs/host/host-*.log
+      server       logs/server/server-*.log
+      cli          logs/cli/cli-*.log
 
     \b
     Examples:
@@ -11978,10 +12100,10 @@ def debug_logs(
       omnigent debug logs
       # List all local runner log files with sizes
       omnigent debug logs --list
-      # Show host-runner logs for a specific session (across relaunches)
-      omnigent debug logs --type host-runner --session conv_abc123
-      # List host-runner log files for a session
-      omnigent debug logs --type host-runner --session conv_abc123 --list
+      # Show runner logs for a specific session (across relaunches)
+      omnigent debug logs --type runner --session conv_abc123
+      # List runner log files for a session
+      omnigent debug logs --type runner --session conv_abc123 --list
       # Follow the latest server log in real-time
       omnigent debug logs --type server --follow
       # Show the full latest CLI diagnostics log
@@ -11992,35 +12114,59 @@ def debug_logs(
 
     from omnigent.host.local_server import _local_data_dir
 
-    if session_id is not None and log_type != "host-runner":
-        raise click.UsageError("--session is only supported with --type host-runner")
+    log_type = log_type.lower()
+    alias_map = {"host-runner": "runner", "host-daemon": "host"}
+    requested_log_type = log_type
+    log_type = alias_map.get(log_type, log_type)
+
+    if session_id is not None and log_type != "runner":
+        raise click.UsageError("--session is only supported with --type runner")
 
     if follow and IS_WINDOWS:
         raise click.UsageError("--follow is not supported on Windows")
 
     data_dir = _local_data_dir()
 
-    _log_configs: dict[str, tuple[Path, str]] = {
-        "runner": (data_dir / "logs" / "runner", "runner-*.log"),
-        "host-runner": (data_dir / "logs" / "host-runner", "runner-*.log"),
-        # Covers both server-*.log (omnigent run) and local-server-*.log (daemon).
-        "server": (data_dir / "logs" / "server", "*server*.log"),
-        "cli": (data_dir / "logs", "cli-*.log"),
+    _log_configs: dict[str, list[tuple[Path, str]]] = {
+        # Include the legacy host-runner dir so old session logs remain visible.
+        "runner": [
+            (data_dir / "logs" / "runner", "runner-*.log"),
+            (data_dir / "logs" / "host-runner", "runner-*.log"),
+        ],
+        "host": [
+            (data_dir / "logs" / "host", "host-*.log"),
+            (data_dir / "logs" / "host-daemon", "daemon-*.log"),
+        ],
+        # Covers both server-*.log and legacy local-server-*.log.
+        "server": [(data_dir / "logs" / "server", "*server*.log")],
+        "cli": [
+            (data_dir / "logs" / "cli", "cli-*.log"),
+            (data_dir / "logs", "cli-*.log"),
+        ],
     }
-
-    log_dir, pattern = _log_configs[log_type]
-
-    if not log_dir.exists():
-        raise click.ClickException(f"No {log_type} logs found — {log_dir} does not exist.")
 
     if session_id is not None:
         # Sanitize the same way connect.py does so the glob matches.
         slug = re.sub(r"[^\w-]", "", session_id)[:32]
         pattern = f"runner-{slug}-*.log"
+        configs = [(directory, pattern) for directory, _pattern in _log_configs[log_type]]
+    else:
+        configs = _log_configs[log_type]
+
+    existing_dirs = [directory for directory, _pattern in configs if directory.exists()]
+    if not existing_dirs:
+        dirs = ", ".join(str(directory) for directory, _pattern in configs)
+        raise click.ClickException(f"No {requested_log_type} logs found — none of {dirs} exist.")
 
     # Exclude symlinks (e.g. latest-cli.log), sort newest first.
     log_files = sorted(
-        (f for f in log_dir.glob(pattern) if not f.is_symlink()),
+        (
+            f
+            for directory, pattern in configs
+            if directory.exists()
+            for f in directory.glob(pattern)
+            if not f.is_symlink()
+        ),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
@@ -12028,17 +12174,18 @@ def debug_logs(
     if not log_files:
         if session_id is not None:
             raise click.ClickException(
-                f"No host-runner logs found for session {session_id!r}. "
+                f"No runner logs found for session {session_id!r}. "
                 "Session ids appear in filenames only for runners launched "
                 "after this feature was added."
             )
-        raise click.ClickException(f"No {log_type} log files found in {log_dir}.")
+        dirs = ", ".join(str(directory) for directory, _pattern in configs)
+        raise click.ClickException(f"No {requested_log_type} log files found in {dirs}.")
 
     if list_only:
         header = (
-            f"host-runner logs for session {session_id!r} in {log_dir}:"
+            f"runner logs for session {session_id!r}:"
             if session_id
-            else f"{log_type} logs in {log_dir}:"
+            else f"{requested_log_type} logs:"
         )
         click.echo(header)
         for f in log_files:

--- a/omnigent/cli_diagnostics.py
+++ b/omnigent/cli_diagnostics.py
@@ -2,7 +2,7 @@
 Always-on CLI diagnostics log.
 
 Captures exceptions, warnings, and diagnostic info to a per-invocation
-log file under ``~/.omnigent/logs/cli-*.log``. Separate from the
+log file under ``<data-dir>/logs/cli/cli-*.log``. Separate from the
 ``--log`` conversation JSON transcript and the ``--debug-events`` SSE
 tape — this layer is always on so crash context is available even when
 the user didn't know to enable debugging ahead of time.
@@ -36,14 +36,14 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import cast
 
-from omnigent_ui_sdk import state_dir
+from omnigent.process_logging import effective_log_level, env_truthy, process_log_dir
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-#: Subdirectory under :func:`state_dir` for CLI diagnostic logs.
-_LOGS_SUBDIR = "logs"
+#: Destination subdirectory under ``<data-dir>/logs`` for CLI diagnostics.
+_LOG_DESTINATION = "cli"
 
 #: Maximum number of ``cli-*.log`` files kept before pruning.
 MAX_LOG_FILES = 20
@@ -224,12 +224,12 @@ def _log_dir() -> Path:
     """
     Return the CLI diagnostics log directory.
 
-    Uses :func:`omnigent_ui_sdk.state_dir` as the shared
-    ``~/.omnigent`` root so the path is defined in one place.
+    Uses the shared Omnigent runtime data dir so ``OMNIGENT_DATA_DIR``
+    isolates diagnostics with the DB, artifacts, and process logs.
 
-    :returns: ``~/.omnigent/logs``.
+    :returns: ``<data-dir>/logs/cli``.
     """
-    return Path(state_dir()) / _LOGS_SUBDIR
+    return process_log_dir(_LOG_DESTINATION)
 
 
 def setup_cli_logging(argv: list[str]) -> CliLogContext:
@@ -261,12 +261,14 @@ def setup_cli_logging(argv: list[str]) -> CliLogContext:
     log_path = log_dir / filename
 
     # Rotating handler — caps a single invocation at MAX_LOG_BYTES.
+    log_level = effective_log_level()
     handler = RotatingFileHandler(
         log_path,
         maxBytes=MAX_LOG_BYTES,
         backupCount=_BACKUP_COUNT,
         encoding="utf-8",
     )
+    handler.setLevel(log_level)
     # Best-effort 0600 permissions on the log file.
     with contextlib.suppress(OSError):
         os.chmod(log_path, 0o600)
@@ -278,12 +280,20 @@ def setup_cli_logging(argv: list[str]) -> CliLogContext:
         )
     )
 
-    # Wire our two package hierarchies at INFO so their records reach
+    stream_handler: logging.Handler | None = None
+    if env_truthy(os.environ.get("OMNIGENT_LOG_TO_STDERR")) and sys.stderr.isatty():
+        stream_handler = logging.StreamHandler(sys.stderr)
+        stream_handler.setLevel(log_level)
+        stream_handler.setFormatter(handler.formatter)
+
+    # Wire our two package hierarchies at the effective level so their records reach
     # the file handler.
     for name in ("omnigent", "omnigent_ui_sdk"):
         logger = logging.getLogger(name)
-        logger.setLevel(logging.INFO)
+        logger.setLevel(log_level)
         logger.addHandler(handler)
+        if stream_handler is not None:
+            logger.addHandler(stream_handler)
         logger.propagate = False
 
     # Suppress noisy third-party loggers that are commonly present.

--- a/omnigent/host/_daemon_entry.py
+++ b/omnigent/host/_daemon_entry.py
@@ -15,7 +15,6 @@ Two modes:
 from __future__ import annotations
 
 import argparse
-import logging
 
 
 def main() -> None:
@@ -44,10 +43,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s [%(name)s] %(message)s",
-    )
+    from omnigent.process_logging import configure_process_logging
+
+    configure_process_logging("host", force=True)
 
     if args.local == bool(args.server):
         # Both or neither — the CLI always passes exactly one; fail loud.

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -60,6 +60,14 @@ from omnigent.onboarding.harness_readiness import (
     configured_harness_map,
     harness_is_configured,
 )
+from omnigent.process_logging import (
+    LOG_TTY_FD_ENV_VAR,
+    PROCESS_LOG_FILE_ENV_VAR,
+    child_logging_popen_kwargs,
+    configure_process_logging,
+    open_process_log_file,
+    process_log_dir,
+)
 from omnigent.runner.identity import (
     RUNNER_ID_ENV_VAR,
     RUNNER_PARENT_PID_ENV_VAR,
@@ -90,17 +98,17 @@ def _runner_log_dir() -> Path:
     (not a module constant) so tests that repoint ``Path.home`` see the
     override.
 
-    :returns: The host-runner log directory, e.g.
-        ``Path.home() / ".omnigent" / "logs" / "host-runner"``.
+    :returns: The runner log directory, e.g.
+        ``<data-dir>/logs/runner``.
     """
-    return Path.home() / ".omnigent" / "logs" / "host-runner"
+    return process_log_dir("runner")
 
 
 def _display_log_path(path: Path) -> str:
     """Format a log path for display, collapsing the home prefix to ``~``.
 
     :param path: Absolute path, typically under the user's state dir, e.g.
-        ``Path("/Users/alice/.omnigent/logs/host-runner/runner-ab12.log")``.
+        ``Path("/Users/alice/.omnigent/logs/runner/runner-ab12.log")``.
     :returns: ``"~/.omnigent/..."`` when *path* is under ``$HOME``,
         otherwise ``str(path)``.
     """
@@ -171,7 +179,7 @@ def _read_log_tail(path: Path, max_bytes: int = _LOG_TAIL_MAX_BYTES) -> str:
     """Read the last portion of a runner log file for diagnostics.
 
     :param path: The runner's captured stdout/stderr log file, e.g.
-        ``Path("~/.omnigent/logs/host-runner/runner-ab12.log")``.
+        ``Path("~/.omnigent/logs/runner/runner-ab12.log")``.
     :param max_bytes: Max bytes to read from the end of the file,
         e.g. ``4096``.
     :returns: The decoded tail (lossy UTF-8 — runner output may
@@ -323,6 +331,10 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # alias, still propagated so existing setups keep working.
         "OMNIGENT_AUTH_ENABLED",
         "OMNIGENT_ACCOUNTS_ENABLED",
+        # Process logging controls. These are diagnostics knobs, not secrets.
+        "OMNIGENT_LOG_LEVEL",
+        "OMNIGENT_LOG_TO_STDERR",
+        LOG_TTY_FD_ENV_VAR,
         # Secret-store backend selector. The CLI's `configure harnesses` stores
         # pasted API keys via the file backend when this is set (headless /
         # locked-keyring hosts), writing `keychain:<name>` refs. The runner
@@ -602,7 +614,7 @@ class _RunnerHandle:
 
     :param proc: The runner subprocess handle.
     :param log_path: File capturing the runner's stdout/stderr, e.g.
-        ``Path("~/.omnigent/logs/host-runner/runner-ab12.log")``.
+        ``Path("~/.omnigent/logs/runner/runner-ab12.log")``.
         Read back for diagnostics when the runner dies before
         connecting its tunnel.
     """
@@ -1066,39 +1078,39 @@ class HostProcess:
         )
 
         try:
-            log_dir = _runner_log_dir()
-            log_dir.mkdir(parents=True, exist_ok=True)
             # Embed the session id so operators can find all logs for a
             # session with `omnigent debug logs --session <id>`. Cap at 32
             # chars to keep filenames manageable; strip anything non-word to
             # guard against unexpected id shapes from older servers.
             import re
-            import tempfile
 
             _session_slug = (
                 re.sub(r"[^\w-]", "", frame.session_id)[:32] + "-" if frame.session_id else ""
             )
-            _log_fd, _log_name = tempfile.mkstemp(
+            log_path, _log_fh = open_process_log_file(
+                "runner",
                 prefix=f"runner-{_session_slug}",
-                suffix=".log",
-                dir=log_dir,
             )
-            _log_fh = os.fdopen(_log_fd, "wb")
-            proc = subprocess.Popen(
-                [sys.executable, "-m", "omnigent.runner._entry"],
-                env=env,
-                # Runners are WS-tunnel clients with no interactive input.
-                # Give them a clean /dev/null stdin instead of inheriting the
-                # daemon's: a long-lived daemon (e.g. backgrounded / nohup'd)
-                # can end up with a closed or recycled stdin fd, and an
-                # inherited bad fd makes the runner die at interpreter startup
-                # with "init_sys_streams: Bad file descriptor" — it never
-                # connects, so the session fails with "runner did not connect".
-                stdin=subprocess.DEVNULL,
-                stdout=_log_fh,
-                stderr=_log_fh,
-            )
-            _log_fh.close()
+            env[PROCESS_LOG_FILE_ENV_VAR] = str(log_path)
+            try:
+                with child_logging_popen_kwargs(env) as logging_kwargs:
+                    proc = subprocess.Popen(
+                        [sys.executable, "-m", "omnigent.runner._entry"],
+                        env=env,
+                        # Runners are WS-tunnel clients with no interactive input.
+                        # Give them a clean /dev/null stdin instead of inheriting the
+                        # daemon's: a long-lived daemon (e.g. backgrounded / nohup'd)
+                        # can end up with a closed or recycled stdin fd, and an
+                        # inherited bad fd makes the runner die at interpreter startup
+                        # with "init_sys_streams: Bad file descriptor" — it never
+                        # connects, so the session fails with "runner did not connect".
+                        stdin=subprocess.DEVNULL,
+                        stdout=_log_fh,
+                        stderr=_log_fh,
+                        **logging_kwargs,
+                    )
+            finally:
+                _log_fh.close()
         except OSError as exc:
             return HostLaunchRunnerResultFrame(
                 request_id=frame.request_id,
@@ -1106,7 +1118,6 @@ class HostProcess:
                 error=f"failed to spawn runner: {exc}",
             )
 
-        log_path = Path(_log_name)
         if proc.poll() is not None:
             # The runner died before Popen returned — its actual error
             # is in the captured log, so ship the tail with the result
@@ -1955,6 +1966,7 @@ def run_host_process(
         (auth / authorization / outdated server). The
         actionable cause is printed to stderr first.
     """
+    host_log_path = configure_process_logging("host")
     # Initialize tracing so the host daemon exports its own spans
     # (e.g. handling launch_runner / stat / list_dir frames) into the
     # same distributed trace as the server that requested them. The
@@ -1972,17 +1984,16 @@ def run_host_process(
     print(f"Connecting to {server_url} as {identity.name!r} ({identity.host_id})")
     # Tell the user where logs land up front — `omnigent host` used to run
     # silently, so a stuck/quiet host gave no hint where to look. Session
-    # work goes to per-runner files under the host-runner dir (the exact
-    # file is printed when each runner launches). The foreground process's
-    # own diagnostics (warnings, tracebacks) go to the always-on cli-*.log;
-    # that path is None in the background daemon (no setup_cli_logging) —
-    # its stdout is already captured to the daemon log, so skip the line.
+    # work goes to per-runner files under the runner dir (the exact
+    # file is printed when each runner launches). The host process's
+    # own diagnostics go to the host destination.
     print(f"Session logs: {_display_log_path(_runner_log_dir())}/")
+    print(f"This host's log: {_display_log_path(host_log_path)}")
     from omnigent.cli_diagnostics import current_cli_log_path
 
     _cli_log = current_cli_log_path()
-    if _cli_log is not None:
-        print(f"This host's log: {_display_log_path(_cli_log)}")
+    if _cli_log is not None and _cli_log != host_log_path:
+        print(f"CLI diagnostics: {_display_log_path(_cli_log)}")
 
     host = HostProcess(identity, server_url)
     try:

--- a/omnigent/host/daemon_launch.py
+++ b/omnigent/host/daemon_launch.py
@@ -159,7 +159,7 @@ async def wait_for_runner_online(
     message = f"Runner {runner_id!r} did not connect within {timeout_s:.0f}s."
     if last_error is not None:
         message += f" Last connection error: {last_error!r}."
-    message += " Check the host-runner logs under ~/.omnigent/logs/host-runner/."
+    message += " Check the runner logs under ~/.omnigent/logs/runner/."
     raise click.ClickException(message)
 
 

--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -29,6 +29,11 @@ import click
 import psutil
 
 from omnigent.inner import _proc
+from omnigent.process_logging import (
+    PROCESS_LOG_FILE_ENV_VAR,
+    child_logging_popen_kwargs,
+    open_process_log_file,
+)
 
 _LOCAL_SERVER_READY_TIMEOUT_SECONDS = 45.0
 
@@ -76,7 +81,7 @@ _LOCAL_SERVER_SIG_PATH = _local_data_dir() / "local_server.sig"
 
 # Sidecar carrying the absolute path of the background server's captured
 # stdout/stderr log file (one line). Lets `server start` / `server status`
-# point at the exact ``logs/server/local-server-*.log`` even when reusing a
+# point at the exact ``logs/server/server-*.log`` even when reusing a
 # server this invocation didn't spawn. Absent for a foreground
 # ``omnigent server`` (its logs stream to the terminal, not a file).
 _LOCAL_SERVER_LOG_REF_PATH = _local_data_dir() / "local_server.logpath"
@@ -213,7 +218,7 @@ def _write_local_server_record(
     :param port: Loopback port the server bound, e.g. ``6767``.
     :param sig: Config signature from :func:`server_config_signature`.
     :param log_path: Absolute path of the spawned server's captured log file,
-        e.g. ``Path("/Users/alice/.omnigent/logs/server/local-server-ab12cd.log")``.
+        e.g. ``Path("/Users/alice/.omnigent/logs/server/server-ab12cd.log")``.
         ``None`` for a foreground server whose logs stream to the terminal —
         any stale log-ref sidecar is then removed so status never reports a
         log file that doesn't apply to the running server.
@@ -237,7 +242,7 @@ def _read_local_server_log_path() -> Path | None:
     """Read the running local server's captured-log path from its sidecar.
 
     :returns: The absolute log path the background server writes to, e.g.
-        ``Path("/Users/alice/.omnigent/logs/server/local-server-ab12cd.log")``, or
+        ``Path("/Users/alice/.omnigent/logs/server/server-ab12cd.log")``, or
         ``None`` when the sidecar is absent (foreground server, legacy
         record, or no server) or unreadable.
     """
@@ -374,7 +379,7 @@ class LocalServerInfo:
     :param url: Base URL when running, e.g. ``"http://127.0.0.1:8123"``;
         ``None`` when not running.
     :param log_path: Absolute path of the background server's captured log
-        file, e.g. ``Path("/Users/alice/.omnigent/logs/server/local-server-ab12cd.log")``.
+        file, e.g. ``Path("/Users/alice/.omnigent/logs/server/server-ab12cd.log")``.
         ``None`` for a foreground server (logs stream to its terminal) or a
         legacy record without the log-path sidecar.
     """
@@ -421,7 +426,7 @@ class LocalServerStartup:
         offer to stop a server they actually brought up, never one the user
         started independently.
     :param log_path: Absolute path of the background server's captured log
-        file, e.g. ``Path("/Users/alice/.omnigent/logs/server/local-server-ab12cd.log")``
+        file, e.g. ``Path("/Users/alice/.omnigent/logs/server/server-ab12cd.log")``
         — surfaced so callers (``server start``) can point the user at the
         exact log. For a spawned server this is the freshly created log; for
         a reused one it is read back from the log-path sidecar, and may be
@@ -526,7 +531,7 @@ class _SpawnedLocalServer:
 
     :param proc: The ``omnigent server`` subprocess handle.
     :param log_path: File capturing the child's stdout/stderr, e.g.
-        ``Path("~/.omnigent/logs/server/local-server-ab12cd.log")``.
+        ``Path("~/.omnigent/logs/server/server-ab12cd.log")``.
     :param base_url: Loopback URL the child was asked to bind, e.g.
         ``"http://127.0.0.1:6767"``.
     """
@@ -598,11 +603,7 @@ def _spawn_local_server(port: int) -> _SpawnedLocalServer:
     # isolated sqlite db under the runtime data dir.
     db_uri = os.environ.get("OMNIGENT_DATABASE_URI") or f"sqlite:///{db_path}"
 
-    log_dir = data_dir / "logs" / "server"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_fd, log_name = tempfile.mkstemp(prefix="local-server-", suffix=".log", dir=log_dir)
-    log_path = Path(log_name)
-    log_fh = os.fdopen(log_fd, "wb")
+    log_path, log_fh = open_process_log_file("server", root=data_dir / "logs")
 
     # Pass the full parent env: this server IS the local runtime —
     # loopback-only, same single user, and it needs the LLM creds to
@@ -617,7 +618,7 @@ def _spawn_local_server(port: int) -> _SpawnedLocalServer:
     # POV, `omnigent run` (no --server) in accounts mode gets
     # "browser auto-opens signed in + TUI auto-signed in" once
     # the spawned server's bootstrap fires.
-    child_env = {**os.environ}
+    child_env = {**os.environ, PROCESS_LOG_FILE_ENV_VAR: str(log_path)}
     # Mirror create_auth_provider's resolution via the shared helper so the
     # daemon-owned server agrees with the server's own auth wiring: header is
     # the env-unset default; OMNIGENT_AUTH_ENABLED=1 opts into accounts (or
@@ -645,26 +646,28 @@ def _spawn_local_server(port: int) -> _SpawnedLocalServer:
         child_env["OMNIGENT_ACCOUNTS_BASE_URL"] = f"http://127.0.0.1:{port}"
 
     try:
-        proc = subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "omnigent.cli",
-                "server",
-                "--host",
-                "127.0.0.1",
-                "--port",
-                str(port),
-                "--database-uri",
-                db_uri,
-                "--artifact-location",
-                str(artifact_path),
-            ],
-            env=child_env,
-            stdout=log_fh,
-            stderr=log_fh,
-            **_proc.spawn_kwargs(),
-        )
+        with child_logging_popen_kwargs(child_env) as logging_kwargs:
+            proc = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "omnigent.cli",
+                    "server",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(port),
+                    "--database-uri",
+                    db_uri,
+                    "--artifact-location",
+                    str(artifact_path),
+                ],
+                env=child_env,
+                stdout=log_fh,
+                stderr=log_fh,
+                **_proc.spawn_kwargs(),
+                **logging_kwargs,
+            )
     finally:
         log_fh.close()
 

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -120,7 +120,7 @@ def terminal_stream_handler() -> logging.Handler:
     if stream is None:
         return logging.NullHandler()
     handler = logging.StreamHandler(stream)
-    setattr(handler, "_omnigent_process_log_stderr", True)
+    handler._omnigent_process_log_stderr = True
     return handler
 
 
@@ -151,7 +151,7 @@ def configure_process_logging(
     file_handler = logging.FileHandler(path, encoding="utf-8")
     file_handler.setLevel(resolved_level)
     file_handler.setFormatter(formatter)
-    setattr(file_handler, "_omnigent_process_log_path", str(path))
+    file_handler._omnigent_process_log_path = str(path)
     handlers.append(file_handler)
 
     mirror = should_log_to_stderr() if log_to_stderr is None else log_to_stderr

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -1,0 +1,237 @@
+"""Shared process logging setup for Omnigent entrypoints."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import sys
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import BinaryIO
+
+from omnigent._platform import IS_POSIX
+
+DATA_DIR_ENV_VAR = "OMNIGENT_DATA_DIR"
+LOG_LEVEL_ENV_VAR = "OMNIGENT_LOG_LEVEL"
+LOG_TO_STDERR_ENV_VAR = "OMNIGENT_LOG_TO_STDERR"
+PROCESS_LOG_FILE_ENV_VAR = "OMNIGENT_PROCESS_LOG_FILE"
+LOG_TTY_FD_ENV_VAR = "OMNIGENT_LOG_TTY_FD"
+
+DEFAULT_LOG_FORMAT = "%(asctime)s %(levelname)s:%(name)s:%(message)s"
+DEFAULT_LOG_DATEFMT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+def data_dir() -> Path:
+    """Return the runtime data directory used for DBs, artifacts, and logs."""
+    value = os.environ.get(DATA_DIR_ENV_VAR)
+    return Path(value).expanduser() if value else Path.home() / ".omnigent"
+
+
+def logs_root() -> Path:
+    """Return ``<data-dir>/logs``."""
+    return data_dir() / "logs"
+
+
+def process_log_dir(destination: str, *, root: str | Path | None = None) -> Path:
+    """Return the directory for one process-log destination."""
+    base = Path(root).expanduser() if root is not None else logs_root()
+    return base / destination
+
+
+def _timestamp() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+
+
+def create_process_log_path(
+    destination: str,
+    *,
+    root: str | Path | None = None,
+    prefix: str | None = None,
+) -> Path:
+    """Create and return a unique timestamped log path."""
+    log_dir = process_log_dir(destination, root=root)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    base = prefix or f"{destination}-"
+    for counter in range(100):
+        suffix = "" if counter == 0 else f"-{counter}"
+        candidate = log_dir / f"{base}{_timestamp()}{suffix}.log"
+        try:
+            fd = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            continue
+        os.close(fd)
+        return candidate
+    raise FileExistsError(f"could not allocate a {destination!r} log file in {log_dir}")
+
+
+def open_process_log_file(
+    destination: str,
+    *,
+    root: str | Path | None = None,
+    prefix: str | None = None,
+) -> tuple[Path, BinaryIO]:
+    """Create and open a process log file for binary stdout/stderr capture."""
+    path = create_process_log_path(destination, root=root, prefix=prefix)
+    return path, open(path, "ab", buffering=0)
+
+
+def env_truthy(value: str | None) -> bool:
+    """Return whether an environment-style boolean value is truthy."""
+    return value is not None and value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def effective_log_level(default: str = "INFO") -> int:
+    """Resolve the effective numeric logging level from ``OMNIGENT_LOG_LEVEL``."""
+    name = os.environ.get(LOG_LEVEL_ENV_VAR, default).upper()
+    value = getattr(logging, name, None)
+    return value if isinstance(value, int) else logging.INFO
+
+
+def should_log_to_stderr() -> bool:
+    """Return whether process logs should also mirror to an interactive stderr."""
+    return env_truthy(os.environ.get(LOG_TO_STDERR_ENV_VAR))
+
+
+def _process_log_file_from_env() -> Path | None:
+    value = os.environ.get(PROCESS_LOG_FILE_ENV_VAR)
+    return Path(value).expanduser() if value else None
+
+
+def _terminal_stream() -> object | None:
+    fd_value = os.environ.get(LOG_TTY_FD_ENV_VAR)
+    if fd_value and IS_POSIX:
+        try:
+            fd = int(fd_value)
+            dup = os.dup(fd)
+            return os.fdopen(dup, "w", buffering=1, encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            return None
+    if sys.stderr.isatty():
+        return sys.stderr
+    return None
+
+
+def terminal_stream_handler() -> logging.Handler:
+    """Return a stream handler for the requested terminal mirror."""
+    stream = _terminal_stream()
+    if stream is None:
+        return logging.NullHandler()
+    handler = logging.StreamHandler(stream)
+    setattr(handler, "_omnigent_process_log_stderr", True)
+    return handler
+
+
+def configure_process_logging(
+    destination: str,
+    *,
+    log_path: str | Path | None = None,
+    level: int | None = None,
+    log_to_stderr: bool | None = None,
+    logger_names: Sequence[str] = ("omnigent",),
+    root: bool = True,
+    force: bool = False,
+) -> Path:
+    """Configure Python logging for one process destination.
+
+    The returned file always receives logs. Stderr receives logs only when
+    requested and an interactive terminal stream is available.
+    """
+    resolved_level = effective_log_level() if level is None else level
+    path = Path(log_path).expanduser() if log_path is not None else _process_log_file_from_env()
+    if path is None:
+        path = create_process_log_path(destination)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    formatter = logging.Formatter(DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATEFMT)
+    handlers: list[logging.Handler] = []
+
+    file_handler = logging.FileHandler(path, encoding="utf-8")
+    file_handler.setLevel(resolved_level)
+    file_handler.setFormatter(formatter)
+    setattr(file_handler, "_omnigent_process_log_path", str(path))
+    handlers.append(file_handler)
+
+    mirror = should_log_to_stderr() if log_to_stderr is None else log_to_stderr
+    if mirror:
+        stream_handler = terminal_stream_handler()
+        if not isinstance(stream_handler, logging.NullHandler):
+            stream_handler.setLevel(resolved_level)
+            stream_handler.setFormatter(formatter)
+            handlers.append(stream_handler)
+
+    if root:
+        root_logger = logging.getLogger()
+        root_logger.setLevel(resolved_level)
+        if force:
+            logging.basicConfig(
+                level=resolved_level,
+                format=DEFAULT_LOG_FORMAT,
+                datefmt=DEFAULT_LOG_DATEFMT,
+                handlers=handlers,
+                force=True,
+            )
+            # ``basicConfig`` uses the supplied handlers as-is.
+        else:
+            for handler in handlers:
+                _add_handler_once(root_logger, handler)
+
+    for name in logger_names:
+        logger = logging.getLogger(name)
+        logger.setLevel(resolved_level)
+        if not logger.propagate or not root:
+            for handler in handlers:
+                _add_handler_once(logger, handler)
+
+    logging.captureWarnings(True)
+    return path
+
+
+def _add_handler_once(logger: logging.Logger, handler: logging.Handler) -> None:
+    path = getattr(handler, "_omnigent_process_log_path", None)
+    is_stderr = getattr(handler, "_omnigent_process_log_stderr", False)
+    for existing in logger.handlers:
+        if path is not None and getattr(existing, "_omnigent_process_log_path", None) == path:
+            handler.close()
+            return
+        if is_stderr and getattr(existing, "_omnigent_process_log_stderr", False):
+            handler.close()
+            return
+    logger.addHandler(handler)
+
+
+@contextmanager
+def child_logging_popen_kwargs(env: dict[str, str]) -> Iterator[dict[str, object]]:
+    """Prepare inherited terminal-fd kwargs for a child process.
+
+    Mutates *env* only when ``--log-to-stderr`` requested a mirror and the
+    current process has an interactive stderr. On POSIX the returned kwargs
+    include ``pass_fds`` so a detached child can still write logs to that TTY.
+    """
+    owned_fd: int | None = None
+    if env_truthy(env.get(LOG_TO_STDERR_ENV_VAR)) and IS_POSIX:
+        fd_text = env.get(LOG_TTY_FD_ENV_VAR)
+        if fd_text:
+            with contextlib.suppress(OSError, ValueError):
+                owned_fd = os.dup(int(fd_text))
+                os.set_inheritable(owned_fd, True)
+                env[LOG_TTY_FD_ENV_VAR] = str(owned_fd)
+        else:
+            with contextlib.suppress(OSError):
+                if sys.stderr.isatty():
+                    owned_fd = os.dup(sys.stderr.fileno())
+                    os.set_inheritable(owned_fd, True)
+                    env[LOG_TTY_FD_ENV_VAR] = str(owned_fd)
+    try:
+        fd_values: list[int] = []
+        fd_text = env.get(LOG_TTY_FD_ENV_VAR)
+        if fd_text and IS_POSIX:
+            with contextlib.suppress(ValueError):
+                fd_values.append(int(fd_text))
+        yield {"pass_fds": tuple(fd_values)} if fd_values else {}
+    finally:
+        if owned_fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(owned_fd)

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -7328,7 +7328,7 @@ async def _build_debug_overview(
     :param server_log_path: Optional path to the local server log.
     :param event_log_path: Optional path to the JSONL event log.
     :param cli_log_path: Optional path to the always-on CLI
-        diagnostics log (``~/.omnigent/logs/cli-*.log``).
+        diagnostics log (``~/.omnigent/logs/cli/cli-*.log``).
     :returns: A Rich :class:`Group` suitable for passing to
         :meth:`TerminalHost.add_overlay`'s ``builder`` contract.
     """

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1228,13 +1228,9 @@ def main() -> None:
 
     :returns: None.
     """
-    log_level = os.environ.get("OMNIGENT_LOG_LEVEL", "INFO").upper()
-    logging.basicConfig(
-        level=getattr(logging, log_level, logging.INFO),
-        format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S%z",
-        stream=sys.stderr,
-    )
+    from omnigent.process_logging import configure_process_logging
+
+    configure_process_logging("runner", force=True)
     try:
         asyncio.run(_run_tunnel_from_env())
     except RuntimeError as exc:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -31,6 +31,7 @@ from omnigent.cli import (
     _dispatch_run,
     _ensure_sqlite_parent_dir,
     _expand_config_env_vars,
+    _extract_global_logging_flags,
     _HostHttpResult,
     _is_removed_ad_hoc_invocation,
     _is_run_shorthand,
@@ -50,6 +51,7 @@ from omnigent.cli import (
     _resolve_default_agent_target,
     _resolve_first_run_plan,
     _save_global_config,
+    _server_uvicorn_log_config,
     _start_cli_runner_process,
     _warn_missing_harness_dependencies,
     cli,
@@ -150,6 +152,92 @@ def test_removed_ad_hoc_detection(argv: list[str], expected: bool) -> None:
         prompt shape.
     """
     assert _is_removed_ad_hoc_invocation(argv) is expected
+
+
+def test_extract_global_logging_flags_preserves_run_shorthand() -> None:
+    """Global logging flags are stripped before run-shorthand detection."""
+    argv, debug, log_to_stderr = _extract_global_logging_flags(
+        ["--debug", "--log-to-stderr", "--harness", "claude"]
+    )
+
+    assert argv == ["--harness", "claude"]
+    assert debug is True
+    assert log_to_stderr is True
+    assert _is_run_shorthand(argv) is False
+
+
+def test_extract_global_logging_flags_preserves_passthrough_args() -> None:
+    """Logging flag names after ``--`` belong to the wrapped CLI."""
+    argv, debug, log_to_stderr = _extract_global_logging_flags(
+        ["claude", "--debug", "--", "--log-to-stderr", "--debug"]
+    )
+
+    assert argv == ["claude", "--", "--log-to-stderr", "--debug"]
+    assert debug is True
+    assert log_to_stderr is False
+
+
+def test_server_uvicorn_log_config_uses_terminal_handler_when_requested(
+    tmp_path: Path,
+) -> None:
+    """Uvicorn logs mirror through the shared terminal handler on request."""
+    log_config = _server_uvicorn_log_config(tmp_path / "server.log", log_to_stderr=True)
+
+    assert log_config["handlers"]["server_terminal"]["()"] == (
+        "omnigent.process_logging.terminal_stream_handler"
+    )
+    assert log_config["handlers"]["server_access_terminal"]["()"] == (
+        "omnigent.process_logging.terminal_stream_handler"
+    )
+    assert log_config["loggers"]["uvicorn"]["handlers"] == [
+        "server_terminal",
+        "server_file",
+    ]
+    assert log_config["loggers"]["uvicorn.access"]["handlers"] == [
+        "server_access_terminal",
+        "server_access_file",
+    ]
+
+
+def test_debug_logs_runner_session_reads_new_and_legacy_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``debug logs --session`` finds canonical runner and legacy host-runner logs."""
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(data_dir))
+    runner_dir = data_dir / "logs" / "runner"
+    legacy_dir = data_dir / "logs" / "host-runner"
+    runner_dir.mkdir(parents=True)
+    legacy_dir.mkdir(parents=True)
+    (runner_dir / "runner-conv_abc-new.log").write_text("new\n", encoding="utf-8")
+    (legacy_dir / "runner-conv_abc-old.log").write_text("old\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        ["debug", "logs", "--type", "runner", "--session", "conv_abc", "--list"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "runner-conv_abc-new.log" in result.output
+    assert "runner-conv_abc-old.log" in result.output
+
+
+def test_debug_logs_host_daemon_alias_reads_host_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy host-daemon type aliases to the canonical host destination."""
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(data_dir))
+    host_dir = data_dir / "logs" / "host"
+    host_dir.mkdir(parents=True)
+    (host_dir / "host-20260101-000000-000000.log").write_text("host log\n", encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["debug", "logs", "--type", "host-daemon", "-n", "0"])
+
+    assert result.exit_code == 0, result.output
+    assert "host log" in result.output
 
 
 def _fake_run_claude_native_capture(

--- a/tests/cli/test_cli_diagnostics.py
+++ b/tests/cli/test_cli_diagnostics.py
@@ -152,6 +152,36 @@ def test_redirect_stderr_to_log_redacts_direct_stderr_writes(
     )
 
 
+def test_setup_cli_logging_uses_data_dir_cli_destination(
+    isolated_cli_diagnostics: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """CLI diagnostics live under ``<data-dir>/logs/cli``."""
+    del isolated_cli_diagnostics
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(data_dir))
+
+    ctx = cli_diagnostics.setup_cli_logging(["run", "agent.yaml"])
+
+    assert ctx.path.parent == data_dir / "logs" / "cli"
+    assert ctx.path.name.startswith("cli-")
+
+
+def test_setup_cli_logging_honors_debug_level(
+    isolated_cli_diagnostics: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``OMNIGENT_LOG_LEVEL=DEBUG`` makes debug records reach cli logs."""
+    del isolated_cli_diagnostics
+    monkeypatch.setenv("OMNIGENT_LOG_LEVEL", "DEBUG")
+    ctx = cli_diagnostics.setup_cli_logging(["run", "agent.yaml"])
+
+    logging.getLogger("omnigent.test").debug("debug-visible")
+
+    assert "debug-visible" in ctx.path.read_text(encoding="utf-8")
+
+
 def test_restore_stderr_returns_writes_to_original_terminal(
     isolated_cli_diagnostics: None,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/test_server_lifecycle.py
+++ b/tests/cli/test_server_lifecycle.py
@@ -82,7 +82,7 @@ def test_server_status_json(monkeypatch: pytest.MonkeyPatch) -> None:
             pid=4321,
             port=8123,
             url="http://127.0.0.1:8123",
-            log_path=Path("/tmp/.omnigent/logs/server/local-server-ab12.log"),
+            log_path=Path("/tmp/.omnigent/logs/server/server-ab12.log"),
         ),
     )
     monkeypatch.setattr("omnigent.cli._find_daemon_record", lambda target: None)
@@ -99,7 +99,7 @@ def test_server_status_json(monkeypatch: pytest.MonkeyPatch) -> None:
         "pid": 4321,
         "port": 8123,
         "url": "http://127.0.0.1:8123",
-        "log_path": "/tmp/.omnigent/logs/server/local-server-ab12.log",
+        "log_path": "/tmp/.omnigent/logs/server/server-ab12.log",
         "live_sessions": 0,
         "daemon_attached": False,
     }
@@ -114,7 +114,7 @@ def test_server_status_text_reports_log_path(monkeypatch: pytest.MonkeyPatch) ->
             pid=4321,
             port=8123,
             url="http://127.0.0.1:8123",
-            log_path=Path.home() / ".omnigent" / "logs" / "server" / "local-server-ab12.log",
+            log_path=Path.home() / ".omnigent" / "logs" / "server" / "server-ab12.log",
         ),
     )
     monkeypatch.setattr("omnigent.cli._find_daemon_record", lambda target: None)
@@ -127,7 +127,7 @@ def test_server_status_text_reports_log_path(monkeypatch: pytest.MonkeyPatch) ->
 
     assert result.exit_code == 0, result.output
     assert "running at http://127.0.0.1:8123" in result.output
-    assert "log: ~/.omnigent/logs/server/local-server-ab12.log" in result.output
+    assert "log: ~/.omnigent/logs/server/server-ab12.log" in result.output
 
 
 def test_server_status_session_count_failure_is_graceful(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -160,7 +160,7 @@ def test_server_start_spawns(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda: LocalServerStartup(
             url="http://127.0.0.1:8123",
             spawned=True,
-            log_path=Path.home() / ".omnigent" / "logs" / "server" / "local-server-ab12.log",
+            log_path=Path.home() / ".omnigent" / "logs" / "server" / "server-ab12.log",
         ),
     )
 
@@ -170,7 +170,7 @@ def test_server_start_spawns(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Started background server at http://127.0.0.1:8123" in result.output
     # The exact captured-log file is surfaced so the detached server isn't a
     # black box — collapsed to ``~`` for readability.
-    assert "log: ~/.omnigent/logs/server/local-server-ab12.log" in result.output
+    assert "log: ~/.omnigent/logs/server/server-ab12.log" in result.output
 
 
 def test_server_start_reuses(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -180,7 +180,7 @@ def test_server_start_reuses(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda: LocalServerStartup(
             url="http://127.0.0.1:8123",
             spawned=False,
-            log_path=Path.home() / ".omnigent" / "logs" / "server" / "local-server-cd34.log",
+            log_path=Path.home() / ".omnigent" / "logs" / "server" / "server-cd34.log",
         ),
     )
 
@@ -190,7 +190,7 @@ def test_server_start_reuses(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "already running at http://127.0.0.1:8123" in result.output
     # Even a reused server (one this invocation didn't spawn) names its log,
     # read back from the sidecar.
-    assert "log: ~/.omnigent/logs/server/local-server-cd34.log" in result.output
+    assert "log: ~/.omnigent/logs/server/server-cd34.log" in result.output
 
 
 def test_server_start_omits_log_when_unknown(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/e2e/integrations/deploy/cwsandbox/e2e_managed.py
+++ b/tests/e2e/integrations/deploy/cwsandbox/e2e_managed.py
@@ -205,7 +205,7 @@ def _dump_server_logs(sb: Sandbox | None) -> None:
         [
             "bash",
             "-lc",
-            "tail -50 ~/.omnigent/logs/cli-*.log 2>/dev/null; "
+            "tail -50 ~/.omnigent/logs/cli/cli-*.log 2>/dev/null; "
             "echo '--- stdout ---'; tail -15 /tmp/omnigent-server.log",
         ]
     ).result()

--- a/tests/e2e/omnigent/test_repl_session_lifecycle.py
+++ b/tests/e2e/omnigent/test_repl_session_lifecycle.py
@@ -444,10 +444,11 @@ def _runner_pid_from_daemon_log(home: Path, runner_id: str) -> int:
     :returns: The runner subprocess pid.
     :raises AssertionError: When the pid is not found in the daemon log.
     """
-    log_dir = home / ".omnigent" / "logs" / "host-daemon"
-    logs = sorted(log_dir.glob("daemon-*.log"))
+    log_root = home / ".omnigent" / "logs"
+    logs = sorted((log_root / "host").glob("host-*.log"))
+    logs += sorted((log_root / "host-daemon").glob("daemon-*.log"))
     if not logs:
-        raise AssertionError(f"no connect-daemon log under {log_dir}")
+        raise AssertionError(f"no connect-daemon log under {log_root}")
     text = "".join(p.read_text(errors="replace") for p in logs)
     matches = re.findall(
         rf"Launched runner {re.escape(runner_id)}\b.*?\(pid=(\d+)\)",
@@ -455,7 +456,7 @@ def _runner_pid_from_daemon_log(home: Path, runner_id: str) -> int:
     )
     if not matches:
         raise AssertionError(
-            f"runner {runner_id!r} launch pid not found in daemon log under {log_dir}"
+            f"runner {runner_id!r} launch pid not found in daemon log under {log_root}"
         )
     return int(matches[-1])
 

--- a/tests/e2e/test_host_e2e.py
+++ b/tests/e2e/test_host_e2e.py
@@ -31,6 +31,7 @@ import httpx
 import pytest
 import yaml
 
+from omnigent.process_logging import PROCESS_LOG_FILE_ENV_VAR
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e.conftest import (
     POLL_INTERVAL_S,
@@ -100,16 +101,16 @@ def _spawn_host_daemon(
             sort_keys=True,
         )
     )
+    # Route process logs to a deterministic file so tests can read the
+    # "Launched runner ... (pid=NNNN)" line and inspect it on failure.
+    daemon_log = tmp_path / "host-daemon.log"
     env = {
         **os.environ,
         "HOME": str(tmp_path),
         "OPENAI_BASE_URL": f"{mock_llm_server_url}/v1",
         "OPENAI_API_KEY": "mock-key",
+        PROCESS_LOG_FILE_ENV_VAR: str(daemon_log),
     }
-    # Capture the daemon's stderr to a file so tests can read the
-    # "Launched runner ... (pid=NNNN)" line (and inspect it on failure).
-    # The child keeps its own dup of the fd after this handle is closed.
-    daemon_log = tmp_path / "host-daemon.log"
     with open(daemon_log, "w") as log_fh:
         proc = subprocess.Popen(
             # Compat-aware: pinned OLD host venv in runner compat mode (Config 2),
@@ -690,6 +691,7 @@ def _spawn_host_daemon_for_mock_claude(
             sort_keys=True,
         )
     )
+    daemon_log = tmp_path / "host-daemon.log"
     env = {
         **os.environ,
         "HOME": str(tmp_path),
@@ -701,8 +703,8 @@ def _spawn_host_daemon_for_mock_claude(
         "ANTHROPIC_API_KEY": "mock-key",
         # Suppress beta headers so the mock server doesn't reject them.
         "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        PROCESS_LOG_FILE_ENV_VAR: str(daemon_log),
     }
-    daemon_log = tmp_path / "host-daemon.log"
     with open(daemon_log, "w") as log_fh:
         proc = subprocess.Popen(
             # Compat-aware: pinned OLD host venv in runner compat mode (Config 2),

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -419,14 +419,14 @@ async def test_handle_launch_prints_exact_runner_log_path(
         result = await host._handle_launch(frame)
 
     assert result.status == "launched", result.error
-    # Exactly one runner-*.log was created under the host-runner dir.
-    runner_log_dir = tmp_path / ".omnigent" / "logs" / "host-runner"
+    # Exactly one runner-*.log was created under the runner log dir.
+    runner_log_dir = tmp_path / ".omnigent" / "logs" / "runner"
     log_files = list(runner_log_dir.glob("runner-*.log"))
     assert len(log_files) == 1
     out = capsys.readouterr().out
     assert "↑ Runner started:" in out
     # The exact file path is printed, home-collapsed to ``~`` for readability.
-    assert f"log: ~/.omnigent/logs/host-runner/{log_files[0].name}" in out
+    assert f"log: ~/.omnigent/logs/runner/{log_files[0].name}" in out
     assert "session: conv_log" in out
 
     _cleanup_host(host)
@@ -515,7 +515,7 @@ async def test_handle_launch_immediate_exit_reports_exit_code_and_log_tail(
     # The exit code identifies the failure class without log-reading.
     assert "code 7" in error
     # The log path lets the user fetch the full log on the host.
-    assert "~/.omnigent/logs/host-runner/runner-" in error
+    assert "~/.omnigent/logs/runner/runner-" in error
     # The tail carries the actual cause — the whole point of the report.
     assert "RuntimeError: boom-traceback" in error
 
@@ -1236,6 +1236,9 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "KUBECONFIG": "/home/alice/.kube/config",
         "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
         "OMNIGENT_DATABRICKS_EXTRA_HEADERS": '{"x-databricks-route-hint": "instance-abc"}',
+        "OMNIGENT_LOG_LEVEL": "DEBUG",
+        "OMNIGENT_LOG_TO_STDERR": "1",
+        "OMNIGENT_LOG_TTY_FD": "9",
     }
 
     env = _build_runner_env(
@@ -1285,6 +1288,11 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     assert (
         env["OMNIGENT_DATABRICKS_EXTRA_HEADERS"] == '{"x-databricks-route-hint": "instance-abc"}'
     )
+    # Process logging controls forward so host-spawned runners honor --debug
+    # and --log-to-stderr.
+    assert env["OMNIGENT_LOG_LEVEL"] == "DEBUG"
+    assert env["OMNIGENT_LOG_TO_STDERR"] == "1"
+    assert env["OMNIGENT_LOG_TTY_FD"] == "9"
     # Non-harness secrets are stripped — the point of the allowlist.
     assert "DATABRICKS_TOKEN" not in env
     assert "AWS_SECRET_ACCESS_KEY" not in env
@@ -2372,4 +2380,5 @@ def test_run_host_process_announces_session_log_dir_on_start(
     )
 
     out = capsys.readouterr().out
-    assert "Session logs: ~/.omnigent/logs/host-runner/" in out
+    assert "Session logs: ~/.omnigent/logs/runner/" in out
+    assert "This host's log: ~/.omnigent/logs/host/host-" in out

--- a/tests/host/test_local_server.py
+++ b/tests/host/test_local_server.py
@@ -623,7 +623,7 @@ def test_ensure_local_omnigent_server_spawn_records_and_returns_log_path(
     # The captured log lives under the per-user server log dir as a .log file.
     assert result.log_path.parent == tmp_path / ".omnigent" / "logs" / "server"
     assert result.log_path.suffix == ".log"
-    assert result.log_path.name.startswith("local-server-")
+    assert result.log_path.name.startswith("server-")
     # Recorded in the sidecar so a later status/reuse names the same file.
     assert log_ref.read_text().strip() == str(result.log_path)
 
@@ -654,7 +654,7 @@ def test_ensure_local_omnigent_server_reuse_reads_log_path_sidecar(
     sig_file = tmp_path / "local_server.sig"
     sig_file.write_text(local_server.server_config_signature() + "\n")
     log_ref = tmp_path / "local_server.logpath"
-    recorded = tmp_path / ".omnigent" / "logs" / "server" / "local-server-cd34.log"
+    recorded = tmp_path / ".omnigent" / "logs" / "server" / "server-cd34.log"
     log_ref.write_text(str(recorded) + "\n")
     monkeypatch.setattr(local_server, "_LOCAL_SERVER_SIG_PATH", sig_file)
     monkeypatch.setattr(local_server, "_LOCAL_SERVER_LOG_REF_PATH", log_ref)

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import importlib
 import io
-import logging
 import os
 import tarfile
 import time
@@ -1445,30 +1444,28 @@ def test_main_reports_tunnel_rejection_without_traceback(
     assert "Traceback" not in stderr
 
 
-def test_main_installs_timestamped_runner_log_format(
+def test_main_configures_runner_process_logging(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Runner process logs include timestamps at the formatter boundary.
-
-    Host-spawned runners redirect stderr to
-    ``~/.omnigent/logs/host-runner/runner-*.log``. The entrypoint's
-    logging formatter therefore has to include ``asctime`` globally; adding
-    timestamps to individual messages would miss library and framework logs.
+    Runner process logs are configured through the shared process logger.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
     captured: dict[str, Any] = {}
 
-    def _capture_basic_config(**kwargs: Any) -> None:
+    def _capture_process_logging(destination: str, **kwargs: Any) -> None:
         """
-        Record the logging configuration requested by ``main``.
+        Record the process logging configuration requested by ``main``.
 
-        :param kwargs: Keyword arguments passed to ``logging.basicConfig``.
+        :param destination: Process-log destination.
+        :param kwargs: Keyword arguments passed to ``configure_process_logging``.
         :returns: None.
         """
+        captured["destination"] = destination
         captured.update(kwargs)
+        return
 
     async def _stop_immediately() -> None:
         """
@@ -1478,8 +1475,8 @@ def test_main_installs_timestamped_runner_log_format(
         """
 
     monkeypatch.setattr(
-        "omnigent.runner._entry.logging.basicConfig",
-        _capture_basic_config,
+        "omnigent.process_logging.configure_process_logging",
+        _capture_process_logging,
     )
     monkeypatch.setattr(
         "omnigent.runner._entry._run_tunnel_from_env",
@@ -1488,10 +1485,7 @@ def test_main_installs_timestamped_runner_log_format(
 
     main()
 
-    assert captured["level"] == logging.INFO
-    assert captured["format"].startswith("%(asctime)s ")
-    assert "%(levelname)s:%(name)s:%(message)s" in captured["format"]
-    assert captured["datefmt"] == "%Y-%m-%dT%H:%M:%S%z"
+    assert captured == {"destination": "runner", "force": True}
 
 
 def test_main_preserves_unexpected_runtime_errors(

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -1,0 +1,66 @@
+"""Tests for shared process logging helpers."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+
+import pytest
+
+from omnigent._platform import IS_POSIX
+from omnigent.process_logging import (
+    LOG_TO_STDERR_ENV_VAR,
+    LOG_TTY_FD_ENV_VAR,
+    child_logging_popen_kwargs,
+    terminal_stream_handler,
+)
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="pass_fds is POSIX-only")
+def test_child_logging_popen_kwargs_duplicates_explicit_log_fd() -> None:
+    """An explicit mirror fd is duplicated before child stderr is redirected."""
+    read_fd, write_fd = os.pipe()
+    forwarded_fd: int | None = None
+    try:
+        env = {
+            LOG_TO_STDERR_ENV_VAR: "1",
+            LOG_TTY_FD_ENV_VAR: str(write_fd),
+        }
+
+        with child_logging_popen_kwargs(env) as kwargs:
+            forwarded_fd = int(env[LOG_TTY_FD_ENV_VAR])
+            assert forwarded_fd != write_fd
+            assert kwargs == {"pass_fds": (forwarded_fd,)}
+
+            os.write(forwarded_fd, b"x")
+            assert os.read(read_fd, 1) == b"x"
+    finally:
+        for fd in (read_fd, write_fd, forwarded_fd):
+            if fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="fd-based terminal mirroring is POSIX-only")
+def test_terminal_stream_handler_writes_to_explicit_log_fd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The terminal mirror can target an inherited fd instead of stderr."""
+    read_fd, write_fd = os.pipe()
+    handler: logging.Handler | None = None
+    try:
+        monkeypatch.setenv(LOG_TTY_FD_ENV_VAR, str(write_fd))
+        handler = terminal_stream_handler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        record = logging.LogRecord("test", logging.INFO, __file__, 1, "hello", (), None)
+        handler.emit(record)
+
+        assert os.read(read_fd, 6) == b"hello\n"
+    finally:
+        if handler is not None:
+            handler.close()
+        for fd in (read_fd, write_fd):
+            with contextlib.suppress(OSError):
+                os.close(fd)


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Route server, host, runner, and CLI logs through shared process logging under $OMNIGENT_DATA_DIR/logs/<destination>/.
- Add global --debug and --log-to-stderr controls, including fd-based terminal mirroring for omnidev.
- Update omnidev to pass --log-to-stderr to Omnigent server and host processes.

ELI5: each Omnigent process now writes to its own log folder, and --log-to-stderr copies those same logs back to the terminal or omnidev pane.

```text
omnidev / terminal
  --log-to-stderr + mirror fd
        |
        +-- server -> logs/server/server-*.log
        +-- host   -> logs/host/host-*.log
        +-- runner -> logs/runner/runner-*.log
        +-- cli    -> logs/cli/cli-*.log
```

## Test Plan

- `cargo fmt --check`
- `cargo test` in `dev/omnidev`
- `.venv/bin/python -m pytest tests/test_process_logging.py tests/cli/test_cli_diagnostics.py tests/cli/test_cli.py tests/cli/test_server_lifecycle.py tests/host/test_local_server.py tests/host/test_connect.py tests/runner/test_runner_entry.py`
- `.venv/bin/pre-commit run --all-files`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover process logging helpers, CLI flags/log discovery, server lifecycle, host-spawned runner logging, runner entrypoint logging, and omnidev commandconstruction.