### PR TITLE
fix(onboarding): degrade interactive select to fallback when termios is missing (Windows crash)

### DIFF
--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -401,8 +401,17 @@ def select(
     if not sys.stdin.isatty():
         return _select_fallback(title, options, default=default, selectable=mask)
 
-    import termios
-    import tty
+    try:
+        import termios
+        import tty
+    except ImportError:
+        # termios/tty are POSIX-only. On Windows a real TTY (PowerShell,
+        # Windows Terminal) reports isatty() == True, so the non-TTY guard
+        # above does not catch it — without this guard the import raises
+        # ModuleNotFoundError and crashes ``omnigent setup`` on entry.
+        # Degrade to the numbered fallback instead, mirroring the
+        # ``termios.error`` path below.
+        return _select_fallback(title, options, default=default, selectable=mask)
 
     fd = sys.stdin.fileno()
     selected = _first_selectable(mask, default)

--- a/tests/onboarding/test_interactive.py
+++ b/tests/onboarding/test_interactive.py
@@ -139,6 +139,35 @@ def test_select_empty_options_raises(non_tty: None) -> None:
         interactive.select("Pick", [])
 
 
+def test_select_degrades_to_fallback_when_termios_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``select`` falls back when ``termios`` cannot be imported (Windows TTY).
+
+    On Windows a real terminal (PowerShell, Windows Terminal) reports
+    ``isatty() == True``, so the non-TTY guard does not short-circuit and
+    the function reaches ``import termios`` — a POSIX-only module that does
+    not exist there. Without the ImportError guard this raises
+    ``ModuleNotFoundError`` and crashes ``omnigent setup`` on entry.
+
+    This test reproduces that environment: stdin is a TTY, but ``termios``
+    is unimportable (``sys.modules["termios"] = None`` makes the import
+    raise ``ImportError``). ``select`` must degrade to the numbered
+    fallback rather than crash. Feeds ``"1"`` against two options and
+    expects index ``0`` back.
+    """
+    # Pretend stdin is a real TTY (the Windows Terminal case).
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    # Make ``import termios`` raise ImportError, as it does on Windows.
+    monkeypatch.setitem(sys.modules, "termios", None)
+    monkeypatch.setitem(sys.modules, "tty", None)
+
+    _feed(monkeypatch, ["1"])
+    result = interactive.select("Pick one", ["alpha", "beta"])
+    # Fell back to the numbered path instead of crashing on the import.
+    assert result == 0
+
+
 def test_select_fallback_skips_header_rows_in_numbering(
     non_tty: None,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

`omnigent setup` crashes on entry on Windows with:

```
File ".../omnigent/onboarding/interactive.py", line 404, in select
    import termios
ModuleNotFoundError: No module named 'termios'
```

## Root cause

`interactive.select()` guards the raw-termios arrow-key loop with
`if not sys.stdin.isatty(): return _select_fallback(...)`. On Windows a
real TTY (PowerShell, Windows Terminal) reports `isatty() == True`, so
the guard does **not** short-circuit and execution reaches
`import termios` — a POSIX-only module that does not exist on Windows.
The bare import raises `ModuleNotFoundError`. The surrounding
`except termios.error` only covers `tcgetattr` failures, not a missing
module, so there is no degradation path.

## Fix

Guard the `import termios` / `import tty` with `try/except ImportError`
and degrade to the existing numbered fallback
(`_select_fallback`) — mirroring the `termios.error` path below it and
the `sys.platform != "win32"` guard already used in `claude_native.py`.

This is a minimal, surgical change: only the import is wrapped; the TTY
loop is untouched. On Windows users now get the numbered prompt instead
of a crash; on POSIX behavior is identical.

## Testing

- New regression test `test_select_degrades_to_fallback_when_termios_unavailable`
  reproduces the Windows environment (`isatty() == True` + `termios`
  unimportable via `sys.modules["termios"] = None`) and asserts `select`
  falls back instead of raising.
- Full onboarding interactive suite passes (22/22).
- Reproduced the original crash pre-fix and confirmed the fix resolves it
  via a direct `interactive.select(...)` call in the simulated env.
- `ruff check` clean. (mypy reports 5 pre-existing `termios` attr errors
  that also exist on `main` — the project type-checks on Linux, where
  `termios` has stubs; no new errors introduced.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)