### PR TITLE
fix(polly): default Cursor workers to don't-ask permissions

### DIFF
--- a/examples/polly/agents/cursor/config.yaml
+++ b/examples/polly/agents/cursor/config.yaml
@@ -3,14 +3,18 @@ name: cursor
 description: Cursor coding sub-agent — implements, cross-vendor reviews, or explores a scoped task in its own worktree.
 
 # Native Cursor TUI harness (`cursor-agent`): runs in its own terminal the
-# human can open in the UI's Subagents panel and TAKE OVER. cursor-agent owns
-# its own tool-approval gating (omnigent does not intercept it), so dangerous
-# actions surface in the cursor TUI / mirrored web cards rather than being
-# auto-bypassed.
+# human can open in the UI's Subagents panel and TAKE OVER. Headless workers
+# can't answer ApprovalCards, so YOLO skips cursor-agent's in-terminal
+# prompts (and the mirrored web cards). Omnigent ``blast_radius`` still
+# DENYs the catastrophic set. Opt out with ``yolo: false``; or set
+# ``permission_mode: auto`` for Smart Auto (``--auto-review``) instead.
 executor:
   type: omnigent
   config:
     harness: cursor-native
+    # YOLO: headless workers can't answer approval prompts, so run
+    # cursor-agent with full bypass (``--yolo``).
+    yolo: true
 
 prompt: |
   You are Cursor, a coding sub-agent dispatched by the polly

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -466,6 +466,7 @@ class CursorExecutor(Executor):
         bundle_dir: Path | None = None,
         agent_name: str | None = None,
         skills_filter: str | list[str] = "all",
+        permission_mode: str = "auto",
     ) -> None:
         """Create a CursorExecutor.
 
@@ -480,6 +481,10 @@ class CursorExecutor(Executor):
         :param bundle_dir: Reserved for future skill wiring; unused in v1.
         :param agent_name: Optional agent name passed to the SDK.
         :param skills_filter: Accepted for parity; cursor has no skill mechanism here.
+        :param permission_mode: Omnigent permission stance. ``"auto"`` (default)
+            and ``"bypassPermissions"`` skip web-UI elicitation for native
+            tools (policy DENY still blocks). Any other value keeps the
+            interactive per-tool approval card.
         """
         self._cwd = cwd or (os_env.cwd if os_env is not None else None)
         self._os_env_spec = os_env
@@ -488,6 +493,7 @@ class CursorExecutor(Executor):
         self._bundle_dir = bundle_dir
         self._agent_name = agent_name
         self._skills_filter = skills_filter
+        self._permission_mode = permission_mode or "auto"
         self._session_states: dict[str, _CursorSessionState] = {}
         # Installed by the runtime adapter; routes a bridged-tool call back into
         # Omnigent's session (policy gating, sub-agent dispatch, logging).
@@ -546,10 +552,12 @@ class CursorExecutor(Executor):
            ``POLICY_ACTION_DENY``, block immediately without prompting the
            user (the admin already decided).
 
-        2. **Native elicitation**: for any other outcome (ALLOW, ASK, or no
-           evaluator wired), invoke ``_elicitation_handler`` so the user can
-           review the call and approve or abort the remainder of the turn
-           from the web-UI approval card.
+        2. **Native elicitation**: for interactive permission modes, invoke
+           ``_elicitation_handler`` so the user can review the call from the
+           web-UI approval card. Under ``auto`` / ``bypassPermissions``
+           (the default for headless / Polly workers) this step is skipped
+           so native tools don't stall on ApprovalCards — matching
+           claude-sdk's ``permission_mode: auto`` ergonomics.
 
         Cursor native tools execute inside the Cursor process, so they have
         already started by the time the executor observes
@@ -567,8 +575,11 @@ class CursorExecutor(Executor):
                     "reason": getattr(verdict, "reason", "") or "blocked by policy",
                 }
 
-        # Stage 2 — native elicitation: surface an approval card so the
-        # user can decide whether the rest of the turn should continue.
+        # Stage 2 — native elicitation: skip under auto / bypass so headless
+        # Cursor SDK workers (and Polly dispatches) don't prompt per tool.
+        if self._permission_mode in ("auto", "bypassPermissions"):
+            return {"block": False, "reason": ""}
+
         handler = self._elicitation_handler
         if handler is not None:
             logger.info("surfacing elicitation for native cursor tool %s", name)

