### PR TITLE
fix(cli): hide sessions from host status by default

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7841,12 +7841,14 @@ def _echo_daemon_payloads(payloads: list[_HostPayload]) -> None:
 @host.command("status")
 @click.option("--server", default=None, help="Inspect only this server target.")
 @click.option("--all", "all_targets", is_flag=True, help="Inspect all known daemon targets.")
+@click.option("--sessions", is_flag=True, help="Include session table.")
 @click.option("--json", "json_output", is_flag=True, help="Emit JSON.")
 @click.pass_context
 def host_status(
     ctx: click.Context,
     server: str | None,
     all_targets: bool,
+    sessions: bool,
     json_output: bool,
 ) -> None:
     """
@@ -7856,6 +7858,7 @@ def host_status(
     :param server: Optional server target to inspect, e.g.
         ``"https://example.databricksapps.com"``.
     :param all_targets: Whether to inspect every known daemon target.
+    :param sessions: Whether to include the session table.
     :param json_output: Whether to emit machine-readable JSON.
     """
     if server is None:
@@ -7864,7 +7867,7 @@ def host_status(
     payloads = [
         _daemon_status_payload(
             record,
-            include_sessions=True,
+            include_sessions=sessions,
             connected_sessions_only=True,
         )
         for record in records

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -994,7 +994,7 @@ def test_host_status_json_reports_daemon_host_and_sessions(
 
     monkeypatch.setattr(cli, "_host_http_json", _fake_http_json)
 
-    result = CliRunner().invoke(cli_group, ["host", "status", "--json"])
+    result = CliRunner().invoke(cli_group, ["host", "status", "--json", "--sessions"])
 
     assert result.exit_code == 0, result.output
     assert '"target": "https://server.example.com"' in result.output


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `omnigent host status` was slow because it fetched all sessions and made one sequential HTTP request per unique runner to check online status, each with a 10 s timeout.
- Sessions are now hidden by default. Pass `--sessions` to include the session table (and accept the extra latency).

## Test Plan

```
# Fast — no session fetching
omnigent host status --server http://localhost:6767

# Opt in to sessions
omnigent host status --server http://localhost:6767 --sessions
```

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

Verified locally: default invocation returns immediately; `--sessions` restores the old behaviour.

## Changelog

`omnigent host status` now hides the session table by default (use `--sessions` to show it), making the command significantly faster.