### PR TITLE
feat(oidc): manage the admin flag from a configurable id_token claim

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -419,6 +419,13 @@ admins: [you@yourcompany.com]         # who can manage members
 ```
 
 > [!TIP]
+> Prefer to manage admins in your IdP? Set `OMNIGENT_OIDC_ADMIN_CLAIM` (e.g.
+> `groups`) and `OMNIGENT_OIDC_ADMIN_VALUE` (the group/role that grants admin).
+> Membership becomes the source of truth — matching users are promoted on
+> login and losing the claim demotes them. The `admins:` list stays as a
+> break-glass override that only ever promotes.
+
+> [!TIP]
 > Need to let in one outsider, say a contractor on a personal account? Set
 > `OMNIGENT_OIDC_ALLOW_INVITES=1` and send them a one-time invite link,
 > instead of opening up the whole allowlist.

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -152,6 +152,19 @@ POSTGRES_PASSWORD=change-me-please
 # user's identity. Off by default.
 # OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION=1
 
+# Manage admins in the IdP: the named id_token claim becomes
+# authoritative for the admin flag at every login — a matching value
+# promotes, a present-but-unmatching claim demotes. A token WITHOUT
+# the claim changes nothing (fail-safe), and the admin list file
+# (/data/admins) still promotes afterwards as the break-glass
+# override. ADMIN_VALUE is the value that grants admin: for a list
+# claim (groups/roles) an element, for a scalar the exact value;
+# optional only when the claim is boolean. Requires the IdP app to
+# actually emit the claim (e.g. enable the group attribute and add
+# its scope to OMNIGENT_OIDC_SCOPES if needed).
+# OMNIGENT_OIDC_ADMIN_CLAIM=groups
+# OMNIGENT_OIDC_ADMIN_VALUE=omnigent-admins
+
 # ── Server config file (admins, allowed domains, …) ──────
 # Non-secret settings live in a YAML config file — the same one
 # `omnigent server -c` reads. Default location is <data_dir>/config.yaml

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -101,6 +101,10 @@ services:
       # without API Access Management) that omit the claim for
       # directory-provisioned users. Off unless set; see .env.example.
       OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION: "${OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION:-}"
+      # IdP-driven admin management: this id_token claim is authoritative
+      # for the admin flag at every login. Off unless set; see .env.example.
+      OMNIGENT_OIDC_ADMIN_CLAIM: "${OMNIGENT_OIDC_ADMIN_CLAIM:-}"
+      OMNIGENT_OIDC_ADMIN_VALUE: "${OMNIGENT_OIDC_ADMIN_VALUE:-}"
       # Opt-in OIDC invites (admin pre-authorizes one off-domain email).
       # Off unless set. The admin list (/data/admins) and the optional
       # allowed-domains file (/data/allowed_domains) need no env var —

--- a/omnigent/server/admin_list.py
+++ b/omnigent/server/admin_list.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Protocol
 
@@ -241,3 +242,89 @@ def promote_if_listed(admin_list: AdminList, store: AdminFlagStore, user_id: str
     store.set_admin(user_id, True)
     logger.info("admin_list: promoted %s to admin", user_id)
     return True
+
+
+def evaluate_admin_claim(
+    claims: Mapping[str, object],
+    claim: str,
+    expected: str | None,
+) -> bool | None:
+    """Decide the admin flag from an IdP ``id_token`` claim.
+
+    The verdict is authoritative when reached (``True`` promotes,
+    ``False`` demotes), so every undecidable shape returns ``None``
+    (no-op) rather than ``False`` — a misconfigured IdP app or claim
+    mapping must never mass-demote existing admins:
+
+    - claim absent from the token, or JSON ``null`` → ``None``
+    - list value → *expected* must be set; ``True`` iff any element
+      stringifies to it (the groups/roles case)
+    - bool value → the bool itself when *expected* is unset, else
+      compared against ``"true"``/``"false"`` case-insensitively
+    - any other scalar → *expected* must be set; compared as strings
+
+    :param claims: The validated ``id_token`` claims.
+    :param claim: The claim name to consult, e.g. ``"groups"``.
+    :param expected: The value that grants admin, e.g.
+        ``"omnigent-admins"``; ``None`` only makes sense for a
+        boolean claim.
+    :returns: ``True``/``False`` when the claim yields a verdict,
+        ``None`` when the token carries no usable signal.
+    """
+    if claim not in claims:
+        return None
+    value = claims[claim]
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        if expected is None:
+            return value
+        return str(value).lower() == expected.strip().lower()
+    if expected is None:
+        logger.warning(
+            "admin claim %r has a non-boolean value but no expected "
+            "value is configured (OMNIGENT_OIDC_ADMIN_VALUE); ignoring",
+            claim,
+        )
+        return None
+    if isinstance(value, (list, tuple)):
+        return any(str(item) == expected for item in value)
+    return str(value) == expected
+
+
+def sync_admin_claim(
+    store: AdminFlagStore,
+    user_id: str,
+    claims: Mapping[str, object],
+    claim: str,
+    expected: str | None,
+) -> bool | None:
+    """Make the store's admin flag match the IdP claim's verdict.
+
+    Unlike :func:`promote_if_listed`, this is authoritative in both
+    directions: a matching claim promotes and a present-but-unmatching
+    claim demotes. When the token carries no usable signal (claim
+    absent/null — see :func:`evaluate_admin_claim`) the flag is left
+    untouched, so an IdP that stops sending the claim can't demote
+    everyone. Callers should apply :func:`promote_if_listed` *after*
+    this so the file-backed list stays a break-glass override.
+
+    :param store: The store backing ``users.is_admin``.
+    :param user_id: The just-authenticated identity (row must exist).
+    :param claims: The validated ``id_token`` claims.
+    :param claim: The claim name to consult.
+    :param expected: The value that grants admin, or ``None``.
+    :returns: The verdict applied, or ``None`` if no-op.
+    """
+    verdict = evaluate_admin_claim(claims, claim, expected)
+    if verdict is None:
+        return None
+    if store.is_admin(user_id) != verdict:
+        store.set_admin(user_id, verdict)
+        logger.info(
+            "admin claim %r %s %s",
+            claim,
+            "promoted" if verdict else "demoted",
+            user_id,
+        )
+    return verdict

--- a/omnigent/server/oidc.py
+++ b/omnigent/server/oidc.py
@@ -163,6 +163,13 @@ class OIDCConfig:
         ``id_token`` email claim without requiring
         ``email_verified``. Only affects the generic-OIDC path;
         GitHub always requires a verified primary email.
+    :param admin_claim: Optional ``id_token`` claim name that drives
+        the admin flag at every login (e.g. ``"groups"``). ``None``
+        disables IdP-driven admin management. See
+        :func:`omnigent.server.admin_list.sync_admin_claim` for the
+        authoritative-with-fail-safe semantics.
+    :param admin_value: The claim value that grants admin (e.g. a
+        group name). Optional only for a boolean claim.
     """
 
     issuer: str
@@ -181,6 +188,8 @@ class OIDCConfig:
     userinfo_endpoint: str | None
     allow_invites: bool
     skip_email_verification: bool = False
+    admin_claim: str | None = None
+    admin_value: str | None = None
 
     @property
     def base_url(self) -> str:
@@ -306,6 +315,25 @@ class OIDCConfig:
                 issuer,
             )
 
+        # IdP-driven admin management: the named id_token claim becomes
+        # authoritative for the admin flag at every login (promotes AND
+        # demotes; a token without the claim is a no-op, and the
+        # file-backed admin list still promotes afterwards as the
+        # break-glass override).
+        admin_claim = os.environ.get("OMNIGENT_OIDC_ADMIN_CLAIM", "").strip() or None
+        admin_value = os.environ.get("OMNIGENT_OIDC_ADMIN_VALUE", "").strip() or None
+        if admin_value and not admin_claim:
+            raise RuntimeError(
+                "OMNIGENT_OIDC_ADMIN_VALUE requires OMNIGENT_OIDC_ADMIN_CLAIM to be set"
+            )
+        if admin_claim:
+            _logger.info(
+                "OIDC admin management enabled: id_token claim %r "
+                "(expected value: %s) is authoritative for the admin flag",
+                admin_claim,
+                admin_value if admin_value is not None else "<boolean claim>",
+            )
+
         # Determine provider type and resolve endpoints.
         is_github = issuer.rstrip("/") == _GITHUB_ISSUER
 
@@ -329,6 +357,8 @@ class OIDCConfig:
                 userinfo_endpoint=_GITHUB_USERINFO_ENDPOINT,
                 allow_invites=allow_invites,
                 skip_email_verification=skip_email_verification,
+                admin_claim=admin_claim,
+                admin_value=admin_value,
             )
 
         # Standard OIDC: fetch discovery document.
@@ -371,4 +401,6 @@ class OIDCConfig:
             userinfo_endpoint=doc.get("userinfo_endpoint"),
             allow_invites=allow_invites,
             skip_email_verification=skip_email_verification,
+            admin_claim=admin_claim,
+            admin_value=admin_value,
         )

--- a/omnigent/server/routes/auth.py
+++ b/omnigent/server/routes/auth.py
@@ -24,7 +24,7 @@ from fastapi import APIRouter, Request
 from starlette.responses import RedirectResponse, Response
 
 from omnigent.server.accounts_store import SqlAlchemyAccountStore
-from omnigent.server.admin_list import AdminList, promote_if_listed
+from omnigent.server.admin_list import AdminList, promote_if_listed, sync_admin_claim
 from omnigent.server.auth import (
     _RESERVED_USERS,
     UnifiedAuthProvider,
@@ -281,11 +281,13 @@ def create_auth_router(
 
             token_json = token_resp.json()
 
-            # Extract user email.
+            # Extract user email (and, for generic OIDC, the validated
+            # id_token claims — the admin-claim sync below reads them).
+            id_claims: dict[str, object] = {}
             if config.provider_type == "github":
                 email = await _resolve_github_email(client, token_json.get("access_token", ""))
             else:
-                email = _resolve_oidc_email(token_json, config)
+                email, id_claims = _resolve_oidc_identity(token_json, config)
 
         if not email:
             return JSONResponse(
@@ -327,13 +329,23 @@ def create_auth_router(
                 content={"error": f"Reserved user name {email!r}"},
             )
 
-        # Ensure user exists in the permission store, then apply the
-        # file-backed admin list. Promotion is additive (never demotes)
-        # and is OIDC's only path to admin — the IdP doesn't tell us
-        # who is an operator. ensure_user must run first so the
-        # set_admin UPDATE inside promote_if_listed matches a row.
+        # Ensure the user row exists, then derive the admin flag.
+        # ensure_user must run first so the set_admin UPDATEs below
+        # match a row. Order matters after that: the IdP claim (when
+        # configured) is authoritative and may demote, but the
+        # file-backed admin list runs LAST as a break-glass override
+        # that still promotes — so an operator can always recover
+        # admin access even when the IdP claim mapping is wrong.
         if permission_store is not None:
             permission_store.ensure_user(email)
+            if config.admin_claim:
+                sync_admin_claim(
+                    permission_store,
+                    email,
+                    id_claims,
+                    config.admin_claim,
+                    config.admin_value,
+                )
             promote_if_listed(admin_list, permission_store, email)
 
         # Mint session cookie.
@@ -739,11 +751,11 @@ def _claim_is_verified_true(value: object) -> bool:
     return isinstance(value, str) and value.strip().lower() == "true"
 
 
-def _resolve_oidc_email(
+def _resolve_oidc_identity(
     token_json: dict,
     config: OIDCConfig,
-) -> str | None:
-    """Extract the verified email from the OIDC ``id_token``.
+) -> tuple[str | None, dict[str, object]]:
+    """Extract the verified email + validated claims from the ``id_token``.
 
     Validates the JWT signature against the IdP's JWKS, verifies
     ``iss`` and ``aud`` claims, and returns the ``email`` claim
@@ -765,14 +777,15 @@ def _resolve_oidc_email(
         ``id_token``.
     :param config: The OIDC configuration with JWKS URI and
         expected issuer/audience.
-    :returns: The user's email from the ``id_token`` when present and
-        marked verified; ``None`` if the token is missing/invalid,
-        the email claim is absent, or ``email_verified`` is not
-        truthy (and verification is not skipped via config).
+    :returns: ``(email, claims)`` — the email from the ``id_token``
+        when present and marked verified (else ``None``), and the
+        full validated claims dict (``{}`` when the token is
+        missing/invalid). Claims are only ever non-empty when the
+        signature and ``iss``/``aud`` checks passed.
     """
     id_token = token_json.get("id_token")
     if not id_token:
-        return None
+        return None, {}
 
     try:
         jwks_client = jwt.PyJWKClient(config.jwks_uri)
@@ -786,11 +799,11 @@ def _resolve_oidc_email(
         )
     except jwt.InvalidTokenError as exc:
         _logger.warning("id_token validation failed: %s", exc)
-        return None
+        return None, {}
 
     email = claims.get("email")
     if not email:
-        return None
+        return None, {}
 
     # Reject unless the IdP affirmatively verified the email. A signed
     # token only proves IdP provenance, not mailbox ownership.
@@ -804,14 +817,14 @@ def _resolve_oidc_email(
                 "(OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION is set)",
                 email,
             )
-            return email
+            return email, claims
         _logger.warning(
             "Rejecting id_token: email %r present but email_verified is not true",
             email,
         )
-        return None
+        return None, {}
 
-    return email
+    return email, claims
 
 
 # Forward ref for type annotation.

--- a/tests/server/test_admin_list.py
+++ b/tests/server/test_admin_list.py
@@ -34,10 +34,12 @@ from omnigent.server.accounts_store import SqlAlchemyAccountStore
 from omnigent.server.admin_list import (
     AdminList,
     MtimeCachedIdentitySet,
+    evaluate_admin_claim,
     load_admin_list,
     promote_if_listed,
     resolve_admin_list_path,
     resolve_data_dir,
+    sync_admin_claim,
 )
 from omnigent.server.auth import UnifiedAuthProvider
 from omnigent.server.passwords import hash_password
@@ -382,3 +384,75 @@ def test_login_unlisted_user_stays_member_end_to_end(
     assert resp.status_code == 200
     assert resp.json()["user"]["is_admin"] is False
     assert account_store.is_admin("erin") is False
+
+
+# ── evaluate_admin_claim: verdict semantics ──────────────────────────
+
+
+class _FlagStore:
+    """In-memory AdminFlagStore capturing set_admin calls."""
+
+    def __init__(self, admins: set[str] | None = None) -> None:
+        self.admins = admins or set()
+        self.calls: list[tuple[str, bool]] = []
+
+    def is_admin(self, user_id: str) -> bool:
+        return user_id in self.admins
+
+    def set_admin(self, user_id: str, is_admin: bool) -> None:
+        self.calls.append((user_id, is_admin))
+        (self.admins.add if is_admin else self.admins.discard)(user_id)
+
+
+@pytest.mark.parametrize(
+    ("claims", "expected_value", "verdict"),
+    [
+        # List claims (the groups/roles case).
+        ({"groups": ["dev", "omnigent-admins"]}, "omnigent-admins", True),
+        ({"groups": ["dev"]}, "omnigent-admins", False),
+        ({"groups": []}, "omnigent-admins", False),
+        # Scalar string claim.
+        ({"role": "admin"}, "admin", True),
+        ({"role": "member"}, "admin", False),
+        # Boolean claim: expected optional.
+        ({"is_operator": True}, None, True),
+        ({"is_operator": False}, None, False),
+        ({"is_operator": True}, "true", True),
+        ({"is_operator": True}, "false", False),
+        # Non-string list elements stringify.
+        ({"groups": [1, 2]}, "2", True),
+        # Fail-safe no-ops: absent or null claim, or a non-boolean
+        # claim with no expected value configured.
+        ({}, "omnigent-admins", None),
+        ({"groups": None}, "omnigent-admins", None),
+        ({"groups": ["dev"]}, None, None),
+        ({"role": "admin"}, None, None),
+    ],
+)
+def test_evaluate_admin_claim_verdicts(
+    claims: dict[str, object],
+    expected_value: str | None,
+    verdict: bool | None,
+) -> None:
+    """Table of claim shapes vs verdicts; None means leave-untouched."""
+    claim = next(iter(claims), "groups")
+    assert evaluate_admin_claim(claims, claim, expected_value) is verdict
+
+
+def test_sync_admin_claim_promotes_demotes_and_noops() -> None:
+    """sync applies True/False verdicts and skips the store on None."""
+    store = _FlagStore()
+
+    # Promote.
+    assert sync_admin_claim(store, "a@x", {"g": ["adm"]}, "g", "adm") is True
+    assert store.is_admin("a@x")
+    # Idempotent: matching verdict again writes nothing new.
+    sync_admin_claim(store, "a@x", {"g": ["adm"]}, "g", "adm")
+    assert store.calls == [("a@x", True)]
+    # Demote when the claim is present without the value.
+    assert sync_admin_claim(store, "a@x", {"g": ["dev"]}, "g", "adm") is False
+    assert not store.is_admin("a@x")
+    # Claim absent: verdict None, flag untouched.
+    store.admins.add("a@x")
+    assert sync_admin_claim(store, "a@x", {}, "g", "adm") is None
+    assert store.is_admin("a@x")

--- a/tests/server/test_oidc_callback.py
+++ b/tests/server/test_oidc_callback.py
@@ -44,7 +44,11 @@ _ISSUER = "https://accounts.google.com"
 _CLIENT_ID = "cid"
 
 
-def _oidc_config(skip_email_verification: bool = False) -> OIDCConfig:
+def _oidc_config(
+    skip_email_verification: bool = False,
+    admin_claim: str | None = None,
+    admin_value: str | None = None,
+) -> OIDCConfig:
     """Build a generic-OIDC config over plain HTTP (so TestClient cookies stick).
 
     ``allowed_domains=None`` means admit-all, so the test isolates the
@@ -52,6 +56,10 @@ def _oidc_config(skip_email_verification: bool = False) -> OIDCConfig:
 
     :param skip_email_verification: Waive the ``email_verified`` gate,
         as ``OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION`` would.
+    :param admin_claim: Claim name driving the admin flag, as
+        ``OMNIGENT_OIDC_ADMIN_CLAIM`` would.
+    :param admin_value: Claim value that grants admin, as
+        ``OMNIGENT_OIDC_ADMIN_VALUE`` would.
     """
     return OIDCConfig(
         issuer=_ISSUER,
@@ -70,6 +78,8 @@ def _oidc_config(skip_email_verification: bool = False) -> OIDCConfig:
         userinfo_endpoint=None,
         allow_invites=False,
         skip_email_verification=skip_email_verification,
+        admin_claim=admin_claim,
+        admin_value=admin_value,
     )
 
 
@@ -124,15 +134,21 @@ def callback_client(
     ``post`` — exposed on ``app.state.pending_id_token`` so ``_do_callback``
     can set the signed token the IdP should return.
 
-    Indirect parametrization (``request.param``, default ``False``) sets
-    the config's ``skip_email_verification`` flag.
+    Indirect parametrization (``request.param``): a bool sets the
+    config's ``skip_email_verification`` flag; a dict is passed to
+    ``_oidc_config`` as keyword arguments (the admin-claim tests use
+    this for ``admin_claim`` / ``admin_value``).
     """
     keys = _IdpKeys()
     perm_store = SqlAlchemyPermissionStore(db_uri)
     admins = tmp_path / "admins"
     admins.write_text("")
 
-    config = _oidc_config(skip_email_verification=getattr(request, "param", False))
+    param = getattr(request, "param", False)
+    if isinstance(param, dict):
+        config = _oidc_config(**param)
+    else:
+        config = _oidc_config(skip_email_verification=bool(param))
     provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
 
     # The signed id_token the mocked token endpoint will return. Each
@@ -166,6 +182,10 @@ def callback_client(
         prefix="/auth",
     )
     app.state.pending_id_token = pending_id_token
+    # Exposed for the admin-claim tests: assert the flag after login and
+    # seed the break-glass admins file.
+    app.state.perm_store = perm_store
+    app.state.admins_path = admins
 
     with TestClient(app) as client:
         yield client, keys
@@ -313,3 +333,107 @@ def test_callback_accepts_boolean_and_string_true(
     # Accepted as a verified identity → redirect + session.
     assert resp.status_code == 302, resp.text
     assert resp.cookies.get("ap_session") is not None
+
+
+# ── OMNIGENT_OIDC_ADMIN_CLAIM: IdP-driven admin flag ─────────────────
+
+_ADMIN_CLAIM_CFG = {"admin_claim": "roles", "admin_value": "omnigent-admin"}
+
+
+@pytest.mark.parametrize("callback_client", [_ADMIN_CLAIM_CFG], indirect=True)
+def test_callback_admin_claim_promotes(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """A login whose token carries the configured claim value promotes."""
+    client, keys = callback_client
+    token = keys.sign_id_token(
+        {
+            "email": "alice@example.com",
+            "email_verified": True,
+            "roles": ["dev", "omnigent-admin"],
+        }
+    )
+
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 302, resp.text
+    assert client.app.state.perm_store.is_admin("alice@example.com") is True
+
+
+@pytest.mark.parametrize("callback_client", [_ADMIN_CLAIM_CFG], indirect=True)
+def test_callback_admin_claim_demotes_on_next_login(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """The claim is authoritative: losing the value demotes at login."""
+    client, keys = callback_client
+    store = client.app.state.perm_store
+    store.ensure_user("alice@example.com", is_admin=True)
+
+    token = keys.sign_id_token(
+        {"email": "alice@example.com", "email_verified": True, "roles": ["dev"]}
+    )
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 302, resp.text
+    assert store.is_admin("alice@example.com") is False
+
+
+@pytest.mark.parametrize("callback_client", [_ADMIN_CLAIM_CFG], indirect=True)
+def test_callback_admin_claim_absent_leaves_flag_untouched(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """Fail-safe: a token WITHOUT the claim never demotes.
+
+    An SSO app that stops sending the claim (misconfiguration, IdP
+    change) must not strip every admin at their next login.
+    """
+    client, keys = callback_client
+    store = client.app.state.perm_store
+    store.ensure_user("alice@example.com", is_admin=True)
+
+    token = keys.sign_id_token({"email": "alice@example.com", "email_verified": True})
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 302, resp.text
+    assert store.is_admin("alice@example.com") is True
+
+
+@pytest.mark.parametrize("callback_client", [_ADMIN_CLAIM_CFG], indirect=True)
+def test_callback_admin_list_is_break_glass_over_claim_demotion(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """The file-backed admin list re-promotes after a claim demotion.
+
+    promote_if_listed runs after sync_admin_claim precisely so an
+    operator listed in the file keeps admin even when the IdP claim
+    says otherwise — the recovery path for a wrong claim mapping.
+    """
+    client, keys = callback_client
+    store = client.app.state.perm_store
+    store.ensure_user("alice@example.com", is_admin=True)
+    client.app.state.admins_path.write_text("alice@example.com\n")
+
+    token = keys.sign_id_token(
+        {"email": "alice@example.com", "email_verified": True, "roles": ["dev"]}
+    )
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 302, resp.text
+    assert store.is_admin("alice@example.com") is True
+
+
+def test_callback_without_admin_claim_config_never_touches_flag(
+    callback_client: tuple[TestClient, _IdpKeys],
+) -> None:
+    """Default config (no admin claim): a roles claim in the token is inert."""
+    client, keys = callback_client
+    store = client.app.state.perm_store
+    store.ensure_user("alice@example.com", is_admin=True)
+
+    token = keys.sign_id_token(
+        {"email": "alice@example.com", "email_verified": True, "roles": ["dev"]}
+    )
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 302, resp.text
+    assert store.is_admin("alice@example.com") is True

--- a/tests/server/test_oidc_open_redirect.py
+++ b/tests/server/test_oidc_open_redirect.py
@@ -250,7 +250,9 @@ def test_callback_redirects_to_root_for_hostile_cookie(
     # Rebind on the auth module's own namespace (contained, auto-undone)
     # rather than walking through the global httpx module.
     monkeypatch.setattr(auth_module.httpx, "AsyncClient", _FakeAsyncClient)
-    monkeypatch.setattr(auth_module, "_resolve_oidc_email", lambda token_json, config: "u@x.com")
+    monkeypatch.setattr(
+        auth_module, "_resolve_oidc_identity", lambda token_json, config: ("u@x.com", {})
+    )
 
     oidc_client.cookies.set(_STATE_COOKIE, _mint_state_cookie(state=state, return_to=malicious))
     resp = oidc_client.get(
@@ -277,7 +279,9 @@ def test_callback_preserves_safe_cookie_return_to(
     """A same-origin ``return_to`` in the cookie is honored at callback."""
     state = "csrf-state-token"
     monkeypatch.setattr(auth_module.httpx, "AsyncClient", _FakeAsyncClient)
-    monkeypatch.setattr(auth_module, "_resolve_oidc_email", lambda token_json, config: "u@x.com")
+    monkeypatch.setattr(
+        auth_module, "_resolve_oidc_identity", lambda token_json, config: ("u@x.com", {})
+    )
 
     oidc_client.cookies.set(
         _STATE_COOKIE, _mint_state_cookie(state=state, return_to="/sessions/abc?tab=files")


### PR DESCRIPTION
## Related issue

Closes #2577. Builds on #1846 (OIDC admin surface) and #1859 (`email_verified` opt-out); originally raised in #1489 (closed).

## Summary

- Manage admins from the **OIDC/SSO IdP** instead of only the box-local admin-list file. Set `OMNIGENT_OIDC_ADMIN_CLAIM` (+ optional `OMNIGENT_OIDC_ADMIN_VALUE`) and that `id_token` claim becomes **authoritative** for `users.is_admin` at every login — matching users are promoted, losing the claim demotes them.
- **Fail-safe:** a token *without* the claim (or a null/undecidable shape) is a **no-op**, so an IdP that stops sending the claim can never mass-demote existing admins. The file-backed admin list still runs afterward as a **break-glass**, promote-only override.
- Handles the common claim shapes: **list** (groups/roles — any element matches), **scalar string** (exact match), and **boolean** (the bool itself).

**ELI5:** put someone in your `omnigent-admins` IdP group and they become an Omnigent admin next login; remove them and they stop being one. A local admins file stays as a spare key so you can't lock yourself out.

```mermaid
flowchart LR
  A[id_token verified<br/>sig + iss + aud] --> B{ADMIN_CLAIM set?}
  B -- no --> D[promote_if_listed<br/>break-glass file]
  B -- yes --> C[evaluate claim]
  C -- match --> P[is_admin = true]
  C -- present, no match --> M[is_admin = false]
  C -- absent / null --> N[no-op]
  P --> D
  M --> D
  N --> D
