### PR TITLE
fix(pi-native): circuit-breaker on PermissionRequest hook — deny after 30s

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1236,14 +1236,11 @@ def build_hook_settings(
         permission_hook: dict[str, Any] = {
             "type": "command",
             "command": shlex.join(permission_command_parts),
-            # Wait up to a day for the verdict. Claude Code's default
-            # command-hook timeout (~60s) would otherwise kill the hook
-            # subprocess long before the user answers, putting the
-            # prompt back in the TUI and flipping the web card to
-            # "Resolved elsewhere". A day is effectively wait-forever
-            # for an interactive permission prompt; it stays in lockstep
-            # with the subprocess/AP-side budgets so none caps first.
-            "timeout": 86400,
+            # 30-second circuit breaker: if no web verdict arrives the
+            # server returns an explicit deny, failing the tool call.
+            # Kept in lockstep with the subprocess/AP-side budgets so
+            # no single layer caps the wait first.
+            "timeout": 30,
         }
         hooks["PermissionRequest"] = [{"hooks": [permission_hook]}]
 

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1237,9 +1237,9 @@ def build_hook_settings(
             "type": "command",
             "command": shlex.join(permission_command_parts),
             # 30-second circuit breaker: if no web verdict arrives the
-            # server returns an explicit deny, failing the tool call.
-            # Kept in lockstep with the subprocess/AP-side budgets so
-            # no single layer caps the wait first.
+            # hook exits with empty output so Claude falls back to its
+            # TUI prompt (fail-ask). Kept in lockstep with the
+            # subprocess/AP-side budgets so no single layer caps first.
             "timeout": 30,
         }
         hooks["PermissionRequest"] = [{"hooks": [permission_hook]}]

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -46,14 +46,12 @@ from omnigent.native_policy_hook import (
 # ``_CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S`` and Claude Code's own
 # command-hook ``timeout`` so no single layer caps the wait early.
 #
-# NOTE: this bounds a SINGLE long-poll (a slow human), NOT the retry loop.
-# Re-POST attempts after a *failure* are bounded separately by
+# NOTE: this bounds a SINGLE long-poll, NOT the retry loop. Re-POST
+# attempts after a *failure* are bounded separately by
 # ``_PERMISSION_MAX_CONSECUTIVE_FAILURES`` — see :func:`_post_hook_with_reattach`.
-# Before #1782 the retry deadline was also one day, so a persistently
-# sick/unreachable server made the hook re-POST (each re-driving the turn and
-# respawning harness/tool subprocesses) every ≤30s for 24h — the spin-loop half
-# of the zombie pileup.
-_PERMISSION_TIMEOUT_S = 86400.0
+# 30-second circuit breaker: if no verdict arrives the server returns
+# an explicit deny, so the hook subprocess relays that deny decision.
+_PERMISSION_TIMEOUT_S = 30.0
 # First retry must land inside the server's re-park grace (proxies
 # sever idle long-polls); later retries back off.
 _PERMISSION_RETRY_INITIAL_BACKOFF_S = 1.0

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -49,8 +49,8 @@ from omnigent.native_policy_hook import (
 # NOTE: this bounds a SINGLE long-poll, NOT the retry loop. Re-POST
 # attempts after a *failure* are bounded separately by
 # ``_PERMISSION_MAX_CONSECUTIVE_FAILURES`` — see :func:`_post_hook_with_reattach`.
-# 30-second circuit breaker: if no verdict arrives the server returns
-# an explicit deny, so the hook subprocess relays that deny decision.
+# 30-second circuit breaker: if no verdict arrives the hook exits with
+# empty output so Claude falls back to its TUI prompt (fail-ask).
 _PERMISSION_TIMEOUT_S = 30.0
 # First retry must land inside the server's re-park grace (proxies
 # sever idle long-polls); later retries back off.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -609,18 +609,14 @@ _RUNNER_CONVICTION_POLL_S = 0.25
 # through to the connect wait, preserving the prior fire-and-forget
 # behavior rather than blocking the turn.
 _HOST_LAUNCH_RESULT_TIMEOUT_S = 10.0
-# Server-side wait budget for Claude's ``PermissionRequest`` hook. Set
-# to one day so a native permission prompt waits ~indefinitely for the
-# user to answer in EITHER the web UI or the terminal, rather than
-# auto-resolving after a few minutes. The terminal prompt stays usable
-# the whole time: answering it closes the hook connection, which the
-# disconnect poll catches and resolves the web card. Kept in lockstep
-# with the hook subprocess httpx budget (``_PERMISSION_TIMEOUT_S`` in
-# ``claude_native_hook``) and Claude Code's own command-hook
-# ``timeout`` (set in ``build_hook_settings``) so no single layer caps
-# the wait first. Empty 2xx body on timeout → Claude defers to its
-# built-in prompt (fail-ask).
-_CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S = 86400.0
+# Server-side wait budget for Claude's ``PermissionRequest`` hook.
+# 30-second circuit breaker: if the web UI doesn't deliver a verdict
+# within 30s the server returns an explicit ``"deny"`` decision and
+# the tool call fails. Kept in lockstep with the hook subprocess
+# httpx budget (``_PERMISSION_TIMEOUT_S`` in ``claude_native_hook``)
+# and Claude Code's own command-hook ``timeout`` (set in
+# ``build_hook_settings``) so no single layer caps the wait first.
+_CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S = 30.0
 
 # ── Embedded-browser action bridge ──────────────────────────────────
 # In-process registries (keyed by action_id) bridging a runner-side
@@ -16140,10 +16136,8 @@ def create_sessions_router(
         Response shape follows Claude Code's PermissionRequest hook
         contract: ``hookSpecificOutput.decision.behavior`` is
         ``"allow"`` or ``"deny"``. On timeout the endpoint returns
-        ``200`` with an empty body — Claude Code treats that as
-        "defer to the TUI prompt", which matches the wrapper's
-        fail-ask contract (UI unreachable / unattended → fall back
-        to terminal-side approval).
+        ``200`` with an explicit ``"deny"`` decision — the tool call
+        fails rather than deferring to the TUI (circuit breaker).
 
         Auth: standard session ACL — the wrapper's outbound headers
         (``ap_auth_headers`` in :func:`build_hook_settings`) carry
@@ -16154,8 +16148,9 @@ def create_sessions_router(
         :param request: FastAPI request — body is Claude Code's
             PermissionRequest payload as JSON.
         :param session_id: Omnigent conversation id from the URL path.
-        :returns: Claude PermissionRequest hookSpecificOutput JSON,
-            or ``200`` with empty body on timeout (fail-ask).
+        :returns: Claude PermissionRequest hookSpecificOutput JSON
+            with ``"allow"`` or ``"deny"``; on timeout returns
+            ``"deny"`` (circuit breaker).
         :raises OmnigentError: 404 if the session doesn't exist,
             400 if the body fails JSON parse or is missing
             ``tool_name``.
@@ -16303,10 +16298,18 @@ def create_sessions_router(
             tool_input=tool_input if isinstance(tool_input, dict) else None,
         )
         if result is None:
-            # Disconnect or timeout. Either way Claude is no
-            # longer waiting on this response; empty 2xx → Claude
-            # defers to its built-in TUI prompt (fail-ask).
-            return Response(status_code=status.HTTP_200_OK)
+            # Timeout or disconnect — circuit breaker: explicitly deny
+            # so the tool call fails rather than deferring to the TUI.
+            deny_body = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {"behavior": "deny"},
+                },
+            }
+            return Response(
+                content=json.dumps(deny_body),
+                media_type="application/json",
+            )
 
         behavior = "allow" if result.action == "accept" else "deny"
         decision: dict[str, Any] = {"behavior": behavior}

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -610,11 +610,11 @@ _RUNNER_CONVICTION_POLL_S = 0.25
 # behavior rather than blocking the turn.
 _HOST_LAUNCH_RESULT_TIMEOUT_S = 10.0
 # Server-side wait budget for Claude's ``PermissionRequest`` hook.
-# 30-second circuit breaker: if the web UI doesn't deliver a verdict
-# within 30s the server returns an explicit ``"deny"`` decision and
-# the tool call fails. Kept in lockstep with the hook subprocess
-# httpx budget (``_PERMISSION_TIMEOUT_S`` in ``claude_native_hook``)
-# and Claude Code's own command-hook ``timeout`` (set in
+# 30-second circuit breaker: if no verdict arrives within 30s the
+# server returns an empty 2xx and Claude defers to its built-in TUI
+# prompt (fail-ask). Kept in lockstep with the hook subprocess httpx
+# budget (``_PERMISSION_TIMEOUT_S`` in ``claude_native_hook``) and
+# Claude Code's own command-hook ``timeout`` (set in
 # ``build_hook_settings``) so no single layer caps the wait first.
 _CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S = 30.0
 
@@ -16136,8 +16136,8 @@ def create_sessions_router(
         Response shape follows Claude Code's PermissionRequest hook
         contract: ``hookSpecificOutput.decision.behavior`` is
         ``"allow"`` or ``"deny"``. On timeout the endpoint returns
-        ``200`` with an explicit ``"deny"`` decision — the tool call
-        fails rather than deferring to the TUI (circuit breaker).
+        ``200`` with an empty body — Claude Code treats that as
+        "defer to the TUI prompt" (fail-ask).
 
         Auth: standard session ACL — the wrapper's outbound headers
         (``ap_auth_headers`` in :func:`build_hook_settings`) carry
@@ -16148,9 +16148,8 @@ def create_sessions_router(
         :param request: FastAPI request — body is Claude Code's
             PermissionRequest payload as JSON.
         :param session_id: Omnigent conversation id from the URL path.
-        :returns: Claude PermissionRequest hookSpecificOutput JSON
-            with ``"allow"`` or ``"deny"``; on timeout returns
-            ``"deny"`` (circuit breaker).
+        :returns: Claude PermissionRequest hookSpecificOutput JSON,
+            or ``200`` with empty body on timeout (fail-ask).
         :raises OmnigentError: 404 if the session doesn't exist,
             400 if the body fails JSON parse or is missing
             ``tool_name``.
@@ -16298,18 +16297,9 @@ def create_sessions_router(
             tool_input=tool_input if isinstance(tool_input, dict) else None,
         )
         if result is None:
-            # Timeout or disconnect — circuit breaker: explicitly deny
-            # so the tool call fails rather than deferring to the TUI.
-            deny_body = {
-                "hookSpecificOutput": {
-                    "hookEventName": "PermissionRequest",
-                    "decision": {"behavior": "deny"},
-                },
-            }
-            return Response(
-                content=json.dumps(deny_body),
-                media_type="application/json",
-            )
+            # Timeout or disconnect — empty 2xx → Claude defers to its
+            # built-in TUI prompt (fail-ask).
+            return Response(status_code=status.HTTP_200_OK)
 
         behavior = "allow" if result.action == "accept" else "deny"
         decision: dict[str, Any] = {"behavior": behavior}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- **Previously:** `/v1/sessions/{id}/hooks/permission-request` held the long-poll for up to **24 hours** before timing out.
- **Now:** 30-second circuit breaker — if no web verdict arrives within 30s the endpoint returns an empty `200` and Claude defers to its built-in TUI prompt (fail-ask), same as before but much sooner.
- The three lockstep budgets are all reduced from `86400` → `30`: server-side wait (`_CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S`), the hook subprocess's httpx read timeout (`_PERMISSION_TIMEOUT_S` in `claude_native_hook.py`), and Claude Code's command-hook `timeout` in `build_hook_settings`.

## Test Plan

- Manual: trigger a PermissionRequest hook in a claude-native session, let the 30s window elapse without answering in the web UI — Claude should fall back to its TUI prompt.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

Timeout path returns empty `200` (unchanged behavior); only the budget shrinks from 24h to 30s.

## Changelog

Permission-request hook now fails fast to the TUI prompt after 30 seconds instead of parking for 24 hours.