### PR TITLE
feat(policies): expose conversation identity in the policy event context

### DIFF
--- a/omnigent/policies/function.py
+++ b/omnigent/policies/function.py
@@ -201,7 +201,10 @@ def _build_event(ctx: EvaluationContext) -> dict[str, Any]:
             "data": <phase-specific-payload>,
             "context": {"actor": {"run_as": "...", "client_id": "..."},
                         "usage": {"input_tokens": N, ...},
-                        "model": "<active-model-or-None>"},
+                        "model": "<active-model-or-None>",
+                        "conversation_id": "<conv-id-or-None>",
+                        "root_conversation_id": "<root-id-or-None>",
+                        "sub_agent_name": "<child-name-or-None>"},
             "session_state": {...},
             "llm_client": <PolicyLLMClient-or-None>,
             "request_data": <original-tool-call-on-TOOL_RESULT>,
@@ -236,6 +239,14 @@ def _build_event(ctx: EvaluationContext) -> dict[str, Any]:
             "harness": ctx.harness,
             # Conversation labels (engine hot cache), empty when unpopulated.
             "labels": dict(ctx.labels) if ctx.labels is not None else {},
+            # Conversation identity, injected by the engine (None on
+            # paths that never populated it — runner-local gate, test
+            # contexts). root_conversation_id != conversation_id marks a
+            # sub-agent child; sub_agent_name is the dispatched child's
+            # name (None for top-level sessions).
+            "conversation_id": ctx.conversation_id,
+            "root_conversation_id": ctx.root_conversation_id,
+            "sub_agent_name": ctx.sub_agent_name,
             # Subtree-scoped cumulative cost (this conversation + its
             # descendants only), injected by the engine only when a
             # subagent_cost_budget policy is present; empty dict otherwise.

--- a/omnigent/policies/schema.py
+++ b/omnigent/policies/schema.py
@@ -158,6 +158,18 @@ class EventContext(TypedDict, total=False):
         labels, e.g. ``{"cost_control.plan": "{...}"}``. Populated by
         the server-side engine; empty on paths that don't carry labels
         (the runner-local gate). Read via ``event["context"]["labels"]``.
