### PR TITLE
perf(db): index conversation_items by (workspace_id, conversation_id, type, position DESC)

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -639,6 +639,18 @@ class SqlConversationItem(ConversationBase):
             "response_id",
             "id",
         ),
+        # Latest-message previews scan one type per conversation ordered by
+        # position DESC (list_latest_message_items_for_conversations). Ordering
+        # type before position lets the scan seek to (workspace_id,
+        # conversation_id, type) and walk position DESC directly, avoiding a
+        # heap recheck on type — which no other index covers.
+        Index(
+            "ix_conversation_items_conv_type_position",
+            "workspace_id",
+            "conversation_id",
+            "type",
+            text("position DESC"),
+        ),
         CheckConstraint(
             "type IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)",
             name="ck_conversation_items_type",

--- a/omnigent/db/migrations/versions/cc3d4e5f6a7b_add_conversation_items_conv_type_position_index.py
+++ b/omnigent/db/migrations/versions/cc3d4e5f6a7b_add_conversation_items_conv_type_position_index.py
@@ -1,0 +1,58 @@
+"""Add (workspace_id, conversation_id, type, position DESC) index on conversation_items.
+
+Revision ID: cc3d4e5f6a7b
+Revises: bb2c3d4e5f6a
+Create Date: 2026-07-14 00:00:00.000000
+
+Adds a composite index that backs the latest-message-preview query
+(``list_latest_message_items_for_conversations`` /
+``_ranked_latest_message_items``) powering the child-session sidebar:
+
+    SELECT ... FROM conversation_items
+    WHERE workspace_id = ? AND conversation_id IN (...) AND type = 'message'
+    -- ranked per conversation by position DESC, top-N kept
+
+The existing unique index ``(workspace_id, conversation_id, position)`` covers
+the partition + order but not the ``type`` filter, so Postgres reads every
+item in the matched conversations and rechecks ``type`` on the heap —
+discarding the majority (messages are a minority of items in agent
+transcripts). Ordering ``type`` before ``position`` lets the scan seek to
+``(workspace_id, conversation_id, type)`` and walk ``position DESC`` directly.
+
+Plain (non-partial) index so it builds identically on SQLite, PostgreSQL, and
+MySQL — the codebase dropped partial indexes for MySQL compatibility in
+``z5a2b3c4d5e6``. DESC ordering is expressed via ``sa.text`` because Alembic's
+column list takes no per-column sort direction; all three dialects honor DESC
+in a ``CREATE INDEX`` column list.
+
+Index-only: ``CREATE INDEX`` / ``DROP INDEX`` are native on every dialect, so
+no batch table-rebuild (and no SQLite ``foreign_keys`` guard) is needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "cc3d4e5f6a7b"
+down_revision: str | None = "bb2c3d4e5f6a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_conversation_items_conv_type_position",
+        "conversation_items",
+        ["workspace_id", "conversation_id", "type", sa.text("position DESC")],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_conversation_items_conv_type_position",
+        table_name="conversation_items",
+    )


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The child-session sidebar previews run a per-conversation "newest N message items" query (`list_latest_message_items_for_conversations` / `_ranked_latest_message_items`) that filters `workspace_id + conversation_id IN (...) + type = 'message'`, ranked by `position DESC`. It's the single most frequently issued application query in production `pg_stat_activity` (tens of thousands of calls).
- The existing unique index `(workspace_id, conversation_id, position)` covers the partition + order but **not** the `type` filter, so Postgres seeks the conversation's item range and heap-rechecks `type` on every row — discarding the non-message majority (`function_call` / `function_call_output` / `reasoning` items dominate an agent transcript). This PR adds `(workspace_id, conversation_id, type, position DESC)` so the scan seeks straight to `(ws, conv, type)` and walks `position DESC`. The same index also serves `list_items(type=...)` (compaction lookups, latest-assistant-text), which filter the identical column shape.
- Added to **both** the model `__table_args__` and an Alembic migration so the migrated (single-DB) and `create_all` (split AP DB) schema paths stay in sync.

### Scope / honesty note

This is a **secondary** optimization. The full-table-scan pathology originally observed on this query (~4–9 s in production) was the `id`-only self-join, already fixed in #2546 (4563 ms → 830 ms). This index removes the *residual* `type` heap-recheck that survives that fix. It is **independent of the conversations/metadata DB split** — neither split migration touches `conversation_items`, and the query is byte-identical pre/post split. The impact here is inferred from the query plan, not yet measured against the post-#2546 production query; it is low-risk and additive regardless.

## Test Plan

- `uv run alembic ... heads` → single linear head at `cc3d4e5f6a7b`.
- Migration round-trip on SQLite: `upgrade head` creates `ix_conversation_items_conv_type_position` with columns `(workspace_id, conversation_id, type, position)`; `downgrade -1` removes it.
- `ConversationBase.metadata.create_all()` (the split-DB path) produces the identical index — verified the two schema paths match.
- `tests/db/test_migrations_sqlite_safe.py` + `tests/db/test_db_models.py` — 37 passed.
- `tests/stores/test_conversation_store.py` — passed.
- `ruff check` / `ruff format --check` / `mypy` clean on the changed files.

## Demo

N/A — no user-visible / UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

The change is a schema-only index addition. Existing DB tests
(`test_migrations_sqlite_safe`, `test_db_models`) exercise the full migration
chain and the model schema, and `test_conversation_store` covers the query
paths that use the index. Manually verified the migration up/down round-trip and
that the migration and `create_all` schema paths produce an identical index (so
both single-DB and split-AP-DB deployments get it). No new behavior to unit-test
beyond schema presence.

## Changelog

<Add a line to describe the change, else delete this section>