### PR TITLE
fix: fall back to tempdir when codex cwd is read-only

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -1209,9 +1209,16 @@ class _CodexAppServerSession:
             return
         self._loop = asyncio.get_running_loop()
         codex_home_root = Path(tempfile.gettempdir())
-        if self._cwd:
-            codex_home_root = Path(self._cwd) / ".codex-tmp"
-            codex_home_root.mkdir(parents=True, exist_ok=True)
+        if self._cwd and self._cwd != "/":
+            try:
+                codex_home_root = Path(self._cwd) / ".codex-tmp"
+                codex_home_root.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                # The cwd may be on a read-only filesystem — e.g. macOS
+                # root ``/`` inherited from a runner whose working
+                # directory was never explicitly set.  Fall back to the
+                # system temp directory so the codex home is still writable.
+                codex_home_root = Path(tempfile.gettempdir())
         self._codex_home_dir = Path(
             tempfile.mkdtemp(prefix="omnigent-codex-home-", dir=str(codex_home_root))
         )

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import contextlib
 import json
 import tempfile
 import unittest
@@ -2827,3 +2828,74 @@ def test_declared_passthrough_reads_sandbox_env_passthrough():
     assert _declared_passthrough(None) == ()
     assert _declared_passthrough(OSEnvSpec(sandbox=None)) == ()
     assert _declared_passthrough(OSEnvSpec(sandbox=OSEnvSandboxSpec(type="none"))) == ()
+
+
+class TestCodexAppServerSessionReadOnlyCwd(unittest.TestCase):
+    """Regression tests for .codex-tmp fallback on read-only cwd."""
+
+    def _run_start_and_capture_mkdtemp_dir(self, cwd: str) -> str:
+        """Run ``_CodexAppServerSession.start()`` with *cwd* and return
+        the ``dir=`` keyword passed to ``tempfile.mkdtemp`` for the
+        codex-home directory.
+
+        ``start()`` is stopped just after ``mkdtemp`` by forcing a
+        ``RuntimeError`` from the subprocess launch; the session's
+        ``close()`` cleans up the temp dir before we can inspect it,
+        so we capture the argument instead.
+        """
+        import tempfile as _tempfile
+
+        mkdtemp_dirs: list[str] = []
+        original_mkdtemp = _tempfile.mkdtemp
+
+        def _capture(**kwargs):
+            mkdtemp_dirs.append(kwargs.get("dir", ""))
+            return original_mkdtemp(**kwargs)
+
+        async def _t():
+            session = _CodexAppServerSession(
+                codex_path="/bin/echo",
+                cwd=cwd,
+                env={},
+                tool_executor=None,
+            )
+            with (
+                patch("omnigent.inner.codex_executor.populate_codex_skills_from_bundle"),
+                patch("omnigent.inner.codex_executor._populate_codex_home_config"),
+                patch(
+                    "omnigent.inner.codex_executor._codex_home_config_source_from_env",
+                    return_value=None,
+                ),
+                patch(
+                    "omnigent.inner.codex_executor._create_subprocess_exec",
+                    new_callable=AsyncMock,
+                    side_effect=RuntimeError("stop"),
+                ),
+                patch("tempfile.mkdtemp", side_effect=_capture),
+            ):
+                with contextlib.suppress(RuntimeError):
+                    await session.start()
+
+            self.assertTrue(mkdtemp_dirs, "mkdtemp was never called")
+            return mkdtemp_dirs[0]
+
+        return _run(_t())
+
+    def test_start_falls_back_to_tempdir_when_cwd_is_readonly(self):
+        """When cwd is ``/`` (read-only on macOS SSV), the codex home
+        must be placed under the system temp directory, not under
+        ``/.codex-tmp``.
+        """
+        import tempfile as _tempfile
+
+        dir_used = self._run_start_and_capture_mkdtemp_dir("/")
+        self.assertEqual(dir_used, _tempfile.gettempdir())
+
+    def test_start_uses_cwd_when_writable(self):
+        """When cwd is writable, .codex-tmp is placed there as before."""
+        import tempfile as _tempfile
+
+        with _tempfile.TemporaryDirectory() as writable_dir:
+            dir_used = self._run_start_and_capture_mkdtemp_dir(writable_dir)
+            expected = str(Path(writable_dir) / ".codex-tmp")
+            self.assertEqual(dir_used, expected)


### PR DESCRIPTION
## Related issue

N/A — discovered while running a multi-headed agent (Debby) with a codex-harness GPT sub-agent on macOS.

## Summary

On macOS, the Omnigent desktop app launches the runner process with `cwd` set to `/` (the root filesystem, which is a read-only Signed System Volume). The codex harness subprocess inherits this working directory because `HarnessProcessManager._spawn_entry` passes no explicit `cwd` to `create_subprocess_exec`. Inside the harness, `_CodexAppServerSession.start()` resolves `effective_cwd` via the fallback chain (`HARNESS_CODEX_CWD` → `os_env_spec.cwd` → `os.getcwd()`), all of which resolve to `/`, then attempts `mkdir /.codex-tmp` — which fails with `[Errno 30] Read-only file system`.

Fix: wrap the `.codex-tmp` `mkdir` in a `try/except OSError` that falls back to `tempfile.gettempdir()` (the same path already used when `self._cwd` is unset), and short-circuit `/` explicitly since it is never a useful working directory.

## Test Plan

- Added two unit tests in `tests/inner/test_codex_executor.py`:
  - `test_start_falls_back_to_tempdir_when_cwd_is_readonly` — verifies that `cwd=/` causes `mkdtemp` to use `tempfile.gettempdir()` instead of `/.codex-tmp`
  - `test_start_uses_cwd_when_writable` — verifies that a writable cwd still places `.codex-tmp` in the cwd (no regression)
- Manually verified by patching the installed package in-place and successfully dispatching a GPT sub-agent that previously failed consistently with `[Errno 30]`
- All 90 existing tests in `test_codex_executor.py` continue to pass

## Demo

Non-visual backend fix — no UI change. Before/after demonstrated via CLI:

**Before (every attempt):**
```
[Errno 30] Read-only file system: '.codex-tmp'
```

**After (first attempt post-patch):**
```
$ # GPT sub-agent dispatched successfully
[System: sub-agent gpt/gpt-fix-test finished (completed) — 1 result waiting in inbox.]
```

Root cause confirmed: `lsof -p <runner_pid> | grep cwd` → `cwd DIR 1,15 704 2 /`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: patched `codex_executor.py` in the installed package (`~/.local/share/uv/tools/omnigent/lib/python3.12/site-packages/omnigent/inner/codex_executor.py`), cleared `.pyc` cache, and dispatched a codex-harness GPT sub-agent via `sys_session_send`. Previously failed on every attempt with `[Errno 30] Read-only file system: '.codex-tmp'`; after the fix, the sub-agent launched and responded successfully. Confirmed runner cwd is `/` via `lsof -p <pid> | grep cwd`.

## Changelog

Codex-harness sub-agents no longer crash on macOS when the runner inherits a read-only working directory (e.g. `/` from the desktop app).