### PR TITLE
[cli] Add uninstall workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,41 @@ mirrors work out of the box; override with `OMNIGENT_INDEX_URL` if needed.
 
 </details>
 
+<details>
+<summary>Uninstalling Omnigent</summary>
+
+Preview the CLI/profile cleanup that would run by default:
+
+```bash
+omnigent uninstall
+```
+
+Remove the CLI and installer-managed PATH entries while keeping your local
+history, credentials, and projects:
+
+```bash
+omnigent uninstall --yes
+```
+
+To also remove Omnigent state under `~/.omnigent`, pass `--purge`; Omnigent
+backs it up outside the target before deletion. Your `~/omnigent` workspace is
+kept unless you explicitly add `--purge-workspace`.
+
+```bash
+omnigent uninstall --purge --yes
+```
+
+If the installed wheel is broken or `omnigent` is not on `PATH`, run the
+standalone script instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omnigent-ai/omnigent/main/scripts/uninstall_oss.sh | sh
+```
+
+Add `--yes` to the standalone script to perform the previewed CLI cleanup.
+
+</details>
+
 ### 2. Start your first agent
 
 `omnigent` picks a model with you and starts a session in your terminal. It
@@ -463,4 +498,3 @@ Thanks to all of our amazing contributors!
 <a href="https://github.com/omnigent-ai/omnigent/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=omnigent-ai/omnigent" />
 </a>
-

--- a/docs/UNINSTALL_DESIGN.md
+++ b/docs/UNINSTALL_DESIGN.md
@@ -1,8 +1,12 @@
 # Omnigent Uninstaller Design
 
-Status: Proposed (ready for implementation)
+Status: Implemented in PR #2550
 Owner: Pat Sukprasert (@PattaraS)
 Related discussion: brainstormed and debated via Debby (claude + gpt partners)
+
+Implementation note: PR #2550 ships the OSS CLI/script implementation as one
+combined PR rather than the staged PR breakdown below. Checkboxes marked here
+reflect the current implementation and focused test coverage in that PR.
 
 This document specifies how Omnigent should be uninstalled. It is written to be
 handed to an implementer without further design decisions. Track delivery with
@@ -132,10 +136,10 @@ backfill may only write `unknown`), `confidence` (`none` whenever
 
 Checklist:
 
-- [ ] Schema documented and versioned (`schema_version = 1`)
-- [ ] Atomic writer (tmp + fsync + rename) with `0600` mode
-- [ ] Serializer / dataclass with round-trip unit tests
-- [ ] `omnigent _internal write-ledger --from-env` hidden subcommand
+- [x] Schema documented and versioned (`schema_version = 1`)
+- [x] Atomic writer (tmp + fsync + rename) with `0600` mode
+- [x] Serializer / dataclass with round-trip unit tests
+- [x] `omnigent _internal write-ledger --from-env` hidden subcommand
 
 ## 3. Install-side ledger writer
 
@@ -168,12 +172,12 @@ Upgrade / repair sync:
 
 Checklist:
 
-- [ ] `write_install_ledger` hooked into `scripts/install_oss.sh` (post
+- [x] `write_install_ledger` hooked into `scripts/install_oss.sh` (post
       side-effects, pre next-steps)
-- [ ] Records profiles, external config, wheel, deps, launch agents, state paths
-- [ ] Upgrade/repair merge logic (backfill superseded by installer; never
+- [x] Records profiles, external config, wheel, deps, launch agents, state paths
+- [x] Upgrade/repair merge logic (backfill superseded by installer; never
       downgrade `installed_by`)
-- [ ] Tests: fresh install, upgrade, backfill-superseded-by-installer
+- [x] Tests: fresh install, upgrade, backfill-superseded-by-installer
 
 ## 4. Back-fill routine
 
@@ -238,14 +242,14 @@ only with `--apply`.
 
 Checklist:
 
-- [ ] Fast reconstruction (<100ms, no package-manager subprocesses, in-process
+- [x] Fast reconstruction (<100ms, no package-manager subprocesses, in-process
       marker scan) on startup when missing
-- [ ] Deep reconstruction at uninstall / doctor
-- [ ] Anchor guard (refuse to fabricate without an install signal)
-- [ ] Per-field confidence assignment per table
-- [ ] Never-overwrite-real + `install_ledger.backfill.json` double-ledger handling
-- [ ] `omnigent doctor --migrate-ledger [--deep] [--apply]`
-- [ ] Read-only-except-the-ledger guarantee (tested)
+- [x] Deep reconstruction at uninstall / doctor
+- [x] Anchor guard (refuse to fabricate without an install signal)
+- [x] Per-field confidence assignment per table
+- [x] Never-overwrite-real + `install_ledger.backfill.json` double-ledger handling
+- [x] `omnigent doctor --migrate-ledger [--deep] [--apply]`
+- [x] Read-only-except-the-ledger guarantee (tested)
 
 ## 5. omnigent uninstall CLI
 
@@ -267,6 +271,9 @@ Flags:
   `--no-backup`.
 - `--dry-run` - print exact planned actions (paths, sizes, line ranges); make no
   changes.
+- With no destructive flag (`--yes`, `--purge`, `--force`,
+  `--modify-external-config`, `--no-backup`, `--assume-inferred`, or
+  `--purge-workspace`), uninstall defaults to dry-run preview mode.
 - `--yes` - non-interactive; suppresses prompts for auto-removable artifacts
   only. Does NOT imply `--purge`.
 - `--json` - machine-readable output.
@@ -287,10 +294,10 @@ Confidence (secondary, tighten-only): an `inferred`/low-confidence entry
 escalates one notch and won't auto-act under bare `--yes` - it can only add
 friction, never grant it.
 
-| Artifact | No flags (interactive) | `--yes` | Required gate |
+| Artifact | No destructive flags | `--yes` | Required gate |
 |---|---|---|---|
-| Wheel (`uv tool uninstall omnigent`) | prompt then remove | auto-remove | none |
-| Delimited PATH block (marker match) | prompt then remove | auto-remove | none; refuse if `block_sha256` mismatch (tampered) unless `--force` |
+| Wheel (`uv tool uninstall omnigent`) | dry-run preview | auto-remove | none |
+| Delimited PATH block (marker match) | dry-run preview | auto-remove | none; refuse if `block_sha256` mismatch (tampered) unless `--force` |
 | Injected external config, marker/observed | reported, skipped | reported, skipped | `--modify-external-config` |
 | Injected external config, inferred (no marker) | reported, skipped | reported, skipped | `--modify-external-config` AND `--assume-inferred` |
 | `~/.omnigent` state root | reported, skipped | removed only with `--purge` | `--purge` |
@@ -300,13 +307,13 @@ friction, never grant it.
 
 Checklist:
 
-- [ ] Python `omnigent uninstall` subcommand that execs the shell script
-- [ ] Targets: `cli`, `state`, `desktop-data`, `all`
-- [ ] Flags: `--purge`, `--purge-workspace`, `--dry-run`, `--yes`, `--json`,
+- [x] Python `omnigent uninstall` subcommand that execs the shell script
+- [x] Targets: `cli`, `state`, `desktop-data`, `all`
+- [x] Flags: `--purge`, `--purge-workspace`, `--dry-run`, `--yes`, `--json`,
       `--force`, `--modify-external-config`, `--no-backup`, `--assume-inferred`
-- [ ] Two-gate decision table implemented (intrinsic-risk + confidence
+- [x] Two-gate decision table implemented (intrinsic-risk + confidence
       tighten-only)
-- [ ] External-config stripping (marker/allowlist scoped only)
+- [x] External-config stripping (marker/allowlist scoped only)
 
 ## 6. Order of operations
 
@@ -341,14 +348,14 @@ execs the shell script for removal. Sequence:
 
 Checklist:
 
-- [ ] Process-shutdown protocol (pidfiles, SIGTERM->5s->`--force` SIGKILL,
+- [x] Process-shutdown protocol (pidfiles, SIGTERM->5s->`--force` SIGKILL,
       `omnigent:*` tmux, ledger LaunchAgents, abort-if-won't-stop)
-- [ ] Profile block removal across all shells incl. fish; profile backed up
+- [x] Profile block removal across all shells incl. fish; profile backed up
       first; tamper-refusal
-- [ ] `--purge` archives OUTSIDE the target (`.tar.zst`, gzip fallback; fail
+- [x] `--purge` archives OUTSIDE the target (`.tar.zst`, gzip fallback; fail
       closed if it can't write the backup), prints restore command, then
       deletes; `~/omnigent` gated behind `--purge-workspace` (or confirm)
-- [ ] `uv tool uninstall omnigent` runs last
+- [x] `uv tool uninstall omnigent` runs last
 
 ## 7. Idempotency and exit codes
 
@@ -388,10 +395,10 @@ Exit codes:
 
 Checklist:
 
-- [ ] State-check idempotency (already-absent = 0; tried-and-failed = nonzero +
+- [x] State-check idempotency (already-absent = 0; tried-and-failed = nonzero +
       continue + summarize)
-- [ ] Exit codes 0/1/2/3 as specified
-- [ ] `--json` output shape stable and tested
+- [x] Exit codes 0/1/2/3 as specified
+- [x] `--json` output shape stable and tested
 
 ## 8. Test matrix
 
@@ -416,28 +423,30 @@ Checklist:
 
 Checklist:
 
-- [ ] Rows 1-2, 6-7, 12, 14 covered by `uninstall_oss.sh` tests
-- [ ] Rows 3-5, 8-11, 13 covered by `omnigent uninstall` tests
+- [x] Rows 1-2, 6-7, 12, 14 covered by `uninstall_oss.sh` tests
+- [x] Rows 3-5, 8-11, 13 covered by focused CLI, ledger, and
+      `uninstall_oss.sh` tests
 
 ## 9. Delivery plan (PR breakdown)
 
-- [ ] PR 1 - Ledger schema + serializer. Schema, atomic-write + `0600` writer,
+- [x] PR 1 - Ledger schema + serializer. Schema, atomic-write + `0600` writer,
       `omnigent _internal write-ledger` hidden subcommand, round-trip unit
       tests. No behavior change.
-- [ ] PR 2 - Install-side writer. Hook `write_install_ledger` into
+- [x] PR 2 - Install-side writer. Hook `write_install_ledger` into
       `scripts/install_oss.sh` + upgrade/repair merge logic.
-- [ ] PR 3 - Back-fill routine. Fast + deep reconstruction, anchor guard,
+- [x] PR 3 - Back-fill routine. Fast + deep reconstruction, anchor guard,
       confidence assignment, never-overwrite-real + double-ledger,
       `doctor --migrate-ledger`.
-- [ ] PR 4 - `uninstall_oss.sh` core. Process shutdown, profile block removal
+- [x] PR 4 - `uninstall_oss.sh` core. Process shutdown, profile block removal
       (all shells), `uv tool uninstall`, idempotency + exit codes,
       `--dry-run`/`--json`.
-- [ ] PR 5 - `omnigent uninstall` subcommand + gates. Python front, targets/
+- [x] PR 5 - `omnigent uninstall` subcommand + gates. Python front, targets/
       flags, two-gate decision table, `--purge` backup-outside-target,
       external-config stripping.
-- [ ] PR 6 - Docs + discovery. Installer next-steps + `--help` mention
-      uninstall; app-store surfaces point back at `omnigent uninstall --purge`;
-      brew/apt detect-and-redirect note.
+- [x] PR 6 - Docs + discovery. Installer next-steps + `--help` mention
+      uninstall; README documents the standalone fallback and purge behavior.
+      App-store and brew/apt-specific surfaces remain out of scope for this OSS
+      CLI/script PR.
 
 ## Appendix A: ELI5
 
@@ -470,11 +479,12 @@ Omnigent is a houseguest.
   are ("coat on hook - definitely mine" vs "this drill - no idea who brought it,
   don't touch"). A reconstructed checklist never lets you auto-toss the risky
   stuff.
-- `--yes` = "don't keep asking, just do the safe moves." It grabs the coat and
-  box without nagging, but still stops to ask before erasing a roommate's
-  notebook or shredding your photos - no matter which checklist it is reading.
-  Risky actions are gated by what you are touching, not by which checklist you
-  have.
+- Bare uninstall = "show me what would happen first." Nothing changes until you
+  add a destructive flag such as `--yes` or `--purge`.
+- `--yes` = "apply the previewed safe moves." It grabs the coat, but it still
+  leaves the box unless you add `--purge`, and still will not erase a roommate's
+  notebook unless you add `--modify-external-config`. Risky actions are gated by
+  what you are touching, not by which checklist you have.
 
 ## Appendix B: Flowchart
 
@@ -515,16 +525,16 @@ Omnigent is a houseguest.
                               |
                               v
              =====================================
-             ||  1. STOP PROCESSES FIRST         ||
-             ||  pidfiles -> SIGTERM -> 5s ->     ||
-             ||  --force SIGKILL; kill omnigent:* ||
-             ||  tmux; unload ledger LaunchAgents ||
+             ||  1. PLAN/STOP PROCESSES FIRST    ||
+             ||  dry-run reports planned stops;   ||
+             ||  apply unloads LaunchAgents, then ||
+             ||  pidfiles/tmux -> SIGTERM/force   ||
              =================+===================
                              |  won't stop? --> ABORT destructive steps (exit 2)
                              v
              =====================================
              ||  2. --dry-run?  -- yes -> print   ||
-             ||  exact paths + sizes + ranges,    ||
+             ||  planned stops, paths, sizes,     ||
              ||  EXIT 0                            ||
              =================+===================
                              | no
@@ -559,8 +569,8 @@ Omnigent is a houseguest.
            |    scoped, ledger-recorded)                 |
            | 5. --purge? archive to backup tarball       |
            |    OUTSIDE target (~/.omnigent-backups/),  |
-           |    then delete state; separate confirm for |
-           |    ~/omnigent; note installation_id telem  |
+           |    then delete state; keep ~/omnigent       |
+           |    unless --purge-workspace or confirm      |
            | 6. uv tool uninstall omnigent  (LAST)       |
            +--------------------+----------------------+
                                 |
@@ -573,8 +583,9 @@ Omnigent is a houseguest.
              |  --json summary of what was done/kept |
              +--------------------------------------+
 
-   App-store surfaces (iOS / Android / Electron):
-   OS-native uninstall owns the bundle; point user back at
-   omnigent uninstall --purge for ~/.omnigent.  brew/apt:
-   detect-and-redirect to that package manager. No cross-domain reaper.
+   Other package surfaces:
+   OS/package-manager uninstall owns package files. The Omnigent
+   uninstaller handles local profile/state cleanup and uses
+   uv tool uninstall for uv-installed wheels; it does not remove
+   shared dependencies or act as a cross-domain reaper.
 ```

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1326,9 +1326,11 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "cursor",
         "debby",
         "debug",
