### PR TITLE
fix(pi-native): merge bearer refresh over existing authHeaders instead of replacing

### DIFF
--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -258,7 +258,7 @@ def write_extension_files(
 
 def refresh_config_auth_headers(bridge_dir: Path, auth_headers: dict[str, str]) -> bool:
     """
-    Rewrite only the ``authHeaders`` of an existing extension config.
+    Merge fresh headers into the ``authHeaders`` of an existing extension config.
 
     The bearer baked into ``config.json`` at launch dies with the ~1h
     Databricks OAuth lifetime. The resident extension re-reads the config on
@@ -268,12 +268,17 @@ def refresh_config_auth_headers(bridge_dir: Path, auth_headers: dict[str, str]) 
     Best-effort and behavior-preserving: it touches only ``authHeaders``,
     leaving ``serverUrl`` / ``tools`` / etc. intact.
 
+    Headers are **merged** (fresh values win on collision) rather than replaced,
+    so launch-written headers such as ``X-Omnigent-Runner-Tunnel-Token`` — set
+    when the binding token was available in the runner-main process env and
+    needed for guest-on-shared-host self-access — survive every bearer rotation.
+
     :param bridge_dir: Native Pi bridge directory.
-    :param auth_headers: Fresh outbound auth headers, e.g.
+    :param auth_headers: Fresh outbound auth headers to merge in, e.g.
         ``{"Authorization": "Bearer <token>"}``.
     :returns: ``True`` when the config was rewritten; ``False`` when
         *auth_headers* is empty (local/unauthenticated), the config is
-        missing/unreadable, or the headers already match.
+        missing/unreadable, or the merged result is unchanged.
     """
     if not auth_headers:
         return False
@@ -282,9 +287,13 @@ def refresh_config_auth_headers(bridge_dir: Path, auth_headers: dict[str, str]) 
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return False
-    if not isinstance(payload, dict) or payload.get("authHeaders") == auth_headers:
+    if not isinstance(payload, dict):
         return False
-    payload["authHeaders"] = auth_headers
+    existing = payload.get("authHeaders") or {}
+    merged = {**existing, **auth_headers}
+    if merged == existing:
+        return False
+    payload["authHeaders"] = merged
     _atomic_json(path, payload)
     return True
 

--- a/tests/test_pi_native_bridge.py
+++ b/tests/test_pi_native_bridge.py
@@ -273,3 +273,36 @@ def test_refresh_config_auth_headers_noops(tmp_path: Path) -> None:
         pi_native_bridge.refresh_config_auth_headers(bridge_dir, {"Authorization": "Bearer x"})
         is False
     )
+
+
+def test_refresh_config_auth_headers_preserves_launch_written_headers(tmp_path: Path) -> None:
+    """Bearer refresh merges over existing headers; launch-written extras survive.
+
+    On guest-on-shared-host runners the extension config is written at launch
+    with both the OAuth bearer and an ``X-Omnigent-Runner-Tunnel-Token`` header
+    needed for the extension's ``/events`` POSTs to be authorised as self-access.
+    The per-turn bearer refresh must not wipe that header — it only knows about
+    the fresh bearer, not the tunnel token.
+    """
+    bridge_dir = tmp_path / "bridge"
+    pi_native_bridge.write_extension_files(
+        bridge_dir,
+        session_id="conv_abc",
+        server_url="http://omnigent.test",
+        conversation_url="http://omnigent.test/c/conv_abc",
+        auth_headers={
+            "Authorization": "Bearer stale",
+            "X-Omnigent-Runner-Tunnel-Token": "tunnel-tok",
+        },
+    )
+
+    assert (
+        pi_native_bridge.refresh_config_auth_headers(bridge_dir, {"Authorization": "Bearer fresh"})
+        is True
+    )
+
+    payload = json.loads(pi_native_bridge.config_path(bridge_dir).read_text(encoding="utf-8"))
+    # Bearer is updated to the fresh value.
+    assert payload["authHeaders"]["Authorization"] == "Bearer fresh"
+    # Tunnel token written at launch is preserved across the bearer rotation.
+    assert payload["authHeaders"]["X-Omnigent-Runner-Tunnel-Token"] == "tunnel-tok"


### PR DESCRIPTION
## Summary

- `refresh_config_auth_headers` was doing a hard replace of the entire `authHeaders` dict, clobbering any extra headers written at launch — notably `X-Omnigent-Runner-Tunnel-Token` on guest-on-shared-host runners.
- That header is required for the extension's `/events` POSTs to pass the server's self-access check (`LEVEL_EDIT`). Its removal caused the chat mirror to 404 on every turn while the PTY kept working (the WS attach is separately authorised) — root cause of #2356.
- Fix: merge the fresh bearer **over** the existing dict (fresh wins on collision) so launch-written headers survive every bearer rotation.
- Adds a regression test asserting `X-Omnigent-Runner-Tunnel-Token` survives a bearer rotation.

**Note:** This is part of the fix for #2356. The launch-time tunnel-token write and binding-token env-scrub caching land separately with the external-host runner-auth foundation (`RUNNER_PREFER_BINDING_TOKEN_MINT` gate).

## Test Plan

- [x] All 13 `tests/test_pi_native_bridge.py` tests pass, including the new `test_refresh_config_auth_headers_preserves_launch_written_headers`
- [x] Existing `test_refresh_config_auth_headers_replaces_only_auth` and `test_refresh_config_auth_headers_noops` still pass unchanged (single-header case is unaffected by the merge)
- [x] `pre-commit run --all-files` clean

## Demo

N/A — no UI change

## Type of change

- [x] Bug fix

## Test coverage

- [x] New tests added

## Coverage notes

N/A