### PR TITLE
fix: faster host-bound session cold start + keep "Working…" lit on the first turn

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -604,7 +604,7 @@ _NATIVE_TERMINAL_ENSURE_FAILED_CODE = "native_terminal_ensure_failed"
 # the reason once via ``policy_hook_disabled_reason`` in its
 # terminal-ensure 200 response.
 _NATIVE_POLICY_NOT_ENFORCED_CODE = "native_policy_not_enforced"
-_HOST_BOUND_RUNNER_CONNECT_GRACE_S = 3.0
+_HOST_BOUND_RUNNER_CONNECT_GRACE_S = 10.0
 _HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S = 30.0
 _MANAGED_RESUMABLE_TUNNEL_STALE_S = 30.0
 # How often the runner-connect wait re-checks the crash-report store while

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -632,9 +632,14 @@ describe("computeShowsWorking", () => {
     expect(computeShowsWorking("running", opts({ hasPendingElicitation: true }))).toBe(false);
   });
 
-  it("a known-offline runner suppresses stale working status", () => {
-    expect(computeShowsWorking("running", opts({ runnerOnline: false }))).toBe(false);
-    expect(computeShowsWorking("waiting", opts({ runnerOnline: false }))).toBe(false);
+  it("live running/waiting status wins over a stale offline poll", () => {
+    // The `/health` poll reads stale-offline during the runner's connect
+    // window on a fresh session's first turn (10s poll cadence). A session
+    // actively reporting running/waiting cannot have an offline runner, so its
+    // live status must keep the indicator lit rather than being suppressed by
+    // the lagging poll.
+    expect(computeShowsWorking("running", opts({ runnerOnline: false }))).toBe(true);
+    expect(computeShowsWorking("waiting", opts({ runnerOnline: false }))).toBe(true);
   });
 
   it("unresolved runner health does not suppress active parent work", () => {
@@ -653,9 +658,11 @@ describe("computeShowsWorking", () => {
     expect(computeShowsWorking("idle", opts({ backgroundTaskCount: 0 }))).toBe(false);
   });
 
-  it("a known-offline runner suppresses the indicator even with background shells", () => {
-    // Offline beats every other signal: a stale shell count must not keep a
-    // dead session spinning.
+  it("a known-offline runner suppresses the indicator for an idle session with background shells", () => {
+    // For a session that is NOT actively working, known-offline beats a stale
+    // shell count: a dead session must not keep spinning on a background tally.
+    // (An actively running/waiting session is handled above — its live status
+    // wins over the offline poll.)
     expect(computeShowsWorking("idle", opts({ runnerOnline: false, backgroundTaskCount: 2 }))).toBe(
       false,
     );

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5006,8 +5006,12 @@ export function computeIsWorking(sessionStatus: SessionStatus): boolean {
  * @param options.hasPendingElicitation - ``true`` when an elicitation prompt
  *   owns the in-progress slot and should suppress the shimmer/pinned pill.
  * @param options.runnerOnline - Runner liveness: ``true`` online, ``false``
- *   known offline, ``undefined`` before the health poll resolves. Only known
- *   offline suppresses the indicator.
+ *   known offline, ``undefined`` before the health poll resolves. A known-offline
+ *   runner suppresses the indicator ONLY when the session is otherwise idle: a
+ *   session actively reporting ``running``/``waiting`` cannot have an offline
+ *   runner, so its live status wins over the ``/health`` poll — which polls at a
+ *   10s cadence and reads stale-offline during the runner's connect window on a
+ *   fresh session's first turn (it would otherwise hide "Working…" for seconds).
  * @param options.backgroundTaskCount - Background shells still running after
  *   the turn ended. A claude-native turn settles to ``idle`` (the PTY-activity
  *   watcher's edge) even while shells run, so the bare status alone would hide
@@ -5023,9 +5027,14 @@ export function computeShowsWorking(
     backgroundTaskCount?: number;
   },
 ): boolean {
-  if (options.runnerOnline === false) return false;
   if (options.hasPendingElicitation) return false;
-  return computeIsWorking(sessionStatus) || (options.backgroundTaskCount ?? 0) > 0;
+  const isWorking = computeIsWorking(sessionStatus);
+  // A running/waiting session is proof the runner is up, so a stale
+  // poll-derived ``runnerOnline === false`` must not suppress it. Only gate on
+  // known-offline for the not-actively-working case (e.g. a background-shell
+  // tally on an idle session).
+  if (options.runnerOnline === false && !isWorking) return false;
+  return isWorking || (options.backgroundTaskCount ?? 0) > 0;
 }
 
 /**


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two related fixes to new-session first-message latency and its fallout, both surfaced by tracing new-session startup in Jaeger.

**1. Faster host-bound runner connect (server).** On the first message to a **host-bound** session, the server waits for the create-time runner's tunnel to register before forwarding. That wait was capped at **3s** (`_HOST_BOUND_RUNNER_CONNECT_GRACE_S`), but a freshly-launched runner needs **~5.5s** to boot and connect its WebSocket tunnel. The wait timed out, **abandoned the still-booting runner, and relaunched a second one from scratch** — paying the full boot cost twice (~12.7s observed) and orphaning the first runner. Widened to **10s** so the first message rides the runner that `create_session` already launched. The wait stays event-driven (wakes on the runner's hello frame) and still exits early when the daemon convicts the runner dead, so a genuine startup failure doesn't now cost a full 10s.

**2. Keep "Working…" lit on the first turn (web).** The faster connect exposed a client bug: the main chat's "Working…" indicator was suppressed whenever the open session's runner read offline, checked *before* the running/waiting status. The open-session `/health` poll is strict (`runner_online` true only while a tunnel is registered) and runs on a 10s cadence, so on a fresh session's first turn its first request lands while the runner is still connecting and returns `runner_online=false` — held for up to 10s. The authoritative `session.status: running` SSE edge arrives in that window but the gate ignored it, so the indicator never appeared. Now a session actively reporting running/waiting wins over the lagging poll; known-offline only suppresses when the session is otherwise idle (preserving the don't-spin-a-dead-session-on-a-background-shell-tally case).

### ELI5

Session-create kicks off a runner, then hands the UI back its session; the UI immediately sends the first message (~300ms later). Before, the message waited only 3s for that runner — but it takes ~5.5s to come up — so it gave up and started a *second* runner, doubling the wait. We now wait 10s and use the runner we already started. That speedup then revealed that the "Working…" spinner was keyed off a runner-liveness poll that lags ~10s behind reality on a cold start, so it stayed dark for the whole first turn even though the agent was running. The spinner now trusts the live turn status.

```
Before (3s grace):
 create ─launch runner A─▶ (returns 41ms)
 msg ─wait 3s─▶ TIMEOUT ─relaunch runner B─▶ boot ~5.5s ─▶ init ─▶ harness   (~12.7s, runner A orphaned)

After (10s grace):
 create ─launch runner A─▶ (returns 41ms)
 msg ─wait for A's hello frame (~5.5s)─▶ init ─▶ harness                     (no relaunch, no orphan)
```

## Test Plan

- **Server:** traced new-session first-message startup with Jaeger (OTLP). Baseline showed two `host.launch_runner` calls inside the `POST /v1/sessions/{id}/events` span (3s grace timeout + redundant relaunch). After the change: verified a fresh host-bound session's first message rides the original runner (no relaunch), and confirmed the end-to-end first-message time drops.
- **Web:** captured the SSE stream on a fast first turn — confirmed `session.status: running` is on the wire yet the indicator stayed dark; instrumented `computeShowsWorking` and found `runnerOnline=false` short-circuiting it. After the fix, "Working…" lights immediately on the first turn (verified live in the running dev UI). `computeShowsWorking` unit tests updated; full `ChatPage.test.ts` suite passes (134 tests). oxlint + prettier clean on changed files.

## Demo

"Working…" indicator now appears immediately on a new session's first turn (previously stayed dark for the whole turn). Verified live in the dev UI.

<!-- screen recording of the first-turn indicator to be attached -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

- Web fix has unit coverage: `computeShowsWorking` tests in `web/src/pages/ChatPage.test.ts` updated to assert live running/waiting status wins over a stale offline poll; full ChatPage suite (134 tests) green.
- Server grace-constant change verified manually via Jaeger traces of new-session first-message startup (single tuning constant on an existing event-driven wait path; the early-exit-on-conviction and relaunch-when-genuinely-dead behaviours are unchanged).

## Changelog

New sessions respond faster to their first message, and the "Working…" indicator now appears immediately on the first turn instead of staying dark while the runner finishes connecting

This pull request and its description were written by Isaac.
