### PR TITLE
fix(pi-native): pass --approve to suppress first-run trust dialog

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1615,14 +1615,15 @@ class PiExecutor(Executor):
         # off (they don't route through Omnigent policies / history and
         # can 400 against the Databricks Responses API), and the bridge
         # extension's tools are explicitly allowlisted.
-        self._extra_args: list[str] = [
-            "--no-tools",
-            # Pre-accept the project-folder trust dialog. Pi 0.80+ shows a
+        from omnigent.pi_native import pi_supports_approve
+
+        self._extra_args: list[str] = ["--no-tools"]
+        if pi_supports_approve(self._pi_path):
+            # Pre-accept the project-folder trust dialog. Pi 0.79+ shows a
             # blocking TUI prompt on first launch in a directory with .pi/
             # resources. In a runner-driven session there is nobody at the
-            # terminal to answer it, so we approve unconditionally.
-            "--approve",
-        ]
+            # terminal to answer it, so we approve when the flag is supported.
+            self._extra_args.append("--approve")
         self._bundle_dir = bundle_dir
         self._agent_name = agent_name
         self._skills_filter = skills_filter

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1615,7 +1615,14 @@ class PiExecutor(Executor):
         # off (they don't route through Omnigent policies / history and
         # can 400 against the Databricks Responses API), and the bridge
         # extension's tools are explicitly allowlisted.
