### PR TITLE
feat(packaging): add PostgreSQL installation extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ uv tool install -q --python 3.12 git+https://github.com/omnigent-ai/omnigent.git
   `uv tool install "omnigent[databricks]"` — or pass it to the bootstrap
   installer with `... | sh -s -- --extra databricks`. Signing in to the
   workspace also uses the [Databricks CLI](https://docs.databricks.com/aws/en/dev-tools/cli/install).
+- **PostgreSQL** (optional). To use a PostgreSQL `database_uri`, install the
+  database driver with `uv tool install "omnigent[postgres]"`.
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,9 @@ cursor = ["cursor-sdk>=0.1.7"]
 # _reflect). The tools import the client lazily, so only users who enable a
 # Hindsight memory tool need this extra.
 memory = ["hindsight-client>=0.4.0"]
+# PostgreSQL database backend. SQLAlchemy support ships in the base package;
+# the driver is opt-in so SQLite-only installs stay lean.
+postgres = ["psycopg[binary]>=3.1,<4"]
 databricks = [
     # Floor matches what core code was tested against when the SDK was a
     # default dependency (it moved here from `dependencies` above).

--- a/uv.lock
+++ b/uv.lock
@@ -2909,6 +2909,9 @@ modal = [
 openshell = [
     { name = "openshell" },
 ]
+postgres = [
+    { name = "psycopg", extra = ["binary"] },
+]
 s3 = [
     { name = "boto3" },
     { name = "botocore" },
@@ -2975,6 +2978,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=6,<7" },
     { name = "psutil", specifier = ">=5.9,<8" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'databricks'", specifier = ">=3.1,<4" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1,<4" },
     { name = "pydantic", specifier = ">=2.0,<3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8,<3" },
     { name = "pymysql", marker = "extra == 'databricks'", specifier = ">=1.1,<2" },
@@ -3002,7 +3006,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=10.4,<15" },
     { name = "zstandard", specifier = ">=0.22,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "openshell", "kubernetes", "tracing", "agents-sdk", "antigravity", "copilot", "cursor", "memory", "databricks", "dev"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "openshell", "kubernetes", "tracing", "agents-sdk", "antigravity", "copilot", "cursor", "memory", "postgres", "databricks", "dev"]
 
 [[package]]
 name = "omnigent-client"


### PR DESCRIPTION
## Related issue

Closes #2505

## Summary

- Add a standalone `postgres` extra for the existing PostgreSQL `database_uri` backend.
- Document `uv tool install "omnigent[postgres]"` while keeping the default SQLite installation unchanged.

## Test Plan

- Ran `uv lock --check` against the exact diff with uv 0.11.21 on macOS and uv 0.11.22 on Linux.
- Built non-editable release wheels for Omnigent and its two exact-version SDK dependencies.
- Installed the Omnigent wheel with `[postgres]`; verified `psycopg 3.3.4`, libpq `180000`, and wheel-based `direct_url.json` metadata with no `editable: true` marker.
- Installed the same wheel without the extra; verified `psycopg` was absent.
- Booted the default wheel with isolated state and SQLite; verified HTTP 200 from `/health` and `/openapi.json`.

## Demo

N/A - packaging and installation metadata only.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This patch changes optional dependency metadata and its installation documentation. The release-shaped verification built and installed the wheel with and without the new extra, checked the installed metadata and driver import, and smoke-tested the unchanged default SQLite server path. Runtime PostgreSQL behavior is unchanged.

## Changelog

PostgreSQL deployments can install the database driver with the new `postgres` extra.
