### PR TITLE
test(runner): deterministically stabilize required-terminal idle-exit test

### DIFF
--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -303,6 +303,15 @@ class SessionResourceRegistry:
         # lifecycle relationship so the runner can decide whether the owning
         # session should fail.
         self._terminal_exit_publisher: Callable[[TerminalExitEvent], None] | None = None
+        # Live ``_handle_terminal_exit`` tasks plus a "a task was scheduled"
+        # signal. A terminal exit hops from the watcher thread onto the loop via
+        # ``call_soon_threadsafe``, so the cleanup task materializes only after
+        # the loop turns. The set keeps a strong reference to the otherwise
+        # fire-and-forget task (so the loop can't drop it mid-flight); the event
+        # lets callers on the loop await that scheduling + completion instead of
+        # polling. Entries self-remove on completion.
+        self._terminal_exit_tasks: set[asyncio.Task[None]] = set()
+        self._terminal_exit_scheduled: asyncio.Event = asyncio.Event()
 
     def set_terminal_activity_publisher(
         self,
@@ -359,6 +368,21 @@ class SessionResourceRegistry:
         :param publisher: Callable receiving a :class:`TerminalExitEvent`.
         """
         self._terminal_exit_publisher = publisher
+
+    async def wait_for_terminal_exit_cleanup(self) -> None:
+        """Await the next scheduled terminal-exit cleanup task to completion.
+
+        A terminal exit hops from the watcher thread onto the loop via
+        ``call_soon_threadsafe``, so the ``_handle_terminal_exit`` task
+        materializes only after the loop turns. Awaiting the "scheduled" event
+        first lets the loop run that scheduling callback; then the tracked task
+        is awaited so the ``session.resource.deleted`` publish (and the harness
+        release it spawns) is observable without polling. Intended for tests
+        that need to synchronize on the fan-out deterministically.
+        """
+        await self._terminal_exit_scheduled.wait()
+        for task in list(self._terminal_exit_tasks):
+            await task
 
     def _set_session_status_memo(self, session_id: str, status: str) -> None:
         """Record the session's latest PTY status for exit classification."""
@@ -1062,6 +1086,9 @@ class SessionResourceRegistry:
                         instance=instance,
                     )
                 )
+                self._terminal_exit_tasks.add(task)
+                self._terminal_exit_scheduled.set()
+                task.add_done_callback(self._terminal_exit_tasks.discard)
                 task.add_done_callback(_log_terminal_exit_task_result)
 
             try:

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -303,13 +303,9 @@ class SessionResourceRegistry:
         # lifecycle relationship so the runner can decide whether the owning
         # session should fail.
         self._terminal_exit_publisher: Callable[[TerminalExitEvent], None] | None = None
-        # Live ``_handle_terminal_exit`` tasks plus a "a task was scheduled"
-        # signal. A terminal exit hops from the watcher thread onto the loop via
-        # ``call_soon_threadsafe``, so the cleanup task materializes only after
-        # the loop turns. The set keeps a strong reference to the otherwise
-        # fire-and-forget task (so the loop can't drop it mid-flight); the event
-        # lets callers on the loop await that scheduling + completion instead of
-        # polling. Entries self-remove on completion.
+        # Strong reference to the fire-and-forget terminal-exit cleanup tasks,
+        # plus an event so loop-side callers can await scheduling/completion
+        # instead of polling. Entries self-remove on completion.
         self._terminal_exit_tasks: set[asyncio.Task[None]] = set()
         self._terminal_exit_scheduled: asyncio.Event = asyncio.Event()
 
@@ -370,19 +366,11 @@ class SessionResourceRegistry:
         self._terminal_exit_publisher = publisher
 
     async def wait_for_terminal_exit_cleanup(self) -> None:
-        """Await the next scheduled terminal-exit cleanup task to completion.
+        """Await the scheduled terminal-exit cleanup to completion so its
+        ``session.resource.deleted`` publish is observable without polling.
 
-        A terminal exit hops from the watcher thread onto the loop via
-        ``call_soon_threadsafe``, so the ``_handle_terminal_exit`` task
-        materializes only after the loop turns. Awaiting the "scheduled" event
-        first lets the loop run that scheduling callback; then the tracked task
-        is awaited so the ``session.resource.deleted`` publish (and the harness
-        release it spawns) is observable without polling. Intended for tests
-        that need to synchronize on the fan-out deterministically.
-
-        Single-shot: the "scheduled" event is never cleared, so a second call
-        returns immediately. Use it to synchronize on one terminal exit, not a
-        sequence of them.
+        Single-shot: the "scheduled" event is never cleared, so this
+        synchronizes on one terminal exit, not a sequence of them.
         """
         await self._terminal_exit_scheduled.wait()
         tasks = list(self._terminal_exit_tasks)

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -379,10 +379,15 @@ class SessionResourceRegistry:
         is awaited so the ``session.resource.deleted`` publish (and the harness
         release it spawns) is observable without polling. Intended for tests
         that need to synchronize on the fan-out deterministically.
+
+        Single-shot: the "scheduled" event is never cleared, so a second call
+        returns immediately. Use it to synchronize on one terminal exit, not a
+        sequence of them.
         """
         await self._terminal_exit_scheduled.wait()
