### PR TITLE
feat(pi-native): support mid-session model switching in the web composer

### DIFF
--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -190,6 +190,33 @@ def enqueue_compact(bridge_dir: Path, custom_instructions: str | None = None) ->
     return compact_id
 
 
+def enqueue_model_change(bridge_dir: Path, model: str) -> str:
+    """
+    Queue a UI-originated model switch for the resident Pi extension.
+
+    Pi owns the active model inside the already-open TUI process, so a
+    web-picked model must be applied there rather than at the next spawn's
+    ``--model`` arg (which would only take effect on relaunch). Mirrors
+    :func:`enqueue_compact`: the extension consumes this inbox payload in the
+    Pi process, resolves *model* against ``ctx.modelRegistry`` and calls Pi's
+    ``setModel`` — taking effect immediately, no ``/reload`` required.
+
+    :param bridge_dir: Native Pi bridge directory.
+    :param model: Model id to switch to, e.g.
+        ``"databricks-claude-sonnet-4-6"``.
+    :returns: Opaque model-change id.
+    """
+    model_change_id = f"model_change_{uuid.uuid4().hex}"
+    payload = {
+        "id": model_change_id,
+        "type": "model_change",
+        "model": model,
+        "created_at": time.time(),
+    }
+    _enqueue_payload(bridge_dir, model_change_id, payload)
+    return model_change_id
+
+
 def _enqueue_payload(bridge_dir: Path, item_id: str, payload: dict[str, Any]) -> None:
     inbox = bridge_dir / _INBOX_DIR
     inbox.mkdir(mode=0o700, parents=True, exist_ok=True)

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -843,8 +843,19 @@ async function applyModelChange(pi, config, ctx, modelId) {
   const id = typeof modelId === "string" ? modelId.trim() : "";
   if (!id) return false;
   const registry = ctx ? ctx.modelRegistry : undefined;
-  const canResolve = registry && typeof registry.getAll === "function";
-  if (!pi || typeof pi.setModel !== "function" || !canResolve) {
+  // Resolve against whichever listing method exists. Accept EITHER getAll or
+  // getAvailable so the resolve path can never be narrower than the picker's:
+  // postModelOptions lists from getAvailable(), so gating apply on getAll alone
+  // would fail every switch on a hypothetical Pi build exposing only
+  // getAvailable. getAll (the full catalog) is a superset of getAvailable, so
+  // prefer it to resolve; fall back to getAvailable when getAll is absent.
+  const listModels =
+    registry && typeof registry.getAll === "function"
+      ? () => registry.getAll()
+      : registry && typeof registry.getAvailable === "function"
+        ? () => registry.getAvailable()
+        : null;
+  if (!pi || typeof pi.setModel !== "function" || !listModels) {
     await postModelChangeError(
       config,
       `Omnigent: could not switch to model "${id}" — this Pi session exposes ` +
@@ -854,7 +865,7 @@ async function applyModelChange(pi, config, ctx, modelId) {
   }
   let model;
   try {
-    model = registry.getAll().find((m) => m && m.id === id);
+    model = listModels().find((m) => m && m.id === id);
   } catch (_err) {
     model = undefined;
   }
@@ -1074,11 +1085,9 @@ function startInboxPoller(pi, config, handleInterrupt, handleCompact, handleMode
         // handleModelChange owns its visible-error item and posts nothing on
         // success — the paired model_select handler mirrors the applied model
         // back — so the returned promise is intentionally discarded.
-        if (typeof handleModelChange === "function") {
-          handleModelChange(
-            typeof payload.model === "string" ? payload.model : undefined,
-          );
-        }
+        handleModelChange(
+          typeof payload.model === "string" ? payload.model : undefined,
+        );
       }
       if (id !== null) rememberSeen(id);
       try {

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -820,7 +820,137 @@ async function triggerCompaction(config, ctx, customInstructions) {
   }
 }
 
-function startInboxPoller(pi, config, handleInterrupt, handleCompact) {
+/**
+ * Apply a web-picked model switch to the resident Pi process.
+ *
+ * Pi owns the active model inside this TUI process, so a model picked in the
+ * Omnigent web UI must be applied here (the ``--model`` launch arg is baked in
+ * at spawn). Resolves *modelId* against the session's ``modelRegistry`` (the
+ * same catalog Pi's own ``/model`` picker uses, sourced from the generated
+ * models.json) and calls Pi's ``setModel`` — immediate, no ``/reload``.
+ *
+ * Outcomes (mirrors triggerCompaction's visible-error contract so a web pick
+ * never silently vanishes — the runner already returned 204, so there is no
+ * server-side fallback):
+ *   - No resident context / registry: post an error item, return false.
+ *   - Model id not in the registry: post an error item, return false.
+ *   - setModel returned false (no API key for the model): post an error item,
+ *     return false.
+ *   - Applied: return true. The paired ``model_select`` handler mirrors the
+ *     resulting model back to Omnigent, so the web pill reflects the switch.
+ */
+async function applyModelChange(pi, config, ctx, modelId) {
+  const id = typeof modelId === "string" ? modelId.trim() : "";
+  if (!id) return false;
+  const registry = ctx ? ctx.modelRegistry : undefined;
+  const canResolve = registry && typeof registry.getAll === "function";
+  if (!pi || typeof pi.setModel !== "function" || !canResolve) {
+    await postModelChangeError(
+      config,
+      `Omnigent: could not switch to model "${id}" — this Pi session exposes ` +
+        "no model-switch API (the model or Pi version may not support it).",
+    );
+    return false;
+  }
+  let model;
+  try {
+    model = registry.getAll().find((m) => m && m.id === id);
+  } catch (_err) {
+    model = undefined;
+  }
+  if (!model) {
+    await postModelChangeError(
+      config,
+      `Omnigent: model "${id}" is not available in this Pi session.`,
+    );
+    return false;
+  }
+  try {
+    const applied = await pi.setModel(model);
+    if (applied === false) {
+      await postModelChangeError(
+        config,
+        `Omnigent: could not switch to model "${id}" — no API key is ` +
+          "configured for it.",
+      );
+      return false;
+    }
+    return true;
+  } catch (_err) {
+    await postModelChangeError(
+      config,
+      `Omnigent: switching to model "${id}" failed inside Pi.`,
+    );
+    return false;
+  }
+}
+
+async function postModelChangeError(config, message) {
+  await postEvent(config, {
+    type: "external_conversation_item",
+    data: {
+      response_id: `pi-model-change-error-${Date.now()}`,
+      item_type: "error",
+      item_data: {
+        source: "execution",
+        code: "pi_model_change_failed",
+        message,
+      },
+    },
+  });
+}
+
+/**
+ * Report Pi's live model catalog to Omnigent for the Web UI model picker.
+ *
+ * Sourced from Pi's model registry — the models Pi actually loaded for THIS
+ * session, whatever their origin: an Omnigent-configured provider's generated
+ * models.json, or Pi's own ``/login`` / ``~/.pi`` config. Posting the live
+ * registry (rather than the server reading a launch-written file) means the
+ * picker populates in every auth path, including ``/login`` where no Omnigent
+ * models.json exists.
+ *
+ * Prefers ``getAvailable()`` — only models with configured auth — over
+ * ``getAll()`` (Pi's entire built-in catalog spanning every vendor, most with
+ * no credentials). This scopes the picker to models the user can actually
+ * switch to, and naturally to whichever provider(s) they are logged into.
+ * Falls back to ``getAll()`` only when ``getAvailable()`` is unavailable
+ * (older Pi). Best-effort and fire-and-forget: an empty or unavailable
+ * registry posts nothing, leaving the picker hidden.
+ */
+async function postModelOptions(config, ctx) {
+  const registry = ctx ? ctx.modelRegistry : undefined;
+  if (!registry) return;
+  let models;
+  try {
+    if (typeof registry.getAvailable === "function") {
+      models = registry.getAvailable();
+    } else if (typeof registry.getAll === "function") {
+      models = registry.getAll();
+    } else {
+      return;
+    }
+  } catch (_err) {
+    return;
+  }
+  if (!Array.isArray(models) || models.length === 0) return;
+  const options = [];
+  const seen = new Set();
+  for (const model of models) {
+    const id = model && typeof model.id === "string" ? model.id : "";
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const name = model && typeof model.name === "string" && model.name ? model.name : id;
+    options.push({ id, displayName: name });
+  }
+  if (options.length === 0) return;
+  await postEvent(config, {
+    type: "external_model_options",
+    data: { models: options },
+  });
+}
+
+function startInboxPoller(pi, config, handleInterrupt, handleCompact, handleModelChange) {
   if (!config || !config.inboxDir || pi.__omnigentInboxPoller) return;
   // Bound the dedup set (FIFO eviction) — delivered files are unlinked, so a
   // long-lived TUI mustn't grow it unboundedly.
@@ -935,6 +1065,18 @@ function startInboxPoller(pi, config, handleInterrupt, handleCompact) {
             typeof payload.custom_instructions === "string"
               ? payload.custom_instructions
               : undefined,
+          );
+        }
+      }
+      if (payload.type === "model_change") {
+        // Point-in-time like compact/interrupt: one delivery attempt against
+        // the resident context, then always consume the file (below).
+        // handleModelChange owns its visible-error item and posts nothing on
+        // success — the paired model_select handler mirrors the applied model
+        // back — so the returned promise is intentionally discarded.
+        if (typeof handleModelChange === "function") {
+          handleModelChange(
+            typeof payload.model === "string" ? payload.model : undefined,
           );
         }
       }
@@ -1336,15 +1478,52 @@ module.exports = function (pi) {
       () => requestInterrupt(latestContext),
       (customInstructions) =>
         triggerCompaction(config, latestContext, customInstructions),
+      (model) => applyModelChange(pi, config, latestContext, model),
     );
     const nativeSessionId =
       ctx && ctx.sessionManager && ctx.sessionManager.getSessionId
         ? ctx.sessionManager.getSessionId()
         : undefined;
     await patchExternalSessionId(config, nativeSessionId);
+    // Publish Pi's live model catalog so the Web UI picker populates from what
+    // Pi actually loaded, independent of how it authenticated.
+    await postModelOptions(config, ctx);
+    // Report the model Pi launched with so the composer pill and the picker's
+    // active row reflect the current model from the start. Without this, a
+    // ``/login`` session (no Omnigent ``model_override``, no ``llm_model``)
+    // shows no active model until the user switches. Mirrors the
+    // ``model_select`` handler, but for the startup value ``ctx.model``.
+    const startupModelId =
+      ctx && ctx.model && typeof ctx.model.id === "string" ? ctx.model.id : "";
+    if (startupModelId) {
+      await postEvent(config, {
+        type: "external_model_change",
+        data: { model: startupModelId },
+      });
+    }
     await postEvent(config, {
       type: "external_session_status",
       data: { status: "idle", response_id: `pi-${Date.now()}-${++sequence}` },
+    });
+  });
+
+  pi.on("model_select", async (event, ctx) => {
+    rememberContext(ctx);
+    // Mirror a model switch made inside the Pi TUI (the ``/model`` command or
+    // Ctrl+P cycling) back to Omnigent so the web picker reflects it. Skip
+    // ``restore`` — that is Pi re-applying the session's saved model at
+    // startup, not a user switch, and posting it could clobber a pending
+    // web-side override. The server dedups against ``model_override``, so a
+    // web-initiated switch (which already persisted the value before queuing
+    // the inbox ``model_change``) round-trips here as a no-op.
+    const source = event && typeof event.source === "string" ? event.source : "";
+    if (source === "restore") return;
+    const model = event && event.model ? event.model : undefined;
+    const modelId = model && typeof model.id === "string" ? model.id : "";
+    if (!modelId) return;
+    await postEvent(config, {
+      type: "external_model_change",
+      data: { model: modelId },
     });
   });
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11130,6 +11130,58 @@ def create_runner_app(
         _wake_parent_after_native_interrupt(conv_id)
         return Response(status_code=204)
 
+    async def _handle_pi_native_model_change(
+        conv_id: str,
+        model: str | None,
+    ) -> Response:
+        """
+        Switch a pi-native session's model inside the resident Pi process.
+
+        Pi-native turns run inside the terminal's Pi process, and the
+        ``--model`` flag on the ``pi`` binary is baked in at spawn. To
+        propagate a web-picked model live — without relaunching the pane —
+        queue a ``model_change`` payload; the extension consumes it in the
+        TUI process, resolves the id against ``ctx.modelRegistry`` and calls
+        Pi's ``setModel`` (immediate, no ``/reload``).
+
+        Skipped silently when *model* is ``None`` or empty / whitespace only:
+        Pi has no "use the spawn default" API, so a clear only takes effect on
+        the next spawn via ``--model``.
+
+        :param conv_id: Session/conversation identifier, e.g.
+            ``"conv_abc123"``.
+        :param model: New persisted model identifier, e.g.
+            ``"databricks-claude-sonnet-4-6"``; ``None`` when the user
+            cleared the override.
+        :returns: 204 when the payload was queued or skipped; 503 if the
+            bridge inbox could not be written (persisted value still applies
+            on the next spawn).
+        """
+        from omnigent.pi_native_bridge import bridge_dir_for_session_id, enqueue_model_change
+
+        if model is None or not model.strip():
+            return Response(status_code=204)
+        try:
+            await asyncio.to_thread(
+                enqueue_model_change,
+                bridge_dir_for_session_id(conv_id),
+                model.strip(),
+            )
+        except OSError as exc:
+            _logger.warning(
+                "Pi-native model change failed for session=%s",
+                conv_id,
+                exc_info=True,
+            )
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "pi_native_model_failed",
+                    "detail": _client_safe_error_detail(exc, context="pi-native model change"),
+                },
+            )
+        return Response(status_code=204)
+
     async def _teardown_session_terminals(conv_id: str) -> None:
         """Close a session's terminal resources and announce their removal.
 
@@ -15238,8 +15290,9 @@ def create_runner_app(
             # boundaries can propagate it live. Claude-native and
             # cursor-native type ``/model`` into their tmux pane;
             # codex-native queues a Codex app-server next-turn settings
-            # update. Other harnesses pick up the persisted value on the
-            # next turn and 204 here.
+            # update; pi-native queues an inbox ``model_change`` its
+            # extension applies via Pi's ``setModel``. Other harnesses pick
+            # up the persisted value on the next turn and 204 here.
             harness = _session_harness_name(conversation_id)
             if harness in (
                 "claude-native",
@@ -15247,6 +15300,7 @@ def create_runner_app(
                 "cursor-native",
                 "opencode-native",
                 "kiro-native",
+                "pi-native",
             ):
                 model = body.get("model") if isinstance(body, dict) else None
                 if model is not None and not isinstance(model, str):
@@ -15276,6 +15330,11 @@ def create_runner_app(
                     )
                 if harness == "kiro-native":
                     return await _handle_kiro_native_model_change(
+                        conversation_id,
+                        model,
+                    )
+                if harness == "pi-native":
+                    return await _handle_pi_native_model_change(
                         conversation_id,
                         model,
                     )
@@ -17646,11 +17705,14 @@ def create_runner_app(
                 },
             )
 
-    # Note: cursor-native has no model-options route. Its catalog is a curated
-    # *static* base list served directly by the AP server (see
-    # ``_fetch_model_options`` in omnigent/server/routes/sessions.py), so it
-    # needs no runner round-trip and stays immune to the runner-backed cache
-    # invalidation that would otherwise blank the picker on an effort change.
+    # Note: neither cursor-native nor pi-native has a model-options route.
+    # Cursor's catalog is a curated *static* base list served directly by the
+    # AP server (see ``_fetch_model_options`` in
+    # omnigent/server/routes/sessions.py). Pi's is PUSHED by its resident
+    # extension (``external_model_options``, from the live ``ctx.modelRegistry``)
+    # rather than read from a file, so the picker works in every auth path
+    # (Omnigent-configured provider OR pi's own ``/login``) — a launch-written
+    # ``models.json`` isn't present in the ``/login`` case.
 
     @app.post("/v1/sessions/{session_id}/skills/resolve")
     async def resolve_session_skill(session_id: str, request: Request) -> JSONResponse:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -3669,16 +3669,25 @@ async def _persist_external_model_change(
     session_stream.publish(session_id, event.model_dump())
 
 
-def _persist_external_model_options(session_id: str, body: SessionEventInput) -> None:
+def _persist_external_model_options(
+    session_id: str,
+    conv: Conversation,
+    body: SessionEventInput,
+) -> None:
     """
     Record the model catalog a native harness's extension reported.
 
     Sourced from the harness's live model registry (pi-native:
-    ``ctx.modelRegistry.getAll()``), so it reflects the models the harness
-    actually loaded no matter how it authenticated — an Omnigent-configured
-    provider OR the harness's own ``/login``. This is why the pi picker
-    populates even in the ``/login`` path, where no ``models.json`` is written
-    into the bridge dir for the runner file-read to find.
+    ``ctx.modelRegistry.getAvailable()``), so it reflects the models the
+    harness actually loaded no matter how it authenticated — an
+    Omnigent-configured provider OR the harness's own ``/login``. This is why
+    the pi picker populates even in the ``/login`` path, where no
+    ``models.json`` is written into the bridge dir for a file-read to find.
+
+    Gated to the pi-native wrapper: only :func:`_fetch_model_options` *serves*
+    this cache for pi-native, so accepting a push from any other session would
+    just leave a stray cache entry alive until teardown. Reject at ingest to
+    keep the contract explicit.
 
     Stores into :data:`_pushed_model_options_cache` (which a browser reload
     does NOT clear — the extension only pushes on session start) and publishes
