### PR TITLE
feat(UI): Show per-file line-change counts in changed-files panel

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -17073,6 +17073,8 @@ def create_runner_app(
                 "status": rec["status"],
                 "bytes": rec.get("bytes"),
                 "modified_at": rec.get("modified_at"),
+                "lines_added": rec.get("lines_added"),
+                "lines_removed": rec.get("lines_removed"),
             }
             for rec in raw_changes
         ]

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -35,12 +35,6 @@ from typing import Any
 
 _logger = logging.getLogger(__name__)
 
-# Cap for reading an untracked file just to count its lines for the changed-files
-# badge. Mirrors the canonical read cap in
-# ``omnigent.runner.environment_filesystem._MAX_READ_BYTES`` (10 MiB); not imported
-# to avoid a runtime→runner layering dependency on a private name.
-_MAX_READ_BYTES = 10 * 1024 * 1024  # 10 MiB
-
 
 class GitStatusUnavailable(RuntimeError):
     """A ``git`` invocation backing the changed-files view could not complete.
@@ -771,7 +765,9 @@ class GitFilesystemRegistry(FilesystemRegistry):
             first_component = Path(rel_path).parts[0] if Path(rel_path).parts else ""
             if first_component in _SKIP_DIRS:
                 continue
-            counts = self._line_counts(rel_path, operation, numstat)
+            # Counts come only from `git diff HEAD` (via numstat). Files git
+            # doesn't diff — untracked new files, binaries — get no counter.
+            counts = numstat.get(rel_path, (None, None))
             records.append(self._make_record(rel_path, operation, counts))
 
         records.sort(key=lambda r: (r["modified_at"] or 0, r["path"]), reverse=True)
@@ -940,47 +936,6 @@ class GitFilesystemRegistry(FilesystemRegistry):
             "lines_added": added,
             "lines_removed": removed,
         }
-
-    def _line_counts(
-        self,
-        rel_path: str,
-        operation: str,
-        numstat: dict[str, tuple[int | None, int | None]],
-    ) -> tuple[int | None, int | None]:
-        """Return ``(lines_added, lines_removed)`` for a changed file.
-
-        Tracked changes come from *numstat*. Untracked new files are absent
-        from ``git diff HEAD``, so their added-line count is read directly off
-        disk (removed is 0). Anything else — a binary file (numstat ``-``), a
-        path missing from numstat, or an unreadable untracked file — is
-        ``(None, None)`` so the UI omits the counter.
-
-        :param rel_path: Path relative to ``self._cwd``.
-        :param operation: Net operation for the file.
-        :param numstat: Map of cwd-relative path → ``(added, removed)``.
-        :returns: ``(lines_added, lines_removed)``, each possibly ``None``.
-        """
-        if rel_path in numstat:
-            return numstat[rel_path]
-        if operation == "created":
-            # Untracked new file: absent from `git diff HEAD`, so count its
-            # lines directly. Skip files too large to slurp for a badge, and
-            # skip binaries (NUL byte) — both would otherwise return a bogus
-            # count. Degrades to (None, None) so the UI omits the counter.
-            abs_path = self._cwd / rel_path
-            try:
-                if abs_path.stat().st_size > _MAX_READ_BYTES:
-                    return (None, None)
-                data = abs_path.read_bytes()
-            except OSError:
-                return (None, None)
-            if b"\x00" in data:  # binary; mirrors environment_filesystem NUL check
-                return (None, None)
-            # Count lines, treating a missing final newline as one more line
-            # (matches str.splitlines(): "a\nb\nc" → 3). Empty file → 0.
-            added = data.count(b"\n") + (1 if data and not data.endswith(b"\n") else 0)
-            return (added, 0)
-        return (None, None)
 
     def _run_git_numstat(self) -> dict[str, tuple[int | None, int | None]]:
         """Return per-file line counts from ``git diff --numstat HEAD``.

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -35,6 +35,11 @@ from typing import Any
 
 _logger = logging.getLogger(__name__)
 
+# Wall-clock cap for git subprocesses backing the changed-files view. Kept
+# short so a slow/hung repo can't block the panel; each call degrades cleanly
+# on timeout rather than raising. Bump if very large repos need more headroom.
+_GIT_TIMEOUT_SECONDS = 5
+
 
 class GitStatusUnavailable(RuntimeError):
     """A ``git`` invocation backing the changed-files view could not complete.
@@ -711,7 +716,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 argv,
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=5,
+                timeout=_GIT_TIMEOUT_SECONDS,
             )
         except subprocess.TimeoutExpired as exc:
             elapsed = time.monotonic() - started
@@ -806,7 +811,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 argv,
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=5,
+                timeout=_GIT_TIMEOUT_SECONDS,
             )
         except subprocess.TimeoutExpired as exc:
             elapsed = time.monotonic() - started
@@ -874,7 +879,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 ["git", "show", f"HEAD:{git_path}"],
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=5,
+                timeout=_GIT_TIMEOUT_SECONDS,
             )
             if result.returncode == 0:
                 return result.stdout.decode("utf-8", errors="replace")
@@ -957,7 +962,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 argv,
                 cwd=str(self._git_root),
                 capture_output=True,
-                timeout=5,
+                timeout=_GIT_TIMEOUT_SECONDS,
             )
         except (subprocess.TimeoutExpired, OSError):
             _logger.warning(

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -35,6 +35,12 @@ from typing import Any
 
 _logger = logging.getLogger(__name__)
 
+# Cap for reading an untracked file just to count its lines for the changed-files
+# badge. Mirrors the canonical read cap in
+# ``omnigent.runner.environment_filesystem._MAX_READ_BYTES`` (10 MiB); not imported
+# to avoid a runtime→runner layering dependency on a private name.
+_MAX_READ_BYTES = 10 * 1024 * 1024  # 10 MiB
+
 
 class GitStatusUnavailable(RuntimeError):
     """A ``git`` invocation backing the changed-files view could not complete.
@@ -748,6 +754,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 f"git status exited {result.returncode}" + (f": {stderr}" if stderr else "")
             )
 
+        numstat = self._run_git_numstat()
         records: list[dict[str, Any]] = []
         for line in result.stdout.decode("utf-8", errors="replace").splitlines():
             parsed = _parse_git_porcelain_line(line)
@@ -764,7 +771,8 @@ class GitFilesystemRegistry(FilesystemRegistry):
             first_component = Path(rel_path).parts[0] if Path(rel_path).parts else ""
             if first_component in _SKIP_DIRS:
                 continue
-            records.append(self._make_record(rel_path, operation))
+            counts = self._line_counts(rel_path, operation, numstat)
+            records.append(self._make_record(rel_path, operation, counts))
 
         records.sort(key=lambda r: (r["modified_at"] or 0, r["path"]), reverse=True)
         return records[:limit]
@@ -897,13 +905,22 @@ class GitFilesystemRegistry(FilesystemRegistry):
         except ValueError:
             return None
 
