### PR TITLE
feat(opencode): add web model selector

### DIFF
--- a/omnigent/opencode_native_app_server.py
+++ b/omnigent/opencode_native_app_server.py
@@ -94,6 +94,8 @@ _ENV_OPENCODE_CONFIG_DENYLIST = frozenset(
 )
 
 _VERSION_RE = re.compile(r"(\d+\.\d+\.\d+(?:[-.][0-9A-Za-z]+)*)")
+# Strip ANSI escape sequences from ``opencode models`` output.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 # Escape hatch: set truthy to bypass the OpenCode CLI version gate (e.g. to
 # try an as-yet-unvalidated 1.18+/v2 release). Mirrors OMNIGENT_NO_UPDATE_CHECK.
@@ -193,6 +195,72 @@ def resolve_opencode_version(opencode_path: str) -> str:
     if version is None:
         raise OpenCodeVersionError(f"Could not parse OpenCode version from: {output!r}")
     return version
+
+
+def list_opencode_cli_model_options(
+    *,
+    opencode_path: str | None = None,
+    refresh: bool = True,
+    timeout: float = 30.0,
+    env: Mapping[str, str] | None = None,
+) -> list[dict[str, object]]:
+    """
+    List OpenCode models using the CLI catalog command.
+
+    ``opencode serve`` currently exposes only the public/free subset from
+    ``GET /api/model`` on some installs, while ``opencode models`` returns the
+    logged-in, refreshed catalog users see in the native TUI. Use this for the
+    Omnigent picker and fall back to the server API if it fails.
+
+    :param opencode_path: Optional explicit executable path.
+    :param refresh: Whether to pass ``--refresh`` so newly released models
+        appear without waiting for OpenCode's cache TTL.
+    :param timeout: Maximum command duration in seconds.
+    :param env: Environment for the subprocess. Pass the same ``XDG_DATA_HOME``
+        / ``XDG_CONFIG_HOME`` the bound ``opencode serve`` uses so model
+        discovery sees the per-session auth/catalog as the native TUI.
+    :returns: Model option dicts with full ``provider/model`` ids.
+    """
+    cli = find_opencode_cli(opencode_path)
+    args = [cli, "models"]
+    if refresh:
+        args.append("--refresh")
+    try:
+        completed = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(f"Could not run 'opencode models': {exc}") from exc
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"'opencode models' failed with code {completed.returncode}: {completed.stderr[:500]}"
+        )
+    options: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for raw_line in completed.stdout.splitlines():
+        line = _ANSI_RE.sub("", raw_line).strip()
+        if not line or "/" not in line or line.lower().startswith("models cache "):
+            continue
+        provider_id, model_id = line.split("/", 1)
+        if not provider_id or not model_id or line in seen:
+            continue
+        seen.add(line)
+        options.append(
+            {
+                "id": line,
+                "model": model_id,
+                "providerID": provider_id,
+                "displayName": line,
+                "name": model_id,
+                "isDefault": False,
+            }
+        )
+    return options
 
 
 def allocate_loopback_port() -> int:

--- a/omnigent/opencode_native_client.py
+++ b/omnigent/opencode_native_client.py
@@ -259,6 +259,20 @@ class OpenCodeClient:
         data = await self._request_json("GET", f"/session/{session_id}/message/{message_id}")
         return data if isinstance(data, dict) else {}
 
