### PR TITLE
fix(spawn): allow to specify model in sys_session_create

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -172,7 +172,15 @@ class PiProviderConfig:
             # Include all known models, ensuring the selected model is present.
             # The selected model may be a newer id not yet in the static list.
             models: list[dict[str, Any]] = list(self.extra_models)
-            if not any(m.get("id") == self.model for m in models):
+            # Only append to this (Anthropic) provider when the model is absent
+            # from ALL providers. Non-Claude models (GLM, GPT…) live in
+            # additional_providers (openai-completions); appending them here
+            # too would register them under the wrong wire protocol.
+            in_additional = any(
+                any(m.get("id") == self.model for m in prov.get("models", []))
+                for prov in self.additional_providers.values()
+            )
+            if not any(m.get("id") == self.model for m in models) and not in_additional:
                 models.append({"id": self.model, "input": ["text", "image"]})
         else:
             models = [{"id": self.model}]
@@ -801,5 +809,14 @@ def pi_native_provider_launch(
     """
     write_pi_models_config(agent_dir, provider)
     env = {PI_CODING_AGENT_DIR_ENV_VAR: str(agent_dir)}
-    args = ["--provider", provider.provider_id, "--model", provider.model]
+    # Resolve which provider the selected model lives in. Non-Claude models
+    # (GLM, GPT, Llama…) are in additional_providers (omnigent-openai);
+    # Claude models are in the primary provider (omnigent). Pass the correct
+    # --provider so Pi can resolve the model id.
+    model_provider_id = provider.provider_id
+    for extra_id, extra_cfg in provider.additional_providers.items():
+        if any(m.get("id") == provider.model for m in extra_cfg.get("models", [])):
+            model_provider_id = extra_id
+            break
+    args = ["--provider", model_provider_id, "--model", provider.model]
     return env, args

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -172,16 +172,7 @@ class PiProviderConfig:
             # Include all known models, ensuring the selected model is present.
             # The selected model may be a newer id not yet in the static list.
             models: list[dict[str, Any]] = list(self.extra_models)
-            # Only append to this (Anthropic) provider when the selected model
-            # is absent from ALL providers — not just this one. A non-Claude
-            # model (e.g. databricks-glm-5-2) lives in additional_providers
-            # (openai-completions); appending it here too would register it
-            # under the wrong wire protocol (anthropic-messages).
-            in_additional = any(
-                any(m.get("id") == self.model for m in prov.get("models", []))
-                for prov in self.additional_providers.values()
-            )
-            if not any(m.get("id") == self.model for m in models) and not in_additional:
+            if not any(m.get("id") == self.model for m in models):
                 models.append({"id": self.model, "input": ["text", "image"]})
         else:
             models = [{"id": self.model}]

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -172,7 +172,16 @@ class PiProviderConfig:
             # Include all known models, ensuring the selected model is present.
             # The selected model may be a newer id not yet in the static list.
             models: list[dict[str, Any]] = list(self.extra_models)
-            if not any(m.get("id") == self.model for m in models):
+            # Only append to this (Anthropic) provider when the selected model
+            # is absent from ALL providers — not just this one. A non-Claude
+            # model (e.g. databricks-glm-5-2) lives in additional_providers
+            # (openai-completions); appending it here too would register it
+            # under the wrong wire protocol (anthropic-messages).
+            in_additional = any(
+                any(m.get("id") == self.model for m in prov.get("models", []))
+                for prov in self.additional_providers.values()
+            )
+            if not any(m.get("id") == self.model for m in models) and not in_additional:
                 models.append({"id": self.model, "input": ["text", "image"]})
         else:
             models = [{"id": self.model}]

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -522,7 +522,8 @@ class _PiNativeLaunchConfig:
     A generic session-snapshot reader shared by the pi-native and
     cursor-native launch paths (workspace + terminal_launch_args +
     model_override). Each path consumes the subset it needs: pi-native
-    ignores ``model_override``; cursor-native applies it as ``--model``.
+    uses ``model_override`` as ``--model`` (overrides the spec's pinned
+    model); cursor-native does the same.
 
     :param workspace: Workspace cwd for the native TUI.
     :param server_url: Omnigent server URL for the extension/forwarder.
@@ -2008,7 +2009,9 @@ async def _auto_create_pi_terminal(
         # appended ``--model`` arg (see ``pi_native_provider_launch``) — select
         # it, reaching parity with claude-native / cursor-native. ``None``
         # (no model declared) keeps the provider's default model.
-        spec_model = _pi_native_model_from_spec(agent_spec)
+        # model_override (set by /model or sys_session_create's model arg)
+        # takes precedence over the spec's pinned executor.model.
+        spec_model = launch_config.model_override or _pi_native_model_from_spec(agent_spec)
         provider = resolve_pi_native_provider(model=spec_model)
         if provider is not None:
             cred_env, cred_args = pi_native_provider_launch(bridge_dir / "pi-agent", provider)

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2037,15 +2037,16 @@ def _build_session_create_body(
     conversation_id: str,
     title: Any,
     message: Any,
+    model: Any = None,
 ) -> dict[str, Any]:
     """
     Build the JSON ``POST /v1/sessions`` body for ``sys_session_create``.
 
     ``parent_session_id`` is hard-forced to ``conversation_id`` — this is
     what makes the write child-only (an orchestrator cannot create a
-    top-level or sibling session). A non-empty ``title`` and ``message``
-    are included when provided; the message becomes the child's first
-    queued user turn via ``initial_items``.
+    top-level or sibling session). A non-empty ``title``, ``message``, and
+    ``model`` are included when provided; the message becomes the child's
+    first queued user turn via ``initial_items``.
 
     :param agent_id: The existing agent to launch, e.g. ``"ag_abc123"``.
     :param conversation_id: The caller's session id — the forced parent.
