### PR TITLE
fix(ios): delegate OIDC login to system browser

### DIFF
--- a/tests/e2e_ui/mobile/test_ios_oidc_handoff.py
+++ b/tests/e2e_ui/mobile/test_ios_oidc_handoff.py
@@ -22,16 +22,16 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlencode
 
-import httpx
 import pytest
 import uvicorn
 from fastapi import FastAPI, Request
-from playwright.sync_api import Browser, expect
+from playwright.sync_api import Browser, Playwright, expect
 from starlette.responses import HTMLResponse
 
 from omnigent.server.admin_list import AdminList
 from omnigent.server.auth import UnifiedAuthProvider
 from omnigent.server.oidc import OIDCConfig
+from omnigent.server.routes import auth as auth_routes
 from omnigent.server.routes.auth import create_auth_router
 from tests.e2e_ui.conftest import _find_free_port
 
@@ -135,15 +135,13 @@ def _build_auth_app(base_url: str, admin_list_path: Path) -> FastAPI:
     return app
 
 
-def _wait_for_server(base_url: str, timeout: float = 10.0) -> None:
-    """Wait until the local uvicorn listener accepts HTTP requests."""
+def _wait_for_server(server: uvicorn.Server, base_url: str, timeout: float = 10.0) -> None:
+    """Wait until the local uvicorn server reports that it has started."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        try:
-            httpx.get(base_url, timeout=0.5)
+        if server.started:
             return
-        except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException):
-            time.sleep(0.05)
+        time.sleep(0.05)
     raise RuntimeError(f"OIDC handoff test server did not start at {base_url}")
 
 
@@ -163,12 +161,13 @@ def oidc_handoff_server(tmp_path: Path) -> Iterator[OidcHandoffServer]:
     )
     server_thread = threading.Thread(target=server.run, daemon=True)
 
-    with patch(
-        "omnigent.server.routes.auth.httpx.AsyncClient",
+    with patch.object(
+        auth_routes.httpx,  # type: ignore[attr-defined]
+        "AsyncClient",
         return_value=_mock_idp_client(),
     ):
         server_thread.start()
-        _wait_for_server(base_url)
+        _wait_for_server(server, base_url)
         try:
             yield OidcHandoffServer(base_url=base_url)
         finally:
@@ -181,28 +180,28 @@ def oidc_handoff_server(tmp_path: Path) -> Iterator[OidcHandoffServer]:
 
 def test_system_browser_session_is_bridged_to_isolated_webview(
     browser: Browser,
+    playwright: Playwright,
     oidc_handoff_server: OidcHandoffServer,
 ) -> None:
     """Complete browser OIDC, poll its ticket, and authenticate the WebView."""
     base_url = oidc_handoff_server.base_url
-
-    ticket_response = httpx.post(f"{base_url}/auth/cli-login", timeout=5)
-    ticket_response.raise_for_status()
-    ticket_payload = ticket_response.json()
-    ticket = ticket_payload["ticket"]
-    login_url = f"{base_url}{ticket_payload['login_url']}"
-
-    pending_response = httpx.get(
-        f"{base_url}/auth/cli-poll",
-        params={"ticket": ticket},
-        timeout=5,
-    )
-    assert pending_response.status_code == 202
-    assert pending_response.json() == {"status": "pending"}
-
+    native_request_context = playwright.request.new_context(base_url=base_url)
     system_browser_context = browser.new_context()
     webview_context = browser.new_context()
     try:
+        ticket_response = native_request_context.post("/auth/cli-login")
+        assert ticket_response.ok, ticket_response.text()
+        ticket_payload = ticket_response.json()
+        ticket = ticket_payload["ticket"]
+        login_url = f"{base_url}{ticket_payload['login_url']}"
+
+        pending_response = native_request_context.get(
+            "/auth/cli-poll",
+            params={"ticket": ticket},
+        )
+        assert pending_response.status == 202
+        assert pending_response.json() == {"status": "pending"}
+
         system_browser_page = system_browser_context.new_page()
         system_browser_page.goto(login_url)
         expect(
@@ -213,12 +212,11 @@ def test_system_browser_session_is_bridged_to_isolated_webview(
         expect(system_browser_page.get_by_role("heading", name="Login successful")).to_be_visible()
         expect(system_browser_page.get_by_text(_TEST_EMAIL)).to_be_visible()
 
-        poll_response = httpx.get(
-            f"{base_url}/auth/cli-poll",
+        poll_response = native_request_context.get(
+            "/auth/cli-poll",
             params={"ticket": ticket},
-            timeout=5,
         )
-        poll_response.raise_for_status()
+        assert poll_response.ok, poll_response.text()
         session_token = poll_response.json()["token"]
 
         webview_page = webview_context.new_page()
@@ -234,12 +232,12 @@ def test_system_browser_session_is_bridged_to_isolated_webview(
         expect(webview_page.get_by_role("heading", name="Authenticated WebView")).to_be_visible()
         expect(webview_page.get_by_text(_TEST_EMAIL)).to_be_visible()
 
-        consumed_response = httpx.get(
-            f"{base_url}/auth/cli-poll",
+        consumed_response = native_request_context.get(
+            "/auth/cli-poll",
             params={"ticket": ticket},
-            timeout=5,
         )
-        assert consumed_response.status_code == 410
+        assert consumed_response.status == 410
     finally:
         webview_context.close()
         system_browser_context.close()
+        native_request_context.dispose()

--- a/tests/e2e_ui/mobile/test_ios_oidc_handoff.py
+++ b/tests/e2e_ui/mobile/test_ios_oidc_handoff.py
@@ -1,0 +1,245 @@
+"""E2E coverage for the iOS system-browser OIDC session handoff.
+
+The iOS shell and Safari have isolated cookie stores. The native shell starts
+the production browser-ticket flow, Safari completes OIDC, and the shell polls
+the ticket before installing the returned session JWT in its WebView.
+
+Playwright cannot execute UIKit or ``WKNavigationDelegate`` on Linux CI, so this
+test covers the shared production contract at the browser boundary: real auth
+routes, a browser-driven IdP redirect, a separately polled ticket, and an
+isolated WebView-like context that becomes authenticated only after receiving
+the polled session.
+"""
+
+from __future__ import annotations
+
+import html
+import threading
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import urlencode
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI, Request
+from playwright.sync_api import Browser, expect
+from starlette.responses import HTMLResponse
+
+from omnigent.server.admin_list import AdminList
+from omnigent.server.auth import UnifiedAuthProvider
+from omnigent.server.oidc import OIDCConfig
+from omnigent.server.routes.auth import create_auth_router
+from tests.e2e_ui.conftest import _find_free_port
+
+_COOKIE_SECRET = b"i" * 32
+_IDP_TOKEN_URL = "https://idp.example.test/token"
+_IDP_USERINFO_URL = "https://idp.example.test/user"
+_TEST_EMAIL = "ios-user@example.test"
+
+
+@dataclass(frozen=True)
+class OidcHandoffServer:
+    """A live auth router used by the browser handoff test."""
+
+    base_url: str
+
+
+def _oidc_config(base_url: str) -> OIDCConfig:
+    """Build a GitHub-shaped config whose browser endpoint is intercepted."""
+    return OIDCConfig(
+        issuer="https://idp.example.test",
+        client_id="ios-e2e-client",
+        client_secret="ios-e2e-secret",
+        redirect_uri=f"{base_url}/auth/callback",
+        cookie_secret=_COOKIE_SECRET,
+        scopes="read:user user:email",
+        session_ttl_hours=8,
+        logout_redirect_uri=None,
+        allowed_domains=None,
+        provider_type="github",
+        authorization_endpoint=(
+            f"{base_url.replace('127.0.0.1', 'localhost')}/test-idp/authorize"
+        ),
+        token_endpoint=_IDP_TOKEN_URL,
+        jwks_uri=None,
+        userinfo_endpoint=_IDP_USERINFO_URL,
+        allow_invites=False,
+    )
+
+
+def _mock_idp_client() -> AsyncMock:
+    """Return the async client used by the callback's token and email calls."""
+    token_response = MagicMock()
+    token_response.status_code = 200
+    token_response.json.return_value = {
+        "access_token": "ios-e2e-access-token",
+        "token_type": "bearer",
+    }
+    token_response.text = "token response"
+
+    email_response = MagicMock()
+    email_response.status_code = 200
+    email_response.json.return_value = [{"email": _TEST_EMAIL, "primary": True, "verified": True}]
+
+    client = AsyncMock()
+    client.post.return_value = token_response
+    client.get.return_value = email_response
+
+    context_manager = AsyncMock()
+    context_manager.__aenter__.return_value = client
+    context_manager.__aexit__.return_value = False
+    return context_manager
+
+
+def _build_auth_app(base_url: str, admin_list_path: Path) -> FastAPI:
+    """Build the real OIDC auth router plus one protected browser page."""
+    auth_provider = UnifiedAuthProvider(source="oidc", oidc_config=_oidc_config(base_url))
+    app = FastAPI()
+    app.include_router(
+        create_auth_router(
+            auth_provider=auth_provider,
+            permission_store=None,
+            admin_list=AdminList(admin_list_path),
+        ),
+        prefix="/auth",
+    )
+
+    @app.get("/test-idp/authorize")
+    async def test_idp_authorize(request: Request) -> HTMLResponse:
+        callback_url = request.query_params["redirect_uri"]
+        callback_query = urlencode(
+            {
+                "code": "ios-e2e-authorization-code",
+                "state": request.query_params["state"],
+            }
+        )
+        continue_url = f"{callback_url}?{callback_query}"
+        return HTMLResponse(
+            "<html><body>"
+            "<h1>Test identity provider</h1>"
+            f'<a href="{html.escape(continue_url, quote=True)}">Continue as test user</a>'
+            "</body></html>"
+        )
+
+    @app.get("/")
+    async def protected_page(request: Request) -> HTMLResponse:
+        user_id = auth_provider.get_user_id(request)
+        if user_id is None:
+            return HTMLResponse("<h1>Authentication required</h1>", status_code=401)
+        return HTMLResponse(f"<h1>Authenticated WebView</h1><p>{html.escape(user_id)}</p>")
+
+    return app
+
+
+def _wait_for_server(base_url: str, timeout: float = 10.0) -> None:
+    """Wait until the local uvicorn listener accepts HTTP requests."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            httpx.get(base_url, timeout=0.5)
+            return
+        except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException):
+            time.sleep(0.05)
+    raise RuntimeError(f"OIDC handoff test server did not start at {base_url}")
+
+
+@pytest.fixture
+def oidc_handoff_server(tmp_path: Path) -> Iterator[OidcHandoffServer]:
+    """Serve a deterministic production OIDC router for one browser test."""
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    server = uvicorn.Server(
+        uvicorn.Config(
+            _build_auth_app(base_url, tmp_path / "admins"),
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            access_log=False,
+        )
+    )
+    server_thread = threading.Thread(target=server.run, daemon=True)
+
+    with patch(
+        "omnigent.server.routes.auth.httpx.AsyncClient",
+        return_value=_mock_idp_client(),
+    ):
+        server_thread.start()
+        _wait_for_server(base_url)
+        try:
+            yield OidcHandoffServer(base_url=base_url)
+        finally:
+            server.should_exit = True
+            server_thread.join(timeout=10)
+            if server_thread.is_alive():
+                server.force_exit = True
+                server_thread.join(timeout=5)
+
+
+def test_system_browser_session_is_bridged_to_isolated_webview(
+    browser: Browser,
+    oidc_handoff_server: OidcHandoffServer,
+) -> None:
+    """Complete browser OIDC, poll its ticket, and authenticate the WebView."""
+    base_url = oidc_handoff_server.base_url
+
+    ticket_response = httpx.post(f"{base_url}/auth/cli-login", timeout=5)
+    ticket_response.raise_for_status()
+    ticket_payload = ticket_response.json()
+    ticket = ticket_payload["ticket"]
+    login_url = f"{base_url}{ticket_payload['login_url']}"
+
+    pending_response = httpx.get(
+        f"{base_url}/auth/cli-poll",
+        params={"ticket": ticket},
+        timeout=5,
+    )
+    assert pending_response.status_code == 202
+    assert pending_response.json() == {"status": "pending"}
+
+    system_browser_context = browser.new_context()
+    webview_context = browser.new_context()
+    try:
+        system_browser_page = system_browser_context.new_page()
+        system_browser_page.goto(login_url)
+        expect(
+            system_browser_page.get_by_role("heading", name="Test identity provider")
+        ).to_be_visible()
+
+        system_browser_page.get_by_role("link", name="Continue as test user").click()
+        expect(system_browser_page.get_by_role("heading", name="Login successful")).to_be_visible()
+        expect(system_browser_page.get_by_text(_TEST_EMAIL)).to_be_visible()
+
+        poll_response = httpx.get(
+            f"{base_url}/auth/cli-poll",
+            params={"ticket": ticket},
+            timeout=5,
+        )
+        poll_response.raise_for_status()
+        session_token = poll_response.json()["token"]
+
+        webview_page = webview_context.new_page()
+        unauthenticated_response = webview_page.goto(base_url)
+        assert unauthenticated_response is not None
+        assert unauthenticated_response.status == 401
+        expect(webview_page.get_by_role("heading", name="Authentication required")).to_be_visible()
+
+        webview_context.add_cookies(
+            [{"name": "ap_session", "value": session_token, "url": base_url}]
+        )
+        webview_page.reload()
+        expect(webview_page.get_by_role("heading", name="Authenticated WebView")).to_be_visible()
+        expect(webview_page.get_by_text(_TEST_EMAIL)).to_be_visible()
+
+        consumed_response = httpx.get(
+            f"{base_url}/auth/cli-poll",
+            params={"ticket": ticket},
+            timeout=5,
+        )
+        assert consumed_response.status_code == 410
+    finally:
+        webview_context.close()
+        system_browser_context.close()

--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		B10000000000000000000015 /* ManagedConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000015 /* ManagedConfiguration.swift */; };
 		B10000000000000000000016 /* ManagedConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000016 /* ManagedConfigurationProvider.swift */; };
 		B10000000000000000000017 /* WorkspaceChromeScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000017 /* WorkspaceChromeScript.swift */; };
+		B10000000000000000000018 /* OidcLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000018 /* OidcLoginManager.swift */; };
 		B1000000000000000000000D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000D /* Assets.xcassets */; };
 		B1000000000000000000000E /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000E /* AppIcon.icon */; };
 		B10000000000000000000013 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000013 /* PrivacyInfo.xcprivacy */; };
@@ -37,6 +38,7 @@
 		B20000000000000000000007 /* ManagedConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000007 /* ManagedConfigurationTests.swift */; };
 		B20000000000000000000006 /* MockHTTPServer.swift in Sources (OmnigentTests) */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* MockHTTPServer.swift */; };
 		B40000000000000000000004 /* MockHTTPServer.swift in Sources (OmnigentUITests) */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* MockHTTPServer.swift */; };
+		B20000000000000000000009 /* OidcLoginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000009 /* OidcLoginManagerTests.swift */; };
 		B40000000000000000000001 /* OmnigentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000001 /* OmnigentUITests.swift */; };
 		B40000000000000000000002 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000002 /* SnapshotHelper.swift */; };
 		B40000000000000000000003 /* RedirectConsentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000003 /* RedirectConsentUITests.swift */; };
@@ -84,6 +86,7 @@
 		A1000000000000000000000F /* Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Debug.plist"; sourceTree = "<group>"; };
 		A10000000000000000000010 /* Info-Release.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Release.plist"; sourceTree = "<group>"; };
 		A10000000000000000000013 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		A10000000000000000000018 /* OidcLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcLoginManager.swift; sourceTree = "<group>"; };
 		A20000000000000000000001 /* ServerURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerURLTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000002 /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpanderTests.swift; sourceTree = "<group>"; };
@@ -92,6 +95,7 @@
 		A20000000000000000000007 /* ManagedConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedConfigurationTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000008 /* WorkspaceChromeScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceChromeScriptTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000006 /* MockHTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPServer.swift; sourceTree = "<group>"; };
+		A20000000000000000000009 /* OidcLoginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcLoginManagerTests.swift; sourceTree = "<group>"; };
 		A30000000000000000000003 /* OmnigentUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A40000000000000000000001 /* OmnigentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnigentUITests.swift; sourceTree = "<group>"; };
 		A40000000000000000000002 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
@@ -168,6 +172,7 @@
 				A10000000000000000000012 /* SafariView.swift */,
 				A10000000000000000000015 /* ManagedConfiguration.swift */,
 				A10000000000000000000016 /* ManagedConfigurationProvider.swift */,
+				A10000000000000000000018 /* OidcLoginManager.swift */,
 				A1000000000000000000000D /* Assets.xcassets */,
 				A10000000000000000000013 /* PrivacyInfo.xcprivacy */,
 				A1000000000000000000000F /* Info-Debug.plist */,
@@ -187,6 +192,7 @@
 				A20000000000000000000007 /* ManagedConfigurationTests.swift */,
 				A20000000000000000000008 /* WorkspaceChromeScriptTests.swift */,
 				A20000000000000000000006 /* MockHTTPServer.swift */,
+				A20000000000000000000009 /* OidcLoginManagerTests.swift */,
 			);
 			path = OmnigentTests;
 			sourceTree = "<group>";
@@ -359,6 +365,7 @@
 				B10000000000000000000012 /* SafariView.swift in Sources */,
 				B10000000000000000000015 /* ManagedConfiguration.swift in Sources */,
 				B10000000000000000000016 /* ManagedConfigurationProvider.swift in Sources */,
+				B10000000000000000000018 /* OidcLoginManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -374,6 +381,7 @@
 				B20000000000000000000007 /* ManagedConfigurationTests.swift in Sources */,
 				B20000000000000000000008 /* WorkspaceChromeScriptTests.swift in Sources */,
 				B20000000000000000000006 /* MockHTTPServer.swift in Sources (OmnigentTests) */,
+				B20000000000000000000009 /* OidcLoginManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/web/ios/Omnigent/OidcLoginManager.swift
+++ b/web/ios/Omnigent/OidcLoginManager.swift
@@ -1,0 +1,157 @@
+import Foundation
+import UIKit
+import WebKit
+
+final class OidcLoginManager {
+  @MainActor
+  private var loginTask: Task<Void, Never>?
+
+  @MainActor
+  var isInFlight: Bool { loginTask != nil }
+
+  @MainActor
+  func start(origin: String, cookieStore: WKHTTPCookieStore, onSession: @escaping () -> Void) {
+    guard loginTask == nil, let originURL = URL(string: origin) else { return }
+
+    loginTask = Task { [weak self] in
+      defer { self?.loginTask = nil }
+      do {
+        let ticket = try await Self.requestTicket(origin: originURL)
+        guard await UIApplication.shared.open(ticket.loginURL) else { return }
+        guard let token = try await Self.pollForToken(origin: originURL, ticket: ticket.id)
+        else { return }
+        let cookie = try Self.sessionCookie(origin: originURL, token: token)
+        await cookieStore.setCookie(cookie)
+        guard !Task.isCancelled else { return }
+        onSession()
+      } catch is CancellationError {
+        return
+      } catch {
+        return
+      }
+    }
+  }
+
+  @MainActor
+  func cancel() {
+    loginTask?.cancel()
+    loginTask = nil
+  }
+
+  struct Ticket: Equatable {
+    let id: String
+    let loginURL: URL
+  }
+
+  static func ticket(from data: Data, origin: URL) throws -> Ticket {
+    let response = try JSONDecoder().decode(TicketResponse.self, from: data)
+    guard !response.ticket.isEmpty,
+      response.loginURL.hasPrefix("/"),
+      !response.loginURL.hasPrefix("//"),
+      let loginURL = URL(string: response.loginURL, relativeTo: origin)?.absoluteURL,
+      loginURL.omnigentOrigin == origin.omnigentOrigin
+    else { throw LoginError.invalidResponse }
+    return Ticket(id: response.ticket, loginURL: loginURL)
+  }
+
+  static func token(from data: Data) throws -> String {
+    let response = try JSONDecoder().decode(PollResponse.self, from: data)
+    guard isJWTShaped(response.token) else { throw LoginError.invalidResponse }
+    return response.token
+  }
+
+  static func sessionCookie(origin: URL, token: String) throws -> HTTPCookie {
+    guard origin.host != nil, isJWTShaped(token) else { throw LoginError.invalidResponse }
+    var properties: [HTTPCookiePropertyKey: Any] = [
+      .originURL: origin,
+      .path: "/",
+      .name: origin.scheme?.lowercased() == "https" ? "__Host-ap_session" : "ap_session",
+      .value: token,
+    ]
+    if origin.scheme?.lowercased() == "https" {
+      properties[.secure] = "TRUE"
+    }
+    guard let cookie = HTTPCookie(properties: properties) else { throw LoginError.invalidResponse }
+    return cookie
+  }
+
+  private static func requestTicket(origin: URL) async throws -> Ticket {
+    var request = URLRequest(url: endpoint("/auth/cli-login", origin: origin))
+    request.httpMethod = "POST"
+    request.httpBody = Data()
+    request.timeoutInterval = requestTimeout
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+      throw LoginError.invalidResponse
+    }
+    return try ticket(from: data, origin: origin)
+  }
+
+  private static func pollForToken(origin: URL, ticket: String) async throws -> String? {
+    let clock = ContinuousClock()
+    let deadline = clock.now + pollTimeout
+    while clock.now < deadline {
+      try await Task.sleep(for: pollInterval)
+      var components = URLComponents(
+        url: endpoint("/auth/cli-poll", origin: origin), resolvingAgainstBaseURL: false)
+      components?.queryItems = [URLQueryItem(name: "ticket", value: ticket)]
+      guard let url = components?.url else { throw LoginError.invalidResponse }
+      var request = URLRequest(url: url)
+      request.timeoutInterval = requestTimeout
+      do {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        switch (response as? HTTPURLResponse)?.statusCode {
+        case 200:
+          return try token(from: data)
+        case 202:
+          continue
+        case 410:
+          return nil
+        default:
+          continue
+        }
+      } catch is CancellationError {
+        throw CancellationError()
+      } catch {
+        continue
+      }
+    }
+    return nil
+  }
+
+  private static func endpoint(_ path: String, origin: URL) -> URL {
+    URL(string: path, relativeTo: origin)!.absoluteURL
+  }
+
+  private static func isJWTShaped(_ value: String) -> Bool {
+    let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3 else { return false }
+    let allowed = CharacterSet(
+      charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+    return parts.allSatisfy {
+      !$0.isEmpty && $0.unicodeScalars.allSatisfy(allowed.contains)
+    }
+  }
+
+  private struct TicketResponse: Decodable {
+    let ticket: String
+    let loginURL: String
+
+    enum CodingKeys: String, CodingKey {
+      case ticket
+      case loginURL = "login_url"
+    }
+  }
+
+  private struct PollResponse: Decodable {
+    let token: String
+  }
+
+  private enum LoginError: Error {
+    case invalidResponse
+  }
+
+  private static let pollInterval = Duration.seconds(2)
+  private static let pollTimeout = Duration.seconds(300)
+  private static let requestTimeout: TimeInterval = 10
+}

--- a/web/ios/Omnigent/OmnigentWebView.swift
+++ b/web/ios/Omnigent/OmnigentWebView.swift
@@ -307,6 +307,7 @@ struct OmnigentWebView: UIViewRepresentable {
     private var rootBounces = 0
     private static let maxRootBounces = 1
     private var urlObservation: NSKeyValueObservation?
+    private let oidcLoginManager = OidcLoginManager()
 
     init(_ parent: OmnigentWebView) {
       self.parent = parent
@@ -329,6 +330,7 @@ struct OmnigentWebView: UIViewRepresentable {
     func detach() {
       parent.model.cancelServerSwitcherWatchdog()
       urlObservation = nil
+      oidcLoginManager.cancel()
       webView = nil
     }
 
@@ -461,6 +463,14 @@ struct OmnigentWebView: UIViewRepresentable {
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+      if let url = webView.url,
+        ["http", "https"].contains(url.scheme?.lowercased() ?? ""),
+        url.omnigentOrigin != pinnedOrigin
+      {
+        webView.stopLoading()
+        startLogin(in: webView)
+        return
+      }
       parent.model.isLoading = true
       parent.model.currentURL = webView.url ?? parent.model.currentURL
       parent.model.serverSwitcherHidden = true
@@ -544,6 +554,19 @@ struct OmnigentWebView: UIViewRepresentable {
         return
       }
 
+      if navigationAction.targetFrame?.isMainFrame == true,
+        ["http", "https"].contains(scheme),
+        url.omnigentOrigin != pinnedOrigin
+      {
+        if navigationAction.navigationType == .linkActivated {
+          openExternal(url)
+        } else {
+          startLogin(in: webView)
+        }
+        decisionHandler(.cancel)
+        return
+      }
+
       if ["http", "https", "about", "blob", "data"].contains(scheme) {
         decisionHandler(.allow)
         return
@@ -611,6 +634,17 @@ struct OmnigentWebView: UIViewRepresentable {
         return
       }
       promptForExternalURL(url, scheme: scheme)
+    }
+
+    private func startLogin(in webView: WKWebView) {
+      guard let pinnedOrigin else { return }
+      oidcLoginManager.start(
+        origin: pinnedOrigin,
+        cookieStore: webView.configuration.websiteDataStore.httpCookieStore
+      ) { [weak self, weak webView] in
+        guard let self, let webView, let pinnedURL = self.pinnedURL else { return }
+        webView.load(URLRequest(url: pinnedURL))
+      }
     }
 
     private func promptForExternalURL(_ url: URL, scheme: String) {

--- a/web/ios/OmnigentTests/OidcLoginManagerTests.swift
+++ b/web/ios/OmnigentTests/OidcLoginManagerTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+
+@testable import Omnigent
+
+final class OidcLoginManagerTests: XCTestCase {
+  func testTicketAcceptsRootedSameOriginLoginPath() throws {
+    let origin = try XCTUnwrap(URL(string: "https://example.com"))
+    let data = try XCTUnwrap(
+      #"{"ticket":"abc","login_url":"/auth/login?ticket=abc"}"#.data(using: .utf8))
+
+    let ticket = try OidcLoginManager.ticket(from: data, origin: origin)
+
+    XCTAssertEqual(ticket.id, "abc")
+    XCTAssertEqual(ticket.loginURL.absoluteString, "https://example.com/auth/login?ticket=abc")
+  }
+
+  func testTicketRejectsAbsoluteAndSchemeRelativeLoginURLs() throws {
+    let origin = try XCTUnwrap(URL(string: "https://example.com"))
+    for loginURL in ["https://evil.example/auth", "//evil.example/auth", "auth/login"] {
+      let data = try XCTUnwrap(
+        #"{"ticket":"abc","login_url":"\#(loginURL)"}"#.data(using: .utf8))
+      XCTAssertThrowsError(try OidcLoginManager.ticket(from: data, origin: origin))
+    }
+  }
+
+  func testTokenRejectsCookieInjectionCharacters() throws {
+    let valid = try XCTUnwrap(#"{"token":"aaa.bbb.ccc"}"#.data(using: .utf8))
+    XCTAssertEqual(try OidcLoginManager.token(from: valid), "aaa.bbb.ccc")
+
+    for token in ["aaa.bbb.ccc; Domain=evil.example", "aaa.bbb", "aaa..ccc"] {
+      let data = try XCTUnwrap(#"{"token":"\#(token)"}"#.data(using: .utf8))
+      XCTAssertThrowsError(try OidcLoginManager.token(from: data))
+    }
+  }
+
+  func testHTTPSCookieUsesHostPrefixAndSecureFlag() throws {
+    let origin = try XCTUnwrap(URL(string: "https://example.com"))
+    let cookie = try OidcLoginManager.sessionCookie(origin: origin, token: "aaa.bbb.ccc")
+
+    XCTAssertEqual(cookie.name, "__Host-ap_session")
+    XCTAssertEqual(cookie.domain, "example.com")
+    XCTAssertEqual(cookie.path, "/")
+    XCTAssertTrue(cookie.isSecure)
+  }
+
+  func testDebugHTTPCookieUsesUnprefixedName() throws {
+    let origin = try XCTUnwrap(URL(string: "http://localhost:6767"))
+    let cookie = try OidcLoginManager.sessionCookie(origin: origin, token: "aaa.bbb.ccc")
+
+    XCTAssertEqual(cookie.name, "ap_session")
+    XCTAssertFalse(cookie.isSecure)
+  }
+}

--- a/web/ios/README.md
+++ b/web/ios/README.md
@@ -16,8 +16,10 @@ Security defaults and require remote servers to use `https://`.
 
 The first version provides native setup chrome, recent servers, WKWebView
 loading, foreground local notifications, app badge updates, and notification
-tap routing back into the SPA. It does not implement APNs, background polling,
-or localhost proxy/CORS behavior.
+tap routing back into the SPA. OIDC authentication is delegated to the system
+browser and the resulting session is copied into the isolated WKWebView cookie
+store, so providers such as Google that reject embedded user agents work. It
+does not implement APNs, background polling, or localhost proxy/CORS behavior.
 
 ## Managed app configuration
 


### PR DESCRIPTION
## Related issue

Closes #2549. Follow-up to #1708 (iOS parity).

## Summary

Google does not allow users to sign in inside the app's embedded browser. The app now sends sign-in to Safari, waits for Omnigent to confirm it, and then transfers only the resulting Omnigent session back into the app.

- Detect non-user-initiated OIDC redirects away from the configured Omnigent server before they load in the embedded WebView.
- Complete authentication in system Safari through the existing `/auth/cli-login` ticket flow, then validate the returned session, install the appropriate WebView cookie, and reload the server.
- Preserve normal handling for user-initiated external links and keep the native bridge restricted to the configured origin.

```text
WKWebView -> /auth/cli-login -> Safari -> OIDC/Google
   ^                                  |
   |        session JWT <- poll <-----+
   +------ cookie + reload -----------+
```

## Test Plan

- `xcodebuild test -project web/ios/Omnigent.xcodeproj -scheme Omnigent -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -derivedDataPath /tmp/omnigent-ios-delegate-login-browser-ios26-fix-derived-data -only-testing:OmnigentTests` → 16 tests passed.
- `uv run --extra all --extra dev pytest tests/e2e_ui/mobile/test_ios_oidc_handoff.py -q` → 1 passed.
- `uv run --extra dev pre-commit run --files web/ios/Omnigent.xcodeproj/project.pbxproj web/ios/Omnigent/OmnigentWebView.swift web/ios/Omnigent/OidcLoginManager.swift web/ios/OmnigentTests/OidcLoginManagerTests.swift web/ios/README.md` → all checks passed.

New tests cover valid same-origin login paths, rejection of absolute and scheme-relative login URLs, JWT and cookie-injection validation, and secure HTTPS versus local debug HTTP cookie construction.

Manual iPhone 17 Pro simulator verification on iOS 26.5 against the Google OAuth-protected server → `main` reproduces the embedded-browser failure; this branch opens Safari, completes authentication, and reloads the app with the authenticated session. Demo videos found below.

## Demo

**Before (main):**

https://github.com/user-attachments/assets/a6d3fc5d-0d92-44b4-b55d-c6f2025b05e5

**After (fix/ios-delegate-login-browser):**

https://github.com/user-attachments/assets/7fe3b68b-0792-4436-8579-87f893062af3

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover login URL validation, JWT-shape validation, cookie-injection rejection, and HTTPS/debug cookie construction. Native Safari handoff and authenticated WebView reload are shown in the recorded manual verification above.

## Changelog

Sign in to Google-backed Omnigent servers from the iOS app without hitting `disallowed_useragent`
