### PR TITLE
Gate sys_advise_models on routing client availability

### DIFF
--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.runtime import get_caps
 from omnigent.inner.os_env import OSEnvironment
 from omnigent.spec import AgentSpec
 from omnigent.spec.types import SharePolicy, ToolRuntime
@@ -459,11 +460,11 @@ class ToolManager:
         # Model awareness pairs with the dispatch grant: the per-worker
         # listing exists to pick a valid ``args.model`` for send.
         self._tools[SysListModelsTool.name()] = SysListModelsTool(spec=self._spec)
-        # Advise-models is registered unconditionally alongside the
-        # dispatch grant — same pattern as sys_list_models. The server's
-        # MCP intercept returns router_on:false when routing is off,
-        # giving the model a clear signal without hiding the tool.
-        self._tools[SysAdviseModelsTool.name()] = SysAdviseModelsTool()
+        # Advise-models is capability-gated: expose it only when the server
+        # has a routing client configured. Hiding the tool prevents agents
+        # from probing router_on via a no-op call when routing is disabled.
+        if get_caps().routing_client is not None:
+            self._tools[SysAdviseModelsTool.name()] = SysAdviseModelsTool()
 
         # create: spawning OUTSIDE the declared list (existing agents
         # by id, or custom bundles via config_path) requires the

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.errors import ErrorCode, OmnigentError
-from omnigent.runtime import get_caps
 from omnigent.inner.os_env import OSEnvironment
+from omnigent.runtime import get_caps
 from omnigent.spec import AgentSpec
 from omnigent.spec.types import SharePolicy, ToolRuntime
 from omnigent.tools._srt import is_srt_available

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5394,6 +5394,8 @@ def test_native_relay_builtin_set_matches_toolmanager_gating(
     assert relayed & spawn_writes == expected_writes
     # Model awareness rides the dispatch grant: relayed iff send is.
     assert ("sys_list_models" in relayed) == ("sys_session_send" in expected_writes)
+    # Advise-models also requires a routing client; default caps have none.
+    assert "sys_advise_models" not in relayed
 
     # OS tools ride a separate unconditional relay path (overriding the
     # bridge's static versions), so they must never be in the builtin set —

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -431,6 +433,8 @@ def test_spawn_flag_registers_write_tools_without_sub_agents() -> None:
     assert "sys_session_create" in names
     # The dispatch grant brings model awareness along with it.
     assert "sys_list_models" in names
+    # Intelligent routing advisor stays hidden when routing is disabled.
+    assert "sys_advise_models" not in names
     # Sharing is DECOUPLED from spawn — its own `share:` flag governs it,
     # so `spawn: true` alone (share defaulting to `none`) does NOT
     # register it. A regression coupling them would re-expose sharing to
@@ -493,9 +497,38 @@ def test_declared_agents_grant_send_close_but_not_create() -> None:
     assert "sys_session_create" not in names
     # Model awareness rides the same grant as send.
     assert "sys_list_models" in names
+    # Advisor is capability-gated — absent without a routing client.
+    assert "sys_advise_models" not in names
     # Declaring sub-agents does NOT enable sharing — that is the separate
     # `share:` flag's job, decoupled from the spawn/agents grant.
     assert "sys_session_share" not in names
+
+
+@dataclass
+class _FakeRoutingCaps:
+    routing_client: object | None = None
+
+
+def _spawn_spec() -> AgentSpec:
+    return AgentSpec(spec_version=1, spawn=True)
+
+
+def test_advise_models_hidden_when_routing_disabled() -> None:
+    """sys_advise_models must not appear when RuntimeCaps.routing_client is None."""
+    caps = _FakeRoutingCaps(routing_client=None)
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        names = {s["function"]["name"] for s in ToolManager(_spawn_spec()).get_tool_schemas()}
+    assert "sys_list_models" in names
+    assert "sys_advise_models" not in names
+
+
+def test_advise_models_exposed_when_routing_enabled() -> None:
+    """sys_advise_models is advertised alongside send when routing is configured."""
+    caps = _FakeRoutingCaps(routing_client=object())
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        names = {s["function"]["name"] for s in ToolManager(_spawn_spec()).get_tool_schemas()}
+    assert "sys_list_models" in names
+    assert "sys_advise_models" in names
 
 
 def test_share_non_public_registers_share_tool_without_public() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Agents were calling `sys_advise_models` as an availability probe when intelligent routing was disabled — the tool stayed in the schema and returned `router_on: false`, which encouraged probe-then-fan-out behavior instead of skipping routing entirely.

This change gates `sys_advise_models` on `RuntimeCaps.routing_client` in `ToolManager`, so the tool is only advertised when the server can actually produce recommendations. `sys_list_models` remains available with the spawn/dispatch grant.

## Test Plan

- [x] `uv run --extra dev pytest tests/tools/test_manager.py::test_advise_models_hidden_when_routing_disabled`
- [x] `uv run --extra dev pytest tests/tools/test_manager.py::test_advise_models_exposed_when_routing_enabled`
- [x] `uv run --extra dev pytest tests/tools/test_manager.py::test_spawn_flag_registers_write_tools_without_sub_agents`
- [x] `uv run --extra dev pytest tests/tools/test_manager.py::test_declared_agents_grant_send_close_but_not_create`
- [x] `uv run --extra dev pytest tests/runner/test_runner_dispatch.py::test_native_relay_builtin_set_matches_toolmanager_gating`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused unit tests cover routing off (tool absent from schema and native relay) and routing on (tool present with spawn grant). No Polly workflow or prompt changes included.

## Changelog

`sys_advise_models` is only offered to agents when intelligent routing is configured on the server.