### PR TITLE
🐛 fix(logging): Restore foreground log stream

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -141,7 +141,10 @@ def _server_uvicorn_log_config(
         level_name = logging.getLevelName(effective_log_level())
         if not isinstance(level_name, str):
             level_name = "INFO"
-        mirror = should_log_to_stderr() if log_to_stderr is None else log_to_stderr
+        if log_to_stderr is None:
+            mirror = should_log_to_stderr() or sys.stderr.isatty()
+        else:
+            mirror = log_to_stderr
         log_config["handlers"]["server_file"] = {
             "class": "logging.FileHandler",
             "formatter": "default_file",

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -23,7 +23,9 @@ LOG_TTY_FD_ENV_VAR = "OMNIGENT_LOG_TTY_FD"
 
 DEFAULT_LOG_SOURCE_WIDTH = 32
 DEFAULT_LOG_FUNC_WIDTH = 18
-DEFAULT_LOG_PREFIX_FORMAT = "%(levelname)s %(asctime)s %(source_name)s %(func_name)s | "
+DEFAULT_LOG_PREFIX_FORMAT = (
+    "%(levelname)s %(asctime)s.%(msecs)03d %(source_name)s %(func_name)s | "
+)
 DEFAULT_LOG_FORMAT = f"{DEFAULT_LOG_PREFIX_FORMAT}%(message)s"
 DEFAULT_LOG_DATEFMT = "%m-%d %H:%M:%S"
 _LEVEL_WIDTH = 5

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -211,6 +211,42 @@ def test_server_uvicorn_log_config_uses_terminal_handler_when_requested(
     ]
 
 
+def test_server_uvicorn_log_config_mirrors_foreground_tty_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Foreground ``omnigent server`` keeps uvicorn access logs on stderr."""
+    monkeypatch.delenv("OMNIGENT_LOG_TO_STDERR", raising=False)
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+
+    log_config = _server_uvicorn_log_config(tmp_path / "server.log")
+
+    assert log_config["loggers"]["uvicorn"]["handlers"] == [
+        "server_terminal",
+        "server_file",
+    ]
+    assert log_config["loggers"]["uvicorn.access"]["handlers"] == [
+        "server_access_terminal",
+        "server_access_file",
+    ]
+
+
+def test_server_uvicorn_log_config_keeps_noninteractive_default_file_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Spawned or redirected servers do not mirror uvicorn logs by default."""
+    monkeypatch.delenv("OMNIGENT_LOG_TO_STDERR", raising=False)
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: False)
+
+    log_config = _server_uvicorn_log_config(tmp_path / "server.log")
+
+    assert "server_terminal" not in log_config["handlers"]
+    assert "server_access_terminal" not in log_config["handlers"]
+    assert log_config["loggers"]["uvicorn"]["handlers"] == ["server_file"]
+    assert log_config["loggers"]["uvicorn.access"]["handlers"] == ["server_access_file"]
+
+
 def test_server_uvicorn_log_config_standardizes_timestamp_and_color(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/server/test_performance_metrics.py
+++ b/tests/server/test_performance_metrics.py
@@ -408,7 +408,7 @@ def test_request_duration_access_formatter_colors_standard_level_name() -> None:
     output = formatter.format(record)
 
     assert re.match(
-        r"\x1b\[32mINFO \x1b\[0m \d{2}-\d{2} \d{2}:\d{2}:\d{2} "
+        r"\x1b\[32mINFO \x1b\[0m \d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} "
         r"\x1b\[34muvicorn\.access\s+\x1b\[0m "
         r"\x1b\[35m-\s+\x1b\[0m \| "
         r'"\x1b\[1mGET /v1/sessions/conv_abc/events HTTP/1\.1\x1b\[0m" '

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -87,7 +87,7 @@ def test_terminal_log_formatter_colors_level_name() -> None:
     output = formatter.format(record)
 
     assert re.match(
-        r"\x1b\[32mINFO \x1b\[0m \d{2}-\d{2} \d{2}:\d{2}:\d{2} "
+        r"\x1b\[32mINFO \x1b\[0m \d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} "
         r"\x1b\[34mexample\s+\x1b\[0m \x1b\[35mserve\s+\x1b\[0m \| ready",
         output,
     )
@@ -113,7 +113,7 @@ def test_terminal_log_formatter_abbreviates_warning_and_source() -> None:
     output = formatter.format(record)
 
     assert re.match(
-        r"WARN  \d{2}-\d{2} \d{2}:\d{2}:\d{2} "
+        r"WARN  \d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} "
         r"codex_native_app_server\s+native_codex\s+\| native-codex: ready",
         output,
     )


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Restore foreground `omnigent server` behavior so uvicorn default/error/access logs mirror to stderr by default when the server is attached to an interactive TTY.
- Keep non-interactive and spawned server processes file-only by default unless `--log-to-stderr` is set.
- Add millisecond precision to the shared log timestamp prefix, rendering `MM-DD HH:MM:SS.XXX` across Python and uvicorn logs.

ELI5: people running `omnigent server` directly still see request logs live, and every log line now shows milliseconds for easier ordering.

## Test Plan

- `.venv/bin/python -m pytest tests/test_process_logging.py tests/server/test_performance_metrics.py::test_request_duration_access_formatter_colors_standard_level_name tests/cli/test_cli.py::test_server_uvicorn_log_config_uses_terminal_handler_when_requested tests/cli/test_cli.py::test_server_uvicorn_log_config_standardizes_timestamp_and_color tests/cli/test_cli.py::test_server_uvicorn_log_config_mirrors_foreground_tty_by_default tests/cli/test_cli.py::test_server_uvicorn_log_config_keeps_noninteractive_default_file_only tests/cli/test_cli.py::test_server_command_reads_tunnel_token_and_does_not_spawn_runner tests/cli/test_server_lifecycle.py`
- `.venv/bin/pre-commit run --files omnigent/process_logging.py omnigent/cli.py tests/test_process_logging.py tests/server/test_performance_metrics.py tests/cli/test_cli.py`

## Demo

N/A

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover explicit terminal mirroring, foreground TTY default mirroring, non-interactive file-only defaults, and millisecond timestamps in Python and uvicorn log formatters.
