### PR TITLE
fix(cursor-sdk): map legacy auto model id to auto-smart

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -81,8 +81,10 @@ ToolExecutor: TypeAlias = Callable[[str, dict[str, Any]], Awaitable[Any]]  # typ
 
 # Cursor's auto model-select, used when a spec pins no cursor model (the SDK
 # requires a model for local agents, so unlike the old ACP path we can't pass
-# ``None``).
-_DEFAULT_CURSOR_MODEL = "auto"
+# ``None``). The SDK renamed the id from ``auto`` to ``auto-smart``; keep
+# mapping the legacy id for specs/env that still say ``auto``.
+_DEFAULT_CURSOR_MODEL = "auto-smart"
+_LEGACY_AUTO_MODEL = "auto"
 
 # Upper bound (seconds) on one bridged-tool call: generous (sub-agent dispatches
 # can run for minutes) but finite, so a wedged tool surfaces a timeout error
@@ -98,10 +100,11 @@ _HOOK_APPROVAL_TIMEOUT_S = 86400
 def _resolve_model(model: str | None) -> str:
     """Resolve the cursor model id, dropping ids cursor can't honor.
 
-    cursor-sdk accepts only Cursor model ids (``auto``, ``gpt-5``,
+    cursor-sdk accepts only Cursor model ids (``auto-smart``, ``gpt-5``,
     ``composer-2.5``, ...), so a gateway-routed model id (carried by a spec
     authored for another harness) falls back to cursor's auto-select. ``None``
-    likewise resolves to ``auto`` (the SDK requires a model).
+    likewise resolves to :data:`_DEFAULT_CURSOR_MODEL` (the SDK requires a model).
+    The legacy ``auto`` id is remapped to ``auto-smart``.
     """
     if not model or model.startswith(("databricks-", "databricks/")):
         if model:
@@ -114,6 +117,8 @@ def _resolve_model(model: str | None) -> str:
                 model,
                 _DEFAULT_CURSOR_MODEL,
             )
+        return _DEFAULT_CURSOR_MODEL
+    if model == _LEGACY_AUTO_MODEL:
         return _DEFAULT_CURSOR_MODEL
     return model
 
@@ -474,7 +479,8 @@ class CursorExecutor(Executor):
         :param os_env: Optional OS environment / sandbox spec (its ``cwd`` is
             used when *cwd* is unset).
         :param model: Cursor model id (e.g. ``"gpt-5"``); a gateway-routed id
-            or ``None`` falls back to cursor's ``auto`` select.
+            or ``None`` falls back to cursor's ``auto-smart`` select. Legacy
+            ``"auto"`` is remapped to ``auto-smart``.
         :param api_key: Cursor API key. ``None`` falls back to ``CURSOR_API_KEY``
             in the environment.
         :param bundle_dir: Reserved for future skill wiring; unused in v1.

--- a/omnigent/inner/cursor_harness.py
+++ b/omnigent/inner/cursor_harness.py
@@ -17,8 +17,8 @@ route through the Databricks AI gateway.
 
 Env vars read at startup:
 
-- ``HARNESS_CURSOR_MODEL``: Cursor model id, e.g. ``"gpt-5"`` or ``"auto"``.
-  ``None`` resolves to cursor's ``auto`` select. A ``databricks-*`` id (from a
+- ``HARNESS_CURSOR_MODEL``: Cursor model id, e.g. ``"gpt-5"`` or ``"auto-smart"``.
+  ``None`` resolves to cursor's ``auto-smart`` select. A ``databricks-*`` id (from a
   spec authored for another harness) is dropped by the executor.
 - ``HARNESS_CURSOR_CWD``: working directory the session operates in.
   ``None`` falls back to ``os_env.cwd`` then the process cwd.

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -203,11 +203,12 @@ def _tool(
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_model_drops_databricks_and_defaults_to_auto() -> None:
+def test_resolve_model_drops_databricks_and_defaults_to_auto_smart() -> None:
     assert _resolve_model("gpt-5") == "gpt-5"
-    assert _resolve_model("databricks-claude-sonnet-4-6") == "auto"
-    assert _resolve_model("databricks/kimi") == "auto"
-    assert _resolve_model(None) == "auto"
+    assert _resolve_model("databricks-claude-sonnet-4-6") == "auto-smart"
+    assert _resolve_model("databricks/kimi") == "auto-smart"
+    assert _resolve_model(None) == "auto-smart"
+    assert _resolve_model("auto") == "auto-smart"
 
 
 def test_resolve_model_warns_when_dropping_a_pinned_model(
@@ -218,7 +219,7 @@ def test_resolve_model_warns_when_dropping_a_pinned_model(
     import logging
 
     with caplog.at_level(logging.WARNING, logger="omnigent.inner.cursor_executor"):
-        assert _resolve_model("databricks-claude-opus-4-8") == "auto"
+        assert _resolve_model("databricks-claude-opus-4-8") == "auto-smart"
     assert any(
         r.levelno == logging.WARNING and "not a Cursor model" in r.getMessage()
         for r in caplog.records
@@ -226,7 +227,7 @@ def test_resolve_model_warns_when_dropping_a_pinned_model(
     # No warning when there was no explicit model to honor.
     caplog.clear()
     with caplog.at_level(logging.WARNING, logger="omnigent.inner.cursor_executor"):
-        assert _resolve_model(None) == "auto"
+        assert _resolve_model(None) == "auto-smart"
     assert not caplog.records
 
 
@@ -477,14 +478,14 @@ async def test_session_restart_on_system_prompt_change(monkeypatch: pytest.Monke
     assert state["closed"] >= 1
 
 
-async def test_databricks_model_resolved_to_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_databricks_model_resolved_to_auto_smart(monkeypatch: pytest.MonkeyPatch) -> None:
     state = _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
     executor = CursorExecutor(model="databricks-claude-sonnet-4-6", api_key="crsr_x")
     try:
         _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
     finally:
         await executor.close()
-    assert state["create_models"] == ["auto"]
+    assert state["create_models"] == ["auto-smart"]
 
 
 async def test_api_key_threaded_to_create(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1090,11 +1091,11 @@ async def test_run_turn_captures_usage_from_turn_ended_update(
     assert usage["input_tokens"] == 1000
     assert usage["output_tokens"] == 200
     assert usage["total_tokens"] == 1200
-    assert usage["model"] == "auto"
+    assert usage["model"] == "auto-smart"
 
     # _notify_usage_from_dict was called with the same data.
     assert len(notified) == 1
-    assert notified[0]["model"] == "auto"
+    assert notified[0]["model"] == "auto-smart"
     assert notified[0]["usage"] == usage
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

The Cursor Python SDK (`cursor-sdk`) no longer accepts the model id `auto` when starting a local agent — it now requires `auto-smart`. Polly and other `harness: cursor` agents that omit an explicit model (or still pin `model: auto`) were failing at startup with:

```
Failed to start cursor-sdk agent: invalid_argument: Cannot use this model: auto
```

This change updates the cursor-sdk harness default to `auto-smart` and remaps the legacy `auto` id for backward compatibility with existing specs and `HARNESS_CURSOR_MODEL` env values.

## Test Plan

- [x] `uv run python -c` smoke test: `_resolve_model(None)`, `_resolve_model("auto")`, and databricks fallbacks all resolve to `auto-smart`
- [x] Updated unit tests in `tests/inner/test_cursor_executor.py` for the new default and legacy remap

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover `_resolve_model` default/remap behavior and the databricks-model integration path that feeds `AsyncAgent.create`.