### PR TITLE
fix(subagents): preserve named spawn authorization for bundled named children

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12349,28 +12349,44 @@ async def _create_session_from_existing_agent(
             code=ErrorCode.NOT_FOUND,
         )
 
-    # Session-scoped agents belong to a specific session.
-    # The caller must have at least READ access to that owning
-    # session — otherwise they can execute another user's private
-    # agent by guessing the raw agent id.
-    if agent.session_id is not None:
-        await _require_access(
-            user_id,
-            agent.session_id,
-            LEVEL_READ,
-            permission_store,
-            conversation_store,
-        )
-
     # Authorize parent_session_id before inheriting anything.
     # The caller must own or have READ access to the parent session;
     # otherwise a forged parent link lets them inherit runner
     # bindings and establish a parent-child relationship with a
     # session they don't control.
+    named_child_uses_parent_agent = False
     if body.parent_session_id is not None:
         await _require_access(
             user_id,
             body.parent_session_id,
+            LEVEL_READ,
+            permission_store,
+            conversation_store,
+        )
+        if body.sub_agent_name is not None:
+            parent_conv = await asyncio.to_thread(
+                conversation_store.get_conversation,
+                body.parent_session_id,
+            )
+            if parent_conv is None:
+                raise OmnigentError(
+                    "Conversation not found",
+                    code=ErrorCode.NOT_FOUND,
+                )
+            if parent_conv.agent_id != body.agent_id:
+                raise OmnigentError(
+                    "Named sub-agent sessions must use the parent session's agent",
+                    code=ErrorCode.FORBIDDEN,
+                )
+            named_child_uses_parent_agent = True
+
+    # Session-scoped agents belong to a specific session. Named children
+    # reuse their authorized parent's agent, so that parent check is the
+    # ownership boundary; all other creates must authorize the owning session.
+    if agent.session_id is not None and not named_child_uses_parent_agent:
+        await _require_access(
+            user_id,
+            agent.session_id,
             LEVEL_READ,
             permission_store,
             conversation_store,

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -9,6 +9,7 @@ from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
     SqlAgent,
     SqlAgentConfiguration,
+    SqlConversation,
     current_workspace_id,
 )
 from omnigent.db.enum_codecs import encode_agent_kind
@@ -75,10 +76,19 @@ class SqlAlchemyAgentStore(AgentStore):
         with self._conv_session() as conv_sess:
             return conv_sess.execute(
                 select(SqlAgentConfiguration.conversation_id)
+                .join(
+                    SqlConversation,
+                    and_(
+                        SqlConversation.workspace_id == SqlAgentConfiguration.workspace_id,
+                        SqlConversation.id == SqlAgentConfiguration.conversation_id,
+                    ),
+                )
                 .where(
                     SqlAgentConfiguration.workspace_id == current_workspace_id(),
                     SqlAgentConfiguration.agent_id == agent_id,
                 )
+                # Named children break the one-conversation-per-agent assumption.
+                .order_by(asc(SqlConversation.created_at), asc(SqlConversation.id))
                 .limit(1)
             ).scalar_one_or_none()
 

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -18,26 +18,87 @@ conversation row's ``agent_id`` column.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import tarfile
-from dataclasses import dataclass
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import Any, NoReturn
 
 import httpx
 import pytest
+import pytest_asyncio
 import yaml
+from fastapi import FastAPI
 
+from omnigent.db.utils import builtin_agent_id
 from omnigent.entities import Conversation
 from omnigent.entities.conversation import MessageData, NewConversationItem
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import _ensure_default_cursor_agent, create_app
 from omnigent.server.routes import sessions as sessions_module
 from omnigent.session_lifecycle import CLOSED_LABEL_KEY, CLOSED_LABEL_VALUE
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
+)
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.permission_store.sqlalchemy_store import (
+    SqlAlchemyPermissionStore,
 )
 from tests.server.helpers import build_agent_bundle, create_test_agent
 
 pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class _SpawnAuthContext:
