### PR TITLE
perf(store): drop search_text from the child-session preview query

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -597,20 +597,31 @@ def _ranked_latest_message_items(conversation_ids: list[str]) -> Subquery:
     """
     Build a ranked latest-message subquery for multiple conversations.
 
-    Selects all ``SqlConversationItem`` columns plus a per-conversation
-    ``row_num`` so the caller can filter to the top-N rows without a
-    join back to the base table. Avoiding the join is critical: the
-    primary key is ``(workspace_id, conversation_id, id)``, so a join
-    on ``id`` alone forces a full table scan.
+    Selects only the columns :func:`_to_item` needs (plus ``conversation_id``
+    and ``position`` for grouping/ordering) and a per-conversation ``row_num``
+    so the caller can filter to the top-N rows without a join back to the base
+    table. Avoiding the join is critical: the primary key is
+    ``(workspace_id, conversation_id, id)``, so a join on ``id`` alone forces a
+    full table scan. The heavy ``search_text`` column is deliberately omitted —
+    the message-preview caller never reads it, and it roughly doubles the bytes
+    pulled per row on a chatty conversation.
 
     :param conversation_ids: Conversation ids to fetch messages for,
         e.g. ``["conv_child1", "conv_child2"]``.
-    :returns: SQLAlchemy subquery with all item columns plus per-conversation
-        ``row_num``, newest message first.
+    :returns: SQLAlchemy subquery with the projected item columns plus
+        per-conversation ``row_num``, newest message first.
     """
     return (
         select(
-            SqlConversationItem,
+            SqlConversationItem.conversation_id,
+            SqlConversationItem.id,
+            SqlConversationItem.response_id,
+            SqlConversationItem.created_at,
+            SqlConversationItem.status,
+            SqlConversationItem.position,
+            SqlConversationItem.type,
+            SqlConversationItem.data,
+            SqlConversationItem.created_by,
             func.row_number()
             .over(
                 partition_by=SqlConversationItem.conversation_id,

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -180,6 +180,62 @@ def test_list_latest_message_items_for_conversations(
     assert result["conv_missing"] == []
 
 
+def test_ranked_latest_message_items_omits_search_text(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The ranked-message subquery must not select the heavy ``search_text``
+    column — the preview caller never reads it, and pulling it roughly doubles
+    the bytes transferred per row on a chatty child.
+
+    Guards the projection so a future refactor can't silently go back to
+    ``select(SqlConversationItem)`` (the whole row). Also seeds a message whose
+    ``search_text`` differs from its visible text and asserts the returned item
+    still carries the visible text, proving the preview reads ``data``.
+    """
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        _ranked_latest_message_items,
+    )
+
+    ranked = _ranked_latest_message_items(["conv_x"])
+    columns = {c.key for c in ranked.c}
+    assert "search_text" not in columns
+    # The columns _to_item + the preview actually consume must all be present.
+    assert {
+        "conversation_id",
+        "id",
+        "response_id",
+        "created_at",
+        "status",
+        "position",
+        "type",
+        "data",
+        "created_by",
+        "row_num",
+    } <= columns
+
+    conv = conversation_store.create_conversation(title="chatty")
+    conversation_store.append(
+        conv.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_x",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "visible reply"}],
+                    agent="worker",
+                ),
+            )
+        ],
+    )
+    result = conversation_store.list_latest_message_items_for_conversations(
+        [conv.id], per_conversation_limit=1
+    )
+    item = result[conv.id][0]
+    assert isinstance(item.data, MessageData)
+    assert item.data.content[0]["text"] == "visible reply"
+
+
 def test_update_title(conversation_store: SqlAlchemyConversationStore) -> None:
     conv = conversation_store.create_conversation()
     updated = conversation_store.update_conversation(conv.id, title="Chat 1")


### PR DESCRIPTION
## Related issue

N/A

## Summary

Small follow-up on the child-sessions query path.

The query that fetches recent messages for the child-session rail previews was
selecting the whole message row, including the large `search_text` column. The
preview only needs the message body (`data`), so `search_text` was pure wasted
bytes on every row — and it roughly doubles the row size on a chatty child.

This selects only the columns the preview actually uses. No behavior change.

Independent of #2562 (touches a different function); can merge in either order.

## Test Plan

```
uv run --extra dev pytest \
  tests/stores/test_conversation_store.py \
  tests/stores/test_conversation_store_split_db.py \
  tests/server/integration/test_sessions_child_sessions.py
```

All green. Lint + format clean, no new mypy errors. Added a test that asserts the
query no longer selects `search_text` while previews still render.

## Demo

N/A — server-side query change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by new + existing automated tests.
