### PR TITLE
fix(polly): remove Sonnet model pins from brain and Claude Code

### DIFF
--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -4,10 +4,6 @@ description: Claude Code coding sub-agent — implements, cross-vendor reviews, 
 
 executor:
   type: omnigent
-  # Faster default for Polly Claude Code workers. Pin Claude Code's
-  # version-agnostic ``sonnet`` alias (not ``claude-sonnet-5`` — that full id
-  # 404s under API-key auth). Override per-session with ``/model``.
-  model: sonnet
   config:
     harness: claude-native
     # Headless workers can't answer ApprovalCards, and managed Claude

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -19,18 +19,15 @@ spawn: true
 # Orchestrator "brain": Claude Agent SDK. polly writes no code itself — it
 # delegates ALL coding work (investigation, implementation, review) to the
 # claude_code / codex / opencode / cursor / hermes / pi sub-agents, doing only non-code authoring (docs /
-# Markdown / text edits, skills) itself. Auth still comes from whatever Claude
-# provider is configured as the default (`omnigent setup --no-internal-beta`) —
-# an Anthropic API key, a Claude subscription, an OpenAI-compatible gateway, or
-# a Databricks workspace — but the brain is pinned to Claude Code's ``sonnet``
-# alias (faster than the catalog Opus default). Use the version-agnostic alias,
-# not a concrete ``claude-sonnet-*`` id: bare dated/full ids 404 under API-key
-# auth, while ``sonnet`` resolves to the provider's current Sonnet. Override
-# with ``/model`` or ``-m`` (e.g. ``sonnet_5`` when the custom slot is wired).
+# Markdown / text edits, skills) itself. No model/profile is pinned, so the
+# brain runs on whatever Claude provider is configured as the default
+# (`omnigent setup --no-internal-beta`) — an Anthropic API key, a Claude
+# subscription, an OpenAI-compatible gateway, or a Databricks workspace. With
+# no model named the claude-sdk harness resolves the configured provider's
+# default Claude model.
 executor:
   type: omnigent
   context_window: 1000000
-  model: sonnet
   config:
     harness: claude-sdk
 

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3232,7 +3232,7 @@ def _apply_overrides_to_raw(raw: _YamlMapping, overrides: ChatOverrides) -> None
         # A harness-only override drops any prior model pin so the new
         # harness resolves its provider default — e.g. ``omnigent run
         # examples/polly --harness pi`` must not keep Polly's Claude-only
-        # ``executor.model: sonnet``. An explicit ``--model``
+        # a Claude-only ``executor.model``. An explicit ``--model``
         # (applied above) wins and is left alone.
         if overrides.model is None:
             executor_block.pop("model", None)

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1701,9 +1701,8 @@ def test_apply_overrides_harness_only_clears_pinned_model() -> None:
     """
     ``--harness`` alone drops a prior ``executor.model`` pin.
 
-    Polly pins ``sonnet`` on its claude-sdk brain; swapping the brain to
-    ``pi`` / ``openai-agents`` must not leave that Claude id behind for a
-    harness that can't run it. Pair with ``--model`` to keep a pin.
+    A brain with a Claude-only model pin must not keep that id when swapped
+    to ``pi`` / ``openai-agents``. Pair with ``--model`` to keep a pin.
     """
     raw: dict[str, object] = {
         "spec_version": 1,

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -38,19 +38,19 @@ def polly_spec() -> AgentSpec:
 
 def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
     """
-    The orchestrator runs on claude-sdk with a 1M window and a ``sonnet``
-    alias pin for faster planning. Auth still comes from whatever Claude
-    provider the user configured via ``omnigent setup --no-internal-beta``
-    (Anthropic key, subscription, gateway, or Databricks). The pin is Claude
-    Code's version-agnostic ``sonnet`` alias — concrete ``claude-sonnet-*``
-    ids 404 under API-key auth, while ``sonnet`` resolves to the provider's
-    current Sonnet.
+    The orchestrator runs on claude-sdk with a 1M window and **no pinned
+    model or profile**, so it inherits whatever Claude provider the user
+    configured via ``omnigent setup --no-internal-beta`` (Anthropic key,
+    subscription, gateway, or Databricks) and resolves that provider's
+    default Claude model.
 
-    The old ``databricks-gpt-5-4`` fallback crash that an accidental GPT pin
-    papered over is fixed at the root in ``chat.py``
-    ``_spec_declares_harness_or_model``, which recognizes the nested
-    ``executor.config.harness`` and so never injects the ad-hoc default.
-    Fail here if the ``sonnet`` pin regresses or a Databricks-only id sneaks in.
+    Un-pinning is load-bearing for OSS (a Databricks-specific model id would
+    404 on a plain Anthropic key). The old ``databricks-gpt-5-4`` fallback
+    crash that a pin papered over is fixed at the root in
+    ``chat.py`` ``_spec_declares_harness_or_model``, which recognizes the
+    nested ``executor.config.harness`` and so never injects the ad-hoc
+    default. Re-pinning a ``model`` here would re-couple polly to one
+    provider — fail here so that regression is caught.
 
     Reads ``executor.config.harness`` (not a flat ``harness:``) because this
     is a bundle: a regression that drops the harness into a flat key would
@@ -59,9 +59,9 @@ def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
     assert polly_spec.name == "polly"
     ex = polly_spec.executor
     assert ex.config.get("harness") == "claude-sdk"
-    # Faster planning pin — Claude Code alias so Anthropic / gateway /
-    # Databricks auth still resolve. A Databricks-only id here would re-couple OSS.
-    assert ex.model == "sonnet"
+    # No model pin — the configured provider's default Claude model is used.
+    # Re-introducing a pin (Databricks or otherwise) fails here.
+    assert ex.model is None
     # Profile is intentionally NOT pinned either.
     assert ex.profile is None
     assert ex.context_window == 1000000
@@ -99,7 +99,7 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
     # Headless bypass knobs so workers don't stall on ApprovalCards.
     by_name = {a.name: a for a in polly_spec.sub_agents}
     assert by_name["claude_code"].executor.config.get("permission_mode") == "auto"
-    assert by_name["claude_code"].executor.model == "sonnet"
+    assert by_name["claude_code"].executor.model is None
     assert by_name["codex"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.model == "grok-4.5"


### PR DESCRIPTION
## Related issue

N/A

## Summary

Polly's Claude brain and Claude Code worker were pinned to \`sonnet\` (#2504) after \`claude-sonnet-5\` proved unavailable on Databricks auth. That still forces a model choice that may not match the workspace default / access. Un-pin Claude again so the configured provider picks the model; leave the Cursor \`grok-4.5\` pin (#2503) alone.

- Polly brain + Claude Code worker: remove \`executor.model\`
- Restore structural e2e expectations (\`model is None\` for those two)
- Cursor worker stays on \`grok-4.5\`

## Test Plan

- [x] \`tests/e2e/omnigent/test_example_polly.py::{test_orchestrator_executor,test_coding_subagents\`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Structural e2e assertions updated for the un-pin.

## Changelog

Polly Claude brain and Claude Code workers inherit the provider default model again