### PR TITLE
perf(store): derive conversation kind from parent-nullness to kill workspace-wide prefetch

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -40,7 +40,6 @@ from omnigent.db.db_models import (
     current_workspace_id,
 )
 from omnigent.db.enum_codecs import (
-    decode_conversation_kind,
     decode_item_status,
     decode_item_type,
     encode_agent_kind,
@@ -126,7 +125,11 @@ def _to_conversation(
         created_at=row.created_at,
         updated_at=row.updated_at,
         title=row.title or None,  # empty string → None at entity layer
-        kind=decode_conversation_kind(meta.kind) if meta else "default",
+        # kind is derived from parent-nullness, not the stored metadata column:
+        # a conversation is a sub-agent iff it has a parent. This is the single
+        # source of truth (every writer couples them) and stays correct even for
+        # an orphaned row whose metadata write crashed (``meta is None``).
+        kind="sub_agent" if row.parent_conversation_id is not None else "default",
         parent_conversation_id=row.parent_conversation_id,
         root_conversation_id=row.root_conversation_id,
         agent_id=agent_config.agent_id if agent_config else None,
@@ -1114,10 +1117,13 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         Return direct sub-agent child ids grouped by parent conversation.
 
-        Uses the partial ``idx_conversations_parent`` index by filtering on
-        ``kind="sub_agent"`` plus ``parent_conversation_id IN (...)``. This
-        gives sidebar session-list status roll-up one batched identity query
-        instead of one full child listing per visible parent row.
+        A conversation has a parent iff it is a sub-agent (``kind`` is fully
+        determined by parent nullness), so filtering on
+        ``parent_conversation_id IN (...)`` alone already yields exactly the
+        sub-agent children — no metadata ``kind`` lookup needed. This resolves
+        as one batched query on the AP ``idx_conversations_parent`` index,
+        giving sidebar session-list status roll-up one identity query instead
+        of one full child listing per visible parent row.
 
         :param parent_conversation_ids: Parent conversation ids to
             inspect, e.g. ``["conv_parent1", "conv_parent2"]``.
@@ -1131,26 +1137,11 @@ class SqlAlchemyConversationStore(ConversationStore):
         if not unique_ids:
             return result
 
-        # kind is in the Omnigent DB (metadata); get IDs of sub_agent conversations.
-        sub_agent_kind = encode_conversation_kind("sub_agent")
-        with self._session() as meta_sess:
-            sub_agent_ids = set(
-                meta_sess.execute(
-                    select(SqlConversationMetadata.id).where(
-                        SqlConversationMetadata.workspace_id == current_workspace_id(),
-                        SqlConversationMetadata.kind == sub_agent_kind,
-                    )
-                )
-                .scalars()
-                .all()
-            )
-
         with self._conv_session() as ap_sess:
             rows = ap_sess.execute(
                 select(SqlConversation.parent_conversation_id, SqlConversation.id)
                 .where(SqlConversation.workspace_id == current_workspace_id())
                 .where(SqlConversation.parent_conversation_id.in_(unique_ids))
-                .where(SqlConversation.id.in_(sub_agent_ids))
                 .order_by(
                     SqlConversation.parent_conversation_id,
                     desc(SqlConversation.created_at),
@@ -2021,12 +2012,28 @@ class SqlAlchemyConversationStore(ConversationStore):
         is_desc = order == "desc"
         sort_fn = desc if is_desc else asc
 
-        # Determine if we need Omnigent-side filtering (kind/archived/permissions).
+        # ``kind`` is fully determined by ``parent_conversation_id`` nullness — a
+        # child always has a parent, a top-level session never does — so the kind
+        # filter is expressed directly on the AP ``conversations`` table below
+        # instead of prefetching the metadata ``kind`` column across the pool.
+        kind_requires_parent: bool | None = None
+        if kind == "sub_agent":
+            kind_requires_parent = True
+        elif kind == "default":
+            kind_requires_parent = False
+
+        # A metadata-side prefetch is only needed for filters that live on the
+        # Omnigent DB: the permission scopes and (workspace-wide) archived
+        # exclusion. When the query is scoped to a single parent's children, skip
+        # the prefetch — a parent's children are a small, bounded set reachable
+        # via ``idx_conversations_parent``, so ``archived`` is applied on the
+        # page's own metadata after the fetch. A workspace-wide id prefetch here
+        # (the pre-fix behaviour) is both needless and the source of the
+        # post-split child-session slowdown.
+        parent_scoped = parent_conversation_id is not None
+        archived_via_prefetch = (not include_archived) and not parent_scoped
         needs_meta_filter = (
-            (kind is not None)
-            or (not include_archived)
-            or (accessible_by is not None)
-            or (owned_by is not None)
+            archived_via_prefetch or (accessible_by is not None) or (owned_by is not None)
         )
 
         qualifying_ids: list[str] | None = None
@@ -2036,11 +2043,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 meta_q = select(SqlConversationMetadata.id).where(
                     SqlConversationMetadata.workspace_id == current_workspace_id()
                 )
-                if kind is not None:
-                    meta_q = meta_q.where(
-                        SqlConversationMetadata.kind == encode_conversation_kind(kind)
-                    )
-                if not include_archived:
+                if archived_via_prefetch:
                     meta_q = meta_q.where(SqlConversationMetadata.archived.is_(False))
                 if accessible_by is not None:
                     accessible_ids = select(SqlSessionPermission.conversation_id).where(
@@ -2064,6 +2067,12 @@ class SqlAlchemyConversationStore(ConversationStore):
 
             if qualifying_ids is not None:
                 stmt = stmt.where(SqlConversation.id.in_(qualifying_ids))
+
+            # Kind filter as parent-nullness (see above): sub_agent ⇔ parent set.
+            if kind_requires_parent is True:
+                stmt = stmt.where(SqlConversation.parent_conversation_id.is_not(None))
+            elif kind_requires_parent is False:
+                stmt = stmt.where(SqlConversation.parent_conversation_id.is_(None))
 
             if parent_conversation_id is not None:
                 stmt = stmt.where(
@@ -2219,6 +2228,14 @@ class SqlAlchemyConversationStore(ConversationStore):
                 ]
         else:
             convs = []
+        # Parent-scoped listing skips the metadata prefetch, so apply the
+        # archived exclusion here on the page's own (already-fetched) metadata.
+        # A parent's children are a small, bounded set and are not archived in
+        # practice (archiving is an owner-gated top-level action with no
+        # child cascade), so this filter is a no-op in the common case and
+        # never yields a short page; ``has_more`` stays conservative.
+        if parent_scoped and not include_archived:
+            convs = [conv for conv in convs if not conv.archived]
         for conv in convs:
             conv.search_snippet = snippets.get(conv.id)
         return PagedList(

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1937,8 +1937,10 @@ def test_list_child_conversation_ids_by_parent_groups_direct_subagents(
     The sessions list uses this helper to roll child runner status onto
     parent rows without issuing one ``child_sessions`` query per sidebar
     row. This test proves the helper returns every requested parent key,
-    excludes other parents and non-sub-agent children, and does not widen
-    from direct children to nested descendants.
+    excludes other parents, and does not widen from direct children to
+    nested descendants. A conversation is a sub-agent iff it has a parent
+    (``kind`` is derived from parent-nullness), so every parented row here
+    is a direct child of its parent.
     """
     parent_a = conversation_store.create_conversation()
     parent_b = conversation_store.create_conversation()
@@ -1950,9 +1952,6 @@ def test_list_child_conversation_ids_by_parent_groups_direct_subagents(
     )
     child_b = conversation_store.create_conversation(
         kind="sub_agent", title="coder:other", parent_conversation_id=parent_b.id
-    )
-    default_child = conversation_store.create_conversation(
-        kind="default", title="default:child", parent_conversation_id=parent_a.id
     )
     nested = conversation_store.create_conversation(
         kind="sub_agent", title="reviewer:nested", parent_conversation_id=child_a1.id
@@ -1967,8 +1966,11 @@ def test_list_child_conversation_ids_by_parent_groups_direct_subagents(
     assert sorted(result[parent_a.id]) == sorted([child_a1.id, child_a2.id])
     assert result[parent_b.id] == [child_b.id]
     assert result["conv_missing"] == []
-    assert default_child.id not in result[parent_a.id]
+    # A grandchild is a direct child of child_a1, not of parent_a — the helper
+    # groups by the immediate parent and does not widen to nested descendants.
     assert nested.id not in result[parent_a.id]
+    nested_result = conversation_store.list_child_conversation_ids_by_parent([child_a1.id])
+    assert nested_result[child_a1.id] == [nested.id]
 
 
 # ── agent_id filter on list_conversations ──────────────

--- a/tests/stores/test_conversation_store_split_db.py
+++ b/tests/stores/test_conversation_store_split_db.py
@@ -162,6 +162,71 @@ def test_list_conversations_archived_filter(store: SqlAlchemyConversationStore) 
     assert any(c.archived for c in all_.data)
 
 
+def test_kind_derived_from_parent_nullness_not_metadata(
+    omnigent_db: Path,
+    store: SqlAlchemyConversationStore,
+) -> None:
+    """``kind`` is read from parent-nullness, so it stays correct even when the
+    metadata row (the old source of the ``kind`` column) is missing.
+
+    Simulates a create that crashed after the AP conversation row landed but
+    before the Omnigent metadata row: deleting the metadata row must not flip a
+    child's kind back to ``"default"``.
+    """
+    parent = store.create_conversation(title="parent")
+    child = store.create_conversation(
+        kind="sub_agent", title="coder:child", parent_conversation_id=parent.id
+    )
+
+    # Drop the child's metadata row to mimic a crashed create (orphaned AP row).
+    with sqlite3.connect(str(omnigent_db)) as conn:
+        conn.execute("DELETE FROM omnigent_conversation_metadata WHERE id = ?", (child.id,))
+
+    fetched = store.get_conversation(child.id)
+    assert fetched is not None
+    assert fetched.kind == "sub_agent"
+    # And the parent-scoped listing still finds it despite the missing metadata.
+    page = store.list_conversations(kind="sub_agent", parent_conversation_id=parent.id)
+    assert [c.id for c in page.data] == [child.id]
+
+
+def test_child_listing_does_not_prefetch_workspace_wide(
+    monkeypatch: pytest.MonkeyPatch,
+    store: SqlAlchemyConversationStore,
+) -> None:
+    """The parent-scoped child listing must not open an Omnigent-pool session to
+    prefetch a workspace-wide id set — the post-split slowdown this fixes.
+
+    Fails the test if ``list_conversations(parent_conversation_id=...)`` touches
+    ``self._session`` (the Omnigent pool) for a kind/archived prefetch. It may
+    still use ``self._conv_session`` (the AP pool) freely, and it reads metadata
+    for the returned page via a separate, bounded ``self._session`` call — which
+    is why we only assert the *prefetch* path is gone by counting sessions: a
+    parent-scoped page fetch opens the Omnigent pool at most once (page-metadata
+    merge), never twice (prefetch + merge).
+    """
+    parent = store.create_conversation(title="parent")
+    for i in range(3):
+        store.create_conversation(
+            kind="sub_agent", title=f"coder:c{i}", parent_conversation_id=parent.id
+        )
+
+    calls = {"omnigent_sessions": 0}
+    real_session = store._session
+
+    def counting_session(*args: object, **kwargs: object) -> object:
+        calls["omnigent_sessions"] += 1
+        return real_session(*args, **kwargs)
+
+    monkeypatch.setattr(store, "_session", counting_session)
+    page = store.list_conversations(kind="sub_agent", parent_conversation_id=parent.id)
+
+    assert len(page.data) == 3
+    # One Omnigent-pool session for the page-metadata merge; the workspace-wide
+    # prefetch (a second, unbounded one) must be gone.
+    assert calls["omnigent_sessions"] <= 1
+
+
 # ── labels ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes the "child sessions" query slowness that showed up after the conversations
table was split (#2341).

The split put `kind`/`archived` on one table (Omnigent DB) and
`parent_conversation_id` on another (Agent Platform DB), behind separate
connection pools. Because the two filters could no longer be combined in one
query, listing a session's children started by loading **every sub-agent id in
the whole workspace** from one pool and feeding that giant list into a query on
the other pool. That ran on every child-sessions rail refresh and every SSE
reconnect.

A conversation is a sub-agent exactly when it has a parent, and every code path
that creates one already sets them together. So this derives `kind` from whether
`parent_conversation_id` is set, filters directly on the conversations table, and
drops the cross-pool preload for parent-scoped lists. That restores the original
single indexed query. The same fix removes an identical workspace-wide preload in
the sidebar's child-status rollup.

No schema change — the two pools still point at one physical database.

## Test Plan

```
uv run --extra dev pytest \
  tests/stores/test_conversation_store.py \
  tests/stores/test_conversation_store_split_db.py \
  tests/server/integration/
```

All green. Lint + format clean, no new mypy errors. Added two split-DB
regression tests: `kind` stays correct when the metadata row is missing, and the
parent-scoped list no longer does the workspace-wide preload.

## Demo

N/A — server-side query change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by new + existing automated tests.
