### PR TITLE
feat(web): Appearance setting for new-chat Workspace panel default

### DIFF
--- a/tests/e2e_ui/sessions/test_workspace_panel_default.py
+++ b/tests/e2e_ui/sessions/test_workspace_panel_default.py
@@ -78,7 +78,9 @@ def test_workspace_panel_default_control_defaults_and_persists(
     expect(page.get_by_test_id("workspace-panel-default-collapsed")).to_have_attribute(
         "aria-checked", "true"
     )
-    assert _stored_default(page) == "collapsed", "the Workspace panel default did not survive a reload"
+    assert _stored_default(page) == "collapsed", (
+        "the Workspace panel default did not survive a reload"
+    )
 
 
 def test_new_chat_follows_workspace_panel_default(

--- a/tests/e2e_ui/sessions/test_workspace_panel_default.py
+++ b/tests/e2e_ui/sessions/test_workspace_panel_default.py
@@ -1,0 +1,153 @@
+"""E2E: Settings → Appearance Workspace panel default for new chats.
+
+The Workspace panel control (``WorkspacePanelDefaultControl`` on
+``pages/SettingsPage.tsx``) is a two-card radiogroup — Open / Collapsed —
+under Settings → Appearance. Picking a mode writes to
+``localStorage["omnigent:default-workspace-panel"]`` (absent = "open").
+
+AppShell applies that preference only when a session has no saved
+``SessionWorkspaceState.open``. Once the user toggles the rail in a chat,
+that chat's own open-state wins on restore — so changing Appearance later
+does not rewrite existing layouts.
+
+This covers the pair the feature exists for: a brand-new session starts
+collapsed after picking Collapsed, and a session the user already toggled
+keeps its saved open-state even when the Appearance default is Collapsed.
+No LLM turn is needed.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+STORAGE_KEY = "omnigent:default-workspace-panel"
+_COMPOSER = "Ask the agent anything…"
+
+
+def _stored_default(page: Page) -> str | None:
+    """The persisted Workspace panel default, or None when unset (open)."""
+    return page.evaluate(f"() => window.localStorage.getItem('{STORAGE_KEY}')")
+
+
+def _open_appearance(page: Page, base_url: str) -> None:
+    """Navigate to Settings Appearance and wait for the Workspace panel control."""
+    page.goto(f"{base_url}/settings/appearance")
+    expect(page.get_by_role("radiogroup", name="Workspace panel")).to_be_visible(timeout=30_000)
+
+
+def _pick_workspace_panel_default(page: Page, value: str) -> None:
+    """Pick Open or Collapsed via its Appearance radio card."""
+    card = page.get_by_test_id(f"workspace-panel-default-{value}")
+    card.click()
+    expect(card).to_have_attribute("aria-checked", "true")
+
+
+def _wait_session_ready(page: Page) -> None:
+    """Wait until the session chrome has settled enough to assert rail state.
+
+    The Expand/Collapse toggle only mounts once the rail has content (Agents is
+    always available), so its presence is the portable "shell is ready" signal
+    whether the rail itself is open or collapsed.
+    """
+    expect(
+        page.locator(
+            'button[aria-label="Expand right panel"], button[aria-label="Collapse right panel"]'
+        ).first
+    ).to_be_visible(timeout=60_000)
+    expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+
+
+def test_workspace_panel_default_control_defaults_and_persists(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """Open is the default; picking Collapsed persists and survives a reload."""
+    base_url, _session_id = seeded_session
+    _open_appearance(page, base_url)
+
+    # Fresh context → Open is selected and nothing is stored.
+    expect(page.get_by_test_id("workspace-panel-default-open")).to_have_attribute(
+        "aria-checked", "true"
+    )
+    assert _stored_default(page) is None, "a fresh load should store no Workspace panel default"
+
+    _pick_workspace_panel_default(page, "collapsed")
+    assert _stored_default(page) == "collapsed"
+
+    page.reload()
+    expect(page.get_by_role("radiogroup", name="Workspace panel")).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id("workspace-panel-default-collapsed")).to_have_attribute(
+        "aria-checked", "true"
+    )
+    assert _stored_default(page) == "collapsed", "the Workspace panel default did not survive a reload"
+
+
+def test_new_chat_follows_workspace_panel_default(
+    page: Page, seeded_session_pair: tuple[str, str, str]
+) -> None:
+    """Collapsed seeds a never-visited chat; Open seeds a different never-visited chat.
+
+    Uses two fresh sessions so neither has a saved per-chat ``open`` state when
+    first opened. Session A is visited only after Collapsed is selected; session
+    B only after Open is restored — proving the Appearance default applies to
+    brand-new chats without rewriting chats the user has not opened yet.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+
+    _open_appearance(page, base_url)
+    _pick_workspace_panel_default(page, "collapsed")
+    assert _stored_default(page) == "collapsed"
+
+    # Session A has never been opened in this browser → Collapsed applies.
+    page.goto(f"{base_url}/c/{session_a}")
+    _wait_session_ready(page)
+    expect(page.get_by_role("complementary", name="Workspace")).to_have_count(0)
+    expect(page.get_by_role("button", name="Expand right panel")).to_be_visible()
+
+    # Restore Open and open a different never-visited session → rail starts open.
+    _open_appearance(page, base_url)
+    _pick_workspace_panel_default(page, "open")
+    assert _stored_default(page) is None, "Open clears the storage key (product default)"
+
+    page.goto(f"{base_url}/c/{session_b}")
+    _wait_session_ready(page)
+    expect(page.get_by_role("complementary", name="Workspace")).to_be_visible()
+    expect(page.get_by_role("button", name="Collapse right panel")).to_be_visible()
+
+
+def test_saved_session_open_state_wins_over_appearance_default(
+    page: Page, seeded_session_pair: tuple[str, str, str]
+) -> None:
+    """Expanding the rail in a chat sticks even after Appearance is set to Collapsed.
+
+    Opens session A under the product default (Open), collapses then re-expands
+    so ``open: true`` is written, switches Appearance to Collapsed, and remounts
+    session A — the saved open-state must win. Session B (never visited until
+    after the preference change) still follows Collapsed, proving the default
+    only seeds sessions without saved open-state.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+
+    # Visit session A while the product default is still Open, then toggle so
+    # the per-session store records an explicit open=true.
+    page.goto(f"{base_url}/c/{session_a}")
+    _wait_session_ready(page)
+    expect(page.get_by_role("complementary", name="Workspace")).to_be_visible(timeout=30_000)
+    page.get_by_role("button", name="Collapse right panel").click()
+    expect(page.get_by_role("complementary", name="Workspace")).to_have_count(0)
+    page.get_by_role("button", name="Expand right panel").click()
+    expect(page.get_by_role("complementary", name="Workspace")).to_be_visible()
+
+    _open_appearance(page, base_url)
+    _pick_workspace_panel_default(page, "collapsed")
+
+    # Remount session A: saved open=true beats the Collapsed Appearance default.
+    page.goto(f"{base_url}/c/{session_a}")
+    _wait_session_ready(page)
+    expect(page.get_by_role("complementary", name="Workspace")).to_be_visible()
+    expect(page.get_by_role("button", name="Collapse right panel")).to_be_visible()
+
+    # A never-visited session still follows Collapsed.
+    page.goto(f"{base_url}/c/{session_b}")
+    _wait_session_ready(page)
+    expect(page.get_by_role("complementary", name="Workspace")).to_have_count(0)
+    expect(page.get_by_role("button", name="Expand right panel")).to_be_visible()

--- a/web/src/lib/sessionWorkspaceState.ts
+++ b/web/src/lib/sessionWorkspaceState.ts
@@ -1,8 +1,8 @@
 // Per-session UI state for the right "Workspace" rail, keyed by conversationId
 // so each session restores its own layout: whether the rail is open, its width,
 // the selected rail tab, and the set of open file tabs (plus which one is
-// active). A brand-new session (no stored entry) starts closed at the default
-// width with no open files.
+// active). A brand-new session (no stored `open`) follows the Appearance
+// Workspace panel default; width and file tabs start empty.
 
 import type { RightRailTab } from "@/shell/railTabs";
 

--- a/web/src/lib/workspacePanelPreferences.test.ts
+++ b/web/src/lib/workspacePanelPreferences.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  normalizeWorkspacePanelDefault,
+  readDefaultWorkspacePanelOpen,
+  readWorkspacePanelDefault,
+  WORKSPACE_PANEL_DEFAULT,
+  writeWorkspacePanelDefault,
+} from "./workspacePanelPreferences";
+
+const STORAGE_KEY = "omnigent:default-workspace-panel";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("workspacePanelPreferences — read/write", () => {
+  it("returns open when nothing is stored", () => {
+    expect(readWorkspacePanelDefault()).toBe(WORKSPACE_PANEL_DEFAULT);
+    expect(readDefaultWorkspacePanelOpen()).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("stores collapsed and clears the key for open", () => {
+    writeWorkspacePanelDefault("collapsed");
+    expect(readWorkspacePanelDefault()).toBe("collapsed");
+    expect(readDefaultWorkspacePanelOpen()).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("collapsed");
+
+    writeWorkspacePanelDefault("open");
+    expect(readWorkspacePanelDefault()).toBe("open");
+    expect(readDefaultWorkspacePanelOpen()).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("normalizeWorkspacePanelDefault", () => {
+  it("passes through valid values", () => {
+    expect(normalizeWorkspacePanelDefault("open")).toBe("open");
+    expect(normalizeWorkspacePanelDefault("collapsed")).toBe("collapsed");
+  });
+
+  it("maps unknown, null, and garbage to open", () => {
+    expect(normalizeWorkspacePanelDefault("closed")).toBe("open");
+    expect(normalizeWorkspacePanelDefault("bogus")).toBe("open");
+    expect(normalizeWorkspacePanelDefault(null)).toBe("open");
+    expect(normalizeWorkspacePanelDefault(undefined)).toBe("open");
+  });
+});

--- a/web/src/lib/workspacePanelPreferences.ts
+++ b/web/src/lib/workspacePanelPreferences.ts
@@ -1,0 +1,79 @@
+// Persisted, app-global preference for whether a brand-new chat's right
+// Workspace rail (Files / Agents / Shells) starts open or collapsed.
+//
+// This only seeds sessions that have no saved per-chat `open` state. Once a
+// user toggles the rail in a session, that session's own
+// `SessionWorkspaceState.open` wins on restore. Set from Appearance settings.
+
+const STORAGE_KEY = "omnigent:default-workspace-panel";
+
+export const workspacePanelDefaults = ["open", "collapsed"] as const;
+export type WorkspacePanelDefault = (typeof workspacePanelDefaults)[number];
+
+/** Match today's product default: new chats open the Workspace rail. */
+export const WORKSPACE_PANEL_DEFAULT: WorkspacePanelDefault = "open";
+
+/** Return whether a string is one of the selectable Workspace panel defaults. */
+export function isWorkspacePanelDefault(
+  value: string | null | undefined,
+): value is WorkspacePanelDefault {
+  return value === "open" || value === "collapsed";
+}
+
+/**
+ * Normalize a stored Workspace panel default to the product default.
+ *
+ * Unknown values can only come from localStorage drift or manual edits.
+ * Falling back to `open` preserves backwards-compatible "rail starts open"
+ * behavior for sessions with no saved open-state.
+ */
+export function normalizeWorkspacePanelDefault(
+  value: string | null | undefined,
+): WorkspacePanelDefault {
+  return isWorkspacePanelDefault(value) ? value : WORKSPACE_PANEL_DEFAULT;
+}
+
+/**
+ * Read the persisted default for new-chat Workspace rail visibility.
+ *
+ * Returns "open" when nothing is stored, on a server render (no `window`),
+ * or when the stored value is missing/unknown — never throws, so a corrupt
+ * entry can't break app boot.
+ */
+export function readWorkspacePanelDefault(): WorkspacePanelDefault {
+  if (typeof window === "undefined") return WORKSPACE_PANEL_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return WORKSPACE_PANEL_DEFAULT;
+    return normalizeWorkspacePanelDefault(raw);
+  } catch {
+    return WORKSPACE_PANEL_DEFAULT;
+  }
+}
+
+/**
+ * Persist the default Workspace panel visibility for new chats. "open" clears
+ * the key (the product default). Swallows quota/access errors so a failed
+ * write can't break settings.
+ */
+export function writeWorkspacePanelDefault(value: WorkspacePanelDefault): void {
+  if (typeof window === "undefined") return;
+  try {
+    const normalized = normalizeWorkspacePanelDefault(value);
+    if (normalized === WORKSPACE_PANEL_DEFAULT) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, normalized);
+    }
+  } catch {
+    // localStorage quota or access errors shouldn't break settings.
+  }
+}
+
+/**
+ * Boolean form of {@link readWorkspacePanelDefault} for AppShell's
+ * `rightPanelOpen` fallback when a session has no saved `open` state.
+ */
+export function readDefaultWorkspacePanelOpen(): boolean {
+  return readWorkspacePanelDefault() === "open";
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -9,8 +9,8 @@
  *
  * Sections:
  *
- * - **Appearance** — theme mode (System / Light / Dark). This is the new
- *   home of the theme control that used to sit in the sidebar header.
+ * - **Appearance** — theme mode (System / Light / Dark), terminal theme,
+ *   Workspace panel default for new chats, and UI/code font controls.
  * - **Git** — Git behavior, e.g. the default base branch pre-filled when
  *   naming a new worktree branch in the composer.
  * - **Keyboard shortcuts** — the full shortcuts reference, shown inline.
@@ -39,19 +39,19 @@ import {
 } from "react";
 import {
   ArchiveRestoreIcon,
-  KeyRoundIcon,
-  LogOutIcon,
-  Trash2Icon,
-  UserCogIcon,
-} from "lucide-react";
-import {
   CheckIcon,
+  KeyRoundIcon,
   LaptopMinimalIcon,
+  LogOutIcon,
   MinusIcon,
   MonitorIcon,
   MoonIcon,
+  PanelRightCloseIcon,
+  PanelRightIcon,
   PlusIcon,
   SunIcon,
+  Trash2Icon,
+  UserCogIcon,
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { PageScroll } from "@/components/PageScroll";
@@ -119,6 +119,11 @@ import {
   writeTerminalThemeMode,
   type TerminalThemeMode,
 } from "@/lib/terminalThemePreferences";
+import {
+  readWorkspacePanelDefault,
+  writeWorkspacePanelDefault,
+  type WorkspacePanelDefault,
+} from "@/lib/workspacePanelPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import {
   applyThemePalette,
@@ -222,6 +227,15 @@ const terminalThemeCards: { mode: TerminalThemeMode; label: string; icon: typeof
   { mode: "auto", label: "Match app", icon: MonitorIcon },
   { mode: "light", label: "Light", icon: SunIcon },
   { mode: "dark", label: "Dark", icon: MoonIcon },
+];
+
+const workspacePanelCards: {
+  value: WorkspacePanelDefault;
+  label: string;
+  icon: typeof PanelRightIcon;
+}[] = [
+  { value: "open", label: "Open", icon: PanelRightIcon },
+  { value: "collapsed", label: "Collapsed", icon: PanelRightCloseIcon },
 ];
 
 /**
@@ -478,6 +492,40 @@ function TerminalThemeControl() {
 }
 
 /**
+ * Default open/collapsed state for the right Workspace rail on brand-new chats.
+ * Only applies when a session has no saved per-chat open state — existing
+ * sessions keep restoring whatever the user last left them as.
+ */
+function WorkspacePanelDefaultControl() {
+  const [value, setValue] = useState(() => readWorkspacePanelDefault());
+  const labelId = useId();
+  const choose = useCallback((next: WorkspacePanelDefault) => {
+    setValue(next);
+    writeWorkspacePanelDefault(next);
+  }, []);
+  return (
+    <ThemeSubsection
+      labelId={labelId}
+      title="Workspace panel"
+      helper="Whether new chats open with the Files / Agents / Shells panel visible. Existing chats keep their last layout."
+    >
+      <CardRadioGroup<WorkspacePanelDefault>
+        labelledBy={labelId}
+        value={value}
+        onSelect={choose}
+        className="grid grid-cols-2 gap-3"
+        cardClassName="items-center gap-2 p-4"
+        items={workspacePanelCards.map((card) => ({
+          value: card.value,
+          testId: `workspace-panel-default-${card.value}`,
+          body: iconCardBody(card.icon, card.label),
+        }))}
+      />
+    </ThemeSubsection>
+  );
+}
+
+/**
  * Color-theme (palette) picker — a dropdown (à la Codex). Each option shows a
  * swatch chip + name and the trigger mirrors the current selection. Choosing
  * one applies it live to <html> via `data-theme`, persists it, and composes on
@@ -602,6 +650,8 @@ function AppearanceSection() {
         )}
 
         <TerminalThemeControl />
+
+        <WorkspacePanelDefaultControl />
 
         <UiFontSizeControl />
 

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -13,6 +13,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ServerInfo } from "@/lib/capabilities";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 import { writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
+import { writeWorkspacePanelDefault } from "@/lib/workspacePanelPreferences";
 
 vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
@@ -1653,9 +1654,10 @@ describe("Right workspace card visibility", () => {
   });
 
   it("starts open for a fresh session (no stored open-state)", () => {
-    // A brand-new session has no persisted open-state, so the rail opens by
-    // default — the card is mounted and the header offers Collapse, not
-    // Expand.
+    // A brand-new session has no persisted open-state, so the Appearance
+    // Workspace panel default applies. With no preference stored that
+    // default is open — the card is mounted and the header offers Collapse,
+    // not Expand.
     useEnvironmentMock.mockReturnValue({
       data: { available: false, root: null, home: null },
       isLoading: false,
@@ -1667,6 +1669,38 @@ describe("Right workspace card visibility", () => {
     expect(screen.getByRole("complementary", { name: "Workspace" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Collapse right panel" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Expand right panel" })).toBeNull();
+  });
+
+  it("starts collapsed for a fresh session when Appearance default is collapsed", () => {
+    // The Appearance setting only seeds sessions with no saved open-state.
+    writeWorkspacePanelDefault("collapsed");
+    useEnvironmentMock.mockReturnValue({
+      data: { available: false, root: null, home: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_fresh_collapsed", permission_level: null }]);
+
+    renderShell("/c/conv_fresh_collapsed");
+
+    expect(screen.queryByRole("complementary", { name: "Workspace" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Expand right panel" })).toBeInTheDocument();
+  });
+
+  it("restores a saved open-state even when Appearance default is collapsed", () => {
+    // Per-chat persistence wins over the Appearance default once the user
+    // has toggled the rail in that session.
+    writeWorkspacePanelDefault("collapsed");
+    writeSessionWorkspaceState("conv_saved_open", { open: true });
+    useEnvironmentMock.mockReturnValue({
+      data: { available: false, root: null, home: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_saved_open", permission_level: null }]);
+
+    renderShell("/c/conv_saved_open");
+
+    expect(screen.getByRole("complementary", { name: "Workspace" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse right panel" })).toBeInTheDocument();
   });
 
   it("persists the open-state per session across remounts", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -745,9 +745,7 @@ export function AppShell() {
       viewParam === "changed" ||
       viewParam === "explore" ||
       (commentParam !== null && commentParam !== "");
-    setRightPanelOpen(
-      (persisted.open ?? readDefaultWorkspacePanelOpen()) || hasWorkspaceUrlSignal,
-    );
+    setRightPanelOpen((persisted.open ?? readDefaultWorkspacePanelOpen()) || hasWorkspaceUrlSignal);
 
     stateConvRef.current = conversationId;
   }, [conversationId]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -27,6 +27,7 @@ import {
   type DesignModeElement,
 } from "@/lib/designModePrompt";
 import { readSessionWorkspaceState, writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
+import { readDefaultWorkspacePanelOpen } from "@/lib/workspacePanelPreferences";
 import {
   Dialog,
   DialogContent,
@@ -227,15 +228,17 @@ export function AppShell() {
   const [subagentsPanelOpen, setSubagentsPanelOpen] = useState(false);
   const [shellsPanelOpen, setShellsPanelOpen] = useState(false);
   const [todosPanelOpen, setTodosPanelOpen] = useState(false);
-  // The right "Workspace" rail (WorkspacePanel) is open by default and
-  // remembers its open/closed state per session — a brand-new session starts
-  // open; reopening a session restores how the user last left it. Toggled
-  // via the header's PanelRightIcon, mirroring the sidebar collapse. With no
-  // conversation the rail can't render, so the state stays false — leaving it
-  // true would let rail-gated side effects (the ?view= URL sync) fire on
-  // non-session routes like the home page.
+  // The right "Workspace" rail (WorkspacePanel) remembers its open/closed
+  // state per session. A brand-new session (no saved `open`) follows the
+  // Appearance "Workspace panel" default; reopening a session restores how
+  // the user last left it. Toggled via the header's PanelRightIcon, mirroring
+  // the sidebar collapse. With no conversation the rail can't render, so the
+  // state stays false — leaving it true would let rail-gated side effects
+  // (the ?view= URL sync) fire on non-session routes like the home page.
   const [rightPanelOpen, setRightPanelOpen] = useState(() =>
-    conversationId ? (readSessionWorkspaceState(conversationId).open ?? true) : false,
+    conversationId
+      ? (readSessionWorkspaceState(conversationId).open ?? readDefaultWorkspacePanelOpen())
+      : false,
   );
   const [shareOpen, setShareOpen] = useState(false);
   const [forkOpen, setForkOpen] = useState(false);
@@ -742,7 +745,9 @@ export function AppShell() {
       viewParam === "changed" ||
       viewParam === "explore" ||
       (commentParam !== null && commentParam !== "");
-    setRightPanelOpen((persisted.open ?? true) || hasWorkspaceUrlSignal);
+    setRightPanelOpen(
+      (persisted.open ?? readDefaultWorkspacePanelOpen()) || hasWorkspaceUrlSignal,
+    );
 
     stateConvRef.current = conversationId;
   }, [conversationId]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -824,12 +829,11 @@ export function AppShell() {
       setRightRailTab((prev) =>
         prev === "terminals" || prev === "subagents" || prev === "todos" ? "files" : prev,
       );
-      // Reveal the rail so the viewer is actually visible — the rail defaults
-      // open but a session the user collapsed restores collapsed, so opening a
-      // file (e.g. via a chat file-path link) there would otherwise route the
-      // file into an invisible panel. Persist open=true so the rail stays in
-      // sync with the open file on the next visit (mirroring the header
-      // toggle's persistence).
+      // Reveal the rail so the viewer is actually visible — a session the user
+      // collapsed (or one that started collapsed via the Appearance default)
+      // would otherwise route the file into an invisible panel. Persist
+      // open=true so the rail stays in sync with the open file on the next
+      // visit (mirroring the header toggle's persistence).
       setRightPanelOpen(true);
       if (conversationId) writeSessionWorkspaceState(conversationId, { open: true });
       // Set URL in the callback (not a useEffect) to avoid racing with


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds an Appearance setting so users can choose whether brand-new chats start with the right Workspace rail (Files / Agents / Shells) open or collapsed.

- New device preference (`omnigent:default-workspace-panel`) with Open / Collapsed options in Settings → Appearance
- AppShell uses that preference only when a session has no saved `open` state
- Existing chats still restore their last per-session Files / Agents / Shells panel layout

## Test Plan

- [x] Unit tests for `workspacePanelPreferences` read/write/normalize
- [x] AppShell tests: fresh session uses Appearance default (open and collapsed); saved per-session `open` wins over collapsed default
- [x] E2E UI (`tests/e2e_ui/sessions/test_workspace_panel_default.py`): control persists; new chats follow Open/Collapsed; saved session open-state wins over Appearance default
- [ ] Manual: Settings → Appearance → set Workspace panel to Collapsed → open a new chat → rail starts collapsed
- [ ] Manual: Expand/collapse in that chat, leave, return → last per-chat state is restored
- [ ] Manual: Set preference back to Open → new chat starts with rail visible; older chats with saved state are unchanged

## Demo

N/A — setting control follows existing Appearance card radiogroup pattern; behavior is open/collapsed rail defaulting.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit + AppShell tests cover preference persistence and restore/defaulting. E2E UI covers Settings → Appearance control persistence and new-chat vs saved-session rail visibility.

## Changelog

New chats can start with the Workspace panel collapsed via Appearance settings