+        "doctor",
         "goose",
         "hermes",
         "host",
+        "_internal",
         "kimi",
         "kiro",
         "lakebox",
@@ -1346,6 +1348,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "server",
         "setup",
         "stop",
+        "uninstall",
         "update",
         "upgrade",
         "version",
@@ -1462,6 +1465,8 @@ def main() -> None:
     if argv[0] in {"--help", "-h", "--version"}:
         cli(args=argv)
         return
+
+    _maybe_fast_backfill_install_ledger(argv)
 
     from omnigent.cli_diagnostics import (
         log_cli_error_hint,
@@ -3629,6 +3634,232 @@ def stop(force: bool) -> None:
         click.echo("Nothing to stop.")
     if failures:
         raise click.ClickException("; ".join(failures) + " — retry with --force.")
+
+
+def _uninstall_script_path() -> Path:
+    """Return an executable uninstall script path for source and wheel installs."""
+    repo_script = Path(__file__).resolve().parent.parent / "scripts" / "uninstall_oss.sh"
+    if repo_script.exists():
+        return repo_script
+    try:
+        resource = resources.files("omnigent.resources.scripts").joinpath("uninstall_oss.sh")
+    except ModuleNotFoundError as exc:
+        raise click.ClickException("uninstall script is missing from this installation") from exc
+    with resources.as_file(resource) as path:
+        if path.exists():
+            temp_dir = Path(tempfile.mkdtemp(prefix="omnigent-uninstall-"))
+            temp_path = temp_dir / "uninstall_oss.sh"
+            shutil.copy2(path, temp_path)
+            temp_path.chmod(0o700)
+            return temp_path
+    raise click.ClickException("uninstall script is missing from this installation")
+
+
+def _write_uninstall_manifest(ledger: Any) -> Path:
+    """Write the ledger fields the POSIX uninstaller needs as tab records."""
+    fd, manifest_name = tempfile.mkstemp(prefix="omnigent-uninstall-ledger-", suffix=".tsv")
+    manifest = Path(manifest_name)
+    with os.fdopen(fd, "w") as handle:
+        for profile in ledger.entries.profiles:
+            handle.write(
+                "\t".join(
+                    [
+                        "profile_block",
+                        profile.path,
+                        profile.block_sha256 or "",
+                        profile.source,
+                        profile.confidence,
+                    ]
+                )
+                + "\n"
+            )
+        for config in ledger.entries.injected_external_config:
+            handle.write(
+                "\t".join(
+                    [
+                        "external_config",
+                        config.path,
+                        config.marker,
+                        config.format,
+                        config.block_sha256 or "",
+                        config.source,
+                        config.confidence,
+                    ]
+                )
+                + "\n"
+            )
+        for launch_agent in ledger.entries.launch_agents:
+            handle.write(
+                "\t".join(
+                    [
+                        "launch_agent",
+                        launch_agent.kind,
+                        launch_agent.path,
+                        launch_agent.label,
+                        launch_agent.source,
+                        launch_agent.confidence,
+                    ]
+                )
+                + "\n"
+            )
+    manifest.chmod(0o600)
+    return manifest
+
+
+def _maybe_fast_backfill_install_ledger(argv: Sequence[str]) -> None:
+    """Create a cheap backfill ledger on first user-facing CLI run."""
+    if argv[0] in {"--help", "-h", "--version", "version", "_internal", "uninstall"}:
+        return
+    with contextlib.suppress(Exception):
+        from omnigent.install_ledger import backfill_install_ledger
+
+        backfill_install_ledger(deep=False, apply=True)
+
+
+@cli.group("_internal", hidden=True)
+def _internal() -> None:
+    """Hidden commands used by installer scripts."""
+
+
+@_internal.command("write-ledger")
+@click.option("--from-env", "from_env", is_flag=True, required=True)
+def _internal_write_ledger(from_env: bool) -> None:
+    """Write install_ledger.json from installer-observed environment."""
+    del from_env
+    from omnigent.install_ledger import ledger_path, write_install_ledger_from_env
+
+    ledger = write_install_ledger_from_env()
+    click.echo(json.dumps({"path": str(ledger_path()), "source": ledger.ledger_source}))
+
+
+@cli.command("doctor")
+@click.option("--migrate-ledger", is_flag=True, help="Backfill install_ledger metadata.")
+@click.option("--deep", is_flag=True, help="Use package-manager and PATH probes.")
+@click.option("--apply", "apply_changes", is_flag=True, help="Write the backfilled ledger.")
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON.")
+def doctor(
+    migrate_ledger: bool,
+    deep: bool,
+    apply_changes: bool,
+    json_output: bool,
+) -> None:
+    """Run maintenance checks and one-off migrations."""
+    if not migrate_ledger:
+        raise click.UsageError("Pass --migrate-ledger to run the install ledger migration.")
+    from omnigent.install_ledger import backfill_install_ledger, backfill_ledger_path
+
+    ledger = backfill_install_ledger(deep=deep, apply=apply_changes)
+    payload = {
+        "applied": apply_changes and ledger is not None,
+        "path": str(backfill_ledger_path()),
+        "ledger": ledger.to_dict() if ledger is not None else None,
+    }
+    if json_output:
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+    elif ledger is None:
+        click.echo("No Omnigent install detected; no ledger written.")
+    elif apply_changes:
+        click.echo(f"Wrote backfill ledger to {backfill_ledger_path()}.")
+    else:
+        click.echo(json.dumps(ledger.to_dict(), indent=2, sort_keys=True))
+
+
+@cli.command("uninstall")
+@click.argument(
+    "targets",
+    nargs=-1,
+    type=click.Choice(["cli", "state", "desktop-data", "all"]),
+)
+@click.option("--purge", is_flag=True, help="Remove state data after writing a backup.")
+@click.option("--purge-workspace", is_flag=True, help="Also remove ~/omnigent with --purge.")
+@click.option("--dry-run", is_flag=True, help="Print planned actions only.")
+@click.option("--yes", is_flag=True, help="Run non-interactively for auto-removable artifacts.")
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON.")
+@click.option("--force", is_flag=True, help="Force stubborn processes and tamper refusals.")
+@click.option("--modify-external-config", is_flag=True, help="Allow third-party config edits.")
+@click.option("--no-backup", is_flag=True, help="Skip purge backup creation.")
+@click.option("--assume-inferred", is_flag=True, help="Act on inferred entries when gated.")
+def uninstall(
+    targets: tuple[str, ...],
+    purge: bool,
+    purge_workspace: bool,
+    dry_run: bool,
+    yes: bool,
+    json_output: bool,
+    force: bool,
+    modify_external_config: bool,
+    no_backup: bool,
+    assume_inferred: bool,
+) -> None:
+    """Uninstall Omnigent while preserving user data unless --purge is set."""
+    from omnigent.install_ledger import resolve_uninstall_ledger
+
+    ledger = resolve_uninstall_ledger()
+    destructive_flag = any(
+        (
+            purge,
+            purge_workspace,
+            yes,
+            force,
+            modify_external_config,
+            no_backup,
+            assume_inferred,
+        )
+    )
+    effective_dry_run = dry_run or not destructive_flag
+    if ledger is None:
+        if json_output:
+            click.echo(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "dry_run": effective_dry_run,
+                        "ledger_source": None,
+                        "actions": [],
+                        "backups": [],
+                        "summary": {"done": 0, "skipped": 0, "failed": 0, "reported": 0},
+                        "exit_code": 3,
+                        "error": "no Omnigent install detected",
+                    },
+                    indent=2,
+                )
+            )
+            raise SystemExit(3)
+        click.echo("No Omnigent install detected; nothing to uninstall.", err=True)
+        raise SystemExit(3)
+
+    script_path = _uninstall_script_path()
+    args = [str(script_path)]
+    args.extend(targets)
+    for enabled, flag in (
+        (purge, "--purge"),
+        (purge_workspace, "--purge-workspace"),
+        (effective_dry_run, "--dry-run"),
+        (yes, "--yes"),
+        (json_output, "--json"),
+        (force, "--force"),
+        (modify_external_config, "--modify-external-config"),
+        (no_backup, "--no-backup"),
+        (assume_inferred, "--assume-inferred"),
+    ):
+        if enabled:
+            args.append(flag)
+    env = os.environ.copy()
+    env["OMNIGENT_UNINSTALL_LEDGER_SOURCE"] = ledger.ledger_source
+    manifest = _write_uninstall_manifest(ledger)
+    env["OMNIGENT_UNINSTALL_LEDGER_MANIFEST"] = str(manifest)
+    try:
+        result = subprocess.run(args, env=env, check=False)
+    finally:
+        with contextlib.suppress(OSError):
+            manifest.unlink()
+        if (
+            script_path.name == "uninstall_oss.sh"
+            and script_path.parent.name.startswith("omnigent-uninstall-")
+            and script_path.parent.parent == Path(tempfile.gettempdir())
+        ):
+            shutil.rmtree(script_path.parent, ignore_errors=True)
+    raise SystemExit(result.returncode)
 
 
 def _count_running_sessions(base_url: str) -> int:

