### PR TITLE
fix(conversation-store): join latest messages on the full item key

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -526,15 +526,17 @@ def _to_item(row: SqlConversationItem) -> ConversationItem:
 
 def _ranked_latest_message_item_ids(conversation_ids: list[str]) -> Subquery:
     """
-    Build a ranked latest-message-id subquery for multiple conversations.
+    Build a ranked latest-message-key subquery for multiple conversations.
 
     :param conversation_ids: Conversation ids to fetch messages for,
         e.g. ``["conv_child1", "conv_child2"]``.
-    :returns: SQLAlchemy subquery with ``item_id`` and per-conversation
-        ``row_num`` columns, newest message first.
+    :returns: SQLAlchemy subquery with the composite item primary key and
+        per-conversation ``row_num`` column, newest message first.
     """
     return (
         select(
+            SqlConversationItem.workspace_id.label("workspace_id"),
+            SqlConversationItem.conversation_id.label("conversation_id"),
             SqlConversationItem.id.label("item_id"),
             func.row_number()
             .over(
@@ -1551,7 +1553,14 @@ class SqlAlchemyConversationStore(ConversationStore):
             rows = (
                 session.execute(
                     select(SqlConversationItem)
-                    .join(ranked, SqlConversationItem.id == ranked.c.item_id)
+                    .join(
+                        ranked,
+                        and_(
+                            SqlConversationItem.workspace_id == ranked.c.workspace_id,
+                            SqlConversationItem.conversation_id == ranked.c.conversation_id,
+                            SqlConversationItem.id == ranked.c.item_id,
+                        ),
+                    )
                     .where(
                         SqlConversationItem.workspace_id == current_workspace_id(),
                         ranked.c.row_num <= per_conversation_limit,

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -180,6 +180,61 @@ def test_list_latest_message_items_for_conversations(
     assert result["conv_missing"] == []
 
 
+def test_list_latest_message_items_joins_on_full_item_primary_key(
+    conversation_store: SqlAlchemyConversationStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Latest-message lookup keeps rows scoped to their conversation.
+
+    ``conversation_items`` uses ``(workspace_id, conversation_id, id)`` as
+    its primary key, so the same item id may exist in different
+    conversations. The ranked subquery must join back on that full key or
+    each matching id is duplicated across conversations.
+    """
+    monkeypatch.setattr(
+        "omnigent.stores.conversation_store.sqlalchemy_store.generate_item_id",
+        lambda _item_type: "msg_shared",
+    )
+    conv_a = conversation_store.create_conversation(title="alpha")
+    conv_b = conversation_store.create_conversation(title="beta")
+    conversation_store.append(
+        conv_a.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_a",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "alpha"}],
+                    agent="worker",
+                ),
+            )
+        ],
+    )
+    conversation_store.append(
+        conv_b.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_b",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "beta"}],
+                    agent="worker",
+                ),
+            )
+        ],
+    )
+
+    result = conversation_store.list_latest_message_items_for_conversations(
+        [conv_a.id, conv_b.id],
+        per_conversation_limit=1,
+    )
+
+    assert [item.data.content[0]["text"] for item in result[conv_a.id]] == ["alpha"]
+    assert [item.data.content[0]["text"] for item in result[conv_b.id]] == ["beta"]
+
+
 def test_update_title(conversation_store: SqlAlchemyConversationStore) -> None:
     conv = conversation_store.create_conversation()
     updated = conversation_store.update_conversation(conv.id, title="Chat 1")


### PR DESCRIPTION
## Related issue

Fixes #2429

## Summary

- Carry `workspace_id` and `conversation_id` through the ranked latest-message subquery, then join message rows on the complete `(workspace_id, conversation_id, id)` primary key.
- Prevent SQLite from scanning the workspace-wide item range for every child-session preview lookup.
- Add a regression test that reuses the same item ID in two conversations and verifies that each conversation receives only its own message.

No API contract, response-shape, UI, or frontend code changes are included.
No schema migration or persisted conversation data changes are required.

### Root cause and amplification

#2212 widened the `conversation_items` primary key from `(workspace_id, id)` to `(workspace_id, conversation_id, id)`, but this latest-message lookup still joined the ranked result back on `id` alone. Because `conversation_id` is the middle column of the composite key, SQLite could not seek through the complete key and instead searched the wider workspace prefix.

The Agents tree polls `GET /v1/sessions/{id}/child_sessions` for every rendered parent node every 15 seconds, down to a maximum depth of three. Each response builds `last_message_preview` through this lookup, multiplying the incomplete-key query cost across the rendered tree.

On the reproduced SQLite database, `EXPLAIN QUERY PLAN` changed from a workspace-prefix search to an exact composite-primary-key lookup:

```text
Before: SEARCH ci USING INDEX ix_conversation_items_conversation_id_position (workspace_id=?)
After:  SEARCH ci USING INDEX sqlite_autoindex_conversation_items_1
        (workspace_id=? AND conversation_id=? AND id=?)
```

This PR fixes the CPU-runaway root cause observed in #2429. It does not change client polling or add a server watchdog; those are separate resilience concerns rather than requirements for this query correction.

### ELI5

The query previously looked up a message using only its item ID, even though a message is identified by three values. SQLite therefore had to search a much larger part of the database. The query now supplies all three values, allowing a direct indexed lookup.

```mermaid
flowchart LR
    A[Child-session preview request] --> B[Rank latest message items]
    B --> C1[Before: join by item ID]
    C1 --> D1[Workspace-wide SQLite scan]
    B --> C2[After: join by workspace + conversation + item]
    C2 --> D2[Composite primary-key lookup]
```

## Test Plan

Automated verification:

- `.venv/bin/ruff check omnigent/stores/conversation_store/sqlalchemy_store.py tests/stores/test_conversation_store.py`
- `.venv/bin/ruff format --check omnigent/stores/conversation_store/sqlalchemy_store.py tests/stores/test_conversation_store.py`
- `.venv/bin/pytest tests/stores/test_conversation_store.py -q` — **158 passed**
- `.venv/bin/pytest tests/server/integration/test_sessions_child_sessions.py -q` — **39 passed**
- The new unit regression forces two conversations to share an item ID and verifies that the batched latest-message lookup preserves conversation isolation.

Manual verification against the reproduced SQLite workload:

- Before the patch, the child-sessions endpoint did not complete within the **30-second timeout**.
- After the patch, the same endpoint completed in approximately **37 ms cold** and **8–9 ms warm**.
- Server CPU remained approximately **0.0–0.6%** after the patch.

## Demo

N/A — this is a backend-only query and index-usage fix with no UI or frontend changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new store-level regression reproduces the incomplete-key join by assigning
the same item ID to messages in two different conversations. It fails unless
the ranked result is joined back on the complete composite primary key.

The existing child-sessions integration suite verifies the endpoint path that
consumes the batched latest-message lookup. Manual verification used the
previously reproduced populated SQLite workload and confirmed the endpoint
latency and server CPU improvements listed above.

No UI behavior changed, so an E2E UI test or visual demo is not applicable.

## Changelog

Child-session previews remain responsive on large local SQLite histories instead of driving sustained server CPU.

