### PR TITLE
fix(timer): reject zero-delay repeats and surface HTTP delivery failures

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2787,7 +2787,7 @@ async def _timer_loop(
             if note:
                 text += f"\nnote: {note!r}"
             try:
-                await server_client.post(
+                resp = await server_client.post(
                     f"/v1/sessions/{conversation_id}/events",
                     json={
                         "type": "message",
@@ -2799,6 +2799,9 @@ async def _timer_loop(
                     },
                     timeout=30.0,
                 )
+                # httpx does not raise on 4xx/5xx by default; treat those
+                # as delivery failures so they share the warning path below.
+                resp.raise_for_status()
             except (httpx.HTTPError, asyncio.TimeoutError):
                 _logger.warning(
                     "Timer %s firing persist failed for %s",

--- a/omnigent/tools/builtins/timer.py
+++ b/omnigent/tools/builtins/timer.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
@@ -74,6 +75,10 @@ def validate_timer_set_args(
     if not isinstance(seconds_raw, (int, float)) or isinstance(seconds_raw, bool):
         return "seconds must be a number"
     seconds = float(seconds_raw)
+    # NaN/Inf pass isinstance(float) but fail every comparison, so they
+    # would bypass the non-negative, cap, and repeat>0 guards.
+    if not math.isfinite(seconds):
+        return "seconds must be a finite number"
     if seconds < 0:
         return "seconds must be non-negative"
     if seconds > _MAX_TIMER_SECONDS:
@@ -141,10 +146,12 @@ class SysTimerSetTool(Tool):
                             "type": "number",
                             "description": (
                                 "Delay before the timer fires, in "
-                                "seconds. Must be non-negative; the "
-                                "first firing happens after this "
-                                "delay. For repeat=true, also the "
-                                "interval between firings."
+                                "seconds. Must be a finite "
+                                "non-negative number; the first "
+                                "firing happens after this delay. "
+                                "For repeat=true, must be > 0 and "
+                                "is also the interval between "
+                                "firings."
                             ),
                         },
                         "repeat": {

--- a/omnigent/tools/builtins/timer.py
+++ b/omnigent/tools/builtins/timer.py
@@ -81,6 +81,10 @@ def validate_timer_set_args(
     repeat = args.get("repeat", False)
     if not isinstance(repeat, bool):
         return "repeat must be a boolean"
+    # repeat=true with seconds=0 would busy-loop sleep(0) + POST forever.
+    # One-shot seconds=0 remains valid (immediate single firing).
+    if repeat and seconds == 0:
+        return "seconds must be > 0 when repeat is true"
     note = args.get("note")
     if note is not None and not isinstance(note, str):
         return "note must be a string"

--- a/tests/runner/test_tool_dispatch_timer.py
+++ b/tests/runner/test_tool_dispatch_timer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import Any
 
 import httpx
@@ -120,3 +121,74 @@ async def test_timer_set_rejects_invalid_args_via_shared_validator() -> None:
 
     assert json.loads(output) == {"error": "seconds must be non-negative"}
     assert recorder.posts == []
+
+
+@pytest.mark.asyncio
+async def test_timer_set_rejects_zero_delay_repeating() -> None:
+    """
+    ``repeat=true`` with ``seconds=0`` is rejected with the same error
+    the builtin validator returns, and no wake POST is started.
+
+    Without this guard the firing loop would busy-loop ``sleep(0)`` and
+    hammer the sessions endpoint forever.
+    """
+    recorder = _TimerPostRecorder()
+    transport = httpx.MockTransport(recorder)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://server") as server_client:
+        output = await execute_tool(
+            tool_name="sys_timer_set",
+            arguments=json.dumps({"seconds": 0, "repeat": True}),
+            conversation_id="conv_parent",
+            server_client=server_client,
+        )
+
+    assert json.loads(output) == {"error": "seconds must be > 0 when repeat is true"}
+    assert recorder.posts == []
+
+
+@pytest.mark.asyncio
+async def test_timer_delivery_logs_http_error_status(caplog: pytest.LogCaptureFixture) -> None:
+    """
+    HTTP 4xx/5xx on the wake POST is treated as delivery failure.
+
+    ``httpx`` does not raise on error status codes by default; without an
+    explicit check the timer would silently ignore a rejected firing.
+    """
+
+    class _ErrorResponder:
+        """Mock transport that records the POST and returns HTTP 500."""
+
+        def __init__(self) -> None:
+            self.posts: list[dict[str, Any]] = []
+            self.post_seen = asyncio.Event()
+
+        async def __call__(self, request: httpx.Request) -> httpx.Response:
+            self.posts.append({"url": request.url.path, "method": request.method})
+            self.post_seen.set()
+            return httpx.Response(500, text="internal error")
+
+    responder = _ErrorResponder()
+    transport = httpx.MockTransport(responder)
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.runner.tool_dispatch"):
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://server"
+        ) as server_client:
+            output = await execute_tool(
+                tool_name="sys_timer_set",
+                arguments=json.dumps({"seconds": 0, "note": "boom"}),
+                conversation_id="conv_parent",
+                server_client=server_client,
+            )
+            result = json.loads(output)
+            assert result["status"] == "scheduled"
+            await asyncio.wait_for(responder.post_seen.wait(), timeout=1.0)
+            # Let the one-shot loop finish after the failed POST.
+            await asyncio.sleep(0.05)
+
+    assert len(responder.posts) == 1
+    assert any(
+        "firing persist failed" in record.getMessage() and result["timer_id"] in record.getMessage()
+        for record in caplog.records
+    )

--- a/tests/runner/test_tool_dispatch_timer.py
+++ b/tests/runner/test_tool_dispatch_timer.py
@@ -189,6 +189,7 @@ async def test_timer_delivery_logs_http_error_status(caplog: pytest.LogCaptureFi
 
     assert len(responder.posts) == 1
     assert any(
-        "firing persist failed" in record.getMessage() and result["timer_id"] in record.getMessage()
+        "firing persist failed" in record.getMessage()
+        and result["timer_id"] in record.getMessage()
         for record in caplog.records
     )

--- a/tests/tools/builtins/test_timer.py
+++ b/tests/tools/builtins/test_timer.py
@@ -121,6 +121,11 @@ def test_tools_are_synchronous() -> None:
         ('{"seconds": 1, "note": 5}', "note must be a string"),
         # Zero-delay repeating timers would busy-loop sleep(0)+POST.
         ('{"seconds": 0, "repeat": true}', "seconds must be > 0 when repeat is true"),
+        # Non-standard JSON NaN/Inf are floats, but every comparison is
+        # false — without an isfinite guard, repeat=true would hot-loop.
+        ('{"seconds": NaN, "repeat": true}', "seconds must be a finite number"),
+        ('{"seconds": Infinity}', "seconds must be a finite number"),
+        ('{"seconds": -Infinity}', "seconds must be a finite number"),
     ],
 )
 def test_set_invalid_args_return_error(args_json: str, expected_error_substring: str) -> None:
@@ -223,6 +228,9 @@ def test_validate_timer_set_args_accepts_valid_shapes() -> None:
         ({"seconds": 1, "repeat": "yes"}, "repeat must be a boolean"),
         ({"seconds": 1, "note": 5}, "note must be a string"),
         ({"seconds": 0, "repeat": True}, "seconds must be > 0 when repeat is true"),
+        ({"seconds": float("nan"), "repeat": True}, "seconds must be a finite number"),
+        ({"seconds": float("inf")}, "seconds must be a finite number"),
+        ({"seconds": float("-inf")}, "seconds must be a finite number"),
     ],
 )
 def test_validate_timer_set_args_rejects_bad_shapes(

--- a/tests/tools/builtins/test_timer.py
+++ b/tests/tools/builtins/test_timer.py
@@ -119,6 +119,8 @@ def test_tools_are_synchronous() -> None:
         ('{"seconds": 1, "repeat": "yes"}', "repeat must be a boolean"),
         # ``note`` MUST be a string when present.
         ('{"seconds": 1, "note": 5}', "note must be a string"),
+        # Zero-delay repeating timers would busy-loop sleep(0)+POST.
+        ('{"seconds": 0, "repeat": true}', "seconds must be > 0 when repeat is true"),
     ],
 )
 def test_set_invalid_args_return_error(args_json: str, expected_error_substring: str) -> None:
@@ -206,6 +208,9 @@ def test_validate_timer_set_args_accepts_valid_shapes() -> None:
         True,
         "x",
     )
