### PR TITLE
fix(sessions): serialize explicit /compact per session

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -10899,9 +10899,29 @@ async def _ensure_runner_relay_ready(
     return handle
 
 
-# Per-session compaction locks so concurrent ``/compact`` POSTs
-# don't race.
-_COMPACT_LOCKS: dict[str, asyncio.Lock] = {}
+# Weak values bound the per-session lock registry without splitting waiters
+# across different lock objects during eviction.
+_COMPACT_LOCKS: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+
+
+def _compact_lock(session_id: str) -> asyncio.Lock:
+    """
+    Return the lock serializing explicit compaction for one session.
+
+    Concurrent ``/compact`` events for the same session must not overlap;
+    different sessions get distinct locks so they may compact concurrently.
+    Get-or-create is race-free because there is no ``await`` between the
+    lookup and the insert (single event loop).
+
+    :param session_id: Session/conversation id being compacted.
+    :returns: A process-wide :class:`asyncio.Lock` shared by every concurrent
+        caller for the same ``session_id``.
+    """
+    lock = _COMPACT_LOCKS.get(session_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _COMPACT_LOCKS[session_id] = lock
+    return lock
 
 
 async def _run_compact_locked(
@@ -10918,67 +10938,71 @@ async def _run_compact_locked(
     :param agent_store: Agent store for spec lookup.
     :param agent_cache: Agent cache for bundle loading.
     """
-    if conv.agent_id is None:
-        raise OmnigentError("Session has no agent binding", code=ErrorCode.INTERNAL_ERROR)
-    if agent_cache is None:
-        raise OmnigentError(
-            "Compaction is unavailable: agent cache is not configured",
-            code=ErrorCode.INTERNAL_ERROR,
+    lock = _compact_lock(session_id)
+    async with lock:
+        if conv.agent_id is None:
+            raise OmnigentError("Session has no agent binding", code=ErrorCode.INTERNAL_ERROR)
+        if agent_cache is None:
+            raise OmnigentError(
+                "Compaction is unavailable: agent cache is not configured",
+                code=ErrorCode.INTERNAL_ERROR,
+            )
+        # Recheck after acquiring — a turn may have started while waiting.
+        if _session_status_cache.get(session_id) in ("running", "waiting"):
+            raise OmnigentError(
+                "Cannot compact while a turn is running; cancel or wait for it to finish first",
+                code=ErrorCode.CONFLICT,
+            )
+        agent = await asyncio.to_thread(agent_store.get, conv.agent_id)
+        if agent is None or agent.bundle_location is None:
+            raise OmnigentError(
+                f"Agent not found: {conv.agent_id!r}",
+                code=ErrorCode.NOT_FOUND,
+            )
+        loaded = agent_cache.load(
+            agent.id, agent.bundle_location, expand_env=agent.session_id is None
         )
-    # Check live status via cache; tasks table has been removed.
-    if _session_status_cache.get(session_id) in ("running", "waiting"):
-        raise OmnigentError(
-            "Cannot compact while a turn is running; cancel or wait for it to finish first",
-            code=ErrorCode.CONFLICT,
-        )
-    agent = await asyncio.to_thread(agent_store.get, conv.agent_id)
-    if agent is None or agent.bundle_location is None:
-        raise OmnigentError(
-            f"Agent not found: {conv.agent_id!r}",
-            code=ErrorCode.NOT_FOUND,
-        )
-    loaded = agent_cache.load(agent.id, agent.bundle_location, expand_env=agent.session_id is None)
-    spec = loaded.spec
-    if spec.llm is not None:
-        llm_config = spec.llm
-    elif spec.executor.model is not None:
-        from omnigent.spec.types import LLMConfig
+        spec = loaded.spec
+        if spec.llm is not None:
+            llm_config = spec.llm
+        elif spec.executor.model is not None:
+            from omnigent.spec.types import LLMConfig
 
-        llm_config = LLMConfig(model=spec.executor.model, connection=spec.executor.connection)
-    else:
-        harness = spec.executor.harness_kind
-        raise OmnigentError(
-            f"/compact is unavailable for this {harness} session because the agent "
-            "does not declare an LLM model for server-side compaction. Configure "
-            "`llm.model` or `executor.model`, or use a harness-native compaction "
-            "control when one is available.",
-            code=ErrorCode.INVALID_INPUT,
-        )
-    task_id = f"compact_{int(time.time() * 1000)}"
-    _publish_status(session_id, "running")
-    # compact() publishes its own in_progress / completed SSE events
-    # when conversation_id is set — don't double-publish here.
-    from omnigent.runtime.workflow import compact_conversation_now
+            llm_config = LLMConfig(model=spec.executor.model, connection=spec.executor.connection)
+        else:
+            harness = spec.executor.harness_kind
+            raise OmnigentError(
+                f"/compact is unavailable for this {harness} session because the agent "
+                "does not declare an LLM model for server-side compaction. Configure "
+                "`llm.model` or `executor.model`, or use a harness-native compaction "
+                "control when one is available.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        task_id = f"compact_{int(time.time() * 1000)}"
+        _publish_status(session_id, "running")
+        # compact() publishes its own in_progress / completed SSE events
+        # when conversation_id is set — don't double-publish here.
+        from omnigent.runtime.workflow import compact_conversation_now
 
-    try:
-        await compact_conversation_now(
-            task_id=task_id,
-            conversation_id=session_id,
-            spec=spec,
-            llm_config=llm_config,
-            tool_schemas=[],
-            preserve_recent_window=1,
-        )
-    except Exception as exc:
-        _logger.exception("Explicit session compaction failed for %s", session_id)
-        detail = str(exc) or repr(exc)
-        _publish_compaction_failed(session_id)
+        try:
+            await compact_conversation_now(
+                task_id=task_id,
+                conversation_id=session_id,
+                spec=spec,
+                llm_config=llm_config,
+                tool_schemas=[],
+                preserve_recent_window=1,
+            )
+        except Exception as exc:
+            _logger.exception("Explicit session compaction failed for %s", session_id)
+            detail = str(exc) or repr(exc)
+            _publish_compaction_failed(session_id)
+            _publish_status(session_id, "idle")
+            raise OmnigentError(
+                f"Compaction failed while generating a summary: {detail}",
+                code=ErrorCode.INTERNAL_ERROR,
+            ) from exc
         _publish_status(session_id, "idle")
-        raise OmnigentError(
-            f"Compaction failed while generating a summary: {detail}",
-            code=ErrorCode.INTERNAL_ERROR,
-        ) from exc
-    _publish_status(session_id, "idle")
 
 
 def _agent_provider_family(agent: Agent) -> str | None:

--- a/tests/server/integration/test_sessions_compact.py
+++ b/tests/server/integration/test_sessions_compact.py
@@ -22,7 +22,9 @@ HTTP response and asserting whether the AP-side compaction ran.
 
 from __future__ import annotations
 
+import asyncio
 import json
+from collections import defaultdict
 from typing import Any
 
 import httpx
@@ -232,6 +234,157 @@ async def test_compact_model_less_sdk_harness_returns_clear_unavailable_message(
     assert "openai-agents" in resp.text
     assert "llm.model" in resp.text
     assert "executor.model" in resp.text
+
+
+async def test_compact_single_flight_per_session(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Explicit compaction is single-flight per session, not globally.
+
+    Two ``/compact`` POSTs for one session must never overlap inside
+    ``compact_conversation_now``. Different sessions may overlap. A
+    failed compaction must release the lock so a later request can run.
+    """
+    from omnigent.runtime import set_runner_client
+    from omnigent.server.routes import sessions as sessions_routes
+
+    active: dict[str, int] = defaultdict(int)
+    max_active: dict[str, int] = defaultdict(int)
+    simultaneous_sessions = 0
+    entered: dict[str, asyncio.Event] = {}
+    release: dict[str, asyncio.Event] = {}
+    fail_once: set[str] = set()
+    calls: list[str] = []
+    lock_requests: dict[str, int] = defaultdict(int)
+    second_lock_requested: dict[str, asyncio.Event] = {}
+
+    real_compact_lock = sessions_routes._compact_lock
+
+    def _instrumented_compact_lock(session_id: str) -> asyncio.Lock:
+        lock_requests[session_id] += 1
+        if lock_requests[session_id] == 2:
+            second_lock_requested.setdefault(session_id, asyncio.Event()).set()
+        return real_compact_lock(session_id)
+
+    monkeypatch.setattr(sessions_routes, "_compact_lock", _instrumented_compact_lock)
+
+    async def _gated(**kwargs: Any) -> CompactionResult:
+        """Hold inside compaction until the test releases this session."""
+        nonlocal simultaneous_sessions
+        cid = kwargs["conversation_id"]
+        assert isinstance(cid, str)
+        calls.append(cid)
+        active[cid] += 1
+        max_active[cid] = max(max_active[cid], active[cid])
+        simultaneous_sessions = max(
+            simultaneous_sessions,
+            sum(1 for count in active.values() if count > 0),
+        )
+        entered.setdefault(cid, asyncio.Event()).set()
+        try:
+            if cid in fail_once:
+                fail_once.discard(cid)
+                raise RuntimeError("injected compact failure")
+            await release.setdefault(cid, asyncio.Event()).wait()
+            return CompactionResult(messages=[], summary_metadata=None, total_tokens=1)
+        finally:
+            active[cid] -= 1
+
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.compact_conversation_now",
+        _gated,
+    )
+
+    runner, _captured = _fake_runner_returning(204)
+    set_runner_client(runner)
+    try:
+        agent = await create_test_agent(client)
+        sid_a = await _create_session(client, agent["id"])
+        sid_b = await _create_session(client, agent["id"])
+        release[sid_a] = asyncio.Event()
+        release[sid_b] = asyncio.Event()
+        entered[sid_a] = asyncio.Event()
+        entered[sid_b] = asyncio.Event()
+        second_lock_requested[sid_a] = asyncio.Event()
+
+        # Same session: second request must wait outside compact_conversation_now
+        # until the first releases — never overlap.
+        first_a = asyncio.create_task(
+            client.post(f"/v1/sessions/{sid_a}/events", json={"type": "compact", "data": {}})
+        )
+        await asyncio.wait_for(entered[sid_a].wait(), timeout=5.0)
+        entered[sid_a].clear()
+        second_a = asyncio.create_task(
+            client.post(f"/v1/sessions/{sid_a}/events", json={"type": "compact", "data": {}})
+        )
+        await asyncio.wait_for(second_lock_requested[sid_a].wait(), timeout=5.0)
+        assert active[sid_a] == 1, (
+            f"Same-session compact overlapped inside compact_conversation_now; "
+            f"active={active[sid_a]}."
+        )
+        assert not entered[sid_a].is_set(), (
+            "Second same-session compact entered before the first released."
+        )
+        release[sid_a].set()
+        resp_a1, resp_a2 = await asyncio.wait_for(
+            asyncio.gather(first_a, second_a),
+            timeout=5.0,
+        )
+        assert resp_a1.status_code == 202, resp_a1.text
+        assert resp_a2.status_code == 202, resp_a2.text
+        assert max_active[sid_a] == 1, (
+            f"Same-session compact overlapped; max_active={max_active[sid_a]}."
+        )
+
+        # Different sessions may hold compact_conversation_now concurrently.
+        release[sid_a].clear()
+        release[sid_b].clear()
+        entered[sid_a].clear()
+        entered[sid_b].clear()
+        task_a = asyncio.create_task(
+            client.post(f"/v1/sessions/{sid_a}/events", json={"type": "compact", "data": {}})
+        )
+        task_b = asyncio.create_task(
+            client.post(f"/v1/sessions/{sid_b}/events", json={"type": "compact", "data": {}})
+        )
+        await asyncio.wait_for(
+            asyncio.gather(entered[sid_a].wait(), entered[sid_b].wait()),
+            timeout=5.0,
+        )
+        assert simultaneous_sessions >= 2, (
+            "Different sessions failed to overlap inside compact_conversation_now; "
+            f"simultaneous_sessions={simultaneous_sessions}."
+        )
+        release[sid_a].set()
+        release[sid_b].set()
+        resp_cross_a, resp_cross_b = await asyncio.wait_for(
+            asyncio.gather(task_a, task_b),
+            timeout=5.0,
+        )
+        assert resp_cross_a.status_code == 202, resp_cross_a.text
+        assert resp_cross_b.status_code == 202, resp_cross_b.text
+
+        # Failure must release the lock so a later compact can run.
+        fail_once.add(sid_a)
+        release[sid_a].set()
+        fail_resp = await client.post(
+            f"/v1/sessions/{sid_a}/events",
+            json={"type": "compact", "data": {}},
+        )
+        assert fail_resp.status_code == 500, fail_resp.text
+        retry_resp = await client.post(
+            f"/v1/sessions/{sid_a}/events",
+            json={"type": "compact", "data": {}},
+        )
+        assert retry_resp.status_code == 202, retry_resp.text
+        assert calls.count(sid_a) >= 4, (
+            f"Expected failed compact plus successful retry for {sid_a}; calls={calls!r}."
+        )
+    finally:
+        await runner.aclose()
+        set_runner_client(None)
 
 
 async def test_compact_errors_when_runner_injection_fails(


### PR DESCRIPTION
## Related issue

N/A

## Summary

Explicit `/compact` claimed to be single-flight via `_COMPACT_LOCKS` / `_run_compact_locked`, but no lock was ever acquired. Concurrent compact events for the same session could both observe idle and compact simultaneously.

- Acquire a per-session `asyncio.Lock` from a `WeakValueDictionary` (same pattern as native ASK gates) so same-session compact is serialized without an unbounded lock leak, while different sessions can still overlap.
- Recheck session status after acquiring the lock so a turn that started while waiting still conflicts cleanly.
- Leave native-runner dispatch unchanged: runner `200` still skips in-process compaction; only the Omnigent fall-through path is locked.
- Add a deterministic concurrency integration test for non-overlap, cross-session overlap, and lock release after failure.

## Test Plan

- [x] `uv run pytest tests/server/integration/test_sessions_compact.py -v` — 9 passed, including `test_compact_single_flight_per_session`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the new deterministic concurrency integration test plus existing compact dispatch tests.

## Changelog

`/compact` no longer races when multiple compact requests hit the same session at once