+    :param conversation_id: The conversation under evaluation, e.g.
+        ``"conv_abc123"``. Populated by the server-side engine; ``None``
+        on paths that don't carry it (the runner-local gate). Read via
+        ``event["context"]["conversation_id"]``.
+    :param root_conversation_id: The root of the conversation's spawn
+        tree — equal to ``conversation_id`` for top-level sessions,
+        different exactly for sub-agent children. Read via
+        ``event["context"]["root_conversation_id"]``.
+    :param sub_agent_name: The dispatched sub-agent's name for child
+        conversations (``None`` for top-level sessions), e.g.
+        ``"researcher"``. Read via
+        ``event["context"]["sub_agent_name"]``.
     """
 
     actor: ActorContext
@@ -170,6 +182,11 @@ class EventContext(TypedDict, total=False):
     model: str | None
     harness: str | None
     labels: dict[str, str]
+    # Conversation identity — ``None`` (carried, not absent) on paths
+    # that never populated it (runner-local gate, test contexts).
+    conversation_id: str | None
+    root_conversation_id: str | None
+    sub_agent_name: str | None
 
 
 class PolicyEvent(TypedDict, total=False):

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -175,6 +175,23 @@ class EvaluationContext:
         label state via ``event["context"]["labels"]``. ``None`` means
         "not populated" (runner-local gate, test contexts) — policies
         must treat that the same as an empty mapping.
+    :param conversation_id: The conversation this evaluation belongs
+        to, e.g. ``"conv_abc123"``. Injected by the engine (it owns the
+        id) so policies can key session-scoped state or telemetry
+        without a side channel — callers leave it ``None``. Surfaced as
+        ``event["context"]["conversation_id"]``. ``None`` means "engine
+        never populated it" (runner-local gate, test contexts).
+    :param root_conversation_id: The root of this conversation's spawn
+        tree. Equal to ``conversation_id`` for a top-level session;
+        differs exactly when the conversation is a sub-agent child.
+        Injected by the engine alongside ``conversation_id``. Surfaced
+        as ``event["context"]["root_conversation_id"]``.
+    :param sub_agent_name: The dispatched sub-agent's name (the
+        conversation row's ``sub_agent_name``), e.g. ``"researcher"``;
+        ``None`` for top-level sessions. Injected by the engine so
+        policies can tell child evaluations apart without label
+        conventions. Surfaced as
+        ``event["context"]["sub_agent_name"]``.
     :param llm_client: An :class:`~omnigent.policies.types.PolicyLLMClient`
         instance configured with the server-level LLM credentials.
         Available to function policy callables via
@@ -196,6 +213,9 @@ class EvaluationContext:
     model: str | None = None
     harness: str | None = None
     labels: dict[str, str] | None = None
+    conversation_id: str | None = None
+    root_conversation_id: str | None = None
+    sub_agent_name: str | None = None
     llm_client: Any = None  # PolicyLLMClient | None — Any to avoid import cycle
 
 

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -366,6 +366,7 @@ def build_policy_engine(
     # root-seeding pattern below).
     conv = conversation_store.get_conversation(conversation_id)
     root_conversation_id = conv.root_conversation_id if conv is not None else conversation_id
+    sub_agent_name = conv.sub_agent_name if conv is not None else None
     if root_conversation_id != conversation_id:
         root_policy_specs = _load_session_policy_specs(root_conversation_id, policy_store)
         # Deduplicate: skip root policies already present on the child
@@ -460,6 +461,7 @@ def build_policy_engine(
         initial_model=initial_model,
         conversation_store=conversation_store,
         root_conversation_id=root_conversation_id,
+        sub_agent_name=sub_agent_name,
         llm_client=llm_client,
     )
 

--- a/omnigent/runtime/policies/engine.py
+++ b/omnigent/runtime/policies/engine.py
@@ -117,6 +117,7 @@ class PolicyEngine:
         initial_model: str | None = None,
         conversation_store: ConversationStore,
         root_conversation_id: str | None = None,
+        sub_agent_name: str | None = None,
         llm_client: Any = None,
     ) -> None:
         self.policies = policies
@@ -128,6 +129,11 @@ class PolicyEngine:
         # approving once covers the whole tree — a sub-agent runs as its own
         # conversation. Defaults to ``conversation_id`` for a top-level session.
         self._root_conversation_id = root_conversation_id or conversation_id
+        # The dispatched sub-agent's name when this conversation is a
+        # child (the conversation row's ``sub_agent_name``); ``None`` for
+        # top-level sessions. Surfaced to policies via
+        # ``event["context"]["sub_agent_name"]``.
+        self._sub_agent_name = sub_agent_name
         self._labels = dict(initial_labels)
         self._session_state: dict[str, Any] = dict(initial_session_state or {})
         self._usage: dict[str, float] = dict(
@@ -346,6 +352,7 @@ class PolicyEngine:
         ctx = self._inject_user_daily_cost(ctx)
         ctx = self._inject_model(ctx)
         ctx = self._inject_labels(ctx)
+        ctx = self._inject_conversation(ctx)
         ctx = self._inject_llm_client(ctx)
 
         for policy in self.policies:
@@ -758,6 +765,35 @@ class PolicyEngine:
         if ctx.model is not None:
             return ctx
         return replace(ctx, model=self._model)
+
+    def _inject_conversation(self, ctx: EvaluationContext) -> EvaluationContext:
+        """
+        Return a copy of *ctx* with conversation identity populated.
+
+        Injects the engine's ``conversation_id`` / ``root_conversation_id``
+        (it owns both) and the dispatched sub-agent's name so function
+        policy callables can key session-scoped state or telemetry and
+        recognize sub-agent children via
+        ``event["context"]["conversation_id"]`` /
+        ``["root_conversation_id"]`` / ``["sub_agent_name"]`` without a
+        label convention or side channel. When the caller already
+        supplied a ``conversation_id`` on *ctx* (test contexts), *ctx*
+        is returned unchanged.
+
+        :param ctx: Original :class:`EvaluationContext` from the
+            caller.
+        :returns: *ctx* unchanged when it already carries a
+            conversation id, else a copy with all three identity fields
+            set from the engine.
+        """
+        if ctx.conversation_id is not None:
+            return ctx
+        return replace(
+            ctx,
+            conversation_id=self._conversation_id,
+            root_conversation_id=self._root_conversation_id,
+            sub_agent_name=self._sub_agent_name,
+        )
 
     def _inject_labels(self, ctx: EvaluationContext) -> EvaluationContext:
         """

