### PR TITLE
✨ feat(claude): Track native input state

### DIFF
--- a/docs/claude/native-runner-state.md
+++ b/docs/claude/native-runner-state.md
@@ -1,0 +1,118 @@
+# Claude Native Runner State
+
+Claude native has two separate state surfaces:
+
+- Public Omnigent `session.status` is a coarse lifecycle signal for the web UI
+  and sub-agent wakeups. It uses only `idle`, `running`, `waiting`, and `failed`.
+- Bridge input state is an internal Claude-native driver signal recorded in
+  `input_state.json`. It tracks startup/readiness/delivery edges such as
+  `waiting_for_session_start`, `awaiting_ack`, and `attention_required`.
+
+Do not treat public `idle` as "Claude is ready for input." A new session can be
+publicly idle simply because Omnigent has not observed a running Claude turn yet.
+The bridge still waits for `tmux.json`, parent `SessionStart`, and a structured
+delivery acknowledgement before it considers an injected message accepted.
+
+## Public Session Status
+
+Claude native public busy state is driven by Claude Code hook events, not by tmux
+pane diffs. The tmux watcher still emits terminal activity pulses and detects
+terminal exit, but pane output does not publish `session.status` for Claude
+native.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle: no running turn observed
+
+    Idle --> Running: UserPromptSubmit hook\nexternal_session_status running
+    Waiting --> Running: next UserPromptSubmit hook
+    Failed --> Running: next UserPromptSubmit hook
+
+    Running --> Idle: Stop hook\nbackground_task_count == 0
+    Running --> Waiting: Stop hook\nbackground_task_count > 0
+    Waiting --> Idle: later Stop hook\nbackground_task_count == 0
+    Waiting --> Waiting: Stop hook\nbackground_task_count > 0
+
+    Running --> Failed: StopFailure hook
+    Waiting --> Failed: StopFailure hook
+    Running --> Failed: required terminal exits before idle
+    Waiting --> Failed: required terminal exits before idle
+
+    Idle --> Failed: required terminal exits before any clean idle memo
+```
+
+## Transition Sources
+
+| Source | Public transition | Details |
+| --- | --- | --- |
+| `UserPromptSubmit` hook | `idle` / `waiting` / `failed` to `running` | Posted as `external_session_status: running` without `response_id` or `background_task_count`. This opens the session-level busy state. |
+| First assistant transcript output | stays `running` | Posts an id-bearing `external_session_status: running` with `response_id`. This opens the web `activeResponse`; it is not the source of session readiness. |
+| `Stop` hook with no running background tasks | `running` / `waiting` to `idle` | Posted as `external_session_status: idle` with `background_task_count: 0`, plus `response_id` when known. This closes the active response and clears any shell tally. |
+| `Stop` hook with running background tasks | `running` / `waiting` to `waiting` | Posted as `external_session_status: waiting` with a positive `background_task_count`, plus `response_id` when known. The model turn is done, but background shells remain visible. |
+| `StopFailure` hook | `running` / `waiting` to `failed` | Posted as `external_session_status: failed`, plus `response_id` when known. Server-side failed status remains sticky until a later `running` edge. |
+| Required Claude terminal exit | clean release or `failed` | Exit after the latest observed status memo is `idle` is clean. Exit while the memo is `running` / `waiting`, or before any clean idle memo, is treated as a mid-turn failure. |
+
+## Non-Transitions
+
+| Source | Behavior |
+| --- | --- |
+| tmux pane activity | Emits `session.terminal.activity` only. It lights the terminal active badge but does not change Claude `session.status`. |
+| runner message dispatch | Calls `note_session_turn_started()` for exit classification only. It does not publish Claude `session.status`; the hook forwarder owns that. |
+| interrupt request | Sends Escape to Claude Code and publishes no status. The state changes only when Claude later emits `Stop` or `StopFailure`; if no hook arrives, the session stays visibly non-idle. |
+| transcript `queue-operation` | Used as input-delivery evidence only. It is not a lifecycle transition. |
+| subagent hooks | Ignored for parent busy state. Parent status changes only from parent-session lifecycle hooks. |
+
+## Bridge Input State
+
+The bridge writes its last input-readiness/delivery transition to
+`input_state.json` and exposes it through `read_claude_input_state()`. This state
+is diagnostic and gating-oriented; it is not emitted as public `session.status`.
+
+```mermaid
+stateDiagram-v2
+    [*] --> NotAdvertised: no input_state.json yet
+    NotAdvertised --> WaitingForTmux: inject_user_message starts
+    NotAdvertised --> WaitingForSessionStart: write_tmux_target writes tmux.json
+    WaitingForTmux --> WaitingForSessionStart: tmux.json found
+    WaitingForTmux --> Failed: tmux.json timeout
+
+    WaitingForSessionStart --> SessionStarted: parent SessionStart hook
+    WaitingForSessionStart --> AttentionRequired: SessionStart timeout
+
+    SessionStarted --> Delivering: paste delivery begins
+    ReadyAfterStop --> Delivering: next injected message
+    Delivering --> Failed: tmux command fails
+    Delivering --> AwaitingAck: paste + Enter sent
+
+    AwaitingAck --> TurnRunning: UserPromptSubmit hook recorded
+    TurnRunning --> Accepted: same hook matched as delivery ack
+    AwaitingAck --> Accepted: transcript user row
+    AwaitingAck --> Queued: transcript queue-operation enqueue
+    AwaitingAck --> Failed: retry Enter tmux command fails
+    AwaitingAck --> AttentionRequired: no structured ack after retry
+
+    SessionStarted --> TurnRunning: direct terminal input submits prompt
+    ReadyAfterStop --> TurnRunning: direct terminal input submits prompt
+    Queued --> TurnRunning: later parent UserPromptSubmit hook
+    TurnRunning --> ReadyAfterStop: parent Stop hook
+    Accepted --> ReadyAfterStop: parent Stop hook
+    TurnRunning --> Failed: parent StopFailure hook
+    Accepted --> Failed: parent StopFailure hook
+```
+
+## Input Transitions
+
+| State | Entered when | Why it exists |
+| --- | --- | --- |
+| `not_advertised` | `input_state.json` is missing | No bridge readiness information exists yet. |
+| `waiting_for_tmux` | `inject_user_message()` starts before `tmux.json` is found | Prevents typing before the runner has advertised the Claude pane. |
+| `waiting_for_session_start` | `tmux.json` is written or found | The pane exists, but Claude has not yet reported a parent interactive session. |
+| `session_started` | A parent `SessionStart` hook is observed, or the injection gate finds prior parent session state | Lower-bound structured readiness. This still does not prove no startup dialog is on screen. |
+| `delivering` | The bridge starts clearing/pasting into tmux | A message is being written to the TUI. |
+| `awaiting_ack` | Paste and submit `Enter` have been sent | The bridge is waiting for `UserPromptSubmit`, a transcript user row, or a native queue row. |
+| `accepted` | `UserPromptSubmit` or a transcript user row matches the exact prompt | Claude accepted the injected prompt as user input. |
+| `queued` | A transcript `queue-operation` enqueue row matches the exact prompt | Claude accepted the prompt into its native queue while another turn was running. |
+| `turn_running` | A parent `UserPromptSubmit` hook is recorded | Claude has started processing a user prompt. |
+| `ready_after_stop` | A parent `Stop` hook is recorded | The foreground Claude turn ended; public status may be `idle` or `waiting` depending on background tasks. |
+| `attention_required` | Parent `SessionStart` never arrives, or delivery never receives structured ack after retry | Claude likely needs visible terminal attention, such as an auth/trust/onboarding/startup dialog, or the prompt remains in the composer. |
+| `failed` | tmux delivery fails or a parent `StopFailure` hook is recorded | The bridge or Claude turn reached a hard failure. |

--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -1470,9 +1470,9 @@ async def _launch_antigravity_terminal(
         #
         # Deliberately NOT ``bridge_inject_dir``: on the runner, that marker
         # triggers Claude-native machinery — it starts the Claude comment relay,
-        # tags the terminal ``CLAUDE_NATIVE_TERMINAL_ROLE`` (which drives the
-        # session's PTY-derived working status), and publishes Claude tmux
-        # metadata. None of that is owned by antigravity teardown, and
+        # tags the terminal ``CLAUDE_NATIVE_TERMINAL_ROLE`` for Claude activity
+        # / exit tracking, and publishes Claude tmux metadata. None of that is
+        # owned by antigravity teardown, and
         # antigravity derives its working status from the RPC reader's
         # ``external_session_status`` edges, not PTY activity.
         # ``ensure_native_terminal`` is allowlisted the same

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -81,6 +81,7 @@ _BRIDGE_ROOT = _BRIDGE_ROOT_PARENT / "claude-native"
 _CONFIG_FILE = "bridge.json"
 _SERVER_FILE = "server.json"
 _STATE_FILE = "state.json"
+_INPUT_STATE_FILE = "input_state.json"
 _HOOKS_FILE = "hooks.jsonl"
 _RECENT_LOCAL_COMMAND_LINE_LIMIT = 200
 _RECENT_LOCAL_COMMAND_WINDOW_S = 10.0
@@ -118,59 +119,34 @@ _TOOL_RELAY_POST_TIMEOUT_S = _TOOL_CALL_TIMEOUT_S + 30.0
 # tails it and shells out to tmux.
 _TMUX_READY_TIMEOUT_S = 30.0
 _TMUX_SEND_TIMEOUT_S = 5.0
-# Claude Code renders this prompt glyph in its input box once the TUI
-# is interactive. We poll ``capture-pane`` for it before injecting the
-# first message so keystrokes typed during Claude's boot aren't dropped.
-# The glyph persists while Claude is busy responding, so its presence
-# means "input box mounted" (not "idle"), which is what injection needs.
-_CLAUDE_PROMPT_GLYPH = "❯"
-# Matches a selected numbered menu row (``❯ 2. No (recommended)``): the glyph
-# followed by a numbered choice, which the chat input never renders. Used to
-# exclude startup menus from the readiness scan (see ``_is_selected_menu_row``).
-_SELECTED_MENU_ROW_RE = re.compile(rf"{_CLAUDE_PROMPT_GLYPH}\s*\d+\.\s")
-# Box-drawing glyphs Claude Code's input-box frame is made of. A line of
-# these below ``❯`` marks the live input box (see ``_is_box_rule``),
-# distinguishing it from a bare prompt echoed into scrollback.
-_BOX_RULE_CHARS = frozenset("─━╭╮╰╯│┃╌╍")
-# How many trailing non-empty lines to scan for the prompt glyph. The
-# input box sits near the bottom of the pane; scanning only the tail
-# avoids false positives from the glyph appearing in scrollback output.
-# The window has to clear the footer rendered below the box — some
-# people's statuslines run ~3 lines — so the ``❯`` row isn't the last
-# non-empty line.
-_PROMPT_SCAN_TAIL_LINES = 5
 _CLAUDE_READY_POLL_INTERVAL_S = 0.15
 _PASTE_SETTLE_S = 0.1  # let the TUI commit a paste before the separate submit Enter
-# How long to wait for the pasted draft to visibly land in Claude's
-# input box before sending the submit Enter. Claude Code coalesces
-# rapid stdin bursts into a paste, so an Enter sent while the TUI is
-# still consuming the paste gets folded in as a newline instead of
-# submitting — the draft then sits unsent. Polling for the draft makes
-# the handoff deterministic where the old fixed sleep raced it.
-_PASTE_COMMIT_TIMEOUT_S = 5.0
-# After the submit Enter, how long to keep checking that the draft
-# actually left the input box (re-sending Enter while it hasn't)
-# before failing loud.
-_SUBMIT_VERIFY_TIMEOUT_S = 10.0
-# Minimum spacing between repeated submit Enters during verification.
-# Long enough for the TUI to clear the box after a successful submit
-# (so a slow-but-successful first Enter isn't double-tapped), short
-# enough that a swallowed Enter is retried promptly.
-_SUBMIT_RETRY_INTERVAL_S = 1.0
-# Claude Code collapses large pastes into this placeholder in the
-# input box instead of rendering the text itself.
-_PASTED_PLACEHOLDER_PREFIX = "[Pasted text"
-# How many characters of the draft's first line to use when checking
-# whether the draft is rendered in the input box. Short enough to fit
-# on the prompt row of a default 80-column detached pane.
-_DRAFT_NEEDLE_MAX_CHARS = 24
-# When Claude Code's input prompt never renders (it failed to boot), the
-# readiness gate attaches the tail of the captured pane to its error so
-# the real cause — often Claude Code's own startup crash, e.g. a
-# ``JSON Parse error`` from an HTML page served to its API client —
-# surfaces in the web UI error banner instead of only in the terminal.
+# Delivery acknowledgement budget after the paste+Enter pair. Startup still
+# uses the caller's tmux timeout, but a submitted prompt should be acknowledged
+# promptly by a hook or transcript record.
+_DELIVERY_ACK_TIMEOUT_S = 10.0
+# If Claude does not acknowledge the first Enter quickly, send one delayed
+# retry. This covers the known paste/Enter coalescing race without screen
+# scraping the draft.
+_DELIVERY_ENTER_RETRY_AFTER_S = 1.0
+# When structured delivery acknowledgement fails, the bridge attaches the tail
+# of the captured pane so Claude Code's own visible error state surfaces in the
+# web UI banner instead of only in the terminal.
 _TERMINAL_FAILURE_TAIL_LINES = 12
 _TERMINAL_FAILURE_TAIL_CHARS = 800
+
+_INPUT_STATE_NOT_ADVERTISED = "not_advertised"
+_INPUT_STATE_WAITING_FOR_TMUX = "waiting_for_tmux"
+_INPUT_STATE_WAITING_FOR_SESSION_START = "waiting_for_session_start"
+_INPUT_STATE_SESSION_STARTED = "session_started"
+_INPUT_STATE_DELIVERING = "delivering"
+_INPUT_STATE_AWAITING_ACK = "awaiting_ack"
+_INPUT_STATE_ACCEPTED = "accepted"
+_INPUT_STATE_QUEUED = "queued"
+_INPUT_STATE_TURN_RUNNING = "turn_running"
+_INPUT_STATE_READY_AFTER_STOP = "ready_after_stop"
+_INPUT_STATE_ATTENTION_REQUIRED = "attention_required"
+_INPUT_STATE_FAILED = "failed"
 
 ToolExecutor = Callable[[str, dict[str, Any]], Awaitable[Any]]
 
@@ -375,6 +351,10 @@ class ClaudeHookRecord:
     :param transcript_path: Claude transcript path from the hook
         payload, e.g. ``"/home/user/.claude/projects/x/session.jsonl"``,
         or ``None`` when absent.
+    :param prompt_id: Claude prompt id from prompt/stop hooks, e.g.
+        ``"2157eb33-5137-41c4-a41e-c39df3668f7a"``.
+    :param prompt: Prompt text from ``UserPromptSubmit``, or ``None``
+        for hook records that do not carry user input.
     :param previous_claude_session_id: Claude session id that was
         active immediately before this hook, e.g.
         ``"a1b2c3d4-1234-5678-9abc-def012345678"``, or ``None``
@@ -422,6 +402,8 @@ class ClaudeHookRecord:
     source: str | None = None
     claude_session_id: str | None = None
     transcript_path: Path | None = None
+    prompt_id: str | None = None
+    prompt: str | None = None
     previous_claude_session_id: str | None = None
     claude_session_was_seen: bool | None = None
     clear_rotated_to: str | None = None
@@ -449,6 +431,45 @@ class HookReadResult:
     event_cursor: int
     byte_offset: int
     records: list[ClaudeHookRecord]
+
+
+@dataclass(frozen=True)
+class ClaudeDeliveryAck:
+    """
+    Structured acknowledgement that Claude Code accepted a tmux-injected prompt.
+
+    :param prompt_id: Claude prompt id once known. Queued prompts may not have
+        one until Claude drains its native queue.
+    :param claude_session_id: Claude session id that accepted or queued the
+        prompt.
+    :param transcript_path: Transcript file that produced the acknowledgement.
+    :param ack_source: Source of the acknowledgement:
+        ``"hook"``, ``"transcript_user"``, or ``"transcript_queue"``.
+    :param queued: ``True`` when Claude accepted the prompt into its native queue
+        while another turn was still running.
+    """
+
+    prompt_id: str | None
+    claude_session_id: str | None
+    transcript_path: Path | None
+    ack_source: str
+    queued: bool = False
+
+
+@dataclass(frozen=True)
+class ClaudeInputState:
+    """
+    Last observed bridge-side input delivery state.
+
+    :param state: State name, e.g. ``"waiting_for_session_start"``.
+    :param updated_at: Wall-clock update time, or ``None`` when no
+        state file exists yet.
+    :param details: Small JSON-compatible diagnostic fields.
+    """
+
+    state: str
+    updated_at: float | None
+    details: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -1168,8 +1189,8 @@ def build_hook_settings(
         # ``UserPromptSubmit`` is the symmetric counterpart to
         # ``Stop`` — fires when a new user prompt reaches Claude
         # (web-UI message via tmux send-keys, or direct keystrokes
-        # into the embedded terminal). The transcript forwarder
-        # translates it into ``session.status: running``.
+        # into the embedded terminal). The input bridge uses it as the
+        # structured acknowledgement for tmux delivery.
         "UserPromptSubmit": [{"hooks": [hook]}],
         # ``TaskCreated`` fires when Claude creates a new native task
         # (shown with ``□`` in the TUI). The payload carries ``task_id``
@@ -1519,6 +1540,88 @@ def record_hook_event(bridge_dir: Path, payload: dict[str, Any]) -> None:
         state["seen_claude_session_ids"] = sorted(seen)
     state["updated_at"] = time.time()
     _write_json_file(bridge_dir / _STATE_FILE, state)
+    _record_hook_input_state(bridge_dir, payload)
+
+
+def _record_hook_input_state(bridge_dir: Path, payload: dict[str, Any]) -> None:
+    """
+    Mirror parent Claude hook lifecycle into the bridge input state.
+
+    :param bridge_dir: Bridge directory path.
+    :param payload: Claude hook payload.
+    :returns: None.
+    """
+    event_name = payload.get("hook_event_name")
+    if not isinstance(event_name, str):
+        return
+    transcript_path = payload.get("transcript_path")
+    if not isinstance(transcript_path, str) or _is_subagent_transcript_path(transcript_path):
+        return
+    claude_session_id = payload.get("session_id")
+    prompt_id = payload.get("prompt_id")
+    details: dict[str, Any] = {
+        "hook_event_name": event_name,
+        "transcript_path": transcript_path,
+    }
+    if isinstance(claude_session_id, str) and claude_session_id:
+        details["claude_session_id"] = claude_session_id
+    if isinstance(prompt_id, str) and prompt_id:
+        details["prompt_id"] = prompt_id
+
+    if event_name == "SessionStart":
+        _write_claude_input_state(bridge_dir, _INPUT_STATE_SESSION_STARTED, **details)
+    elif event_name == "UserPromptSubmit":
+        _write_claude_input_state(bridge_dir, _INPUT_STATE_TURN_RUNNING, **details)
+    elif event_name == "Stop":
+        _write_claude_input_state(bridge_dir, _INPUT_STATE_READY_AFTER_STOP, **details)
+    elif event_name == "StopFailure":
+        _write_claude_input_state(bridge_dir, _INPUT_STATE_FAILED, **details)
+
+
+def read_claude_input_state(bridge_dir: Path) -> ClaudeInputState:
+    """
+    Return the bridge's last input-readiness/delivery state.
+
+    This is an internal Claude-native driver state, not the public
+    Omnigent ``session.status``. Missing state means the bridge has not
+    advertised a tmux pane or observed hooks yet.
+
+    :param bridge_dir: Bridge directory path.
+    :returns: Last input state, defaulting to ``not_advertised``.
+    """
+    payload = _read_json_file(bridge_dir / _INPUT_STATE_FILE)
+    raw_state = payload.get("state")
+    state = raw_state if isinstance(raw_state, str) and raw_state else _INPUT_STATE_NOT_ADVERTISED
+    raw_updated_at = payload.get("updated_at")
+    updated_at = (
+        raw_updated_at
+        if isinstance(raw_updated_at, (int, float)) and not isinstance(raw_updated_at, bool)
+        else None
+    )
+    details = {key: value for key, value in payload.items() if key not in {"state", "updated_at"}}
+    return ClaudeInputState(state=state, updated_at=updated_at, details=details)
+
+
+def _write_claude_input_state(bridge_dir: Path, state: str, **details: Any) -> None:
+    """
+    Persist one bridge input-state transition.
+
+    :param bridge_dir: Bridge directory path.
+    :param state: State name.
+    :param details: Optional JSON-compatible diagnostic fields.
+    :returns: None.
+    """
+    payload: dict[str, Any] = {"state": state, "updated_at": time.time()}
+    for key, value in details.items():
+        if value is None:
+            continue
+        if isinstance(value, Path):
+            payload[key] = str(value)
+        elif isinstance(value, (str, int, float, bool)):
+            payload[key] = value
+        else:
+            payload[key] = str(value)
+    _write_json_file(bridge_dir / _INPUT_STATE_FILE, payload)
 
 
 def read_transcript_path(bridge_dir: Path) -> Path | None:
@@ -2262,6 +2365,8 @@ def _hook_record_from_jsonl_record(record: _JsonlRecord) -> ClaudeHookRecord:
     raw_recorded_at = envelope.get("recorded_at") if isinstance(envelope, dict) else None
     raw_claude_session_id = payload.get("session_id") if isinstance(payload, dict) else None
     raw_transcript_path = payload.get("transcript_path") if isinstance(payload, dict) else None
+    raw_prompt_id = payload.get("prompt_id") if isinstance(payload, dict) else None
+    raw_prompt = payload.get("prompt") if isinstance(payload, dict) else None
     raw_previous_claude_session_id = (
         payload.get("omnigent_previous_claude_session_id") if isinstance(payload, dict) else None
     )
@@ -2347,6 +2452,8 @@ def _hook_record_from_jsonl_record(record: _JsonlRecord) -> ClaudeHookRecord:
             if isinstance(raw_transcript_path, str) and raw_transcript_path
             else None
         ),
+        prompt_id=raw_prompt_id if isinstance(raw_prompt_id, str) and raw_prompt_id else None,
+        prompt=raw_prompt if isinstance(raw_prompt, str) else None,
         previous_claude_session_id=(
             raw_previous_claude_session_id
             if isinstance(raw_previous_claude_session_id, str) and raw_previous_claude_session_id
@@ -2482,6 +2589,268 @@ def write_tmux_target(
     if pid is not None:
         payload["pid"] = pid
     _write_json_file(bridge_dir / _TMUX_FILE, payload)
+    _write_claude_input_state(
+        bridge_dir,
+        _INPUT_STATE_WAITING_FOR_SESSION_START,
+        socket_path=str(socket_path),
+        tmux_target=tmux_target,
+        pid=pid,
+    )
+
+
+def _wait_for_parent_session_start(
+    bridge_dir: Path,
+    *,
+    start_event_count: int,
+    timeout_s: float,
+) -> None:
+    """
+    Wait until Claude has reported the parent interactive session.
+
+    :param bridge_dir: Bridge directory path.
+    :param start_event_count: Hook count captured before waiting.
+    :param timeout_s: Seconds to wait for ``SessionStart``.
+    :raises RuntimeError: If no parent session is known before timeout.
+    """
+    existing_transcript_path = read_transcript_path(bridge_dir)
+    if (
+        read_claude_session_id(bridge_dir)
+        and existing_transcript_path is not None
+        and not _is_subagent_transcript_path(existing_transcript_path)
+    ):
+        return
+    deadline = time.monotonic() + timeout_s
+    cursor = start_event_count
+    while True:
+        result = read_hook_events_since_with_position(bridge_dir, cursor)
+        cursor = result.event_cursor
+        for record in result.records:
+            if (
+                record.event_name == "SessionStart"
+                and record.claude_session_id
+                and record.transcript_path is not None
+                and not _is_subagent_transcript_path(record.transcript_path)
+            ):
+                return
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+    raise RuntimeError(
+        f"Claude Code did not report SessionStart within {timeout_s}s. "
+        "The message was not delivered because the terminal is not ready."
+    )
+
+
+def _is_subagent_transcript_path(path: Path | str | None) -> bool:
+    """
+    Return whether a transcript path belongs to a Claude subagent.
+
+    :param path: Transcript path from a hook payload.
+    :returns: ``True`` for ``.../subagents/...`` paths.
+    """
+    return path is not None and "/subagents/" in os.fspath(path)
+
+
+def _transcript_delivery_offset(transcript_path: Path | None) -> int:
+    """
+    Return the current transcript byte offset for delivery matching.
+
+    :param transcript_path: Active Claude transcript path.
+    :returns: Existing file size, or ``0`` when no transcript file exists yet.
+    """
+    if transcript_path is None:
+        return 0
+    with contextlib.suppress(OSError):
+        return transcript_path.stat().st_size
+    return 0
+
+
+def _wait_for_delivery_ack(
+    bridge_dir: Path,
+    *,
+    content: str,
+    start_event_count: int,
+    transcript_path: Path | None,
+    transcript_byte_offset: int,
+    timeout_s: float,
+) -> ClaudeDeliveryAck | None:
+    """
+    Wait for Claude to acknowledge an injected prompt.
+
+    :param bridge_dir: Bridge directory path.
+    :param content: Exact prompt content sent through tmux.
+    :param start_event_count: Hook count captured immediately before injection.
+    :param transcript_path: Transcript active when injection started.
+    :param transcript_byte_offset: Transcript offset captured before injection.
+    :param timeout_s: Seconds to poll.
+    :returns: Delivery acknowledgement, or ``None`` on timeout.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        ack = _delivery_ack_from_hooks(
+            bridge_dir,
+            content=content,
+            start_event_count=start_event_count,
+        )
+        if ack is not None:
+            return ack
+        active_transcript = transcript_path or read_transcript_path(bridge_dir)
+        active_offset = transcript_byte_offset if active_transcript == transcript_path else 0
+        ack = _delivery_ack_from_transcript(
+            active_transcript,
+            content=content,
+            byte_offset=active_offset,
+        )
+        if ack is not None:
+            return ack
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+
+
+def _record_delivery_ack_input_state(bridge_dir: Path, ack: ClaudeDeliveryAck) -> None:
+    """
+    Persist the structured acknowledgement that ended input delivery.
+
+    :param bridge_dir: Bridge directory path.
+    :param ack: Delivery acknowledgement from hooks or transcript.
+    :returns: None.
+    """
+    _write_claude_input_state(
+        bridge_dir,
+        _INPUT_STATE_QUEUED if ack.queued else _INPUT_STATE_ACCEPTED,
+        ack_source=ack.ack_source,
+        prompt_id=ack.prompt_id,
+        claude_session_id=ack.claude_session_id,
+        transcript_path=ack.transcript_path,
+        queued=ack.queued,
+    )
+
+
+def _delivery_ack_from_hooks(
+    bridge_dir: Path,
+    *,
+    content: str,
+    start_event_count: int,
+) -> ClaudeDeliveryAck | None:
+    """
+    Match a ``UserPromptSubmit`` hook for an injected prompt.
+
+    :param bridge_dir: Bridge directory path.
+    :param content: Exact prompt content sent through tmux.
+    :param start_event_count: Hook count captured immediately before injection.
+    :returns: Delivery acknowledgement, or ``None`` when no match exists.
+    """
+    result = read_hook_events_since_with_position(bridge_dir, start_event_count)
+    for record in result.records:
+        if record.event_name != "UserPromptSubmit":
+            continue
+        if record.prompt != content:
+            continue
+        if _is_subagent_transcript_path(record.transcript_path):
+            continue
+        return ClaudeDeliveryAck(
+            prompt_id=record.prompt_id,
+            claude_session_id=record.claude_session_id,
+            transcript_path=record.transcript_path,
+            ack_source="hook",
+            queued=False,
+        )
+    return None
+
+
+def _delivery_ack_from_transcript(
+    transcript_path: Path | None,
+    *,
+    content: str,
+    byte_offset: int,
+) -> ClaudeDeliveryAck | None:
+    """
+    Match transcript evidence that Claude accepted or queued a prompt.
+
+    :param transcript_path: Active Claude transcript path.
+    :param content: Exact prompt content sent through tmux.
+    :param byte_offset: Transcript byte offset captured before injection.
+    :returns: Delivery acknowledgement, or ``None`` when no match exists.
+    """
+    if transcript_path is None:
+        return None
+    read_result = _read_complete_jsonl_records(
+        transcript_path,
+        byte_offset=byte_offset,
+        start_line=0,
+    )
+    for record in read_result.records:
+        if record.text is None:
+            continue
+        try:
+            entry = json.loads(record.text)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("type") == "queue-operation" and entry.get("operation") == "enqueue":
+            queued_content = entry.get("content")
+            if queued_content == content:
+                return ClaudeDeliveryAck(
+                    prompt_id=None,
+                    claude_session_id=_string_or_none(entry.get("sessionId")),
+                    transcript_path=transcript_path,
+                    ack_source="transcript_queue",
+                    queued=True,
+                )
+        message = entry.get("message")
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        if message.get("content") != content:
+            continue
+        return ClaudeDeliveryAck(
+            prompt_id=_string_or_none(entry.get("promptId")),
+            claude_session_id=_string_or_none(entry.get("sessionId")),
+            transcript_path=transcript_path,
+            ack_source="transcript_user",
+            queued=entry.get("promptSource") == "queued",
+        )
+    return None
+
+
+def _string_or_none(value: object) -> str | None:
+    """
+    Return non-empty strings as-is.
+
+    :param value: Candidate value.
+    :returns: ``value`` when it is a non-empty string, otherwise ``None``.
+    """
+    return value if isinstance(value, str) and value else None
+
+
+def _format_delivery_failure_context(
+    bridge_dir: Path,
+    *,
+    start_event_count: int,
+    transcript_path: Path | None,
+    transcript_byte_offset: int,
+) -> str:
+    """
+    Format hook/transcript context for an injection failure.
+
+    :param bridge_dir: Bridge directory path.
+    :param start_event_count: Hook count captured immediately before injection.
+    :param transcript_path: Transcript active when injection started.
+    :param transcript_byte_offset: Transcript offset captured before injection.
+    :returns: Short diagnostic suffix.
+    """
+    result = read_hook_events_since_with_position(bridge_dir, start_event_count)
+    hook_events = [record.event_name or "<malformed>" for record in result.records[-5:]]
+    transcript_note = "none"
+    if transcript_path is not None:
+        transcript_note = os.fspath(transcript_path)
+        with contextlib.suppress(OSError):
+            transcript_note += f" bytes={transcript_path.stat().st_size}"
+    return (
+        f" Hook events since injection: {hook_events or 'none'}."
+        f" Transcript at injection: {transcript_note} offset={transcript_byte_offset}."
+    )
 
 
 def inject_user_message(
@@ -2489,15 +2858,15 @@ def inject_user_message(
     *,
     content: str,
     timeout_s: float = _TMUX_READY_TIMEOUT_S,
-) -> None:
+) -> ClaudeDeliveryAck:
     r"""
     Deliver a user message into the Claude terminal via tmux send-keys.
 
-    Before typing, this waits for two readiness conditions: the runner
-    advertising ``tmux.json``, then Claude Code's input box rendering
-    (see :func:`_wait_for_claude_prompt_ready`). The second gate closes
-    a race on freshly-created sessions where the first message would
-    otherwise be typed into a still-booting TUI and silently dropped.
+    Before typing, this waits for two structured readiness conditions:
+    the runner advertising ``tmux.json``, then Claude reporting a parent
+    ``SessionStart`` hook. A live probe against Claude Code 2.1.207 showed
+    that a tmux pane can exist before the TUI is ready; waiting for
+    ``SessionStart`` closes that startup drop without relying on prompt glyphs.
 
     Delivered as one bracketed paste via ``tmux load-buffer`` (from a
     temp file) + ``paste-buffer -p`` so interior newlines ride as raw CR
@@ -2511,113 +2880,199 @@ def inject_user_message(
     client→server command at ~16KB, so a large message — e.g. a PR diff
     in a sub-agent dispatch — failed with "command too long".
 
-    The submit is **verified, not fire-and-forget**: Claude Code
-    coalesces rapid stdin bursts into a paste, so an Enter that lands
-    while the TUI is still consuming the paste is folded in as a
-    newline and the draft sits unsent. This helper first polls
-    ``capture-pane`` until the draft is visible in the input box (the
-    paste was committed), sends Enter, then polls that the draft left
-    the box — re-sending Enter while it hasn't — and raises if the
-    message never submits.
+    The submit is **acknowledged, not fire-and-forget**: after Enter,
+    this helper waits for Claude's ``UserPromptSubmit`` hook carrying
+    the exact prompt, or for the transcript to record either the user
+    prompt or Claude's native ``queue-operation`` when a turn is already
+    running. If no acknowledgement arrives quickly, it sends one delayed
+    Enter retry to cover the paste/Enter coalescing race, then fails loud
+    if Claude still does not acknowledge the prompt.
+
+    The bridge records these gates in ``input_state.json``. ``SessionStart``
+    is only lower-bound readiness; a startup dialog after that point is
+    detected by missing structured delivery acknowledgement and recorded as
+    ``attention_required``.
 
     :param bridge_dir: Bridge directory path.
     :param content: User text from the Omnigent web UI. Must be non-empty.
     :param timeout_s: Seconds to wait for each readiness gate
-        (``tmux.json`` advertised, then prompt rendered), e.g. ``30.0``.
-    :returns: None.
+        (``tmux.json`` advertised, then parent ``SessionStart``),
+        e.g. ``30.0``.
+    :returns: Structured delivery acknowledgement from hooks or transcript.
     :raises RuntimeError: If the tmux target is not advertised in time,
-        if Claude's input prompt never renders, if a ``tmux send-keys``
-        invocation fails, or if the draft never leaves the input box
-        after repeated submit Enters (message not delivered).
+        if Claude has not emitted a parent ``SessionStart`` yet, if a
+        ``tmux`` invocation fails, or if Claude never acknowledges the
+        submitted message.
     """
-    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
-    # tmux.json only means the tmux session exists; Claude Code's input
-    # box mounts a few seconds later. Block until the prompt renders so
-    # the first message isn't typed into a still-booting TUI and dropped.
-    _wait_for_claude_prompt_ready(
-        info["socket_path"],
-        info["tmux_target"],
-        timeout_s=timeout_s,
-    )
-    # Clear any leftover text in Claude's input field before typing.
-    # After Escape-cancel, Claude Code re-populates the prompt area
-    # with the previous input for re-editing. Without this clear,
-    # the new message appends to the stale buffer (e.g.
-    # "old promptnew prompt" with no separator).
-    # Ctrl-A (Home) + Ctrl-K (kill-to-end) is the safest pair —
-    # Ctrl-U only clears backwards from cursor.
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "C-a")
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "C-k")
-    # Trailing newline absorbs a trailing "\" so it can't escape the submit Enter.
-    # Delivered through a tmux buffer, NOT ``send-keys`` argv: tmux caps one
-    # client→server command at ~16KB, so per-byte hex argv blew up with
-    # "command too long" on large payloads (a PR diff in a sub-agent
-    # dispatch). ``load-buffer`` streams the file without that cap, and
-    # ``paste-buffer -p`` wraps it in the same bracketed-paste markers so
-    # interior newlines (mapped to CR below) stay data instead of becoming
-    # per-line submits. See anthropics/claude-code#52126.
-    with tempfile.NamedTemporaryFile(
-        dir=bridge_dir, prefix="paste_", suffix=".bin", delete=False
-    ) as paste_file:
-        paste_file.write(_paste_payload_bytes(content + "\n"))
-        paste_path = paste_file.name
+    hook_start_count = count_hook_events(bridge_dir)
+    _write_claude_input_state(bridge_dir, _INPUT_STATE_WAITING_FOR_TMUX)
     try:
-        _run_tmux(info["socket_path"], "load-buffer", "-b", "omnigent-paste", paste_path)
-        _run_tmux(
-            info["socket_path"],
-            "paste-buffer",
-            "-p",  # bracketed-paste markers — the TUI keeps newlines as data
-            "-d",  # drop the buffer after pasting (no stale copies server-side)
-            "-b",
-            "omnigent-paste",
-            "-t",
-            info["tmux_target"],
+        info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    except RuntimeError as exc:
+        _write_claude_input_state(
+            bridge_dir,
+            _INPUT_STATE_FAILED,
+            phase=_INPUT_STATE_WAITING_FOR_TMUX,
+            error=str(exc),
         )
-    finally:
-        with contextlib.suppress(OSError):
-            os.unlink(paste_path)
-    # Wait until the TUI has visibly committed the paste into its input
-    # box before submitting. Claude Code coalesces rapid stdin bursts
-    # into a paste; an Enter that arrives while it is still consuming
-    # the paste becomes a newline inside the draft instead of a submit,
-    # and the message sits unsent. A fixed sleep raced this (lost under
-    # load / large payloads); polling is deterministic. Best-effort:
-    # when the draft never becomes identifiable (e.g. whitespace-only
-    # first line, custom statusline containing the glyph), fall through
-    # after the timeout and submit blind, matching the old behavior.
-    needle = _submit_needle(content)
-    draft_seen = False
-    deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
-    while time.monotonic() < deadline:
-        if _draft_in_input_box(_capture_pane(info["socket_path"], info["tmux_target"]), needle):
-            draft_seen = True
-            break
-        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-    time.sleep(_PASTE_SETTLE_S)
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
-    if not draft_seen:
-        # The draft was never observed, so its absence proves nothing —
-        # verification would trivially "pass". Submit blind as before.
-        return
-    # Verify the submit took: a successful Enter clears the input box.
-    # If the draft is still sitting there the Enter was swallowed into
-    # the paste burst as a newline — re-send it (the retry lands well
-    # after the burst, so it submits). Each Enter only fires while the
-    # draft is verifiably still present, so a retry can never hit an
-    # empty prompt or a permission dialog of the started turn.
-    deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
-    last_enter = time.monotonic()
-    while time.monotonic() < deadline:
-        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-        pane = _capture_pane(info["socket_path"], info["tmux_target"])
-        if not _draft_in_input_box(pane, needle):
-            return
-        if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
-            _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
-            last_enter = time.monotonic()
+        raise
+    _write_claude_input_state(
+        bridge_dir,
+        _INPUT_STATE_WAITING_FOR_SESSION_START,
+        socket_path=info["socket_path"],
+        tmux_target=info["tmux_target"],
+    )
+    try:
+        _wait_for_parent_session_start(
+            bridge_dir,
+            start_event_count=hook_start_count,
+            timeout_s=timeout_s,
+        )
+    except RuntimeError as exc:
+        pane_tail = _format_terminal_failure_tail(
+            _capture_pane(info["socket_path"], info["tmux_target"])
+        )
+        _write_claude_input_state(
+            bridge_dir,
+            _INPUT_STATE_ATTENTION_REQUIRED,
+            phase=_INPUT_STATE_WAITING_FOR_SESSION_START,
+            error=str(exc),
+            terminal_tail=pane_tail,
+        )
+        if pane_tail:
+            raise RuntimeError(str(exc) + pane_tail) from exc
+        raise
+    transcript_path = read_transcript_path(bridge_dir)
+    _write_claude_input_state(
+        bridge_dir,
+        _INPUT_STATE_SESSION_STARTED,
+        claude_session_id=read_claude_session_id(bridge_dir),
+        transcript_path=transcript_path,
+    )
+    transcript_offset = _transcript_delivery_offset(transcript_path)
+    hook_ack_start_count = count_hook_events(bridge_dir)
+
+    _write_claude_input_state(
+        bridge_dir,
+        _INPUT_STATE_DELIVERING,
+        socket_path=info["socket_path"],
+        tmux_target=info["tmux_target"],
+    )
+    try:
+        # Clear any leftover text in Claude's input field before typing.
+        # After Escape-cancel, Claude Code re-populates the prompt area
+        # with the previous input for re-editing. Without this clear,
+        # the new message appends to the stale buffer (e.g.
+        # "old promptnew prompt" with no separator).
+        # Ctrl-A (Home) + Ctrl-K (kill-to-end) is the safest pair —
+        # Ctrl-U only clears backwards from cursor.
+        _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "C-a")
+        _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "C-k")
+        # Trailing newline absorbs a trailing "\" so it can't escape the submit Enter.
+        # Delivered through a tmux buffer, NOT ``send-keys`` argv: tmux caps one
+        # client→server command at ~16KB, so per-byte hex argv blew up with
+        # "command too long" on large payloads (a PR diff in a sub-agent
+        # dispatch). ``load-buffer`` streams the file without that cap, and
+        # ``paste-buffer -p`` wraps it in the same bracketed-paste markers so
+        # interior newlines (mapped to CR below) stay data instead of becoming
+        # per-line submits. See anthropics/claude-code#52126.
+        with tempfile.NamedTemporaryFile(
+            dir=bridge_dir, prefix="paste_", suffix=".bin", delete=False
+        ) as paste_file:
+            paste_file.write(_paste_payload_bytes(content + "\n"))
+            paste_path = paste_file.name
+        try:
+            _run_tmux(info["socket_path"], "load-buffer", "-b", "omnigent-paste", paste_path)
+            _run_tmux(
+                info["socket_path"],
+                "paste-buffer",
+                "-p",  # bracketed-paste markers — the TUI keeps newlines as data
+                "-d",  # drop the buffer after pasting (no stale copies server-side)
+                "-b",
+                "omnigent-paste",
+                "-t",
+                info["tmux_target"],
+            )
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(paste_path)
+        time.sleep(_PASTE_SETTLE_S)
+        _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
+    except RuntimeError as exc:
+        _write_claude_input_state(
+            bridge_dir,
+            _INPUT_STATE_FAILED,
+            phase=_INPUT_STATE_DELIVERING,
+            error=str(exc),
+        )
+        raise
+
+    ack_timeout_s = min(timeout_s, _DELIVERY_ACK_TIMEOUT_S)
+    first_wait_s = min(ack_timeout_s, _DELIVERY_ENTER_RETRY_AFTER_S)
+    started = time.monotonic()
+    _write_claude_input_state(
+        bridge_dir,
+        _INPUT_STATE_AWAITING_ACK,
+        ack_timeout_s=ack_timeout_s,
+        transcript_path=transcript_path,
+        transcript_byte_offset=transcript_offset,
+    )
+    ack = _wait_for_delivery_ack(
+        bridge_dir,
+        content=content,
+        start_event_count=hook_ack_start_count,
+        transcript_path=transcript_path,
+        transcript_byte_offset=transcript_offset,
+        timeout_s=first_wait_s,
+    )
+    if ack is not None:
+        _record_delivery_ack_input_state(bridge_dir, ack)
+        return ack
+
+    try:
+        _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
+    except RuntimeError as exc:
+        _write_claude_input_state(
+            bridge_dir,
+            _INPUT_STATE_FAILED,
+            phase=_INPUT_STATE_AWAITING_ACK,
+            error=str(exc),
+        )
+        raise
+    elapsed = time.monotonic() - started
+    ack = _wait_for_delivery_ack(
+        bridge_dir,
+        content=content,
+        start_event_count=hook_ack_start_count,
+        transcript_path=transcript_path,
+        transcript_byte_offset=transcript_offset,
+        timeout_s=max(0.0, ack_timeout_s - elapsed),
+    )
+    if ack is not None:
+        _record_delivery_ack_input_state(bridge_dir, ack)
+        return ack
+    pane_tail = _format_terminal_failure_tail(
+        _capture_pane(info["socket_path"], info["tmux_target"])
+    )
+    failure_context = _format_delivery_failure_context(
+        bridge_dir,
+        start_event_count=hook_ack_start_count,
+        transcript_path=transcript_path,
+        transcript_byte_offset=transcript_offset,
+    )
+    _write_claude_input_state(
+        bridge_dir,
+        _INPUT_STATE_ATTENTION_REQUIRED,
+        phase=_INPUT_STATE_AWAITING_ACK,
+        ack_timeout_s=ack_timeout_s,
+        failure_context=failure_context,
+        terminal_tail=pane_tail,
+    )
     raise RuntimeError(
-        f"Claude Code did not accept the submitted message within {_SUBMIT_VERIFY_TIMEOUT_S}s "
-        "(the draft is still in the input box). The message was not delivered."
+        f"Claude Code did not acknowledge the submitted message within {ack_timeout_s:.1f}s. "
+        "The message may still be sitting in the TUI input box or a startup dialog."
+        + failure_context
+        + pane_tail
     )
 
 
@@ -2893,8 +3348,8 @@ def _capture_pane(socket_path: str, tmux_target: str) -> str:
     Capture the current visible contents of a tmux pane.
 
     Unlike :func:`_run_tmux`, this returns stdout instead of raising on
-    output, and never raises — a transient capture failure during boot
-    should be treated as "not ready yet" by the caller, not an error.
+    output, and never raises — diagnostics should not mask the original
+    structured delivery failure.
 
     :param socket_path: Absolute path to the tmux socket, e.g.
         ``"/tmp/.../tmux.sock"``.
@@ -2916,156 +3371,15 @@ def _capture_pane(socket_path: str, tmux_target: str) -> str:
     return proc.stdout if proc.returncode == 0 else ""
 
 
-def _claude_prompt_rendered(pane: str) -> bool:
-    """
-    Return whether Claude Code's input prompt is rendered in a pane.
-
-    Scans the last :data:`_PROMPT_SCAN_TAIL_LINES` non-empty lines for
-    :data:`_CLAUDE_PROMPT_GLYPH`. Restricting to the tail avoids false
-    positives from the glyph appearing in scrollback (e.g. echoed in a
-    prior response), since the live input box always sits at the bottom.
-
-    A mid-turn injection grows the footer with running-state rows (a
-    ``○ Explore …`` subagent line, extra spinners) that can push ``❯``
-    past that window — arbitrarily far, since a subagent fan-out adds one
-    row per concurrent subagent. To reach it at any depth without also
-    matching a scrollback echo, a glyph above the window counts only when
-    it's framed by a box rule — the ``────`` closing line the live input
-    box always renders below ``❯`` but a bare echoed prompt never has.
-
-    A bare ``❯`` on a selected numbered menu row is not the chat input. A
-    numbered line with an input-box rule below it still counts, however: the
-    readiness gate runs before every injection, so a restored composer draft
-    may legitimately begin with text such as ``2. buy milk``.
-
-    :param pane: Captured pane text from :func:`_capture_pane`.
-    :returns: ``True`` when the input box appears mounted.
-    """
-    non_empty = [line for line in pane.splitlines() if line.strip()]
-    tail_start = max(0, len(non_empty) - _PROMPT_SCAN_TAIL_LINES)
-    for idx in range(tail_start, len(non_empty)):
-        line = non_empty[idx]
-        if _CLAUDE_PROMPT_GLYPH not in line:
-            continue
-        if not _is_selected_menu_row(line) or any(
-            _is_box_rule(rule) for rule in non_empty[idx + 1 :]
-        ):
-            return True
-    # Above that window, trust the glyph only when a box rule sits below
-    # it — the live input box's closing frame, absent from scrollback.
-    # The footer height scales with concurrent subagents (a fan-out of
-    # ``○ Explore …`` rows), so no fixed window can bound it; the box rule
-    # is a reliable structural signal at any depth, and `capture-pane -p`
-    # returns only the visible pane, so this stays within one screen.
-    for idx, line in enumerate(non_empty):
-        if _CLAUDE_PROMPT_GLYPH not in line:
-            continue
-        if any(_is_box_rule(rule) for rule in non_empty[idx + 1 :]):
-            return True
-    return False
-
-
-def _is_selected_menu_row(line: str) -> bool:
-    """
-    Return whether a ``❯`` line is a selected numbered menu row.
-
-    Claude Code's startup menus (e.g. the "Detected a custom API key"
-    confirmation) mark the highlighted choice with the same ``❯`` glyph the
-    chat input uses (``❯ 2. No (recommended)``). The readiness scan must not
-    treat such a row as the chat composer, or the first message gets typed
-    into the menu. A chat prompt never renders a numbered choice after the
-    glyph, so the ``<glyph> <digit>.`` shape distinguishes them.
-
-    :param line: A single pane line, e.g. ``"❯ 2. No (recommended)"``.
-    :returns: ``True`` when the line is a selected numbered menu choice.
-    """
-    return bool(_SELECTED_MENU_ROW_RE.match(line.strip()))
-
-
-def _is_box_rule(line: str) -> bool:
-    """
-    Return whether a line is a TUI box-drawing horizontal rule.
-
-    Claude Code frames its input box with rows of ``─`` (plus corner
-    glyphs). Such a rule below ``❯`` marks the live input box, letting
-    the readiness scan reach a prompt buried under a tall running-turn
-    footer without matching a bare ``❯`` echoed into scrollback.
-
-    :param line: A single pane line, e.g. ``"──────────"``.
-    :returns: ``True`` when the line is predominantly box-rule glyphs.
-    """
-    stripped = line.strip()
-    return len(stripped) >= 3 and all(ch in _BOX_RULE_CHARS for ch in stripped)
-
-
-def _submit_needle(content: str) -> str:
-    r"""
-    Derive a short marker string used to spot a draft in the input box.
-
-    Takes the first non-empty line of *content* (after the same
-    line-ending normalization the paste payload gets), truncated at the
-    first control character and to :data:`_DRAFT_NEEDLE_MAX_CHARS`, so
-    it matches what Claude Code renders verbatim on the prompt row.
-
-    :param content: Raw user text, possibly multi-line,
-        e.g. ``"fix the bug\nin foo.py"``.
-    :returns: The needle, e.g. ``"fix the bug"``. Empty string when no
-        usable line exists (whitespace-only content) — callers must
-        then skip draft-visibility checks.
-    """
-    normalized = content.replace("\r\n", "\n").replace("\r", "\n")
-    for line in normalized.split("\n"):
-        # Truncate at the first control char (e.g. an interior tab):
-        # the TUI renders those differently, so they can't be matched
-        # verbatim against the captured pane text.
-        for idx, ch in enumerate(line):
-            if ord(ch) < 0x20:
-                line = line[:idx]
-                break
-        line = line.strip()
-        if line:
-            return line[:_DRAFT_NEEDLE_MAX_CHARS]
-    return ""
-
-
-def _draft_in_input_box(pane: str, needle: str) -> bool:
-    """
-    Return whether the pasted draft is visible in Claude's input box.
-
-    Looks only at the **last** line containing
-    :data:`_CLAUDE_PROMPT_GLYPH` — the live input box always sits at
-    the bottom of the pane, below the transcript, so this never
-    matches the submitted message's transcript echo. The draft counts
-    as visible when the text after the glyph contains *needle* (small
-    pastes render verbatim) or the
-    :data:`_PASTED_PLACEHOLDER_PREFIX` placeholder (Claude Code
-    collapses large pastes).
-
-    :param pane: Captured pane text from :func:`_capture_pane`.
-    :param needle: Marker from :func:`_submit_needle`, e.g.
-        ``"fix the bug"``. Empty means the draft can't be identified;
-        only the paste placeholder is then considered.
-    :returns: ``True`` when the draft is still sitting in the input box.
-    """
-    glyph_lines = [line for line in pane.splitlines() if _CLAUDE_PROMPT_GLYPH in line]
-    if not glyph_lines:
-        return False
-    tail = glyph_lines[-1].rsplit(_CLAUDE_PROMPT_GLYPH, 1)[1]
-    if _PASTED_PLACEHOLDER_PREFIX in tail:
-        return True
-    return bool(needle) and needle in tail
-
-
 def _format_terminal_failure_tail(pane: str) -> str:
     r"""
     Format the tail of a captured tmux pane for a failure message.
 
-    When Claude Code's input prompt never renders, its own on-screen
-    output — often a startup error or stack trace (e.g. a ``JSON Parse
-    error`` raised when its API client receives an HTML page instead of
-    JSON) — is the only signal of the real cause. The readiness gate
-    raises into the web UI's error banner, so attaching this tail
-    surfaces that cause without the user having to open the terminal.
+    When structured delivery acknowledgement fails, Claude Code's
+    visible output may be the only signal of the cause, e.g. a startup
+    dialog, prompt still sitting in the composer, or a terminal error.
+    Attaching this tail surfaces that state without requiring the user
+    to open the terminal.
 
     :param pane: Captured pane text from :func:`_capture_pane`.
     :returns: A ``" Last terminal output:\n<tail>"`` block — the last
@@ -3080,78 +3394,6 @@ def _format_terminal_failure_tail(pane: str) -> str:
     if len(tail) > _TERMINAL_FAILURE_TAIL_CHARS:
         tail = "…" + tail[-_TERMINAL_FAILURE_TAIL_CHARS:]
     return f" Last terminal output:\n{tail}"
-
-
-def _wait_for_claude_prompt_ready(
-    socket_path: str,
-    tmux_target: str,
-    *,
-    timeout_s: float,
-) -> None:
-    """
-    Block until Claude Code's TUI input box is ready for keystrokes.
-
-    The runner advertises ``tmux.json`` as soon as the tmux session
-    exists, but Claude Code's input box mounts a few seconds later
-    (longer on a cold first boot). Keystrokes sent into that gap are
-    dropped, so the first web-UI message silently vanishes. This gate
-    polls ``capture-pane`` for the input prompt before injection;
-    it returns immediately once mounted, so 2nd+ messages are
-    unaffected.
-
-    Claude-native only — this is called from :func:`inject_user_message`,
-    which exclusively serves the Claude Code terminal. It must never be
-    used for generic terminals, whose programs never render
-    :data:`_CLAUDE_PROMPT_GLYPH` and would always time out.
-
-    :param socket_path: Absolute path to the tmux socket, e.g.
-        ``"/tmp/.../tmux.sock"``.
-    :param tmux_target: tmux pane target string, e.g. ``"main"``.
-    :param timeout_s: Seconds to wait for the prompt, e.g. ``30.0``.
-    :returns: None.
-    :raises RuntimeError: If the prompt never renders within
-        *timeout_s* (Claude failed to boot). The message carries a poll
-        count, how many of those polls saw an empty capture, and the tail
-        of the last non-empty capture the loop actually observed (see
-        :func:`_format_terminal_failure_tail`) so the true failure mode —
-        a startup crash, a torn/empty capture under a mid-turn repaint, or
-        a box that never appeared — is diagnosable from the error alone.
-    """
-    deadline = time.monotonic() + timeout_s
-    polls = 0
-    empty_polls = 0
-    # Keep the last non-empty capture the loop actually saw, not a fresh
-    # capture taken after the deadline. A post-timeout re-capture can show
-    # a different (often healthier-looking) frame than any decision the
-    # loop made — e.g. the input box repainting just as the turn settles —
-    # which misrepresents why the gate failed. Attaching what was observed
-    # while it mattered keeps the error honest.
-    last_nonempty = ""
-    # Poll at least once even at timeout_s=0: a single readiness check is
-    # still meaningful, and it guarantees a capture to attach on failure.
-    while True:
-        pane = _capture_pane(socket_path, tmux_target)
-        polls += 1
-        if pane.strip():
-            last_nonempty = pane
-        else:
-            empty_polls += 1
-        if _claude_prompt_rendered(pane):
-            return
-        if time.monotonic() >= deadline:
-            break
-        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-    # Timed out. The poll/empty-capture counts separate the failure modes:
-    # mostly-empty captures point at a torn read under a busy repaint (the
-    # session is alive but capture-pane came back blank); non-empty captures
-    # with no box point at Claude never rendering the prompt (a boot crash,
-    # e.g. a ``JSON Parse error``, whose text the tail then surfaces).
-    raise RuntimeError(
-        f"Claude Code terminal did not become ready within {timeout_s}s "
-        f"(input prompt never rendered in {polls} polls, "
-        f"{empty_polls} empty captures). The message was not delivered."
-        + _format_terminal_failure_tail(last_nonempty)
-    )
 
 
 def _paste_payload_bytes(text: str) -> bytes:

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -236,18 +236,14 @@ _SUPERVISOR_HEALTHY_UPTIME_S = 60.0
 # published on the per-conversation SSE stream. Unmapped events emit
 # no status.
 #
-# ``Stop`` → idle and ``StopFailure`` → failed are the authoritative
-# turn-end edges (each fires once when Claude finishes / errors a turn);
-# they drive sub-agent terminal delivery via the codex-shared
-# ``external_session_status`` path (→ parent inbox + wake). The
-# PTY-activity ``idle`` cannot: it is a ~1s-quiescence heuristic that
-# oscillates on every mid-turn lull, so delivering on it fired a
-# premature completion and idempotently locked out the real one.
-# ``UserPromptSubmit`` → running stays PTY-derived — the pane watcher
-# drives the UI running/idle badge and catches what ``Stop`` misses
-# (interrupts, compaction failures, TUI edits). ``_publish_status``
-# keeps ``failed`` sticky against the trailing PTY idle.
+# ``UserPromptSubmit`` → running, ``Stop`` → idle, and ``StopFailure`` →
+# failed are the authoritative parent-turn lifecycle edges. They drive the
+# Omnigent busy state and sub-agent terminal delivery via the codex-shared
+# ``external_session_status`` path (→ parent inbox + wake). The tmux pane
+# watcher is intentionally not a Claude busy source: a quiescence heuristic can
+# oscillate on mid-turn lulls and does not carry Claude's background-task count.
 _HOOK_EVENT_TO_STATUS: dict[str, str] = {
+    "UserPromptSubmit": "running",
     "Stop": "idle",
     "StopFailure": "failed",
 }
@@ -2529,12 +2525,12 @@ async def _forward_available_status_events(
     """
     Forward currently available hook events as ``session.status``.
 
-    Maps ``Stop`` → ``idle`` and ``StopFailure`` → ``failed`` via
-    ``POST /v1/sessions/{id}/events`` with type ``external_session_status``
-    — the authoritative turn-end edges that drive sub-agent terminal
-    delivery (see :data:`_HOOK_EVENT_TO_STATUS`). ``running`` stays
-    PTY-derived (the pane-activity watcher drives the UI badge). Other hook
-    event names advance the cursor without emitting (no status meaning).
+    Maps ``UserPromptSubmit`` → ``running``, ``Stop`` → ``idle``, and
+    ``StopFailure`` → ``failed`` via ``POST /v1/sessions/{id}/events`` with
+    type ``external_session_status`` — the authoritative parent-turn lifecycle
+    edges that drive Claude native busy state and sub-agent terminal delivery
+    (see :data:`_HOOK_EVENT_TO_STATUS`). Other hook event names advance the
+    cursor without emitting (no status meaning).
 
     Also forwards native task state changes (``TaskCreated``,
     ``TaskCompleted``, ``PostToolUse``/``TaskUpdate``) and
@@ -2560,9 +2556,9 @@ async def _forward_available_status_events(
         e.g. ``["1", "2", "3"]``. Appended in-place from ``TaskCreated``
         events. Used to render the task list in a stable order.
     :param response_id: Active turn's response id, stamped on the
-        ``Stop``→``idle`` / ``StopFailure``→``failed`` edges so ap-web
-        closes the streaming ``activeResponse`` opened by the matching
-        turn-start ``running`` edge. ``None`` when no turn id is known
+        ``Stop``→``idle`` / ``StopFailure``→``failed`` edges so ap-web closes
+        the streaming ``activeResponse`` opened by the matching id-bearing
+        assistant-output ``running`` edge. ``None`` when no turn id is known
         (the status still posts, just without a turn association).
     :returns: Updated state. On post failure, returns the last
         durable state so successfully-posted statuses are not
@@ -2594,12 +2590,9 @@ async def _forward_available_status_events(
             ),
         )
         # Subagent lifecycle hooks land in the same hooks.jsonl as parent
-        # events because subagent processes inherit the parent's hook
-        # settings. With running/idle now PTY-derived, the only mapped
-        # status left is ``StopFailure`` → ``failed``: a subagent's
-        # failure must NOT flip the parent session to ``failed`` — the
-        # parent turn is still running while it awaits the Agent tool
-        # result.
+        # events because subagent processes inherit the parent's hook settings.
+        # They must not flip the parent running/idle/failed: the parent turn is
+        # still running while it awaits the Agent tool result.
         if status is not None and _is_subagent_hook_record(record):
             _logger.debug(
                 "Skipping subagent hook status; session=%s event=%s status=%s transcript=%s",
@@ -2726,14 +2719,12 @@ async def _forward_available_status_events(
                 client,
                 session_id=session_id,
                 status=effective_status,
-                response_id=response_id,
+                response_id=None if status == "running" else response_id,
                 # Only the ``Stop`` (idle/waiting) edge carries an authoritative
                 # background-shell count — ``0`` clears the tally, ``N`` sets it.
-                # ``StopFailure`` (failed) clears it on the server regardless, so
-                # leave its count off the wire.
-                background_task_count=(
-                    None if status == "failed" else record.background_task_count
-                ),
+                # ``UserPromptSubmit`` (running) and ``StopFailure`` (failed)
+                # clear stale tallies on the server without a count.
+                background_task_count=(record.background_task_count if status == "idle" else None),
             )
         except httpx.HTTPError as exc:
             decision = retry_tracker.record_failure(retry_key, exc)
@@ -2908,18 +2899,17 @@ async def _forward_available_items(
     seen_source_ids = list(state.seen_source_ids)
     seen = set(seen_source_ids)
     # NOTE: the old "re-assert running on resumed agent output" hack lived
-    # here. It only existed to paper over the hook model's compaction
-    # blind spot (``Stop`` → idle, then an ``isCompactSummary`` resume that
-    # never fired ``UserPromptSubmit``). PTY-activity status makes it
-    # obsolete: the pane keeps changing through a mid-turn compaction, so
-    # the runner's watcher holds the session ``running`` directly.
+    # here. It only existed to paper over older hook-model blind spots. The
+    # bare session busy state is now owned by ``UserPromptSubmit`` /
+    # ``Stop`` / ``StopFailure`` hooks; this path is only for the id-bearing
+    # streaming lifecycle below.
     #
     # Turn-start edge: the first time we see a turn's response id, publish a
-    # ``running`` status carrying it. The PTY watcher already drives the
-    # running/idle BADGE with a bare (id-less) status; this id-bearing edge is
-    # what lets ap-web open a *streaming* ``activeResponse`` for the turn, so
-    # the forwarded tool-call cards (which carry the same response id) render
-    # LIVE — spinner + elapsed timer — instead of as static completed cards.
+    # ``running`` status carrying it. The ``UserPromptSubmit`` hook already
+    # drives the bare busy badge; this id-bearing edge lets ap-web open a
+    # *streaming* ``activeResponse`` for the turn, so the forwarded tool-call
+    # cards (which carry the same response id) render LIVE — spinner + elapsed
+    # timer — instead of as static completed cards.
     # Deduped on the persistent ``dedupe`` baseline (NOT ``state``): when an
     # assistant item is held across polls for delta ordering, this function
     # early-returns with ``state`` unadvanced, so a ``state``-based guard would

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5805,8 +5805,9 @@ async def _auto_create_claude_terminal(
             session_key="main",
             spec=env_spec,
             parent_os_env=agent_os_env,
-            # Mark this as the claude-native agent terminal so its pane
-            # activity drives the session's PTY-derived working status.
+            # Mark this as the claude-native agent terminal so activity pulses
+            # and required-terminal exits are scoped to the agent pane. Claude
+            # busy state itself is structured-hook-derived.
             resource_role=CLAUDE_NATIVE_TERMINAL_ROLE,
         )
     except Exception:
@@ -7957,12 +7958,10 @@ def create_runner_app(
     # Turn sequencing (SESSION_REARCHITECTURE Step 5 / SESSION_STEERING_MIGRATION Step 1)
     _active_turns: dict[str, asyncio.Task[None] | None] = {}
     # Latest working status per session ("running"/"idle"/...), mirrored from
-    # every session.status edge at the _publish_event chokepoint (so it covers the
-    # PTY watcher's roles AND codex/antigravity/opencode, whose edges are published
-    # directly). The native-pane idle reaper (#1349) reads this as its "currently
-    # working" signal: native turns clear _active_turns right after the prompt is
-    # pasted, so for a long autonomous turn this status is the only reliable
-    # in-memory liveness signal.
+    # every session.status edge at the _publish_event chokepoint. The native-pane
+    # idle reaper (#1349) reads this as its "currently working" signal: native
+    # turns clear _active_turns right after the prompt is pasted, so for a long
+    # autonomous turn this status is the reliable in-memory liveness signal.
     _native_pane_status: dict[str, str] = {}
     _session_message_buffers: dict[str, list[dict[str, Any]]] = {}
     # Per-conversation message-ingest ordering (RUNNER_MESSAGE_INGEST.md
@@ -8057,12 +8056,9 @@ def create_runner_app(
         queue.put_nowait(event)
         # Mirror the latest session.status edge so the native-pane idle reaper
         # (#1349) can tell a pane working autonomously ("running") from an idle
-        # one. This is the single chokepoint every session.status publish flows
-        # through, so it covers BOTH the PTY watcher's roles (via
-        # _publish_session_status) AND codex/antigravity/opencode, whose
-        # running/idle edges are published here directly rather than by the PTY
-        # watcher. Recorded for every session (SDK too); the reaper only consults
-        # it for native panes.
+        # one. This single chokepoint covers pane-derived native roles,
+        # structured native forwarders, and runner-owned statuses. Recorded for
+        # every session (SDK too); the reaper only consults it for native panes.
         if event.get("type") == "session.status":
             _status_value = event.get("status")
             if isinstance(_status_value, str):
@@ -8290,10 +8286,10 @@ def create_runner_app(
     resource_registry.set_terminal_activity_publisher(_publish_terminal_activity)
 
     def _publish_session_status(session_id: str, status: str) -> None:
-        """Publish a PTY-activity-derived ``session.status`` edge.
+        """Publish a pane-activity-derived ``session.status`` edge.
 
-        Invoked on the event loop by the resource registry's claude-native
-        agent-terminal watcher when the pane crosses an activity/idle edge.
+        Invoked on the event loop by the resource registry for native roles
+        whose panes still own running/idle status.
         Emitting the same ``session.status`` shape the runner uses for its
         own turns lets the Omnigent server relay it through the normal status
         path (cache + SSE). The watcher already dedupes to edges, so this
@@ -10477,22 +10473,17 @@ def create_runner_app(
         terminal observer already owns that edge.
 
         Terminal-backed sessions do not all have the same safe edge source.
-        For claude-native, pi-native, and cursor-native, the PTY-activity
-        watcher owns ``running`` and ``idle`` because a runner turn only types
-        into the agent's own pane and ``run_turn`` returns the instant the
-        message is injected — the model turn then runs entirely in the TUI.
-        Publishing the turn-lifecycle ``idle`` here would race ahead of (and
-        clobber) the watcher's ``running``, dropping the web "Working…" spinner
-        the moment the message is sent. For codex-native AND antigravity-native,
-        the runner may publish ``running`` when it accepts
-        a web turn for dispatch, but the native observer owns
-        ``idle`` because the runner's injection task returns as soon as the agent
-        accepts the message, while the user-visible model turn may still be
-        active — for codex-native the Codex app-server forwarder owns ``idle``;
-        for antigravity-native the RPC read driver owns it (the executor's
-        ``SendUserCascadeMessage`` returns as soon as agy accepts the turn, so the
-        runner's ``idle`` would fire ~2s before agy's reasoning/output streams,
-        prematurely completing the response — the double-idle the live e2e found).
+        For claude-native, the structured Claude hook forwarder owns
+        ``running`` and ``idle`` because the runner turn only types into the
+        agent's pane and returns before the visible model turn completes. For
+        pi/cursor/kiro/goose/qwen/kimi/hermes, the pane watcher still owns those
+        edges because those integrations do not have a structured lifecycle
+        forwarder. Publishing the turn-lifecycle ``idle`` here would race ahead
+        of the real native turn completion and clear the web "Working…" spinner
+        too early. For codex-native and antigravity-native, the runner may
+        publish ``running`` when it accepts a web turn for dispatch, but the
+        native observer owns ``idle`` because the injection task returns before
+        the user-visible model turn finishes.
 
         ``failed`` always publishes: a turn-setup error is not observable
         from terminal activity and must surface regardless of harness.
@@ -10608,14 +10599,11 @@ def create_runner_app(
         only forged a ``role:"user"`` bubble the user never sent into the
         AP-side mirror, diverging it from Claude's real transcript.
 
-        Status is intentionally NOT synthesized here. The terminal's PTY
-        activity watcher is the single source of truth: it emits
-        ``session.status: idle`` once the pane quiesces after the Escape,
-        and keeps the session ``running`` if the interrupt didn't actually
-        stop Claude. Emitting ``idle`` here too (as this used to, back when
-        the hook-based status couldn't observe idle-on-Escape) would
-        bypass — and desync — the watcher's running/idle dedupe, and could
-        strand the UI on ``idle`` while Claude kept working.
+        Status is intentionally NOT synthesized here. The Claude hook
+        forwarder is the source of truth: a successful stop should produce a
+        ``Stop`` edge, a failure should produce ``StopFailure``, and a missing
+        hook leaves the session visibly non-idle instead of lying to the web UI
+        that Claude has stopped.
 
         :param conv_id: Session/conversation identifier,
             e.g. ``"conv_abc123"``.
@@ -10652,9 +10640,8 @@ def create_runner_app(
         # No ``_append_cancellation_items``: the synthetic marker is for
         # in-process LLM harnesses only (see docstring). The /events dispatch
         # already keeps native out of ``_interrupted_sessions``.
-        # NB: no synthesized ``session.status: idle`` here — the PTY watcher
-        # emits idle when the pane quiesces after the Escape (and re-asserts
-        # running if the interrupt didn't take). See the docstring.
+        # NB: no synthesized ``session.status: idle`` here — the Claude hook
+        # forwarder owns completion/failure. See the docstring.
         _wake_parent_after_native_interrupt(conv_id)
         return Response(status_code=204)
 
@@ -16287,10 +16274,10 @@ def create_runner_app(
                 cwd_override=cwd_override,
                 sandbox_override=sandbox_override,
                 parent_os_env=agent_os_env,
-                # The bridge-inject path is the ``omnigent claude``
-                # wrapper launching the claude-native agent terminal —
-                # mark it so its pane activity drives the session's
-                # PTY-derived working status.
+                # The bridge-inject path is the ``omnigent claude`` wrapper
+                # launching the claude-native agent terminal. Mark it so
+                # activity pulses and required-terminal exits are scoped to the
+                # agent pane; busy state comes from Claude hooks.
                 resource_role=(CLAUDE_NATIVE_TERMINAL_ROLE if bridge_inject else None),
             )
         except RuntimeError as exc:

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -72,37 +72,23 @@ OMNIGENT_REPL_TERMINAL_ROLE = "omnigent-repl"
 _IS_ALIVE_CACHE_TTL_S = 2.0
 _IS_ALIVE_CACHE_MAX = 256
 
-# Diff-track idle threshold (seconds) for the claude-native agent
-# terminal's status watcher. Claude Code redraws its busy line every
-# ~200ms while a turn is in progress, so a poll that sees no pane change
-# only happens once Claude has actually stopped — making a short
-# threshold safe against mid-turn false-idle. Kept distinct from the
-# generic terminal-activity watcher's longer default so the session's
-# "Working…" indicator flips to idle promptly (~1s) after Claude stops,
-# matching the responsiveness of the hook-based ``Stop`` edge it
-# replaces.
-_CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS = 1.0
+# Diff-track idle threshold (seconds) for native agent terminals whose working
+# status is still pane-derived. Claude native is deliberately not in that set:
+# its busy state comes from Claude Code hooks instead.
+_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS = 1.0
 
-# Poll interval (seconds) for the claude-native agent terminal's status
-# watcher. Tighter than the generic terminal-activity watcher's 1s so the
-# session's running/idle transitions feel responsive (~200ms) and so a
-# pane change can be attributed to a recent client interaction within a
-# tight window. Applied ONLY to this watcher (gated by the role) so we
-# don't 5x the capture-pane subprocess load on every terminal.
-_CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS = 0.2
+# Poll interval (seconds) for native agent terminals whose working status is
+# still pane-derived. Tighter than the generic terminal-activity watcher so
+# their running/idle transitions remain responsive without increasing
+# capture-pane load for ordinary terminals.
+_NATIVE_STATUS_POLL_INTERVAL_SECONDS = 0.2
 
 # Minimum wall-clock interval (seconds) between consecutive
-# ``session.terminal.activity`` emissions for a single terminal. The
-# claude-native agent terminal polls its pane every 200ms
-# (:data:`_CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS`) and Claude redraws
-# its busy line on nearly every poll, so emitting an event on every
-# pane-changed tick would push ~5 activity events/second for the whole
-# turn. The web only needs a pulse inside its 1.5s "active" window
-# (``ACTIVE_OUTPUT_WINDOW_MS`` in ``useTerminalStatuses``) to keep the
-# badge lit, so coalescing to at most one emit per second cuts the event
-# volume ~5x while keeping the badge solid. Generic terminals already poll
-# at 1s, so this throttle is a no-op for them (their own poll spacing
-# already exceeds the threshold).
+# ``session.terminal.activity`` emissions for a single terminal. Some native
+# agent terminals poll their panes faster than ordinary shells; the web only
+# needs a pulse inside its 1.5s "active" window
+# (``ACTIVE_OUTPUT_WINDOW_MS`` in ``useTerminalStatuses``), so coalescing to at
+# most one emit per second avoids redundant traffic while keeping the badge lit.
 _TERMINAL_ACTIVITY_EMIT_MIN_INTERVAL_SECONDS = 1.0
 _TERMINAL_EXIT_OUTPUT_MAX_LINES = 40
 _TERMINAL_EXIT_OUTPUT_MAX_CHARS = 4000
@@ -130,10 +116,10 @@ class TerminalExitEvent:
         specs may contain credentials or other launch-only secrets.
     :param cwd: Working directory used to launch the terminal, if known.
     :param last_output: Last visible pane text captured before exit, if any.
-    :param session_was_idle: Whether the session's last PTY-derived status was
+    :param session_was_idle: Whether the session's last observed status was
         ``idle`` at exit. ``True`` marks a clean shutdown after the turn
-        finished; ``False`` (the default — last seen ``running``, or never
-        observed) keeps a mid-turn crash or boot failure a failure.
+        finished; ``False`` (the default — last seen ``running`` / ``waiting``,
+        or never observed) keeps a mid-turn crash or boot failure a failure.
     """
 
     session_id: str
@@ -285,17 +271,14 @@ class SessionResourceRegistry:
         # Set by the runner via :meth:`set_terminal_activity_publisher`.
         self._terminal_activity_publisher: Callable[[str, str], None] | None = None
         # Optional callback ``(session_id, status) -> None`` invoked (on
-        # the event loop) when the claude-native *agent* terminal's pane
-        # crosses an activity/idle edge, so the runner can emit a
-        # ``session.status`` event. This is the PTY-activity-derived
-        # working status that replaces the hook-based ``UserPromptSubmit``
-        # → running / ``Stop`` → idle bracketing. Set by the runner via
-        # :meth:`set_session_status_publisher`.
+        # the event loop) when a pane-status-owned native terminal crosses an
+        # activity/idle edge, so the runner can emit a ``session.status`` event.
+        # Claude native does not use this path; its busy state is hook-derived.
         self._session_status_publisher: Callable[[str, str], None] | None = None
-        # Latest PTY-derived status (running/idle) per session. Lets
+        # Latest observed status (running/idle/waiting) per session. Lets
         # :meth:`_handle_terminal_exit` tell a clean shutdown (idle) from a
         # mid-turn crash. Written from the watcher thread and the turn-start
-        # hook; all access goes through the ``_*_session_status_memo`` helpers
+        # / external-status hooks; all access goes through the ``_*_session_status_memo`` helpers
         # under ``self._lock``.
         self._last_session_status: dict[str, str] = {}
         # Optional callback invoked on the event loop when a watched terminal
@@ -324,15 +307,15 @@ class SessionResourceRegistry:
         self,
         publisher: Callable[[str, str], None],
     ) -> None:
-        """Install the PTY-activity-derived session-status publisher.
+        """Install the pane-derived session-status publisher.
 
         The runner passes a callback that publishes a ``session.status``
         event onto the session's SSE queue (which the Omnigent server relays
         through its normal status path). It is invoked on the event loop
         (the watcher thread hops via ``loop.call_soon_threadsafe``), so
         the callback itself may use the loop-only ``_publish_event``
-        directly. Only the claude-native agent terminal's watcher calls
-        it — see :meth:`_start_terminal_activity_watcher`.
+        directly. Only native roles that still lack structured lifecycle
+        events call it — see :meth:`_start_terminal_activity_watcher`.
 
         :param publisher: Callable ``(session_id, status) -> None`` where
             *status* is ``"running"`` or ``"idle"``.
@@ -361,22 +344,23 @@ class SessionResourceRegistry:
         self._terminal_exit_publisher = publisher
 
     def _set_session_status_memo(self, session_id: str, status: str) -> None:
-        """Record the session's latest PTY status for exit classification."""
+        """Record the session's latest observed status for exit classification."""
         with self._lock:
             self._last_session_status[session_id] = status
 
     def _take_session_status_memo(self, session_id: str) -> str | None:
-        """Pop and return the session's recorded PTY status (or ``None``)."""
+        """Pop and return the session's recorded status (or ``None``)."""
         with self._lock:
             return self._last_session_status.pop(session_id, None)
 
     def note_session_turn_started(self, session_id: str) -> None:
         """Mark a session as having an in-flight turn.
 
-        Closes the window between a new turn starting and the watcher's first
-        ``running`` edge: without it, a crash in that gap would read the prior
-        turn's stale ``idle`` and be misclassified as a clean shutdown. The
-        watcher flips the memo back to ``idle`` once the turn completes.
+        Closes the window between a new native turn starting and its first
+        structured or pane-derived ``running`` edge: without it, a crash in
+        that gap would read the prior turn's stale ``idle`` and be
+        misclassified as a clean shutdown. The status owner flips the memo back
+        to ``idle`` once the turn completes.
 
         :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
         """
@@ -385,10 +369,10 @@ class SessionResourceRegistry:
     def note_external_session_status(self, session_id: str, status: str) -> None:
         """Record a terminal-observed external status for exit classification.
 
-        Structured native forwarders can know turn completion more reliably than
-        a PTY diff heuristic. Keep the required-terminal exit memo aligned so a
-        terminal that closes after a forwarded ``idle`` edge is treated as a
-        clean shutdown, while ``running`` / ``waiting`` still classify a later
+        Structured native forwarders can know turn completion more reliably
+        than a pane diff heuristic. Keep the required-terminal exit memo aligned
+        so a terminal that closes after a forwarded ``idle`` edge is treated as
+        a clean shutdown, while ``running`` / ``waiting`` still classify a later
         exit as mid-turn.
 
         :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
@@ -955,15 +939,13 @@ class SessionResourceRegistry:
         aligned with the underlying tmux process. No-op when no publisher
         is installed (e.g. embedded/test runners).
 
-        For the claude-native *agent* terminal (``resource_role`` ==
-        :data:`CLAUDE_NATIVE_TERMINAL_ROLE` or
-        :data:`PI_NATIVE_TERMINAL_ROLE`) the same watcher also drives the
-        session's working status: pane activity → ``running`` and a short
-        quiescence → ``idle``, emitted via the session-status publisher.
-        This PTY-derived status catches cases lifecycle hooks can miss
-        because it observes the terminal directly. The status edges are
-        gated to these roles so a side shell's output never flips the
-        session's status.
+        For native agent terminals that still lack a structured lifecycle
+        source, the same watcher also drives the session's working status: pane
+        activity → ``running`` and a short quiescence → ``idle``, emitted via
+        the session-status publisher. Claude native is not status-owned by this
+        watcher; its ``UserPromptSubmit`` / ``Stop`` / ``StopFailure`` hooks own
+        busy state. Status edges are gated to known native roles so a side
+        shell's output never flips the session's status.
 
         :param session_id: Session/conversation identifier.
         :param terminal_name: Terminal name from the agent spec.
@@ -983,10 +965,9 @@ class SessionResourceRegistry:
         # Status edges are derived only from native agent terminals — a
         # generic shell's output must not move the session's working status.
         emit_status = status_publisher is not None and resource_role in {
-            CLAUDE_NATIVE_TERMINAL_ROLE,
             PI_NATIVE_TERMINAL_ROLE,
             # cursor-native has no forwarder/hook (run_turn returns immediately
-            # after the paste), so — like pi/claude — the PTY watcher is its only
+            # after the paste), so — like pi — the PTY watcher is its only
             # status source. Without this the web "Working…" badge never clears.
             CURSOR_NATIVE_TERMINAL_ROLE,
             KIRO_NATIVE_TERMINAL_ROLE,
@@ -999,7 +980,7 @@ class SessionResourceRegistry:
             QWEN_NATIVE_TERMINAL_ROLE,
             # kimi-native also has no forwarder/hook (the injection run_turn
             # returns right after the tmux paste), so the PTY watcher is its
-            # only running/idle status source — same as cursor/pi/claude.
+            # only running/idle status source — same as cursor/pi.
             KIMI_NATIVE_TERMINAL_ROLE,
             # hermes-native injects then returns (its forwarder only mirrors the
             # SQLite transcript, not status), so the PTY watcher is its status
@@ -1013,9 +994,8 @@ class SessionResourceRegistry:
 
         # Last status edge emitted for this terminal, mutated only on the
         # watcher daemon thread (single-threaded), so the running/idle
-        # transition is deduped without a lock. Scoped to this watcher's
-        # lifetime, so a fresh terminal gets a fresh baseline — no stale
-        # cross-launch state to clean up.
+        # transition is deduped without a lock. Unused for Claude native
+        # because Claude status is structured-hook-derived.
         last_status: dict[str, str | None] = {"value": None}
         # Monotonic time of the last activity pulse published for this
         # terminal, mutated only on the watcher daemon thread (so no lock),
@@ -1028,11 +1008,9 @@ class SessionResourceRegistry:
             # Runs on the watcher daemon thread; hop to the loop so the
             # loop-only publishers (queue.put_nowait) are touched safely.
             #
-            # Throttle the activity pulse to one per second: the
-            # claude-native pane changes on nearly every 200ms poll while
-            # Claude works, but the web badge only needs a pulse inside its
-            # 1.5s window — emitting on every tick would push ~5 events/sec
-            # of redundant traffic.
+            # Throttle the activity pulse to one per second: the web badge
+            # only needs a pulse inside its 1.5s window, so emitting on every
+            # changed tick would be redundant traffic.
             if activity_publisher is not None:
                 now = _monotonic()
                 previous = last_activity_emit["value"]
@@ -1042,9 +1020,9 @@ class SessionResourceRegistry:
                 ):
                     last_activity_emit["value"] = now
                     loop.call_soon_threadsafe(activity_publisher, session_id, resource_id)
-            # Pane changed → the agent is working. Coalesce to the
-            # idle→running edge so a continuously-redrawing pane doesn't
-            # re-emit ``running`` every poll.
+            # For pane-status-owned native roles, pane changed → the agent is
+            # working. Coalesce to the idle→running edge so a continuously
+            # redrawing pane doesn't re-emit ``running`` every poll.
             if emit_status and status_publisher is not None and last_status["value"] != "running":
                 last_status["value"] = "running"
                 # Track for exit classification: a pane exit now reads as a crash.
@@ -1097,9 +1075,9 @@ class SessionResourceRegistry:
             return
 
         def _on_idle() -> None:
-            # Pane quiet for the claude-native status threshold → the
-            # agent has stopped. Edge-triggered: re-arms only after new
-            # output mutates the pane (which flips back to ``running``).
+            # Pane quiet for the native status threshold → the agent has
+            # stopped. Edge-triggered: re-arms only after new output mutates
+            # the pane (which flips back to ``running``).
             if status_publisher is not None and last_status["value"] != "idle":
                 last_status["value"] = "idle"
                 # Track for exit classification: a pane exit now reads as clean.
@@ -1108,18 +1086,16 @@ class SessionResourceRegistry:
                 self._set_session_status_memo(session_id, "idle")
                 loop.call_soon_threadsafe(status_publisher, session_id, "idle")
             # Clear the activity throttle so the next working episode emits
-            # its first pulse immediately, keeping the activity badge
-            # aligned with the running-status edge (which also re-fires on
-            # the next pane change) rather than lagging up to a second
-            # behind it.
+            # its first pulse immediately, keeping the activity badge aligned
+            # with the running-status edge rather than lagging up to a second.
             last_activity_emit["value"] = None
 
         instance.start_idle_watcher_thread(
             on_activity=_on_activity,
             on_idle=_on_idle,
             on_exit=_on_exit,
-            idle_threshold_s=_CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS,
-            poll_interval_s=_CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS,
+            idle_threshold_s=_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS,
+            poll_interval_s=_NATIVE_STATUS_POLL_INTERVAL_SECONDS,
             replace=replace,
         )
 
@@ -1265,7 +1241,7 @@ class SessionResourceRegistry:
                 lifecycle = self._terminal_lifecycles.pop((source_session_id, terminal_id), None)
                 if lifecycle is not None:
                     self._terminal_lifecycles[(target_session_id, terminal_id)] = lifecycle
-            # Move the PTY-status memo with the pane so a post-transfer exit is
+            # Move the status memo with the pane so a post-transfer exit is
             # classified against the right session. Don't clobber a status the
             # target already has from its own terminal.
             with self._lock:

--- a/omnigent/terminals/pane_reaper.py
+++ b/omnigent/terminals/pane_reaper.py
@@ -12,10 +12,12 @@ This reaps a single native pane only when it is genuinely unused. "Busy" is the
 disjunction of three signals (any one spares the pane):
 
   * an in-flight runner turn (``has_active_turn``), OR
-  * the pane's PTY watcher currently reports ``running`` — i.e. the vendor CLI is
-    working autonomously *between* runner turns (native turns clear the runner's
-    ``_active_turns`` right after the prompt is pasted, so this is the load-bearing
-    signal for a long autonomous turn), OR
+  * the latest ``session.status`` is ``running`` / ``waiting`` — i.e. the vendor
+    CLI is working autonomously *between* runner turns (native turns clear the
+    runner's ``_active_turns`` right after the prompt is pasted, so this is the
+    load-bearing signal for a long autonomous turn; for Claude native the signal
+    comes from hooks, while some other native harnesses still use pane activity),
+    OR
   * a tmux client is attached (a human is watching the pane).
 
 A pane idle on all three for longer than the window is reaped, with a **second

--- a/tests/e2e/test_host_claude_native_e2e.py
+++ b/tests/e2e/test_host_claude_native_e2e.py
@@ -11,8 +11,8 @@ Code's input box mounts several seconds later, and Claude flushes any
 pending terminal input when its TUI initializes. So a first message
 typed into that gap is silently dropped — the UI shows "Working…"
 forever and nothing is persisted. ``inject_user_message`` now waits for
-Claude's input prompt to render before typing (see
-``omnigent.claude_native_bridge._wait_for_claude_prompt_ready``).
+Claude's parent ``SessionStart`` hook before typing, which is the structured
+startup signal that the interactive session and transcript are available.
 
 Making the race deterministic
 -----------------------------
@@ -27,7 +27,7 @@ wrapper (first on ``PATH``) that:
    exec'ing the real ``claude`` — faithfully modeling Claude Code's
    own boot-time input flush, which is what discards early keystrokes.
 
-With the wrapper, a pre-prompt inject is reliably lost: **gate absent →
+With the wrapper, a pre-session-start inject is reliably lost: **gate absent →
 this test fails (marker never answered); gate present → it passes.**
 Verified red→green by toggling the gate.
 

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -4237,9 +4237,8 @@ async def test_create_session_preserves_existing_event_queue() -> None:
     queue, orphaning the relay on the now-dead object: ``_publish_event``
     then enqueued onto the new queue while the relay's generator blocked
     forever on the old one, so later events never reached the server. For
-    claude-native that dropped the PTY-watcher ``idle`` edge (emitted
-    asynchronously after the turn), stranding the session's web status at
-    "working". Init must PRESERVE an existing queue — assert the
+    claude-native that dropped forwarded lifecycle status, stranding the
+    session's web status at "working". Init must PRESERVE an existing queue — assert the
     pre-attached queue object survives init unchanged.
     """
     from omnigent.runner.app import _session_event_queues_ref
@@ -8800,18 +8799,15 @@ async def test_events_interrupt_on_native_session_injects_escape_without_marker(
     )
 
     # 3) The interrupt handler must NOT synthesize session.status: idle.
-    # Idle on interrupt now comes from the terminal's PTY activity watcher
-    # (it sees the pane quiesce after the Escape) — the single source of
-    # truth, which also keeps the session ``running`` if the interrupt
-    # didn't take. Synthesizing idle here would bypass the watcher's
-    # running/idle dedupe and could strand the UI on idle. This guards
-    # against re-adding the pre-PTY synthesized idle.
+    # Claude's hook forwarder owns completion/failure. If the interrupt
+    # succeeds, Claude should emit Stop; if it does not, keeping the session
+    # non-idle is more accurate than lying to the UI.
     status_idle = [
         e for e in queued_events if e.get("type") == "session.status" and e.get("status") == "idle"
     ]
     assert status_idle == [], (
         f"The native interrupt handler must not enqueue session.status: idle "
-        f"(the PTY watcher emits it on quiesce); got {status_idle!r} on the "
+        f"(the hook forwarder owns completion); got {status_idle!r} on the "
         f"queue: {queued_events!r}."
     )
 
@@ -8819,9 +8815,8 @@ async def test_events_interrupt_on_native_session_injects_escape_without_marker(
 @pytest.mark.parametrize(
     ("harness", "expected_statuses"),
     [
-        # claude-native's working status is owned by the PTY-activity
-        # watcher, so the runner injection task must not publish its
-        # own running/idle edges.
+        # claude-native's working status is owned by Claude hook events, so the
+        # runner injection task must not publish its own running/idle edges.
         ("claude-native", []),
         # codex-native may use the runner's running edge so the thread
         # shows work as soon as Omnigent accepts the turn, but must not use the
@@ -8874,7 +8869,7 @@ async def test_message_turn_lifecycle_status_suppressed_for_terminal_backed_harn
         # executor.type="omnigent" + config.harness=<harness> is the
         # canonical shape the runner reads at session start to populate
         # _session_spec_cache; _session_harness_name reads it back to
-        # decide whether a PTY watcher owns this session's status.
+        # decide whether an external native source owns this session's status.
         executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
     )
     stream_finished = asyncio.Event()
@@ -8942,7 +8937,7 @@ async def test_message_turn_lifecycle_status_suppressed_for_terminal_backed_harn
     assert statuses == expected_statuses, (
         f"harness={harness}: expected runner turn lifecycle statuses "
         f"{expected_statuses!r}, got {statuses!r}. Claude-native must rely "
-        f"fully on the PTY watcher, Codex-native must keep only the runner "
+        f"fully on Claude hooks, Codex-native must keep only the runner "
         f"running edge, and non-terminal harnesses must keep the full runner "
         f"lifecycle source."
     )

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -16,8 +16,8 @@ from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpe
 from omnigent.inner.os_env import EditEntry, OpResult, OSEnvironment
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner.resource_registry import (
-    CLAUDE_NATIVE_TERMINAL_ROLE,
     CODEX_NATIVE_TERMINAL_ROLE,
+    PI_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
     TerminalExitEvent,
     TerminalLifecycle,
@@ -391,7 +391,7 @@ async def _observe_native_agent_terminal_and_capture(
         instance.name,  # type: ignore[attr-defined]
         instance.session_key,  # type: ignore[attr-defined]
         instance,
-        resource_role=CLAUDE_NATIVE_TERMINAL_ROLE,
+        resource_role=PI_NATIVE_TERMINAL_ROLE,
     )
     return callbacks
 
@@ -400,7 +400,7 @@ async def _observe_native_agent_terminal_and_capture(
 async def test_required_terminal_exit_while_idle_is_clean_shutdown(tmp_path: Path) -> None:
     """A required terminal that exits after going idle is not a failure.
 
-    The native agent terminal is long-lived: it goes ``idle`` when its turn
+    A pane-status native agent terminal is long-lived: it goes ``idle`` when its turn
     finishes. A pane exit observed while idle means the work was already
     delivered and the process simply shut down, so the exit event must carry
     ``session_was_idle=True`` — the runner uses that to avoid flipping the chat

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -30,10 +30,11 @@ from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner import create_runner_app
 from omnigent.runner import resource_registry as resource_registry_mod
 from omnigent.runner.resource_registry import (
-    _CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS,
-    _CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS,
+    _NATIVE_STATUS_IDLE_THRESHOLD_SECONDS,
+    _NATIVE_STATUS_POLL_INTERVAL_SECONDS,
     _TERMINAL_ACTIVITY_EMIT_MIN_INTERVAL_SECONDS,
     CLAUDE_NATIVE_TERMINAL_ROLE,
+    PI_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
 )
 from omnigent.spec.types import AgentSpec, ExecutorSpec
@@ -1604,20 +1605,18 @@ def _claude_terminal_spec(tmp_path: Path) -> TerminalEnvSpec:
 
 
 @pytest.mark.asyncio
-async def test_claude_native_terminal_drives_session_status_from_pane_activity(
+async def test_pi_native_terminal_drives_session_status_from_pane_activity(
     tmp_path: Path,
 ) -> None:
-    """The claude-native agent terminal's pane edges drive session status.
+    """Pane-status-owned native terminals still drive session status.
 
-    Launching with ``CLAUDE_NATIVE_TERMINAL_ROLE`` must wire the idle
-    edge (with the short claude-native status threshold) and translate
-    pane activity → ``running`` / quiescence → ``idle``, deduped to the
-    transition so a continuously-redrawing pane doesn't spam ``running``.
-    This is the PTY-activity-derived status that replaces the hook-based
-    ``UserPromptSubmit``/``Stop`` bracketing.
+    Launching a native role that still lacks structured lifecycle hooks must
+    wire the idle edge and translate pane activity → ``running`` / quiescence
+    → ``idle``, deduped to the transition so a continuously redrawing pane
+    doesn't spam ``running``.
     """
     capture = _WatcherCapture()
-    instance = _make_capturing_instance(tmp_path, capture, name="claude", session_key="main")
+    instance = _make_capturing_instance(tmp_path, capture, name="pi", session_key="main")
     registry = SessionResourceRegistry(terminal_registry=_LaunchReturningRegistry(instance))
     status_edges: list[_StatusEdge] = []
     registry.set_terminal_activity_publisher(lambda _sid, _tid: None)
@@ -1627,21 +1626,19 @@ async def test_claude_native_terminal_drives_session_status_from_pane_activity(
 
     await registry.launch_required_terminal(
         session_id="conv_x",
-        terminal_name="claude",
+        terminal_name="pi",
         session_key="main",
         spec=_claude_terminal_spec(tmp_path),
-        resource_role=CLAUDE_NATIVE_TERMINAL_ROLE,
+        resource_role=PI_NATIVE_TERMINAL_ROLE,
     )
 
-    # The agent terminal wires the idle edge with the short status
-    # threshold and the fast (200ms) poll interval; absence here would mean
-    # status never flips to idle (the regression the hook-based path
-    # suffered on interrupts) or transitions lag at the 1s default.
+    # Pane-status-owned native terminals wire the idle edge with the short
+    # native threshold and fast poll interval.
     assert capture.started is True
     assert capture.on_idle is not None
     assert capture.on_activity is not None
-    assert capture.idle_threshold_s == _CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS
-    assert capture.poll_interval_s == _CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS
+    assert capture.idle_threshold_s == _NATIVE_STATUS_IDLE_THRESHOLD_SECONDS
+    assert capture.poll_interval_s == _NATIVE_STATUS_POLL_INTERVAL_SECONDS
 
     # Two pane changes in one working stretch must yield exactly one
     # ``running`` edge — the dedupe holds. A second ``running`` here would
@@ -1665,6 +1662,47 @@ async def test_claude_native_terminal_drives_session_status_from_pane_activity(
     assert [e.status for e in status_edges] == ["running", "idle", "running"]
     # Every edge was published for the launching session, never a stray id.
     assert all(e.session_id == "conv_x" for e in status_edges)
+
+
+@pytest.mark.asyncio
+async def test_claude_native_terminal_activity_does_not_drive_session_status(
+    tmp_path: Path,
+) -> None:
+    """Claude native pane activity emits terminal pulses, not busy status.
+
+    Claude's ``UserPromptSubmit`` / ``Stop`` / ``StopFailure`` hooks own the
+    session busy state. The tmux watcher remains useful for the terminal-active
+    badge and required-terminal exits, but pane changes and quiescence must not
+    publish ``session.status``.
+    """
+    capture = _WatcherCapture()
+    instance = _make_capturing_instance(tmp_path, capture, name="claude", session_key="main")
+    registry = SessionResourceRegistry(terminal_registry=_LaunchReturningRegistry(instance))
+    status_edges: list[_StatusEdge] = []
+    activity_pulses: list[str] = []
+    registry.set_terminal_activity_publisher(lambda _sid, tid: activity_pulses.append(tid))
+    registry.set_session_status_publisher(
+        lambda sid, status: status_edges.append(_StatusEdge(session_id=sid, status=status))
+    )
+
+    await registry.launch_required_terminal(
+        session_id="conv_claude",
+        terminal_name="claude",
+        session_key="main",
+        spec=_claude_terminal_spec(tmp_path),
+        resource_role=CLAUDE_NATIVE_TERMINAL_ROLE,
+    )
+
+    assert capture.started is True
+    assert capture.on_activity is not None
+    assert capture.on_idle is None
+    assert capture.idle_threshold_s is None
+    assert capture.poll_interval_s is None
+
+    capture.on_activity()
+    await asyncio.sleep(0)
+    assert activity_pulses == ["terminal_claude_main"]
+    assert status_edges == []
 
 
 @pytest.mark.asyncio
@@ -1720,15 +1758,12 @@ async def test_terminal_activity_pulses_throttled_to_one_per_second(
 ) -> None:
     """Activity emission is throttled to one pulse per second per terminal.
 
-    The claude-native pane watcher polls every 200ms and Claude redraws
-    its busy line on nearly every poll, so ``_on_activity`` fires ~5x/sec
-    while a turn runs. Without throttling that would push ~5
-    ``session.terminal.activity`` events/second; the watcher must coalesce
-    them to at most one per
-    :data:`_TERMINAL_ACTIVITY_EMIT_MIN_INTERVAL_SECONDS`. A fresh idle
-    edge resets the throttle so the next working episode pulses
-    immediately rather than lagging up to a second behind the
-    running-status edge.
+    Pane-status-owned native watchers can poll faster than the default shell
+    watcher, so ``_on_activity`` may fire several times per second while a turn
+    runs. The watcher must coalesce those into at most one
+    ``session.terminal.activity`` per
+    :data:`_TERMINAL_ACTIVITY_EMIT_MIN_INTERVAL_SECONDS`. A fresh idle edge
+    resets the throttle so the next working episode pulses immediately.
 
     A fake monotonic clock makes the throttle window deterministic — the
     real watcher's 200ms poll spacing is replaced by hand-advanced time so
@@ -1744,20 +1779,20 @@ async def test_terminal_activity_pulses_throttled_to_one_per_second(
     monkeypatch.setattr(resource_registry_mod, "_monotonic", lambda: clock["now"])
 
     capture = _WatcherCapture()
-    instance = _make_capturing_instance(tmp_path, capture, name="claude", session_key="main")
+    instance = _make_capturing_instance(tmp_path, capture, name="pi", session_key="main")
     registry = SessionResourceRegistry(terminal_registry=_LaunchReturningRegistry(instance))
     activity_pulses: list[str] = []
     registry.set_terminal_activity_publisher(lambda _sid, tid: activity_pulses.append(tid))
-    # The idle-reset behaviour is only wired for the claude-native role, so
+    # The idle-reset behaviour is only wired for pane-status-owned roles, so
     # the status publisher must be installed to exercise on_idle.
     registry.set_session_status_publisher(lambda _sid, _status: None)
 
     await registry.launch_required_terminal(
         session_id="conv_throttle",
-        terminal_name="claude",
+        terminal_name="pi",
         session_key="main",
         spec=_claude_terminal_spec(tmp_path),
-        resource_role=CLAUDE_NATIVE_TERMINAL_ROLE,
+        resource_role=PI_NATIVE_TERMINAL_ROLE,
     )
     assert capture.on_activity is not None
     assert capture.on_idle is not None
@@ -1809,7 +1844,7 @@ async def test_terminal_activity_pulses_throttled_to_one_per_second(
         f"activity throttle, so a new episode lags behind the status edge."
     )
     # Every pulse carried this terminal's resource id, never a stray one.
-    assert set(activity_pulses) == {"terminal_claude_main"}
+    assert set(activity_pulses) == {"terminal_pi_main"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -22,7 +22,6 @@ import pytest
 
 from omnigent import claude_native_bridge, native_cost_popup
 from omnigent.claude_native_bridge import (
-    _claude_prompt_rendered,
     _hook_record_from_jsonl_record,
     _JsonlRecord,
     augment_claude_args,
@@ -35,6 +34,7 @@ from omnigent.claude_native_bridge import (
     post_tools_changed,
     prepare_bridge_dir,
     read_assistant_text_since,
+    read_claude_input_state,
     read_hook_events_from_offset,
     read_launch_model,
     read_message_deltas_from_offset,
@@ -73,12 +73,27 @@ def subprocess_bridge_root() -> Iterator[Path]:
         ``python -m omnigent.claude_native_bridge`` accepts bridge
         writes without inheriting pytest monkeypatches.
     """
-    production_root = Path("/tmp") / f"omnigent-{os.getuid()}" / "claude-native"
+    production_root = (
+        Path(tempfile.gettempdir())
+        / f"omnigent-{claude_native_bridge.stable_user_id()}"
+        / "claude-native"
+    )
     production_root.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(production_root.parent, 0o700)
     os.chmod(production_root, 0o700)
     with tempfile.TemporaryDirectory(prefix="bridge-test-", dir=production_root) as raw:
         yield Path(raw)
+
+
+def _subprocess_trusted_parent(subprocess_bridge_root: Path) -> Path:
+    """
+    Return the trusted parent used by a child bridge process.
+
+    :param subprocess_bridge_root: Test root under
+        ``$TMPDIR/omnigent-<uid>/claude-native``.
+    :returns: The child process's default ``tempfile.gettempdir()`` root.
+    """
+    return subprocess_bridge_root.parents[2]
 
 
 class _NoPrefixReadFile:
@@ -2307,7 +2322,10 @@ def test_mcp_server_initialize_omits_blocked_channel_capability(
     Code would refuse to start with that capability advertised under
     org policy, breaking the native wrapper.
     """
-    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", Path("/tmp"))
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._TRUSTED_PARENT",
+        _subprocess_trusted_parent(subprocess_bridge_root),
+    )
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", subprocess_bridge_root)
     bridge_dir = prepare_bridge_dir("conv_abc", workspace=tmp_path)
     proc = subprocess.Popen(
@@ -2382,6 +2400,77 @@ def test_write_tmux_target_persists_socket_and_target(tmp_path: Path) -> None:
     assert payload["tmux_target"] == "claude:0.0"
     assert payload["pid"] == 12345
     assert before <= payload["updated_at"] <= after
+    input_state = read_claude_input_state(bridge_dir)
+    assert input_state.state == "waiting_for_session_start"
+    assert input_state.details["tmux_target"] == "claude:0.0"
+    assert input_state.details["pid"] == 12345
+
+
+def test_parent_hooks_update_claude_input_state(tmp_path: Path) -> None:
+    """
+    Parent Claude hooks move the bridge input state; subagent hooks do not.
+    """
+    bridge_dir = tmp_path / "bridge"
+    parent_transcript = tmp_path / "session.jsonl"
+    subagent_transcript = tmp_path / "subagents" / "agent-abc.jsonl"
+
+    assert read_claude_input_state(bridge_dir).state == "not_advertised"
+
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "parent-session",
+            "transcript_path": str(parent_transcript),
+        },
+    )
+    input_state = read_claude_input_state(bridge_dir)
+    assert input_state.state == "session_started"
+    assert input_state.details["claude_session_id"] == "parent-session"
+
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "Stop",
+            "session_id": "subagent-session",
+            "transcript_path": str(subagent_transcript),
+        },
+    )
+    assert read_claude_input_state(bridge_dir).state == "session_started"
+
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "parent-session",
+            "transcript_path": str(parent_transcript),
+            "prompt_id": "prompt-1",
+            "prompt": "hello",
+        },
+    )
+    input_state = read_claude_input_state(bridge_dir)
+    assert input_state.state == "turn_running"
+    assert input_state.details["prompt_id"] == "prompt-1"
+
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "Stop",
+            "session_id": "parent-session",
+            "transcript_path": str(parent_transcript),
+        },
+    )
+    assert read_claude_input_state(bridge_dir).state == "ready_after_stop"
+
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "StopFailure",
+            "session_id": "parent-session",
+            "transcript_path": str(parent_transcript),
+        },
+    )
+    assert read_claude_input_state(bridge_dir).state == "failed"
 
 
 @pytest.mark.parametrize(
@@ -2431,47 +2520,50 @@ def test_inject_user_message_pastes_content_then_submits(
         socket_path=Path("/tmp/example/tmux.sock"),
         tmux_target="claude:0.0",
     )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(tmp_path / "session.jsonl"),
+        },
+    )
 
     captured: list[list[str]] = []
     loaded_payloads: list[bytes] = []
-    # Simulates Claude Code's input-box state machine: empty before the
-    # paste, draft (collapsed-paste placeholder) after the paste, empty
-    # again once Enter submits. The paste-committed and submit-verified
-    # gates both poll capture-pane, so a static pane would either stall
-    # the paste gate (draft never appears) or fail verification.
-    tui = {"pane": "❯ "}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         """
-        Record tmux calls; simulate the TUI's input-box state.
+        Record tmux calls and emit Claude's submit hook on Enter.
 
-        ``capture-pane`` calls (the readiness / paste-committed /
-        submit-verified polls) return the current simulated pane and
-        are not recorded — the assertions below count only the
-        delivery invocations. ``load-buffer`` calls read the temp
-        file's bytes at call time (the harness unlinks it after the
-        paste, so asserting later would race the cleanup).
-        ``paste-buffer`` puts the draft into the simulated input box;
-        ``Enter`` clears it (submit).
+        ``load-buffer`` calls read the temp file's bytes at call time
+        (the harness unlinks it after the paste, so asserting later
+        would race the cleanup). ``Enter`` appends the structured
+        ``UserPromptSubmit`` acknowledgement that the bridge now waits for.
 
         :param cmd: Argv list passed to subprocess.run.
         :param kwargs: Subprocess kwargs (capture_output, text, etc.).
         :returns: A fake CompletedProcess with rc=0.
         """
         del kwargs
-        if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
         if "load-buffer" in cmd:
             loaded_payloads.append(Path(cmd[-1]).read_bytes())
-        if "paste-buffer" in cmd:
-            tui["pane"] = "❯ [Pasted text #1 +2 lines]"
         if cmd[-1] == "Enter":
-            tui["pane"] = "❯ "
+            record_hook_event(
+                bridge_dir,
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "session_id": "claude-session",
+                    "transcript_path": str(tmp_path / "session.jsonl"),
+                    "prompt_id": "prompt-1",
+                    "prompt": content,
+                },
+            )
         captured.append(cmd)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    inject_user_message(bridge_dir, content=content)
+    ack = inject_user_message(bridge_dir, content=content)
 
     # C-a, C-k (clear), load-buffer, paste-buffer, Enter — fewer than 5
     # means a delivery step was dropped.
@@ -2516,6 +2608,13 @@ def test_inject_user_message_pastes_content_then_submits(
         "claude:0.0",
         "Enter",
     ]
+    assert ack.prompt_id == "prompt-1"
+    assert ack.ack_source == "hook"
+    assert not ack.queued
+    input_state = read_claude_input_state(bridge_dir)
+    assert input_state.state == "accepted"
+    assert input_state.details["ack_source"] == "hook"
+    assert input_state.details["prompt_id"] == "prompt-1"
 
 
 def test_inject_user_message_raises_when_tmux_target_never_published(
@@ -2531,6 +2630,9 @@ def test_inject_user_message_raises_when_tmux_target_never_published(
     """
     with pytest.raises(RuntimeError, match="tmux target is not advertised"):
         inject_user_message(tmp_path / "bridge", content="hi", timeout_s=0.0)
+    input_state = read_claude_input_state(tmp_path / "bridge")
+    assert input_state.state == "failed"
+    assert input_state.details["phase"] == "waiting_for_tmux"
 
 
 def test_inject_user_message_raises_on_tmux_failure(
@@ -2550,24 +2652,27 @@ def test_inject_user_message_raises_on_tmux_failure(
         socket_path=Path("/tmp/example/tmux.sock"),
         tmux_target="claude:0.0",
     )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(tmp_path / "session.jsonl"),
+        },
+    )
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         """
-        Pass the readiness gate, then fail the send-keys call.
+        Fail the first tmux delivery command.
 
-        ``capture-pane`` returns a ready pane (rc=0) so the test
-        exercises the send-keys failure path specifically, not the
-        readiness timeout. All other tmux calls return rc=1 to
-        simulate a dead tmux server.
+        The test pre-records ``SessionStart`` so it exercises the
+        tmux failure path specifically, not the readiness timeout.
 
         :param cmd: Argv list passed to subprocess.run.
         :param kwargs: Subprocess kwargs (ignored).
-        :returns: A fake CompletedProcess (rc=0 for capture-pane,
-            rc=1 otherwise).
+        :returns: A fake non-zero CompletedProcess.
         """
         del kwargs
-        if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout="❯ ", stderr="")
         return SimpleNamespace(
             returncode=1,
             stdout="",
@@ -2579,177 +2684,261 @@ def test_inject_user_message_raises_on_tmux_failure(
         inject_user_message(bridge_dir, content="hi")
 
 
-def test_inject_user_message_waits_for_claude_prompt_before_typing(
+def test_inject_user_message_waits_for_session_start_before_typing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Injection polls for Claude's prompt before sending any keystrokes.
+    Injection waits for Claude's structured SessionStart before typing.
 
     On a freshly-created session ``tmux.json`` is advertised before
-    Claude Code's input box mounts. If we typed immediately the first
-    message would be dropped into the still-booting TUI. This pins that
-    no send-keys is issued until ``capture-pane`` shows the prompt
-    glyph, and that injection proceeds once it does.
+    Claude Code is ready. If we typed immediately the first message
+    could be dropped into the still-booting TUI. This pins that no
+    tmux command is issued until the parent ``SessionStart`` hook is
+    recorded.
     """
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
     bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
     write_tmux_target(
         bridge_dir,
         socket_path=Path("/tmp/example/tmux.sock"),
         tmux_target="claude:0.0",
     )
 
-    send_keys: list[list[str]] = []
-    # Prompt is absent for the first two polls (TUI still booting),
-    # then renders. A wrong gate would send keys during the empty
-    # polls; a correct gate waits for the third capture. After boot the
-    # fake behaves like the live input box: the paste deposits the
-    # draft, Enter clears it (so the submit-verification gate passes).
-    boot_panes = ["", "", "❯ "]
-    capture_calls = {"n": 0}
-    tui = {"pane": "❯ "}
+    captured: list[list[str]] = []
+
+    def _emit_session_start() -> None:
+        time.sleep(0.05)
+        record_hook_event(
+            bridge_dir,
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": "claude-session",
+                "transcript_path": str(transcript_path),
+            },
+        )
+
+    thread = threading.Thread(target=_emit_session_start)
+    thread.start()
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         """
-        Serve a not-ready-then-ready pane; record send-keys calls.
+        Record tmux calls after the structured readiness gate opens.
 
         :param cmd: Argv list passed to subprocess.run.
         :param kwargs: Subprocess kwargs (ignored).
-        :returns: Fake CompletedProcess; capture-pane returns the next
-            boot pane until the prompt renders, then the simulated
-            input-box state; send-keys returns rc=0.
+        :returns: Fake CompletedProcess with rc=0.
         """
         del kwargs
-        if "capture-pane" in cmd:
-            idx = min(capture_calls["n"], len(boot_panes) - 1)
-            capture_calls["n"] += 1
-            # No keystrokes may have been sent before the prompt shows.
-            if boot_panes[idx] == "":
-                assert send_keys == [], "typed before Claude prompt rendered"
-                return SimpleNamespace(returncode=0, stdout="", stderr="")
-            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
-        if "paste-buffer" in cmd:
-            tui["pane"] = "❯ hello"
+        assert claude_native_bridge.read_claude_session_id(bridge_dir) == "claude-session"
         if cmd[-1] == "Enter":
-            tui["pane"] = "❯ "
-        send_keys.append(cmd)
+            record_hook_event(
+                bridge_dir,
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "session_id": "claude-session",
+                    "transcript_path": str(transcript_path),
+                    "prompt_id": "prompt-1",
+                    "prompt": "hello",
+                },
+            )
+        captured.append(cmd)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    inject_user_message(bridge_dir, content="hello")
+    try:
+        inject_user_message(bridge_dir, content="hello", timeout_s=1.0)
+    finally:
+        thread.join(timeout=1.0)
 
-    # Gate polled until the third capture (prompt present), then the
-    # five delivery calls (C-a, C-k, load-buffer, paste-buffer, Enter)
-    # fired.
-    assert capture_calls["n"] >= 3, (
-        f"Expected >=3 capture-pane polls before the prompt rendered, got {capture_calls['n']}."
+    assert len(captured) == 5, (
+        f"Expected 5 tmux calls (C-a, C-k, load-buffer, paste-buffer, Enter), got {len(captured)}."
     )
-    assert len(send_keys) == 5, (
-        f"Expected 5 tmux calls (C-a, C-k, load-buffer, paste-buffer, Enter), "
-        f"got {len(send_keys)}."
-    )
-    clear_home, clear_kill, load, paste, submit = send_keys
+    clear_home, clear_kill, load, paste, submit = captured
     assert clear_home[-1] == "C-a"
     assert clear_kill[-1] == "C-k"
-    # The paste fires after the gate via the buffer path. The exact
-    # payload/flag assertions live in the dedicated paste test; here the
-    # gate ordering is the claim.
     assert load[3] == "load-buffer"
     assert paste[3] == "paste-buffer"
     assert submit[-1] == "Enter"
 
 
-def test_inject_user_message_raises_when_prompt_never_renders(
+def test_inject_user_message_ignores_subagent_state_for_readiness(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Injection fails loud if Claude's prompt never renders (boot failed).
+    A subagent transcript in bridge state is not parent-session readiness.
+
+    Claude subagent hooks carry their own transcript path. If that path
+    is the most recent bridge state, injection must still wait for a
+    parent ``SessionStart`` instead of typing into the terminal early.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
+    bridge_dir = tmp_path / "bridge"
+    parent_transcript_path = tmp_path / "session.jsonl"
+    subagent_transcript_path = tmp_path / "subagents" / "agent-abc.jsonl"
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path("/tmp/example/tmux.sock"),
+        tmux_target="claude:0.0",
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "Stop",
+            "session_id": "subagent-session",
+            "transcript_path": str(subagent_transcript_path),
+        },
+    )
+
+    captured: list[list[str]] = []
+
+    def _emit_parent_session_start() -> None:
+        time.sleep(0.05)
+        record_hook_event(
+            bridge_dir,
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": "parent-session",
+                "transcript_path": str(parent_transcript_path),
+            },
+        )
+
+    thread = threading.Thread(target=_emit_parent_session_start)
+    thread.start()
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        """
+        Record tmux calls only after parent readiness is observed.
+
+        :param cmd: Argv list passed to subprocess.run.
+        :param kwargs: Subprocess kwargs (ignored).
+        :returns: Fake CompletedProcess with rc=0.
+        """
+        del kwargs
+        assert claude_native_bridge.read_claude_session_id(bridge_dir) == "parent-session"
+        if cmd[-1] == "Enter":
+            record_hook_event(
+                bridge_dir,
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "session_id": "parent-session",
+                    "transcript_path": str(parent_transcript_path),
+                    "prompt_id": "prompt-1",
+                    "prompt": "hello",
+                },
+            )
+        captured.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    try:
+        inject_user_message(bridge_dir, content="hello", timeout_s=1.0)
+    finally:
+        thread.join(timeout=1.0)
+
+    assert captured[-1][-1] == "Enter"
+
+
+def test_inject_user_message_raises_when_session_start_never_arrives(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Injection fails loud if Claude never reports SessionStart.
 
     Without this the turn would complete with the message dropped and
     the web UI stuck on "Working…". The RuntimeError surfaces as an
-    ExecutorError instead. No keystrokes must be sent on this path.
+    ExecutorError instead. No tmux delivery command must be sent on
+    this path.
     """
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(
         bridge_dir,
         socket_path=Path("/tmp/example/tmux.sock"),
         tmux_target="claude:0.0",
     )
-    send_keys: list[list[str]] = []
+    captured: list[list[str]] = []
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
-        """
-        Always report an empty (never-ready) pane.
-
-        :param cmd: Argv list passed to subprocess.run.
-        :param kwargs: Subprocess kwargs (ignored).
-        :returns: Fake CompletedProcess; capture-pane returns "".
-        """
+        """Record unexpected tmux invocations."""
         del kwargs
         if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
-        send_keys.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="Do you want to continue?", stderr="")
+        captured.append(cmd)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    with pytest.raises(RuntimeError, match="did not become ready"):
+    with pytest.raises(RuntimeError, match="SessionStart"):
         inject_user_message(bridge_dir, content="hi", timeout_s=0.3)
-    assert send_keys == [], "no keystrokes should be sent when the prompt never renders"
+    assert captured == [], "no tmux delivery commands should be sent before SessionStart"
+    input_state = read_claude_input_state(bridge_dir)
+    assert input_state.state == "attention_required"
+    assert input_state.details["phase"] == "waiting_for_session_start"
+    assert "Do you want to continue?" in input_state.details["terminal_tail"]
 
 
-def test_inject_user_message_ignores_prompt_glyph_in_scrollback(
+def test_inject_user_message_does_not_capture_pane_on_success(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    The readiness gate only trusts the prompt glyph in the pane tail.
+    Successful delivery does not inspect screen glyphs.
 
-    Claude echoes prior user input (which may contain ``❯``) into
-    scrollback. If the gate matched anywhere in the pane it would
-    falsely pass while the live input box is still booting. Here ``❯``
-    appears only in an early line, with later non-empty lines lacking
-    it, so the gate must NOT treat the pane as ready.
+    The bridge should rely on hooks/transcript for readiness and ack.
+    ``capture-pane`` remains available only for diagnostics after a
+    failed delivery.
     """
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
     write_tmux_target(
         bridge_dir,
         socket_path=Path("/tmp/example/tmux.sock"),
         tmux_target="claude:0.0",
     )
-    # `❯` only on an early line; the last several non-empty lines (the
-    # tail the gate scans) do not contain it.
-    scrollback = "\n".join(
-        [
-            "❯ old prompt echo",
-            "output line 1",
-            "output line 2",
-            "output line 3",
-            "output line 4",
-            "output line 5",
-        ]
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
     )
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         """
-        Return a pane with the glyph only in scrollback.
+        Fail if screen capture is used, otherwise emit submit ack.
 
         :param cmd: Argv list passed to subprocess.run.
         :param kwargs: Subprocess kwargs (ignored).
-        :returns: Fake CompletedProcess; capture-pane returns the
-            scrollback pane.
+        :returns: Fake CompletedProcess with rc=0.
         """
         del kwargs
         if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout=scrollback, stderr="")
+            raise AssertionError("inject_user_message must not capture the pane on success")
+        if cmd[-1] == "Enter":
+            record_hook_event(
+                bridge_dir,
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "session_id": "claude-session",
+                    "transcript_path": str(transcript_path),
+                    "prompt_id": "prompt-1",
+                    "prompt": "hi",
+                },
+            )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    with pytest.raises(RuntimeError, match="did not become ready"):
-        inject_user_message(bridge_dir, content="hi", timeout_s=0.3)
+    ack = inject_user_message(bridge_dir, content="hi")
+
+    assert ack.ack_source == "hook"
 
 
 def test_inject_user_message_resends_enter_when_first_submit_swallowed(
@@ -2757,118 +2946,250 @@ def test_inject_user_message_resends_enter_when_first_submit_swallowed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A submit Enter swallowed by the TUI's paste burst is retried.
+    A submit Enter with no structured acknowledgement is retried once.
 
     Claude Code coalesces rapid stdin bursts into a paste; an Enter
     that lands inside that window becomes a newline in the draft
-    instead of a submit, and the message sits unsent — the "typed but
-    never sent" bug. The helper must observe (via capture-pane) that
-    the draft is still in the input box after Enter and re-send Enter
-    until it clears. Here the fake TUI swallows the first Enter
-    (draft stays put) and submits on the second; a regression to
-    fire-and-forget Enter would send exactly one and return "success"
-    with the message undelivered.
+    instead of a submit, and the message sits unsent. The bridge now
+    detects that by absence of ``UserPromptSubmit``/transcript ack and
+    sends one delayed Enter retry.
     """
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
-    # Shrink the polling cadence so the retry happens in milliseconds —
-    # the production defaults (1s retry spacing) would make this test slow.
     monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
-    monkeypatch.setattr("omnigent.claude_native_bridge._SUBMIT_RETRY_INTERVAL_S", 0.02)
+    monkeypatch.setattr("omnigent.claude_native_bridge._DELIVERY_ENTER_RETRY_AFTER_S", 0.02)
+    monkeypatch.setattr("omnigent.claude_native_bridge._DELIVERY_ACK_TIMEOUT_S", 0.3)
     monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_SETTLE_S", 0.0)
     bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
     write_tmux_target(
         bridge_dir,
         socket_path=Path("/tmp/example/tmux.sock"),
         tmux_target="claude:0.0",
     )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
+    )
 
     enters: list[list[str]] = []
-    # Input-box state machine: the paste deposits the draft; the FIRST
-    # Enter is swallowed (folded into the paste burst — draft stays);
-    # the second Enter submits and clears the box.
-    tui = {"pane": "❯ ", "swallowed_enters": 0}
+    swallowed = {"done": False}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         """
-        Simulate a TUI that swallows the first submit Enter.
+        Simulate a TUI that only acknowledges the second Enter.
 
         :param cmd: Argv list passed to subprocess.run.
         :param kwargs: Subprocess kwargs (ignored).
-        :returns: Fake CompletedProcess; capture-pane returns the
-            simulated input-box pane, other calls return rc=0.
+        :returns: Fake CompletedProcess with rc=0.
         """
         del kwargs
-        if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
-        if "paste-buffer" in cmd:
-            tui["pane"] = "❯ fix the flaky test"
         if cmd[-1] == "Enter":
             enters.append(cmd)
-            if tui["swallowed_enters"] == 0:
-                tui["swallowed_enters"] = 1  # folded into the paste — draft stays
+            if not swallowed["done"]:
+                swallowed["done"] = True
             else:
-                tui["pane"] = "❯ "  # submitted — input box clears
+                record_hook_event(
+                    bridge_dir,
+                    {
+                        "hook_event_name": "UserPromptSubmit",
+                        "session_id": "claude-session",
+                        "transcript_path": str(transcript_path),
+                        "prompt_id": "prompt-1",
+                        "prompt": "fix the flaky test",
+                    },
+                )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    inject_user_message(bridge_dir, content="fix the flaky test")
+    ack = inject_user_message(bridge_dir, content="fix the flaky test")
 
-    # Exactly two Enters: the swallowed one plus one retry. One means
-    # the verify-retry loop regressed to fire-and-forget (the bug);
-    # three+ means retries keep firing after the draft cleared.
     assert len(enters) == 2, (
         f"Expected the swallowed Enter to be retried exactly once, got {len(enters)} Enter(s)."
     )
+    assert ack.prompt_id == "prompt-1"
 
 
-def test_inject_user_message_raises_when_draft_never_submits(
+def test_inject_user_message_accepts_busy_queue_transcript_ack(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Injection fails loud when the draft never leaves the input box.
+    A busy Claude turn can acknowledge delivery with ``queue-operation``.
 
-    If every submit Enter is swallowed (e.g. the pane is wedged in a
-    dialog), returning success would complete the Omnigent turn with
-    the message still sitting unsent in Claude's input box. The
-    RuntimeError surfaces as an ExecutorError instead.
+    When text is sent while Claude is still working, Claude records the
+    queued prompt in the transcript immediately and delays
+    ``UserPromptSubmit`` until the previous turn stops. The bridge must
+    treat that transcript row as successful queued delivery.
     """
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
-    monkeypatch.setattr("omnigent.claude_native_bridge._SUBMIT_RETRY_INTERVAL_S", 0.02)
-    monkeypatch.setattr("omnigent.claude_native_bridge._SUBMIT_VERIFY_TIMEOUT_S", 0.2)
     monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_SETTLE_S", 0.0)
     bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
     write_tmux_target(
         bridge_dir,
         socket_path=Path("/tmp/example/tmux.sock"),
         tmux_target="claude:0.0",
     )
-
-    tui = {"pane": "❯ "}
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
+    )
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
-        """
-        Simulate a TUI where the draft never submits.
-
-        The paste deposits the draft and every Enter is ignored, so
-        the input box never clears.
-
-        :param cmd: Argv list passed to subprocess.run.
-        :param kwargs: Subprocess kwargs (ignored).
-        :returns: Fake CompletedProcess; capture-pane returns the
-            simulated input-box pane, other calls return rc=0.
-        """
+        """Append the queued transcript row when Enter is sent."""
         del kwargs
-        if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
-        if "paste-buffer" in cmd:
-            tui["pane"] = "❯ fix the flaky test"
+        if cmd[-1] == "Enter":
+            with transcript_path.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            "type": "queue-operation",
+                            "operation": "enqueue",
+                            "content": "steer me",
+                            "sessionId": "claude-session",
+                        }
+                    )
+                    + "\n"
+                )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    with pytest.raises(RuntimeError, match="message was not delivered"):
+    ack = inject_user_message(bridge_dir, content="steer me")
+
+    assert ack.ack_source == "transcript_queue"
+    assert ack.queued
+    assert ack.prompt_id is None
+    input_state = read_claude_input_state(bridge_dir)
+    assert input_state.state == "queued"
+    assert input_state.details["ack_source"] == "transcript_queue"
+    assert input_state.details["queued"] is True
+
+
+def test_inject_user_message_accepts_transcript_user_ack_without_hook(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Transcript user rows are a fallback delivery acknowledgement.
+
+    Hooks are the preferred ack source, but Claude also records accepted
+    prompts in the transcript. If the hook forwarder misses a
+    ``UserPromptSubmit`` line, the exact transcript user row still proves
+    delivery.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_SETTLE_S", 0.0)
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path("/tmp/example/tmux.sock"),
+        tmux_target="claude:0.0",
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
+    )
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        """Append the user transcript row when Enter is sent."""
+        del kwargs
+        if cmd[-1] == "Enter":
+            with transcript_path.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            "type": "user",
+                            "promptId": "prompt-from-transcript",
+                            "sessionId": "claude-session",
+                            "promptSource": "typed",
+                            "message": {"role": "user", "content": "hello"},
+                        }
+                    )
+                    + "\n"
+                )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    ack = inject_user_message(bridge_dir, content="hello")
+
+    assert ack.ack_source == "transcript_user"
+    assert ack.prompt_id == "prompt-from-transcript"
+    assert not ack.queued
+
+
+def test_inject_user_message_raises_when_prompt_never_acknowledged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Injection fails loud when Claude never acknowledges the prompt.
+
+    If both the first Enter and the retry fail to produce a hook or
+    transcript record, returning success would complete the Omnigent
+    turn with no proof that Claude received the message.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr("omnigent.claude_native_bridge._DELIVERY_ENTER_RETRY_AFTER_S", 0.02)
+    monkeypatch.setattr("omnigent.claude_native_bridge._DELIVERY_ACK_TIMEOUT_S", 0.08)
+    monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_SETTLE_S", 0.0)
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path("/tmp/example/tmux.sock"),
+        tmux_target="claude:0.0",
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
+    )
+    enters: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        """
+        Ignore submit Enters and return pane text for failure diagnostics.
+
+        :param cmd: Argv list passed to subprocess.run.
+        :param kwargs: Subprocess kwargs (ignored).
+        :returns: Fake CompletedProcess with rc=0.
+        """
+        del kwargs
+        if "capture-pane" in cmd:
+            return SimpleNamespace(returncode=0, stdout="❯ fix the flaky test", stderr="")
+        if cmd[-1] == "Enter":
+            enters.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    with pytest.raises(RuntimeError, match="did not acknowledge"):
         inject_user_message(bridge_dir, content="fix the flaky test")
+    assert len(enters) == 2
+    input_state = read_claude_input_state(bridge_dir)
+    assert input_state.state == "attention_required"
+    assert input_state.details["phase"] == "awaiting_ack"
+    assert "fix the flaky test" in input_state.details["terminal_tail"]
 
 
 def test_inject_interrupt_sends_escape_keystroke(
@@ -3233,7 +3554,10 @@ async def test_channel_server_relays_active_omnigent_tools(
     This fails if Claude Code can receive web-channel inputs but cannot
     call the Omnigent tools made available to the server-side agent.
     """
-    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", Path("/tmp"))
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._TRUSTED_PARENT",
+        _subprocess_trusted_parent(subprocess_bridge_root),
+    )
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", subprocess_bridge_root)
     bridge_dir = prepare_bridge_dir("conv_tools", workspace=tmp_path)
     proc = subprocess.Popen(
@@ -3440,7 +3764,10 @@ async def test_serve_mcp_survives_handler_exception_and_keeps_serving(
     ``-32000: Connection closed``). Without the guard, the decode error kills
     ``_serve_mcp`` and the ``tools/list`` read below times out.
     """
-    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", Path("/tmp"))
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._TRUSTED_PARENT",
+        _subprocess_trusted_parent(subprocess_bridge_root),
+    )
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", subprocess_bridge_root)
     bridge_dir = prepare_bridge_dir("conv_crash", workspace=tmp_path)
 
@@ -3761,7 +4088,10 @@ async def test_relay_close_keeps_advertisement_owned_by_newer_relay(
     and leave it in place. Unconditional unlinking here would erase the
     still-active newer session's ``list_comments`` / ``update_comment``.
     """
-    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", Path("/tmp"))
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._TRUSTED_PARENT",
+        _subprocess_trusted_parent(subprocess_bridge_root),
+    )
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", subprocess_bridge_root)
     bridge_dir = prepare_bridge_dir("conv_shared_bridge", workspace=tmp_path)
     relay_file = bridge_dir / claude_native_bridge._TOOL_RELAY_FILE
@@ -4892,166 +5222,6 @@ def test_display_cost_approval_popup_raises_when_pane_not_advertised(
         )
 
 
-def test_claude_prompt_rendered_sees_prompt_above_default_footer() -> None:
-    """
-    The readiness scan reaches the prompt glyph above Claude's footer.
-
-    Claude Code 2.1.x renders a footer below the input box (the box's
-    closing rule line, the cwd/status line, the model+effort line, and
-    the permission-mode hint), so the live ``❯`` row is the 5th
-    non-empty line from the bottom — NOT the last. The prior 4-line scan
-    window never reached it and the web-UI readiness gate timed out with
-    "did not become ready" even though the box was mounted. A failure
-    here means the scan window regressed below 5 and the first web
-    message would be dropped.
-    """
-    pane = "\n".join(
-        [
-            "────────────────────────────────────────",  # input box top rule
-            "❯ ",  # the live prompt row (5th non-empty line from bottom)
-            "────────────────────────────────────────",  # box closing rule
-            "  alice: /home/alice/proj   Remote Control failed",  # status line
-            "  Opus 4.8 (1M context) | effort:high",  # model + effort line
-            "  ⏵⏵ don't ask on (shift+tab to cycle) · ← for agents",  # hint line
-        ]
-    )
-    # ``❯`` is 5 non-empty lines above the bottom (rule + status + model
-    # + hint sit below it), so only a scan window of >= 5 reaches it.
-    assert _claude_prompt_rendered(pane) is True
-
-
-def test_claude_prompt_rendered_sees_prompt_above_running_turn_footer() -> None:
-    """
-    The readiness scan reaches the prompt above a tall running-turn footer.
-
-    When a web-UI message is injected while Claude is mid-turn, the footer
-    grows extra status rows below the input box — a running-subagent line
-    (``○ Explore …``) on top of the usual box rule, model, auto-mode, and
-    branch rows. That pushes the live ``❯`` row to the 6th non-empty line
-    from the bottom, one past the old 5-line window, so the readiness gate
-    timed out and the web UI rendered a spurious "did not become ready"
-    runtime-error card even though the terminal was healthy.
-    """
-    pane = "\n".join(
-        [
-            "────────────────────────────────────────",  # input box top rule
-            "❯ ",  # the live prompt row (6th non-empty line from bottom)
-            "────────────────────────────────────────",  # box closing rule
-            "  Opus 4.8 (1M context) | thinking medium",  # model + effort line
-            "  ⏵⏵ auto mode on (shift+tab to cycle)",  # permission-mode hint
-            "  main",  # branch label
-            "  ○ Explore  Find session sidebar state… 1m 4s",  # subagent status
-        ]
-    )
-    assert _claude_prompt_rendered(pane) is True
-
-
-def test_claude_prompt_rendered_sees_prompt_above_subagent_fanout_footer() -> None:
-    """
-    The readiness scan reaches the prompt above an unbounded subagent footer.
-
-    A subagent fan-out renders one ``○ Explore …`` row per concurrent
-    subagent, so the running-turn footer height is unbounded. Here five
-    subagents plus the model/auto-mode/branch rows push the live ``❯`` row
-    to the 12th non-empty line from the bottom — far past any fixed scan
-    window. The box rule below ``❯`` (the input box's closing frame) is
-    what admits it, so the scan must reach the glyph at this depth and the
-    web UI must NOT render a spurious "did not become ready" card.
-    """
-    pane = "\n".join(
-        [
-            "────────────────────────────────────────",  # input box top rule
-            "❯ Press up to edit queued messages",  # the live prompt row
-            "────────────────────────────────────────",  # box closing rule
-            "  Opus 4.8 (1M context) | thinking medium | 398.1k/1M (39%)",
-            "  ⏵⏵ auto mode on (shift+tab to cycle)",
-            "  main",
-            "  ○ Explore  Angle A: line-by-line diff scan   1m 35s",
-            "  ○ Explore  Angle C: cross-file tracer         56s",
-            "  ○ Explore  Angle D: reuse                      46s",
-            "  ○ Explore  Angle F: efficiency                 31s",
-            "  ○ Explore  Angle G: altitude                   21s",
-        ]
-    )
-    assert _claude_prompt_rendered(pane) is True
-
-
-def test_claude_prompt_rendered_ignores_unframed_glyph_deep_in_tail() -> None:
-    """
-    A glyph in the wider window without a box rule below is not trusted.
-
-    The framed window that lets the scan reach a prompt under a tall
-    running-turn footer must not resurrect the scrollback false positive:
-    a ``❯`` echoed into prior output sits in the wider window too, but
-    without the input box's closing ``────`` rule beneath it. Only plain
-    output follows here, so the gate must still report "not ready".
-    """
-    pane = "\n".join(
-        [
-            "❯ old prompt echo",  # 6th non-empty line from bottom, no rule below
-            "output line 1",
-            "output line 2",
-            "output line 3",
-            "output line 4",
-            "output line 5",
-        ]
-    )
-    assert _claude_prompt_rendered(pane) is False
-
-
-def test_claude_prompt_rendered_ignores_custom_api_key_menu() -> None:
-    """The custom-API-key menu's selected row is not the chat input.
-
-    Claude Code's startup "Detected a custom API key" confirmation renders
-    its highlighted choice with the same ``❯`` glyph the chat composer uses
-    (``❯ 2. No (recommended)``). Treating it as ready pastes the first web
-    message into the menu, so no turn starts — the tmux delivery false
-    positive this guards against.
-    """
-    pane = "\n".join(
-        [
-            "Detected a custom API key in your environment",
-            "Do you want to use this API key?",
-            "  1. Yes",
-            "❯ 2. No (recommended)",  # selected menu row, NOT the chat input
-        ]
-    )
-    assert _claude_prompt_rendered(pane) is False
-
-
-def test_claude_prompt_rendered_sees_chat_input_below_menu_glyph() -> None:
-    """A real chat prompt still reads ready even past a menu-shaped echo.
-
-    A numbered ``❯`` choice echoed into scrollback must not suppress the
-    live input box below it: the chat ``❯`` row (no numbered choice after
-    the glyph) is the one that marks readiness.
-    """
-    pane = "\n".join(
-        [
-            "❯ 2. No (recommended)",  # scrollback echo of a prior menu row
-            "output",
-            "────────────────────────────────────────",  # input box top rule
-            "❯ ",  # the live chat prompt
-            "────────────────────────────────────────",  # box closing rule
-            "  Opus 4.8 (1M context) | effort:high",
-        ]
-    )
-    assert _claude_prompt_rendered(pane) is True
-
-
-def test_claude_prompt_rendered_sees_numbered_draft_in_framed_input() -> None:
-    """A numbered composer draft is distinguished from an unframed menu row."""
-    pane = "\n".join(
-        [
-            "────────────────────────────────────────",
-            "❯ 2. buy milk",
-            "────────────────────────────────────────",
-            "  Opus 4.8 (1M context) | effort:high",
-        ]
-    )
-    assert _claude_prompt_rendered(pane) is True
-
-
 def _write_deltas_lines(bridge_dir: Path, lines: list[str]) -> None:
     """
     Append raw JSONL lines to the bridge deltas file.
@@ -5403,120 +5573,6 @@ def test_format_terminal_failure_tail_caps_length(monkeypatch: pytest.MonkeyPatc
     assert body.startswith("…")
     # Leading ellipsis marker plus at most the configured character cap.
     assert len(body) <= 51
-
-
-def test_wait_for_claude_prompt_ready_surfaces_terminal_output_on_timeout(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """
-    On a readiness timeout, the RuntimeError carries Claude Code's own
-    terminal output (e.g. a startup ``JSON Parse error``) so the cause
-    surfaces in the web UI error banner, not only in the terminal.
-
-    Without the tail, the user sees a generic "terminal did not become
-    ready" timeout in the UI while the actual crash sits unread in the
-    terminal pane.
-
-    :param monkeypatch: Pytest monkeypatch fixture.
-    :returns: None.
-    """
-    crash_pane = (
-        "ERROR  JSON Parse error: Unrecognized token '<'\n"
-        "  at <parse> (:0)\n"
-        "  at parse (unknown)\n"
-    )
-    monkeypatch.setattr(
-        "omnigent.claude_native_bridge._capture_pane",
-        lambda socket_path, tmux_target: crash_pane,
-    )
-    with pytest.raises(RuntimeError) as excinfo:
-        claude_native_bridge._wait_for_claude_prompt_ready(
-            "/tmp/example/tmux.sock",
-            "claude:0.0",
-            timeout_s=0.0,
-        )
-    message = str(excinfo.value)
-    assert "did not become ready" in message
-    assert "Last terminal output:" in message
-    assert "JSON Parse error: Unrecognized token '<'" in message
-
-
-def test_wait_for_claude_prompt_ready_reports_empty_capture_count(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """
-    A timeout where every capture came back empty says so in the error.
-
-    An empty ``capture-pane`` (a torn read under a busy mid-turn repaint,
-    not a boot crash) leaves no tail to attach. Without the poll/empty
-    counts the error is indistinguishable from "Claude never rendered a
-    prompt", which is what sent triage down the wrong path. The counts make
-    the two failure modes tell themselves apart.
-
-    :param monkeypatch: Pytest monkeypatch fixture.
-    :returns: None.
-    """
-    monkeypatch.setattr(
-        "omnigent.claude_native_bridge._capture_pane",
-        lambda socket_path, tmux_target: "",
-    )
-    with pytest.raises(RuntimeError) as excinfo:
-        claude_native_bridge._wait_for_claude_prompt_ready(
-            "/tmp/example/tmux.sock",
-            "claude:0.0",
-            timeout_s=0.0,
-        )
-    message = str(excinfo.value)
-    assert "did not become ready" in message
-    # One poll happened (do-while), and it was empty.
-    assert "1 polls, 1 empty captures" in message
-    # No pane text to surface when every capture was empty.
-    assert "Last terminal output:" not in message
-
-
-def test_wait_for_claude_prompt_ready_tail_is_observed_not_recaptured(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """
-    The attached tail is a capture the loop saw, not a post-timeout one.
-
-    The bug this guards: attaching a fresh capture taken *after* the
-    deadline can show a healthier frame (e.g. the input box repainting as
-    the turn settles) than any decision the loop actually made, so the
-    error misrepresents why the gate failed. The tail must come from a
-    capture observed while the loop was still deciding. A box-less capture
-    followed by a box-present one that arrives only after the deadline
-    proves the point: the box-present frame must NOT leak into the error.
-
-    :param monkeypatch: Pytest monkeypatch fixture.
-    :returns: None.
-    """
-    observed = "  ✱ Working…\n  ⏵⏵ auto mode on (shift+tab to cycle)\n"
-    # A frame that would satisfy the readiness check, but only ever returned
-    # after the deadline has passed — mimicking the box repainting late.
-    late_ready = "────────────────\n❯ \n────────────────\n  Opus 4.8\n"
-    calls = {"n": 0}
-
-    def fake_capture(socket_path: str, tmux_target: str) -> str:
-        calls["n"] += 1
-        # First (and only, at timeout_s=0) in-loop capture: no box.
-        # Any later capture would be the box-present frame — which the
-        # rewritten gate must never fetch, since it does not re-capture.
-        return observed if calls["n"] == 1 else late_ready
-
-    monkeypatch.setattr("omnigent.claude_native_bridge._capture_pane", fake_capture)
-    with pytest.raises(RuntimeError) as excinfo:
-        claude_native_bridge._wait_for_claude_prompt_ready(
-            "/tmp/example/tmux.sock",
-            "claude:0.0",
-            timeout_s=0.0,
-        )
-    message = str(excinfo.value)
-    # The tail reflects what the loop observed, and the late box-present
-    # frame never appears — proving no post-deadline re-capture happened.
-    assert "auto mode on" in message
-    assert "❯" not in message
-    assert calls["n"] == 1
 
 
 # ── _hook_record_from_jsonl_record: background_task_count ────────────────────

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -1396,18 +1396,15 @@ async def test_forwarder_posts_web_injected_terminal_transcript_items(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_forwarder_posts_idle_on_stop_and_ignores_user_prompt_submit(
+async def test_forwarder_posts_running_on_user_prompt_submit_and_idle_on_stop(
     tmp_path: Path,
 ) -> None:
     """
-    ``Stop`` → idle (the authoritative turn-end); ``UserPromptSubmit`` ignored.
+    ``UserPromptSubmit`` → running and ``Stop`` → idle.
 
-    ``Stop`` is the fire-once turn-end edge that drives sub-agent terminal
-    delivery (via ``external_session_status``, the codex-shared path). The
-    ``running`` edge stays PTY-derived, so ``UserPromptSubmit`` must NOT post a
-    status. We record ``UserPromptSubmit`` ahead of ``Stop``: the first (and
-    only) ``external_session_status`` POST must be the ``idle`` from ``Stop``.
-    A ``running`` arriving first would mean ``UserPromptSubmit`` still maps.
+    Claude's lifecycle hooks are the busy-state source for claude-native. The
+    prompt hook opens the bare session busy state; the Stop hook closes it and
+    carries the authoritative background-shell count.
     """
     bridge_dir = tmp_path / "bridge"
     transcript_path = tmp_path / "session.jsonl"
@@ -1441,7 +1438,8 @@ async def test_forwarder_posts_idle_on_stop_and_ignores_user_prompt_submit(
         )
     )
     try:
-        request = await _get_recorded_request(server)
+        running = await _get_recorded_request(server)
+        idle = await _get_recorded_request(server)
     finally:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -1450,12 +1448,15 @@ async def test_forwarder_posts_idle_on_stop_and_ignores_user_prompt_submit(
         server.server_close()
         thread.join(timeout=5.0)
 
-    # The first (and only) status POST is the Stop → idle. A ``running``
-    # arriving first would mean UserPromptSubmit is still wrongly mapped.
-    assert request["path"] == "/v1/sessions/conv_abc/events"
+    assert running["path"] == "/v1/sessions/conv_abc/events"
+    assert running["body"] == {
+        "type": "external_session_status",
+        "data": {"status": "running"},
+    }
+    assert idle["path"] == "/v1/sessions/conv_abc/events"
     # The Stop hook carries its authoritative background-shell count (0 here,
     # no background tasks) so a finished shell clears the indicator.
-    assert request["body"] == {
+    assert idle["body"] == {
         "type": "external_session_status",
         "data": {"status": "idle", "background_task_count": 0},
     }
@@ -1474,9 +1475,8 @@ async def test_forwarder_ignores_subagent_stop_failure_hook(
     failed — the parent is still running while it awaits the Agent tool
     result. Subagent transcripts live under a ``subagents/`` directory,
     which the forwarder uses to distinguish them from parent events.
-    (Running/idle are no longer hook-derived; ``StopFailure`` →
-    ``failed`` is the only mapped status left, so this is the surviving
-    subagent-skip case.)
+    All lifecycle hooks are skipped for subagents so parent status is not
+    polluted by child turn edges.
     """
     bridge_dir = tmp_path / "bridge"
     transcript_path = tmp_path / "session.jsonl"
@@ -1776,8 +1776,8 @@ async def test_forwarder_does_not_post_compaction_on_non_compact_session_start(
     are processed in order, a spurious compaction POST would land BEFORE
     the ``StopFailure`` → failed POST, so asserting the first POST is the
     failed status proves the startup SessionStart emitted nothing.
-    (``StopFailure`` is used as the anchor because ``Stop`` no longer
-    posts a status — idle now comes from PTY pane activity.)
+    (``StopFailure`` is used as the anchor because a failed status is easy to
+    distinguish from compaction output.)
     """
     bridge_dir = tmp_path / "bridge"
     transcript_path = tmp_path / "session.jsonl"
@@ -1882,8 +1882,8 @@ async def test_forwarder_uses_auth_to_refresh_token_per_request(tmp_path: Path) 
     # Two assistant transcript items → two external_conversation_item
     # POSTs, which is all this test needs: distinct bearers on two
     # outbound requests. We use transcript items rather than hook status
-    # because running/idle are no longer hook-derived (only
-    # StopFailure→failed remains, a single edge).
+    # because this test only needs transcript item POSTs. A StopFailure hook
+    # would add an unrelated status edge.
     transcript_path.write_text(
         "\n".join(
             [
@@ -2688,8 +2688,8 @@ async def test_forwarder_migrates_hook_cursor_state_to_byte_offset(tmp_path: Pat
     Hook state migration must be per-record: a skipped ``SessionStart``
     and a posted ``StopFailure`` should advance the durable byte offset
     so the next poll does not rescan or repost either record.
-    (``StopFailure`` is the posted-status anchor because ``Stop`` no
-    longer maps to a status — idle now comes from PTY pane activity.)
+    (``StopFailure`` is the posted-status anchor because it produces one
+    status edge with no background-task count.)
     """
     bridge_dir = tmp_path / "bridge"
     transcript_path = tmp_path / "session.jsonl"
@@ -3280,9 +3280,8 @@ async def test_forwarder_mirrors_external_session_id_at_most_once(
         + "\n",
         encoding="utf-8",
     )
-    # ``StopFailure`` (not ``Stop``) so the hook still produces one status
-    # POST — ``Stop`` no longer maps to a status (idle comes from PTY pane
-    # activity). Its ``session_id`` is what the mirror PATCH latches onto;
+    # ``StopFailure`` produces one status POST without a background-task
+    # count. Its ``session_id`` is what the mirror PATCH latches onto;
     # the failed status is the third POST the loop-pump below consumes.
     record_hook_event(
         bridge_dir,
@@ -6765,9 +6764,15 @@ async def test_forward_status_events_stamps_response_id_on_idle(tmp_path: Path) 
     A ``Stop`` → idle edge carries the turn's ``response_id`` when one is known.
 
     This is what closes the streaming ``activeResponse`` ap-web opened from the
-    turn-start ``running`` edge, so the trailing tool card stops spinning.
+    id-bearing assistant-output ``running`` edge, so the trailing tool card
+    stops spinning. The preceding ``UserPromptSubmit`` running edge must remain
+    id-less; it opens only the session-level busy state.
     """
     bridge_dir = tmp_path / "bridge"
+    record_hook_event(
+        bridge_dir,
+        {"hook_event_name": "UserPromptSubmit", "session_id": "claude-session"},
+    )
     record_hook_event(
         bridge_dir,
         {"hook_event_name": "Stop", "session_id": "claude-session"},
@@ -6798,6 +6803,10 @@ async def test_forward_status_events_stamps_response_id_on_idle(tmp_path: Path) 
     assert bodies == [
         {
             "type": "external_session_status",
+            "data": {"status": "running"},
+        },
+        {
+            "type": "external_session_status",
             # The Stop→idle edge carries the turn's response id AND the
             # background-shell tally (0 here — no shells); the live-tool-card
             # and background-task features share this one status edge.
@@ -6806,7 +6815,7 @@ async def test_forward_status_events_stamps_response_id_on_idle(tmp_path: Path) 
                 "background_task_count": 0,
                 "response_id": "resp_turn_1",
             },
-        }
+        },
     ]
 
 
@@ -6815,10 +6824,11 @@ async def test_forwarder_emits_turn_start_running_with_response_id(tmp_path: Pat
     """
     The first assistant output of a turn publishes ``running`` + its response id.
 
-    Native Claude's running/idle BADGE stays PTY-derived; this id-bearing
-    ``running`` edge is the additional signal that lets ap-web open a streaming
-    ``activeResponse`` for the turn, so the forwarded tool cards (which share
-    the same response id) render LIVE rather than as static completed cards.
+    The hook-derived ``UserPromptSubmit`` edge drives the bare busy badge; this
+    id-bearing ``running`` edge is the additional signal that lets ap-web open a
+    streaming ``activeResponse`` for the turn, so the forwarded tool cards
+    (which share the same response id) render LIVE rather than as static
+    completed cards.
     The running edge's response id must equal the forwarded items' response id.
     """
     bridge_dir = tmp_path / "bridge"

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -2429,7 +2429,7 @@ async function bindStream(
         sessionStatus: session.status,
         // Re-show "N background tasks still running" after a reload/navigate-back: the
         // live SSE edge that set this is long gone, so the count rides in on
-        // the snapshot (server keeps it sticky past the trailing PTY `idle`).
+        // the snapshot (server keeps it sticky until a structured clear).
         backgroundTaskCount: session.backgroundTaskCount ?? 0,
         selectedEffort: effectiveEffort,
         selectedModel: effectiveModel,
@@ -4018,19 +4018,14 @@ export function handleSessionEvent(event: StreamEvent): void {
           return {};
         }
         const patch: Partial<ChatState> = { sessionStatus: event.status };
-        // The background-shell tally is STICKY. Only the Stop-hook-derived
-        // status carries an authoritative count (the forwarder relabels its
-        // `idle` to `waiting` and attaches `background_task_count`); the
-        // PTY-activity watcher's running/idle edges carry none (`undefined`).
-        // A claude-native turn that ends with shells still running emits, in
-        // order: the Stop hook's `waiting`(+count), then — ~1s later, once the
-        // pane quiesces — a bare PTY-activity `idle` (no count). If that
-        // trailing `idle` reset the count the spinner would vanish a beat
-        // after it appeared. So: an explicit count is authoritative (a Stop
-        // hook's `0` clears it, so a finished shell drops the indicator on the
-        // next turn end; a positive count sets it); `undefined` leaves it
-        // untouched; and a new turn (`running`) or a failure clears it —
-        // mirroring the server's `_publish_status`.
+        // The background-shell tally is STICKY. Only a structured turn-end
+        // status carries an authoritative count (Claude Stop relabels `idle`
+        // to `waiting` and attaches `background_task_count`). Bare
+        // running/idle edges from native sources carry no count (`undefined`),
+        // so they must not wipe a positive tally. An explicit count is
+        // authoritative (a Stop hook's `0` clears it; a positive count sets
+        // it); `undefined` leaves it untouched; and a new turn (`running`) or
+        // a failure clears it — mirroring the server's `_publish_status`.
         if (event.backgroundTaskCount !== undefined) {
           patch.backgroundTaskCount = event.backgroundTaskCount;
         } else if (event.status === "running" || event.status === "failed") {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace brittle Claude-native screen/glyph readiness with structured startup and delivery gates.
- Add bridge-owned `input_state.json` tracking for startup, delivery, queued prompts, failures, and `attention_required` cases.
- Document public `session.status` separately from internal Claude input state, including Mermaid state diagrams.

ELI5: Omnigent no longer assumes Claude is ready just because the terminal looks idle. It now waits for Claude's structured signals and records when Claude needs terminal attention.

## Test Plan

- `uv run --extra dev pytest tests/test_claude_native_bridge.py -q`
- `uv run --extra dev ruff check omnigent/claude_native_bridge.py tests/test_claude_native_bridge.py`
- `git diff --check`
- `pre-commit run`

## Demo

N/A

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage exercises parent `SessionStart` readiness, delivery acknowledgements, queued prompts, missing ack failures, and parent-vs-subagent hook state handling.

## Changelog

Claude native sessions now use structured input readiness and surface startup attention-required states more reliably.