-    def _make_record(self, rel_path: str, operation: str) -> dict[str, Any]:
+    def _make_record(
+        self,
+        rel_path: str,
+        operation: str,
+        line_counts: tuple[int | None, int | None] = (None, None),
+    ) -> dict[str, Any]:
         """Build a file-record dict for *rel_path*.
 
         :param rel_path: Path relative to ``self._cwd``.
         :param operation: One of ``"created"``, ``"modified"``, ``"deleted"``.
-        :returns: File-record dict with ``path``, ``status``, ``bytes``, and
-            ``modified_at`` fields.
+        :param line_counts: ``(lines_added, lines_removed)`` for this file, each
+            ``None`` when unknown (binary file, path missing from numstat, or
+            numstat unavailable). Defaults to ``(None, None)`` so callers that
+            don't need counts (e.g. the diff endpoint) can omit them.
+        :returns: File-record dict with ``path``, ``status``, ``bytes``,
+            ``modified_at``, ``lines_added``, and ``lines_removed`` fields.
         """
         bytes_: int | None = None
         modified_at: int | None = None
@@ -914,7 +931,105 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 modified_at = int(st.st_mtime)
             except OSError:
                 pass
-        return {"path": rel_path, "status": operation, "bytes": bytes_, "modified_at": modified_at}
+        added, removed = line_counts
+        return {
+            "path": rel_path,
+            "status": operation,
+            "bytes": bytes_,
+            "modified_at": modified_at,
+            "lines_added": added,
+            "lines_removed": removed,
+        }
+
+    def _line_counts(
+        self,
+        rel_path: str,
+        operation: str,
+        numstat: dict[str, tuple[int | None, int | None]],
+    ) -> tuple[int | None, int | None]:
+        """Return ``(lines_added, lines_removed)`` for a changed file.
+
+        Tracked changes come from *numstat*. Untracked new files are absent
+        from ``git diff HEAD``, so their added-line count is read directly off
+        disk (removed is 0). Anything else — a binary file (numstat ``-``), a
+        path missing from numstat, or an unreadable untracked file — is
+        ``(None, None)`` so the UI omits the counter.
+
+        :param rel_path: Path relative to ``self._cwd``.
+        :param operation: Net operation for the file.
+        :param numstat: Map of cwd-relative path → ``(added, removed)``.
+        :returns: ``(lines_added, lines_removed)``, each possibly ``None``.
+        """
+        if rel_path in numstat:
+            return numstat[rel_path]
+        if operation == "created":
+            # Untracked new file: absent from `git diff HEAD`, so count its
+            # lines directly. Skip files too large to slurp for a badge, and
+            # skip binaries (NUL byte) — both would otherwise return a bogus
+            # count. Degrades to (None, None) so the UI omits the counter.
+            abs_path = self._cwd / rel_path
+            try:
+                if abs_path.stat().st_size > _MAX_READ_BYTES:
+                    return (None, None)
+                data = abs_path.read_bytes()
+            except OSError:
+                return (None, None)
+            if b"\x00" in data:  # binary; mirrors environment_filesystem NUL check
+                return (None, None)
+            # Count lines, treating a missing final newline as one more line
+            # (matches str.splitlines(): "a\nb\nc" → 3). Empty file → 0.
+            added = data.count(b"\n") + (1 if data and not data.endswith(b"\n") else 0)
+            return (added, 0)
+        return (None, None)
+
+    def _run_git_numstat(self) -> dict[str, tuple[int | None, int | None]]:
+        """Return per-file line counts from ``git diff --numstat HEAD``.
+
+        ``--no-renames`` splits renames into delete+add so the paths line up
+        with ``git status``'s destination-only entries rather than an
+        ``old -> new`` pair. Binary files report ``-\\t-`` → ``(None, None)``.
+        Paths are keyed cwd-relative via :meth:`_git_to_rel`.
+
+        Never raises: a numstat failure (timeout, spawn error, non-zero exit)
+        returns ``{}`` so the changed-files list still renders with counts
+        degraded to ``None``. This is the sole guard for numstat failures.
+
+        :returns: Map of cwd-relative path → ``(lines_added, lines_removed)``.
+        """
+        argv = ["git", "diff", "--numstat", "--no-renames", "HEAD"]
+        try:
+            result = subprocess.run(
+                argv,
+                cwd=str(self._git_root),
+                capture_output=True,
+                timeout=5,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            _logger.warning(
+                "GitFilesystemRegistry._run_git_numstat: %r in %s failed",
+                argv,
+                self._git_root,
+                exc_info=True,
+            )
+            return {}
+        if result.returncode != 0:
+            return {}
+        counts: dict[str, tuple[int | None, int | None]] = {}
+        for line in result.stdout.decode("utf-8", errors="replace").splitlines():
+            fields = line.split("\t")
+            if len(fields) != 3:
+                continue
+            added_s, removed_s, git_path = fields
+            rel_path = self._git_to_rel(_strip_git_quotes(git_path))
+            if rel_path is None:
+                continue
+            try:
+                added = None if added_s == "-" else int(added_s)
+                removed = None if removed_s == "-" else int(removed_s)
+            except ValueError:
+                continue
+            counts[rel_path] = (added, removed)
+        return counts
 
 
 # ── Factory ───────────────────────────────────────────────────────────────────

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -945,10 +945,12 @@ class GitFilesystemRegistry(FilesystemRegistry):
     def _run_git_numstat(self) -> dict[str, tuple[int | None, int | None]]:
         """Return per-file line counts from ``git diff --numstat HEAD``.
 
-        ``--no-renames`` splits renames into delete+add so the paths line up
-        with ``git status``'s destination-only entries rather than an
-        ``old -> new`` pair. Binary files report ``-\\t-`` → ``(None, None)``.
-        Paths are keyed cwd-relative via :meth:`_git_to_rel`.
+        ``--no-renames`` splits a rename into two independent entries — a full
+        add on the destination path and a full delete on the old path — so the
+        paths line up with ``git status``'s destination-only entries rather than
+        an ``old -> new`` pair. (A pure rename therefore shows ``+N`` on the
+        moved file, not ``(None, None)``.) Binary files report ``-\\t-`` →
+        ``(None, None)``. Paths are keyed cwd-relative via :meth:`_git_to_rel`.
 
         Never raises: a numstat failure (timeout, spawn error, non-zero exit)
         returns ``{}`` so the changed-files list still renders with counts

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -773,6 +773,11 @@ async def test_filesystem_changes_modified(
     entries_by_path = {e["path"]: e for e in body["data"]}
     assert "hello.txt" in entries_by_path, "Modified file must appear in changes"
     assert entries_by_path["hello.txt"]["status"] == "modified"
+    # Line-count fields are always serialized; null in non-git (agent-edit)
+    # mode since those records carry no counts (see .get() in the endpoint).
+    entry = entries_by_path["hello.txt"]
+    assert entry["lines_added"] is None
+    assert entry["lines_removed"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -926,3 +926,136 @@ def test_unquote_git_path(raw: str, expected: str) -> None:
     assert result == expected, (
         f"_unquote_git_path({raw!r}) returned {result!r}, expected {expected!r}."
     )
+
+
+# ── Git-mode line counts (numstat) ─────────────────────────────────────────
+
+
+def _init_git_with_commit(tmp_path: Path, name: str, content: str) -> dict[str, str]:
+    """Init a git repo in *tmp_path* with one committed file, return the env."""
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    (tmp_path / name).write_text(content)
+    subprocess.run(["git", "add", name], cwd=tmp_path, check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=tmp_path, check=True, capture_output=True, env=env
+    )
+    return env
+
+
+def test_git_line_counts_modified(tmp_path: Path) -> None:
+    """A tracked modified file reports added/removed line counts from numstat."""
+    _init_git_with_commit(tmp_path, "f.py", "a\nb\nc\n")
+    (tmp_path / "f.py").write_text("a\nB\nc\nd\n")  # 1 line changed, 1 added → +2 -1
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    [rec] = reg.list_changed_files("any-conv", limit=100)
+    assert rec["status"] == "modified"
+    assert rec["lines_added"] == 2, rec
+    assert rec["lines_removed"] == 1, rec
+
+
+def test_git_line_counts_untracked_added_only(tmp_path: Path) -> None:
+    """An untracked new file (absent from `git diff HEAD`) reports adds only."""
+    _init_git_with_commit(tmp_path, "committed.py", "x\n")
+    (tmp_path / "new.py").write_text("one\ntwo\nthree\n")
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "new.py")
+    assert rec["status"] == "created"
+    assert rec["lines_added"] == 3, rec
+    assert rec["lines_removed"] == 0, rec
+
+
+def test_git_line_counts_deleted_removed_only(tmp_path: Path) -> None:
+    """A deleted tracked file reports removed lines only (added side is 0)."""
+    _init_git_with_commit(tmp_path, "gone.py", "a\nb\nc\n")
+    (tmp_path / "gone.py").unlink()
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    [rec] = reg.list_changed_files("any-conv", limit=100)
+    assert rec["status"] == "deleted"
+    assert rec["lines_added"] == 0, rec
+    assert rec["lines_removed"] == 3, rec
+
+
+def test_git_line_counts_binary_is_none(tmp_path: Path) -> None:
+    """A binary file reports (None, None) — numstat emits `-\\t-`."""
+    _init_git_with_commit(tmp_path, "keep.txt", "hi\n")
+    (tmp_path / "img.bin").write_bytes(bytes(range(256)) * 4)
+    subprocess.run(
+        ["git", "add", "img.bin"], cwd=tmp_path, check=True, capture_output=True, env=_git_env()
+    )
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "img.bin")
+    assert rec["lines_added"] is None, rec
+    assert rec["lines_removed"] is None, rec
+
+
+def test_git_line_counts_untracked_binary_is_none(tmp_path: Path) -> None:
+    """An untracked binary file (NUL bytes, never git-add'd) reports (None, None).
+
+    Regression guard: the untracked-`created` branch reads the file to count
+    lines; without a NUL check it returned a bogus count for binaries (a
+    downloaded PNG rendered "+N"). The tracked-binary case is covered by
+    numstat's `-\\t-`; this covers the untracked case that bypasses numstat.
+    """
+    _init_git_with_commit(tmp_path, "keep.txt", "hi\n")
+    # Fake PNG header with an embedded NUL — untracked (not git-add'd).
+    (tmp_path / "fake.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "fake.png")
+    assert rec["status"] == "created"
+    assert rec["lines_added"] is None, rec
+    assert rec["lines_removed"] is None, rec
+
+
+def test_git_line_counts_untracked_large_file_is_none(tmp_path: Path, monkeypatch) -> None:
+    """An untracked file over the read cap reports (None, None), not a full read.
+
+    Regression guard: the untracked-`created` branch used to slurp the whole
+    file into memory to count lines (a 22 MB file rendered "+220000"). The cap
+    is monkeypatched tiny so the test stays fast rather than writing 10 MiB.
+    """
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry._MAX_READ_BYTES", 16)
+    _init_git_with_commit(tmp_path, "keep.txt", "hi\n")
+    # Untracked text file larger than the (patched) 16-byte cap.
+    (tmp_path / "big.txt").write_text("line\n" * 100)
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "big.txt")
+    assert rec["status"] == "created"
+    assert rec["lines_added"] is None, rec
+    assert rec["lines_removed"] is None, rec
+
+
+def test_git_line_counts_numstat_failure_degrades_but_status_intact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If numstat fails, counts are None but the status list still renders.
+
+    Only the numstat subprocess is broken; `git status` still runs, so the
+    file must still appear (with counts degraded to None) rather than the whole
+    list failing.
+    """
+    _init_git_with_commit(tmp_path, "f.py", "a\nb\n")
+    (tmp_path / "f.py").write_text("a\nb\nc\n")
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    real_run = subprocess.run
+
+    def _fail_numstat(argv, *args, **kwargs):
+        if isinstance(argv, list) and "--numstat" in argv:
+            raise subprocess.TimeoutExpired(cmd="git diff --numstat", timeout=5)
+        return real_run(argv, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "omnigent.runtime.filesystem_registry.subprocess.run", _fail_numstat
+    )
+
+    [rec] = reg.list_changed_files("any-conv", limit=100)
+    assert rec["status"] == "modified"
+    assert rec["lines_added"] is None, rec
+    assert rec["lines_removed"] is None, rec

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -955,10 +955,29 @@ def test_git_line_counts_modified(tmp_path: Path) -> None:
     assert rec["lines_removed"] == 1, rec
 
 
-def test_git_line_counts_untracked_added_only(tmp_path: Path) -> None:
-    """An untracked new file (absent from `git diff HEAD`) reports adds only."""
+def test_git_line_counts_untracked_is_none(tmp_path: Path) -> None:
+    """An untracked new file (absent from `git diff HEAD`) reports no counts.
+
+    Counts come only from numstat; git doesn't diff untracked files, so the UI
+    omits the counter for them — matching VS Code / Cursor's source-control view.
+    """
     _init_git_with_commit(tmp_path, "committed.py", "x\n")
     (tmp_path / "new.py").write_text("one\ntwo\nthree\n")
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "new.py")
+    assert rec["status"] == "created"
+    assert rec["lines_added"] is None, rec
+    assert rec["lines_removed"] is None, rec
+
+
+def test_git_line_counts_staged_new_file_added_only(tmp_path: Path) -> None:
+    """A staged new file IS in `git diff HEAD`, so it reports adds from numstat."""
+    _init_git_with_commit(tmp_path, "committed.py", "x\n")
+    (tmp_path / "new.py").write_text("one\ntwo\nthree\n")
+    subprocess.run(
+        ["git", "add", "new.py"], cwd=tmp_path, check=True, capture_output=True, env=_git_env()
+    )
 
     reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
     rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "new.py")
