### PR TITLE
fix(async-inbox): use handle_id as the canonical sys_call_async identifier

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -5306,22 +5306,28 @@ async def _execute_rest_tool(
                     f"Error: sys_call_async event post returned "
                     f"{event_resp.status_code}: {event_resp.text[:200]}"
                 )
-            # Return session_id as the handle (replaces task_id).
-            return json.dumps({"task_id": session_id, "status": "running"})
+            return json.dumps(
+                {
+                    "handle_id": session_id,
+                    # Compatibility alias for older clients; remove in 0.8.0.
+                    "task_id": session_id,
+                    "status": "running",
+                }
+            )
         except Exception as exc:  # noqa: BLE001
             return f"Error: sys_call_async failed: {exc}"
 
     if tool_name == SysCancelAsyncTool.name():
-        # task_id from sys_call_async is now a session_id.
-        task_id = args.get("task_id", "")
+        # ``task_id`` fallback supports older clients; remove in 0.8.0.
+        handle_id = args.get("handle_id") or args.get("task_id", "")
         try:
             resp = await server_client.post(
-                f"/v1/sessions/{task_id}/events",
+                f"/v1/sessions/{handle_id}/events",
                 json={"type": "interrupt", "data": {}},
                 timeout=30.0,
             )
             if resp.status_code in (200, 201, 202):
-                return f"Cancelled task {task_id}"
+                return f"Cancelled async handle {handle_id}"
             return f"Error: sys_cancel_async returned {resp.status_code}"
         except Exception as exc:  # noqa: BLE001
             return f"Error: sys_cancel_async failed: {exc}"
