### PR TITLE
fix(electron): make recent server URLs copyable

### DIFF
--- a/tests/e2e_ui/desktop/test_setup_connect.py
+++ b/tests/e2e_ui/desktop/test_setup_connect.py
@@ -17,6 +17,8 @@ the ``live_server`` omnigent backend.
 
 from __future__ import annotations
 
+import json
+from collections.abc import Sequence
 from pathlib import Path
 
 from playwright.sync_api import Page, expect
@@ -27,16 +29,17 @@ from playwright.sync_api import Page, expect
 _SETUP_PAGE = Path(__file__).resolve().parents[3] / "web" / "electron" / "setup" / "index.html"
 
 # The setup page expects the Electron preload bridge (window.omnigentSetup),
-# which is absent in a plain browser. Stub it: getServerUrl/getRecentServers
-# feed page load, and setServerUrl records the value the page would hand the
-# main process while resolving WITHOUT navigating, so the page stays put for
-# assertions.
+# which is absent in a plain browser. Stub it: reads feed page load, while
+# setServerUrl/copyText record native actions without navigating or touching
+# the system clipboard.
 _PRELOAD_STUB = """
   window.__connectCalls = [];
+  window.__copiedTexts = [];
   window.omnigentSetup = {
     getServerUrl: () => Promise.resolve(""),
-    getRecentServers: () => Promise.resolve([]),
+    getRecentServers: () => Promise.resolve(__RECENT_SERVERS__),
     setServerUrl: (value) => { window.__connectCalls.push(value); return Promise.resolve(); },
+    copyText: (value) => { window.__copiedTexts.push(value); return Promise.resolve(); },
   };
 """
 
