### PR TITLE
fix(polly): pin Claude brain/workers to sonnet alias

### DIFF
--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -4,8 +4,10 @@ description: Claude Code coding sub-agent — implements, cross-vendor reviews, 
 
 executor:
   type: omnigent
-  # Faster default for Polly Claude Code workers; override per-session with ``/model``.
-  model: claude-sonnet-5
+  # Faster default for Polly Claude Code workers. Pin Claude Code's
+  # version-agnostic ``sonnet`` alias (not ``claude-sonnet-5`` — that full id
+  # 404s under API-key auth). Override per-session with ``/model``.
+  model: sonnet
   config:
     harness: claude-native
     # Headless workers can't answer ApprovalCards, and managed Claude

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -22,12 +22,15 @@ spawn: true
 # Markdown / text edits, skills) itself. Auth still comes from whatever Claude
 # provider is configured as the default (`omnigent setup --no-internal-beta`) —
 # an Anthropic API key, a Claude subscription, an OpenAI-compatible gateway, or
-# a Databricks workspace — but the brain is pinned to Sonnet 5 for faster
-# planning turns (override with ``/model`` or ``-m``).
+# a Databricks workspace — but the brain is pinned to Claude Code's ``sonnet``
+# alias (faster than the catalog Opus default). Use the version-agnostic alias,
+# not a concrete ``claude-sonnet-*`` id: bare dated/full ids 404 under API-key
+# auth, while ``sonnet`` resolves to the provider's current Sonnet. Override
+# with ``/model`` or ``-m`` (e.g. ``sonnet_5`` when the custom slot is wired).
 executor:
   type: omnigent
   context_window: 1000000
-  model: claude-sonnet-5
+  model: sonnet
   config:
     harness: claude-sdk
 

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3232,7 +3232,7 @@ def _apply_overrides_to_raw(raw: _YamlMapping, overrides: ChatOverrides) -> None
         # A harness-only override drops any prior model pin so the new
         # harness resolves its provider default — e.g. ``omnigent run
         # examples/polly --harness pi`` must not keep Polly's Claude-only
-        # ``executor.model: claude-sonnet-5``. An explicit ``--model``
+        # ``executor.model: sonnet``. An explicit ``--model``
         # (applied above) wins and is left alone.
         if overrides.model is None:
             executor_block.pop("model", None)

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1701,7 +1701,7 @@ def test_apply_overrides_harness_only_clears_pinned_model() -> None:
     """
     ``--harness`` alone drops a prior ``executor.model`` pin.
 
-    Polly pins Sonnet 5 on its claude-sdk brain; swapping the brain to
+    Polly pins ``sonnet`` on its claude-sdk brain; swapping the brain to
     ``pi`` / ``openai-agents`` must not leave that Claude id behind for a
     harness that can't run it. Pair with ``--model`` to keep a pin.
     """
@@ -1711,7 +1711,7 @@ def test_apply_overrides_harness_only_clears_pinned_model() -> None:
         "prompt": "orchestrate",
         "executor": {
             "type": "omnigent",
-            "model": "claude-sonnet-5",
+            "model": "sonnet",
             "config": {"harness": "claude-sdk"},
         },
     }

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -38,17 +38,19 @@ def polly_spec() -> AgentSpec:
 
 def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
     """
-    The orchestrator runs on claude-sdk with a 1M window and a Sonnet 5 pin
-    for faster planning. Auth still comes from whatever Claude provider the
-    user configured via ``omnigent setup --no-internal-beta`` (Anthropic key,
-    subscription, gateway, or Databricks) — the pin is the bare vendor id
-    ``claude-sonnet-5``, not a Databricks-only endpoint name.
+    The orchestrator runs on claude-sdk with a 1M window and a ``sonnet``
+    alias pin for faster planning. Auth still comes from whatever Claude
+    provider the user configured via ``omnigent setup --no-internal-beta``
+    (Anthropic key, subscription, gateway, or Databricks). The pin is Claude
+    Code's version-agnostic ``sonnet`` alias — concrete ``claude-sonnet-*``
+    ids 404 under API-key auth, while ``sonnet`` resolves to the provider's
+    current Sonnet.
 
     The old ``databricks-gpt-5-4`` fallback crash that an accidental GPT pin
     papered over is fixed at the root in ``chat.py``
     ``_spec_declares_harness_or_model``, which recognizes the nested
     ``executor.config.harness`` and so never injects the ad-hoc default.
-    Fail here if the Sonnet 5 pin regresses or a Databricks-only id sneaks in.
+    Fail here if the ``sonnet`` pin regresses or a Databricks-only id sneaks in.
 
     Reads ``executor.config.harness`` (not a flat ``harness:``) because this
     is a bundle: a regression that drops the harness into a flat key would
@@ -57,9 +59,9 @@ def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
     assert polly_spec.name == "polly"
     ex = polly_spec.executor
     assert ex.config.get("harness") == "claude-sdk"
-    # Faster planning pin — bare Claude id so Anthropic / gateway / Databricks
-    # auth still resolve. A Databricks-only id here would re-couple OSS.
-    assert ex.model == "claude-sonnet-5"
+    # Faster planning pin — Claude Code alias so Anthropic / gateway /
+    # Databricks auth still resolve. A Databricks-only id here would re-couple OSS.
+    assert ex.model == "sonnet"
     # Profile is intentionally NOT pinned either.
     assert ex.profile is None
     assert ex.context_window == 1000000
@@ -97,7 +99,7 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
     # Headless bypass knobs so workers don't stall on ApprovalCards.
     by_name = {a.name: a for a in polly_spec.sub_agents}
     assert by_name["claude_code"].executor.config.get("permission_mode") == "auto"
-    assert by_name["claude_code"].executor.model == "claude-sonnet-5"
+    assert by_name["claude_code"].executor.model == "sonnet"
     assert by_name["codex"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.model == "cursor-grok-4.5-high"


### PR DESCRIPTION
## Related issue

N/A

## Summary

#2500 pinned Polly's Claude brain and Claude Code worker to `claude-sonnet-5`, but that concrete id fails at runtime under API-key auth with Claude Code's \"selected model … may not exist or you may not have access\" error. Live probe: `claude --model sonnet` works; `claude-sonnet-5` / dated full ids do not.

- Polly brain + Claude Code worker: `executor.model: sonnet` (version-agnostic alias; faster than catalog Opus)
- Update structural / harness-override test expectations
- Cursor pin is handled separately in #2503 (`grok-4.5`)

## Test Plan

- [x] Live `claude --model` probe: `sonnet` ok; `claude-sonnet-5` rejected
- [x] `tests/e2e/omnigent/test_example_polly.py` + harness-clear unit test

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified Claude Code accepts `sonnet` and rejects `claude-sonnet-5` under the local API-key auth path.

## Changelog

Polly Claude brain and Claude Code workers default to the sonnet alias