### PR TITLE
feat(bench): probe session fork replay

### DIFF
--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -7,7 +7,7 @@ instead of a human hand-maintaining a spreadsheet and hoping it still reflects
 reality.
 
 > **Status:** shipped and in use. The bench on `main` has three transport
-> drivers, six P0 probes, four report-only P1 probes, automatic live/offline
+> drivers, six P0 probes, five report-only P1 probes, automatic live/offline
 > selection, and a capability-derived matrix that has already caught and
 > corrected real declaration drift. See
 > [Current state](#current-state-shipped) for what is live vs. still open. The
@@ -202,6 +202,7 @@ Validated for presence and shape only: `Owner`, `Transport`, `Implementation`,
 | Dimension | How the probe proves it |
 |---|---|
 | Basic turn (P0 prerequisite) | complete a marker-echo turn and require assistant text |
+| Fork replay (P1) | clone the session after Basic turn, require copied marker history, and require the clone to recall it |
 | Streaming (P0) | count output-text deltas; repeated single-delta output is `PARTIAL` |
 | Tool calling (P0) | provoke the transport's tool mechanism and require a surfaced call |
 | Omnigent MCP (P1, native only) | call read-only `sys_session_list` through the generated `omnigent` MCP relay and require a matching function-call item |
@@ -212,7 +213,7 @@ Validated for presence and shape only: `Owner`, `Transport`, `Implementation`,
 | Cost tracking (P1) | read priced cost or token usage from the turn/session |
 | Interrupt (P0) | interrupt a long turn and require cancellation or early termination |
 
-Planned dimensions are steering, live queue, resume/fork, reasoning, images,
+Planned dimensions are steering, live queue, resume, reasoning, images,
 and compaction.
 
 Every behavioral probe also reads the corresponding declared flag and returns
@@ -267,7 +268,7 @@ The bench on `main` includes:
 
 - **Six P0 probes:** Basic turn, Streaming, Tool calling, Policy DENY, Model
   override, and Interrupt.
-- **Four P1 probes:** Omnigent MCP, Policy ALLOW, Policy ASK, and Cost tracking. P1 verdicts
+- **Five P1 probes:** Fork replay, Omnigent MCP, Policy ALLOW, Policy ASK, and Cost tracking. P1 verdicts
   are report-only and do not gate the same way as P0 declarations.
 - **Three transport drivers:** `full-server`, `native-tui`, and `sdk-inproc`,
   selected by harness family with `--transport` and `--fast` overrides.
@@ -288,7 +289,7 @@ The bench on `main` includes:
 ### Not yet wired
 
 - Registry-driven server seeding for community native UI agents.
-- Steering, live queue, resume/fork, reasoning, images, and compaction probes.
+- Steering, live queue, resume, reasoning, images, and compaction probes.
 - Automatic provisioning of vendor login/provider configuration for native
   harnesses; unavailable environments skip cleanly.
 
@@ -351,6 +352,7 @@ stream, the bench flags a real drift on the next run, rather than a false
 | Dimension | `sdk-inproc` (`--fast`) | `full-server` (SDK default) | `native-tui` |
 |---|---|---|---|
 | Basic turn, Streaming, Model override, Interrupt | Wrap-level observation | End-to-end server/runner observation | End-to-end server/runner/vendor observation |
+| Fork replay | Not observable | Clone + copied-history replay through server/runner | Clone + copied-history replay through server/runner/vendor |
 | Tool calling | Request-level wrap tool | Server-dispatched builtin | Vendor tool mirrored into session items |
 | Omnigent MCP | Not applicable | Not applicable | Generated `omnigent` MCP relay when supported by the vendor |
 | Policy DENY | Not observable | Fixed policy blocks the builtin | Session CEL policy triggers the native policy hook |
@@ -423,5 +425,5 @@ agree with it.
 - **Per-harness native provisioning** — some vendors require login or provider
   configuration that the bench deliberately cannot create. Improve diagnostics
   where possible while retaining clean skips.
-- **Additional dimensions** — steering, live queue, resume/fork, reasoning,
+- **Additional dimensions** — steering, live queue, resume, reasoning,
   images, and compaction.

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -81,6 +81,7 @@ A profile's `transport` is a harness-family marker. The resolved driver is:
 | Probe | What it verifies | Priority |
 | --- | --- | --- |
 | **Basic turn** | A turn completes and returns assistant text. | P0 |
+| **Fork replay** | A cloned session copies the source history and can use it on its first turn. | P1 |
 | **Streaming** | More than one output-text delta is emitted; a repeated single delta is `PARTIAL`. | P0 |
 | **Tool calling** | A tool call is surfaced and the turn closes after its result. | P0 |
 | **Omnigent MCP** | A native harness calls the read-only `sys_session_list` relay tool through its generated `omnigent` MCP server. | P1 |
@@ -101,6 +102,7 @@ transport; it does not claim the harness lacks the capability.
 | Dimension | `full-server` | `native-tui` | `sdk-inproc` (`--fast`) |
 | --- | --- | --- | --- |
 | Basic turn, Streaming, Model override, Interrupt | End-to-end through server + runner | End-to-end through server + runner + vendor CLI | Wrap boundary only |
+| Fork replay | Clone + copied-history replay through server + runner | Clone + copied-history replay through server + runner + vendor CLI | Not observable |
 | Tool calling | Server-dispatched builtin | Vendor tool mirrored as a session item | Request-level wrap tool |
 | Omnigent MCP | Not applicable | Generated `omnigent` MCP relay when supported by the vendor | Not applicable |
 | Policy DENY | Fixed policy in the agent spec | Session CEL policy + native policy hook | Not observable |
@@ -161,5 +163,5 @@ inside drivers so probes remain harness-agnostic.
   the harness registry, which limits community-native end-to-end execution.
 - Some native harnesses require vendor login/provider setup that the bench
   cannot provision and therefore skip cleanly.
-- Steering, live queue, resume/fork, reasoning, images, and compaction do not
+- Steering, live queue, resume, reasoning, images, and compaction do not
   yet have probes.

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -88,9 +88,11 @@ def _error_text(error: object) -> str:
 
 def infra_failure_reason(result: TurnResult | ForkResult) -> str | None:
     """Return a skip reason when failure reflects infrastructure, not capability."""
-    if not result.failed:
-        return None
     text = _error_text(result.error)
+    if isinstance(result, TurnResult) and result.text:
+        text = f"{text} {result.text}"
+    if not result.failed and not any(marker in text for marker in _INFRA_ERROR_MARKERS):
+        return None
     if not any(marker in text for marker in _INFRA_ERROR_MARKERS):
         return None
     for code in ("403", "401"):

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -86,7 +86,7 @@ def _error_text(error: object) -> str:
     return str(error or "")
 
 
-def infra_failure_reason(result: TurnResult) -> str | None:
+def infra_failure_reason(result: TurnResult | ForkResult) -> str | None:
     """Return a skip reason when failure reflects infrastructure, not capability."""
     if not result.failed:
         return None
@@ -156,6 +156,19 @@ class TurnResult:
     @property
     def event_types(self) -> list[str]:
         return [e.get("type", "") for e in self.events]
+
+
+@dataclass
+class ForkResult:
+    """Probe-observable state from cloning a session and replaying its history."""
+
+    created: bool = False
+    history_copied: bool = False
+    recalled: bool = False
+    text: str = ""
+    failed: bool = False
+    error: Any = None
+    timed_out: bool = False
 
 
 def fill_snapshot_cost(result: TurnResult, snapshot: dict[str, Any]) -> None:
@@ -286,6 +299,9 @@ class SdkInprocDriver:
 
     async def run_mcp_tool_turn(self) -> TurnResult:
         return TurnResult(error="Omnigent MCP relay is not observable on sdk-inproc")
+
+    async def run_fork_turn(self, marker: str) -> ForkResult:
+        return ForkResult(error="session fork is not observable on sdk-inproc")
 
     async def run_policy_turn(self, *, action: str) -> TurnResult:
         """Return unmeasured because wrap-direct cannot observe ALLOW or ASK."""

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -13,7 +13,7 @@ from typing import Any
 import httpx
 
 from tests.e2e._harness_probes import cli_unavailable_reason
-from tests.harness_bench.driver import TurnResult, fill_snapshot_cost
+from tests.harness_bench.driver import ForkResult, TurnResult, fill_snapshot_cost
 from tests.harness_bench.full_server import (
     _DENY_REASON,
     _POLL_INTERVAL_S,
@@ -116,6 +116,9 @@ class FullServerDriver:
     async def run_mcp_tool_turn(self) -> TurnResult:
         return TurnResult(error="Omnigent MCP relay is a native-harness dimension")
 
+    async def run_fork_turn(self, marker: str) -> ForkResult:
+        return await asyncio.to_thread(self.fork_probe_turn, marker)
+
     async def run_policy_turn(self, *, action: str) -> TurnResult:
         return await asyncio.to_thread(lambda: self.policy_probe_turn(action=action))
 
@@ -129,6 +132,40 @@ class FullServerDriver:
             name = self._shared.register_agent(self._profile, policy_action=action)
             self._policy_session_ids[action] = self._shared.create_session(name)
         return self._policy_session_ids[action]
+
+    def fork_probe_turn(self, marker: str, *, timeout: float = 180.0) -> ForkResult:
+        """Fork the current session and verify copied history is visible to the clone."""
+        assert self._client is not None and self._session_id is not None
+        assert self._shared is not None
+        result = ForkResult()
+        try:
+            forked = self._client.post(f"/v1/sessions/{self._session_id}/fork", json={})
+            forked.raise_for_status()
+            fork_id = str(forked.json()["id"])
+            result.created = fork_id != self._session_id
+            bound = self._client.patch(
+                f"/v1/sessions/{fork_id}", json={"runner_id": self._shared.runner_id}
+            )
+            bound.raise_for_status()
+            snapshot = self._client.get(f"/v1/sessions/{fork_id}")
+            snapshot.raise_for_status()
+            result.history_copied = contains_user_text(snapshot.json().get("items", []), marker)
+
+            recall = self._run_turn_on_session(
+                fork_id,
+                "Reply with exactly the literal string you were instructed to return "
+                "in the first user message, and nothing else.",
+                timeout=timeout,
+            )
+            result.text = recall.text
+            result.recalled = recall.completed and marker in recall.text
+            result.failed = recall.failed
+            result.error = recall.error
+            result.timed_out = recall.timed_out
+        except httpx.HTTPError as exc:
+            result.failed = True
+            result.error = repr(exc)
+        return result
 
     def _poll_session(
         self,
@@ -389,13 +426,18 @@ class FullServerDriver:
         Posts the user message and polls the session snapshot to a terminal
         state, filling text, completion, failure, timeout, and usage fields.
         """
-        assert self._client is not None and self._session_id is not None
+        assert self._session_id is not None
+        return self._run_turn_on_session(self._session_id, prompt, timeout=timeout)
+
+    def _run_turn_on_session(self, sid: str, prompt: str, *, timeout: float) -> TurnResult:
+        """Drive one basic turn on *sid* and return its terminal result."""
+        assert self._client is not None
         result = TurnResult()
         body: dict[str, Any] = {
             "type": "message",
             "data": {"role": "user", "content": [{"type": "input_text", "text": prompt}]},
         }
-        posted = self._client.post(f"/v1/sessions/{self._session_id}/events", json=body)
+        posted = self._client.post(f"/v1/sessions/{sid}/events", json=body)
         if posted.status_code == 202 and posted.json().get("denied"):
             result.failed = True
             result.error = {"denied": True, "reason": posted.json().get("reason")}
@@ -403,7 +445,7 @@ class FullServerDriver:
         posted.raise_for_status()
 
         return self._poll_session(
-            self._session_id,
+            sid,
             result,
             timeout=timeout,
             fill_cost=True,

--- a/tests/harness_bench/native_tui_driver.py
+++ b/tests/harness_bench/native_tui_driver.py
@@ -32,7 +32,12 @@ from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests._helpers.live_server import find_free_port
 from tests.e2e._harness_probes import cli_unavailable_reason
-from tests.harness_bench.driver import ProvisioningError, TurnResult, fill_snapshot_cost
+from tests.harness_bench.driver import (
+    ForkResult,
+    ProvisioningError,
+    TurnResult,
+    fill_snapshot_cost,
+)
 from tests.harness_bench.full_server import spawn_omnigent_server
 from tests.harness_bench.mcp_tools import is_target_omnigent_mcp_tool
 from tests.harness_bench.profile import BenchProfile
@@ -41,7 +46,13 @@ from tests.harness_bench.runtime_env import (
     bench_creds_skip_reason,
     resolve_bench_env,
 )
-from tests.harness_bench.session_items import assistant_text, function_calls, item_role, item_type
+from tests.harness_bench.session_items import (
+    assistant_text,
+    contains_user_text,
+    function_calls,
+    item_role,
+    item_type,
+)
 
 # Timeouts are "clearly stuck" ceilings, not expected durations: provisioning is
 # local (server/runner/host/forwarder boot, no model call) and a healthy native
@@ -207,6 +218,7 @@ class NativeTuiDriver:
         self._daemon: subprocess.Popen[bytes] | None = None
         self._client: httpx.Client | None = None
         self._session_id: str | None = None
+        self._runner_id: str | None = None
         self._base_url = ""
         self._tmp = Path("/tmp") / f"omni-bench-nt-{uuid.uuid4().hex[:8]}"
         self._policy_hook_disabled_reason: str | None = None
@@ -249,6 +261,9 @@ class NativeTuiDriver:
 
     async def run_mcp_tool_turn(self) -> TurnResult:
         return await asyncio.to_thread(self._drive_mcp_tool_turn)
+
+    async def run_fork_turn(self, marker: str) -> ForkResult:
+        return await asyncio.to_thread(self._drive_fork_turn, marker)
 
     async def run_policy_turn(self, *, action: str) -> TurnResult:
         return await asyncio.to_thread(self._drive_policy_turn, action=action)
@@ -306,7 +321,7 @@ class NativeTuiDriver:
         assert self._client is not None and self._session_id is not None
         assert self._vendor is not None
         session_id = self._session_id
-        self._launch_and_bind_runner(host_id, workspace)
+        self._runner_id = self._launch_and_bind_runner(host_id, workspace)
         ensure = self._client.post(
             f"/v1/sessions/{session_id}/resources/terminals",
             json={
@@ -611,6 +626,40 @@ class NativeTuiDriver:
                 result.completed = True
                 break
             baseline += len(result.tool_calls) - calls_before
+        return result
+
+    def _drive_fork_turn(self, marker: str, *, timeout: float = _TURN_TIMEOUT_S) -> ForkResult:
+        """Fork the native session and verify the clone replays copied history."""
+        assert self._client is not None and self._session_id is not None
+        assert self._runner_id is not None
+        source_id = self._session_id
+        result = ForkResult()
+        try:
+            forked = self._client.post(f"/v1/sessions/{source_id}/fork", json={})
+            forked.raise_for_status()
+            fork_id = str(forked.json()["id"])
+            result.created = fork_id != source_id
+            bound = self._client.patch(
+                f"/v1/sessions/{fork_id}", json={"runner_id": self._runner_id}
+            )
+            bound.raise_for_status()
+            copied = self._client.get(f"/v1/sessions/{fork_id}/items", params={"order": "asc"})
+            copied.raise_for_status()
+            result.history_copied = contains_user_text(copied.json().get("data", []), marker)
+
+            self._session_id = fork_id
+            recall = self._drive_turn(
+                "Reply with exactly the literal string you were instructed to return "
+                "in the first user message, and nothing else."
+            )
+            result.text = recall.text
+            result.recalled = recall.completed and marker in recall.text
+            result.failed = recall.failed
+            result.error = recall.error
+            result.timed_out = recall.timed_out
+        except httpx.HTTPError as exc:
+            result.failed = True
+            result.error = repr(exc)
         return result
 
     def _drive_policy_turn(self, *, action: str) -> TurnResult:

--- a/tests/harness_bench/probes/__init__.py
+++ b/tests/harness_bench/probes/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.probes.basic_turn import BasicTurnProbe
 from tests.harness_bench.probes.cost_tracking import CostTrackingProbe
+from tests.harness_bench.probes.fork_replay import ForkReplayProbe
 from tests.harness_bench.probes.interrupt import InterruptProbe
 from tests.harness_bench.probes.model_override import ModelOverrideProbe
 from tests.harness_bench.probes.omnigent_mcp import OmnigentMcpProbe
@@ -17,6 +18,7 @@ from tests.harness_bench.probes.tool_calling import ToolCallingProbe
 # Basic turn gates the run; interrupt stays last because cancellation can linger.
 ALL_PROBES: list[CapabilityProbe] = [
     BasicTurnProbe(),
+    ForkReplayProbe(),
     StreamingProbe(),
     ToolCallingProbe(),
     OmnigentMcpProbe(),

--- a/tests/harness_bench/probes/fork_replay.py
+++ b/tests/harness_bench/probes/fork_replay.py
@@ -1,0 +1,46 @@
+"""Fork replay probe — does a cloned session retain usable conversation history?"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import infra_failure_reason
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+
+class ForkReplayProbe(CapabilityProbe):
+    name = "fork_replay"
+    title = "Fork replay"
+    priority = Priority.P1
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_fork_turn(profile.marker)
+        detail = {
+            "created": result.created,
+            "history_copied": result.history_copied,
+            "recalled": result.recalled,
+            "text": result.text,
+            "timed_out": result.timed_out,
+        }
+        if result.created and result.history_copied and result.recalled:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note="fork copied history and the clone recalled the original marker",
+                detail=detail,
+            )
+        if result.error:
+            infra = infra_failure_reason(result)
+            return ProbeResult(Verdict.SKIPPED, note=infra or str(result.error), detail=detail)
+        if result.timed_out:
+            return ProbeResult(Verdict.SKIPPED, note="fork replay turn timed out", detail=detail)
+        if not result.created:
+            return ProbeResult(Verdict.UNSUPPORTED, note="fork endpoint did not create a clone")
+        if not result.history_copied:
+            return ProbeResult(Verdict.UNSUPPORTED, note="fork did not copy the source history")
+        return ProbeResult(
+            Verdict.UNSUPPORTED,
+            note="fork copied history but the clone did not recall the marker",
+            detail=detail,
+        )

--- a/tests/harness_bench/test_basic_turn.py
+++ b/tests/harness_bench/test_basic_turn.py
@@ -1,0 +1,28 @@
+"""Verdict tests for the Basic turn prerequisite."""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.probes.basic_turn import BasicTurnProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Verdict
+
+_PROFILE = BenchProfile(
+    harness="qwen-native",
+    model="m",
+    env_prefix="HARNESS_QWEN_NATIVE_",
+    marker="QWEN_NATIVE_OK",
+    transport="native-tui",
+)
+
+
+class _Driver:
+    async def run_basic_turn(self, marker: str) -> TurnResult:
+        return TurnResult(completed=True, text="[API Error: 403 Invalid Token]")
+
+
+async def test_textual_auth_error_skips_prerequisite() -> None:
+    result = await BasicTurnProbe().run(_Driver(), _PROFILE)
+
+    assert result.verdict is Verdict.SKIPPED
+    assert "403" in result.note

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -292,7 +292,7 @@ async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None
     Uses a fake driver so no creds/subprocess are needed: a basic turn passes,
     which lets every probe run and produce a ProbeFinished.
     """
-    from tests.harness_bench.driver import TurnResult
+    from tests.harness_bench.driver import ForkResult, TurnResult
     from tests.harness_bench.events import (
         HarnessFinished,
         HarnessStarted,
@@ -338,6 +338,9 @@ async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None
         async def run_tool_turn(self, *, deny: bool) -> TurnResult:
             return TurnResult(completed=True)
 
+        async def run_fork_turn(self, marker: str) -> ForkResult:
+            return ForkResult(created=True, history_copied=True, recalled=True)
+
         async def run_interrupt_turn(self) -> TurnResult:
             return TurnResult(cancelled=True)
 
@@ -381,7 +384,7 @@ async def test_run_bench_jobs_preserves_order(monkeypatch: pytest.MonkeyPatch) -
     """--jobs > 1 runs harnesses concurrently but keeps report order == input order."""
     import asyncio as _asyncio
 
-    from tests.harness_bench.driver import TurnResult
+    from tests.harness_bench.driver import ForkResult, TurnResult
 
     class _SlowDriver:
         transport = "sdk-inproc"
@@ -409,6 +412,9 @@ async def test_run_bench_jobs_preserves_order(monkeypatch: pytest.MonkeyPatch) -
         async def run_tool_turn(self, *, deny: bool) -> TurnResult:
             return TurnResult(completed=True)
 
+        async def run_fork_turn(self, marker: str) -> ForkResult:
+            return ForkResult(created=True, history_copied=True, recalled=True)
+
         async def run_interrupt_turn(self) -> TurnResult:
             return TurnResult(cancelled=True)
 
@@ -431,7 +437,7 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
     one SharedFullServer is entered once and each harness registers its own
     agent+session on it.
     """
-    from tests.harness_bench.driver import TurnResult
+    from tests.harness_bench.driver import ForkResult, TurnResult
 
     built: list[object] = []
 
@@ -481,6 +487,9 @@ async def test_parallel_full_server_shares_one_server(monkeypatch: pytest.Monkey
 
         async def run_tool_turn(self, *, deny: bool) -> TurnResult:
             return TurnResult(completed=True, tool_call_denied=deny)
+
+        async def run_fork_turn(self, marker: str) -> ForkResult:
+            return ForkResult(created=True, history_copied=True, recalled=True)
 
         async def run_interrupt_turn(self) -> TurnResult:
             return TurnResult(cancelled=True)
@@ -570,7 +579,7 @@ async def test_full_server_async_shims_delegate_to_sync(monkeypatch: pytest.Monk
     in the async binding is caught without a server+runner. Builds no driver
     state — every sync method is stubbed.
     """
-    from tests.harness_bench.driver import TurnResult
+    from tests.harness_bench.driver import ForkResult, TurnResult
     from tests.harness_bench.full_server_driver import FullServerDriver
     from tests.harness_bench.profile import BenchProfile
 
@@ -582,11 +591,16 @@ async def test_full_server_async_shims_delegate_to_sync(monkeypatch: pytest.Monk
         calls.append(f"{name}:{kw}")
         return TurnResult(completed=True)
 
+    def _fork_stub(marker: str):
+        calls.append(f"fork:{marker}")
+        return ForkResult(created=True, history_copied=True, recalled=True)
+
     monkeypatch.setattr(driver, "__enter__", lambda: (calls.append("enter"), driver)[1])
     monkeypatch.setattr(driver, "__exit__", lambda *a: calls.append("exit"))
     monkeypatch.setattr(driver, "run_turn", lambda prompt, **kw: _stub("run_turn", prompt=prompt))
     monkeypatch.setattr(driver, "streaming_probe_turn", lambda **kw: _stub("streaming"))
     monkeypatch.setattr(driver, "tool_probe_turn", lambda **kw: _stub("tool", **kw))
+    monkeypatch.setattr(driver, "fork_probe_turn", _fork_stub)
     monkeypatch.setattr(driver, "interrupt_probe_turn", lambda **kw: _stub("interrupt"))
 
     async with driver as d:
@@ -594,6 +608,7 @@ async def test_full_server_async_shims_delegate_to_sync(monkeypatch: pytest.Monk
         assert (await d.run_basic_turn("STUB_OK")).completed
         assert (await d.run_streaming_turn()).completed
         assert (await d.run_tool_turn(deny=True)).completed
+        assert (await d.run_fork_turn("STUB_OK")).recalled
         assert (await d.run_interrupt_turn()).completed
 
     assert calls[0] == "enter" and calls[-1] == "exit"

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -220,6 +220,10 @@ def test_infra_failure_reason_classifies_auth_and_ignores_capability_gaps() -> N
 
     assert infra_failure_reason(TurnResult(failed=True, error="model refused the tool")) is None
     assert infra_failure_reason(TurnResult(completed=True, text="ok")) is None
+    text_auth = infra_failure_reason(
+        TurnResult(completed=True, text="[API Error: 403 Invalid Token]")
+    )
+    assert text_auth is not None and "403" in text_auth
 
     for msg in (
         "inner executor error: provider auth command `sh` produced an empty token",

--- a/tests/harness_bench/test_fork_replay.py
+++ b/tests/harness_bench/test_fork_replay.py
@@ -1,0 +1,57 @@
+"""Verdict tests for the fork-history replay probe."""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import ForkResult
+from tests.harness_bench.probes.fork_replay import ForkReplayProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Priority, Verdict
+
+_PROFILE = BenchProfile(
+    harness="claude-sdk",
+    model="m",
+    env_prefix="HARNESS_X_",
+    marker="FORK_MARKER",
+)
+
+
+class _Driver:
+    def __init__(self, result: ForkResult) -> None:
+        self._result = result
+        self.marker = ""
+
+    async def run_fork_turn(self, marker: str) -> ForkResult:
+        self.marker = marker
+        return self._result
+
+
+async def test_supported_when_clone_copies_and_replays_history() -> None:
+    driver = _Driver(ForkResult(created=True, history_copied=True, recalled=True))
+
+    result = await ForkReplayProbe().run(driver, _PROFILE)
+
+    assert result.verdict is Verdict.SUPPORTED
+    assert driver.marker == _PROFILE.marker
+
+
+async def test_unsupported_when_history_was_not_copied() -> None:
+    result = await ForkReplayProbe().run(
+        _Driver(ForkResult(created=True, history_copied=False)),
+        _PROFILE,
+    )
+
+    assert result.verdict is Verdict.UNSUPPORTED
+    assert "did not copy" in result.note
+
+
+async def test_skipped_when_transport_cannot_observe_fork() -> None:
+    result = await ForkReplayProbe().run(
+        _Driver(ForkResult(error="session fork is not observable on sdk-inproc")),
+        _PROFILE,
+    )
+
+    assert result.verdict is Verdict.SKIPPED
+
+
+def test_probe_is_report_only_p1() -> None:
+    assert ForkReplayProbe().priority is Priority.P1

--- a/tests/harness_bench/test_full_server_driver.py
+++ b/tests/harness_bench/test_full_server_driver.py
@@ -12,8 +12,9 @@ _PROFILE = BenchProfile(harness="fake", model="m", env_prefix="HARNESS_FAKE_", m
 
 
 class _Response:
-    def __init__(self, payload: dict[str, Any]) -> None:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
         self._payload = payload
+        self.status_code = status_code
 
     def raise_for_status(self) -> None:
         pass
@@ -25,16 +26,29 @@ class _Response:
 class _Client:
     def __init__(self, snapshots: list[dict[str, Any]]) -> None:
         self._snapshots = iter(snapshots)
+        self.patches: list[tuple[str, dict[str, Any]]] = []
+        self.posts: list[tuple[str, dict[str, Any]]] = []
 
     def get(self, _url: str) -> _Response:
         return _Response(next(self._snapshots))
+
+    def post(self, url: str, json: dict[str, Any]) -> _Response:
+        self.posts.append((url, json))
+        return _Response({"id": "forked"}, status_code=201)
+
+    def patch(self, url: str, json: dict[str, Any]) -> _Response:
+        self.patches.append((url, json))
+        return _Response({})
 
 
 def _driver(snapshots: list[dict[str, Any]]) -> FullServerDriver:
     class _Shared:
         client = _Client(snapshots)
+        runner_id = "runner-test"
 
-    return FullServerDriver(_PROFILE, databricks_profile=None, shared=_Shared())
+    driver = FullServerDriver(_PROFILE, databricks_profile=None, shared=_Shared())
+    driver._session_id = "source"
+    return driver
 
 
 def test_poll_session_collects_terminal_snapshot_once(monkeypatch) -> None:
@@ -67,3 +81,26 @@ def test_poll_session_reports_failure(monkeypatch) -> None:
 
     assert result.failed
     assert result.error == {"message": "boom"}
+
+
+def test_fork_probe_binds_clone_and_recalls_copied_history(monkeypatch) -> None:
+    marker_item = {
+        "type": "message",
+        "data": {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "MARK"}],
+        },
+    }
+    driver = _driver([{"items": [marker_item]}])
+
+    def _recall(sid: str, prompt: str, *, timeout: float) -> TurnResult:
+        assert sid == "forked"
+        assert "MARK" not in prompt
+        return TurnResult(completed=True, text="MARK")
+
+    monkeypatch.setattr(driver, "_run_turn_on_session", _recall)
+
+    result = driver.fork_probe_turn("MARK")
+
+    assert result.created and result.history_copied and result.recalled
+    assert driver._client.patches == [("/v1/sessions/forked", {"runner_id": "runner-test"})]

--- a/tests/harness_bench/test_native_tui_driver.py
+++ b/tests/harness_bench/test_native_tui_driver.py
@@ -90,21 +90,30 @@ class _FakeClient:
         self.deleted_policies: list[str] = []
         self.posted_events: list[dict] = []
         self._items_calls = 0
+        self.patched_sessions: list[tuple[str, dict]] = []
 
     def get(self, url: str, params: dict | None = None, timeout: float | None = None):
         if url.endswith("/items"):
+            if "/conv_fork/" in url:
+                return _FakeResponse(200, {"data": self._items})
             self._items_calls += 1
             data = [] if self._items_calls == 1 else self._items
             return _FakeResponse(200, {"data": data})
         return _FakeResponse(200, {})
 
     def post(self, url: str, json: dict | None = None, timeout: float | None = None):
+        if url.endswith("/fork"):
+            return _FakeResponse(201, {"id": "conv_fork"})
         if url.endswith("/policies"):
             self.attached_policies.append(json or {})
             return _FakeResponse(self._policy_status, {"id": "spol_test"})
         if url.endswith("/events"):
             self.posted_events.append(json or {})
         return _FakeResponse(202, {})
+
+    def patch(self, url: str, json: dict | None = None):
+        self.patched_sessions.append((url, json or {}))
+        return _FakeResponse(200, {})
 
     def delete(self, url: str, timeout: float | None = None):
         self.deleted_policies.append(url.rsplit("/", 1)[-1])
@@ -364,6 +373,37 @@ def test_mcp_tool_turn_skips_non_mcp_native_relay() -> None:
 
     assert result.error and "no Omnigent MCP bridge" in result.error
     assert client.posted_events == []
+
+
+def test_fork_turn_binds_clone_and_replays_copied_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    marker = "FORK_MARKER"
+    copied_message = {
+        "type": "message",
+        "data": {
+            "role": "user",
+            "content": [{"type": "input_text", "text": marker}],
+        },
+    }
+    client = _FakeClient(items=[copied_message])
+    driver = _driver_with_fake("claude-native", client)
+    driver._runner_id = "runner_test"
+    seen_session_ids: list[str | None] = []
+
+    def _recall(prompt: str) -> TurnResult:
+        assert marker not in prompt
+        seen_session_ids.append(driver._session_id)
+        return TurnResult(completed=True, text=marker)
+
+    monkeypatch.setattr(driver, "_drive_turn", _recall)
+
+    result = driver._drive_fork_turn(marker)
+
+    assert result.created and result.history_copied and result.recalled
+    assert seen_session_ids == ["conv_fork"]
+    assert client.patched_sessions == [("/v1/sessions/conv_fork", {"runner_id": "runner_test"})]
+    assert driver._session_id == "conv_fork"
 
 
 async def test_probes_read_native_tool_result_as_supported() -> None:

--- a/tests/harness_bench/transport.py
+++ b/tests/harness_bench/transport.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.driver import ForkResult, TurnResult
 from tests.harness_bench.profile import BenchProfile
 
 
@@ -51,6 +51,9 @@ class Driver(Protocol):
         the vendor's own shell/tool surface. Unsupported transports return an
         unmeasured result so the probe SKIPs.
         """
+
+    async def run_fork_turn(self, marker: str) -> ForkResult:
+        """Fork the current session and prove its history is replayed."""
 
     async def run_policy_turn(self, *, action: str) -> TurnResult:
         """Provoke a tool call under an explicit tool-call policy *action*


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a report-only P1 `Fork replay` dimension that clones a session after Basic turn, verifies the source marker was copied, and requires the clone to recall it on its first turn.
- Exercise the deployed fork/history-replay path through both `full-server` and `native-tui`; `sdk-inproc` reports the behavior as unobservable.
- Keep a successful native fork active for later probes and update the bench README/design status.

**ELI5:** the bench now starts a conversation, makes a copy, and checks that the copied conversation can still remember what was said before it was copied.

```text
Basic turn stores marker
          |
          v
POST /sessions/{id}/fork
          |
          +--> copied items contain marker
          `--> clone's first reply recalls marker
```

## Test Plan

- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync ruff check tests/harness_bench`
- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync pytest -q -p no:rerunfailures tests/harness_bench` — 136 passed, 19 skipped
- `pre-commit run --files docs/harness-bench-design.md tests/harness_bench/README.md tests/harness_bench/driver.py tests/harness_bench/full_server_driver.py tests/harness_bench/native_tui_driver.py tests/harness_bench/probes/__init__.py tests/harness_bench/probes/fork_replay.py tests/harness_bench/test_bench.py tests/harness_bench/test_fork_replay.py tests/harness_bench/test_full_server_driver.py tests/harness_bench/test_native_tui_driver.py tests/harness_bench/transport.py`
- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync python -m tests.harness_bench --harness claude-native --jobs 1 --no-rich` — live `Fork replay` reported `SUPPORTED`.

## Demo

N/A — command-line test infrastructure only.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover probe verdicts plus full-server and native-tui clone binding/history replay behavior. The live native run exercised the actual server, host daemon, vendor CLI, fork endpoint, copied session items, and first-turn recall on the clone.

## Changelog

Harness bench now reports whether forked sessions retain and replay their source conversation history.
