### PR TITLE
fix(pi-native): share one response_id across a turn's running/idle status pair

### DIFF
--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -951,6 +951,12 @@ module.exports = function (pi) {
   let sequence = 0;
   let turnOrdinal = 0;
   let activeResponseId = null;
+  // Response id shared across a turn's ``running`` → ``idle`` status pair.
+  // The web store only clears its local "streaming" flag when an ``idle``
+  // edge's response_id matches the ``running`` edge that opened the turn; a
+  // fresh id per edge would leave the composer stuck in "queued" until a tab
+  // switch resets the store. Minted on agent_start, reused on agent_end.
+  let turnStatusResponseId = null;
   // Dedicated loop-state flag, set on agent_start / cleared on agent_end. Used
   // as the no-isIdle() fallback for requestInterrupt instead of
   // !activeResponseId: agent_start resets activeResponseId to null and only
@@ -1367,11 +1373,12 @@ module.exports = function (pi) {
     streamedTextIndex.clear();
     finalizedTextBlocks.clear();
     streamingMessageOrdinal = 0;
+    turnStatusResponseId = `pi-${Date.now()}-${++sequence}`;
     await postEvent(config, {
       type: "external_session_status",
       data: {
         status: "running",
-        response_id: `pi-${Date.now()}-${++sequence}`,
+        response_id: turnStatusResponseId,
       },
     });
   });
