### PR TITLE
feat(logging): align process log output

### DIFF
--- a/dev/omnidev/src/process.rs
+++ b/dev/omnidev/src/process.rs
@@ -17,8 +17,11 @@ impl ProcSpec {
     fn omnigent_log_env() -> Vec<(String, String)> {
         // Child stderr is a pipe that omnidev reads into its process panes.
         // Let Omnigent's process logger mirror to that pipe despite it not
-        // being a terminal.
-        vec![("OMNIGENT_LOG_TTY_FD".into(), "2".into())]
+        // being a terminal, and force ANSI colors because omnidev parses them.
+        vec![
+            ("OMNIGENT_LOG_TTY_FD".into(), "2".into()),
+            ("OMNIGENT_LOG_FORCE_COLOR".into(), "1".into()),
+        ]
     }
 
     /// `uv run omnigent --log-to-stderr server --host 127.0.0.1 --port <p>
@@ -160,6 +163,13 @@ mod tests {
                     .find(|(key, _)| key == "OMNIGENT_LOG_TTY_FD")
                     .map(|(_, value)| value.as_str()),
                 Some("2")
+            );
+            assert_eq!(
+                spec.extra_env
+                    .iter()
+                    .find(|(key, _)| key == "OMNIGENT_LOG_FORCE_COLOR")
+                    .map(|(_, value)| value.as_str()),
+                Some("1")
             );
         }
     }

--- a/dev/omnidev/src/tui/render.rs
+++ b/dev/omnidev/src/tui/render.rs
@@ -26,6 +26,7 @@ const SERVER: Color = Color::Rgb(38, 139, 210); // blue
 const HOST: Color = Color::Rgb(42, 161, 152); // cyan
 const VITE: Color = Color::Rgb(211, 54, 130); // magenta
 const EVENT: Color = Color::Rgb(181, 137, 0); // amber (omnidev channel)
+const LABEL_WIDTH: usize = 7;
 
 const OK: Color = Color::Rgb(133, 153, 0); // green (running)
 const WARN: Color = Color::Rgb(203, 75, 22); // orange (starting/restarting)