+    client: httpx.AsyncClient
+    agent_store: SqlAlchemyAgentStore
+
+
+@pytest_asyncio.fixture()
+async def spawn_auth_context(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    mock_llm: Any,
+) -> AsyncIterator[_SpawnAuthContext]:
+    """Auth-enabled client plus its agent store for named-spawn tests."""
+    from omnigent.runtime import set_harness_process_manager
+    from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+    from omnigent.server.auth import UnifiedAuthProvider
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "spawn-auth-artifacts"))
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    agent_cache = AgentCache(
+        artifact_store=artifact_store,
+        cache_dir=tmp_path / "spawn-auth-cache",
+    )
+    _ensure_default_cursor_agent(agent_store, artifact_store, agent_cache)
+    app: FastAPI = create_app(
+        agent_store=agent_store,
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=agent_cache,
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        permission_store=SqlAlchemyPermissionStore(db_uri),
+        auth_provider=UnifiedAuthProvider(source="header", local_single_user=False),
+    )
+    process_manager = HarnessProcessManager(tmp_parent=tmp_path / "spawn-auth-harnesses")
+    await process_manager.start()
+    set_harness_process_manager(process_manager)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield _SpawnAuthContext(client=client, agent_store=agent_store)
+    mock_llm.release_all()
+    set_harness_process_manager(None)
+    await process_manager.shutdown()
 
 
 @pytest.fixture(autouse=True)
