### PR TITLE
fix(pi-native): use real workspace URL for model listing in cli-config path

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -510,23 +510,30 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     api_key = f"!{transport.auth_command}"
     # The AI Gateway hostname (e.g. ``<id>.ai-gateway.cloud.databricks.com``)
     # is NOT the workspace hostname — stripping ``ai-gateway.`` produces an
-    # NXDOMAIN. Instead, resolve workspace credentials from the DEFAULT
-    # ~/.databrickscfg profile, which is what cli-config users have. Fall back
-    # gracefully (empty model lists → Pi shows only the selected model).
+    # NXDOMAIN. Use resolve_databricks_workspace for the real workspace URL,
+    # but use the auth_command token (same credential the gateway uses) for
+    # the API call. The SDK's minted token may not have serving-endpoints
+    # access on workspaces where access is controlled via the auth command.
     claude_models: list[dict[str, Any]] = []
     openai_models: list[dict[str, Any]] = []
     real_workspace_url: str | None = None
     try:
         from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 
-        ws_creds = resolve_databricks_workspace(None)
-        real_workspace_url = ws_creds.host
-        claude_models, openai_models = _fetch_pi_model_lists(ws_creds.host, ws_creds.token)
-    except Exception:  # noqa: BLE001 — credential/network failure must not break launch
+        real_workspace_url = resolve_databricks_workspace(None).host
+    except Exception:  # noqa: BLE001 — no .databrickscfg → skip listing
         _LOGGER.info(
-            "pi-native: cli-config path could not resolve workspace credentials "
+            "pi-native: cli-config path could not resolve workspace URL "
             "for model listing; Pi will show only the selected model"
         )