--- a/omnigent/inner/cursor_harness.py
+++ b/omnigent/inner/cursor_harness.py
@@ -32,6 +32,10 @@ Env vars read at startup:
   cursor has no skill mechanism here). Defaults to ``"all"``.
 - ``HARNESS_CURSOR_BUNDLE_DIR`` / ``HARNESS_CURSOR_AGENT_NAME``:
   reserved for future use.
+- ``HARNESS_CURSOR_PERMISSION_MODE``: Omnigent permission stance
+  (``auto`` default, ``bypassPermissions``, or an interactive mode).
+  ``auto`` / ``bypassPermissions`` skip web-UI elicitation for native
+  tools; other values keep per-tool approval cards.
 """
 
 from __future__ import annotations
@@ -57,6 +61,8 @@ _ENV_OS_ENV = "HARNESS_CURSOR_OS_ENV"
 _ENV_SKILLS_FILTER = "HARNESS_CURSOR_SKILLS_FILTER"
 _ENV_BUNDLE_DIR = "HARNESS_CURSOR_BUNDLE_DIR"
 _ENV_AGENT_NAME = "HARNESS_CURSOR_AGENT_NAME"
+_ENV_PERMISSION_MODE = "HARNESS_CURSOR_PERMISSION_MODE"
+_DEFAULT_PERMISSION_MODE = "auto"
 
 
 def _resolve_os_env() -> OSEnvSpec:
@@ -136,6 +142,9 @@ def _build_cursor_executor() -> Executor:
         bundle_dir=bundle_dir,
         agent_name=os.environ.get(_ENV_AGENT_NAME, "").strip() or None,
         skills_filter=_resolve_skills_filter(),
+        permission_mode=(
+            os.environ.get(_ENV_PERMISSION_MODE, "").strip() or _DEFAULT_PERMISSION_MODE
+        ),
     )
 
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1756,6 +1756,12 @@ def _build_cursor_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_CURSOR_OS_ENV"] = os_env_payload
+    # Permission stance for native-tool elicitation. Default ``auto`` (set by
+    # the harness wrap when unset) skips ApprovalCards so headless / Polly
+    # Cursor SDK workers don't stall; an explicit config value overrides.
+    permission_mode = spec.executor.config.get("permission_mode")
+    if permission_mode is not None:
+        env["HARNESS_CURSOR_PERMISSION_MODE"] = str(permission_mode)
     return env
 
 

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -582,6 +582,7 @@ _CODEX_NATIVE_WRAPPER_LABEL_VALUE = CODEX_NATIVE_CODING_AGENT.wrapper_label
 _CODEX_NATIVE_HARNESS = CODEX_NATIVE_CODING_AGENT.harness
 _CODEX_NATIVE_MODEL = CODEX_NATIVE_CODING_AGENT.agent_name
 _CURSOR_NATIVE_WRAPPER_LABEL_VALUE = CURSOR_NATIVE_CODING_AGENT.wrapper_label
+_CURSOR_NATIVE_HARNESS = CURSOR_NATIVE_CODING_AGENT.harness
 _KIRO_NATIVE_WRAPPER_LABEL_VALUE = KIRO_NATIVE_CODING_AGENT.wrapper_label
 _CLAUDE_NATIVE_MESSAGE_TIMEOUT_S = 30.0
 _NATIVE_TERMINAL_START_FAILED_CODE = "native_terminal_start_failed"
@@ -12070,12 +12071,12 @@ def _derive_terminal_launch_args_from_spec(sub_spec: AgentSpec) -> list[str] | N
     """
     Derive native-terminal YOLO pass-through args from a trusted sub-spec.
 
-    polly's native workers (claude-native / codex-native) launch in a
-    headless pane where no human can answer an ApprovalCard, so every
-    Edit/Write/Bash that prompts stalls the worker. This translates a
+    polly's native workers (claude-native / codex-native / cursor-native)
+    launch in a headless pane where no human can answer an ApprovalCard, so
+    every Edit/Write/Bash that prompts stalls the worker. This translates a
     worker bundle's declared full-bypass intent into the per-session
-    ``terminal_launch_args`` the runner already appends to the claude /
-    codex argv:
+    ``terminal_launch_args`` the runner already appends to the native CLI
+    argv:
 
     - claude-native + ``executor.config.permission_mode`` set ->
       ``["--permission-mode", "<value>"]``. The value is passed through
