### PR TITLE
fix(deps): floor databricks-mcp + ai-bridge so pyarrow resolves on py3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,8 +188,17 @@ databricks = [
     "psycopg[binary]>=3.1,<4",
     "pymysql>=1.1,<2",
     # Databricks-specific MCP servers. Not imported by core Omnigent
-    # code, so it is opt-in here rather than a default dependency.
-    "databricks-mcp>=0.1.0",
+    # code, so it is opt-in here rather than a default dependency. Floored
+    # at 0.9.0 (the release the lock already resolves): with the old >=0.1.0
+    # floor, a fresh install could satisfy the ai-bridge floor below by
+    # dropping mcp to 0.1.0, which pulls no mlflow/pyarrow at all.
+    "databricks-mcp>=0.9.0",
+    # Floor the transitive databricks-ai-bridge: older releases pull a
+    # databricks-vectorsearch that pins protobuf 5.x (conflicts with our
+    # protobuf>=6), so the resolver backtracks to an ai-bridge that caps
+    # mlflow at 3.2 and pyarrow<22 — and pyarrow 21 has no cp314 wheel, so a
+    # fresh install on Python 3.14 tries (and fails) to build it from source.
+    "databricks-ai-bridge>=0.19",
 ]
 dev = [
     "pytest>=7.0",

--- a/scripts/update_versions.py
+++ b/scripts/update_versions.py
@@ -18,7 +18,7 @@ It edits ONLY the ``[project].version`` line and the sibling ``==``
 pins, matched by package name — never a blind version-string replace —
 so unrelated version literals (host/runner wire-protocol versions,
 docstring examples, third-party dependency floors like
-``databricks-mcp>=0.1.0``) are left untouched.
+``databricks-mcp>=0.9.0``) are left untouched.
 
 ``web/package.json`` (a ``0.0.0`` sentinel for the private SPA) and
 ``web/electron/package.json`` (the desktop app's independent

--- a/tests/scripts/test_update_versions.py
+++ b/tests/scripts/test_update_versions.py
@@ -101,9 +101,9 @@ def test_set_version_preserves_unrelated_version_literals(repo_copy: Path) -> No
     before = root_pyproject.read_text()
     # Real third-party floor that shares the old version digits — must
     # survive a bump untouched (anchored-on-name replacement, not blind).
-    assert '"databricks-mcp>=0.1.0",' in before
+    assert '"databricks-mcp>=0.9.0",' in before
     update_versions.set_version(repo_copy, "9.9.9")
-    assert '"databricks-mcp>=0.1.0",' in root_pyproject.read_text()
+    assert '"databricks-mcp>=0.9.0",' in root_pyproject.read_text()
 
 
 def test_check_detects_version_drift(repo_copy: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2906,6 +2906,7 @@ cwsandbox = [
     { name = "cwsandbox" },
 ]
 databricks = [
+    { name = "databricks-ai-bridge" },
     { name = "databricks-mcp" },
     { name = "databricks-sdk" },
     { name = "opentelemetry-distro" },
@@ -2978,7 +2979,8 @@ requires-dist = [
     { name = "click", specifier = ">=8.0,<10" },
     { name = "cursor-sdk", marker = "extra == 'cursor'", specifier = ">=0.1.7" },
     { name = "cwsandbox", marker = "extra == 'cwsandbox'", specifier = ">=0.24,<1" },
-    { name = "databricks-mcp", marker = "extra == 'databricks'", specifier = ">=0.1.0" },
+    { name = "databricks-ai-bridge", marker = "extra == 'databricks'", specifier = ">=0.19" },
+    { name = "databricks-mcp", marker = "extra == 'databricks'", specifier = ">=0.9.0" },
     { name = "databricks-sdk", marker = "extra == 'all'", specifier = ">=0.56.0,<1" },
     { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.56.0,<1" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.180,<1" },


### PR DESCRIPTION
## Related issue

N/A

## Summary

`uv tool install "omnigent[databricks] @ git+https://github.com/omnigent-ai/omnigent.git"` fails on **Python 3.14** while trying to build `pyarrow==21.0.0` from source (e.g. `CMake 3.25 or higher is required` on Linux, or a toolchain failure on macOS arm64).

Root cause is a resolver back-off, not pyarrow itself. A git install resolves fresh from `pyproject.toml` and **ignores `uv.lock`**. In that resolve:

- omnigent pins `protobuf>=6,<7` directly.
- The newer `databricks-vectorsearch` that recent `databricks-ai-bridge` wants pins `protobuf==5.29.6`, which conflicts.
- So uv backtracks `databricks-ai-bridge` to `0.17.0` → which pins `mlflow==3.2.0` → which caps `pyarrow<22` → `21.0.0`.
- `pyarrow==21.0.0` ships **no cp314 wheel**, so on 3.14 uv falls back to a source build and fails.

Fix: two floors in the `databricks` extra, both required (neither works alone):

- **`databricks-ai-bridge>=0.19`** — the first release that accepts a `protobuf>=6`-compatible `databricks-vectorsearch` (0.66), lifting `mlflow` to `3.14` and `pyarrow` to `24` (which has cp314 wheels).
- **`databricks-mcp>=0.9.0`** (was `>=0.1.0`) — stops the resolver from "escaping" the ai-bridge floor by dropping `databricks-mcp` to `0.1.0`, a release that pulls no `mlflow`/`pyarrow` at all (which would silently gut the databricks-mcp servers).

This matches what `uv.lock` already resolved, so there is no version churn — the lock delta is just the dependency edges.

## Test Plan

i manually tested:
<details>
<summary>terminal output off of main vs this branch w/ python 3.14</summary>
Last login: Tue Jul 14 00:51:55 on ttys002
You have mail.
bbqiu: ~/universe [master] $
bbqiu: ~/universe [master] $
bbqiu: ~/universe [master] $ uv tool install --force --python 3.14 \
  "omnigent[databricks] @ git+https://github.com/omnigent-ai/omnigent.git@main"

    Updated https://github.com/omnigent-ai/omnigent.git (95baa07aee94ae4f8a3d7
Resolved 150 packages in 21.37s
      Built omnigent-client @ git+https://github.com/omnigent-ai/omnigent.git@
      Built omnigent-ui-sdk @ git+https://github.com/omnigent-ai/omnigent.git@
  × Failed to build `pyarrow==21.0.0`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stdout]
      running bdist_wheel
      running build
      running build_py
      creating build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/orc.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/conftest.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_generated_version.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/benchmark.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_compute_docstrings.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/ipc.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/util.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/flight.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/cffi.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/substrait.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/__init__.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/types.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/dataset.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/cuda.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/feather.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/pandas_compat.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/fs.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/acero.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/csv.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/jvm.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/json.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/compute.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      running egg_info
      writing pyarrow.egg-info/PKG-INFO
      writing dependency_links to pyarrow.egg-info/dependency_links.txt
      writing requirements to pyarrow.egg-info/requires.txt
      writing top-level names to pyarrow.egg-info/top_level.txt
      reading manifest file 'pyarrow.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      writing manifest file 'pyarrow.egg-info/SOURCES.txt'
      copying pyarrow/__init__.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_acero.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_acero.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_azurefs.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_compute.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_compute.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_csv.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_csv.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_cuda.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_cuda.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_dataset.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_dataset.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_dataset_orc.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_dataset_parquet.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_dataset_parquet.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_dataset_parquet_encryption.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_dlpack.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_feather.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_flight.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_fs.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_fs.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_gcsfs.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_hdfs.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_json.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_json.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_orc.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_orc.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_parquet.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_parquet.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_parquet_encryption.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_parquet_encryption.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_pyarrow_cpp_tests.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_pyarrow_cpp_tests.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_s3fs.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/_substrait.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/array.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/benchmark.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/builder.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/compat.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/config.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/device.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/error.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/gandiva.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/io.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/ipc.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/lib.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/lib.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/memory.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/pandas-shim.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/public-api.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/scalar.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/table.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/tensor.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      copying pyarrow/types.pxi ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      creating build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/__init__.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/common.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow_acero.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow_cuda.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow_dataset.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow_dataset_parquet.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow_feather.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow_flight.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow_fs.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow_python.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libarrow_substrait.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libgandiva.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libparquet.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      copying pyarrow/includes/libparquet_encryption.pxd ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/includes
      creating build/lib.macosx-26.0-arm64-cpython-314/pyarrow/interchange
      copying pyarrow/interchange/__init__.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/interchange
      copying pyarrow/interchange/buffer.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/interchange
      copying pyarrow/interchange/column.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/interchange
      copying pyarrow/interchange/dataframe.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/interchange
      copying pyarrow/interchange/from_dataframe.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/interchange
      creating build/lib.macosx-26.0-arm64-cpython-314/pyarrow/parquet
      copying pyarrow/parquet/__init__.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/parquet
      copying pyarrow/parquet/core.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/parquet
      copying pyarrow/parquet/encryption.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/parquet
      creating
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/CMakeLists.txt ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/api.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/arrow_to_pandas.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/arrow_to_pandas.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/arrow_to_python_internal.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/async.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/benchmark.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/benchmark.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/common.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/common.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/csv.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/csv.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/datetime.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/datetime.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/decimal.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/decimal.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/extension_type.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/extension_type.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/filesystem.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/filesystem.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/flight.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/flight.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/gdb.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/gdb.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/helpers.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/helpers.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/inference.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/inference.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/io.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/io.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/ipc.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/ipc.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/iterators.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/numpy_convert.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/numpy_convert.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/numpy_init.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/numpy_init.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/numpy_internal.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/numpy_interop.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/numpy_to_arrow.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/numpy_to_arrow.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/parquet_encryption.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/parquet_encryption.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/platform.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/pyarrow.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/pyarrow.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/pyarrow_api.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/pyarrow_lib.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/python_test.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/python_test.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/python_to_arrow.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/python_to_arrow.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/type_traits.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/udf.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/udf.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/util.cc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/util.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      copying pyarrow/src/arrow/python/visibility.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python
      creating
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python/vendored
      copying pyarrow/src/arrow/python/vendored/CMakeLists.txt ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python/vendored
      copying pyarrow/src/arrow/python/vendored/pythoncapi_compat.h ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/src/arrow/python/vendored
      creating build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/__init__.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/arrow_16597.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/arrow_39313.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/arrow_7980.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/bound_function_visit_strings.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/conftest.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/extensions.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/pandas_examples.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/pandas_threaded_import.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/pyarrow_cython_example.pyx ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/read_record_batch.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/strategies.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_acero.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_adhoc_memory_leak.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_array.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_builder.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_cffi.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_compute.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_convert_builtin.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_cpp_internals.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_csv.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_cuda.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_cuda_numba_interop.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_cython.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_dataset.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_dataset_encryption.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_deprecations.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_device.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_dlpack.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_exec_plan.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_extension_type.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_feather.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_flight.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_flight_async.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_fs.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_gandiva.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_gdb.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_io.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_ipc.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_json.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_jvm.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_memory.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_misc.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_orc.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_pandas.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_scalars.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_schema.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_sparse_tensor.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_strategies.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_substrait.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_table.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_tensor.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_types.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_udf.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_util.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/test_without_numpy.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/util.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      copying pyarrow/tests/wsgi_examples.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests
      creating
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/feather
      copying
      pyarrow/tests/data/feather/v0.17.0.version.2-compression.lz4.feather
      -> build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/feather
      creating build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      copying pyarrow/tests/data/orc/README.md ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      copying pyarrow/tests/data/orc/TestOrcFile.emptyFile.jsn.gz ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      copying pyarrow/tests/data/orc/TestOrcFile.emptyFile.orc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      copying pyarrow/tests/data/orc/TestOrcFile.test1.jsn.gz ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      copying pyarrow/tests/data/orc/TestOrcFile.test1.orc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      copying pyarrow/tests/data/orc/TestOrcFile.testDate1900.jsn.gz ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      copying pyarrow/tests/data/orc/TestOrcFile.testDate1900.orc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      copying pyarrow/tests/data/orc/decimal.jsn.gz ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      copying pyarrow/tests/data/orc/decimal.orc ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/orc
      creating
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/parquet
      copying pyarrow/tests/data/parquet/v0.7.1.all-named-index.parquet ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/parquet
      copying
      pyarrow/tests/data/parquet/v0.7.1.column-metadata-handling.parquet ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/parquet
      copying pyarrow/tests/data/parquet/v0.7.1.parquet ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/parquet
      copying pyarrow/tests/data/parquet/v0.7.1.some-named-index.parquet ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/data/parquet
      creating
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/interchange
      copying pyarrow/tests/interchange/__init__.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/interchange
      copying pyarrow/tests/interchange/test_conversion.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/interchange
      copying pyarrow/tests/interchange/test_interchange_spec.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/interchange
      creating build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/__init__.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/common.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/conftest.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/encryption.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_basic.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_compliant_nested_type.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_data_types.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_dataset.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_datetime.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_encryption.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_metadata.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_pandas.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_parquet_file.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      copying pyarrow/tests/parquet/test_parquet_writer.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/tests/parquet
      creating build/lib.macosx-26.0-arm64-cpython-314/pyarrow/vendored
      copying pyarrow/vendored/__init__.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/vendored
      copying pyarrow/vendored/docscrape.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/vendored
      copying pyarrow/vendored/version.py ->
      build/lib.macosx-26.0-arm64-cpython-314/pyarrow/vendored
      running build_ext
      creating
      /Users/bryan.qiu/.cache/uv/sdists-v9/index/0e509984163dcdbd/pyarrow/21.0.0/9Vc_5fZ3Kai98p3G/src/build/temp.macosx-26.0-arm64-cpython-314
      -- Running cmake for PyArrow
      cmake
      -DCMAKE_INSTALL_PREFIX=/Users/bryan.qiu/.cache/uv/sdists-v9/index/0e509984163dcdbd/pyarrow/21.0.0/9Vc_5fZ3Kai98p3G/src/build/lib.macosx-26.0-arm64-cpython-314/pyarrow
      -DPYTHON_EXECUTABLE=/Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/bin/python
      -DPython3_EXECUTABLE=/Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/bin/python
      -DPYARROW_CXXFLAGS= -DPYARROW_BUNDLE_ARROW_CPP=off
      -DPYARROW_BUNDLE_CYTHON_CPP=off
      -DPYARROW_GENERATE_COVERAGE=off -DCMAKE_BUILD_TYPE=release
      /Users/bryan.qiu/.cache/uv/sdists-v9/index/0e509984163dcdbd/pyarrow/21.0.0/9Vc_5fZ3Kai98p3G/src

      [stderr]
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/config/_apply_pyprojecttoml.py:82:
      SetuptoolsDeprecationWarning: `project.license` as a TOML table is
      deprecated
      !!


      ********************************************************************************
              Please use a simple string containing a SPDX expression for
      `project.license`. You can also use `project.license-files`. (Both
      options available on setuptools>=77.0.0).

              By 2027-Feb-18, you need to update your project and remove
      deprecated calls
              or your builds will no longer be supported.

              See
      https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
      for details.

      ********************************************************************************

      !!
        corresp(dist, value, root_dir)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/config/_apply_pyprojecttoml.py:61:
      SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!


      ********************************************************************************
              Please consider removing the following classifiers in favor of
      a SPDX license expression:

              License :: OSI Approved :: Apache Software License

              See
      https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
      for details.

      ********************************************************************************

      !!
        dist._finalize_license_expression()
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/dist.py:483:
      SetuptoolsDeprecationWarning: Pattern '../LICENSE.txt' cannot contain
      '..'
      !!


      ********************************************************************************
              Please ensure the files specified are contained by the root
              of the Python package (normally marked by `pyproject.toml`).

              By 2027-Feb-18, you need to update your project and remove
      deprecated calls
              or your builds will no longer be supported.

              See
      https://packaging.python.org/en/latest/specifications/glob-patterns/
      for details.

      ********************************************************************************

      !!
        for path in sorted(cls._find_pattern(pattern, enforce_match))
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/dist.py:483:
      SetuptoolsDeprecationWarning: Cannot find any files for the given
      pattern.
      !!


      ********************************************************************************
              Pattern '../LICENSE.txt' did not match any files.

              By 2027-Feb-18, you need to update your project and remove
      deprecated calls
              or your builds will no longer be supported.

      ********************************************************************************

      !!
        for path in sorted(cls._find_pattern(pattern, enforce_match))
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/dist.py:483:
      SetuptoolsDeprecationWarning: Pattern '../NOTICE.txt' cannot contain
      '..'
      !!


      ********************************************************************************
              Please ensure the files specified are contained by the root
              of the Python package (normally marked by `pyproject.toml`).

              By 2027-Feb-18, you need to update your project and remove
      deprecated calls
              or your builds will no longer be supported.

              See
      https://packaging.python.org/en/latest/specifications/glob-patterns/
      for details.

      ********************************************************************************

      !!
        for path in sorted(cls._find_pattern(pattern, enforce_match))
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/dist.py:483:
      SetuptoolsDeprecationWarning: Cannot find any files for the given
      pattern.
      !!


      ********************************************************************************
              Pattern '../NOTICE.txt' did not match any files.

              By 2027-Feb-18, you need to update your project and remove
      deprecated calls
              or your builds will no longer be supported.

      ********************************************************************************

      !!
        for path in sorted(cls._find_pattern(pattern, enforce_match))
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/dist.py:765:
      SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!


      ********************************************************************************
              Please consider removing the following classifiers in favor of
      a SPDX license expression:

              License :: OSI Approved :: Apache Software License

              See
      https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
      for details.

      ********************************************************************************

      !!
        self._finalize_license_expression()
      listing git files failed - pretending there aren't any
      warning: no files found matching '../LICENSE.txt'
      warning: no files found matching '../NOTICE.txt'
      warning: no previously-included files matching '*.so' found anywhere
      in distribution
      warning: no previously-included files matching '*.pyc' found anywhere
      in distribution
      warning: no previously-included files matching '*~' found anywhere
      in distribution
      warning: no previously-included files matching '#*' found anywhere
      in distribution
      warning: no previously-included files matching '.git*' found anywhere
      in distribution
      warning: no previously-included files matching '.DS_Store' found
      anywhere in distribution
      no previously-included directories found matching '.asv'
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.includes' is absent from the `packages`
      configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.includes' as an importable
      package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.includes' is
      explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.includes' to be distributed and are
              already explicitly excluding 'pyarrow.includes' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.interchange' is absent from the `packages`
      configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.interchange' as an importable
      package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.interchange' is
      explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.interchange' to be distributed
      and are
              already explicitly excluding 'pyarrow.interchange' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.parquet' is absent from the `packages`
      configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.parquet' as an importable
      package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.parquet' is explicitly
      added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.parquet' to be distributed and are
              already explicitly excluding 'pyarrow.parquet' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.src.arrow.python' is absent from the
      `packages` configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.src.arrow.python' as an importable
      package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.src.arrow.python' is
      explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.src.arrow.python' to be distributed
      and are
              already explicitly excluding 'pyarrow.src.arrow.python' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.src.arrow.python.vendored' is absent from
      the `packages` configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.src.arrow.python.vendored' as an
      importable package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that
      'pyarrow.src.arrow.python.vendored' is explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.src.arrow.python.vendored' to be
      distributed and are
              already explicitly excluding
      'pyarrow.src.arrow.python.vendored' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.tests' is absent from the `packages`
      configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.tests' as an importable
      package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.tests' is explicitly
      added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.tests' to be distributed and are
              already explicitly excluding 'pyarrow.tests' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.tests.data.feather' is absent from the
      `packages` configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.tests.data.feather' as an
      importable package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.tests.data.feather' is
      explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.tests.data.feather' to be
      distributed and are
              already explicitly excluding 'pyarrow.tests.data.feather' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.tests.data.orc' is absent from the
      `packages` configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.tests.data.orc' as an importable
      package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.tests.data.orc' is
      explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.tests.data.orc' to be distributed
      and are
              already explicitly excluding 'pyarrow.tests.data.orc' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.tests.data.parquet' is absent from the
      `packages` configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.tests.data.parquet' as an
      importable package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.tests.data.parquet' is
      explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.tests.data.parquet' to be
      distributed and are
              already explicitly excluding 'pyarrow.tests.data.parquet' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.tests.interchange' is absent from the
      `packages` configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.tests.interchange' as an importable
      package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.tests.interchange' is
      explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.tests.interchange' to be
      distributed and are
              already explicitly excluding 'pyarrow.tests.interchange' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.tests.parquet' is absent from the
      `packages` configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.tests.parquet' as an importable
      package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.tests.parquet' is
      explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.tests.parquet' to be distributed
      and are
              already explicitly excluding 'pyarrow.tests.parquet' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      /Users/bryan.qiu/.cache/uv/builds-v0/.tmpw3VIAA/lib/python3.14/site-packages/setuptools/command/build_py.py:215:
      _Warning: Package 'pyarrow.vendored' is absent from the `packages`
      configuration.
      !!


      ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'pyarrow.vendored' as an importable
      package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want
      to distribute this
              package, please make sure that 'pyarrow.vendored' is
      explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery
      methods
              (for example by using
      `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools
      documentation page:

              -
      https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'pyarrow.vendored' to be distributed and are
              already explicitly excluding 'pyarrow.vendored' via
              `find_namespace_packages(...)/find_namespace` or
      `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or
      `include-package-data=False` in
              combination with a more fine grained `package-data`
      configuration.

              You can read more about "package data files" on setuptools
      documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can
      be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of
      package data
                    directory, all directories are treated like packages.

      ********************************************************************************

      !!
        check.warn(importable)
      error: command 'cmake' failed: No such file or directory


hint: `pyarrow` (v21.0.0) was included because `omnigent[databricks]` (v0.6.0.dev0) depends on `databricks-mcp` (v0.9.0) which depends on `mlflow` (v3.2.0) which depends on `pyarrow`
hint: Build failures usually indicate a problem with the package or the build environment%
bbqiu: ~/universe [master] $ uv tool install --force --python 3.14 \
  "omnigent[databricks] @ git+https://github.com/omnigent-ai/omnigent.git@stack/fix-pyarrow-py314"

    Updated https://github.com/omnigent-ai/omnigent.git (d050c6ca993f84cc98825
Resolved 161 packages in 12.96s
      Built omnigent-ui-sdk @ git+https://github.com/omnigent-ai/omnigent.git@
      Built omnigent @ git+https://github.com/omnigent-ai/omnigent.git@d050c6c
      Built omnigent-client @ git+https://github.com/omnigent-ai/omnigent.git@
Prepared 16 packages in 1m 24s
Installed 161 packages in 1.33s
 + aiohappyeyeballs==2.7.1
 + aiohttp==3.14.1
 + aiosignal==1.4.0
 + alembic==1.18.5
 + annotated-doc==0.0.4
 + annotated-types==0.7.0
 + anyio==4.14.1
 + argon2-cffi==23.1.0
 + argon2-cffi-bindings==25.1.0
 + asgiref==3.11.1
 + attrs==26.1.0
 + blinker==1.9.0
 + cachetools==6.2.6
 + cel-expr-python==0.1.3
 + certifi==2026.6.17
 + cffi==2.1.0
 + charset-normalizer==3.4.9
 + claude-agent-sdk==0.2.111
 + click==8.4.2
 + cloudpickle==3.1.2
 + contourpy==1.3.3
 + cryptography==48.0.1
 + cycler==0.12.1
 + databricks-ai-bridge==0.19.0
 + databricks-mcp==0.9.0
 + databricks-sdk==0.120.0
 + databricks-vectorsearch==0.66
 + deprecation==2.1.0
 + distro==1.9.0
 + docker==7.1.0
 + fastapi==0.139.0
 + flask==3.1.3
 + flask-cors==6.0.5
 + fonttools==4.63.0
 + frozenlist==1.8.0
 + ftfy==6.3.1
 + gitdb==4.0.12
 + gitpython==3.1.50
 + google-auth==2.55.2
 + googleapis-common-protos==1.75.0
 + graphene==3.4.3
 + graphql-core==3.2.11
 + graphql-relay==3.2.0
 + griffelib==2.1.0
 + grpcio==1.81.1
 + gunicorn==26.0.0
 + h11==0.16.0
 + httpcore==1.0.9
 + httptools==0.8.0
 + httpx==0.28.1
 + httpx-sse==0.4.3
 + huey==3.1.1
 + idna==3.18
 + importlib-metadata==9.0.0
 + itsdangerous==2.2.0
 + jaraco-classes==3.4.0
 + jaraco-context==6.1.2
 + jaraco-functools==4.5.0
 + jinja2==3.1.6
 + jiter==0.16.0
 + joblib==1.5.3
 + jsonschema==4.26.0
 + jsonschema-specifications==2025.9.1
 + keyring==25.7.0
 + kiwisolver==1.5.0
 + mako==1.3.12
 + markdown-it-py==4.2.0
 + markupsafe==3.0.3
 + matplotlib==3.11.0
 + mcp==1.28.1
 + mdurl==0.1.2
 + mlflow==3.14.0
 + mlflow-skinny==3.14.0
 + mlflow-tracing==3.14.0
 + more-itertools==11.1.0
 + multidict==6.7.1
 + narwhals==2.23.0
 + numpy==2.5.1
 + omnigent==0.6.0.dev0 (from git+https://github.com/omnigent-ai/omnigent.git@d050c6ca993f84cc98825f1dd7383ec6858742a4)
 + omnigent-client==0.6.0.dev0 (from git+https://github.com/omnigent-ai/omnigent.git@d050c6ca993f84cc98825f1dd7383ec6858742a4#subdirectory=sdks/python-client)
 + omnigent-ui-sdk==0.6.0.dev0 (from git+https://github.com/omnigent-ai/omnigent.git@d050c6ca993f84cc98825f1dd7383ec6858742a4#subdirectory=sdks/ui)
 + openai==2.44.0
 + openai-agents==0.13.6
 + opentelemetry-api==1.43.0
 + opentelemetry-distro==0.64b0
 + opentelemetry-exporter-otlp-proto-common==1.43.0
 + opentelemetry-exporter-otlp-proto-grpc==1.43.0
 + opentelemetry-exporter-otlp-proto-http==1.43.0
 + opentelemetry-instrumentation==0.64b0
 + opentelemetry-instrumentation-asgi==0.64b0
 + opentelemetry-instrumentation-fastapi==0.64b0
 + opentelemetry-instrumentation-httpx==0.64b0
 + opentelemetry-instrumentation-sqlalchemy==0.64b0
 + opentelemetry-proto==1.43.0
 + opentelemetry-sdk==1.43.0
 + opentelemetry-semantic-conventions==0.64b0
 + opentelemetry-util-http==0.64b0
 + packaging==25.0
 + pandas==2.3.3
 + pexpect==4.9.0
 + pillow==12.3.0
 + prettytable==3.18.0
 + prompt-toolkit==3.0.52
 + propcache==0.5.2
 + protobuf==6.33.6
 + psutil==7.2.2
 + psycopg==3.3.4
 + psycopg-binary==3.3.4
 + ptyprocess==0.7.0
 + pyarrow==24.0.0
 + pyasn1==0.6.3
 + pyasn1-modules==0.4.2
 + pycparser==3.0
 + pydantic==2.13.4
 + pydantic-core==2.46.4
 + pydantic-settings==2.14.2
 + pygments==2.20.0
 + pyjwt==2.13.0
 + pymysql==1.2.0
 + pyparsing==3.3.2
 + pyte==0.8.2
 + python-dateutil==2.9.0.post0
 + python-dotenv==1.2.2
 + python-multipart==0.0.32
 + pytz==2026.2
 + pyyaml==6.0.3
 + referencing==0.37.0
 + regex==2026.6.28
 + requests==2.34.2
 + rich==14.3.4
 + rpds-py==2026.6.3
 + scikit-learn==1.9.0
 + scipy==1.18.0
 + six==1.17.0
 + skops==0.14.0
 + smmap==5.0.3
 + sniffio==1.3.1
 + sqlalchemy==2.0.51
 + sqlparse==0.5.5
 + sse-starlette==3.4.5
 + starlette==1.3.1
 + tabulate==0.10.0
 + threadpoolctl==3.6.0
 + tiktoken==0.13.0
 + tomlkit==0.15.0
 + tqdm==4.68.4
 + types-requests==2.33.0.20260518
 + typing-extensions==4.16.0
 + typing-inspection==0.4.2
 + tzdata==2026.2
 + urllib3==2.7.0
 + uvicorn==0.50.2
 + uvloop==0.22.1
 + watchfiles==1.2.0
 + wcwidth==0.8.2
 + websockets==14.2
 + werkzeug==3.1.8
 + wrapt==2.2.2
 + yarl==1.24.2
 + zipp==4.1.0
 + zstandard==0.25.0
Installed 2 executables: omni, omnigent
bbqiu: ~/universe [master] $
</details>


Reproduced and verified with `uv` against the real dependency graph (under the repo's `uv.toml` P7D cooldown):

- **Before** (`origin/main`, `.[databricks]`, Python 3.14): `uv pip install` resolves `pyarrow==21.0.0` → `Building pyarrow==21.0.0` → `Failed to build` (`CMake 3.25 or higher is required. You are running version 3.16.3`).
- **After** both floors, full `.[databricks]` install completes from wheels on **Python 3.12, 3.13, and 3.14** — 164 packages, no source build. Confirmed resolved versions on all three: `databricks-mcp==0.9.0`, `databricks-ai-bridge==0.19.0`, `databricks-vectorsearch==0.66`, `mlflow==3.14.0`, `protobuf==6.33.6`, `pyarrow==24.0.0`.
- Confirmed **each floor alone is insufficient**: `databricks-mcp>=0.9.0` alone still backtracks ai-bridge to 0.17.0 → pyarrow 21.0.0; `databricks-ai-bridge>=0.19` alone drops mcp to 0.1.0 (no pyarrow/mlflow).
- `uv.lock`: only the dependency-edge specifiers change; all pinned versions and registry URLs are unchanged (verified structurally identical to a fresh `uv lock`).

## Demo

N/A — dependency-metadata change, no user-visible UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually by installing the `databricks` extra with `uv` under Python 3.12, 3.13, and 3.14 (from the committed pyproject, under the repo's cooldown) and confirming the resolution no longer selects `pyarrow==21.0.0` and keeps `databricks-mcp==0.9.0` (no source build, full 164-package set). The change is dependency metadata only; there is no runtime code path to unit-test, and CI's `uv sync --extra dev` lockfile-freshness check exercises the resolution.

## Changelog

Fix `uv tool install` of the `databricks` extra failing to build pyarrow from source on Python 3.14
