### PR TITLE
fix(policy): commit input-deny sentinel so the web deny survives live

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -10985,6 +10985,16 @@ async def _persist_policy_deny_sentinel(
     policy DENY keeps follow-up turns and the items API consistent with the
     streamed deny users already see.
 
+    After persisting, publish the committed item as a
+    ``response.output_item.done`` — the same commit event a streamed
+    assistant message emits (see :func:`_flush_relay_text`). Without it the
+    live deny only exists as the ``_publish_policy_deny`` sentinel delta,
+    which the web folds into a provisional ``live:`` preview block that the
+    terminal ``response.completed`` sweeps; the deny then reappeared only
+    after a refresh re-hydrated the persisted item. Emitting the commit event
+    lets the web reconcile the preview into a durable, itemId-keyed block that
+    survives the sweep, a reconnect, and a refresh alike.
+
     :param session_id: Session/conversation identifier.
     :param conv: Conversation whose agent/model name tags the message.
     :param reason: Human-readable deny reason from the policy verdict.
@@ -11009,7 +11019,13 @@ async def _persist_policy_deny_sentinel(
             },
         ),
     )
-    await asyncio.to_thread(conversation_store.append, session_id, [item])
+    persisted = await asyncio.to_thread(conversation_store.append, session_id, [item])
+    if persisted:
+        done_event = OutputItemDoneEvent(
+            type="response.output_item.done",
+            item=persisted[0].to_api_dict(),
+        )
+        session_stream.publish(session_id, done_event.model_dump())
 
 
 async def _evaluate_input_policy(

--- a/tests/server/integration/test_policy_deny_lifecycle_e2e.py
+++ b/tests/server/integration/test_policy_deny_lifecycle_e2e.py
@@ -345,8 +345,8 @@ async def test_input_deny_publishes_committed_item_event(
     item = done_events[0]["item"]
     assert item.get("id"), f"committed item must carry a store-assigned id; got {item}"
     text = "".join(
-        part.get("text", "")
-        for part in item.get("content", [])
-        if isinstance(part, dict)
+        part.get("text", "") for part in item.get("content", []) if isinstance(part, dict)
     )
-    assert "Blocked by test policy" in text, f"deny sentinel missing from committed item; got {item}"
+    assert "Blocked by test policy" in text, (
+        f"deny sentinel missing from committed item; got {item}"
+    )

--- a/tests/server/integration/test_policy_deny_lifecycle_e2e.py
+++ b/tests/server/integration/test_policy_deny_lifecycle_e2e.py
@@ -311,3 +311,42 @@ async def test_deny_policy_only_blocks_matching_phase(
     assert body.get("denied") is not True, (
         f"tool_call-only DENY policy incorrectly blocked an input message; got {body}"
     )
+
+
+async def test_input_deny_publishes_committed_item_event(
+    policy_client: httpx.AsyncClient,
+    mock_llm: ControllableMockClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An input-phase DENY publishes the sentinel as ``output_item.done``.
+
+    The deny text streams live as an ``output_text.delta`` (a provisional
+    web preview) and is persisted as an assistant item. Without a commit
+    event the web preview is swept by the terminal ``response.completed``,
+    so the deny only reappeared on refresh. Assert the persisted item is
+    published as ``response.output_item.done`` — carrying a real itemId —
+    so the web reconciles it into a durable block.
+    """
+    published: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda sid, ev: published.append((sid, ev)),
+    )
+
+    agent = await create_test_agent(policy_client)
+    session_id = await _create_session(policy_client, agent["id"])
+    await _attach_deny_policy(policy_client, session_id)
+
+    resp = await _send_user_message(policy_client, session_id, "Hello, this should be blocked.")
+    assert resp.json().get("denied") is True, f"expected synchronous DENY; got {resp.json()}"
+
+    done_events = [ev for _sid, ev in published if ev.get("type") == "response.output_item.done"]
+    assert len(done_events) == 1, f"expected one committed-item event; got {done_events}"
+    item = done_events[0]["item"]
+    assert item.get("id"), f"committed item must carry a store-assigned id; got {item}"
+    text = "".join(
+        part.get("text", "")
+        for part in item.get("content", [])
+        if isinstance(part, dict)
+    )
+    assert "Blocked by test policy" in text, f"deny sentinel missing from committed item; got {item}"

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7570,6 +7570,80 @@ describe("chatStore — policy deny renders once", () => {
       await run({ delta: "[Denied by policy: over budget]", message_id: "deny_abc", index: 0 }),
     ).toBe(1);
   });
+
+  it("keeps the deny visible after its terminal response.completed", async () => {
+    // Full server sequence for an input-phase deny: the sentinel delta (a
+    // `live:` provisional preview), the committed item as
+    // `response.output_item.done` (carrying the persisted itemId), then the
+    // terminal `response.completed`. The terminal sweeps unfinalized `live:`
+    // previews; the commit event upgrades the deny to a durable, itemId-keyed
+    // `text_done` block that survives the sweep (and, being itemId-keyed, a
+    // reconnect and a refresh too). Without it the deny vanished until a
+    // refresh re-hydrated the persisted item.
+    const sentinel = "[Denied by policy: over budget]";
+    // Non-native session: the committed item reconciles via the itemId-stamp
+    // path (not the native-terminal provisional-replace path).
+    useChatStore.setState({
+      conversationId: "conv_deny2",
+      blocks: [],
+      isNativeTerminalSession: false,
+    });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    const manual = manualSched();
+    void pumpStreamEvents(
+      "conv_deny2",
+      sink.stream,
+      controller,
+      setState,
+      getState,
+      manual.scheduler,
+    );
+    sink.push(
+      sse("response.output_text.delta", {
+        delta: sentinel,
+        message_id: "deny_xyz",
+        index: 0,
+      }),
+    );
+    sink.push(
+      sse("response.output_item.done", {
+        item: {
+          id: "msg_deny_1",
+          type: "message",
+          role: "assistant",
+          response_id: "deny_resp_1",
+          content: [{ type: "output_text", text: sentinel }],
+        },
+      }),
+    );
+    sink.push(
+      sse("response.completed", {
+        id: "deny_term",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: sentinel }],
+          },
+        ],
+      }),
+    );
+    await tick();
+    manual.fire();
+    await tick();
+    const denyBlocks = useChatStore
+      .getState()
+      .blocks.filter(
+        (b) => b.type === "text_done" && (b as TextDone).fullText.includes("Denied by policy"),
+      );
+    controller.abort();
+    // Exactly one durable deny block survives the terminal sweep, keyed by
+    // the persisted itemId (not a swept `live:` provisional id).
+    expect(denyBlocks).toHaveLength(1);
+    expect(denyBlocks[0]!.ctx.itemId).toBe("msg_deny_1");
+  });
 });
 
 describe("chatStore — client-side message queue", () => {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -7644,6 +7644,76 @@ describe("chatStore — policy deny renders once", () => {
     expect(denyBlocks).toHaveLength(1);
     expect(denyBlocks[0]!.ctx.itemId).toBe("msg_deny_1");
   });
+
+  it("keeps the deny visible on a native-terminal session", async () => {
+    // Same server sequence as the non-native case, but on a native-terminal
+    // session the committed `text_done` reconciles via a DIFFERENT branch:
+    // it replaces the `live:` provisional IN PLACE (and retires the live
+    // message id) rather than appending and letting the terminal sweep drop
+    // the provisional. Both paths must yield exactly one durable, itemId-keyed
+    // deny block.
+    const sentinel = "[Denied by policy: over budget]";
+    useChatStore.setState({
+      conversationId: "conv_deny3",
+      blocks: [],
+      isNativeTerminalSession: true,
+    });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    const manual = manualSched();
+    void pumpStreamEvents(
+      "conv_deny3",
+      sink.stream,
+      controller,
+      setState,
+      getState,
+      manual.scheduler,
+    );
+    sink.push(
+      sse("response.output_text.delta", {
+        delta: sentinel,
+        message_id: "deny_native",
+        index: 0,
+      }),
+    );
+    sink.push(
+      sse("response.output_item.done", {
+        item: {
+          id: "msg_deny_native",
+          type: "message",
+          role: "assistant",
+          response_id: "deny_resp_native",
+          content: [{ type: "output_text", text: sentinel }],
+        },
+      }),
+    );
+    sink.push(
+      sse("response.completed", {
+        id: "deny_term",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: sentinel }],
+          },
+        ],
+      }),
+    );
+    await tick();
+    manual.fire();
+    await tick();
+    const denyBlocks = useChatStore
+      .getState()
+      .blocks.filter(
+        (b) => b.type === "text_done" && (b as TextDone).fullText.includes("Denied by policy"),
+      );
+    controller.abort();
+    // The in-place replace leaves exactly one deny block, keyed by the
+    // persisted itemId — no swept `live:` provisional, no duplicate.
+    expect(denyBlocks).toHaveLength(1);
+    expect(denyBlocks[0]!.ctx.itemId).toBe("msg_deny_native");
+  });
 });
 
 describe("chatStore — client-side message queue", () => {


### PR DESCRIPTION
## Related issue

N/A

## Summary

An input-phase policy DENY (e.g. the cost-budget policy) rejected the user's
message correctly, but the `[Denied by policy: ...]` response only appeared
**after a page refresh** — it flashed briefly, then vanished.

Root cause: the input-deny path streamed the sentinel as an
`response.output_text.delta` and persisted it as an assistant conversation
item, but never published the **commit event** a normal streamed message emits.
The web folds a `message_id`-stamped delta into a provisional `live:` preview
block; the terminal `response.completed` then sweeps every unfinalized `live:`
block, taking the deny with it. It only reappeared on refresh, when the
persisted item cold-loads from history.

The fix mirrors how a normal assistant message becomes durable: after
`_persist_policy_deny_sentinel` appends the item, publish it as a
`response.output_item.done` carrying the store-assigned itemId (the same commit
event `_flush_relay_text` emits for streamed text). The web reconciles the
`live:` preview into a durable, itemId-keyed block that survives the terminal
sweep, an SSE reconnect, and a refresh alike.

## Test Plan

- `web/`: `npm test` (3809 passed) and `npm run build` — both green. Added a
  regression test in `chatStore.test.ts`
  ("keeps the deny visible after its terminal response.completed") that pushes
  the full server sequence (sentinel delta → `output_item.done` → terminal
  `response.completed`) and asserts exactly one durable deny block survives,
  keyed by the persisted itemId. Verified it genuinely catches the bug:
  removing the `output_item.done` push drops the surviving block from 1 → 0.
- Server: `pytest tests/server/integration/test_policy_deny_lifecycle_e2e.py`
  (3 passed). Added `test_input_deny_publishes_committed_item_event`, which
  spies on `session_stream.publish` and asserts the input deny publishes a
  `response.output_item.done` carrying a real itemId + the sentinel text.

## Demo

N/A — the change is a stream-event addition; behaviour is covered by the
regression tests above (live rendering verified via the pump-level test).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated coverage added on both sides (web pump-level regression test +
server publish-assertion test).

## Changelog

A policy-denied message (e.g. hitting the cost budget) now shows immediately instead of only after a page refresh

This pull request and its description were written by Isaac.
