### PR TITLE
perf(telemetry): cache is_disabled() to eliminate per-request file I/O

### DIFF
--- a/omnigent/telemetry/client.py
+++ b/omnigent/telemetry/client.py
@@ -107,6 +107,11 @@ _CONFIG_URL_PROD = "https://config.omnigent-telemetry.io"
 _CONFIG_URL_STAGING = "https://config-staging.omnigent-telemetry.io"
 
 
+# Cached result of is_disabled() — computed once on first call, then reused.
+# Using a list so it's mutable from within the function (avoids global keyword).
+_IS_DISABLED_CACHE: list[bool | None] = [None]
+
+
 @dataclass
 class TelemetryConfig:
     """Resolved remote configuration for the telemetry client."""
@@ -210,6 +215,10 @@ def _config_telemetry_disabled() -> bool:
 def is_disabled() -> bool:
     """Return ``True`` when telemetry should be completely suppressed.
 
+    Result is cached after the first call — env vars and config.yaml are
+    checked once at startup and not re-read on every emit, so there is no
+    per-request I/O overhead.
+
     Checks (in order):
     1. ``OMNIGENT_TELEMETRY=0``
     2. ``DISABLE_TELEMETRY=true`` or ``OMNIGENT_DISABLE_TELEMETRY=true``
@@ -219,19 +228,28 @@ def is_disabled() -> bool:
 
     Always returns a ``bool``; never raises.
     """
+    if _IS_DISABLED_CACHE[0] is not None:
+        return _IS_DISABLED_CACHE[0]
     try:
-        if os.environ.get("OMNIGENT_TELEMETRY", "").strip() == "0":
-            return True
-        for var in ("DISABLE_TELEMETRY", "OMNIGENT_DISABLE_TELEMETRY"):
-            if os.environ.get(var, "").strip().lower() in ("1", "true", "yes"):
-                return True
-        if os.environ.get("DO_NOT_TRACK", "").strip() == "1":
-            return True
-        if any(var in os.environ for var in _CI_ENV_VARS):
-            return True
-        return _config_telemetry_disabled()
+        result = _compute_is_disabled()
     except Exception:
+        result = True
+    _IS_DISABLED_CACHE[0] = result
+    return result
+
+
+def _compute_is_disabled() -> bool:
+    """Compute whether telemetry is disabled (uncached)."""
+    if os.environ.get("OMNIGENT_TELEMETRY", "").strip() == "0":
         return True
+    for var in ("DISABLE_TELEMETRY", "OMNIGENT_DISABLE_TELEMETRY"):
+        if os.environ.get(var, "").strip().lower() in ("1", "true", "yes"):
+            return True
+    if os.environ.get("DO_NOT_TRACK", "").strip() == "1":
+        return True
+    if any(var in os.environ for var in _CI_ENV_VARS):
+        return True
+    return _config_telemetry_disabled()
 
 
 def _detect_environment() -> str | None:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -63,10 +63,14 @@ def test_classify_surface_regular_browser() -> None:
 # ── is_disabled ─────────────────────────────────────────────────────────────
 
 
-def _import_is_disabled():
-    from omnigent.telemetry.client import is_disabled
+@pytest.fixture(autouse=True)
+def _reset_is_disabled_cache():
+    """Reset the is_disabled() cache before each test so env patches take effect."""
+    import omnigent.telemetry.client as _mod
 
-    return is_disabled
+    _mod._IS_DISABLED_CACHE[0] = None
+    yield
+    _mod._IS_DISABLED_CACHE[0] = None
 
 
 def test_is_disabled_omnigent_telemetry_zero(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

`is_disabled()` was calling `_config_telemetry_disabled()` on every `emit()` call, which reads `~/.omnigent/config.yaml` from disk synchronously each time. With three `emit()` call sites (session created, stopped, deleted), this adds unnecessary file I/O to request handlers on the async event loop.

Fix: cache the result of `is_disabled()` after the first call in a module-level variable. Env vars and config.yaml don't change at runtime, so the result is stable.

## Test plan

- Existing 22 telemetry unit tests all pass
- Added `_reset_is_disabled_cache` autouse fixture to reset cache between tests so monkeypatched env vars still take effect

## Demo

N/A — performance fix, no visible behavior change

## Type of change

- [x] Bug fix / performance improvement
- [ ] New feature

## Test coverage

- [x] Existing tests updated
- [x] No new test surface added (pure caching change)

## Coverage notes

Existing `is_disabled()` tests cover all opt-out paths; the cache reset fixture ensures they remain independent.