### PR TITLE
Add Nord appearance theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ generated at release time from each PR's `## Changelog` section, tagged by the
 PR's `Type of change` (e.g. `[UI]`); the concise, curated highlights live on the
 website under `/releases`.
 
+## [Unreleased]
+
+### Features
+
+- [UI / Feature] Added a Nord color theme (arctic frost-blue palette) to the Appearance settings palette picker.
+
 ## [v0.5.0] — 2026-07-10
 
 - [Bug fix] Messaging a long-idle session no longer risks the new turn being killed mid-flight by the idle reaper (#1834)

--- a/tests/e2e_ui/sessions/test_color_theme.py
+++ b/tests/e2e_ui/sessions/test_color_theme.py
@@ -3,7 +3,7 @@
 Alongside the light/dark **mode** tiles, ``AppearanceSection``
 (``pages/SettingsPage.tsx``) renders a "Color theme" dropdown (a shadcn
 ``Select``) — one option per palette (Omnigent, Dracula, GitHub, Catppuccin,
-Gruvbox). Choosing one calls ``applyThemePalette`` (``lib/themePalette.ts``),
+Gruvbox, Nord). Choosing one calls ``applyThemePalette`` (``lib/themePalette.ts``),
 which sets ``data-theme`` on ``<html>`` and persists the id to
 ``localStorage["omnigent:ui-theme-palette"]``. The default "Omnigent" palette
 carries no override, so choosing it removes the attribute and clears the key.

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1808,7 +1808,7 @@
   --muted: #d8dee9;
   --muted-foreground: #4c566a;
   --code-bg: #d8dee9;
-  --accent: #d8dee9;
+  --accent: #e5e9f0;
   --accent-foreground: #5e81ac;
   --border: #d8dee9;
   --border-strong: #81a1c1;
@@ -1840,7 +1840,7 @@
   --secondary-foreground: #eceff4;
   --muted: #434c5e;
   --muted-foreground: #d8dee9;
-  --code-bg: #2e3440;
+  --code-bg: #3b4252;
   --accent: #434c5e;
   --accent-foreground: #88c0d0;
   --border: #4c566a;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1790,3 +1790,80 @@
     radial-gradient(ellipse at 80% 20%, rgba(255, 121, 198, 0.1) 0%, transparent 45%),
     linear-gradient(160deg, #2a2c3a 0%, #282a36 55%, #21222c 100%);
 }
