### PR TITLE
fix(polly): default Cursor brain to Grok 4.5

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -28,6 +28,8 @@ spawn: true
 executor:
   type: omnigent
   context_window: 1000000
+  harness_models:
+    cursor: grok-4.5
   config:
     harness: claude-sdk
 

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3229,16 +3229,23 @@ def _apply_overrides_to_raw(raw: _YamlMapping, overrides: ChatOverrides) -> None
         executor_block["model"] = overrides.model
     if overrides.harness is not None:
         _apply_harness_override_to_executor(raw, executor_block, overrides.harness)
-        # A harness-only override drops any prior model pin so the new
-        # harness resolves its provider default — e.g. ``omnigent run
-        # examples/polly --harness pi`` must not keep Polly's Claude-only
-        # a Claude-only ``executor.model``. An explicit ``--model``
-        # (applied above) wins and is left alone.
+        # Drop the original harness's pin, then use an agent-scoped default
+        # when one is declared for the replacement harness.
         if overrides.model is None:
             executor_block.pop("model", None)
             llm_block = raw.get("llm")
             if isinstance(llm_block, dict):
                 llm_block.pop("model", None)
+            harness_models = executor_block.get("harness_models")
+            if isinstance(harness_models, dict):
+                canonical = canonicalize_harness(overrides.harness) or overrides.harness
+                for configured_harness, configured_model in harness_models.items():
+                    configured = canonicalize_harness(str(configured_harness)) or str(
+                        configured_harness
+                    )
+                    if configured == canonical and isinstance(configured_model, str):
+                        executor_block["model"] = configured_model
+                        break
     # When neither harness nor model is declared — after overrides —
     # inject the ad-hoc default. Gated on harness absence so a YAML
     # like ``claude_code_agent.yaml`` (declares harness, no model)

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -95,7 +95,7 @@ from omnigent.harness_plugins import (
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE as _HARNESS_NOT_CONFIGURED_ERROR_CODE,
 )
-from omnigent.model_override import validate_model_override
+from omnigent.model_override import model_family_mismatch, validate_model_override
 from omnigent.native_coding_agents import (
     native_coding_agent_for_agent_name,
     native_coding_agent_for_harness,
@@ -2944,6 +2944,32 @@ def _validated_harness_override(value: str | None, agent: Agent) -> str | None:
             code=ErrorCode.INVALID_INPUT,
         )
     return canonical
