### PR TITLE
fix(polly): pin Sonnet 5 / Cursor Grok 4.5 as faster Polly defaults

### DIFF
--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -4,6 +4,8 @@ description: Claude Code coding sub-agent — implements, cross-vendor reviews, 
 
 executor:
   type: omnigent
+  # Faster default for Polly Claude Code workers; override per-session with ``/model``.
+  model: claude-sonnet-5
   config:
     harness: claude-native
     # Headless workers can't answer ApprovalCards, and managed Claude

--- a/examples/polly/agents/cursor/config.yaml
+++ b/examples/polly/agents/cursor/config.yaml
@@ -10,6 +10,8 @@ description: Cursor coding sub-agent — implements, cross-vendor reviews, or ex
 # ``permission_mode: auto`` for Smart Auto (``--auto-review``) instead.
 executor:
   type: omnigent
+  # Faster default for Polly Cursor workers; override per-session with ``/model``.
+  model: cursor-grok-4.5
   config:
     harness: cursor-native
     # YOLO: headless workers can't answer approval prompts, so run

--- a/examples/polly/agents/cursor/config.yaml
+++ b/examples/polly/agents/cursor/config.yaml
@@ -11,7 +11,9 @@ description: Cursor coding sub-agent — implements, cross-vendor reviews, or ex
 executor:
   type: omnigent
   # Faster default for Polly Cursor workers; override per-session with ``/model``.
-  model: cursor-grok-4.5
+  # Must be the compound id from ``cursor-agent models`` (bare ``cursor-grok-4.5``
+  # is rejected — use ``cursor-grok-4.5-high`` / ``-medium`` / ``-low``).
+  model: cursor-grok-4.5-high
   config:
     harness: cursor-native
     # YOLO: headless workers can't answer approval prompts, so run

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -19,15 +19,15 @@ spawn: true
 # Orchestrator "brain": Claude Agent SDK. polly writes no code itself — it
 # delegates ALL coding work (investigation, implementation, review) to the
 # claude_code / codex / opencode / cursor / hermes / pi sub-agents, doing only non-code authoring (docs /
-# Markdown / text edits, skills) itself. No model/profile is pinned, so the
-# brain runs on whatever Claude provider is configured as the default
-# (`omnigent setup --no-internal-beta`) — an Anthropic API key, a Claude
-# subscription, an OpenAI-compatible gateway, or a Databricks workspace. With
-# no model named the claude-sdk harness resolves the configured provider's
-# default Claude model (the bundled catalog default is claude-opus-4-8).
+# Markdown / text edits, skills) itself. Auth still comes from whatever Claude
+# provider is configured as the default (`omnigent setup --no-internal-beta`) —
+# an Anthropic API key, a Claude subscription, an OpenAI-compatible gateway, or
+# a Databricks workspace — but the brain is pinned to Sonnet 5 for faster
+# planning turns (override with ``/model`` or ``-m``).
 executor:
   type: omnigent
   context_window: 1000000
+  model: claude-sonnet-5
   config:
     harness: claude-sdk
 

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3229,6 +3229,16 @@ def _apply_overrides_to_raw(raw: _YamlMapping, overrides: ChatOverrides) -> None
         executor_block["model"] = overrides.model
     if overrides.harness is not None:
         _apply_harness_override_to_executor(raw, executor_block, overrides.harness)
+        # A harness-only override drops any prior model pin so the new
+        # harness resolves its provider default — e.g. ``omnigent run
+        # examples/polly --harness pi`` must not keep Polly's Claude-only
+        # ``executor.model: claude-sonnet-5``. An explicit ``--model``
+        # (applied above) wins and is left alone.
+        if overrides.model is None:
+            executor_block.pop("model", None)
+            llm_block = raw.get("llm")
+            if isinstance(llm_block, dict):
+                llm_block.pop("model", None)
     # When neither harness nor model is declared — after overrides —
     # inject the ad-hoc default. Gated on harness absence so a YAML
     # like ``claude_code_agent.yaml`` (declares harness, no model)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4813,6 +4813,30 @@ def _codex_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) -
     return model if isinstance(model, str) and model else None
 
 
