### PR TITLE
fix(web): align admin settings pages with the rest of Settings

### DIFF
--- a/web/src/pages/MembersPage.tsx
+++ b/web/src/pages/MembersPage.tsx
@@ -112,12 +112,12 @@ export function MembersPage() {
 
   if (isSingleUser) {
     return (
-      <div className="mx-auto w-full max-w-2xl px-6 py-12">
+      <PageScroll contentClassName="px-8" extraBottom="2.5rem">
         <h1 className="mb-2 text-2xl font-semibold">Members</h1>
         <p className="text-sm text-muted-foreground">
           Member management is not available in single-user mode.
         </p>
-      </div>
+      </PageScroll>
     );
   }
 
@@ -137,12 +137,12 @@ export function MembersPage() {
   // Non-admin: hard stop. Server would also 403, this is just UX.
   if (meIsAdmin === false) {
     return (
-      <div className="mx-auto w-full max-w-2xl px-6 py-12">
+      <PageScroll contentClassName="px-8" extraBottom="2.5rem">
         <h1 className="mb-2 text-2xl font-semibold">Members</h1>
         <p className="text-sm text-muted-foreground">
           You don't have permission to manage members.
         </p>
-      </div>
+      </PageScroll>
     );
   }
 
@@ -189,7 +189,7 @@ export function MembersPage() {
   }
 
   return (
-    <PageScroll contentClassName="px-6">
+    <PageScroll contentClassName="px-8" extraBottom="2.5rem">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Members</h1>
         {/* Invite mints a password-backed account — accounts mode only.

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -476,12 +476,12 @@ export function PoliciesPage() {
 
   if (!isSingleUser && meIsAdmin === false) {
     return (
-      <div className="mx-auto w-full max-w-2xl px-6 py-12">
+      <PageScroll contentClassName="px-8" extraBottom="2.5rem">
         <h1 className="mb-2 text-2xl font-semibold">Global Policies</h1>
         <p className="text-sm text-muted-foreground">
           You don't have permission to manage global policies.
         </p>
-      </div>
+      </PageScroll>
     );
   }
 
@@ -502,7 +502,7 @@ export function PoliciesPage() {
   }
 
   return (
-    <PageScroll contentClassName="px-6">
+    <PageScroll contentClassName="px-8" extraBottom="2.5rem">
       <div className="mb-6 flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold">Global Policies</h1>

--- a/web/src/pages/SharingPage.tsx
+++ b/web/src/pages/SharingPage.tsx
@@ -82,12 +82,12 @@ export function SharingPage() {
 
   if (!isSingleUser && meIsAdmin === false) {
     return (
-      <div className="mx-auto w-full max-w-2xl px-6 py-12">
+      <PageScroll contentClassName="px-8" extraBottom="2.5rem">
         <h1 className="mb-2 text-2xl font-semibold">Session sharing</h1>
         <p className="text-sm text-muted-foreground">
           You don't have permission to manage session sharing.
         </p>
-      </div>
+      </PageScroll>
     );
   }
 
@@ -109,8 +109,8 @@ export function SharingPage() {
   }
 
   return (
-    <PageScroll contentClassName="px-6">
-      <div className="mx-auto w-full max-w-2xl py-2">
+    <PageScroll contentClassName="px-8" extraBottom="2.5rem">
+      <div>
         <div className="mb-6">
           <h1 className="text-2xl font-semibold">Session sharing</h1>
           <p className="mt-1 text-sm text-muted-foreground">


### PR DESCRIPTION
## Related issue

N/A

## Summary

The Members, Policies, and Sharing admin settings sub-categories didn't line up with the rest of Settings (e.g. Appearance). They used `px-6` padding — and Sharing added an extra centered `max-w-2xl` wrapper — so their titles sat further left/right and lower than sibling sections. Their single-user / non-admin early-return states also used a centered `max-w-2xl px-6 py-12` wrapper, which pushed the title inward and down.

- Switch every render path in all three pages to the shared `PageScroll` with `contentClassName="px-8" extraBottom="2.5rem"`, matching the reference Settings sections.
- Now all three (including their loading / single-user / no-permission states) align flush-left at the same top offset as Appearance.

## Test Plan

- `cd web && npm test` — 3989 passed.
- `cd web && npm run build` — clean.
- Manually eyeballed `/settings/members`, `/settings/policies`, `/settings/sharing` against `/settings/appearance` for matching left + top alignment across the normal, single-user, and non-admin states.

## Demo

| Before | After |
| --- | --- |
| Members (single-user) title indented/centered and pushed down | Title flush-left at the same top offset as Appearance |

<!-- Screenshots from the reporting session showed Members in single-user mode centered with `px-6 py-12`; after the fix it uses the shared `px-8` PageScroll. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Purely a layout/padding alignment change (Tailwind class swaps on the page wrappers) with no behavioral logic, so no new tests. Existing page tests still pass; verified visually across the normal, single-user, and non-admin render states of each page.

## Changelog

Admin Settings pages (Members, Policies, Sharing) now share the same left and top alignment as the rest of Settings.

This pull request and its description were written by Isaac.