@@ -2053,6 +2054,8 @@ def _build_session_create_body(
         string.
     :param message: Optional first user message; included only when a
         non-empty string.
+    :param model: Optional model override, e.g. ``"databricks-glm-5-2"``;
+        written as ``model_override`` on the session.
     :returns: The JSON request body.
     """
     body: dict[str, Any] = {
@@ -2061,6 +2064,8 @@ def _build_session_create_body(
     }
     if isinstance(title, str) and title:
         body["title"] = title
+    if isinstance(model, str) and model:
+        body["model_override"] = model
     if isinstance(message, str) and message:
         body["initial_items"] = [
             {
@@ -2206,7 +2211,11 @@ async def _execute_session_create(
             runner_workspace=runner_workspace,
         )
     body = _build_session_create_body(
-        str(agent_id), conversation_id, args.get("title"), args.get("message")
+        str(agent_id),
+        conversation_id,
+        args.get("title"),
+        args.get("message"),
+        model=args.get("model"),
     )
     try:
         resp = await server_client.post("/v1/sessions", json=body, timeout=30.0)

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -128,7 +128,8 @@ class SysSessionSendTool(Tool):
             "Returns the child's output when its turn completes. To run "
             "multiple sessions in parallel, emit multiple "
             "sys_session_send tool_calls in the same response — they "
-            "dispatch concurrently. To attach previously-uploaded files, "
+            "dispatch concurrently. "
+            "To attach previously-uploaded files, "
             "pass their file ids via the object args form's 'file_ids' "
             "list on the first named (agent, title) send only; file_ids "
             "cannot be used with session_id or when continuing an existing "
@@ -917,6 +918,16 @@ class SysSessionCreateTool(Tool):
                                 "for the child. Omit to create an idle "
                                 "session and drive it later via "
                                 "sys_session_send."
+                            ),
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Optional model override for the child "
+                                "session, e.g. 'databricks-glm-5-2' or "
+                                "'databricks-claude-opus-4-8'. Sets the "
+                                "harness model at session creation; "
+                                "omit to use the agent's default."
                             ),
                         },
                     },


### PR DESCRIPTION
## Related issue

n/a

## Problem

sys_session_create doesn't contain model argument

## Fix

Add model argument to sys_session_create

## Test Plan

Manual: retry the same prompt — Pi should correctly spawn a named Pi sub-session with the GLM model on the first try.

## Demo

<img width="528" height="148" alt="image" src="https://github.com/user-attachments/assets/bb3abf84-57fa-4fed-b2ab-4e3a6c944579" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

Schema description change — no unit test applicable.

## Changelog

`sys_session_send` now reliably accepts model overrides when spawning named sub-agent sessions with a specific model