### PR TITLE
feat(bench): declare planned capability dimensions

### DIFF
--- a/docs/harness-bench-design.md
+++ b/docs/harness-bench-design.md
@@ -216,6 +216,12 @@ Validated for presence and shape only: `Owner`, `Transport`, `Implementation`,
 
 Planned dimensions are steering, live queue, resume, images, and compaction.
 
+Their declarations already have a place in `HarnessCapabilities`: resume uses
+the `Resume` mechanism enum, while steering, live queue, images, and compaction
+are optional booleans. An unset optional value makes no claim and therefore
+stays `UNKNOWN` until the corresponding probe work establishes the harness's
+expected behavior.
+
 Every behavioral probe also reads the corresponding declared flag and returns
 `DRIFT` when observed disagrees with declared.
 
@@ -433,5 +439,5 @@ agree with it.
 - **Per-harness native provisioning** — some vendors require login or provider
   configuration that the bench deliberately cannot create. Improve diagnostics
   where possible while retaining clean skips.
-- **Additional dimensions** — steering, live queue, resume, reasoning,
-  images, and compaction.
+- **Additional dimensions** — steering, live queue, resume, images, and
+  compaction.

--- a/omnigent/harness_capabilities.py
+++ b/omnigent/harness_capabilities.py
@@ -44,6 +44,7 @@ class Elicitation(str, Enum):
 class Resume(str, Enum):
     """Whether a prior conversation is reattached or rebuilt."""
 
+    NONE = "none"  # prior conversations cannot be resumed
     WARM_REATTACH = "warm-reattach"  # reattach to a live vendor session / terminal
     COLD_ONLY = "cold-only"  # rebuild from Omnigent transcript / history replay
 
@@ -92,6 +93,14 @@ class HarnessCapabilities:
     :param streaming: Whether the harness forwards token-level deltas (vs a
         single complete blob). Declared claim; verified by the bench's
         streaming probe.
