### PR TITLE
feat(web): add opt-in setting to hide unconfigured harnesses in the picker

### DIFF
--- a/tests/e2e_ui/chat/test_hide_unconfigured_harnesses.py
+++ b/tests/e2e_ui/chat/test_hide_unconfigured_harnesses.py
@@ -1,0 +1,229 @@
+"""E2E: the "Hide unconfigured harnesses" setting filters the New Chat picker.
+
+The landing composer (``NewChatLandingScreen`` in
+``web/src/shell/NewChatDialog.tsx``) lists every harness and badges the ones
+that aren't set up on the selected host. The Settings → Appearance toggle
+``HideUnconfiguredHarnessesControl`` (``pages/SettingsPage.tsx``) writes
+``localStorage["omnigent:hide-unconfigured-harnesses"]``; when on, the picker's
+**Harnesses** group drops rows the selected host reports as unconfigured
+(``harnessUnconfiguredOnHost`` against the host's ``configured_harnesses`` map).
+
+This drives the whole flow end to end against the rendered UI: the toggle
+starts off (every harness shown), flipping the real Switch persists the
+preference, and the picker then hides the harness the stubbed host reports as
+unconfigured while keeping the configured one.
+
+Why the ``page.route`` stubbing and the async-in-a-fresh-thread shape: both are
+inherited from ``chat/test_codex_auth_availability.py`` — the e2e harness's
+runner tunnels into the server and registers no *host*, so faking ``/v1/hosts``
+(with ``configured_harnesses``) and ``/v1/agents`` is the established way to
+drive the landing picker, and once a pytest-playwright *sync* test has run in
+the session, pytest-asyncio can't start a loop on the main thread, so each
+async body runs in its own thread via :func:`asyncio.run`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+# Stubbed host the composer auto-selects (the tunneled runner registers no
+# host). Keyed identically in the recent-workspaces localStorage seed.
+_HOST_ID = "host_e2e"
+_HOST_NAME = "e2e-host"
+
+_TOGGLE_KEY = "omnigent:hide-unconfigured-harnesses"
+
+# Two native harness agents: Claude Code is configured on the stubbed host,
+# Goose is not. Both are native coding agents, so both render under the
+# picker's "Harnesses" group — the surface the filter acts on.
+_CLAUDE_AGENT_ID = "ag_claude_e2e"
+_GOOSE_AGENT_ID = "ag_goose_e2e"
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* to completion in a dedicated thread with its own event loop.
+
+    The e2e_ui suite runs many pytest-playwright **sync** tests in the same
+    session; once one has run, pytest-asyncio can't start a loop on the main
+    thread. Running the coroutine from a fresh thread via :func:`asyncio.run`
+    sidesteps that. Any exception (including assertion failures) is captured and
+    re-raised on the calling thread so the test fails normally.
+
+    :param coro: The coroutine to run to completion.
+    :raises Exception: Whatever the coroutine raised, re-raised here.
+    """
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+def _hosts_body() -> str:
+    """Stub body for ``GET /v1/hosts``: one online host the composer picks.
+
+    Its ``configured_harnesses`` marks ``claude-native`` available and
+    ``goose-native`` unconfigured — the wire shape the ``host.hello`` readiness
+    map produces, so the stub exercises the real availability → picker path.
+    """
+    return json.dumps(
+        {
+            "hosts": [
+                {
+                    "host_id": _HOST_ID,
+                    "name": _HOST_NAME,
+                    "owner": "e2e",
+                    "status": "online",
+                    "configured_harnesses": {
+                        "claude-native": True,
+                        "goose-native": False,
+                    },
+                }
+            ]
+        }
+    )
+
+
+def _agents_body() -> str:
+    """Stub body for ``GET /v1/agents``: the Claude and Goose native agents."""
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": _CLAUDE_AGENT_ID,
+                    "name": "claude-native-ui",
+                    "display_name": "Claude Code",
+                    "description": "Anthropic's coding agent",
+                    "harness": "claude-native",
+                    "skills": [],
+                },
+                {
+                    "id": _GOOSE_AGENT_ID,
+                    "name": "goose-native-ui",
+                    "display_name": "Goose",
+                    "description": "Block's coding agent",
+                    "harness": "goose-native",
+                    "skills": [],
+                },
+            ]
+        }
+    )
+
+
+async def _register_routes(page) -> None:
+    """Register the host/agent stubs and neutralize agent discovery.
+
+    :param page: The Playwright page to install routes on.
+    """
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_hosts_body())
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_agents_body())
+
+    async def handle_agent_scan(route: Route) -> None:
+        # Neutralize agent discovery so only the stubbed agents feed the picker;
+        # sessions other tests left behind would otherwise leak in and swap the
+        # selection out from under the assertions.
+        await route.fulfill(
+            status=200, content_type="application/json", body=json.dumps({"data": []})
+        )
+
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+
+async def _open_picker(page) -> None:
+    """Open the landing agent/harness picker dropdown."""
+    await page.get_by_test_id("new-chat-landing-agent-select").click()
+
+
+def test_hide_unconfigured_harnesses_filters_the_picker(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Off shows every harness; flipping the setting hides host-unconfigured ones.
+
+    1. **default (off)** — the picker lists both Claude Code and Goose, even
+       though the host reports Goose unconfigured (it's badged, not hidden).
+    2. **toggle on** — flipping the real Settings → Appearance Switch persists
+       the preference; the picker now drops the Goose row while keeping Claude.
+    """
+    base_url, session_id = seeded_session
+    del session_id  # this flow never creates a session — only reads the picker
+    _run_in_fresh_loop(_drive(base_url))
+
+
+async def _drive(base_url: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(page)
+            # Seed a recent working directory so the composer auto-fills (it
+            # never has to touch the host-less file browser).
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            # 1. Default (toggle off): both harnesses listed. Goose is badged
+            #    "needs setup" but still selectable.
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await _open_picker(page)
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-agent-{_CLAUDE_AGENT_ID}")
+            ).to_be_visible(timeout=30_000)
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-agent-{_GOOSE_AGENT_ID}")
+            ).to_be_visible()
+
+            # 2. Flip the real Settings → Appearance Switch on and confirm it
+            #    persists to localStorage.
+            await page.goto(f"{base_url}/settings/appearance")
+            toggle = page.get_by_test_id("hide-unconfigured-harnesses-toggle")
+            await expect(toggle).to_be_visible(timeout=30_000)
+            await expect(toggle).to_have_attribute("aria-checked", "false")
+            await toggle.click()
+            await expect(toggle).to_have_attribute("aria-checked", "true")
+            stored = await page.evaluate(f"() => window.localStorage.getItem('{_TOGGLE_KEY}')")
+            assert stored == "true", f"toggle did not persist (got {stored!r})"
+
+            # Back on the composer, the picker remounts and re-reads the
+            # preference: Goose (unconfigured on the host) is gone; Claude stays.
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await _open_picker(page)
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-agent-{_CLAUDE_AGENT_ID}")
+            ).to_be_visible(timeout=30_000)
+            # count()==0 (not "not visible"): the row is conditionally rendered,
+            # never just hidden.
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-agent-{_GOOSE_AGENT_ID}")
+            ).to_have_count(0)
+        finally:
+            await browser.close()

--- a/web/src/lib/harnessVisibilityPreferences.test.ts
+++ b/web/src/lib/harnessVisibilityPreferences.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_HIDE_UNCONFIGURED_HARNESSES,
+  readHideUnconfiguredHarnesses,
+  writeHideUnconfiguredHarnesses,
+} from "./harnessVisibilityPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("harnessVisibilityPreferences", () => {
+  it("defaults to off (show every harness) when nothing is stored", () => {
+    // Opt-in: with no stored preference the picker keeps surfacing harnesses to
+    // set up, so read must report the feature off.
+    expect(DEFAULT_HIDE_UNCONFIGURED_HARNESSES).toBe(false);
+    expect(readHideUnconfiguredHarnesses()).toBe(false);
+  });
+
+  it("round-trips both boolean values", () => {
+    writeHideUnconfiguredHarnesses(true);
+    expect(readHideUnconfiguredHarnesses()).toBe(true);
+
+    writeHideUnconfiguredHarnesses(false);
+    expect(readHideUnconfiguredHarnesses()).toBe(false);
+  });
+
+  it('treats any non-"true" stored value as off (defensive against hand edits)', () => {
+    // Only the exact string "true" enables the filter; garbage or a stale
+    // format reads as off rather than silently hiding harnesses.
+    localStorage.setItem("omnigent:hide-unconfigured-harnesses", "1");
+    expect(readHideUnconfiguredHarnesses()).toBe(false);
+
+    localStorage.setItem("omnigent:hide-unconfigured-harnesses", "yes");
+    expect(readHideUnconfiguredHarnesses()).toBe(false);
+
+    localStorage.setItem("omnigent:hide-unconfigured-harnesses", "true");
+    expect(readHideUnconfiguredHarnesses()).toBe(true);
+  });
+
+  it("never throws when storage is inaccessible", () => {
+    // Private-mode / quota failures surface as throws from the Storage API.
+    // Both helpers must swallow them — a broken preference must not break the
+    // picker or settings.
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    expect(() => writeHideUnconfiguredHarnesses(true)).not.toThrow();
+    expect(readHideUnconfiguredHarnesses()).toBe(false);
+  });
+});

--- a/web/src/lib/harnessVisibilityPreferences.ts
+++ b/web/src/lib/harnessVisibilityPreferences.ts
@@ -1,0 +1,44 @@
+// Persisted, per-device preference for which harnesses the new-chat picker
+// shows.
+//
+// The picker normally lists every harness and badges the ones that aren't set
+// up on the selected host ("needs setup" / "binary missing" / "needs auth").
+// When this opt-in preference is on, those unconfigured harnesses are hidden
+// instead of badged, so the picker only offers harnesses that can actually
+// launch on the chosen host. It's a device-local UI filter — no account or
+// host state is changed — so it lives in localStorage like the other
+// `*Preferences` helpers.
+
+const STORAGE_KEY = "omnigent:hide-unconfigured-harnesses";
+
+export const DEFAULT_HIDE_UNCONFIGURED_HARNESSES = false;
+
+/**
+ * Read the persisted "hide unconfigured harnesses" preference. Returns the
+ * default (off) when nothing is stored, on a server render (no `window`), or
+ * when the stored value is malformed — never throws, so a corrupt entry can't
+ * break the app.
+ */
+export function readHideUnconfiguredHarnesses(): boolean {
+  if (typeof window === "undefined") return DEFAULT_HIDE_UNCONFIGURED_HARNESSES;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_HIDE_UNCONFIGURED_HARNESSES;
+    return raw === "true";
+  } catch {
+    return DEFAULT_HIDE_UNCONFIGURED_HARNESSES;
+  }
+}
+
+/**
+ * Persist the "hide unconfigured harnesses" preference. Swallows quota/access
+ * errors so a failed write can't break the app.
+ */
+export function writeHideUnconfiguredHarnesses(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? "true" : "false");
+  } catch {
+    // localStorage quota or access errors shouldn't break the app.
+  }
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -57,6 +57,7 @@ import { useTheme } from "next-themes";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -125,6 +126,10 @@ import {
   type WorkspacePanelDefault,
 } from "@/lib/workspacePanelPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
+import {
+  readHideUnconfiguredHarnesses,
+  writeHideUnconfiguredHarnesses,
+} from "@/lib/harnessVisibilityPreferences";
 import {
   applyThemePalette,
   isThemePalette,
@@ -625,6 +630,41 @@ function PaletteSwatchPreview({ swatch }: { swatch: PaletteSwatch }) {
   );
 }
 
+/**
+ * Opt-in filter for the new-chat harness picker: when on, harnesses that
+ * aren't set up on the selected host (missing CLI / auth) are hidden instead
+ * of badged. Off by default so the picker keeps surfacing harnesses to set up.
+ * Fails open — with no connected host or readiness info, nothing is hidden.
+ */
+function HideUnconfiguredHarnessesControl() {
+  const [value, setValue] = useState(() => readHideUnconfiguredHarnesses());
+  const labelId = useId();
+  const toggle = useCallback((next: boolean) => {
+    setValue(next);
+    writeHideUnconfiguredHarnesses(next);
+  }, []);
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="flex flex-col">
+        <span id={labelId} className="text-sm font-medium">
+          Hide unconfigured harnesses
+        </span>
+        <span className="text-sm text-muted-foreground">
+          Only show harnesses that are set up on the selected host in the new-chat picker. Harnesses
+          needing a CLI install or sign-in are hidden instead of badged.
+        </span>
+      </div>
+      <Switch
+        aria-labelledby={labelId}
+        checked={value}
+        onCheckedChange={toggle}
+        data-testid="hide-unconfigured-harnesses-toggle"
+        className="mt-0.5 shrink-0"
+      />
+    </div>
+  );
+}
+
 function AppearanceSection() {
   // Embedded: the host owns light/dark, so the Mode and Color theme pickers
   // would be no-ops — hide them and say so (matching ThemeModeMenu). Terminal
@@ -652,6 +692,8 @@ function AppearanceSection() {
         <TerminalThemeControl />
 
         <WorkspacePanelDefaultControl />
+
+        <HideUnconfiguredHarnessesControl />
 
         <UiFontSizeControl />
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -32,6 +32,7 @@ import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import type { Conversation } from "@/hooks/useConversations";
 import { setOmnigentHostConfig } from "@/lib/host";
+import { writeHideUnconfiguredHarnesses } from "@/lib/harnessVisibilityPreferences";
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -806,6 +807,93 @@ describe("NewChatLandingScreen", () => {
     expect(cursor.compareDocumentPosition(pi) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(pi.compareDocumentPosition(kiro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(kiro.compareDocumentPosition(polly) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  // The default agents are claude-native (a1) and codex-native (a2); the host
+  // below reports codex-native as unconfigured on this machine.
+  function mockHostWithHarnessReadiness() {
+    mockHosts([
+      {
+        ...host("online"),
+        configured_harnesses: { "claude-native": true, "codex-native": false },
+      } as Host,
+    ]);
+  }
+
+  it("shows unconfigured harnesses by default (opt-in preference off)", () => {
+    // With the preference untouched the picker keeps listing harnesses that
+    // aren't set up on the host — they're badged, not hidden — so users can
+    // still discover and configure them.
+    mockHostWithHarnessReadiness();
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
+    expect(screen.getByTestId("new-chat-landing-agent-a2")).toBeTruthy();
+  });
+
+  it("hides harnesses unconfigured on the selected host when the preference is on", () => {
+    // Preference on → codex-native (reported unconfigured on host_1) drops out
+    // of the picker while claude-native (configured) stays.
+    writeHideUnconfiguredHarnesses(true);
+    mockHostWithHarnessReadiness();
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-agent-a2")).toBeNull();
+  });
+
+  // Polly is a bundle agent whose brain harness (claude-sdk) is overridable, so
+  // its config submenu lists every brain harness — each badged when unconfigured.
+  function mockPollyWithBrainReadiness() {
+    mockHosts([
+      {
+        ...host("online"),
+        configured_harnesses: {
+          "claude-sdk": true,
+          codex: "binary-missing",
+          cursor: false,
+          pi: false,
+          antigravity: true,
+          copilot: false,
+        },
+      } as Host,
+    ]);
+    mockAgents([
+      {
+        id: "a_polly",
+        name: "polly",
+        display_name: "Polly",
+        description: null,
+        harness: "claude-sdk",
+        skills: [],
+      },
+    ]);
+  }
+
+  it("lists every brain harness in a bundle agent's override submenu by default", () => {
+    // Preference off → the brain override still offers unconfigured harnesses
+    // (badged), so they remain discoverable.
+    mockPollyWithBrainReadiness();
+    renderLanding();
+    openAgentConfig("a_polly");
+    expect(screen.getByTestId("new-chat-landing-harness-codex")).toBeTruthy();
+    expect(screen.getByTestId("new-chat-landing-harness-cursor")).toBeTruthy();
+    expect(screen.getByTestId("new-chat-landing-harness-copilot")).toBeTruthy();
+  });
+
+  it("hides unconfigured brain harnesses in the override submenu when the preference is on", () => {
+    // Preference on → only brains that can launch on the host remain, plus the
+    // selected default (claude-sdk) which always stays for radio coherence.
+    writeHideUnconfiguredHarnesses(true);
+    mockPollyWithBrainReadiness();
+    renderLanding();
+    openAgentConfig("a_polly");
+    expect(screen.getByTestId("new-chat-landing-harness-claude-sdk")).toBeTruthy();
+    expect(screen.getByTestId("new-chat-landing-harness-antigravity")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-harness-codex")).toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-harness-cursor")).toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-harness-pi")).toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-harness-copilot")).toBeNull();
   });
 
   it("seeds the working directory from the host's most-recent path", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -68,6 +68,7 @@ import {
   SANDBOX_HOST_CHOICE,
 } from "@/lib/hostPreferences";
 import { readLastHarness, writeLastHarness } from "@/lib/harnessPreferences";
+import { readHideUnconfiguredHarnesses } from "@/lib/harnessVisibilityPreferences";
 import { readDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import { readHarnessOptions, writeHarnessOption } from "@/lib/modePreferences";
 import { useBrainHarnessLabels } from "@/lib/agentLabels";
@@ -1118,19 +1119,27 @@ function BrainHarnessOptions({
   onValueChange,
   host,
   labels,
+  hideUnconfigured,
 }: {
   value: string;
   onValueChange: (harness: string) => void;
   host: Host | undefined | null;
   labels: Record<string, string>;
+  hideUnconfigured: boolean;
 }) {
+  // With "hide unconfigured harnesses" on, drop brain options that can't launch
+  // on the host — except the current selection, which stays so the radio group
+  // still reflects the active pick.
+  const entries = Object.entries(labels).filter(
+    ([id]) => id === value || !hideUnconfigured || !harnessUnconfiguredOnHost(id, host),
+  );
   return (
     <>
       <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
         Agent Harness
       </div>
       <DropdownMenuRadioGroup value={value} onValueChange={onValueChange}>
-        {Object.entries(labels).map(([id, label]) => (
+        {entries.map(([id, label]) => (
           <DropdownMenuRadioItem
             key={id}
             value={id}
@@ -1488,6 +1497,7 @@ function AgentHarnessPicker({
           }}
           host={host}
           labels={brainHarnessLabels}
+          hideUnconfigured={hideUnconfigured}
         />
       );
     }
@@ -1565,6 +1575,19 @@ function AgentHarnessPicker({
     );
   };
 
+  // Opt-in "hide unconfigured harnesses" filter (Settings › Appearance). When
+  // on, drop harness rows that can't launch on the selected host. Fails open:
+  // harnessUnconfiguredOnHost returns false with no host / no readiness map, so
+  // nothing is hidden in those cases, and unrecognized harnesses stay visible.
+  const hideUnconfigured = useMemo(() => readHideUnconfiguredHarnesses(), []);
+  const visibleHarnessEntries = useMemo(
+    () =>
+      hideUnconfigured
+        ? harnessEntries.filter((a) => !harnessUnconfiguredOnHost(a.harness, host))
+        : harnessEntries,
+    [hideUnconfigured, harnessEntries, host],
+  );
+
   return (
     <DropdownMenu
       open={open}
@@ -1638,10 +1661,10 @@ function AgentHarnessPicker({
           <>
             {/* Harnesses group first — the native terminal CLIs (Claude Code is
             the default), so the most-used picks lead. */}
-            {harnessEntries.length > 0 && (
+            {visibleHarnessEntries.length > 0 && (
               <>
                 <PickerSectionHeader>Harnesses</PickerSectionHeader>
-                {harnessEntries.map(renderEntry)}
+                {visibleHarnessEntries.map(renderEntry)}
                 <DropdownMenuSeparator />
               </>
             )}


### PR DESCRIPTION
## Related issue

Addresses #2423 — implements its suggested **direction #2** ("filter them out when the selected host can't run them"), host-aware via `/v1/hosts` `configured_harnesses`. Intentionally **not** using a closing keyword: this is an opt-in first pass scoped to the new-chat picker and doesn't cover the issue's part B (surfacing online hosts / CLI versions) or its grey-out / fallback directions. Related backend gap: #152.

## Summary

The new-chat agent picker lists every harness and badges the ones not set up on the selected host ("needs setup" / "binary missing" / "needs auth"). For users who run only a couple of harnesses, that's a lot of rows to scan past.

- Adds a per-device **"Hide unconfigured harnesses"** toggle in **Settings → Appearance** (off by default).
- When on, the picker's **Harnesses** group drops rows that are unconfigured on the selected host, and the bundle-agent (Polly / Debby) **brain-harness override** submenu drops unconfigured brains too — always keeping the current selection so the radio group stays coherent.
- **Fails open:** no connected host / no readiness map / unrecognized harness → nothing is hidden.
- Data-driven off the host's `configured_harnesses` map, so newly added harnesses need no code change.
- Scoped to `NewChatDialog`; the fork / switch / create-agent dialogs are left for a follow-up.

### Relation to #2381 ("Hide dismissed harnesses from picker")

These are complementary, not duplicates — different trigger and scope:

| | #2381 (draft) | This PR |
|---|---|---|
| Trigger | **Manual** — operator lists harnesses to hide (`dismissed_harnesses` in config) | **Automatic** — hides what's unconfigured on the selected host |
| Driver | Backend `/v1/harnesses` catalog + `omnigent harness hide/unhide` CLI | Per-device localStorage toggle + host readiness map |
| Surface | New-chat picker (server-driven) | New-chat picker (client-side filter) |

#2381 answers "hide harnesses I never want to see" (persistent, per-deployment); this answers "show only what can actually launch on the host I'm targeting right now" (dynamic, per-device). They overlap on the `NewChatDialog` Harnesses group, so if both land they should be reconciled to filter that list once. Opening this to surface the automatic / host-aware approach for maintainer input alongside #2381's manual one.

### Scope note (ties to #152)

In-process SDK harnesses (`claude-sdk`, `openai-agents`, `antigravity`) always report available — their credentials resolve at runtime from sources the host daemon can't enumerate — so this filter can't hide them, matching the existing readiness model. Making SDK readiness credential-aware is the backend change #152 tracks; deliberately out of scope here.

## Test Plan

- `npm run type-check`, `oxlint`, `prettier` — clean.
- `vitest`:
  - New `harnessVisibilityPreferences.test.ts` — localStorage read/write, default-off, defensive parsing.
  - New `NewChatDialog.test.tsx` cases — default shows all; toggle-on hides host-unconfigured harnesses; brain-override submenu filters likewise while retaining the selected default.
  - Full `NewChatDialog.test.tsx` suite green (137 tests).
- Playwright `tests/e2e_ui/chat/test_hide_unconfigured_harnesses.py` — drives the flow end to end against a real browser: stub a host whose `configured_harnesses` marks a native harness unconfigured, flip the real Settings → Appearance Switch, and assert the picker drops that harness row while keeping the configured one. Passes locally (1 passed).
- Manual: brought up a local server + connected host reporting a real `configured_harnesses` map; toggled the setting and confirmed both the Harnesses group and the Polly / Debby brain-override submenu filter correctly; installed a harness CLI (`pi`) + reconnected the host and watched it flip hidden → available live, then uninstalled + reconnected to confirm it reverts.

## Demo

<!-- UI change — screenshot to be attached before marking ready -->
Before (toggle **off**): all harnesses listed; unconfigured ones badged "needs setup" / "binary missing".
<img width="609" height="691" alt="image" src="https://github.com/user-attachments/assets/1f041de6-889e-4ade-bd08-b84e4d52eed8" />



After (toggle **on**): only harnesses set up on the selected host remain.
<img width="609" height="691" alt="image" src="https://github.com/user-attachments/assets/fa94608c-d9eb-4bad-a1af-aec58cf0f2dc" />



## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: brought up a local server + host reporting a real `configured_harnesses` map; confirmed the Harnesses group and the brain-override submenu filter correctly, the selected brain is retained, and that installing a CLI + reconnecting flips a harness from hidden to available (and uninstall + reconnect reverts it). Automated unit + integration tests cover the preference module and the picker filtering.

## Changelog

Add an opt-in "Hide unconfigured harnesses" setting that filters the new-chat picker to harnesses set up on the selected host
