### PR TITLE
test(e2e_ui): de-flake file-search + agent-info-copy tests

### DIFF
--- a/tests/e2e_ui/files/test_file_search.py
+++ b/tests/e2e_ui/files/test_file_search.py
@@ -58,6 +58,25 @@ def _row(rail: Locator, name: str) -> Locator:
     return rail.get_by_role("button", name=re.compile(re.escape(name))).filter(has_text=name)
 
 
+def _search_for(search: Locator, query: str) -> None:
+    """Type ``query`` into the All search box and confirm it stuck.
+
+    The rail restores its ``?view=explore`` scope and lists files on mount at
+    the same time the chat composer autofocuses its textarea. A ``fill`` issued
+    in that window can lose focus mid-keystroke (or land in the composer), so
+    the search input reads back empty and the debounced ``/search`` never fires
+    — leaving the tree unfiltered. Asserting the value landed retries the fill
+    until it holds, so the query actually runs before we assert on results.
+    """
+    search.fill(query)
+    expect(search).to_have_value(query)
+
+
+# The fill can race the rail's mount-time re-render (scope restore + first
+# listing) and the composer autofocus, dropping the typed query so the tree
+# stays unfiltered. ``_search_for`` waits the value in to make that rare, and
+# the rerun covers the residual race rather than widening per-action waits.
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_search_filters_all_files(
     page: Page,
     all_search_session: tuple[str, str],
@@ -69,15 +88,21 @@ def test_search_filters_all_files(
     rail = page.get_by_role("complementary", name="Workspace")
     search = rail.get_by_role("searchbox", name="Search all files")
     expect(search).to_be_visible(timeout=30_000)
+    # Wait for the All tree to finish its initial listing before searching: the
+    # seeded files must be on screen so the panel has settled out of its mount
+    # -time re-render (scope restore + first fetch) that would otherwise reset
+    # the search box.
+    for name in _ALL_FILES:
+        expect(_row(rail, name)).to_be_visible(timeout=15_000)
 
     # Server-side recursive search (debounced ~300ms): only beta matches.
-    search.fill("beta_three")
+    _search_for(search, "beta_three")
     expect(_row(rail, _BETA)).to_be_visible(timeout=15_000)
     expect(_row(rail, _ALPHA_ONE)).to_have_count(0)
     expect(_row(rail, _ALPHA_TWO)).to_have_count(0)
 
     # Re-querying for the shared fragment surfaces both alpha files.
-    search.fill("alpha_")
+    _search_for(search, "alpha_")
     expect(_row(rail, _ALPHA_ONE)).to_be_visible(timeout=15_000)
     expect(_row(rail, _ALPHA_TWO)).to_be_visible()
     expect(_row(rail, _BETA)).to_have_count(0)

--- a/tests/e2e_ui/sessions/test_agent_info_copy_session_id.py
+++ b/tests/e2e_ui/sessions/test_agent_info_copy_session_id.py
@@ -11,9 +11,16 @@ from __future__ import annotations
 import uuid
 
 import httpx
+import pytest
 from playwright.sync_api import Page, expect
 
 
+# The header only mounts once the session binds and hydrates, so the
+# info trigger can lag behind ``goto`` — clicking it while the header is
+# still settling occasionally times out (or opens a popover that re-renders
+# out from under the copy button). Rerun on failure rather than paper over
+# the race with longer per-action waits.
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_agent_info_copies_session_id(
     page: Page,
     seeded_session: tuple[str, str],
@@ -42,7 +49,12 @@ def test_agent_info_copies_session_id(
     page.context.grant_permissions(["clipboard-read", "clipboard-write"], origin=base_url)
     page.goto(f"{base_url}/c/{session_id}")
 
-    page.get_by_test_id("agent-info-trigger").click()
+    # Wait for the header info trigger to mount + become actionable before
+    # clicking: the button only renders once the session binds, and clicking
+    # mid-hydration is the main flake source here.
+    trigger = page.get_by_test_id("agent-info-trigger")
+    expect(trigger).to_be_visible(timeout=30_000)
+    trigger.click()
 
     expect(page.get_by_test_id("agent-info-session-id")).to_have_text(session_id)
     copy_button = page.get_by_test_id("agent-info-copy-session-id")


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two E2E-UI shard-0 tests flake on mount-time races — surfaced on an
unrelated PR's CI, but not caused by any product change:

- **`test_search_filters_all_files`** — `search.fill(...)` can race the
  Files rail's mount-time re-render (`?view=explore` scope restore + first
  listing) and the composer's autofocus. The typed query gets dropped
  before the debounced `/search` fires, so the tree stays unfiltered and
  the `alpha_one.py` count-0 assertion fails. A Playwright trace from the
  failing run confirmed it: the search box read back empty, the text
  "beta_three" landed in the **chat composer**, and `/search` was never
  called. Fix: wait for the initial listing to settle (all seeded files
  visible), then assert the search value actually landed before checking
  results.
- **`test_agent_info_copies_session_id`** — the header info trigger mounts
  only after the session binds/hydrates, so clicking it right after `goto`
  can time out (observed across runs as a `click` timeout, a
  `to_be_visible` failure, etc.). Fix: wait for the trigger to be visible
  before clicking.

Both also get the repo's `@pytest.mark.flaky(reruns=2, reruns_delay=5)`
marker (already used by `test_clone_session` and `test_mobile_workflow`)
as a backstop for the residual timing race, rather than widening
per-action waits.

## Test Plan

```
OMNIGENT_SKIP_WEB_UI=true uv run --extra dev pytest \
  tests/e2e_ui/files/test_file_search.py \
  tests/e2e_ui/sessions/test_agent_info_copy_session_id.py
```

Both pass. `test_file_search` was additionally stress-run 5× in a loop
(`--ui-skip-build`) — 5/5 green — to confirm the race fix holds. Ruff
check + format clean.

## Demo

N/A — test-only change; no UI/behaviour change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The changed files *are* the E2E tests. Verified manually by running both
tests locally (green) and stress-running the previously-failing
`test_file_search` 5× in a row without a flake.
