### PR TITLE
feat(bench): add focused run flags

### DIFF
--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -222,11 +222,10 @@ Every behavioral probe also reads the corresponding declared flag and returns
 The CLI can slice this catalog with repeatable or comma-separated
 `--dimension` values. A slice always includes `basic_turn` because it proves
 the harness is exercisable before interpreting another probe's result. Reports
-and the live Rich grid contain only the selected columns. `--model` provides a
-direct per-run model override, avoiding test model-pool environment variables
-for focused manual checks. A single harness accepts bare `--model MODEL`;
-multi-harness runs use complete, explicit `--model HARNESS=MODEL` mappings so a
-model is never assigned to the wrong harness family by position or omission.
+and the live Rich grid contain only the selected columns. Each repeated
+`--harness NAME[=MODEL]` binds an optional model override directly to that
+harness, avoiding both test model-pool environment variables and positional
+cross-family assignment. Omitting `=MODEL` keeps that profile's default.
 
 ### Illustrative probe shape
 

--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -223,8 +223,10 @@ The CLI can slice this catalog with repeatable or comma-separated
 `--dimension` values. A slice always includes `basic_turn` because it proves
 the harness is exercisable before interpreting another probe's result. Reports
 and the live Rich grid contain only the selected columns. `--model` provides a
-direct per-run model override when exactly one harness is selected, avoiding
-test model-pool environment variables for focused manual checks.
+direct per-run model override, avoiding test model-pool environment variables
+for focused manual checks. A single harness accepts bare `--model MODEL`;
+multi-harness runs use complete, explicit `--model HARNESS=MODEL` mappings so a
+model is never assigned to the wrong harness family by position or omission.
 
 ### Illustrative probe shape
 

--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -219,6 +219,13 @@ Planned dimensions are steering, live queue, resume, images, and compaction.
 Every behavioral probe also reads the corresponding declared flag and returns
 `DRIFT` when observed disagrees with declared.
 