@@ -1141,6 +1202,7 @@ async def _create_parent_with_subagents(
     client: httpx.AsyncClient,
     name: str,
     sub_agents: list[dict[str, Any]],
+    headers: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """
     Register a bundle with harnessed sub-agents and create a parent session.
@@ -1150,6 +1212,7 @@ async def _create_parent_with_subagents(
     :param sub_agents: Sub-agent dicts with ``name`` + ``harness`` and an
         optional ``config`` mapping (see
         :func:`_bundle_with_harnessed_subagents`).
+    :param headers: Optional request headers, e.g. an authenticated user.
     :returns: A dict with ``session_id`` (the parent session) and
         ``agent_id`` (the durable agent id resolved from the session).
     """
@@ -1158,12 +1221,129 @@ async def _create_parent_with_subagents(
         "/v1/sessions",
         data={"metadata": json.dumps({})},
         files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers=headers,
     )
     assert resp.status_code == 201, f"parent create failed: {resp.text}"
     session_id = resp.json()["session_id"]
-    agent_resp = await client.get(f"/v1/sessions/{session_id}/agent")
+    agent_resp = await client.get(f"/v1/sessions/{session_id}/agent", headers=headers)
     assert agent_resp.status_code == 200, f"parent agent lookup failed: {agent_resp.text}"
     return {"session_id": session_id, "agent_id": agent_resp.json()["id"]}
+
+
+def _named_child_body(parent: dict[str, Any], agent: str, title: str) -> dict[str, str]:
+    """Build the JSON body used by named-mode ``sys_session_send`` creates."""
+    return {
+        "agent_id": parent["agent_id"],
+        "parent_session_id": parent["session_id"],
+        "title": f"{agent}:{title}",
+        "sub_agent_name": agent,
+    }
+
+
+async def test_bundled_parent_creates_two_named_children_sequentially(
+    spawn_auth_context: _SpawnAuthContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second named child does not re-authorize an ambiguous agent owner."""
+    headers = {"X-Forwarded-Email": "owner@example.com"}
+    parent = await _create_parent_with_subagents(
+        spawn_auth_context.client,
+        name="sequential-named-spawn",
+        sub_agents=[
+            {"name": "researcher", "harness": "claude-sdk"},
+            {"name": "reviewer", "harness": "claude-sdk"},
+        ],
+        headers=headers,
+    )
+    first = await spawn_auth_context.client.post(
+        "/v1/sessions",
+        json=_named_child_body(parent, "researcher", "first"),
+        headers=headers,
+    )
+    assert first.status_code == 201, first.text
+
+    original_get = spawn_auth_context.agent_store.get
+
+    def _get_with_ambiguous_owner(agent_id: str) -> Any:
+        agent = original_get(agent_id)
+        if agent is not None and agent.id == parent["agent_id"]:
+            return replace(agent, session_id="conv_stale_named_child_owner")
+        return agent
+
+    monkeypatch.setattr(spawn_auth_context.agent_store, "get", _get_with_ambiguous_owner)
+    second = await spawn_auth_context.client.post(
+        "/v1/sessions",
+        json=_named_child_body(parent, "reviewer", "second"),
+        headers=headers,
+    )
+    assert second.status_code == 201, second.text
+    assert first.json()["parent_session_id"] == parent["session_id"]
+    assert second.json()["parent_session_id"] == parent["session_id"]
+
+
+async def test_bundled_parent_creates_two_named_children_concurrently(
+    spawn_auth_context: _SpawnAuthContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parallel named children rely on the authorized parent, not owner selection."""
+    headers = {"X-Forwarded-Email": "owner@example.com"}
+    parent = await _create_parent_with_subagents(
+        spawn_auth_context.client,
+        name="parallel-named-spawn",
+        sub_agents=[
+            {"name": "researcher", "harness": "claude-sdk"},
+            {"name": "reviewer", "harness": "claude-sdk"},
+        ],
+        headers=headers,
+    )
+    original_get = spawn_auth_context.agent_store.get
+
+    def _get_with_ambiguous_owner(agent_id: str) -> Any:
+        agent = original_get(agent_id)
+        if agent is not None and agent.id == parent["agent_id"]:
+            return replace(agent, session_id="conv_stale_named_child_owner")
+        return agent
+
+    monkeypatch.setattr(spawn_auth_context.agent_store, "get", _get_with_ambiguous_owner)
+    responses = await asyncio.gather(
+        spawn_auth_context.client.post(
+            "/v1/sessions",
+            json=_named_child_body(parent, "researcher", "parallel-a"),
+            headers=headers,
+        ),
+        spawn_auth_context.client.post(
+            "/v1/sessions",
+            json=_named_child_body(parent, "reviewer", "parallel-b"),
+            headers=headers,
+        ),
+    )
+    assert [response.status_code for response in responses] == [201, 201], [
+        response.text for response in responses
+    ]
+
+
+async def test_builtin_agent_direct_child_create_is_unaffected(
+    spawn_auth_context: _SpawnAuthContext,
+) -> None:
+    """A direct child created from a builtin agent keeps the existing path."""
+    headers = {"X-Forwarded-Email": "owner@example.com"}
+    parent = await _create_parent_with_subagents(
+        spawn_auth_context.client,
+        name="builtin-direct-spawn-parent",
+        sub_agents=[{"name": "researcher", "harness": "claude-sdk"}],
+        headers=headers,
+    )
+    response = await spawn_auth_context.client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": builtin_agent_id("cursor-native-ui"),
+            "parent_session_id": parent["session_id"],
+            "title": "direct builtin child",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    assert response.json()["parent_session_id"] == parent["session_id"]
 
 
 @pytest.mark.parametrize(

--- a/tests/stores/test_agent_store.py
+++ b/tests/stores/test_agent_store.py
@@ -92,6 +92,65 @@ def test_get_by_name_and_list_hide_session_scoped_agents(
     assert template_agent.name in listed_names
 
 
+def test_get_session_scoped_agent_uses_earliest_conversation(
+    agent_store: SqlAlchemyAgentStore,
+    db_uri: str,
+) -> None:
+    """Session ownership is deterministic when named children share an agent."""
+    engine = get_or_create_engine(db_uri)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO agents "
+                "(id, created_at, name, bundle_location, version, kind) "
+                "VALUES (:id, :ts, :name, :loc, 1, 2)",
+            ),
+            {
+                "id": "ag_shared_session",
+                "ts": 100,
+                "name": "shared-session-agent",
+                "loc": "ag_shared_session/bundle",
+            },
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversations "
+                "(id, created_at, updated_at, root_conversation_id) "
+                "VALUES (:id, :ts, :ts, :id)",
+            ),
+            {
+                "id": "conv_newer_reference",
+                "ts": 300,
+            },
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversations "
+                "(id, created_at, updated_at, root_conversation_id) "
+                "VALUES (:id, :ts, :ts, :id)",
+            ),
+            {
+                "id": "conv_original_owner",
+                "ts": 200,
+            },
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO agent_configuration (conversation_id, agent_id) "
+                "VALUES (:newer_id, :agent_id), (:owner_id, :agent_id)",
+            ),
+            {
+                "newer_id": "conv_newer_reference",
+                "owner_id": "conv_original_owner",
+                "agent_id": "ag_shared_session",
+            },
+        )
+
+    fetched = agent_store.get("ag_shared_session")
+    assert fetched is not None
+    assert fetched.session_id == "conv_original_owner"
+
+
 def test_create_with_description(agent_store: SqlAlchemyAgentStore) -> None:
     agent = agent_store.create(
         agent_id="ag_test_helper",


### PR DESCRIPTION
## Related issue

Closes #2539

## Summary

- Named-mode `sys_session_send(agent, title)` from a bundle-created (session-scoped) parent failed with `404 not_found "Conversation not found"` for every named child after the first, regardless of sub-agent harness. Builtin/template agents were unaffected.
- Root cause: named children intentionally reuse the parent's `agent_id`, but `_session_id_for_agent()` derives the agent's "owning" conversation with an unordered `.limit(1)` over `agent_configuration` rows — the first named child breaks the one-owner assumption, and `_create_session_from_existing_agent()` then authorizes against an arbitrary (inaccessible) reference and 404s.
- Fix: for a verified named child (`parent_session_id` + `sub_agent_name` set, and `parent.agent_id == body.agent_id`), authorize via the explicit parent and skip the ambiguous owner check; make `_session_id_for_agent()` deterministic (join conversation, `ORDER BY created_at, id`). Security boundary preserved: the caller must have access to the parent, and the requested agent must be the parent's own agent.

### ELI5

A bundled agent's sub-agents share their parent's agent ID. The server assumed "one agent ID = one owning session" to decide who may use the agent. As soon as the first sub-agent session existed, that assumption broke, and the server started checking permissions against the wrong session — so every later sub-agent spawn was rejected as "not found".

```mermaid
flowchart LR
    P["parent session\n(bundled, agent ag_X)"] -- "spawn #1 (agent ag_X)" --> C1["child #1 OK"]
    P -- "spawn #2 (agent ag_X)" --> A{{"owner lookup:\nunordered LIMIT 1\nover ag_X refs"}}
    A -- "picks child #1 ref" --> D["_require_access fails\n→ 404 not_found"]
    A -. "fix: verified named child →\nauthorize explicit parent,\nskip ambiguous owner check" .-> C2["child #2 OK"]
```

## Test Plan

- `uv run --extra dev pytest tests/stores/test_agent_store.py tests/server/integration/test_sessions_child_sessions.py -q` → 65 passed.
- New regression tests go through the real HTTP path (`POST /v1/sessions` → `_create_session_from_existing_agent`) with a session-scoped agent from an uploaded multipart bundle.
- Red/green proof — the new tests were copied (tests only, no src fix) onto a clean `main` worktree:
  - `main` without the fix: `test_bundled_parent_creates_two_named_children_sequentially` and `..._concurrently` fail with exactly the production error (`assert 404 == 201`, body `{"error":{"code":"not_found","message":"Conversation not found"}}`); `test_get_session_scoped_agent_uses_earliest_conversation` fails (arbitrary owner picked). 3 failed, 1 passed.
  - With the fix: 4 passed.
- The bug was originally reproduced against a live deployment (first named spawn OK, all subsequent named spawns 404; builtin orchestrators unaffected), matching the tests' red behavior.
- `uv run --extra dev ruff check` / `ruff format --check` / pre-commit hooks on touched files: passed.

## Demo

N/A — non-visual backend fix (server authorization path); behavior is demonstrated by the red/green integration tests above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = live reproduction of the failure mode before the fix (named spawns from a bundled supervisor: first OK, then consistent 404s across codex-native / cursor-native / claude-sdk workers) plus the baseline red/green run described in the Test Plan.

## Changelog

Named sub-agent dispatches (`sys_session_send(agent, title)`) from bundled agents no longer fail with 404 after the first child.
