### PR TITLE
feat(web): add Monokai color palette/theme

### DIFF
--- a/tests/e2e_ui/sessions/test_color_theme.py
+++ b/tests/e2e_ui/sessions/test_color_theme.py
@@ -3,7 +3,7 @@
 Alongside the light/dark **mode** tiles, ``AppearanceSection``
 (``pages/SettingsPage.tsx``) renders a "Color theme" dropdown (a shadcn
 ``Select``) — one option per palette (Omnigent, Dracula, GitHub, Catppuccin,
-Gruvbox). Choosing one calls ``applyThemePalette`` (``lib/themePalette.ts``),
+Gruvbox, Monokai). Choosing one calls ``applyThemePalette`` (``lib/themePalette.ts``),
 which sets ``data-theme`` on ``<html>`` and persists the id to
 ``localStorage["omnigent:ui-theme-palette"]``. The default "Omnigent" palette
 carries no override, so choosing it removes the attribute and clears the key.

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1790,3 +1790,80 @@
     radial-gradient(ellipse at 80% 20%, rgba(255, 121, 198, 0.1) 0%, transparent 45%),
     linear-gradient(160deg, #2a2c3a 0%, #282a36 55%, #21222c 100%);
 }
+
+/* ── Monokai — vibrant lime & magenta on charcoal (dark-first classic) ─────── */
+:root:not(.dark)[data-theme="monokai"] {
+  --background: #f5f4ef;
+  --foreground: #272822;
+  --card: #ffffff;
+  --card-solid: #ffffff;
+  --card-foreground: #272822;
+  --tray: #ffffff;
+  --popover: #ffffff;
+  --popover-foreground: #272822;
+  --primary: #6b8e23;
+  --primary-foreground: #ffffff;
+  --secondary: #ebeae2;
+  --secondary-foreground: #272822;
+  --muted: #ebeae2;
+  --muted-foreground: #6f6f66;
+  --code-bg: #ebeae2;
+  --accent: #eef0e0;
+  --accent-foreground: #1f7a8c;
+  --border: #d4d0c4;
+  --border-strong: #b3ae9e;
+  --button-border: #d4d0c4;
+  --input: #d4d0c4;
+  --ring: #6b8e23;
+  --brand-accent: #c2185b;
+  --sidebar: #efeee6;
+  --sidebar-foreground: #272822;
+  --sidebar-primary: #6b8e23;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #eef0e0;
+  --sidebar-accent-foreground: #1f7a8c;
+  --sidebar-border: #d4d0c4;
+  --sidebar-ring: #6b8e23;
+}
+.dark[data-theme="monokai"] {
+  --background: #272822;
+  --foreground: #f8f8f2;
+  --card: rgba(62, 61, 50, 0.6);
+  --card-solid: #2d2e28;
+  --card-foreground: #f8f8f2;
+  --tray: rgba(62, 61, 50, 0.6);
+  --popover: rgba(30, 31, 28, 0.92);
+  --popover-foreground: #f8f8f2;
+  --primary: #a6e22e;
+  --primary-foreground: #272822;
+  --secondary: #3e3d32;
+  --secondary-foreground: #f8f8f2;
+  --muted: #3e3d32;
+  --muted-foreground: #90908a;
+  --code-bg: #1e1f1c;
+  --accent: #3e3d32;
+  --accent-foreground: #66d9ef;
+  --border: #414339;
+  --border-strong: #75715e;
+  --button-border: #414339;
+  --input: #414339;
+  --ring: #a6e22e;
+  --brand-accent: #f92672;
+  --sidebar: rgba(30, 31, 28, 0.8);
+  --sidebar-foreground: #f8f8f2;
+  --sidebar-primary: #a6e22e;
+  --sidebar-primary-foreground: #272822;
+  --sidebar-accent: #3e3d32;
+  --sidebar-accent-foreground: #66d9ef;
+  --sidebar-border: #414339;
+  --sidebar-ring: #66d9ef;
+}
+:root:not(.dark)[data-theme="monokai"] .app-shell {
+  background: linear-gradient(160deg, #f7f6f0 0%, #f5f4ef 55%, #efeee6 100%);
+}
+.dark[data-theme="monokai"] .app-shell {
+  background:
+    radial-gradient(ellipse at 20% 30%, rgba(166, 226, 46, 0.1) 0%, transparent 55%),
+    radial-gradient(ellipse at 80% 20%, rgba(249, 38, 114, 0.08) 0%, transparent 45%),
+    linear-gradient(160deg, #2d2e28 0%, #272822 60%, #1e1f1c 100%);
+}

--- a/web/src/lib/themePalette.test.ts
+++ b/web/src/lib/themePalette.test.ts
@@ -51,9 +51,29 @@ describe("themePalette", () => {
   it("guards known vs unknown palette ids", () => {
     expect(isThemePalette("github")).toBe(true);
     expect(isThemePalette("omni")).toBe(true);
+    expect(isThemePalette("monokai")).toBe(true);
     expect(isThemePalette("nope")).toBe(false);
     expect(isThemePalette(undefined)).toBe(false);
     expect(isThemePalette(42)).toBe(false);
+  });
+
+  it("round-trips the monokai palette", () => {
+    writeThemePalette("monokai");
+    expect(readThemePalette()).toBe("monokai");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify("monokai"));
+  });
+
+  it("applies monokai as data-theme on the document root", () => {
+    applyThemePalette("monokai");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("monokai");
+  });
+
+  it("monokai swatch has expected dark palette colors", () => {
+    const palette = PALETTES.find((p) => p.id === "monokai");
+    expect(palette).toBeDefined();
+    expect(palette!.dark.bg).toBe("#272822");
+    expect(palette!.dark.text.toLowerCase()).toBe("#f8f8f2");
+    expect(palette!.dark.accent.toLowerCase()).toBe("#a6e22e");
   });
 
   it("sets data-theme on the document root for a non-default palette", () => {

--- a/web/src/lib/themePalette.ts
+++ b/web/src/lib/themePalette.ts
@@ -22,7 +22,14 @@
 const STORAGE_KEY = "omnigent:ui-theme-palette";
 
 /** Selectable color palettes. The first entry is the default (brand) look. */
-export const themePalettes = ["omni", "dracula", "github", "catppuccin", "gruvbox"] as const;
+export const themePalettes = [
+  "omni",
+  "dracula",
+  "github",
+  "catppuccin",
+  "gruvbox",
+  "monokai",
+] as const;
 
 export type ThemePalette = (typeof themePalettes)[number];
 
@@ -123,6 +130,19 @@ export const PALETTES: readonly PaletteMeta[] = [
       text: "#3c3836",
     },
     dark: { bg: "#282828", card: "#3c3836", accent: "#fe8019", border: "#504945", text: "#ebdbb2" },
+  },
+  {
+    id: "monokai",
+    label: "Monokai",
+    blurb: "Vibrant lime and magenta on charcoal.",
+    light: {
+      bg: "#f5f4ef",
+      card: "#ffffff",
+      accent: "#6b8e23",
+      border: "#d4d0c4",
+      text: "#272822",
+    },
+    dark: { bg: "#272822", card: "#2d2e28", accent: "#A6E22E", border: "#414339", text: "#f8f8f2" },
   },
 ] as const;
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds **Monokai** as a sixth selectable color palette in Appearance settings, alongside Omnigent, Dracula, GitHub, Catppuccin, and Gruvbox.

- **Dark mode** uses canonical Monokai colors: charcoal `#272822` background, lime `#a6e22e` primary, magenta `#f92672` brand accent, and cyan `#66d9ef` accent foreground — faithful to the original Monokai editor theme.
- **Light mode** derives a warm off-white variant: parchment `#f5f4ef` background, olive green `#6b8e23` primary (readable on light), subdued muted/border tones drawn from Monokai's comment brown, keeping the brand identity without the jarring contrast of dropping neon lime on a white canvas.
- The swatch previewed in the picker shows the lime/charcoal identity for dark and the olive/off-white identity for light.

## Test Plan

1. `vitest run` — 225 test files, 3 977 tests, all pass (zero new failures).
2. `pre-commit run --files` on all three changed files — all hooks pass (web-prettier, ruff, no-skipped-tests, secret-scan, trailing-whitespace, etc.).
3. `themePalette.test.ts` (12 tests, all pass) now includes four explicit monokai assertions added in the second commit:
   - `isThemePalette("monokai")` returns `true` (added to the "guards known vs unknown palette ids" test).
   - Round-trip: `writeThemePalette("monokai")` → `readThemePalette()` returns `"monokai"` and localStorage is set correctly.
   - `applyThemePalette("monokai")` sets `data-theme="monokai"` on the document root.
   - Dark swatch: `palette.dark.bg === "#272822"`, `palette.dark.text.toLowerCase() === "#f8f8f2"`, `palette.dark.accent.toLowerCase() === "#a6e22e"`.
4. The existing `exposes swatch metadata for every selectable palette` assertion requires `PALETTES.map(p => p.id)` to equal `[...themePalettes]` — both arrays contain `"monokai"` and the test passes.
5. `SettingsPage.test.tsx` (30 tests) continues to pass; the palette picker `<Select>` renders one `<option>` per entry in `PALETTES` automatically, so no component change was needed.

## Demo

The new palette was verified by inspecting the CSS blocks added to `index.css` and the swatch metadata in `themePalette.ts`. Because the theme system is fully data-driven (one CSS block per palette with the standard token set, one `PaletteMeta` entry), the Monokai option will appear in the Appearance → Color theme dropdown as soon as the app is loaded.

**Dark mode** renders on the canonical Monokai charcoal background (`#272822`) with:
- Primary buttons / active states in lime green (`#a6e22e`)
- Brand accent / highlights in hot pink (`#f92672`)
- Code blocks on a deeper near-black (`#1e1f1c`)
- Sidebar on a slightly darker variant (`rgba(30, 31, 28, 0.8)`)
- App-shell gradient: subtle lime glow at 20 % left + faint magenta at 80 % top, on a dark charcoal ramp

**Light mode** renders on an off-white parchment (`#f5f4ef`) with olive green primary, warm beige borders (`#d4d0c4`), and a muted Monokai-brown comment tone for secondary text.

A dev-server screenshot was not captured in this session (no browser automation available on the dev host), but the rendered output is fully deterministic from the CSS variables above — reviewers can verify by checking out the branch and selecting "Monokai" in Settings → Appearance. **A manual screenshot before merge is still needed** to satisfy the UI-change demo requirement.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Explicit monokai test cases added in `themePalette.test.ts` (second commit): `isThemePalette`, round-trip write/read, `applyThemePalette`, and dark-swatch color assertions. The suite also dynamically iterates over `themePalettes` and `PALETTES`, so the new palette is covered structurally as well. Manual verification: confirmed all pre-commit hooks pass and all 3 977 vitest tests remain green on this branch. The E2E suite (`tests/e2e_ui/sessions/test_color_theme.py`) has been updated to enumerate Monokai; the actual test logic exercises palette persistence/application generically and does not need a new test case per palette.

## Changelog

New "Monokai" color theme available in Appearance settings — vibrant lime and magenta on a classic charcoal background (dark mode), warm olive on parchment (light mode)