### PR TITLE
fix(pi-native): register all Databricks Claude models in models.json

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -63,6 +63,10 @@ _PI_PROVIDER_ID = "omnigent"
 # carries no explicit model override.
 _DATABRICKS_PI_DEFAULT_MODEL = "databricks-claude-sonnet-4-6"
 
+# Provider id for the secondary OpenAI Completions provider registered alongside
+# the primary Anthropic provider in Databricks gateway configs.
+_PI_OPENAI_PROVIDER_ID = "omnigent-openai"
+
 # All Claude models available on the Databricks AI Gateway Anthropic surface.
 # Keep in sync with _DATABRICKS_ANTHROPIC_MODELS in omnigent/inner/pi_executor.py.
 # Declaring ``input`` is required so Pi's transformMessages doesn't strip
@@ -87,6 +91,39 @@ _DATABRICKS_ANTHROPIC_NATIVE_MODELS: list[dict[str, Any]] = [
         "name": "Claude Sonnet 4.5",
         "contextWindow": 200000,
         "maxTokens": 16384,
+        "input": ["text", "image"],
+    },
+]
+
+# GPT models available on the Databricks workspace serving-endpoints.
+# Keep in sync with _DATABRICKS_RESPONSES_MODELS in omnigent/inner/pi_executor.py.
+_DATABRICKS_RESPONSES_NATIVE_MODELS: list[dict[str, Any]] = [
+    {
+        "id": "databricks-gpt-5-4-mini",
+        "name": "GPT-5.4 Mini",
+        "contextWindow": 1047576,
+        "maxTokens": 32768,
+        "input": ["text", "image"],
+    },
+    {
+        "id": "databricks-gpt-5-4",
+        "name": "GPT-5.4",
+        "contextWindow": 1047576,
+        "maxTokens": 32768,
+        "input": ["text", "image"],
+    },
+    {
+        "id": "databricks-gpt-5-5",
+        "name": "GPT-5.5",
+        "contextWindow": 400000,
+        "maxTokens": 128000,
+        "input": ["text", "image"],
+    },
+    {
+        "id": "databricks-gpt-5-5-pro",
+        "name": "GPT-5.5 Pro",
+        "contextWindow": 400000,
+        "maxTokens": 128000,
         "input": ["text", "image"],
     },
 ]
@@ -177,6 +214,10 @@ class PiProviderConfig:
     # Databricks Anthropic gateway). Excluded from __hash__ so the frozen
     # dataclass stays hashable even though list[dict] is not hashable.
     extra_models: list[dict[str, Any]] = field(default_factory=list, hash=False)
+    # Extra providers to merge into models.json alongside the primary one (e.g.
+    # an OpenAI Completions provider for GPT models on the Databricks gateway).
+    # Keys are provider ids; values are complete Pi provider config dicts.
+    additional_providers: dict[str, Any] = field(default_factory=dict, hash=False)
 
     def to_models_config(self) -> dict[str, Any]:
         """Render this provider as a Pi ``models.json`` mapping."""
@@ -196,7 +237,9 @@ class PiProviderConfig:
         }
         if self.auth_header:
             provider["authHeader"] = True
-        return {"providers": {self.provider_id: provider}}
+        providers: dict[str, Any] = {self.provider_id: provider}
+        providers.update(self.additional_providers)
+        return {"providers": providers}
 
 
 def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiProviderConfig | None:
@@ -217,6 +260,7 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         return None
     host = host.rstrip("/")
     auth_command = _databricks_codex_auth_command(host, entry.profile)