+    async def list_models(self) -> list[dict[str, Any]]:
+        """
+        List available models (``GET /api/model``).
+
+        :returns: A list of model objects; empty when the server exposes
+            no model catalog.
+        """
+        data = await self._request_json("GET", "/api/model")
+        if isinstance(data, dict):
+            models = data.get("models")
+            if isinstance(models, list):
+                return [m for m in models if isinstance(m, dict)]
+        return []
+
     async def prompt(self, session_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         """
         Send a (blocking) prompt (``POST /session/{id}/message``).

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -12167,6 +12167,42 @@ def create_runner_app(
             await client.aclose()
         return Response(status_code=200)
 
+    async def _opencode_native_model_options(conv_id: str) -> list[dict[str, Any]]:
+        """Return the OpenCode model catalog for the session picker."""
+        from omnigent.opencode_native_app_server import (
+            filtered_server_env,
+            list_opencode_cli_model_options,
+        )
+        from omnigent.opencode_native_bridge import bridge_dir_for_bridge_id, read_bridge_state
+        from omnigent.opencode_native_client import OpenCodeClient
+
+        bridge_dir = bridge_dir_for_bridge_id(conv_id)
+        state = read_bridge_state(bridge_dir)
+        if state is None or not state.server_base_url:
+            raise _CodexNativeModelOptionsNotReady("OpenCode-native app-server is not ready yet.")
+
+        # Run ``opencode models`` with the same per-session XDG dirs as the
+        # bound ``opencode serve`` (and therefore the native TUI). Without this
+        # isolation the CLI would read the user's global OpenCode config and
+        # could return a different catalog or no authenticated models.
+        cli_env = filtered_server_env(
+            bridge_dir=bridge_dir,
+            auth_secret=state.auth_secret or "",
+        )
+        try:
+            return await asyncio.to_thread(list_opencode_cli_model_options, env=cli_env)
+        except Exception as exc:  # noqa: BLE001 - fall back to the server catalog.
+            _logger.debug("OpenCode CLI model list failed for %s: %r", conv_id, exc)
+
+        client = OpenCodeClient(
+            base_url=state.server_base_url,
+            auth_secret=state.auth_secret,
+        )
+        try:
+            return await client.list_models()
+        finally:
+            await client.aclose()
+
     async def _handle_opencode_native_model_change(conv_id: str, model: str | None) -> Response:
         """
         Apply an Omnigent-initiated model switch to an opencode-native session.
@@ -17688,8 +17724,32 @@ def create_runner_app(
         :returns: JSON ``{"models": [...]}``, where each model is a raw
             Codex ``model/list`` object.
         """
-        if _session_harness_name(session_id) != "codex-native":
+        harness = _session_harness_name(session_id)
+        if harness not in ("codex-native", "opencode-native"):
             return JSONResponse(status_code=200, content={"models": []})
+        if harness == "opencode-native":
+            try:
+                models = await _opencode_native_model_options(session_id)
+                return JSONResponse(status_code=200, content={"models": models})
+            except _CodexNativeModelOptionsNotReady:
+                return JSONResponse(
+                    status_code=503,
+                    content={
+                        "error": "opencode_native_model_options_failed",
+                        "detail": "OpenCode-native app-server is not ready yet.",
+                    },
+                )
+            except Exception as exc:  # noqa: BLE001 - picker failures are retryable.
+                _logger.warning("OpenCode-native model list failed for %s: %s", session_id, exc)
+                return JSONResponse(
+                    status_code=503,
+                    content={
+                        "error": "opencode_native_model_options_failed",
+                        "detail": _client_safe_error_detail(
+                            exc, context="opencode-native model options"
+                        ),
+                    },
+                )
         try:
             return JSONResponse(
                 status_code=200,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -90,6 +90,7 @@ from omnigent.harness_plugins import (
     CODEX_NATIVE_CODING_AGENT,
     CURSOR_NATIVE_CODING_AGENT,
     KIRO_NATIVE_CODING_AGENT,
+    OPENCODE_NATIVE_CODING_AGENT,
     PI_NATIVE_CODING_AGENT,
     NativeCodingAgent,
 )
@@ -590,6 +591,7 @@ _CLAUDE_NATIVE_MODEL = CLAUDE_NATIVE_CODING_AGENT.agent_name
 _CODEX_NATIVE_WRAPPER_LABEL_VALUE = CODEX_NATIVE_CODING_AGENT.wrapper_label
 _CODEX_NATIVE_HARNESS = CODEX_NATIVE_CODING_AGENT.harness
 _CODEX_NATIVE_MODEL = CODEX_NATIVE_CODING_AGENT.agent_name
+_OPENCODE_NATIVE_WRAPPER_LABEL_VALUE = OPENCODE_NATIVE_CODING_AGENT.wrapper_label
 _CURSOR_NATIVE_WRAPPER_LABEL_VALUE = CURSOR_NATIVE_CODING_AGENT.wrapper_label
 _CURSOR_NATIVE_HARNESS = CURSOR_NATIVE_CODING_AGENT.harness
 _KIRO_NATIVE_WRAPPER_LABEL_VALUE = KIRO_NATIVE_CODING_AGENT.wrapper_label
@@ -21373,6 +21375,7 @@ def _model_options_from_wire(raw_models: Any) -> list[dict[str, Any]]:
 # the cursor picker mid-session.
 _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER: dict[str, str] = {
     _CODEX_NATIVE_WRAPPER_LABEL_VALUE: "codex-model-options",
+    _OPENCODE_NATIVE_WRAPPER_LABEL_VALUE: "codex-model-options",
     # pi-native is deliberately NOT here: its catalog is PUSHED by the resident
     # extension (``external_model_options`` → ``_pushed_model_options_cache``),
     # not fetched from a runner route, so the picker works in every auth path

--- a/tests/e2e_ui/chat/test_opencode_model_metadata.py
+++ b/tests/e2e_ui/chat/test_opencode_model_metadata.py
@@ -1,10 +1,9 @@
-"""E2E: opencode-native surfaces its live model as a read-only pill.
+"""E2E: opencode-native exposes its live model and session model catalog.
 
 opencode owns its model (the user switches it inside the opencode TUI), but it
 mirrors the live model into the session's ``model_override`` — set at launch and
-updated by the forwarder on every in-TUI switch. The web UI must surface *that*
-in the model pill so the indicator tracks the TUI, even though opencode ships no
-switchable web model list (the dropdown stays empty / display-only).
+updated by the forwarder on every in-TUI switch. The web UI surfaces *that* in
+the model pill and lists the session-scoped catalog returned by the runner.
 """
 
 from __future__ import annotations
@@ -19,57 +18,80 @@ LAUNCH_MODEL = "openrouter/nemotron"
 # The model the user switched to inside the opencode TUI; the forwarder mirrored
 # it into ``model_override``. This — not the launch default — must show.
 LIVE_TUI_MODEL = "openrouter/llama-3.3-70b-instruct"
+ALTERNATE_MODEL = "opencode-go/glm-5.2"
 
 
-def _patch_session_as_opencode_native(page: Page, session_id: str) -> None:
+def _patch_session_as_opencode_native(page: Page, session_id: str) -> list[dict]:
     """Patch the browser's session snapshot into an opencode-native response.
 
     The server fixture seeds a normal ``hello_world`` session so the page can
     boot against the real app/server. This route patch rewrites only the
     ``GET /v1/sessions/{session_id}`` response as seen by the browser, mirroring
     the AP snapshot after an opencode-native runner has mirrored its live TUI
-    model into ``model_override``. opencode exposes no switchable web model
-    list, so ``model_options`` stays absent.
+    model into ``model_override`` and carrying the runner-discovered model
+    catalog. PATCH responses mirror model selections back into the snapshot.
 
     :param page: Playwright page before navigation.
     :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
-    :returns: None.
+    :returns: Captured PATCH request bodies.
     """
+    latest_payload: dict | None = None
+    patch_bodies: list[dict] = []
 
     def _handle(route: Route) -> None:
+        nonlocal latest_payload
         request = route.request
         parsed = urlparse(request.url)
-        if parsed.path != f"/v1/sessions/{session_id}" or request.method != "GET":
+        if parsed.path != f"/v1/sessions/{session_id}":
             route.continue_()
             return
 
-        response = route.fetch()
-        payload = response.json()
+        headers = {"content-type": "application/json"}
+        if request.method == "GET":
+            response = route.fetch()
+            payload = response.json()
+            headers = {**response.headers, **headers}
+        elif request.method == "PATCH":
+            request_body = json.loads(request.post_data or "{}")
+            patch_bodies.append(request_body)
+            payload = dict(latest_payload or {})
+            if "model_override" in request_body:
+                payload["model_override"] = request_body["model_override"]
+        else:
+            route.continue_()
+            return
+
         payload["labels"] = {
             **payload.get("labels", {}),
             "omnigent.wrapper": "opencode-native-ui",
         }
         payload["harness"] = "opencode"
         payload["llm_model"] = LAUNCH_MODEL
-        payload["model_override"] = LIVE_TUI_MODEL
+        payload.setdefault("model_override", LIVE_TUI_MODEL)
+        payload["model_options"] = [
+            {"id": LIVE_TUI_MODEL, "displayName": LIVE_TUI_MODEL},
+            {"id": ALTERNATE_MODEL, "displayName": ALTERNATE_MODEL},
+        ]
+        latest_payload = dict(payload)
         route.fulfill(
             status=200,
-            headers={**response.headers, "content-type": "application/json"},
+            headers=headers,
             body=json.dumps(payload),
         )
 
     page.route("**/v1/sessions/**", _handle)
+    return patch_bodies
 
 
-def test_opencode_native_pill_shows_live_tui_model(
+def test_opencode_native_model_command_opens_picker_and_persists_pick(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """The model pill surfaces opencode's mirrored ``model_override``.
+    """Bare ``/model`` opens the catalog and a pick persists its override.
 
-    Covers the PR's user-facing path: an opencode-native session shows its live
-    model (the override the forwarder mirrors from the TUI), not the stale
-    launch default, and the harness identity reads "OpenCode".
+    Covers the user-facing path required by the PR: bare ``/model`` opens the
+    server-backed catalog, and selecting a row PATCHes the same
+    ``model_override`` used by the native bridge.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` for a real server-backed
@@ -77,18 +99,38 @@ def test_opencode_native_pill_shows_live_tui_model(
     :returns: None.
     """
     base_url, session_id = seeded_session
-    _patch_session_as_opencode_native(page, session_id)
+    patch_bodies = _patch_session_as_opencode_native(page, session_id)
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    # The pill mirrors the live TUI model (the override), NOT the launch default.
     trigger = page.get_by_test_id("agent-picker-trigger")
-    expect(trigger).to_contain_text(LIVE_TUI_MODEL, timeout=15_000)
-    expect(trigger).not_to_contain_text(LAUNCH_MODEL)
+    expect(trigger).to_be_visible(timeout=15_000)
 
     # opencode is identified as its own native wrapper in the status tray.
     expect(page.get_by_test_id("composer-harness")).to_contain_text("OpenCode")
 
-    # Display-only: opencode ships no switchable web model rows. (Switching
-    # stays in the opencode TUI; the web pill only reflects it.)
-    expect(page.locator('[data-testid="model-picker-item"]')).to_have_count(0)
+    # Bare /model opens the existing picker with the session-scoped catalog.
+    composer = page.get_by_placeholder("Ask the agent anything…")
+    composer.fill("/model ")
+    composer.press("Enter")
+
+    current_row = page.locator(
+        f'[data-testid="model-picker-item"][data-model-id="{LIVE_TUI_MODEL}"]'
+    )
+    alternate_row = page.locator(
+        f'[data-testid="model-picker-item"][data-model-id="{ALTERNATE_MODEL}"]'
+    )
+    expect(current_row).to_be_visible()
+    expect(alternate_row).to_be_visible()
+
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "PATCH"
+            and urlparse(response.url).path == f"/v1/sessions/{session_id}"
+            and response.status == 200
+        )
+    ):
+        alternate_row.click()
+
+    assert patch_bodies[-1] == {"model_override": ALTERNATE_MODEL}
+    expect(trigger).to_contain_text(ALTERNATE_MODEL)

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -17,7 +17,7 @@ import shutil
 import sys
 import threading
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -9279,6 +9279,72 @@ async def test_events_codex_native_settings_change_uses_thread_settings_update(
         f"codex-native {event_payload['type']} must call thread/settings/update "
         f"with next-turn settings; got {fake_client.requests!r}."
     )
+
+
+@pytest.mark.asyncio
+async def test_opencode_native_model_options_uses_cli_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from omnigent import opencode_native_app_server, opencode_native_bridge
+    from omnigent.opencode_native_bridge import OpenCodeNativeBridgeState
+    from omnigent.spec.types import ExecutorSpec
+
+    conv_id = "conv_opencode_native_model_options"
+    monkeypatch.setattr(opencode_native_bridge, "_BRIDGE_ROOT", tmp_path)
+    monkeypatch.setattr(
+        opencode_native_bridge,
+        "read_bridge_state",
+        lambda _dir: OpenCodeNativeBridgeState(
+            session_id=conv_id,
+            server_base_url="http://127.0.0.1:49231",
+            opencode_session_id="ses_1",
+        ),
+    )
+    captured_envs: list[Mapping[str, str] | None] = []
+
+    def _fake_list_options(*, env: Mapping[str, str] | None = None) -> list[dict[str, object]]:
+        captured_envs.append(env)
+        return [{"id": "opencode-go/glm-5.2", "displayName": "opencode-go/glm-5.2"}]
+
+    monkeypatch.setattr(
+        opencode_native_app_server,
+        "list_opencode_cli_model_options",
+        _fake_list_options,
+    )
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "opencode-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        response = await client.get(f"/v1/sessions/{conv_id}/codex-model-options")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "models": [{"id": "opencode-go/glm-5.2", "displayName": "opencode-go/glm-5.2"}]
+    }
+    assert len(captured_envs) == 1
+    cli_env = captured_envs[0]
+    assert cli_env is not None
+    bridge_dir = opencode_native_bridge.bridge_dir_for_bridge_id(conv_id)
+    assert cli_env["XDG_DATA_HOME"] == str(bridge_dir / "xdg-data")
+    assert cli_env["XDG_CONFIG_HOME"] == str(bridge_dir / "xdg-config")
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -557,8 +557,17 @@ async def test_session_snapshot_includes_skills_from_runner(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("session_id", "wrapper_attr"),
+    [
+        ("conv_codex_options", "_CODEX_NATIVE_WRAPPER_LABEL_VALUE"),
+        ("conv_opencode_options", "_OPENCODE_NATIVE_WRAPPER_LABEL_VALUE"),
+    ],
+)
 async def test_session_snapshot_includes_model_options_from_runner(
     monkeypatch: pytest.MonkeyPatch,
+    session_id: str,
+    wrapper_attr: str,
 ) -> None:
     """
     Codex-native model and effort controls use Codex's live ``model/list``.
@@ -620,32 +629,32 @@ async def test_session_snapshot_includes_model_options_from_runner(
     monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
 
     conv = Conversation(
-        id="conv_codex_options",
+        id=session_id,
         created_at=1,
         updated_at=1,
-        root_conversation_id="conv_codex_options",
+        root_conversation_id=session_id,
         agent_id="ag_test",
         labels={
-            _mod._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: _mod._CODEX_NATIVE_WRAPPER_LABEL_VALUE,
+            _mod._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: getattr(_mod, wrapper_attr),
         },
     )
     conv_store = _ConversationStore(
         [_message_item("item_1", "hi")],
-        conversations={"conv_codex_options": conv},
+        conversations={session_id: conv},
     )
 
     first = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_codex_options",
+        session_id,
     )
     assert first.model_options == []
-    await _drain_model_options("conv_codex_options")
+    await _drain_model_options(session_id)
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
-        "conv_codex_options",
+        session_id,
     )
 
-    assert "/v1/sessions/conv_codex_options/codex-model-options" in fake_client.get_calls
+    assert f"/v1/sessions/{session_id}/codex-model-options" in fake_client.get_calls
     assert [m["id"] for m in snapshot.model_options] == ["gpt-5.5"]
     assert snapshot.model_options[0]["displayName"] == "GPT-5.5"
     assert snapshot.model_options[0]["supportedReasoningEfforts"] == [

--- a/tests/test_opencode_native_app_server.py
+++ b/tests/test_opencode_native_app_server.py
@@ -276,3 +276,32 @@ def test_resolve_opencode_version_unparseable_raises(monkeypatch: pytest.MonkeyP
     )
     with pytest.raises(appsrv.OpenCodeVersionError):
         appsrv.resolve_opencode_version("/x/opencode")
+
+
+def test_list_opencode_cli_model_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    import subprocess
+
+    monkeypatch.setattr(appsrv, "find_opencode_cli", lambda _path=None: "/x/opencode")
+
+    captured: dict[str, object] = {}
+
+    def _fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout="\x1b[32mopencode-go/glm-5.2\x1b[0m\nopencode-go/kimi-k2.7-code\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(appsrv.subprocess, "run", _fake_run)
+
+    options = appsrv.list_opencode_cli_model_options(
+        env={"XDG_DATA_HOME": "/xdg/data", "XDG_CONFIG_HOME": "/xdg/config"},
+    )
+
+    assert [option["id"] for option in options] == [
+        "opencode-go/glm-5.2",
+        "opencode-go/kimi-k2.7-code",
+    ]
+    assert captured["env"] == {"XDG_DATA_HOME": "/xdg/data", "XDG_CONFIG_HOME": "/xdg/config"}

--- a/tests/test_opencode_native_client.py
+++ b/tests/test_opencode_native_client.py
@@ -70,6 +70,16 @@ async def test_list_messages() -> None:
     await client.aclose()
 
 
+async def test_list_models() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/model"
+        return httpx.Response(200, json={"models": [{"id": "opencode-go/glm-5.2"}]})
+
+    client = _client(handler)
+    assert await client.list_models() == [{"id": "opencode-go/glm-5.2"}]
+    await client.aclose()
+
+
 async def test_prompt_async_posts_parts() -> None:
     captured: dict[str, object] = {}
 

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -403,16 +403,12 @@ describe("Composer slash-command submit routing", () => {
     expect(screen.getAllByTestId("model-picker-item").length).toBeGreaterThan(0);
   });
 
-  it("shows the read-only model hint for bare /model on opencode-native", () => {
-    // opencode surfaces showModels (its pill mirrors the live TUI model) but
-    // has no web model options to populate a dropdown. The bare-/model intercept
-    // must NOT fire — opening an empty picker and swallowing the command was the
-    // regression. Instead it falls through to the builtin /model handler, which
-    // surfaces the current model as a read-only hint. ("/model <name>" still
-    // routes to setModel below — opencode reads model_override on the next turn,
-    // so a web switch is functional even though the picker list is empty.)
+  it("opens the server-backed model picker for bare /model on opencode-native", () => {
     const setModel = vi.fn().mockResolvedValue(undefined);
-    useChatStore.setState({ setModel, llmModel: "openrouter/nemotron" });
+    useChatStore.setState({
+      setModel,
+      llmModel: "opencode-go/glm-5.2",
+    });
     const onSend = vi.fn();
     render(
       <Composer
@@ -422,6 +418,7 @@ describe("Composer slash-command submit routing", () => {
           isNativeWrapper: true,
           showModels: true,
           modelPickerKind: "opencode",
+          codexModelOptions: [{ id: "opencode-go/glm-5.2", displayName: "opencode-go/glm-5.2" }],
         })}
       />,
     );
@@ -429,12 +426,11 @@ describe("Composer slash-command submit routing", () => {
     fireEvent.change(ta, { target: { value: "/model " } });
     fireEvent.keyDown(ta, { key: "Enter" });
 
-    // Not sent as plaintext, not a switch, and the (empty) web picker stays shut.
+    // Bare /model opens the picker without sending text or changing the model.
     expect(onSend).not.toHaveBeenCalled();
     expect(setModel).not.toHaveBeenCalled();
-    expect(screen.queryAllByTestId("model-picker-item")).toHaveLength(0);
-    // The builtin handler surfaced the current model as a read-only hint.
-    expect(screen.getByText(/openrouter\/nemotron/)).toBeTruthy();
+    expect(screen.getAllByTestId("model-picker-item")).toHaveLength(1);
+    expect(screen.getByText("opencode-go/glm-5.2")).toBeTruthy();
   });
 
   it("routes /model <name> to setModel on opencode-native (functional switch)", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4367,13 +4367,15 @@ export function Composer({
       // the user choose there. "/model <name>" takes the builtin route below to
       // setModel — the same write the picker makes.
       //
-      // opencode is excluded: it surfaces showModels (the pill mirrors its live
-      // TUI model) but ships no web model options, so intercepting bare "/model"
-      // would pop an empty dropdown and swallow the command. Fall through to the
-      // builtin "/model" handler below, which surfaces the current model as a
-      // read-only hint. ("/model <name>" still routes to setModel there —
-      // opencode reads model_override on the next web-injected turn.)
-      if (cmd === "/model" && !arg && showModels && modelPickerKind !== "opencode") {
+      // opencode-native now surfaces server-backed model options too, so bare
+      // "/model" opens the picker when options are loaded. When the options are
+      // still empty (e.g. the runner catalog hasn't arrived yet), fall through
+      // to the builtin "/model" handler, which surfaces the current model as a
+      // read-only hint instead of popping an empty dropdown. ("/model <name>"
+      // still routes to setModel there — opencode reads model_override on the
+      // next web-injected turn.)
+      const canOpenModelPicker = modelPickerKind !== "opencode" || codexModelOptions.length > 0;
+      if (cmd === "/model" && !arg && showModels && canOpenModelPicker) {
         dirtyRef.current = true;
         setValue("");
         setCommandError(null);
@@ -5361,14 +5363,15 @@ function AgentPicker({
   const sessionModelOverride = useChatStore((s) => s.sessionModelOverride);
   const llmModel = useChatStore((s) => s.llmModel);
 
-  // Codex, cursor, kiro, and pi all populate the picker from the
+  // Codex, cursor, kiro, pi, and opencode all populate the picker from the
   // server-provided ``codexModelOptions`` channel (the snapshot's
   // ``model_options`` field); claude uses the static local catalog.
   const usesServerModelOptions =
     modelPickerKind === "codex" ||
     modelPickerKind === "cursor" ||
     modelPickerKind === "kiro" ||
-    modelPickerKind === "pi";
+    modelPickerKind === "pi" ||
+    modelPickerKind === "opencode";
   const modelOptions: ReadonlyArray<{ id: string; label?: string; displayName?: string }> =
     modelPickerKind === "claude"
       ? CLAUDE_NATIVE_MODELS


### PR DESCRIPTION
## Related issue

Closes #2518

## Summary

- Populate OpenCode-native's existing web model picker from `opencode models --refresh`, using the session's isolated OpenCode configuration and data directories.
- Fall back to the bound OpenCode app server's model endpoint when CLI discovery fails, then carry the options through the existing runner and session-snapshot pipeline.
- Open the picker for bare `/model` once options are available, while preserving the read-only fallback during startup so the UI never opens an empty dropdown.

This follows #1328, which surfaced OpenCode-native's active model and identified web-side model switching as follow-up work.

**ELI5:** Omnigent could already display which OpenCode model was active, but it did not know which other models that particular OpenCode session could use. This change asks the session for its own list and feeds that list into the picker already present in the web UI.

```text
session OpenCode config
        |
        v
opencode models --refresh ----failure----> OpenCode /api/model
        |                                      |
        +------------------+-------------------+
                           v
runner model-options -> session snapshot -> web model picker
```

## Test Plan

- `pytest -q tests/test_opencode_native_app_server.py tests/test_opencode_native_client.py tests/test_opencode_native_provider.py tests/test_opencode_native_bridge.py tests/test_opencode_native.py tests/server/routes/test_sessions_snapshot.py` — 182 passed.
- `cd web && npm test -- --run src/pages/ChatPage.composer.test.tsx` — 63 passed.
- `cd web && npm run type-check` — passed.
- `pytest -q tests/e2e_ui/chat/test_opencode_model_metadata.py` — 1 Chromium Playwright test passed.
- `pre-commit run` on the changed files — passed, including Ruff, Ruff format, and Prettier.

## Demo

Automated browser proof is included in `tests/e2e_ui/chat/test_opencode_model_metadata.py`: bare `/model` opens the OpenCode catalog, selecting a row PATCHes `model_override`, and the visible model updates. The test passed locally in Chromium. No separate recording is attached.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit and integration coverage verifies CLI parsing and ANSI stripping, session-specific XDG propagation, OpenCode server fallback, runner and snapshot wiring, and composer picker behavior. Playwright coverage verifies the complete browser interaction and persistence request.

## Changelog

OpenCode-native sessions now show their available models in the web model picker.