### PR TITLE
fix(runner): keep idle watchdog alive for async tools, timers, and approvals

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -137,8 +137,8 @@ async def _run_inactivity_monitor(
         disables the monitor.
     :param get_last_activity: Callback returning the most recent real
         activity time from the event loop's monotonic clock.
-    :param has_active_work: Callback returning whether any agent turn is
-        currently running.
+    :param has_active_work: Callback returning whether delivery-critical
+        work is outstanding (turns, live async tools, timers, approvals).
     :param request_shutdown: Callback that requests graceful runner shutdown.
     :param poll_interval_s: Optional test override for the monitor cadence,
         e.g. ``0.01``. ``None`` derives a bounded production cadence from

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7977,6 +7977,20 @@ def _truncate_child_preview(text: str) -> str:
 _session_timers: dict[str, dict[str, asyncio.Task[None]]] = {}
 
 
+def _has_live_async_tasks(
+    session_async_tasks: Mapping[
+        str,
+        Mapping[str, tuple[asyncio.Task[Any], asyncio.Event]],
+    ],
+) -> bool:
+    """Return whether an async-tool registry contains unfinished work."""
+    return any(
+        not task.done()
+        for handles in session_async_tasks.values()
+        for task, _cancel_event in handles.values()
+    )
+
+
 def register_timer(
     session_id: str,
     timer_id: str,
@@ -8315,21 +8329,47 @@ def create_runner_app(
 
     def _has_active_work() -> bool:
         """
-        Return whether this runner is currently executing agent work.
+        Return whether this runner must stay up for in-flight work.
 
-        Used by the out-of-process runner's inactivity watchdog. The
-        closure-local ``_active_turns`` catches turns owned directly by
-        ``runner/app.py``; ``process_manager.has_active_turn`` catches
-        in-flight responses tracked by the harness subprocess manager.
+        Used by the out-of-process runner's inactivity watchdog. Counts:
 
-        :returns: ``True`` while any session has an active agent turn.
+        * Foreground turns in ``_active_turns``.
+        * Live ``sys_call_async`` tasks in ``_session_async_tasks`` (not
+          ``done()``) — their results still need to land in the inbox.
+        * Live ``sys_timer_set`` tasks in ``_session_timers`` — firing
+          must POST into the session; shutdown would drop the schedule.
+        * Parked approval Futures in ``pending_approvals`` — the human
+          gate is still open.
+        * Harness turns via ``process_manager.has_active_turn``.
+
+        Explicitly excluded (must not pin the runner forever):
+
+        * Completed / cancelled tasks and other stale registry entries
+          (``task.done()`` / ``Future.done()``).
+        * ``_background_tasks`` (mixes short wake POSTs with unrelated
+          housekeeping).
+        * ``_subagent_wake_pending`` (debounce flag outlives delivery
+          until the parent turn starts or idles).
+        * Non-empty inboxes (results wait for the next turn; unread
+          items must not block idle shutdown).
+
+        :returns: ``True`` while delivery-critical work is outstanding.
         """
         if _active_turns:
             return True
-        if process_manager is None:
-            return False
-        session_ids = set(_session_start_cache) | set(_session_agent_ids)
-        return any(process_manager.has_active_turn(session_id) for session_id in session_ids)
+        if _has_live_async_tasks(_session_async_tasks):
+            return True
+        for timers in _session_timers.values():
+            for timer_task in timers.values():
+                if not timer_task.done():
+                    return True
+        if pending_approvals.has_any_pending():
+            return True
+        if process_manager is not None:
+            session_ids = set(_session_start_cache) | set(_session_agent_ids)
+            if any(process_manager.has_active_turn(session_id) for session_id in session_ids):
+                return True
+        return False
 
     app.state.has_active_work = _has_active_work
 

--- a/omnigent/runner/pending_approvals.py
+++ b/omnigent/runner/pending_approvals.py
@@ -76,6 +76,11 @@ def has_pending(conversation_id: str) -> bool:
     return _session_pending.get(conversation_id, 0) > 0
 
 
+def has_any_pending() -> bool:
+    """Return whether any unresolved approval verdict is registered."""
+    return any(not fut.done() for fut in _pending.values())
+
+
 def register(elicitation_id: str) -> asyncio.Future[bool]:
     """
     Create and store a Future for an outstanding ASK verdict.

--- a/tests/runner/test_runner_idle_active_work.py
+++ b/tests/runner/test_runner_idle_active_work.py
@@ -1,0 +1,293 @@
+"""Idle-monitor active-work accounting for background runner work.
+
+Pins that ``app.state.has_active_work`` keeps the inactivity watchdog from
+shutting down while ``sys_call_async`` tools, scheduled timers, or parked
+approvals are still live — and that completion / cancel / failure release
+the pin so a short idle timeout can shut down.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+
+from omnigent.runner import create_runner_app, pending_approvals
+from omnigent.runner._entry import _run_inactivity_monitor
+from omnigent.runner.app import (
+    _has_live_async_tasks,
+    _session_timers,
+    register_timer,
+    unregister_timer,
+)
+from tests.runner.helpers import NullServerClient
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_active_work_state() -> None:
+    """
+    Reset module-global timer / approval registries between tests.
+
+    :returns: None.
+    """
+    pending_approvals.reset_for_tests()
+    for session_timers in list(_session_timers.values()):
+        for task in list(session_timers.values()):
+            task.cancel()
+    _session_timers.clear()
+    yield
+    pending_approvals.reset_for_tests()
+    for session_timers in list(_session_timers.values()):
+        for task in list(session_timers.values()):
+            task.cancel()
+    _session_timers.clear()
+
+
+def _scaffold_app() -> FastAPI:
+    """
+    Build a scaffold runner app (no harness process manager).
+
+    :returns: Fresh FastAPI runner app.
+    """
+    return create_runner_app(server_client=NullServerClient())  # type: ignore[arg-type]
+
+
+def _register_async_handle(
+    registry: dict[str, dict[str, tuple[asyncio.Task[str], asyncio.Event]]],
+    *,
+    session_id: str,
+    handle_id: str,
+    task: asyncio.Task[str],
+) -> None:
+    """
+    Insert a live ``sys_call_async`` registry entry for idle-monitor tests.
+
+    :param registry: Async-tool registry to mutate.
+    :param session_id: Session key, e.g. ``"conv_async"``.
+    :param handle_id: Async handle id, e.g. ``"handle_test"``.
+    :param task: Background task standing in for the async tool.
+    :returns: None.
+    """
+    registry.setdefault(session_id, {})[handle_id] = (task, asyncio.Event())
+
+
+async def _assert_monitor_blocked_then_shuts_down(
+    *,
+    has_active_work: Any,
+    release: Any,
+) -> None:
+    """
+    Prove a short idle timeout waits for active work, then shuts down.
+
+    :param has_active_work: Callback matching ``app.state.has_active_work``.
+    :param release: Awaitable that clears the active-work pin.
+    :returns: None.
+    """
+    loop = asyncio.get_running_loop()
+    shutdowns: list[str] = []
+    monitor = asyncio.create_task(
+        _run_inactivity_monitor(
+            idle_timeout_s=0.01,
+            get_last_activity=lambda: loop.time() - 1.0,
+            has_active_work=has_active_work,
+            request_shutdown=lambda: shutdowns.append("shutdown"),
+            poll_interval_s=0.005,
+        )
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(monitor), timeout=0.03)
+    assert shutdowns == []
+    assert not monitor.done()
+
+    await release()
+    await asyncio.wait_for(monitor, timeout=0.2)
+    assert shutdowns == ["shutdown"]
+
+
+@pytest.mark.asyncio
+async def test_running_async_tool_blocks_idle_shutdown() -> None:
+    """A live ``sys_call_async`` task prevents idle shutdown.
+
+    :returns: None.
+    """
+    registry: dict[str, dict[str, tuple[asyncio.Task[str], asyncio.Event]]] = {}
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def _bg() -> str:
+        started.set()
+        await finish.wait()
+        return "ok"
+
+    task = asyncio.create_task(_bg(), name="async-handle_live")
+    _register_async_handle(registry, session_id="conv_async", handle_id="handle_live", task=task)
+    await started.wait()
+    assert _has_live_async_tasks(registry) is True
+
+    async def _release() -> None:
+        finish.set()
+        await task
+        registry["conv_async"].pop("handle_live", None)
+
+    await _assert_monitor_blocked_then_shuts_down(
+        has_active_work=lambda: _has_live_async_tasks(registry),
+        release=_release,
+    )
+    assert _has_live_async_tasks(registry) is False
+
+
+@pytest.mark.asyncio
+async def test_completed_async_tool_is_idle_eligible() -> None:
+    """After an async tool finishes, the runner is idle-eligible.
+
+    :returns: None.
+    """
+    registry: dict[str, dict[str, tuple[asyncio.Task[str], asyncio.Event]]] = {}
+
+    async def _bg() -> str:
+        return "done"
+
+    task = asyncio.create_task(_bg(), name="async-handle_done")
+    _register_async_handle(registry, session_id="conv_async", handle_id="handle_done", task=task)
+    await task
+    # Stale registry entry must not count once the task is done.
+    assert _has_live_async_tasks(registry) is False
+
+    loop = asyncio.get_running_loop()
+    shutdowns: list[str] = []
+    await asyncio.wait_for(
+        _run_inactivity_monitor(
+            idle_timeout_s=0.01,
+            get_last_activity=lambda: loop.time() - 1.0,
+            has_active_work=lambda: _has_live_async_tasks(registry),
+            request_shutdown=lambda: shutdowns.append("shutdown"),
+            poll_interval_s=0.001,
+        ),
+        timeout=0.2,
+    )
+    assert shutdowns == ["shutdown"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_async_tool_releases_active_work() -> None:
+    """Cancellation clears active-work status for idle shutdown.
+
+    :returns: None.
+    """
+    registry: dict[str, dict[str, tuple[asyncio.Task[str], asyncio.Event]]] = {}
+    gate = asyncio.Event()
+
+    async def _bg() -> str:
+        await gate.wait()
+        return "never"
+
+    task = asyncio.create_task(_bg(), name="async-handle_cancel")
+    _register_async_handle(registry, session_id="conv_async", handle_id="handle_cancel", task=task)
+    assert _has_live_async_tasks(registry) is True
+
+    async def _release() -> None:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        registry["conv_async"].pop("handle_cancel", None)
+
+    await _assert_monitor_blocked_then_shuts_down(
+        has_active_work=lambda: _has_live_async_tasks(registry),
+        release=_release,
+    )
+    assert _has_live_async_tasks(registry) is False
+
+
+@pytest.mark.asyncio
+async def test_failed_async_tool_releases_active_work() -> None:
+    """A failed async tool releases active-work status.
+
+    :returns: None.
+    """
+    registry: dict[str, dict[str, tuple[asyncio.Task[str], asyncio.Event]]] = {}
+    gate = asyncio.Event()
+
+    async def _bg() -> str:
+        await gate.wait()
+        raise RuntimeError("async tool boom")
+
+    task = asyncio.create_task(_bg(), name="async-handle_fail")
+    _register_async_handle(registry, session_id="conv_async", handle_id="handle_fail", task=task)
+    assert _has_live_async_tasks(registry) is True
+
+    async def _release() -> None:
+        gate.set()
+        with pytest.raises(RuntimeError, match="async tool boom"):
+            await task
+        # Leave the stale entry; done() must still make the runner idle-eligible.
+        assert "handle_fail" in registry["conv_async"]
+
+    await _assert_monitor_blocked_then_shuts_down(
+        has_active_work=lambda: _has_live_async_tasks(registry),
+        release=_release,
+    )
+    assert _has_live_async_tasks(registry) is False
+
+
+@pytest.mark.asyncio
+async def test_live_timer_blocks_idle_shutdown() -> None:
+    """A registered timer task pins the runner until it completes.
+
+    :returns: None.
+    """
+    app = _scaffold_app()
+    finish = asyncio.Event()
+
+    async def _timer() -> None:
+        await finish.wait()
+
+    task = asyncio.create_task(_timer(), name="timer-pin")
+    register_timer("conv_timer", "timer_pin", task)
+    assert app.state.has_active_work() is True
+
+    async def _release() -> None:
+        finish.set()
+        await task
+        unregister_timer("conv_timer", "timer_pin")
+
+    await _assert_monitor_blocked_then_shuts_down(
+        has_active_work=app.state.has_active_work,
+        release=_release,
+    )
+    assert app.state.has_active_work() is False
+
+
+@pytest.mark.asyncio
+async def test_parked_approval_blocks_idle_shutdown() -> None:
+    """A parked ASK Future keeps the runner alive until resolved.
+
+    :returns: None.
+    """
+    app = _scaffold_app()
+    fut = pending_approvals.register("elicit_idle_pin")
+    assert app.state.has_active_work() is True
+
+    async def _release() -> None:
+        fut.set_result(True)
+        pending_approvals.cleanup("elicit_idle_pin")
+
+    await _assert_monitor_blocked_then_shuts_down(
+        has_active_work=app.state.has_active_work,
+        release=_release,
+    )
+    assert app.state.has_active_work() is False
+
+
+@pytest.mark.asyncio
+async def test_done_approval_future_does_not_pin_runner() -> None:
+    """A completed approval Future left in the registry is not active work.
+
+    :returns: None.
+    """
+    app = _scaffold_app()
+    fut = pending_approvals.register("elicit_stale")
+    fut.set_result(False)
+    assert fut.done()
+    assert app.state.has_active_work() is False


### PR DESCRIPTION
## Related issue

N/A

## Summary

The runner idle watchdog could shut down while `sys_call_async` work (and other delivery-critical background work) was still outstanding, because `app.state.has_active_work()` only checked foreground turns and harness process-manager turns.

This change updates active-work accounting to also count:

- live `sys_call_async` tasks (not `done()`)
- live timer tasks
- parked approval Futures (not `done()`)

Completed / stale registry entries are ignored. Housekeeping background tasks, the sub-agent wake debounce flag, and non-empty inboxes are intentionally excluded so unrelated work cannot pin the runner forever.

## Test Plan

- `uv run pytest tests/runner/test_runner_idle_active_work.py -q`
- Also re-ran existing idle / `has_active_work` coverage:
  - `tests/runner/test_app_sessions_native.py::test_has_active_work_reports_process_manager_turns`
  - `tests/runner/test_runner_entry.py::test_inactivity_monitor_requests_shutdown_when_idle`
  - `tests/runner/test_runner_entry.py::test_inactivity_monitor_waits_for_active_work_to_finish`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused idle-monitor tests with a very short timeout cover: running async tool blocks shutdown; completion makes the runner idle-eligible; cancel/failure release the pin; live timers and parked approvals also pin; completed/stale entries do not.

## Changelog

Runner idle timeout no longer kills sessions waiting on async tools, timers, or approval prompts