### PR TITLE
fix(databricks): clearer extra-install hint on workspace login

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9174,9 +9174,10 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         # `databricks auth login` browser flow, `ucode configure`) so the
         # user isn't signed into a workspace that routing then can't use.
         from omnigent.onboarding.databricks_config import (
-            DATABRICKS_EXTRA_INSTALL_HINT,
+            DATABRICKS_EXTRA,
             databricks_sdk_installed,
         )
+        from omnigent.onboarding.extra_install import extra_install_display
 
         if not databricks_sdk_installed():
             from rich.markup import escape as _rich_escape
@@ -9185,7 +9186,7 @@ def _configure_harness_add(family: str | None = None) -> str | None:
             # `[databricks]` in the install command would parse as a tag.
             return (
                 "✗ Databricks routing needs the databricks extra — "
-                f"{_rich_escape(DATABRICKS_EXTRA_INSTALL_HINT)}"
+                f"{_rich_escape(extra_install_display(DATABRICKS_EXTRA))}"
             )
 
         # The intro + URL prompt render inline, exactly like every other add
@@ -11826,14 +11827,16 @@ def setup(internal_beta: bool) -> None:
         # extra rather than the default install. Fail loud up front instead
         # of completing the whole login flow and breaking on the first turn.
         from omnigent.onboarding.databricks_config import (
-            DATABRICKS_EXTRA_INSTALL_HINT,
+            DATABRICKS_EXTRA,
             databricks_sdk_installed,
         )
+        from omnigent.onboarding.extra_install import extra_install_display
 
         if not databricks_sdk_installed():
             raise click.ClickException(
-                "Databricks internal-beta setup needs the databricks extra "
-                f"(databricks-sdk). Reinstall with:\n  {DATABRICKS_EXTRA_INSTALL_HINT}"
+                "Databricks internal-beta setup needs the `databricks` extra. "
+                "Install `omnigent[databricks]` and retry:\n  "
+                f"{extra_install_display(DATABRICKS_EXTRA)}"
             )
         # Surface missing external tooling (Node, tmux) before the Databricks
         # bootstrap so a fresh machine sees every gap at once.