```

The claim name and value are both env-driven (nothing IdP-specific is hardcoded): JumpCloud uses `memberOf`, Okta/Entra/Google typically `groups`, others `roles`.

## Test Plan

- `pytest tests/server/test_admin_list.py tests/server/test_oidc_callback.py tests/server/test_oidc_open_redirect.py` — **69 passed** on a clean `main` checkout.
- New coverage: 5 end-to-end callback tests driving real RS256 `id_token`s through the production decode path (promote / demote / absent-claim no-op / admin-list break-glass / feature-off inert), plus a verdict-table + `sync_admin_claim` unit tests.
- `ruff format --check` + `ruff check` clean on all touched files.
- **Verified in production** against a JumpCloud-backed deployment: with the app emitting `memberOf`, a login carrying `memberOf=['omnigent-admins', …]` promoted a user who was **not** in the admin file (pure claim path); server logged `admin claim 'memberOf' promoted <user>` and the DB flag flipped.

## Demo

`N/A` — no UI change (env-configured server behaviour).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified end-to-end against a live JumpCloud OIDC deployment (see Test Plan): confirmed the claim promotes a non-file user, and that `memberOf` must be emitted in the `id_token` (the server reads decoded `id_token` claims, not UserInfo) and only carries app-bound group names.

## Changelog

Manage OIDC/SSO admins from an `id_token` group/role claim via `OMNIGENT_OIDC_ADMIN_CLAIM`
