### PR TITLE
fix(server): re-put missing built-in agent artifact-store bundles on matching-hash seed (#1920)

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -477,11 +477,12 @@ def _ensure_builtin_agent(
         # Sha-segment compare: legacy rows keep an ``ag_``-prefixed left
         # segment (physical artifact key); only the sha encodes content.
         if existing.bundle_location.rsplit("/", 1)[-1] == bundle_hash:
-            # Row current, but the blob can be gone while the row survives
-            # (pruned artifacts, or DB restored without the store). Re-put from
-            # the in-hand bytes so boot self-heals instead of failing launches.
-            if not artifact_store.exists(new_loc):
-                artifact_store.put(new_loc, bundle_bytes)
+            # Blob can vanish while the row survives (pruned artifacts, DB
+            # restored without the store); re-put so boot self-heals. Keyed on
+            # the row's location, not ``new_loc``: this path never rewrites the
+            # row, so a legacy ``ag_``-prefixed value is what the loader reads.
+            if not artifact_store.exists(existing.bundle_location):
+                artifact_store.put(existing.bundle_location, bundle_bytes)
             # Evict so a lagging replica's stale cache reloads the bundle.
             agent_cache.evict(existing.id)
             return

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -443,8 +443,10 @@ def _ensure_builtin_agent(
       update the row in place (keeps the ``agent_id`` stable so task
       history isn't cascade-deleted; bumps ``version`` so the runner's
       version-keyed spec cache re-fetches), then warm-swap the cache.
-    - **Row exists, content hash matches** → evict the local cache so
-      the next load re-fetches from ``bundle_location``, then return.
+    - **Row exists, content hash matches** → re-``put`` the bundle if
+      the artifact store is missing the blob (self-heals a lost
+      bundle), evict the local cache so the next load re-fetches from
+      ``bundle_location``, then return.
 
     The evict on the matching-hash path matters because
     :meth:`AgentCache.load` is keyed by ``agent_id`` and trusts its
@@ -475,7 +477,12 @@ def _ensure_builtin_agent(
         # Sha-segment compare: legacy rows keep an ``ag_``-prefixed left
         # segment (physical artifact key); only the sha encodes content.
         if existing.bundle_location.rsplit("/", 1)[-1] == bundle_hash:
-            # Row current; evict so a lagging replica's stale cache reloads the bundle.
+            # Row current, but the blob can be gone while the row survives
+            # (pruned artifacts, or DB restored without the store). Re-put from
+            # the in-hand bytes so boot self-heals instead of failing launches.
+            if not artifact_store.exists(new_loc):
+                artifact_store.put(new_loc, bundle_bytes)
+            # Evict so a lagging replica's stale cache reloads the bundle.
             agent_cache.evict(existing.id)
             return
         artifact_store.put(new_loc, bundle_bytes)

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -1494,6 +1494,56 @@ def test_ensure_default_polly_agent_repairs_stale_cache(
     assert repaired != "STALE CACHED SPEC"
 
 
+def test_ensure_default_polly_agent_repairs_lost_bundle_blob(
+    seed_stores: _SeedStores,
+) -> None:
+    """
+    A matching-hash re-seed restores a bundle blob lost from the store.
+
+    The matching-hash fast path trusts the artifact store without
+    checking the blob is present. If the row survives but the bundle is
+    gone (artifacts pruned, or the DB restored without the matching
+    store), every restart re-computes the same hash, matches the stored
+    ``bundle_location``, and returns without re-``put``-ing — so boot can
+    never self-heal and each session launch raises ``failed to load
+    agent spec``. The seeder must re-``put`` on the matching path when
+    the store is missing the blob. Without the fix this test fails: the
+    blob stays absent and the reload raises ``KeyError``.
+    """
+    server_app._ensure_default_polly_agent(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+    agent = seed_stores.agent_store.get_by_name(server_app._POLLY_AGENT_NAME)
+    assert agent is not None
+    assert seed_stores.artifact_store.exists(agent.bundle_location)
+
+    # Lose the blob while the row survives, and drop the local cache so
+    # nothing masks the missing bundle at load time.
+    seed_stores.artifact_store.delete(agent.bundle_location)
+    seed_stores.agent_cache.evict(agent.id)
+    assert not seed_stores.artifact_store.exists(agent.bundle_location)
+
+    # Re-seed: source unchanged → hash matches the row (the fast path).
+    server_app._ensure_default_polly_agent(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+
+    # The fast path re-put the lost bundle: the store has it again and a
+    # fresh load succeeds instead of raising.
+    assert seed_stores.artifact_store.exists(agent.bundle_location)
+    reloaded = seed_stores.agent_cache.load(agent.id, agent.bundle_location)
+    assert reloaded.spec is not None
+    # Row untouched on the matching path: same location, no version bump.
+    still = seed_stores.agent_store.get_by_name(server_app._POLLY_AGENT_NAME)
+    assert still is not None
+    assert still.bundle_location == agent.bundle_location
+    assert still.version == agent.version
+
+
 def test_tar_gz_dir_is_order_independent(tmp_path: Path) -> None:
     """
     Same content, different file-creation order → identical bundle bytes.

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -1544,6 +1544,67 @@ def test_ensure_default_polly_agent_repairs_lost_bundle_blob(
     assert still.version == agent.version
 
 
+def test_ensure_default_polly_agent_repairs_legacy_prefixed_bundle_location(
+    seed_stores: _SeedStores,
+) -> None:
+    """
+    The lost-blob repair targets the row's own ``bundle_location``, so it
+    also heals a legacy ``ag_``-prefixed one.
+
+    Rows seeded before the binary-uuid migration keep an ``ag_``-prefixed
+    left segment in ``bundle_location`` while ``id`` is bare hex (the
+    migration excluded ``bundle_location`` as a physical artifact key), and
+    they reach the matching-hash path through the sha-segment compare.
+
+    What breaks if this fails: keying the repair off ``f"{id}/{hash}"``
+    probes and writes a key nothing reads, so an upgraded deployment whose
+    built-in blob was pruned keeps raising ``failed to load agent spec`` on
+    every session launch while boot leaves an orphan bundle behind.
+    """
+    server_app._ensure_default_polly_agent(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+    agent = seed_stores.agent_store.get_by_name(server_app._POLLY_AGENT_NAME)
+    assert agent is not None
+    bundle_hash = agent.bundle_location.rsplit("/", 1)[-1]
+    bundle_bytes = seed_stores.artifact_store.get(agent.bundle_location)
+
+    # Rewrite the row into the pre-migration shape: bare-hex id, blob and
+    # location under the ``ag_``-prefixed physical key.
+    legacy_loc = f"ag_{agent.id}/{bundle_hash}"
+    seed_stores.artifact_store.put(legacy_loc, bundle_bytes)
+    seed_stores.artifact_store.delete(agent.bundle_location)
+    legacy = seed_stores.agent_store.update(agent.id, legacy_loc)
+    assert legacy is not None
+
+    # Lose the blob while the row survives, and drop the local cache so
+    # nothing masks the missing bundle at load time.
+    seed_stores.artifact_store.delete(legacy_loc)
+    seed_stores.agent_cache.evict(agent.id)
+    assert not seed_stores.artifact_store.exists(legacy_loc)
+
+    # Re-seed: source unchanged -> hash matches the row (the fast path).
+    server_app._ensure_default_polly_agent(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+
+    # Repaired at the key the loader reads, and nothing written to the
+    # bare-hex key the row does not point at.
+    assert seed_stores.artifact_store.exists(legacy_loc)
+    assert not seed_stores.artifact_store.exists(f"{agent.id}/{bundle_hash}")
+    reloaded = seed_stores.agent_cache.load(agent.id, legacy_loc)
+    assert reloaded.spec is not None
+    # Row untouched on the matching path: same location, no version bump.
+    still = seed_stores.agent_store.get_by_name(server_app._POLLY_AGENT_NAME)
+    assert still is not None
+    assert still.bundle_location == legacy_loc
+    assert still.version == legacy.version
+
+
 def test_tar_gz_dir_is_order_independent(tmp_path: Path) -> None:
     """
     Same content, different file-creation order → identical bundle bytes.


### PR DESCRIPTION
## Related issue

Closes #1920

## Summary

- `_ensure_builtin_agent`'s matching-hash fast path returned without checking the artifact store actually holds the bundle. When the `agents` row survives but the bundle blob is lost (operator prunes `/data/artifacts`, Postgres restored from a backup without the matching artifacts, or separately-mounted volumes drift), every restart recomputed the same content hash, matched the stored `bundle_location`, and returned **without re-`put()`-ing** — so boot could never self-heal and each session launch raised `failed to load agent spec: 'ag_<id>/<sha256>'`.
- On the matching path, re-`put()` the bundle from the in-hand `bundle_bytes` when `artifact_store.exists(new_loc)` is false, then evict as before. No version bump, no row rewrite — the row is already current.

**ELI5:** Startup checks off "agent already installed" by matching a fingerprint, but never checked the actual bundle file was still there. If the file went missing, it stayed convinced everything was fine and kept failing on every launch. Now, on a fingerprint match, it re-saves the bundle if the store is missing it.

```
                         ┌── hash != row ──> put + update row + replace cache   (unchanged)
seed built-in agent ─────┤
                         └── hash == row ──┬── blob present ──> evict cache, return   (unchanged)
                                           └── blob MISSING  ──> put (restore) ──> evict, return   (NEW)
```

## Test Plan

- Added `tests/server/test_app.py::test_ensure_default_polly_agent_repairs_lost_bundle_blob`: seeds polly, deletes the blob and evicts the cache (row survives, blob lost), re-seeds through the matching-hash path, then asserts the blob is restored, a fresh `AgentCache.load` succeeds, and the row is untouched (same `bundle_location`, no version bump).
- Ran it in an isolated env; also reverted the fix to confirm the test **fails** at the `exists` assertion — i.e. it's a real regression guard, not a tautology.
- Full seeder suite stays green and lint is clean:
  - `python -m pytest tests/server/test_app.py -k "polly or ensure_default or builtin or tar_gz"` → 17 passed
  - `ruff check omnigent/server/app.py tests/server/test_app.py` → clean

## Demo
Tested by setting `OMNIGENT_DATA_DIR` to a new directory and cleaned all bundle files.
Before running server, the bundle directories are all empty.
<img width="519" height="95" alt="image" src="https://github.com/user-attachments/assets/eafe2e1c-8bfa-4231-bba4-2af4e26605eb" />

### Before
Before the fix, could see that  in the web UI, the agent failed with error and could not start. Bundle directory was not repopulated.
<img width="519" height="95" alt="image" src="https://github.com/user-attachments/assets/91fa05c3-411a-4a3b-8a15-fd9e76e42f6f" />
<img width="777" height="358" alt="image" src="https://github.com/user-attachments/assets/43620093-3851-4c01-a931-1c84210c086d" />

### After
After the fix, the web UI succeeds and the bundle directory was repopulated.
<img width="512" height="83" alt="image" src="https://github.com/user-attachments/assets/cd73baa2-4103-425c-9032-d1652d8278c4" />
<img width="606" height="241" alt="image" src="https://github.com/user-attachments/assets/a977f143-e4fc-43ef-b642-e844c35e25fb" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit test reproduces the lost-blob scenario on the matching-hash path and is verified to fail without the fix. Surrounding seeder tests (idempotency, spec-change refresh, stale-cache repair, absent-bundle skip) continue to pass unchanged.

## Changelog

A built-in agent whose bundle is missing from the artifact store is now re-uploaded at server startup, so a pruned or unrestored bundle self-heals instead of failing every session launch.