+The CLI can slice this catalog with repeatable or comma-separated
+`--dimension` values. A slice always includes `basic_turn` because it proves
+the harness is exercisable before interpreting another probe's result. Reports
+and the live Rich grid contain only the selected columns. `--model` provides a
+direct per-run model override when exactly one harness is selected, avoiding
+test model-pool environment variables for focused manual checks.
+
 ### Illustrative probe shape
 
 ```python

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -20,14 +20,12 @@ python -m tests.harness_bench --harness codex
 python -m tests.harness_bench --harness codex --dimension reasoning
 
 # Pin one harness to an exact model for this run.
-python -m tests.harness_bench --harness codex --model system.ai.gpt-5-6-sol
+python -m tests.harness_bench --harness codex=system.ai.gpt-5-6-sol
 
-# Pin every harness in a multi-harness run explicitly.
+# Mix custom and default models in a multi-harness run.
 python -m tests.harness_bench \
-  --harness codex \
-  --harness claude-sdk \
-  --model codex=system.ai.gpt-5-6-sol \
-  --model claude-sdk=databricks-claude-opus-4-8
+  --harness codex=system.ai.gpt-5-6-sol \
+  --harness claude-sdk
 
 # Override the configured/ambient Databricks profile.
 python -m tests.harness_bench --harness codex --profile my-profile
@@ -48,18 +46,15 @@ non-zero exit means at least one `DRIFT` cell was found.
   `--live` requires resolvable gateway credentials.
 - `--profile NAME` -- optional Databricks profile override; it is not required
   when config or ambient `OPENAI_*` already supplies credentials.
-- `--harness NAME` -- probe one harness (repeatable). Accepts an official name
-  or a `module:attr` / `module.ATTR` reference to a community `BenchProfile`.
-  Defaults to every official harness.
+- `--harness NAME[=MODEL]` -- probe one harness (repeatable), optionally
+  replacing that harness profile's model for this run. `NAME` accepts an
+  official name or a `module:attr` / `module.ATTR` community `BenchProfile`.
+  Omitting `=MODEL` keeps the profile default. This is the simple alternative
+  to test model-pool environment variables. Defaults to every official harness.
 - `--dimension NAME[,NAME...]` -- run only selected dimensions. Repeat the flag
   or pass a comma-separated list. Names use the identifiers shown by
   `--list-dimensions`; `basic_turn` is added automatically as the
   exercisability prerequisite.
-- `--model [HARNESS=]MODEL` -- replace selected profile models for this run.
-  With one explicit harness, bare `MODEL` is shorthand. With multiple
-  harnesses, repeat `HARNESS=MODEL` and provide exactly one mapping for every
-  selected resolved harness. This is the simple alternative to test model-pool
-  environment variables.
 - `--list-dimensions` -- list dimension identifiers, display titles, and
   priorities.
 - `--fast` -- run SDK harnesses on `sdk-inproc` instead of the `full-server`

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -16,6 +16,12 @@ python -m tests.harness_bench --no-live
 # Probe one harness. Credentials are resolved like `omni run`.
 python -m tests.harness_bench --harness codex
 
+# Run only Reasoning (plus its automatic Basic turn prerequisite).
+python -m tests.harness_bench --harness codex --dimension reasoning
+
+# Pin one harness to an exact model for this run.
+python -m tests.harness_bench --harness codex --model system.ai.gpt-5-6-sol
+
 # Override the configured/ambient Databricks profile.
 python -m tests.harness_bench --harness codex --profile my-profile
 
@@ -38,6 +44,15 @@ non-zero exit means at least one `DRIFT` cell was found.
 - `--harness NAME` -- probe one harness (repeatable). Accepts an official name
   or a `module:attr` / `module.ATTR` reference to a community `BenchProfile`.
   Defaults to every official harness.
+- `--dimension NAME[,NAME...]` -- run only selected dimensions. Repeat the flag
+  or pass a comma-separated list. Names use the identifiers shown by
+  `--list-dimensions`; `basic_turn` is added automatically as the
+  exercisability prerequisite.
+- `--model MODEL` -- replace the selected profile's model for this run. Requires
+  exactly one explicit `--harness`; this is the simple alternative to test
+  model-pool environment variables.
+- `--list-dimensions` -- list dimension identifiers, display titles, and
+  priorities.
 - `--fast` -- run SDK harnesses on `sdk-inproc` instead of the `full-server`
   default. This skips server startup, but policy ALLOW/ASK/DENY are not
   observable and tool/cost verdicts are limited to what the wrap forwards.

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -22,6 +22,13 @@ python -m tests.harness_bench --harness codex --dimension reasoning
 # Pin one harness to an exact model for this run.
 python -m tests.harness_bench --harness codex --model system.ai.gpt-5-6-sol
 
+# Pin every harness in a multi-harness run explicitly.
+python -m tests.harness_bench \
+  --harness codex \
+  --harness claude-sdk \
+  --model codex=system.ai.gpt-5-6-sol \
+  --model claude-sdk=databricks-claude-opus-4-8
+
 # Override the configured/ambient Databricks profile.
 python -m tests.harness_bench --harness codex --profile my-profile
 
@@ -48,9 +55,11 @@ non-zero exit means at least one `DRIFT` cell was found.
   or pass a comma-separated list. Names use the identifiers shown by
   `--list-dimensions`; `basic_turn` is added automatically as the
   exercisability prerequisite.
-- `--model MODEL` -- replace the selected profile's model for this run. Requires
-  exactly one explicit `--harness`; this is the simple alternative to test
-  model-pool environment variables.
+- `--model [HARNESS=]MODEL` -- replace selected profile models for this run.
+  With one explicit harness, bare `MODEL` is shorthand. With multiple
+  harnesses, repeat `HARNESS=MODEL` and provide exactly one mapping for every
+  selected resolved harness. This is the simple alternative to test model-pool
+  environment variables.
 - `--list-dimensions` -- list dimension identifiers, display titles, and
   priorities.
 - `--fast` -- run SDK harnesses on `sdk-inproc` instead of the `full-server`

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -24,10 +24,12 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--harness",
         action="append",
-        metavar="NAME",
-        help="Harness to probe (repeatable). An official name, or a "
+        metavar="NAME[=MODEL]",
+        help="Harness to probe, optionally with a model override (repeatable). "
+        "NAME may be an official name, or a "
         "'module:attr' / 'module.ATTR' reference to a community "
-        "BenchProfile. Defaults to every official harness.",
+        "BenchProfile. Examples: 'codex' or "
+        "'codex=system.ai.gpt-5-6-sol'. Defaults to every official harness.",
     )
     parser.add_argument(
         "--dimension",
@@ -36,13 +38,6 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="Capability dimension to run (repeatable or comma-separated), e.g. "
         "'reasoning' or 'streaming,reasoning'. Basic turn is included as the "
         "exercisability prerequisite. Defaults to every dimension.",
-    )
-    parser.add_argument(
-        "--model",
-        action="append",
-        metavar="[HARNESS=]MODEL",
-        help="Model override (repeatable). One harness accepts bare MODEL. "
-        "Multiple harnesses require HARNESS=MODEL for every selected harness.",
     )
     parser.add_argument(
         "--profile",
@@ -133,10 +128,21 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _resolve_profiles(names: list[str] | None) -> list[BenchProfile]:
-    if not names:
+def _resolve_profiles(values: list[str] | None) -> list[BenchProfile]:
+    if not values:
         return list(OFFICIAL_PROFILES.values())
-    return [resolve_profile(name) for name in names]
+    profiles: list[BenchProfile] = []
+    for value in values:
+        name, separator, model = value.partition("=")
+        name = name.strip()
+        model = model.strip()
+        if not name:
+            raise ValueError("--harness name cannot be empty")
+        if separator and not model:
+            raise ValueError(f"--harness {name!r} has an empty model override")
+        profile = resolve_profile(name)
+        profiles.append(replace(profile, model=model) if separator else profile)
+    return profiles
 
 
 def _resolve_probes(values: list[str] | None) -> list[CapabilityProbe]:
@@ -156,46 +162,6 @@ def _resolve_probes(values: list[str] | None) -> list[CapabilityProbe]:
     return [probe for probe in ALL_PROBES if probe.name in selected]
 
 
-def _apply_model_overrides(
-    profiles: list[BenchProfile],
-    harness_args: list[str] | None,
-    values: list[str] | None,
-) -> list[BenchProfile]:
-    if not values:
-        return profiles
-    if harness_args is None:
-        raise ValueError("--model requires at least one explicit --harness")
-    if len(profiles) == 1 and len(values) == 1 and "=" not in values[0]:
-        model = values[0].strip()
-        if not model:
-            raise ValueError("--model cannot be empty")
-        return [replace(profiles[0], model=model)]
-
-    selected = [profile.harness for profile in profiles]
-    if len(set(selected)) != len(selected):
-        raise ValueError("model mappings require unique --harness selections")
-    mappings: dict[str, str] = {}
-    for value in values:
-        harness, separator, model = value.partition("=")
-        harness = harness.strip()
-        model = model.strip()
-        if not separator or not harness or not model:
-            raise ValueError(
-                "multiple harnesses require --model HARNESS=MODEL for every selected harness"
-            )
-        if harness in mappings:
-            raise ValueError(f"duplicate --model mapping for harness {harness!r}")
-        mappings[harness] = model
-
-    unknown = sorted(mappings.keys() - set(selected))
-    if unknown:
-        raise ValueError(f"--model mapping names unselected harness {unknown[0]!r}")
-    missing = [harness for harness in selected if harness not in mappings]
-    if missing:
-        raise ValueError(f"missing --model mapping for selected harness {missing[0]!r}")
-    return [replace(profile, model=mappings[profile.harness]) for profile in profiles]
-
-
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv if argv is not None else sys.argv[1:])
 
@@ -213,13 +179,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         profiles = _resolve_profiles(args.harness)
         probes = _resolve_probes(args.dimension)
-    except KeyError as exc:
-        print(str(exc), file=sys.stderr)
-        return 2
-
-    try:
-        profiles = _apply_model_overrides(profiles, args.harness, args.model)
-    except ValueError as exc:
+    except (KeyError, ValueError) as exc:
         print(str(exc), file=sys.stderr)
         return 2
 

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+from dataclasses import replace
 
 from tests.harness_bench.bench import run_bench
 from tests.harness_bench.events import LineSink
 from tests.harness_bench.manifest import OFFICIAL_PROFILES
+from tests.harness_bench.probes import ALL_PROBES, PROBES_BY_NAME, CapabilityProbe
 from tests.harness_bench.profile import BenchProfile, resolve_profile
 from tests.harness_bench.report import render_json, render_markdown, render_table
 from tests.harness_bench.transport import driver_registry, resolve_transport_name
@@ -26,6 +28,20 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="Harness to probe (repeatable). An official name, or a "
         "'module:attr' / 'module.ATTR' reference to a community "
         "BenchProfile. Defaults to every official harness.",
+    )
+    parser.add_argument(
+        "--dimension",
+        action="append",
+        metavar="NAME[,NAME...]",
+        help="Capability dimension to run (repeatable or comma-separated), e.g. "
+        "'reasoning' or 'streaming,reasoning'. Basic turn is included as the "
+        "exercisability prerequisite. Defaults to every dimension.",
+    )
+    parser.add_argument(
+        "--model",
+        metavar="MODEL",
+        help="Model override for this bench run. Requires exactly one --harness; "
+        "replaces the profile model without model-pool environment variables.",
     )
     parser.add_argument(
         "--profile",
@@ -110,6 +126,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         "--markdown, else inferred from the extension (.json / .md), else plain text.",
     )
     parser.add_argument("--list", action="store_true", help="List official harnesses and exit.")
+    parser.add_argument(
+        "--list-dimensions", action="store_true", help="List capability dimensions and exit."
+    )
     return parser.parse_args(argv)
 
 
@@ -117,6 +136,23 @@ def _resolve_profiles(names: list[str] | None) -> list[BenchProfile]:
     if not names:
         return list(OFFICIAL_PROFILES.values())
     return [resolve_profile(name) for name in names]
+
+
+def _resolve_probes(values: list[str] | None) -> list[CapabilityProbe]:
+    if not values:
+        return ALL_PROBES
+    requested = [
+        name.strip().lower().replace("-", "_") for value in values for name in value.split(",")
+    ]
+    requested = [name for name in requested if name]
+    unknown = sorted(set(requested) - PROBES_BY_NAME.keys())
+    if unknown:
+        known = ", ".join(PROBES_BY_NAME)
+        raise KeyError(f"unknown --dimension {unknown[0]!r}; known dimensions: {known}")
+    selected = set(requested)
+    if selected != {"basic_turn"}:
+        selected.add("basic_turn")
+    return [probe for probe in ALL_PROBES if probe.name in selected]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -128,11 +164,23 @@ def main(argv: list[str] | None = None) -> int:
             print(f"{name}\t{transport}\t{profile.model}")
         return 0
 
+    if args.list_dimensions:
+        for probe in ALL_PROBES:
+            print(f"{probe.name}\t{probe.title}\t{probe.priority.value}")
+        return 0
+
     try:
         profiles = _resolve_profiles(args.harness)
+        probes = _resolve_probes(args.dimension)
     except KeyError as exc:
         print(str(exc), file=sys.stderr)
         return 2
+
+    if args.model is not None:
+        if args.harness is None or len(profiles) != 1:
+            print("--model requires exactly one --harness", file=sys.stderr)
+            return 2
+        profiles = [replace(profiles[0], model=args.model)]
 
     if args.transport is not None and args.transport not in driver_registry():
         known = ", ".join(sorted(driver_registry()))
@@ -155,11 +203,12 @@ def main(argv: list[str] | None = None) -> int:
 
     sink = None
     if live:
-        sink = _select_progress_sink(args.rich)
+        sink = _select_progress_sink(args.rich, probes=probes)
 
     matrix = asyncio.run(
         run_bench(
             profiles,
+            probes=probes,
             databricks_profile=args.profile,
             live=live,
             transport=args.transport,
@@ -199,7 +248,7 @@ def _grid_already_shown(sink) -> bool:
     return bool(getattr(sink, "drew_grid", False))
 
 
-def _select_progress_sink(rich_flag: bool | None):
+def _select_progress_sink(rich_flag: bool | None, *, probes: list[CapabilityProbe] | None = None):
     """Pick the progress sink for a live run.
 
     ``rich_flag``: ``True`` forces rich, ``False`` forces plain, ``None`` =
@@ -213,7 +262,7 @@ def _select_progress_sink(rich_flag: bool | None):
     if rich_flag is not False:
         from tests.harness_bench.richreport import rich_sink_or_none
 
-        rich_sink = rich_sink_or_none(force=bool(rich_flag))
+        rich_sink = rich_sink_or_none(force=bool(rich_flag), probes=probes)
         if rich_sink is not None:
             return rich_sink
         if rich_flag is True:

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -39,9 +39,10 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--model",
-        metavar="MODEL",
-        help="Model override for this bench run. Requires exactly one --harness; "
-        "replaces the profile model without model-pool environment variables.",
+        action="append",
+        metavar="[HARNESS=]MODEL",
+        help="Model override (repeatable). One harness accepts bare MODEL. "
+        "Multiple harnesses require HARNESS=MODEL for every selected harness.",
     )
     parser.add_argument(
         "--profile",
@@ -155,6 +156,46 @@ def _resolve_probes(values: list[str] | None) -> list[CapabilityProbe]:
     return [probe for probe in ALL_PROBES if probe.name in selected]
 
 
+def _apply_model_overrides(
+    profiles: list[BenchProfile],
+    harness_args: list[str] | None,
+    values: list[str] | None,
+) -> list[BenchProfile]:
+    if not values:
+        return profiles
+    if harness_args is None:
+        raise ValueError("--model requires at least one explicit --harness")
+    if len(profiles) == 1 and len(values) == 1 and "=" not in values[0]:
+        model = values[0].strip()
+        if not model:
+            raise ValueError("--model cannot be empty")
+        return [replace(profiles[0], model=model)]
+
+    selected = [profile.harness for profile in profiles]
+    if len(set(selected)) != len(selected):
+        raise ValueError("model mappings require unique --harness selections")
+    mappings: dict[str, str] = {}
+    for value in values:
+        harness, separator, model = value.partition("=")
+        harness = harness.strip()
+        model = model.strip()
+        if not separator or not harness or not model:
+            raise ValueError(
+                "multiple harnesses require --model HARNESS=MODEL for every selected harness"
+            )
+        if harness in mappings:
+            raise ValueError(f"duplicate --model mapping for harness {harness!r}")
+        mappings[harness] = model
+
+    unknown = sorted(mappings.keys() - set(selected))
+    if unknown:
+        raise ValueError(f"--model mapping names unselected harness {unknown[0]!r}")
+    missing = [harness for harness in selected if harness not in mappings]
+    if missing:
+        raise ValueError(f"missing --model mapping for selected harness {missing[0]!r}")
+    return [replace(profile, model=mappings[profile.harness]) for profile in profiles]
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv if argv is not None else sys.argv[1:])
 
@@ -176,11 +217,11 @@ def main(argv: list[str] | None = None) -> int:
         print(str(exc), file=sys.stderr)
         return 2
 
-    if args.model is not None:
-        if args.harness is None or len(profiles) != 1:
-            print("--model requires exactly one --harness", file=sys.stderr)
-            return 2
-        profiles = [replace(profiles[0], model=args.model)]
+    try:
+        profiles = _apply_model_overrides(profiles, args.harness, args.model)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
 
     if args.transport is not None and args.transport not in driver_registry():
         known = ", ".join(sorted(driver_registry()))

--- a/tests/harness_bench/probes/__init__.py
+++ b/tests/harness_bench/probes/__init__.py
@@ -32,4 +32,6 @@ ALL_PROBES: list[CapabilityProbe] = [
     InterruptProbe(),
 ]
 
-__all__ = ["ALL_PROBES", "CapabilityProbe"]
+PROBES_BY_NAME: dict[str, CapabilityProbe] = {probe.name: probe for probe in ALL_PROBES}
+
+__all__ = ["ALL_PROBES", "PROBES_BY_NAME", "CapabilityProbe"]

--- a/tests/harness_bench/report.py
+++ b/tests/harness_bench/report.py
@@ -6,7 +6,6 @@ import json
 from typing import Any
 
 from tests.harness_bench.bench import BenchMatrix, CellResult, HarnessReport
-from tests.harness_bench.probes import ALL_PROBES
 from tests.harness_bench.verdict import Verdict
 
 # ANSI colors per verdict, applied only when writing to a TTY.
@@ -28,6 +27,14 @@ _OFFLINE_NOTE = "offline (declared shown)"
 # about which transport produced it (e.g. `claude-sdk [full-server]`). The
 # native-tui driver is abbreviated to `native` to match how it is spoken about.
 _TRANSPORT_LABEL = {"native-tui": "native"}
+
+
+def _matrix_dimensions(matrix: BenchMatrix) -> list[tuple[str, str]]:
+    """Return selected dimensions in their report order."""
+    for report in matrix.reports:
+        if report.cells:
+            return [(cell.probe_name, cell.title) for cell in report.cells]
+    return []
 
 
 def _harness_label(report: HarnessReport) -> str:
@@ -84,12 +91,13 @@ def render_table(
         live table already painted the grid to the same terminal, so the report
         adds the per-cell explanations without re-printing the grid.
     """
-    titles = [p.title for p in ALL_PROBES]
-    names = [p.name for p in ALL_PROBES]
+    dimensions = _matrix_dimensions(matrix)
+    names = [name for name, _ in dimensions]
+    titles = [title for _, title in dimensions]
 
     # Column widths from the visible (uncolored) content.
     labels = {id(r): _harness_label(r) for r in matrix.reports}
-    harness_w = max(len("Harness"), *(len(v) for v in labels.values()))
+    harness_w = max([len("Harness"), *(len(v) for v in labels.values())])
     glyphs: dict[tuple[int, str], str] = {}
     verdicts: dict[tuple[int, str], Verdict] = {}
     for r in matrix.reports:
@@ -169,8 +177,9 @@ def render_markdown(matrix: BenchMatrix, *, declared: bool = False) -> str:
     :param declared: When true (offline mode), render declared glyphs so the
         table shows the claimed matrix rather than a grid of skips.
     """
-    columns = [p.title for p in ALL_PROBES]
-    names = [p.name for p in ALL_PROBES]
+    dimensions = _matrix_dimensions(matrix)
+    names = [name for name, _ in dimensions]
+    columns = [title for _, title in dimensions]
 
     header = "| Harness | " + " | ".join(columns) + " |"
     sep = "| --- | " + " | ".join("---" for _ in columns) + " |"

--- a/tests/harness_bench/richreport.py
+++ b/tests/harness_bench/richreport.py
@@ -9,7 +9,7 @@ from tests.harness_bench.events import (
     ProbeFinished,
     ProbeStarted,
 )
-from tests.harness_bench.probes import ALL_PROBES
+from tests.harness_bench.probes import ALL_PROBES, CapabilityProbe
 from tests.harness_bench.verdict import Verdict
 
 # Cell state → what the table shows. Verdicts reuse the report glyphs; the two
@@ -31,7 +31,7 @@ _RUNNING = "[cyan]…[/cyan]"
 _TRANSPORT_LABEL = {"native-tui": "native"}
 
 
-def rich_sink_or_none(*, force: bool = False):
+def rich_sink_or_none(*, force: bool = False, probes: list[CapabilityProbe] | None = None):
     """Return a rich live sink, or ``None`` if rich/TTY is unavailable.
 
     :param force: Build the sink even if stdout is not a TTY (for tests /
@@ -45,7 +45,7 @@ def rich_sink_or_none(*, force: bool = False):
     console = Console(stderr=True)
     if not force and not console.is_terminal:
         return None
-    return _RichLiveSink(console)
+    return _RichLiveSink(console, probes=probes)
 
 
 class _RichLiveSink:
@@ -60,12 +60,13 @@ class _RichLiveSink:
     # re-printing it in the stdout report (see __main__._grid_already_shown).
     drew_grid = True
 
-    def __init__(self, console) -> None:
+    def __init__(self, console, *, probes: list[CapabilityProbe] | None = None) -> None:
         from rich.live import Live
 
         self._console = console
-        self._dimensions = [p.title for p in ALL_PROBES]
-        self._dim_by_name = {p.name: p.title for p in ALL_PROBES}
+        selected = probes if probes is not None else ALL_PROBES
+        self._dimensions = [p.title for p in selected]
+        self._dim_by_name = {p.name: p.title for p in selected}
         # harness → {dim_title: markup}; insertion order = display order.
         self._rows: dict[str, dict[str, str]] = {}
         self._transport: dict[str, str] = {}  # harness → resolved transport label

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -591,16 +591,7 @@ def test_unknown_dimension_is_a_cli_error(capsys: pytest.CaptureFixture[str]) ->
     assert "unknown --dimension 'telepathy'" in capsys.readouterr().err
 
 
-def test_model_override_requires_an_explicit_harness(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    from tests.harness_bench.__main__ import main
-
-    assert main(["--no-live", "--model", "system.ai.gpt-5-6-sol"]) == 2
-    assert "--model requires at least one explicit --harness" in capsys.readouterr().err
-
-
-def test_model_override_and_dimension_slice_reach_report(capsys) -> None:
+def test_harness_model_override_and_dimension_slice_reach_report(capsys) -> None:
     from tests.harness_bench.__main__ import main
 
     assert (
@@ -608,9 +599,7 @@ def test_model_override_and_dimension_slice_reach_report(capsys) -> None:
             [
                 "--no-live",
                 "--harness",
-                "codex",
-                "--model",
-                "system.ai.gpt-5-6-sol",
+                "codex=system.ai.gpt-5-6-sol",
                 "--dimension",
                 "reasoning",
                 "--json",
@@ -624,7 +613,7 @@ def test_model_override_and_dimension_slice_reach_report(capsys) -> None:
     assert [cell["dimension"] for cell in harness["cells"]] == ["basic_turn", "reasoning"]
 
 
-def test_multi_harness_model_mappings_reach_report(capsys) -> None:
+def test_multi_harness_specs_keep_models_attached(capsys) -> None:
     from tests.harness_bench.__main__ import main
 
     assert (
@@ -632,12 +621,8 @@ def test_multi_harness_model_mappings_reach_report(capsys) -> None:
             [
                 "--no-live",
                 "--harness",
-                "codex",
-                "--harness",
-                "claude-sdk",
-                "--model",
                 "codex=system.ai.gpt-5-6-sol",
-                "--model",
+                "--harness",
                 "claude-sdk=databricks-claude-opus-4-8",
                 "--dimension",
                 "reasoning",
@@ -654,7 +639,7 @@ def test_multi_harness_model_mappings_reach_report(capsys) -> None:
     }
 
 
-def test_multi_harness_model_mappings_require_complete_coverage(capsys) -> None:
+def test_multi_harness_specs_allow_default_and_custom_models(capsys) -> None:
     from tests.harness_bench.__main__ import main
 
     assert (
@@ -662,60 +647,25 @@ def test_multi_harness_model_mappings_require_complete_coverage(capsys) -> None:
             [
                 "--no-live",
                 "--harness",
-                "codex",
-                "--harness",
-                "claude-sdk",
-                "--model",
                 "codex=system.ai.gpt-5-6-sol",
-            ]
-        )
-        == 2
-    )
-    assert "missing --model mapping for selected harness 'claude-sdk'" in capsys.readouterr().err
-
-
-def test_multi_harness_model_mappings_reject_positional_models(capsys) -> None:
-    from tests.harness_bench.__main__ import main
-
-    assert (
-        main(
-            [
-                "--no-live",
-                "--harness",
-                "codex",
                 "--harness",
                 "claude-sdk",
-                "--model",
-                "system.ai.gpt-5-6-sol",
-                "--model",
-                "databricks-claude-opus-4-8",
+                "--json",
             ]
         )
-        == 2
+        == 0
     )
-    assert "multiple harnesses require --model HARNESS=MODEL" in capsys.readouterr().err
+    payload = json.loads(capsys.readouterr().out)
+    models = {harness["harness"]: harness["model"] for harness in payload["harnesses"]}
+    assert models["codex"] == "system.ai.gpt-5-6-sol"
+    assert models["claude-sdk"] == OFFICIAL_PROFILES["claude-sdk"].model
 
 
-def test_multi_harness_model_mappings_reject_unselected_harness(capsys) -> None:
+def test_harness_spec_rejects_empty_model(capsys: pytest.CaptureFixture[str]) -> None:
     from tests.harness_bench.__main__ import main
 
-    assert (
-        main(
-            [
-                "--no-live",
-                "--harness",
-                "codex",
-                "--harness",
-                "claude-sdk",
-                "--model",
-                "codex=system.ai.gpt-5-6-sol",
-                "--model",
-                "pi=databricks-claude-sonnet-4-6",
-            ]
-        )
-        == 2
-    )
-    assert "--model mapping names unselected harness 'pi'" in capsys.readouterr().err
+    assert main(["--no-live", "--harness", "codex="]) == 2
+    assert "--harness 'codex' has an empty model override" in capsys.readouterr().err
 
 
 @pytest.fixture

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -269,6 +269,20 @@ def test_grid_already_shown_only_for_grid_drawing_sink() -> None:
     assert _grid_already_shown(_GridSink()) is True
 
 
+def test_progress_sink_receives_selected_probes(monkeypatch) -> None:
+    from tests.harness_bench import __main__ as cli
+
+    captured = []
+    sentinel = object()
+    monkeypatch.setattr(
+        "tests.harness_bench.richreport.rich_sink_or_none",
+        lambda *, force, probes: (captured.extend(probes), sentinel)[1],
+    )
+    selected = [ALL_PROBES[0], ALL_PROBES[3]]
+    assert cli._select_progress_sink(True, probes=selected) is sentinel
+    assert captured == selected
+
+
 async def test_render_table_grid_false_drops_grid_keeps_footer() -> None:
     """grid=False omits the heading + glyph rows but keeps the legend/notes.
 
@@ -549,6 +563,65 @@ def test_cli_writes_report_file(tmp_path) -> None:
     main(["--no-live", "--report", str(js)])
     payload = json.loads(js.read_text())
     assert payload.get("harnesses")
+
+
+def test_dimension_selection_includes_basic_prerequisite() -> None:
+    from tests.harness_bench.__main__ import _resolve_probes
+
+    probes = _resolve_probes(["reasoning", "streaming,tool-calling"])
+    assert [probe.name for probe in probes] == [
+        "basic_turn",
+        "streaming",
+        "reasoning",
+        "tool_calling",
+    ]
+
+
+def test_dimension_selection_deduplicates_and_preserves_registry_order() -> None:
+    from tests.harness_bench.__main__ import _resolve_probes
+
+    probes = _resolve_probes(["reasoning,basic-turn", "reasoning"])
+    assert [probe.name for probe in probes] == ["basic_turn", "reasoning"]
+
+
+def test_unknown_dimension_is_a_cli_error(capsys: pytest.CaptureFixture[str]) -> None:
+    from tests.harness_bench.__main__ import main
+
+    assert main(["--no-live", "--dimension", "telepathy"]) == 2
+    assert "unknown --dimension 'telepathy'" in capsys.readouterr().err
+
+
+def test_model_override_requires_one_explicit_harness(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from tests.harness_bench.__main__ import main
+
+    assert main(["--no-live", "--model", "system.ai.gpt-5-6-sol"]) == 2
+    assert "--model requires exactly one --harness" in capsys.readouterr().err
+
+
+def test_model_override_and_dimension_slice_reach_report(capsys) -> None:
+    from tests.harness_bench.__main__ import main
+
+    assert (
+        main(
+            [
+                "--no-live",
+                "--harness",
+                "codex",
+                "--model",
+                "system.ai.gpt-5-6-sol",
+                "--dimension",
+                "reasoning",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    harness = payload["harnesses"][0]
+    assert harness["model"] == "system.ai.gpt-5-6-sol"
+    assert [cell["dimension"] for cell in harness["cells"]] == ["basic_turn", "reasoning"]
 
 
 @pytest.fixture

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -591,13 +591,13 @@ def test_unknown_dimension_is_a_cli_error(capsys: pytest.CaptureFixture[str]) ->
     assert "unknown --dimension 'telepathy'" in capsys.readouterr().err
 
 
-def test_model_override_requires_one_explicit_harness(
+def test_model_override_requires_an_explicit_harness(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     from tests.harness_bench.__main__ import main
 
     assert main(["--no-live", "--model", "system.ai.gpt-5-6-sol"]) == 2
-    assert "--model requires exactly one --harness" in capsys.readouterr().err
+    assert "--model requires at least one explicit --harness" in capsys.readouterr().err
 
 
 def test_model_override_and_dimension_slice_reach_report(capsys) -> None:
@@ -622,6 +622,100 @@ def test_model_override_and_dimension_slice_reach_report(capsys) -> None:
     harness = payload["harnesses"][0]
     assert harness["model"] == "system.ai.gpt-5-6-sol"
     assert [cell["dimension"] for cell in harness["cells"]] == ["basic_turn", "reasoning"]
+
+
+def test_multi_harness_model_mappings_reach_report(capsys) -> None:
+    from tests.harness_bench.__main__ import main
+
+    assert (
+        main(
+            [
+                "--no-live",
+                "--harness",
+                "codex",
+                "--harness",
+                "claude-sdk",
+                "--model",
+                "codex=system.ai.gpt-5-6-sol",
+                "--model",
+                "claude-sdk=databricks-claude-opus-4-8",
+                "--dimension",
+                "reasoning",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    models = {harness["harness"]: harness["model"] for harness in payload["harnesses"]}
+    assert models == {
+        "codex": "system.ai.gpt-5-6-sol",
+        "claude-sdk": "databricks-claude-opus-4-8",
+    }
+
+
+def test_multi_harness_model_mappings_require_complete_coverage(capsys) -> None:
+    from tests.harness_bench.__main__ import main
+
+    assert (
+        main(
+            [
+                "--no-live",
+                "--harness",
+                "codex",
+                "--harness",
+                "claude-sdk",
+                "--model",
+                "codex=system.ai.gpt-5-6-sol",
+            ]
+        )
+        == 2
+    )
+    assert "missing --model mapping for selected harness 'claude-sdk'" in capsys.readouterr().err
+
+
+def test_multi_harness_model_mappings_reject_positional_models(capsys) -> None:
+    from tests.harness_bench.__main__ import main
+
+    assert (
+        main(
+            [
+                "--no-live",
+                "--harness",
+                "codex",
+                "--harness",
+                "claude-sdk",
+                "--model",
+                "system.ai.gpt-5-6-sol",
+                "--model",
+                "databricks-claude-opus-4-8",
+            ]
+        )
+        == 2
+    )
+    assert "multiple harnesses require --model HARNESS=MODEL" in capsys.readouterr().err
+
+
+def test_multi_harness_model_mappings_reject_unselected_harness(capsys) -> None:
+    from tests.harness_bench.__main__ import main
+
+    assert (
+        main(
+            [
+                "--no-live",
+                "--harness",
+                "codex",
+                "--harness",
+                "claude-sdk",
+                "--model",
+                "codex=system.ai.gpt-5-6-sol",
+                "--model",
+                "pi=databricks-claude-sonnet-4-6",
+            ]
+        )
+        == 2
+    )
+    assert "--model mapping names unselected harness 'pi'" in capsys.readouterr().err
 
 
 @pytest.fixture


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add `--dimension` slicing so focused bench runs execute and render only requested capability columns, with `basic_turn` included automatically as the exercisability prerequisite.
- Extend repeatable `--harness` to accept `NAME[=MODEL]`, keeping model overrides attached to the harness they configure.
- Add `--list-dimensions`, sliced plain/Markdown/Rich rendering, validation tests, and usage documentation.

### ELI5

Previously, checking one capability still ran the entire matrix, and trying a specific model required knowing internal test model-pool environment variables. A focused check is now:

```bash
python -m tests.harness_bench \
  --harness codex=system.ai.gpt-5-6-sol \
  --dimension reasoning