+    api_key = f"!{auth_command}"
     return PiProviderConfig(
         provider_id=_PI_PROVIDER_ID,
         base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
@@ -225,10 +269,59 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token is refreshed per request (the auth command itself
         # force-refreshes), matching codex-native's refresh semantics.
-        api_key=f"!{auth_command}",
+        api_key=api_key,
         auth_header=True,
         extra_models=list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
+        additional_providers={
+            _PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(
+                api_key, f"{host}/serving-endpoints"
+            )
+        },
     )
+
+
+def _gateway_serving_endpoints_url(gateway_base_url: str) -> str | None:
+    """Derive the Databricks workspace serving-endpoints URL from a gateway URL.
+
+    The AI Gateway hostname carries an ``ai-gateway`` DNS label that the
+    workspace host does not (e.g. ``12345.ai-gateway.cloud.databricks.com`` →
+    ``12345.cloud.databricks.com``). GPT models route through the workspace's
+    ``/serving-endpoints`` path, not the gateway itself.
+
+    :param gateway_base_url: An AI Gateway base URL, e.g.
+        ``"https://<id>.ai-gateway.cloud.databricks.com/codex/v1"``.
+    :returns: ``https://<workspace>/serving-endpoints``, or ``None`` when the
+        URL doesn't carry the expected ``ai-gateway`` label.
+    """
+    parsed = urlparse(gateway_base_url)
+    if not parsed.hostname:
+        return None
+    labels = parsed.hostname.split(".")
+    if _DATABRICKS_AI_GATEWAY_LABEL not in labels:
+        return None
+    labels.remove(_DATABRICKS_AI_GATEWAY_LABEL)
+    return f"https://{'.'.join(labels)}/serving-endpoints"
+
+
+def _databricks_openai_provider(api_key: str, serving_endpoints_url: str) -> dict[str, Any]:
+    """Build a Pi OpenAI Completions provider config for the Databricks gateway.
+
+    GPT models on the Databricks workspace are served via the OpenAI
+    Completions API at ``/serving-endpoints``. The ``compat`` block disables
+    OpenAI-specific features the Databricks endpoint doesn't support.
+    """
+    return {
+        "baseUrl": serving_endpoints_url,
+        "apiKey": api_key,
+        "api": "openai-completions",
+        "compat": {
+            "supportsDeveloperRole": False,
+            "supportsStore": False,
+            "supportsStrictMode": False,
+            "supportsReasoningEffort": False,
+        },
+        "models": list(_DATABRICKS_RESPONSES_NATIVE_MODELS),
+    }
 
 
 def _gateway_anthropic_base_url(codex_base_url: str) -> str:
@@ -359,6 +452,16 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     transport = _cli_config_databricks_transport(entry)
     if transport is None:
         return None
+    api_key = f"!{transport.auth_command}"
+    # Derive the workspace serving-endpoints URL from the AI Gateway URL so Pi
+    # can also list GPT models. Falls back gracefully to Claude-only when the
+    # URL doesn't carry the expected ``ai-gateway`` label.
+    serving_endpoints = _gateway_serving_endpoints_url(transport.base_url)
+    additional: dict[str, Any] = (
+        {_PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(api_key, serving_endpoints)}
+        if serving_endpoints
+        else {}
+    )
     return PiProviderConfig(
         provider_id=_PI_PROVIDER_ID,
         base_url=_gateway_anthropic_base_url(transport.base_url),
@@ -367,9 +470,10 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token (the codex auth command prints it) is refreshed per
         # request — matching codex-native's refresh semantics.
-        api_key=f"!{transport.auth_command}",
+        api_key=api_key,
         auth_header=True,
         extra_models=list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
+        additional_providers=additional,
     )
 
 

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -261,6 +261,21 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     host = host.rstrip("/")
     auth_command = _databricks_codex_auth_command(host, entry.profile)
     api_key = f"!{auth_command}"
+    # Fetch the live model list from the workspace API so Pi's /model shows
+    # exactly the endpoints available on this workspace. Falls back to the
+    # bundled static lists when credentials can't be resolved or the API call
+    # fails (e.g. network blip, new workspace with no endpoints yet).
+    try:
+        from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
+
+        creds = resolve_databricks_workspace(entry.profile)
+        claude_models, gpt_models, _ = _fetch_pi_model_lists(creds.host, creds.token)
+    except Exception:  # noqa: BLE001 — credential/network failure must not break launch
+        _LOGGER.info(
+            "pi-native: falling back to bundled model list (could not resolve credentials)"
+        )
+        claude_models = list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS)
+        gpt_models = list(_DATABRICKS_RESPONSES_NATIVE_MODELS)
     return PiProviderConfig(
         provider_id=_PI_PROVIDER_ID,
         base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
@@ -271,27 +286,32 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # force-refreshes), matching codex-native's refresh semantics.
         api_key=api_key,
         auth_header=True,
-        extra_models=list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
-        additional_providers={
-            _PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(
-                api_key, f"{host}/serving-endpoints"
-            )
-        },
+        extra_models=claude_models,
+        additional_providers=(
+            {
+                _PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(
+                    api_key, f"{host}/serving-endpoints", gpt_models
+                )
+            }
+            if gpt_models
+            else {}
+        ),
     )
 
 
-def _gateway_serving_endpoints_url(gateway_base_url: str) -> str | None:
-    """Derive the Databricks workspace serving-endpoints URL from a gateway URL.
+def _gateway_workspace_url(gateway_base_url: str) -> str | None:
+    """Derive the Databricks workspace base URL from an AI Gateway URL.
 
     The AI Gateway hostname carries an ``ai-gateway`` DNS label that the
     workspace host does not (e.g. ``12345.ai-gateway.cloud.databricks.com`` →
-    ``12345.cloud.databricks.com``). GPT models route through the workspace's
-    ``/serving-endpoints`` path, not the gateway itself.
+    ``12345.cloud.databricks.com``). The workspace URL is the root for both
+    ``/api/2.0/serving-endpoints`` (model catalog) and ``/serving-endpoints``
+    (OpenAI Completions base URL).
 
     :param gateway_base_url: An AI Gateway base URL, e.g.
         ``"https://<id>.ai-gateway.cloud.databricks.com/codex/v1"``.
-    :returns: ``https://<workspace>/serving-endpoints``, or ``None`` when the
-        URL doesn't carry the expected ``ai-gateway`` label.
+    :returns: ``https://<workspace>``, or ``None`` when the URL doesn't carry
+        the expected ``ai-gateway`` label.
     """
     parsed = urlparse(gateway_base_url)
     if not parsed.hostname:
@@ -300,10 +320,14 @@ def _gateway_serving_endpoints_url(gateway_base_url: str) -> str | None:
     if _DATABRICKS_AI_GATEWAY_LABEL not in labels:
         return None
     labels.remove(_DATABRICKS_AI_GATEWAY_LABEL)
-    return f"https://{'.'.join(labels)}/serving-endpoints"
+    return f"https://{'.'.join(labels)}"
 
 
-def _databricks_openai_provider(api_key: str, serving_endpoints_url: str) -> dict[str, Any]:
+def _databricks_openai_provider(
+    api_key: str,
+    serving_endpoints_url: str,
+    models: list[dict[str, Any]],
+) -> dict[str, Any]:
     """Build a Pi OpenAI Completions provider config for the Databricks gateway.
 
     GPT models on the Databricks workspace are served via the OpenAI
@@ -320,8 +344,127 @@ def _databricks_openai_provider(api_key: str, serving_endpoints_url: str) -> dic
             "supportsStrictMode": False,
             "supportsReasoningEffort": False,
         },