@@ -12092,12 +12093,21 @@ def _derive_terminal_launch_args_from_spec(sub_spec: AgentSpec) -> list[str] | N
       and the codex-sdk executor's ``approvalPolicy="never"``). An explicit
       ``executor.config.yolo: false`` opts back out for a read-only / must
       -keep-prompting sub-agent. See issue #171.
+    - cursor-native -> ``["--yolo"]`` by DEFAULT. Headless cursor workers
+      otherwise stall on cursor-agent's in-terminal approval prompts (also
+      mirrored as web elicitation cards). ``--yolo`` is cursor-agent's
+      don't-ask / full-bypass flag (``--auto-review`` still prompts for
+      some calls). An explicit ``executor.config.yolo: false`` opts back
+      out. When ``executor.config.permission_mode`` / ``exec_mode`` is set
+      to ``auto`` or ``auto-review``, emit ``["--auto-review"]`` instead
+      (Smart Auto) so a bundle can choose Claude-style auto without full
+      yolo.
 
-    Only the two native harnesses are translated; for any other harness
-    (e.g. ``claude-sdk``, whose bypass is set via the SDK ``permissionMode``
-    spawn env, not a terminal flag) this returns ``None`` so no terminal
-    args are set. ``None`` is also returned when the relevant field is
-    absent / falsey.
+    Only those native harnesses are translated; for any other harness
+    (e.g. ``claude-sdk`` / ``cursor``, whose bypass is set via the SDK
+    ``permissionMode`` / ``auto_review`` spawn path, not a terminal flag)
+    this returns ``None`` so no terminal args are set. ``None`` is also
+    returned when the relevant field is absent / falsey.
 
     :param sub_spec: The trusted child sub-agent spec, resolved from the
         server-loaded parent bundle via :func:`_resolve_subagent_spec`.
@@ -12124,6 +12134,22 @@ def _derive_terminal_launch_args_from_spec(sub_spec: AgentSpec) -> list[str] | N
         if _spec_config_flag_explicitly_disabled(sub_spec, "yolo"):
             return None
         return _validate_terminal_launch_args(["--dangerously-bypass-approvals-and-sandbox"])
+    if harness == _CURSOR_NATIVE_HARNESS:
+        # Prefer an explicit Smart Auto mode when the bundle asks for it
+        # (mirrors Claude's ``permission_mode: auto``), else full --yolo
+        # by default so headless polly workers don't stall on mirrored
+        # approval cards. ``yolo: false`` is the keep-prompting opt-out.
+        mode = (
+            sub_spec.executor.config.get("permission_mode")
+            or sub_spec.executor.config.get("exec_mode")
+            or ""
+        )
+        mode_norm = str(mode).strip().lower()
+        if mode_norm in ("auto", "auto-review"):
+            return _validate_terminal_launch_args(["--auto-review"])
+        if _spec_config_flag_explicitly_disabled(sub_spec, "yolo"):
+            return None
+        return _validate_terminal_launch_args(["--yolo"])
     return None
 
 