@@ -3687,10 +3696,17 @@ def _persist_external_model_options(session_id: str, body: SessionEventInput) ->
 
     :param session_id: Session/conversation identifier, e.g.
         ``"conv_abc123"``.
+    :param conv: Conversation row whose labels identify the wrapper.
     :param body: External model-options event body. ``data.models`` must be a
         list of ``{"id": str, ...}`` objects.
-    :raises OmnigentError: If ``data.models`` is missing or malformed.
+    :raises OmnigentError: If the session is not pi-native, or ``data.models``
+        is missing or malformed.
     """
+    if conv.labels.get(_CLAUDE_NATIVE_WRAPPER_LABEL_KEY) != _PI_NATIVE_WRAPPER_LABEL_VALUE:
+        raise OmnigentError(
+            "external_model_options is only accepted for pi-native sessions",
+            code=ErrorCode.INVALID_INPUT,
+        )
     raw_models = body.data.get("models")
     if not isinstance(raw_models, list):
         raise OmnigentError(
@@ -19830,7 +19846,7 @@ def create_sessions_router(
             )
             return {"queued": False}
         if body.type == _EXTERNAL_MODEL_OPTIONS_TYPE:
-            _persist_external_model_options(session_id, body)
+            _persist_external_model_options(session_id, conv, body)
             return {"queued": False}
         if body.type == _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE:
             await _persist_external_reasoning_effort_change(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -90,6 +90,7 @@ from omnigent.harness_plugins import (
     CODEX_NATIVE_CODING_AGENT,
     CURSOR_NATIVE_CODING_AGENT,
     KIRO_NATIVE_CODING_AGENT,
+    PI_NATIVE_CODING_AGENT,
     NativeCodingAgent,
 )
 from omnigent.host.frames import (
@@ -435,6 +436,14 @@ _EXTERNAL_SESSION_USAGE_TYPE: str = "external_session_usage"
 # on the conversation and publishes a ``session.model`` SSE event so the
 # web model picker reflects the switch. Payload: ``{"model": "opus"}``.
 _EXTERNAL_MODEL_CHANGE_TYPE: str = "external_model_change"
+# Full model catalog a native harness loaded, reported by its resident
+# extension on session start (pi-native: ``ctx.modelRegistry.getAll()``).
+# Unlike the runner file-read path, this reflects whatever models the harness
+# actually has regardless of how it authenticated (Omnigent-configured
+# provider OR the harness's own ``/login``), so the Web UI picker populates in
+# every auth path. Cached (reload-surviving) and published as
+# ``session.model_options``. Payload: ``{"models": [{"id": "..."}, ...]}``.
+_EXTERNAL_MODEL_OPTIONS_TYPE: str = "external_model_options"
 # Active reasoning-effort switch observed inside a native terminal. Persists
 # ``reasoning_effort`` on the conversation and publishes a
 # ``session.reasoning_effort`` SSE event so the web effort picker reflects the
@@ -584,6 +593,7 @@ _CODEX_NATIVE_MODEL = CODEX_NATIVE_CODING_AGENT.agent_name
 _CURSOR_NATIVE_WRAPPER_LABEL_VALUE = CURSOR_NATIVE_CODING_AGENT.wrapper_label
 _CURSOR_NATIVE_HARNESS = CURSOR_NATIVE_CODING_AGENT.harness
 _KIRO_NATIVE_WRAPPER_LABEL_VALUE = KIRO_NATIVE_CODING_AGENT.wrapper_label
+_PI_NATIVE_WRAPPER_LABEL_VALUE = PI_NATIVE_CODING_AGENT.wrapper_label
 _CLAUDE_NATIVE_MESSAGE_TIMEOUT_S = 30.0
 _NATIVE_TERMINAL_START_FAILED_CODE = "native_terminal_start_failed"
 _NATIVE_TERMINAL_ENSURE_FAILED_CODE = "native_terminal_ensure_failed"
@@ -894,6 +904,7 @@ _ALLOWED_EVENT_TYPES: frozenset[str] = frozenset(ITEM_TYPE_TO_DATA_CLS.keys()) |
     _EXTERNAL_COMPACTION_STATUS_TYPE,
     _EXTERNAL_MCP_STARTUP_TYPE,
     _EXTERNAL_MODEL_CHANGE_TYPE,
+    _EXTERNAL_MODEL_OPTIONS_TYPE,
     _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE,
     _EXTERNAL_SESSION_TODOS_TYPE,
     _EXTERNAL_SUBAGENT_START_TYPE,
@@ -1131,6 +1142,13 @@ _runner_skills_inflight: dict[str, asyncio.Task[None]] = {}
 _model_options_cache: dict[str, list[dict[str, Any]]] = {}
 _model_options_inflight: dict[str, asyncio.Task[None]] = {}
 _CODEX_MODEL_OPTIONS_RETRY_DELAYS_S = (0.25, 0.5, 1.0, 2.0, 2.0)
+# Per-session model catalog PUSHED by a native harness's extension
+# (``external_model_options``), as opposed to the runner-fetched
+# ``_model_options_cache`` above. Kept in a separate cache that a browser
+# reload (``refresh_state``) does NOT clear: the extension only pushes on
+# session start, which does not re-fire on reload, so clearing it would blank
+# the picker on every refresh. Dropped only on session teardown/delete.
+_pushed_model_options_cache: dict[str, list[dict[str, Any]]] = {}
 
 
 @dataclass
@@ -3649,6 +3667,56 @@ async def _persist_external_model_change(
         model=model,
     )
     session_stream.publish(session_id, event.model_dump())
+
+
+def _persist_external_model_options(session_id: str, body: SessionEventInput) -> None:
+    """
+    Record the model catalog a native harness's extension reported.
+
+    Sourced from the harness's live model registry (pi-native:
+    ``ctx.modelRegistry.getAll()``), so it reflects the models the harness
+    actually loaded no matter how it authenticated — an Omnigent-configured
+    provider OR the harness's own ``/login``. This is why the pi picker
+    populates even in the ``/login`` path, where no ``models.json`` is written
+    into the bridge dir for the runner file-read to find.
+
+    Stores into :data:`_pushed_model_options_cache` (which a browser reload
+    does NOT clear — the extension only pushes on session start) and publishes
+    ``session.model_options`` so open clients re-read the snapshot. An empty
+    list evicts the entry rather than caching nothing.
+
+    :param session_id: Session/conversation identifier, e.g.
+        ``"conv_abc123"``.
+    :param body: External model-options event body. ``data.models`` must be a
+        list of ``{"id": str, ...}`` objects.
+    :raises OmnigentError: If ``data.models`` is missing or malformed.
+    """
+    raw_models = body.data.get("models")
+    if not isinstance(raw_models, list):
+        raise OmnigentError(
+            "external_model_options requires data.models to be a list",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    options: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in raw_models:
+        model_id = raw.get("id") if isinstance(raw, dict) else None
+        if not isinstance(model_id, str) or not model_id or model_id in seen:
+            continue
+        seen.add(model_id)
+        display = raw.get("displayName") if isinstance(raw, dict) else None
+        options.append(
+            {
+                "id": model_id,
+                "displayName": display if isinstance(display, str) and display else model_id,
+                "isDefault": bool(raw.get("isDefault", False)) if isinstance(raw, dict) else False,
+            }
+        )
+    if options:
+        _pushed_model_options_cache[session_id] = options
+    else:
+        _pushed_model_options_cache.pop(session_id, None)
+    _publish_model_options(session_id)
 
 
 def _validate_external_reasoning_effort(body: SessionEventInput) -> str | None:
@@ -19089,6 +19157,10 @@ def create_sessions_router(
         - ``"external_model_change"`` persists a terminal-observed
           model switch to ``model_override`` and publishes a
           ``session.model`` SSE event so the web picker reflects it.
+        - ``"external_model_options"`` records the model catalog a native
+          harness's extension reported (its live model registry) into a
+          reload-surviving cache and publishes ``session.model_options`` so
+          the web picker populates regardless of how the harness authenticated.
         - ``"external_reasoning_effort_change"`` persists a terminal-observed
           thinking-level switch to ``reasoning_effort`` and publishes a
           ``session.reasoning_effort`` SSE event so the web picker reflects it.
@@ -19172,6 +19244,7 @@ def create_sessions_router(
             _EXTERNAL_COMPACTION_STATUS_TYPE,
             _EXTERNAL_MCP_STARTUP_TYPE,
             _EXTERNAL_MODEL_CHANGE_TYPE,
+            _EXTERNAL_MODEL_OPTIONS_TYPE,
             _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE,
             _EXTERNAL_SESSION_TODOS_TYPE,
             _EXTERNAL_SUBAGENT_START_TYPE,
@@ -19755,6 +19828,9 @@ def create_sessions_router(
                 body,
                 conversation_store,
             )
+            return {"queued": False}
+        if body.type == _EXTERNAL_MODEL_OPTIONS_TYPE:
+            _persist_external_model_options(session_id, body)
             return {"queued": False}
         if body.type == _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE:
             await _persist_external_reasoning_effort_change(
@@ -20435,6 +20511,10 @@ def create_sessions_router(
         # for reload visibility while the session exists, so a session
         # whose MCP startup never settled clean would leak its entry.
         _session_mcp_startup_cache.pop(session_id, None)
+        # Same for the extension-pushed model catalog: kept across reloads
+        # while the session exists (the extension only pushes on start), so a
+        # deleted session would otherwise leak its entry for the process life.
+        _pushed_model_options_cache.pop(session_id, None)
         # Drop the deleted session's per-user read-state from every user's
         # caches so they don't accumulate orphan entries for the process
         # lifetime.
@@ -21277,6 +21357,10 @@ def _model_options_from_wire(raw_models: Any) -> list[dict[str, Any]]:
 # the cursor picker mid-session.
 _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER: dict[str, str] = {
     _CODEX_NATIVE_WRAPPER_LABEL_VALUE: "codex-model-options",
+    # pi-native is deliberately NOT here: its catalog is PUSHED by the resident
+    # extension (``external_model_options`` → ``_pushed_model_options_cache``),
+    # not fetched from a runner route, so the picker works in every auth path
+    # (Omnigent provider OR pi's own ``/login``) — see ``_fetch_model_options``.
 }
 
 
@@ -21318,6 +21402,14 @@ async def _fetch_model_options(
         from omnigent.kiro_native import kiro_base_model_options
 
         return kiro_base_model_options()
+    if wrapper == _PI_NATIVE_WRAPPER_LABEL_VALUE:
+        # pi-native's catalog is PUSHED by its extension (its live
+        # ``ctx.modelRegistry``), not fetched: that reflects the models pi
+        # actually loaded regardless of auth path (Omnigent provider OR pi's
+        # own ``/login``), so the picker populates even when no ``models.json``
+        # is written into the bridge dir. Empty until the extension posts
+        # ``external_model_options`` on session start.
+        return _pushed_model_options_cache.get(session_id, [])
     endpoint = _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER.get(wrapper or "")
     if endpoint is None:
         return []

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -10325,6 +10325,84 @@ async def test_events_interrupt_and_stop_on_pi_native_enqueue_bridge_interrupt(
     ), f"no interrupt marker should enter _session_histories; got {captured_history!r}"
 
 
+@pytest.mark.asyncio
+async def test_events_model_change_on_pi_native_enqueues_bridge_model_change(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    POST ``/events`` ``model_change`` on a pi-native session queues a
+    ``model_change`` payload to the Pi extension inbox.
+
+    A pi-native turn runs inside the resident Pi TUI process, and the
+    ``--model`` launch flag is baked in at spawn. The dispatch must route to
+    ``_handle_pi_native_model_change``, which drops a ``model_change`` payload
+    the extension applies live via Pi's ``setModel``.
+
+    Regression guard: the ``model_change`` branch originally enumerated only
+    claude/codex/cursor/opencode/kiro, so pi-native fell through to the no-op
+    and a web-picked model never reached the running Pi process.
+
+    Pins:
+    1. 204 returned.
+    2. A ``model_change_*`` payload carrying the model id is written to the
+       session's bridge inbox.
+    """
+    import json as _json
+
+    import omnigent.pi_native_bridge as pi_native_bridge
+    from omnigent.spec.types import ExecutorSpec
+
+    conv_id = "conv_pi_native_model_change"
+    monkeypatch.setattr(pi_native_bridge, "_BRIDGE_ROOT", tmp_path / "pi-bridge")
+
+    pi_native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "pi-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return pi_native_spec
+
+    server_client = _EventRecordingServerClient()
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=server_client,  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": "model_change", "model": "databricks-claude-opus-4-1"},
+        )
+
+    assert resp.status_code == 204, (
+        f"pi-native model_change must return 204; got {resp.status_code}: {resp.text}"
+    )
+
+    inbox = pi_native_bridge.bridge_dir_for_session_id(conv_id) / "inbox"
+    payloads = [
+        _json.loads(p.read_text(encoding="utf-8"))
+        for p in (inbox.glob("*.json") if inbox.exists() else [])
+    ]
+    model_changes = [p for p in payloads if p.get("type") == "model_change"]
+    assert len(model_changes) == 1, (
+        f"pi-native model_change must enqueue exactly one payload; got {payloads!r}."
+    )
+    assert model_changes[0]["model"] == "databricks-claude-opus-4-1"
+    assert model_changes[0]["id"].startswith("model_change_")
+
+
 def test_interrupted_sessions_isolated_per_app_instance() -> None:
     """
     Each ``create_runner_app()`` gets its own ``_interrupted_sessions`` set.

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -5233,6 +5233,107 @@ async def test_post_external_model_change_does_not_forward_to_runner(
     )
 
 
+async def test_post_external_model_options_populates_picker_and_publishes(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``external_model_options`` fills the snapshot picker and posts SSE.
+
+    A native harness's extension (pi-native: its live ``ctx.modelRegistry``)
+    posts its model catalog so the Web UI picker populates from what the
+    harness actually loaded — regardless of how it authenticated. The route
+    caches it (reload-surviving) and publishes ``session.model_options`` so
+    open clients re-read the snapshot. Asserts the deduped/normalized options
+    land on the snapshot and the SSE fires.
+    """
+    from omnigent.server.routes import sessions as _mod
+
+    _mod._pushed_model_options_cache.clear()
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda sid, ev: published.append((sid, ev)),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(
+        client,
+        agent["id"],
+        labels={"omnigent.ui": "terminal", "omnigent.wrapper": "pi-native-ui"},
+    )
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_model_options",
+            "data": {
+                "models": [
+                    {"id": "databricks-claude-sonnet-4-6", "displayName": "Sonnet 4.6"},
+                    # No displayName → falls back to the id.
+                    {"id": "anthropic-claude-opus-4-1"},
+                    # Duplicate id collapses.
+                    {"id": "databricks-claude-sonnet-4-6"},
+                ]
+            },
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"queued": False}
+
+    assert "session.model_options" in [event["type"] for _, event in published]
+
+    snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+    assert [m["id"] for m in snapshot["model_options"]] == [
+        "databricks-claude-sonnet-4-6",
+        "anthropic-claude-opus-4-1",
+    ]
+    assert snapshot["model_options"][0]["displayName"] == "Sonnet 4.6"
+    # Missing displayName defaults to the id.
+    assert snapshot["model_options"][1]["displayName"] == "anthropic-claude-opus-4-1"
+
+
+async def test_post_external_model_options_empty_evicts_cache(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    An empty ``data.models`` clears any prior pushed catalog; a non-list 400s.
+
+    Empty means "no catalog to show" — the entry is evicted so the picker
+    hides rather than serving a stale list. A malformed (non-list) payload
+    fails loud at the boundary.
+    """
+    from omnigent.server.routes import sessions as _mod
+
+    agent = await create_test_agent(client)
+    session = await _create_session(
+        client,
+        agent["id"],
+        labels={"omnigent.ui": "terminal", "omnigent.wrapper": "pi-native-ui"},
+    )
+
+    # Seed a catalog, then clear it with an empty push.
+    seed = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_model_options", "data": {"models": [{"id": "m-1"}]}},
+    )
+    assert seed.status_code == 202, seed.text
+    assert _mod._pushed_model_options_cache.get(session["id"])
+
+    cleared = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_model_options", "data": {"models": []}},
+    )
+    assert cleared.status_code == 202, cleared.text
+    assert session["id"] not in _mod._pushed_model_options_cache
+
+    bad = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_model_options", "data": {"models": "nope"}},
+    )
+    assert bad.status_code == 400, bad.text
+    assert "external_model_options" in bad.text
+
+
 async def test_post_external_reasoning_effort_change_publishes_session_effort(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -5334,6 +5334,32 @@ async def test_post_external_model_options_empty_evicts_cache(
     assert "external_model_options" in bad.text
 
 
+async def test_post_external_model_options_rejects_non_pi_native_session(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``external_model_options`` is only accepted for pi-native sessions.
+
+    Only ``_fetch_model_options`` serves this cache for the pi-native wrapper,
+    so accepting a push from any other session would just leave a stray cache
+    entry alive until teardown. The route rejects it at ingest (400) and writes
+    nothing, keeping the contract explicit.
+    """
+    from omnigent.server.routes import sessions as _mod
+
+    agent = await create_test_agent(client)
+    # A plain (non-native) session — no pi-native wrapper label.
+    session = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_model_options", "data": {"models": [{"id": "m-1"}]}},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "external_model_options" in resp.text
+    assert session["id"] not in _mod._pushed_model_options_cache
+
+
 async def test_post_external_reasoning_effort_change_publishes_session_effort(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -657,6 +657,103 @@ async def test_session_snapshot_includes_model_options_from_runner(
 
 
 @pytest.mark.asyncio
+async def test_session_snapshot_serves_pi_model_options_from_extension_push(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Pi-native model options come from the extension-PUSHED cache, not a fetch.
+
+    Pi's picker catalog is reported by the resident extension (its live
+    ``ctx.modelRegistry``) via ``external_model_options``, landing in
+    ``_pushed_model_options_cache``. The snapshot serves that directly — no
+    runner round-trip — so the picker populates regardless of how pi
+    authenticated (Omnigent provider OR pi's own ``/login``). Before any push,
+    the snapshot returns ``[]`` and hides the picker.
+    """
+    from omnigent.server.routes import sessions as _mod
+
+    _mod._session_status_cache.clear()
+    _mod._runner_skills_cache.clear()
+    _mod._runner_skills_inflight.clear()
+    _mod._model_options_cache.clear()
+    _mod._model_options_inflight.clear()
+    _mod._pushed_model_options_cache.clear()
+
+    class _FakeResponse:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self.status_code = 200
+            self._payload = payload
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    class _FakeRunnerClient:
+        def __init__(self) -> None:
+            self.get_calls: list[str] = []
+
+        async def get(self, url: str, timeout: float = 5.0) -> _FakeResponse:
+            self.get_calls.append(url)
+            if url.endswith("/skills"):
+                return _FakeResponse({"skills": []})
+            return _FakeResponse({"status": "idle"})
+
+    fake_client = _FakeRunnerClient()
+    monkeypatch.setattr("omnigent.runtime.get_runner_client", lambda: fake_client)
+    monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
+
+    conv = Conversation(
+        id="conv_pi_options",
+        created_at=1,
+        updated_at=1,
+        root_conversation_id="conv_pi_options",
+        agent_id="ag_test",
+        labels={
+            _mod._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: _mod._PI_NATIVE_WRAPPER_LABEL_VALUE,
+        },
+    )
+    conv_store = _ConversationStore(
+        [_message_item("item_1", "hi")],
+        conversations={"conv_pi_options": conv},
+    )
+
+    # Before the extension pushes its catalog, the picker has nothing.
+    before = await _get_session_snapshot(
+        conv_store,  # type: ignore[arg-type]
+        "conv_pi_options",
+    )
+    assert before.model_options == []
+
+    # The ``external_model_options`` handler lands the catalog here.
+    from omnigent.server.schemas import SessionEventInput
+
+    _mod._persist_external_model_options(
+        "conv_pi_options",
+        SessionEventInput(
+            type="external_model_options",
+            data={
+                "models": [
+                    {"id": "databricks-claude-sonnet-4-6", "displayName": "Sonnet 4.6"},
+                    {"id": "anthropic-claude-opus-4-1", "displayName": "Opus 4.1"},
+                ]
+            },
+        ),
+    )
+
+    snapshot = await _get_session_snapshot(
+        conv_store,  # type: ignore[arg-type]
+        "conv_pi_options",
+    )
+
+    # Served straight from the pushed cache — no runner model-options fetch.
+    assert not any("model-options" in url for url in fake_client.get_calls)
+    assert [m["id"] for m in snapshot.model_options] == [
+        "databricks-claude-sonnet-4-6",
+        "anthropic-claude-opus-4-1",
+    ]
+    assert snapshot.model_options[0]["displayName"] == "Sonnet 4.6"
+
+
+@pytest.mark.asyncio
 async def test_session_snapshot_serves_static_cursor_model_options(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -728,6 +728,7 @@ async def test_session_snapshot_serves_pi_model_options_from_extension_push(
 
     _mod._persist_external_model_options(
         "conv_pi_options",
+        conv,
         SessionEventInput(
             type="external_model_options",
             data={

--- a/tests/test_pi_native_bridge.py
+++ b/tests/test_pi_native_bridge.py
@@ -93,6 +93,30 @@ def test_enqueue_compact_includes_custom_instructions(tmp_path: Path) -> None:
     assert with_instructions[0]["custom_instructions"] == "focus on the refactor"
 
 
+def test_enqueue_model_change_payload_shape(tmp_path: Path) -> None:
+    """A queued model change round-trips as well-formed JSON the extension reads.
+
+    The extension dispatches on ``payload.type == "model_change"`` and resolves
+    ``payload.model`` against ``ctx.modelRegistry`` before calling Pi's
+    ``setModel``. The id must equal the returned ``model_change_`` id (the
+    extension dedups on it).
+    """
+    bridge_dir = tmp_path / "bridge"
+    (bridge_dir / "inbox").mkdir(parents=True)
+
+    model_change_id = pi_native_bridge.enqueue_model_change(
+        bridge_dir, "databricks-claude-sonnet-4-6"
+    )
+
+    (path,) = list((bridge_dir / "inbox").glob("*.json"))
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["id"] == model_change_id
+    assert model_change_id.startswith("model_change_")
+    assert payload["type"] == "model_change"
+    assert payload["model"] == "databricks-claude-sonnet-4-6"
+    assert isinstance(payload["created_at"], (int, float))
+
+
 def test_enqueue_user_message_payload_shape(tmp_path: Path) -> None:
     """A queued user message round-trips as well-formed JSON the extension reads.
 

--- a/tests/test_pi_native_extension.py
+++ b/tests/test_pi_native_extension.py
@@ -2593,3 +2593,289 @@ function usage(id) {
 });
 """
     _run_extension_script(node, _extension_path(), script)
+
+
+# Shared Node preamble for the model-switch tests: loads the extension with a
+# mocked ``pi`` that records ``setModel`` calls and drives the real inbox
+# poller through a temp inbox directory (so an inbox ``model_change`` payload
+# exercises the same path the runner uses).
+_MODEL_SWITCH_HARNESS = r"""
+const assert = require("assert").strict;
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const extensionPath = process.argv[1];
+const inboxDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-model-inbox-"));
+const configPath = path.join(inboxDir, "config.json");
+fs.writeFileSync(
+  configPath,
+  JSON.stringify({ serverUrl: "http://omnigent.test", sessionId: "session-1", inboxDir }),
+);
+process.env.OMNIGENT_PI_NATIVE_CONFIG = configPath;
+
+const posted = [];
+global.fetch = async (_url, request) => {
+  posted.push(JSON.parse(request.body));
+  return { ok: true };
+};
+
+const setModelCalls = [];
+// The catalog Pi's modelRegistry exposes; setModel returns false for a model
+// with no configured API key (mirrors Pi's real contract).
+const catalog = [
+  { id: "databricks-claude-sonnet-4-6", name: "Sonnet", hasKey: true },
+  { id: "databricks-claude-opus-4-1", name: "Opus", hasKey: true },
+  { id: "no-key-model", name: "NoKey", hasKey: false },
+];
+const pi = {
+  registerCommand() {},
+  on(name, handler) { (pi.__handlers = pi.__handlers || {})[name] = handler; },
+  sendUserMessage() {},
+  async setModel(model) {
+    setModelCalls.push(model);
+    return !!(model && model.hasKey);
+  },
+};
+
+require(extensionPath)(pi);
+const handlers = pi.__handlers;
+
+const ctx = {
+  isIdle: () => true,
+  ui: { setTitle() {}, setStatus() {}, notify() {} },
+  // ``model`` is the model Pi launched with (used for the startup
+  // external_model_change). ``getAvailable`` returns only auth-configured
+  // models (what the picker should show); ``getAll`` is Pi's full built-in
+  // catalog (the fallback for older Pi).
+  model: { id: "databricks-claude-sonnet-4-6", name: "Sonnet" },
+  modelRegistry: {
+    getAll: () => catalog,
+    getAvailable: () => catalog.filter((m) => m.hasKey),
+  },
+};
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+// Drop a model_change payload into the inbox and wait for the poller to consume it.
+async function deliverModelChange(model) {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const file = path.join(inboxDir, `000-model-${suffix}.json`);
+  fs.writeFileSync(file, JSON.stringify({ id: path.basename(file), type: "model_change", model }));
+  const deadline = Date.now() + 3000;
+  while (fs.existsSync(file)) {
+    if (Date.now() > deadline) throw new Error("model_change file was not consumed");
+    await sleep(20);
+  }
+  // The poller invokes handleModelChange (async, discarded) then unlinks; give
+  // the microtask/awaits a beat to settle.
+  await sleep(20);
+}
+
+function errorItems() {
+  return posted.filter(
+    (e) =>
+      e.type === "external_conversation_item" &&
+      e.data && e.data.item_data && e.data.item_data.code === "pi_model_change_failed",
+  );
+}
+
+function finish() {
+  if (pi.__omnigentInboxPoller) clearInterval(pi.__omnigentInboxPoller);
+  try { fs.rmSync(inboxDir, { recursive: true, force: true }); } catch (_err) {}
+}
+"""
+
+
+def test_inbox_model_change_applies_via_set_model(tmp_path: Path) -> None:
+    """A web-picked ``model_change`` inbox payload calls Pi's ``setModel``.
+
+    The runner queues the payload after the Omnigent server persisted the
+    override; the extension must resolve the id against ``ctx.modelRegistry``
+    and apply it live via ``pi.setModel`` — with no error item posted.
+    """
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the pi-native extension e2e test")
+
+    script = (
+        _MODEL_SWITCH_HARNESS
+        + r"""
+(async () => {
+  await handlers.session_start({}, ctx); // starts the inbox poller
+  await deliverModelChange("databricks-claude-opus-4-1");
+
+  assert.equal(setModelCalls.length, 1, JSON.stringify(setModelCalls));
+  assert.equal(setModelCalls[0].id, "databricks-claude-opus-4-1");
+  // Success posts no error item (the model_select mirror handles the web pill).
+  assert.equal(errorItems().length, 0, JSON.stringify(posted));
+  finish();
+})().catch((error) => {
+  finish();
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+"""
+    )
+    _run_extension_script(node, _extension_path(), script)
+
+
+def test_inbox_model_change_unknown_model_posts_error(tmp_path: Path) -> None:
+    """An unresolvable model id posts a visible error item and never calls setModel."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the pi-native extension e2e test")
+
+    script = (
+        _MODEL_SWITCH_HARNESS
+        + r"""
+(async () => {
+  await handlers.session_start({}, ctx);
+  await deliverModelChange("model-that-does-not-exist");
+
+  assert.equal(setModelCalls.length, 0, JSON.stringify(setModelCalls));
+  const errs = errorItems();
+  assert.equal(errs.length, 1, JSON.stringify(posted));
+  assert.match(errs[0].data.item_data.message, /not available/);
+  finish();
+})().catch((error) => {
+  finish();
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+"""
+    )
+    _run_extension_script(node, _extension_path(), script)
+
+
+def test_model_select_mirrors_to_external_model_change(tmp_path: Path) -> None:
+    """A user ``/model`` pick inside Pi posts ``external_model_change`` (two-way sync).
+
+    Pi fires ``model_select`` for both in-TUI switches and startup restores.
+    A ``set`` / ``cycle`` source must mirror back to Omnigent; a ``restore``
+    (Pi re-applying the saved model at startup) must NOT.
+    """
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the pi-native extension e2e test")
+
+    script = (
+        _MODEL_SWITCH_HARNESS
+        + r"""
+(async () => {
+  await handlers.session_start({}, ctx);
+  assert.equal(typeof handlers.model_select, "function");
+
+  // session_start itself mirrors the launch model (ctx.model) so the pill
+  // resolves from the start; ignore that when checking the user switch.
+  const startupChanges = posted.filter((e) => e.type === "external_model_change");
+  assert.equal(startupChanges.length, 1, JSON.stringify(posted));
+  assert.equal(startupChanges[0].data.model, "databricks-claude-sonnet-4-6");
+
+  // A genuine user switch mirrors back.
+  await handlers.model_select(
+    { source: "set", model: { id: "databricks-claude-opus-4-1" } },
+    ctx,
+  );
+  // A startup restore must be ignored (could clobber a pending web override).
+  await handlers.model_select(
+    { source: "restore", model: { id: "databricks-claude-sonnet-4-6" } },
+    ctx,
+  );
+
+  const changes = posted.filter((e) => e.type === "external_model_change");
+  // Two total: the startup mirror + the one user switch (restore ignored).
+  assert.equal(changes.length, 2, JSON.stringify(posted));
+  assert.equal(changes[1].data.model, "databricks-claude-opus-4-1");
+  finish();
+})().catch((error) => {
+  finish();
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+"""
+    )
+    _run_extension_script(node, _extension_path(), script)
+
+
+def test_session_start_posts_model_options_from_registry(tmp_path: Path) -> None:
+    """
+    On ``session_start`` the extension posts Pi's auth-configured model catalog.
+
+    The Web UI picker is populated from ``external_model_options``. The
+    extension prefers ``ctx.modelRegistry.getAvailable()`` — only models with
+    configured auth — over ``getAll()`` (Pi's entire built-in catalog), so the
+    picker shows only models the user can actually switch to (scoped to the
+    provider(s) they are logged into), not hundreds of credential-less models.
+    It also posts ``external_model_change`` for the launch model (``ctx.model``)
+    so the composer pill resolves from the start.
+    """
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the pi-native extension e2e test")
+
+    script = (
+        _MODEL_SWITCH_HARNESS
+        + r"""
+(async () => {
+  await handlers.session_start({}, ctx);
+
+  const opts = posted.filter((e) => e.type === "external_model_options");
+  assert.equal(opts.length, 1, JSON.stringify(posted));
+  const models = opts[0].data.models;
+  // getAvailable() filters out ``no-key-model`` (no configured auth).
+  assert.deepEqual(
+    models.map((m) => m.id),
+    ["databricks-claude-sonnet-4-6", "databricks-claude-opus-4-1"],
+    JSON.stringify(models),
+  );
+  // Display name falls back to the model's ``name``.
+  assert.equal(models[0].displayName, "Sonnet");
+
+  // The launch model is mirrored so the pill/active-row resolve immediately.
+  const changes = posted.filter((e) => e.type === "external_model_change");
+  assert.equal(changes.length, 1, JSON.stringify(posted));
+  assert.equal(changes[0].data.model, "databricks-claude-sonnet-4-6");
+  finish();
+})().catch((error) => {
+  finish();
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+"""
+    )
+    _run_extension_script(node, _extension_path(), script)
+
+
+def test_session_start_empty_registry_posts_no_model_options(tmp_path: Path) -> None:
+    """
+    An empty / unavailable model registry posts no ``external_model_options``.
+
+    Best-effort: when Pi exposes no registry (older Pi, or a registry that
+    throws), the extension stays silent rather than posting an empty catalog —
+    the server would only evict, and the picker stays hidden as before.
+    """
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the pi-native extension e2e test")
+
+    script = (
+        _MODEL_SWITCH_HARNESS
+        + r"""
+(async () => {
+  // Registry present but empty.
+  await handlers.session_start({}, { ...ctx, modelRegistry: { getAll: () => [] } });
+  // No registry at all.
+  await handlers.session_start({}, { ...ctx, modelRegistry: undefined });
+
+  const opts = posted.filter((e) => e.type === "external_model_options");
+  assert.equal(opts.length, 0, JSON.stringify(posted));
+  finish();
+})().catch((error) => {
+  finish();
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+"""
+    )
+    _run_extension_script(node, _extension_path(), script)

--- a/web/src/pages/ChatPage.capabilities.test.ts
+++ b/web/src/pages/ChatPage.capabilities.test.ts
@@ -64,6 +64,9 @@ describe("shouldShowModelPicker", () => {
     );
     // kiro applies the picked model as --model at launch (no in-session mirror).
     expect(shouldShowModelPicker({ labels: { "omnigent.wrapper": "kiro-native-ui" } })).toBe(true);
+    // pi injects a live model switch into the running Pi process (via the bridge
+    // inbox → setModel) and mirrors in-TUI /model picks back to model_override.
+    expect(shouldShowModelPicker({ labels: { "omnigent.wrapper": "pi-native-ui" } })).toBe(true);
   });
 
   it("hides the picker for other wrappers and missing labels (fail closed)", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5160,7 +5160,7 @@ const EFFORT_LEVELS = ["low", "medium", "high"] as const;
 /** Anthropic-side efforts for claude-native sessions (matches ANTHROPIC_EFFORTS in reasoning_effort.py). */
 const CLAUDE_NATIVE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
-type NativeModelPickerKind = "claude" | "codex" | "cursor" | "kiro" | "opencode";
+type NativeModelPickerKind = "claude" | "codex" | "cursor" | "kiro" | "opencode" | "pi";
 
 type LabelSource = { labels?: Record<string, string | null> | null } | null | undefined;
 
@@ -5234,6 +5234,12 @@ export function modelPickerKindForConv(
       // model into the session ``model_override`` (the forwarder's terminal→web
       // mirror), so the picker surfaces that as the live model.
       return "opencode";
+    case "pi-native-ui":
+      // Like cursor: the runner types a model switch into the live Pi process
+      // (via the bridge inbox → Pi's ``setModel``) and Pi mirrors its own
+      // ``/model`` picks back to ``model_override`` via the extension's
+      // model_select handler, so the picker surfaces that as the live model.
+      return "pi";
     default:
       return null;
   }
@@ -5355,11 +5361,14 @@ function AgentPicker({
   const sessionModelOverride = useChatStore((s) => s.sessionModelOverride);
   const llmModel = useChatStore((s) => s.llmModel);
 
-  // Codex and cursor both populate the picker from the server-provided
-  // ``codexModelOptions`` channel (the snapshot's ``model_options`` field);
-  // claude uses the static local catalog.
+  // Codex, cursor, kiro, and pi all populate the picker from the
+  // server-provided ``codexModelOptions`` channel (the snapshot's
+  // ``model_options`` field); claude uses the static local catalog.
   const usesServerModelOptions =
-    modelPickerKind === "codex" || modelPickerKind === "cursor" || modelPickerKind === "kiro";
+    modelPickerKind === "codex" ||
+    modelPickerKind === "cursor" ||
+    modelPickerKind === "kiro" ||
+    modelPickerKind === "pi";
   const modelOptions: ReadonlyArray<{ id: string; label?: string; displayName?: string }> =
     modelPickerKind === "claude"
       ? CLAUDE_NATIVE_MODELS
@@ -5396,8 +5405,15 @@ function AgentPicker({
   // There is no terminal→web mirror, so the picker reflects the web-side
   // ``sessionModelOverride`` (which stays correct since a web pick sets it), like
   // cursor/opencode surface theirs.
+  // pi mirrors both ways into ``model_override`` (a web pick persists it before
+  // the live ``setModel``; a TUI ``/model`` pick posts external_model_change),
+  // so like cursor/kiro/opencode the live model is the session override, never
+  // the cross-session sticky ``selectedModel``.
   const pickerSelectedModel =
-    modelPickerKind === "cursor" || modelPickerKind === "kiro" || modelPickerKind === "opencode"
+    modelPickerKind === "cursor" ||
+    modelPickerKind === "kiro" ||
+    modelPickerKind === "opencode" ||
+    modelPickerKind === "pi"
       ? sessionModelOverride
       : (sessionModelOverride ?? selectedModel);
   // SDK/bundle agents (no native picker) never have the cross-session sticky
@@ -5416,10 +5432,11 @@ function AgentPicker({
         // on a web pick (which also drives a live ``/model`` switch). Either way
         // the Omnigent-visible model is ``model_override``.
         sessionModelOverride
-      : modelPickerKind === "opencode"
-        ? // opencode mirrors its live TUI model into ``model_override`` (set at
-          // launch and updated by the forwarder on a TUI switch); show that,
-          // falling back to the launch-resolved model before any switch.
+      : modelPickerKind === "opencode" || modelPickerKind === "pi"
+        ? // opencode/pi mirror their live TUI model into ``model_override``
+          // (set on a web pick, updated by the extension's model_select
+          // handler on a TUI switch); show that, falling back to the
+          // launch-resolved model before any switch.
           (sessionModelOverride ?? llmModel)
         : null
     : nonNativeModel;
@@ -5430,14 +5447,16 @@ function AgentPicker({
       : null;
   const hasPickerActions = showAgents || modelOptions.length > 0 || showEffort;
 
-  // Until kiro mirrors its live model (its first session ``.json`` write), there
-  // is no resolved model to show; fall back to the catalog default (e.g. "Auto")
-  // so the trigger reads as a model rather than the harness name ("Kiro").
-  const kiroDefaultOption =
-    modelPickerKind === "kiro"
+  // Before kiro/pi resolve a live model, there is no model to show: kiro until
+  // its first session ``.json`` write, pi until its snapshot fills llmModel (or
+  // the workspace model-list fetch failed, leaving only the launch model). Fall
+  // back to the catalog default (e.g. "Auto") / first option so the trigger
+  // reads as a model rather than the harness name ("Kiro" / "Pi").
+  const launchFallbackOption =
+    modelPickerKind === "kiro" || modelPickerKind === "pi"
       ? (codexModelOptions.find((m) => m.isDefault) ?? codexModelOptions[0])
       : undefined;
-  const kiroLaunchFallbackLabel = kiroDefaultOption?.displayName ?? kiroDefaultOption?.id;
+  const launchFallbackLabel = launchFallbackOption?.displayName ?? launchFallbackOption?.id;
 
   // Model in foreground (black), effort in muted (grey). Static fallbacks
   // first; the final `else` returns null so a session with nothing to show
@@ -5468,10 +5487,10 @@ function AgentPicker({
     // spec may carry no executor model and no sticky/override is set), but the
     // dropdown still has model rows to switch. Keep the trigger rendered — and
     // the model dropdown + bare-`/model` open path reachable — with a stable
-    // identity fallback rather than hiding the picker entirely. For kiro, prefer
-    // the catalog default (e.g. "Auto") over the agent name so the launch-window
-    // label reads as a model.
-    triggerContent = kiroLaunchFallbackLabel ?? agentDisplayName ?? "Model";
+    // identity fallback rather than hiding the picker entirely. For kiro/pi,
+    // prefer the catalog default (e.g. "Auto") over the agent name so the
+    // launch-window label reads as a model.
+    triggerContent = launchFallbackLabel ?? agentDisplayName ?? "Model";
   } else {
     return null;
   }


### PR DESCRIPTION
## Related issue

N/A

## Summary

Native Pi (`pi-native`) sessions had no model picker in the web composer — you couldn't switch model mid-session the way you can for claude-native. This wires it up end-to-end with two-way sync.

- **Why it was missing:** the frontend picker gate (`modelPickerKindForConv`) had no `pi-native-ui` case, and the runner's `model_change` dispatch didn't handle `pi-native`.
- **How:** unlike the tmux-keystroke harnesses (claude/cursor/kiro), Pi exposes a real extension API (`pi.setModel` + `ctx.modelRegistry`), so web-picked switches apply live via the resident extension — no relaunch — and in-TUI `/model` picks mirror back to the web pill.
- **Catalog source:** the picker's model list is **pushed by the extension** from Pi's live registry (`getAvailable()` — only auth-configured models), so it populates in every auth path, including Pi's own `/login` where no Omnigent `models.json` exists. The current launch model is also reported so the pill/active-row resolve from the start.

ELI5: the web dropdown now lists the Pi models you're actually logged into, shows which one is active, and lets you switch — and if you switch inside the terminal, the web UI follows.

```
web pick ─PATCH model_override─▶ server ─model_change─▶ runner ─inbox─▶ extension.pi.setModel()  (live, no relaunch)
in-TUI /model ─model_select─▶ extension ─external_model_change─▶ server (model_override)  ─▶ web pill follows
session_start ─▶ extension posts ctx.model (current) + getAvailable() catalog ─external_model_options─▶ server cache ─▶ picker
```

## Test Plan

- `tests/test_pi_native_bridge.py` — `enqueue_model_change` payload shape.
- `tests/test_pi_native_extension.py` — extension applies web-picked switch via `setModel`; unknown-model error item; `model_select` mirror (ignores `restore`); `session_start` posts `getAvailable()` catalog + current-model `external_model_change`; empty/absent registry posts nothing.
- `tests/runner/test_app_sessions_native.py` — `model_change` dispatch enqueues a bridge payload for pi-native.
- `tests/server/integration/test_sessions_endpoints.py` — `external_model_options` populates the snapshot + publishes `session.model_options`; empty push evicts; non-list 400s.
- `tests/server/routes/test_sessions_snapshot.py` — snapshot serves the extension-pushed catalog with no runner fetch.
- UI gate: `npm test` (226 files / 3989 passed) and `npm run build` both green.
- `ruff format`/`ruff check` and pre-commit hooks pass; frontend `tsc` clean.

Note: two pre-existing `codex-native` tests fail identically on a clean tree (unrelated to this change).

## Demo

https://github.com/user-attachments/assets/e5e596b1-c697-4a96-9c87-2d4cebc48f2f

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified in a live local pi-native session: the composer model picker appears, shows the current model, lists only auth-configured models, and switching works. Automated coverage spans the bridge payload, extension push/apply/mirror logic, runner dispatch, server ingest/publish, and snapshot read. E2E not added — the repo has no pi-native web-UI e2e harness (the pi-native e2e skill drives the TUI, not the composer picker).

## Changelog

Native Pi sessions can now switch model mid-session from the web composer, with the picker scoped to your logged-in models and synced to in-terminal `/model` changes

This pull request and its description were written by Isaac.