-        self._extra_args: list[str] = ["--no-tools"]
+        self._extra_args: list[str] = [
+            "--no-tools",
+            # Pre-accept the project-folder trust dialog. Pi 0.80+ shows a
+            # blocking TUI prompt on first launch in a directory with .pi/
+            # resources. In a runner-driven session there is nobody at the
+            # terminal to answer it, so we approve unconditionally.
+            "--approve",
+        ]
         self._bundle_dir = bundle_dir
         self._agent_name = agent_name
         self._skills_filter = skills_filter

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -117,6 +117,58 @@ def resolve_pi_executable(
     return resolved
 
 
+def pi_version(executable: str) -> tuple[int, int, int] | None:
+    """Return the Pi CLI version as ``(major, minor, patch)``, or ``None``.
+
+    Runs ``pi --version`` synchronously with a short timeout. Returns
+    ``None`` on any failure (not installed, hung, unexpected output) so
+    callers treat an unknown version as "feature not supported" and avoid
+    passing flags the installed Pi may not recognise.
+
+    :param executable: Resolved path to the Pi CLI.
+    :returns: Parsed version tuple, e.g. ``(0, 79, 10)``, or ``None``.
+    """
+    import re
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    # Older Pi (mariozechner package) prints the version to stderr via
+    # console.error; newer Pi (earendil-works) prints to stdout via
+    # console.log. Check both so the probe works across all versions.
+    combined = result.stdout + result.stderr
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", combined)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def pi_supports_approve(executable: str) -> bool:
+    """Return ``True`` when the Pi CLI at *executable* supports ``--approve``.
+
+    ``--approve`` (``projectTrustOverride=true``) was added in
+    ``@earendil-works/pi-coding-agent@0.79.0``. Passing it to an older
+    version produces an "Unknown option" error and Pi exits immediately.
+
+    Fails open — returns ``False`` on any version-probe error so an older
+    Pi keeps working without the flag.
+
+    :param executable: Resolved path to the Pi CLI.
+    :returns: ``True`` iff the installed Pi version is >= 0.79.0.
+    """
+    ver = pi_version(executable)
+    if ver is None:
+        return False
+    return ver >= (0, 79, 0)
+
+
 def build_pi_launch(
     pi_args: Sequence[str],
     *,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1707,6 +1707,7 @@ def _build_pi_native_args(
     extension_path: Path,
     session_dir: Path,
     external_session_id: str | None,
+    approve: bool = False,
 ) -> list[str]:
     """
     Build Pi CLI args for a runner-owned native TUI session.
@@ -1715,19 +1716,18 @@ def _build_pi_native_args(
     :param extension_path: Generated Omnigent Pi extension path.
     :param session_dir: Per-Omnigent-session Pi session directory.
     :param external_session_id: Captured Pi session id, if any.
+    :param approve: When ``True``, pass ``--approve`` to pre-accept Pi's
+        project-folder trust dialog (supported from Pi 0.79+).
     :returns: Complete Pi arg vector excluding the executable.
     """
     user_args = list(terminal_launch_args or [])
-    args = [
-        "--extension",
-        str(extension_path),
-        # Pre-accept the project-folder trust dialog. Pi 0.80+ shows a blocking
-        # TUI prompt ("Trust project folder?") on first launch in a directory
-        # that has .pi/ resources. In a web-UI-driven native session there is
-        # nobody at the terminal to answer it, so we approve unconditionally —
-        # mirroring how ensure_claude_workspace_trusted handles Claude's dialog.
-        "--approve",
-    ]
+    args = ["--extension", str(extension_path)]
+    if approve:
+        # Pre-accept the project-folder trust dialog. Pi 0.79+ shows a
+        # blocking TUI prompt on first launch in a directory with .pi/
+        # resources. In a web-UI-driven session there is nobody at the
+        # terminal to answer it — mirroring ensure_claude_workspace_trusted.
+        args.append("--approve")
     if not _pi_args_have_session_control(user_args):
         args.extend(["--session-dir", str(session_dir)])
         if external_session_id:
@@ -1977,11 +1977,14 @@ async def _auto_create_pi_terminal(
         workspace=launch_config.workspace,
         server_client=server_client,
     )
+    from omnigent.pi_native import pi_supports_approve
+
     pi_args = _build_pi_native_args(
         terminal_launch_args=launch_config.terminal_launch_args,
         extension_path=pi_extension,
         session_dir=session_dir,
         external_session_id=resume_session_id,
+        approve=pi_supports_approve(pi_command),
     )
     pi_env = {
         PI_NATIVE_CONFIG_ENV_VAR: str(config),

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1718,7 +1718,16 @@ def _build_pi_native_args(
     :returns: Complete Pi arg vector excluding the executable.
     """
     user_args = list(terminal_launch_args or [])
-    args = ["--extension", str(extension_path)]
+    args = [
+        "--extension",
+        str(extension_path),
+        # Pre-accept the project-folder trust dialog. Pi 0.80+ shows a blocking
+        # TUI prompt ("Trust project folder?") on first launch in a directory
+        # that has .pi/ resources. In a web-UI-driven native session there is
+        # nobody at the terminal to answer it, so we approve unconditionally —
+        # mirroring how ensure_claude_workspace_trusted handles Claude's dialog.
+        "--approve",
+    ]
     if not _pi_args_have_session_control(user_args):
         args.extend(["--session-dir", str(session_dir)])
         if external_session_id:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Pi 0.79+ (`@earendil-works/pi-coding-agent`) shows a blocking "Trust project folder?" TUI prompt on first launch in a directory with `.pi/` resources. In a web-UI-driven session there is nobody at the terminal to answer it — the chat view shows nothing and the session hangs.

**Fix:** pass `--approve` (`projectTrustOverride=true`) to pre-accept the dialog. This flag was added in Pi 0.79.0; older versions treat it as an unknown option and `process.exit(1)`. So `--approve` is gated on a version probe.

**Changes:**

- `pi_native.py`: add `pi_version(executable)` and `pi_supports_approve(executable)`. `pi_version()` runs `pi --version` synchronously, reading both stdout (earendil-works 0.79+) and stderr (mariozechner, where version is printed via `console.error`). Fails open — returns `None`/`False` on any error.

- `runner/app.py`: `_build_pi_native_args()` gains an `approve=` flag. The call site probes the resolved Pi binary via `pi_supports_approve()` and passes `approve=True` only on 0.79+.

- `pi_executor.py`: `PiExecutor.__init__` calls `pi_supports_approve` and appends `--approve` to `_extra_args` only when supported.

## Test Plan

- Pi 0.70.0 (mariozechner): `pi_supports_approve` → `False`, `--approve` not passed, Pi launches normally.
- Pi 0.79+ (earendil-works): `pi_supports_approve` → `True`, `--approve` passed, trust dialog skipped.

## Demo

<img width="681" height="401" alt="image" src="https://github.com/user-attachments/assets/23b4a11f-a628-4160-9001-ca8a20d51bfe" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

`pi_version()` verified locally against Pi 0.70.0 (parses version from stderr correctly). The `pi_supports_approve` logic is a simple version comparison.

## Changelog

Pi no longer shows a blocking "Trust project folder?" dialog when launched via Omnigent in a project with `.pi/` settings or extensions (requires Pi 0.79+)