### PR TITLE
fix(electron): avoid dark JSON screens during server connection

### DIFF
--- a/tests/e2e_ui/desktop/test_json_document_theme.py
+++ b/tests/e2e_ui/desktop/test_json_document_theme.py
@@ -1,0 +1,68 @@
+"""Desktop raw-JSON fallback behavior."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from playwright.sync_api import Page, Route
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _production_theme_script() -> str:
+    """Load the exact script Electron injects after a JSON document is ready."""
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            "process.stdout.write(require('./web/electron/src/json-document-theme.js')"
+            ".FORCE_LIGHT_JSON_DOCUMENT_SCRIPT)",
+        ],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def test_raw_401_json_fallback_uses_light_palette(page: Page) -> None:
+    """A generated JSON document remains readable under dark OS appearance."""
+    page.emulate_media(color_scheme="dark")
+
+    def fulfill_json(route: Route) -> None:
+        route.fulfill(
+            status=401,
+            content_type="application/json",
+            body=json.dumps({"error_code": 401, "message": "unsupported credential type"}),
+        )
+
+    page.route("https://example.test/raw-json", fulfill_json)
+    response = page.goto("https://example.test/raw-json")
+
+    assert response is not None
+    assert response.status == 401
+    assert page.evaluate("() => document.contentType") == "application/json"
+    assert page.evaluate("() => matchMedia('(prefers-color-scheme: dark)').matches") is True
+    assert page.evaluate(_production_theme_script()) is True
+
+    palette = page.evaluate(
+        """
+        () => ({
+          rootBackground: getComputedStyle(document.documentElement).backgroundColor,
+          rootColor: getComputedStyle(document.documentElement).color,
+          rootScheme: document.documentElement.style.colorScheme,
+          bodyBackground: getComputedStyle(document.body).backgroundColor,
+          bodyColor: getComputedStyle(document.body).color,
+        })
+        """
+    )
+    assert palette == {
+        "rootBackground": "rgb(255, 255, 255)",
+        "rootColor": "rgb(17, 17, 17)",
+        "rootScheme": "light only",
+        "bodyBackground": "rgb(255, 255, 255)",
+        "bodyColor": "rgb(17, 17, 17)",
+    }

--- a/tests/e2e_ui/desktop/test_setup_connect.py
+++ b/tests/e2e_ui/desktop/test_setup_connect.py
@@ -163,6 +163,6 @@ def test_shared_url_module_routes_workspace_api_mount_to_ui(page: Page) -> None:
     )
 
     assert result == {
-        "target": "https://dbc-x.cloud.databricks.com/ml/omnigents?o=123#session",
+        "target": "https://dbc-x.cloud.databricks.com/omnigent?o=123#session",
         "probes": 0,
     }

--- a/tests/e2e_ui/desktop/test_setup_connect.py
+++ b/tests/e2e_ui/desktop/test_setup_connect.py
@@ -134,3 +134,35 @@ def test_shared_url_module_defaults_scheme_in_browser(page: Page) -> None:
         page.evaluate("() => window.omnigentUrl.normalizeUrl('localhost:6767')")
         == "http://localhost:6767/"
     )
+
+
+def test_shared_url_module_routes_workspace_api_mount_to_ui(page: Page) -> None:
+    """A pasted workspace API URL resolves directly to the desktop UI."""
+    _open_setup_page(page)
+
+    result = page.evaluate(
+        """
+        async () => {
+          const originalFetch = window.fetch;
+          let probes = 0;
+          window.fetch = () => {
+            probes += 1;
+            throw new Error("unexpected workspace probe");
+          };
+          try {
+            const target =
+              await window.omnigentUrl.expandDatabricksWorkspaceUrl(
+                "https://dbc-x.cloud.databricks.com/api/2.0/omnigent/?o=123#session"
+              );
+            return { target, probes };
+          } finally {
+            window.fetch = originalFetch;
+          }
+        }
+        """
+    )
+
+    assert result == {
+        "target": "https://dbc-x.cloud.databricks.com/ml/omnigents?o=123#session",
+        "probes": 0,
+    }

--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -638,13 +638,13 @@ server in the desktop app — the way a browser deep link opens a page:
 
 ```
 omnigent://localhost:8000/c/conv_abc              → http://localhost:8000/c/conv_abc
-omnigent://my-workspace.cloud.databricks.com/c/x → https://…/ml/omnigents/c/x
+omnigent://my-workspace.cloud.databricks.com/c/x → https://…/omnigent/c/x
 ```
 
 The link names a server by **host** (with port if non-default) and carries no
 `http`/`https` — the shell infers the scheme with the same rule the setup page
 uses (`http` for loopback, `https` for a remote host), so a deep link and a
-pasted URL can never disagree. The Databricks workspace mount (`/ml/omnigents`)
+pasted URL can never disagree. The Databricks workspace mount (`/omnigent`)
 is **not** in the link; it is server-determined and discovered the same way a
 pasted workspace URL is. v1 accepts only `/c/<session_id>`; other paths are
 ignored.

--- a/web/electron/src/deepLink.js
+++ b/web/electron/src/deepLink.js
@@ -8,7 +8,7 @@
 // The link carries no http/https scheme — we infer it with the SAME rule the
 // setup page uses (defaultSchemeFor: http for loopback, https for remote),
 // so a deep link and a pasted URL can never disagree on scheme. The
-// workspace mount (`/ml/omnigents`) is deliberately NOT in the link: it is
+// workspace mount (`/omnigent`) is deliberately NOT in the link: it is
 // server-determined and discovered by expandDatabricksWorkspaceUrl, exactly
 // as for a pasted workspace URL.
 

--- a/web/electron/src/json-document-theme.js
+++ b/web/electron/src/json-document-theme.js
@@ -1,0 +1,48 @@
+// Chromium's generated JSON viewer follows the OS color scheme. Keep raw JSON
+// responses readable without changing the setup page or SPA theme.
+
+"use strict";
+
+/**
+ * Apply light colors only when `doc` is a browser-generated JSON document.
+ *
+ * @param {Document} doc
+ * @returns {boolean} Whether the document was changed.
+ */
+function forceLightJsonDocument(doc) {
+  const type = String(doc?.contentType ?? "").toLowerCase();
+  if (type !== "application/json" && type !== "text/json" && !type.endsWith("+json")) {
+    return false;
+  }
+  const root = doc.documentElement;
+  if (!root) return false;
+
+  root.style.colorScheme = "only light";
+  root.style.backgroundColor = "#fff";
+  root.style.color = "#111";
+  if (doc.body) {
+    doc.body.style.backgroundColor = "#fff";
+    doc.body.style.color = "#111";
+  }
+  return true;
+}
+
+const FORCE_LIGHT_JSON_DOCUMENT_SCRIPT = `(${forceLightJsonDocument.toString()})(document);`;
+
+/**
+ * Reapply the JSON-only theme after each full document navigation.
+ *
+ * @param {{ on: (event: string, listener: () => void) => void,
+ *   executeJavaScript: (script: string) => Promise<unknown> }} webContents
+ */
+function registerLightJsonDocumentTheme(webContents) {
+  webContents.on("dom-ready", () => {
+    void webContents.executeJavaScript(FORCE_LIGHT_JSON_DOCUMENT_SCRIPT).catch(() => {});
+  });
+}
+
+module.exports = {
+  FORCE_LIGHT_JSON_DOCUMENT_SCRIPT,
+  forceLightJsonDocument,
+  registerLightJsonDocumentTheme,
+};

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -37,7 +37,12 @@ const path = require("node:path");
 const { pathToFileURL } = require("node:url");
 const { execFile } = require("node:child_process");
 const { registerLocalhostCors } = require("./localhost_cors");
-const { normalizeUrl, expandDatabricksWorkspaceUrl } = require("./url");
+const { registerLightJsonDocumentTheme } = require("./json-document-theme");
+const {
+  normalizeUrl,
+  canonicalizeDesktopServerUrl,
+  expandDatabricksWorkspaceUrl,
+} = require("./url");
 const { parseOmnigentDeepLink, chooseDeepLinkStrategy } = require("./deepLink");
 const { registerWorkspaceChromeHide } = require("./workspace-chrome");
 const { createBrowserViewRegistry } = require("./browserViewRegistry");
@@ -669,7 +674,22 @@ function settingsPath() {
 
 function loadSettings() {
   try {
-    return JSON.parse(fs.readFileSync(settingsPath(), "utf8"));
+    const settings = JSON.parse(fs.readFileSync(settingsPath(), "utf8"));
+    // The workspace API mount is a server address, not a browser destination.
+    // Canonicalize it for saved defaults, recents, and server switching.
+    if (typeof settings.server_url === "string") {
+      settings.server_url = canonicalizeDesktopServerUrl(settings.server_url);
+    }
+    if (Array.isArray(settings.recent_servers)) {
+      settings.recent_servers = [
+        ...new Set(
+          settings.recent_servers
+            .filter((url) => typeof url === "string")
+            .map(canonicalizeDesktopServerUrl),
+        ),
+      ];
+    }
+    return settings;
   } catch {
     // Missing/corrupt file → empty settings (first launch).
     return {};
@@ -1024,6 +1044,7 @@ function createWindow(targetUrl, opts = {}) {
       spellcheck: true,
     },
   });
+  registerLightJsonDocumentTheme(win.webContents);
   const explicit =
     typeof targetUrl === "string" && /^https?:\/\//i.test(targetUrl) ? targetUrl : undefined;
   const saved = loadSettings().server_url;
@@ -1033,10 +1054,13 @@ function createWindow(targetUrl, opts = {}) {
   // override (deep link); else the explicit target (New Window cloning a
   // sibling — preserves prior behavior); else the saved default for normal
   // windows; else null (ephemeral windows start on the setup page).
-  const serverUrl =
+  const requestedServerUrl =
     (typeof opts.serverUrl === "string" && opts.serverUrl.length > 0 ? opts.serverUrl : null) ??
     explicit ??
     (ephemeral ? null : typeof saved === "string" && saved.length > 0 ? saved : null);
+  const serverUrl = requestedServerUrl
+    ? canonicalizeDesktopServerUrl(requestedServerUrl)
+    : null;
   // loadUrl: what the webContents actually loads. A deep-link path resolves
   // under the server URL (mount-aware — see resolveServerPath); an explicit
   // target (New Window) loads that exact URL; otherwise load the server URL.
@@ -1044,7 +1068,7 @@ function createWindow(targetUrl, opts = {}) {
     (typeof opts.path === "string" && opts.path.length > 0 && serverUrl
       ? resolveServerPath(serverUrl, opts.path)
       : null) ??
-    explicit ??
+    (explicit ? canonicalizeDesktopServerUrl(explicit) : null) ??
     serverUrl;
   // A serverUrl that doesn't parse (hand-edited/corrupt settings.json) is
   // treated as "no server configured" rather than crashing window creation.

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -569,7 +569,7 @@ function pinWindow(win, origin) {
 /**
  * Record (or clear) the full server URL a window is connected to. The pinned
  * `origin` drops any path, but the host/server CLI commands need the exact URL
- * the user connected with (e.g. a Databricks ``…/ml/omnigents`` mount), so the
+ * the user connected with (e.g. a Databricks ``…/omnigent`` mount), so the
  * window keeps both.
  *
  * @param {BrowserWindow} win
@@ -951,10 +951,10 @@ function hardenOauthPopup(child) {
 
 /**
  * Join a basename-less SPA path (e.g. ``/c/conv_abc``) onto a server URL that
- * may carry a workspace mount (e.g. ``https://host/ml/omnigents/``). The path
+ * may carry a workspace mount (e.g. ``https://host/omnigent/``). The path
  * is an ABSOLUTE in-app route, but it lives UNDER the server's mount —
  * ``new URL("/c/x", serverUrl)`` would resolve against the ORIGIN and drop
- * ``/ml/omnigents`` — so we string-concatenate: strip the server URL's trailing
+ * ``/omnigent`` — so we string-concatenate: strip the server URL's trailing
  * slash, append the path. The SPA's react-router basename then matches
  * ``${mount}/c/:id``. Shared by createWindow (cold open) and loadServerUrl
  * (re-pointing an existing window) so the mount-aware join is in one place.
@@ -1058,9 +1058,7 @@ function createWindow(targetUrl, opts = {}) {
     (typeof opts.serverUrl === "string" && opts.serverUrl.length > 0 ? opts.serverUrl : null) ??
     explicit ??
     (ephemeral ? null : typeof saved === "string" && saved.length > 0 ? saved : null);
-  const serverUrl = requestedServerUrl
-    ? canonicalizeDesktopServerUrl(requestedServerUrl)
-    : null;
+  const serverUrl = requestedServerUrl ? canonicalizeDesktopServerUrl(requestedServerUrl) : null;
   // loadUrl: what the webContents actually loads. A deep-link path resolves
   // under the server URL (mount-aware — see resolveServerPath); an explicit
   // target (New Window) loads that exact URL; otherwise load the server URL.
@@ -2698,7 +2696,7 @@ function drainPendingDeepLinks() {
  * (expandDatabricksWorkspaceUrl) runs ONLY after the user consents to an
  * UNKNOWN server — so clicking (or the OS dispatching) a link to an
  * attacker-chosen host makes no HTTP request until the user has agreed. The
- * probe is safe post-consent because it can only append a path (`/ml/omnigents`)
+ * probe is safe post-consent because it can only append a path (`/omnigent`)
  * under the SAME origin — it never changes the origin the user approved.
  *
  * @param {string} raw The raw `omnigent://...` URL.
@@ -2713,7 +2711,7 @@ async function handleDeepLink(raw) {
   // same origin, so approving the origin is approving the server.
   const targetOrigin = parsed.origin;
   // A KNOWN server: reuse its recorded URL (already mount-bearing, e.g.
-  // `https://host/ml/omnigents`) so we SKIP the probe entirely. null for an
+  // `https://host/omnigent`) so we SKIP the probe entirely. null for an
   // unknown server — the mount is discovered AFTER consent (see consent-unknown).
   const known = findKnownServerUrl(targetOrigin);
 

--- a/web/electron/src/url.js
+++ b/web/electron/src/url.js
@@ -114,6 +114,34 @@
    */
   const WORKSPACE_UI_PATH = "/ml/omnigents";
 
+  /** Internal API mount used by workspace-hosted Omnigent servers. */
+  const WORKSPACE_API_PATH = "/api/2.0/omnigent";
+
+  /**
+   * Convert a workspace API base into the URL that serves the desktop SPA.
+   *
+   * The CLI connects to ``/api/2.0/omnigent``, so that URL is commonly copied
+   * into the desktop setup form. Loading it in Chromium renders the API's JSON
+   * response instead of Omnigent. Match only the exact, reserved API mount;
+   * arbitrary server paths remain untouched.
+   *
+   * @param {string} serverUrl A normalized server URL.
+   * @returns {string} The workspace UI URL, or the input unchanged.
+   */
+  function canonicalizeDesktopServerUrl(serverUrl) {
+    let url;
+    try {
+      url = new URL(serverUrl);
+    } catch {
+      return serverUrl;
+    }
+    if (url.pathname !== WORKSPACE_API_PATH && url.pathname !== `${WORKSPACE_API_PATH}/`) {
+      return serverUrl;
+    }
+    url.pathname = WORKSPACE_UI_PATH;
+    return url.toString();
+  }
+
   /**
    * Databricks Apps are served from ``*.databricksapps.com`` and answer with the
    * same ``server: databricks`` header as a workspace, but they are NOT
@@ -149,6 +177,9 @@
    *   else the input unchanged.
    */
   async function expandDatabricksWorkspaceUrl(normalized) {
+    const canonical = canonicalizeDesktopServerUrl(normalized);
+    if (canonical !== normalized) return canonical;
+
     let url;
     try {
       url = new URL(normalized);
@@ -190,8 +221,10 @@
     defaultSchemeFor,
     normalizeUrl,
     isPlainHttpRemote,
+    WORKSPACE_API_PATH,
     WORKSPACE_UI_PATH,
     WORKSPACE_PROBE_TIMEOUT_MS,
+    canonicalizeDesktopServerUrl,
     expandDatabricksWorkspaceUrl,
   };
 });

--- a/web/electron/src/url.js
+++ b/web/electron/src/url.js
@@ -99,20 +99,10 @@
   }
 
   /**
-   * Path under a Databricks workspace where the Omnigent web UI is mounted. A
-   * bare workspace URL serves the workspace's own web app at the root, so a
-   * user who pastes just the workspace host (e.g.
-   * ``https://<ws>.azuredatabricks.net``) lands on a 404 unless this suffix is
-   * appended.
-   *
-   * NOTE: the Python CLI records the UI mount as ``/omnigent`` in
-   * ``omnigent/conversation_browser.py`` (WORKSPACE_UI_PATH), whereas the
-   * desktop deliberately keeps ``/ml/omnigents`` for now — that is the path the
-   * live workspace serves the embedded SPA on. The two are intentionally
-   * divergent pending reconciliation; do not "fix" this to ``/omnigent``
-   * without verifying what the workspace actually serves to the desktop shell.
+   * Canonical workspace mount for the Omnigent web UI. A bare workspace URL
+   * serves the workspace app at the root, so the desktop appends this path.
    */
-  const WORKSPACE_UI_PATH = "/ml/omnigents";
+  const WORKSPACE_UI_PATH = "/omnigent";
 
   /** Internal API mount used by workspace-hosted Omnigent servers. */
   const WORKSPACE_API_PATH = "/api/2.0/omnigent";
@@ -145,7 +135,7 @@
   /**
    * Databricks Apps are served from ``*.databricksapps.com`` and answer with the
    * same ``server: databricks`` header as a workspace, but they are NOT
-   * workspaces and have no ``/ml/omnigents`` mount. Skip expansion for these
+   * workspaces and have no ``/omnigent`` mount. Skip expansion for these
    * hosts so a user who points the shell at a Databricks App is left on the URL
    * they entered.
    */
@@ -166,7 +156,7 @@
    * hostnames, probe the URL and adopt the mount only when the host answers
    * like a Databricks workspace — a response carrying the ``server: databricks``
    * header. URLs that already carry a path, or aren't https, are returned
-   * untouched WITHOUT a probe, so a user who pastes the full ``…/ml/omnigents``
+   * untouched WITHOUT a probe, so a user who pastes the full ``…/omnigent``
    * URL (or connects to any non-workspace server) is never second-guessed.
    *
    * The CLI appends the API mount because it's an API client; the desktop shell
@@ -193,7 +183,7 @@
       return normalized;
     }
     // Databricks Apps share the workspace ``server: databricks`` header but have
-    // no ``/ml/omnigents`` mount, so never expand them.
+    // no ``/omnigent`` mount, so never expand them.
     const host = url.hostname.toLowerCase();
     if (host === DATABRICKS_APPS_HOST_SUFFIX || host.endsWith(`.${DATABRICKS_APPS_HOST_SUFFIX}`)) {
       return normalized;

--- a/web/electron/test/json-document-theme.test.js
+++ b/web/electron/test/json-document-theme.test.js
@@ -1,0 +1,69 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const vm = require("node:vm");
+
+const {
+  FORCE_LIGHT_JSON_DOCUMENT_SCRIPT,
+  registerLightJsonDocumentTheme,
+} = require("../src/json-document-theme");
+
+function fakeDocument(contentType) {
+  return {
+    contentType,
+    documentElement: { style: {} },
+    body: { style: {} },
+  };
+}
+
+function runThemeScript(contentType) {
+  const document = fakeDocument(contentType);
+  const changed = vm.runInNewContext(FORCE_LIGHT_JSON_DOCUMENT_SCRIPT, { document });
+  return { changed, document };
+}
+
+describe("light JSON document theme", () => {
+  for (const contentType of ["application/json", "text/json", "application/problem+json"]) {
+    it(`forces ${contentType} onto a readable light palette`, () => {
+      const { changed, document } = runThemeScript(contentType);
+
+      assert.equal(changed, true);
+      assert.deepEqual(
+        { ...document.documentElement.style },
+        { colorScheme: "only light", backgroundColor: "#fff", color: "#111" },
+      );
+      assert.deepEqual({ ...document.body.style }, { backgroundColor: "#fff", color: "#111" });
+    });
+  }
+
+  it("leaves normal HTML documents untouched", () => {
+    const { changed, document } = runThemeScript("text/html");
+
+    assert.equal(changed, false);
+    assert.deepEqual({ ...document.documentElement.style }, {});
+    assert.deepEqual({ ...document.body.style }, {});
+  });
+});
+
+describe("registerLightJsonDocumentTheme", () => {
+  it("runs the JSON theme script on every dom-ready event", () => {
+    const listeners = new Map();
+    const executed = [];
+    const webContents = {
+      on: (event, listener) => listeners.set(event, listener),
+      executeJavaScript: (script) => {
+        executed.push(script);
+        return Promise.resolve();
+      },
+    };
+
+    registerLightJsonDocumentTheme(webContents);
+    assert.deepEqual(executed, []);
+
+    listeners.get("dom-ready")();
+    listeners.get("dom-ready")();
+    assert.deepEqual(executed, [
+      FORCE_LIGHT_JSON_DOCUMENT_SCRIPT,
+      FORCE_LIGHT_JSON_DOCUMENT_SCRIPT,
+    ]);
+  });
+});

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -327,3 +327,33 @@ describe("deep-link ingestion wiring (src/main.js)", () => {
     );
   });
 });
+
+describe("workspace API URL canonicalization wiring (src/main.js)", () => {
+  it("canonicalizes saved defaults and recents when settings load", () => {
+    assert.match(
+      liveCode,
+      /settings\.server_url\s*=\s*canonicalizeDesktopServerUrl\(settings\.server_url\)/,
+    );
+    assert.match(
+      liveCode,
+      /settings\.recent_servers[\s\S]{0,400}\.map\(canonicalizeDesktopServerUrl\)/,
+    );
+  });
+
+  it("canonicalizes selected and explicit window destinations before navigation", () => {
+    assert.match(
+      liveCode,
+      /const serverUrl\s*=\s*requestedServerUrl\s*\?\s*canonicalizeDesktopServerUrl\(requestedServerUrl\)\s*:\s*null/,
+    );
+    assert.match(
+      liveCode,
+      /explicit\s*\?\s*canonicalizeDesktopServerUrl\(explicit\)\s*:\s*null/,
+    );
+  });
+});
+
+describe("fallback JSON document theme wiring (src/main.js)", () => {
+  it("registers the light JSON theme on each shell window", () => {
+    assert.match(liveCode, /registerLightJsonDocumentTheme\(win\.webContents\)/);
+  });
+});

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -158,7 +158,7 @@ describe("OAuth popup COOP-strip wiring (src/main.js)", () => {
 });
 
 // Guard for the deep-link path join in createWindow. A basename-less SPA path
-// (/c/<id>) lives UNDER the server's workspace mount (/ml/omnigents), so it
+// (/c/<id>) lives UNDER the server's workspace mount (/omnigent), so it
 // must be string-concatenated (resolveServerPath) — NOT resolved with
 // `new URL(path, serverUrl)`, which would anchor against the ORIGIN and drop
 // the mount, opening the wrong URL for every workspace deep link. This catches
@@ -170,7 +170,7 @@ describe("deep-link path join wiring (src/main.js)", () => {
       /resolveServerPath\(serverUrl, opts\.path\)/,
       [
         "createWindow no longer joins opts.path onto opts.serverUrl via",
-        "resolveServerPath. A deep link to a workspace server (origin + /ml/omnigents",
+        "resolveServerPath. A deep link to a workspace server (origin + /omnigent",
         "mount) would lose the mount and 404. Restore the mount-aware join (see",
         "resolveServerPath); do not replace it with `new URL(path, serverUrl)`.",
       ].join(" "),
@@ -345,10 +345,7 @@ describe("workspace API URL canonicalization wiring (src/main.js)", () => {
       liveCode,
       /const serverUrl\s*=\s*requestedServerUrl\s*\?\s*canonicalizeDesktopServerUrl\(requestedServerUrl\)\s*:\s*null/,
     );
-    assert.match(
-      liveCode,
-      /explicit\s*\?\s*canonicalizeDesktopServerUrl\(explicit\)\s*:\s*null/,
-    );
+    assert.match(liveCode, /explicit\s*\?\s*canonicalizeDesktopServerUrl\(explicit\)\s*:\s*null/);
   });
 });
 

--- a/web/electron/test/omnigent_cli.test.js
+++ b/web/electron/test/omnigent_cli.test.js
@@ -26,7 +26,7 @@ describe("normalizeServerUrl", () => {
   it("strips trailing slashes and trims", () => {
     assert.equal(normalizeServerUrl("https://x.com/"), "https://x.com");
     assert.equal(normalizeServerUrl("  http://localhost:6767//  "), "http://localhost:6767");
-    assert.equal(normalizeServerUrl("https://x.com/ml/omnigents"), "https://x.com/ml/omnigents");
+    assert.equal(normalizeServerUrl("https://x.com/omnigent"), "https://x.com/omnigent");
   });
 
   it("returns empty string for non-strings", () => {

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -110,6 +110,7 @@ function loadMainHarness({
     "./localhost_cors": { registerLocalhostCors: () => {} },
     "./url": {
       normalizeUrl: (url) => url,
+      canonicalizeDesktopServerUrl: (url) => url,
       expandDatabricksWorkspaceUrl: async (url) => url,
     },
     "./workspace-chrome": { registerWorkspaceChromeHide: () => {} },

--- a/web/electron/test/url.test.js
+++ b/web/electron/test/url.test.js
@@ -12,7 +12,6 @@ const {
   isPlainHttpRemote,
   WORKSPACE_API_PATH,
   expandDatabricksWorkspaceUrl,
-  WORKSPACE_UI_PATH,
   canonicalizeDesktopServerUrl,
 } = require("../src/url");
 
@@ -112,7 +111,7 @@ describe("canonicalizeDesktopServerUrl", () => {
   it("maps the workspace API mount to the desktop UI mount", () => {
     assert.equal(
       canonicalizeDesktopServerUrl(`https://ws.cloud.databricks.com${WORKSPACE_API_PATH}`),
-      `https://ws.cloud.databricks.com${WORKSPACE_UI_PATH}`,
+      "https://ws.cloud.databricks.com/omnigent",
     );
   });
 
@@ -121,7 +120,7 @@ describe("canonicalizeDesktopServerUrl", () => {
       canonicalizeDesktopServerUrl(
         `https://ws.cloud.databricks.com${WORKSPACE_API_PATH}/?o=123#section`,
       ),
-      `https://ws.cloud.databricks.com${WORKSPACE_UI_PATH}?o=123#section`,
+      "https://ws.cloud.databricks.com/omnigent?o=123#section",
     );
   });
 
@@ -172,7 +171,7 @@ describe("expandDatabricksWorkspaceUrl", () => {
           await expandDatabricksWorkspaceUrl(
             `https://ws.cloud.databricks.com${WORKSPACE_API_PATH}`,
           ),
-          `https://ws.cloud.databricks.com${WORKSPACE_UI_PATH}`,
+          "https://ws.cloud.databricks.com/omnigent",
         );
       },
     );
@@ -188,7 +187,7 @@ describe("expandDatabricksWorkspaceUrl", () => {
       },
       async () => {
         const out = await expandDatabricksWorkspaceUrl("https://ws.cloud.databricks.com/");
-        assert.equal(out, `https://ws.cloud.databricks.com${WORKSPACE_UI_PATH}`);
+        assert.equal(out, "https://ws.cloud.databricks.com/omnigent");
       },
     );
     // Probed the root with a HEAD request.

--- a/web/electron/test/url.test.js
+++ b/web/electron/test/url.test.js
@@ -10,8 +10,10 @@ const {
   defaultSchemeFor,
   normalizeUrl,
   isPlainHttpRemote,
+  WORKSPACE_API_PATH,
   expandDatabricksWorkspaceUrl,
   WORKSPACE_UI_PATH,
+  canonicalizeDesktopServerUrl,
 } = require("../src/url");
 
 describe("defaultSchemeFor", () => {
@@ -106,6 +108,35 @@ describe("isPlainHttpRemote", () => {
   });
 });
 
+describe("canonicalizeDesktopServerUrl", () => {
+  it("maps the workspace API mount to the desktop UI mount", () => {
+    assert.equal(
+      canonicalizeDesktopServerUrl(`https://ws.cloud.databricks.com${WORKSPACE_API_PATH}`),
+      `https://ws.cloud.databricks.com${WORKSPACE_UI_PATH}`,
+    );
+  });
+
+  it("accepts a trailing slash and preserves the workspace selector", () => {
+    assert.equal(
+      canonicalizeDesktopServerUrl(
+        `https://ws.cloud.databricks.com${WORKSPACE_API_PATH}/?o=123#section`,
+      ),
+      `https://ws.cloud.databricks.com${WORKSPACE_UI_PATH}?o=123#section`,
+    );
+  });
+
+  it("leaves unrelated and nested API paths untouched", () => {
+    for (const url of [
+      "https://ws.cloud.databricks.com/omnigent",
+      `https://ws.cloud.databricks.com${WORKSPACE_API_PATH}/v1/me`,
+      "https://example.com/custom",
+      "not a url",
+    ]) {
+      assert.equal(canonicalizeDesktopServerUrl(url), url);
+    }
+  });
+});
+
 /**
  * Run `fn` with `globalThis.fetch` swapped for `stub` and `AbortSignal.timeout`
  * neutralized (no real timer), restoring both afterward.
@@ -129,6 +160,25 @@ function fakeResponse(serverHeader) {
 }
 
 describe("expandDatabricksWorkspaceUrl", () => {
+  it("maps a pasted workspace API URL without probing it", async () => {
+    let probed = false;
+    await withFetch(
+      async () => {
+        probed = true;
+        return fakeResponse("databricks");
+      },
+      async () => {
+        assert.equal(
+          await expandDatabricksWorkspaceUrl(
+            `https://ws.cloud.databricks.com${WORKSPACE_API_PATH}`,
+          ),
+          `https://ws.cloud.databricks.com${WORKSPACE_UI_PATH}`,
+        );
+      },
+    );
+    assert.equal(probed, false);
+  });
+
   it("expands a bare https Databricks workspace root to the UI mount", async () => {
     const calls = [];
     await withFetch(

--- a/web/electron/test/workspace-chrome.test.js
+++ b/web/electron/test/workspace-chrome.test.js
@@ -22,7 +22,7 @@ describe("applyWorkspaceChromeHideCss", () => {
   it("injects the chrome-hide CSS even when the URL is not under the workspace path", () => {
     const injected = [];
     const webContents = {
-      // A path variant the old guard would have skipped (not /ml/omnigents).
+      // A path variant the old guard would have skipped (not /omnigent).
       getURL: () => "https://dbc-x.cloud.databricks.com/dashboard",
       insertCSS: (css) => {
         injected.push(css);
@@ -37,7 +37,7 @@ describe("applyWorkspaceChromeHideCss", () => {
       [WORKSPACE_CHROME_HIDE_CSS],
       [
         "applyWorkspaceChromeHideCss must inject WORKSPACE_CHROME_HIDE_CSS for ANY loaded",
-        "URL, but it did not fire for a non-/ml/omnigents path. A URL/path guard has likely",
+        "URL, but it did not fire for a non-/omnigent path. A URL/path guard has likely",
         "been reintroduced. That is the original bug: gating injection by path left the",
         "Databricks workspace switcher visible on auth redirects and path variants. Injection",
         "must stay unconditional — the CSS only targets .omnigent-app (workspace-embedded",


### PR DESCRIPTION
## Related issue

N/A — reported directly during desktop connection testing.

## Summary

Entering a workspace API URL such as `/api/2.0/omnigent` could navigate Chromium to the API itself, producing a raw 401 JSON page instead of the Omnigent UI.

- Canonicalize the exact workspace API mount to `/omnigent` before navigating, including saved defaults, recent servers, and explicit new-window destinations.
- Leave unrelated and nested paths unchanged.
- When a server legitimately returns JSON, apply a light palette only to JSON documents so Chromium's fallback remains readable without changing the setup page or SPA theme.

### ELI5

The desktop app now recognizes when someone gives it the backend door and redirects them to the UI door. If a backend response still appears, it is shown as readable dark text on white instead of a black page.

```text
.../api/2.0/omnigent
            |
            v
 exact path canonicalization
            |
            v
       .../omnigent  --> Omnigent UI

 other URL           --> unchanged
 JSON response       --> JSON-only light palette
```

## Test Plan

- `cd web/electron && npm test` — 233 tests passed.
- `.venv/bin/pytest tests/e2e_ui/desktop/test_setup_connect.py tests/e2e_ui/desktop/test_json_document_theme.py -q` — 6 tests passed in Chromium.
- Ran pre-commit checks on all changed files.
- With macOS in Dark appearance, connected to a local endpoint returning `401 application/json`.
- Confirmed the raw JSON fallback has a white background, dark text, and light “Pretty print” controls.
- Confirmed the setup page retains its existing theme.

## Demo

**Before**

![Raw 401 JSON rendered with an unreadable dark background](https://raw.githubusercontent.com/s-sanjay/omnigent/3ad6b1dfc2b82debe1372fa3b95636c24f7f3294/pr-demos/omnigent-black-screen-repro.gif)

**After**

![Raw 401 JSON rendered with a readable light background](https://raw.githubusercontent.com/s-sanjay/omnigent/3ad6b1dfc2b82debe1372fa3b95636c24f7f3294/pr-demos/omnigent-json-fallback-after.gif)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover exact API-mount canonicalization, trailing slashes and workspace selectors, unrelated paths, supported JSON MIME types, HTML documents, and repeated document loads. Playwright exercises the production URL module and exact theme script against a real Chromium-generated `401 application/json` document under dark appearance. Manual verification used a real Electron window and local 401 JSON endpoint under macOS Dark appearance.

## Changelog

Desktop connections no longer open workspace API URLs as an unreadable dark JSON page.
