### PR TITLE
perf(web): follow-up cleanups for the turn-rail minimap

### DIFF
--- a/web/src/pages/TurnRail.test.tsx
+++ b/web/src/pages/TurnRail.test.tsx
@@ -101,6 +101,34 @@ describe("TurnRail", () => {
     expect(screen.getByText("prompt number 2")).toBeInTheDocument();
   });
 
+  it("shows the preview on keyboard focus and clears it on blur", () => {
+    // Keyboard users reach ticks via Tab: onFocus opens the preview, and
+    // blurring the tick must close it so tabbing away doesn't strand a stale
+    // preview on screen.
+    renderRail(makeTurns(3));
+    const ticks = screen.getAllByRole("button");
+    fireEvent.focus(ticks[1]!);
+    expect(screen.getByText("prompt number 1")).toBeInTheDocument();
+
+    fireEvent.blur(ticks[1]!);
+    expect(screen.queryByText("prompt number 1")).not.toBeInTheDocument();
+  });
+
+  it("a tick's blur doesn't clear a preview owned by another tick", () => {
+    // The blur handler only clears when the blurring tick still owns the
+    // preview, so a late blur from a previously-focused tick can't wipe the
+    // preview a newer focus just opened.
+    renderRail(makeTurns(3));
+    const ticks = screen.getAllByRole("button");
+    fireEvent.focus(ticks[0]!);
+    fireEvent.focus(ticks[2]!);
+    expect(screen.getByText("prompt number 2")).toBeInTheDocument();
+
+    // Stale blur from the first tick — the preview is now turn 2's, so it stays.
+    fireEvent.blur(ticks[0]!);
+    expect(screen.getByText("prompt number 2")).toBeInTheDocument();
+  });
+
   it("makes the rail interactive only once revealed", () => {
     // hasMoreHistory=false → the rail latches revealed on mount, so the inner
     // scroller must be pointer-interactive rather than a dead (or silent) box.

--- a/web/src/pages/TurnRail.tsx
+++ b/web/src/pages/TurnRail.tsx
@@ -120,14 +120,19 @@ export function TurnRail({
         return next;
       });
     };
-    const onScroll = () => {
+    const schedule = () => {
       if (frame === 0) frame = requestAnimationFrame(recompute);
     };
-    recompute();
-    scrollEl.addEventListener("scroll", onScroll, { passive: true });
+    // Schedule the initial recompute through the same rAF gate rather than
+    // running it synchronously: `turns` is a fresh array on every stream token,
+    // so a synchronous read here would force a layout pass per token. Deferring
+    // to rAF (and cancelling the pending frame on cleanup) coalesces a burst of
+    // token-level re-renders into at most one layout read per frame.
+    schedule();
+    scrollEl.addEventListener("scroll", schedule, { passive: true });
     return () => {
       if (frame !== 0) cancelAnimationFrame(frame);
-      scrollEl.removeEventListener("scroll", onScroll);
+      scrollEl.removeEventListener("scroll", schedule);
     };
   }, [scrollEl, turns]);
 
@@ -239,6 +244,17 @@ export function TurnRail({
     const id = el.dataset.turnTick;
     if (id) tickRefs.current.set(id, el);
   }, []);
+
+  // Drop ref entries for turns no longer rendered. setTickRef never deletes on
+  // unmount (to avoid churn), so on a session switch — where every itemId
+  // changes — the old entries would otherwise leak references to detached
+  // buttons for the component's lifetime. Prune to the live turn id-set here.
+  useEffect(() => {
+    const live = new Set(turns.map((t) => t.itemId));
+    for (const id of tickRefs.current.keys()) {
+      if (!live.has(id)) tickRefs.current.delete(id);
+    }
+  }, [turns]);
 
   const handleHover = useCallback((itemId: string) => {
     const rail = railRef.current;
@@ -371,6 +387,9 @@ export function TurnRail({
               ref={setTickRef}
               onMouseEnter={(e) => handleTickEnter(turn.itemId, e.clientX, e.clientY)}
               onFocus={() => handleHover(turn.itemId)}
+              // Keyboard focus shows the preview via onFocus; clear it on blur
+              // so tabbing away doesn't leave the preview stranded on-screen.
+              onBlur={() => setHoveredId((cur) => (cur === turn.itemId ? null : cur))}
               onClick={() => scrollToUserMessage(turn.itemId, flashUserMessage)}
               aria-label={`Jump to: ${turn.userText.slice(0, 80) || "message"}`}
               // Full-pitch hit area (h-4, no gap between ticks) so clicking


### PR DESCRIPTION
## Related issue

N/A — non-blocking follow-ups from the review on #2285 (now merged).

## Summary

Three small, self-contained cleanups in `TurnRail.tsx`, all raised as non-blocking notes in the #2285 review:

- **Per-token layout thrash (perf):** `turns` is a fresh array on every stream token, and the visible-tracking effect ran `recompute()` **synchronously** (only the scroll handler was rAF-throttled) — a `querySelector` + `getBoundingClientRect` per turn, per token, on a long scrolled-back rail. The initial recompute now goes through the same rAF gate, coalescing a burst of token-level changes into at most one layout read per frame.
- **`tickRefs` retention (leak):** `setTickRef` never deletes on unmount (intentional, to avoid ref-callback churn), so on a session switch — where every `itemId` changes — the old entries would linger, holding references to detached `<button>`s for the component's lifetime. An effect now prunes `tickRefs` to the live turn id-set on every `turns` change.
- **Stuck keyboard preview (a11y):** `onFocus` opened the preview but nothing cleared it on blur, so tabbing away stranded it. Added an `onBlur` that clears `hoveredId` only when the blurring tick still owns the preview, so a stale blur can't wipe a preview a newer focus just opened.

No rendered-appearance change, so the committed UI snapshot baseline still holds.

## Test Plan

- `npx vitest run src/pages/TurnRail.test.tsx` → **11/11 pass** (2 new cases).
- `tsc -b` clean, prettier clean.
- **Live verification** via the `tests/e2e_ui/` Playwright harness against a rebuilt bundle: rail revealed (2 ticks), hover preview, keyboard-focus preview, and **blur-clears-preview** all confirmed at the browser surface; scrolling stayed responsive.

## Demo

Verified against the running app through the e2e_ui Playwright harness (rebuilt bundle): hover a tick → preview shows; Tab focus a tick → preview shows; move focus to the composer → preview clears. Screenshot confirmed no stranded preview after blur. These are behavior/perf-only changes with no new rendered appearance, so there's nothing new to show statically.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added vitest cases for the focus-shows-preview / blur-clears-preview behavior and the stale-blur guard. The two layout-dependent changes (rAF throttle, `tickRefs` prune) have no jsdom-observable surface — jsdom reports `offsetTop`/`clientHeight` as `0` — so they're verified by the live Playwright run (no observable regression) plus code inspection rather than unit assertions.

This pull request and its description were written by Isaac.