@@ -6177,8 +6183,11 @@ def _spawn_async_tool(
         ``GET …/changes`` endpoint.
     :param resource_registry: Optional session-resource registry used by
         async terminal-tool launches.
-    :returns: JSON handle string with ``handle_id``, ``tool_name``,
-        ``status``.
+    :returns: JSON handle string with canonical ``handle_id``,
+        plus compatibility ``task_id`` (identical value; remove in 0.8.0),
+        ``tool_name``, ``status``, and ``message``. Prefer
+        ``handle_id``; ``task_id`` exists only so older clients
+        that still parse the pre-handle_id field keep working.
     """
     target_tool = args.get("tool")
     target_args = args.get("args", "{}")
@@ -6286,12 +6295,15 @@ def _spawn_async_tool(
     return json.dumps(
         {
             "handle_id": handle_id,
+            # Compatibility alias for older clients; remove in 0.8.0.
+            "task_id": handle_id,
             "tool_name": target_tool,
             "status": "in_progress",
             "message": (
                 f"[System: {target_tool} dispatched as background "
                 f"task {handle_id}. Result will appear in your "
-                f"inbox — call sys_read_inbox to check.]"
+                f"inbox — call sys_read_inbox to check. To abort, "
+                f"call sys_cancel_async with handle_id={handle_id!r}.]"
             ),
         }
     )

--- a/omnigent/tools/builtins/async_inbox.py
+++ b/omnigent/tools/builtins/async_inbox.py
@@ -148,11 +148,20 @@ class SysCallAsyncTool(Tool):
       meta-dispatch would let the LLM build infinite handle chains
       with no useful semantic; reject explicitly.
 
-    The handle round-trip is identical to the existing async
-    dispatch path (see
-    :class:`~omnigent.runtime.workflow._AsyncToolHandle`):
+    The handle round-trip uses ``handle_id`` as the canonical
+    identifier (cancel via ``sys_cancel_async`` with that same
+    field). Runner dispatch also echoes ``task_id`` with an
+    identical value as a compatibility alias (remove in 0.8.0) for
+    clients that still read the older field name — prefer
+    ``handle_id``; do not confuse it with
+    :class:`SysCancelTaskTool`'s distinct ``task_id`` contract.
 
-    - ``task_id`` — the freshly created child task's id.
+    Handle fields:
+
+    - ``handle_id`` — the freshly created async-work handle id
+      (canonical; pass to ``sys_cancel_async``).
+    - ``task_id`` — compatibility alias, identical to ``handle_id``;
+      remove in 0.8.0.
     - ``tool_name`` — the TARGET tool's name (not
       ``"sys_call_async"``).
     - ``status`` — ``"in_progress"``.
@@ -170,12 +179,14 @@ class SysCallAsyncTool(Tool):
         """:returns: Human-readable description for the LLM."""
         return (
             "Dispatch a local Python tool as a background task. "
-            "Returns a task handle immediately; the result auto-"
-            "delivers as a system message when ready (or call "
-            "sys_read_inbox to drain proactively when that lands "
-            "in 11a.ii). Use this when you want to run a normally-"
-            "synchronous tool concurrently with other work — e.g., "
-            "kicking off several long calls in parallel."
+            "Returns a handle immediately (canonical field: "
+            "handle_id); the result auto-delivers as a system "
+            "message when ready (or call sys_read_inbox to drain "
+            "proactively). To abort, pass that handle_id to "
+            "sys_cancel_async. Use this when you want to run a "
+            "normally-synchronous tool concurrently with other "
+            "work — e.g., kicking off several long calls in "
+            "parallel."
         )
 
     def get_schema(self) -> dict[str, Any]:
@@ -367,12 +378,13 @@ class SysCancelAsyncTool(SysCancelTaskTool):
         """:returns: Human-readable description for the LLM."""
         return (
             "Cancel a task you previously dispatched via "
-            "sys_call_async, using the handle id (the value of the "
-            "task_id field from the handle JSON). Non-blocking — "
-            "the task transitions to cancelled status and a "
-            "[System: task ... cancelled] block arrives in the "
-            "inbox or auto-deliver. Already-terminal tasks return "
-            "without changing state."
+            "sys_call_async, using the handle_id from the handle "
+            "JSON. Non-blocking — the task transitions to "
+            "cancelled status and a [System: task ... cancelled] "
+            "block arrives in the inbox or auto-deliver. "
+            "Already-terminal tasks return without changing "
+            "state. Distinct from sys_cancel_task, which takes "
+            "task_id for non-async-handle cancellations."
         )
 
     def get_schema(self) -> dict[str, Any]:
@@ -398,10 +410,10 @@ class SysCancelAsyncTool(SysCancelTaskTool):
                         "handle_id": {
                             "type": "string",
                             "description": (
-                                "The handle's task_id — same value "
-                                "as the ``task_id`` field of the "
-                                "handle JSON returned by "
-                                "sys_call_async."
+                                "The ``handle_id`` from the JSON "
+                                "handle returned by "
+                                "sys_call_async (canonical "
+                                "async-dispatch identifier)."
                             ),
                         },
                     },

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7121,6 +7121,59 @@ async def test_approval_event_without_content_flattened() -> None:
 
 
 @pytest.mark.asyncio
+async def test_spawn_handle_round_trips_to_sys_cancel_async(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spawned handle can be passed directly to ``sys_cancel_async``."""
+    from omnigent.runner import tool_dispatch
+
+    async def _slow(**_kw: Any) -> str:
+        await asyncio.sleep(30)
+        return "late"
+
+    monkeypatch.setattr(tool_dispatch, "execute_tool", _slow)
+    inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] = {}
+    spawn_kw: dict[str, Any] = {
+        "server_client": None,
+        "terminal_registry": None,
+        "resource_registry": None,
+        "agent_spec": None,
+        "conversation_id": "conv_roundtrip",
+        "task_id": None,
+        "agent_id": None,
+        "agent_name": None,
+        "runner_workspace": None,
+        "mcp_manager": None,
+        "filesystem_registry": None,
+    }
+    handle_raw = tool_dispatch._spawn_async_tool(
+        {"tool": "slow", "args": "{}"},
+        session_inbox=inbox,
+        session_async_tasks=tasks,
+        **spawn_kw,
+    )
+    handle = json.loads(handle_raw)
+    assert handle["task_id"] == handle["handle_id"]
+    assert handle["status"] == "in_progress"
+    assert "sys_cancel_async" in handle["message"]
+    assert f"handle_id={handle['handle_id']!r}" in handle["message"]
+
+    bg_task, _evt = tasks[handle["handle_id"]]
+    cancel_raw = tool_dispatch._cancel_async_tool(
+        {"handle_id": handle["handle_id"]},
+        session_async_tasks=tasks,
+    )
+    assert json.loads(cancel_raw) == {
+        "cancelled": True,
+        "handle_id": handle["handle_id"],
+    }
+
+    await bg_task
+    assert inbox.get_nowait()["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
 async def test_spawn_async_tool_cancels_losing_future_no_leak(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/tools/builtins/test_async_inbox.py
+++ b/tests/tools/builtins/test_async_inbox.py
@@ -229,15 +229,53 @@ def test_cancel_async_schema_uses_handle_id(
 
     The parameter rename from ``task_id`` (parent) to ``handle_id``
     is the one place the schema differs — pin it. A regression
-    that reverted to ``task_id`` would still work (since invoke
-    delegates with task_id JSON), but the LLM's mental model
-    breaks: ``sys_call_async`` returns a "handle", and the cancel
-    parameter should match that vocabulary.
+    that reverted to ``task_id`` would still work (cancel accepts
+    ``task_id`` as a legacy alias), but the LLM's mental model
+    breaks: ``sys_call_async`` returns ``handle_id``, and the
+    cancel parameter must match that vocabulary.
     """
     schema = cancel_tool.get_schema()["function"]["parameters"]
     assert schema["required"] == ["handle_id"]
     assert schema["additionalProperties"] is False
     assert set(schema["properties"].keys()) == {"handle_id"}
+    handle_desc = schema["properties"]["handle_id"]["description"]
+    assert "handle_id" in handle_desc
+    assert "task_id field" not in handle_desc
+
+
+def test_cancel_async_description_names_handle_id(
+    cancel_tool: SysCancelAsyncTool,
+) -> None:
+    """
+    LLM-facing description tells the model to pass ``handle_id``,
+    not the older ``task_id`` field name from the handle JSON.
+    """
+    desc = cancel_tool.description()
+    assert "handle_id" in desc
+    assert "task_id field" not in desc
+    # Keep sys_cancel_task's task_id contract visibly distinct.
+    assert "sys_cancel_task" in desc
+    assert "task_id" in desc
+
+
+def test_call_async_description_names_handle_id(tool: SysCallAsyncTool) -> None:
+    """
+    ``sys_call_async`` description names ``handle_id`` as the
+    canonical identifier for cancel round-trips.
+    """
+    desc = tool.description()
+    assert "handle_id" in desc
+    assert "sys_cancel_async" in desc
+
+
+def test_sys_cancel_task_schema_keeps_task_id_contract() -> None:
+    """
+    Generic ``sys_cancel_task`` stays on ``task_id`` — distinct
+    from ``sys_cancel_async``'s ``handle_id`` contract.
+    """
+    schema = SysCancelTaskTool().get_schema()["function"]["parameters"]
+    assert schema["required"] == ["task_id"]
+    assert set(schema["properties"].keys()) == {"task_id"}
 
 
 # ── Manager registration gating ───────────────────────────


### PR DESCRIPTION
## Related issue

N/A

## Summary

`sys_call_async` already returned `handle_id`, and `sys_cancel_async` already accepted `handle_id`, but tool descriptions kept telling the model to cancel with the handle's `task_id` field. That mismatch made the cancel round-trip unreliable for the LLM.

- Make `handle_id` the canonical async-dispatch identifier in descriptions, schemas, handle messages, and docstrings.
- Keep returning an identical `task_id` compatibility alias through 0.7.x for older clients; remove the alias in 0.8.0.
- Leave generic `sys_cancel_task`'s distinct `task_id` contract unchanged.
- Add a spawn→cancel round-trip test that passes the dispatched `handle_id` straight into `sys_cancel_async`.

## Test Plan

- [x] Ran focused async-inbox and runner round-trip tests (18 passed)
- [x] Confirmed spawn handle includes canonical `handle_id`, the temporary `task_id` alias, and a cancel message naming `sys_cancel_async`
- [x] Confirmed `sys_cancel_task` schema still requires `task_id`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused unit coverage in `tests/tools/builtins/test_async_inbox.py` and `tests/runner/test_runner_dispatch.py`, including description/schema pins and a dispatch→cancel round-trip.

## Changelog

`sys_call_async` / `sys_cancel_async` now consistently use `handle_id` as the cancel identifier.