-        for task in list(self._terminal_exit_tasks):
-            await task
+        tasks = list(self._terminal_exit_tasks)
+        if tasks:
+            await asyncio.gather(*tasks)
 
     def _set_session_status_memo(self, session_id: str, status: str) -> None:
         """Record the session's latest PTY status for exit classification."""

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -11090,31 +11090,35 @@ async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path:
         on_exit = callbacks.get("on_exit")
         assert callable(on_exit)
         on_exit()
-        # Terminal-exit cleanup fans out across two independent background
-        # tasks: one publishes the resource events, a second releases the
-        # harness subprocess. Their completion order is not guaranteed, so
-        # settle on BOTH the published ``deleted`` event and the subprocess
-        # release — accumulating drained events each tick — rather than using
-        # the release as a proxy for the publish (which raced: the release
-        # task could finish first, leaving the drain empty).
+        # Terminal-exit cleanup fans out across two background tasks scheduled
+        # onto the loop: ``_handle_terminal_exit`` publishes the resource events
+        # and, from inside that same publish, spawns a second task that releases
+        # the harness subprocess. Await the cleanup deterministically instead of
+        # polling — the registry signals when its cleanup task is scheduled and
+        # exposes it, so awaiting drives the publish (the ``deleted`` event is
+        # enqueued and the release task is created) to completion regardless of
+        # event-loop scheduling. The release task is created synchronously
+        # inside that publish, so once the cleanup task is awaited it is either
+        # already done (``pm.released`` set) or still pending; await any pending
+        # instance so the release is observed by construction, not by a drain.
+        await resource_registry.wait_for_terminal_exit_cleanup()
+        release_task_name = f"required-terminal-release:{conv_id}"
+        pending_release = [
+            task
+            for task in asyncio.all_tasks()
+            if task.get_name() == release_task_name and not task.done()
+        ]
+        if pending_release:
+            await asyncio.gather(*pending_release)
+
         deleted_event = {
             "type": "session.resource.deleted",
             "resource_id": "terminal_worker_main",
             "resource_type": "terminal",
             "session_id": conv_id,
         }
