### PR TITLE
fix(codex): pass conversation_store to _ensure_runner_session_initialized

### DIFF
--- a/omnigent/server/routes/codex/sessions.py
+++ b/omnigent/server/routes/codex/sessions.py
@@ -294,7 +294,9 @@ async def _initialize_codex_goal_runner(
             "Session not found",
             code=ErrorCode.NOT_FOUND,
         )
-    await _ensure_runner_session_initialized(session_id, refreshed_conv, runner_client)
+    await _ensure_runner_session_initialized(
+        session_id, refreshed_conv, runner_client, conversation_store
+    )
 
 
 async def _launch_runner_for_codex_goal(


### PR DESCRIPTION
## Related issue

Closes #2442

## Summary

- `_initialize_codex_goal_runner` had `conversation_store` in scope as a parameter but omitted it when calling `_ensure_runner_session_initialized`, causing a `TypeError` on the "cold runner" path (set goal on a session whose runner just relaunched).
- One-line fix: thread `conversation_store` through to the nested call.

## Test Plan

1. Trigger the cold-runner path: restart the host process backing a Codex session, then immediately call `PUT /v1/sessions/{id}/codex_goal`.
2. Verify the request succeeds instead of 500-ing with `TypeError: _ensure_runner_session_initialized() missing 1 required positional argument: 'conversation_store'`.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

The regression path only fires when the runner is cold/reconnected at the exact moment a goal is set — difficult to cover with a targeted unit test without additional test infrastructure. Manually verified by tracing the call path and confirming the argument is now passed.