@@ -993,44 +1012,6 @@ def test_git_line_counts_binary_is_none(tmp_path: Path) -> None:
     assert rec["lines_removed"] is None, rec
 
 
-def test_git_line_counts_untracked_binary_is_none(tmp_path: Path) -> None:
-    """An untracked binary file (NUL bytes, never git-add'd) reports (None, None).
-
-    Regression guard: the untracked-`created` branch reads the file to count
-    lines; without a NUL check it returned a bogus count for binaries (a
-    downloaded PNG rendered "+N"). The tracked-binary case is covered by
-    numstat's `-\\t-`; this covers the untracked case that bypasses numstat.
-    """
-    _init_git_with_commit(tmp_path, "keep.txt", "hi\n")
-    # Fake PNG header with an embedded NUL — untracked (not git-add'd).
-    (tmp_path / "fake.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
-
-    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
-    rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "fake.png")
-    assert rec["status"] == "created"
-    assert rec["lines_added"] is None, rec
-    assert rec["lines_removed"] is None, rec
-
-
-def test_git_line_counts_untracked_large_file_is_none(tmp_path: Path, monkeypatch) -> None:
-    """An untracked file over the read cap reports (None, None), not a full read.
-
-    Regression guard: the untracked-`created` branch used to slurp the whole
-    file into memory to count lines (a 22 MB file rendered "+220000"). The cap
-    is monkeypatched tiny so the test stays fast rather than writing 10 MiB.
-    """
-    monkeypatch.setattr("omnigent.runtime.filesystem_registry._MAX_READ_BYTES", 16)
-    _init_git_with_commit(tmp_path, "keep.txt", "hi\n")
-    # Untracked text file larger than the (patched) 16-byte cap.
-    (tmp_path / "big.txt").write_text("line\n" * 100)
-
-    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
-    rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "big.txt")
-    assert rec["status"] == "created"
-    assert rec["lines_added"] is None, rec
-    assert rec["lines_removed"] is None, rec
-
-
 def test_git_line_counts_numstat_failure_degrades_but_status_intact(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -1051,9 +1032,7 @@ def test_git_line_counts_numstat_failure_degrades_but_status_intact(
             raise subprocess.TimeoutExpired(cmd="git diff --numstat", timeout=5)
         return real_run(argv, *args, **kwargs)
 
-    monkeypatch.setattr(
-        "omnigent.runtime.filesystem_registry.subprocess.run", _fail_numstat
-    )
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry.subprocess.run", _fail_numstat)
 
     [rec] = reg.list_changed_files("any-conv", limit=100)
     assert rec["status"] == "modified"

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -100,6 +100,10 @@ export interface WorkspaceChangedFile {
   status: "created" | "modified" | "deleted";
   bytes: number | null;
   modified_at: number | null;
+  /** Lines added, or null when unknown (binary, rename, numstat unavailable). */
+  lines_added: number | null;
+  /** Lines removed, or null when unknown. */
+  lines_removed: number | null;
 }
 
 export interface WorkspaceChangedFilesResult {
@@ -180,6 +184,8 @@ interface ChangedFilesResponse {
     status: "created" | "modified" | "deleted";
     bytes: number | null;
     modified_at: number | null;
+    lines_added: number | null;
+    lines_removed: number | null;
   }>;
   has_more: boolean;
 }
@@ -220,6 +226,8 @@ async function fetchWorkspaceChangedFiles(
     status: e.status,
     bytes: e.bytes,
     modified_at: e.modified_at,
+    lines_added: e.lines_added ?? null,
+    lines_removed: e.lines_removed ?? null,
   }));
   return { available: true, data };
 }

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { useState } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -46,6 +46,8 @@ function file(path: string, bytes = 10): WorkspaceFile {
 function changedFile(
   path: string,
   status: WorkspaceChangedFile["status"] = "modified",
+  linesAdded: number | null = null,
+  linesRemoved: number | null = null,
 ): WorkspaceChangedFile {
   return {
     bytes: 10,
@@ -53,6 +55,8 @@ function changedFile(
     name: path.split("/").at(-1) ?? path,
     path,
     status,
+    lines_added: linesAdded,
+    lines_removed: linesRemoved,
   };
 }
 
@@ -379,6 +383,105 @@ describe("FilesPanel scope switch (Changed | All) visibility", () => {
     fireEvent.click(screen.getByRole("radio", { name: /^changed$/i }));
     // Selecting Changed switches to the changed-files-only flat list.
     expect(onFlatViewChange).toHaveBeenCalledWith(true);
+  });
+});
+
+describe("FilesPanel Changed pill line totals", () => {
+  // The Changed pill's aria-label is the fixed "Changed"; the totals live in a
+  // nested span. Query within the pill so we assert on the totals, not
+  // per-file counters elsewhere. "−" is U+2212 (the &minus; glyph rendered).
+  function changedPill() {
+    return screen.getByRole("radio", { name: /^changed$/i });
+  }
+
+  it("sums lines_added/lines_removed across files (+15 −3, count 2)", () => {
+    renderPanel({
+      conversationId: "conv_totals_sum",
+      flatView: true,
+      files: [],
+      changedFiles: [
+        changedFile("src/a.ts", "modified", 10, 2),
+        changedFile("src/b.ts", "modified", 5, 1),
+      ],
+    });
+
+    const pill = changedPill();
+    expect(within(pill).getByText("2")).toBeInTheDocument(); // file count
+    expect(within(pill).getByText("+15")).toBeInTheDocument();
+    expect(within(pill).getByText("−3")).toBeInTheDocument();
+  });
+
+  it("omits the +/− totals when every file's counts are null (count still shows)", () => {
+    renderPanel({
+      conversationId: "conv_totals_allnull",
+      flatView: true,
+      files: [],
+      changedFiles: [changedFile("a.bin"), changedFile("b.bin")], // null/null
+    });
+
+    const pill = changedPill();
+    expect(within(pill).getByText("2")).toBeInTheDocument();
+    expect(within(pill).queryByText(/^\+/)).not.toBeInTheDocument();
+    expect(within(pill).queryByText(/^−/)).not.toBeInTheDocument();
+  });
+
+  it("folds a deleted file (0/7) in with a modified (+4/−1) → +4 −8", () => {
+    renderPanel({
+      conversationId: "conv_totals_delete",
+      flatView: true,
+      files: [],
+      changedFiles: [
+        changedFile("del.ts", "deleted", 0, 7),
+        changedFile("mod.ts", "modified", 4, 1),
+      ],
+    });
+
+    const pill = changedPill();
+    expect(within(pill).getByText("+4")).toBeInTheDocument();
+    expect(within(pill).getByText("−8")).toBeInTheDocument();
+  });
+
+  it("skips a binary (null/null) but still sums the text file (+3 −2)", () => {
+    renderPanel({
+      conversationId: "conv_totals_binary",
+      flatView: true,
+      files: [],
+      changedFiles: [
+        changedFile("img.png", "modified"), // null/null binary
+        changedFile("code.ts", "modified", 3, 2),
+      ],
+    });
+
+    const pill = changedPill();
+    expect(within(pill).getByText("+3")).toBeInTheDocument();
+    expect(within(pill).getByText("−2")).toBeInTheDocument();
+  });
+
+  it("totals reflect the full fetched set, unchanged by a search filter", () => {
+    renderPanel({
+      conversationId: "conv_totals_search",
+      flatView: true,
+      files: [],
+      changedFiles: [
+        changedFile("keepme.ts", "modified", 10, 2),
+        changedFile("other.ts", "modified", 5, 1),
+      ],
+    });
+
+    // Before search: pill sums both files.
+    expect(within(changedPill()).getByText("+15")).toBeInTheDocument();
+    expect(within(changedPill()).getByText("−3")).toBeInTheDocument();
+    expect(within(changedPill()).getByText("2")).toBeInTheDocument();
+
+    // Type a query matching only one file — filtering happens inside
+    // FlatFileList, so the pill total (full fetched set) must not change.
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search changed files" }), {
+      target: { value: "keepme" },
+    });
+
+    expect(within(changedPill()).getByText("+15")).toBeInTheDocument();
+    expect(within(changedPill()).getByText("−3")).toBeInTheDocument();
+    expect(within(changedPill()).getByText("2")).toBeInTheDocument();
   });
 });
 

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -386,17 +386,15 @@ describe("FilesPanel scope switch (Changed | All) visibility", () => {
   });
 });
 