+def _claude_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) -> str | None:
+    """
+    Read the Claude Code model id to launch the native TUI with, from a spec.
+
+    Reads the canonical ``spec.executor.model`` field (the same field the
+    in-process claude-sdk harness consumes via ``_resolve_spec_model``). Unlike
+    cursor-native, gateway-routed ``databricks-*`` ids are valid Claude Code
+    models when the launch is wired through the Databricks AI gateway, so they
+    are passed through.
+
+    :param agent_spec: Agent spec object, or a resolved wrapper carrying a
+        ``spec`` attribute. ``None`` means no spec was available.
+    :returns: A Claude model id, e.g. ``"claude-sonnet-5"``, or ``None`` when
+        the spec declares no model pin.
+    """
+    spec = agent_spec.spec if isinstance(agent_spec, ResolvedSpec) else agent_spec
+    if spec is None:
+        return None
+    model = spec.executor.model
+    if not isinstance(model, str) or not model:
+        return None
+    return model
+
+
 def _cursor_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) -> str | None:
     """
     Read the cursor-agent model id to launch the native TUI with, from a spec.
@@ -5716,11 +5740,12 @@ async def _auto_create_claude_terminal(
 
     base_claude_args = _build_claude_native_base_args(
         reasoning_effort=session_effort,
-        # Session override wins; the ucode gateway model is the default
-        # when no per-session override is set. Both yield to an explicit
-        # ``--model`` in the user's pass-through args (handled in the
+        # Precedence: per-session ``/model`` override > agent-spec pin
+        # (``executor.model``) > provider/ucode default. All three yield to an
+        # explicit ``--model`` in the user's pass-through args (handled in the
         # helper).
         model_override=session_model_override
+        or _claude_native_model_from_spec(agent_spec)
         or (claude_config.model if claude_config is not None else None),
         terminal_launch_args=session_launch_args,
         resume_external_session_id=resume_external_session_id,

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1697,6 +1697,33 @@ def test_apply_overrides_harness_and_model_together_for_spec_version_bundle() ->
     assert executor["model"] == "databricks-claude-sonnet-4-6"
 
 
+def test_apply_overrides_harness_only_clears_pinned_model() -> None:
+    """
+    ``--harness`` alone drops a prior ``executor.model`` pin.
+
+    Polly pins Sonnet 5 on its claude-sdk brain; swapping the brain to
+    ``pi`` / ``openai-agents`` must not leave that Claude id behind for a
+    harness that can't run it. Pair with ``--model`` to keep a pin.
+    """
+    raw: dict[str, object] = {
+        "spec_version": 1,
+        "name": "polly",
+        "prompt": "orchestrate",
+        "executor": {
+            "type": "omnigent",
+            "model": "claude-sonnet-5",
+            "config": {"harness": "claude-sdk"},
+        },
+    }
+
+    _apply_overrides_to_raw(raw, ChatOverrides(harness="pi"))
+
+    executor = raw["executor"]
+    assert isinstance(executor, dict)
+    assert executor["config"]["harness"] == "pi"
+    assert executor.get("model") is None
+
+
 def test_apply_overrides_rejects_harness_for_non_omnigent_executor_type() -> None:
     """
     A spec_version bundle with a non-omnigent ``executor.type`` fails

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -38,19 +38,17 @@ def polly_spec() -> AgentSpec:
 
 def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
     """
-    The orchestrator runs on claude-sdk with a 1M window and **no pinned
-    model or profile**, so it inherits whatever Claude provider the user
-    configured via ``omnigent setup --no-internal-beta`` (Anthropic key,
-    subscription, gateway, or Databricks) and resolves that provider's
-    default Claude model.
+    The orchestrator runs on claude-sdk with a 1M window and a Sonnet 5 pin
+    for faster planning. Auth still comes from whatever Claude provider the
+    user configured via ``omnigent setup --no-internal-beta`` (Anthropic key,
+    subscription, gateway, or Databricks) — the pin is the bare vendor id
+    ``claude-sonnet-5``, not a Databricks-only endpoint name.
 
-    Un-pinning is load-bearing for OSS (a Databricks-specific model id would
-    404 on a plain Anthropic key). The old ``databricks-gpt-5-4`` fallback
-    crash that a pin papered over is fixed at the root in
-    ``chat.py`` ``_spec_declares_harness_or_model``, which recognizes the
-    nested ``executor.config.harness`` and so never injects the ad-hoc
-    default. Re-pinning a ``model`` here would re-couple polly to one
-    provider — fail here so that regression is caught.
+    The old ``databricks-gpt-5-4`` fallback crash that an accidental GPT pin
+    papered over is fixed at the root in ``chat.py``
+    ``_spec_declares_harness_or_model``, which recognizes the nested
+    ``executor.config.harness`` and so never injects the ad-hoc default.
+    Fail here if the Sonnet 5 pin regresses or a Databricks-only id sneaks in.
 
     Reads ``executor.config.harness`` (not a flat ``harness:``) because this
     is a bundle: a regression that drops the harness into a flat key would
@@ -59,9 +57,9 @@ def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
     assert polly_spec.name == "polly"
     ex = polly_spec.executor
     assert ex.config.get("harness") == "claude-sdk"
-    # No model pin — the configured provider's default Claude model is used.
-    # Re-introducing a pin (Databricks or otherwise) fails here.
-    assert ex.model is None
+    # Faster planning pin — bare Claude id so Anthropic / gateway / Databricks
+    # auth still resolve. A Databricks-only id here would re-couple OSS.
+    assert ex.model == "claude-sonnet-5"
     # Profile is intentionally NOT pinned either.
     assert ex.profile is None
     assert ex.context_window == 1000000
@@ -99,8 +97,10 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
     # Headless bypass knobs so workers don't stall on ApprovalCards.
     by_name = {a.name: a for a in polly_spec.sub_agents}
     assert by_name["claude_code"].executor.config.get("permission_mode") == "auto"
+    assert by_name["claude_code"].executor.model == "claude-sonnet-5"
     assert by_name["codex"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.config.get("yolo") in (True, "True", "true")
+    assert by_name["cursor"].executor.model == "cursor-grok-4.5-high"
     for name in ("claude_code", "codex", "opencode", "cursor", "hermes", "pi"):
         prompt = (_POLLY_BUNDLE / "agents" / name / "config.yaml").read_text(encoding="utf-8")
         assert "IMPLEMENT — write real product code" in prompt

--- a/tests/runner/test_app_claude_native_model.py
+++ b/tests/runner/test_app_claude_native_model.py
@@ -1,0 +1,55 @@
+"""Tests for claude-native model resolution from the agent spec.
+
+``_claude_native_model_from_spec`` is the seam that turns a session's
+``executor.model`` (set via a config.yaml ``model:`` key) into the
+``claude --model`` value the native TUI launches with. Gateway-routed
+``databricks-*`` ids are valid Claude Code models on the Databricks AI
+gateway path, so they pass through (unlike cursor-native).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.runner.app import ResolvedSpec, _claude_native_model_from_spec
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+
+def _spec(model: str | None) -> AgentSpec:
+    """Build a minimal agent spec carrying *model* on its executor block."""
+    return AgentSpec(spec_version=1, name="claude_code", executor=ExecutorSpec(model=model))
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("claude-sonnet-5", "claude-sonnet-5"),
+        ("claude-opus-4-8", "claude-opus-4-8"),
+        ("databricks-claude-sonnet-5", "databricks-claude-sonnet-5"),
+        (None, None),
+        ("", None),
+    ],
+    ids=[
+        "sonnet-5",
+        "opus-passthrough",
+        "databricks-passthrough",
+        "no-model",
+        "empty-model",
+    ],
+)
+def test_claude_native_model_from_spec(model: str | None, expected: str | None) -> None:
+    """A pinned Claude model id is returned; missing/empty pins resolve to None."""
+    assert _claude_native_model_from_spec(_spec(model)) == expected
+
+
+def test_claude_native_model_from_spec_none_spec() -> None:
+    """A missing spec yields no model (no ``--model`` injected)."""
+    assert _claude_native_model_from_spec(None) is None
+
+
+def test_claude_native_model_from_spec_resolved_wrapper() -> None:
+    """A ResolvedSpec wrapper unwraps to the same model pin."""
+    wrapped = ResolvedSpec(spec=_spec("claude-sonnet-5"), workdir=Path("/tmp"))
+    assert _claude_native_model_from_spec(wrapped) == "claude-sonnet-5"


