### PR TITLE
fix(bench): render inapplicable live cells

### DIFF
--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -255,7 +255,18 @@ async def run_harness(
         prereq_skip: str | None = None
         for probe in probes:
             if not _applicable(probe, profile):
-                cells.append(_cell(probe, profile, ProbeResult.not_applicable()))
+                observed = ProbeResult.not_applicable()
+                cells.append(_cell(probe, profile, observed))
+                _emit(
+                    sink,
+                    ProbeFinished(
+                        profile.harness,
+                        probe.name,
+                        probe.title,
+                        observed.verdict,
+                        observed.note,
+                    ),
+                )
                 continue
             if prereq_skip is not None:
                 observed = ProbeResult.skipped(prereq_skip)

--- a/tests/harness_bench/events.py
+++ b/tests/harness_bench/events.py
@@ -103,6 +103,8 @@ class LineSink:
         elif isinstance(event, ProbeStarted):
             self._write(f"[{event.harness}]   {event.title}: running...")
         elif isinstance(event, ProbeFinished):
+            if event.verdict is Verdict.NOT_APPLICABLE:
+                return
             suffix = f" ({event.note})" if event.note else ""
             self._write(f"[{event.harness}]   {event.title}: {event.verdict.name}{suffix}")
         # HarnessFinished is silent in line mode (the per-probe lines suffice).

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -370,6 +370,8 @@ async def test_run_harness_emits_structured_events_and_linesink_adapts() -> None
     assert any(isinstance(e, ProbeStarted) for e in sink.events)
     finished = [e for e in sink.events if isinstance(e, ProbeFinished)]
     assert {e.probe for e in finished} >= {"basic_turn", "streaming"}
+    mcp = next(e for e in finished if e.probe == "omnigent_mcp")
+    assert mcp.verdict is Verdict.NOT_APPLICABLE
 
     lines: list[str] = []
     monkeypatch = pytest.MonkeyPatch()


### PR DESCRIPTION
## Related issue

N/A

## Summary

The harness bench's rich live table initialized every probe cell with the skipped glyph (`·`). Native-only probes do not run for full-server harnesses, so no progress event replaced that placeholder even though the final report correctly classified the cell as not applicable (`—`).

- Emit a completed progress event for non-applicable probes so live renderers receive the actual verdict.
- Keep the plain line renderer quiet for non-applicable events, preserving its existing output.
- Assert that the full-server Omnigent MCP cell is emitted as `NOT_APPLICABLE`.

## Test Plan

- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync pytest -q tests/harness_bench` — 137 passed, 19 skipped.
- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync ruff check tests/harness_bench/bench.py tests/harness_bench/events.py tests/harness_bench/test_bench.py`
- `pre-commit run --all-files`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The structured progress-event test now verifies that a native-only probe emits `NOT_APPLICABLE` for a full-server profile; the existing report and event tests cover the surrounding behavior.

## Changelog

Harness benchmark live tables now distinguish not-applicable capabilities from skipped probes.