--- a/omnigent/install_ledger.py
+++ b/omnigent/install_ledger.py
@@ -1,0 +1,551 @@
+"""Install ledger and uninstall backfill helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+LEDGER_NAME = "install_ledger.json"
+BACKFILL_LEDGER_NAME = "install_ledger.backfill.json"
+PROFILE_MARKER_BEGIN = "# >>> Omnigent installer >>>"
+PROFILE_MARKER_END = "# <<< Omnigent installer <<<"
+CONSOLE_SCRIPTS = ["omnigent", "omni"]
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def state_dir() -> Path:
+    if data_dir := os.environ.get("OMNIGENT_DATA_DIR"):
+        return Path(data_dir).expanduser()
+    return Path.home() / ".omnigent"
+
+
+def ledger_path() -> Path:
+    return state_dir() / LEDGER_NAME
+
+
+def backfill_ledger_path() -> Path:
+    return state_dir() / BACKFILL_LEDGER_NAME
+
+
+def platform_name() -> str:
+    match platform.system():
+        case "Darwin":
+            return "macos"
+        case "Linux":
+            return "linux"
+        case other:
+            return other.lower() or "unknown"
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+@dataclass
+class ProfileEntry:
+    path: str
+    marker_begin: str = PROFILE_MARKER_BEGIN
+    marker_end: str = PROFILE_MARKER_END
+    line_range: list[int] = field(default_factory=list)
+    block_sha256: str | None = None
+    content_matches_current: bool = True
+    source: str = "recorded"
+    confidence: str = "certain"
+
+
+@dataclass
+class ExternalConfigEntry:
+    path: str
+    marker: str
+    format: str
+    allowlist: list[str] = field(default_factory=list)
+    block_sha256: str | None = None
+    source: str = "recorded"
+    confidence: str = "certain"
+
+
+@dataclass
+class DepEntry:
+    present: bool
+    path: str | None = None
+    version: str | None = None
+    installed_by: str = "unknown"
+    confidence: str = "none"
+    notes: str | None = None
+
+
+@dataclass
+class WheelEntry:
+    installed: bool
+    uv_tool_dir: str | None = None
+    bin_dir: str | None = None
+    console_scripts: list[str] = field(default_factory=lambda: CONSOLE_SCRIPTS.copy())
+    source: str = "recorded"
+    confidence: str = "certain"
+
+
+@dataclass
+class LaunchAgentEntry:
+    kind: str
+    path: str
+    label: str
+    source: str = "recorded"
+    confidence: str = "high"
+
+
+@dataclass
+class StatePathsEntry:
+    omnigent_home: str
+    workspace: str
+    desktop_data: list[str] = field(default_factory=list)
+
+
+@dataclass
+class LedgerEntries:
+    profiles: list[ProfileEntry] = field(default_factory=list)
+    injected_external_config: list[ExternalConfigEntry] = field(default_factory=list)
+    deps: dict[str, DepEntry] = field(default_factory=dict)
+    wheel: WheelEntry = field(default_factory=lambda: WheelEntry(installed=False))
+    launch_agents: list[LaunchAgentEntry] = field(default_factory=list)
+    state_paths: StatePathsEntry = field(
+        default_factory=lambda: StatePathsEntry(
+            omnigent_home=str(state_dir()), workspace=str(Path.home() / "omnigent")
+        )
+    )
+
+
+@dataclass
+class InstallLedger:
+    schema_version: int
+    ledger_source: str
+    generator: dict[str, str]
+    installation_id: str | None
+    created_at: str
+    updated_at: str
+    last_validated_at: str
+    entries: LedgerEntries
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InstallLedger:
+        entries_data = data.get("entries") or {}
+        entries = LedgerEntries(
+            profiles=[ProfileEntry(**item) for item in entries_data.get("profiles", [])],
+            injected_external_config=[
+                ExternalConfigEntry(**item)
+                for item in entries_data.get("injected_external_config", [])
+            ],
+            deps={
+                name: DepEntry(**value) for name, value in (entries_data.get("deps") or {}).items()
+            },
+            wheel=WheelEntry(**(entries_data.get("wheel") or {"installed": False})),
+            launch_agents=[
+                LaunchAgentEntry(**item) for item in entries_data.get("launch_agents", [])
+            ],
+            state_paths=StatePathsEntry(
+                **(
+                    entries_data.get("state_paths")
+                    or {
+                        "omnigent_home": str(state_dir()),
+                        "workspace": str(Path.home() / "omnigent"),
+                    }
+                )
+            ),
+        )
+        return cls(
+            schema_version=int(data.get("schema_version", SCHEMA_VERSION)),
+            ledger_source=str(data.get("ledger_source", "backfill")),
+            generator=dict(data.get("generator") or {}),
+            installation_id=data.get("installation_id"),
+            created_at=str(data.get("created_at") or utc_now()),
+            updated_at=str(data.get("updated_at") or utc_now()),
+            last_validated_at=str(data.get("last_validated_at") or utc_now()),
+            entries=entries,
+        )
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    data = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(tmp, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        os.chmod(path, 0o600)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def load_ledger(path: Path) -> InstallLedger | None:
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError:
+        return None
+    if data.get("schema_version") != SCHEMA_VERSION:
+        return None
+    return InstallLedger.from_dict(data)
+
+
+def write_ledger(ledger: InstallLedger, *, path: Path | None = None) -> None:
+    atomic_write_json(path or ledger_path(), ledger.to_dict())
+
+
+def _backfill_content_key(ledger: InstallLedger) -> dict[str, Any]:
+    data = ledger.to_dict()
+    for key in ("created_at", "updated_at", "last_validated_at"):
+        data.pop(key, None)
+    generator = data.get("generator")
+    if isinstance(generator, dict):
+        generator.pop("wrote_at", None)
+    return data
+
+
+def _merge_external_configs(
+    current: list[ExternalConfigEntry], existing: list[ExternalConfigEntry]
+) -> list[ExternalConfigEntry]:
+    merged: dict[tuple[str, str, str], ExternalConfigEntry] = {}
+    for entry in existing:
+        merged[(entry.path, entry.marker, entry.format)] = entry
+    for entry in current:
+        merged[(entry.path, entry.marker, entry.format)] = entry
+    return list(merged.values())
+
+
+def read_installation_id(home: Path | None = None) -> str | None:
+    install_id_path = (home or state_dir()) / "installation_id"
+    try:
+        value = install_id_path.read_text().strip()
+    except OSError:
+        return None
+    return value or None
+
+
+def profile_candidates() -> list[Path]:
+    home = Path.home()
+    candidates = [
+        home / ".zprofile",
+        home / ".zshrc",
+        home / ".bash_profile",
+        home / ".bashrc",
+        home / ".profile",
+        home / ".config" / "fish" / "config.fish",
+    ]
+    confd = home / ".config" / "fish" / "conf.d"
+    if confd.is_dir():
+        candidates.extend(sorted(confd.glob("*.fish")))
+    return candidates
+
+
+def find_profile_block(path: Path) -> tuple[int, int, str] | None:
+    try:
+        lines = path.read_text().splitlines(keepends=True)
+    except OSError:
+        return None
+    begin: int | None = None
+    for index, line in enumerate(lines):
+        if line.rstrip("\n") == PROFILE_MARKER_BEGIN:
+            begin = index
+        elif begin is not None and line.rstrip("\n") == PROFILE_MARKER_END:
+            block = "".join(lines[begin : index + 1])
+            return begin + 1, index + 1, block
+    return None
+
+
+def _cmd_output(*args: str) -> str | None:
+    try:
+        result = subprocess.run(args, check=False, text=True, capture_output=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or result.stderr.strip() or None
+
+
+def _version_for(path: str | None) -> str | None:
+    if not path:
+        return None
+    output = _cmd_output(path, "--version")
+    if not output:
+        return None
+    return output.splitlines()[0]
+
+
+def _dep(name: str, *, deep: bool, installed_by: str = "unknown") -> DepEntry:
+    path = shutil.which(name) if deep else None
+    return DepEntry(
+        present=path is not None,
+        path=path,
+        version=_version_for(path) if deep else None,
+        installed_by=installed_by if installed_by != "unknown" else "unknown",
+        confidence="none" if installed_by == "unknown" else "certain",
+    )
+
+
+def _uv_tool_dir(*, bin_dir: bool = False) -> str | None:
+    if not shutil.which("uv"):
+        return None
+    args = ["uv", "tool", "dir"] + (["--bin"] if bin_dir else [])
+    return _cmd_output(*args)
+
+
+def _wheel_entry(*, deep: bool, source: str, confidence: str) -> WheelEntry:
+    bin_dir = _uv_tool_dir(bin_dir=True) if deep else None
+    tool_dir = _uv_tool_dir(bin_dir=False) if deep else None
+    installed = any(shutil.which(script) for script in CONSOLE_SCRIPTS) if deep else False
+    if not installed and bin_dir:
+        installed = any((Path(bin_dir) / script).exists() for script in CONSOLE_SCRIPTS)
+    return WheelEntry(
+        installed=installed,
+        uv_tool_dir=tool_dir,
+        bin_dir=bin_dir,
+        console_scripts=CONSOLE_SCRIPTS.copy(),
+        source=source,
+        confidence=confidence if installed else "low",
+    )
+
+
+def desktop_data_paths() -> list[str]:
+    home = Path.home()
+    candidates: list[Path]
+    if platform.system() == "Darwin":
+        candidates = [
+            home / "Library" / "Application Support" / "Omnigent",
+            home / "Library" / "Caches" / "Omnigent",
+            home / "Library" / "Logs" / "Omnigent",
+        ]
+    else:
+        xdg_config = Path(os.environ.get("XDG_CONFIG_HOME", home / ".config"))
+        xdg_cache = Path(os.environ.get("XDG_CACHE_HOME", home / ".cache"))
+        xdg_state = Path(os.environ.get("XDG_STATE_HOME", home / ".local" / "state"))
+        candidates = [xdg_config / "Omnigent", xdg_cache / "Omnigent", xdg_state / "Omnigent"]
+    return [str(path) for path in candidates if path.exists()]
+
+
+def _json_has_key_path(path: Path, key_path: str) -> bool:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    current: Any = data
+    for part in key_path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return True
+
+
+def _toml_has_table(path: Path, table: str) -> bool:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+    return any(line.strip() == f"[{table}]" for line in lines)
+
+
+def observed_external_configs(*, deep: bool) -> list[ExternalConfigEntry]:
+    if not deep:
+        return []
+    cwd = Path.cwd()
+    candidates = [
+        (cwd / ".cursor" / "mcp.json", "mcpServers.omnigent", "json"),
+        (cwd / ".kiro" / "settings" / "mcp.json", "mcpServers.omnigent", "json"),
+        (Path.home() / ".claude.json", "mcpServers.omnigent", "json"),
+        (Path.home() / ".codex" / "config.toml", "mcp_servers.omnigent", "toml"),
+    ]
+    entries: list[ExternalConfigEntry] = []
+    for path, marker, fmt in candidates:
+        found = (
+            _json_has_key_path(path, marker) if fmt == "json" else _toml_has_table(path, marker)
+        )
+        if found:
+            entries.append(
+                ExternalConfigEntry(
+                    path=str(path),
+                    marker=marker,
+                    format=fmt,
+                    allowlist=[marker],
+                    source="observed",
+                    confidence="certain",
+                )
+            )
+    return entries
+
+
+def observed_launch_agents(*, deep: bool) -> list[LaunchAgentEntry]:
+    if not deep:
+        return []
+    entries: list[LaunchAgentEntry] = []
+    launchd_dir = Path.home() / "Library" / "LaunchAgents"
+    if launchd_dir.is_dir():
+        for path in sorted(launchd_dir.glob("*omnigent*.plist")):
+            entries.append(
+                LaunchAgentEntry(
+                    kind="launchd",
+                    path=str(path),
+                    label=path.stem,
+                    source="observed",
+                    confidence="high",
+                )
+            )
+    systemd_dir = Path.home() / ".config" / "systemd" / "user"
+    if systemd_dir.is_dir():
+        for path in sorted(systemd_dir.glob("*omnigent*.service")):
+            entries.append(
+                LaunchAgentEntry(
+                    kind="systemd_user",
+                    path=str(path),
+                    label=path.name,
+                    source="observed",
+                    confidence="high",
+                )
+            )
+    return entries
+
+
+def new_ledger(*, source: str, strategy: str, deep: bool) -> InstallLedger:
+    now = utc_now()
+    profiles: list[ProfileEntry] = []
+    for path in profile_candidates():
+        found = find_profile_block(path)
+        if found is None:
+            continue
+        start, end, block = found
+        profiles.append(
+            ProfileEntry(
+                path=str(path),
+                line_range=[start, end],
+                block_sha256=sha256_text(block),
+                source="observed" if source == "backfill" else "recorded",
+                confidence="certain",
+            )
+        )
+    entries = LedgerEntries(
+        profiles=profiles,
+        injected_external_config=observed_external_configs(deep=deep),
+        deps={name: _dep(name, deep=deep) for name in ("uv", "node", "npm", "tmux", "bwrap")},
+        wheel=_wheel_entry(
+            deep=deep, source="observed" if source == "backfill" else "recorded", confidence="high"
+        ),
+        launch_agents=observed_launch_agents(deep=deep),
+        state_paths=StatePathsEntry(
+            omnigent_home=str(state_dir()),
+            workspace=str(Path.home() / "omnigent"),
+            desktop_data=desktop_data_paths(),
+        ),
+    )
+    return InstallLedger(
+        schema_version=SCHEMA_VERSION,
+        ledger_source=source,
+        generator={
+            "name": "omnigent",
+            "version": _version_for(shutil.which("omnigent")) or "unknown",
+            "strategy": strategy,
+            "os": platform_name(),
+            "wrote_at": now,
+        },
+        installation_id=read_installation_id(),
+        created_at=now,
+        updated_at=now,
+        last_validated_at=now,
+        entries=entries,
+    )
+
+
+def has_install_signal(ledger: InstallLedger) -> bool:
+    return bool(
+        ledger.installation_id or ledger.entries.profiles or ledger.entries.wheel.installed
+    )
+
+
+def backfill_install_ledger(*, deep: bool, apply: bool = True) -> InstallLedger | None:
+    real = load_ledger(ledger_path())
+    if real and real.ledger_source == "installer":
+        return real
+
+    strategy = "deep-backfill" if deep else "fast-backfill"
+    ledger = new_ledger(source="backfill", strategy=strategy, deep=deep)
+    if not has_install_signal(ledger):
+        return None
+    if apply:
+        existing = load_ledger(backfill_ledger_path())
+        if existing:
+            if _backfill_content_key(existing) == _backfill_content_key(ledger):
+                return existing
+            ledger.created_at = existing.created_at
+        write_ledger(ledger, path=backfill_ledger_path())
+    return ledger
+
+
+def resolve_uninstall_ledger() -> InstallLedger | None:
+    real = load_ledger(ledger_path())
+    if real and real.ledger_source == "installer":
+        return real
+    backfill = load_ledger(backfill_ledger_path())
+    if backfill:
+        return backfill
+    return backfill_install_ledger(deep=True, apply=True)
+
+
+def write_install_ledger_from_env() -> InstallLedger:
+    existing = load_ledger(ledger_path())
+    ledger = new_ledger(source="installer", strategy="install", deep=True)
+    if existing and existing.ledger_source == "installer":
+        ledger.created_at = existing.created_at
+        ledger.entries.injected_external_config = _merge_external_configs(
+            ledger.entries.injected_external_config, existing.entries.injected_external_config
+        )
+        ledger.entries.launch_agents = existing.entries.launch_agents
+        for name, dep in existing.entries.deps.items():
+            if name in ledger.entries.deps and dep.installed_by in {"omnigent", "preexisting"}:
+                current = ledger.entries.deps[name]
+                if current.installed_by == "unknown" or dep.installed_by == "omnigent":
+                    current.installed_by = dep.installed_by
+                    current.confidence = dep.confidence
+    for name in list(ledger.entries.deps):
+        env_name = f"OMNIGENT_LEDGER_DEP_{name.upper()}"
+        installed_by = os.environ.get(env_name)
+        if installed_by in {"omnigent", "preexisting", "unknown"}:
+            ledger.entries.deps[name].installed_by = installed_by
+            ledger.entries.deps[name].confidence = (
+                "none" if installed_by == "unknown" else "certain"
+            )
+    profile_env = os.environ.get("OMNIGENT_LEDGER_PROFILE")
+    if profile_env:
+        path = Path(profile_env).expanduser()
+        found = find_profile_block(path)
+        ledger.entries.profiles = []
+        if found is not None:
+            start, end, block = found
+            ledger.entries.profiles.append(
+                ProfileEntry(
+                    path=str(path),
+                    line_range=[start, end],
+                    block_sha256=sha256_text(block),
+                    source="recorded",
+                    confidence="certain",
+                )
+            )
+    write_ledger(ledger)
+    return ledger

--- a/omnigent/resources/scripts/__init__.py
+++ b/omnigent/resources/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled maintenance shell scripts."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,6 +292,7 @@ include = ["omnigent*"]
 "omnigent.db.migrations" = ["script.py.mako"]
 "omnigent.resources.examples" = ["*.yaml", "*.sh", "debby/**/*", "polly/**/*"]
 "omnigent.resources.pi_native" = ["*.js"]
+"omnigent.resources.scripts" = ["*.sh"]
 # include UI assets in build, plus the static API-only landing page served
 # at "/" when no web UI bundle is present
 "omnigent.server" = ["static/web-ui/**/*", "static/api_only_landing.html"]

--- a/scripts/install_oss.sh
+++ b/scripts/install_oss.sh
@@ -36,6 +36,7 @@ PYTHON_VERSION="3.12"
 INSTALL_URL=
 NON_INTERACTIVE=false
 VERBOSE=false
+LEDGER_PROFILE=
 ESC=$(printf '\033')
 RESET=
 BOLD=
@@ -322,6 +323,8 @@ ensure_git() {
 # and fall back to a fail-with-hint on decline/non-interactive/failure.
 ensure_uv() {
   if command -v uv >/dev/null 2>&1; then
+    OMNIGENT_LEDGER_DEP_UV=preexisting
+    export OMNIGENT_LEDGER_DEP_UV
     step "uv is available"
     return
   fi
@@ -340,6 +343,8 @@ ensure_uv() {
       done
     fi
     if command -v uv >/dev/null 2>&1; then
+      OMNIGENT_LEDGER_DEP_UV=omnigent
+      export OMNIGENT_LEDGER_DEP_UV
       step "Installed uv"
       return
     fi
@@ -369,6 +374,8 @@ check_node() {
     require_or_warn "node not found — Node.js 22+ is needed for the Claude/Codex/Pi harnesses (https://nodejs.org)."
     return
   fi
+  OMNIGENT_LEDGER_DEP_NODE=preexisting
+  export OMNIGENT_LEDGER_DEP_NODE
   if node -e "process.exit(typeof require('node:worker_threads').markAsUncloneable === 'function' ? 0 : 1)" >/dev/null 2>&1; then
     step "Node.js is new enough for the harness CLIs"
   else
@@ -378,6 +385,8 @@ check_node() {
 
 check_npm() {
   if command -v npm >/dev/null 2>&1; then
+    OMNIGENT_LEDGER_DEP_NPM=preexisting
+    export OMNIGENT_LEDGER_DEP_NPM
     step "npm is available (installs the Claude/Codex/Pi harness CLIs on first run)"
   else
     require_or_warn "npm not found — needed to install the Claude/Codex/Pi harness CLIs (https://nodejs.org)."
@@ -406,6 +415,8 @@ linux_pkg_install_cmd() {
 
 check_tmux() {
   if command -v tmux >/dev/null 2>&1; then
+    OMNIGENT_LEDGER_DEP_TMUX=preexisting
+    export OMNIGENT_LEDGER_DEP_TMUX
     step "tmux is available"
     return
   fi
@@ -425,7 +436,11 @@ check_tmux() {
       if [ -n "$install_cmd" ] && prompt_yes_no "tmux is missing (needed for \`omnigent claude\` / \`omnigent codex\`). Install it now ($install_cmd)?"; then
         # Run directly (not via run_with_spinner) so sudo can prompt for a password.
         sh -c "$install_cmd" || warn "tmux install failed — run manually: $install_cmd"
-        command -v tmux >/dev/null 2>&1 && step "tmux installed"
+        if command -v tmux >/dev/null 2>&1; then
+          OMNIGENT_LEDGER_DEP_TMUX=omnigent
+          export OMNIGENT_LEDGER_DEP_TMUX
+          step "tmux installed"
+        fi
         return
       fi
       if [ -n "$install_cmd" ]; then
@@ -446,6 +461,8 @@ check_bubblewrap() {
   [ "$(uname -s)" = Linux ] || return 0
 
   if command -v bwrap >/dev/null 2>&1; then
+    OMNIGENT_LEDGER_DEP_BWRAP=preexisting
+    export OMNIGENT_LEDGER_DEP_BWRAP
     step "bubblewrap (bwrap) is available"
     return
   fi
@@ -453,6 +470,10 @@ check_bubblewrap() {
   install_cmd="$(linux_pkg_install_cmd bubblewrap)"
   if [ -n "$install_cmd" ] && prompt_yes_no "bubblewrap is missing (needed to sandbox native \`omnigent claude\` / \`omnigent codex\` terminals). Install it now ($install_cmd)?"; then
     run_with_spinner "install bubblewrap" sh -c "$install_cmd" || warn "bubblewrap install failed — run manually: $install_cmd"
+    if command -v bwrap >/dev/null 2>&1; then
+      OMNIGENT_LEDGER_DEP_BWRAP=omnigent
+      export OMNIGENT_LEDGER_DEP_BWRAP
+    fi
     return
   fi
   if [ -n "$install_cmd" ]; then
@@ -554,6 +575,7 @@ maybe_add_bin_to_path() {
 
   if [ -f "$profile" ] && grep -F "$begin_marker" "$profile" >/dev/null 2>&1; then
     if grep -F "$path_line" "$profile" >/dev/null 2>&1; then
+      LEDGER_PROFILE="$profile"
       step "PATH is already configured in $profile"
       return
     fi
@@ -571,7 +593,29 @@ maybe_add_bin_to_path() {
     printf '%s\n' "$path_line"
     printf '%s\n' "$end_marker"
   } >>"$profile"
+  LEDGER_PROFILE="$profile"
   step "Added $bin_dir to PATH in $profile"
+}
+
+write_install_ledger() {
+  bin_dir="$1"
+  cli_path="$bin_dir/omnigent"
+  if [ ! -x "$cli_path" ]; then
+    cli_path="$(command -v omnigent 2>/dev/null || true)"
+  fi
+  if [ -z "$cli_path" ]; then
+    warn "Could not write install ledger: omnigent command not found."
+    return 0
+  fi
+  if [ -n "$LEDGER_PROFILE" ]; then
+    OMNIGENT_LEDGER_PROFILE="$LEDGER_PROFILE"
+    export OMNIGENT_LEDGER_PROFILE
+  fi
+  if "$cli_path" _internal write-ledger --from-env >/dev/null 2>&1; then
+    step "Recorded install ledger"
+  else
+    warn "Could not write install ledger; uninstall can backfill it later."
+  fi
 }
 
 verify_omnigent() {
@@ -616,6 +660,8 @@ print_next_steps() {
   printf '  %somnigent codex           # Codex\n\n' "$command_prefix"
   printf 'Manage model credentials any time:\n'
   printf '  %somnigent setup\n\n' "$command_prefix"
+  printf 'Uninstall the CLI but keep local history and credentials:\n'
+  printf '  %somnigent uninstall --yes\n\n' "$command_prefix"
   printf '%sUsing a Databricks workspace as your model provider? Install the\n' "$DIM"
   printf 'Databricks CLI (https://docs.databricks.com/aws/en/dev-tools/cli/install)\n'
   printf 'and add it via: omnigent setup -> Databricks.%s\n' "$RESET"
@@ -636,6 +682,7 @@ main() {
   bin_dir="$(uv_tool_bin_dir)"
   verify_omnigent "$bin_dir"
   maybe_add_bin_to_path "$bin_dir"
+  write_install_ledger "$bin_dir"
   print_next_steps "$bin_dir"
 }
 

--- a/scripts/uninstall_oss.sh
+++ b/scripts/uninstall_oss.sh
@@ -1,0 +1,746 @@
+#!/bin/sh
+
+# Omnigent uninstaller. POSIX sh by design so it still works when the Python
+# wheel is wedged or PATH is broken.
+
+set -u
+
+MARKER_BEGIN="# >>> Omnigent installer >>>"
+MARKER_END="# <<< Omnigent installer <<<"
+TAB=$(printf '\t')
+TARGETS=""
+DRY_RUN=false
+YES=false
+JSON=false
+FORCE=false
+PURGE=false
+NO_BACKUP=false
+PURGE_WORKSPACE=false
+MODIFY_EXTERNAL_CONFIG=false
+ASSUME_INFERRED=false
+DESTRUCTIVE_FLAG=false
+EXPLICIT_TARGET=false
+DONE=0
+SKIPPED=0
+FAILED=0
+REPORTED=0
+EXIT_CODE=0
+ACTIONS_FILE="$(mktemp "${TMPDIR:-/tmp}/omnigent-uninstall-actions.XXXXXX")" || exit 1
+BACKUPS_FILE="$(mktemp "${TMPDIR:-/tmp}/omnigent-uninstall-backups.XXXXXX")" || exit 1
+
+cleanup() {
+  rm -f "$ACTIONS_FILE" "$BACKUPS_FILE"
+}
+trap cleanup EXIT HUP INT TERM
+
+usage() {
+  cat <<'EOF'
+Usage: uninstall_oss.sh [cli|state|desktop-data|all ...] [flags]
+
+Flags:
+  --purge                    Remove state data (backs up first)
+  --purge-workspace          With --purge, also remove ~/omnigent non-interactively
+  --dry-run                  Print planned actions only
+  --yes                      Non-interactive for auto-removable artifacts
+  --json                     Emit a machine-readable summary
+  --force                    SIGKILL stubborn processes and override refusals
+  --modify-external-config   Allow marker-scoped third-party config edits
+  --no-backup                Skip purge backup creation
+  --assume-inferred          Allow inferred entries when combined with their gates
+EOF
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g'
+}
+
+record_action() {
+  artifact="$1"
+  path="$2"
+  planned="$3"
+  status="$4"
+  gate="$5"
+  detail="$6"
+  case "$status" in
+    done) DONE=$((DONE + 1)) ;;
+    skipped) SKIPPED=$((SKIPPED + 1)) ;;
+    failed) FAILED=$((FAILED + 1)); EXIT_CODE=1 ;;
+    reported) REPORTED=$((REPORTED + 1)) ;;
+  esac
+  printf '{"artifact":"%s","path":"%s","planned":"%s","status":"%s","gate":%s,"detail":"%s"}\n' \
+    "$(json_escape "$artifact")" \
+    "$(json_escape "$path")" \
+    "$(json_escape "$planned")" \
+    "$(json_escape "$status")" \
+    "$(if [ -n "$gate" ]; then printf '"%s"' "$(json_escape "$gate")"; else printf 'null'; fi)" \
+    "$(json_escape "$detail")" >>"$ACTIONS_FILE"
+  if [ "$JSON" != true ]; then
+    printf '%s: %s (%s)\n' "$status" "$artifact${path:+ $path}" "$detail"
+  fi
+}
+
+has_target() {
+  case " $TARGETS " in
+    *" $1 "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+add_target() {
+  case "$1" in
+    all)
+      add_target cli
+      add_target state
+      add_target desktop-data
+      ;;
+    cli | state | desktop-data)
+      if ! has_target "$1"; then
+        TARGETS="${TARGETS}${TARGETS:+ }$1"
+      fi
+      ;;
+    *)
+      usage >&2
+      exit 3
+      ;;
+  esac
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --purge) PURGE=true; DESTRUCTIVE_FLAG=true; add_target state ;;
+    --purge-workspace) PURGE_WORKSPACE=true; DESTRUCTIVE_FLAG=true ;;
+    --dry-run) DRY_RUN=true ;;
+    --yes) YES=true; DESTRUCTIVE_FLAG=true ;;
+    --json) JSON=true ;;
+    --force) FORCE=true; DESTRUCTIVE_FLAG=true ;;
+    --modify-external-config) MODIFY_EXTERNAL_CONFIG=true; DESTRUCTIVE_FLAG=true ;;
+    --no-backup) NO_BACKUP=true; DESTRUCTIVE_FLAG=true ;;
+    --assume-inferred) ASSUME_INFERRED=true; DESTRUCTIVE_FLAG=true ;;
+    -h | --help) usage; exit 0 ;;
+    --*) usage >&2; exit 3 ;;
+    *) EXPLICIT_TARGET=true; add_target "$1" ;;
+  esac
+  shift
+done
+
+if [ "$EXPLICIT_TARGET" != true ]; then
+  add_target cli
+fi
+
+if [ "$DESTRUCTIVE_FLAG" != true ]; then
+  DRY_RUN=true
+fi
+
+state_home() {
+  if [ -n "${OMNIGENT_DATA_DIR:-}" ]; then
+    printf '%s\n' "$OMNIGENT_DATA_DIR"
+  else
+    printf '%s/.omnigent\n' "$HOME"
+  fi
+}
+
+is_pid_alive() {
+  pid="$1"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  state="$(ps -o stat= -p "$pid" 2>/dev/null | awk 'NR == 1 { print $1 }')"
+  case "$state" in
+    Z*) return 1 ;;
+  esac
+  return 0
+}
+
+stop_pid() {
+  pid="$1"
+  origin="$2"
+  if ! is_pid_alive "$pid"; then
+    record_action process "$origin" stop done "" "already stopped"
+    return 0
+  fi
+  if [ "$DRY_RUN" = true ]; then
+    record_action process "$origin" stop reported "" "would SIGTERM pid $pid"
+    return 0
+  fi
+  kill -TERM "$pid" 2>/dev/null || true
+  i=0
+  while [ "$i" -lt 50 ]; do
+    if ! is_pid_alive "$pid"; then
+      record_action process "$origin" stop done "" "stopped pid $pid"
+      return 0
+    fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if [ "$FORCE" = true ]; then
+    kill -KILL "$pid" 2>/dev/null || true
+    record_action process "$origin" stop done "" "SIGKILL sent to pid $pid"
+    return 0
+  fi
+  record_action process "$origin" stop failed "--force" "pid $pid did not stop"
+  EXIT_CODE=2
+  return 1
+}
+
+stop_processes() {
+  home_dir="$(state_home)"
+  pidfiles="$(mktemp "${TMPDIR:-/tmp}/omnigent-uninstall-pidfiles.XXXXXX")" || return 1
+  : >"$pidfiles"
+  if [ -d "$home_dir" ]; then
+    for root in "$home_dir/run" "$home_dir/daemons" "$home_dir/runners" "$home_dir/local_server"; do
+      [ -d "$root" ] || continue
+      find "$root" -type f \( -name '*.pid' -o -name 'local_server.pid' \) 2>/dev/null >>"$pidfiles" || true
+    done
+    for pidfile in "$home_dir/local_server.pid" "$home_dir/host.pid"; do
+      [ -f "$pidfile" ] && printf '%s\n' "$pidfile" >>"$pidfiles"
+    done
+    while IFS= read -r pidfile; do
+      [ -n "$pidfile" ] || continue
+      pid="$(awk 'NR == 1 { sub(/[^0-9].*$/, ""); print; exit }' "$pidfile" 2>/dev/null || true)"
+      [ -n "$pid" ] && stop_pid "$pid" "$pidfile" || true
+    done <"$pidfiles"
+  fi
+  if command -v tmux >/dev/null 2>&1; then
+    sessions_file="$(mktemp "${TMPDIR:-/tmp}/omnigent-uninstall-tmux.XXXXXX")" || return 1
+    tmux list-sessions -F '#S' >"$sessions_file" 2>/dev/null || true
+    while IFS= read -r session; do
+      case "$session" in
+        omnigent:*)
+          if [ "$DRY_RUN" = true ]; then
+            record_action tmux "$session" stop reported "" "would kill tmux session"
+          elif tmux kill-session -t "$session" 2>/dev/null; then
+            record_action tmux "$session" stop done "" "killed tmux session"
+          else
+            record_action tmux "$session" stop failed "" "failed to kill tmux session"
+          fi
+          ;;
+      esac
+    done <"$sessions_file"
+    rm -f "$sessions_file"
+  fi
+  rm -f "$pidfiles"
+  if [ "$EXIT_CODE" = 2 ]; then
+    return 1
+  fi
+}
+
+unload_launch_agents() {
+  [ -n "${OMNIGENT_UNINSTALL_LEDGER_MANIFEST:-}" ] && [ -f "$OMNIGENT_UNINSTALL_LEDGER_MANIFEST" ] || return 0
+  while IFS="$TAB" read -r artifact kind unit_path label source confidence rest; do
+    [ "$artifact" = launch_agent ] || continue
+    if [ "$DRY_RUN" = true ]; then
+      record_action launch_agent "$unit_path" unload reported "" "would unload $kind $label"
+      continue
+    fi
+    case "$kind" in
+      launchd)
+        if command -v launchctl >/dev/null 2>&1; then
+          launchctl bootout "gui/$(id -u)" "$unit_path" >/dev/null 2>&1 || launchctl unload "$unit_path" >/dev/null 2>&1 || true
+          record_action launch_agent "$unit_path" unload done "" "requested launchd unload for $label"
+        else
+          record_action launch_agent "$unit_path" unload skipped "" "launchctl not found"
+        fi
+        ;;
+      systemd_user)
+        if command -v systemctl >/dev/null 2>&1; then
+          systemctl --user disable --now "$label" >/dev/null 2>&1 || systemctl --user stop "$label" >/dev/null 2>&1 || true
+          record_action launch_agent "$unit_path" unload done "" "requested systemd user stop for $label"
+        else
+          record_action launch_agent "$unit_path" unload skipped "" "systemctl not found"
+        fi
+        ;;
+      *)
+        record_action launch_agent "$unit_path" unload skipped "" "unknown launch agent kind $kind"
+        ;;
+    esac
+    if [ -e "$unit_path" ]; then
+      if rm -f "$unit_path"; then
+        record_action launch_agent "$unit_path" remove done "" "removed unit file"
+      else
+        record_action launch_agent "$unit_path" remove failed "" "failed to remove unit file"
+      fi
+    else
+      record_action launch_agent "$unit_path" remove skipped "" "unit file already absent"
+    fi
+  done <"$OMNIGENT_UNINSTALL_LEDGER_MANIFEST"
+}
+
+profile_candidates() {
+  printf '%s\n' \
+    "$HOME/.zprofile" \
+    "$HOME/.zshrc" \
+    "$HOME/.bash_profile" \
+    "$HOME/.bashrc" \
+    "$HOME/.profile" \
+    "$HOME/.config/fish/config.fish"
+  if [ -d "$HOME/.config/fish/conf.d" ]; then
+    find "$HOME/.config/fish/conf.d" -type f -name '*.fish' 2>/dev/null
+  fi
+}
+
+has_shell_install_signal() {
+  [ -n "${OMNIGENT_UNINSTALL_LEDGER_SOURCE:-}" ] && [ "$OMNIGENT_UNINSTALL_LEDGER_SOURCE" != unknown ] && return 0
+  [ -f "$(state_home)/installation_id" ] && return 0
+  command -v omnigent >/dev/null 2>&1 && return 0
+  command -v omni >/dev/null 2>&1 && return 0
+  profiles_file="$(mktemp "${TMPDIR:-/tmp}/omnigent-uninstall-anchor-profiles.XXXXXX")" || return 1
+  profile_candidates >"$profiles_file"
+  while IFS= read -r profile; do
+    if profile_has_block "$profile"; then
+      rm -f "$profiles_file"
+      return 0
+    fi
+  done <"$profiles_file"
+  rm -f "$profiles_file"
+  return 1
+}
+
+profile_has_block() {
+  [ -f "$1" ] || return 1
+  awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" '
+    $0 == begin { found_begin=1 }
+    found_begin && $0 == end { found_end=1 }
+    END { exit(found_begin && found_end ? 0 : 1) }
+  ' "$1"
+}
+
+sha256_file() {
+  file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$file" | awk '{print $NF}'
+  else
+    return 1
+  fi
+}
+
+write_profile_block() {
+  profile="$1"
+  output="$2"
+  awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" '
+    $0 == begin { printing=1 }
+    printing { print }
+    printing && $0 == end { exit }
+  ' "$profile" >"$output"
+}
+
+remove_profile_block() {
+  profile="$1"
+  expected_sha="${2:-}"
+  if ! profile_has_block "$profile"; then
+    record_action profile_block "$profile" remove skipped "" "marker block absent"
+    return 0
+  fi
+  line_range="$(awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" '
+    $0 == begin { start=NR }
+    start && $0 == end { print start "-" NR; exit }
+  ' "$profile")"
+  if [ "$DRY_RUN" = true ]; then
+    record_action profile_block "$profile" remove reported "" "would remove lines $line_range"
+    return 0
+  fi
+  if [ -n "$expected_sha" ]; then
+    block_file="$(mktemp "${TMPDIR:-/tmp}/omnigent-uninstall-block.XXXXXX")" || return 1
+    write_profile_block "$profile" "$block_file"
+    actual_sha="$(sha256_file "$block_file" 2>/dev/null || true)"
+    rm -f "$block_file"
+    if [ -z "$actual_sha" ]; then
+      record_action profile_block "$profile" remove failed "" "could not verify block hash"
+      return 1
+    fi
+    if [ "$actual_sha" != "$expected_sha" ] && [ "$FORCE" != true ]; then
+      record_action profile_block "$profile" remove failed "--force" "marker block hash mismatch; refusing tampered block"
+      EXIT_CODE=3
+      return 1
+    fi
+  fi
+  backup="$profile.omnigent.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+  tmp="$(mktemp "$profile.omnigent.tmp.XXXXXX")" || return 1
+  if ! cp "$profile" "$backup"; then
+    record_action profile_block "$profile" remove failed "" "failed to write backup"
+    return 1
+  fi
+  if awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" '
+    $0 == begin { skipping=1; found=1; next }
+    skipping && $0 == end { skipping=0; next }
+    !skipping { print }
+    END { exit(found ? 0 : 42) }
+  ' "$profile" >"$tmp" && mv "$tmp" "$profile"; then
+    record_action profile_block "$profile" remove done "" "block removed, backup at $backup"
+  else
+    rm -f "$tmp"
+    record_action profile_block "$profile" remove failed "" "failed to remove block"
+  fi
+}
+
+cleanup_profiles() {
+  if [ -n "${OMNIGENT_UNINSTALL_LEDGER_MANIFEST:-}" ] && [ -f "$OMNIGENT_UNINSTALL_LEDGER_MANIFEST" ]; then
+    while IFS="$TAB" read -r artifact profile expected_sha source confidence rest; do
+      [ "$artifact" = profile_block ] || continue
+      remove_profile_block "$profile" "$expected_sha"
+      [ "$EXIT_CODE" = 3 ] && return 1
+    done <"$OMNIGENT_UNINSTALL_LEDGER_MANIFEST"
+  else
+    profiles_file="$(mktemp "${TMPDIR:-/tmp}/omnigent-uninstall-profiles.XXXXXX")" || return 1
+    profile_candidates >"$profiles_file"
+    while IFS= read -r profile; do
+      [ -n "$profile" ] || continue
+      if profile_has_block "$profile"; then
+        remove_profile_block "$profile" ""
+        if [ "$EXIT_CODE" = 3 ]; then
+          rm -f "$profiles_file"
+          return 1
+        fi
+      fi
+    done <"$profiles_file"
+    rm -f "$profiles_file"
+  fi
+}
+
+remove_delimited_external_config() {
+  path="$1"
+  marker="$2"
+  [ -f "$path" ] || { record_action external_config "$path" remove skipped "" "already absent"; return 0; }
+  if ! grep -F "$marker" "$path" >/dev/null 2>&1; then
+    record_action external_config "$path" remove skipped "" "marker absent"
+    return 0
+  fi
+  if [ "$DRY_RUN" = true ]; then
+    record_action external_config "$path" remove reported "" "would remove marker block $marker"
+    return 0
+  fi
+  backup="$path.omnigent.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+  tmp="$(mktemp "$path.omnigent.tmp.XXXXXX")" || return 1
+  cp "$path" "$backup" || { record_action external_config "$path" remove failed "" "failed to write backup"; return 1; }
+  if awk -v marker="$marker" '
+    index($0, marker) && !skipping { skipping=1; found=1; next }
+    index($0, marker) && skipping { skipping=0; next }
+    !skipping { print }
+    END { exit(found && !skipping ? 0 : 42) }
+  ' "$path" >"$tmp" && mv "$tmp" "$path"; then
+    record_action external_config "$path" remove done "" "removed marker block, backup at $backup"
+  else
+    rm -f "$tmp"
+    record_action external_config "$path" remove failed "" "failed to remove marker block"
+  fi
+}
+
+remove_keyed_external_config() {
+  path="$1"
+  marker="$2"
+  format="$3"
+  [ -f "$path" ] || { record_action external_config "$path" remove skipped "" "already absent"; return 0; }
+  if [ "$DRY_RUN" = true ]; then
+    record_action external_config "$path" remove reported "" "would remove $marker from $format config"
+    return 0
+  fi
+  if [ "$format" = toml ]; then
+    backup="$path.omnigent.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+    tmp="$(mktemp "$path.omnigent.tmp.XXXXXX")" || return 1
+    cp "$path" "$backup" || { record_action external_config "$path" remove failed "" "failed to write backup"; return 1; }
+    if awk -v marker="$marker" '
+      $0 == "[" marker "]" || $0 ~ "^\\[" marker "\\." { skipping=1; found=1; next }
+      skipping && /^\[/ { skipping=0 }
+      !skipping { print }
+      END { exit(found ? 0 : 42) }
+    ' "$backup" >"$tmp" && mv "$tmp" "$path"; then
+      record_action external_config "$path" remove done "" "removed TOML table $marker, backup at $backup"
+    else
+      rm -f "$tmp"
+      record_action external_config "$path" remove skipped "" "TOML table $marker absent"
+    fi
+    return 0
+  fi
+  py="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+  if [ -z "$py" ]; then
+    record_action external_config "$path" remove skipped "" "python not found for structured config edit"
+    return 0
+  fi
+  backup="$path.omnigent.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+  cp "$path" "$backup" || { record_action external_config "$path" remove failed "" "failed to write backup"; return 1; }
+  if "$py" - "$path" "$marker" "$format" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+marker = sys.argv[2]
+fmt = sys.argv[3]
+if fmt != "json":
+    raise SystemExit(42)
+original = path.read_text()
+data = json.loads(original)
+current = data
+parts = marker.split(".")
+for part in parts[:-1]:
+    current = current.get(part, {}) if isinstance(current, dict) else {}
+if not isinstance(current, dict) or parts[-1] not in current:
+    raise SystemExit(42)
+current.pop(parts[-1])
+indent = 2 if "\n  \"" in original else None
+path.write_text(json.dumps(data, indent=indent, sort_keys=False) + "\n")
+PY
+  then
+    record_action external_config "$path" remove done "" "removed $marker, backup at $backup"
+  else
+    record_action external_config "$path" remove skipped "" "unsupported structured format; backup kept at $backup"
+  fi
+}
+
+cleanup_external_configs() {
+  [ -n "${OMNIGENT_UNINSTALL_LEDGER_MANIFEST:-}" ] && [ -f "$OMNIGENT_UNINSTALL_LEDGER_MANIFEST" ] || return 0
+  while IFS="$TAB" read -r artifact path marker format expected_sha source confidence rest; do
+    [ "$artifact" = external_config ] || continue
+    if [ "$MODIFY_EXTERNAL_CONFIG" != true ]; then
+      record_action external_config "$path" remove skipped "--modify-external-config" "gate not provided"
+      continue
+    fi
+    if { [ "$source" = inferred ] || [ "$confidence" = low ] || [ "$confidence" = medium ]; } && [ "$ASSUME_INFERRED" != true ]; then
+      record_action external_config "$path" remove skipped "--assume-inferred" "confidence gate not provided"
+      continue
+    fi
+    if [ "$format" = delimited_block ]; then
+      remove_delimited_external_config "$path" "$marker"
+    else
+      remove_keyed_external_config "$path" "$marker" "$format"
+    fi
+  done <"$OMNIGENT_UNINSTALL_LEDGER_MANIFEST"
+}
+
+archive_path_for() {
+  target="$1"
+  if [ -n "${XDG_STATE_HOME:-}" ]; then
+    backup_root="$XDG_STATE_HOME/omnigent-backups"
+  else
+    backup_root="$HOME/.omnigent-backups"
+  fi
+  mkdir -p "$backup_root" || return 1
+  ts="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+  base="$(printf '%s' "$target" | sed 's/[^A-Za-z0-9._-]/_/g; s/^_*//; s/_*$//')"
+  if command -v zstd >/dev/null 2>&1; then
+    printf '%s/%s-%s-%s.tar.zst\n' "$backup_root" "$ts" "$base" "$$"
+  else
+    printf '%s/%s-%s-%s.tar.gz\n' "$backup_root" "$ts" "$base" "$$"
+  fi
+}
+
+backup_path() {
+  target="$1"
+  [ -e "$target" ] || return 0
+  if [ "$NO_BACKUP" = true ]; then
+    return 0
+  fi
+  archive="$(archive_path_for "$target")" || return 1
+  parent="$(dirname "$target")"
+  base="$(basename "$target")"
+  case "$archive" in
+    *.tar.zst)
+      tar_tmp="$(mktemp "$archive.tar.XXXXXX")" || return 1
+      if ! tar -cf "$tar_tmp" -C "$parent" "$base"; then
+        rm -f "$tar_tmp" "$archive"
+        return 1
+      fi
+      if ! zstd -q -o "$archive" "$tar_tmp"; then
+        rm -f "$tar_tmp" "$archive"
+        return 1
+      fi
+      rm -f "$tar_tmp"
+      ;;
+    *.tar.gz)
+      tar -czf "$archive" -C "$parent" "$base" || return 1
+      ;;
+  esac
+  printf '%s\n' "$archive" >>"$BACKUPS_FILE"
+  record_action backup "$target" archive done "" "restore with: tar -xf $archive -C $parent"
+}
+
+remove_tree() {
+  artifact="$1"
+  path="$2"
+  gate="$3"
+  if [ ! -e "$path" ]; then
+    record_action "$artifact" "$path" remove skipped "" "already absent"
+    return 0
+  fi
+  if [ -n "$gate" ]; then
+    record_action "$artifact" "$path" remove skipped "$gate" "gate not provided"
+    return 0
+  fi
+  if [ "$DRY_RUN" = true ]; then
+    size="$(du -sk "$path" 2>/dev/null | awk '{print $1 " KiB"}' || printf unknown)"
+    record_action "$artifact" "$path" remove reported "" "would remove $size"
+    return 0
+  fi
+  if backup_path "$path" && rm -rf "$path"; then
+    record_action "$artifact" "$path" remove done "" "removed"
+  else
+    record_action "$artifact" "$path" remove failed "" "failed to remove"
+  fi
+}
+
+desktop_paths() {
+  case "$(uname -s)" in
+    Darwin)
+      printf '%s\n' \
+        "$HOME/Library/Application Support/Omnigent" \
+        "$HOME/Library/Caches/Omnigent" \
+        "$HOME/Library/Logs/Omnigent"
+      ;;
+    *)
+      printf '%s\n' \
+        "${XDG_CONFIG_HOME:-$HOME/.config}/Omnigent" \
+        "${XDG_CACHE_HOME:-$HOME/.cache}/Omnigent" \
+        "${XDG_STATE_HOME:-$HOME/.local/state}/Omnigent"
+      ;;
+  esac
+}
+
+purge_state() {
+  remove_tree state "$(state_home)" ""
+  workspace="$HOME/omnigent"
+  if [ -e "$workspace" ]; then
+    if [ "$PURGE_WORKSPACE" = true ]; then
+      remove_tree workspace "$workspace" ""
+    elif [ "$YES" = true ]; then
+      record_action workspace "$workspace" remove skipped "--purge-workspace" "workspace kept"
+    elif [ "$DRY_RUN" = true ]; then
+      record_action workspace "$workspace" remove reported "--purge-workspace" "would prompt separately"
+    else
+      printf 'Remove workspace %s? [y/N] ' "$workspace" >/dev/tty 2>/dev/null || true
+      answer=
+      IFS= read -r answer </dev/tty 2>/dev/null || true
+      case "$answer" in
+        y | Y | yes | YES | Yes) remove_tree workspace "$workspace" "" ;;
+        *) record_action workspace "$workspace" remove skipped "--purge-workspace" "workspace kept" ;;
+      esac
+    fi
+  fi
+}
+
+purge_desktop_data() {
+  desktop_file="$(mktemp "${TMPDIR:-/tmp}/omnigent-uninstall-desktop.XXXXXX")" || return 1
+  desktop_paths >"$desktop_file"
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    remove_tree desktop_data "$path" ""
+  done <"$desktop_file"
+  rm -f "$desktop_file"
+}
+
+report_shared_deps() {
+  for dep in uv node npm tmux bwrap; do
+    dep_path="$(command -v "$dep" 2>/dev/null || true)"
+    if [ -n "$dep_path" ]; then
+      record_action shared_dep "$dep" report reported "" "present at $dep_path; not removed"
+    fi
+  done
+}
+
+uninstall_wheel() {
+  if [ "$DRY_RUN" = true ]; then
+    record_action wheel omnigent remove reported "" "would run uv tool uninstall omnigent"
+    return 0
+  fi
+  if ! command -v uv >/dev/null 2>&1; then
+    if ! command -v omnigent >/dev/null 2>&1 && ! command -v omni >/dev/null 2>&1; then
+      record_action wheel omnigent remove skipped "" "already absent"
+      return 0
+    fi
+    record_action wheel omnigent remove failed "" "uv not found; remove the tool manually"
+    return 1
+  fi
+  uv_output="$(mktemp "${TMPDIR:-/tmp}/omnigent-uninstall-uv.XXXXXX")" || return 1
+  if uv tool uninstall omnigent >"$uv_output" 2>&1; then
+    rm -f "$uv_output"
+    record_action wheel omnigent remove done "" "uv tool uninstall omnigent"
+  else
+    output="$(cat "$uv_output" 2>/dev/null || true)"
+    rm -f "$uv_output"
+    case "$output" in
+      *'not installed'* | *'No tool'* | *'not found'*)
+        record_action wheel omnigent remove skipped "" "already absent"
+        ;;
+      *)
+        record_action wheel omnigent remove failed "" "uv tool uninstall failed: $output"
+        ;;
+    esac
+  fi
+}
+
+emit_json() {
+  printf '{\n'
+  printf '  "schema_version": 1,\n'
+  printf '  "dry_run": %s,\n' "$DRY_RUN"
+  printf '  "ledger_source": "%s",\n' "${OMNIGENT_UNINSTALL_LEDGER_SOURCE:-unknown}"
+  printf '  "actions": [\n'
+  first=true
+  if [ -f "$ACTIONS_FILE" ]; then
+    while IFS= read -r line; do
+      if [ "$first" = true ]; then first=false; else printf ',\n'; fi
+      printf '    %s' "$line"
+    done <"$ACTIONS_FILE"
+  fi
+  printf '\n  ],\n'
+  printf '  "backups": ['
+  first=true
+  if [ -f "$BACKUPS_FILE" ]; then
+    while IFS= read -r line; do
+      if [ "$first" = true ]; then first=false; else printf ','; fi
+      printf '"%s"' "$(json_escape "$line")"
+    done <"$BACKUPS_FILE"
+  fi
+  printf '],\n'
+  printf '  "summary": {"done": %s, "skipped": %s, "failed": %s, "reported": %s},\n' "$DONE" "$SKIPPED" "$FAILED" "$REPORTED"
+  printf '  "exit_code": %s\n' "$EXIT_CODE"
+  printf '}\n'
+}
+
+if ! has_shell_install_signal; then
+  record_action anchor omnigent detect failed "" "no Omnigent install detected"
+  EXIT_CODE=3
+  [ "$JSON" = true ] && emit_json
+  exit "$EXIT_CODE"
+fi
+
+unload_launch_agents
+if ! stop_processes; then
+  [ "$JSON" = true ] && emit_json
+  exit "$EXIT_CODE"
+fi
+
+if has_target cli; then
+  cleanup_profiles
+  if [ "$EXIT_CODE" = 3 ]; then
+    [ "$JSON" = true ] && emit_json
+    exit "$EXIT_CODE"
+  fi
+  cleanup_external_configs
+fi
+if has_target state; then
+  if [ "$PURGE" = true ]; then
+    purge_state
+  else
+    record_action state "$(state_home)" remove skipped "--purge" "state preserved"
+  fi
+fi
+if has_target desktop-data; then
+  purge_desktop_data
+fi
+report_shared_deps
+if has_target cli; then
+  uninstall_wheel
+fi
+
+if [ "$JSON" = true ]; then
+  emit_json
+elif [ "$DRY_RUN" = true ]; then
+  printf 'Preview only — nothing was changed. Re-run with --yes to apply CLI cleanup, or --purge --yes to remove state.\n'
+elif [ -f "$BACKUPS_FILE" ]; then
+  while IFS= read -r backup; do
+    printf 'backup: %s\n' "$backup"
+  done <"$BACKUPS_FILE"
+fi
+
+exit "$EXIT_CODE"

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,19 @@ class _GenerateBuildInfo(build_py):
         self._write_build_info()
         super().run()
         self._bundle_examples()
+        self._bundle_scripts()
+
+    def _bundle_scripts(self) -> None:
+        """Copy top-level maintenance scripts into package resources."""
+        import shutil
+
+        root = Path(__file__).resolve().parent
+        src = root / "scripts" / "uninstall_oss.sh"
+        if not src.is_file():
+            return
+        dest = Path(self.build_lib) / "omnigent" / "resources" / "scripts" / src.name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
 
     def _bundle_examples(self) -> None:
         """Copy bundled example agents into the wheel as real directories.

