### PR TITLE
feat(web): show project name in pinned session hover flyout

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_pinned_project_flyout.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pinned_project_flyout.py
@@ -1,0 +1,108 @@
+"""Browser e2e for the pinned-row project hover flyout.
+
+Pinning lifts a session out of its project folder into the flat "Pinned"
+section (see ``test_sidebar_pin_unpin`` / ``test_sidebar_projects``), which
+drops the visual cue for which project the session came from. To restore it,
+hovering a pinned, project-owned row opens a flyout
+(``data-testid="pinned-project-flyout"``) showing the session title plus a
+folder icon and the project name (``ConversationRow`` / ``HoverCard`` in
+Sidebar.tsx).
+
+This drives the real chain the ``Sidebar`` unit tests mock out: the live
+``PATCH /v1/sessions/{id}`` project move → the ``omni_project`` label on the
+refreshed ``GET /v1/sessions`` list → the pinned peel keeping the label →
+the hover flyout resolving the project name from it. A browser hover (which
+jsdom can't do) is what actually opens the Radix HoverCard here.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+from playwright.sync_api import Locator, Page, expect
+
+
+def _set_title(base_url: str, session_id: str, title: str) -> None:
+    """Give a session a unique title via ``PATCH /v1/sessions/{id}`` so its row
+    is easy to spot among other tests' sessions in the shared server."""
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _section(page: Page, title: str) -> Locator:
+    """Locate the sidebar ``<section>`` whose collapse-header button reads
+    *title* (e.g. "Pinned" or a project name)."""
+    return page.locator("section").filter(has=page.get_by_role("button", name=title, exact=True))
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _move_to_new_project(page: Page, row: Locator, name: str) -> None:
+    """Drive the row kebab → "Add to project" → "Create new project" flow,
+    typing *name* and committing with Enter."""
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("move-to-project").click()
+    page.get_by_role("menuitem", name="Create new project").click()
+    new_input = page.get_by_placeholder("Project name…")
+    new_input.fill(name)
+    new_input.press("Enter")
+
+
+def test_pinned_project_row_hover_shows_project_name(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Hovering a pinned, project-owned row surfaces its project name.
+
+    Files the session into a fresh project, pins it (which lifts it into the
+    flat "Pinned" section, away from the project folder), then hovers the
+    pinned row and asserts the flyout shows the session title plus the project
+    name. Catches a regression where the pinned peel drops the project label or
+    the flyout stops resolving it.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-flyout-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+    project = f"Project {uuid.uuid4().hex[:6]}"
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    # File it into a new project first, then pin it out of that folder.
+    _move_to_new_project(page, row, project)
+    expect(_section(page, project).locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+
+    project_row = (
+        _section(page, project)
+        .locator("li")
+        .filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+    )
+    project_row.hover()
+    project_row.get_by_test_id("quick-pin-conversation").click()
+
+    # Now under "Pinned" — the project folder no longer conveys its project.
+    pinned_row = (
+        _section(page, "Pinned")
+        .locator("li")
+        .filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+    )
+    expect(pinned_row).to_be_visible()
+
+    # Hovering the pinned row opens the project flyout with the folder icon +
+    # project name and the session title.
+    pinned_row.get_by_role("link").hover()
+    flyout = page.get_by_test_id("pinned-project-flyout")
+    expect(flyout).to_be_visible()
+    expect(flyout).to_contain_text(project)
+    expect(flyout).to_contain_text(title)

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -143,6 +143,9 @@ function renderSidebar(activeId?: string, info?: ServerInfo) {
 beforeEach(() => {
   mocks.rename.mutate.mockReset();
   useConvMock.mockReset();
+  // Pins persist to localStorage; clear it so a seeded pin doesn't leak into
+  // the next test's row state.
+  localStorage.clear();
   // The read-state mirror is module-level (in-memory), so reset it between
   // tests to avoid a mark-unread leaking into later rows.
   __resetReadStateForTests();
@@ -278,6 +281,43 @@ describe("double-click to rename", () => {
 
     expect(screen.queryByTestId("rename-conversation-input")).toBeNull();
     expect(mocks.rename.mutate).not.toHaveBeenCalled();
+  });
+});
+
+describe("pinned row project flyout", () => {
+  // Pinning lifts a session out of its project folder into the flat "Pinned"
+  // section, so the folder no longer conveys which project it came from. The
+  // hover flyout restores that cue: title + folder icon + project name. It
+  // opens on focus/hover — fire focus on the row link and await the portal.
+
+  it("shows the project name in the flyout for a pinned, project-owned row", async () => {
+    // Seed the pin so the row lifts into the always-expanded Pinned section
+    // (a project-owned row otherwise sits inside a collapsed project folder).
+    localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_1"]));
+    mockConversations([{ ...CONV, labels: { omni_project: "Moonshot" } }]);
+    renderSidebar();
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+
+    // Focus opens the HoverCard (onFocus is one of its open triggers); the
+    // content is portalled, so query the whole document after the open delay.
+    fireEvent.focus(screen.getByRole("link", { name: /My Session/ }));
+    const flyout = await screen.findByTestId("pinned-project-flyout");
+    expect(within(flyout).getByText("Moonshot")).toBeInTheDocument();
+    expect(within(flyout).getByText("My Session")).toBeInTheDocument();
+  });
+
+  it("renders no project flyout for a pinned row with no project", () => {
+    // No project label → nothing to surface, so the row keeps its plain native
+    // title tooltip and never mounts a hover-card trigger.
+    localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_1"]));
+    mockConversations([{ ...CONV, labels: {} }]);
+    renderSidebar();
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+
+    const row = screen.getByRole("link", { name: /My Session/ });
+    expect(row).not.toHaveAttribute("data-slot", "hover-card-trigger");
+    fireEvent.focus(row);
+    expect(screen.queryByTestId("pinned-project-flyout")).toBeNull();
   });
 });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2976,7 +2976,10 @@ function PinnedProjectFlyoutContent({
       className="w-64"
       data-testid="pinned-project-flyout"
     >
-      <p className="truncate font-medium text-sm">{title}</p>
+      {/* Titles have no length cap (server + rename input are unbounded), so
+          clamp to 3 wrapped lines to keep the card tidy — full text stays in
+          the DOM. */}
+      <p className="line-clamp-3 font-medium text-sm">{title}</p>
       <p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
         <FolderIcon className="size-3.5 shrink-0" />
         <span className="truncate">{projectName}</span>

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -79,6 +79,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -2370,6 +2371,11 @@ function ConversationRow({
   // The session's current project (reserved label), or null when unfiled —
   // drives the kebab submenu label ("Add to project" vs "Change project").
   const currentProject = conversation.labels?.[PROJECT_LABEL_KEY] ?? null;
+  // Pinned sessions are lifted OUT of their project folder into the flat
+  // "Pinned" section, so the row no longer shows which project it belongs to.
+  // For those rows only, surface the project in a hover flyout. Non-pinned
+  // rows already sit inside their project folder, so they don't need it.
+  const projectFlyoutName = isPinned ? currentProject : null;
 
   const label = conversationDisplayLabel(conversation);
   // Recompute unseen state the moment the last-seen map changes (e.g. the
@@ -2605,7 +2611,9 @@ function ConversationRow({
         e.preventDefault();
         setIsEditing(true);
       }}
-      title={conversation.title ?? conversation.id}
+      // The rich project flyout replaces the native tooltip on pinned,
+      // project-owned rows so the two don't stack; other rows keep it.
+      title={projectFlyoutName ? undefined : (conversation.title ?? conversation.id)}
     >
       {/* Row 1: the session name. Status markers (working, needs-approval,
           unseen) render in the trailing time-marker slot below, replacing
@@ -2643,9 +2651,42 @@ function ConversationRow({
           Suppressed in selection mode (bulk-select owns the row), where the
           bare link is rendered instead. ContextMenuTrigger preventDefaults the
           native contextmenu event, so right-click never navigates; asChild
-          merges its handler onto the Link, preserving left-click / double-click. */}
+          merges its handler onto the Link, preserving left-click / double-click.
+          Pinned, project-owned rows nest a HoverCardTrigger around the Link so
+          hovering surfaces the project flyout — the trigger sits innermost so
+          both the context menu and the hover card keep their handlers/refs on
+          the Link. */}
       {selectionMode ? (
-        rowLink
+        projectFlyoutName ? (
+          <HoverCard openDelay={150} closeDelay={0}>
+            <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
+            <PinnedProjectFlyoutContent
+              title={conversation.title ?? conversation.id}
+              projectName={projectFlyoutName}
+            />
+          </HoverCard>
+        ) : (
+          rowLink
+        )
+      ) : projectFlyoutName ? (
+        <HoverCard openDelay={150} closeDelay={0}>
+          <ContextMenu>
+            <ContextMenuTrigger asChild>
+              <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
+            </ContextMenuTrigger>
+            <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
+              <ConversationMenuItems
+                components={contextBundle}
+                setMenuOpen={() => {}}
+                {...menuItemProps}
+              />
+            </ContextMenuContent>
+          </ContextMenu>
+          <PinnedProjectFlyoutContent
+            title={conversation.title ?? conversation.id}
+            projectName={projectFlyoutName}
+          />
+        </HoverCard>
       ) : (
         <ContextMenu>
           <ContextMenuTrigger asChild>{rowLink}</ContextMenuTrigger>
@@ -2908,6 +2949,39 @@ function ConversationRow({
         </DialogContent>
       </Dialog>
     </li>
+  );
+}
+
+/**
+ * Hover flyout body for a pinned, project-owned conversation row.
+ *
+ * Pinning lifts a session out of its project folder into the flat "Pinned"
+ * section, dropping the visual project cue the folder provided. Hovering the
+ * row surfaces it again: the session title, then a folder icon + project name.
+ * Mirrors {@link AgentHoverCard}'s Cursor-style placement (right / top-aligned)
+ * and the muted, small-icon foreground used elsewhere in the sidebar.
+ */
+function PinnedProjectFlyoutContent({
+  title,
+  projectName,
+}: {
+  title: string;
+  projectName: string;
+}) {
+  return (
+    <HoverCardContent
+      side="right"
+      align="start"
+      sideOffset={8}
+      className="w-64"
+      data-testid="pinned-project-flyout"
+    >
+      <p className="truncate font-medium text-sm">{title}</p>
+      <p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+        <FolderIcon className="size-3.5 shrink-0" />
+        <span className="truncate">{projectName}</span>
+      </p>
+    </HoverCardContent>
   );
 }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Pinning a session lifts it out of its project folder into the flat **Pinned** sidebar section, which dropped the only visual cue for which project the session belonged to.
- Hovering a pinned, project-owned row now opens a flyout showing the session **title** plus a **folder icon + project name** — restoring that cue without un-pinning.
- The project name is sourced from the same `conversation.labels[PROJECT_LABEL_KEY]` value already resolved for the row's kebab menu (`currentProject`), so there's no new source of truth. The flyout is scoped to **pinned** rows only; non-pinned rows still convey their project via the folder they sit in.

## Test Plan

- `cd web && npm test` — full vitest suite green (4001 passed).
- `cd web && npm run build` — `tsc -b && vite build` clean.
- `npm run type-check`, `npm run lint`, `prettier --check` on the touched files — clean (no new warnings).
- Added two unit tests in `Sidebar.rowActions.test.tsx` (project name + title appear in the pinned flyout; no flyout when the pinned session has no project), plus a Playwright e2e (`tests/e2e_ui/sessions/test_sidebar_pinned_project_flyout.py`) that files a session into a project, pins it, hovers, and asserts the flyout shows the folder icon + project name. The e2e passes locally against a real browser + server.

## Demo

<img width="597" height="142" alt="image" src="https://github.com/user-attachments/assets/89c1d747-5d5d-4004-aecb-9c5170a28238" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover both the positive (pinned + project → flyout shows folder icon + project name) and negative (pinned, no project → no flyout) paths. Manually verified the full web test suite and production build pass with the change.

## Changelog

Hovering a pinned session now shows its project name in a flyout

This pull request and its description were written by Isaac.