+
+
+def _harness_override_model_default(agent: Agent, harness: str) -> str | None:
+    """Return an agent's model default for a create-time harness override."""
+    from omnigent.harness_aliases import canonicalize_harness
+    from omnigent.runtime import get_agent_cache
+
+    loaded = get_agent_cache().load(
+        agent.id, agent.bundle_location, expand_env=agent.session_id is None
+    )
+    canonical = canonicalize_harness(harness) or harness
+    for configured_harness, configured_model in loaded.spec.executor.harness_models.items():
+        configured = canonicalize_harness(configured_harness) or configured_harness
+        if configured != canonical:
+            continue
+        try:
+            model = validate_model_override(configured_model)
+        except ValueError as exc:
+            raise OmnigentError(
+                f"invalid executor.harness_models default for {canonical!r}: {exc}",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
+        if mismatch := model_family_mismatch(canonical, model):
+            raise OmnigentError(mismatch, code=ErrorCode.INVALID_INPUT)
+        return model
+    return None
 
 
 def _utc_day(epoch_seconds: int) -> str:
@@ -12408,6 +12434,10 @@ async def _create_session_from_existing_agent(
     harness_override = await asyncio.to_thread(
         _validated_harness_override, body.harness_override, agent
     )
+    if model_override is None and harness_override is not None:
+        model_override = await asyncio.to_thread(
+            _harness_override_model_default, agent, harness_override
+        )
 
     # Inherit runner affinity from the parent session so the child
     # is assigned to the same runner (sub-agent co-location).

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -201,6 +201,21 @@ def validate_omnigent_executor(
             f"must be one of {sorted(_OMNIGENT_ACCEPTED_HARNESSES)}, got {harness!r}"
             f"{install_hint}",
         )
+    from omnigent.model_override import model_family_mismatch, validate_model_override
+
+    for configured_harness, configured_model in spec.executor.harness_models.items():
+        canonical = canonicalize_harness(configured_harness) or configured_harness
+        field = f"executor.harness_models.{configured_harness}"
+        if canonical not in OMNIGENT_HARNESSES:
+            result.add(field, f"unknown harness {configured_harness!r}")
+            continue
+        try:
+            validate_model_override(configured_model)
+        except ValueError as exc:
+            result.add(field, str(exc))
+            continue
+        if mismatch := model_family_mismatch(canonical, configured_model):
+            result.add(field, mismatch)
 
 
 # ── YAML detection + loading ───────────────────────────────────

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -622,6 +622,26 @@ def _parse_executor(
     )
     raw_model = raw.get("model")
     model: str | None = str(raw_model) if raw_model is not None else None
+    raw_harness_models = raw.get("harness_models")
+    harness_models: dict[str, str] = {}
+    if raw_harness_models is not None:
+        if not isinstance(raw_harness_models, dict):
+            raise OmnigentError(
+                "executor.harness_models must map harness ids to model ids",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        for raw_harness, raw_default_model in raw_harness_models.items():
+            if not isinstance(raw_harness, str) or not raw_harness.strip():
+                raise OmnigentError(
+                    "executor.harness_models keys must be non-empty strings",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            if not isinstance(raw_default_model, str) or not raw_default_model.strip():
+                raise OmnigentError(
+                    f"executor.harness_models[{raw_harness!r}] must be a non-empty string",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            harness_models[raw_harness.strip()] = raw_default_model.strip()
     # Parse ``executor.connection:`` — same shape as ``llm.connection:``
     # (a flat dict of string key-value pairs with optional ${VAR}
     # expansion). Lifted from the ``executor:`` block so connection
@@ -642,6 +662,7 @@ def _parse_executor(
         profile=profile,
         config=config,
         model=model,
+        harness_models=harness_models,
         connection=connection,
         context_window=context_window,
         auth=auth,

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -543,6 +543,8 @@ class ExecutorSpec:  # type: ignore[explicit-any]  # config: dict[str, Any] fiel
         key. Used by harness spawn-env builders, context-window
         auto-detection, telemetry, and tool-provider inference.
         ``None`` only when no model is declared anywhere in the spec.
+    :param harness_models: Model defaults for create-time brain-harness
+        overrides, keyed by harness id. Explicit model overrides win.
     :param connection: Per-provider connection overrides (credentials,
         endpoint URLs), e.g.
         ``{"api_key": "sk-...", "base_url": "https://..."}``.
@@ -585,6 +587,8 @@ class ExecutorSpec:  # type: ignore[explicit-any]  # config: dict[str, Any] fiel
     # Primary model identifier for all executor types. Populated by
     # the parser from executor.model or (backward compat) llm.model.
     model: str | None = None
+    # Agent-scoped defaults for create-time brain-harness overrides.
+    harness_models: dict[str, str] = field(default_factory=dict)
     # Per-provider connection overrides (api_key, base_url, etc.).
     # Populated from executor.connection or (backward compat) llm.connection.
     # None means rely on environment variable / profile defaults.

--- a/omnigent/spec/validator.py
+++ b/omnigent/spec/validator.py
@@ -146,6 +146,12 @@ def _validate_executor_type(
         )
         return
 
+    if etype != OMNIGENT_EXECUTOR_TYPE and spec.executor.harness_models:
+        result.add(
+            "executor.harness_models",
+            f"only supported when executor.type is {OMNIGENT_EXECUTOR_TYPE!r}",
+        )
+
     if etype == "claude_sdk":
         _validate_claude_sdk_executor(spec, result)
     elif etype == "agents_sdk":

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1723,6 +1723,28 @@ def test_apply_overrides_harness_only_clears_pinned_model() -> None:
     assert executor.get("model") is None
 
 
+def test_apply_overrides_harness_only_uses_agent_model_default() -> None:
+    """A bundle can select a model when its brain harness is overridden."""
+    raw: dict[str, object] = {
+        "spec_version": 1,
+        "name": "polly",
+        "prompt": "orchestrate",
+        "executor": {
+            "type": "omnigent",
+            "model": "sonnet",
+            "harness_models": {"cursor": "grok-4.5"},
+            "config": {"harness": "claude-sdk"},
+        },
+    }
+
+    _apply_overrides_to_raw(raw, ChatOverrides(harness="cursor"))
+
+    executor = raw["executor"]
+    assert isinstance(executor, dict)
+    assert executor["config"]["harness"] == "cursor"
+    assert executor["model"] == "grok-4.5"
+
+
 def test_apply_overrides_rejects_harness_for_non_omnigent_executor_type() -> None:
     """
     A spec_version bundle with a non-omnigent ``executor.type`` fails

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -62,6 +62,7 @@ def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
     # No model pin — the configured provider's default Claude model is used.
     # Re-introducing a pin (Databricks or otherwise) fails here.
     assert ex.model is None
+    assert ex.harness_models == {"cursor": "grok-4.5"}
     # Profile is intentionally NOT pinned either.
     assert ex.profile is None
     assert ex.context_window == 1000000

--- a/tests/server/integration/test_sessions_harness_override.py
+++ b/tests/server/integration/test_sessions_harness_override.py
@@ -112,6 +112,54 @@ async def test_create_without_harness_override_reports_spec_default(
     assert resp.json().get("harness") == "claude-sdk"
 
 
+async def test_create_harness_override_applies_agent_model_default(
+    client: httpx.AsyncClient,
+) -> None:
+    """A harness override inherits its agent-scoped model default."""
+    agent = await create_test_agent(
+        client,
+        executor={
+            "type": "omnigent",
+            "harness_models": {"cursor": "grok-4.5"},
+            "config": {"harness": "claude-sdk"},
+        },
+    )
+    resp = await client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "initial_items": [], "harness_override": "cursor"},
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["harness"] == "cursor"
+    assert resp.json()["model_override"] == "grok-4.5"
+
+
+async def test_explicit_model_wins_over_harness_model_default(
+    client: httpx.AsyncClient,
+) -> None:
+    """An explicit model takes precedence over the bundle default."""
+    agent = await create_test_agent(
+        client,
+        executor={
+            "type": "omnigent",
+            "harness_models": {"cursor": "grok-4.5"},
+            "config": {"harness": "claude-sdk"},
+        },
+    )
+    resp = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "initial_items": [],
+            "harness_override": "cursor",
+            "model_override": "gpt-5",
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["model_override"] == "gpt-5"
+
+
 async def test_create_harness_override_alias_canonicalizes(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -38,6 +38,25 @@ def test_parse_minimal(agent_dir: Path) -> None:
     assert spec.sub_agents == []
 
 
+def test_parse_executor_harness_models(agent_dir: Path) -> None:
+    """Harness-specific model defaults retain their mapping shape."""
+    config = {
+        "spec_version": 1,
+        "name": "multi-harness-agent",
+        "executor": {
+            "type": "omnigent",
+            "model": "claude-sonnet-4-6",
+            "harness_models": {"cursor": "grok-4.5"},
+            "config": {"harness": "claude-sdk"},
+        },
+    }
+    (agent_dir / "config.yaml").write_text(yaml.dump(config))
+
+    spec = parse(agent_dir)
+
+    assert spec.executor.harness_models == {"cursor": "grok-4.5"}
+
+
 def test_parse_missing_config_yaml(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match=r"config.yaml not found"):
         parse(tmp_path)


### PR DESCRIPTION
## Related issue

N/A

## Summary

Selecting Cursor as Polly's brain harness currently clears Polly's Claude model pin but supplies no Cursor-specific replacement, so the Cursor SDK silently falls back to Composer. This adds agent-scoped harness model defaults and declares Grok 4.5 for Polly's Cursor brain.

- Add typed and validated `executor.harness_models` configuration.
- Apply the configured default for both CLI-materialized and server-created harness overrides; an explicit model always wins.
- Keep Polly's default Claude SDK brain unpinned while selecting `grok-4.5` only when Cursor is chosen.

**ELI5:** Polly can now say, "use Grok when I run on Cursor," without changing which model it uses on Claude or overriding a model the user selected.

```mermaid
flowchart LR
    A[Select Cursor for Polly] --> B{Explicit model?}
    B -->|Yes| C[Use explicit model]
    B -->|No| D[Read Polly harness default]
    D --> E[Launch Cursor SDK with grok-4.5]
```

## Test Plan

- [x] `python -m pytest tests/cli/test_chat.py tests/spec/test_parser.py tests/server/integration/test_sessions_harness_override.py tests/e2e/omnigent/test_example_polly.py -q` (339 passed)
- [x] `pre-commit run --all-files`
- [x] Ruff and `git diff --check`

## Demo

N/A

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage exercises parser preservation and validation, CLI override materialization, server-side session creation, and explicit-model precedence. The Polly bundle assertion pins the intended Cursor default.

## Changelog

Polly uses Grok 4.5 when its brain is launched with the Cursor SDK harness.