+    :param steering: Whether input can be added to an active turn.
+    :param live_queue: Whether follow-up input can be queued during an active
+        turn.
+    :param images: Whether the harness accepts image input.
+    :param compaction: Whether the harness can compact conversation history.
+        Optional capability fields use ``None`` when the harness makes no claim;
+        the bench reports those declarations as ``UNKNOWN`` rather than assuming
+        the capability is unsupported.
     """
 
     integration_mode: IntegrationMode
@@ -103,8 +112,12 @@ class HarnessCapabilities:
     subagents: bool
     interrupt: bool
     streaming: bool
+    steering: bool | None = None
+    live_queue: bool | None = None
+    images: bool | None = None
+    compaction: bool | None = None
 
-    def as_dict(self) -> dict[str, str | bool]:
+    def as_dict(self) -> dict[str, str | bool | None]:
         """Return a JSON-serializable view for the ``/v1/harnesses`` catalog."""
         return {
             "integration_mode": self.integration_mode.value,
@@ -116,4 +129,8 @@ class HarnessCapabilities:
             "subagents": self.subagents,
             "interrupt": self.interrupt,
             "streaming": self.streaming,
+            "steering": self.steering,
+            "live_queue": self.live_queue,
+            "images": self.images,
+            "compaction": self.compaction,
         }

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -174,8 +174,10 @@ open platform item.
 
 Add a `CapabilityProbe` under `probes/`, register it in
 `probes/__init__.py:ALL_PROBES`, add a semantic method to the driver protocol,
-and derive or declare the expected verdict. Keep transport-specific mechanics
-inside drivers so probes remain harness-agnostic.
+and map its `HarnessCapabilities` declaration to the expected verdict. Optional
+capability values remain `UNKNOWN` until a harness makes an explicit claim.
+Keep transport-specific mechanics inside drivers so probes remain
+harness-agnostic.
 
 ## Current gaps
 

--- a/tests/harness_bench/manifest.py
+++ b/tests/harness_bench/manifest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from omnigent.harness_aliases import is_native_harness
-from omnigent.harness_capabilities import AuthModel, HarnessCapabilities, IntegrationMode
+from omnigent.harness_capabilities import AuthModel, HarnessCapabilities, IntegrationMode, Resume
 from omnigent.harness_plugins import (
     harness_aliases,
     harness_capabilities,
@@ -59,6 +59,15 @@ def _declared_from_capabilities(harness: str) -> dict[str, Verdict]:
     if caps is not None:
         declared["streaming"] = Verdict.SUPPORTED if caps.streaming else Verdict.UNSUPPORTED
         declared["interrupt"] = Verdict.SUPPORTED if caps.interrupt else Verdict.UNSUPPORTED
+        resume = getattr(caps, "resume", None)
+        if resume is not None:
+            declared["resume"] = (
+                Verdict.UNSUPPORTED if resume is Resume.NONE else Verdict.SUPPORTED
+            )
+        for dimension in ("steering", "live_queue", "images", "compaction"):
+            supported = getattr(caps, dimension, None)
+            if supported is not None:
+                declared[dimension] = Verdict.SUPPORTED if supported else Verdict.UNSUPPORTED
 
     if harness in model_env_keys() or is_native_harness(harness):
         declared["model_override"] = Verdict.SUPPORTED

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -77,6 +77,44 @@ def test_streaming_capability_declares_binary_verdict() -> None:
         assert declared is not Verdict.PARTIAL, f"{harness!r}: PARTIAL is never a declared verdict"
 
 
+def test_remaining_capabilities_map_to_declared_verdicts(monkeypatch: pytest.MonkeyPatch) -> None:
+    from omnigent.harness_capabilities import (
+        AuthModel,
+        EffortFamily,
+        Elicitation,
+        HarnessCapabilities,
+        IntegrationMode,
+        ModelFamily,
+        Resume,
+    )
+    from tests.harness_bench import manifest
+
+    capability = HarnessCapabilities(
+        IntegrationMode.SDK_IN_PROCESS,
+        Elicitation.NONE,
+        Resume.NONE,
+        EffortFamily.NONE,
+        ModelFamily.MULTI,
+        AuthModel.OWN_AUTH,
+        subagents=False,
+        interrupt=True,
+        streaming=True,
+        steering=True,
+        live_queue=False,
+        images=None,
+        compaction=True,
+    )
+    monkeypatch.setattr(manifest, "harness_capabilities", lambda: {"fake": capability})
+
+    declared = manifest._declared_from_capabilities("fake")
+
+    assert declared["resume"] is Verdict.UNSUPPORTED
+    assert declared["steering"] is Verdict.SUPPORTED
+    assert declared["live_queue"] is Verdict.UNSUPPORTED
+    assert "images" not in declared
+    assert declared["compaction"] is Verdict.SUPPORTED
+
+
 def test_reconcile_flags_concrete_mismatch() -> None:
     assert reconcile(Verdict.UNSUPPORTED, Verdict.SUPPORTED) is Verdict.DRIFT
     assert reconcile(Verdict.SUPPORTED, Verdict.UNSUPPORTED) is Verdict.DRIFT

--- a/tests/test_harness_capabilities.py
+++ b/tests/test_harness_capabilities.py
@@ -95,6 +95,40 @@ def test_p0_bench_harnesses_declare_interrupt_and_streaming() -> None:
         assert caps[harness].streaming is True, harness
 
 
+def test_optional_bench_capabilities_default_to_unknown() -> None:
+    capability = HarnessCapabilities(
+        IntegrationMode.SDK_IN_PROCESS,
+        Elicitation.NONE,
+        Resume.COLD_ONLY,
+        EffortFamily.NONE,
+        ModelFamily.MULTI,
+        AuthModel.OWN_AUTH,
+        subagents=False,
+        interrupt=True,
+        streaming=True,
+    )
+
+    assert capability.steering is None
+    assert capability.live_queue is None
+    assert capability.images is None
+    assert capability.compaction is None
+    assert capability.as_dict() == {
+        "integration_mode": "sdk-in-process",
+        "elicitation": "none",
+        "resume": "cold-only",
+        "effort": "none",
+        "model_family": "multi",
+        "auth": "own-auth",
+        "subagents": False,
+        "interrupt": True,
+        "streaming": True,
+        "steering": None,
+        "live_queue": None,
+        "images": None,
+        "compaction": None,
+    }
+
+
 def test_community_capabilities_cannot_override_builtin() -> None:
     # `capabilities` is part of the collision-key set, so a community plugin that
     # declares capabilities for a built-in harness id is rejected rather than
@@ -128,6 +162,6 @@ def test_catalog_rows_include_capabilities() -> None:
     for row in rows:
         if row["id"] in caps:
             assert "capabilities" in row, row["id"]
-            # JSON-serializable: values are str/bool, not enums.
+            # JSON-serializable: values are primitives, not enums.
             for value in row["capabilities"].values():
-                assert isinstance(value, (str, bool))
+                assert value is None or isinstance(value, (str, bool))


### PR DESCRIPTION
## Related issue

N/A

## Summary

The next harness-bench dimensions need declared expectations before their live probes can detect drift. This adds backward-compatible capability slots for steering, live queue, images, and compaction, and maps the existing resume mechanism into a bench verdict.

- Optional declarations use `None` to mean “no claim,” so existing and community harnesses remain `UNKNOWN` rather than being incorrectly labeled unsupported.
- `Resume.NONE` represents an explicit lack of resume support; warm reattach and cold transcript replay both declare resume support.
- Removes reasoning from the stale list of unimplemented dimensions and documents how future probes should adopt the declarations.

### ELI5

The bench compares what a harness says it can do with what a live test observes. We had future tests planned, but nowhere for harnesses to record their expected answers. This PR adds those answer boxes without filling unknown answers with “no.”

```text
HarnessCapabilities
  ├─ resume: warm / cold / none ────────┐
  ├─ steering: true / false / unknown ──┤
  ├─ live_queue: true / false / unknown ┤
  ├─ images: true / false / unknown ────┤──> BenchProfile.declared
  └─ compaction: true / false / unknown ┘         │
                                                   v
                                        live observation -> DRIFT or verdict
```

### Change map

- `omnigent/harness_capabilities.py` — adds `Resume.NONE`, optional future-dimension fields, and catalog serialization.
- `tests/harness_bench/manifest.py` — converts concrete declarations into expected verdicts while treating missing/older fields as `UNKNOWN`.
- `tests/test_harness_capabilities.py` — covers constructor compatibility, defaults, and JSON-safe catalog output.
- `tests/harness_bench/test_bench.py` — covers supported, unsupported, and unknown verdict mapping.
- `docs/harness-bench-design.md` / `tests/harness_bench/README.md` — documents declaration semantics and removes the stale reasoning follow-up.

## Test Plan

- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync pytest -q tests/harness_bench tests/test_harness_capabilities.py` — 165 passed, 19 skipped.
- `UV_CACHE_DIR=/tmp/omnigent-uv-cache uv run --no-sync ruff check omnigent/harness_capabilities.py tests/harness_bench/manifest.py tests/harness_bench/test_bench.py tests/test_harness_capabilities.py`
- `pre-commit run --files omnigent/harness_capabilities.py tests/harness_bench/manifest.py tests/harness_bench/test_bench.py tests/test_harness_capabilities.py docs/harness-bench-design.md tests/harness_bench/README.md`

## Demo

N/A — capability metadata, bench reconciliation, tests, and documentation only.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests verify old constructor compatibility, older registry capability shapes, catalog serialization, and supported/unsupported/unknown bench declarations.

## Changelog

Harness metadata can now declare resume, steering, live queue, image, and compaction support for capability conformance checks.