@@ -45,12 +48,14 @@ _PRELOAD_STUB = """
 _DEFAULT_PREFILL = "http://localhost:6767"
 
 
-def _open_setup_page(page: Page) -> None:
+def _open_setup_page(page: Page, recent_servers: Sequence[str] = ()) -> None:
     """Load the setup page with the preload bridge stubbed and prefill settled.
 
     :param page: Playwright page fixture.
     """
-    page.add_init_script(_PRELOAD_STUB)
+    page.add_init_script(
+        _PRELOAD_STUB.replace("__RECENT_SERVERS__", json.dumps(list(recent_servers)))
+    )
     page.goto(_SETUP_PAGE.as_uri())
     # getServerUrl() populates the input asynchronously; wait for that so the
     # per-test fill() below overwrites a settled value rather than racing it.
@@ -110,6 +115,27 @@ def test_loopback_connects_over_http_without_warning(page: Page) -> None:
     page.wait_for_function("() => window.__connectCalls.length === 1")
     assert page.evaluate("() => window.__connectCalls") == ["localhost:6767"]
     expect(page.locator("#err")).to_have_text("")
+
+
+def test_recent_server_connect_and_copy_actions_are_independent(page: Page) -> None:
+    """The URL connects immediately, while its clipboard icon only copies."""
+    recent_url = "https://dbc-x.cloud.databricks.com/omnigent?o=12345678901234567890"
+    _open_setup_page(page, [recent_url])
+
+    recent = page.locator(".recent-btn")
+    expect(recent).to_have_text(recent_url)
+    expect(recent).to_have_attribute("title", recent_url)
+
+    page.click(".recent-copy")
+    page.wait_for_function("() => window.__copiedTexts.length === 1")
+    assert page.evaluate("() => window.__copiedTexts") == [recent_url]
+    assert page.evaluate("() => window.__connectCalls") == []
+    expect(page.locator(".recent-copy")).to_have_attribute("title", "Copied")
+    expect(page.locator(".recent-copy")).to_have_attribute("data-copied", "true")
+
+    recent.click()
+    page.wait_for_function("() => window.__connectCalls.length === 1")
+    assert page.evaluate("() => window.__connectCalls") == [recent_url]
 
 
 def test_shared_url_module_defaults_scheme_in_browser(page: Page) -> None:

--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -127,8 +127,14 @@
         font-weight: 500;
         color: var(--muted-foreground);
       }
-      .recent-btn {
+      .recent-row {
+        display: flex;
+        gap: 8px;
         margin-top: 6px;
+      }
+      .recent-btn {
+        flex: 1;
+        min-width: 0;
         padding: 8px 12px;
         text-align: left;
         border: 1px solid var(--border);
@@ -138,7 +144,34 @@
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      .recent-btn:hover {
+      .recent-copy {
+        width: 36px;
+        flex: 0 0 36px;
+        display: grid;
+        place-items: center;
+        padding: 0;
+        border: 1px solid var(--border);
+        background: transparent;
+        color: var(--foreground);
+      }
+      .recent-copy svg {
+        width: 16px;
+        height: 16px;
+        fill: none;
+        stroke: currentColor;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 2;
+      }
+      .recent-copy .copied-icon,
+      .recent-copy[data-copied="true"] .copy-icon {
+        display: none;
+      }
+      .recent-copy[data-copied="true"] .copied-icon {
+        display: block;
+      }
+      .recent-btn:hover,
+      .recent-copy:hover {
         background: color-mix(in srgb, var(--foreground) 5%, transparent);
       }
       .err {
@@ -454,10 +487,9 @@
       }
 
       // Recently-connected servers (persisted by the main process on every
-      // successful non-ephemeral Connect). Clicking one fills the input and
-      // connects immediately; the plain-http warning in connect() still
-      // applies. An empty/unavailable list keeps the section hidden — the
-      // form works without it.
+      // successful non-ephemeral Connect). The URL keeps its one-click Connect
+      // behavior; the adjacent clipboard action copies without navigating.
+      // An empty/unavailable list keeps the section hidden.
       const recentsSection = document.getElementById("recents");
       const recentsList = document.getElementById("recents-list");
       setup
@@ -465,17 +497,53 @@
         .then((recents) => {
           if (!Array.isArray(recents) || recents.length === 0) return;
           for (const url of recents) {
-            const btn = document.createElement("button");
-            btn.type = "button";
-            btn.className = "recent-btn";
-            // textContent, never innerHTML: the URL comes from disk and must
-            // be rendered as inert text.
-            btn.textContent = url;
-            btn.addEventListener("click", () => {
+            const row = document.createElement("div");
+            row.className = "recent-row";
+
+            const serverButton = document.createElement("button");
+            serverButton.type = "button";
+            serverButton.className = "recent-btn";
+            serverButton.textContent = url;
+            serverButton.title = url;
+            serverButton.setAttribute("aria-label", `Connect to recent server ${url}`);
+            serverButton.addEventListener("click", () => {
               input.value = url;
-              connect();
+              void connect();
             });
-            recentsList.appendChild(btn);
+
+            const copyButton = document.createElement("button");
+            copyButton.type = "button";
+            copyButton.className = "recent-copy";
+            copyButton.title = "Copy URL";
+            copyButton.setAttribute("aria-label", `Copy recent server URL ${url}`);
+            copyButton.innerHTML = `
+              <svg class="copy-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <rect width="8" height="4" x="8" y="2" rx="1"></rect>
+                <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
+              </svg>
+              <svg class="copied-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="m5 12 4 4L19 6"></path>
+              </svg>`;
+            copyButton.addEventListener("click", async (event) => {
+              event.stopPropagation();
+              err.textContent = "";
+              try {
+                await setup.copyText(url);
+                copyButton.dataset.copied = "true";
+                copyButton.title = "Copied";
+                copyButton.setAttribute("aria-label", `Copied recent server URL ${url}`);
+                setTimeout(() => {
+                  delete copyButton.dataset.copied;
+                  copyButton.title = "Copy URL";
+                  copyButton.setAttribute("aria-label", `Copy recent server URL ${url}`);
+                }, 1500);
+              } catch {
+                err.textContent = "Could not copy recent server URL.";
+              }
+            });
+
+            row.append(serverButton, copyButton);
+            recentsList.appendChild(row);
           }
           recentsSection.hidden = false;
         })

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -2101,6 +2101,16 @@ function registerIpc() {
     return Array.isArray(recents) ? recents.filter((u) => typeof u === "string") : [];
   });
 
+  ipcMain.handle("omnigent:copy-setup-text", (event, text) => {
+    if (!isSetupPageSender(event)) {
+      throw new Error("copy-setup-text is only available to the setup page");
+    }
+    if (typeof text !== "string") {
+      throw new TypeError("copy-setup-text requires a string");
+    }
+    clipboard.writeText(text);
+  });
+
   // SPA title-bar server picker → the sender window's pinned origin plus the
   // persisted recent-servers list, so the picker can render "current server"
   // and the switch targets. Foreign pages get null (nothing to fingerprint).

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -406,6 +406,8 @@ contextBridge.exposeInMainWorld("omnigentSetup", {
   setServerUrl: (url) => ipcRenderer.invoke("omnigent:set-server-url", url),
   /** Recently-connected server URLs, most recent first. */
   getRecentServers: () => ipcRenderer.invoke("omnigent:get-recent-servers"),
+  /** Copy text from the bundled setup page to the native clipboard. */
+  copyText: (text) => ipcRenderer.invoke("omnigent:copy-setup-text", text),
   /**
    * Whether the `omnigent` CLI is installed/runnable, e.g.
    * `{installed, path, version, source, installCommand}`.

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -21,9 +21,26 @@ const { readFileSync } = require("node:fs");
 const path = require("node:path");
 
 const mainSource = readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
+const preloadSource = readFileSync(path.join(__dirname, "../src/preload.js"), "utf8");
 
 // Strip block comments, then line comments (leaving `://` in URLs intact).
 const liveCode = mainSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+describe("setup clipboard IPC wiring", () => {
+  it("exposes a narrow copy action through the setup bridge", () => {
+    assert.match(
+      preloadSource,
+      /copyText:\s*\(text\)\s*=>\s*ipcRenderer\.invoke\("omnigent:copy-setup-text",\s*text\)/,
+    );
+  });
+
+  it("checks the setup-page sender before writing to the clipboard", () => {
+    assert.match(
+      liveCode,
+      /ipcMain\.handle\("omnigent:copy-setup-text",[\s\S]{0,200}!isSetupPageSender\(event\)[\s\S]{0,300}clipboard\.writeText\(text\)/,
+    );
+  });
+});
 
 describe("workspace chrome injection wiring (src/main.js)", () => {
   it("invokes registerWorkspaceChromeHide(win.webContents) as live code", () => {


### PR DESCRIPTION
## Related issue

N/A — reported directly during desktop setup testing.

## Summary

Recent server URLs remain one-click connection targets, preserving the existing setup flow.

- Clicking a recent URL connects immediately, including the existing plain-HTTP warning.
- A separate clipboard button copies the complete URL without connecting and shows a brief check-mark confirmation.
- Native clipboard access is restricted to the bundled setup page; connected remote pages cannot invoke it.

## Test Plan

- `cd web/electron && npm test` — 223 tests passed across 57 suites.
- `.venv/bin/pytest tests/e2e_ui/desktop/test_setup_connect.py -q` — 5 tests passed in Chromium.
- Ran pre-commit checks on all five changed files.
- Verified the copy action receives the full URL without connecting, and clicking the recent URL connects exactly once.

## Demo

**Separate copy action**

![Recent server row with a separate clipboard action](https://raw.githubusercontent.com/s-sanjay/omnigent/1be16f1c13d97e9398e31f250c1dd5f611155958/pr-demos/omnigent-recent-server-copy.png)

**Copied confirmation**

![Clipboard action showing its copied confirmation](https://raw.githubusercontent.com/s-sanjay/omnigent/1be16f1c13d97e9398e31f250c1dd5f611155958/pr-demos/omnigent-recent-server-copied.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The setup-page E2E test exercises the independent copy and connect paths. Electron source-wiring tests assert that clipboard IPC is exposed narrowly and rejects non-setup senders before writing.

## Changelog

Recent servers remain one-click connectable and now include a separate copy action.
