### PR TITLE
[telemetry] Honor all opt-out signals

### DIFF
--- a/PLAN_2487.md
+++ b/PLAN_2487.md
@@ -1,0 +1,290 @@
+# Implementation Plan — Issue #2487: Telemetry opt-out (v0.6.0)
+
+## Goal
+
+Guarantee that a user can opt out of anonymous usage telemetry via **any**
+of three mechanisms, and that opting out reliably suppresses **all** telemetry
+for the affected sessions:
+
+1. **Server-side env vars**: `OMNIGENT_TELEMETRY=0`, `DISABLE_TELEMETRY=true`,
+   `OMNIGENT_DISABLE_TELEMETRY=true`, `DO_NOT_TRACK=1`.
+2. **config.yaml**: `telemetry: false` in `~/.omnigent/config.yaml` **or** the
+   `-c` file passed to `omnigent server`.
+3. **Host machine (`omnigent host`)**: the same env vars set on the host; the
+   host signals opt-out to the server, and the server skips telemetry for all
+   sessions on that host.
+
+## Current state (what already exists)
+
+The product-analytics telemetry system was landed by PR #2457
+(`feat(telemetry): add usage telemetry system for session lifecycle events`).
+It lives in `omnigent/telemetry/` and is **entirely separate** from the
+OpenTelemetry tracing module `omnigent/runtime/telemetry.py` — do not confuse
+the two. `VERSION` is currently `0.6.0.dev0`.
+
+Working pieces:
+
+- **Env-var opt-out** — `omnigent/telemetry/client.py::is_disabled()` checks all
+  four required env vars (plus a `_CI_ENV_VARS` set). This function is the
+  master server-side gate; it is re-checked at every `emit()` and at
+  `init_client()`. Covered by `tests/test_telemetry.py`.
+- **`~/.omnigent/config.yaml` `telemetry: false`** — `is_disabled()` calls
+  `_config_telemetry_disabled()`, which reads the file at `OMNIGENT_CONFIG_HOME`
+  (or `~/.omnigent`) and matches `telemetry: false` with a **regex on raw text**
+  (deliberately avoiding PyYAML — see the YAML-corruption note below). Works.
+- **Host→server wire signal** — `HostHelloFrame.telemetry_opt_out` (in
+  `omnigent/host/frames.py`) and the runner `HelloFrame.telemetry_opt_out` (in
+  `omnigent/runner/transports/ws_tunnel/frames.py`) are both encoded/decoded.
+  `omnigent/host/connect.py` and `omnigent/runner/transports/ws_tunnel/serve.py`
+  populate them from `is_disabled()` at hello time.
+- **Server-side registry accessors** — `HostRegistry.is_host_telemetry_opted_out()`
+  (`omnigent/server/host_registry.py:306`) and
+  `TunnelRegistry.is_runner_telemetry_opted_out()`
+  (`omnigent/runner/transports/ws_tunnel/registry.py:357`).
+- **One gated emit** — the `SessionCreatedEvent` emit in
+  `omnigent/server/routes/sessions.py` (~line 12620) consults
+  `is_host_telemetry_opted_out(conv.host_id)` before emitting.
+
+## Gap analysis (what is missing or broken)
+
+| # | Gap | Severity | Location |
+|---|-----|----------|----------|
+| G1 | **`-c config.yaml` `telemetry: false` is silently ignored.** `init_client(config=cfg)` checks `cfg.get("telemetry") is False`, but `cfg` is produced by `yaml.safe_load` in `cli.py::_load_config`, and importing `omnigent.spec.parser` (which happens on the `omnigent server` path) mutates the **global** `SafeLoader.yaml_implicit_resolvers`, so `false` parses as the **string** `'false'`. `'false' is False` → `False`, so telemetry is **not** disabled. Empirically confirmed. | **HIGH — a required opt-out path is broken** | `omnigent/telemetry/client.py::init_client`, `omnigent/cli.py::_load_config`, `omnigent/spec/parser.py::_ConfigYamlLoader` |
+| G2 | **Host opt-out is not honored for `SessionStoppedEvent` / `SessionDeletedEvent`.** Only the created-event emit checks `is_host_telemetry_opted_out`. The stopped emit (~line 19414) and deleted emit (~line 20472) fire regardless. The issue requires the server to "skip telemetry for **all** sessions on that host" — i.e. all three event types. | **HIGH — opt-out is partially ignored** | `omnigent/server/routes/sessions.py` |
+| G3 | **Runner opt-out signal is never consulted.** `TunnelRegistry.is_runner_telemetry_opted_out()` exists but has **zero callers**. A session bound to a runner whose host opted out — but where `conv.host_id` is unset or the host tunnel has since dropped — will still emit. | **MEDIUM — opt-out leaks for some session topologies** | `omnigent/server/routes/sessions.py`, `omnigent/runner/transports/ws_tunnel/registry.py` |
+| G4 | **No user-facing docs / example.** No README or `docs/` section lists the opt-out mechanisms; the top-level `config.yaml` has no `telemetry:` key or comment. The issue is effectively a public announcement, so a documented opt-out surface is expected. | **MEDIUM** | `README.md` / `docs/`, `config.yaml` |
+| G5 | **`telemetry` is not a recognized server-config key.** `omnigent/server/server_config.py` / `omnigent/spec` do not model `telemetry`; it is read ad-hoc. Not strictly required, but normalizing it at the `-c` boundary is the clean fix for G1. | LOW | `omnigent/server/server_config.py` (optional) |
+
+## Precedence & merge rules (authoritative — implement exactly)
+
+Telemetry is a **default-on, opt-out** system. The rule is monotonic: **any**
+opt-out signal wins; there is no "force-on" that overrides an opt-out.
+
+1. **Master server gate — `is_disabled()`** (evaluated on the server process
+   and again on host/runner processes). Returns `True` (disabled) if **any** of:
+   - `OMNIGENT_TELEMETRY == "0"`, or
+   - `DISABLE_TELEMETRY` / `OMNIGENT_DISABLE_TELEMETRY` ∈ {`1`,`true`,`yes`} (case-insensitive), or
+   - `DO_NOT_TRACK == "1"`, or
+   - any CI env var is present, or
+   - `telemetry: false` in the resolved config.yaml (`OMNIGENT_CONFIG_HOME` or `~/.omnigent`).
+   If disabled, `init_client()` never creates `_CLIENT`, and `emit()` no-ops.
+   **This is a hard global off switch.**
+
+2. **`-c` config-file gate (server startup only)** — `init_client(config=cfg)`
+   ALSO disables when the parsed `-c` config's `telemetry` value is falsey. This
+   is additive to (1): it covers a `-c` file that is **not** at
+   `~/.omnigent/config.yaml` (which `is_disabled()`'s regex would not find).
+
+3. **Per-session host/runner gate (server, per event)** — even when telemetry is
+   globally ON, an individual session's event is skipped when the session's
+   **host OR runner** signalled opt-out. `opt_out = host_opted_out(conv.host_id)
+   OR runner_opted_out(conv.runner_id)`. Applied identically to
+   `SessionCreatedEvent`, `SessionStoppedEvent`, and `SessionDeletedEvent`.
+
+Conflict resolution: `true`/opt-out always wins over `false`/opt-in at every
+layer. A globally-enabled server still skips a host that opted out; a host that
+opted in cannot re-enable a globally-disabled server.
+
+## File-by-file changes
+
+### 1. Fix the `-c config.yaml` boolean bug (G1) — `omnigent/telemetry/client.py`
+
+Replace the brittle identity check in `init_client` with a robust coercion that
+tolerates both a real bool `False` and the corrupted string `'false'`.
+
+- Add a module-level helper:
+  ```python
+  def _config_opts_out(value: object) -> bool:
+      """True when a config.yaml `telemetry:` value means opt-out.
+
+      Accepts bool False and the string spellings the YAML loader may
+      produce ('false'/'no'/'off'/'0') because omnigent.spec.parser
+      rewrites the shared SafeLoader bool resolver at import time, so a
+      `-c` file loaded via yaml.safe_load yields 'false' (a str), not
+      False.
+      """
+      if value is False:
+          return True
+      if isinstance(value, str):
+          return value.strip().lower() in ("false", "no", "off", "0")
+      return False
+  ```
+- In `init_client`, change:
+  ```python
+  if config is not None and config.get("telemetry") is False:
+      return
+  ```
+  to:
+  ```python
+  if config is not None and "telemetry" in config and _config_opts_out(config["telemetry"]):
+      return
+  ```
+  Keep the `is_disabled()` early-return above it unchanged.
+
+  Rationale for coercing here rather than un-corrupting the global YAML loader:
+  `_ConfigYamlLoader` intentionally rewrites `SafeLoader.yaml_implicit_resolvers`
+  and other code depends on that behavior; a localized coercion is the low-risk
+  fix. (See Open Question 1 for the alternative.)
+
+### 2. Gate stopped/deleted events on host+runner opt-out (G2, G3) — `omnigent/server/routes/sessions.py`
+
+Add one shared helper near the other telemetry imports (~line 290):
+
+```python
+def _session_telemetry_opted_out(request: Request, conv: Conversation) -> bool:
+    """True when the session's host OR runner signalled telemetry opt-out.
+
+    Best-effort: any lookup error resolves to False (do not suppress on a
+    transient registry miss). Mirrors the created-event gate so all three
+    lifecycle events honour host/runner opt-out identically.
+    """
+    try:
+        hr = getattr(request.app.state, "host_registry", None)
+        if hr is not None and conv.host_id is not None and hr.is_host_telemetry_opted_out(conv.host_id):
+            return True
+        tr = getattr(request.app.state, "tunnel_registry", None)
+        if tr is not None and conv.runner_id is not None and tr.is_runner_telemetry_opted_out(conv.runner_id):
+            return True
+    except Exception:  # noqa: BLE001 — telemetry gating must never disrupt the request
+        return False
+    return False
+```
+
+- **Created event (~line 12620):** refactor the existing inline
+  `_host_opted_out` block to call `_session_telemetry_opted_out(request, conv)`
+  so created/stopped/deleted share one code path (also picks up the runner
+  signal for created — closing part of G3 there too).
+- **Stopped event (~line 19406–19422, in `post_event`):** `post_event` has
+  `request: Request`. Load the conversation row (already fetched as `stop_conv`
+  a few lines above at ~19393) and wrap the `_tel_emit(_TelSessionStoppedEvent(...))`
+  in `if stop_conv is not None and not _session_telemetry_opted_out(request, stop_conv):`.
+- **Deleted event (~line 20459–20484, in `delete_session`):** `delete_session`
+  has `request: Request` and `conv` in scope. Wrap the
+  `_tel_emit(_TelSessionDeletedEvent(...))` in
+  `if not _session_telemetry_opted_out(request, conv):`.
+
+`app.state.tunnel_registry` is set in `omnigent/server/app.py:1390`, so the
+route can reach the runner registry.
+
+### 3. Documentation (G4)
+
+- **`config.yaml`** (top-level, repo root): add a commented example:
+  ```yaml
+  # Anonymous usage telemetry (default: on). Set to false to opt out.
+  # Env vars OMNIGENT_TELEMETRY=0 / DISABLE_TELEMETRY=true / DO_NOT_TRACK=1
+  # also opt out. See docs/telemetry.md.
+  # telemetry: false
+  ```
+- **`docs/telemetry.md`** (new): describe what is collected (anonymous only —
+  no PII, no conversation content, no code), the schema/fields
+  (from `omnigent/telemetry/events.py`), and **all three** opt-out mechanisms
+  with exact env-var names and the host-machine behaviour. Link it from
+  `README.md`.
+- **`README.md`**: one short "Telemetry" section pointing at `docs/telemetry.md`
+  and listing the env vars + `telemetry: false`.
+
+### 4. (Optional) recognize `telemetry` in server config (G5) — `omnigent/server/server_config.py`
+
+Not required if change #1 lands (init_client coerces at the boundary). If a
+canonical parse is preferred, add a `telemetry: bool` field to the server config
+model and pass the normalized bool into `init_client`, removing reliance on the
+raw `-c` dict. Keep the `is_disabled()` env/`~/.omnigent` path unchanged.
+
+## Edge cases to handle / verify
+
+- **Corrupted-string bool**: `-c` file with `telemetry: false` → opt-out
+  (G1 fix); `telemetry: true` → opt-in. Also verify `False`/`True` real booleans
+  still work (pure-unit context where `spec.parser` was not imported).
+- **`is_disabled()` never raises**: it wraps everything and returns `True` on
+  unexpected error (fail-closed). Preserve that.
+- **`_session_telemetry_opted_out` fails open** on registry errors — returns
+  `False` so a transient registry miss does not suppress telemetry (opposite of
+  `is_disabled`, intentionally: this is a per-session refinement, not the master
+  gate). Document the asymmetry.
+- **Missing `host_id`/`runner_id`**: local/in-process sessions may have neither;
+  the helper must treat `None` as "no signal" (not opted out).
+- **Older host/runner** (pre-#2457): `telemetry_opt_out` defaults to `False` in
+  the frame decoders — never treat a missing field as opt-out.
+- **Host opts out but tunnel dropped before delete**: the host connection may be
+  gone at delete time, so `is_host_telemetry_opted_out` returns `False` — the
+  runner signal (via `conv.runner_id`) is the backstop (G3). If both are gone,
+  the event may emit; acceptable per "best-effort", but note it.
+- **`emit()` defense-in-depth**: `client.emit` re-checks `is_disabled()`, so a
+  late env-var flip is honored — but it does NOT know about a `-c`-only file, so
+  the `init_client` gate must be correct (change #1).
+- **CI env**: existing CI-var suppression must remain (tests already cover it).
+- **`DISABLE_TELEMETRY` value casing**: `1`/`true`/`yes` (case-insensitive) all
+  opt out; `OMNIGENT_TELEMETRY` opts out only on exact `"0"`; `DO_NOT_TRACK` only
+  on exact `"1"` — keep this asymmetry (matches the issue and current code).
+
+## Tests to add (`tests/test_telemetry.py` and route tests)
+
+**Unit — `-c` config parsing / init_client (G1):**
+- `test_config_opts_out_bool_false` / `_true` — helper accepts real bools.
+- `test_config_opts_out_corrupted_string` — helper returns True for `'false'`,
+  `'no'`, `'off'`, `'0'`; False for `'true'`.
+- `test_init_client_c_file_false_after_spec_import` — **regression for G1**:
+  `import omnigent.spec.parser` first (to corrupt the loader), then
+  `cfg = yaml.safe_load("telemetry: false")`, assert `init_client(config=cfg)`
+  leaves `_CLIENT is None`. This reproduces the real `omnigent server -c` path.
+- Keep/extend the existing `test_init_client_server_config_disabled`.
+
+**Unit — env var variants (already partly covered; fill gaps):**
+- Explicit cases for each of `OMNIGENT_TELEMETRY=0`, `DISABLE_TELEMETRY` in
+  {`1`,`true`,`yes`,`TRUE`}, `OMNIGENT_DISABLE_TELEMETRY`, `DO_NOT_TRACK=1`.
+- Negative: `OMNIGENT_TELEMETRY=1`, `DO_NOT_TRACK=0`, `DISABLE_TELEMETRY=false`
+  do **not** opt out.
+
+**Unit — config.yaml regex path (already covered):** keep
+`test_is_disabled_config_yaml` / `_telemetry_true`; add `OMNIGENT_CONFIG_HOME`
+override case and a malformed-file returns-False case.
+
+**Unit — host/runner propagation (frames):**
+- `HostHelloFrame` / runner `HelloFrame` round-trip `telemetry_opt_out=True` and
+  default `False` (encode→decode). Add to `tests/host/test_frames.py` and the
+  runner frames test.
+- `is_host_telemetry_opted_out` / `is_runner_telemetry_opted_out` return the
+  hello value, and `False` for unknown/offline host/runner.
+
+**Route/integration — per-session gating (G2, G3):** in the server route tests
+(e.g. `tests/server/routes/…` alongside `test_sessions_cost_labels.py`):
+- Fake a `host_registry`/`tunnel_registry` on `app.state`. Assert that when the
+  host is opted out, **none** of created/stopped/deleted emit (patch `_tel_emit`
+  and assert not called).
+- Assert that when the **runner** is opted out but the host is not, all three are
+  still suppressed (G3).
+- Assert that when neither opts out, all three emit.
+- Assert `_session_telemetry_opted_out` returns `False` (fails open) when a
+  registry lookup raises.
+
+**Docs:** none automated; verify links resolve.
+
+## Suggested implementation order
+
+1. Change #1 (G1 fix) + its unit tests — smallest, highest-severity.
+2. Change #2 (G2/G3 gating helper + wire into all three emits) + route tests.
+3. Change #3 (docs).
+4. Change #4 (optional config-schema normalization) only if reviewers prefer a
+   canonical parse over boundary coercion.
+
+## Open questions for a human/implementer
+
+1. **G1 fix location**: coerce the value inside `init_client` (recommended,
+   low-risk) vs. fix `cli.py::_load_config` to parse config with a
+   non-corrupted loader vs. stop `omnigent.spec.parser` from mutating the global
+   `SafeLoader`. The last two are broader-blast-radius and could change YAML
+   semantics elsewhere. Confirm the localized coercion is acceptable.
+2. **Runner-signal scope (G3)**: should per-session gating consult the runner
+   opt-out in addition to the host, or is host-only sufficient? Recommendation:
+   consult both (`host OR runner`) so sessions without a `host_id` are still
+   covered. Confirm no session topology should be exempt.
+3. **Docs placement**: new `docs/telemetry.md` + README section — confirm the
+   canonical location and whether a `NOTICE`/first-run console notice is also
+   wanted for the v0.6.0 announcement.
+4. **Exact collected-data disclosure**: the doc should enumerate fields from
+   `events.py` + the wire envelope (`omnigent_version`, `python_version`,
+   `operating_system`, `installation_id`, `anon_user_id`, session metadata).
+   Confirm this list is complete and approved for public disclosure.
+5. **Managed hosts**: server-provisioned (`host_type="managed"`) sandboxes —
+   should they be treated as always opted-in, or inherit a server-level policy?
+   Current plan applies the same per-session gate uniformly.

--- a/README.md
+++ b/README.md
@@ -400,6 +400,18 @@ See the [policy guide](https://github.com/omnigent-ai/omnigent/blob/main/docs/PO
 
 ---
 
+## Telemetry
+
+Omnigent collects limited anonymous session lifecycle telemetry by default; it
+does not send prompts, responses, code, file contents, tool arguments, or
+workspace paths. Opt out with `telemetry: false` in `~/.omnigent/config.yaml` or
+an `omnigent server -c` config file, or set `OMNIGENT_TELEMETRY=0`,
+`DISABLE_TELEMETRY=true`, `OMNIGENT_DISABLE_TELEMETRY=true`, or `DO_NOT_TRACK=1`.
+Hosts started with `omnigent host` forward their opt-out state so the server skips
+telemetry for sessions on that host. See [docs/telemetry.md](docs/telemetry.md).
+
+---
+
 ## Write your own agent
 
 An agent is a short YAML file: your prompt, your tools — local Python
@@ -463,4 +475,3 @@ Thanks to all of our amazing contributors!
 <a href="https://github.com/omnigent-ai/omnigent/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=omnigent-ai/omnigent" />
 </a>
-

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,9 @@
 llm:
   model: databricks-claude-haiku-4-5
   profile: oss
+
+# Anonymous usage telemetry is default-on. Set to false to opt out.
+# Env vars OMNIGENT_TELEMETRY=0 / DISABLE_TELEMETRY=true /
+# OMNIGENT_DISABLE_TELEMETRY=true / DO_NOT_TRACK=1 also opt out.
+# See docs/telemetry.md.
+# telemetry: false

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,64 @@
+# Anonymous Usage Telemetry
+
+Omnigent collects limited anonymous usage telemetry to understand whether the
+session lifecycle is working reliably across harnesses and client surfaces. It is
+default-on and best effort: telemetry must never affect session behavior, and any
+opt-out signal disables collection.
+
+## What Is Collected
+
+Telemetry events describe session lifecycle edges only. Omnigent does not send
+conversation content, prompts, responses, code, file contents, tool arguments, or
+workspace paths.
+
+Every event is sent with a wire envelope containing:
+
+- `event_name`: the lifecycle event type.
+- `session_id`: the Omnigent session/conversation ID.
+- `omnigent_version`, `schema_version`, `python_version`, and `operating_system`.
+- `timestamp_ns`, `status`, `duration_ms`, and optional environment tag.
+- `installation_id`: a locally generated installation UUID.
+- `anon_user_id`: a short salted hash of the authenticated user ID when one is available.
+- `params`: event-specific metadata encoded as JSON.
+
+Current lifecycle events are:
+
+- `SessionCreatedEvent`: `agent_id`, harness, client surface, whether the session is a fork, and whether it is a sub-agent session.
+- `SessionStoppedEvent`: session stop lifecycle edge.
+- `SessionDeletedEvent`: session lifetime duration and aggregate usage totals when available (`input_tokens`, `output_tokens`, `total_cost_usd`).
+
+## Opt Out
+
+Any one of these mechanisms disables telemetry; there is no force-on setting that
+overrides an opt-out.
+
+### Environment Variables
+
+Set any of the following in the server process environment before starting
+Omnigent:
+
+```bash
+OMNIGENT_TELEMETRY=0
+DISABLE_TELEMETRY=true
+OMNIGENT_DISABLE_TELEMETRY=true
+DO_NOT_TRACK=1
+```
+
+`DISABLE_TELEMETRY` and `OMNIGENT_DISABLE_TELEMETRY` also accept `1` and `yes`
+(case-insensitive). CI environments automatically disable telemetry.
+
+### Config File
+
+Set `telemetry: false` in `~/.omnigent/config.yaml`, or in the config file passed
+to `omnigent server -c`:
+
+```yaml
+telemetry: false
+```
+
+### Host Machines
+
+For sessions launched through `omnigent host`, set the same environment variables
+on the host machine before starting the host process. The host sends its opt-out
+state to the server when it connects, and the server skips telemetry events for
+sessions on that host or runner even if the server itself has telemetry enabled.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -297,6 +297,31 @@ from omnigent.tools.client_specified import parse_client_side_tool_specs
 
 _logger = logging.getLogger(__name__)
 
+
+def _session_telemetry_opted_out(request: Request, conv: Conversation) -> bool:
+    """Return whether this session's host or runner opted out of telemetry."""
+    try:
+        host_registry: HostRegistry | None = getattr(request.app.state, "host_registry", None)
+        if (
+            host_registry is not None
+            and conv.host_id is not None
+            and host_registry.is_host_telemetry_opted_out(conv.host_id)
+        ):
+            return True
+        tunnel_registry: TunnelRegistry | None = getattr(
+            request.app.state, "tunnel_registry", None
+        )
+        if (
+            tunnel_registry is not None
+            and conv.runner_id is not None
+            and tunnel_registry.is_runner_telemetry_opted_out(conv.runner_id)
+        ):
+            return True
+    except Exception:  # noqa: BLE001 — telemetry gating must never disrupt requests
+        return False
+    return False
+
+
 # ── Module-level constants (rule 34) ──────────────────────────────
 
 # Wire literal for the interrupt input type. Lives here so the
@@ -12618,17 +12643,11 @@ async def _create_session_from_existing_agent(
         await asyncio.to_thread(conversation_store.set_labels, conv.id, body.labels)
 
     # Emit session.created exactly once at creation time.
-    # Best-effort: skip if the host opted out via HostHelloFrame.
+    # Best-effort: skip if the host or runner opted out.
     try:
         import hashlib as _hashlib
 
-        _hr: HostRegistry | None = getattr(request.app.state, "host_registry", None)
-        _host_opted_out = (
-            _hr is not None
-            and conv.host_id is not None
-            and _hr.is_host_telemetry_opted_out(conv.host_id)
-        )
-        if not _host_opted_out:
+        if not _session_telemetry_opted_out(request, conv):
             _install_id = _get_installation_id()
             _anon_uid: str | None = None
             if user_id is not None:
@@ -19406,18 +19425,19 @@ def create_sessions_router(
             try:
                 import hashlib as _hashlib
 
-                _srv_id = _get_installation_id()
-                _anon: str | None = None
-                if user_id is not None:
-                    _salt = f"{_srv_id}:{user_id}" if _srv_id else user_id
-                    _anon = _hashlib.sha256(_salt.encode()).hexdigest()[:16]
-                _tel_emit(
-                    _TelSessionStoppedEvent(
-                        session_id=session_id,
-                        installation_id=_srv_id,
-                        anon_user_id=_anon,
+                if stop_conv is not None and not _session_telemetry_opted_out(request, stop_conv):
+                    _srv_id = _get_installation_id()
+                    _anon: str | None = None
+                    if user_id is not None:
+                        _salt = f"{_srv_id}:{user_id}" if _srv_id else user_id
+                        _anon = _hashlib.sha256(_salt.encode()).hexdigest()[:16]
+                    _tel_emit(
+                        _TelSessionStoppedEvent(
+                            session_id=session_id,
+                            installation_id=_srv_id,
+                            anon_user_id=_anon,
+                        )
                     )
-                )
             except Exception:  # noqa: BLE001 — telemetry is best-effort
                 pass
             return {"queued": False}
@@ -20460,26 +20480,27 @@ def create_sessions_router(
             import hashlib as _hashlib
             import time as _time
 
-            _srv_id = _get_installation_id()
-            _anon_d: str | None = None
-            if user_id is not None:
-                _salt_d = f"{_srv_id}:{user_id}" if _srv_id else user_id
-                _anon_d = _hashlib.sha256(_salt_d.encode()).hexdigest()[:16]
-            _usage = conv.session_usage or {}
-            _duration: float | None = None
-            with contextlib.suppress(Exception):
-                _duration = _time.time() - conv.created_at
-            _tel_emit(
-                _TelSessionDeletedEvent(
-                    session_id=session_id,
-                    installation_id=_srv_id,
-                    anon_user_id=_anon_d,
-                    duration_seconds=_duration,
-                    input_tokens=_usage.get("input_tokens"),
-                    output_tokens=_usage.get("output_tokens"),
-                    total_cost_usd=_usage.get("total_cost_usd"),
+            if not _session_telemetry_opted_out(request, conv):
+                _srv_id = _get_installation_id()
+                _anon_d: str | None = None
+                if user_id is not None:
+                    _salt_d = f"{_srv_id}:{user_id}" if _srv_id else user_id
+                    _anon_d = _hashlib.sha256(_salt_d.encode()).hexdigest()[:16]
+                _usage = conv.session_usage or {}
+                _duration: float | None = None
+                with contextlib.suppress(Exception):
+                    _duration = _time.time() - conv.created_at
+                _tel_emit(
+                    _TelSessionDeletedEvent(
+                        session_id=session_id,
+                        installation_id=_srv_id,
+                        anon_user_id=_anon_d,
+                        duration_seconds=_duration,
+                        input_tokens=_usage.get("input_tokens"),
+                        output_tokens=_usage.get("output_tokens"),
+                        total_cost_usd=_usage.get("total_cost_usd"),
+                    )
                 )
-            )
         except Exception:  # noqa: BLE001 — telemetry is best-effort
             pass
         return ConversationDeleted(id=session_id)

--- a/omnigent/telemetry/client.py
+++ b/omnigent/telemetry/client.py
@@ -207,6 +207,15 @@ def _config_telemetry_disabled() -> bool:
         return False
 
 
+def _config_opts_out(value: object) -> bool:
+    """Return whether a parsed ``telemetry`` config value opts out."""
+    if value is False:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in ("false", "no", "off", "0")
+    return False
+
+
 def is_disabled() -> bool:
     """Return ``True`` when telemetry should be completely suppressed.
 
@@ -522,13 +531,13 @@ def init_client(*, config: dict[str, Any] | None = None) -> None:
     Safe to call multiple times; idempotent after the first call.
 
     :param config: Optional parsed server config dict (e.g. from ``-c
-        config.yaml``).  When ``config.get("telemetry") is False``
+        config.yaml``).  When ``telemetry`` is an opt-out value,
         telemetry is disabled regardless of env vars.
     """
     global _CLIENT
     if is_disabled():
         return
-    if config is not None and config.get("telemetry") is False:
+    if config is not None and "telemetry" in config and _config_opts_out(config["telemetry"]):
         return
     # Prime the installation-id cache on startup so later request
     # handlers do not perform synchronous file I/O on the event loop.

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -82,6 +82,7 @@ def test_hello_frame_round_trip() -> None:
         frame_protocol_version=1,
         name="corey-laptop",
         runners=["runner_token_aaa", "runner_token_bbb"],
+        telemetry_opt_out=True,
     )
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostHelloFrame)
@@ -89,6 +90,7 @@ def test_hello_frame_round_trip() -> None:
     assert decoded.frame_protocol_version == 1
     assert decoded.name == "corey-laptop"
     assert decoded.runners == ["runner_token_aaa", "runner_token_bbb"]
+    assert decoded.telemetry_opt_out is True
 
 
 def test_hello_frame_empty_runners() -> None:
@@ -105,6 +107,7 @@ def test_hello_frame_empty_runners() -> None:
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostHelloFrame)
     assert decoded.runners == []
+    assert decoded.telemetry_opt_out is False
 
 
 def test_launch_runner_frame_round_trip() -> None:

--- a/tests/runner/transports/ws_tunnel/test_frames.py
+++ b/tests/runner/transports/ws_tunnel/test_frames.py
@@ -37,6 +37,7 @@ def test_hello_round_trip() -> None:
         frame_protocol_version=1,
         harnesses=["claude-sdk", "codex"],
         envs=["os_sandbox"],
+        telemetry_opt_out=True,
     )
     decoded = decode_frame(encode_frame(f))
     assert isinstance(decoded, HelloFrame)
@@ -44,6 +45,20 @@ def test_hello_round_trip() -> None:
     assert decoded.frame_protocol_version == 1
     assert decoded.harnesses == ["claude-sdk", "codex"]
     assert decoded.envs == ["os_sandbox"]
+    assert decoded.telemetry_opt_out is True
+
+
+def test_hello_telemetry_opt_out_defaults_false() -> None:
+    payload = {
+        "kind": "hello",
+        "runner_version": "0.1.2",
+        "frame_protocol_version": 1,
+        "harnesses": [],
+        "envs": [],
+    }
+    decoded = decode_frame(json.dumps(payload))
+    assert isinstance(decoded, HelloFrame)
+    assert decoded.telemetry_opt_out is False
 
 
 def test_request_round_trip_with_body_and_query_string() -> None:

--- a/tests/runner/transports/ws_tunnel/test_registry.py
+++ b/tests/runner/transports/ws_tunnel/test_registry.py
@@ -39,8 +39,14 @@ class _NoopWS:
         return await asyncio.Future()
 
 
-def _hello() -> HelloFrame:
-    return HelloFrame(runner_version="0.1.0", frame_protocol_version=1, harnesses=[], envs=[])
+def _hello(*, telemetry_opt_out: bool = False) -> HelloFrame:
+    return HelloFrame(
+        runner_version="0.1.0",
+        frame_protocol_version=1,
+        harnesses=[],
+        envs=[],
+        telemetry_opt_out=telemetry_opt_out,
+    )
 
 
 async def _wait_until(predicate: Callable[[], object], *, timeout_s: float = 1.0) -> None:
@@ -73,6 +79,20 @@ async def test_register_then_get_returns_session() -> None:
 def test_get_returns_none_for_unknown() -> None:
     reg = TunnelRegistry()
     assert reg.get("ghost") is None
+
+
+@pytest.mark.asyncio
+async def test_is_runner_telemetry_opted_out_reads_hello_flag() -> None:
+    reg = TunnelRegistry()
+    reg.register("r1", _NoopWS(), _hello(telemetry_opt_out=True))
+
+    assert reg.is_runner_telemetry_opted_out("r1") is True
+
+
+def test_is_runner_telemetry_opted_out_false_for_unknown() -> None:
+    reg = TunnelRegistry()
+
+    assert reg.is_runner_telemetry_opted_out("ghost") is False
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_telemetry.py
+++ b/tests/server/routes/test_sessions_telemetry.py
@@ -1,0 +1,289 @@
+"""Telemetry opt-out tests for session lifecycle routes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from omnigent.errors import OmnigentError
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+from omnigent.server.routes import sessions as sessions_routes
+from omnigent.server.routes.sessions import _session_telemetry_opted_out, create_sessions_router
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+
+class _FakeTelemetryRegistry:
+    """Fake host/runner registries exposing telemetry opt-out accessors."""
+
+    def __init__(self, *, host_opted_out: bool = False, runner_opted_out: bool = False) -> None:
+        self.host_opted_out = host_opted_out
+        self.runner_opted_out = runner_opted_out
+
+    def is_host_telemetry_opted_out(self, host_id: str) -> bool:
+        return self.host_opted_out
+
+    def is_runner_telemetry_opted_out(self, runner_id: str) -> bool:
+        return self.runner_opted_out
+
+
+class _RaisingTelemetryRegistry:
+    """Registry fake that verifies telemetry gating fails open."""
+
+    def is_host_telemetry_opted_out(self, host_id: str) -> bool:
+        raise RuntimeError("host lookup failed")
+
+    def is_runner_telemetry_opted_out(self, runner_id: str) -> bool:
+        raise RuntimeError("runner lookup failed")
+
+
+def _install_error_handler(app: FastAPI) -> None:
+    @app.exception_handler(OmnigentError)
+    async def _handle_omnigent_error(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+
+def _app(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+    *,
+    host_registry: object | None = None,
+    tunnel_registry: object | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    _install_error_handler(app)
+    app.state.host_registry = host_registry
+    app.state.tunnel_registry = tunnel_registry
+    app.include_router(
+        create_sessions_router(
+            conversation_store=conversation_store,
+            agent_store=agent_store,
+        ),
+        prefix="/v1",
+    )
+    return app
+
+
+@pytest.fixture
+def stores(db_uri: str) -> tuple[SqlAlchemyConversationStore, SqlAlchemyAgentStore]:
+    return SqlAlchemyConversationStore(db_uri), SqlAlchemyAgentStore(db_uri)
+
+
+def _seed_agent(agent_store: SqlAlchemyAgentStore) -> None:
+    if agent_store.get("ag_test") is None:
+        agent_store.create(
+            agent_id="ag_test",
+            name="test-agent",
+            bundle_location="ag_test/bundle",
+        )
+
+
+def _seed_session(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+    *,
+    host_id: str | None = None,
+    runner_id: str | None = None,
+) -> str:
+    _seed_agent(agent_store)
+    conv = conversation_store.create_conversation(
+        title="telemetry session",
+        agent_id="ag_test",
+        host_id=host_id,
+        runner_id=runner_id,
+        workspace="/tmp/telemetry-session" if host_id is not None else None,
+    )
+    return conv.id
+
+
+def test_session_telemetry_opted_out_checks_host_or_runner() -> None:
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                host_registry=_FakeTelemetryRegistry(host_opted_out=True),
+                tunnel_registry=_FakeTelemetryRegistry(runner_opted_out=False),
+            )
+        )
+    )
+    conv = SimpleNamespace(host_id="host_1", runner_id="runner_1")
+
+    assert _session_telemetry_opted_out(request, conv) is True
+
+    request.app.state.host_registry = _FakeTelemetryRegistry(host_opted_out=False)
+    request.app.state.tunnel_registry = _FakeTelemetryRegistry(runner_opted_out=True)
+
+    assert _session_telemetry_opted_out(request, conv) is True
+
+
+def test_session_telemetry_opted_out_fails_open() -> None:
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                host_registry=_RaisingTelemetryRegistry(),
+                tunnel_registry=_RaisingTelemetryRegistry(),
+            )
+        )
+    )
+    conv = SimpleNamespace(host_id="host_1", runner_id="runner_1")
+
+    assert _session_telemetry_opted_out(request, conv) is False
+
+
+def test_create_session_skips_telemetry_when_runner_opted_out(
+    stores: tuple[SqlAlchemyConversationStore, SqlAlchemyAgentStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conversation_store, agent_store = stores
+    _seed_agent(agent_store)
+    parent = conversation_store.create_conversation(
+        title="parent",
+        agent_id="ag_test",
+        runner_id="runner_opted_out",
+    )
+    app = _app(
+        conversation_store,
+        agent_store,
+        tunnel_registry=_FakeTelemetryRegistry(runner_opted_out=True),
+    )
+    emit = Mock()
+    monkeypatch.setattr(sessions_routes, "_tel_emit", emit)
+    monkeypatch.setattr(sessions_routes, "_get_installation_id", lambda: "install_test")
+
+    resp = TestClient(app).post(
+        "/v1/sessions",
+        json={"agent_id": "ag_test", "parent_session_id": parent.id},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+
+    assert resp.status_code == 201
+    emit.assert_not_called()
+
+
+def test_create_session_emits_telemetry_without_session_opt_out(
+    stores: tuple[SqlAlchemyConversationStore, SqlAlchemyAgentStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conversation_store, agent_store = stores
+    _seed_agent(agent_store)
+    app = _app(
+        conversation_store,
+        agent_store,
+        host_registry=_FakeTelemetryRegistry(host_opted_out=False),
+        tunnel_registry=_FakeTelemetryRegistry(runner_opted_out=False),
+    )
+    emit = Mock()
+    monkeypatch.setattr(sessions_routes, "_tel_emit", emit)
+    monkeypatch.setattr(sessions_routes, "_get_installation_id", lambda: "install_test")
+
+    resp = TestClient(app).post(
+        "/v1/sessions",
+        json={"agent_id": "ag_test"},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+
+    assert resp.status_code == 201
+    assert emit.call_count == 1
+    assert type(emit.call_args.args[0]).__name__ == "SessionCreatedEvent"
+
+
+def test_stop_session_skips_telemetry_when_host_opted_out(
+    stores: tuple[SqlAlchemyConversationStore, SqlAlchemyAgentStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conversation_store, agent_store = stores
+    session_id = _seed_session(conversation_store, agent_store, host_id="host_opted_out")
+    app = _app(
+        conversation_store,
+        agent_store,
+        host_registry=_FakeTelemetryRegistry(host_opted_out=True),
+    )
+    emit = Mock()
+    monkeypatch.setattr(sessions_routes, "_tel_emit", emit)
+    monkeypatch.setattr(sessions_routes, "_get_installation_id", lambda: "install_test")
+    monkeypatch.setattr(sessions_routes, "_stop_session_via_runner", AsyncMock(return_value=False))
+
+    resp = TestClient(app).post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "stop_session"},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+
+    assert resp.status_code == 202
+    emit.assert_not_called()
+
+
+def test_stop_session_emits_telemetry_without_session_opt_out(
+    stores: tuple[SqlAlchemyConversationStore, SqlAlchemyAgentStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conversation_store, agent_store = stores
+    session_id = _seed_session(conversation_store, agent_store)
+    app = _app(conversation_store, agent_store)
+    emit = Mock()
+    monkeypatch.setattr(sessions_routes, "_tel_emit", emit)
+    monkeypatch.setattr(sessions_routes, "_get_installation_id", lambda: "install_test")
+    monkeypatch.setattr(sessions_routes, "_stop_session_via_runner", AsyncMock(return_value=False))
+
+    resp = TestClient(app).post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "stop_session"},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+
+    assert resp.status_code == 202
+    assert emit.call_count == 1
+    assert type(emit.call_args.args[0]).__name__ == "SessionStoppedEvent"
+
+
+def test_delete_session_skips_telemetry_when_runner_opted_out(
+    stores: tuple[SqlAlchemyConversationStore, SqlAlchemyAgentStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conversation_store, agent_store = stores
+    session_id = _seed_session(conversation_store, agent_store, runner_id="runner_opted_out")
+    app = _app(
+        conversation_store,
+        agent_store,
+        tunnel_registry=_FakeTelemetryRegistry(runner_opted_out=True),
+    )
+    emit = Mock()
+    monkeypatch.setattr(sessions_routes, "_tel_emit", emit)
+    monkeypatch.setattr(sessions_routes, "_get_installation_id", lambda: "install_test")
+
+    resp = TestClient(app).delete(
+        f"/v1/sessions/{session_id}",
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+
+    assert resp.status_code == 200
+    emit.assert_not_called()
+
+
+def test_delete_session_emits_telemetry_without_session_opt_out(
+    stores: tuple[SqlAlchemyConversationStore, SqlAlchemyAgentStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conversation_store, agent_store = stores
+    session_id = _seed_session(conversation_store, agent_store)
+    app = _app(conversation_store, agent_store)
+    emit = Mock()
+    monkeypatch.setattr(sessions_routes, "_tel_emit", emit)
+    monkeypatch.setattr(sessions_routes, "_get_installation_id", lambda: "install_test")
+
+    resp = TestClient(app).delete(
+        f"/v1/sessions/{session_id}",
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+
+    assert resp.status_code == 200
+    assert emit.call_count == 1
+    assert type(emit.call_args.args[0]).__name__ == "SessionDeletedEvent"

--- a/tests/server/test_host_registry.py
+++ b/tests/server/test_host_registry.py
@@ -39,7 +39,7 @@ class FakeWebSocket:
         return ""  # pragma: no cover
 
 
-def _make_hello(name: str = "test-host") -> HostHelloFrame:
+def _make_hello(name: str = "test-host", *, telemetry_opt_out: bool = False) -> HostHelloFrame:
     """Build a minimal HostHelloFrame for tests.
 
     :param name: Human-readable host name.
@@ -49,6 +49,7 @@ def _make_hello(name: str = "test-host") -> HostHelloFrame:
         version="0.1.0",
         frame_protocol_version=1,
         name=name,
+        telemetry_opt_out=telemetry_opt_out,
     )
 
 
@@ -114,6 +115,26 @@ def test_online_host_ids() -> None:
     registry.deregister("host_c1")
     ids = registry.online_host_ids()
     assert ids == ["host_c2"]
+
+
+def test_is_host_telemetry_opted_out_reads_hello_flag() -> None:
+    """The registry exposes the host hello telemetry opt-out bit."""
+    registry = HostRegistry()
+    registry.register(
+        "host_telemetry",
+        FakeWebSocket(),
+        _make_hello(telemetry_opt_out=True),
+        owner="alice",
+    )
+
+    assert registry.is_host_telemetry_opted_out("host_telemetry") is True
+
+
+def test_is_host_telemetry_opted_out_false_for_unknown() -> None:
+    """Unknown/offline hosts are treated as no opt-out signal."""
+    registry = HostRegistry()
+
+    assert registry.is_host_telemetry_opted_out("missing") is False
 
 
 def test_register_replaces_stale_connection() -> None:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from omnigent.telemetry.surface import classify_surface
 
@@ -123,6 +124,7 @@ def test_is_disabled_none_set(monkeypatch: pytest.MonkeyPatch) -> None:
     """When none of the opt-out vars are set, telemetry is enabled."""
     _ci_vars = [
         "OMNIGENT_TELEMETRY",
+        "DISABLE_TELEMETRY",
         "OMNIGENT_DISABLE_TELEMETRY",
         "DO_NOT_TRACK",
         "CI",
@@ -195,6 +197,65 @@ _ALL_OPT_OUT_VARS = [
 ]
 
 
+def _clear_opt_out_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove env vars that can disable telemetry."""
+    for var in _ALL_OPT_OUT_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.parametrize(
+    ("var", "value"),
+    [
+        ("OMNIGENT_TELEMETRY", "0"),
+        ("DISABLE_TELEMETRY", "1"),
+        ("DISABLE_TELEMETRY", "true"),
+        ("DISABLE_TELEMETRY", "yes"),
+        ("DISABLE_TELEMETRY", "TRUE"),
+        ("OMNIGENT_DISABLE_TELEMETRY", "1"),
+        ("OMNIGENT_DISABLE_TELEMETRY", "true"),
+        ("OMNIGENT_DISABLE_TELEMETRY", "yes"),
+        ("DO_NOT_TRACK", "1"),
+    ],
+)
+def test_is_disabled_env_var_variants(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    var: str,
+    value: str,
+) -> None:
+    """Every documented env-var opt-out disables telemetry."""
+    _clear_opt_out_env(monkeypatch)
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv(var, value)
+    from omnigent.telemetry.client import is_disabled
+
+    assert is_disabled() is True
+
+
+@pytest.mark.parametrize(
+    ("var", "value"),
+    [
+        ("OMNIGENT_TELEMETRY", "1"),
+        ("DISABLE_TELEMETRY", "false"),
+        ("OMNIGENT_DISABLE_TELEMETRY", "false"),
+        ("DO_NOT_TRACK", "0"),
+    ],
+)
+def test_is_disabled_env_var_non_opt_out_values(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    var: str,
+    value: str,
+) -> None:
+    """Truthy-only env vars do not opt out on unrelated values."""
+    _clear_opt_out_env(monkeypatch)
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv(var, value)
+    from omnigent.telemetry.client import is_disabled
+
+    assert is_disabled() is False
+
+
 def test_is_disabled_config_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """``telemetry: false`` in config.yaml disables telemetry."""
     config_file = tmp_path / "config.yaml"
@@ -202,6 +263,18 @@ def test_is_disabled_config_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
     for var in _ALL_OPT_OUT_VARS:
         monkeypatch.delenv(var, raising=False)
+    from omnigent.telemetry.client import is_disabled
+
+    assert is_disabled() is True
+
+
+def test_is_disabled_config_home_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``OMNIGENT_CONFIG_HOME`` controls which config.yaml is read."""
+    config_home = tmp_path / "custom-home"
+    config_home.mkdir()
+    (config_home / "config.yaml").write_text("telemetry: false\n", encoding="utf-8")
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(config_home))
+    _clear_opt_out_env(monkeypatch)
     from omnigent.telemetry.client import is_disabled
 
     assert is_disabled() is True
@@ -219,6 +292,49 @@ def test_is_disabled_config_yaml_telemetry_true(
     from omnigent.telemetry.client import is_disabled
 
     assert is_disabled() is False
+
+
+def test_is_disabled_malformed_config_yaml_returns_false(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Malformed config text does not silently suppress telemetry."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("telemetry: [false\n", encoding="utf-8")
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    _clear_opt_out_env(monkeypatch)
+    from omnigent.telemetry.client import is_disabled
+
+    assert is_disabled() is False
+
+
+def test_config_opts_out_bool_false() -> None:
+    """A real YAML bool false opts out."""
+    from omnigent.telemetry.client import _config_opts_out
+
+    assert _config_opts_out(False) is True
+
+
+def test_config_opts_out_bool_true() -> None:
+    """A real YAML bool true does not opt out."""
+    from omnigent.telemetry.client import _config_opts_out
+
+    assert _config_opts_out(True) is False
+
+
+@pytest.mark.parametrize("value", ["false", "no", "off", "0", " FALSE "])
+def test_config_opts_out_corrupted_string_opt_out(value: str) -> None:
+    """String spellings produced by the corrupted loader opt out."""
+    from omnigent.telemetry.client import _config_opts_out
+
+    assert _config_opts_out(value) is True
+
+
+@pytest.mark.parametrize("value", ["true", "yes", "on", "1", ""])
+def test_config_opts_out_corrupted_string_not_opt_out(value: str) -> None:
+    """Opt-in string spellings do not disable telemetry."""
+    from omnigent.telemetry.client import _config_opts_out
+
+    assert _config_opts_out(value) is False
 
 
 # ── init_client — server_config ──────────────────────────────────────────────
@@ -252,6 +368,26 @@ def test_init_client_server_config_disabled(monkeypatch: pytest.MonkeyPatch) -> 
     try:
         monkeypatch.setattr(_mod, "_CLIENT", None)
         _mod.init_client(config={"telemetry": False})
+        assert _mod._CLIENT is None
+    finally:
+        monkeypatch.setattr(_mod, "_CLIENT", original_client)
+
+
+def test_init_client_c_file_false_after_spec_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``telemetry: false`` from ``omnigent server -c`` disables telemetry."""
+    import omnigent.spec.parser  # noqa: F401 — reproduces the SafeLoader mutation
+    import omnigent.telemetry.client as _mod
+
+    for var in _ALL_OPT_OUT_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    config = yaml.safe_load("telemetry: false\n")
+    assert config["telemetry"] == "false"
+
+    original_client = _mod._CLIENT
+    try:
+        monkeypatch.setattr(_mod, "_CLIENT", None)
+        _mod.init_client(config=config)
         assert _mod._CLIENT is None
     finally:
         monkeypatch.setattr(_mod, "_CLIENT", original_client)


### PR DESCRIPTION
## Related issue

Closes #2487

## Summary

Anonymous telemetry is default-on, but every documented opt-out path now wins consistently across server config, server env, and host/runner session propagation.

- Coerces parsed `telemetry:` config values at the telemetry boundary so `telemetry: false` from `omnigent server -c` still disables telemetry after the spec parser mutates PyYAML boolean parsing.
- Uses one shared session gate for `SessionCreatedEvent`, `SessionStoppedEvent`, and `SessionDeletedEvent`, checking host OR runner opt-out signals and failing open on transient registry lookup errors.
- Documents collected lifecycle fields and all opt-out mechanisms in `docs/telemetry.md`, `README.md`, and the example root `config.yaml`.

ELI5: if any switch says “no telemetry,” Omnigent now treats that session as no-telemetry everywhere instead of only at session creation.

```text
server env/config off ─┐
-c telemetry:false ────┼─> no telemetry client / no events
host hello opt-out ────┤
runner hello opt-out ──┘     per-session lifecycle events skipped
```

## Test Plan

- [x] `pre-commit run --all-files`
- [x] `.venv/bin/python -m pytest tests/test_telemetry.py tests/host/test_frames.py tests/runner/transports/ws_tunnel/test_frames.py tests/server/test_host_registry.py tests/runner/transports/ws_tunnel/test_registry.py tests/server/routes/test_sessions_telemetry.py`

## Demo

N/A — non-visual backend/config behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added unit coverage for env-var variants, `config.yaml` parsing/coercion, frame round-trips, and host/runner registry accessors. Added route-level lifecycle coverage proving opted-out host/runner sessions suppress created/stopped/deleted telemetry while non-opted sessions still emit.

## Changelog

Telemetry opt-out now works via env vars, `telemetry: false`, and `omnigent host` session propagation.
