### PR TITLE
feat(web): wrap-lines toggle + fold diff-viewer controls into a "⋯" menu

### DIFF
--- a/web/src/lib/fileViewPreferences.test.ts
+++ b/web/src/lib/fileViewPreferences.test.ts
@@ -24,6 +24,7 @@ describe("fileViewPreferences", () => {
       diffLayout: "split",
       previewableViewMode: "source",
       hideWhitespace: true,
+      wrapLines: true,
     });
     // The exact object written must come back — proves both the write
     // serialized and the read parsed/validated every field correctly.
@@ -32,6 +33,7 @@ describe("fileViewPreferences", () => {
       diffLayout: "split",
       previewableViewMode: "source",
       hideWhitespace: true,
+      wrapLines: true,
     });
   });
 
@@ -60,6 +62,7 @@ describe("fileViewPreferences", () => {
       diffLayout: "unified",
       previewableViewMode: "editor",
       hideWhitespace: false,
+      wrapLines: false,
     });
   });
 });

--- a/web/src/lib/fileViewPreferences.ts
+++ b/web/src/lib/fileViewPreferences.ts
@@ -21,6 +21,8 @@ export interface FileViewPreferences {
   previewableViewMode: "editor" | "preview" | "source";
   /** Whether whitespace-only changes are hidden in the diff view. */
   hideWhitespace: boolean;
+  /** Whether long lines soft-wrap in the diff view (no horizontal scroll). */
+  wrapLines: boolean;
 }
 
 const STORAGE_KEY = "omnigent:file-view-preferences";