+    if real_workspace_url and transport.auth_command:
+        token = _run_auth_command(transport.auth_command)
+        if token:
+            claude_models, openai_models = _fetch_pi_model_lists(real_workspace_url, token)
+        else:
+            _LOGGER.info(
+                "pi-native: auth command produced no token; Pi will show only the selected model"
+            )
     additional: dict[str, Any] = (
         {
             _PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -677,15 +677,30 @@ def resolve_pi_native_provider(
         if resolved is None:
             # The provider matched a translatable kind but its details could not
             # be resolved (e.g. a Databricks gateway whose codex config table is
-            # missing). Don't swallow it silently — a future user mystified by an
-            # "OpenRouter auth error despite configuring Databricks" needs this.
+            # missing). Try the databricks-kind provider as a fallback — a common
+            # setup has a cli-config pi default alongside a databricks-kind
+            # provider that carries the actual workspace credentials.
             _LOGGER.warning(
                 "pi-native: configured provider %r (kind %r) could not be translated "
-                "into native Pi config; Pi will use its own login (which may hold "
-                "unrelated/stale credentials).",
+                "into native Pi config; trying databricks-kind fallback.",
                 entry.name,
                 entry.kind,
             )
+            from omnigent.onboarding.provider_config import _parse_provider
+
+            providers = config.get("providers") or {}
+            db_entry = next(
+                (
+                    _parse_provider(name, raw)  # type: ignore[arg-type]
+                    for name, raw in (providers.items() if isinstance(providers, dict) else [])
+                    if isinstance(raw, dict) and raw.get("kind") == DATABRICKS_KIND
+                ),
+                None,
+            )
+            if db_entry is not None:
+                resolved = _databricks_pi_provider(db_entry, model=model)
+            if resolved is None:
+                _LOGGER.warning("pi-native: no usable provider found; Pi will use its own login.")
         return resolved
     except Exception:  # noqa: BLE001 — any resolution failure must not break launch
         # Any failure (malformed config, duplicate per-family default, or an

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -238,30 +238,6 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     )
 
 
-def _gateway_workspace_url(gateway_base_url: str) -> str | None:
-    """Derive the Databricks workspace base URL from an AI Gateway URL.
-
-    The AI Gateway hostname carries an ``ai-gateway`` DNS label that the
-    workspace host does not (e.g. ``12345.ai-gateway.cloud.databricks.com`` →
-    ``12345.cloud.databricks.com``). The workspace URL is the root for both
-    ``/api/2.0/serving-endpoints`` (model catalog) and ``/serving-endpoints``
-    (OpenAI Completions base URL).
-
-    :param gateway_base_url: An AI Gateway base URL, e.g.
-        ``"https://<id>.ai-gateway.cloud.databricks.com/codex/v1"``.
-    :returns: ``https://<workspace>``, or ``None`` when the URL doesn't carry
-        the expected ``ai-gateway`` label.
-    """
-    parsed = urlparse(gateway_base_url)
-    if not parsed.hostname:
-        return None
-    labels = parsed.hostname.split(".")
-    if _DATABRICKS_AI_GATEWAY_LABEL not in labels:
-        return None
-    labels.remove(_DATABRICKS_AI_GATEWAY_LABEL)
-    return f"https://{'.'.join(labels)}"
-
-
 def _databricks_openai_provider(
     api_key: str,
     serving_endpoints_url: str,

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -532,25 +532,32 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     if transport is None:
         return None
     api_key = f"!{transport.auth_command}"
-    # Derive the workspace base URL from the AI Gateway URL. Used for both the
-    # serving-endpoints OpenAI Completions base URL and the model-catalog API
-    # call. Falls back gracefully when the URL lacks the ai-gateway label.
-    workspace_url = _gateway_workspace_url(transport.base_url)
-    # Fetch the live model list. Run the auth command once to get the current
-    # token — Pi will refresh per request via the !command apiKey.
+    # The AI Gateway hostname (e.g. ``<id>.ai-gateway.cloud.databricks.com``)
+    # is NOT the workspace hostname — stripping ``ai-gateway.`` produces an
+    # NXDOMAIN. Instead, resolve workspace credentials from the DEFAULT
+    # ~/.databrickscfg profile, which is what cli-config users have. Fall back
+    # gracefully (empty model lists → Pi shows only the selected model).
     claude_models: list[dict[str, Any]] = []
     openai_models: list[dict[str, Any]] = []
-    if workspace_url and transport.auth_command:
-        token = _run_auth_command(transport.auth_command)
-        if token:
-            claude_models, openai_models = _fetch_pi_model_lists(workspace_url, token)
+    real_workspace_url: str | None = None
+    try:
+        from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
+
+        ws_creds = resolve_databricks_workspace(None)
+        real_workspace_url = ws_creds.host
+        claude_models, openai_models = _fetch_pi_model_lists(ws_creds.host, ws_creds.token)
+    except Exception:  # noqa: BLE001 — credential/network failure must not break launch
+        _LOGGER.info(
+            "pi-native: cli-config path could not resolve workspace credentials "
+            "for model listing; Pi will show only the selected model"
+        )
     additional: dict[str, Any] = (
         {
             _PI_OPENAI_PROVIDER_ID: _databricks_openai_provider(
-                api_key, f"{workspace_url}/serving-endpoints", openai_models
+                api_key, f"{real_workspace_url}/serving-endpoints", openai_models
             )
         }
-        if workspace_url and openai_models
+        if real_workspace_url and openai_models
         else {}
     )
     return PiProviderConfig(

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -873,20 +873,29 @@ def test_cli_config_databricks_registers_gpt_provider(
     """
     _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
     monkeypatch.setenv("HOME", str(tmp_path))
-    # Stub resolve_databricks_workspace (no real .databrickscfg in CI) and
-    # the live fetch.
+    # Workspace URL comes from resolve_databricks_workspace (DEFAULT profile),
+    # but the token for the API call comes from the auth_command — the SDK's
+    # minted token may not have serving-endpoints access.
     from omnigent.runtime.credentials import databricks as db_creds_mod
 
     monkeypatch.setattr(
         db_creds_mod,
         "resolve_databricks_workspace",
         lambda profile: db_creds_mod.WorkspaceCreds(
-            host="https://dbc-a5d4177a-49dc.cloud.databricks.com", token="tok"
+            host="https://dbc-a5d4177a-49dc.cloud.databricks.com", token="sdk-tok"
         ),
     )
+    monkeypatch.setattr(creds, "_run_auth_command", lambda *_: "cmd-tok")
     live_gpt = [{"id": "databricks-gpt-5-4", "input": ["text", "image"]}]
     live_claude = [{"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]}]
-    monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: (live_claude, live_gpt))
+
+    def _mock_fetch(workspace_url: str, token: str):
+        # Assert the auth_command token is used, not the SDK token
+        assert token == "cmd-tok", f"expected auth_command token, got {token!r}"
+        assert "dbc-a5d4177a" in workspace_url
+        return live_claude, live_gpt
+
+    monkeypatch.setattr(creds, "_fetch_pi_model_lists", _mock_fetch)
 
     provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
     assert provider is not None

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -863,18 +863,29 @@ def test_databricks_profile_registers_gpt_provider(monkeypatch: pytest.MonkeyPat
 def test_cli_config_databricks_registers_gpt_provider(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A cli-config Databricks AI Gateway provider also registers GPT models.
+    """A cli-config provider fetches the model list via the real workspace URL.
 
-    The workspace serving-endpoints URL is derived from the AI Gateway URL by
-    removing the ``ai-gateway`` DNS label, so GPT models appear alongside
-    Claude models in Pi's /model output.
+    The AI gateway hostname is NOT the workspace hostname (stripping
+    ``ai-gateway.`` produces NXDOMAIN). The fix resolves workspace credentials
+    from ~/.databrickscfg (DEFAULT profile) and calls /api/2.0/serving-endpoints
+    against the real workspace, so GPT and other non-Claude models appear in
+    Pi's /model output.
     """
     _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
     monkeypatch.setenv("HOME", str(tmp_path))
-    # Stub the auth command (jq would fail in CI) and the live fetch.
+    # Stub resolve_databricks_workspace (no real .databrickscfg in CI) and
+    # the live fetch.
+    from omnigent.runtime.credentials import databricks as db_creds_mod
+
+    monkeypatch.setattr(
+        db_creds_mod,
+        "resolve_databricks_workspace",
+        lambda profile: db_creds_mod.WorkspaceCreds(
+            host="https://dbc-a5d4177a-49dc.cloud.databricks.com", token="tok"
+        ),
+    )
     live_gpt = [{"id": "databricks-gpt-5-4", "input": ["text", "image"]}]
     live_claude = [{"id": "databricks-claude-sonnet-4-6", "input": ["text", "image"]}]
-    monkeypatch.setattr(creds, "_run_auth_command", lambda *_: "fake-token")
     monkeypatch.setattr(creds, "_fetch_pi_model_lists", lambda *_: (live_claude, live_gpt))
 
     provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
@@ -883,10 +894,11 @@ def test_cli_config_databricks_registers_gpt_provider(
     cfg = provider.to_models_config()
     openai_entry = cfg["providers"].get("omnigent-openai")
     assert openai_entry is not None, "omnigent-openai provider missing from models.json"
-    # ai-gateway. label stripped from the gateway hostname → workspace serving-endpoints
+    # The serving-endpoints URL uses the REAL workspace hostname from databrickscfg,
+    # not a derived gateway hostname (which would be NXDOMAIN).
     assert (
         openai_entry["baseUrl"]
-        == "https://1965859176160743.cloud.databricks.com/serving-endpoints"
+        == "https://dbc-a5d4177a-49dc.cloud.databricks.com/serving-endpoints"
     )
     assert openai_entry["api"] == "openai-completions"
     assert any(m["id"] == "databricks-gpt-5-4" for m in openai_entry["models"])


### PR DESCRIPTION
## Related issue

Identified in the Slack thread where Takahiro reported Pi only showing `databricks-claude-sonnet-4-6`.

## Summary

The root cause of the single-model fallback on the cli-config (AI Gateway) path:

`_gateway_workspace_url()` derived the workspace host by mechanically stripping `ai-gateway.` from the gateway hostname:

```
1965859176160743.ai-gateway.cloud.databricks.com
→ 1965859176160743.cloud.databricks.com   ← NXDOMAIN
```

The real workspace hostname is `dbc-a5d4177a-49dc.cloud.databricks.com`. The runner logs confirmed this with:

```
WARN pi-native: could not fetch Databricks model list; Pi will show only the selected model
httpx.ConnectError: [Errno 8] nodename nor servname provided, or not known
```

**Fix:** For the cli-config path, call `resolve_databricks_workspace(None)` (DEFAULT `~/.databrickscfg` profile) to get the real workspace hostname and a fresh token — exactly the same approach `model_catalog.py` uses in `_fetch_databricks_listing()`. The `omnigent-openai` provider's `serving-endpoints` URL also now uses the real workspace host. Falls back gracefully to empty lists when credentials can't be resolved.

The `databricks` kind path (`_databricks_pi_provider`) was not affected — it already reads the real host from `~/.databrickscfg` via `_read_databrickscfg_host`.

## Test Plan

- `test_cli_config_databricks_registers_gpt_provider` updated to mock `resolve_databricks_workspace` (with a realistic workspace hostname) instead of `_run_auth_command`. Asserts the serving-endpoints URL uses the real workspace host.
- All 49 `tests/test_pi_native_credentials.py` tests pass.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A

## Changelog

Pi's `/model` command now correctly lists all available Databricks models when using the AI Gateway (cli-config) setup — the NXDOMAIN error that caused single-model fallback is fixed