--- a/tests/runtime/policies/test_conversation_identity.py
+++ b/tests/runtime/policies/test_conversation_identity.py
@@ -1,0 +1,197 @@
+"""
+Tests for conversation identity in the policy event context —
+``conversation_id`` / ``root_conversation_id`` / ``sub_agent_name``.
+
+Verifies:
+- ``_build_event`` carries all three keys (``None``, not absent, when
+  unpopulated) so callables can read them without ``KeyError``.
+- ``_build_event`` passes populated values through unchanged.
+- The engine injects its own ids and the dispatched sub-agent's name
+  into ``event["context"]`` on every evaluation.
+- A caller-supplied ``conversation_id`` on the context wins (test
+  contexts), mirroring ``_inject_model``.
+- Top-level sessions see ``root_conversation_id == conversation_id``
+  and ``sub_agent_name is None``; sub-agent children see the root id
+  and their name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from omnigent.policies.function import FunctionPolicy, _build_event
+from omnigent.policies.types import EvaluationContext
+from omnigent.runtime.policies.engine import PolicyEngine
+from omnigent.spec.types import (
+    FunctionPolicySpec,
+    FunctionRef,
+    Phase,
+    PhaseSelector,
+)
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+
+def _identity_capturing_policy(bucket: dict[str, Any]) -> FunctionPolicy:
+    """
+    Build a :class:`FunctionPolicy` that records the event context's
+    conversation identity into *bucket* for assertion.
+
+    :param bucket: Dict the captured ``conversation_id`` /
+        ``root_conversation_id`` / ``sub_agent_name`` are written into.
+    :returns: A capturing :class:`FunctionPolicy`.
+    """
+
+    def _evaluate(event: dict[str, Any]) -> dict[str, Any]:
+        context = event["context"]
+        bucket["conversation_id"] = context["conversation_id"]
+        bucket["root_conversation_id"] = context["root_conversation_id"]
+        bucket["sub_agent_name"] = context["sub_agent_name"]
+        return {"result": "ALLOW"}
+
+    spec = FunctionPolicySpec(
+        name="capture_identity",
+        on=[PhaseSelector(phase=Phase.REQUEST)],
+        function=FunctionRef(path="test.not.used"),
+    )
+    return FunctionPolicy(spec, _evaluate)
+
+
+# ── _build_event carries the identity keys ──────────────────────────────────
+
+
+def test_build_event_identity_keys_default_none() -> None:
+    """
+    ``_build_event`` includes all three identity keys as ``None`` when
+    the context never populated them.
+
+    What breaks if this fails: the keys are missing from the event
+    dict, causing ``KeyError`` in policy callables that read
+    ``event["context"]["conversation_id"]`` on paths that don't inject
+    identity (the runner-local gate, test contexts).
+    """
+    event = _build_event(EvaluationContext(phase=Phase.REQUEST, content="hello"))
+    context = event["context"]
+    assert context["conversation_id"] is None
+    assert context["root_conversation_id"] is None
+    assert context["sub_agent_name"] is None
+
+
+def test_build_event_identity_passthrough() -> None:
+    """
+    ``_build_event`` passes populated identity values through unchanged.
+
+    What breaks if this fails: the engine's injected ids are dropped or
+    renamed, so callables can't correlate evaluations to conversations.
+    """
+    ctx = EvaluationContext(
+        phase=Phase.REQUEST,
+        content="hello",
+        conversation_id="conv_child",
+        root_conversation_id="conv_root",
+        sub_agent_name="researcher",
+    )
+    context = _build_event(ctx)["context"]
+    assert context["conversation_id"] == "conv_child"
+    assert context["root_conversation_id"] == "conv_root"
+    assert context["sub_agent_name"] == "researcher"
+
+
+# ── Engine injection ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_engine_injects_identity_for_top_level_session(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    The engine injects its ``conversation_id`` into the event context;
+    a top-level session's root equals its own id and has no
+    ``sub_agent_name``.
+
+    What breaks if this fails: policies keying session-scoped state or
+    telemetry by conversation have no identity to key on and must fall
+    back to fragile label conventions.
+    """
+    conv = conversation_store.create_conversation()
+    bucket: dict[str, Any] = {}
+    engine = PolicyEngine(
+        policies=[_identity_capturing_policy(bucket)],
+        label_defs={},
+        ask_timeout=30,
+        conversation_id=conv.id,
+        initial_labels={},
+        conversation_store=conversation_store,
+    )
+    await engine.evaluate(EvaluationContext(phase=Phase.REQUEST, content="hi"))
+    assert bucket["conversation_id"] == conv.id
+    assert bucket["root_conversation_id"] == conv.id
+    assert bucket["sub_agent_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_engine_injects_identity_for_sub_agent_child(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    A sub-agent child's evaluations carry the child id, the tree root,
+    and the dispatched sub-agent's name.
+
+    What breaks if this fails: policies cannot distinguish child
+    evaluations from top-level ones (``root_conversation_id`` equals
+    ``conversation_id``), so per-child attribution and child-aware
+    budgets silently degrade.
+    """
+    root = conversation_store.create_conversation()
+    child = conversation_store.create_conversation(
+        kind="sub_agent",
+        parent_conversation_id=root.id,
+        sub_agent_name="researcher",
+    )
+    bucket: dict[str, Any] = {}
+    engine = PolicyEngine(
+        policies=[_identity_capturing_policy(bucket)],
+        label_defs={},
+        ask_timeout=30,
+        conversation_id=child.id,
+        initial_labels={},
+        conversation_store=conversation_store,
+        root_conversation_id=root.id,
+        sub_agent_name="researcher",
+    )
+    await engine.evaluate(EvaluationContext(phase=Phase.REQUEST, content="hi"))
+    assert bucket["conversation_id"] == child.id
+    assert bucket["root_conversation_id"] == root.id
+    assert bucket["sub_agent_name"] == "researcher"
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_conversation_id_wins(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    A context that already carries a ``conversation_id`` is not
+    overwritten by the engine (mirrors ``_inject_model``'s
+    caller-wins rule).
+
+    What breaks if this fails: test contexts and future callers that
+    resolve identity from a fresher source get silently clobbered by
+    the engine's snapshot.
+    """
+    conv = conversation_store.create_conversation()
+    bucket: dict[str, Any] = {}
+    engine = PolicyEngine(
+        policies=[_identity_capturing_policy(bucket)],
+        label_defs={},
+        ask_timeout=30,
+        conversation_id=conv.id,
+        initial_labels={},
+        conversation_store=conversation_store,
+    )
+    await engine.evaluate(
+        EvaluationContext(phase=Phase.REQUEST, content="hi", conversation_id="conv_preset")
+    )
+    assert bucket["conversation_id"] == "conv_preset"


### PR DESCRIPTION
## Motivation

Function policy callables have no way to tell which conversation an evaluation belongs to. The event context carries `actor`, `usage`, `model`, `harness`, and `labels` — but no conversation id, and no way to recognize a sub-agent child short of out-of-band label conventions. Policy modules that key per-session state or attribute usage per conversation (rate limiting, telemetry, budget attribution) end up smuggling an identity through `session_state` or labels, which fragments the moment state persistence and the policy disagree.

The engine already owns all three values (`_conversation_id`, `_root_conversation_id`, and the conversation row's `sub_agent_name` the builder loads anyway) — this PR surfaces them read-only to callables.

## Changes

- `EvaluationContext` gains `conversation_id`, `root_conversation_id`, `sub_agent_name` (all default `None` — existing callers and test contexts unaffected).
- `PolicyEngine` injects them per evaluation via a new `_inject_conversation`, following the existing `_inject_model` caller-wins pattern; `build_policy_engine` passes the conversation row's `sub_agent_name` it already resolves.
- `FunctionPolicy._build_event` surfaces them under `event["context"]`, carried as `None` (not absent) on paths that never populate them — the same contract as the other context keys.

Semantics: `root_conversation_id != conversation_id` marks a sub-agent child; `sub_agent_name` is the dispatched child's name (`None` for top-level sessions).

## Testing

- New `tests/runtime/policies/test_conversation_identity.py`: `_build_event` key presence + passthrough, engine injection for top-level and sub-agent-child conversations, caller-wins on a pre-populated context.
- `uv run pytest tests/runtime/policies/ tests/policies/` — 869 passed.
- `ruff check` / `ruff format --check` clean on touched files.