### PR TITLE
fix(pi): tag reasoning-first gateway models with Pi's reasoning flag

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -809,11 +809,26 @@ def _build_models_json(
             # provider-side 400 on image turns — a deliberate trade (loud error
             # over silent loss), since most current gateway models are
             # multimodal and text-only turns are unaffected.
-            provider["models"] = [
-                *provider["models"],
-                {"id": model, "input": ["text", "image"]},
-            ]
+            entry: dict[str, Any] = {"id": model, "input": ["text", "image"]}  # type: ignore[explicit-any]
+            if _pi_model_is_reasoning(model):
+                entry["reasoning"] = True
+            provider["models"] = [*provider["models"], entry]
     return config
+
+
+# Model-id fragments of completions-gateway models that stream their output on
+# the ``reasoning_content`` channel (GLM, DeepSeek-R1, ...). Pi's
+# openai-completions parser only consumes that channel when the model entry
+# declares ``reasoning: true``; without it the stream carries no ``content``
+# and the turn dies with "Stream ended without finish_reason". Extend this
+# tuple when the gateway grows another reasoning-first model family.
+_PI_REASONING_MODEL_FRAGMENTS: tuple[str, ...] = ("glm", "deepseek")
+
+
+def _pi_model_is_reasoning(model: str) -> bool:
+    """Return whether *model* needs Pi's ``reasoning: true`` model flag."""
+    lower = model.lower()
+    return any(fragment in lower for fragment in _PI_REASONING_MODEL_FRAGMENTS)
 
 
 def _pi_provider_for_model(model: str) -> str:

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -445,6 +445,24 @@ class TestBuildModelsJson(unittest.TestCase):
         entry = next(e for e in provider["models"] if e["id"] == model)
         self.assertEqual(entry.get("input"), ["text", "image"])
 
+    def test_dynamic_reasoning_model_gets_reasoning_flag(self):
+        # GLM/DeepSeek stream their output on ``reasoning_content``;
+        # without ``reasoning: true`` Pi's openai-completions parser never
+        # consumes that channel and the turn dies with "Stream ended without
+        # finish_reason".
+        for model in ("databricks-glm-5-2", "databricks-deepseek-r1"):
+            result = _build_models_json("https://host.example.com", "tok", model=model)
+            provider = result["providers"][_pi_provider_for_model(model)]
+            entry = next(e for e in provider["models"] if e["id"] == model)
+            self.assertIs(entry.get("reasoning"), True, model)
+
+    def test_dynamic_non_reasoning_model_has_no_reasoning_flag(self):
+        model = "databricks-gemini-2-5-pro"
+        result = _build_models_json("https://host.example.com", "tok", model=model)
+        provider = result["providers"][_pi_provider_for_model(model)]
+        entry = next(e for e in provider["models"] if e["id"] == model)
+        self.assertNotIn("reasoning", entry)
+
     def test_static_model_declared_image_capable(self):
         # #516 review: a STATIC (pre-registered) vision model must also
         # advertise image input. The dynamic-registration append is gated on


### PR DESCRIPTION
## Related issue

Closes #2560

## Summary

- Databricks GLM-5.2 (and DeepSeek-R1-style models) stream their output on the `reasoning_content` channel. Pi's openai-completions parser only consumes that channel when the model entry declares `reasoning: true`, so the bare entry `_build_models_json` registered dynamically left the stream with no `content` — the turn failed with `inner executor error: Stream ended without finish_reason`.
- Fix: a `_pi_model_is_reasoning()` helper (model-id fragment match on `glm` / `deepseek`) sets `"reasoning": True` on the dynamically-registered entry. Those fragments never contain `claude`/`gpt`, so only `databricks-completions`-routed models are affected; Claude/GPT keep their native thinking paths.

ELI5: the model whispers its whole answer in a side channel Pi wasn't told to listen to, so Pi thought the model said nothing. The fix tells Pi "this model whispers — listen to the side channel."

## Test Plan

- New unit tests: GLM/DeepSeek dynamic entries carry `reasoning: true`; a non-reasoning dynamic model (gemini) does not.
- Full `tests/inner/test_pi_executor.py` suite: 137 passed.
- The issue reporter verified this exact change live against `databricks-glm-5-2` (and `[1m]`): reasoning turns complete cleanly with correct output and usage.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Changelog

Pi harness: Databricks GLM/DeepSeek reasoning models no longer fail with "Stream ended without finish_reason"

This pull request and its description were written by Isaac.