### PR TITLE
Clarify polly prompt: skip sys_advise_models when routing is off

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -94,11 +94,13 @@ prompt: |
   turn runs on; it does NOT constrain how many sub-agents you spawn, which
   workers, or which models they get. Those choices stay entirely yours.
 
-  Before any fan-out, call `sys_advise_models` if it is available (the tool
-  appears in your tool list when intelligent routing is configured). Pass the
-  full list of tasks you are about to dispatch — one entry per planned
-  `sys_session_send` — and use each recommendation's `model` as the
-  `args.model` for that dispatch.
+  `sys_advise_models` stays in your tool list even when intelligent routing is
+  off — do NOT call it unless routing is active. The signal is the `[Cost
+  advisor:` system note on your turns; without that note the call returns
+  `router_on: false` with no recommendations and wastes a tool call. Before any
+  fan-out with routing active, call it once with the full list of tasks you are
+  about to dispatch — one entry per planned `sys_session_send` — and use each
+  recommendation's `model` as the `args.model` for that dispatch.
 
   Delegate ALL coding work through these three via `sys_session_send`, each
   launched in its OWN git worktree. They run autonomously to completion (you


### PR DESCRIPTION
## Related issue

N/A

## Summary

`sys_advise_models` is always registered for polly (alongside the sub-agent dispatch grant), but the prompt told polly to call it whenever the tool appeared in its tool list — which is always. With intelligent routing off, that call returns `router_on: false` and empty recommendations, wasting a turn.

Updated the polly orchestrator prompt to use the `[Cost advisor:` system note as the signal that routing is active, and to skip `sys_advise_models` entirely when that note is absent.

## Test Plan

- [x] Verified the prompt text matches the actual tool-registration behavior in `ToolManager._register_sub_agent_tools`
- [x] Confirmed `omnigent/resources/examples/polly` is a symlink to `examples/polly` (single file change)

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Prompt-only change; no runtime behavior to unit-test. Behavior is verified by reading the prompt against `ToolManager` registration and the server-side `router_on: false` path.

## Changelog

Polly no longer wastes a tool call on `sys_advise_models` when intelligent routing is off.