### PR TITLE
perf(store): move archived to conversations table to kill list_sessions prefetch

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -405,9 +405,6 @@ class SqlConversationMetadata(OmnigentBase):
     # Required when host_id is set; enforced by check constraint below.
     workspace: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     git_branch: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    archived: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False, server_default=false()
-    )
 
     __table_args__ = (
         CheckConstraint("kind IN (1, 2)", name="ck_conversation_metadata_kind"),
@@ -529,10 +526,20 @@ class SqlConversation(ConversationBase):
     )
     # Monotonic allocator for the next item position in this conversation.
     next_position: Mapped[int | None] = mapped_column(Integer, nullable=True, default=0)
+    # Whether the session is archived (hidden from the default sidebar). Lives
+    # here on the AP table so list_conversations can filter it inline alongside
+    # the created_at/updated_at sort keys, instead of pre-fetching ids from the
+    # Omnigent metadata DB.
+    archived: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=false()
+    )
 
     __table_args__ = (
         Index("ix_conversations_created_at", "workspace_id", "created_at", "id"),
         Index("ix_conversations_updated_at", "workspace_id", "updated_at", "id"),
+        # Default sidebar filters archived=false and sorts by updated_at DESC;
+        # archived leads as an equality so the page walk stays index-only.
+        Index("ix_conversations_archived_updated", "workspace_id", "archived", "updated_at", "id"),
         Index(
             "ix_conversations_root_conversation_id",
             "workspace_id",

--- a/omnigent/db/migrations/versions/9d820f91deef_move_archived_to_conversations.py
+++ b/omnigent/db/migrations/versions/9d820f91deef_move_archived_to_conversations.py
@@ -1,0 +1,116 @@
+"""move archived column from metadata back to conversations
+
+Revision ID: 9d820f91deef
+Revises: cc3d4e5f6a7b
+Create Date: 2026-07-14 00:00:00.000000
+
+The conversations split (``aa1b2c3d4e5f``) moved ``archived`` onto
+``omnigent_conversation_metadata``. That forced ``list_conversations`` to
+pre-fetch every non-archived conversation id from the Omnigent DB and filter
+the AP query with a giant ``IN (...)``, because the sort keys
+(``created_at``/``updated_at``) stayed on ``conversations`` while the filter
+moved to the other logical DB.
+
+This migration moves ``archived`` back onto ``conversations`` so the AP query
+can filter it inline next to the sort keys. It adds the column, backfills from
+``omnigent_conversation_metadata`` via a portable correlated subquery, drops
+it from the metadata table, and adds a composite index supporting the default
+sidebar (``archived=false ORDER BY updated_at DESC``). ``kind`` intentionally
+stays on the metadata table — the list filter now derives it from
+``parent_conversation_id`` instead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9d820f91deef"
+down_revision: str | None = "cc3d4e5f6a7b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """
+    Add ``conversations.archived``, backfill it from the metadata table,
+    then drop it from ``omnigent_conversation_metadata``.
+
+    ``server_default=sa.false()`` backfills existing rows for the NOT NULL
+    add; the subsequent UPDATE overwrites them with the real value copied
+    from metadata. Batch mode is used for the column add/drop for SQLite
+    compatibility; the backfill uses a correlated subquery so it runs on
+    SQLite, MySQL, and PostgreSQL alike (``UPDATE … FROM`` is
+    PostgreSQL-only).
+    """
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "archived",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+    op.execute(
+        """
+        UPDATE conversations
+        SET archived = COALESCE(
+            (SELECT m.archived
+             FROM omnigent_conversation_metadata m
+             WHERE m.workspace_id = conversations.workspace_id
+               AND m.id = conversations.id),
+            FALSE
+        )
+        """
+    )
+
+    # Default sidebar: archived=false ORDER BY updated_at DESC. archived leads
+    # as an equality so the page walk stays index-only.
+    op.create_index(
+        "ix_conversations_archived_updated",
+        "conversations",
+        ["workspace_id", "archived", "updated_at", "id"],
+    )
+
+    with op.batch_alter_table("omnigent_conversation_metadata") as batch_op:
+        batch_op.drop_column("archived")
+
+
+def downgrade() -> None:
+    """
+    Reverse the move: re-add ``archived`` to the metadata table, backfill it
+    from ``conversations``, drop the sidebar index, and drop the column from
+    ``conversations``.
+    """
+    with op.batch_alter_table("omnigent_conversation_metadata") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "archived",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+    op.execute(
+        """
+        UPDATE omnigent_conversation_metadata
+        SET archived = COALESCE(
+            (SELECT c.archived
+             FROM conversations c
+             WHERE c.workspace_id = omnigent_conversation_metadata.workspace_id
+               AND c.id = omnigent_conversation_metadata.id),
+            FALSE
+        )
+        """
+    )
+
+    op.drop_index("ix_conversations_archived_updated", table_name="conversations")
+
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.drop_column("archived")

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -157,7 +157,7 @@ def _to_conversation(
         ),
         workspace=meta.workspace if meta else None,
         git_branch=meta.git_branch if meta else None,
-        archived=meta.archived if meta else False,
+        archived=row.archived,
     )
 
 
@@ -265,7 +265,6 @@ def _new_session_metadata_row(
         terminal_launch_args=(
             json.dumps(terminal_launch_args) if terminal_launch_args is not None else None
         ),
-        archived=False,
     )
 
 
@@ -917,7 +916,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 terminal_launch_args=(
                     json.dumps(terminal_launch_args) if terminal_launch_args is not None else None
                 ),
-                archived=False,
             )
             with self._session() as meta_sess:
                 meta_sess.add(meta)
@@ -1884,29 +1882,45 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         from omnigent.server.auth import LEVEL_OWNER
 
-        # Get non-archived IDs from Omnigent, then filter labels in AP.
-        with self._session() as meta_sess:
-            non_archived_q = select(SqlConversationMetadata.id).where(
-                SqlConversationMetadata.workspace_id == current_workspace_id(),
-                SqlConversationMetadata.archived.is_(False),
-            )
-            if accessible_by is not None:
-                accessible_ids = select(SqlSessionPermission.conversation_id).where(
-                    SqlSessionPermission.workspace_id == current_workspace_id(),
-                    SqlSessionPermission.user_id == accessible_by,
-                )
-                non_archived_q = non_archived_q.where(
-                    SqlConversationMetadata.id.in_(accessible_ids)
-                )
-            if owned_by is not None:
-                owned_ids = select(SqlSessionPermission.conversation_id).where(
-                    SqlSessionPermission.workspace_id == current_workspace_id(),
-                    SqlSessionPermission.user_id == owned_by,
-                    SqlSessionPermission.level >= LEVEL_OWNER,
-                )
-                non_archived_q = non_archived_q.where(SqlConversationMetadata.id.in_(owned_ids))
-            non_archived_ids = list(meta_sess.execute(non_archived_q).scalars().all())
+        # ACL (accessible_by/owned_by) resolves against session_permissions on
+        # the Omnigent DB, so it still needs a pre-fetch; archived now lives on
+        # the AP conversations table and is filtered inline below.
+        permission_ids: list[str] | None = None
+        if accessible_by is not None or owned_by is not None:
+            with self._session() as meta_sess:
+                accessible_set: set[str] | None = None
+                owned_set: set[str] | None = None
+                if accessible_by is not None:
+                    accessible_set = set(
+                        meta_sess.execute(
+                            select(SqlSessionPermission.conversation_id).where(
+                                SqlSessionPermission.workspace_id == current_workspace_id(),
+                                SqlSessionPermission.user_id == accessible_by,
+                            )
+                        ).scalars()
+                    )
+                if owned_by is not None:
+                    owned_set = set(
+                        meta_sess.execute(
+                            select(SqlSessionPermission.conversation_id).where(
+                                SqlSessionPermission.workspace_id == current_workspace_id(),
+                                SqlSessionPermission.user_id == owned_by,
+                                SqlSessionPermission.level >= LEVEL_OWNER,
+                            )
+                        ).scalars()
+                    )
+                if accessible_set is not None and owned_set is not None:
+                    permission_ids = list(accessible_set & owned_set)
+                else:
+                    permission_ids = list(
+                        accessible_set if accessible_set is not None else owned_set or set()
+                    )
         with self._conv_session() as ap_sess:
+            # Non-archived conversations, resolved on the AP table.
+            non_archived_ids = select(SqlConversation.id).where(
+                SqlConversation.workspace_id == current_workspace_id(),
+                SqlConversation.archived.is_(False),
+            )
             stmt = (
                 select(SqlConversationLabel.value)
                 .where(
@@ -1917,6 +1931,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                 .distinct()
                 .order_by(SqlConversationLabel.value)
             )
+            if permission_ids is not None:
+                stmt = stmt.where(SqlConversationLabel.conversation_id.in_(permission_ids))
             return [row[0] for row in ap_sess.execute(stmt).all()]
 
     def delete_label(
@@ -2033,43 +2049,46 @@ class SqlAlchemyConversationStore(ConversationStore):
         elif kind == "default":
             kind_requires_parent = False
 
-        # A metadata-side prefetch is only needed for filters that live on the
-        # Omnigent DB: the permission scopes and (workspace-wide) archived
-        # exclusion. When the query is scoped to a single parent's children, skip
-        # the prefetch — a parent's children are a small, bounded set reachable
-        # via ``idx_conversations_parent``, so ``archived`` is applied on the
-        # page's own metadata after the fetch. A workspace-wide id prefetch here
-        # (the pre-fix behaviour) is both needless and the source of the
-        # post-split child-session slowdown.
-        parent_scoped = parent_conversation_id is not None
-        archived_via_prefetch = (not include_archived) and not parent_scoped
-        needs_meta_filter = (
-            archived_via_prefetch or (accessible_by is not None) or (owned_by is not None)
-        )
+        # kind and archived both live on the AP ``conversations`` table now
+        # (kind derived from parent-nullness, archived a real column), so they
+        # are filtered directly on the AP query below. The only filters that
+        # still require an Omnigent-side prefetch are the permission scopes.
+        needs_meta_filter = (accessible_by is not None) or (owned_by is not None)
 
         qualifying_ids: list[str] | None = None
         if needs_meta_filter:
-            # Pre-fetch qualifying IDs from Omnigent DB, then filter the AP query.
+            # Pre-fetch permission-qualifying IDs from the Omnigent DB
+            # (session_permissions), then filter the AP query. accessible_by and
+            # owned_by are intersected (both applied) to match the prior
+            # behaviour. (ACL pushdown to a single AP query is a follow-up.)
             with self._session() as meta_sess:
-                meta_q = select(SqlConversationMetadata.id).where(
-                    SqlConversationMetadata.workspace_id == current_workspace_id()
-                )
-                if archived_via_prefetch:
-                    meta_q = meta_q.where(SqlConversationMetadata.archived.is_(False))
+                accessible_set: set[str] | None = None
+                owned_set: set[str] | None = None
                 if accessible_by is not None:
-                    accessible_ids = select(SqlSessionPermission.conversation_id).where(
-                        SqlSessionPermission.workspace_id == current_workspace_id(),
-                        SqlSessionPermission.user_id == accessible_by,
+                    accessible_set = set(
+                        meta_sess.execute(
+                            select(SqlSessionPermission.conversation_id).where(
+                                SqlSessionPermission.workspace_id == current_workspace_id(),
+                                SqlSessionPermission.user_id == accessible_by,
+                            )
+                        ).scalars()
                     )
-                    meta_q = meta_q.where(SqlConversationMetadata.id.in_(accessible_ids))
                 if owned_by is not None:
-                    owned_ids = select(SqlSessionPermission.conversation_id).where(
-                        SqlSessionPermission.workspace_id == current_workspace_id(),
-                        SqlSessionPermission.user_id == owned_by,
-                        SqlSessionPermission.level >= LEVEL_OWNER,
+                    owned_set = set(
+                        meta_sess.execute(
+                            select(SqlSessionPermission.conversation_id).where(
+                                SqlSessionPermission.workspace_id == current_workspace_id(),
+                                SqlSessionPermission.user_id == owned_by,
+                                SqlSessionPermission.level >= LEVEL_OWNER,
+                            )
+                        ).scalars()
                     )
-                    meta_q = meta_q.where(SqlConversationMetadata.id.in_(owned_ids))
-                qualifying_ids = list(meta_sess.execute(meta_q).scalars().all())
+                if accessible_set is not None and owned_set is not None:
+                    qualifying_ids = list(accessible_set & owned_set)
+                else:
+                    qualifying_ids = list(
+                        accessible_set if accessible_set is not None else owned_set or set()
+                    )
 
         with self._conv_session() as session:
             stmt = select(SqlConversation).where(
@@ -2084,6 +2103,11 @@ class SqlAlchemyConversationStore(ConversationStore):
                 stmt = stmt.where(SqlConversation.parent_conversation_id.is_not(None))
             elif kind_requires_parent is False:
                 stmt = stmt.where(SqlConversation.parent_conversation_id.is_(None))
+
+            # archived lives on the AP conversations table, so exclude it inline
+            # (no metadata prefetch, no post-fetch filtering).
+            if not include_archived:
+                stmt = stmt.where(SqlConversation.archived.is_(False))
 
             if parent_conversation_id is not None:
                 stmt = stmt.where(
@@ -2239,14 +2263,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 ]
         else:
             convs = []
-        # Parent-scoped listing skips the metadata prefetch, so apply the
-        # archived exclusion here on the page's own (already-fetched) metadata.
-        # A parent's children are a small, bounded set and are not archived in
-        # practice (archiving is an owner-gated top-level action with no
-        # child cascade), so this filter is a no-op in the common case and
-        # never yields a short page; ``has_more`` stays conservative.
-        if parent_scoped and not include_archived:
-            convs = [conv for conv in convs if not conv.archived]
         for conv in convs:
             conv.search_snippet = snippets.get(conv.id)
         return PagedList(
@@ -2430,10 +2446,12 @@ class SqlAlchemyConversationStore(ConversationStore):
                 agent_config.harness_override = harness_override
                 ap_changed = True
             if archived is not None:
-                ap_changed = True  # archived is a visible state change
+                # archived lives on the AP conversations row; a visible state change.
+                row.archived = archived
+                ap_changed = True
             if ap_changed:
                 row.updated_at = now
-        if archived is not None or terminal_launch_args is not None:
+        if terminal_launch_args is not None:
             with self._session() as meta_sess:
                 meta = meta_sess.get(
                     SqlConversationMetadata, (current_workspace_id(), conversation_id)
@@ -2453,10 +2471,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                         parent_conversation_id=row.parent_conversation_id,
                     )
                     meta_sess.add(meta)
-                if archived is not None:
-                    meta.archived = archived
-                if terminal_launch_args is not None:
-                    meta.terminal_launch_args = json.dumps(terminal_launch_args)
+                meta.terminal_launch_args = json.dumps(terminal_launch_args)
         return self.get_conversation(conversation_id)
 
     def set_runner_id(self, conversation_id: str, runner_id: str) -> bool:

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -69,6 +69,7 @@ def _make_conversation(
     parent_conversation_id: str | None = None,
     root_conversation_id: str | None = None,
     title: str | None = None,
+    archived: bool = False,
 ) -> SqlConversation:
     return SqlConversation(
         id=id,
@@ -77,6 +78,7 @@ def _make_conversation(
         parent_conversation_id=parent_conversation_id,
         root_conversation_id=root_conversation_id or id,
         title=title,
+        archived=archived,
     )
 
 
@@ -94,7 +96,6 @@ def _make_metadata(
     return SqlConversationMetadata(
         id=id,
         kind=encode_conversation_kind(kind),
-        archived=False,
     )
 
 
@@ -380,7 +381,7 @@ class TestSqlConversation:
             assert loaded.agent_id is None
 
     def test_metadata_kind_and_archived(self, db_uri: str) -> None:
-        """kind and archived live on SqlConversationMetadata, not SqlConversation."""
+        """kind lives on SqlConversationMetadata; archived on SqlConversation."""
         engine = get_or_create_engine(db_uri)
         managed = make_managed_session_maker(engine)
 
@@ -391,10 +392,12 @@ class TestSqlConversation:
             session.add(meta)
 
         with managed() as session:
-            loaded = session.get(SqlConversationMetadata, (0, "conv_test1"))
-            assert loaded is not None
-            assert loaded.kind == encode_conversation_kind("default")
-            assert loaded.archived is False
+            loaded_meta = session.get(SqlConversationMetadata, (0, "conv_test1"))
+            assert loaded_meta is not None
+            assert loaded_meta.kind == encode_conversation_kind("default")
+            loaded_conv = session.get(SqlConversation, (0, "conv_test1"))
+            assert loaded_conv is not None
+            assert loaded_conv.archived is False
 
     def test_metadata_check_constraint_rejects_invalid_kind(self, db_uri: str) -> None:
         engine = get_or_create_engine(db_uri)

--- a/tests/db/test_migration_archived.py
+++ b/tests/db/test_migration_archived.py
@@ -1,12 +1,15 @@
-"""Tests for the ``omnigent_conversation_metadata.archived`` column and its migration.
+"""Tests for the ``conversations.archived`` column and its migration.
 
 Per the archive-session feature: archived sessions are hidden from the
 default ``GET /v1/sessions`` listing. The column is NOT NULL with a
 ``server_default`` of false so existing rows backfill to not-archived
 when the migration applies to a populated database.
 
-After the schema split (aa1b2c3d4e5f), ``archived`` lives on
-``omnigent_conversation_metadata`` rather than ``conversations``.
+The schema split (aa1b2c3d4e5f) moved ``archived`` onto
+``omnigent_conversation_metadata``. Migration ``9d820f91deef`` moves it back
+onto ``conversations`` so ``list_conversations`` can filter it inline next to
+the created_at/updated_at sort keys; these tests assert the post-move state
+and the backfill.
 """
 
 from __future__ import annotations
@@ -16,9 +19,18 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
+from alembic import command
 from sqlalchemy.engine import Engine
 
-from omnigent.db.utils import clear_engine_cache, get_or_create_engine
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+# Revision just before ``archived`` was moved back to conversations.
+_PRE_MOVE_REVISION = "cc3d4e5f6a7b"
+_MOVE_REVISION = "9d820f91deef"
 
 
 @pytest.fixture
@@ -40,35 +52,47 @@ def db_engine(tmp_path: Path) -> Iterator[Engine]:
 
 def test_archived_column_present_and_not_nullable(db_engine: Engine) -> None:
     """
-    The migration creates ``omnigent_conversation_metadata.archived`` as a
-    NOT NULL boolean.
+    The migration creates ``conversations.archived`` as a NOT NULL boolean and
+    removes it from ``omnigent_conversation_metadata``.
 
-    A failure on presence means the migration didn't apply — the ORM
-    mapping would then crash on every conversation read. NOT NULL
-    matters because the listing filter (``archived IS false``) and the
-    entity field (``bool``) both assume a concrete value, never NULL.
+    A failure on presence means the migration didn't apply — the ORM mapping
+    would then crash on every conversation read. NOT NULL matters because the
+    listing filter (``archived IS false``) and the entity field (``bool``)
+    both assume a concrete value, never NULL.
     """
-    cols = sa.inspect(db_engine).get_columns("omnigent_conversation_metadata")
-    archived_cols = [c for c in cols if c["name"] == "archived"]
-    assert len(archived_cols) == 1, (
-        f"Expected exactly one 'archived' column on omnigent_conversation_metadata, "
-        f"got {len(archived_cols)}. If 0, the migration didn't apply."
+    insp = sa.inspect(db_engine)
+    conv_cols = [c for c in insp.get_columns("conversations") if c["name"] == "archived"]
+    assert len(conv_cols) == 1, (
+        f"Expected exactly one 'archived' column on conversations, got "
+        f"{len(conv_cols)}. If 0, the migration didn't apply."
     )
-    assert not archived_cols[0]["nullable"], (
-        "omnigent_conversation_metadata.archived must be NOT NULL — the listing filter "
-        "and entity field both assume a concrete true/false value."
+    assert not conv_cols[0]["nullable"], (
+        "conversations.archived must be NOT NULL — the listing filter and "
+        "entity field both assume a concrete true/false value."
     )
+    meta_cols = [
+        c for c in insp.get_columns("omnigent_conversation_metadata") if c["name"] == "archived"
+    ]
+    assert not meta_cols, (
+        "archived must no longer exist on omnigent_conversation_metadata after the move."
+    )
+
+
+def test_archived_index_present(db_engine: Engine) -> None:
+    """The default-sidebar support index lives on ``conversations``."""
+    idx = {i["name"] for i in sa.inspect(db_engine).get_indexes("conversations")}
+    assert "ix_conversations_archived_updated" in idx
 
 
 def test_archived_defaults_false_on_insert(db_engine: Engine) -> None:
     """
     An insert that omits ``archived`` lands as false (0).
 
-    This exercises the ``server_default`` clause — the same default
-    that backfills pre-existing rows when the column is added to a
-    populated table. If it regressed, a NOT NULL insert without the
-    column would fail, or existing sessions would come back archived
-    (vanished from the sidebar) after the upgrade.
+    This exercises the ``server_default`` clause — the same default that
+    backfills pre-existing rows when the column is added to a populated
+    table. If it regressed, a NOT NULL insert without the column would fail,
+    or existing sessions would come back archived (vanished from the sidebar)
+    after the upgrade.
     """
     with db_engine.connect() as conn:
         # root_conversation_id is a NOT NULL self-FK; a top-level row's
@@ -81,13 +105,50 @@ def test_archived_defaults_false_on_insert(db_engine: Engine) -> None:
             ),
             {"id": "conv_arch_default", "ts": 1700000000},
         )
-        conn.execute(
-            sa.text("INSERT INTO omnigent_conversation_metadata (id, kind) VALUES (:id, 1)"),
-            {"id": "conv_arch_default"},
-        )
         conn.commit()
         value = conn.execute(
-            sa.text("SELECT archived FROM omnigent_conversation_metadata WHERE id = :id"),
+            sa.text("SELECT archived FROM conversations WHERE id = :id"),
             {"id": "conv_arch_default"},
         ).scalar_one()
         assert value == 0, f"Expected archived to default to 0 (false); got {value!r}."
+
+
+def test_archived_backfilled_from_metadata(tmp_path: Path) -> None:
+    """
+    The move migration copies each row's ``archived`` value from
+    ``omnigent_conversation_metadata`` onto ``conversations``.
+
+    Seed rows at the pre-move revision (archived still on metadata), apply the
+    move, and assert the AP column matches the original metadata value.
+    """
+    uri = f"sqlite:///{tmp_path / 'backfill.db'}"
+    cfg = _build_alembic_config(uri)
+    raw_engine = sa.create_engine(uri)
+    try:
+        with raw_engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.upgrade(cfg, _PRE_MOVE_REVISION)
+            conn.execute(
+                sa.text(
+                    "INSERT INTO conversations "
+                    "(id, created_at, updated_at, root_conversation_id) "
+                    "VALUES ('conv_a', 1, 1, 'conv_a'), ('conv_b', 2, 2, 'conv_b')"
+                )
+            )
+            conn.execute(
+                sa.text(
+                    "INSERT INTO omnigent_conversation_metadata (id, kind, archived) "
+                    "VALUES ('conv_a', 1, 1), ('conv_b', 1, 0)"
+                )
+            )
+        with raw_engine.begin() as conn:
+            cfg.attributes["connection"] = conn
+            command.upgrade(cfg, _MOVE_REVISION)
+        with raw_engine.connect() as conn:
+            rows = dict(
+                conn.execute(sa.text("SELECT id, archived FROM conversations ORDER BY id")).all()
+            )
+        assert rows == {"conv_a": 1, "conv_b": 0}
+    finally:
+        raw_engine.dispose()
+        clear_engine_cache()

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1303,6 +1303,54 @@ def test_list_conversations_excludes_archived_by_default(
     )
 
 
+def test_list_conversations_kind_filter_returns_only_matching(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    ``kind`` filtering (derived from ``parent_conversation_id``) returns exactly
+    the default rows or exactly the sub-agent rows.
+
+    A top-level and a sub-agent conversation must land in the right bucket,
+    ``kind=None`` must return both, and the sub-agent must never appear in the
+    default listing (the sidebar's view).
+    """
+    top = conversation_store.create_conversation(kind="default", title="top")
+    parent = conversation_store.create_conversation(kind="default", title="parent")
+    child = conversation_store.create_conversation(
+        kind="sub_agent", title="child", parent_conversation_id=parent.id
+    )
+
+    default_ids = {c.id for c in conversation_store.list_conversations(kind="default").data}
+    sub_ids = {c.id for c in conversation_store.list_conversations(kind="sub_agent").data}
+    any_ids = {c.id for c in conversation_store.list_conversations(kind=None).data}
+
+    assert default_ids == {top.id, parent.id}, (
+        f"kind=default must return only top-level rows; got {default_ids}"
+    )
+    assert sub_ids == {child.id}, f"kind=sub_agent must return only children; got {sub_ids}"
+    assert child.id not in default_ids, "sub-agent must never appear in the default listing"
+    assert any_ids >= {top.id, parent.id, child.id}, "kind=None must return every kind"
+
+
+def test_list_conversations_archive_toggle_round_trips(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    Archiving then unarchiving a session moves it out of and back into the
+    default listing — the AP-side ``archived`` column is the source of truth.
+    """
+    conv = conversation_store.create_conversation(title="toggle")
+    assert conv.id in {c.id for c in conversation_store.list_conversations().data}
+
+    archived = conversation_store.update_conversation(conv.id, archived=True)
+    assert archived is not None and archived.archived is True
+    assert conv.id not in {c.id for c in conversation_store.list_conversations().data}
+
+    unarchived = conversation_store.update_conversation(conv.id, archived=False)
+    assert unarchived is not None and unarchived.archived is False
+    assert conv.id in {c.id for c in conversation_store.list_conversations().data}
+
+
 # ── Delete ───────────────────────────────────────────
 
 
@@ -1551,8 +1599,16 @@ def test_subagent_conversations_are_isolated(
     in ``list_items`` is broken, which would cause sub-agents to
     see each other's messages and produce incoherent LLM prompts.
     """
-    conv_a = conversation_store.create_conversation(kind="sub_agent")
-    conv_b = conversation_store.create_conversation(kind="sub_agent")
+    # Sub-agents require a parent (kind="sub_agent" iff parent set). A shared
+    # parent is fine — the test only asserts the two children's items are
+    # isolated from each other.
+    parent = conversation_store.create_conversation(kind="default")
+    conv_a = conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id, title="alpha"
+    )
+    conv_b = conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id, title="bravo"
+    )
 
     # Append distinct items to each conversation.
     conversation_store.append(

--- a/tests/stores/test_conversation_store_split_db.py
+++ b/tests/stores/test_conversation_store_split_db.py
@@ -454,16 +454,17 @@ def test_agent_store_resolves_session_id_across_dbs(
 # ── Orphan repair: update with a missing metadata row ─────────────────
 
 
-def test_update_conversation_repairs_missing_metadata(
+def test_update_conversation_archives_without_metadata_row(
     omnigent_db: Path,
     conv_db: Path,
     store: SqlAlchemyConversationStore,
 ) -> None:
     """
-    A crash between the AP and metadata transactions during creation
-    leaves a conversation with no metadata row. An archive update must
-    recreate the row (deriving ``kind`` from the parent pointer) rather
-    than silently dropping the write and reporting ``archived=False``.
+    A crash between the AP and metadata transactions during creation leaves a
+    conversation with no metadata row. ``archived`` now lives on the AP
+    conversations row, so an archive update must persist and report correctly
+    even without a metadata row — and ``kind`` stays correct (derived from the
+    parent pointer), never silently reporting ``archived=False``.
     """
     parent = store.create_conversation(title="orphan parent")
     child = store.create_conversation(
@@ -483,17 +484,20 @@ def test_update_conversation_repairs_missing_metadata(
     updated = store.update_conversation(parent.id, archived=True)
     assert updated is not None
     assert updated.archived is True
+    assert updated.kind == "default"
 
     child_updated = store.update_conversation(child.id, archived=True)
     assert child_updated is not None
     assert child_updated.archived is True
-    # kind is rederived from the parent pointer during repair.
+    # kind is derived from the parent pointer, not the (missing) metadata row.
     assert child_updated.kind == "sub_agent"
 
-    # Both metadata rows were recreated in the Omnigent DB.
-    assert sorted(_col(omnigent_db, "omnigent_conversation_metadata", "id")) == sorted(
+    # archived is persisted on the AP conversations rows.
+    assert sorted(_col(conv_db, "conversations", "id", where="archived = 1")) == sorted(
         [parent.id, child.id]
     )
+    # The archive path does not resurrect metadata rows (archived is AP-side now).
+    assert _count(omnigent_db, "omnigent_conversation_metadata") == 0
 
 
 # ── Session-scoped agent cleanup on conversation delete ───────────────


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #2562, which fixed the `kind` half of the post-split (#2341) `list_conversations` slowdown. `#2562` left the sidebar (`GET /v1/sessions`) still pre-fetching `archived` from the Omnigent DB: the split put `archived` on `omnigent_conversation_metadata` while the sort keys (`created_at`/`updated_at`) stayed on the AP `conversations` table, so the two couldn't be combined in one query and the listing pre-loaded a workspace-wide id set into a giant `IN (...)`.

This moves `archived` back onto `conversations` so it's filtered inline next to the sort keys:

- **Migration `9d820f91deef`**: add `conversations.archived`, backfill from `omnigent_conversation_metadata` (portable correlated-subquery `UPDATE`), drop it from metadata, add `ix_conversations_archived_updated (workspace_id, archived, updated_at, id)` — the sidebar sorts by `updated_at`.
- **Store**: `_to_conversation` reads `row.archived`; `create`/`update_conversation` write the AP row; `list_conversations` and `list_projects` filter `archived` inline. Removes #2562's parent-scoped in-memory archived post-filter, and rewrites the permission pre-fetch to read `session_permissions` directly (no metadata table).

After this, `list_conversations`' remaining Omnigent-side pre-fetch is **ACL-only**. ACL push-down (`session_permissions` lives on the Omnigent DB) is intentionally out of scope for a follow-up.

## Test Plan

```
uv run pytest \
  tests/db/test_migration_archived.py \
  tests/db/test_db_models.py \
  tests/db/test_migrations_sqlite_safe.py \
  tests/stores/test_conversation_store.py \
  tests/stores/test_conversation_store_split_db.py
```

All green. Verified the migration up→down→up round-trip on SQLite and that `archived` values backfill correctly from metadata. Added single-DB regression tests for the `kind` filter and an archive/unarchive round-trip; updated the split-DB orphan test to the new AP-side behaviour.

## Demo

N/A — server-side query/schema change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by new + existing automated tests (db + store suites). The `tests/server/integration/` suite was not run locally.

## Changelog

Sessions list no longer does a workspace-wide id pre-fetch for the archived filter, restoring the single indexed query on the sidebar path.

This pull request and its description were written by Isaac.
