### PR TITLE
fix(cli): surface clean errors when binding a session runner times out

### DIFF
--- a/omnigent/native_terminal.py
+++ b/omnigent/native_terminal.py
@@ -62,10 +62,38 @@ async def bind_session_runner(
     :returns: None.
     :raises click.ClickException: If binding fails.
     """
-    resp = await client.patch(
-        f"/v1/sessions/{url_component(session_id)}",
-        json={"runner_id": runner_id},
-    )
+    try:
+        resp = await client.patch(
+            f"/v1/sessions/{url_component(session_id)}",
+            json={"runner_id": runner_id},
+        )
+    except httpx.ConnectError as exc:
+        # Connection refused/reset or DNS failure: the server was never reached.
+        raise click.ClickException(
+            f"Couldn't reach the Omnigent server to bind session {session_id!r} ({exc!r}). "
+            "Check the server URL and your connection."
+        ) from exc
+    except httpx.ConnectTimeout as exc:
+        # Connect phase timed out: also never reached the server (down or wrong
+        # host), so point at the URL/connection rather than server load.
+        raise click.ClickException(
+            f"Couldn't reach the Omnigent server to bind session {session_id!r}: connection "
+            f"timed out ({exc!r}). Check the server URL and your connection."
+        ) from exc
+    except httpx.TimeoutException as exc:
+        # Connected, but the server didn't respond in time: it's reachable and
+        # likely slow rather than down.
+        raise click.ClickException(
+            f"Timed out binding session {session_id!r}: the Omnigent server is responding too "
+            f"slowly ({exc!r}); retry shortly."
+        ) from exc
+    except httpx.TransportError as exc:
+        # Any other transport failure (protocol error, etc.): no response, so
+        # there is no status to report.
+        raise click.ClickException(
+            f"Couldn't reach the Omnigent server to bind session {session_id!r} ({exc!r}). "
+            "Check the server URL and your connection."
+        ) from exc
     if resp.status_code >= 400:
         raise click.ClickException(
             f"Native terminal session runner bind failed ({resp.status_code}): {error_text(resp)}"

--- a/tests/test_native_terminal.py
+++ b/tests/test_native_terminal.py
@@ -75,6 +75,90 @@ async def test_bind_session_runner_raises_click_exception_on_http_error() -> Non
             await native_terminal.bind_session_runner(client, "conv_abc", "runner_abc")
 
 
+@pytest.mark.asyncio
+async def test_bind_session_runner_raises_click_exception_on_timeout() -> None:
+    """
+    Read timeouts surface as a "server overloaded" ClickException.
+
+    When the server connects but is too slow to answer, the PATCH raises
+    before any response exists. A timeout means reachable-but-slow, so the
+    message must say to retry rather than a raw ``httpx.ReadTimeout`` trace.
+    """
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """
+        Simulate the server never sending response headers.
+
+        :param request: HTTP request produced by
+            :func:`native_terminal.bind_session_runner`.
+        :raises httpx.ReadTimeout: Always, to model a slow/overloaded server.
+        """
+        raise httpx.ReadTimeout("read timed out", request=request)
+
+    async with httpx.AsyncClient(
+        base_url="https://example.databricks.com",
+        transport=httpx.MockTransport(_handler),
+    ) as client:
+        with pytest.raises(click.ClickException, match="responding too slowly"):
+            await native_terminal.bind_session_runner(client, "conv_abc", "runner_abc")
+
+
+@pytest.mark.asyncio
+async def test_bind_session_runner_raises_click_exception_on_connect_error() -> None:
+    """
+    Connection failures surface as an "unreachable" ClickException.
+
+    A connect error (bad URL, reset, DNS failure) means the server was
+    never reached, so the message points at the URL/connection rather
+    than leaking a raw ``httpx.ConnectError`` stack trace.
+    """
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """
+        Simulate a failed connection attempt.
+
+        :param request: HTTP request produced by
+            :func:`native_terminal.bind_session_runner`.
+        :raises httpx.ConnectError: Always, to model an unreachable server.
+        """
+        raise httpx.ConnectError("connection refused", request=request)
+
+    async with httpx.AsyncClient(
+        base_url="https://example.databricks.com",
+        transport=httpx.MockTransport(_handler),
+    ) as client:
+        with pytest.raises(click.ClickException, match="Couldn't reach the Omnigent server"):
+            await native_terminal.bind_session_runner(client, "conv_abc", "runner_abc")
+
+
+@pytest.mark.asyncio
+async def test_bind_session_runner_treats_connect_timeout_as_unreachable() -> None:
+    """
+    Connect timeouts point at the URL/connection, not server load.
+
+    ``httpx.ConnectTimeout`` subclasses ``TimeoutException``, but the
+    connect phase timing out means the server was never reached, so it
+    must not use the "responding too slowly" message.
+    """
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """
+        Simulate the connect phase timing out.
+
+        :param request: HTTP request produced by
+            :func:`native_terminal.bind_session_runner`.
+        :raises httpx.ConnectTimeout: Always, to model an unreachable server.
+        """
+        raise httpx.ConnectTimeout("connect timed out", request=request)
+
+    async with httpx.AsyncClient(
+        base_url="https://example.databricks.com",
+        transport=httpx.MockTransport(_handler),
+    ) as client:
+        with pytest.raises(click.ClickException, match="Couldn't reach the Omnigent server"):
+            await native_terminal.bind_session_runner(client, "conv_abc", "runner_abc")
+
+
 def test_terminal_attach_url_encodes_path_components_and_switches_scheme() -> None:
     """
     Attach URLs preserve base paths and percent-encode ids.


### PR DESCRIPTION
## Related issue

N/A

## Summary

I hit this today with the Databricks-internal hosted Omnigent server: if the session-bind PATCH hits a server that is slow or unreachable, bind_session_runner will leak the raw httpx exception and the CLI ends up dumping a full traceback instead of showing a useful error.

- Wrap the session-bind `PATCH` so transport failures become a clean one-line `Error:` (full traceback still logged to `~/.omnigent/logs/`).
 - Distinguish unreachable (connect error/timeout → "check the URL & connection") from reachable-but-slow (read timeout -> "retry shortly").

## Test Plan

- `uv run --extra dev pytest tests/test_native_terminal.py` — 6 passed, including 3 new tests injecting `ReadTimeout`, `ConnectError`, and `ConnectTimeout` and asserting the matching clean message.
- `uv run --extra dev ruff check` / `ruff format --check` — clean.
- `pre-commit run --files ...` — passed.
- Drove the real function via a `MockTransport` handler that raises each transport error and confirmed the rendered `Error:` strings (no traceback).

## Demo

Before:

<img width="1362" height="737" alt="Screenshot 2026-07-14 at 5 29 59 PM" src="https://github.com/user-attachments/assets/83a30c68-c5e9-46be-9efa-bdaa72984cde" />

After:

<img width="1179" height="81" alt="Screenshot 2026-07-14 at 5 32 04 PM" src="https://github.com/user-attachments/assets/8ba773d8-6559-420d-a9e3-2a8be78cfcde" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added unit tests for all three transport-failure branches (read timeout,
connect error, connect timeout) using `httpx.MockTransport`. Manually verified
by invoking `bind_session_runner` against a mock transport that raises each
exception and confirming the one-line `Error:` output.

Not exercised end-to-end through the live CLI.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

The CLI now shows a clear error instead of a raw traceback when the server is too slow or unreachable while starting a session.