### PR TITLE
fix(web): show project picker in place in mobile session kebab

### DIFF
--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -22,6 +22,10 @@ import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 const mocks = vi.hoisted(() => ({
   rename: { mutate: vi.fn() },
   isMobile: false,
+  // Projects surfaced by the picker + the move-to-project mutation, so the
+  // mobile in-place project view test can assert both the list and the pick.
+  projects: [] as string[],
+  moveToProject: { mutate: vi.fn() },
 }));
 
 // Mock the mobile-viewport hook — jsdom doesn't evaluate media queries, so
@@ -48,8 +52,20 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
-  useProjects: () => ({ data: [] }),
-  useMoveToProject: () => ({ mutate: vi.fn() }),
+  useProjects: () => ({ data: mocks.projects }),
+  // A non-empty `useProjects` renders a project folder, which queries its
+  // sessions — return the collapsed (disabled) shape so the folder is inert
+  // (this suite keeps its test row unfiled; the picker only needs the name).
+  useProjectSessions: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+  useMoveToProject: () => mocks.moveToProject,
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
@@ -152,6 +168,8 @@ function renderSidebar(activeId?: string, info?: ServerInfo) {
 
 beforeEach(() => {
   mocks.rename.mutate.mockReset();
+  mocks.moveToProject.mutate.mockReset();
+  mocks.projects = [];
   // Default every test to the desktop viewport; the mobile flyout test opts in.
   mocks.isMobile = false;
   useConvMock.mockReset();
@@ -350,6 +368,80 @@ describe("pinned row project flyout", () => {
     // Focusing the row opens nothing — the flyout never mounts on mobile.
     fireEvent.focus(row);
     expect(screen.queryByTestId("pinned-project-flyout")).toBeNull();
+  });
+});
+
+describe("mobile in-place project picker", () => {
+  // Desktop opens the "Add to project" item as a side-flyout submenu, but a
+  // side flyout has no room on mobile. There the item instead swaps the kebab
+  // body in place: the main actions are replaced by the project picker (search
+  // + list + Create new project) plus a Back control that returns to the main
+  // menu — no submenu, no close/reopen. Desktop keeps the flyout untouched.
+
+  it("swaps the kebab body to the project picker in place, and Back returns", () => {
+    mocks.isMobile = true;
+    mocks.projects = ["Sprint 42"];
+    renderSidebar();
+
+    // Radix DropdownMenu opens on pointerdown, not click.
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+
+    // Main view shows the everyday actions and the (unfiled) project entry.
+    expect(screen.getByTestId("rename-conversation")).toBeInTheDocument();
+    expect(screen.getByTestId("delete-conversation")).toBeInTheDocument();
+    const moveItem = screen.getByTestId("move-to-project");
+    expect(moveItem).toHaveTextContent("Add to project");
+    // It's a plain item on mobile, NOT a side-flyout submenu trigger.
+    expect(moveItem).not.toHaveAttribute("aria-haspopup", "menu");
+
+    // Tapping it swaps the body in place to the project picker — the main
+    // actions are gone, and the picker (search + project + Create new project)
+    // plus a Back control are shown.
+    fireEvent.click(moveItem);
+    expect(screen.getByPlaceholderText("Search projects")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Sprint 42/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Create new project/ })).toBeInTheDocument();
+    expect(screen.getByTestId("project-picker-back")).toBeInTheDocument();
+    // The main actions are no longer rendered — the body was replaced, not
+    // stacked beside a flyout.
+    expect(screen.queryByTestId("rename-conversation")).toBeNull();
+    expect(screen.queryByTestId("delete-conversation")).toBeNull();
+
+    // Back returns to the main menu without closing it: the everyday actions
+    // are visible again and the picker is gone.
+    fireEvent.click(screen.getByTestId("project-picker-back"));
+    expect(screen.getByTestId("rename-conversation")).toBeInTheDocument();
+    expect(screen.getByTestId("delete-conversation")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search projects")).toBeNull();
+  });
+
+  it("moves the session into a picked project just like desktop", () => {
+    mocks.isMobile = true;
+    mocks.projects = ["Sprint 42"];
+    renderSidebar();
+
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    fireEvent.click(screen.getByTestId("move-to-project"));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Sprint 42/ }));
+
+    // Same mutation contract as the desktop submenu pick.
+    expect(mocks.moveToProject.mutate).toHaveBeenCalledWith({
+      id: "conv_1",
+      project: "Sprint 42",
+    });
+  });
+
+  it("keeps the desktop side-flyout submenu (no in-place swap)", () => {
+    // Desktop viewport (default). The project entry is a submenu trigger, and
+    // opening the kebab never renders the in-place Back control.
+    mocks.projects = ["Sprint 42"];
+    renderSidebar();
+
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    const moveItem = screen.getByTestId("move-to-project");
+    // Radix SubTrigger advertises a submenu popup.
+    expect(moveItem).toHaveAttribute("aria-haspopup", "menu");
+    expect(screen.queryByTestId("project-picker-back")).toBeNull();
   });
 });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   ArchiveRestoreIcon,
   CheckIcon,
   CheckIcon as CheckMarkIcon,