+    # Immediate one-shot remains valid; only repeating timers reject 0.
+    assert validate_timer_set_args({"seconds": 0}) == (0.0, False, None)
+    assert validate_timer_set_args({"seconds": 0, "repeat": False}) == (0.0, False, None)
 
 
 @pytest.mark.parametrize(
@@ -217,6 +222,7 @@ def test_validate_timer_set_args_accepts_valid_shapes() -> None:
         ({"seconds": True}, "seconds must be a number"),
         ({"seconds": 1, "repeat": "yes"}, "repeat must be a boolean"),
         ({"seconds": 1, "note": 5}, "note must be a string"),
+        ({"seconds": 0, "repeat": True}, "seconds must be > 0 when repeat is true"),
     ],
 )
 def test_validate_timer_set_args_rejects_bad_shapes(


### PR DESCRIPTION
## Related issue

N/A

## Summary

Repeating timers with `seconds=0` could busy-loop `sleep(0)` and hammer wake POSTs forever, and timer delivery ignored HTTP 4xx/5xx because the firing loop never checked `status_code`.

- Reject `seconds=0` only for `repeat=true` in the shared `validate_timer_set_args` helper (builtin + runner stay in lockstep); immediate one-shot timers remain valid.
- Call `raise_for_status()` on wake POSTs so 4xx/5xx go through the existing timer delivery failure warning path.

## Test Plan

- `uv run pytest tests/runner/test_tool_dispatch_timer.py tests/tools/builtins/test_timer.py -q --tb=short`
- Covered: zero-delay repeating rejection, zero-delay one-shot success, successful delivery, HTTP 500 failure logging

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes