### PR TITLE
fix(pi-native): support ucode/workspace-hosted Databricks AI Gateway configs

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -100,14 +100,18 @@ _DATABRICKS_AI_GATEWAY_LABEL = "ai-gateway"
 def _is_databricks_ai_gateway_url(base_url: str) -> bool:
     """Return ``True`` only for a genuine Databricks AI Gateway base URL.
 
-    Hardens the old substring scan over the whole base_url (scheme+host+path),
-    which look-alikes such as ``https://databricks-ai-gateway.evil.test/...``,
-    ``https://x.cloud.databricks.com.evil.test/...`` or
-    ``https://evil.test/databricks/ai-gateway/v1`` all defeated — leaking the
-    workspace bearer token to an attacker-controlled host. We parse the URL and
-    validate the *hostname* (not the raw string): require an ``https`` scheme, a
-    resolvable hostname carrying the ``ai-gateway`` DNS label, and a hostname
-    that ends with a trusted Databricks-owned parent domain suffix.
+    Two URL shapes are accepted:
+
+    1. **Dedicated AI Gateway subdomain** — ``ai-gateway`` is a full DNS label
+       in the hostname (e.g. ``<id>.ai-gateway.cloud.databricks.com``). Used by
+       the standard ``isaac configure codex`` setup.
+    2. **Workspace-hosted gateway** — the hostname is a plain Databricks
+       workspace (ends with a trusted suffix) and the path starts with
+       ``/ai-gateway/`` (e.g. ``<workspace>.cloud.databricks.com/ai-gateway/...``).
+       Used by ucode / Codex app profile setups.
+
+    Both cases require ``https`` and a hostname ending with a trusted
+    Databricks-owned domain suffix to prevent token-forwarding attacks.
 
     :param base_url: The codex provider table's ``base_url``.
     :returns: ``True`` iff the URL is an https Databricks AI Gateway endpoint.
@@ -119,12 +123,16 @@ def _is_databricks_ai_gateway_url(base_url: str) -> bool:
     if not hostname:
         return False
     hostname = hostname.lower()
-    # ``ai-gateway`` must be a full DNS label, not a substring of one (so
-    # ``databricks-ai-gateway.evil.test`` does not qualify on the label alone).
-    labels = hostname.split(".")
-    if _DATABRICKS_AI_GATEWAY_LABEL not in labels:
+    trusted = any(hostname.endswith(suffix) for suffix in _DATABRICKS_TRUSTED_HOST_SUFFIXES)
+    if not trusted:
         return False
-    return any(hostname.endswith(suffix) for suffix in _DATABRICKS_TRUSTED_HOST_SUFFIXES)
+    # Shape 1: ``ai-gateway`` is a full DNS label in the hostname.
+    labels = hostname.split(".")
+    if _DATABRICKS_AI_GATEWAY_LABEL in labels:
+        return True
+    # Shape 2: workspace hostname + /ai-gateway/ path prefix.
+    path = parsed.path or ""
+    return path.startswith("/ai-gateway/")
 
 
 @dataclass(frozen=True)
@@ -428,9 +436,26 @@ def _cli_config_databricks_transport(entry: ProviderEntry) -> CodexConfigTranspo
 
     transport = codex_config_provider_transport(_codex_config_path(), entry.model_provider)
     if transport is None:
+        # The model_provider may live in a sibling config file (e.g. config1.toml
+        # used by ucode / Codex app profile switching). Scan other config*.toml
+        # files in ~/.codex/ for the matching model_provider table.
+        codex_dir = _codex_config_path().parent
+        for alt_config in sorted(codex_dir.glob("config*.toml")):
+            if alt_config == _codex_config_path():
+                continue
+            transport = codex_config_provider_transport(alt_config, entry.model_provider)
+            if transport is not None:
+                _LOGGER.info(
+                    "pi-native: cli-config provider %r (model_provider %r) found in %s",
+                    entry.name,
+                    entry.model_provider,
+                    alt_config.name,
+                )
+                break
+    if transport is None:
         _LOGGER.info(
             "pi-native: cli-config provider %r (model_provider %r) has no resolvable "
-            "[model_providers.%s] base_url in ~/.codex/config.toml; Pi will use its own login.",
+            "[model_providers.%s] base_url in ~/.codex/config*.toml; Pi will use its own login.",
             entry.name,
             entry.model_provider,
             entry.model_provider,
@@ -451,13 +476,32 @@ def _cli_config_databricks_transport(entry: ProviderEntry) -> CodexConfigTranspo
         )
         return None
     if not transport.auth_command:
-        _LOGGER.info(
-            "pi-native: Databricks cli-config provider %r carries no [model_providers.%s.auth] "
-            "token command; Pi will use its own login.",
-            entry.name,
-            entry.model_provider,
-        )
-        return None
+        # No explicit auth command (e.g. ucode config using ambient SDK auth).
+        # Try to build a !command using the SDK, same as the databricks-kind path.
+        try:
+            from omnigent.inner.codex_executor import _databricks_codex_auth_command
+            from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
+
+            ws = resolve_databricks_workspace(None)
+            auth_cmd = _databricks_codex_auth_command(ws.host, None)
+            transport = CodexConfigTransport(
+                base_url=transport.base_url,
+                auth_command=auth_cmd,
+            )
+            _LOGGER.info(
+                "pi-native: cli-config provider %r has no auth command; "
+                "using SDK-derived auth for %s",
+                entry.name,
+                ws.host,
+            )
+        except Exception:  # noqa: BLE001
+            _LOGGER.info(
+                "pi-native: Databricks cli-config provider %r (model_provider %r) "
+                "has no auth command and SDK auth is unavailable; Pi will use its own login.",
+                entry.name,
+                entry.model_provider,
+            )
+            return None
     return transport
 
 
@@ -516,16 +560,28 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     # access on workspaces where access is controlled via the auth command.
     claude_models: list[dict[str, Any]] = []
     openai_models: list[dict[str, Any]] = []
-    real_workspace_url: str | None = None
-    try:
-        from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
+    # Derive the workspace URL for the serving-endpoints API call.
+    # For dedicated-subdomain URLs (ai-gateway.cloud.databricks.com), the
+    # real workspace hostname must come from ~/.databrickscfg. For
+    # workspace-hosted gateway URLs (workspace.cloud.databricks.com/ai-gateway/),
+    # the transport's own hostname IS the workspace.
+    parsed_gateway = urlparse(transport.base_url)
+    gateway_labels = (parsed_gateway.hostname or "").split(".")
+    if _DATABRICKS_AI_GATEWAY_LABEL in gateway_labels:
+        # Dedicated subdomain: derive workspace from ~/.databrickscfg DEFAULT.
+        real_workspace_url: str | None = None
+        try:
+            from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 
-        real_workspace_url = resolve_databricks_workspace(None).host
-    except Exception:  # noqa: BLE001 — no .databrickscfg → skip listing
-        _LOGGER.info(
-            "pi-native: cli-config path could not resolve workspace URL "
-            "for model listing; Pi will show only the selected model"
-        )
+            real_workspace_url = resolve_databricks_workspace(None).host
+        except Exception:  # noqa: BLE001 — no .databrickscfg → skip listing
+            _LOGGER.info(
+                "pi-native: cli-config path could not resolve workspace URL "
+                "for model listing; Pi will show only the selected model"
+            )
+    else:
+        # Workspace-hosted gateway: the transport hostname is the workspace.
+        real_workspace_url = f"https://{parsed_gateway.hostname}"
     if real_workspace_url and transport.auth_command:
         token = _run_auth_command(transport.auth_command)
         if token:


### PR DESCRIPTION
## Related issue

n/a

## Summary

Three issues prevented model listing for the ucode/workspace-hosted Databricks AI Gateway setup:

**1. Sibling config file not searched**

The ucode Codex app writes \`~/.codex/config1.toml\` (profile-switched setup), but omnigent only looked in \`~/.codex/config.toml\`. Now scans all \`config*.toml\` siblings when the primary file has no matching \`[model_providers.X]\` table.

**2. No auth command in ucode config**

The ucode provider table has no \`[X.auth]\` section — it uses ambient Databricks SDK auth. Previously this caused \`_cli_config_databricks_transport\` to return \`None\` and fall through to Pi's own login. Now derives a \`!command\` from \`resolve_databricks_workspace\` + \`_databricks_codex_auth_command\` so Pi refreshes bearer tokens per request.

**3. Workspace-hosted gateway URL rejected**

The ucode config uses \`workspace.cloud.databricks.com/ai-gateway/...\` (path prefix) rather than the dedicated \`id.ai-gateway.cloud.databricks.com\` subdomain. \`_is_databricks_ai_gateway_url\` only accepted the subdomain form. Now accepts both:
- Subdomain form: \`ai-gateway\` as a full DNS label in the hostname
- Path form: trusted Databricks hostname + \`/ai-gateway/\` path prefix

For model listing, the workspace URL is extracted directly from the transport hostname (for path-form URLs) instead of requiring a \`~/.databrickscfg\` DEFAULT profile.

**Result:** \`resolve_pi_native_provider()\` now correctly fetches the live model list (11 Claude + 35 GPT/GLM/Gemini/Llama models) for ucode setups.

## Test Plan

- All 49 \`tests/test_pi_native_credentials.py\` tests pass.
- Verified locally: \`resolve_pi_native_provider()\` returns 46 models from \`ai-oss-ecosystem-integration-testing.cloud.databricks.com\` using the ucode config.

## Demo

<img width="540" height="231" alt="image" src="https://github.com/user-attachments/assets/d00df751-10a5-4dfa-9ffd-378f9dca80dc" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Existing tests cover this change
- [x] Manual verification completed

## Coverage notes

Manual verification: ran \`resolve_pi_native_provider()\` locally — correctly found \`config1.toml\`, derived SDK auth, extracted workspace URL from path-form gateway URL, and fetched 46 live models via the serving-endpoints API.

## Changelog

Pi's \`/model\` command now shows all available Databricks models for ucode / Codex app profile-switched setups