@@ -12460,12 +12486,12 @@ async def _create_session_from_existing_agent(
     # from the trusted, server-loaded sub-spec only — any caller-supplied
     # ``body.terminal_launch_args`` is ignored. This is the YOLO seam:
     # claude-native maps ``permission_mode`` to ``--permission-mode``,
-    # while codex-native defaults to full bypass
-    # (``--dangerously-bypass-approvals-and-sandbox``) so a headless
-    # codex worker can edit/run unattended without stalling on codex's
-    # on-request approval default (opt out with ``yolo: false``). A
-    # caller cannot inject launch wiring by smuggling args through the
-    # spawn body.
+    # codex-native defaults to full bypass
+    # (``--dangerously-bypass-approvals-and-sandbox``), and cursor-native
+    # defaults to ``--yolo`` so a headless worker can edit/run unattended
+    # without stalling on native approval prompts (opt out with
+    # ``yolo: false``). A caller cannot inject launch wiring by smuggling
+    # args through the spawn body.
     #
     # Sessions that resolve their own agent (top-level sessions and the
     # manual Add Agent child flow where ``sub_agent_name`` is null) keep

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -96,6 +96,11 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
     assert fam["pi"] == "pi"
     # Six distinct vendors → any implementer's diff is reviewable by another.
     assert len(set(fam.values())) == 6
+    # Headless bypass knobs so workers don't stall on ApprovalCards.
+    by_name = {a.name: a for a in polly_spec.sub_agents}
+    assert by_name["claude_code"].executor.config.get("permission_mode") == "auto"
+    assert by_name["codex"].executor.config.get("yolo") in (True, "True", "true")
+    assert by_name["cursor"].executor.config.get("yolo") in (True, "True", "true")
     for name in ("claude_code", "codex", "opencode", "cursor", "hermes", "pi"):
         prompt = (_POLLY_BUNDLE / "agents" / name / "config.yaml").read_text(encoding="utf-8")
         assert "IMPLEMENT — write real product code" in prompt

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1371,7 +1371,8 @@ async def test_run_turn_native_tool_handler_approves(
         "result": "Done.",
     }
     _install_fake_sdk(monkeypatch, [script])
-    executor = CursorExecutor(api_key="crsr_x")
+    # Interactive mode keeps per-tool elicitation; auto (default) would skip it.
+    executor = CursorExecutor(api_key="crsr_x", permission_mode="default")
     # No policy evaluator — handler alone is sufficient to show the card.
 
     async def _approve(_name: str, _args: dict[str, Any]) -> bool:
@@ -1400,7 +1401,7 @@ async def test_run_turn_native_tool_handler_denies(
         "result": "",
     }
     _install_fake_sdk(monkeypatch, [script])
-    executor = CursorExecutor(api_key="crsr_x")
+    executor = CursorExecutor(api_key="crsr_x", permission_mode="default")
 
     async def _deny(_name: str, _args: dict[str, Any]) -> bool:
         return False
@@ -1473,7 +1474,7 @@ async def test_run_turn_native_tool_ask_user_approves(
         "result": "Done.",
     }
     _install_fake_sdk(monkeypatch, [script])
-    executor = CursorExecutor(api_key="crsr_x")
+    executor = CursorExecutor(api_key="crsr_x", permission_mode="default")
     executor._policy_evaluator = _policy_ask("PHASE_TOOL_CALL")
 
     async def _approve(_name: str, _args: dict[str, Any]) -> bool:
@@ -1502,7 +1503,7 @@ async def test_run_turn_native_tool_ask_user_denies(
         "result": "",
     }
     _install_fake_sdk(monkeypatch, [script])
-    executor = CursorExecutor(api_key="crsr_x")
+    executor = CursorExecutor(api_key="crsr_x", permission_mode="default")
     executor._policy_evaluator = _policy_ask("PHASE_TOOL_CALL")
 
     async def _deny(_name: str, _args: dict[str, Any]) -> bool:
@@ -1517,6 +1518,40 @@ async def test_run_turn_native_tool_ask_user_denies(
     errors = [e for e in events if isinstance(e, ExecutorError)]
     assert len(errors) == 1
     assert not any(isinstance(e, TurnComplete) for e in events)
+
+
+async def test_run_turn_native_tool_auto_mode_skips_elicitation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default ``permission_mode=auto`` skips the web-UI approval card."""
+    script = {
+        "messages": [
+            _assistant("Running."),
+            _tool("bash", "t1", "running", args={"cmd": "ls"}),
+            _tool("bash", "t1", "completed", result="file.txt"),
+            _assistant("Done."),
+        ],
+        "status": "finished",
+        "result": "Done.",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+    executor = CursorExecutor(api_key="crsr_x")  # default permission_mode=auto
+    handler_called = False
+
+    async def _deny(_name: str, _args: dict[str, Any]) -> bool:
+        nonlocal handler_called
+        handler_called = True
+        return False
+
+    executor._elicitation_handler = _deny
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    assert not handler_called
+    assert any(isinstance(e, TurnComplete) for e in events)
+    assert not any(isinstance(e, ExecutorError) for e in events)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/test_cursor_spawn_env.py
+++ b/tests/runtime/test_cursor_spawn_env.py
@@ -44,11 +44,14 @@ def _make_spec(
     model: str | None = "gpt-5",
     name: str = "test-cursor",
     auth: ApiKeyAuth | DatabricksAuth | None = None,
+    permission_mode: str | None = None,
 ) -> AgentSpec:
     """Build a minimal cursor :class:`AgentSpec` for the spawn-env tests."""
     config: dict[str, object] = {"harness": "cursor"}
     if model is not None:
         config["model"] = model
+    if permission_mode is not None:
+        config["permission_mode"] = permission_mode
     return AgentSpec(
         spec_version=1,
         name=name,
@@ -123,6 +126,18 @@ def test_skills_filter_always_set() -> None:
     falls back to ``"all"`` and overrides an explicit ``skills: none``."""
     env = _build_cursor_spawn_env(_make_spec())
     assert "HARNESS_CURSOR_SKILLS_FILTER" in env
+
+
+def test_permission_mode_threads_into_env_var() -> None:
+    """``executor.config.permission_mode`` sets ``HARNESS_CURSOR_PERMISSION_MODE``."""
+    env = _build_cursor_spawn_env(_make_spec(permission_mode="default"))
+    assert env["HARNESS_CURSOR_PERMISSION_MODE"] == "default"
+
+
+def test_no_permission_mode_omits_env_var() -> None:
+    """Absent ``permission_mode`` leaves the harness wrap on its ``auto`` default."""
+    env = _build_cursor_spawn_env(_make_spec())
+    assert "HARNESS_CURSOR_PERMISSION_MODE" not in env
 
 
 def test_name_threads_into_agent_name_env_var() -> None:

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -1219,6 +1219,11 @@ async def test_native_subagent_session_stamps_terminal_ui_labels(
             {"yolo": True},
             ["--dangerously-bypass-approvals-and-sandbox"],
         ),
+        (
+            "cursor-native",
+            {"yolo": True},
+            ["--yolo"],
+        ),
     ],
 )
 async def test_native_subagent_yolo_args_derived_from_trusted_spec(
@@ -1232,11 +1237,12 @@ async def test_native_subagent_yolo_args_derived_from_trusted_spec(
 
     The worker sub-agent's own bundle declares its full-bypass intent
     (``permission_mode: bypassPermissions`` for claude-native,
-    ``yolo: true`` for codex-native). On a sub-agent create, the server
-    derives the matching flag list from that trusted, server-loaded spec
-    and persists it as the child session's ``terminal_launch_args`` —
-    which the runner appends to the claude / codex argv so the headless
-    worker can edit without stalling on an ApprovalCard.
+    ``yolo: true`` for codex-native / cursor-native). On a sub-agent create,
+    the server derives the matching flag list from that trusted,
+    server-loaded spec and persists it as the child session's
+    ``terminal_launch_args`` — which the runner appends to the native CLI
+    argv so the headless worker can edit without stalling on an
+    ApprovalCard.
 
     A failure here means the translation seam regressed and the worker
     would launch in its default prompting mode (and hang headless).

--- a/tests/server/routes/test_sessions_yolo_launch_args.py
+++ b/tests/server/routes/test_sessions_yolo_launch_args.py
@@ -1,12 +1,13 @@
 """Unit tests for native-worker YOLO ``terminal_launch_args`` derivation.
 
-Nessie's native sub-agent workers (claude-native / codex-native) launch
-in a headless pane where no human can answer an approval prompt. The
-server translates a worker's bypass stance into the per-session
-``terminal_launch_args`` the runner appends to the claude / codex argv:
-claude-native opts in via ``permission_mode``, while codex-native
-defaults to full bypass (issue #171) because the headless seam has no
-safe non-bypass default, with ``yolo: false`` as the opt-out.
+Nessie's native sub-agent workers (claude-native / codex-native /
+cursor-native) launch in a headless pane where no human can answer an
+approval prompt. The server translates a worker's bypass stance into the
+per-session ``terminal_launch_args`` the runner appends to the native
+CLI argv: claude-native opts in via ``permission_mode``, while
+codex-native and cursor-native default to full bypass (issue #171 /
+cursor ``--yolo``) because the headless seam has no safe non-bypass
+default, with ``yolo: false`` as the opt-out.
 
 These tests exercise the pure translation helper
 ``_derive_terminal_launch_args_from_spec`` directly with real
@@ -139,20 +140,57 @@ def test_codex_native_yolo_false_string_opts_out_of_bypass() -> None:
     assert _derive_terminal_launch_args_from_spec(spec) is None
 
 
+def test_cursor_native_defaults_to_yolo_flag() -> None:
+    """
+    A headless cursor-native sub-agent defaults to ``--yolo``.
+
+    Polly's cursor worker launches in a pane where no human answers
+    cursor-agent's in-terminal approval prompts (also mirrored as web
+    elicitation cards). Without ``--yolo`` the worker stalls on the first
+    gated tool call — the same headless seam that forced codex's default
+    bypass (issue #171).
+    """
+    cursor = _spec_with_config({"harness": "cursor-native"})
+    assert _derive_terminal_launch_args_from_spec(cursor) == ["--yolo"]
+
+
+def test_cursor_native_yolo_true_translates_to_yolo_flag() -> None:
+    """cursor-native + ``yolo: true`` (string ``"True"``) -> ``--yolo``."""
+    spec = _spec_with_config({"harness": "cursor-native", "yolo": "True"})
+    assert _derive_terminal_launch_args_from_spec(spec) == ["--yolo"]
+
+
+def test_cursor_native_yolo_false_opts_out() -> None:
+    """``yolo: false`` keeps cursor-native prompting (no launch args)."""
+    spec = _spec_with_config({"harness": "cursor-native", "yolo": "False"})
+    assert _derive_terminal_launch_args_from_spec(spec) is None
+
+
+def test_cursor_native_permission_mode_auto_uses_auto_review() -> None:
+    """
+    cursor-native + ``permission_mode: auto`` -> ``--auto-review``.
+
+    Mirrors Claude's ``permission_mode: auto`` for bundles that want Smart
+    Auto rather than full don't-ask YOLO.
+    """
+    spec = _spec_with_config({"harness": "cursor-native", "permission_mode": "auto"})
+    assert _derive_terminal_launch_args_from_spec(spec) == ["--auto-review"]
+
+
 @pytest.mark.parametrize(
     "harness",
-    ["claude-sdk", "codex", "openai-agents"],
+    ["claude-sdk", "codex", "openai-agents", "cursor"],
 )
 def test_non_native_harness_with_bypass_fields_is_ignored(harness: str) -> None:
     """
     Non-native harnesses never get terminal args, even with bypass fields.
 
-    ``terminal_launch_args`` is a native-terminal (claude/codex TUI)
-    concept; a claude-sdk worker sets bypass via the SDK ``permissionMode``
-    spawn env, not a CLI flag. Translating these fields for a non-native
-    harness would emit a flag the runner has no terminal to apply it to.
-    A failure means the harness gate leaked. Both bypass fields are set to
-    prove neither branch fires for a non-native harness.
+    ``terminal_launch_args`` is a native-terminal (claude/codex/cursor TUI)
+    concept; a claude-sdk / cursor-sdk worker sets bypass via the SDK
+    permission mode spawn env, not a CLI flag. Translating these fields for
+    a non-native harness would emit a flag the runner has no terminal to
+    apply it to. A failure means the harness gate leaked. Both bypass
+    fields are set to prove neither branch fires for a non-native harness.
     """
     spec = _spec_with_config(
         {"harness": harness, "permission_mode": "bypassPermissions", "yolo": "True"}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Polly's Cursor sub-agent was launching without a don't-ask flag, so every gated tool stalled on cursor-agent approval prompts (and the mirrored web elicitation cards). Claude and Codex already opt into headless bypass (`permission_mode: auto` / `yolo`); Cursor was missing from that seam.

Confirmed on this machine: recent Polly `cursor` child sessions had `terminal_launch_args: null`, while sibling `claude_code` / `codex` sessions carried their bypass flags.

- Derive `--yolo` by default for `cursor-native` sub-agents (opt out with `yolo: false`; `permission_mode: auto` → `--auto-review`)
- Set Polly's cursor worker to `yolo: true`
- Default Cursor SDK (`harness: cursor`) `permission_mode` to `auto` so native tools skip web ApprovalCards (policy DENY still blocks)

## Test Plan

- [x] `uv run --frozen --extra dev python -m pytest tests/server/routes/test_sessions_yolo_launch_args.py tests/runtime/test_cursor_spawn_env.py tests/e2e/omnigent/test_example_polly.py -q`
- [x] `uv run --frozen --extra dev python -m pytest tests/inner/test_cursor_executor.py -k "handler or ask_user or auto_mode or policy_deny" -q`
- [x] Inspected local `~/.omnigent/chat.db`: Polly cursor children had null launch args pre-fix

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified local Polly Cursor child sessions were missing `terminal_launch_args` while Claude/Codex siblings had bypass flags. After this change, cursor-native derivation returns `["--yolo"]` by default.

## Changelog

Polly Cursor workers no longer ask for tool permissions by default (YOLO / auto)