@@ -12596,18 +12599,19 @@ def _databricks_login(server: str, workspace_host: str, org_id: str | None = Non
         rejects the workspace token.
     """
     from omnigent.onboarding.databricks_config import (
-        DATABRICKS_EXTRA_INSTALL_HINT,
+        DATABRICKS_EXTRA,
         databricks_sdk_installed,
     )
+    from omnigent.onboarding.extra_install import extra_install_display
 
     click.echo(f"{server} authenticates via the Databricks workspace {workspace_host}.")
 
     if not databricks_sdk_installed():
         raise click.ClickException(
             "Logging in to a Databricks-fronted server (a Databricks App or "
-            "workspace-hosted omnigent) requires the `databricks` extra "
-            f"(databricks-sdk is not installed). Reinstall with:\n  "
-            f"{DATABRICKS_EXTRA_INSTALL_HINT}"
+            "workspace-hosted omnigent) needs the `databricks` extra, which is "
+            "not installed. Install `omnigent[databricks]` and retry:\n  "
+            f"{extra_install_display(DATABRICKS_EXTRA)}"
         )
 
     token = _databricks_workspace_token(workspace_host)

--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -40,18 +40,12 @@ def normalize_workspace_url(raw: str) -> str:
     return raw.strip().rstrip("/")
 
 
-# The install command surfaced wherever a Databricks flow is gated on the
-# `databricks` extra (the add-provider menu, `setup --internal-beta`).
-# Matches the README's canonical `uv tool install` path. Dev clones use
-# `uv sync --extra databricks` instead, but the tool install is the path
-# end users actually took. The repo URL sits on its own line: the slug
-# differs per distribution, and inlining it into the hint string would
-# make the line's width — and therefore its ruff formatting — depend on
-# which slug a checkout carries.
-_SOURCE_REPO_URL = "https://github.com/omnigent-ai/omnigent.git"
-DATABRICKS_EXTRA_INSTALL_HINT = (
-    f'uv tool install --force "omnigent[databricks] @ git+{_SOURCE_REPO_URL}"'
-)
+# The pip extra that ships databricks-sdk. Surfaced wherever a Databricks
+# flow is gated on it (the add-provider menu, `setup --internal-beta`,
+# workspace login), passed to
+# :func:`omnigent.onboarding.extra_install.extra_install_display` for the
+# install command matched to how omnigent was actually installed.
+DATABRICKS_EXTRA = "databricks"
 
 
 def databricks_sdk_installed() -> bool:
@@ -61,8 +55,8 @@ def databricks_sdk_installed() -> bool:
     ``databricks`` (and ``all``) extras. The ``kind: databricks`` provider
     path needs it to mint workspace OAuth tokens at runtime
     (:mod:`omnigent.runtime.credentials.databricks`), so onboarding flows
-    gate the Databricks option on this check and surface
-    :data:`DATABRICKS_EXTRA_INSTALL_HINT` when it fails.
+    gate the Databricks option on this check and surface the
+    ``omnigent[databricks]`` install command when it fails.
 
     Uses :func:`importlib.util.find_spec` so the check never pays the cost
     of actually importing the SDK.

--- a/tests/onboarding/test_extra_install.py
+++ b/tests/onboarding/test_extra_install.py
@@ -12,6 +12,7 @@ from omnigent.onboarding import extra_install
 from omnigent.onboarding.antigravity_auth import ANTIGRAVITY_EXTRA
 from omnigent.onboarding.copilot_auth import COPILOT_EXTRA
 from omnigent.onboarding.cursor_auth import CURSOR_EXTRA
+from omnigent.onboarding.databricks_config import DATABRICKS_EXTRA
 from omnigent.onboarding.extra_install import (
     _installed_vcs_url,
     _is_uv_tool_install,
@@ -131,13 +132,27 @@ def test_extra_install_display_matches_command(
     assert display.startswith("uv")
 
 
+# -- databricks extra install hint -------------------------------------------
+
+
+def test_databricks_extra_install_display_not_hardcoded_git(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registry uv tool install yields the short form, not a hardcoded git URL."""
+    monkeypatch.setattr(extra_install, "_is_uv_tool_install", lambda: True)
+    monkeypatch.setattr(extra_install, "_installed_vcs_url", lambda: None)
+    hint = extra_install_display(DATABRICKS_EXTRA)
+    assert hint == "uv tool install --with 'omnigent[databricks]' omnigent --force"
+    assert "git+" not in hint
+
+
 # -- extra names stay in sync with pyproject packaging -----------------------
 
 
 @pytest.mark.parametrize(
     "extra",
-    [CURSOR_EXTRA, ANTIGRAVITY_EXTRA, COPILOT_EXTRA],
-    ids=["cursor", "antigravity", "copilot"],
+    [CURSOR_EXTRA, ANTIGRAVITY_EXTRA, COPILOT_EXTRA, DATABRICKS_EXTRA],
+    ids=["cursor", "antigravity", "copilot", "databricks"],
 )
 def test_harness_extra_is_a_real_pyproject_extra(extra: str) -> None:
     """Each harness ``*_EXTRA`` must name a real ``optional-dependencies`` key.


### PR DESCRIPTION
## What

The `databricks` extra gates — workspace login (`omnigent login <dbx-url>`), `setup --internal-beta`, and the add-provider menu — printed a hardcoded, long `git+https://…` reinstall command regardless of how omnigent was actually installed, and buried the `omnigent[databricks]` package spec inside that command.

## Why

The repo already has an install-aware helper, `extra_install.extra_install_display()`, which reads PEP 610 install metadata and emits the *shortest correct* command for the actual install method. Cursor, Antigravity, and Copilot all route their extra-install hint through it. Databricks was the one extra that skipped it and hardcoded the git form — both longer than needed and wrong for a PyPI install.

## Change

- Reuse `extra_install_display(DATABRICKS_EXTRA)` at all three gates (matching the cursor/antigravity/copilot pattern) — no new wrapper.
- Name `omnigent[databricks]` explicitly in the user-facing prose.
- Drop the hardcoded `DATABRICKS_EXTRA_INSTALL_HINT` / `_SOURCE_REPO_URL`; add a `DATABRICKS_EXTRA = "databricks"` constant parallel to `CURSOR_EXTRA`.

### Before
```
… requires the `databricks` extra (databricks-sdk is not installed). Reinstall with:
  uv tool install --force "omnigent[databricks] @ git+https://github.com/omnigent-ai/omnigent.git"
```
### After (PyPI install)
```
… needs the `databricks` extra, which is not installed. Install `omnigent[databricks]` and retry:
  uv tool install --with 'omnigent[databricks]' omnigent --force
```
(git-source installs still get the correct git form.)

## Tests

- Added `test_databricks_extra_install_display_not_hardcoded_git`.
- Added `databricks` to the pyproject-extra-sync param test.
- `uv run --extra dev pytest tests/onboarding/test_extra_install.py tests/cli/test_configure_models.py -q` → 127 passed; ruff clean.
