### PR TITLE
fix(polly): pin Cursor workers to grok-4.5

### DIFF
--- a/examples/polly/agents/cursor/config.yaml
+++ b/examples/polly/agents/cursor/config.yaml
@@ -11,9 +11,10 @@ description: Cursor coding sub-agent — implements, cross-vendor reviews, or ex
 executor:
   type: omnigent
   # Faster default for Polly Cursor workers; override per-session with ``/model``.
-  # Must be the compound id from ``cursor-agent models`` (bare ``cursor-grok-4.5``
-  # is rejected — use ``cursor-grok-4.5-high`` / ``-medium`` / ``-low``).
-  model: cursor-grok-4.5-high
+  # Use the base id from Cursor's model list / SDK (``grok-4.5``). The compound
+  # ``cursor-grok-4.5-high`` also works on cursor-agent, but the SDK catalog
+  # exposes ``grok-4.5``.
+  model: grok-4.5
   config:
     harness: cursor-native
     # YOLO: headless workers can't answer approval prompts, so run

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -100,7 +100,7 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
     assert by_name["claude_code"].executor.model == "claude-sonnet-5"
     assert by_name["codex"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.config.get("yolo") in (True, "True", "true")
-    assert by_name["cursor"].executor.model == "cursor-grok-4.5-high"
+    assert by_name["cursor"].executor.model == "grok-4.5"
     for name in ("claude_code", "codex", "opencode", "cursor", "hermes", "pi"):
         prompt = (_POLLY_BUNDLE / "agents" / name / "config.yaml").read_text(encoding="utf-8")
         assert "IMPLEMENT — write real product code" in prompt


### PR DESCRIPTION
## Related issue

N/A

## Summary

#2500 pinned Polly's Cursor worker to `cursor-grok-4.5-high`, but Cursor's SDK/catalog id for that model is `grok-4.5` (confirmed via live `cursor-agent --model` and the SDK available-models list). Wrong id breaks or confuses Cursor worker launches.

- Polly Cursor worker: `executor.model: grok-4.5`
- Update the structural e2e assertion to match

Claude Sonnet 5 pin is intentionally left for a follow-up PR.

## Test Plan

- [x] Live probe: `cursor-agent --model grok-4.5 --trust --print` succeeds
- [x] Updated `tests/e2e/omnigent/test_example_polly.py` expectation

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified `grok-4.5` launches with cursor-agent in a trusted temp dir. Structural e2e assertion updated.

## Changelog

Polly Cursor workers default to grok-4.5