+
+/* ── Nord — arctic frost blues, polar-night neutrals ──────────────────────── */
+:root:not(.dark)[data-theme="nord"] {
+  --background: #eceff4;
+  --foreground: #2e3440;
+  --card: #e5e9f0;
+  --card-solid: #e5e9f0;
+  --card-foreground: #2e3440;
+  --tray: #e5e9f0;
+  --popover: #e5e9f0;
+  --popover-foreground: #2e3440;
+  --primary: #5e81ac;
+  --primary-foreground: #eceff4;
+  --secondary: #d8dee9;
+  --secondary-foreground: #2e3440;
+  --muted: #d8dee9;
+  --muted-foreground: #4c566a;
+  --code-bg: #d8dee9;
+  --accent: #d8dee9;
+  --accent-foreground: #5e81ac;
+  --border: #d8dee9;
+  --border-strong: #81a1c1;
+  --button-border: #d8dee9;
+  --input: #d8dee9;
+  --ring: #5e81ac;
+  --brand-accent: #5e81ac;
+  --sidebar: #e5e9f0;
+  --sidebar-foreground: #2e3440;
+  --sidebar-primary: #5e81ac;
+  --sidebar-primary-foreground: #eceff4;
+  --sidebar-accent: #d8dee9;
+  --sidebar-accent-foreground: #5e81ac;
+  --sidebar-border: #d8dee9;
+  --sidebar-ring: #5e81ac;
+}
+.dark[data-theme="nord"] {
+  --background: #2e3440;
+  --foreground: #eceff4;
+  --card: rgba(59, 66, 82, 0.6);
+  --card-solid: #3b4252;
+  --card-foreground: #eceff4;
+  --tray: rgba(59, 66, 82, 0.6);
+  --popover: rgba(46, 52, 64, 0.92);
+  --popover-foreground: #eceff4;
+  --primary: #88c0d0;
+  --primary-foreground: #2e3440;
+  --secondary: #3b4252;
+  --secondary-foreground: #eceff4;
+  --muted: #434c5e;
+  --muted-foreground: #d8dee9;
+  --code-bg: #2e3440;
+  --accent: #434c5e;
+  --accent-foreground: #88c0d0;
+  --border: #4c566a;
+  --border-strong: #81a1c1;
+  --button-border: #4c566a;
+  --input: #4c566a;
+  --ring: #88c0d0;
+  --brand-accent: #88c0d0;
+  --sidebar: rgba(46, 52, 64, 0.8);
+  --sidebar-foreground: #eceff4;
+  --sidebar-primary: #88c0d0;
+  --sidebar-primary-foreground: #2e3440;
+  --sidebar-accent: #434c5e;
+  --sidebar-accent-foreground: #88c0d0;
+  --sidebar-border: #4c566a;
+  --sidebar-ring: #88c0d0;
+}
+:root:not(.dark)[data-theme="nord"] .app-shell {
+  background: linear-gradient(160deg, #eceff4 0%, #e5e9f0 55%, #d8dee9 100%);
+}
+.dark[data-theme="nord"] .app-shell {
+  background:
+    radial-gradient(ellipse at 20% 30%, rgba(136, 192, 208, 0.12) 0%, transparent 55%),
+    radial-gradient(ellipse at 80% 20%, rgba(94, 129, 172, 0.08) 0%, transparent 45%),
+    linear-gradient(160deg, #434c5e 0%, #2e3440 60%, #2e3440 100%);
+}

--- a/web/src/lib/themePalette.test.ts
+++ b/web/src/lib/themePalette.test.ts
@@ -51,6 +51,7 @@ describe("themePalette", () => {
   it("guards known vs unknown palette ids", () => {
     expect(isThemePalette("github")).toBe(true);
     expect(isThemePalette("omni")).toBe(true);
+    expect(isThemePalette("nord")).toBe(true);
     expect(isThemePalette("nope")).toBe(false);
     expect(isThemePalette(undefined)).toBe(false);
     expect(isThemePalette(42)).toBe(false);

--- a/web/src/lib/themePalette.ts
+++ b/web/src/lib/themePalette.ts
@@ -22,7 +22,14 @@
 const STORAGE_KEY = "omnigent:ui-theme-palette";
 
 /** Selectable color palettes. The first entry is the default (brand) look. */
-export const themePalettes = ["omni", "dracula", "github", "catppuccin", "gruvbox"] as const;
+export const themePalettes = [
+  "omni",
+  "dracula",
+  "github",
+  "catppuccin",
+  "gruvbox",
+  "nord",
+] as const;
 
 export type ThemePalette = (typeof themePalettes)[number];
 
@@ -123,6 +130,19 @@ export const PALETTES: readonly PaletteMeta[] = [
       text: "#3c3836",
     },
     dark: { bg: "#282828", card: "#3c3836", accent: "#fe8019", border: "#504945", text: "#ebdbb2" },
+  },
+  {
+    id: "nord",
+    label: "Nord",
+    blurb: "Arctic frost blues over polar-night neutrals.",
+    light: {
+      bg: "#eceff4",
+      card: "#e5e9f0",
+      accent: "#5e81ac",
+      border: "#d8dee9",
+      text: "#2e3440",
+    },
+    dark: { bg: "#2e3440", card: "#3b4252", accent: "#88c0d0", border: "#4c566a", text: "#eceff4" },
   },
 ] as const;
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Added a Nord color theme using the arctic frost-blue Nord palette to the Appearance color-theme picker.
- Added matching light and dark CSS token blocks plus app-shell gradients so Nord composes with the existing light/dark mode axis.
- Updated palette metadata/test coverage, the E2E color-theme prose list, and the changelog entry.

## Test Plan

- `cd web && npm run type-check` — passed.
- `cd web && npm test` — passed (`226` files, `3998` tests).
- `.venv/bin/pre-commit run --all-files` — passed.
- `cd web && npm run lint -- --quiet` — failed on pre-existing, unrelated lint baseline errors in untouched files (`src/components/blocks/TerminalSession.test.ts`, `src/hooks/useRecentWorkspaces.ts`, `src/lib/lastAssistantText.ts`, `src/shell/AppShell.tsx`, `src/shell/CommentsPanel.tsx`, `src/lib/agentBundle.test.ts`). These are out of scope for this theme-only change.

## Demo

Nord light mode:

![Nord light mode Appearance settings](https://gist.githubusercontent.com/SabhyaC26/16c1e0cb0a6cbbcaff22bb100f42553e/raw/nord-light.svg)

Nord dark mode:

![Nord dark mode Appearance settings](https://gist.githubusercontent.com/SabhyaC26/16c1e0cb0a6cbbcaff22bb100f42553e/raw/nord-dark.svg)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Updated `themePalette.test.ts` to include the new `nord` palette id in the supported-palette guard. Manually verified the Nord palette applies in both light and dark modes by launching the web dev server, preloading `localStorage["omnigent:ui-theme-palette"] = "nord"`, and capturing the Appearance settings page with headless Chrome.

## Changelog

- [UI / Feature] Added a Nord color theme (arctic frost-blue palette) to the Appearance settings palette picker.