### PR DESCRIPTION
## Related issue

N/A

## Summary

Polly's planning / Claude Code / Cursor turns were inheriting the global harness defaults (Claude Opus 4.8 / Cursor auto), which made common Polly flows slower than they need to be. This pins faster models **only on Polly** so other agents keep the existing catalog/SDK defaults.

- Polly brain (`claude-sdk`): pin `executor.model: claude-sonnet-5`
- Polly Claude Code worker (`claude-native`): pin `executor.model: claude-sonnet-5`
- Polly Cursor worker (`cursor-native`): pin `executor.model: cursor-grok-4.5-high` (verified against `cursor-agent --model`; bare `cursor-grok-4.5` is rejected)
- Wire claude-native launch to honor `executor.model` (session `/model` still wins; then spec pin; then provider default)
- Auth/provider resolution is unchanged; users can still override with `/model` or `-m`

## Test Plan

- [x] Parsed Polly YAML configs and confirmed model / harness values
- [x] Unit tests for `_claude_native_model_from_spec` (`tests/runner/test_app_claude_native_model.py`)
- [x] Live `cursor-agent --model` probe: `cursor-grok-4.5` rejected; `cursor-grok-4.5-high` accepted
- [ ] Smoke a Polly session: brain + Claude Code worker report Sonnet 5; Cursor worker launches with Cursor Grok 4.5

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Config pins plus a unit test for the new claude-native spec→`--model` seam. Manually verified the Cursor model id with `cursor-agent --model` in a trusted temp dir.

## Changelog

Polly defaults to Sonnet 5 for its brain and Claude Code workers, and Cursor Grok 4.5 for Cursor workers