@@ -195,7 +196,7 @@ fn render_line(raw: &str, all_view: bool) -> Line<'static> {
                 let label = &rest[..end];
                 let body = &rest[end + 1..];
                 let mut spans = vec![Span::styled(
-                    format!("[{label}]"),
+                    format!("[{label:<LABEL_WIDTH$}]"),
                     Style::default()
                         .fg(label_color(label))
                         .add_modifier(Modifier::BOLD),

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -88,9 +88,9 @@ def _server_uvicorn_log_config(
     """
     Return Uvicorn logging config with request-duration access logs.
 
-    Uvicorn emits the FastAPI access line itself, so Omnigent swaps
-    only the access formatter while preserving Uvicorn's default
-    handlers, levels, and server-log formatting.
+    Uvicorn emits the FastAPI access line itself, so Omnigent standardizes
+    its default and access formatters while preserving handler routing and
+    request-duration enrichment.
 
     :param log_path: Optional server process log file. When set, Uvicorn
         default/error/access logs write there.
@@ -99,12 +99,44 @@ def _server_uvicorn_log_config(
     """
     import uvicorn.config
 
-    from omnigent.process_logging import effective_log_level, should_log_to_stderr
-
-    log_config = copy.deepcopy(uvicorn.config.LOGGING_CONFIG)
-    log_config["formatters"]["access"]["()"] = (
-        "omnigent.server.performance_metrics.RequestDurationAccessFormatter"
+    from omnigent.process_logging import (
+        DEFAULT_LOG_DATEFMT,
+        DEFAULT_LOG_FORMAT,
+        DEFAULT_LOG_PREFIX_FORMAT,
+        effective_log_level,
+        should_log_to_stderr,
+        terminal_supports_color,
     )
+
+    access_log_format = (
+        DEFAULT_LOG_PREFIX_FORMAT + '%(client_addr)s - "%(request_line)s" %(status_code)s'
+    )
+    use_terminal_colors = terminal_supports_color()
+    log_config = copy.deepcopy(uvicorn.config.LOGGING_CONFIG)
+    log_config["formatters"]["default"] = {
+        "()": "omnigent.process_logging.TerminalLogFormatter",
+        "fmt": DEFAULT_LOG_FORMAT,
+        "datefmt": DEFAULT_LOG_DATEFMT,
+        "use_colors": use_terminal_colors,
+    }
+    log_config["formatters"]["access"] = {
+        "()": "omnigent.server.performance_metrics.RequestDurationAccessFormatter",
+        "fmt": access_log_format,
+        "datefmt": DEFAULT_LOG_DATEFMT,
+        "use_colors": use_terminal_colors,
+    }
+    log_config["formatters"]["default_file"] = {
+        "()": "omnigent.process_logging.TerminalLogFormatter",
+        "fmt": DEFAULT_LOG_FORMAT,
+        "datefmt": DEFAULT_LOG_DATEFMT,
+        "use_colors": False,
+    }
+    log_config["formatters"]["access_file"] = {
+        "()": "omnigent.server.performance_metrics.RequestDurationAccessFormatter",
+        "fmt": access_log_format,
+        "datefmt": DEFAULT_LOG_DATEFMT,
+        "use_colors": False,
+    }
     if log_path is not None:
         level_name = logging.getLevelName(effective_log_level())
         if not isinstance(level_name, str):
@@ -112,13 +144,13 @@ def _server_uvicorn_log_config(
         mirror = should_log_to_stderr() if log_to_stderr is None else log_to_stderr
         log_config["handlers"]["server_file"] = {
             "class": "logging.FileHandler",
-            "formatter": "default",
+            "formatter": "default_file",
             "filename": str(log_path),
             "encoding": "utf-8",
         }
         log_config["handlers"]["server_access_file"] = {
             "class": "logging.FileHandler",
-            "formatter": "access",
+            "formatter": "access_file",
             "filename": str(log_path),
             "encoding": "utf-8",
         }

--- a/omnigent/cli_diagnostics.py
+++ b/omnigent/cli_diagnostics.py
@@ -36,7 +36,13 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import cast
 
-from omnigent.process_logging import effective_log_level, env_truthy, process_log_dir
+from omnigent.process_logging import (
+    TerminalLogFormatter,
+    effective_log_level,
+    env_truthy,
+    process_log_dir,
+    terminal_supports_color,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -132,7 +138,7 @@ def _redact(text: str) -> str:
     return text
 
 
-class _RedactingFormatter(logging.Formatter):
+class _RedactingFormatter(TerminalLogFormatter):
     """
     Formatter that scrubs obvious secrets from the *final* formatted
     output — after ``%``-interpolation of ``record.args`` and after
@@ -275,8 +281,7 @@ def setup_cli_logging(argv: list[str]) -> CliLogContext:
 
     handler.setFormatter(
         _RedactingFormatter(
-            fmt="%(asctime)s %(levelname)-5s [%(name)s] %(message)s",
-            datefmt="%H:%M:%S",
+            use_colors=False,
         )
     )
 
@@ -284,7 +289,7 @@ def setup_cli_logging(argv: list[str]) -> CliLogContext:
     if env_truthy(os.environ.get("OMNIGENT_LOG_TO_STDERR")) and sys.stderr.isatty():
         stream_handler = logging.StreamHandler(sys.stderr)
         stream_handler.setLevel(log_level)
-        stream_handler.setFormatter(handler.formatter)
+        stream_handler.setFormatter(_RedactingFormatter(use_colors=terminal_supports_color()))
 
     # Wire our two package hierarchies at the effective level so their records reach
     # the file handler.

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -17,11 +17,126 @@ from omnigent._platform import IS_POSIX
 DATA_DIR_ENV_VAR = "OMNIGENT_DATA_DIR"
 LOG_LEVEL_ENV_VAR = "OMNIGENT_LOG_LEVEL"
 LOG_TO_STDERR_ENV_VAR = "OMNIGENT_LOG_TO_STDERR"
+LOG_FORCE_COLOR_ENV_VAR = "OMNIGENT_LOG_FORCE_COLOR"
 PROCESS_LOG_FILE_ENV_VAR = "OMNIGENT_PROCESS_LOG_FILE"
 LOG_TTY_FD_ENV_VAR = "OMNIGENT_LOG_TTY_FD"
 
-DEFAULT_LOG_FORMAT = "%(asctime)s %(levelname)s:%(name)s:%(message)s"
-DEFAULT_LOG_DATEFMT = "%Y-%m-%dT%H:%M:%S%z"
+DEFAULT_LOG_SOURCE_WIDTH = 32
+DEFAULT_LOG_FUNC_WIDTH = 18
+DEFAULT_LOG_PREFIX_FORMAT = "%(levelname)s %(asctime)s %(source_name)s %(func_name)s | "
+DEFAULT_LOG_FORMAT = f"{DEFAULT_LOG_PREFIX_FORMAT}%(message)s"
+DEFAULT_LOG_DATEFMT = "%m-%d %H:%M:%S"
+_LEVEL_WIDTH = 5
+_ANSI_RESET = "\x1b[0m"
+_SOURCE_COLOR = "\x1b[34m"
+_FUNCTION_COLOR = "\x1b[35m"
+_LEVEL_NAMES = {
+    logging.WARNING: "WARN",
+    logging.CRITICAL: "CRIT",
+}
+_LEVEL_COLORS = {
+    logging.DEBUG: "\x1b[36m",
+    logging.INFO: "\x1b[32m",
+    logging.WARNING: "\x1b[33m",
+    logging.ERROR: "\x1b[31m",
+    logging.CRITICAL: "\x1b[91m",
+}
+
+
+def format_log_level_name(levelno: int, levelname: str, *, use_colors: bool) -> str:
+    """Return the aligned display level for one log record."""
+    display = _LEVEL_NAMES.get(levelno, levelname)
+    display = display[:_LEVEL_WIDTH].ljust(_LEVEL_WIDTH)
+    color = _LEVEL_COLORS.get(levelno) if use_colors else None
+    return f"{color}{display}{_ANSI_RESET}" if color is not None else display
+
+
+def _compact_field(value: str, width: int) -> str:
+    if len(value) <= width:
+        return value
+    if width <= 3:
+        return value[-width:]
+    return "..." + value[-(width - 3) :]
+
+
+def _color_field(value: str, color: str, *, use_colors: bool) -> str:
+    return f"{color}{value}{_ANSI_RESET}" if use_colors else value
+
+
+def short_logger_name(name: str) -> str:
+    """Return a compact, fixed-column logger source name."""
+    for prefix in ("omnigent.", "omnigent_ui_sdk."):
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+            break
+    return _compact_field(name, DEFAULT_LOG_SOURCE_WIDTH)
+
+
+def short_function_name(name: str | None) -> str:
+    """Return a compact function name for log display."""
+    return _compact_field(name or "-", DEFAULT_LOG_FUNC_WIDTH)
+
+
+def format_log_source_name(name: str, *, use_colors: bool) -> str:
+    """Return the padded, optionally colored logger source column."""
+    display = short_logger_name(name).ljust(DEFAULT_LOG_SOURCE_WIDTH)
+    return _color_field(display, _SOURCE_COLOR, use_colors=use_colors)
+
+
+def format_log_function_name(name: str | None, *, use_colors: bool) -> str:
+    """Return the padded, optionally colored function column."""
+    display = short_function_name(name).ljust(DEFAULT_LOG_FUNC_WIDTH)
+    return _color_field(display, _FUNCTION_COLOR, use_colors=use_colors)
+
+
+@contextmanager
+def log_record_display_fields(
+    record: logging.LogRecord,
+    *,
+    use_colors: bool,
+    format_level: bool = True,
+) -> Iterator[None]:
+    """Temporarily add Omnigent display columns to a log record."""
+    original_levelname = record.levelname
+    display_fields = ("source_name", "func_name")
+    originals = {
+        field: (field in record.__dict__, record.__dict__.get(field)) for field in display_fields
+    }
+    if format_level:
+        record.levelname = format_log_level_name(
+            record.levelno,
+            original_levelname,
+            use_colors=use_colors,
+        )
+    record.source_name = format_log_source_name(record.name, use_colors=use_colors)
+    record.func_name = format_log_function_name(record.funcName, use_colors=use_colors)
+    try:
+        yield
+    finally:
+        record.levelname = original_levelname
+        for field, (had_field, value) in originals.items():
+            if had_field:
+                setattr(record, field, value)
+            else:
+                record.__dict__.pop(field, None)
+
+
+class TerminalLogFormatter(logging.Formatter):
+    """Formatter for mirrored terminal logs with optional colored levels."""
+
+    def __init__(
+        self,
+        fmt: str = DEFAULT_LOG_FORMAT,
+        datefmt: str = DEFAULT_LOG_DATEFMT,
+        *,
+        use_colors: bool,
+    ) -> None:
+        super().__init__(fmt, datefmt=datefmt)
+        self._use_colors = use_colors
+
+    def format(self, record: logging.LogRecord) -> str:
+        with log_record_display_fields(record, use_colors=self._use_colors):
+            return super().format(record)
 
 
 def data_dir() -> Path:
@@ -114,6 +229,24 @@ def _terminal_stream() -> object | None:
     return None
 
 
+def terminal_supports_color() -> bool:
+    """Return whether the requested terminal mirror can render ANSI colors."""
+    # Omnigent-owned mirrors (omnidev panes) may force ANSI; otherwise NO_COLOR wins.
+    if env_truthy(os.environ.get(LOG_FORCE_COLOR_ENV_VAR)):
+        return True
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if env_truthy(os.environ.get("FORCE_COLOR")) or env_truthy(os.environ.get("CLICOLOR_FORCE")):
+        return True
+    fd_value = os.environ.get(LOG_TTY_FD_ENV_VAR)
+    if fd_value and IS_POSIX:
+        try:
+            return os.isatty(int(fd_value))
+        except (OSError, ValueError):
+            return False
+    return sys.stderr.isatty()
+
+
 def terminal_stream_handler() -> logging.Handler:
     """Return a stream handler for the requested terminal mirror."""
     stream = _terminal_stream()
@@ -122,6 +255,11 @@ def terminal_stream_handler() -> logging.Handler:
     handler = logging.StreamHandler(stream)
     handler._omnigent_process_log_stderr = True
     return handler
+
+
+def terminal_log_formatter() -> logging.Formatter:
+    """Return the formatter used by mirrored terminal process logs."""
+    return TerminalLogFormatter(use_colors=terminal_supports_color())
 
 
 def configure_process_logging(
@@ -145,7 +283,7 @@ def configure_process_logging(
         path = create_process_log_path(destination)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    formatter = logging.Formatter(DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATEFMT)
+    formatter = TerminalLogFormatter(use_colors=False)
     handlers: list[logging.Handler] = []
 
     file_handler = logging.FileHandler(path, encoding="utf-8")
@@ -159,7 +297,7 @@ def configure_process_logging(
         stream_handler = terminal_stream_handler()
         if not isinstance(stream_handler, logging.NullHandler):
             stream_handler.setLevel(resolved_level)
-            stream_handler.setFormatter(formatter)
+            stream_handler.setFormatter(terminal_log_formatter())
             handlers.append(stream_handler)
 
     if root:

--- a/omnigent/server/performance_metrics.py
+++ b/omnigent/server/performance_metrics.py
@@ -22,6 +22,8 @@ from opentelemetry import metrics as otel_metrics
 from opentelemetry.util.types import Attributes
 from uvicorn.logging import AccessFormatter
 
+from omnigent.process_logging import log_record_display_fields
+
 _DEFAULT_WINDOWS_SECONDS = (1.0, 10.0, 30.0)
 _BYTES_PER_MIB = 1024 * 1024
 _OTEL_METER_NAME = "omnigent.server.performance"
@@ -216,6 +218,16 @@ class RequestDurationAccessFormatter(AccessFormatter):
     """
 
     _MAX_USER_AGENT_LENGTH = 80
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Apply Omnigent's standard source and level display fields."""
+        fmt = getattr(self._style, "_fmt", "")
+        with log_record_display_fields(
+            record,
+            use_colors=self.use_colors,
+            format_level="%(levelprefix)" not in fmt,
+        ):
+            return super().format(record)
 
     def formatMessage(self, record: logging.LogRecord) -> str:
         """

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -58,6 +58,11 @@ from omnigent.cli import (
 )
 from omnigent.errors import OmnigentError
 from omnigent.onboarding.ambient import DetectedProvider
+from omnigent.process_logging import (
+    DEFAULT_LOG_DATEFMT,
+    DEFAULT_LOG_FORMAT,
+    DEFAULT_LOG_PREFIX_FORMAT,
+)
 from omnigent.runner.identity import (
     RUNNER_ID_ENV_VAR,
     RUNNER_PARENT_PID_ENV_VAR,
@@ -178,9 +183,12 @@ def test_extract_global_logging_flags_preserves_passthrough_args() -> None:
 
 
 def test_server_uvicorn_log_config_uses_terminal_handler_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Uvicorn logs mirror through the shared terminal handler on request."""
+    monkeypatch.setattr("omnigent.process_logging.terminal_supports_color", lambda: True)
+
     log_config = _server_uvicorn_log_config(tmp_path / "server.log", log_to_stderr=True)
 
     assert log_config["handlers"]["server_terminal"]["()"] == (
@@ -189,6 +197,10 @@ def test_server_uvicorn_log_config_uses_terminal_handler_when_requested(
     assert log_config["handlers"]["server_access_terminal"]["()"] == (
         "omnigent.process_logging.terminal_stream_handler"
     )
+    assert log_config["handlers"]["server_terminal"]["formatter"] == "default"
+    assert log_config["handlers"]["server_access_terminal"]["formatter"] == "access"
+    assert log_config["handlers"]["server_file"]["formatter"] == "default_file"
+    assert log_config["handlers"]["server_access_file"]["formatter"] == "access_file"
     assert log_config["loggers"]["uvicorn"]["handlers"] == [
         "server_terminal",
         "server_file",
@@ -197,6 +209,36 @@ def test_server_uvicorn_log_config_uses_terminal_handler_when_requested(
         "server_access_terminal",
         "server_access_file",
     ]
+
+
+def test_server_uvicorn_log_config_standardizes_timestamp_and_color(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Uvicorn default and access logs include timestamps and terminal colors."""
+    monkeypatch.setattr("omnigent.process_logging.terminal_supports_color", lambda: True)
+
+    log_config = _server_uvicorn_log_config(tmp_path / "server.log", log_to_stderr=True)
+    expected_access_format = (
+        DEFAULT_LOG_PREFIX_FORMAT + '%(client_addr)s - "%(request_line)s" %(status_code)s'
+    )
+
+    assert log_config["formatters"]["default"]["fmt"] == DEFAULT_LOG_FORMAT
+    assert log_config["formatters"]["default_file"]["fmt"] == DEFAULT_LOG_FORMAT
+    assert log_config["formatters"]["access"]["fmt"] == expected_access_format
+    assert log_config["formatters"]["access_file"]["fmt"] == expected_access_format
+    for formatter in (
+        log_config["formatters"]["default"],
+        log_config["formatters"]["access"],
+        log_config["formatters"]["default_file"],
+        log_config["formatters"]["access_file"],
+    ):
+        assert formatter["datefmt"] == DEFAULT_LOG_DATEFMT
+
+    assert log_config["formatters"]["default"]["use_colors"] is True
+    assert log_config["formatters"]["access"]["use_colors"] is True
+    assert log_config["formatters"]["default_file"]["use_colors"] is False
+    assert log_config["formatters"]["access_file"]["use_colors"] is False
 
 
 def test_debug_logs_runner_session_reads_new_and_legacy_dirs(

--- a/tests/server/test_performance_metrics.py
+++ b/tests/server/test_performance_metrics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import re
 from dataclasses import dataclass, field
 
 import httpx
@@ -14,6 +15,7 @@ from fastapi import FastAPI, Request
 from opentelemetry.util.types import Attributes
 from starlette.types import Scope
 
+from omnigent.process_logging import DEFAULT_LOG_DATEFMT, DEFAULT_LOG_PREFIX_FORMAT
 from omnigent.server.performance_metrics import (
     RequestDurationAccessFormatter,
     ServerMetricsOtelPublisher,
@@ -392,6 +394,28 @@ def test_request_duration_access_formatter_appends_individual_duration() -> None
         )
     finally:
         set_request_duration_for_access_log(None)
+
+
+def test_request_duration_access_formatter_colors_standard_level_name() -> None:
+    """Terminal access logs color the standard display columns."""
+    formatter = RequestDurationAccessFormatter(
+        fmt=DEFAULT_LOG_PREFIX_FORMAT + '"%(request_line)s" %(status_code)s',
+        datefmt=DEFAULT_LOG_DATEFMT,
+        use_colors=True,
+    )
+    record = _make_access_record()
+
+    output = formatter.format(record)
+
+    assert re.match(
+        r"\x1b\[32mINFO \x1b\[0m \d{2}-\d{2} \d{2}:\d{2}:\d{2} "
+        r"\x1b\[34muvicorn\.access\s+\x1b\[0m "
+        r"\x1b\[35m-\s+\x1b\[0m \| "
+        r'"\x1b\[1mGET /v1/sessions/conv_abc/events HTTP/1\.1\x1b\[0m" '
+        r"\x1b\[32m200 OK\x1b\[0m",
+        output,
+    )
+    assert record.levelname == "INFO"
 
 
 def _make_access_record() -> logging.LogRecord:

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import re
 
 import pytest
 
 from omnigent._platform import IS_POSIX
 from omnigent.process_logging import (
+    LOG_FORCE_COLOR_ENV_VAR,
     LOG_TO_STDERR_ENV_VAR,
     LOG_TTY_FD_ENV_VAR,
+    TerminalLogFormatter,
     child_logging_popen_kwargs,
     terminal_stream_handler,
+    terminal_supports_color,
 )
 
 
@@ -62,5 +66,103 @@ def test_terminal_stream_handler_writes_to_explicit_log_fd(
         if handler is not None:
             handler.close()
         for fd in (read_fd, write_fd):
+            with contextlib.suppress(OSError):
+                os.close(fd)
+
+
+def test_terminal_log_formatter_colors_level_name() -> None:
+    """Terminal logs color the level, source, and function columns."""
+    formatter = TerminalLogFormatter(use_colors=True)
+    record = logging.LogRecord(
+        "omnigent.example",
+        logging.INFO,
+        __file__,
+        1,
+        "ready",
+        (),
+        None,
+        "serve",
+    )
+
+    output = formatter.format(record)
+
+    assert re.match(
+        r"\x1b\[32mINFO \x1b\[0m \d{2}-\d{2} \d{2}:\d{2}:\d{2} "
+        r"\x1b\[34mexample\s+\x1b\[0m \x1b\[35mserve\s+\x1b\[0m \| ready",
+        output,
+    )
+    assert record.levelname == "INFO"
+    assert "source_name" not in record.__dict__
+    assert "func_name" not in record.__dict__
+
+
+def test_terminal_log_formatter_abbreviates_warning_and_source() -> None:
+    """Plain log files use the same aligned, compact columns without color."""
+    formatter = TerminalLogFormatter(use_colors=False)
+    record = logging.LogRecord(
+        "omnigent.codex_native_app_server",
+        logging.WARNING,
+        __file__,
+        1,
+        "native-codex: ready",
+        (),
+        None,
+        "native_codex",
+    )
+
+    output = formatter.format(record)
+
+    assert re.match(
+        r"WARN  \d{2}-\d{2} \d{2}:\d{2}:\d{2} "
+        r"codex_native_app_server\s+native_codex\s+\| native-codex: ready",
+        output,
+    )
+    assert "WARNING" not in output
+    assert "omnigent.codex_native_app_server" not in output
+    assert record.levelname == "WARNING"
+
+
+def test_terminal_supports_color_no_color_overrides_ambient_force(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NO_COLOR disables ambient force-color hints, but not Omnigent-owned mirrors."""
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setenv("CLICOLOR_FORCE", "1")
+
+    assert terminal_supports_color() is False
+
+    monkeypatch.setenv(LOG_FORCE_COLOR_ENV_VAR, "1")
+
+    assert terminal_supports_color() is True
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="fd-based terminal mirroring is POSIX-only")
+def test_terminal_supports_color_checks_explicit_log_fd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Color is enabled only when the explicit mirror fd is a terminal."""
+    read_fd, write_fd = os.pipe()
+    master_fd: int | None = None
+    slave_fd: int | None = None
+    try:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv(LOG_TTY_FD_ENV_VAR, str(write_fd))
+
+        assert terminal_supports_color() is False
+
+        monkeypatch.setenv(LOG_FORCE_COLOR_ENV_VAR, "1")
+
+        assert terminal_supports_color() is True
+
+        monkeypatch.delenv(LOG_FORCE_COLOR_ENV_VAR)
+        master_fd, slave_fd = os.openpty()
+        monkeypatch.setenv(LOG_TTY_FD_ENV_VAR, str(slave_fd))
+
+        assert terminal_supports_color() is True
+    finally:
+        for fd in (read_fd, write_fd, master_fd, slave_fd):
+            if fd is None:
+                continue
             with contextlib.suppress(OSError):
                 os.close(fd)


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace the old process-log format with a compact shared prefix: `LEVEL MM-DD HH:MM:SS source function | message`.
- Apply the same formatter to Python, diagnostics, uvicorn default logs, and uvicorn access logs, while preserving plain text in persisted log files.
- Add terminal-only ANSI colors for level/source/function columns, plus an omnidev force-color env and padded process labels so pane logs line up.

ELI5: server, runner, and uvicorn logs now use one readable shape, with colored columns only where a person is watching a terminal.

```text
INFO  07-12 23:19:56 example                          serve              | ready
```

## Test Plan

- `cargo fmt --check`
- `cargo test` in `dev/omnidev`
- `.venv/bin/python -m pytest tests/test_process_logging.py tests/cli/test_cli_diagnostics.py tests/cli/test_cli.py tests/cli/test_server_lifecycle.py tests/host/test_local_server.py tests/host/test_connect.py tests/runner/test_runner_entry.py tests/server/test_performance_metrics.py`
- `.venv/bin/pre-commit run --all-files`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover process-log formatting, ANSI color detection/forcing, uvicorn log configuration, uvicorn access formatting, diagnostics redaction formatting, and omnidev child-process env construction.
