### PR TITLE
fix(web): follow Omnigent theme in file editor

### DIFF
--- a/tests/e2e_ui/sessions/test_file_editor_theme.py
+++ b/tests/e2e_ui/sessions/test_file_editor_theme.py
@@ -1,0 +1,63 @@
+"""E2E: Monaco file surfaces follow Omnigent's theme, not the OS scheme."""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PY_PATH = "theme_probe.py"
+
+
+@pytest.fixture
+def seeded_python(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    base_url, session_id = seeded_session
+    response = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem/{_PY_PATH}",
+        json={"content": "answer = 42\n", "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    try:
+        yield base_url, session_id
+    finally:
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+def test_file_editor_uses_explicit_omnigent_theme(
+    page: Page, seeded_python: tuple[str, str]
+) -> None:
+    """A light Omnigent palette overrides a dark system for Monaco surfaces."""
+    page.emulate_media(color_scheme="dark")
+    page.add_init_script(
+        """
+        localStorage.setItem("web-theme", "light");
+        localStorage.setItem("omnigent:ui-theme-palette", JSON.stringify("gruvbox"));
+        """
+    )
+
+    base_url, session_id = seeded_python
+    page.goto(f"{base_url}/c/{session_id}?file={_PY_PATH}")
+    editor = page.locator('[data-testid="file-viewer"]:visible .monaco-editor')
+    expect(editor).to_be_visible(timeout=30_000)
+
+    assert not page.evaluate("document.documentElement.classList.contains('dark')")
+    editor_background, app_card_background = editor.evaluate(
+        """element => {
+          const probe = document.createElement("div");
+          probe.style.backgroundColor = "var(--card)";
+          document.body.appendChild(probe);
+          const result = [
+            getComputedStyle(element).backgroundColor,
+            getComputedStyle(probe).backgroundColor,
+          ];
+          probe.remove();
+          return result;
+        }"""
+    )
+    assert editor_background == app_card_background

--- a/web/src/shell/monacoCodeEditor.css
+++ b/web/src/shell/monacoCodeEditor.css
@@ -17,22 +17,12 @@
   background-color: rgba(250, 204, 21, 0.3);
 }
 
-/* In dark mode, paint the editor surface with the app's --card tone instead of
-   github-dark's default, so the code editor / diff viewer blend into the card
-   they sit in. Monaco fills .monaco-editor(-background) from its own
-   --vscode-editor-background variable (set per-theme to a single concrete
-   color); rebinding that variable to var(--card) keeps the background tied to
-   the token so it tracks any change to --card with no JS. The .dark prefix
-   outranks Monaco's own single-class rule, and light mode keeps github-light.
-
-   The line-number gutter (.margin) paints from a separate variable,
-   --vscode-editorGutter-background. github-dark doesn't set editorGutter.background
-   explicitly, so Monaco resolves it from editor.background to a concrete hex at
-   theme-registration time — meaning it ignores our editor-background override
-   unless we rebind it too. */
-.dark .monaco-editor,
-.dark .monaco-diff-editor,
-.dark .monaco-component {
+/* Paint Monaco surfaces with the active Omnigent card tone so the file editor
+   follows both the app mode and palette instead of the syntax theme's fixed
+   background. The gutter uses a separate Monaco variable. */
+html .monaco-editor,
+html .monaco-diff-editor,
+html .monaco-component {
   --vscode-editor-background: var(--card);
   --vscode-editorGutter-background: var(--card);
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The Monaco file editor previously kept the syntax theme's fixed background in light mode, so it could disagree with Omnigent's selected web/desktop color palette.
- Apply Omnigent's active `--card` surface to Monaco editor, diff, and gutter backgrounds in both light and dark modes.
- Add a real-browser regression test where a light Omnigent theme overrides a dark operating-system preference.

## Test Plan

- `uv run --frozen --extra dev pre-commit run --all-files`
- `cd web && npm run test -- src/shell/MonacoCodeEditor.test.tsx src/shell/MonacoDiffViewer.test.tsx`
- `cd web && npm run type-check`
- `uv run --frozen --extra dev pytest tests/e2e_ui/sessions/test_file_editor_theme.py -q --tb=short --browser-channel chrome`

## Demo

Automated Chrome coverage opens a Monaco file with a dark OS preference and an explicit light Grüvbox Omnigent theme, then verifies the editor surface matches Omnigent's active card color. No screenshot or recording is attached.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new E2E test contrasts the OS and Omnigent themes so the regression cannot pass by accidentally following the system preference.

## Changelog

The file editor now follows Omnigent's selected web and desktop color theme instead of the operating-system theme.