@@ -1396,8 +1403,15 @@ module.exports = function (pi) {
     if (changed) await postSessionUsage();
     await postEvent(config, {
       type: "external_session_status",
-      data: { status: "idle", response_id: `pi-${Date.now()}-${++sequence}` },
+      data: {
+        status: "idle",
+        // Reuse the running edge's id so the web store's idle-clear matches
+        // and drops the "streaming" flag. Fall back to a fresh id if this
+        // idle somehow lands without a preceding agent_start.
+        response_id: turnStatusResponseId ?? `pi-${Date.now()}-${++sequence}`,
+      },
     });
+    turnStatusResponseId = null;
   });
 
   pi.on("turn_start", async (event, ctx) => {

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.test.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.test.js
@@ -32,11 +32,30 @@ const harnesses = [];
 // Build a fresh extension instance with its own temp inbox directory. Each call
 // produces independent closure state (activeResponseId, pendingInterruptUntil,
 // latestContext, ...).
-function makeHarness() {
+function makeHarness({ captureEvents = false } = {}) {
   const inboxDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-inbox-"));
   const configPath = path.join(inboxDir, "config.json");
-  fs.writeFileSync(configPath, JSON.stringify({ inboxDir }));
+  // A serverUrl + sessionId make postEvent attempt a real fetch; with a mock
+  // global fetch that lets a test capture the posted event bodies. Without
+  // them postEvent fails closed (the interrupt tests rely on that).
+  const config = captureEvents
+    ? { inboxDir, serverUrl: "http://mock", sessionId: "conv_test" }
+    : { inboxDir };
+  fs.writeFileSync(configPath, JSON.stringify(config));
   process.env.OMNIGENT_PI_NATIVE_CONFIG = configPath;
+
+  // Capture posted event bodies (status edges etc.) instead of hitting network.
+  const postedEvents = [];
+  if (captureEvents) {
+    global.fetch = async (url, opts) => {
+      try {
+        if (opts && typeof opts.body === "string" && String(url).endsWith("/events")) {
+          postedEvents.push(JSON.parse(opts.body));
+        }
+      } catch (_err) {}
+      return { ok: true, status: 204, json: async () => ({}) };
+    };
+  }
 
   const handlers = {};
   const pi = {
@@ -52,9 +71,15 @@ function makeHarness() {
   const mod = require(EXT_PATH);
   mod(pi);
 
-  const h = { pi, handlers, inboxDir };
+  const h = { pi, handlers, inboxDir, postedEvents };
   harnesses.push(h);
   return h;
+}
+
+function statusEdges(postedEvents) {
+  return postedEvents
+    .filter((e) => e && e.type === "external_session_status" && e.data)
+    .map((e) => ({ status: e.data.status, responseId: e.data.response_id }));
 }
 
 // ctx mock. `idle` may be true/false (exposes isIdle()) or undefined (no isIdle
@@ -272,8 +297,56 @@ async function testAgentStartClearsStaleWindow() {
   );
 }
 
+// The web store only clears its local "streaming" flag when a turn's `idle`
+// status edge carries the same response_id as the `running` edge that opened
+// it. A fresh id per edge left the composer stuck queueing until a tab switch
+// reset the store. Assert agent_start/agent_end share one id.
+async function testRunningIdleShareResponseId() {
+  const h = makeHarness({ captureEvents: true });
+  const ctx = makeCtx({ idle: false });
+
+  await h.handlers.agent_start({}, ctx);
+  await h.handlers.agent_end({ messages: [] }, ctx);
+
+  const edges = statusEdges(h.postedEvents);
+  const running = edges.find((e) => e.status === "running");
+  const idle = edges.find((e) => e.status === "idle");
+
+  assert(
+    "agent_start posts a running edge with a response_id",
+    running !== undefined && typeof running.responseId === "string" && running.responseId.length > 0,
+    JSON.stringify(running),
+  );
+  assert(
+    "agent_end posts an idle edge with a response_id",
+    idle !== undefined && typeof idle.responseId === "string" && idle.responseId.length > 0,
+    JSON.stringify(idle),
+  );
+  assert(
+    "running and idle edges share the same response_id",
+    running && idle && running.responseId === idle.responseId,
+    `running=${running && running.responseId} idle=${idle && idle.responseId}`,
+  );
+
+  // A second turn mints a fresh id, still paired across its own running/idle.
+  await h.handlers.agent_start({}, ctx);
+  await h.handlers.agent_end({ messages: [] }, ctx);
+  const edges2 = statusEdges(h.postedEvents);
+  const running2 = edges2.filter((e) => e.status === "running");
+  const idle2 = edges2.filter((e) => e.status === "idle");
+  assert(
+    "second turn pairs its own running/idle id and differs from the first",
+    running2.length === 2 &&
+      idle2.length === 2 &&
+      running2[1].responseId === idle2[1].responseId &&
+      running2[1].responseId !== running2[0].responseId,
+    `turn1=${running2[0].responseId} turn2=${running2[1].responseId}`,
+  );
+}
+
 (async () => {
   try {
+    await testRunningIdleShareResponseId();
     await testIdleInterruptDoesNotPoisonNextTurn();
     await testIdleInterruptFallbackNoIsIdle();
     await testMidTurnInterruptStillAborts();


### PR DESCRIPTION
## Related issue

N/A

## Summary

An idle **pi-native** session kept queueing web messages client-side instead of sending them: the composer showed *"Send a follow-up (queued)"* with a **green (idle)** session dot, and only switching tabs unstuck it.

- The pi extension minted a **fresh `response_id` on every `external_session_status` edge** (`agent_start`→running, `agent_end`→idle).
- The web store clears its local `"streaming"` flag only when the idle edge's `response_id` **matches** the running edge that opened the turn (or when `activeResponse` is already null). With mismatched ids, neither branch fired, so `status` stayed `"streaming"` forever — `shouldQueueSend` queued every message and `maybeFlushQueuedHead` refused to drain (both bail on `status === "streaming"`). `switchTo` hard-resets the store, which is why a tab switch masked it.
- `claude-native` never hit this because its forwarder reuses **one turn-scoped id** across both edges.

Fix: mint a per-turn `response_id` in `agent_start` and reuse it in `agent_end` so the running/idle pair matches — the same contract claude-native already honors.

## Test Plan

- New JS unit tests in `omnigent_pi_native_extension.test.js` capture the posted status edges and assert the `running`/`idle` pair shares one `response_id`, and that a second turn mints a fresh-but-paired id. All pass (`node omnigent/resources/pi_native/omnigent_pi_native_extension.test.js`).
- Existing extension interrupt/replay JS tests still pass (unchanged).
- `pytest tests/test_pi_native_extension.py` — 33 passed.
- **Live verification:** launched a fresh pi-native session (regenerating the extension with the fix), then in the web UI sent a message, let the turn finish (green dot), and sent another — it now sends immediately instead of queueing, with no tab switch needed. Confirmed by the user.

## Demo

N/A — behavioural fix in the pi extension; verified live (composer no longer stuck on "queued" for an idle session).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added JS unit tests asserting the per-turn `response_id` is shared across the `running`/`idle` status edges (and fresh per turn). Manually verified live in the web UI against a freshly-launched pi-native session: an idle session now sends a new message immediately instead of holding it in the client-side queue.

## Changelog

Sending a message to an idle native Pi session no longer gets stuck in the "queued" state until you switch tabs

This pull request and its description were written by Isaac.