### PR TITLE
test(cursor): stabilize test_no_repost_when_unchanged on idle signal

### DIFF
--- a/tests/test_cursor_native_usage.py
+++ b/tests/test_cursor_native_usage.py
@@ -330,7 +330,10 @@ class TestForwardLoop:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         usage.record_usage_payload(tmp_path, _TURN1)
-        client = await _run_loop_until(monkeypatch, tmp_path, _usage_posts)
+        # Gate on the idle POST: it is the LAST side effect of processing turn 1
+        # (usage POST, then the state write, then idle), so once it lands both
+        # assertions below read fully-settled state instead of racing the write.
+        client = await _run_loop_until(monkeypatch, tmp_path, _idle_posts)
         # Let several more polls run; with no new turns there must be no 2nd
         # usage POST and no further idle edge.
         await asyncio.sleep(0.1)


### PR DESCRIPTION
## Related issue

N/A

## Summary

`tests/test_cursor_native_usage.py::TestForwardLoop::test_no_repost_when_unchanged` was flaky under xdist. It synchronized on the **wrong** signal:

- `_run_loop_until(...)` exited as soon as the *usage* POST landed (`_usage_posts`), but the assertions read the *idle* POST (`_idle_posts`).
- Between those two POSTs the production loop does `await asyncio.to_thread(_write_usage_state, ...)` — a real event-loop yield. Under xdist load the driver's poll `sleep` could slip into that window, so `_run_loop_until` returned and its `finally: task.cancel()` killed the forwarder **before** the idle POST was emitted → `_idle_posts` empty → `assert 0 == 1`.

Fix (test-only, one line + comment): gate the loop on `_idle_posts` — the signal the assertion actually needs. The idle POST is the **last** side effect of processing turn 1 (usage POST → state write → idle), so once it lands both the usage POST and the state write have already completed and both assertions become race-free. No production code touched; assertions and the `asyncio.sleep(0.1)` upper-bound check are unchanged.

## Test Plan

- Target test in isolation, 30× → **30 passed, 0 failed**:
  `pytest tests/test_cursor_native_usage.py::TestForwardLoop::test_no_repost_when_unchanged`
- Whole file under xdist, 5 rounds → **31 passed** every round:
  `pytest tests/test_cursor_native_usage.py -n8 --dist=worksteal`
- `pre-commit run --files tests/test_cursor_native_usage.py` → all checks pass.

## Demo

N/A (non-visual, test-only change)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Determinism fix for an existing unit test; the test itself is the coverage. Stability verified via the isolation (30×) and xdist (5 rounds) repeat runs above.