@@ -30,6 +32,7 @@ export const DEFAULT_FILE_VIEW_PREFERENCES: FileViewPreferences = {
   diffLayout: "unified",
   previewableViewMode: "editor",
   hideWhitespace: false,
+  wrapLines: false,
 };
 
 /**
@@ -61,6 +64,8 @@ export function readFileViewPreferences(): FileViewPreferences {
         typeof p.hideWhitespace === "boolean"
           ? p.hideWhitespace
           : DEFAULT_FILE_VIEW_PREFERENCES.hideWhitespace,
+      wrapLines:
+        typeof p.wrapLines === "boolean" ? p.wrapLines : DEFAULT_FILE_VIEW_PREFERENCES.wrapLines,
     };
   } catch {
     return DEFAULT_FILE_VIEW_PREFERENCES;

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -67,7 +67,21 @@ vi.mock("./CommentsPanel", () => ({
 }));
 
 vi.mock("./MonacoDiffViewer", () => ({
-  MonacoDiffViewer: () => <div data-testid="diff-viewer" />,
+  // Surface the toggle-driven props as data attributes so tests can assert the
+  // "⋯" menu wires wrap-lines / hide-whitespace through to the diff editor.
+  MonacoDiffViewer: ({
+    wrapLines,
+    hideWhitespace,
+  }: {
+    wrapLines?: boolean;
+    hideWhitespace?: boolean;
+  }) => (
+    <div
+      data-testid="diff-viewer"
+      data-wrap-lines={String(!!wrapLines)}
+      data-hide-whitespace={String(!!hideWhitespace)}
+    />
+  ),
 }));
 
 // ── Mock hooks ────────────────────────────────────────────────────────────────
@@ -1030,6 +1044,7 @@ describe("FileViewer markdown preview/edit/source modes", () => {
       diffLayout: "unified",
       previewableViewMode: "editor",
       hideWhitespace: false,
+      wrapLines: false,
     });
     renderViewer({ open: true, path: "page.html" });
     expect(viewModeOf()).toBe("preview");
@@ -1045,6 +1060,7 @@ describe("FileViewer markdown preview/edit/source modes", () => {
       diffLayout: "unified",
       previewableViewMode: "editor",
       hideWhitespace: false,
+      wrapLines: false,
     });
     renderViewer({ open: true, path: "page.html" });
     expect(viewModeOf()).toBe("preview");
@@ -1077,6 +1093,7 @@ describe("FileViewer markdown preview/edit/source modes", () => {
         diffLayout: "unified",
         previewableViewMode: pref,
         hideWhitespace: false,
+        wrapLines: false,
       });
       useCommentsMock.mockReturnValue(makeCommentsQuery([makeComment("c1")]));
       renderViewer({ open: true, path: "notes.md", initialSearch: "comment=c1" });
@@ -1097,6 +1114,7 @@ describe("FileViewer markdown preview/edit/source modes", () => {
       diffLayout: "unified",
       previewableViewMode: "preview",
       hideWhitespace: false,
+      wrapLines: false,
     });
     useCommentsMock.mockReturnValue(makeCommentsQuery([makeComment("c1")]));
     renderViewer({ open: true, path: "notes.md", initialSearch: "comment=c1" });
@@ -1137,6 +1155,73 @@ describe("FileViewer split-toggle width gating", () => {
     expect(await screen.findByTestId("diff-viewer")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Split view" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Unified view" })).toBeNull();
+  });
+});
+
+// ── View settings "⋯" menu ──────────────────────────────────────────────────
+//
+// Find, Download, and the diff-only toggles (wrap lines, hide whitespace) are
+// folded into one "View settings" overflow menu to save toolbar width. The
+// toggles keep the menu open and drive props on the diff viewer; the diff-only
+// items are hidden outside diff view. Radix menus open on pointerdown.
+
+describe("FileViewer view-settings menu", () => {
+  beforeEach(() => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+  });
+
+  const openSettingsMenu = () =>
+    fireEvent.pointerDown(screen.getByRole("button", { name: "View settings" }), { button: 0 });
+
+  it("offers Find and Download but no diff toggles outside diff view", () => {
+    render(viewerTree({ open: true }));
+    openSettingsMenu();
+    expect(screen.getByRole("menuitem", { name: "Find in file" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Download file" })).toBeInTheDocument();
+    // Wrap / whitespace are diff-only — absent when the source view is showing.
+    expect(screen.queryByRole("menuitem", { name: "Wrap lines" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Hide whitespace changes" })).toBeNull();
+  });
+
+  it("adds the wrap-lines and whitespace toggles in diff view", async () => {
+    render(viewerTree({ open: true, initialSearch: "diff=1" }));
+    expect(await screen.findByTestId("diff-viewer")).toBeInTheDocument();
+    openSettingsMenu();
+    expect(screen.getByRole("menuitem", { name: "Wrap lines" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Hide whitespace changes" })).toBeInTheDocument();
+  });
+
+  it("toggling Wrap lines flips the diff viewer's wrapLines prop", async () => {
+    render(viewerTree({ open: true, initialSearch: "diff=1" }));
+    const diff = await screen.findByTestId("diff-viewer");
+    expect(diff).toHaveAttribute("data-wrap-lines", "false");
+    openSettingsMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Wrap lines" }));
+    // The prop flips without re-opening — the toggle drives the diff editor.
+    expect(screen.getByTestId("diff-viewer")).toHaveAttribute("data-wrap-lines", "true");
+  });
+
+  it("toggling Hide whitespace flips the diff viewer's hideWhitespace prop", async () => {
+    render(viewerTree({ open: true, initialSearch: "diff=1" }));
+    const diff = await screen.findByTestId("diff-viewer");
+    expect(diff).toHaveAttribute("data-hide-whitespace", "false");
+    openSettingsMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Hide whitespace changes" }));
+    expect(screen.getByTestId("diff-viewer")).toHaveAttribute("data-hide-whitespace", "true");
+  });
+
+  it("persists the wrap-lines choice across a refresh", async () => {
+    const first = render(viewerTree({ open: true, initialSearch: "diff=1" }));
+    expect(await screen.findByTestId("diff-viewer")).toBeInTheDocument();
+    openSettingsMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Wrap lines" }));
+    expect(screen.getByTestId("diff-viewer")).toHaveAttribute("data-wrap-lines", "true");
+
+    // A fresh mount (refresh) can only come up wrapped by reading the persisted
+    // preference — ?diff=1 restores diff view, wrap comes from localStorage.
+    first.unmount();
+    render(viewerTree({ open: true, initialSearch: "diff=1" }));
+    expect(await screen.findByTestId("diff-viewer")).toHaveAttribute("data-wrap-lines", "true");
   });
 });
 

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -42,6 +42,7 @@ import {
   SearchIcon,
   SquareArrowOutUpRightIcon,
   Trash2Icon,
+  WrapTextIcon,
 } from "lucide-react";
 import { useSearchParams } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
@@ -636,6 +637,7 @@ function FileViewerBody({
   const [hideWhitespace, setHideWhitespace] = useState(
     () => persistedPrefsRef.current.hideWhitespace,
   );
+  const [wrapLines, setWrapLines] = useState(() => persistedPrefsRef.current.wrapLines);
   const [previewableViewMode, setPreviewableViewMode] = useState<"editor" | "preview" | "source">(
     () => persistedPrefsRef.current.previewableViewMode,
   );
@@ -662,8 +664,14 @@ function FileViewerBody({
   // is intentionally excluded — it's contextual (per-open), not a sticky
   // preference. Idempotent on mount (writes back the seeded values).
   useEffect(() => {
-    writeFileViewPreferences({ diffActive, diffLayout, previewableViewMode, hideWhitespace });
-  }, [diffActive, diffLayout, previewableViewMode, hideWhitespace]);
+    writeFileViewPreferences({
+      diffActive,
+      diffLayout,
+      previewableViewMode,
+      hideWhitespace,
+      wrapLines,
+    });
+  }, [diffActive, diffLayout, previewableViewMode, hideWhitespace, wrapLines]);
   // Markdown supports all three previewable modes (preview / editor / source).
   // HTML and notebooks have no rich-text editor, so their "editor" preference
   // falls back to the rendered preview; "preview" / "source" pass through. The shared
@@ -748,6 +756,13 @@ function FileViewerBody({
     icon: ReactNode;
     onSelect: () => void;
     active: boolean;
+    /** Keep the menu open after selecting — for toggles the user may flip in a
+     * row (e.g. wrap + whitespace). Action items (Find) omit it so the menu
+     * closes as they hand off. */
+    keepOpen?: boolean;
+    /** Suppress the active check mark — for toggles whose icon already reflects
+     * state (e.g. the whitespace eye flips open/closed). */
+    noActiveCheck?: boolean;
   };
   type ToolbarAction = {
     key: string;
@@ -758,9 +773,13 @@ function FileViewerBody({
     icon: ReactNode;
     onSelect?: () => void;
     active?: boolean;
-    /** When set, render a picker (dropdown/submenu) over these choices instead
-     * of a single button. `onSelect` is ignored. */
+    /** When set, render a picker (dropdown/submenu) over these mutually
+     * exclusive choices instead of a single button. `onSelect` is ignored. */
     options?: ToolbarOption[];
+    /** When set, render a menu of independent items (toggles + actions) under a
+     * single trigger. Unlike `options`, these are not mutually exclusive and
+     * carry no "selected choice" semantics. `onSelect` is ignored. */
+    menu?: ToolbarOption[];
   };
   const toolbarActions: ToolbarAction[] = [];
   if (lang === "markdown" && viewMode !== "diff") {
@@ -884,32 +903,61 @@ function FileViewerBody({
       onSelect: () => setDiffLayout((l) => (l === "unified" ? "split" : "unified")),
     });
   }
-  if (viewMode === "diff") {
-    toolbarActions.push({
-      key: "hide-whitespace",
-      label: hideWhitespace ? "Show whitespace changes" : "Hide whitespace changes",
-      icon: hideWhitespace ? <EyeIcon className="size-4" /> : <EyeOffIcon className="size-4" />,
-      active: hideWhitespace,
-      onSelect: () => setHideWhitespace((prev) => !prev),
-    });
-  }
-  toolbarActions.push({
-    key: "search",
-    label: "Find in file",
-    icon: <SearchIcon className="size-4" />,
-    onSelect: openSearch,
-  });
+  // A single "⋯" menu folds the view controls that were previously separate
+  // top-level icons: Find in file and Download (all views), plus the diff-only
+  // toggles (wrap lines, whitespace changes). Grouping them frees toolbar width
+  // — handy when the viewer runs in a narrow pane — and mirrors GitHub's
+  // diff-settings menu. The toggles keep the menu open; actions close it as they
+  // hand off.
+  const settingsMenu: ToolbarOption[] = [
+    {
+      key: "search",
+      label: "Find in file",
+      icon: <SearchIcon className="size-4" />,
+      active: false,
+      onSelect: openSearch,
+    },
+  ];
   if (!isDeletedFile && fileQuery.data) {
-    toolbarActions.push({
+    settingsMenu.push({
       key: "download",
       label: "Download file",
       tooltip: fileQuery.data.truncated
         ? "Download (file was truncated — content may be incomplete)"
         : "Download",
       icon: <DownloadIcon className="size-4" />,
+      active: false,
       onSelect: downloadFile,
     });
   }
+  if (viewMode === "diff") {
+    settingsMenu.push({
+      key: "wrap-lines",
+      label: "Wrap lines",
+      tooltip: "Soft-wrap long lines (no horizontal scroll)",
+      icon: <WrapTextIcon className="size-4" />,
+      active: wrapLines,
+      keepOpen: true,
+      onSelect: () => setWrapLines((prev) => !prev),
+    });
+    settingsMenu.push({
+      key: "hide-whitespace",
+      label: "Hide whitespace changes",
+      icon: hideWhitespace ? <EyeIcon className="size-4" /> : <EyeOffIcon className="size-4" />,
+      active: hideWhitespace,
+      keepOpen: true,
+      // The eye icon already flips open/closed to show state — no check needed.
+      noActiveCheck: true,
+      onSelect: () => setHideWhitespace((prev) => !prev),
+    });
+  }
+  toolbarActions.push({
+    key: "view-settings",
+    label: "View settings",
+    tooltip: "View settings",
+    icon: <MoreHorizontalIcon className="size-4" />,
+    menu: settingsMenu,
+  });
   toolbarActions.push({
     key: "copy-link",
     label: "Copy link to file",
@@ -950,7 +998,51 @@ function FileViewerBody({
   // measurement clone so it stays out of the tab order / a11y tree.
   const renderActionButtons = (interactive: boolean) =>
     toolbarActions.map((action) =>
-      action.options ? (
+      action.menu ? (
+        // A settings menu: one trigger opening a list of independent items
+        // (toggles + actions). Toggles carry `keepOpen` so the menu stays open
+        // as the user flips them; actions close it on select.
+        <DropdownMenu key={action.key}>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={action.label}
+                    tabIndex={interactive ? undefined : -1}
+                  >
+                    {action.icon}
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>{action.tooltip ?? action.label}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <DropdownMenuContent align="end" className="w-auto min-w-40">
+            {action.menu.map((item) => (
+              <DropdownMenuItem
+                key={item.key}
+                className="whitespace-nowrap"
+                onSelect={
+                  interactive
+                    ? (e) => {
+                        if (item.keepOpen) e.preventDefault();
+                        item.onSelect();
+                      }
+                    : undefined
+                }
+              >
+                {item.icon}
+                {item.label}
+                {item.active && !item.noActiveCheck && <CheckIcon className="ml-auto size-4" />}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : action.options ? (
         // A picker: one trigger opening a menu of mutually-exclusive choices.
         <DropdownMenu key={action.key}>
           <TooltipProvider>
@@ -1135,23 +1227,36 @@ function FileViewerBody({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-auto min-w-40">
                   {toolbarActions.map((action) =>
-                    action.options ? (
-                      // A picker collapses to a nested submenu of its choices.
+                    action.options || action.menu ? (
+                      // Pickers and settings menus collapse to a nested submenu
+                      // of their items. Toggle items (keepOpen) prevent the
+                      // submenu from closing so several can be flipped in a row.
                       <DropdownMenuSub key={action.key}>
                         <DropdownMenuSubTrigger className="whitespace-nowrap">
                           {action.icon}
                           {action.tooltip ?? action.label}
                         </DropdownMenuSubTrigger>
                         <DropdownMenuSubContent>
-                          {action.options.map((option) => (
+                          {(action.options ?? action.menu ?? []).map((option) => (
                             <DropdownMenuItem
                               key={option.key}
-                              className={cn("whitespace-nowrap", option.active && "bg-accent")}
-                              onSelect={option.onSelect}
+                              // Settings-menu items lean on the check mark alone;
+                              // the mutually-exclusive picker also highlights the
+                              // active choice.
+                              className={cn(
+                                "whitespace-nowrap",
+                                action.options && option.active && "bg-accent",
+                              )}
+                              onSelect={(e) => {
+                                if (option.keepOpen) e.preventDefault();
+                                option.onSelect();
+                              }}
                             >
                               {option.icon}
                               {option.label}
-                              {option.active && <CheckIcon className="ml-auto size-4" />}
+                              {option.active && !option.noActiveCheck && (
+                                <CheckIcon className="ml-auto size-4" />
+                              )}
                             </DropdownMenuItem>
                           ))}
                         </DropdownMenuSubContent>
@@ -1247,6 +1352,7 @@ function FileViewerBody({
                   path={path}
                   layout={diffLayout}
                   hideWhitespace={hideWhitespace}
+                  wrapLines={wrapLines}
                   conversationId={conversationId}
                   comments={openComments}
                   activeSelection={activeSelection}

--- a/web/src/shell/MonacoDiffViewer.test.tsx
+++ b/web/src/shell/MonacoDiffViewer.test.tsx
@@ -16,6 +16,8 @@ const h = vi.hoisted(() => ({
       renderSideBySide?: boolean;
       readOnly?: boolean;
       hideUnchangedRegions?: { enabled?: boolean };
+      ignoreTrimWhitespace?: boolean;
+      diffWordWrap?: "on" | "off";
     };
   } | null,
   onMount: null as DiffOnMount | null,
@@ -58,6 +60,7 @@ function renderDiff(props: {
   after: string | null;
   layout: "unified" | "split";
   hideWhitespace?: boolean;
+  wrapLines?: boolean;
 }) {
   return render(
     <MonacoDiffViewer
@@ -66,6 +69,7 @@ function renderDiff(props: {
       path="src/a.ts"
       layout={props.layout}
       hideWhitespace={props.hideWhitespace ?? false}
+      wrapLines={props.wrapLines ?? false}
       conversationId="conv_1"
       comments={[]}
       activeSelection={null}
@@ -109,6 +113,27 @@ describe("MonacoDiffViewer", () => {
     await waitFor(() => expect(h.diffProps).not.toBeNull());
     expect(h.diffProps?.options?.renderSideBySide).toBe(sideBySide);
   });
+
+  it.each([
+    { wrapLines: true as const, diffWordWrap: "on" as const },
+    { wrapLines: false as const, diffWordWrap: "off" as const },
+  ])(
+    "maps wrapLines=$wrapLines to diffWordWrap=$diffWordWrap",
+    async ({ wrapLines, diffWordWrap }) => {
+      renderDiff({ before: "a", after: "b", layout: "unified", wrapLines });
+      await waitFor(() => expect(h.diffProps).not.toBeNull());
+      expect(h.diffProps?.options?.diffWordWrap).toBe(diffWordWrap);
+    },
+  );
+
+  it.each([{ hideWhitespace: true as const }, { hideWhitespace: false as const }])(
+    "maps hideWhitespace=$hideWhitespace to ignoreTrimWhitespace",
+    async ({ hideWhitespace }) => {
+      renderDiff({ before: "a", after: "b", layout: "unified", hideWhitespace });
+      await waitFor(() => expect(h.diffProps).not.toBeNull());
+      expect(h.diffProps?.options?.ignoreTrimWhitespace).toBe(hideWhitespace);
+    },
+  );
 
   it("treats a null side (new/deleted file) as empty content", async () => {
     renderDiff({ before: null, after: "created\n", layout: "unified" });

--- a/web/src/shell/MonacoDiffViewer.tsx
+++ b/web/src/shell/MonacoDiffViewer.tsx
@@ -39,6 +39,8 @@ interface MonacoDiffViewerProps {
   layout: "unified" | "split";
   /** Whether whitespace-only changes are hidden. */
   hideWhitespace: boolean;
+  /** Whether long lines soft-wrap (no horizontal scroll). */
+  wrapLines: boolean;
   conversationId: string;
   /** Saved comments — highlighted on the modified side. */
   comments: Comment[];
@@ -62,6 +64,7 @@ export function MonacoDiffViewer({
   path,
   layout,
   hideWhitespace,
+  wrapLines,
   conversationId,
   comments,
   activeSelection,
@@ -178,11 +181,14 @@ export function MonacoDiffViewer({
       automaticLayout: true,
       renderOverviewRuler: false,
       ignoreTrimWhitespace: hideWhitespace,
+      // Soft-wrap long lines in both panes so a narrow diff pane (2–3 side by
+      // side) reads top-to-bottom without horizontal scrolling.
+      diffWordWrap: wrapLines ? "on" : "off",
       // Collapse long unchanged runs into expandable bands (like the old pierre
       // diff / GitHub) so only changed hunks + a few context lines are shown.
       hideUnchangedRegions: { enabled: true, contextLineCount: 3 },
     }),
-    [layout, hideWhitespace],
+    [layout, hideWhitespace, wrapLines],
   );
 
   return (


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Long diff lines had no way to wrap, forcing horizontal scrolling — painful in a narrow file-viewer pane (users commonly run 2–3 side by side). Adds a **Wrap lines** toggle that soft-wraps long lines in both diff panes (Monaco `diffWordWrap`), persisted as a global view preference like diff/layout/whitespace.
- Folds **Find in file**, **Download**, and the diff-only toggles (**Wrap lines**, **Hide whitespace changes**) into a single **"View settings" (⋯)** menu, mirroring GitHub's diff-settings menu and freeing toolbar width for narrow panes. When the whole toolbar collapses, the menu degrades into a nested submenu inside the existing overflow.
- Menu affordances: toggles keep the menu open so several can be flipped in a row; actions (Find, Download) close it. Active state is a check mark, except **Hide whitespace** whose eye icon already flips open/closed (no redundant check).

## Test Plan

- `cd web && npm test` — full suite green (4008 passed, 3 expected-fail, 2 skipped).
- Added targeted tests:
  - `MonacoDiffViewer`: `wrapLines` → `diffWordWrap` on/off, `hideWhitespace` → `ignoreTrimWhitespace`.
  - `FileViewer`: the "⋯" menu shows Find/Download always and the diff toggles only in diff view; toggling Wrap / Hide-whitespace drives the diff viewer props; wrap-lines choice persists across a refresh.
  - `fileViewPreferences`: `wrapLines` round-trips and validates independently.
- `npm run build` (tsc -b && vite build) — passes. `npm run lint` / prettier — clean on touched files.

## Demo


https://github.com/user-attachments/assets/15c9d0fd-f2bd-402f-84b3-cfb8101d9210



## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Component/behavioral coverage added via vitest (see Test Plan). Live in-app verification is still pending — the Monaco diff editor can't mount in jsdom, so wrap/whitespace prop wiring is asserted through the diff-viewer mock rather than a real editor.

## Changelog

Diff viewer gains a "Wrap lines" toggle, and Find / Download / diff toggles now live in a single "⋯" View settings menu

This pull request and its description were written by Isaac.