### PR TITLE
refactor(hindsight): rename memory extra to hindsight; gate tools on SDK

### DIFF
--- a/examples/remy/config.yaml
+++ b/examples/remy/config.yaml
@@ -8,7 +8,7 @@
 # Memory is keyed by the agent id, so all of Remy's runs share one memory bank.
 #
 # Setup:
-#   pip install 'omnigent[memory]'
+#   pip install 'omnigent[hindsight]'
 #   export HINDSIGHT_API_KEY=hsk_...        # https://ui.hindsight.vectorize.io
 #
 # Usage:

--- a/omnigent/onboarding/agent/tools/python/list_builtin_tools.py
+++ b/omnigent/onboarding/agent/tools/python/list_builtin_tools.py
@@ -19,9 +19,6 @@ from omnigent_client import tool
 _TOOL_CLASSES: dict[str, tuple[str, str]] = {
     "download_file": ("omnigent.tools.builtins.download_file", "DownloadFileTool"),
     "export_agent": ("omnigent.tools.builtins.export_agent", "ExportAgentTool"),
-    "hindsight_recall": ("omnigent.tools.builtins.hindsight", "HindsightRecallTool"),
-    "hindsight_reflect": ("omnigent.tools.builtins.hindsight", "HindsightReflectTool"),
-    "hindsight_retain": ("omnigent.tools.builtins.hindsight", "HindsightRetainTool"),
     "list_files": ("omnigent.tools.builtins.list_files", "ListFilesTool"),
     "search_conversations": (
         "omnigent.tools.builtins.search_conversations",
@@ -31,6 +28,25 @@ _TOOL_CLASSES: dict[str, tuple[str, str]] = {
     "web_fetch": ("omnigent.tools.builtins.web_fetch", "WebFetchTool"),
     "web_search": ("omnigent.tools.builtins.web_search", "WebSearchTool"),
 }
+
+
+def _hindsight_available() -> bool:
+    """Return True when the optional ``hindsight-client`` SDK is installed."""
+    import importlib.util
+
+    return importlib.util.find_spec("hindsight_client") is not None
+
+
+# Hindsight memory tools (optional ``hindsight`` extra). Advertised only when
+# the SDK is installed, so the assistant never recommends unusable tools.
+if _hindsight_available():
+    _TOOL_CLASSES.update(
+        {
+            "hindsight_retain": ("omnigent.tools.builtins.hindsight", "HindsightRetainTool"),
+            "hindsight_recall": ("omnigent.tools.builtins.hindsight", "HindsightRecallTool"),
+            "hindsight_reflect": ("omnigent.tools.builtins.hindsight", "HindsightReflectTool"),
+        }
+    )
 
 
 @tool

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -168,25 +168,17 @@ def _create_export_agent(config: dict[str, str]) -> Tool:
     return ExportAgentTool()
 
 
-def _require_hindsight() -> None:
+def _hindsight_available() -> bool:
     """
-    Validate that the Hindsight client SDK is installed.
+    Return ``True`` if the optional ``hindsight-client`` SDK is installed.
 
-    ``hindsight-client`` is an optional dependency (the ``memory`` extra),
-    so the memory tools probe for it at construction time and fail with an
-    actionable message rather than an opaque ImportError mid-run. Mirrors the
-    Modal sandbox launcher's ``_ensure_sdk``.
-
-    :raises ImportError: When ``hindsight-client`` is not installed.
+    Probes via :func:`importlib.util.find_spec` (not ``import``) so the check
+    never loads the SDK or its transitive deps — they stay lazy until a
+    Hindsight tool is actually constructed.
     """
-    try:
-        import hindsight_client  # noqa: F401  # presence probe only
-    except ImportError as exc:
-        raise ImportError(
-            "The 'hindsight-client' SDK is required for the Hindsight memory "
-            "tools (hindsight_retain / hindsight_recall / hindsight_reflect). "
-            "Install it with `pip install 'omnigent[memory]'`."
-        ) from exc
+    import importlib.util
+
+    return importlib.util.find_spec("hindsight_client") is not None
 
 
 def _create_hindsight_retain(config: dict[str, str]) -> Tool:
@@ -196,7 +188,6 @@ def _create_hindsight_retain(config: dict[str, str]) -> Tool:
     :param config: Tool config (Hindsight api_key, bank_id, etc.).
     :returns: A HindsightRetainTool instance.
     """
-    _require_hindsight()
     from omnigent.tools.builtins.hindsight import HindsightRetainTool
 
     return HindsightRetainTool(config=config)
@@ -209,7 +200,6 @@ def _create_hindsight_recall(config: dict[str, str]) -> Tool:
     :param config: Tool config (Hindsight api_key, bank_id, etc.).
     :returns: A HindsightRecallTool instance.
     """
-    _require_hindsight()
     from omnigent.tools.builtins.hindsight import HindsightRecallTool
 
     return HindsightRecallTool(config=config)
@@ -222,7 +212,6 @@ def _create_hindsight_reflect(config: dict[str, str]) -> Tool:
     :param config: Tool config (Hindsight api_key, bank_id, etc.).
     :returns: A HindsightReflectTool instance.
     """
-    _require_hindsight()
     from omnigent.tools.builtins.hindsight import HindsightReflectTool
 
     return HindsightReflectTool(config=config)
@@ -250,11 +239,6 @@ _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     "download_file": _create_download_file,
     "search_conversations": _create_search_conversations,
     "export_agent": _create_export_agent,
-    # Hindsight long-term memory (optional ``memory`` extra). Each factory
-    # probes for ``hindsight-client`` and fails with an install hint if absent.
-    "hindsight_retain": _create_hindsight_retain,
-    "hindsight_recall": _create_hindsight_recall,
-    "hindsight_reflect": _create_hindsight_reflect,
     # Framework-owned: need runtime context. ``web_fetch`` is
     # constructed by ToolManager before reaching this registry.
     # ``list_comments`` and ``update_comment`` are auto-registered by
@@ -290,6 +274,18 @@ _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     "browser_type": None,
     "browser_screenshot": None,
 }
+
+# Hindsight long-term memory (optional ``hindsight`` extra). Registered only
+# when ``hindsight-client`` is installed, so the tools are absent from the
+# builtin list on installs without the extra.
+if _hindsight_available():
+    _BUILTIN_REGISTRY.update(
+        {
+            "hindsight_retain": _create_hindsight_retain,
+            "hindsight_recall": _create_hindsight_recall,
+            "hindsight_reflect": _create_hindsight_reflect,
+        }
+    )
 
 # Canonical set of every reserved builtin name. Derived from
 # the registry so there is a single source of truth — no drift

--- a/omnigent/tools/builtins/hindsight.py
+++ b/omnigent/tools/builtins/hindsight.py
@@ -3,7 +3,7 @@
 Exposes Hindsight's retain / recall / reflect operations as three built-in
 tools so an agent can persist and recall memory across runs. Hindsight
 (https://github.com/vectorize-io/hindsight) is an open-source agent-memory
-system; the client SDK is an optional dependency (``omnigent[memory]``).
+system; the client SDK is an optional dependency (``omnigent[hindsight]``).
 
 The memory bank is resolved per invocation from the agent spec config, falling
 back to the run's identity in :class:`ToolContext` — so a single declaration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ cursor = ["cursor-sdk>=0.1.7"]
 # Hindsight long-term memory built-in tools (hindsight_retain / _recall /
 # _reflect). The tools import the client lazily, so only users who enable a
 # Hindsight memory tool need this extra.
-memory = ["hindsight-client>=0.4.0"]
+hindsight = ["hindsight-client>=0.4.0"]
 databricks = [
     # Floor matches what core code was tested against when the SDK was a
     # default dependency (it moved here from `dependencies` above).
@@ -207,7 +207,7 @@ databricks = [
 ]
 dev = [
     "pytest>=7.0",
-    # hindsight-client is opt-in (the `memory` extra), but the Hindsight
+    # hindsight-client is opt-in (the `hindsight` extra), but the Hindsight
     # memory tool tests import + mock it, so keep it in the dev set.
     "hindsight-client>=0.4.0",
     "pytest-asyncio>=0.21",
@@ -578,8 +578,8 @@ ignore_missing_imports = true
 module = "daytona.*"
 ignore_missing_imports = true
 
-# hindsight-client is an optional dep (the `memory` extra); the memory
-# built-in tools import it lazily so the base install never needs it.
+# hindsight-client is an optional dep (the `hindsight` extra); the
+# hindsights tools import it lazily so the base install never needs it.
 [[tool.mypy.overrides]]
 module = "hindsight_client.*"
 ignore_missing_imports = true

--- a/tests/tools/builtins/test_hindsight.py
+++ b/tests/tools/builtins/test_hindsight.py
@@ -224,3 +224,46 @@ def test_client_exception_is_caught(tool_ctx: ToolContext) -> None:
     with patch("hindsight_client.Hindsight", return_value=client):
         result = tool.invoke(json.dumps({"query": "q"}), tool_ctx)
     assert result.startswith("Hindsight recall failed:")
+
+
+# ---------------------------------------------------------------------------
+# Optional-extra gating
+# ---------------------------------------------------------------------------
+
+
+def test_hindsight_tools_absent_from_registry_when_sdk_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the ``hindsight-client`` SDK the Hindsight tools are not
+    registered — absent from ``BUILTIN_NAMES`` / ``INSTANTIABLE_BUILTINS`` and
+    not instantiable — so they never appear as available builtins on an
+    install without the ``hindsight`` extra.
+
+    ``_hindsight_available`` probes via :func:`importlib.util.find_spec` (no
+    import), so the package is hidden from the finder and the registry module
+    reloaded to observe the gated rebuild.
+    """
+    import importlib
+    import importlib.util
+    from importlib.machinery import ModuleSpec
+
+    import omnigent.tools.builtins as builtins_mod
+
+    real_find_spec = importlib.util.find_spec
+
+    def hide_hindsight(name: str, package: str | None = None) -> ModuleSpec | None:
+        if name == "hindsight_client":
+            return None
+        return real_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", hide_hindsight)
+    importlib.reload(builtins_mod)
+    try:
+        assert "hindsight_retain" not in builtins_mod.BUILTIN_NAMES
+        assert "hindsight_recall" not in builtins_mod.BUILTIN_NAMES
+        assert "hindsight_reflect" not in builtins_mod.BUILTIN_NAMES
+        assert "hindsight_retain" not in builtins_mod.INSTANTIABLE_BUILTINS
+        assert builtins_mod.get_builtin_tool("hindsight_retain", _cfg()) is None
+    finally:
+        monkeypatch.undo()
+        importlib.reload(builtins_mod)

--- a/uv.lock
+++ b/uv.lock
@@ -3010,7 +3010,7 @@ requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0,<3" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.68,<2" },
     { name = "hindsight-client", marker = "extra == 'dev'", specifier = ">=0.4.0" },
-    { name = "hindsight-client", marker = "extra == 'memory'", specifier = ">=0.4.0" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = ">=0.4.0" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "islo", marker = "extra == 'islo'", specifier = ">=0.3.5,<0.4" },
     { name = "keyring", specifier = ">=24,<26" },

--- a/uv.lock
+++ b/uv.lock
@@ -2956,14 +2956,14 @@ dev = [
 e2b = [
     { name = "e2b" },
 ]
+hindsight = [
+    { name = "hindsight-client" },
+]
 islo = [
     { name = "islo" },
 ]
 kubernetes = [
     { name = "kubernetes" },
-]
-memory = [
-    { name = "hindsight-client" },
 ]
 modal = [
     { name = "modal" },
@@ -3067,7 +3067,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=10.4,<15" },
     { name = "zstandard", specifier = ">=0.22,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "tracing", "agents-sdk", "antigravity", "copilot", "cursor", "memory", "databricks", "dev"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "tracing", "agents-sdk", "antigravity", "copilot", "cursor", "hindsight", "databricks", "dev"]
 
 [[package]]
 name = "omnigent-client"


### PR DESCRIPTION
## Related issue
N/A

## Summary
- Rename the optional install extra `memory` -> `hindsight` (the extra that
  pulls `hindsight-client` for the Hindsight long-term memory tools), so the
  extra name matches the tools it enables. Updates `pyproject.toml`,
  `uv.lock`, the install hint, docstrings, and `examples/remy/config.yaml`.
- Hide the three Hindsight tools from the builtin list when
  `hindsight-client` is not installed: they're now absent from
  `BUILTIN_NAMES` / `INSTANTIABLE_BUILTINS` and not instantiable, and the
  onboarding `list_builtin_tools` helper no longer advertises them. The
  presence probe uses `importlib.util.find_spec` so the SDK and its deps
  (aiohttp, ...) stay lazy.

## Test Plan
- `ruff format` + `ruff check` clean; `pre-commit run` passes on all changed
  files (including the `normalize-uv-lock-registry` hook).
- `pytest tests/tools/builtins/test_hindsight.py
  tests/tools/builtins/test_registry_unified.py tests/spec/test_validator.py`
  -> 79 passed; full `tests/tools tests/spec tests/onboarding` -> green (one
  unrelated `databricks_sdk_installed` failure was an env artifact from running
  `--extra dev` instead of `--extra all`; passes with `--extra all`).
- New `test_hindsight_tools_absent_from_registry_when_sdk_missing` hides
  `hindsight_client` from the finder, reloads the registry, asserts the tools
  are absent + not instantiable, and restores the finder in `finally` (no
  state leakage — verified by running it before the registry-size test).

## Demo
N/A

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage
- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes
The extra rename is exercised by the existing registry-size test (which lists
the hindsight names) and the lock line. The gating is covered by the new unit
test. Manually verified `_hindsight_available()` returns True with the SDK and
False when hidden from the finder, in both the registry and the onboarding
helper.

## Changelog
`omnigent[memory]` is renamed to `omnigent[hindsight]`; the Hindsight memory
tools are now hidden from the builtin list when `hindsight-client` is not
installed.

