### PR TITLE
fix(telemetry): honor rollout percentage boundaries

### DIFF
--- a/omnigent/telemetry/client.py
+++ b/omnigent/telemetry/client.py
@@ -164,7 +164,7 @@ def _fetch_remote_config() -> TelemetryConfig | None:
             _logger.debug("Telemetry disabled for OS %s by remote config", platform.system())
             return None
         rollout = cfg.get("rollout_percentage", 100)
-        if random.randint(0, 100) > rollout:
+        if random.random() * 100 >= rollout:
             _logger.debug("Telemetry excluded by rollout_percentage=%s", rollout)
             return None
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -257,6 +257,43 @@ def test_init_client_server_config_disabled(monkeypatch: pytest.MonkeyPatch) -> 
         monkeypatch.setattr(_mod, "_CLIENT", original_client)
 
 
+# ── _fetch_remote_config — rollout percentage ─────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("rollout", "sample", "included"),
+    [
+        (0, 0.0, False),
+        (50, 0.499, True),
+        (50, 0.5, False),
+        (100, 0.999, True),
+    ],
+)
+def test_fetch_remote_config_respects_rollout_percentage_boundaries(
+    rollout: int,
+    sample: float,
+    included: bool,
+) -> None:
+    """Rollout percentages include exactly their half-open share of samples."""
+    import omnigent.telemetry.client as _mod
+
+    config = {
+        "omnigent_version": _mod.VERSION,
+        "ingestion_url": "https://telemetry.example.test",
+        "rollout_percentage": rollout,
+    }
+    with (
+        patch("urllib.request.urlopen") as urlopen,
+        patch.object(_mod.random, "random", return_value=sample) as random_sample,
+    ):
+        response = urlopen.return_value.__enter__.return_value
+        response.read.return_value = json.dumps(config).encode("utf-8")
+        result = _mod._fetch_remote_config()
+
+    random_sample.assert_called_once_with()
+    assert (result is not None) is included
+
+
 # ── get_installation_id ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A — found during a bug audit; no existing issue or PR tracks this rollout boundary bug.

## Summary

Telemetry rollout sampling used 101 integer buckets (`0..100`), so a configured 0% rollout could still enroll a process and intermediate percentages were biased.

- Sample from the half-open `[0, 100)` range so 0% excludes everyone and 100% includes everyone.
- Add deterministic coverage for the 0%, 50%, and 100% boundaries.

## Test Plan

- `.venv/bin/pytest tests/test_telemetry.py -q` — 26 passed.
- `.venv/bin/pre-commit run` — all applicable hooks passed.

## Demo

N/A — non-visual telemetry fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The parameterized unit test pins both sides of the 50% cutoff as well as exact 0% and 100% behavior.

## Changelog

Telemetry rollout percentages now honor 0% and 100% exactly.