+  ChevronLeftIcon,
   ChevronRightIcon,
   CircleStopIcon,
   FolderIcon,
@@ -2043,6 +2044,77 @@ function ConversationMenuItems({
   setMenuOpen: (open: boolean) => void;
   runArchive: () => void;
 }) {
+  // Mobile lacks the horizontal room for a side-opening submenu, so the
+  // project picker replaces the menu body in place instead of flying out
+  // to the side. `view` swaps between the main actions and that sub-view;
+  // desktop always renders the native side-flyout submenu regardless.
+  const isMobile = useIsMobileViewport();
+  const [view, setView] = useState<"main" | "projects">("main");
+
+  // The project pick / create / remove flow — shared verbatim by the desktop
+  // side-flyout submenu and the mobile in-place sub-view so both behave
+  // identically (same moveToProject.mutate, confirmation, and menu close).
+  const handleProjectSelect = (project: string) => {
+    setMenuOpen(false);
+    // Moving to another project is harmless — apply it now, and expand that
+    // (possibly new) project so the session is visible in it rather than
+    // hidden in a collapsed folder.
+    if (project !== "") {
+      moveToProject.mutate({ id: conversation.id, project });
+      onProjectAssigned?.(project);
+      return;
+    }
+    // Removing: only confirm when this is the project's LAST session (removing
+    // it would delete the implicit project). Otherwise remove silently. The
+    // check is server-side so it's accurate regardless of the loaded window.
+    void (async () => {
+      let isLastSession = true;
+      if (currentProject) {
+        try {
+          const ids = await fetchProjectSessionIds(currentProject);
+          isLastSession = ids.every((id) => id === conversation.id);
+        } catch {
+          // If the check fails, fall back to confirming.
+          isLastSession = true;
+        }
+      }
+      if (isLastSession) {
+        setRemoveProjectOpen(true);
+      } else {
+        moveToProject.mutate({ id: conversation.id, project: "" });
+      }
+    })();
+  };
+
+  // Mobile project sub-view: replaces the entire menu body in place (the
+  // "Back" row flips `view` without closing the menu or navigating). Reachable
+  // only via the mobile project item below, which sits behind the same
+  // `canEdit && isOwner` gate.
+  if (isMobile && view === "projects") {
+    return (
+      <>
+        <C.Item
+          data-testid="project-picker-back"
+          className="whitespace-nowrap"
+          // Keep the menu open — just flip back to the main actions.
+          onSelect={(e) => {
+            e.preventDefault();
+            setView("main");
+          }}
+        >
+          <ChevronLeftIcon className="size-3.5" />
+          Back
+        </C.Item>
+        <C.Separator />
+        <ProjectPickerMenu
+          components={C}
+          currentProject={currentProject}
+          onSelect={handleProjectSelect}
+        />
+      </>
+    );
+  }
+
   return (
     <>
       {/* Pin/Unpin — mobile-only (md:hidden); desktop uses the
@@ -2122,56 +2194,42 @@ function ConversationMenuItems({
       )}
       {/* Projects are a My-sessions-only tool, so filing is owner-only — a
           shared session (even editable) shows no project affordance. */}
-      {canEdit && isOwner && (
-        <C.Sub>
-          <C.SubTrigger data-testid="move-to-project" className="whitespace-nowrap">
+      {canEdit &&
+        isOwner &&
+        (isMobile ? (
+          // Mobile: no room for a side flyout, so this item swaps the menu
+          // body to the project picker in place (see the `view === "projects"`
+          // branch above). `preventDefault` keeps the menu open on select.
+          <C.Item
+            data-testid="move-to-project"
+            className="whitespace-nowrap"
+            onSelect={(e) => {
+              e.preventDefault();
+              setView("projects");
+            }}
+          >
             <FolderInputIcon className="size-3.5" />
             {/* "Add to project" until the session is filed, then "Move
                 session" to switch or remove it. */}
             {currentProject ? "Move session" : "Add to project"}
-          </C.SubTrigger>
-          <C.SubContent className="w-56 p-1 [&_[role=menuitem]]:text-xs">
-            {/* A native submenu flyout — no separate popover layer, so no
-                open/dismiss race with the parent menu. */}
-            <ProjectPickerMenu
-              components={C}
-              currentProject={currentProject}
-              onSelect={(project) => {
-                setMenuOpen(false);
-                // Moving to another project is harmless — apply it now,
-                // and expand that (possibly new) project so the session
-                // is visible in it rather than hidden in a collapsed folder.
-                if (project !== "") {
-                  moveToProject.mutate({ id: conversation.id, project });
-                  onProjectAssigned?.(project);
-                  return;
-                }
-                // Removing: only confirm when this is the project's LAST
-                // session (removing it would delete the implicit project).
-                // Otherwise remove silently. The check is server-side so
-                // it's accurate regardless of the loaded window / pins.
-                void (async () => {
-                  let isLastSession = true;
-                  if (currentProject) {
-                    try {
-                      const ids = await fetchProjectSessionIds(currentProject);
-                      isLastSession = ids.every((id) => id === conversation.id);
-                    } catch {
-                      // If the check fails, fall back to confirming.
-                      isLastSession = true;
-                    }
-                  }
-                  if (isLastSession) {
-                    setRemoveProjectOpen(true);
-                  } else {
-                    moveToProject.mutate({ id: conversation.id, project: "" });
-                  }
-                })();
-              }}
-            />
-          </C.SubContent>
-        </C.Sub>
-      )}
+          </C.Item>
+        ) : (
+          <C.Sub>
+            <C.SubTrigger data-testid="move-to-project" className="whitespace-nowrap">
+              <FolderInputIcon className="size-3.5" />
+              {currentProject ? "Move session" : "Add to project"}
+            </C.SubTrigger>
+            <C.SubContent className="w-56 p-1 [&_[role=menuitem]]:text-xs">
+              {/* A native submenu flyout — no separate popover layer, so no
+                  open/dismiss race with the parent menu. */}
+              <ProjectPickerMenu
+                components={C}
+                currentProject={currentProject}
+                onSelect={handleProjectSelect}
+              />
+            </C.SubContent>
+          </C.Sub>
+        ))}
       {/* Stop / Archive / Delete are grouped at the bottom, below a
           divider: lifecycle-ending actions separated from the everyday
           ones above. */}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The session-row kebab / right-click menu opened **"Add to project" / "Move session"** as a **side-flyout submenu** (`C.Sub`/`SubTrigger`/`SubContent`). On **mobile** there's no horizontal room for a side flyout — it overflowed and didn't work.
- On mobile the project item is now a plain menu item that **swaps the menu body in place**: a local `view` state (`'main' | 'projects'`) replaces the main actions with the existing `ProjectPickerMenu` (search + project list + "Create new project") plus a chevron-left **"Back"** row that returns to the main view. Selecting the item and Back both `preventDefault()` so the menu **stays open** rather than closing on select.
- **Desktop keeps the native side-flyout submenu unchanged.** Because the menu body is authored once through the shared `MenuComponents` bundle, the in-place view works for **both** the kebab dropdown and the right-click context-menu families.
- The project select / create / remove flow is extracted into a single `handleProjectSelect` shared verbatim by both paths, so mobile and desktop drive the identical `moveToProject.mutate` / `onProjectAssigned` / remove-confirmation / `setMenuOpen(false)` behavior.

Mobile branches on `useIsMobileViewport()` (the same hook #2599 uses), called unconditionally at the top of `ConversationMenuItems` to respect the Rules of Hooks.

### Mobile two-view flow (ASCII)

```
  Main view (mobile)                 Projects view (in place)
  ┌────────────────────┐            ┌────────────────────────┐
  │ Pin                │            │ ‹ Back                 │
  │ Share              │            │ ──────────────────────  │
  │ Rename             │  tap       │ 🔍 Search projects      │
  │ Add to project  ▸  │ ───────▶   │ • Sprint 42        ✓    │
  │ ─────────────────  │            │ • Moonshot              │
  │ Archive            │  ◀───────  │ ──────────────────────  │
  │ Delete             │   Back     │ + Create new project    │
  └────────────────────┘            └────────────────────────┘
       (menu stays open the whole time — no close/reopen)
```

## Test Plan

- Added `mobile in-place project picker` cases to `web/src/shell/Sidebar.rowActions.test.tsx` (mock `useIsMobileViewport = true`, like #2599):
  - Tapping "Add to project" on mobile swaps the kebab body to the picker in place (search + a mocked project + "Create new project" + Back), and the main actions (Rename/Delete) are gone.
  - "Back" returns to the main menu without closing it (Rename/Delete visible again, picker gone).
  - Picking a project drives the same `moveToProject.mutate({ id, project })` as desktop.
  - Desktop (default viewport) still renders the side-flyout submenu (`aria-haspopup="menu"`), with no in-place Back control.
- Gates: `tsc -b` clean; `oxlint` clean (one pre-existing `no-unstable-nested-components` warning on unrelated code, present on `origin/main`); `prettier --check` clean; `vitest run src/shell/` — 68 files pass, including my new tests and the existing desktop `Sidebar.test.tsx move-to-project` cases.

## Demo

See the ASCII flow above. On a mobile-width viewport, opening the session kebab and tapping "Add to project" replaces the menu contents in place with the project picker + a "Back" row; Back returns to the main actions without the menu closing. Desktop behavior is unchanged (side-flyout submenu).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New vitest cases cover the mobile in-place swap + Back and the mobile project pick; existing desktop unit tests (`Sidebar.test.tsx`) and the e2e `test_sidebar_pinned_project_flyout.py` / `test_sidebar_projects.py` / `test_sidebar_context_menu.py` still exercise the unchanged desktop side-flyout submenu.

## Changelog

Mobile session menu opens the project picker in place instead of an off-screen side flyout

This pull request and its description were written by Isaac.