### PR TITLE
fix(web): disable pinned-project hover flyout on mobile

### DIFF
--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -15,10 +15,20 @@ import type { ServerInfo } from "@/lib/capabilities";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 
 // Controllable rename mutation so the double-click test can assert the
-// committed title was forwarded to the PATCH. Declared via vi.hoisted so the
-// vi.mock factory (hoisted above imports) can reference it.
+// committed title was forwarded to the PATCH. `isMobile` toggles the mocked
+// `useIsMobileViewport` so a test can render the row on a mobile viewport (the
+// project flyout is disabled there). Declared via vi.hoisted so the vi.mock
+// factories (hoisted above imports) can reference them.
 const mocks = vi.hoisted(() => ({
   rename: { mutate: vi.fn() },
+  isMobile: false,
+}));
+
+// Mock the mobile-viewport hook — jsdom doesn't evaluate media queries, so
+// drive it explicitly. Defaults to desktop (false); the mobile flyout test
+// flips `mocks.isMobile` for the duration of that case.
+vi.mock("@/hooks/useIsMobileViewport", () => ({
+  useIsMobileViewport: () => mocks.isMobile,
 }));
 
 vi.mock("@/hooks/useConversations", () => ({
@@ -142,6 +152,8 @@ function renderSidebar(activeId?: string, info?: ServerInfo) {
 
 beforeEach(() => {
   mocks.rename.mutate.mockReset();
+  // Default every test to the desktop viewport; the mobile flyout test opts in.
+  mocks.isMobile = false;
   useConvMock.mockReset();
   // Pins persist to localStorage; clear it so a seeded pin doesn't leak into
   // the next test's row state.
@@ -316,6 +328,26 @@ describe("pinned row project flyout", () => {
 
     const row = screen.getByRole("link", { name: /My Session/ });
     expect(row).not.toHaveAttribute("data-slot", "hover-card-trigger");
+    fireEvent.focus(row);
+    expect(screen.queryByTestId("pinned-project-flyout")).toBeNull();
+  });
+
+  it("disables the flyout on a mobile viewport, keeping the native title", () => {
+    // Mobile has no real hover, so the flyout is gated off there: a tap that
+    // navigates must not also open (and strand) a HoverCard over the chat. The
+    // row falls back to the plain link path — no hover-card trigger, native
+    // title restored — even though it IS pinned + project-owned.
+    mocks.isMobile = true;
+    localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_1"]));
+    mockConversations([{ ...CONV, labels: { omni_project: "Moonshot" } }]);
+    renderSidebar();
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+
+    const row = screen.getByRole("link", { name: /My Session/ });
+    // No hover-card trigger is mounted, and the native title tooltip is kept.
+    expect(row).not.toHaveAttribute("data-slot", "hover-card-trigger");
+    expect(row).toHaveAttribute("title", "My Session");
+    // Focusing the row opens nothing — the flyout never mounts on mobile.
     fireEvent.focus(row);
     expect(screen.queryByTestId("pinned-project-flyout")).toBeNull();
   });

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -128,6 +128,7 @@ import {
   useUnseenTick,
 } from "@/hooks/useUnseenConversations";
 import { cn } from "@/lib/utils";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
@@ -2298,6 +2299,10 @@ function ConversationRow({
   const activeRootId = useActiveRootSessionId(activeId ?? null);
   const isActive = (activeRootId ?? activeId) === conversation.id;
   const navigate = useNavigate();
+  // Mobile has no real hover, so a tap that navigates would also trip the
+  // project flyout's HoverCard and leave it lingering over the chat. Gate the
+  // flyout off below the `md` breakpoint (see `projectFlyoutName`).
+  const isMobile = useIsMobileViewport();
   // Track the *live* active conversation id. Delete is fire-and-forget,
   // so the user can navigate to another conversation before the mutation
   // resolves — the onSuccess redirect must key off where they are now,
@@ -2375,7 +2380,11 @@ function ConversationRow({
   // "Pinned" section, so the row no longer shows which project it belongs to.
   // For those rows only, surface the project in a hover flyout. Non-pinned
   // rows already sit inside their project folder, so they don't need it.
-  const projectFlyoutName = isPinned ? currentProject : null;
+  // Disabled on mobile: there's no hover, so a tap would open the HoverCard
+  // and leave it overlaying the chat after navigation. Forcing null there
+  // routes the row through the plain ContextMenu/link path and restores the
+  // native `title` tooltip.
+  const projectFlyoutName = !isMobile && isPinned ? currentProject : null;
 
   const label = conversationDisplayLabel(conversation);
   // Recompute unseen state the moment the last-seen map changes (e.g. the


### PR DESCRIPTION
## Related issue

N/A — follow-up bug fix to #2595 (the pinned-session project hover flyout).

## Summary

- The pinned-session project flyout added in #2595 opens a Radix `HoverCard` on a pinned, project-owned row. On a touch/mobile viewport there is no real hover, so **tapping the row to navigate also opened the flyout**, which then lingered/overlaid on top of the chat page after navigation.
- Fix: gate the flyout off below Tailwind's `md` breakpoint. `ConversationRow` now calls `useIsMobileViewport()` (unconditionally, alongside its other hooks) and forces `projectFlyoutName` to `null` on mobile. Because every downstream branch (the `HoverCard` wrapper, the native `title` suppression, the flyout content) already keys off `projectFlyoutName`, this cleanly disables the flyout AND restores the native `title` tooltip — the row falls back to the plain `ContextMenu`/link path with no `HoverCard` mounted on mobile.

## Test Plan

- `web/src/shell/Sidebar.rowActions.test.tsx` — added a mobile-viewport case in the "pinned row project flyout" describe block: with `useIsMobileViewport` mocked to `true`, a pinned + project-owned row mounts no hover-card trigger, keeps its native `title`, and focusing it opens no flyout. The existing desktop positive/negative tests stay green (the mock defaults to `false`, reset in `beforeEach`).
- Gates run in the worktree: `tsc -b` (clean), `oxlint` (only a pre-existing unrelated warning at Sidebar.tsx:1443), `prettier --check` (clean), and the full `Sidebar.rowActions.test.tsx` file (18/18 pass).

## Demo

Text description (behavioral, mobile-only):

```
MOBILE (viewport < 768px), pinned + project-owned row:
  BEFORE: tap row → navigates to chat, but the project HoverCard also
          opens and lingers overlaying the chat page.
  AFTER:  tap row → navigates to chat, no flyout. Row keeps its native
          `title` tooltip. No HoverCard is ever mounted.

DESKTOP (>= 768px): unchanged — hovering a pinned row still opens the
          project flyout (title + folder icon + project name).
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

A unit test covers the fix. I opted not to add a mobile-viewport variant to the e2e (`tests/e2e_ui/sessions/test_sidebar_pinned_project_flyout.py`): its flow depends on browser hover and the desktop-only `quick-pin-conversation` button, neither of which applies on mobile, so a mobile e2e would need an entirely different kebab-driven setup for little marginal value over the unit test. The existing desktop e2e still guards the positive (hover-opens-flyout) path.

## Changelog

Pinned-session project flyout no longer opens (and gets stuck over the chat) when tapping a session on mobile

This pull request and its description were written by Isaac.