-describe("FilesPanel Changed pill line totals", () => {
-  // The Changed pill's aria-label is the fixed "Changed"; the totals live in a
-  // nested span. Query within the pill so we assert on the totals, not
-  // per-file counters elsewhere. "−" is U+2212 (the &minus; glyph rendered).
+describe("FilesPanel Changed pill", () => {
+  // The Changed pill shows the file count only — no +/− line totals.
   function changedPill() {
     return screen.getByRole("radio", { name: /^changed$/i });
   }
 
-  it("sums lines_added/lines_removed across files (+15 −3, count 2)", () => {
+  it("shows the file count but no +/− line totals", () => {
     renderPanel({
-      conversationId: "conv_totals_sum",
+      conversationId: "conv_pill_count",
       flatView: true,
       files: [],
       changedFiles: [
@@ -407,81 +405,8 @@ describe("FilesPanel Changed pill line totals", () => {
 
     const pill = changedPill();
     expect(within(pill).getByText("2")).toBeInTheDocument(); // file count
-    expect(within(pill).getByText("+15")).toBeInTheDocument();
-    expect(within(pill).getByText("−3")).toBeInTheDocument();
-  });
-
-  it("omits the +/− totals when every file's counts are null (count still shows)", () => {
-    renderPanel({
-      conversationId: "conv_totals_allnull",
-      flatView: true,
-      files: [],
-      changedFiles: [changedFile("a.bin"), changedFile("b.bin")], // null/null
-    });
-
-    const pill = changedPill();
-    expect(within(pill).getByText("2")).toBeInTheDocument();
     expect(within(pill).queryByText(/^\+/)).not.toBeInTheDocument();
     expect(within(pill).queryByText(/^−/)).not.toBeInTheDocument();
-  });
-
-  it("folds a deleted file (0/7) in with a modified (+4/−1) → +4 −8", () => {
-    renderPanel({
-      conversationId: "conv_totals_delete",
-      flatView: true,
-      files: [],
-      changedFiles: [
-        changedFile("del.ts", "deleted", 0, 7),
-        changedFile("mod.ts", "modified", 4, 1),
-      ],
-    });
-
-    const pill = changedPill();
-    expect(within(pill).getByText("+4")).toBeInTheDocument();
-    expect(within(pill).getByText("−8")).toBeInTheDocument();
-  });
-
-  it("skips a binary (null/null) but still sums the text file (+3 −2)", () => {
-    renderPanel({
-      conversationId: "conv_totals_binary",
-      flatView: true,
-      files: [],
-      changedFiles: [
-        changedFile("img.png", "modified"), // null/null binary
-        changedFile("code.ts", "modified", 3, 2),
-      ],
-    });
-
-    const pill = changedPill();
-    expect(within(pill).getByText("+3")).toBeInTheDocument();
-    expect(within(pill).getByText("−2")).toBeInTheDocument();
-  });
-
-  it("totals reflect the full fetched set, unchanged by a search filter", () => {
-    renderPanel({
-      conversationId: "conv_totals_search",
-      flatView: true,
-      files: [],
-      changedFiles: [
-        changedFile("keepme.ts", "modified", 10, 2),
-        changedFile("other.ts", "modified", 5, 1),
-      ],
-    });
-
-    // Before search: pill sums both files.
-    expect(within(changedPill()).getByText("+15")).toBeInTheDocument();
-    expect(within(changedPill()).getByText("−3")).toBeInTheDocument();
-    expect(within(changedPill()).getByText("2")).toBeInTheDocument();
-
-    // Type a query matching only one file — filtering happens inside
-    // FlatFileList, so the pill total (full fetched set) must not change.
-    fireEvent.change(screen.getByRole("searchbox", { name: "Search changed files" }), {
-      target: { value: "keepme" },
-    });
-
-    expect(within(changedPill()).getByText("+15")).toBeInTheDocument();
-    expect(within(changedPill()).getByText("−3")).toBeInTheDocument();
-    expect(within(changedPill()).getByText("2")).toBeInTheDocument();
   });
 });
 
@@ -530,14 +455,14 @@ describe("FilesPanel changed files search", () => {
     });
 
     expect(screen.getByText((text) => text.includes("Button.tsx"))).toBeInTheDocument();
-    expect(screen.queryByText("docs/Guide.md")).toBeNull();
+    expect(screen.queryByText("Guide.md")).toBeNull();
 
     fireEvent.change(screen.getByRole("searchbox", { name: "Search changed files" }), {
       target: { value: "" },
     });
 
     expect(screen.getByText((text) => text.includes("Button.tsx"))).toBeInTheDocument();
-    expect(screen.getByText("docs/Guide.md")).toBeInTheDocument();
+    expect(screen.getByText("Guide.md")).toBeInTheDocument();
   });
 
   it("clears the search query when switching from Changed to Explore view", () => {

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -170,10 +170,16 @@ function FileScopeSwitch({
   flatView,
   onChange,
   count,
+  linesAdded,
+  linesRemoved,
 }: {
   flatView: boolean;
   onChange: (flatView: boolean) => void;
   count: number;
+  /** Total lines added across changed files, or null to omit the +/− totals. */
+  linesAdded?: number | null;
+  /** Total lines removed across changed files, or null to omit. */
+  linesRemoved?: number | null;
 }) {
   const changedSelected = flatView;
   const allSelected = !flatView;
@@ -197,6 +203,23 @@ function FileScopeSwitch({
         {count > 0 && (
           <span className="shrink-0 font-normal text-[11px] text-muted-foreground tabular-nums">
             {count}
+          </span>
+        )}
+        {(linesAdded != null || linesRemoved != null) && (
+          <span
+            className="shrink-0 font-mono text-[10px]"
+            aria-label={[
+              linesAdded != null && `${linesAdded} lines added`,
+              linesRemoved != null && `${linesRemoved} removed`,
+            ]
+              .filter(Boolean)
+              .join(", ")}
+          >
+            {linesAdded != null && (
+              <span className="text-green-600 dark:text-green-400">+{linesAdded}</span>
+            )}
+            {linesAdded != null && linesRemoved != null && " "}
+            {linesRemoved != null && <span className="text-destructive">&minus;{linesRemoved}</span>}
           </span>
         )}
       </button>
@@ -319,8 +342,21 @@ export function FilesPanel({
     enabled: true,
   });
   const workingDir = envQuery.data?.root ?? null;
-  const changedCount = changedQuery.data?.data.length ?? 0;
-  const hiddenFilesCount = (changedQuery.data?.data ?? []).filter((f) =>
+  const changedFiles = changedQuery.data?.data ?? [];
+  const changedCount = changedFiles.length;
+  // Client-side totals over the FULL fetched set (matches changedCount —
+  // search/hidden filtering happens inside FlatFileList, not here). `?? 0`
+  // skips null/undefined counts (binaries, non-git mode); `any` gates whether
+  // the +/− totals render at all.
+  const lineTotals = changedFiles.reduce(
+    (acc, f) => ({
+      added: acc.added + (f.lines_added ?? 0),
+      removed: acc.removed + (f.lines_removed ?? 0),
+      any: acc.any || f.lines_added != null || f.lines_removed != null,
+    }),
+    { added: 0, removed: 0, any: false },
+  );
+  const hiddenFilesCount = changedFiles.filter((f) =>
     f.path.split("/").some((seg) => seg.startsWith(".")),
   ).length;
 
@@ -418,7 +454,13 @@ export function FilesPanel({
           className="shrink-0 flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch"
           onClick={(e) => e.stopPropagation()}
         >
-          <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
+          <FileScopeSwitch
+            flatView={flatView}
+            onChange={onFlatViewChange}
+            count={changedCount}
+            linesAdded={lineTotals.any ? lineTotals.added : null}
+            linesRemoved={lineTotals.any ? lineTotals.removed : null}
+          />
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
               <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -438,7 +480,13 @@ export function FilesPanel({
       {!flatView && (
         <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch">
-            <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
+            <FileScopeSwitch
+              flatView={flatView}
+              onChange={onFlatViewChange}
+              count={changedCount}
+              linesAdded={lineTotals.any ? lineTotals.added : null}
+              linesRemoved={lineTotals.any ? lineTotals.removed : null}
+            />
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
                 <SearchIcon className="size-4 shrink-0 text-muted-foreground" />

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -170,16 +170,10 @@ function FileScopeSwitch({
   flatView,
   onChange,
   count,
-  linesAdded,
-  linesRemoved,
 }: {
   flatView: boolean;
   onChange: (flatView: boolean) => void;
   count: number;
-  /** Total lines added across changed files, or null to omit the +/− totals. */
-  linesAdded?: number | null;
-  /** Total lines removed across changed files, or null to omit. */
-  linesRemoved?: number | null;
 }) {
   const changedSelected = flatView;
   const allSelected = !flatView;
@@ -203,23 +197,6 @@ function FileScopeSwitch({
         {count > 0 && (
           <span className="shrink-0 font-normal text-[11px] text-muted-foreground tabular-nums">
             {count}
-          </span>
-        )}
-        {(linesAdded != null || linesRemoved != null) && (
-          <span
-            className="shrink-0 font-mono text-[10px]"
-            aria-label={[
-              linesAdded != null && `${linesAdded} lines added`,
-              linesRemoved != null && `${linesRemoved} removed`,
-            ]
-              .filter(Boolean)
-              .join(", ")}
-          >
-            {linesAdded != null && (
-              <span className="text-green-600 dark:text-green-400">+{linesAdded}</span>
-            )}
-            {linesAdded != null && linesRemoved != null && " "}
-            {linesRemoved != null && <span className="text-destructive">&minus;{linesRemoved}</span>}
           </span>
         )}
       </button>
@@ -344,18 +321,6 @@ export function FilesPanel({
   const workingDir = envQuery.data?.root ?? null;
   const changedFiles = changedQuery.data?.data ?? [];
   const changedCount = changedFiles.length;
-  // Client-side totals over the FULL fetched set (matches changedCount —
-  // search/hidden filtering happens inside FlatFileList, not here). `?? 0`
-  // skips null/undefined counts (binaries, non-git mode); `any` gates whether
-  // the +/− totals render at all.
-  const lineTotals = changedFiles.reduce(
-    (acc, f) => ({
-      added: acc.added + (f.lines_added ?? 0),
-      removed: acc.removed + (f.lines_removed ?? 0),
-      any: acc.any || f.lines_added != null || f.lines_removed != null,
-    }),
-    { added: 0, removed: 0, any: false },
-  );
   const hiddenFilesCount = changedFiles.filter((f) =>
     f.path.split("/").some((seg) => seg.startsWith(".")),
   ).length;
@@ -454,13 +419,7 @@ export function FilesPanel({
           className="shrink-0 flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch"
           onClick={(e) => e.stopPropagation()}
         >
-          <FileScopeSwitch
-            flatView={flatView}
-            onChange={onFlatViewChange}
-            count={changedCount}
-            linesAdded={lineTotals.any ? lineTotals.added : null}
-            linesRemoved={lineTotals.any ? lineTotals.removed : null}
-          />
+          <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
               <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -480,13 +439,7 @@ export function FilesPanel({
       {!flatView && (
         <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch">
-            <FileScopeSwitch
-              flatView={flatView}
-              onChange={onFlatViewChange}
-              count={changedCount}
-              linesAdded={lineTotals.any ? lineTotals.added : null}
-              linesRemoved={lineTotals.any ? lineTotals.removed : null}
-            />
+            <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
                 <SearchIcon className="size-4 shrink-0 text-muted-foreground" />

--- a/web/src/shell/FlatFileList.test.tsx
+++ b/web/src/shell/FlatFileList.test.tsx
@@ -61,11 +61,8 @@ describe("FlatFileList runner-offline state", () => {
   });
 });
 
-describe("FlatFileList file size / download alignment", () => {
-  it("overlays the download button on the file size so both share one slot", () => {
-    // The size label and the hover download button must occupy the same
-    // relative container: the size reserves the width and the button overlays
-    // it (absolute inset-0), so the button appears exactly where the size was.
+describe("FlatFileList status / download alignment", () => {
+  it("does not show a file-size label", () => {
     renderList({
       files: [
         {
@@ -80,11 +77,32 @@ describe("FlatFileList file size / download alignment", () => {
       ],
     });
 
-    const size = screen.getByText("2.0 KB");
-    const slot = size.parentElement;
+    expect(screen.queryByText(/\bKB\b/)).not.toBeInTheDocument();
+  });
+
+  it("overlays the download button on the status letter so both share one slot", () => {
+    // The status letter and the hover download button occupy the same relative
+    // container: the letter reserves the width and the button overlays it
+    // (absolute inset-0), so the button appears exactly where the letter was.
+    renderList({
+      files: [
+        {
+          path: "src/app.ts",
+          name: "app.ts",
+          status: "modified",
+          bytes: 2048,
+          modified_at: null,
+          lines_added: null,
+          lines_removed: null,
+        },
+      ],
+    });
+
+    const letter = screen.getByText("M");
+    const slot = letter.parentElement;
     expect(slot).toHaveClass("relative");
-    // Size hides on hover but keeps its width to avoid a layout shift.
-    expect(size).toHaveClass("group-hover:invisible");
+    // The letter hides on hover but keeps its width to avoid a layout shift.
+    expect(letter).toHaveClass("group-hover:invisible");
 
     const download = screen.getByRole("button", { name: /download app\.ts/i });
     const overlay = download.closest("span.absolute") as HTMLElement | null;

--- a/web/src/shell/FlatFileList.test.tsx
+++ b/web/src/shell/FlatFileList.test.tsx
@@ -68,7 +68,15 @@ describe("FlatFileList file size / download alignment", () => {
     // it (absolute inset-0), so the button appears exactly where the size was.
     renderList({
       files: [
-        { path: "src/app.ts", name: "app.ts", status: "modified", bytes: 2048, modified_at: null },
+        {
+          path: "src/app.ts",
+          name: "app.ts",
+          status: "modified",
+          bytes: 2048,
+          modified_at: null,
+          lines_added: null,
+          lines_removed: null,
+        },
       ],
     });
 
@@ -82,5 +90,66 @@ describe("FlatFileList file size / download alignment", () => {
     const overlay = download.closest("span.absolute") as HTMLElement | null;
     expect(overlay).not.toBeNull();
     expect(slot).toContainElement(overlay);
+  });
+});
+
+describe("FlatFileList line-change counter", () => {
+  it("renders +added and −removed when both counts are present", () => {
+    renderList({
+      files: [
+        {
+          path: "src/app.ts",
+          name: "app.ts",
+          status: "modified",
+          bytes: 2048,
+          modified_at: null,
+          lines_added: 12,
+          lines_removed: 3,
+        },
+      ],
+    });
+
+    expect(screen.getByText("+12")).toBeInTheDocument();
+    expect(screen.getByText("−3")).toBeInTheDocument();
+  });
+
+  it("shows only −removed for a deleted file (added is 0)", () => {
+    renderList({
+      files: [
+        {
+          path: "gone.py",
+          name: "gone.py",
+          status: "deleted",
+          bytes: null,
+          modified_at: null,
+          lines_added: 0,
+          lines_removed: 7,
+        },
+      ],
+    });
+
+    expect(screen.getByText("−7")).toBeInTheDocument();
+    // +0 still renders (0 is a real, non-null count) but the removed side is
+    // the meaningful one for a deletion.
+    expect(screen.getByText("+0")).toBeInTheDocument();
+  });
+
+  it("omits the counter entirely when both counts are null (binary/rename/unavailable)", () => {
+    renderList({
+      files: [
+        {
+          path: "img.bin",
+          name: "img.bin",
+          status: "modified",
+          bytes: 1024,
+          modified_at: null,
+          lines_added: null,
+          lines_removed: null,
+        },
+      ],
+    });
+
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^−/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/shell/FlatFileList.test.tsx
+++ b/web/src/shell/FlatFileList.test.tsx
@@ -152,7 +152,7 @@ describe("FlatFileList line-change counter", () => {
     expect(screen.getByText("+0")).toBeInTheDocument();
   });
 
-  it("omits the counter entirely when both counts are null (binary/rename/unavailable)", () => {
+  it("omits the counter entirely when both counts are null (binary/untracked/unavailable)", () => {
     renderList({
       files: [
         {
@@ -163,6 +163,27 @@ describe("FlatFileList line-change counter", () => {
           modified_at: null,
           lines_added: null,
           lines_removed: null,
+        },
+      ],
+    });
+
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^−/)).not.toBeInTheDocument();
+  });
+
+  it("omits the counter for a mode-only change (both counts 0)", () => {
+    // A chmod-only edit shows in numstat as 0/0; a "+0 −0" badge is noise, so
+    // suppress it while still rendering a real deletion's −N.
+    renderList({
+      files: [
+        {
+          path: "script.sh",
+          name: "script.sh",
+          status: "modified",
+          bytes: 512,
+          modified_at: null,
+          lines_added: 0,
+          lines_removed: 0,
         },
       ],
     });

--- a/web/src/shell/FlatFileList.tsx
+++ b/web/src/shell/FlatFileList.tsx
@@ -104,6 +104,25 @@ function FileListItem({
           >
             {gitStatusLetter(file.status)}
           </span>
+          {(file.lines_added !== null || file.lines_removed !== null) && (
+            <span
+              className="shrink-0 font-mono text-[10px]"
+              aria-label={[
+                file.lines_added !== null && `${file.lines_added} lines added`,
+                file.lines_removed !== null && `${file.lines_removed} removed`,
+              ]
+                .filter(Boolean)
+                .join(", ")}
+            >
+              {file.lines_added !== null && (
+                <span className="text-green-600 dark:text-green-400">+{file.lines_added}</span>
+              )}
+              {file.lines_added !== null && file.lines_removed !== null && " "}
+              {file.lines_removed !== null && (
+                <span className="text-destructive">&minus;{file.lines_removed}</span>
+              )}
+            </span>
+          )}
           <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
           <span
             className={cn(

--- a/web/src/shell/FlatFileList.tsx
+++ b/web/src/shell/FlatFileList.tsx
@@ -103,7 +103,7 @@ function FileListItem({
           </span>
           {dir && <span className="truncate text-muted-foreground text-[11px]">{dir}</span>}
         </button>
-        {(file.lines_added !== null || file.lines_removed !== null) && (
+        {((file.lines_added ?? 0) !== 0 || (file.lines_removed ?? 0) !== 0) && (
           <span
             className="shrink-0 font-mono text-[10px]"
             aria-label={[

--- a/web/src/shell/FlatFileList.tsx
+++ b/web/src/shell/FlatFileList.tsx
@@ -3,7 +3,7 @@ import { RunnerOfflineError, type WorkspaceChangedFile } from "@/hooks/useWorksp
 import { RunnerAsleepHint } from "./RunnerAsleepHint";
 import { cn } from "@/lib/utils";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { formatBytes, gitStatusLabel, gitStatusLetter } from "./fileStatusUtils";
+import { gitStatusLabel, gitStatusLetter } from "./fileStatusUtils";
 import { FileDownloadButton } from "./FileDownloadButton";
 import { useCursorTooltip } from "./useCursorTooltip";
 
@@ -73,27 +73,60 @@ function FileListItem({
   conversationId: string | undefined;
 }) {
   const { handlers, tooltip } = useCursorTooltip(file.path);
+  const slash = file.path.lastIndexOf("/");
+  const dir = slash > 0 ? file.path.slice(0, slash) : "";
+  const hasDownload = !isDeleted && Boolean(conversationId);
 
   return (
     <li>
       <div
         className={cn(
-          "group flex w-full min-w-0 items-center gap-1.5 rounded-md px-2 py-1",
+          "group flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1",
           isDeleted ? "opacity-50" : "hover:bg-muted",
         )}
       >
         <button
           type="button"
           className={cn(
-            "flex min-w-0 flex-1 items-center gap-1.5 text-left",
+            "flex min-w-0 flex-1 items-baseline gap-1.5 text-left",
             isDeleted ? "cursor-default" : "cursor-pointer",
           )}
           onClick={() => !isDeleted && onFileSelect(file.path)}
           disabled={isDeleted}
         >
+          <FileIcon className="size-3.5 shrink-0 self-center text-muted-foreground" />
+          <span
+            className={cn("truncate font-mono text-sm md:text-xs", isDeleted && "line-through")}
+            {...handlers}
+          >
+            {file.name}
+          </span>
+          {dir && <span className="truncate text-muted-foreground text-[11px]">{dir}</span>}
+        </button>
+        {(file.lines_added !== null || file.lines_removed !== null) && (
+          <span
+            className="shrink-0 font-mono text-[10px]"
+            aria-label={[
+              file.lines_added !== null && `${file.lines_added} lines added`,
+              file.lines_removed !== null && `${file.lines_removed} removed`,
+            ]
+              .filter(Boolean)
+              .join(", ")}
+          >
+            {file.lines_added !== null && (
+              <span className="text-green-600 dark:text-green-400">+{file.lines_added}</span>
+            )}
+            {file.lines_added !== null && file.lines_removed !== null && " "}
+            {file.lines_removed !== null && (
+              <span className="text-destructive">&minus;{file.lines_removed}</span>
+            )}
+          </span>
+        )}
+        <span className="relative flex shrink-0 items-center justify-center">
           <span
             className={cn(
-              "shrink-0 rounded px-1 py-0.5 font-mono text-[10px]",
+              "rounded px-1 py-0.5 font-mono text-[10px]",
+              hasDownload && "group-hover:invisible",
               isDeleted
                 ? "bg-destructive/10 text-destructive"
                 : file.status === "created"
@@ -104,51 +137,12 @@ function FileListItem({
           >
             {gitStatusLetter(file.status)}
           </span>
-          {(file.lines_added !== null || file.lines_removed !== null) && (
-            <span
-              className="shrink-0 font-mono text-[10px]"
-              aria-label={[
-                file.lines_added !== null && `${file.lines_added} lines added`,
-                file.lines_removed !== null && `${file.lines_removed} removed`,
-              ]
-                .filter(Boolean)
-                .join(", ")}
-            >
-              {file.lines_added !== null && (
-                <span className="text-green-600 dark:text-green-400">+{file.lines_added}</span>
-              )}
-              {file.lines_added !== null && file.lines_removed !== null && " "}
-              {file.lines_removed !== null && (
-                <span className="text-destructive">&minus;{file.lines_removed}</span>
-              )}
+          {hasDownload && conversationId && (
+            <span className="absolute inset-0 flex items-center justify-center">
+              <FileDownloadButton conversationId={conversationId} path={file.path} />
             </span>
           )}
-          <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
-          <span
-            className={cn(
-              "min-w-0 flex-1 truncate text-left font-mono text-sm md:text-xs [direction:rtl]",
-              isDeleted && "line-through",
-            )}
-            {...handlers}
-          >
-            <bdi>{file.path}</bdi>
-          </span>
-        </button>
-        {file.bytes !== null && !isDeleted ? (
-          <div className="relative shrink-0 flex items-center">
-            <span className="text-muted-foreground text-[10px] group-hover:invisible">
-              {formatBytes(file.bytes)}
-            </span>
-            {conversationId && (
-              <span className="absolute inset-0 flex items-center justify-center">
-                <FileDownloadButton conversationId={conversationId} path={file.path} />
-              </span>
-            )}
-          </div>
-        ) : (
-          !isDeleted &&
-          conversationId && <FileDownloadButton conversationId={conversationId} path={file.path} />
-        )}
+        </span>
       </div>
       {tooltip}
     </li>

--- a/web/src/shell/FolderTree.test.tsx
+++ b/web/src/shell/FolderTree.test.tsx
@@ -150,7 +150,15 @@ describe("FolderTree file size / download alignment", () => {
     renderTree({
       files: [dir("src")],
       changedFiles: [
-        { path: "src/app.ts", name: "app.ts", status: "modified", bytes: 1, modified_at: null },
+        {
+          path: "src/app.ts",
+          name: "app.ts",
+          status: "modified",
+          bytes: 1,
+          modified_at: null,
+          lines_added: null,
+          lines_removed: null,
+        },
       ],
     });
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Show a per-file line-change counter (`+N −M`) in each row of the changed-files panel. Deleted files render as `−N`; the counter is omitted when there's nothing meaningful to show.
- Restyle the row layout: filename is left-aligned with a muted parent-directory suffix, and the A/D/M status badge moves to the right edge. The per-row file-size label is removed.
- Line counts come from `git diff --numstat --no-renames HEAD`, computed at the record source (`filesystem_registry.py`) and threaded through the runner API to the web UI. The desktop and iOS apps consume the same web bundle, so they get it for free.
- Counts come only from `git diff HEAD` (staged + unstaged tracked changes). Files git doesn't diff — untracked new files and binaries — render no count, matching VS Code / Cursor's source-control view. Non-git (agent-edit) workspaces render no count. Mode-only (chmod) changes surface as `0/0` and are suppressed rather than shown as `+0 −0`.
- No backend consumer outside the web UI; the new `lines_added` / `lines_removed` fields are additive and nullable. The four git subprocesses backing this view share a single `_GIT_TIMEOUT_SECONDS` (5s) cap.

## Test Plan

- `pytest tests/runtime/test_filesystem_registry.py tests/runner/test_environment_filesystem.py` — **122 passed** (numstat parsing, and untracked / staged-new / deleted / binary / mode-only / numstat-failure cases).
- `cd web && npm run test` — **all passing** (per-file render, deleted-fold, binary-skip, mode-only-suppressed, and the `Changed` pill showing the file count with no `+/−` totals).
- Lint clean (ruff / oxlint / prettier) on touched files.

## Demo

<img width="699" height="264" alt="image" src="https://github.com/user-attachments/assets/efbafa45-c0a7-4086-9e65-8460755cd126" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified via a live temp-repo repro (modified, untracked, staged-new, deleted, and binary files) — counts correct in every case, and untracked/binary files render no counter. The counter only renders in git-backed workspaces; non-git (agent-edit) mode shows the badge with no count by design.

## Changelog

The changed-files panel now shows a per-file line-change count (`+N −M`) beside each file.
