### PR TITLE
fix(pi-native): include GLM and other non-Claude models in Pi /model list

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -208,13 +208,13 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 
         creds = resolve_databricks_workspace(entry.profile)
-        claude_models, gpt_models, _ = _fetch_pi_model_lists(creds.host, creds.token)
+        claude_models, openai_models = _fetch_pi_model_lists(creds.host, creds.token)
     except Exception:  # noqa: BLE001 — credential/network failure must not break launch
         _LOGGER.info(
             "pi-native: falling back to single-model display (could not resolve credentials)"
         )
         claude_models = []
-        gpt_models = []
+        openai_models = []
     return PiProviderConfig(
         provider_id=_PI_PROVIDER_ID,
         base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
@@ -229,10 +229,10 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         additional_providers=(
             {
                 _PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(
-                    api_key, f"{host}/serving-endpoints", gpt_models
+                    api_key, f"{host}/serving-endpoints", openai_models
                 )
             }
-            if gpt_models
+            if openai_models
             else {}
         ),
     )
@@ -320,20 +320,25 @@ def _run_auth_command(auth_command: str, *, timeout: float = 15.0) -> str | None
 def _fetch_pi_model_lists(
     workspace_url: str,
     token: str,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Fetch live model lists from the Databricks serving-endpoints API.
 
-    Calls ``GET <workspace>/api/2.0/serving-endpoints``, filters for
-    READY LLM endpoints, and splits them by family (Claude/GPT/other) into
-    Pi model entry dicts (``{"id": name, "input": ["text", "image"]}``).
-    Falls back to the bundled static lists on any HTTP or auth failure so a
-    network blip or credential gap never breaks Pi session launch.
+    Calls ``GET <workspace>/api/2.0/serving-endpoints``, filters for READY LLM
+    endpoints, and splits them into two Pi model entry dict lists:
+
+    * Claude models → ``anthropic-messages`` provider.
+    * All other LLMs (GPT, GLM, Llama, Qwen, Kimi, …) → ``openai-completions``
+      provider. All non-Claude Databricks LLMs share the same serving-endpoints
+      URL and wire protocol, so a single provider covers them all.
+
+    Falls back to empty lists on any HTTP or auth failure so a network blip
+    never breaks Pi session launch.
 
     :param workspace_url: Databricks workspace base URL, e.g.
         ``"https://wkspc.example.com"`` — **no** trailing slash or path.
     :param token: Bearer token for the workspace API.
-    :returns: ``(claude_models, gpt_models, other_models)`` — each a list
-        of Pi model entry dicts ready to write into ``models.json``.
+    :returns: ``(claude_models, openai_models)`` — Pi model entry dicts ready
+        to write into ``models.json``.
     """
     import httpx
 
@@ -351,12 +356,14 @@ def _fetch_pi_model_lists(
             "Pi will show only the selected model",
             exc_info=True,
         )
-        return [], [], []
+        return [], []
 
     endpoints = payload.get("endpoints") if isinstance(payload, dict) else None
     claude: list[dict[str, Any]] = []
-    gpt: list[dict[str, Any]] = []
-    other: list[dict[str, Any]] = []
+    # All non-Claude LLM models (GPT, GLM, Llama, Qwen, Kimi, …) route to the
+    # same OpenAI Completions provider and serving-endpoints URL, so they share
+    # one list regardless of model family.
+    openai: list[dict[str, Any]] = []
 
     for endpoint in endpoints if isinstance(endpoints, list) else []:
         if not isinstance(endpoint, dict):
@@ -373,7 +380,7 @@ def _fetch_pi_model_lists(
         else:
             is_llm = any(
                 t in name_lower
-                for t in ("claude", "gpt", "codex", "gemini", "llama", "qwen", "kimi")
+                for t in ("claude", "gpt", "codex", "gemini", "llama", "qwen", "kimi", "glm")
             )
         if not is_llm:
             continue
@@ -384,18 +391,16 @@ def _fetch_pi_model_lists(
         entry: dict[str, Any] = {"id": name, "input": ["text", "image"]}
         if "claude" in name_lower:
             claude.append(entry)
-        elif "gpt" in name_lower:
-            gpt.append(entry)
         else:
-            other.append(entry)
+            openai.append(entry)
 
-    if not claude and not gpt and not other:
+    if not claude and not openai:
         _LOGGER.info(
             "pi-native: Databricks serving-endpoints returned no LLM models; "
             "Pi will show only the selected model"
         )
 
-    return claude, gpt, other
+    return claude, openai
 
 
 def _gateway_anthropic_base_url(codex_base_url: str) -> str:
@@ -534,19 +539,18 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     # Fetch the live model list. Run the auth command once to get the current
     # token — Pi will refresh per request via the !command apiKey.
     claude_models: list[dict[str, Any]] = []
-    gpt_models: list[dict[str, Any]] = []
+    openai_models: list[dict[str, Any]] = []
     if workspace_url and transport.auth_command:
         token = _run_auth_command(transport.auth_command)
         if token:
-            live_claude, live_gpt, _ = _fetch_pi_model_lists(workspace_url, token)
-            claude_models, gpt_models = live_claude, live_gpt
+            claude_models, openai_models = _fetch_pi_model_lists(workspace_url, token)
     additional: dict[str, Any] = (
         {
             _PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(
-                api_key, f"{workspace_url}/serving-endpoints", gpt_models
+                api_key, f"{workspace_url}/serving-endpoints", openai_models
             )
         }
-        if workspace_url and gpt_models
+        if workspace_url and openai_models
         else {}
     )
     return PiProviderConfig(

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -847,7 +847,7 @@ def test_databricks_profile_registers_gpt_provider(monkeypatch: pytest.MonkeyPat
     )
     live_gpt = [{"id": "databricks-gpt-5-4", "input": ["text", "image"]}]
     live_claude = [{"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]}]
-    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: (live_claude, live_gpt, []))
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: (live_claude, live_gpt))
 
     provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
     assert provider is not None
@@ -875,7 +875,7 @@ def test_cli_config_databricks_registers_gpt_provider(
     live_gpt = [{"id": "databricks-gpt-5-4", "input": ["text", "image"]}]
     live_claude = [{"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]}]
     monkeypatch.setattr(creds, "_run_auth_command", lambda *_: "fake-token")
-    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: (live_claude, live_gpt, []))
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: (live_claude, live_gpt))
 
     provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
     assert provider is not None
@@ -893,7 +893,7 @@ def test_cli_config_databricks_registers_gpt_provider(
 
 
 def test_fetch_pi_model_lists_parses_serving_endpoints() -> None:
-    """_fetch_pi_model_lists splits live endpoints by family into Pi model dicts."""
+    """_fetch_pi_model_lists splits live endpoints into claude/openai lists."""
     import json
     import unittest.mock
 
@@ -913,6 +913,14 @@ def test_fetch_pi_model_lists_parses_serving_endpoints() -> None:
             },
             {"name": "databricks-gpt-5-4", "task": "llm/v1/chat", "state": {"ready": "READY"}},
             {"name": "databricks-llama-3-70b", "task": "llm/v1/chat", "state": {"ready": "READY"}},
+            # GLM endpoint — task-based detection (no name token needed)
+            {
+                "name": "databricks-zai-org-glm-4-7",
+                "task": "llm/v1/chat",
+                "state": {"ready": "READY"},
+            },
+            # GLM without task field — falls back to name token "glm"
+            {"name": "databricks-glm-4-7", "state": {"ready": "READY"}},
             {"name": "my-embedding-model", "task": "llm/v1/embeddings"},
             {"name": "databricks-gpt-5-5", "task": "llm/v1/chat", "state": {"ready": "NOT_READY"}},
         ]
@@ -929,15 +937,22 @@ def test_fetch_pi_model_lists_parses_serving_endpoints() -> None:
         "httpx.Client",
         lambda **kw: _real_client(transport=_MockTransport()),
     ):
-        claude, gpt, other = creds._fetch_pi_model_lists("https://wkspc.example.com", "tok")
+        claude, openai = creds._fetch_pi_model_lists("https://wkspc.example.com", "tok")
 
     assert [m["id"] for m in claude] == [
         "databricks-claude-sonnet-4-6",
         "databricks-claude-opus-4-8",
     ]
-    assert [m["id"] for m in gpt] == ["databricks-gpt-5-4"]
-    assert [m["id"] for m in other] == ["databricks-llama-3-70b"]
-    assert all(m.get("input") == ["text", "image"] for m in claude + gpt + other)
+    # GPT, Llama, and GLM (both task-detected and name-detected) all go to openai
+    openai_ids = [m["id"] for m in openai]
+    assert "databricks-gpt-5-4" in openai_ids
+    assert "databricks-llama-3-70b" in openai_ids
+    assert "databricks-zai-org-glm-4-7" in openai_ids
+    assert "databricks-glm-4-7" in openai_ids
+    # Embeddings and not-ready endpoints excluded
+    assert "my-embedding-model" not in openai_ids
+    assert "databricks-gpt-5-5" not in openai_ids
+    assert all(m.get("input") == ["text", "image"] for m in claude + openai)
 
 
 def test_fetch_pi_model_lists_falls_back_on_http_error() -> None:
@@ -959,8 +974,7 @@ def test_fetch_pi_model_lists_falls_back_on_http_error() -> None:
         "httpx.Client",
         lambda **kw: _real_client(transport=_ErrorTransport()),
     ):
-        claude, gpt, other = creds._fetch_pi_model_lists("https://wkspc.example.com", "bad-tok")
+        claude, openai = creds._fetch_pi_model_lists("https://wkspc.example.com", "bad-tok")
 
     assert claude == []
-    assert gpt == []
-    assert other == []
+    assert openai == []


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two bugs prevented non-GPT models (GLM, Llama, Qwen, etc.) from appearing in Pi's `/model` list:

1. **GLM not detected as LLM**: The name-based fallback detection (used when an endpoint has no `task` field) didn't include `"glm"`. Added it alongside the existing tokens.

2. **Non-GPT models silently discarded**: `_fetch_pi_model_lists` returned a 3-tuple `(claude, gpt, other)`, but both call sites used `_` for the third slot — Llama, GLM, Qwen, etc. were fetched from the API and then thrown away. Since all non-Claude Databricks LLMs use the same OpenAI Completions API at `/serving-endpoints`, the `gpt`/`other` split was artificial. Collapsed to a 2-tuple `(claude, openai)` where `openai` covers everything non-Claude.

## Test Plan

- `test_fetch_pi_model_lists_parses_serving_endpoints` extended with GLM endpoints in both forms: task-detected (`databricks-zai-org-glm-4-7` with `"task": "llm/v1/chat"`) and name-detected (`databricks-glm-4-7` without task field). Both appear in the `openai` list alongside GPT and Llama.
- All 49 `tests/test_pi_native_credentials.py` tests pass.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A

## Changelog

Pi's `/model` command now shows GLM, Llama, Qwen, and other non-GPT Databricks models alongside Claude and GPT models