-        "models": list(_DATABRICKS_RESPONSES_NATIVE_MODELS),
+        "models": models,
     }
+
+
+def _run_auth_command(auth_command: str, *, timeout: float = 15.0) -> str | None:
+    """Run *auth_command* and return its stdout as a bearer token.
+
+    Used to obtain a short-lived token at session-create time for the
+    one-shot model-catalog API call. Returns ``None`` on any failure so
+    callers can fall back gracefully.
+
+    :param auth_command: Shell command string, e.g.
+        ``"jq -r .access_token /path/token.json"``.
+    :param timeout: Maximum seconds to wait for the command.
+    :returns: Stripped stdout (the token), or ``None`` when the command
+        fails, times out, or produces empty output.
+    """
+    import shlex
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            shlex.split(auth_command),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip() or None
+    except Exception:  # noqa: BLE001 — any subprocess failure should just return None
+        return None
+
+
+def _fetch_pi_model_lists(
+    workspace_url: str,
+    token: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Fetch live model lists from the Databricks serving-endpoints API.
+
+    Calls ``GET <workspace>/api/2.0/serving-endpoints``, filters for
+    READY LLM endpoints, and splits them by family (Claude/GPT/other) into
+    Pi model entry dicts (``{"id": name, "input": ["text", "image"]}``).
+    Falls back to the bundled static lists on any HTTP or auth failure so a
+    network blip or credential gap never breaks Pi session launch.
+
+    :param workspace_url: Databricks workspace base URL, e.g.
+        ``"https://wkspc.example.com"`` — **no** trailing slash or path.
+    :param token: Bearer token for the workspace API.
+    :returns: ``(claude_models, gpt_models, other_models)`` — each a list
+        of Pi model entry dicts ready to write into ``models.json``.
+    """
+    import httpx
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.get(
+                f"{workspace_url.rstrip('/')}/api/2.0/serving-endpoints",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+    except Exception:  # noqa: BLE001 — any HTTP/network failure falls back to statics
+        _LOGGER.warning(
+            "pi-native: could not fetch Databricks model list; using bundled defaults",
+            exc_info=True,
+        )
+        return (
+            list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
+            list(_DATABRICKS_RESPONSES_NATIVE_MODELS),
+            [],
+        )
+
+    endpoints = payload.get("endpoints") if isinstance(payload, dict) else None
+    claude: list[dict[str, Any]] = []
+    gpt: list[dict[str, Any]] = []
+    other: list[dict[str, Any]] = []
+
+    for endpoint in endpoints if isinstance(endpoints, list) else []:
+        if not isinstance(endpoint, dict):
+            continue
+        name = endpoint.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        # Filter to chat/completion LLM endpoints (exclude embeddings/rerankers).
+        task = endpoint.get("task", "")
+        task_lower = task.lower() if isinstance(task, str) else ""
+        name_lower = name.lower()
+        if task_lower:
+            is_llm = any(t in task_lower for t in ("chat", "completion"))
+        else:
+            is_llm = any(
+                t in name_lower
+                for t in ("claude", "gpt", "codex", "gemini", "llama", "qwen", "kimi")
+            )
+        if not is_llm:
+            continue
+        state = endpoint.get("state")
+        ready = state.get("ready") if isinstance(state, dict) else None
+        if isinstance(ready, str) and ready and ready.upper() != "READY":
+            continue
+        entry: dict[str, Any] = {"id": name, "input": ["text", "image"]}
+        if "claude" in name_lower:
+            claude.append(entry)
+        elif "gpt" in name_lower:
+            gpt.append(entry)
+        else:
+            other.append(entry)
+
+    if not claude and not gpt and not other:
+        _LOGGER.info(
+            "pi-native: Databricks serving-endpoints returned no LLM models; "
+            "using bundled defaults"
+        )
+        return (
+            list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
+            list(_DATABRICKS_RESPONSES_NATIVE_MODELS),
+            [],
+        )
+
+    return claude, gpt, other
 
 
 def _gateway_anthropic_base_url(codex_base_url: str) -> str:
@@ -453,13 +596,26 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     if transport is None:
         return None
     api_key = f"!{transport.auth_command}"
-    # Derive the workspace serving-endpoints URL from the AI Gateway URL so Pi
-    # can also list GPT models. Falls back gracefully to Claude-only when the
-    # URL doesn't carry the expected ``ai-gateway`` label.
-    serving_endpoints = _gateway_serving_endpoints_url(transport.base_url)
+    # Derive the workspace base URL from the AI Gateway URL. Used for both the
+    # serving-endpoints OpenAI Completions base URL and the model-catalog API
+    # call. Falls back gracefully when the URL lacks the ai-gateway label.
+    workspace_url = _gateway_workspace_url(transport.base_url)
+    # Fetch the live model list. Run the auth command once to get the current
+    # token — Pi will refresh per request via the !command apiKey.
+    claude_models = list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS)
+    gpt_models = list(_DATABRICKS_RESPONSES_NATIVE_MODELS)
+    if workspace_url and transport.auth_command:
+        token = _run_auth_command(transport.auth_command)
+        if token:
+            live_claude, live_gpt, _ = _fetch_pi_model_lists(workspace_url, token)
+            claude_models, gpt_models = live_claude, live_gpt
     additional: dict[str, Any] = (
-        {_PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(api_key, serving_endpoints)}
-        if serving_endpoints
+        {
+            _PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(
+                api_key, f"{workspace_url}/serving-endpoints", gpt_models
+            )
+        }
+        if workspace_url and gpt_models
         else {}
     )
     return PiProviderConfig(
@@ -472,7 +628,7 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # request — matching codex-native's refresh semantics.
         api_key=api_key,
         auth_header=True,
-        extra_models=list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
+        extra_models=claude_models,
         additional_providers=additional,
     )
 

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -22,7 +22,7 @@ import json
 import logging
 import os
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -62,6 +62,34 @@ _PI_PROVIDER_ID = "omnigent"
 # default the in-process Databricks executor pins. Used when the session
 # carries no explicit model override.
 _DATABRICKS_PI_DEFAULT_MODEL = "databricks-claude-sonnet-4-6"
+
+# All Claude models available on the Databricks AI Gateway Anthropic surface.
+# Keep in sync with _DATABRICKS_ANTHROPIC_MODELS in omnigent/inner/pi_executor.py.
+# Declaring ``input`` is required so Pi's transformMessages doesn't strip
+# image blocks from vision-capable models.
+_DATABRICKS_ANTHROPIC_NATIVE_MODELS: list[dict[str, Any]] = [
+    {
+        "id": "databricks-claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "input": ["text", "image"],
+    },
+    {
+        "id": "databricks-claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "input": ["text", "image"],
+    },
+    {
+        "id": "databricks-claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5",
+        "contextWindow": 200000,
+        "maxTokens": 16384,
+        "input": ["text", "image"],
+    },
+]
 
 # Databricks AI Gateway Anthropic Messages surface. Pi speaks this protocol
 # natively (``api: anthropic-messages``); the gateway authenticates with a
@@ -145,14 +173,26 @@ class PiProviderConfig:
     model: str
     api_key: str
     auth_header: bool
+    # Full model list for providers that expose multiple models (e.g. the
+    # Databricks Anthropic gateway). Excluded from __hash__ so the frozen
+    # dataclass stays hashable even though list[dict] is not hashable.
+    extra_models: list[dict[str, Any]] = field(default_factory=list, hash=False)
 
     def to_models_config(self) -> dict[str, Any]:
         """Render this provider as a Pi ``models.json`` mapping."""
+        if self.extra_models:
+            # Include all known models, ensuring the selected model is present.
+            # The selected model may be a newer id not yet in the static list.
+            models: list[dict[str, Any]] = list(self.extra_models)
+            if not any(m.get("id") == self.model for m in models):
+                models.append({"id": self.model, "input": ["text", "image"]})
+        else:
+            models = [{"id": self.model}]
         provider: dict[str, Any] = {
             "baseUrl": self.base_url,
             "api": self.api,
             "apiKey": self.api_key,
-            "models": [{"id": self.model}],
+            "models": models,
         }
         if self.auth_header:
             provider["authHeader"] = True
@@ -187,6 +227,7 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # force-refreshes), matching codex-native's refresh semantics.
         api_key=f"!{auth_command}",
         auth_header=True,
+        extra_models=list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
     )
 
 
@@ -328,6 +369,7 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # request — matching codex-native's refresh semantics.
         api_key=f"!{transport.auth_command}",
         auth_header=True,
+        extra_models=list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
     )
 
 

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -67,67 +67,6 @@ _DATABRICKS_PI_DEFAULT_MODEL = "databricks-claude-sonnet-4-6"
 # the primary Anthropic provider in Databricks gateway configs.
 _PI_OPENAI_PROVIDER_ID = "omnigent-openai"
 
-# All Claude models available on the Databricks AI Gateway Anthropic surface.
-# Keep in sync with _DATABRICKS_ANTHROPIC_MODELS in omnigent/inner/pi_executor.py.
-# Declaring ``input`` is required so Pi's transformMessages doesn't strip
-# image blocks from vision-capable models.
-_DATABRICKS_ANTHROPIC_NATIVE_MODELS: list[dict[str, Any]] = [
-    {
-        "id": "databricks-claude-opus-4-8",
-        "name": "Claude Opus 4.8",
-        "contextWindow": 1000000,
-        "maxTokens": 128000,
-        "input": ["text", "image"],
-    },
-    {
-        "id": "databricks-claude-sonnet-4-6",
-        "name": "Claude Sonnet 4.6",
-        "contextWindow": 1000000,
-        "maxTokens": 128000,
-        "input": ["text", "image"],
-    },
-    {
-        "id": "databricks-claude-sonnet-4-5",
-        "name": "Claude Sonnet 4.5",
-        "contextWindow": 200000,
-        "maxTokens": 16384,
-        "input": ["text", "image"],
-    },
-]
-
-# GPT models available on the Databricks workspace serving-endpoints.
-# Keep in sync with _DATABRICKS_RESPONSES_MODELS in omnigent/inner/pi_executor.py.
-_DATABRICKS_RESPONSES_NATIVE_MODELS: list[dict[str, Any]] = [
-    {
-        "id": "databricks-gpt-5-4-mini",
-        "name": "GPT-5.4 Mini",
-        "contextWindow": 1047576,
-        "maxTokens": 32768,
-        "input": ["text", "image"],
-    },
-    {
-        "id": "databricks-gpt-5-4",
-        "name": "GPT-5.4",
-        "contextWindow": 1047576,
-        "maxTokens": 32768,
-        "input": ["text", "image"],
-    },
-    {
-        "id": "databricks-gpt-5-5",
-        "name": "GPT-5.5",
-        "contextWindow": 400000,
-        "maxTokens": 128000,
-        "input": ["text", "image"],
-    },
-    {
-        "id": "databricks-gpt-5-5-pro",
-        "name": "GPT-5.5 Pro",
-        "contextWindow": 400000,
-        "maxTokens": 128000,
-        "input": ["text", "image"],
-    },
-]
-
 # Databricks AI Gateway Anthropic Messages surface. Pi speaks this protocol
 # natively (``api: anthropic-messages``); the gateway authenticates with a
 # workspace bearer token, so we set ``authHeader`` (Authorization: Bearer).
@@ -272,10 +211,10 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         claude_models, gpt_models, _ = _fetch_pi_model_lists(creds.host, creds.token)
     except Exception:  # noqa: BLE001 — credential/network failure must not break launch
         _LOGGER.info(
-            "pi-native: falling back to bundled model list (could not resolve credentials)"
+            "pi-native: falling back to single-model display (could not resolve credentials)"
         )
-        claude_models = list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS)
-        gpt_models = list(_DATABRICKS_RESPONSES_NATIVE_MODELS)
+        claude_models = []
+        gpt_models = []
     return PiProviderConfig(
         provider_id=_PI_PROVIDER_ID,
         base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
@@ -406,16 +345,13 @@ def _fetch_pi_model_lists(
             )
             resp.raise_for_status()
             payload = resp.json()
-    except Exception:  # noqa: BLE001 — any HTTP/network failure falls back to statics
+    except Exception:  # noqa: BLE001 — HTTP/network failure → empty
         _LOGGER.warning(
-            "pi-native: could not fetch Databricks model list; using bundled defaults",
+            "pi-native: could not fetch Databricks model list; "
+            "Pi will show only the selected model",
             exc_info=True,
         )
-        return (
-            list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
-            list(_DATABRICKS_RESPONSES_NATIVE_MODELS),
-            [],
-        )
+        return [], [], []
 
     endpoints = payload.get("endpoints") if isinstance(payload, dict) else None
     claude: list[dict[str, Any]] = []
@@ -456,12 +392,7 @@ def _fetch_pi_model_lists(
     if not claude and not gpt and not other:
         _LOGGER.info(
             "pi-native: Databricks serving-endpoints returned no LLM models; "
-            "using bundled defaults"
-        )
-        return (
-            list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS),
-            list(_DATABRICKS_RESPONSES_NATIVE_MODELS),
-            [],
+            "Pi will show only the selected model"
         )
 
     return claude, gpt, other
@@ -602,8 +533,8 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     workspace_url = _gateway_workspace_url(transport.base_url)
     # Fetch the live model list. Run the auth command once to get the current
     # token — Pi will refresh per request via the !command apiKey.
-    claude_models = list(_DATABRICKS_ANTHROPIC_NATIVE_MODELS)
-    gpt_models = list(_DATABRICKS_RESPONSES_NATIVE_MODELS)
+    claude_models: list[dict[str, Any]] = []
+    gpt_models: list[dict[str, Any]] = []
     if workspace_url and transport.auth_command:
         token = _run_auth_command(transport.auth_command)
         if token:

--- a/tests/server/integration/test_hosts_worktrees.py
+++ b/tests/server/integration/test_hosts_worktrees.py
@@ -10,6 +10,7 @@ worktree picker (branch prefill / start-in-existing-worktree).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -170,6 +171,14 @@ async def wt_setup(
             await asyncio.wait_for(drain_task, timeout=1.0)
         except asyncio.TimeoutError:
             drain_task.cancel()
+        # Send an explicit disconnect so the tunnel endpoint's finally-block
+        # calls host_store.set_offline() and registry.deregister() before
+        # this fixture returns. Without this, those calls happen whenever the
+        # comm is GC'd — potentially during the next test's setup window.
+        # Swallow CancelledError: the asgiref communicator may already be done
+        # if the event loop cancelled its internal future during teardown.
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await comm.send_input({"type": "websocket.disconnect", "code": 1000})
 
 
 async def test_list_worktrees_returns_data(
@@ -230,10 +239,12 @@ async def test_list_worktrees_unknown_host_404(
 ) -> None:
     """An unknown host id yields 404 (existence is gated before the offline check)."""
     app, _reg, _hs, _cs = wt_app
+    # Use a host id that no other test or tunnel registers — never "offline", just absent.
+    unknown_id = "host_wt_does_not_exist"
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get(
-            f"/v1/hosts/{_HOST_ID}/worktrees",
+            f"/v1/hosts/{unknown_id}/worktrees",
             params={"path": "/Users/corey/repo"},
         )
-    # No host record was created (no tunnel connected) → 404, not 409.
+    # No host record exists for this id → 404, not 409 ("offline").
     assert resp.status_code == 404, resp.text

--- a/tests/server/integration/test_sessions_tool_result_forward.py
+++ b/tests/server/integration/test_sessions_tool_result_forward.py
@@ -12,6 +12,7 @@ fail-loud behavior with a stubbed runner (no real harness needed).
 
 from __future__ import annotations
 
+import unittest.mock
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -93,7 +94,6 @@ class _CaptureRunnerClient:
 async def test_function_call_output_forwarded_as_tool_result(
     auth_client: httpx.AsyncClient,
     db_uri: str,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The route translates function_call_output → tool_result verbatim.
 
@@ -109,17 +109,18 @@ async def test_function_call_output_forwarded_as_tool_result(
     async def _stub(*_: Any, **__: Any) -> _CaptureRunnerClient:
         return _CaptureRunnerClient(calls)
 
-    monkeypatch.setattr(sessions_mod, "_get_runner_client", _stub)
     session_id = _seed_session(db_uri)
-
-    resp = await auth_client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={
-            "type": "function_call_output",
-            "data": {"call_id": "call_x", "output": "calc-result"},
-        },
-        headers={"X-Forwarded-Email": _ALICE},
-    )
+    # Use unittest.mock.patch so cleanup is guaranteed even when pytest-asyncio
+    # fixture teardown ordering leaves monkeypatch undo too late (CI flake).
+    with unittest.mock.patch.object(sessions_mod, "_get_runner_client", _stub):
+        resp = await auth_client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "function_call_output",
+                "data": {"call_id": "call_x", "output": "calc-result"},
+            },
+            headers={"X-Forwarded-Email": _ALICE},
+        )
 
     assert resp.status_code == 202, resp.text
     assert resp.json() == {"queued": True, "item_id": "call_x"}
@@ -138,7 +139,6 @@ async def test_function_call_output_forwarded_as_tool_result(
 async def test_function_call_output_no_runner_returns_503(
     auth_client: httpx.AsyncClient,
     db_uri: str,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """No bound runner → 503 (the result can't be delivered)."""
     from omnigent.server.routes import sessions as sessions_mod
@@ -146,14 +146,13 @@ async def test_function_call_output_no_runner_returns_503(
     async def _stub_none(*_: Any, **__: Any) -> None:
         return None
 
-    monkeypatch.setattr(sessions_mod, "_get_runner_client", _stub_none)
     session_id = _seed_session(db_uri)
-
-    resp = await auth_client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "function_call_output", "data": {"call_id": "c", "output": "o"}},
-        headers={"X-Forwarded-Email": _ALICE},
-    )
+    with unittest.mock.patch.object(sessions_mod, "_get_runner_client", _stub_none):
+        resp = await auth_client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={"type": "function_call_output", "data": {"call_id": "c", "output": "o"}},
+            headers={"X-Forwarded-Email": _ALICE},
+        )
 
     assert resp.status_code == 503, resp.text
 
