### PR TITLE
perf(store): avoid full-table scan in list_latest_message_items_for_conversations

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -593,18 +593,24 @@ def _to_item(row: SqlConversationItem) -> ConversationItem:
     )
 
 
-def _ranked_latest_message_item_ids(conversation_ids: list[str]) -> Subquery:
+def _ranked_latest_message_items(conversation_ids: list[str]) -> Subquery:
     """
-    Build a ranked latest-message-id subquery for multiple conversations.
+    Build a ranked latest-message subquery for multiple conversations.
+
+    Selects all ``SqlConversationItem`` columns plus a per-conversation
+    ``row_num`` so the caller can filter to the top-N rows without a
+    join back to the base table. Avoiding the join is critical: the
+    primary key is ``(workspace_id, conversation_id, id)``, so a join
+    on ``id`` alone forces a full table scan.
 
     :param conversation_ids: Conversation ids to fetch messages for,
         e.g. ``["conv_child1", "conv_child2"]``.
-    :returns: SQLAlchemy subquery with ``item_id`` and per-conversation
-        ``row_num`` columns, newest message first.
+    :returns: SQLAlchemy subquery with all item columns plus per-conversation
+        ``row_num``, newest message first.
     """
     return (
         select(
-            SqlConversationItem.id.label("item_id"),
+            SqlConversationItem,
             func.row_number()
             .over(
                 partition_by=SqlConversationItem.conversation_id,
@@ -1719,25 +1725,14 @@ class SqlAlchemyConversationStore(ConversationStore):
             return result
 
         with self._conv_session() as session:
-            ranked = _ranked_latest_message_item_ids(unique_ids)
-            rows = (
-                session.execute(
-                    select(SqlConversationItem)
-                    .join(ranked, SqlConversationItem.id == ranked.c.item_id)
-                    .where(
-                        SqlConversationItem.workspace_id == current_workspace_id(),
-                        ranked.c.row_num <= per_conversation_limit,
-                    )
-                    .order_by(
-                        SqlConversationItem.conversation_id,
-                        desc(SqlConversationItem.position),
-                    )
-                )
-                .scalars()
-                .all()
-            )
+            ranked = _ranked_latest_message_items(unique_ids)
+            rows = session.execute(
+                select(ranked)
+                .where(ranked.c.row_num <= per_conversation_limit)
+                .order_by(ranked.c.conversation_id, ranked.c.position.desc())
+            ).all()
             for row in rows:
-                result[row.conversation_id].append(_to_item(row))
+                result[row.conversation_id].append(_to_item(row))  # type: ignore[arg-type]
         return result
 
     def append(


### PR DESCRIPTION
## Related issue

N/A

## Summary

`list_latest_message_items_for_conversations` was causing ~9 s queries visible in `pg_stat_activity`. Root cause: the query computed a window-function subquery selecting only `id + row_num`, then joined back to `conversation_items` on `id` alone. The table's PK is `(workspace_id, conversation_id, id)`, so Postgres had no index path for an `id`-only lookup and fell back to a full seq scan of the entire table (~2M rows) on every call.

- Restructured the ranked subquery to select all `SqlConversationItem` columns, eliminating the join back to the base table entirely.
- Verified on production data: **4563 ms → 830 ms** for a 10-conversation query spanning 228K rows.

## Test Plan

- Ran `pytest -k "latest_message"` — 3 tests pass.
- Ran `EXPLAIN ANALYZE` on production DB before and after against the heaviest conversations.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Existing tests cover this change
- [x] Manual verification completed

## Coverage notes

Verified with `EXPLAIN ANALYZE` directly against the production Databricks Postgres instance. The seq scan on 2M rows is gone; the query now executes entirely within the subquery using the existing `ix_conversation_items_conversation_id_position` index.