```

Repeated harness arguments naturally support any mix of default and custom models:

```bash
python -m tests.harness_bench \
  --harness codex=system.ai.gpt-5-6-sol \
  --harness claude-sdk \
  --dimension reasoning
```

Here Codex uses the explicit model while Claude SDK keeps its profile default. The bench runs Basic turn first for each harness, then Reasoning, and reports only those two columns.

```text
--dimension reasoning ─────────────> [Basic turn, Reasoning]

--harness codex ──────────────────> Codex profile default model
--harness codex=MODEL ────────────> Codex profile copied with model=MODEL

Repeated arguments keep each override structurally attached to its harness;
there is no positional pairing or separate mapping to validate.
```

### Harness specification contract

- `--harness codex`: run Codex with its normal profile model.
- `--harness codex=system.ai.gpt-5-6-sol`: run Codex with that model.
- Repeat either form for multi-harness runs; defaults and overrides may be mixed.
- Empty overrides such as `--harness codex=` fail with exit code 2.
- Community references remain supported: `--harness module:profile=MODEL`.

### Change map

| File | Change |
| --- | --- |
| `tests/harness_bench/__main__.py` | Parses dimension slices and `NAME[=MODEL]` harness specs, then passes selected probes through the run and Rich sink. |
| `tests/harness_bench/probes/__init__.py` | Exposes a name-to-probe registry for CLI resolution. |
| `tests/harness_bench/report.py` | Derives terminal and Markdown columns from the matrix instead of hard-coding every probe. |
| `tests/harness_bench/richreport.py` | Builds the live grid from the selected probes. |
| `tests/harness_bench/test_bench.py` | Covers selection, normalization, harness model overrides/errors, sliced JSON, and Rich propagation. |
| Bench README/design doc | Documents focused commands, prerequisite behavior, and harness-bound model overrides. |

## Test Plan

- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync pytest -q tests/harness_bench` — **154 passed, 19 skipped**.
- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync ruff check tests/harness_bench` — passed.
- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync ruff format --check tests/harness_bench` — passed.
- `UV_CACHE_DIR=/tmp/omnigent-uv-cache pre-commit run --all-files` — all hooks passed.
- Manual mixed-model smoke test:

```bash
UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync python -m tests.harness_bench \
  --no-live \
  --harness codex=system.ai.gpt-5-6-sol \
  --harness claude-sdk \
  --dimension reasoning \
  --json
```

Observed the explicit Codex model, Claude SDK's profile default, and only the `basic_turn` and `reasoning` dimensions in both reports.

## Demo

N/A — command-line test tooling; no frontend change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests exercise repeatable and comma-separated dimensions, hyphen normalization, deduplication, automatic Basic turn inclusion, unknown-dimension errors, default/custom harness specs, mixed models across repeated harnesses, empty-model errors, sliced JSON output, and Rich sink configuration. Manual verification confirms overrides remain attached to the intended harness and reports contain only selected columns.

## Changelog

The harness benchmark can run selected capability dimensions and pin an exact model directly in each harness argument.