-        queued_events: list[dict[str, Any]] = []
-        parent_events: list[dict[str, Any]] = []
-        for _ in range(1000):
-            queued_events.extend(
-                _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
-            )
-            parent_events.extend(
-                _drain_session_event_queue(_session_event_queues_ref.get(parent_id))
-            )
-            if pm.released and deleted_event in queued_events:
-                break
-            await asyncio.sleep(0)
+        queued_events = _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+        parent_events = _drain_session_event_queue(_session_event_queues_ref.get(parent_id))
     finally:
         _session_event_queues_ref.pop(conv_id, None)
         _session_event_queues_ref.pop(parent_id, None)

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -11285,20 +11285,32 @@ async def test_external_idle_status_makes_required_terminal_exit_clean(tmp_path:
         on_exit = callbacks.get("on_exit")
         assert callable(on_exit)
         on_exit()
+        # Await the terminal-exit cleanup deterministically instead of polling
+        # (see the primary idle-exit test): the registry signals when its
+        # cleanup task is scheduled, so awaiting drives the publish (the
+        # ``deleted`` event is enqueued and the release task is created) to
+        # completion regardless of event-loop scheduling. The release task is
+        # created synchronously inside that publish, so once the cleanup task is
+        # awaited it is either already done (``pm.released`` set) or still
+        # pending; await any pending instance so the release is observed by
+        # construction, not by racing a drain.
+        await resource_registry.wait_for_terminal_exit_cleanup()
+        release_task_name = f"required-terminal-release:{conv_id}"
+        pending_release = [
+            task
+            for task in asyncio.all_tasks()
+            if task.get_name() == release_task_name and not task.done()
+        ]
+        if pending_release:
+            await asyncio.gather(*pending_release)
+
         deleted_event = {
             "type": "session.resource.deleted",
             "resource_id": "terminal_kiro_main",
             "resource_type": "terminal",
             "session_id": conv_id,
         }
-        queued_events: list[dict[str, Any]] = []
-        for _ in range(1000):
-            queued_events.extend(
-                _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
-            )
-            if pm.released and deleted_event in queued_events:
-                break
-            await asyncio.sleep(0)
+        queued_events = _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
     finally:
         _session_event_queues_ref.pop(conv_id, None)
 

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -11090,17 +11090,8 @@ async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path:
         on_exit = callbacks.get("on_exit")
         assert callable(on_exit)
         on_exit()
-        # Terminal-exit cleanup fans out across two background tasks scheduled
-        # onto the loop: ``_handle_terminal_exit`` publishes the resource events
-        # and, from inside that same publish, spawns a second task that releases
-        # the harness subprocess. Await the cleanup deterministically instead of
-        # polling — the registry signals when its cleanup task is scheduled and
-        # exposes it, so awaiting drives the publish (the ``deleted`` event is
-        # enqueued and the release task is created) to completion regardless of
-        # event-loop scheduling. The release task is created synchronously
-        # inside that publish, so once the cleanup task is awaited it is either
-        # already done (``pm.released`` set) or still pending; await any pending
-        # instance so the release is observed by construction, not by a drain.
+        # Await terminal-exit cleanup deterministically instead of polling;
+        # then await any pending harness-release task so ``pm.released`` is set.
         await resource_registry.wait_for_terminal_exit_cleanup()
         release_task_name = f"required-terminal-release:{conv_id}"
         pending_release = [
@@ -11285,15 +11276,8 @@ async def test_external_idle_status_makes_required_terminal_exit_clean(tmp_path:
         on_exit = callbacks.get("on_exit")
         assert callable(on_exit)
         on_exit()
-        # Await the terminal-exit cleanup deterministically instead of polling
-        # (see the primary idle-exit test): the registry signals when its
-        # cleanup task is scheduled, so awaiting drives the publish (the
-        # ``deleted`` event is enqueued and the release task is created) to
-        # completion regardless of event-loop scheduling. The release task is
-        # created synchronously inside that publish, so once the cleanup task is
-        # awaited it is either already done (``pm.released`` set) or still
-        # pending; await any pending instance so the release is observed by
-        # construction, not by racing a drain.
+        # Await terminal-exit cleanup deterministically instead of polling;
+        # then await any pending harness-release task so ``pm.released`` is set.
         await resource_registry.wait_for_terminal_exit_cleanup()
         release_task_name = f"required-terminal-release:{conv_id}"
         pending_release = [


### PR DESCRIPTION
## Related issue

N/A

## Summary

`tests/runner/test_app_sessions_native.py::test_required_terminal_exit_while_idle_does_not_fail_session` flaked under `xdist -n8` shard load (CI run 29227239804), failing with `assert deleted_event in queued_events -> ... in []`.

- **Root cause.** Terminal-exit cleanup fans out across two loop-scheduled tasks: `_handle_terminal_exit` publishes the resource events and, from inside that same publish, spawns a second task that releases the harness subprocess (`pm.released`). The test drove this with a ~1000-iteration `await asyncio.sleep(0)` drain loop that broke once both `pm.released` and the `session.resource.deleted` event were observed. `on_exit()` only does `loop.call_soon_threadsafe(_schedule)`, so the cleanup task doesn't even exist at call time — under a starved event loop the publish could lose the scheduling race within the loop's yield budget, leaving the drain empty.
- **Fix — race gone by construction.** `SessionResourceRegistry` now retains its in-flight `_handle_terminal_exit` tasks and sets an `asyncio.Event` when one is scheduled, exposing `wait_for_terminal_exit_cleanup()`. The test `await`s that signal — which lets the loop run the scheduling callback and drives the cleanup task to completion, so the `deleted` event is enqueued and the release task is created — then `await`s any still-pending release task (found by its stable `required-terminal-release:{id}` name). Both are real completion signals, so the test drains the queue **once** and asserts. No `sleep`, no raised iteration budget, no reruns.
- The hook is test-only observability; runtime behavior for non-test callers is unchanged. The task set also gives the otherwise fire-and-forget cleanup task a strong reference so the loop can't drop it mid-flight.

The existing intent is preserved: the test still verifies a required terminal exiting while idle does **not** fail the session, and that `session.resource.deleted` is published. All assertions are unchanged.

## Test Plan

**Target test, repeated 50× in isolation** (`pytest-repeat` unavailable, so a shell loop):

```
$ for i in $(seq 1 50); do uv run --no-sync pytest \
    "tests/runner/test_app_sessions_native.py::test_required_terminal_exit_while_idle_does_not_fail_session" \
    -q -p no:randomly ...; done
RESULT: pass=50 fail=0
```

**Under xdist parallel load** — required-terminal subset, 5 rounds, all green:

```
=== ROUND 1..5 (xdist -n8, -k required_terminal) ===
7 passed in ~3.4s   # every round
```

**Full file under `-n8`, 3 rounds** — the target passes every round; the only failures are 7 `codex_native` tests that fail from a known local-env issue (missing local codex CLI/tmux → "Terminal registry not configured"), unrelated to this change:

```
7 failed, 243 passed in ~54s   # every round
non-codex failures: (none — all failures are codex_native local-env)
TARGET NOT IN FAILURES
```

**Fast gate:**

```
$ uv run --no-sync ruff check omnigent/runner/resource_registry.py tests/runner/test_app_sessions_native.py
All checks passed!
$ uv run --no-sync ruff format --check ...
2 files already formatted
$ uv run --no-sync pre-commit run --files <the two files>
ruff format...Passed   ruff check...Passed   (+ all hygiene hooks Passed)
```

## Demo

N/A — non-visual, test/infra change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

This PR stabilizes an existing test rather than adding new coverage; the test's assertions are unchanged. Verified manually by running the target test 50× in isolation (50/50 green) and under `xdist -n8` load for multiple rounds (target green every round), confirming the flake is eliminated by awaiting a real completion signal instead of polling a starved event loop.
