### PR TITLE
feat(omnidev): skip gitignored files on reload, add --debug, pager log panes

### DIFF
--- a/dev/omnidev/Cargo.lock
+++ b/dev/omnidev/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +91,16 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
 
 [[package]]
 name = "bytes"
@@ -169,6 +188,31 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -276,6 +320,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +369,22 @@ checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -526,6 +599,7 @@ dependencies = [
  "clap",
  "crossterm",
  "if-addrs",
+ "ignore",
  "libc",
  "notify",
  "notify-debouncer-full",
@@ -534,6 +608,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -624,6 +699,23 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"

--- a/dev/omnidev/Cargo.toml
+++ b/dev/omnidev/Cargo.toml
@@ -15,8 +15,10 @@ clap = { version = "4", features = ["derive"] }
 crossterm = "0.28"
 ratatui = "0.29"
 ansi-to-tui = "7"
+unicode-width = "0.2"
 notify = "8"
 notify-debouncer-full = "0.5"
+ignore = "0.4"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/dev/omnidev/README.md
+++ b/dev/omnidev/README.md
@@ -20,8 +20,11 @@ replaces the three-terminal local dev flow (`omnigent server`, `omnigent host`,
 - **supervises** the backend server, the host daemon, and the Vite frontend,
   restarting any that crash (with backoff);
 - **reloads the backend** (server → host) when you edit `omnigent/**/*.py`;
-  the frontend self-reloads through Vite HMR;
-- gives you **scrollable per-process log panes** plus a combined view.
+  gitignored files under `omnigent/` (e.g. the build-time `_build_info.py`) are
+  skipped so generated churn doesn't reload; the frontend self-reloads through
+  Vite HMR;
+- gives you **per-process log panes** plus a combined view, each a `less`-style
+  pager with wrap and search (see [Keys](#keys)).
 
 ## Build & run
 
@@ -85,6 +88,7 @@ canonical checkout path. Per-process logs are written through to
 --pod-dir <PATH>    Use a specific pod dir instead of the per-repo default
 --no-vite           Backend + host only (no frontend)
 --clean             Wipe the pod dir before starting
+--debug             Log each watched file change and whether it reloads
 ```
 
 `--vite-host 0.0.0.0` exposes the Vite dev server on all interfaces for device
@@ -114,12 +118,21 @@ not auto-trusted (add those to `OMNIGENT_WS_ALLOWED_ORIGINS` yourself).
 
 ## Keys
 
+The log pane is a `less`-style pager, so the movement and search keys should
+feel familiar.
+
 | Key | Action |
 |---|---|
 | `1` / `2` / `3` / `0` | Focus server / host / vite / combined pane |
 | `Tab` | Cycle panes |
-| `↑` `↓` `PgUp` `PgDn` | Scroll (detaches from tail) |
-| `f` | Toggle follow-tail |
+| `j` / `k` (or `↓` / `↑`) | Scroll one line |
+| `f` / `Space` / `PgDn` (or `b` / `PgUp`) | Page forward / back one window |
+| `d` / `u` | Half-page forward / back |
+| `g` / `G` | Jump to top / bottom (bottom re-follows the tail) |
+| `F` | Toggle follow-tail (like `less +F`) |
+| `w` | Toggle line wrap (on by default) |
+| `/` `?` | Search forward / back — type, `Enter` to jump, `Esc` to cancel |
+| `n` / `N` | Next / previous match |
 | `r` | Restart the focused process (server/host restart as a pair) |
 | `R` | Restart the backend (server then host) |
 | `c` | Clear the focused pane |

--- a/dev/omnidev/src/main.rs
+++ b/dev/omnidev/src/main.rs
@@ -77,6 +77,11 @@ struct RunArgs {
     /// Wipe the pod directory before starting.
     #[arg(long)]
     clean: bool,
+
+    /// Log every observed file change and whether it triggers a backend reload
+    /// (with the skip reason otherwise).
+    #[arg(long)]
+    debug: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -188,7 +193,13 @@ async fn run_supervisor(args: RunArgs) -> Result<()> {
 
     // File watcher: Python changes -> Reload commands. Keep the debouncer alive
     // for the whole session.
-    let _watcher = watcher::spawn(&pod.omnigent_dir(), cmd_tx.clone())?;
+    let _watcher = watcher::spawn(
+        &pod.repo_root,
+        &pod.omnigent_dir(),
+        shared.clone(),
+        args.debug,
+        cmd_tx.clone(),
+    )?;
 
     // Supervisor runs on the tokio runtime; the TUI drives it via cmd_tx.
     let supervisor = Supervisor::new(

--- a/dev/omnidev/src/tui/mod.rs
+++ b/dev/omnidev/src/tui/mod.rs
@@ -3,6 +3,7 @@
 
 mod render;
 
+use std::cell::Cell;
 use std::io::{self, Stdout};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -30,6 +31,35 @@ pub enum View {
     All,
 }
 
+/// Search direction. `Fwd` scans toward the tail (newer lines), `Back` toward
+/// the head — matching `less`'s `/` and `?`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Dir {
+    Fwd,
+    Back,
+}
+
+impl Dir {
+    fn flip(self) -> Dir {
+        match self {
+            Dir::Fwd => Dir::Back,
+            Dir::Back => Dir::Fwd,
+        }
+    }
+}
+
+/// A committed search: the query and the direction it was entered with.
+pub struct Search {
+    pub query: String,
+    pub dir: Dir,
+}
+
+/// The line-editor state while the user is typing a `/` or `?` query.
+pub struct InputMode {
+    pub dir: Dir,
+    pub query: String,
+}
+
 impl View {
     fn proc(self) -> Option<ProcId> {
         match self {
@@ -46,9 +76,23 @@ pub struct App {
     shared: Arc<Mutex<Shared>>,
     cmds: mpsc::UnboundedSender<Cmd>,
     view: View,
-    /// Lines scrolled up from the bottom; 0 == pinned to tail.
+    /// Display rows scrolled up from the bottom; 0 == pinned to tail. Counted in
+    /// *rendered rows*, so it stays correct whether or not lines wrap.
     scroll_back: usize,
     follow: bool,
+    /// Wrap long lines to the next row (default) vs. clip them at the edge.
+    wrap: bool,
+    /// Body size in rows/cols, refreshed by the renderer each frame so key
+    /// handling can page by a full/half window and lay out wraps for search.
+    /// Seeded so keys pressed before the first draw still behave.
+    viewport_h: Cell<usize>,
+    viewport_w: Cell<usize>,
+    /// The last committed search, if any (drives `n`/`N` and highlighting).
+    search: Option<Search>,
+    /// Logical line index of the match `n`/`N` last jumped to, for anchoring.
+    current_match: Option<usize>,
+    /// Set while the user is typing a query; steals keys from command mode.
+    input: Option<InputMode>,
     should_quit: bool,
 }
 
@@ -61,6 +105,12 @@ impl App {
             view: View::All,
             scroll_back: 0,
             follow: true,
+            wrap: true,
+            viewport_h: Cell::new(20),
+            viewport_w: Cell::new(80),
+            search: None,
+            current_match: None,
+            input: None,
             should_quit: false,
         }
     }
@@ -98,9 +148,21 @@ impl App {
         if key.kind != KeyEventKind::Press {
             return;
         }
-        let page = 20;
+        // Ctrl-C always quits, even mid-search.
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.should_quit = true;
+            return;
+        }
+        // While typing a query, keys build/commit/cancel it instead of running
+        // commands.
+        if self.input.is_some() {
+            self.on_key_input(key);
+            return;
+        }
+
+        let window = self.viewport_h.get().max(1);
+        let half = (window / 2).max(1);
         match (key.code, key.modifiers) {
-            (KeyCode::Char('c'), KeyModifiers::CONTROL) => self.should_quit = true,
             (KeyCode::Char('q'), _) => self.should_quit = true,
 
             (KeyCode::Char('1'), _) => self.set_view(View::Server),
@@ -109,17 +171,33 @@ impl App {
             (KeyCode::Char('0'), _) => self.set_view(View::All),
             (KeyCode::Tab, _) => self.cycle_view(),
 
-            (KeyCode::Up, _) => self.scroll(1),
-            (KeyCode::Down, _) => self.scroll_down(1),
-            (KeyCode::PageUp, _) => self.scroll(page),
-            (KeyCode::PageDown, _) => self.scroll_down(page),
+            // Pager movement — full `less` semantics.
+            (KeyCode::Char('j'), _) | (KeyCode::Down, _) => self.scroll_down(1),
+            (KeyCode::Char('k'), _) | (KeyCode::Up, _) => self.scroll_up(1),
+            (KeyCode::Char('f'), _) | (KeyCode::Char(' '), _) | (KeyCode::PageDown, _) => {
+                self.scroll_down(window)
+            }
+            (KeyCode::Char('b'), _) | (KeyCode::PageUp, _) => self.scroll_up(window),
+            (KeyCode::Char('d'), _) => self.scroll_down(half),
+            (KeyCode::Char('u'), _) => self.scroll_up(half),
+            (KeyCode::Char('g'), _) | (KeyCode::Home, _) => self.scroll_to_top(),
+            (KeyCode::Char('G'), _) | (KeyCode::End, _) => self.scroll_to_bottom(),
 
-            (KeyCode::Char('f'), _) => {
+            // `less +F`: capital F toggles tail-follow.
+            (KeyCode::Char('F'), _) => {
                 self.follow = !self.follow;
                 if self.follow {
                     self.scroll_back = 0;
                 }
             }
+            (KeyCode::Char('w'), _) => self.toggle_wrap(),
+
+            // Search.
+            (KeyCode::Char('/'), _) => self.begin_search(Dir::Fwd),
+            (KeyCode::Char('?'), _) => self.begin_search(Dir::Back),
+            (KeyCode::Char('n'), _) => self.repeat_search(false),
+            (KeyCode::Char('N'), _) => self.repeat_search(true),
+
             (KeyCode::Char('r'), _) => {
                 if let Some(id) = self.view.proc() {
                     let _ = self.cmds.send(Cmd::Restart(id));
@@ -135,9 +213,43 @@ impl App {
         }
     }
 
+    /// Handle a key while a `/` or `?` query is being typed.
+    fn on_key_input(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Enter => {
+                let input = self.input.take().unwrap();
+                if !input.query.is_empty() {
+                    self.search = Some(Search {
+                        query: input.query,
+                        dir: input.dir,
+                    });
+                    self.current_match = None;
+                    self.run_search(input.dir, true);
+                }
+            }
+            KeyCode::Esc => self.input = None,
+            KeyCode::Backspace => {
+                let done = {
+                    let input = self.input.as_mut().unwrap();
+                    input.query.pop();
+                    input.query.is_empty()
+                };
+                if done {
+                    self.input = None;
+                }
+            }
+            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.input.as_mut().unwrap().query.push(c);
+            }
+            _ => {}
+        }
+    }
+
     fn set_view(&mut self, v: View) {
         self.view = v;
         self.scroll_back = 0;
+        // Match indices are per-view; drop the anchor on switch.
+        self.current_match = None;
     }
 
     fn cycle_view(&mut self) {
@@ -148,9 +260,10 @@ impl App {
             View::Vite => View::All,
         };
         self.scroll_back = 0;
+        self.current_match = None;
     }
 
-    fn scroll(&mut self, n: usize) {
+    fn scroll_up(&mut self, n: usize) {
         // Scrolling up detaches from the tail.
         self.follow = false;
         self.scroll_back = self.scroll_back.saturating_add(n);
@@ -163,6 +276,147 @@ impl App {
         }
     }
 
+    fn scroll_to_top(&mut self) {
+        self.follow = false;
+        let lines = self.display_lines();
+        let counts = self.row_counts(&lines);
+        let total: usize = counts.iter().sum();
+        let height = self.viewport_h.get().max(1);
+        self.scroll_back = total.saturating_sub(height);
+    }
+
+    fn scroll_to_bottom(&mut self) {
+        self.scroll_back = 0;
+        self.follow = true;
+    }
+
+    fn toggle_wrap(&mut self) {
+        self.wrap = !self.wrap;
+        // Row counts change with wrap; re-anchor on the matched line if any,
+        // otherwise drop to the tail so we land somewhere sane.
+        match self.current_match {
+            Some(idx) => {
+                let lines = self.display_lines();
+                self.jump_to_logical(idx, &lines);
+            }
+            None => self.scroll_to_bottom(),
+        }
+    }
+
+    fn begin_search(&mut self, dir: Dir) {
+        self.input = Some(InputMode {
+            dir,
+            query: String::new(),
+        });
+    }
+
+    /// `n` repeats the committed search in its direction; `N` (opposite=true)
+    /// reverses it.
+    fn repeat_search(&mut self, opposite: bool) {
+        let Some(search) = self.search.as_ref() else {
+            return;
+        };
+        let dir = if opposite {
+            search.dir.flip()
+        } else {
+            search.dir
+        };
+        self.run_search(dir, false);
+    }
+
+    /// Scan for the next match and jump to it. `fresh` anchors from the current
+    /// viewport; otherwise it steps off the last matched line.
+    fn run_search(&mut self, dir: Dir, fresh: bool) {
+        let Some(query) = self.search.as_ref().map(|s| s.query.to_ascii_lowercase()) else {
+            return;
+        };
+        let lines = self.display_lines();
+        let n = lines.len();
+        if n == 0 || query.is_empty() {
+            return;
+        }
+
+        let start = if fresh {
+            self.anchor(&lines, dir)
+        } else {
+            match self.current_match {
+                Some(m) => match dir {
+                    Dir::Fwd => (m + 1) % n,
+                    Dir::Back => (m + n - 1) % n,
+                },
+                None => self.anchor(&lines, dir),
+            }
+        };
+
+        // Scan every line once, wrapping around the ends.
+        for k in 0..n {
+            let i = match dir {
+                Dir::Fwd => (start + k) % n,
+                Dir::Back => (start + n - (k % n)) % n,
+            };
+            if lines[i].to_ascii_lowercase().contains(&query) {
+                self.current_match = Some(i);
+                self.jump_to_logical(i, &lines);
+                return;
+            }
+        }
+    }
+
+    /// Displayed text (ANSI stripped, `[label]` prefix included in the combined
+    /// view) for every logical line of the focused channel — the exact text the
+    /// renderer shows, so search offsets and wrap counts line up.
+    fn display_lines(&self) -> Vec<String> {
+        let all_view = self.view == View::All;
+        let s = self.shared.lock().unwrap();
+        let iter: Box<dyn Iterator<Item = &String>> = match self.view {
+            View::Server => Box::new(s.buf(ProcId::Server).iter()),
+            View::Host => Box::new(s.buf(ProcId::Host).iter()),
+            View::Vite => Box::new(s.buf(ProcId::Vite).iter()),
+            View::All => Box::new(s.all.iter()),
+        };
+        iter.map(|l| render::display_text(l, all_view)).collect()
+    }
+
+    /// Per-line display-row counts at the current width/wrap.
+    fn row_counts(&self, lines: &[String]) -> Vec<usize> {
+        let width = self.viewport_w.get();
+        lines
+            .iter()
+            .map(|t| render::row_count(t, width, self.wrap))
+            .collect()
+    }
+
+    /// The logical line a fresh search should scan from: the top visible line
+    /// going forward, the bottom visible line going back.
+    fn anchor(&self, lines: &[String], dir: Dir) -> usize {
+        let counts = self.row_counts(lines);
+        let total: usize = counts.iter().sum();
+        let height = self.viewport_h.get().max(1);
+        let back = self.scroll_back.min(total.saturating_sub(height));
+        let end = total.saturating_sub(back); // one past the bottom visible row
+        let top_row = end.saturating_sub(height);
+        match dir {
+            Dir::Fwd => line_at_row(&counts, top_row),
+            Dir::Back => line_at_row(&counts, end.saturating_sub(1)),
+        }
+    }
+
+    /// Scroll so logical line `idx`'s first display row sits at the top of the
+    /// viewport (clamped so we never scroll past the tail).
+    fn jump_to_logical(&mut self, idx: usize, lines: &[String]) {
+        let counts = self.row_counts(lines);
+        if idx >= counts.len() {
+            return;
+        }
+        let height = self.viewport_h.get().max(1);
+        let below: usize = counts[idx + 1..].iter().sum();
+        let own = counts[idx];
+        let total: usize = counts.iter().sum();
+        let max_back = total.saturating_sub(height);
+        self.scroll_back = (own + below).saturating_sub(height).min(max_back);
+        self.follow = false;
+    }
+
     fn clear_current(&mut self) {
         let mut s = self.shared.lock().unwrap();
         match self.view {
@@ -172,9 +426,10 @@ impl App {
             View::All => s.all.clear(),
         }
         self.scroll_back = 0;
+        self.current_match = None;
     }
 
-    /// Total line count of the focused channel, for the status readout.
+    /// Total logical line count of the focused channel, for the status readout.
     pub fn line_count(&self) -> usize {
         let s = self.shared.lock().unwrap();
         match self.view {
@@ -184,6 +439,53 @@ impl App {
             View::All => s.all.iter().count(),
         }
     }
+
+    /// The committed query, ASCII-lowercased, for the renderer's highlight
+    /// pass. `None` when no search is active.
+    pub fn search_query_lower(&self) -> Option<String> {
+        self.search
+            .as_ref()
+            .filter(|s| !s.query.is_empty())
+            .map(|s| s.query.to_ascii_lowercase())
+    }
+
+    /// The in-progress query prompt (`dir`, text) while the user is typing.
+    pub fn input_prompt(&self) -> Option<(Dir, &str)> {
+        self.input.as_ref().map(|i| (i.dir, i.query.as_str()))
+    }
+
+    /// Number of logical lines matching the committed search, for the status
+    /// readout, plus the 1-based rank of the current match within them.
+    pub fn match_stats(&self) -> Option<(usize, usize)> {
+        let query = self.search.as_ref()?.query.to_ascii_lowercase();
+        if query.is_empty() {
+            return None;
+        }
+        let lines = self.display_lines();
+        let mut total = 0;
+        let mut rank = 0;
+        for (i, l) in lines.iter().enumerate() {
+            if l.to_ascii_lowercase().contains(&query) {
+                total += 1;
+                if Some(i) == self.current_match {
+                    rank = total;
+                }
+            }
+        }
+        Some((rank, total))
+    }
+}
+
+/// Map a display-row index to the logical line that contains it.
+fn line_at_row(counts: &[usize], target_row: usize) -> usize {
+    let mut acc = 0;
+    for (i, &rc) in counts.iter().enumerate() {
+        if target_row < acc + rc {
+            return i;
+        }
+        acc += rc;
+    }
+    counts.len().saturating_sub(1)
 }
 
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
@@ -213,4 +515,173 @@ fn spawn_input() -> mpsc::UnboundedReceiver<KeyEvent> {
         }
     });
     rx
+}
+
+#[cfg(test)]
+mod tests {
+    //! Headless end-to-end: drive the real `on_key` and render through
+    //! ratatui's `TestBackend`, so the full key → state → draw path is
+    //! exercised without a TTY or a live pod.
+    use super::*;
+    use crate::ports::Ports;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    /// Build an `App` over a throwaway pod and a channel whose receiver we keep
+    /// so `cmds.send` never fails.
+    fn app() -> (App, mpsc::UnboundedReceiver<Cmd>) {
+        let root = std::env::temp_dir().join(format!("omnidev-tui-{}", std::process::id()));
+        let dir = root.join("pod");
+        let pod = Arc::new(
+            Pod::create(
+                root.clone(),
+                dir,
+                Ports {
+                    server: 6767,
+                    vite: 5173,
+                },
+                "127.0.0.1".into(),
+                Vec::new(),
+            )
+            .unwrap(),
+        );
+        let shared = Shared::new(&pod);
+        let (tx, rx) = mpsc::unbounded_channel();
+        (App::new(pod, shared, tx), rx)
+    }
+
+    fn press(app: &mut App, code: KeyCode) {
+        app.on_key(KeyEvent::new(code, KeyModifiers::NONE));
+    }
+
+    fn type_str(app: &mut App, s: &str) {
+        for c in s.chars() {
+            press(app, KeyCode::Char(c));
+        }
+    }
+
+    /// Render one frame at the given size and return the body rows (everything
+    /// between the 4 header rows and the footer) as trimmed strings.
+    fn body(app: &App, w: u16, h: u16) -> Vec<String> {
+        let mut term = Terminal::new(TestBackend::new(w, h)).unwrap();
+        term.draw(|f| render::draw(f, app)).unwrap();
+        let buf = term.backend().buffer().clone();
+        let mut rows = Vec::new();
+        // Layout: 4 header rows, body fills the middle, 1 footer row.
+        for y in 4..h - 1 {
+            let mut s = String::new();
+            for x in 0..w {
+                s.push_str(buf.cell((x, y)).unwrap().symbol());
+            }
+            rows.push(s.trim_end().to_string());
+        }
+        rows
+    }
+
+    fn seed(app: &App, n: usize) {
+        let mut s = app.shared.lock().unwrap();
+        for i in 0..n {
+            s.all.push(format!("line{i:03}"));
+        }
+    }
+
+    #[test]
+    fn renders_tail_by_default() {
+        let (app, _rx) = app();
+        seed(&app, 100);
+        let rows = body(&app, 40, 12); // 4 header + 7 body + 1 footer
+        assert_eq!(rows.last().unwrap(), "line099");
+        assert!(rows.iter().any(|r| r == "line093"));
+    }
+
+    #[test]
+    fn paging_and_ends_move_the_window() {
+        let (mut app, _rx) = app();
+        seed(&app, 100);
+        // Establish viewport height via a first render (7 body rows).
+        let _ = body(&app, 40, 12);
+        press(&mut app, KeyCode::Char('b')); // page back one window
+        assert!(!app.follow);
+        let rows = body(&app, 40, 12);
+        assert_eq!(rows.last().unwrap(), "line092");
+
+        press(&mut app, KeyCode::Char('g')); // top
+        let rows = body(&app, 40, 12);
+        assert_eq!(rows.first().unwrap(), "line000");
+
+        press(&mut app, KeyCode::Char('G')); // bottom + follow
+        assert!(app.follow);
+        let rows = body(&app, 40, 12);
+        assert_eq!(rows.last().unwrap(), "line099");
+    }
+
+    #[test]
+    fn wrap_toggle_changes_row_shape() {
+        let (mut app, _rx) = app();
+        {
+            let mut s = app.shared.lock().unwrap();
+            s.all.push("X".repeat(30)); // wider than a 10-col body
+        }
+        // Default wrap ON: the 30-char line occupies multiple body rows.
+        let wrapped = body(&app, 10, 8);
+        let nonblank = wrapped.iter().filter(|r| !r.is_empty()).count();
+        assert!(nonblank >= 3, "expected wrap across rows, got {wrapped:?}");
+
+        press(&mut app, KeyCode::Char('w')); // wrap OFF → clipped to one row
+        let clipped = body(&app, 10, 8);
+        let nonblank = clipped.iter().filter(|r| !r.is_empty()).count();
+        assert_eq!(nonblank, 1);
+    }
+
+    #[test]
+    fn search_jumps_and_highlights() {
+        let (mut app, _rx) = app();
+        {
+            let mut s = app.shared.lock().unwrap();
+            for i in 0..100 {
+                let tag = if i == 5 { " ERROR here" } else { "" };
+                s.all.push(format!("line{i:03}{tag}"));
+            }
+        }
+        let _ = body(&app, 40, 12);
+        // `/error` + Enter jumps up to the match near the top of the body.
+        press(&mut app, KeyCode::Char('/'));
+        type_str(&mut app, "error");
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(app.current_match, Some(5));
+        assert_eq!(app.match_stats(), Some((1, 1)));
+
+        // The matched line is visible and its "ERROR" is highlighted.
+        let mut term = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        term.draw(|f| render::draw(f, &app)).unwrap();
+        let buf = term.backend().buffer().clone();
+        let mut highlit = 0;
+        for y in 4..11 {
+            for x in 0..40 {
+                let cell = buf.cell((x, y)).unwrap();
+                let is_match_char = matches!(cell.symbol(), "E" | "R" | "O");
+                if is_match_char && cell.bg == render::match_bg() {
+                    highlit += 1;
+                }
+            }
+        }
+        assert!(
+            highlit >= 5,
+            "expected the match highlighted, got {highlit}"
+        );
+    }
+
+    #[test]
+    fn typing_query_does_not_run_commands() {
+        let (mut app, _rx) = app();
+        seed(&app, 100);
+        let _ = body(&app, 40, 12);
+        press(&mut app, KeyCode::Char('/'));
+        // 'q' would quit in command mode; here it's just query text.
+        type_str(&mut app, "q");
+        assert!(!app.should_quit);
+        assert_eq!(app.input_prompt(), Some((Dir::Fwd, "q")));
+        press(&mut app, KeyCode::Esc);
+        assert!(app.input_prompt().is_none());
+    }
 }

--- a/dev/omnidev/src/tui/render.rs
+++ b/dev/omnidev/src/tui/render.rs
@@ -9,8 +9,9 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Tabs};
 use ratatui::Frame;
+use unicode_width::UnicodeWidthChar;
 
-use super::{App, View};
+use super::{App, Dir, View};
 use crate::state::{ProcId, ProcStatus};
 
 // Palette calibrated (Solarized accents) to stay legible on both light and
@@ -32,9 +33,20 @@ const OK: Color = Color::Rgb(133, 153, 0); // green (running)
 const WARN: Color = Color::Rgb(203, 75, 22); // orange (starting/restarting)
 const ERR: Color = Color::Rgb(220, 50, 47); // red (crashed)
 
+// Search-match highlight: amber background with near-black text, legible on
+// either theme and distinct from the ANSI log colors underneath.
+const MATCH_BG: Color = Color::Rgb(181, 137, 0);
+const MATCH_FG: Color = Color::Rgb(20, 20, 20);
+
 /// Style for the header/footer chrome bars.
 fn chrome() -> Style {
     Style::default().bg(CHROME_BG).fg(CHROME_FG)
+}
+
+/// The search-match background, exposed for tests that assert highlighting.
+#[cfg(test)]
+pub fn match_bg() -> Color {
+    MATCH_BG
 }
 
 pub fn draw(f: &mut Frame, app: &App) {
@@ -55,7 +67,7 @@ pub fn draw(f: &mut Frame, app: &App) {
     draw_chips(f, app, chunks[2]);
     draw_tabs_row(f, app, chunks[3]);
     draw_body(f, app, chunks[4]);
-    draw_footer(f, chunks[5]);
+    draw_footer(f, app, chunks[5]);
 }
 
 fn draw_pod(f: &mut Frame, app: &App, area: Rect) {
@@ -107,7 +119,7 @@ fn draw_tabs_row(f: &mut Frame, app: &App, area: Rect) {
     // Split the row: tabs on the left, scroll/follow status right-aligned.
     let cols = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(0), Constraint::Length(24)])
+        .constraints([Constraint::Min(0), Constraint::Length(36)])
         .split(area);
 
     let entries = [
@@ -135,11 +147,18 @@ fn draw_tabs_row(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(tabs, cols[0]);
 
     let total = app.line_count();
-    let status = if app.follow {
-        format!("{total} ln · follow ")
+    let mut status = format!("{total} ln");
+    if !app.wrap {
+        status.push_str(" · nowrap");
+    }
+    if let Some((rank, count)) = app.match_stats() {
+        status.push_str(&format!(" · {rank}/{count}"));
+    }
+    if app.follow {
+        status.push_str(" · follow ");
     } else {
-        format!("{total} ln · ↑{} ", app.scroll_back)
-    };
+        status.push_str(&format!(" · ↑{} ", app.scroll_back));
+    }
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(status, Style::default().fg(MUTED))))
             .alignment(Alignment::Right)
@@ -150,6 +169,12 @@ fn draw_tabs_row(f: &mut Frame, app: &App, area: Rect) {
 
 fn draw_body(f: &mut Frame, app: &App, area: Rect) {
     let all_view = app.view == View::All;
+    let width = area.width as usize;
+    let height = area.height as usize;
+    // Publish the body geometry so key handling can page and search can wrap.
+    app.viewport_h.set(height);
+    app.viewport_w.set(width);
+
     let shared = app.shared.lock().unwrap();
     let lines: Vec<String> = match app.view {
         View::Server => shared.buf(ProcId::Server).iter().cloned().collect(),
@@ -159,37 +184,89 @@ fn draw_body(f: &mut Frame, app: &App, area: Rect) {
     };
     drop(shared);
 
-    let height = area.height as usize;
-    let total = lines.len();
-    let max_back = total.saturating_sub(height);
-    let back = app.scroll_back.min(max_back);
-    let end = total.saturating_sub(back);
-    let start = end.saturating_sub(height);
-
-    let rendered: Vec<Line> = lines[start..end]
-        .iter()
-        .map(|l| render_line(l, all_view))
-        .collect();
-
-    f.render_widget(Paragraph::new(rendered), area);
-}
-
-fn draw_footer(f: &mut Frame, area: Rect) {
-    let hint = " 1/2/3/0 view · Tab cycle · ↑↓/PgUp/PgDn scroll · f follow · r restart · R backend · c clear · q quit ";
-    f.render_widget(
-        Paragraph::new(Line::from(Span::styled(
-            hint,
-            Style::default().fg(CHROME_FG),
-        )))
-        .style(chrome()),
-        area,
+    let query = app.search_query_lower();
+    let visible = visible_rows(
+        &lines,
+        all_view,
+        width,
+        height,
+        app.wrap,
+        app.scroll_back,
+        query.as_deref(),
     );
+    f.render_widget(Paragraph::new(visible), area);
 }
 
-/// Turn one stored log line into a styled `Line`. In the combined view the
-/// leading `[service]` tag is colored per service and the rest keeps its ANSI
-/// colors; per-service panes just pass their ANSI through.
-fn render_line(raw: &str, all_view: bool) -> Line<'static> {
+/// The window of display rows to show: the `height` rows sitting `scroll_back`
+/// rows above the tail. Rows are built from the bottom up, wrapping only enough
+/// logical lines to cover `scroll_back + height` so a full buffer isn't
+/// re-parsed every frame. Equivalent to wrapping every line and slicing the
+/// flat list, but without the wasted work.
+fn visible_rows(
+    lines: &[String],
+    all_view: bool,
+    width: usize,
+    height: usize,
+    wrap: bool,
+    scroll_back: usize,
+    query: Option<&str>,
+) -> Vec<Line<'static>> {
+    // `acc` holds rows bottom-to-top; each logical line yields one row (wrap
+    // off) or several (wrap on), so `scroll_back` counts rendered rows.
+    let needed = scroll_back.saturating_add(height);
+    let mut acc: Vec<Line> = Vec::with_capacity(needed + 8);
+    let mut exhausted = true;
+    for raw in lines.iter().rev() {
+        let spans = render_line(raw, all_view);
+        let ranges = query.map(|q| match_ranges(raw, all_view, q));
+        let mut line_rows: Vec<Line> = Vec::new();
+        wrap_spans(spans, width, wrap, ranges.as_deref(), &mut line_rows);
+        acc.extend(line_rows.into_iter().rev());
+        if acc.len() >= needed {
+            exhausted = false;
+            break;
+        }
+    }
+
+    // If we ran out of lines the buffer is shorter than the scroll offset, so
+    // clamp to the top; otherwise `scroll_back` is within range as-is.
+    let back = if exhausted {
+        scroll_back.min(acc.len().saturating_sub(height))
+    } else {
+        scroll_back
+    };
+    let end = (back + height).min(acc.len());
+    let mut visible: Vec<Line> = acc.drain(back..end).collect();
+    visible.reverse();
+    visible
+}
+
+fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
+    // While typing a query the footer becomes the search prompt with a cursor
+    // block; otherwise it lists the key hints.
+    let line = if let Some((dir, query)) = app.input_prompt() {
+        let sigil = match dir {
+            Dir::Fwd => '/',
+            Dir::Back => '?',
+        };
+        Line::from(vec![
+            Span::styled(
+                format!(" {sigil}{query}"),
+                Style::default().fg(CHROME_FG).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("█", Style::default().fg(CHROME_FG)),
+        ])
+    } else {
+        let hint = " f/b page · d/u half · j/k line · g/G ends · F follow · w wrap · / ? search · n/N next · 1230/Tab view · r/R restart · c clear · q quit ";
+        Line::from(Span::styled(hint, Style::default().fg(CHROME_FG)))
+    };
+    f.render_widget(Paragraph::new(line).style(chrome()), area);
+}
+
+/// Turn one stored log line into styled spans. In the combined view the leading
+/// `[service]` tag is colored per service and the rest keeps its ANSI colors;
+/// per-service panes just pass their ANSI through.
+fn render_line(raw: &str, all_view: bool) -> Vec<Span<'static>> {
     if all_view {
         if let Some(rest) = raw.strip_prefix('[') {
             if let Some(end) = rest.find(']') {
@@ -202,11 +279,135 @@ fn render_line(raw: &str, all_view: bool) -> Line<'static> {
                         .add_modifier(Modifier::BOLD),
                 )];
                 spans.extend(ansi_spans(body));
-                return Line::from(spans);
+                return spans;
             }
         }
     }
-    Line::from(ansi_spans(raw))
+    ansi_spans(raw)
+}
+
+/// The exact text `render_line` will display (ANSI stripped, `[label]` prefix
+/// included), so search offsets and wrap-row counts line up with what's drawn.
+pub fn display_text(raw: &str, all_view: bool) -> String {
+    render_line(raw, all_view)
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect()
+}
+
+/// Column width of a char for layout. Control and zero-width chars (including
+/// tabs) count as 0 — good enough for log lines.
+fn char_cols(c: char) -> usize {
+    UnicodeWidthChar::width(c).unwrap_or(0)
+}
+
+/// How many display rows `text` occupies at `width` columns. Must stay in step
+/// with `wrap_spans`' row splitting so scroll math and search jumps agree.
+pub fn row_count(text: &str, width: usize, wrap: bool) -> usize {
+    if !wrap || width == 0 {
+        return 1;
+    }
+    let mut rows = 1;
+    let mut col = 0;
+    for c in text.chars() {
+        let w = char_cols(c);
+        if col + w > width && col > 0 {
+            rows += 1;
+            col = 0;
+        }
+        col += w;
+    }
+    rows
+}
+
+/// Char-offset ranges of every case-insensitive occurrence of `query` (already
+/// ASCII-lowercased) in the line's displayed text. Offsets are in chars so they
+/// align with `wrap_spans`' per-char highlight test.
+fn match_ranges(raw: &str, all_view: bool, query: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    if query.is_empty() {
+        return ranges;
+    }
+    let hay: Vec<char> = display_text(raw, all_view)
+        .chars()
+        .map(|c| c.to_ascii_lowercase())
+        .collect();
+    let q: Vec<char> = query.chars().collect();
+    if hay.len() < q.len() {
+        return ranges;
+    }
+    let mut i = 0;
+    while i + q.len() <= hay.len() {
+        if hay[i..i + q.len()] == q[..] {
+            ranges.push((i, i + q.len()));
+            i += q.len();
+        } else {
+            i += 1;
+        }
+    }
+    ranges
+}
+
+/// Split one logical line's spans into display rows, pushing each row onto
+/// `out`. When `wrap` is off (or width 0) the line stays a single row — clipped
+/// at the edge by the renderer, as before. Contiguous same-style chars coalesce
+/// into one span. Chars whose char-offset falls in a `matches` range get the
+/// search-highlight style overlaid, so a match spanning a wrap boundary lights
+/// up on both rows.
+fn wrap_spans(
+    spans: Vec<Span<'static>>,
+    width: usize,
+    wrap: bool,
+    matches: Option<&[(usize, usize)]>,
+    out: &mut Vec<Line<'static>>,
+) {
+    let matches = matches.unwrap_or(&[]);
+    // Nothing to reflow or highlight: emit the spans as one row untouched.
+    if (!wrap || width == 0) && matches.is_empty() {
+        out.push(Line::from(spans));
+        return;
+    }
+
+    let in_match = |off: usize| matches.iter().any(|&(s, e)| off >= s && off < e);
+
+    let mut row: Vec<Span<'static>> = Vec::new();
+    let mut run = String::new();
+    let mut run_style: Option<Style> = None;
+    let mut col = 0usize;
+    let mut offset = 0usize;
+
+    for span in &spans {
+        let base = span.style;
+        for c in span.content.chars() {
+            let w = char_cols(c);
+            if wrap && width > 0 && col + w > width && col > 0 {
+                flush_run(&mut run, run_style.unwrap_or_default(), &mut row);
+                out.push(Line::from(std::mem::take(&mut row)));
+                col = 0;
+            }
+            let style = if in_match(offset) {
+                base.bg(MATCH_BG).fg(MATCH_FG).add_modifier(Modifier::BOLD)
+            } else {
+                base
+            };
+            if run_style != Some(style) {
+                flush_run(&mut run, run_style.unwrap_or_default(), &mut row);
+                run_style = Some(style);
+            }
+            run.push(c);
+            col += w;
+            offset += 1;
+        }
+    }
+    flush_run(&mut run, run_style.unwrap_or_default(), &mut row);
+    out.push(Line::from(row));
+}
+
+/// Emit the buffered same-style run as a span, clearing the buffer.
+fn flush_run(run: &mut String, style: Style, row: &mut Vec<Span<'static>>) {
+    if !run.is_empty() {
+        row.push(Span::styled(std::mem::take(run), style));
+    }
 }
 
 /// Parse a single line of possibly-ANSI text into owned spans, falling back to
@@ -250,5 +451,152 @@ fn status_color(st: &ProcStatus) -> Color {
         ProcStatus::Crashed => ERR,
         ProcStatus::Stopped => VITE,
         ProcStatus::Idle => MUTED,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows(text: &str, width: usize, wrap: bool) -> Vec<String> {
+        let mut out = Vec::new();
+        wrap_spans(
+            vec![Span::raw(text.to_string())],
+            width,
+            wrap,
+            None,
+            &mut out,
+        );
+        out.iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn wrap_off_is_one_row() {
+        assert_eq!(rows("hello world", 4, false), vec!["hello world"]);
+        assert_eq!(row_count("hello world", 4, false), 1);
+    }
+
+    #[test]
+    fn wrap_splits_at_width_and_row_count_agrees() {
+        let text = "abcdefgh";
+        assert_eq!(rows(text, 3, true), vec!["abc", "def", "gh"]);
+        assert_eq!(row_count(text, 3, true), 3);
+    }
+
+    #[test]
+    fn wide_char_that_does_not_fit_wraps_first() {
+        // "a" then a 2-wide char into width 2: the wide char can't share the
+        // row with "a", so it starts the next one.
+        let rows = rows("a世", 2, true);
+        assert_eq!(rows, vec!["a", "世"]);
+        assert_eq!(row_count("a世", 2, true), 2);
+    }
+
+    #[test]
+    fn zero_width_join_does_not_add_a_row() {
+        // A trailing combining mark rides the last column, not a new row.
+        assert_eq!(row_count("abc\u{0301}", 3, true), 1);
+    }
+
+    #[test]
+    fn width_zero_never_panics() {
+        assert_eq!(rows("abc", 0, true), vec!["abc"]);
+        assert_eq!(row_count("abc", 0, true), 1);
+    }
+
+    #[test]
+    fn match_ranges_are_case_insensitive_char_offsets() {
+        assert_eq!(
+            match_ranges("Error: ERROR", false, "error"),
+            vec![(0, 5), (7, 12)]
+        );
+        assert_eq!(match_ranges("nope", false, "error"), vec![]);
+    }
+
+    /// Reference: wrap every line into one flat list, then slice the window —
+    /// the obvious-but-wasteful version `visible_rows` optimizes.
+    fn naive_visible(
+        lines: &[String],
+        width: usize,
+        height: usize,
+        wrap: bool,
+        scroll_back: usize,
+    ) -> Vec<String> {
+        let mut all: Vec<Line> = Vec::new();
+        for raw in lines {
+            wrap_spans(vec![Span::raw(raw.clone())], width, wrap, None, &mut all);
+        }
+        let total = all.len();
+        let back = scroll_back.min(total.saturating_sub(height));
+        let end = total.saturating_sub(back);
+        let start = end.saturating_sub(height);
+        all[start..end].iter().map(row_text).collect()
+    }
+
+    fn row_text(l: &Line) -> String {
+        l.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    fn lazy_visible(
+        lines: &[String],
+        width: usize,
+        height: usize,
+        wrap: bool,
+        scroll_back: usize,
+    ) -> Vec<String> {
+        visible_rows(lines, false, width, height, wrap, scroll_back, None)
+            .iter()
+            .map(row_text)
+            .collect()
+    }
+
+    #[test]
+    fn lazy_slice_matches_naive_across_offsets() {
+        let lines: Vec<String> = (0..30).map(|i| format!("line{i:02}=abcdefghij")).collect();
+        for &wrap in &[false, true] {
+            for width in [6usize, 8, 40] {
+                for height in [1usize, 5, 12] {
+                    for back in [0usize, 3, 10, 25, 999] {
+                        assert_eq!(
+                            lazy_visible(&lines, width, height, wrap, back),
+                            naive_visible(&lines, width, height, wrap, back),
+                            "wrap={wrap} width={width} height={height} back={back}",
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn empty_and_short_buffers_do_not_panic() {
+        assert!(lazy_visible(&[], 10, 5, true, 0).is_empty());
+        let one = vec!["hi".to_string()];
+        assert_eq!(lazy_visible(&one, 10, 5, true, 0), vec!["hi"]);
+        assert_eq!(lazy_visible(&one, 10, 5, true, 99), vec!["hi"]);
+    }
+
+    #[test]
+    fn highlight_survives_a_wrap_boundary() {
+        // "error" at chars 2..7 straddles the width-4 wrap between rows.
+        let ranges = match_ranges("--error--", false, "error");
+        let mut out = Vec::new();
+        wrap_spans(
+            vec![Span::raw("--error--".to_string())],
+            4,
+            true,
+            Some(&ranges),
+            &mut out,
+        );
+        // Every row that overlaps the match must carry a highlighted span.
+        let highlighted: usize = out
+            .iter()
+            .flat_map(|l| &l.spans)
+            .filter(|s| s.style.bg == Some(MATCH_BG))
+            .map(|s| s.content.chars().count())
+            .sum();
+        assert_eq!(highlighted, 5); // all five chars of "error"
     }
 }

--- a/dev/omnidev/src/watcher.rs
+++ b/dev/omnidev/src/watcher.rs
@@ -3,24 +3,38 @@
 //! handles those.
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::RecursiveMode;
 use notify_debouncer_full::new_debouncer;
 use tokio::sync::mpsc;
 
+use crate::state::Shared;
 use crate::supervisor::Cmd;
 
 /// Start watching `omnigent_dir` for `*.py` changes. Coalesced bursts become a
 /// single `Cmd::Reload(n)` on `cmd_tx`. The returned debouncer must be kept
 /// alive for the watch to persist.
+///
+/// Gitignored files (e.g. the build-time `omnigent/_build_info.py`) are skipped
+/// so churn from generated files doesn't trigger reloads. With `debug` on, every
+/// observed change is logged with whether it triggered a reload or why it was
+/// skipped.
 pub fn spawn(
+    repo_root: &Path,
     omnigent_dir: &Path,
+    shared: Arc<Mutex<Shared>>,
+    debug: bool,
     cmd_tx: mpsc::UnboundedSender<Cmd>,
 ) -> Result<impl Send + 'static> {
-    // The debouncer coalesces rapid saves; we still filter to *.py and skip
-    // caches so editor churn and __pycache__ writes don't trigger reloads.
+    let ignore = build_ignore(repo_root);
+    let repo_root = repo_root.to_path_buf();
+
+    // The debouncer coalesces rapid saves; we still filter to *.py, skip caches
+    // and gitignored files so editor churn and generated writes don't reload.
     let mut debouncer = new_debouncer(
         Duration::from_millis(500),
         None,
@@ -29,8 +43,18 @@ pub fn spawn(
             let mut changed = 0usize;
             for event in &events {
                 for path in &event.paths {
-                    if is_relevant(path) {
-                        changed += 1;
+                    match classify(path, &ignore) {
+                        Ok(()) => {
+                            changed += 1;
+                            if debug {
+                                log_watch(&shared, &repo_root, path, "reload trigger");
+                            }
+                        }
+                        Err(reason) => {
+                            if debug {
+                                log_watch(&shared, &repo_root, path, &format!("skip ({reason})"));
+                            }
+                        }
                     }
                 }
             }
@@ -48,9 +72,95 @@ pub fn spawn(
     Ok(debouncer)
 }
 
-fn is_relevant(path: &Path) -> bool {
+/// Build a gitignore matcher from the repo's root `.gitignore` and
+/// `.git/info/exclude`. Both are best-effort — a missing or malformed file just
+/// contributes no rules. Nested `.gitignore` files under `omnigent/` are not
+/// consulted (the repo has none today); add them here if that changes.
+fn build_ignore(repo_root: &Path) -> Gitignore {
+    let mut b = GitignoreBuilder::new(repo_root);
+    b.add(repo_root.join(".gitignore"));
+    b.add(repo_root.join(".git").join("info").join("exclude"));
+    b.build().unwrap_or_else(|_| Gitignore::empty())
+}
+
+/// Decide whether a changed path should trigger a reload, or why not. The `Err`
+/// carries a short reason for the `--debug` log.
+fn classify(path: &Path, ignore: &Gitignore) -> Result<(), &'static str> {
     if path.extension().and_then(|e| e.to_str()) != Some("py") {
-        return false;
+        return Err("non-.py");
     }
-    !path.components().any(|c| c.as_os_str() == "__pycache__")
+    if path.components().any(|c| c.as_os_str() == "__pycache__") {
+        return Err("__pycache__");
+    }
+    // `_or_any_parents` so files inside a gitignored directory (build/, dist/,
+    // *.egg-info/, …) are skipped too, matching git's own behavior — plain
+    // `matched` only catches paths named by a rule directly.
+    if ignore.matched_path_or_any_parents(path, false).is_ignore() {
+        return Err("gitignored");
+    }
+    Ok(())
+}
+
+/// Emit a `--debug` watch line into the combined pane, path shown relative to
+/// the repo root when possible.
+fn log_watch(shared: &Arc<Mutex<Shared>>, repo_root: &Path, path: &Path, what: &str) {
+    let rel = path.strip_prefix(repo_root).unwrap_or(path);
+    shared
+        .lock()
+        .unwrap()
+        .event(format!("watch: {what} {}", rel.display()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ignore_with(line: &str) -> Gitignore {
+        let mut b = GitignoreBuilder::new("/repo");
+        b.add_line(None, line).unwrap();
+        b.build().unwrap()
+    }
+
+    #[test]
+    fn plain_python_file_triggers_reload() {
+        let ig = ignore_with("omnigent/_build_info.py");
+        assert_eq!(classify(Path::new("/repo/omnigent/cli.py"), &ig), Ok(()));
+    }
+
+    #[test]
+    fn gitignored_python_file_is_skipped() {
+        let ig = ignore_with("omnigent/_build_info.py");
+        assert_eq!(
+            classify(Path::new("/repo/omnigent/_build_info.py"), &ig),
+            Err("gitignored")
+        );
+    }
+
+    #[test]
+    fn file_inside_gitignored_dir_is_skipped() {
+        // A directory rule must ignore everything beneath it, like git does.
+        let ig = ignore_with("build/");
+        assert_eq!(
+            classify(Path::new("/repo/omnigent/build/foo.py"), &ig),
+            Err("gitignored")
+        );
+    }
+
+    #[test]
+    fn non_python_file_is_skipped() {
+        let ig = ignore_with("omnigent/_build_info.py");
+        assert_eq!(
+            classify(Path::new("/repo/omnigent/notes.txt"), &ig),
+            Err("non-.py")
+        );
+    }
+
+    #[test]
+    fn pycache_file_is_skipped() {
+        let ig = ignore_with("omnigent/_build_info.py");
+        assert_eq!(
+            classify(Path::new("/repo/omnigent/__pycache__/cli.py"), &ig),
+            Err("__pycache__")
+        );
+    }
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- **Reload watcher: skip gitignored files.** The pod supervisor reloaded the backend on every `*.py` change under `omnigent/`, including gitignored files the build regenerates (notably `omnigent/_build_info.py`), causing needless reloads. It now builds a gitignore matcher from the repo's root `.gitignore` and `.git/info/exclude` and skips ignored paths — including files inside ignored directories (`build/`, `dist/`, `*.egg-info/`, …), matching git.
- **`--debug` flag.** Logs every observed file change into the combined pane as `watch: reload trigger <path>` or `watch: skip <path> (<reason>)`, so it's clear which change triggered (or didn't trigger) a reload. Quiet by default.
- **Pager log panes.** Per-process log panes are now a `less`-style pager with line/half/full-page movement, top/bottom jumps, follow-tail, line wrap, and forward/back incremental search (see the README Keys table).

## Test Plan

- `cargo build`, `cargo clippy --all-targets`, `cargo fmt --check` — clean.
- `cargo test` — passes single-threaded (the parallel-only flake in `create_skips_seed_when_real_config_absent` is a pre-existing env-var race in pod.rs, unrelated to this change).
- Verified `classify()` against the real repo `.gitignore`: `omnigent/cli.py` and `omnigent/inner/foo.py` reload; `_build_info.py`, `build/`, `*.egg-info/`, and `server/static/web-ui/` are skipped as gitignored; `__pycache__` and non-`.py` are skipped.
- `omnidev --help` shows the new `--debug` flag.

## Demo

N/A — pager-pane UI recording to be attached on the PR.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Watcher classification is covered by unit tests in `watcher.rs` (.py filter, `__pycache__`, gitignored file, file inside a gitignored dir). The gitignore behavior was additionally verified against the real repo `.gitignore`, and the `--debug`/pager panes were checked manually — the interactive TUI has no automated harness.