@@ -162,7 +161,6 @@ async def test_function_call_output_no_runner_returns_503(
 async def test_function_call_output_runner_error_returns_503(
     auth_client: httpx.AsyncClient,
     db_uri: str,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A transport failure forwarding the tool_result fails loud (503).
 
@@ -182,13 +180,12 @@ async def test_function_call_output_runner_error_returns_503(
     async def _stub_failing(*_: Any, **__: Any) -> _FailingRunnerClient:
         return _FailingRunnerClient()
 
-    monkeypatch.setattr(sessions_mod, "_get_runner_client", _stub_failing)
     session_id = _seed_session(db_uri)
-
-    resp = await auth_client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "function_call_output", "data": {"call_id": "c", "output": "o"}},
-        headers={"X-Forwarded-Email": _ALICE},
-    )
+    with unittest.mock.patch.object(sessions_mod, "_get_runner_client", _stub_failing):
+        resp = await auth_client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={"type": "function_call_output", "data": {"call_id": "c", "output": "o"}},
+            headers={"X-Forwarded-Email": _ALICE},
+        )
 
     assert resp.status_code == 503, resp.text

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -824,3 +824,59 @@ def test_inline_family_passes_non_mechanical_override_through() -> None:
     assert provider.model == "zai-org/GLM-4.7"
     cfg = provider.to_models_config()
     assert cfg["providers"]["omnigent"]["models"] == [{"id": "zai-org/GLM-4.7"}]