--- a/tests/test_install_ledger.py
+++ b/tests/test_install_ledger.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from omnigent import install_ledger
+
+
+def test_install_ledger_round_trip_and_mode(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))
+    profile = tmp_path / ".zshrc"
+    profile.write_text(
+        "before\n"
+        f"{install_ledger.PROFILE_MARKER_BEGIN}\n"
+        'export PATH="$HOME/.local/bin:$PATH"\n'
+        f"{install_ledger.PROFILE_MARKER_END}\n"
+        "after\n"
+    )
+
+    ledger = install_ledger.new_ledger(source="installer", strategy="install", deep=False)
+    path = install_ledger.ledger_path()
+    install_ledger.write_ledger(ledger, path=path)
+
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    loaded = install_ledger.load_ledger(path)
+    assert loaded is not None
+    assert loaded.to_dict() == ledger.to_dict()
+    assert loaded.entries.profiles[0].path == str(profile)
+
+
+def test_backfill_requires_anchor_signal(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+
+    assert install_ledger.backfill_install_ledger(deep=False, apply=True) is None
+    assert not install_ledger.backfill_ledger_path().exists()
+
+
+def test_write_install_ledger_from_env_records_profile_and_dep_provenance(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+    profile = home / ".profile"
+    profile.write_text(
+        f"{install_ledger.PROFILE_MARKER_BEGIN}\n"
+        'export PATH="$HOME/.local/bin:$PATH"\n'
+        f"{install_ledger.PROFILE_MARKER_END}\n"
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
+    monkeypatch.setenv("OMNIGENT_LEDGER_PROFILE", str(profile))
+    monkeypatch.setenv("OMNIGENT_LEDGER_DEP_UV", "omnigent")
+
+    ledger = install_ledger.write_install_ledger_from_env()
+
+    data = json.loads(install_ledger.ledger_path().read_text())
+    assert data["ledger_source"] == "installer"
+    assert data["installation_id"] == "install-123"
+    assert data["entries"]["profiles"][0]["path"] == str(profile)
+    assert ledger.entries.deps["uv"].installed_by == "omnigent"
+    assert ledger.entries.deps["uv"].confidence == "certain"
+
+
+def test_installer_ledger_supersedes_backfill_and_preserves_dep_ownership(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
+
+    backfill = install_ledger.new_ledger(source="backfill", strategy="deep-backfill", deep=False)
+    install_ledger.write_ledger(backfill, path=install_ledger.backfill_ledger_path())
+    installer = install_ledger.new_ledger(source="installer", strategy="install", deep=False)
+    installer.entries.deps["uv"] = install_ledger.DepEntry(
+        present=True,
+        path="/tmp/uv",
+        version="uv 1.0",
+        installed_by="omnigent",
+        confidence="certain",
+    )
+    install_ledger.write_ledger(installer, path=install_ledger.ledger_path())
+
+    rewritten = install_ledger.write_install_ledger_from_env()
+
+    assert rewritten.ledger_source == "installer"
+    assert rewritten.entries.deps["uv"].installed_by == "omnigent"
+    assert install_ledger.backfill_ledger_path().exists()
+
+
+def test_backfill_skips_write_when_content_is_unchanged(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
+
+    existing = install_ledger.new_ledger(source="backfill", strategy="fast-backfill", deep=False)
+    install_ledger.write_ledger(existing, path=install_ledger.backfill_ledger_path())
+
+    def fail_write(*args, **kwargs) -> None:
+        raise AssertionError("unchanged backfill should not be rewritten")
+
+    monkeypatch.setattr(install_ledger, "write_ledger", fail_write)
+
+    resolved = install_ledger.backfill_install_ledger(deep=False, apply=True)
+
+    assert resolved is not None
+    assert resolved.to_dict() == existing.to_dict()
+
+
+def test_install_ledger_merges_existing_and_observed_external_configs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    state = home / ".omnigent"
+    cursor_dir = workspace / ".cursor"
+    state.mkdir(parents=True)
+    cursor_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
+    monkeypatch.chdir(workspace)
+
+    existing = install_ledger.new_ledger(source="installer", strategy="install", deep=False)
+    old_config = install_ledger.ExternalConfigEntry(
+        path=str(tmp_path / "old.json"),
+        marker="mcpServers.omnigent",
+        format="json",
+        allowlist=["mcpServers.omnigent"],
+    )
+    existing.entries.injected_external_config = [old_config]
+    install_ledger.write_ledger(existing, path=install_ledger.ledger_path())
+    observed_config = cursor_dir / "mcp.json"
+    observed_config.write_text('{"mcpServers": {"omnigent": {"command": "python"}}}\n')
+
+    rewritten = install_ledger.write_install_ledger_from_env()
+
+    config_paths = {entry.path for entry in rewritten.entries.injected_external_config}
+    assert str(tmp_path / "old.json") in config_paths
+    assert str(observed_config) in config_paths
+
+
+def test_deep_backfill_observes_external_config_and_launch_agents(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    state = home / ".omnigent"
+    cursor_dir = workspace / ".cursor"
+    launch_dir = home / "Library" / "LaunchAgents"
+    state.mkdir(parents=True)
+    cursor_dir.mkdir(parents=True)
+    launch_dir.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+    cursor_config = cursor_dir / "mcp.json"
+    cursor_config.write_text('{"mcpServers": {"omnigent": {"command": "python"}}}\n')
+    launch_agent = launch_dir / "ai.omnigent.local.plist"
+    launch_agent.write_text("plist\n")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
+    monkeypatch.chdir(workspace)
+
+    ledger = install_ledger.backfill_install_ledger(deep=True, apply=False)
+
+    assert ledger is not None
+    assert ledger.entries.injected_external_config[0].path == str(cursor_config)
+    assert ledger.entries.injected_external_config[0].marker == "mcpServers.omnigent"
+    assert ledger.entries.launch_agents[0].path == str(launch_agent)
+    assert cursor_config.exists()
+    assert launch_agent.exists()

--- a/tests/test_uninstall_cli.py
+++ b/tests/test_uninstall_cli.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from omnigent import cli as cli_module
+from omnigent.install_ledger import InstallLedger, new_ledger
+
+
+def test_uninstall_cli_resolves_ledger_and_forwards_flags(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    script = tmp_path / "uninstall_oss.sh"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    script.chmod(0o755)
+    ledger = new_ledger(source="installer", strategy="install", deep=False)
+    calls: list[tuple[list[str], str | None]] = []
+
+    monkeypatch.setattr(cli_module, "_uninstall_script_path", lambda: script)
+
+    def _ledger() -> InstallLedger:
+        return ledger
+
+    monkeypatch.setattr("omnigent.install_ledger.resolve_uninstall_ledger", _ledger)
+
+    def _run(args, *, env, check):
+        calls.append((list(args), env.get("OMNIGENT_UNINSTALL_LEDGER_SOURCE")))
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(cli_module.subprocess, "run", _run)
+
+    result = runner.invoke(
+        cli_module.cli,
+        ["uninstall", "all", "--purge", "--yes", "--json", "--purge-workspace"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        (
+            [str(script), "all", "--purge", "--purge-workspace", "--yes", "--json"],
+            "installer",
+        )
+    ]
+
+
+def test_uninstall_cli_refuses_without_install_signal(monkeypatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setattr("omnigent.install_ledger.resolve_uninstall_ledger", lambda: None)
+
+    result = runner.invoke(cli_module.cli, ["uninstall", "--json"])
+
+    assert result.exit_code == 3
+    assert "no Omnigent install detected" in result.output
+
+
+def test_uninstall_cli_defaults_to_dry_run_without_destructive_flags(
+    monkeypatch, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    script = tmp_path / "uninstall_oss.sh"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    script.chmod(0o755)
+    ledger = new_ledger(source="installer", strategy="install", deep=False)
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(cli_module, "_uninstall_script_path", lambda: script)
+    monkeypatch.setattr("omnigent.install_ledger.resolve_uninstall_ledger", lambda: ledger)
+
+    def _run(args, *, env, check):
+        del env, check
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(cli_module.subprocess, "run", _run)
+
+    result = runner.invoke(cli_module.cli, ["uninstall"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [[str(script), "--dry-run"]]
+
+
+def test_uninstall_cli_human_refusal_exits_three(monkeypatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setattr("omnigent.install_ledger.resolve_uninstall_ledger", lambda: None)
+
+    result = runner.invoke(cli_module.cli, ["uninstall"])
+
+    assert result.exit_code == 3
+    assert "No Omnigent install detected" in result.output
+
+
+def test_uninstall_cli_uses_exclusive_manifest_and_cleans_temp_script(
+    monkeypatch, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    temp_script_dir = Path(tempfile.gettempdir()) / "omnigent-uninstall-test-cleanup"
+    temp_script_dir.mkdir(exist_ok=True)
+    script = temp_script_dir / "uninstall_oss.sh"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    script.chmod(0o755)
+    ledger = new_ledger(source="installer", strategy="install", deep=False)
+    manifest_paths: list[Path] = []
+
+    monkeypatch.setattr(cli_module, "_uninstall_script_path", lambda: script)
+    monkeypatch.setattr("omnigent.install_ledger.resolve_uninstall_ledger", lambda: ledger)
+
+    def _run(args, *, env, check):
+        del args, check
+        manifest_paths.append(Path(env["OMNIGENT_UNINSTALL_LEDGER_MANIFEST"]))
+        assert manifest_paths[-1].name.startswith("omnigent-uninstall-ledger-")
+        assert manifest_paths[-1].name.endswith(".tsv")
+        assert str(os.getpid()) not in manifest_paths[-1].name
+        return subprocess.CompletedProcess([], 0)
+
+    monkeypatch.setattr(cli_module.subprocess, "run", _run)
+
+    result = runner.invoke(cli_module.cli, ["uninstall", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert manifest_paths and not manifest_paths[0].exists()
+    assert not temp_script_dir.exists()

--- a/tests/test_uninstall_oss.py
+++ b/tests/test_uninstall_oss.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from omnigent.install_ledger import sha256_text
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "uninstall_oss.sh"
+
+
+def _run_uninstall(
+    home: Path, *args: str, path: str | None = None, env_updates: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["OMNIGENT_DATA_DIR"] = str(home / ".omnigent")
+    env["PATH"] = path or env.get("PATH", "")
+    if env_updates:
+        env.update(env_updates)
+    return subprocess.run(
+        ["sh", str(SCRIPT), *args],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _fake_uv(tmp_path: Path) -> tuple[Path, Path]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir(exist_ok=True)
+    uv_log = tmp_path / "uv.log"
+    uv = fake_bin / "uv"
+    uv.write_text(f"#!/bin/sh\nprintf '%s\\n' \"$*\" > {uv_log}\nexit 0\n")
+    uv.chmod(0o755)
+    return fake_bin, uv_log
+
+
+def _path_without_zstd(tmp_path: Path) -> str:
+    fake_bin = tmp_path / "no-zstd-bin"
+    fake_bin.mkdir()
+    for command in (
+        "awk",
+        "basename",
+        "cat",
+        "date",
+        "dirname",
+        "du",
+        "find",
+        "grep",
+        "gzip",
+        "mktemp",
+        "mkdir",
+        "ps",
+        "rm",
+        "sed",
+        "sh",
+        "sleep",
+        "tar",
+        "uname",
+    ):
+        target = shutil.which(command)
+        if target is not None:
+            (fake_bin / command).symlink_to(target)
+    return str(fake_bin)
+
+
+def test_uninstall_script_removes_profile_block_and_runs_wheel_last(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    profile = home / ".zshrc"
+    profile.write_text(
+        "keep\n"
+        "# >>> Omnigent installer >>>\n"
+        'export PATH="/fake/bin:$PATH"\n'
+        "# <<< Omnigent installer <<<\n"
+        "keep2\n"
+    )
+    fake_bin, uv_log = _fake_uv(tmp_path)
+
+    result = _run_uninstall(
+        home, "--yes", "--json", path=f"{fake_bin}:{os.environ.get('PATH', '')}"
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["done"] >= 2
+    assert "Omnigent installer" not in profile.read_text()
+    assert profile.read_text() == "keep\nkeep2\n"
+    assert uv_log.read_text().strip() == "tool uninstall omnigent"
+    assert list(home.glob(".zshrc.omnigent.bak.*"))
+
+
+def test_uninstall_script_bare_command_is_dry_run(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    profile = home / ".zshrc"
+    profile.write_text(
+        "keep\n"
+        "# >>> Omnigent installer >>>\n"
+        'export PATH="/fake/bin:$PATH"\n'
+        "# <<< Omnigent installer <<<\n"
+        "keep2\n"
+    )
+    fake_bin, uv_log = _fake_uv(tmp_path)
+
+    result = _run_uninstall(home, path=f"{fake_bin}:{os.environ.get('PATH', '')}")
+
+    assert result.returncode == 0, result.stderr
+    assert "reported: profile_block" in result.stdout
+    assert "reported: wheel" in result.stdout
+    assert "Preview only" in result.stdout
+    assert profile.read_text().startswith("keep\n# >>> Omnigent installer >>>")
+    assert not uv_log.exists()
+
+
+def test_uninstall_script_purge_backs_up_state_and_keeps_workspace_without_gate(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    workspace = home / "omnigent"
+    state.mkdir(parents=True)
+    workspace.mkdir(parents=True)
+    (state / "config.yaml").write_text("x: y\n")
+    (state / "installation_id").write_text("install-123\n")
+    (workspace / "project.txt").write_text("work\n")
+
+    result = _run_uninstall(home, "state", "--purge", "--yes", "--json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert not state.exists()
+    assert workspace.exists()
+    assert payload["backups"]
+    assert all(Path(backup).parent != state for backup in payload["backups"])
+    assert any(action.get("gate") == "--purge-workspace" for action in payload["actions"])
+
+
+def test_uninstall_script_purge_without_target_also_removes_cli(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+    profile = home / ".zshrc"
+    profile.write_text(
+        "keep\n"
+        "# >>> Omnigent installer >>>\n"
+        'export PATH="/fake/bin:$PATH"\n'
+        "# <<< Omnigent installer <<<\n"
+        "keep2\n"
+    )
+    fake_bin, uv_log = _fake_uv(tmp_path)
+
+    result = _run_uninstall(
+        home, "--purge", "--yes", "--json", path=f"{fake_bin}:{os.environ.get('PATH', '')}"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not state.exists()
+    assert "Omnigent installer" not in profile.read_text()
+    assert uv_log.read_text().strip() == "tool uninstall omnigent"
+
+
+def test_uninstall_script_purge_uses_unique_backup_paths_for_multiple_trees(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    workspace = home / "omnigent"
+    linux_desktop_dirs = (
+        home / ".config" / "Omnigent",
+        home / ".cache" / "Omnigent",
+        home / ".local" / "state" / "Omnigent",
+    )
+    mac_desktop_dirs = (
+        home / "Library" / "Application Support" / "Omnigent",
+        home / "Library" / "Caches" / "Omnigent",
+        home / "Library" / "Logs" / "Omnigent",
+    )
+    for directory in (state, workspace, *linux_desktop_dirs, *mac_desktop_dirs):
+        directory.mkdir(parents=True)
+        (directory / "data.txt").write_text("data\n")
+    (state / "installation_id").write_text("install-123\n")
+
+    result = _run_uninstall(
+        home,
+        "all",
+        "--purge",
+        "--purge-workspace",
+        "--yes",
+        "--json",
+        path=_path_without_zstd(tmp_path),
+        env_updates={
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+            "XDG_STATE_HOME": str(home / ".local" / "state"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    backups = json.loads(result.stdout)["backups"]
+    assert len(backups) == 5
+    assert len(backups) == len(set(backups))
+    assert all(Path(backup).exists() for backup in backups)
+
+
+def test_uninstall_script_refuses_tampered_profile_and_skips_wheel(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    original_block = (
+        "# >>> Omnigent installer >>>\n"
+        'export PATH="/fake/bin:$PATH"\n'
+        "# <<< Omnigent installer <<<\n"
+    )
+    profile = home / ".zshrc"
+    profile.write_text(original_block.replace("/fake/bin", "/tampered/bin"))
+    manifest = tmp_path / "manifest.tsv"
+    manifest.write_text(
+        "\t".join(
+            ["profile_block", str(profile), sha256_text(original_block), "recorded", "certain"]
+        )
+        + "\n"
+    )
+    fake_bin, uv_log = _fake_uv(tmp_path)
+    env = os.environ.copy()
+    env["OMNIGENT_UNINSTALL_LEDGER_MANIFEST"] = str(manifest)
+    env["OMNIGENT_UNINSTALL_LEDGER_SOURCE"] = "backfill"
+    env["HOME"] = str(home)
+    env["OMNIGENT_DATA_DIR"] = str(home / ".omnigent")
+    env["PATH"] = f"{fake_bin}:{os.environ.get('PATH', '')}"
+
+    result = subprocess.run(
+        ["sh", str(SCRIPT), "--yes", "--json"],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 3
+    payload = json.loads(result.stdout)
+    assert any(action["gate"] == "--force" for action in payload["actions"])
+    assert "tampered" in profile.read_text()
+    assert not uv_log.exists()
+
+
+def test_uninstall_script_external_config_requires_gate_then_removes_json_key(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    config = tmp_path / "harness.json"
+    config.write_text('{"mcp_servers": {"omnigent": {"url": "x"}, "other": {}}}\n')
+    manifest = tmp_path / "manifest.tsv"
+    manifest.write_text(
+        "\t".join(
+            [
+                "external_config",
+                str(config),
+                "mcp_servers.omnigent",
+                "json",
+                "",
+                "observed",
+                "certain",
+            ]
+        )
+        + "\n"
+    )
+    env = os.environ.copy()
+    env["OMNIGENT_UNINSTALL_LEDGER_MANIFEST"] = str(manifest)
+    env["OMNIGENT_UNINSTALL_LEDGER_SOURCE"] = "backfill"
+    env["HOME"] = str(home)
+    env["OMNIGENT_DATA_DIR"] = str(home / ".omnigent")
+
+    skipped = subprocess.run(
+        ["sh", str(SCRIPT), "--yes", "--json"],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    assert skipped.returncode == 0
+    assert "omnigent" in config.read_text()
+    assert any(
+        action["gate"] == "--modify-external-config"
+        for action in json.loads(skipped.stdout)["actions"]
+    )
+
+    removed = subprocess.run(
+        ["sh", str(SCRIPT), "--yes", "--json", "--modify-external-config"],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert removed.returncode == 0, removed.stderr
+    payload = json.loads(config.read_text())
+    assert "omnigent" not in payload["mcp_servers"]
+    assert "other" in payload["mcp_servers"]
+
+
+def test_uninstall_script_toml_config_and_launch_agent_reporting(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    config = tmp_path / "config.toml"
+    config.write_text(
+        '[mcp_servers.omnigent]\ncommand = "omnigent"\n\n[mcp_servers.other]\ncommand = "other"\n'
+    )
+    launch_agent = tmp_path / "ai.omnigent.plist"
+    launch_agent.write_text("plist\n")
+    manifest = tmp_path / "manifest.tsv"
+    manifest.write_text(
+        "\t".join(
+            [
+                "external_config",
+                str(config),
+                "mcp_servers.omnigent",
+                "toml",
+                "",
+                "observed",
+                "certain",
+            ]
+        )
+        + "\n"
+        + "\t".join(
+            ["launch_agent", "launchd", str(launch_agent), "ai.omnigent", "observed", "high"]
+        )
+        + "\n"
+    )
+    env = os.environ.copy()
+    env["OMNIGENT_UNINSTALL_LEDGER_MANIFEST"] = str(manifest)
+    env["HOME"] = str(home)
+    env["OMNIGENT_DATA_DIR"] = str(home / ".omnigent")
+
+    result = subprocess.run(
+        ["sh", str(SCRIPT), "--dry-run", "--json", "--modify-external-config"],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    actions = json.loads(result.stdout)["actions"]
+    assert any(action["artifact"] == "launch_agent" for action in actions)
+    assert any("would remove" in action["detail"] for action in actions)
+
+    removed = subprocess.run(
+        ["sh", str(SCRIPT), "--yes", "--json", "--modify-external-config"],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert removed.returncode == 0, removed.stderr
+    assert "mcp_servers.omnigent" not in config.read_text()
+    assert "mcp_servers.other" in config.read_text()
+
+
+def test_uninstall_script_unloads_launch_agent_before_stopping_host_pid(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    launch_agent = tmp_path / "ai.omnigent.plist"
+    launch_agent.write_text("plist\n")
+    manifest = tmp_path / "manifest.tsv"
+    manifest.write_text(
+        "\t".join(
+            ["launch_agent", "launchd", str(launch_agent), "ai.omnigent", "observed", "high"]
+        )
+        + "\n"
+    )
+    proc = subprocess.Popen(["sleep", "60"])
+    (state / "host.pid").write_text(f"{proc.pid}\nlocal\n")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "launchctl").write_text("#!/bin/sh\nexit 0\n")
+    (fake_bin / "launchctl").chmod(0o755)
+
+    try:
+        result = _run_uninstall(
+            home,
+            "--yes",
+            "--json",
+            path=f"{fake_bin}:{os.environ.get('PATH', '')}",
+            env_updates={
+                "OMNIGENT_UNINSTALL_LEDGER_MANIFEST": str(manifest),
+                "OMNIGENT_UNINSTALL_LEDGER_SOURCE": "installer",
+            },
+        )
+
+        assert result.returncode == 0, result.stderr
+        proc.wait(timeout=5)
+        assert not launch_agent.exists()
+        actions = json.loads(result.stdout)["actions"]
+        launch_index = next(
+            index for index, action in enumerate(actions) if action["artifact"] == "launch_agent"
+        )
+        process_index = next(
+            index for index, action in enumerate(actions) if action["artifact"] == "process"
+        )
+        assert launch_index < process_index
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_uninstall_script_external_json_preserves_key_order(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    config = tmp_path / "harness.json"
+    config.write_text('{"z": 1, "mcp_servers": {"other": {}, "omnigent": {}}, "a": 2}\n')
+    manifest = tmp_path / "manifest.tsv"
+    manifest.write_text(
+        "\t".join(
+            [
+                "external_config",
+                str(config),
+                "mcp_servers.omnigent",
+                "json",
+                "",
+                "observed",
+                "certain",
+            ]
+        )
+        + "\n"
+    )
+
+    result = _run_uninstall(
+        home,
+        "--yes",
+        "--json",
+        "--modify-external-config",
+        env_updates={
+            "OMNIGENT_UNINSTALL_LEDGER_MANIFEST": str(manifest),
+            "OMNIGENT_UNINSTALL_LEDGER_SOURCE": "backfill",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    text = config.read_text()
+    assert text.index('"z"') < text.index('"mcp_servers"') < text.index('"a"')
+    assert "omnigent" not in text
+
+
+def test_uninstall_script_toml_removes_nested_subtables(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    config = tmp_path / "config.toml"
+    config.write_text(
+        '[mcp_servers.omnigent]\ncommand = "omnigent"\n\n'
+        '[mcp_servers.omnigent.env]\nFOO = "bar"\n\n'
+        '[mcp_servers.other]\ncommand = "other"\n'
+    )
+    manifest = tmp_path / "manifest.tsv"
+    manifest.write_text(
+        "\t".join(
+            [
+                "external_config",
+                str(config),
+                "mcp_servers.omnigent",
+                "toml",
+                "",
+                "observed",
+                "certain",
+            ]
+        )
+        + "\n"
+    )
+
+    result = _run_uninstall(
+        home,
+        "--yes",
+        "--json",
+        "--modify-external-config",
+        env_updates={
+            "OMNIGENT_UNINSTALL_LEDGER_MANIFEST": str(manifest),
+            "OMNIGENT_UNINSTALL_LEDGER_SOURCE": "backfill",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    text = config.read_text()
+    assert "mcp_servers.omnigent" not in text
+    assert "mcp_servers.other" in text
+
+
+def test_uninstall_script_refuses_without_install_signal(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = _run_uninstall(home, "--dry-run", "--json", path="/bin:/usr/bin")
+
+    assert result.returncode == 3
+    payload = json.loads(result.stdout)
+    assert payload["exit_code"] == 3
+    assert any(action["artifact"] == "anchor" for action in payload["actions"])
+
+
+def test_uninstall_script_removes_fish_profile_blocks(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    fish_conf = home / ".config" / "fish" / "config.fish"
+    fish_confd = home / ".config" / "fish" / "conf.d" / "omnigent.fish"
+    fish_conf.parent.mkdir(parents=True)
+    fish_confd.parent.mkdir(parents=True)
+    block = (
+        "# >>> Omnigent installer >>>\n"
+        "set -gx PATH /fake/bin $PATH\n"
+        "# <<< Omnigent installer <<<\n"
+    )
+    fish_conf.write_text(f"keep\n{block}keep2\n")
+    fish_confd.write_text(f"before\n{block}after\n")
+
+    result = _run_uninstall(home, "--yes", "--json", path="/bin:/usr/bin")
+
+    assert result.returncode == 0, result.stderr
+    assert fish_conf.read_text() == "keep\nkeep2\n"
+    assert fish_confd.read_text() == "before\nafter\n"
+
+
+def test_uninstall_script_purge_no_backup_removes_state_without_archive(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+
+    result = _run_uninstall(
+        home, "state", "--purge", "--no-backup", "--yes", "--json", path="/bin:/usr/bin"
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert not state.exists()
+    assert payload["backups"] == []
+
+
+def test_uninstall_script_purge_uses_gzip_when_zstd_missing(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+    (state / "config.yaml").write_text("x: y\n")
+
+    result = _run_uninstall(
+        home, "state", "--purge", "--yes", "--json", path=_path_without_zstd(tmp_path)
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["backups"]
+    assert payload["backups"][0].endswith(".tar.gz")
+
+
+def test_uninstall_script_purge_namespaces_xdg_state_backups(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    state_home = tmp_path / "xdg-state"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+    (state / "config.yaml").write_text("x: y\n")
+
+    result = _run_uninstall(
+        home,
+        "state",
+        "--purge",
+        "--yes",
+        "--json",
+        path="/bin:/usr/bin",
+        env_updates={"XDG_STATE_HOME": str(state_home)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["backups"]
+    assert Path(payload["backups"][0]).parent == state_home / "omnigent-backups"
+
+
+def test_uninstall_script_keeps_state_when_zstd_backup_tar_fails(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+    (state / "config.yaml").write_text("x: y\n")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "zstd").write_text("#!/bin/sh\nexit 0\n")
+    (fake_bin / "tar").write_text("#!/bin/sh\nexit 1\n")
+    (fake_bin / "zstd").chmod(0o755)
+    (fake_bin / "tar").chmod(0o755)
+
+    result = _run_uninstall(
+        home,
+        "state",
+        "--purge",
+        "--yes",
+        "--json",
+        path=f"{fake_bin}:{os.environ.get('PATH', '')}",
+    )
+
+    assert result.returncode == 1
+    assert state.exists()
+    payload = json.loads(result.stdout)
+    assert payload["backups"] == []
+
+
+def test_uninstall_script_stops_live_pid_from_state_run_dir(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    run_dir = state / "run"
+    run_dir.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+    proc = subprocess.Popen(["sleep", "60"])
+    try:
+        (run_dir / "daemon.pid").write_text(f"{proc.pid}\n")
+        result = _run_uninstall(home, "state", "--dry-run", "--json")
+        assert result.returncode == 0
+        assert proc.poll() is None
+
+        result = _run_uninstall(home, "state", "--yes", "--json")
+        assert result.returncode == 0, result.stderr
+        proc.wait(timeout=5)
+        assert any(
+            action["artifact"] == "process" and action["status"] == "done"
+            for action in json.loads(result.stdout)["actions"]
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_uninstall_script_rerun_is_idempotent(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    state.mkdir(parents=True)
+    (state / "installation_id").write_text("install-123\n")
+    profile = home / ".zshrc"
+    profile.write_text(
+        "keep\n"
+        "# >>> Omnigent installer >>>\n"
+        'export PATH="/fake/bin:$PATH"\n'
+        "# <<< Omnigent installer <<<\n"
+    )
+    fake_bin, _ = _fake_uv(tmp_path)
+    path = f"{fake_bin}:{os.environ.get('PATH', '')}"
+
+    first = _run_uninstall(home, "--yes", "--json", path=path)
+    second = _run_uninstall(home, "--yes", "--json", path=path)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert "Omnigent installer" not in profile.read_text()


### PR DESCRIPTION
## Related issue

N/A

## Summary

Omnigent had an installer and upgrade path, but no safe, discoverable way to remove the CLI, installer-managed shell edits, and optional local state. This adds an uninstall flow that defaults to preserving user data, records installer-owned artifacts for safe removal, and falls back to a standalone POSIX shell script when the Python wheel or PATH is broken.

- Add `omnigent uninstall` with targets (`cli`, `state`, `desktop-data`, `all`), dry-run/JSON output, explicit purge gates, and ledger-backed profile/external-config cleanup.
- Add `scripts/uninstall_oss.sh` as the shared removal backend with process shutdown, launch-unit unload, tamper checks, state backups outside the target, shared dependency reporting, and `uv tool uninstall omnigent` last.
- Add `install_ledger.json` schema/write/backfill helpers plus installer-side ledger writing and `doctor --migrate-ledger` for pre-ledger installs.
- Document the uninstall path in the README and installer next steps, and add `docs/UNINSTALL_DESIGN.md` with the implemented checklist items ticked for this PR.

ELI5: the installer now leaves a checklist of what Omnigent touched, and uninstall uses that checklist to remove only Omnigent-owned things. It keeps user history and projects unless the user explicitly asks for a purge.

```mermaid
flowchart TD
    A[omnigent uninstall] --> B[resolve install ledger]
    B --> C[plan/stop Omnigent processes]
    C --> D{dry run?}
    D -- yes --> E[print planned actions]
    D -- no --> F[remove marked PATH/config entries]
    F --> G{--purge?}
    G -- yes --> H[backup state outside target, then delete]
    G -- no --> I[preserve state]
    H --> J[uv tool uninstall omnigent]
    I --> J
```

## Test Plan

- `uv sync --extra dev`
- `python -m ruff check omnigent/cli.py omnigent/install_ledger.py setup.py tests/test_install_ledger.py tests/test_uninstall_oss.py tests/test_uninstall_cli.py`
- `pytest -q tests/test_install_ledger.py tests/test_uninstall_oss.py tests/test_uninstall_cli.py` (31 passed)
- `python -m py_compile omnigent/install_ledger.py omnigent/cli.py setup.py`
- `sh -n scripts/install_oss.sh scripts/uninstall_oss.sh`
- `pre-commit run --files README.md docs/UNINSTALL_DESIGN.md omnigent/cli.py omnigent/install_ledger.py omnigent/resources/scripts/__init__.py pyproject.toml scripts/install_oss.sh scripts/uninstall_oss.sh setup.py tests/test_install_ledger.py tests/test_uninstall_cli.py tests/test_uninstall_oss.py`
- Manual verification: `python -m omnigent.cli uninstall --help`
- Manual verification: isolated standalone anchor guard exits 3 and emits valid JSON with `HOME=$(mktemp -d)/home OMNIGENT_DATA_DIR=$HOME/.omnigent PATH=/bin:/usr/bin sh scripts/uninstall_oss.sh --dry-run --json`

## Demo

Representative dry-run output from bare `omnigent uninstall` / `sh scripts/uninstall_oss.sh` with a temporary Omnigent install signal and profile block:

```text
reported: profile_block ~/.zshrc (would remove lines 1-3)
reported: state ~/.omnigent (would remove 4 KiB)
skipped: desktop_data ~/Library/Application Support/Omnigent (already absent)
skipped: desktop_data ~/Library/Caches/Omnigent (already absent)
skipped: desktop_data ~/Library/Logs/Omnigent (already absent)
reported: shared_dep uv (present at /opt/homebrew/bin/uv; not removed)
reported: shared_dep node (present at <node-path>; not removed)
reported: shared_dep npm (present at <npm-path>; not removed)
reported: shared_dep tmux (present at /opt/homebrew/bin/tmux; not removed)
reported: wheel omnigent (would run uv tool uninstall omnigent)
Preview only — nothing was changed. Re-run with --yes to apply CLI cleanup, or --purge --yes to remove state.
```

CLI help remains available via `python -m omnigent.cli uninstall --help`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover ledger serialization/backfill, installer ledger merge semantics, CLI forwarding/refusal, exclusive temp manifest cleanup, stable backfill no-op writes, external-config ledger merging, profile cleanup including fish, tamper refusal, process shutdown from state and host pidfiles, launch-unit unload-before-stop and unit-file removal, external config gates for JSON/TOML, JSON key-order preservation, nested TOML subtable cleanup, purge backups including bare-uninstall dry-run defaults, unique multi-tree archive paths, and gzip fallback, XDG state backup namespacing, failed zstd/tar backup preservation, no-backup purge, workspace preservation, launch-unit reporting, shared dependency reporting, idempotent reruns, and anchor guard behavior. Manual checks verified command help and standalone-script JSON refusal behavior.

## Changelog

Add `omnigent uninstall` for safely removing the CLI, installer-managed shell/config edits, and optionally local Omnigent state.






