### PR TITLE
fix(claude-native): ack message delivery via hooks, not just the input box

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2898,8 +2898,9 @@ def inject_user_message(
                 last_enter = time.monotonic()
         if not submitted:
             raise RuntimeError(
-                f"Claude Code did not accept the submitted message within {_SUBMIT_VERIFY_TIMEOUT_S}s "
-                "(the draft is still in the input box). The message was not delivered."
+                "Claude Code did not accept the submitted message within "
+                f"{_SUBMIT_VERIFY_TIMEOUT_S}s (the draft is still in the input box). "
+                "The message was not delivered."
             )
     if not verify_delivery:
         # Legacy behavior for mid-turn steering: the pane-level submit above

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -153,6 +153,27 @@ _SUBMIT_VERIFY_TIMEOUT_S = 10.0
 # (so a slow-but-successful first Enter isn't double-tapped), short
 # enough that a swallowed Enter is retried promptly.
 _SUBMIT_RETRY_INTERVAL_S = 1.0
+# After the submit registers at the TUI layer, how long to wait for
+# Claude Code to record ``UserPromptSubmit`` in hooks.jsonl — the
+# authoritative signal that the prompt was accepted (not just that the
+# draft left the input box, which draft-restore can undo). If it never
+# arrives the submit did not register and the message was not delivered.
+_SUBMIT_ACK_TIMEOUT_S = 8.0
+# After ``UserPromptSubmit`` is seen, a brief window to let a draft-restore
+# manifest (the text bounces back into the box a moment after submit)
+# before treating an empty box as a healthy, turn-is-starting delivery.
+_TURN_START_SETTLE_S = 2.0
+# Once a draft-restore stall is detected, how long to keep re-submitting the
+# restored draft while waiting for an assistant turn to actually start before
+# surfacing the stall as an error.
+_TURN_START_TIMEOUT_S = 20.0
+# Parent-turn hook events that prove an assistant turn has actually started
+# (as opposed to just the prompt being accepted). ``UserPromptSubmit`` and
+# ``SessionStart`` are deliberately excluded — they fire before/at submit,
+# not at turn start.
+_TURN_START_HOOK_EVENTS: frozenset[str] = frozenset(
+    {"PreToolUse", "PostToolUse", "Notification", "Stop", "StopFailure"}
+)
 # Claude Code collapses large pastes into this placeholder in the
 # input box instead of rendering the text itself.
 _PASTED_PLACEHOLDER_PREFIX = "[Pasted text"
@@ -1532,6 +1553,26 @@ def read_transcript_path(bridge_dir: Path) -> Path | None:
     return Path(raw)
 
 
+def _count_transcript_lines(transcript_path: Path | None) -> int:
+    """
+    Return the current line count of a transcript file.
+
+    Used to snapshot a pre-injection cursor so the delivery ack only reads
+    assistant text appended after this message. ``None`` or a missing file
+    (fresh session) reports ``0``.
+
+    :param transcript_path: Transcript path, or ``None``.
+    :returns: Line count, or ``0`` when absent.
+    """
+    if transcript_path is None:
+        return 0
+    try:
+        with transcript_path.open("r", encoding="utf-8") as handle:
+            return sum(1 for _ in handle)
+    except FileNotFoundError:
+        return 0
+
+
 def read_claude_session_id(bridge_dir: Path) -> str | None:
     """
     Return the Claude-native session id captured from hook events.
@@ -2221,6 +2262,125 @@ def stop_hook_seen_since(bridge_dir: Path, start_event_count: int) -> bool:
     return False
 
 
+def user_prompt_submit_seen_since(bridge_dir: Path, start_event_count: int) -> bool:
+    """
+    Return whether Claude recorded a ``UserPromptSubmit`` after a cursor.
+
+    This is the authoritative "the prompt was accepted" signal for an
+    injected message: Claude Code fires ``UserPromptSubmit`` when a
+    submit registers, before any assistant activity. It is what lets the
+    bridge tell a genuinely-delivered message apart from one whose submit
+    Enter was swallowed (draft still sitting unsent). Subagent prompts
+    (whose ``transcript_path`` contains a ``subagents/`` component) are
+    ignored so they cannot be mistaken for the parent turn's submit.
+
+    :param bridge_dir: Bridge directory path.
+    :param start_event_count: Hook record count captured before the
+        message was injected into the Claude terminal.
+    :returns: ``True`` once a parent-process ``UserPromptSubmit`` hook has
+        been recorded after the cursor.
+    """
+    path = bridge_dir / _HOOKS_FILE
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for index, line in enumerate(handle, start=1):
+                if index <= start_event_count:
+                    continue
+                try:
+                    envelope = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                payload = envelope.get("payload") if isinstance(envelope, dict) else None
+                event_name = payload.get("hook_event_name") if isinstance(payload, dict) else None
+                if event_name != "UserPromptSubmit":
+                    continue
+                transcript_path = (
+                    payload.get("transcript_path") if isinstance(payload, dict) else None
+                )
+                if isinstance(transcript_path, str) and "/subagents/" in transcript_path:
+                    continue
+                return True
+    except FileNotFoundError:
+        return False
+    return False
+
+
+def _turn_activity_hook_seen_since(bridge_dir: Path, start_event_count: int) -> bool:
+    """
+    Return whether a parent-turn activity hook fired after a cursor.
+
+    Turn-start (as opposed to prompt-accept) is proven by any parent
+    ``PreToolUse`` / ``PostToolUse`` / ``Notification`` / ``Stop`` /
+    ``StopFailure`` in ``hooks.jsonl`` after the cursor — see
+    :data:`_TURN_START_HOOK_EVENTS`. Subagent events are skipped so a
+    finishing subagent cannot masquerade as the parent turn starting.
+
+    :param bridge_dir: Bridge directory path.
+    :param start_event_count: Hook record count captured before injection.
+    :returns: ``True`` once a parent turn-activity hook is recorded after
+        the cursor.
+    """
+    path = bridge_dir / _HOOKS_FILE
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for index, line in enumerate(handle, start=1):
+                if index <= start_event_count:
+                    continue
+                try:
+                    envelope = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                payload = envelope.get("payload") if isinstance(envelope, dict) else None
+                event_name = payload.get("hook_event_name") if isinstance(payload, dict) else None
+                if event_name not in _TURN_START_HOOK_EVENTS:
+                    continue
+                transcript_path = (
+                    payload.get("transcript_path") if isinstance(payload, dict) else None
+                )
+                if isinstance(transcript_path, str) and "/subagents/" in transcript_path:
+                    continue
+                return True
+    except FileNotFoundError:
+        return False
+    return False
+
+
+def _assistant_turn_started_since(
+    bridge_dir: Path,
+    *,
+    hook_cursor: int,
+    transcript_path: Path | None,
+    transcript_cursor: int,
+) -> bool:
+    """
+    Return whether an assistant turn actually started after injection.
+
+    Combines two signals so both tool-first and text-only turns are
+    caught: a parent turn-activity hook
+    (:func:`_turn_activity_hook_seen_since`, covers tool calls and the
+    end-of-turn ``Stop``) or new assistant text appended to the transcript
+    after the pre-injection cursor (:func:`read_assistant_text_since`,
+    covers a turn that streams text before any tool). ``read_assistant_text_since``
+    ignores user entries, so the injected prompt itself never counts as a
+    turn start.
+
+    :param bridge_dir: Bridge directory path.
+    :param hook_cursor: Hook record count captured before injection.
+    :param transcript_path: Transcript path captured before injection, or
+        ``None`` when hooks had not yet reported one (re-resolved here).
+    :param transcript_cursor: Transcript line count captured before
+        injection.
+    :returns: ``True`` once assistant activity is observed after injection.
+    """
+    if _turn_activity_hook_seen_since(bridge_dir, hook_cursor):
+        return True
+    path = transcript_path or read_transcript_path(bridge_dir)
+    if path is None:
+        return False
+    _cursor, texts = read_assistant_text_since(path, transcript_cursor)
+    return bool(texts)
+
+
 # Terminal per-task ``status`` values in a ``Stop`` hook's ``background_tasks``
 # array. Claude Code retains finished/stopped shells in that array rather than
 # reaping them (claude-code issues #67895, #59456, #14049), so counting the raw
@@ -2480,11 +2640,112 @@ def write_tmux_target(
     _write_json_file(bridge_dir / _TMUX_FILE, payload)
 
 
+def _await_delivery_ack(
+    info: dict[str, str],
+    bridge_dir: Path,
+    *,
+    needle: str,
+    hook_cursor: int,
+    transcript_path: Path | None,
+    transcript_cursor: int,
+) -> None:
+    """
+    Confirm an injected message was delivered end-to-end, or raise.
+
+    Called after the TUI-level submit. Two bounded phases:
+
+    1. **Submit registered?** Wait up to :data:`_SUBMIT_ACK_TIMEOUT_S`
+       for ``UserPromptSubmit`` after ``hook_cursor``. While waiting,
+       re-send ``Enter`` only while the draft is verifiably still in the
+       input box — this recovers a swallowed submit (and the old
+       blind-Enter path) without ever double-submitting a cleared box. If
+       it never arrives the submit did not register: raise.
+    2. **Turn started?** Once the prompt is accepted, the draft leaving
+       the box is not proof of a turn (draft-restore can undo it). Watch
+       for a real turn start; if instead the draft reappears in the box
+       (the draft-restore signature) re-submit it, spaced out, until a
+       turn starts. Raise only if redelivery never produces a turn within
+       :data:`_TURN_START_TIMEOUT_S`.
+
+    Skipped entirely when ``hooks.jsonl`` does not exist — the hook stream
+    is unobservable for this bridge, so this cannot do better than the
+    pane-based submit and must not newly block delivery.
+
+    :param info: Resolved tmux info (``socket_path`` / ``tmux_target``).
+    :param bridge_dir: Bridge directory path.
+    :param needle: Draft marker from :func:`_submit_needle`.
+    :param hook_cursor: Hook record count captured before injection.
+    :param transcript_path: Transcript path captured before injection.
+    :param transcript_cursor: Transcript line count captured before injection.
+    :raises RuntimeError: If ``UserPromptSubmit`` never registers, or if a
+        draft-restore stall never yields an assistant turn.
+    """
+    if not (bridge_dir / _HOOKS_FILE).exists():
+        return
+
+    # Phase 1 — submit registered (UserPromptSubmit recorded)?
+    deadline = time.monotonic() + _SUBMIT_ACK_TIMEOUT_S
+    last_enter = time.monotonic()
+    submitted = False
+    while time.monotonic() < deadline:
+        if user_prompt_submit_seen_since(bridge_dir, hook_cursor):
+            submitted = True
+            break
+        pane = _capture_pane(info["socket_path"], info["tmux_target"])
+        if (
+            _draft_in_input_box(pane, needle)
+            and time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S
+        ):
+            _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
+            last_enter = time.monotonic()
+        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+    if not submitted:
+        raise RuntimeError(
+            "Claude Code never recorded UserPromptSubmit for the injected message "
+            f"within {_SUBMIT_ACK_TIMEOUT_S}s; the message was not delivered."
+        )
+
+    # Phase 2 — assistant turn actually started?
+    deadline = time.monotonic() + _TURN_START_TIMEOUT_S
+    settle = time.monotonic() + _TURN_START_SETTLE_S
+    last_enter = time.monotonic()
+    saw_restore = False
+    while time.monotonic() < deadline:
+        if _assistant_turn_started_since(
+            bridge_dir,
+            hook_cursor=hook_cursor,
+            transcript_path=transcript_path,
+            transcript_cursor=transcript_cursor,
+        ):
+            return
+        pane = _capture_pane(info["socket_path"], info["tmux_target"])
+        if _draft_in_input_box(pane, needle):
+            # Draft-restore stall: the submit registered but the text
+            # bounced back into the box. Re-submit it (what a human does by
+            # pressing Enter), spaced out, until a turn starts.
+            saw_restore = True
+            if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
+                _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
+                last_enter = time.monotonic()
+        elif not saw_restore and time.monotonic() >= settle:
+            # UserPromptSubmit is in and the box stayed empty through the
+            # settle window with no restore — the turn is starting or is
+            # queued behind a running one. Delivered; don't block further.
+            return
+        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+    raise RuntimeError(
+        "Claude Code recorded the message but no assistant turn started within "
+        f"{_TURN_START_TIMEOUT_S}s (draft-restore stall); redelivery did not recover. "
+        "The message may be sitting unsent in the terminal input box."
+    )
+
+
 def inject_user_message(
     bridge_dir: Path,
     *,
     content: str,
     timeout_s: float = _TMUX_READY_TIMEOUT_S,
+    verify_delivery: bool = True,
 ) -> None:
     r"""
     Deliver a user message into the Claude terminal via tmux send-keys.
@@ -2507,24 +2768,40 @@ def inject_user_message(
     client→server command at ~16KB, so a large message — e.g. a PR diff
     in a sub-agent dispatch — failed with "command too long".
 
-    The submit is **verified, not fire-and-forget**: Claude Code
-    coalesces rapid stdin bursts into a paste, so an Enter that lands
-    while the TUI is still consuming the paste is folded in as a
-    newline and the draft sits unsent. This helper first polls
-    ``capture-pane`` until the draft is visible in the input box (the
-    paste was committed), sends Enter, then polls that the draft left
-    the box — re-sending Enter while it hasn't — and raises if the
-    message never submits.
+    The submit is **verified end-to-end, not fire-and-forget**. Claude
+    Code coalesces rapid stdin bursts into a paste, so an Enter that lands
+    while the TUI is still consuming the paste is folded in as a newline
+    and the draft sits unsent; this helper first polls ``capture-pane``
+    until the draft is visible (paste committed), sends Enter, then polls
+    that the draft left the box, re-sending Enter while it hasn't. That
+    only proves the TUI accepted the keystroke, which draft-restore can
+    undo, so when ``verify_delivery`` is set (the default) it then waits
+    on the authoritative hook signal: ``UserPromptSubmit`` recorded in
+    ``hooks.jsonl`` (submit registered), followed by an assistant turn
+    actually starting. If the prompt never registers, or it registers but
+    the draft is restored to the box and no turn starts even after
+    redelivery, it raises so the caller can surface the failure instead of
+    stranding the message in a terminal the user may not be watching. The
+    hook ack is skipped when ``hooks.jsonl`` is absent (signal
+    unobservable). Pass ``verify_delivery=False`` for mid-turn steering,
+    where a queued message may not fire ``UserPromptSubmit`` promptly.
 
     :param bridge_dir: Bridge directory path.
     :param content: User text from the Omnigent web UI. Must be non-empty.
     :param timeout_s: Seconds to wait for each readiness gate
         (``tmux.json`` advertised, then prompt rendered), e.g. ``30.0``.
+    :param verify_delivery: When ``True`` (default), block after submit
+        until the hook stream acknowledges delivery (``UserPromptSubmit``
+        + assistant turn start), raising on failure. When ``False``, use
+        the legacy pane-only verification — for mid-turn steering, where a
+        queued prompt may not ack promptly.
     :returns: None.
     :raises RuntimeError: If the tmux target is not advertised in time,
         if Claude's input prompt never renders, if a ``tmux send-keys``
-        invocation fails, or if the draft never leaves the input box
-        after repeated submit Enters (message not delivered).
+        invocation fails, if the draft never leaves the input box after
+        repeated submit Enters, or — when ``verify_delivery`` — if the
+        hook stream never acknowledges the message (no ``UserPromptSubmit``,
+        or a draft-restore stall that redelivery cannot start).
     """
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
     # tmux.json only means the tmux session exists; Claude Code's input
@@ -2535,6 +2812,13 @@ def inject_user_message(
         info["tmux_target"],
         timeout_s=timeout_s,
     )
+    # Snapshot the hook + transcript cursors BEFORE injecting so the
+    # delivery ack can tell this message's UserPromptSubmit / turn-start
+    # apart from prior activity. read_hook_events_since(..., 0) returns the
+    # current complete-record count as its cursor.
+    hook_cursor, _names = read_hook_events_since(bridge_dir, 0)
+    ack_transcript_path = read_transcript_path(bridge_dir)
+    transcript_cursor = _count_transcript_lines(ack_transcript_path)
     # Clear any leftover text in Claude's input field before typing.
     # After Escape-cancel, Claude Code re-populates the prompt area
     # with the previous input for re-editing. Without this clear,
@@ -2591,29 +2875,44 @@ def inject_user_message(
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
     time.sleep(_PASTE_SETTLE_S)
     _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
-    if not draft_seen:
-        # The draft was never observed, so its absence proves nothing —
-        # verification would trivially "pass". Submit blind as before.
+    # TUI-level submit verification: a successful Enter clears the input
+    # box. If the draft is still sitting there the Enter was swallowed into
+    # the paste burst as a newline — re-send it (the retry lands well after
+    # the burst, so it submits). Each Enter only fires while the draft is
+    # verifiably still present, so a retry can never hit an empty prompt or
+    # a permission dialog of the started turn. Skipped when the draft was
+    # never identifiable (draft_seen False) — its absence proves nothing, so
+    # the hook ack below is what guards that path.
+    if draft_seen:
+        deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
+        last_enter = time.monotonic()
+        submitted = False
+        while time.monotonic() < deadline:
+            time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+            pane = _capture_pane(info["socket_path"], info["tmux_target"])
+            if not _draft_in_input_box(pane, needle):
+                submitted = True
+                break
+            if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
+                _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
+                last_enter = time.monotonic()
+        if not submitted:
+            raise RuntimeError(
+                f"Claude Code did not accept the submitted message within {_SUBMIT_VERIFY_TIMEOUT_S}s "
+                "(the draft is still in the input box). The message was not delivered."
+            )
+    if not verify_delivery:
+        # Legacy behavior for mid-turn steering: the pane-level submit above
+        # is as far as we verify (a queued steering prompt may not ack).
         return
-    # Verify the submit took: a successful Enter clears the input box.
-    # If the draft is still sitting there the Enter was swallowed into
-    # the paste burst as a newline — re-send it (the retry lands well
-    # after the burst, so it submits). Each Enter only fires while the
-    # draft is verifiably still present, so a retry can never hit an
-    # empty prompt or a permission dialog of the started turn.
-    deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
-    last_enter = time.monotonic()
-    while time.monotonic() < deadline:
-        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-        pane = _capture_pane(info["socket_path"], info["tmux_target"])
-        if not _draft_in_input_box(pane, needle):
-            return
-        if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
-            _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
-            last_enter = time.monotonic()
-    raise RuntimeError(
-        f"Claude Code did not accept the submitted message within {_SUBMIT_VERIFY_TIMEOUT_S}s "
-        "(the draft is still in the input box). The message was not delivered."
+    # End-to-end ack: confirm UserPromptSubmit registered and a turn started.
+    _await_delivery_ack(
+        info,
+        bridge_dir,
+        needle=needle,
+        hook_cursor=hook_cursor,
+        transcript_path=ack_transcript_path,
+        transcript_cursor=transcript_cursor,
     )
 
 

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2816,7 +2816,7 @@ def inject_user_message(
     # delivery ack can tell this message's UserPromptSubmit / turn-start
     # apart from prior activity. read_hook_events_since(..., 0) returns the
     # current complete-record count as its cursor.
-    hook_cursor, _names = read_hook_events_since(bridge_dir, 0)
+    hook_cursor, _ = read_hook_events_since(bridge_dir, 0)
     ack_transcript_path = read_transcript_path(bridge_dir)
     transcript_cursor = _count_transcript_lines(ack_transcript_path)
     # Clear any leftover text in Claude's input field before typing.

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -91,6 +91,10 @@ class ClaudeNativeExecutor(Executor):
                     inject_user_message,
                     self._bridge_dir,
                     content=text,
+                    # Mid-turn steering: a queued prompt may not fire
+                    # UserPromptSubmit promptly, so keep the legacy
+                    # pane-only verification here (see #2061).
+                    verify_delivery=False,
                 )
         except RuntimeError:
             return False

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -266,6 +266,7 @@ async def test_enqueue_session_message_injects_steering_into_terminal(
         *,
         content: str,
         timeout_s: float = 30.0,
+        verify_delivery: bool = True,
     ) -> None:
         """
         Capture a steering injection.
@@ -273,10 +274,17 @@ async def test_enqueue_session_message_injects_steering_into_terminal(
         :param bridge_dir_arg: Bridge directory passed by the executor.
         :param content: Text typed into the Claude tmux pane.
         :param timeout_s: tmux-target readiness timeout (ignored).
+        :param verify_delivery: Delivery-ack toggle passed by the executor.
         :returns: None.
         """
         del timeout_s
-        sent_messages.append({"bridge_dir": bridge_dir_arg, "content": content})
+        sent_messages.append(
+            {
+                "bridge_dir": bridge_dir_arg,
+                "content": content,
+                "verify_delivery": verify_delivery,
+            }
+        )
 
     monkeypatch.setattr(
         claude_native_executor,
@@ -292,10 +300,13 @@ async def test_enqueue_session_message_injects_steering_into_terminal(
     # session_key is intentionally NOT included since there is one
     # tmux pane per conversation; mixing in routing metadata would
     # cause Claude to see arbitrary key-value pairs as user input.
+    # verify_delivery is False: a queued steering prompt may not fire
+    # UserPromptSubmit promptly, so it keeps the legacy pane-only check.
     assert sent_messages == [
         {
             "bridge_dir": tmp_path,
             "content": "steer me",
+            "verify_delivery": False,
         }
     ]
 
@@ -333,15 +344,17 @@ async def test_concurrent_injections_do_not_overlap_in_terminal(
         *,
         content: str,
         timeout_s: float = 30.0,
+        verify_delivery: bool = True,
     ) -> None:
         """Record peak concurrency, then hold the call open until released.
 
         :param bridge_dir_arg: Bridge directory (ignored).
         :param content: Text that would be typed into tmux (ignored).
         :param timeout_s: tmux-target readiness timeout (ignored).
+        :param verify_delivery: Delivery-ack toggle (ignored).
         :returns: None.
         """
-        del bridge_dir_arg, content, timeout_s
+        del bridge_dir_arg, content, timeout_s, verify_delivery
         with state_lock:
             state["now"] += 1
             state["max"] = max(state["max"], state["now"])
@@ -420,8 +433,9 @@ def _stub_inject(
         *,
         content: str,
         timeout_s: float = 30.0,
+        verify_delivery: bool = True,
     ) -> None:
-        del timeout_s
+        del timeout_s, verify_delivery
         sent.append({"bridge_dir": bridge_dir_arg, "content": content})
 
     return _fake

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -45,6 +45,7 @@ from omnigent.claude_native_bridge import (
     record_hook_event,
     start_tool_relay,
     stop_hook_seen_since,
+    user_prompt_submit_seen_since,
     write_tmux_target,
 )
 from omnigent.reasoning_effort import CLAUDE_EFFORTS
@@ -2869,6 +2870,278 @@ def test_inject_user_message_raises_when_draft_never_submits(
     monkeypatch.setattr("subprocess.run", _fake_run)
     with pytest.raises(RuntimeError, match="message was not delivered"):
         inject_user_message(bridge_dir, content="fix the flaky test")
+
+
+# ── user_prompt_submit_seen_since ────────────────────────────────────
+
+
+def test_user_prompt_submit_seen_since_detects_parent_prompt(
+    tmp_path: Path,
+) -> None:
+    """
+    A parent ``UserPromptSubmit`` after the cursor is detected.
+
+    This is the authoritative "submit registered" signal the delivery ack
+    keys on; without it a swallowed submit Enter looks like success.
+    """
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(bridge_dir, {"hook_event_name": "SessionStart", "session_id": "p"})
+    assert not user_prompt_submit_seen_since(bridge_dir, 1)
+    record_hook_event(bridge_dir, {"hook_event_name": "UserPromptSubmit", "session_id": "p"})
+    assert user_prompt_submit_seen_since(bridge_dir, 1)
+
+
+def test_user_prompt_submit_seen_since_ignores_subagent_prompt(
+    tmp_path: Path,
+) -> None:
+    """
+    A subagent ``UserPromptSubmit`` must not count as the parent's submit.
+
+    Subagent hooks land in the same ``hooks.jsonl``; their
+    ``transcript_path`` carries a ``subagents/`` component. Counting one
+    would falsely ack a parent message that never registered.
+    """
+    bridge_dir = tmp_path / "bridge"
+    subagent_transcript = tmp_path / "session" / "subagents" / "agent-abc.jsonl"
+    record_hook_event(bridge_dir, {"hook_event_name": "SessionStart", "session_id": "p"})
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "sub",
+            "transcript_path": str(subagent_transcript),
+        },
+    )
+    assert not user_prompt_submit_seen_since(bridge_dir, 1)
+
+
+def test_user_prompt_submit_seen_since_absent_file_is_false(
+    tmp_path: Path,
+) -> None:
+    """A missing ``hooks.jsonl`` reports no submit rather than raising."""
+    assert not user_prompt_submit_seen_since(tmp_path / "bridge", 0)
+
+
+# ── inject_user_message: end-to-end delivery ack ─────────────────────
+
+
+def _shrink_ack_timers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Collapse the ack poll cadence/timeouts so tests run in milliseconds.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    for name, value in {
+        "_CLAUDE_READY_POLL_INTERVAL_S": 0.01,
+        "_SUBMIT_RETRY_INTERVAL_S": 0.02,
+        "_PASTE_SETTLE_S": 0.0,
+        "_SUBMIT_ACK_TIMEOUT_S": 0.15,
+        "_TURN_START_SETTLE_S": 0.03,
+        "_TURN_START_TIMEOUT_S": 0.15,
+    }.items():
+        monkeypatch.setattr(f"omnigent.claude_native_bridge.{name}", value)
+
+
+def test_inject_user_message_acks_when_turn_starts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Delivery succeeds once ``UserPromptSubmit`` + a turn-start hook land.
+
+    Models Claude accepting the prompt on Enter (fires ``UserPromptSubmit``)
+    and starting a turn (fires ``PreToolUse``). The helper must return
+    without raising and without extra retry Enters.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    _shrink_ack_timers(monkeypatch)
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir, socket_path=Path("/tmp/example/tmux.sock"), tmux_target="claude:0.0"
+    )
+
+    enters: list[list[str]] = []
+    tui = {"pane": "❯ "}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if "capture-pane" in cmd:
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "❯ ship the fix"
+        if cmd[-1] == "Enter":
+            enters.append(cmd)
+            tui["pane"] = "❯ "  # submitted — box clears
+            # Claude accepts the prompt and starts a turn.
+            record_hook_event(
+                bridge_dir, {"hook_event_name": "UserPromptSubmit", "session_id": "p"}
+            )
+            record_hook_event(bridge_dir, {"hook_event_name": "PreToolUse", "session_id": "p"})
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    inject_user_message(bridge_dir, content="ship the fix")  # must not raise
+
+    assert len(enters) == 1, f"Healthy delivery should send exactly one Enter, got {len(enters)}."
+
+
+def test_inject_user_message_raises_when_prompt_never_registers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The box clearing is not enough: no ``UserPromptSubmit`` means not delivered.
+
+    This is the blind-Enter / swallowed-submit gap. Previously the draft
+    leaving the box returned "success"; now, with the hook stream live and
+    no ``UserPromptSubmit`` recorded, the helper raises so the caller can
+    surface the drop.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    _shrink_ack_timers(monkeypatch)
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir, socket_path=Path("/tmp/example/tmux.sock"), tmux_target="claude:0.0"
+    )
+    # Hook stream is live (SessionStart already recorded) but the submit
+    # never produces a UserPromptSubmit.
+    record_hook_event(bridge_dir, {"hook_event_name": "SessionStart", "session_id": "p"})
+
+    tui = {"pane": "❯ "}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if "capture-pane" in cmd:
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "❯ never delivered"
+        if cmd[-1] == "Enter":
+            tui["pane"] = "❯ "  # box clears (looks fine) but no UPS fires
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    with pytest.raises(RuntimeError, match="UserPromptSubmit"):
+        inject_user_message(bridge_dir, content="never delivered")
+
+
+def test_inject_user_message_raises_on_draft_restore_stall(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Submit registers, draft is restored, no turn starts → raise.
+
+    The observed #2061 stall: ``UserPromptSubmit`` fires (submit took) but
+    the draft bounces back into the box and no assistant turn begins. The
+    ack re-submits the restored draft; when redelivery still yields no
+    turn-start it raises rather than stranding the message.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    _shrink_ack_timers(monkeypatch)
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir, socket_path=Path("/tmp/example/tmux.sock"), tmux_target="claude:0.0"
+    )
+    record_hook_event(bridge_dir, {"hook_event_name": "SessionStart", "session_id": "p"})
+
+    state = {"pane": "❯ ", "restored": False}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if "capture-pane" in cmd:
+            # Once restored, the pane keeps showing the draft (the stall).
+            return SimpleNamespace(
+                returncode=0,
+                stdout=("❯ stalled message" if state["restored"] else state["pane"]),
+                stderr="",
+            )
+        if "paste-buffer" in cmd:
+            state["pane"] = "❯ stalled message"
+        if cmd[-1] == "Enter":
+            if not state["restored"]:
+                # First submit registers, box momentarily clears...
+                state["pane"] = "❯ "
+                record_hook_event(
+                    bridge_dir, {"hook_event_name": "UserPromptSubmit", "session_id": "p"}
+                )
+                # ...then draft-restore puts it back; no turn-start hook ever fires.
+                state["restored"] = True
+            # Subsequent (nudge) Enters do NOT start a turn — the stall persists.
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    with pytest.raises(RuntimeError, match="no assistant turn started"):
+        inject_user_message(bridge_dir, content="stalled message")
+
+
+def test_inject_user_message_degrades_without_hooks_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    With no ``hooks.jsonl`` the ack is skipped and delivery is not blocked.
+
+    The hook signal is unobservable for this bridge, so the helper must
+    fall back to pane-only behavior (prior semantics) instead of raising.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    _shrink_ack_timers(monkeypatch)
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir, socket_path=Path("/tmp/example/tmux.sock"), tmux_target="claude:0.0"
+    )
+
+    tui = {"pane": "❯ "}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if "capture-pane" in cmd:
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "❯ no hooks here"
+        if cmd[-1] == "Enter":
+            tui["pane"] = "❯ "
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    inject_user_message(bridge_dir, content="no hooks here")  # must not raise
+    assert not (bridge_dir / "hooks.jsonl").exists()
+
+
+def test_inject_user_message_steering_skips_hook_ack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``verify_delivery=False`` keeps legacy pane-only behavior.
+
+    Mid-turn steering can be queued without a prompt ack, so the strict
+    hook ack is bypassed: even with the hook stream live and no
+    ``UserPromptSubmit``, the helper returns once the box clears.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    _shrink_ack_timers(monkeypatch)
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir, socket_path=Path("/tmp/example/tmux.sock"), tmux_target="claude:0.0"
+    )
+    record_hook_event(bridge_dir, {"hook_event_name": "SessionStart", "session_id": "p"})
+
+    tui = {"pane": "❯ "}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if "capture-pane" in cmd:
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "❯ steer me"
+        if cmd[-1] == "Enter":
+            tui["pane"] = "❯ "  # box clears; no UPS — would raise if strict
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    # Would raise under the default strict ack; verify_delivery=False must not.
+    inject_user_message(bridge_dir, content="steer me", verify_delivery=False)
 
 
 def test_inject_interrupt_sends_escape_keystroke(

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2935,6 +2935,7 @@ def _shrink_ack_timers(monkeypatch: pytest.MonkeyPatch) -> None:
         "_CLAUDE_READY_POLL_INTERVAL_S": 0.01,
         "_SUBMIT_RETRY_INTERVAL_S": 0.02,
         "_PASTE_SETTLE_S": 0.0,
+        "_SUBMIT_VERIFY_TIMEOUT_S": 0.15,
         "_SUBMIT_ACK_TIMEOUT_S": 0.15,
         "_TURN_START_SETTLE_S": 0.03,
         "_TURN_START_TIMEOUT_S": 0.15,
@@ -3044,28 +3045,30 @@ def test_inject_user_message_raises_on_draft_restore_stall(
     )
     record_hook_event(bridge_dir, {"hook_event_name": "SessionStart", "session_id": "p"})
 
-    state = {"pane": "❯ ", "restored": False}
+    state = {"pane": "❯ ", "submitted": False}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         del kwargs
         if "capture-pane" in cmd:
-            # Once restored, the pane keeps showing the draft (the stall).
-            return SimpleNamespace(
-                returncode=0,
-                stdout=("❯ stalled message" if state["restored"] else state["pane"]),
-                stderr="",
-            )
+            pane = state["pane"]
+            # The submit momentarily clears the box — the first capture-pane
+            # read after that clear sees empty, so the TUI-level submit
+            # verification passes — then draft-restore bounces the text back
+            # into the box for the delivery ack to catch as a stall.
+            if state["submitted"] and pane == "❯ ":
+                state["pane"] = "❯ stalled message"
+            return SimpleNamespace(returncode=0, stdout=pane, stderr="")
         if "paste-buffer" in cmd:
             state["pane"] = "❯ stalled message"
         if cmd[-1] == "Enter":
-            if not state["restored"]:
-                # First submit registers, box momentarily clears...
+            if not state["submitted"]:
+                # First submit registers and the box momentarily clears...
                 state["pane"] = "❯ "
                 record_hook_event(
                     bridge_dir, {"hook_event_name": "UserPromptSubmit", "session_id": "p"}
                 )
                 # ...then draft-restore puts it back; no turn-start hook ever fires.
-                state["restored"] = True
+                state["submitted"] = True
             # Subsequent (nudge) Enters do NOT start a turn — the stall persists.
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 


### PR DESCRIPTION
## Related issue

Closes #2061

## Summary

`inject_user_message` (claude-native bridge) verified delivery only at the TUI
layer — it polled `capture-pane` until the pasted draft left the input box and
called that success. That is blind to both failures in #2061: the blind-Enter
early-return when the draft can't be identified, and the submit-then-stall where
the draft leaves the box (verify passes), Claude Code's draft-restore puts it
back, and no assistant turn ever starts. The message strands unsent in a
terminal the web UI can't see.

This adds a **hook-anchored, end-to-end delivery ack** after the existing TUI
submit:

- Confirm `UserPromptSubmit` was recorded in `hooks.jsonl` for this message
  (the authoritative "submit registered" signal), re-sending Enter only while
  the draft is verifiably still in the box. Guards the blind-Enter/swallowed
  path — no `UserPromptSubmit` now raises instead of silently "succeeding."
- Confirm an assistant **turn actually started** (a parent turn-activity hook,
  or new assistant transcript text). If the draft-restore signature appears
  (text back in the box after `UserPromptSubmit`), re-submit it — what a human
  does by pressing Enter — and raise only if redelivery never starts a turn.

The `RuntimeError` already surfaces to the web UI as an `ExecutorError` via
`run_turn`, so a stall becomes a visible error instead of a silent no-reply. The
ack is skipped when `hooks.jsonl` is absent (signal unobservable → unchanged
behavior). The mid-turn steering path opts out (`verify_delivery=False`) because
a queued steering prompt may not `UserPromptSubmit` promptly.

**ELI5.** Before: we pressed Enter and, the moment the text vanished from the
box, declared the message sent — but Claude Code sometimes puts the text right
back and never answers, and we never noticed. Now we wait for Claude to actually
say "got it" (a hook) and to actually start replying; if the text bounces back
we press Enter again for you, and if it still won't go we show an error instead
of pretending it was delivered.

```mermaid
sequenceDiagram
    participant Bridge as inject_user_message
    participant TUI as Claude Code TUI
    participant Hooks as hooks.jsonl / transcript
    Bridge->>TUI: paste draft + Enter
    Bridge->>TUI: poll capture-pane (draft left box?)
    Note over Bridge: OLD: box empty ⇒ "delivered" ✅ (stall invisible)
    Bridge->>Hooks: NEW – UserPromptSubmit recorded? (submit registered)
    alt no UserPromptSubmit within timeout
        Bridge-->>Bridge: raise → ExecutorError (not delivered)
    else submit registered
        Bridge->>Hooks: NEW – assistant turn started?
        alt draft restored to box
            Bridge->>TUI: re-send Enter (redeliver)
        end
        alt turn starts
            Bridge-->>Bridge: return (delivered) ✅
        else no turn after redelivery
            Bridge-->>Bridge: raise → ExecutorError (draft-restore stall)
        end
    end
```

## Test Plan

- New unit tests in `tests/test_claude_native_bridge.py` (fake tmux pane +
  `record_hook_event` fixtures), covering: `UserPromptSubmit` + turn-start →
  success; box clears but no `UserPromptSubmit` → raises; draft-restore stall
  with failed redelivery → raises; no `hooks.jsonl` → degrades to prior
  behavior; `verify_delivery=False` steering bypasses the ack.
- New unit tests for `user_prompt_submit_seen_since` (parent detected, subagent
  ignored, missing file → False), mirroring the `stop_hook_seen_since` tests.
- Existing `inject_user_message` tests are unchanged and must still pass — they
  set up no `hooks.jsonl`, so the ack degrades and the pane-level assertions
  (tmux-call counts, retry-Enter counts, draft-never-submits raise) hold.
- Commands:
  `pytest tests/test_claude_native_bridge.py -q` and
  `pre-commit run --all-files`.

> ⚠️ Not yet run locally — authored while the dev sandbox was unavailable.
> Relying on CI / a local run before marking ready for review. See Coverage notes.

## Demo

N/A — no UI/frontend change (surfaces through the existing `ExecutorError`
path).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover both new failure modes (submit-never-registers, draft-restore
stall) plus the degrade-without-hooks and steering-bypass paths, using fake
tmux/pane state machines and `record_hook_event` fixtures — the same style as
the existing inject and `stop_hook_seen_since` tests. The original incident is a
timing race that can't be reproduced deterministically, so there is no E2E
repro; the tests assert the ack's decisions given each hook/pane sequence.
Because the sandbox was down when this was written, the suite has **not** been
run locally yet — please rely on CI (or a local `pytest` run) before merge.

Open questions for reviewers (also in code comments): (1) on a detected
draft-restore stall, auto-redeliver (current — may duplicate the user turn, as
the manual Enter did in the incident) vs. surface an error immediately; (2)
making mid-turn steering delivery observable is deliberate follow-up.

## Changelog

Claude-native messages that fail to reach Claude (or stall unsent in the
terminal) now surface an error instead of silently showing no reply.