+
+
+def test_databricks_profile_registers_gpt_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Databricks profile provider includes an OpenAI Completions provider for GPT models.
+
+    The ``omnigent-openai`` provider targets ``/serving-endpoints`` so Pi's
+    /model command exposes GPT models alongside the Claude models.
+    """
+    from omnigent.inner import databricks_executor
+
+    monkeypatch.setattr(
+        databricks_executor,
+        "_read_databrickscfg_host",
+        lambda profile: "https://wkspc.example.com/",
+    )
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+    assert provider is not None
+
+    cfg = provider.to_models_config()
+    openai_entry = cfg["providers"].get("omnigent-openai")
+    assert openai_entry is not None, "omnigent-openai provider missing from models.json"
+    assert openai_entry["baseUrl"] == "https://wkspc.example.com/serving-endpoints"
+    assert openai_entry["api"] == "openai-completions"
+    gpt_ids = [m["id"] for m in openai_entry["models"]]
+    assert "databricks-gpt-5-4" in gpt_ids
+    assert "databricks-gpt-5-5" in gpt_ids
+
+
+def test_cli_config_databricks_registers_gpt_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config Databricks AI Gateway provider also registers GPT models.
+
+    The workspace serving-endpoints URL is derived from the AI Gateway URL by
+    removing the ``ai-gateway`` DNS label, so GPT models appear alongside
+    Claude models in Pi's /model output.
+    """
+    _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
+    assert provider is not None
+
+    cfg = provider.to_models_config()
+    openai_entry = cfg["providers"].get("omnigent-openai")
+    assert openai_entry is not None, "omnigent-openai provider missing from models.json"
+    # ai-gateway. label stripped from the gateway hostname → workspace serving-endpoints
+    assert (
+        openai_entry["baseUrl"]
+        == "https://1965859176160743.cloud.databricks.com/serving-endpoints"
+    )
+    assert openai_entry["api"] == "openai-completions"
+    gpt_ids = [m["id"] for m in openai_entry["models"]]
+    assert "databricks-gpt-5-4" in gpt_ids
+    assert "databricks-gpt-5-5" in gpt_ids

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -880,3 +880,75 @@ def test_cli_config_databricks_registers_gpt_provider(
     gpt_ids = [m["id"] for m in openai_entry["models"]]
     assert "databricks-gpt-5-4" in gpt_ids
     assert "databricks-gpt-5-5" in gpt_ids
+
+
+def test_fetch_pi_model_lists_parses_serving_endpoints() -> None:
+    """_fetch_pi_model_lists splits live endpoints by family into Pi model dicts."""
+    import json
+    import unittest.mock
+
+    import httpx
+
+    payload = {
+        "endpoints": [
+            {
+                "name": "databricks-claude-sonnet-4-6",
+                "task": "llm/v1/chat",
+                "state": {"ready": "READY"},
+            },
+            {
+                "name": "databricks-claude-opus-4-8",
+                "task": "llm/v1/chat",
+                "state": {"ready": "READY"},
+            },
+            {"name": "databricks-gpt-5-4", "task": "llm/v1/chat", "state": {"ready": "READY"}},
+            {"name": "databricks-llama-3-70b", "task": "llm/v1/chat", "state": {"ready": "READY"}},
+            {"name": "my-embedding-model", "task": "llm/v1/embeddings"},
+            {"name": "databricks-gpt-5-5", "task": "llm/v1/chat", "state": {"ready": "NOT_READY"}},
+        ]
+    }
+
+    class _MockTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            assert "/api/2.0/serving-endpoints" in str(request.url)
+            assert request.headers["authorization"].startswith("Bearer ")
+            return httpx.Response(200, content=json.dumps(payload).encode())
+
+    _real_client = httpx.Client
+    with unittest.mock.patch(
+        "httpx.Client",
+        lambda **kw: _real_client(transport=_MockTransport()),
+    ):
+        claude, gpt, other = creds._fetch_pi_model_lists("https://wkspc.example.com", "tok")
+
+    assert [m["id"] for m in claude] == [
+        "databricks-claude-sonnet-4-6",
+        "databricks-claude-opus-4-8",
+    ]
+    assert [m["id"] for m in gpt] == ["databricks-gpt-5-4"]
+    assert [m["id"] for m in other] == ["databricks-llama-3-70b"]
+    assert all(m.get("input") == ["text", "image"] for m in claude + gpt + other)
+
+
+def test_fetch_pi_model_lists_falls_back_on_http_error() -> None:
+    """_fetch_pi_model_lists returns static defaults when the API call fails."""
+    import unittest.mock
+
+    import httpx
+
+    class _ErrorTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401)
+
+    _real_client = httpx.Client
+    with unittest.mock.patch(
+        "httpx.Client",
+        lambda **kw: _real_client(transport=_ErrorTransport()),
+    ):
+        claude, gpt, _ = creds._fetch_pi_model_lists("https://wkspc.example.com", "bad-tok")
+
+    claude_ids = [m["id"] for m in claude]
+    assert "databricks-claude-sonnet-4-6" in claude_ids
+    assert "databricks-claude-opus-4-8" in claude_ids
+    gpt_ids = [m["id"] for m in gpt]
+    assert "databricks-gpt-5-4" in gpt_ids

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -697,9 +697,14 @@ def test_model_override_beats_databricks_default(monkeypatch: pytest.MonkeyPatch
 
     assert provider is not None
     assert provider.model == "databricks-claude-opus-4-7"
-    # The override flows all the way into the rendered models.json.
+    # The override flows all the way into the rendered models.json. The full
+    # Databricks Anthropic model list is registered so Pi's /model shows all
+    # available models; the override is appended when not in the static list.
     cfg = provider.to_models_config()
-    assert cfg["providers"]["omnigent"]["models"] == [{"id": "databricks-claude-opus-4-7"}]
+    model_ids = [m["id"] for m in cfg["providers"]["omnigent"]["models"]]
+    assert "databricks-claude-opus-4-7" in model_ids
+    assert "databricks-claude-sonnet-4-6" in model_ids
+    assert "databricks-claude-opus-4-8" in model_ids
 
 
 def test_model_override_beats_inline_family_default() -> None:

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -697,14 +697,12 @@ def test_model_override_beats_databricks_default(monkeypatch: pytest.MonkeyPatch
 
     assert provider is not None
     assert provider.model == "databricks-claude-opus-4-7"
-    # The override flows all the way into the rendered models.json. The full
-    # Databricks Anthropic model list is registered so Pi's /model shows all
-    # available models; the override is appended when not in the static list.
+    # The override flows into the rendered models.json. When the live model
+    # fetch fails (no real credentials in tests), only the selected model is
+    # shown — no stale hardcoded list.
     cfg = provider.to_models_config()
     model_ids = [m["id"] for m in cfg["providers"]["omnigent"]["models"]]
     assert "databricks-claude-opus-4-7" in model_ids
-    assert "databricks-claude-sonnet-4-6" in model_ids
-    assert "databricks-claude-opus-4-8" in model_ids
 
 
 def test_model_override_beats_inline_family_default() -> None:
@@ -830,7 +828,7 @@ def test_databricks_profile_registers_gpt_provider(monkeypatch: pytest.MonkeyPat
     """A Databricks profile provider includes an OpenAI Completions provider for GPT models.
 
     The ``omnigent-openai`` provider targets ``/serving-endpoints`` so Pi's
-    /model command exposes GPT models alongside the Claude models.
+    /model command exposes GPT models returned by the live serving-endpoints API.
     """
     from omnigent.inner import databricks_executor
 
@@ -839,6 +837,17 @@ def test_databricks_profile_registers_gpt_provider(monkeypatch: pytest.MonkeyPat
         "_read_databrickscfg_host",
         lambda profile: "https://wkspc.example.com/",
     )
+    # Mock credential resolution and live fetch — no real Databricks profile needed.
+    from omnigent.runtime.credentials import databricks as db_creds_mod
+
+    monkeypatch.setattr(
+        db_creds_mod,
+        "resolve_databricks_workspace",
+        lambda profile: db_creds_mod.WorkspaceCreds(host="https://wkspc.example.com", token="tok"),
+    )
+    live_gpt = [{"id": "databricks-gpt-5-4", "input": ["text", "image"]}]
+    live_claude = [{"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]}]
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: (live_claude, live_gpt, []))
 
     provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
     assert provider is not None
@@ -848,9 +857,7 @@ def test_databricks_profile_registers_gpt_provider(monkeypatch: pytest.MonkeyPat
     assert openai_entry is not None, "omnigent-openai provider missing from models.json"
     assert openai_entry["baseUrl"] == "https://wkspc.example.com/serving-endpoints"
     assert openai_entry["api"] == "openai-completions"
-    gpt_ids = [m["id"] for m in openai_entry["models"]]
-    assert "databricks-gpt-5-4" in gpt_ids
-    assert "databricks-gpt-5-5" in gpt_ids
+    assert any(m["id"] == "databricks-gpt-5-4" for m in openai_entry["models"])
 
 
 def test_cli_config_databricks_registers_gpt_provider(
@@ -864,6 +871,11 @@ def test_cli_config_databricks_registers_gpt_provider(
     """
     _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
     monkeypatch.setenv("HOME", str(tmp_path))
+    # Stub the auth command (jq would fail in CI) and the live fetch.
+    live_gpt = [{"id": "databricks-gpt-5-4", "input": ["text", "image"]}]
+    live_claude = [{"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]}]
+    monkeypatch.setattr(creds, "_run_auth_command", lambda *_: "fake-token")
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: (live_claude, live_gpt, []))
 
     provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
     assert provider is not None
@@ -877,9 +889,7 @@ def test_cli_config_databricks_registers_gpt_provider(
         == "https://1965859176160743.cloud.databricks.com/serving-endpoints"
     )
     assert openai_entry["api"] == "openai-completions"
-    gpt_ids = [m["id"] for m in openai_entry["models"]]
-    assert "databricks-gpt-5-4" in gpt_ids
-    assert "databricks-gpt-5-5" in gpt_ids
+    assert any(m["id"] == "databricks-gpt-5-4" for m in openai_entry["models"])
 
 
 def test_fetch_pi_model_lists_parses_serving_endpoints() -> None:
@@ -931,7 +941,11 @@ def test_fetch_pi_model_lists_parses_serving_endpoints() -> None:
 
 
 def test_fetch_pi_model_lists_falls_back_on_http_error() -> None:
-    """_fetch_pi_model_lists returns static defaults when the API call fails."""
+    """_fetch_pi_model_lists returns empty lists when the API call fails.
+
+    Empty lists → to_models_config() falls back to single-model display.
+    No stale hardcoded list is used.
+    """
     import unittest.mock
 
     import httpx
@@ -945,10 +959,8 @@ def test_fetch_pi_model_lists_falls_back_on_http_error() -> None:
         "httpx.Client",
         lambda **kw: _real_client(transport=_ErrorTransport()),
     ):
-        claude, gpt, _ = creds._fetch_pi_model_lists("https://wkspc.example.com", "bad-tok")
+        claude, gpt, other = creds._fetch_pi_model_lists("https://wkspc.example.com", "bad-tok")
 
-    claude_ids = [m["id"] for m in claude]
-    assert "databricks-claude-sonnet-4-6" in claude_ids
-    assert "databricks-claude-opus-4-8" in claude_ids
-    gpt_ids = [m["id"] for m in gpt]
-    assert "databricks-gpt-5-4" in gpt_ids
+    assert claude == []
+    assert gpt == []
+    assert other == []


### PR DESCRIPTION
## Related issue

N/A

## Summary

Pi's `/model` command only showed a single model (`databricks-claude-sonnet-4-6`) when running through Omnigent with the Databricks gateway. This PR fixes the native terminal path in three commits:

**Commit 1 — Claude models:** Register all 3 bundled Claude models in `models.json` so Pi's `/model` shows them instead of just the default.

**Commit 2 — GPT models:** Register a second `omnigent-openai` provider pointing at `{workspace}/serving-endpoints` so GPT models also appear. The workspace URL is derived from the AI Gateway URL by stripping the `ai-gateway` DNS label.

**Commit 3 — Live model list:** Replace the hardcoded static lists with a live call to `GET <workspace>/api/2.0/serving-endpoints` at Pi session creation time, so Pi shows exactly the endpoints available on the workspace.

- Add `_fetch_pi_model_lists(workspace_url, token)` — calls the API, filters READY LLM endpoints, splits by family (claude/gpt/other), returns Pi model entry dicts. Falls back to static bundled lists on any failure.
- Add `_run_auth_command(cmd)` — runs the `!command` string once at session creation to get a short-lived token for the catalog call.
- `_databricks_pi_provider` (profile kind): uses `resolve_databricks_workspace()` for the token.
- `_cli_config_pi_provider` (AI Gateway kind): runs the transport auth command for the token; derives workspace URL by stripping `ai-gateway.` from the gateway hostname.
- Static lists remain as fallback if credentials can't be resolved or the API is unreachable.

## Test Plan

- All 49 `tests/test_pi_native_credentials.py` tests pass
- `test_fetch_pi_model_lists_parses_serving_endpoints` — exercises the full parse/filter/split logic with a mock HTTP transport
- `test_fetch_pi_model_lists_falls_back_on_http_error` — asserts 401 response falls back to static defaults
- Existing Databricks tests continue to pass via the fallback path (no real credentials in CI)

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A

## Changelog

Pi's `/model` command now shows all LLM models available on your Databricks workspace (fetched live from the serving-endpoints API) instead of a hardcoded list