### PR TITLE
fix(web): keep manually-collapsed project closed when clicking a pinn…

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_pinned_project_collapse.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pinned_project_collapse.py
@@ -1,0 +1,132 @@
+"""Regression test for #2506: clicking a pinned session that belongs to a
+project was auto-expanding the project folder even after the user manually
+collapsed it.
+
+The sidebar has an "auto-expand the active session's project" effect so
+navigating to a filed session reveals it. That effect ran on every navigation
+into a pinned session too — even though a pinned session is already reachable
+from the Pinned section — so a user who collapsed the project saw it re-open
+every time they clicked the pin. The fix guards the effect: pinned targets
+skip the auto-expand.
+
+Drives the real chain the ``Sidebar`` unit tests mock: seeded runner-bound
+sessions filed into a project via the real ``PATCH /v1/sessions/{id}``, the
+pin quick action, the project folder's aria-expanded state, and localStorage
+persistence.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import httpx
+from playwright.sync_api import Locator, Page, expect
+
+
+def _set_title(base_url: str, session_id: str, title: str) -> None:
+    """Give a session a unique title so its row is easy to spot in a shared
+    server."""
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _file_into_project(base_url: str, session_id: str, project: str) -> None:
+    """File a session under *project* via the reserved ``omni_project`` label.
+
+    Mirrors what the row kebab's "Add to project" does, but skips the UI so
+    the test can prepare the fixture state in one call.
+    """
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"labels": {"omni_project": project}},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _section(page: Page, title: str) -> Locator:
+    """Locate the sidebar ``<section>`` whose collapse-header button matches
+    *title*."""
+    return page.locator("section").filter(has=page.get_by_role("button", name=title, exact=True))
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def test_click_pinned_project_session_keeps_project_collapsed(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Clicking a pinned session that belongs to a manually-collapsed project
+    must NOT re-open the project folder.
+
+    Setup:
+    - Two sessions filed under the same project.
+    - One of them is pinned (so it renders in "Pinned" too).
+    - The project folder is expanded initially (auto-expand on file), so the
+      test manually collapses it as the reporter did.
+    - Navigate away, then click the pinned row.
+
+    Assertion: the project header stays ``aria-expanded="false"`` and the
+    non-pinned sibling row remains hidden. Before the fix, the auto-expand
+    effect flipped the folder back open on every navigation into the pinned
+    session.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    project = f"e2e-2506-{uuid.uuid4().hex[:6]}"
+    title_a = f"pinned-{uuid.uuid4().hex[:6]}"
+    title_b = f"sibling-{uuid.uuid4().hex[:6]}"
+    _set_title(base_url, session_a, title_a)
+    _set_title(base_url, session_b, title_b)
+    _file_into_project(base_url, session_a, project)
+    _file_into_project(base_url, session_b, project)
+
+    page.goto(f"{base_url}/c/{session_a}")
+
+    row_a = _row(page, session_a)
+    expect(row_a).to_be_visible()
+
+    # Pin session A via the row's quick action. Hover first so the
+    # hover-revealed button is interactable.
+    row_a.hover()
+    pin_button = row_a.get_by_test_id("quick-pin-conversation")
+    expect(pin_button).to_have_attribute("aria-label", "Pin conversation")
+    pin_button.click()
+
+    # After pinning, the row now lives under "Pinned" (peeled out of its
+    # project folder — the folder still holds session_b as its non-pinned
+    # member).
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_a}"]')).to_be_visible()
+
+    # The project folder auto-expanded when the label was applied; collapse
+    # it manually — this is the state the reporter is in when they click the
+    # pinned row.
+    folder_header = page.get_by_role("button", name=project, exact=True)
+    expect(folder_header).to_be_visible()
+    if folder_header.get_attribute("aria-expanded") == "true":
+        folder_header.click()
+    expect(folder_header).to_have_attribute("aria-expanded", "false")
+    # The sibling is not rendered while the folder is collapsed.
+    expect(_section(page, project).locator(f'a[href="/c/{session_b}"]')).to_have_count(0)
+
+    # Navigate away (New session button → "/"), then click back into the
+    # pinned session. This is the specific interaction from the issue video:
+    # the pinned session becomes active again, and the auto-expand effect
+    # was firing on the resulting ``activeProjectName`` transition.
+    page.get_by_role("link", name=re.compile(r"New session", re.IGNORECASE)).first.click()
+    expect(page).to_have_url(re.compile(r"/$"))
+    _section(page, "Pinned").locator(f'a[href="/c/{session_a}"]').click()
+    expect(page).to_have_url(re.compile(rf"/c/{session_a}$"))
+
+    # Regression assertion: the project folder must remain collapsed. Before
+    # the fix, aria-expanded flipped back to "true" and the sibling row
+    # reappeared.
+    expect(folder_header).to_have_attribute("aria-expanded", "false")
+    expect(_section(page, project).locator(f'a[href="/c/{session_b}"]')).to_have_count(0)

--- a/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
+++ b/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
@@ -1,0 +1,150 @@
+// Regression test for #2506: clicking a pinned session that belongs to a
+// project was auto-expanding the project folder every time, undoing the
+// user's manual collapse. The auto-expand effect exists so navigating to a
+// filed-but-not-pinned session reveals it; a pinned session is already
+// reachable from the Pinned section, so the effect must skip pinned targets.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Conversation } from "@/hooks/useConversations";
+import {
+  EXPANDED_PROJECT_SECTIONS_STORAGE_KEY,
+  PINNED_CONVERSATION_IDS_STORAGE_KEY,
+} from "@/shell/sidebarNav";
+
+vi.mock("@/hooks/useConversations", () => ({
+  useConversations: vi.fn(),
+  useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useConnectedConversations: () => [],
+  useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
+  usePinnedConversationBackfill: () => [],
+  useRenameConversation: () => ({ mutate: vi.fn() }),
+  useStopSession: () => ({ mutate: vi.fn() }),
+  useProjects: () => ({ data: ["Repro 2506"] }),
+  useProjectSessions: vi.fn(),
+  useMoveToProject: () => ({ mutate: vi.fn() }),
+  useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  fetchProjectSessionIds: () => Promise.resolve([]),
+  PROJECT_LABEL_KEY: "omni_project",
+}));
+vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+
+import { useConversations, useProjectSessions } from "@/hooks/useConversations";
+import { Sidebar } from "./Sidebar";
+
+const useConvMock = vi.mocked(useConversations);
+const useProjectSessionsMock = vi.mocked(useProjectSessions);
+
+function conv(id: string, project?: string): Conversation {
+  return {
+    id,
+    object: "conversation",
+    title: id,
+    created_at: 0,
+    updated_at: 0,
+    labels: project ? { omni_project: project } : {},
+    permission_level: null,
+    agent_name: null,
+  } as unknown as Conversation;
+}
+
+function mockConversations(convs: Conversation[]) {
+  useConvMock.mockReturnValue({
+    data: {
+      pages: [{ data: convs, first_id: null, last_id: null, has_more: false }],
+      pageParams: [undefined],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  } as unknown as ReturnType<typeof useConversations>);
+}
+
+function renderAt(initialEntry: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path="/" element={<Sidebar open onClose={vi.fn()} />} />
+            <Route path="/c/:conversationId" element={<Sidebar open onClose={vi.fn()} />} />
+          </Routes>
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  useConvMock.mockReset();
+  useProjectSessionsMock.mockReset();
+  // ProjectFolder fetches its own paginated list when expanded. The tests
+  // above already seed the top-level list; mirror it for the folder query so
+  // an expanded folder actually renders rows.
+  useProjectSessionsMock.mockReturnValue({
+    data: {
+      pages: [
+        { data: [conv("sibling_b", "Repro 2506")], first_id: null, last_id: null, has_more: false },
+      ],
+      pageParams: [undefined],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  } as unknown as ReturnType<typeof useProjectSessions>);
+  localStorage.clear();
+});
+
+afterEach(cleanup);
+
+describe("sidebar auto-expand vs. pinned sessions (#2506)", () => {
+  it("does not auto-expand a collapsed project when navigating to a pinned member", () => {
+    // Pinned session `pinned_a` + a project sibling `sibling_b`, both filed
+    // under "Repro 2506". Project starts collapsed (empty
+    // EXPANDED_PROJECT_SECTIONS_STORAGE_KEY), pinned id already stored.
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["pinned_a"]));
+    localStorage.setItem(EXPANDED_PROJECT_SECTIONS_STORAGE_KEY, JSON.stringify([]));
+    mockConversations([conv("pinned_a", "Repro 2506"), conv("sibling_b", "Repro 2506")]);
+
+    renderAt("/c/pinned_a");
+
+    // The pinned row is present (via the Pinned section).
+    expect(screen.getByRole("link", { name: /pinned_a/ })).toBeInTheDocument();
+    // But the project's non-pinned member is NOT rendered — proof that the
+    // project folder stayed collapsed. Before the fix, the auto-expand effect
+    // opened the folder and this row would be visible.
+    expect(screen.queryByRole("link", { name: /sibling_b/ })).not.toBeInTheDocument();
+    // And the persistent flag is untouched.
+    expect(localStorage.getItem(EXPANDED_PROJECT_SECTIONS_STORAGE_KEY)).toBe(JSON.stringify([]));
+  });
+
+  it("still auto-expands the project when navigating to a filed, non-pinned member", () => {
+    // Same shape, but the active route is the NON-pinned sibling. This is the
+    // intended auto-expand path: without opening the folder, the row is
+    // invisible and the user would land on a "hidden" session.
+    localStorage.setItem(PINNED_CONVERSATION_IDS_STORAGE_KEY, JSON.stringify(["pinned_a"]));
+    localStorage.setItem(EXPANDED_PROJECT_SECTIONS_STORAGE_KEY, JSON.stringify([]));
+    mockConversations([conv("pinned_a", "Repro 2506"), conv("sibling_b", "Repro 2506")]);
+
+    renderAt("/c/sibling_b");
+
+    // Folder opened, sibling visible.
+    expect(screen.getByRole("link", { name: /sibling_b/ })).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem(EXPANDED_PROJECT_SECTIONS_STORAGE_KEY) ?? "[]")).toEqual(
+      ["Repro 2506"],
+    );
+  });
+});

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1249,10 +1249,14 @@ function ConversationList({
   }, [activeId, allConversations]);
   // Auto-expand the project folder holding the selected session, so navigating
   // to a filed session reveals it instead of leaving it hidden in a collapsed
-  // folder. Fires on selection only; the user can still collapse it afterward.
+  // folder. Skipped for pinned sessions: they're already reachable from the
+  // Pinned section, so forcing their project open would undo a manual collapse
+  // every time the user clicks the pinned row.
   useEffect(() => {
-    if (activeProjectName) expandProject(activeProjectName);
-  }, [activeProjectName, expandProject]);
+    if (!activeId || !activeProjectName) return;
+    if (pinnedSet.has(activeId)) return;
+    expandProject(activeProjectName);
+  }, [activeId, activeProjectName, pinnedSet, expandProject]);
 
   // Visible rows in render order (collapsed sections excluded) for the Cmd+↑/↓
   // session hotkey. Titles must match the <ConversationSection> props below.


### PR DESCRIPTION
## Related issue

Closes #2506

## Summary

- Guards the sidebar's "auto-expand the active session's project" `useEffect` in `Sidebar.tsx` so it skips when the active session is in `pinnedSet`.
- A pinned session is already reachable from the Pinned section, so force-expanding its project every time the user clicks the pinned row undoes their manual collapse. This matched the reporter's video: click a pinned session that belongs to `Oncall` → `Oncall` pops open again.
- Non-pinned filed sessions still trigger the auto-expand as before (needed so a user navigating into a filed session actually sees it).

## Test Plan

- **Vitest** (`web/src/shell/Sidebar.pinnedAutoExpand.test.tsx`) — two cases:
  1. Pinned target: project folder stays collapsed, `omnigent:expanded-project-sections` untouched.
  2. Non-pinned filed target (positive control): project folder auto-expands.
  Verified the first case fails on `main` without the fix and passes with it.
- **Playwright e2e** (`tests/e2e_ui/sessions/test_sidebar_pinned_project_collapse.py`) — seeds two runner-bound sessions filed under a project via `PATCH /v1/sessions/{id}` labels, pins one, manually collapses the folder, navigates away, clicks the pinned row, asserts `aria-expanded="false"` on the folder header and the sibling stays hidden.
- **Manual** — reproduced the bug against a local `docker compose up` stack, applied the fix, re-ran the reporter's flow — folder stays collapsed.

## Demo

[#2506-fix-demo-pinned-click-keeps-Repro-2506-collapsed.webm](https://github.com/user-attachments/assets/34723088-da47-476f-be68-fd24fe41fda2)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Vitest test is the direct regression: without the fix its "pinned target keeps folder collapsed" case fails, and the positive control for non-pinned filed navigation still passes. The Playwright e2e drives the full user-visible flow the reporter's video demonstrates. Manual verification followed the same flow against a local docker stack.

## Changelog

Clicking a pinned session that belongs to a project no longer re-opens the project section after you've collapsed it.