### PR TITLE
feat(desktop): add deep link omnigent://

### DIFF
--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -653,6 +653,59 @@ windows get the same per-window origin pinning as regular ones. With windows
 on more than one server, the dock badge shows the sum of each server's unread
 count and notification titles are prefixed with the firing server's hostname.
 
+## Deep links
+
+An `omnigent://<hostname>/c/<session_id>` URL opens that session on that
+server in the desktop app — the way a browser deep link opens a page:
+
+```
+omnigent://localhost:8000/c/conv_abc              → http://localhost:8000/c/conv_abc
+omnigent://my-workspace.cloud.databricks.com/c/x → https://…/ml/omnigents/c/x
+```
+
+The link names a server by **host** (with port if non-default) and carries no
+`http`/`https` — the shell infers the scheme with the same rule the setup page
+uses (`http` for loopback, `https` for a remote host), so a deep link and a
+pasted URL can never disagree. The Databricks workspace mount (`/ml/omnigents`)
+is **not** in the link; it is server-determined and discovered the same way a
+pasted workspace URL is. v1 accepts only `/c/<session_id>`; other paths are
+ignored.
+
+**Window handling** (the careful part):
+
+- A window already open on that server and currently on its page is **reused
+  in place** — the shell tells the SPA's router to navigate to the conversation
+  without a reload, so the in-flight stream isn't dropped. (Same basename-less
+  `/c/<id>` path a notification click routes.)
+- A window pinned to that server but mid-SSO-redirect (off the server origin)
+  is **reused with a reload** to the conversation, since the SPA's listener
+  isn't reliably mounted on a foreign IdP page.
+- A server you've **previously connected to** (in the recent-servers list or
+  the saved default) but have no live window for opens in a **new window** —
+  no prompt, the way a second tab for a known site would.
+- A server you have **never connected to** prompts with a native confirmation
+  dialog (Cancel is the default). Pinning a new origin is a privilege grant
+  (notifications, badge, mic), so a clicked link never silently pins an
+  attacker-chosen origin; once you allow it, the server is remembered so the
+  next link is frictionless.
+
+**Cold start vs warm start.** On macOS, `open-url` fires for the link and can
+arrive **before** the app is ready, so pre-ready links are queued and drained
+once the windows exist. On Windows/Linux, a second launch carrying the URL is
+funneled to the running instance by the single-instance lock. Links are
+handled one at a time, so two arriving together can't race two consent
+dialogs. At cold start the deep link replaces the default launch window; if you
+cancel an unknown-server prompt, a normal launch window opens instead.
+
+**Registration.** The scheme is registered two ways: the build manifest
+(`build.protocols` in `package.json`, which writes `CFBundleURLSchemes` on
+macOS, a `.desktop` `MimeType` on Linux, and registry entries on Windows) for
+packaged installs, plus a runtime `app.setAsDefaultProtocolClient("omnigent")`
+call so `electron .` dev clicks route to the running dev instance.
+
+The decision logic (parse + window selection) is pure and unit-tested in
+`src/deepLink.js`; the orchestration lives in `src/main.js`.
+
 ## Implementation notes
 
 - **Runtime:** bundled Chromium (so the build is ~100+ MB, but the renderer

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -34,6 +34,14 @@
     "directories": {
       "output": "dist"
     },
+    "protocols": [
+      {
+        "name": "Omnigent session link",
+        "schemes": [
+          "omnigent"
+        ]
+      }
+    ],
     "publish": [
       {
         "provider": "github",

--- a/web/electron/src/deepLink.js
+++ b/web/electron/src/deepLink.js
@@ -1,0 +1,132 @@
+// Deep-link decision logic for the desktop shell, kept PURE (no Electron) so
+// it unit-tests without a BrowserWindow. main.js owns the wiring (ingestion
+// from open-url / second-instance / argv, the queue, and the orchestrator
+// that acts on these decisions); see README "Deep links".
+//
+// An `omnigent://<hostname>/c/<session_id>` URL names a server by host (with
+// port if non-default) and a conversation by the SPA's own `/c/:id` route.
+// The link carries no http/https scheme — we infer it with the SAME rule the
+// setup page uses (defaultSchemeFor: http for loopback, https for remote),
+// so a deep link and a pasted URL can never disagree on scheme. The
+// workspace mount (`/ml/omnigents`) is deliberately NOT in the link: it is
+// server-determined and discovered by expandDatabricksWorkspaceUrl, exactly
+// as for a pasted workspace URL.
+
+"use strict";
+
+const { defaultSchemeFor } = require("./url");
+
+/**
+ * v1 accepted SPA path. `/c/<conversationId>` — a single path segment after
+ * `/c/`, with an optional trailing slash. Anything else (other routes,
+ * nested paths, empty id) is dropped silently: an unrecognized deep link
+ * must never crash or mis-navigate, and the SPA's own router stays the
+ * authority on what a valid conversation id is.
+ */
+const DEEP_LINK_PATH_RE = /^\/c\/[^/]+\/?$/;
+
+/**
+ * Parse an `omnigent://` deep link into a server origin + an in-app path.
+ *
+ * The origin is the http(s) origin inferred from the link's host (loopback →
+ * http, else https), normalized via normalizeUrl. The path is the SPA
+ * conversation route (`/c/<id>`), basename-less — the same shape the SPA
+ * already emits for notification `navigatePath`, so the embedded
+ * (workspace) build's `basenamedRouting` rebases it under the mount.
+ *
+ * @param {string} raw e.g. ``"omnigent://localhost:8000/c/conv_abc"``.
+ * @returns {{ origin: string, path: string } | null} ``null`` for anything
+ *   that isn't a valid `omnigent://.../c/<id>` link (wrong scheme, no host,
+ *   non-`/c/` path, unparseable input).
+ */
+function parseOmnigentDeepLink(raw) {
+  let url;
+  try {
+    url = new URL(String(raw ?? ""));
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "omnigent:") return null;
+  // No host → a bare `omnigent://` or `omnigent:`; nothing to connect to.
+  if (url.host === "") return null;
+  const path = url.pathname;
+  if (!DEEP_LINK_PATH_RE.test(path)) return null;
+  // Infer the http(s) scheme from the host the same way the setup page does,
+  // so a deep link to `localhost` is http and to a remote host is https. The
+  // origin is returned in `new URL(...).origin` form (NO trailing slash) so it
+  // matches `originOf()` everywhere else in the shell — a trailing slash here
+  // would make findKnownServerUrl/knownOrigins miss every known server and
+  // force a wasteful network probe for already-connected workspaces.
+  const scheme = defaultSchemeFor(url.host);
+  let origin;
+  try {
+    origin = new URL(`${scheme}://${url.host}`).origin;
+  } catch {
+    return null;
+  }
+  return { origin, path };
+}
+
+/**
+ * Decide how to open a deep link given a snapshot of the live windows and
+ * the set of servers the user has previously trusted.
+ *
+ * The decision is the careful half of deep-link handling: a deep link is an
+ * "open THIS on THAT server" intent, so we prefer reusing a window already
+ * on that server (no second window, no dropped stream); fall back to
+ * opening a new window on a server the user already chose; and require
+ * explicit consent only for a server the user has NEVER connected to —
+ * because pinning a new origin is a privilege grant (notifications, badge,
+ * mic), and a clicked link must not silently pin an attacker-chosen origin.
+ *
+ * Each window snapshot carries:
+ *   - `origin`: the origin the window is PINNED to (null = setup page);
+ *   - `currentOrigin`: origin of the window's top-level page RIGHT NOW
+ *     (may differ from `origin` mid-SSO redirect on a foreign IdP page).
+ *
+ * @param {Object} state
+ * @param {string} state.targetOrigin The deep link's server origin.
+ * @param {{origin: string | null, currentOrigin: string | null}[]} state.windows
+ *   Live shell windows, in creation order.
+ * @param {string[]} state.knownOrigins Origins the user previously connected
+ *   to (origins of `recent_servers` ∪ {saved `server_url`}).
+ * @param {number | null} [state.focusedIndex] Index into `windows` of the
+ *   currently focused shell window, if any (preferred when several windows
+ *   are pinned to the target origin).
+ * @returns {{ strategy: "reuse-inplace", windowIndex: number }
+ *   | { strategy: "reuse-reload", windowIndex: number }
+ *   | { strategy: "open-known" }
+ *   | { strategy: "consent-unknown" }}
+ */
+function chooseDeepLinkStrategy(state) {
+  const { targetOrigin, windows, knownOrigins } = state;
+  const focusedIndex = state.focusedIndex ?? null;
+
+  // Windows pinned to the target origin — these already trust it.
+  const pinned = windows.map((w, i) => ({ w, i })).filter(({ w }) => w.origin === targetOrigin);
+
+  if (pinned.length > 0) {
+    // Prefer a window currently ON the origin: its SPA router listener is
+    // mounted, so we can navigate in-place without dropping the in-flight
+    // stream OR disrupting another window's auth flow. Focus only breaks ties
+    // AMONG on-origin windows (the user is looking at one of them). When every
+    // pinned window is mid-auth (off-origin), reload — but still prefer the
+    // focused one so a reload hits the window the user expects.
+    const onOrigin = pinned.filter(({ w }) => w.currentOrigin === targetOrigin);
+    if (onOrigin.length > 0) {
+      const pick = onOrigin.find(({ i }) => i === focusedIndex) ?? onOrigin[0];
+      return { strategy: "reuse-inplace", windowIndex: pick.i };
+    }
+    const pick = pinned.find(({ i }) => i === focusedIndex) ?? pinned[0];
+    return { strategy: "reuse-reload", windowIndex: pick.i };
+  }
+
+  // No live window on this server. A server the user already chose by hand
+  // needs no consent; a brand-new one does (pinning is a privilege grant).
+  if (Array.isArray(knownOrigins) && knownOrigins.includes(targetOrigin)) {
+    return { strategy: "open-known" };
+  }
+  return { strategy: "consent-unknown" };
+}
+
+module.exports = { parseOmnigentDeepLink, chooseDeepLinkStrategy, DEEP_LINK_PATH_RE };

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -34,6 +34,7 @@ const { pathToFileURL } = require("node:url");
 const { execFile } = require("node:child_process");
 const { registerLocalhostCors } = require("./localhost_cors");
 const { normalizeUrl, expandDatabricksWorkspaceUrl } = require("./url");
+const { parseOmnigentDeepLink, chooseDeepLinkStrategy } = require("./deepLink");
 const { registerWorkspaceChromeHide } = require("./workspace-chrome");
 const { createBrowserViewRegistry } = require("./browserViewRegistry");
 const { createBrowserViewBoundsController } = require("./browserViewBounds");
@@ -975,19 +976,65 @@ function hardenOauthPopup(child) {
 }
 
 /**
+ * Join a basename-less SPA path (e.g. ``/c/conv_abc``) onto a server URL that
+ * may carry a workspace mount (e.g. ``https://host/ml/omnigents/``). The path
+ * is an ABSOLUTE in-app route, but it lives UNDER the server's mount —
+ * ``new URL("/c/x", serverUrl)`` would resolve against the ORIGIN and drop
+ * ``/ml/omnigents`` — so we string-concatenate: strip the server URL's trailing
+ * slash, append the path. The SPA's react-router basename then matches
+ * ``${mount}/c/:id``. Shared by createWindow (cold open) and loadServerUrl
+ * (re-pointing an existing window) so the mount-aware join is in one place.
+ *
+ * @param {string} serverUrl A normalized server URL (origin or origin+mount).
+ * @param {string} path An absolute in-app path beginning with ``/``.
+ * @returns {string}
+ */
+function resolveServerPath(serverUrl, path) {
+  return serverUrl.replace(/\/+$/, "") + (path.startsWith("/") ? path : "/" + path);
+}
+
+/**
+ * Pin an existing window to a server origin and load a (optionally
+ * path-suffixed) URL. Shared by the deep-link reuse/reload paths so the
+ * pin + identity + load sequence isn't duplicated. ``serverUrl`` is stored as
+ * the window's CLEAN server identity (no conversation path); ``path`` is joined
+ * onto it only for the load URL (see resolveServerPath).
+ *
+ * @param {BrowserWindow} win
+ * @param {string} serverUrl Clean server URL (origin or origin+mount).
+ * @param {string} [path] Optional basename-less in-app path (e.g. ``/c/<id>``).
+ * @returns {Promise<void>}
+ */
+function loadServerUrl(win, serverUrl, path) {
+  pinWindow(win, originOf(serverUrl));
+  setWindowServerUrl(win, serverUrl);
+  return win.loadURL(path ? resolveServerPath(serverUrl, path) : serverUrl);
+}
+
+/**
  * Create a shell window and load a destination, in priority order:
- *   1. `targetUrl`, when given (used by "New Window" to clone the current
+ *   1. `opts.path` joined onto `opts.serverUrl` (a deep link opening a
+ *      specific conversation on a specific server).
+ *   2. `targetUrl`, when given (used by "New Window" to clone the current
  *      window's exact URL — e.g. a specific conversation).
- *   2. the saved server URL (the normal launch path).
- *   3. the bundled setup page (first run / no server configured).
+ *   3. the saved server URL (the normal launch path).
+ *   4. the bundled setup page (first run / no server configured).
+ *
+ * `opts.serverUrl` and `opts.path` decouple the window's server IDENTITY
+ * (clean, no conversation path — used by host/server CLI commands) from the
+ * loaded URL: a deep link loads ``${serverUrl}${path}`` but stores
+ * ``serverUrl`` without the ``/c/<id>`` (see resolveServerPath). Without an
+ * explicit ``opts.serverUrl``, the identity is the loaded URL, preserving the
+ * behavior of the existing New Window / launch callers.
  *
  * @param {string} [targetUrl] Explicit http(s) URL to load instead of the
  *   saved server. Anything not http(s) is ignored (we never load file:// or
  *   internal URLs from an untrusted caller).
- * @param {{ephemeral?: boolean}} [opts] ``ephemeral: true`` creates a debug
- *   multi-server window: it opens on the setup page (ignoring the saved
- *   server) and a URL connected from it is pinned to this window only,
- *   never persisted to settings.
+ * @param {{ephemeral?: boolean, serverUrl?: string, path?: string}} [opts]
+ *   ``ephemeral: true`` creates a debug multi-server window: it opens on the
+ *   setup page (ignoring the saved server) and a URL connected from it is
+ *   pinned to this window only, never persisted to settings. ``serverUrl`` +
+ *   ``path`` open a deep-link conversation (server identity vs. load URL).
  * @returns {BrowserWindow}
  */
 function createWindow(targetUrl, opts = {}) {
@@ -1026,21 +1073,36 @@ function createWindow(targetUrl, opts = {}) {
   const explicit =
     typeof targetUrl === "string" && /^https?:\/\//i.test(targetUrl) ? targetUrl : undefined;
   const saved = loadSettings().server_url;
-  // An explicit target (New Window cloning a sibling) always wins. Otherwise
-  // ephemeral windows start on the setup page so the user can enter the
-  // alternate server, and normal windows fall back to the saved server.
-  const candidate =
-    explicit ?? (ephemeral ? null : typeof saved === "string" && saved.length > 0 ? saved : null);
-  // A candidate that doesn't parse (hand-edited/corrupt settings.json) is
+  // serverUrl: the window's server IDENTITY for host/server CLI commands
+  // (``omnigent host --server``, ``omnigent login``, ``serverAuthed``) — the
+  // origin or origin+mount, WITHOUT the conversation path. Prefer an explicit
+  // override (deep link); else the explicit target (New Window cloning a
+  // sibling — preserves prior behavior); else the saved default for normal
+  // windows; else null (ephemeral windows start on the setup page).
+  const serverUrl =
+    (typeof opts.serverUrl === "string" && opts.serverUrl.length > 0 ? opts.serverUrl : null) ??
+    explicit ??
+    (ephemeral ? null : typeof saved === "string" && saved.length > 0 ? saved : null);
+  // loadUrl: what the webContents actually loads. A deep-link path resolves
+  // under the server URL (mount-aware — see resolveServerPath); an explicit
+  // target (New Window) loads that exact URL; otherwise load the server URL.
+  const loadUrl =
+    (typeof opts.path === "string" && opts.path.length > 0 && serverUrl
+      ? resolveServerPath(serverUrl, opts.path)
+      : null) ??
+    explicit ??
+    serverUrl;
+  // A serverUrl that doesn't parse (hand-edited/corrupt settings.json) is
   // treated as "no server configured" rather than crashing window creation.
-  const destinationOrigin = candidate ? originOf(candidate) : null;
-  const destination = destinationOrigin ? candidate : null;
+  const destinationOrigin = serverUrl ? originOf(serverUrl) : null;
+  const destination = destinationOrigin ? loadUrl : null;
   windows.set(win, {
     // Pin to the destination's origin up front; setup-page windows stay
     // unpinned (null) until the user connects them.
     origin: destinationOrigin,
-    // Full connected URL (incl. any path) for host/server CLI commands.
-    serverUrl: destination,
+    // Clean server identity (no conversation path) for host/server CLI
+    // commands; ``loadUrl`` (possibly /c/<id>) is what gets loaded below.
+    serverUrl: destination ? serverUrl : null,
     ephemeral,
     badgeCount: 0,
     // Per-conversation embedded-browser view registry for this window.
@@ -1053,11 +1115,11 @@ function createWindow(targetUrl, opts = {}) {
     // WindowState is the source of truth for persistence behavior).
     const search = new URLSearchParams();
     if (ephemeral) search.set("ephemeral", "1");
-    if (candidate && !destinationOrigin) {
+    if (serverUrl && !destinationOrigin) {
       // Fail loud on a corrupt hand-edited settings.json: show WHY the
       // window landed on setup instead of silently presenting a blank form.
       search.set("error", "saved server URL in settings.json is not a valid URL");
-      search.set("url", candidate);
+      search.set("url", serverUrl);
     }
     void win.loadFile(SETUP_PAGE, search.size > 0 ? { search: search.toString() } : undefined);
   }
@@ -2357,6 +2419,307 @@ function registerIpc() {
 }
 
 // ---------------------------------------------------------------------------
+// Deep links (`omnigent://<hostname>/c/<session_id>`)
+//
+// An OS-clicked `omnigent://` URL opens the named session on the named server.
+// The decision logic (parse + window selection) is PURE in src/deepLink.js and
+// unit-tested there; this section owns ingestion, the queue, and the
+// orchestrator. See README "Deep links".
+//
+// Ingestion: macOS fires `open-url` (which can precede app.whenReady),
+// Windows/Linux funnel a second launch through `second-instance` (argv), and a
+// cold-start first instance also carries the URL in process.argv. All three
+// push onto one queue drained SERIALIZED (one link at a time) so two links
+// can't race two consent dialogs or two windows onto the same origin.
+// ---------------------------------------------------------------------------
+
+/**
+ * Full server URL (origin, or origin+mount) of a server the user previously
+ * connected to, whose origin matches `origin`; null when none. Reusing the
+ * recorded URL means a deep link to a KNOWN workspace server opens WITHOUT the
+ * network probe — the mount is already in the saved URL. Used both to detect
+ * "known" (for the consent gate) and to skip probe-based expansion.
+ *
+ * @param {string} origin e.g. ``"https://my-workspace.cloud.databricks.com"``.
+ * @returns {string | null}
+ */
+function findKnownServerUrl(origin) {
+  const settings = loadSettings();
+  /** @type {string[]} */
+  const candidates = [];
+  if (typeof settings.server_url === "string") candidates.push(settings.server_url);
+  if (Array.isArray(settings.recent_servers)) {
+    for (const u of settings.recent_servers) if (typeof u === "string") candidates.push(u);
+  }
+  for (const u of candidates) {
+    if (originOf(u) === origin) return u;
+  }
+  return null;
+}
+
+/**
+ * Origins of every server the user previously connected to (saved default +
+ * recent servers). The set used to tell a known server (open without consent)
+ * from a never-connected one (ask consent — pinning is a privilege grant).
+ *
+ * @returns {string[]}
+ */
+function knownOrigins() {
+  const settings = loadSettings();
+  /** @type {Set<string>} */
+  const origins = new Set();
+  if (typeof settings.server_url === "string") {
+    const o = originOf(settings.server_url);
+    if (o) origins.add(o);
+  }
+  if (Array.isArray(settings.recent_servers)) {
+    for (const u of settings.recent_servers) {
+      if (typeof u === "string") {
+        const o = originOf(u);
+        if (o) origins.add(o);
+      }
+    }
+  }
+  return [...origins];
+}
+
+/**
+ * Record a server URL at the head of the persisted recent-servers list (a
+ * user who just consented to a deep link to a new server should not have to
+ * consent again next time). Does NOT overwrite the saved default server — a
+ * clicked link never changes which server you land on at launch.
+ *
+ * @param {string} serverUrl
+ */
+function rememberServerUrl(serverUrl) {
+  const settings = loadSettings();
+  rememberRecentServer(settings, serverUrl);
+  saveSettings(settings);
+}
+
+/**
+ * Restore (if minimized) and focus a window. No-op when absent/destroyed.
+ *
+ * @param {BrowserWindow | null | undefined} win
+ */
+function focusAndRestore(win) {
+  if (!win || win.isDestroyed()) return;
+  if (win.isMinimized()) win.restore();
+  win.focus();
+}
+
+/**
+ * Tell a pinned window's SPA to navigate in-place to an in-app path
+ * (`/c/<id>`), without a reload — reuses the SPA's router, the same path a
+ * notification click routes (basename-less; the embedded build's
+ * `basenamedRouting` rebases it under the mount). Main→renderer only; the page
+ * cannot invoke it. The caller (reuse-inplace) only sends when the window's
+ * top-level page IS the pinned server (SPA listener mounted); this is
+ * defense-in-depth on top of that.
+ *
+ * @param {BrowserWindow | null | undefined} win
+ * @param {string} path
+ */
+function sendOpenPath(win, path) {
+  if (!win || win.isDestroyed()) return;
+  console.log(`[omnigent] deep-link: send open-path ${path}`);
+  try {
+    win.webContents.send("omnigent:open-path", path);
+  } catch {
+    // Window torn down between the check and the send; ignore.
+  }
+}
+
+/**
+ * Native, main-process confirmation before opening a deep link to a server
+ * the user has NEVER connected to — because pinning a new origin is a
+ * privilege grant (notifications, badge, mic), and a clicked link must not
+ * silently pin an attacker-chosen origin. Mirrors confirmHostEnrollment /
+ * confirmExternalProtocol: Cancel is the safe default, the full origin is
+ * shown so the user can see exactly what they'd connect to. The conversation
+ * id is NOT shown (it's an opaque server-owned identifier; the server is the
+ * trust decision, not the path).
+ *
+ * @param {BrowserWindow} parent The window to parent the dialog on.
+ * @param {string} targetOrigin The server origin to connect to.
+ * @returns {Promise<boolean>} True when the user chose Open.
+ */
+async function confirmOpenDeepLink(parent, targetOrigin) {
+  let host = targetOrigin;
+  try {
+    host = new URL(targetOrigin).host || targetOrigin;
+  } catch {
+    // Keep the full origin string if it somehow doesn't parse.
+  }
+  const icon = nativeImage.createFromPath(ICON_PNG);
+  const { response } = await dialog.showMessageBox(parent, {
+    type: "warning",
+    icon: icon.isEmpty() ? undefined : icon,
+    title: "Omnigent",
+    message: `Open this Omnigent link?`,
+    detail:
+      `This link will connect Omnigent to ${host} and open a conversation.\n\n` +
+      `Only open links from a server you trust — once connected, it can show ` +
+      `notifications and (when you allow it) manage this machine as a runner.`,
+    buttons: ["Cancel", "Open"],
+    defaultId: 0, // Cancel is the safe default
+    cancelId: 0,
+    noLink: true,
+  });
+  return response === 1;
+}
+
+/** Deep links awaiting handling, in arrival order. */
+const pendingDeepLinks = [];
+/** True while a deep link is being handled — the drain runs one at a time. */
+let deepLinkInFlight = false;
+
+/**
+ * Queue a deep link for handling. Unrecognized links (parseOmnigentDeepLink
+ * null) are dropped here so they never reach the queue. Draining is a no-op
+ * before app.whenReady (see drainPendingDeepLinks) — `open-url` can fire
+ * pre-ready on macOS, and the cold-start argv scan runs at lock time.
+ *
+ * @param {string} raw
+ */
+function enqueueDeepLink(raw) {
+  if (!parseOmnigentDeepLink(raw)) {
+    console.log(`[omnigent] deep-link: ignored unrecognized URL ${String(raw)}`);
+    return;
+  }
+  console.log(`[omnigent] deep-link: queued ${raw} (ready=${app.isReady()})`);
+  pendingDeepLinks.push(raw);
+  drainPendingDeepLinks();
+}
+
+/**
+ * Handle queued deep links one at a time. No-ops before app.isReady() (the
+ * whenReady block drains once setup is done). After a link is handled, if no
+ * window ended up open (e.g. consent was cancelled at cold start) it opens the
+ * default launch window so the app is never left windowless.
+ */
+function drainPendingDeepLinks() {
+  if (!app.isReady()) return; // queue until ready; whenReady drains
+  if (deepLinkInFlight) return;
+  const next = pendingDeepLinks.shift();
+  if (next === undefined) return;
+  deepLinkInFlight = true;
+  void handleDeepLink(next)
+    .catch((err) => console.warn("[omnigent] deep-link handling failed:", err))
+    .finally(() => {
+      deepLinkInFlight = false;
+      if (pendingDeepLinks.length > 0) {
+        drainPendingDeepLinks();
+      } else if (BrowserWindow.getAllWindows().length === 0) {
+        // A cancelled consent at cold start left no window — open the default.
+        createWindow();
+      }
+    });
+}
+
+/**
+ * Open an `omnigent://` deep link on the right window. The window-selection
+ * decision (reuse an existing window on that server in-place vs. reload it vs.
+ * open a new one vs. ask consent for an unknown server) is made by the PURE
+ * chooseDeepLinkStrategy(); this orchestrator snapshots the live windows and
+ * executes the decision. Serialized by drainPendingDeepLinks.
+ *
+ * No pre-consent network request. The decision runs on `parsed.origin`, which
+ * the link itself fixes (no fetch). A KNOWN server's recorded URL (already
+ * mount-bearing) is reused as-is. The workspace mount probe
+ * (expandDatabricksWorkspaceUrl) runs ONLY after the user consents to an
+ * UNKNOWN server — so clicking (or the OS dispatching) a link to an
+ * attacker-chosen host makes no HTTP request until the user has agreed. The
+ * probe is safe post-consent because it can only append a path (`/ml/omnigents`)
+ * under the SAME origin — it never changes the origin the user approved.
+ *
+ * @param {string} raw The raw `omnigent://...` URL.
+ * @returns {Promise<void>}
+ */
+async function handleDeepLink(raw) {
+  const parsed = parseOmnigentDeepLink(raw);
+  if (!parsed) return;
+
+  // The origin is fixed by the link itself — no network request needed for the
+  // decision. expandDatabricksWorkspaceUrl only appends a mount path under this
+  // same origin, so approving the origin is approving the server.
+  const targetOrigin = parsed.origin;
+  // A KNOWN server: reuse its recorded URL (already mount-bearing, e.g.
+  // `https://host/ml/omnigents`) so we SKIP the probe entirely. null for an
+  // unknown server — the mount is discovered AFTER consent (see consent-unknown).
+  const known = findKnownServerUrl(targetOrigin);
+
+  // Snapshot the live windows (creation order) for the pure decision.
+  const winList = [...windows.keys()];
+  const focused = BrowserWindow.getFocusedWindow();
+  const focusedIndex = focused && windows.has(focused) ? winList.indexOf(focused) : -1;
+  const decision = chooseDeepLinkStrategy({
+    targetOrigin,
+    windows: winList.map((win) => ({
+      origin: windows.get(win).origin,
+      currentOrigin: win.isDestroyed() ? null : originOf(win.webContents.getURL()),
+    })),
+    knownOrigins: knownOrigins(),
+    focusedIndex: focusedIndex < 0 ? null : focusedIndex,
+  });
+  console.log(
+    `[omnigent] deep-link: strategy=${decision.strategy} ` +
+      `target=${targetOrigin} known=${known ? "yes" : "no"} ` +
+      `windows=${winList.length}`,
+  );
+
+  switch (decision.strategy) {
+    case "reuse-inplace": {
+      const win = winList[decision.windowIndex];
+      focusAndRestore(win);
+      sendOpenPath(win, parsed.path);
+      return;
+    }
+    case "reuse-reload": {
+      const win = winList[decision.windowIndex];
+      // Reload against THIS window's own recorded server URL (authoritative for
+      // it, and correct for ephemeral windows whose origin isn't in settings —
+      // `known` would be null there). A pinned window always has a serverUrl.
+      const winServerUrl = windows.get(win).serverUrl;
+      focusAndRestore(win);
+      await loadServerUrl(win, winServerUrl, parsed.path).catch(() => {});
+      return;
+    }
+    case "open-known": {
+      const win = createWindow(undefined, { serverUrl: known, path: parsed.path });
+      focusAndRestore(win);
+      return;
+    }
+    case "consent-unknown": {
+      // Cold start to an unknown server may have no window to parent the dialog
+      // on — create the launch window first so the dialog has a parent and the
+      // app is never stranded windowless (it becomes the deep-link window on
+      // consent, or stays as the normal launch window on cancel).
+      let parent = activeWindow();
+      if (!parent) parent = createWindow();
+      if (!(await confirmOpenDeepLink(parent, targetOrigin))) return; // cancelled
+      // Consent given — NOW probe to discover the workspace mount. The origin
+      // is unchanged (the probe only appends a path under it), so the consent
+      // decision stands; the user approved connecting to this host.
+      const serverUrl = await expandDatabricksWorkspaceUrl(targetOrigin);
+      if (!originOf(serverUrl)) return; // expansion yielded an unparseable URL
+      // Reuse the just-created setup-page window instead of opening a second;
+      // if a window was already open (warm start), open a new one.
+      if (!pinnedOrigin(parent)) {
+        await loadServerUrl(parent, serverUrl, parsed.path).catch(() => {});
+        focusAndRestore(parent);
+      } else {
+        const win = createWindow(undefined, { serverUrl, path: parsed.path });
+        focusAndRestore(win);
+      }
+      // Record the newly-trusted server so the next link is frictionless.
+      rememberServerUrl(serverUrl);
+      return;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // App lifecycle
 // ---------------------------------------------------------------------------
 
@@ -2368,11 +2731,48 @@ const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {
   app.quit();
 } else {
-  app.on("second-instance", () => {
-    const win = activeWindow();
-    if (win) {
-      if (win.isMinimized()) win.restore();
-      win.focus();
+  // Cold-start argv scan. Windows/Linux: the OS launches the app with the
+  // omnigent:// URL as a command-line arg. macOS packaged builds get URLs via
+  // `open-url` (Apple Events), never argv — but in DEV the generic Electron.app
+  // bundle that `setAsDefaultProtocolClient` registers can't be reliably
+  // targeted by `open` (it launches a fresh Electron window instead of the
+  // running `electron .` instance), so we scan argv on ALL platforms to let
+  // `npm start -- 'omnigent://...'` exercise the real code path on macOS too.
+  // Safe: a packaged macOS launch has no omnigent:// in argv, so no double-handling.
+  for (const arg of process.argv) {
+    if (typeof arg === "string" && arg.startsWith("omnigent://")) enqueueDeepLink(arg);
+  }
+
+  // macOS: `open-url` fires for omnigent:// links, including BEFORE
+  // app.whenReady (cold start). preventDefault stops the OS from also handing
+  // the URL to the default browser; enqueueDeepLink queues it and
+  // drainPendingDeepLinks no-ops until ready, so the pre-ready race can't
+  // touch windows that don't exist yet.
+  app.on("open-url", (event, url) => {
+    event.preventDefault();
+    enqueueDeepLink(url);
+  });
+
+  app.on("second-instance", (_event, argv) => {
+    // Deep-link warm start: the OS launched a second instance with the
+    // omnigent:// URL on its command line; the single-instance lock funnels
+    // it here. On Windows/Linux that's the OS dispatch; on macOS it's how a
+    // second `npm start -- 'omnigent://...'` reaches the running DEV instance
+    // (since `open` can't target the dev binary — see the cold-start argv
+    // scan above). A plain second launch (no URL) just focuses an existing window.
+    let handledUrl = false;
+    for (const arg of argv) {
+      if (typeof arg === "string" && arg.startsWith("omnigent://")) {
+        enqueueDeepLink(arg);
+        handledUrl = true;
+      }
+    }
+    if (!handledUrl) {
+      const win = activeWindow();
+      if (win) {
+        if (win.isMinimized()) win.restore();
+        win.focus();
+      }
     }
   });
 
@@ -2402,11 +2802,33 @@ if (!gotLock) {
     // instant (primes the in-memory cache in resolvedCliPath); also lets the
     // setup page / Local CLI settings pre-fill the resolved path immediately.
     resolvedCliPath();
-    createWindow();
+    // Register the omnigent:// scheme so OS clicks route to this app. The
+    // build manifest (package.json `build.protocols`) is the reliable
+    // per-install registration that survives reinstalls; this lets dev
+    // (`electron .`) clicks route to the running dev instance too. No-op
+    // (returns false) when another app is already the default handler.
+    app.setAsDefaultProtocolClient("omnigent");
+    // If a deep link arrived before ready (macOS open-url, or Windows/Linux
+    // argv), open it instead of the default launch window; the drain's
+    // fallback opens a default window if a consent is cancelled. Otherwise
+    // open the saved server (or setup page) as before.
+    if (pendingDeepLinks.length > 0) {
+      drainPendingDeepLinks();
+    } else {
+      createWindow();
+    }
 
     app.on("activate", () => {
-      // macOS: re-create the window when the dock icon is clicked and none open.
-      if (BrowserWindow.getAllWindows().length === 0) createWindow();
+      // macOS: re-create the window when the dock icon is clicked and none
+      // open. Skip while a deep link is being handled (or queued) — it opens
+      // its own window, and racing a default window here would double-open at
+      // cold start (whenReady skipped its own createWindow for the pending link).
+      if (
+        BrowserWindow.getAllWindows().length === 0 &&
+        !deepLinkInFlight &&
+        pendingDeepLinks.length === 0
+      )
+        createWindow();
     });
   });
 

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -53,6 +53,25 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
     return () => ipcRenderer.removeListener("omnigent:notification-activated", listener);
   },
   /**
+   * Subscribe to deep-link navigations. When the user clicks an
+   * `omnigent://.../c/<id>` link for a server this window is already on, the
+   * main process sends the in-app path here so the SPA routes to it in-place
+   * (no reload) — same path shape as onNotificationActivated. Returns an
+   * unsubscribe function.
+   * @param {(path: string) => void} callback
+   * @returns {() => void}
+   */
+  onOpenPath: (callback) => {
+    const listener = (_event, path) => {
+      // Defense-in-depth: only forward in-app, same-origin paths. A leading
+      // "/" rejects absolute/cross-origin URLs and `javascript:` shapes before
+      // the renderer routes on the value, even if main ever sends junk.
+      if (typeof path === "string" && path.startsWith("/")) callback(path);
+    };
+    ipcRenderer.on("omnigent:open-path", listener);
+    return () => ipcRenderer.removeListener("omnigent:open-path", listener);
+  },
+  /**
    * Title-bar server picker data: the window's current server origin and the
    * recently-connected server URLs (most recent first). Resolves null on
    * pages that aren't a connected server.

--- a/web/electron/test/deepLink.test.js
+++ b/web/electron/test/deepLink.test.js
@@ -1,0 +1,182 @@
+// Unit tests for the deep-link decision logic (src/deepLink.js), run with
+// `node --test` (no extra deps, no Electron). Two pure functions:
+//   - parseOmnigentDeepLink: scheme inference + path validation
+//   - chooseDeepLinkStrategy: the window-selection decision table
+//
+// The behavior of the inferred http(s) scheme mirrors src/url.js (loopback →
+// http, remote → https); the workspace-mount discovery and the actual
+// window/IPC wiring live in main.js and are covered by main.test.js guards.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { parseOmnigentDeepLink, chooseDeepLinkStrategy } = require("../src/deepLink");
+
+describe("parseOmnigentDeepLink", () => {
+  it("parses a loopback host with a port as http", () => {
+    assert.deepEqual(parseOmnigentDeepLink("omnigent://localhost:8000/c/conv_abc"), {
+      origin: "http://localhost:8000",
+      path: "/c/conv_abc",
+    });
+    assert.deepEqual(parseOmnigentDeepLink("omnigent://127.0.0.1:8000/c/x"), {
+      origin: "http://127.0.0.1:8000",
+      path: "/c/x",
+    });
+  });
+
+  it("parses a remote host as https", () => {
+    assert.deepEqual(parseOmnigentDeepLink("omnigent://my-workspace.cloud.databricks.com/c/x"), {
+      origin: "https://my-workspace.cloud.databricks.com",
+      path: "/c/x",
+    });
+  });
+
+  it("preserves a non-default port on a remote host", () => {
+    assert.deepEqual(parseOmnigentDeepLink("omnigent://example.com:8443/c/x"), {
+      origin: "https://example.com:8443",
+      path: "/c/x",
+    });
+  });
+
+  it("accepts an IPv6 loopback host as http", () => {
+    assert.deepEqual(parseOmnigentDeepLink("omnigent://[::1]:8000/c/x"), {
+      origin: "http://[::1]:8000",
+      path: "/c/x",
+    });
+  });
+
+  it("accepts an optional trailing slash on the path", () => {
+    assert.equal(
+      parseOmnigentDeepLink("omnigent://localhost:8000/c/conv_abc/").path,
+      "/c/conv_abc/",
+    );
+  });
+
+  it("drops a query string and hash (v1 forwards only the path)", () => {
+    const parsed = parseOmnigentDeepLink("omnigent://localhost:8000/c/conv_abc?reply=1#frag");
+    assert.equal(parsed.path, "/c/conv_abc");
+    assert.equal(parsed.origin, "http://localhost:8000");
+  });
+
+  it("rejects a non-omnigent scheme", () => {
+    assert.equal(parseOmnigentDeepLink("https://localhost:8000/c/x"), null);
+    assert.equal(parseOmnigentDeepLink("vscode://localhost/c/x"), null);
+  });
+
+  it("rejects a link with no host", () => {
+    assert.equal(parseOmnigentDeepLink("omnigent://"), null);
+    assert.equal(parseOmnigentDeepLink("omnigent:///c/x"), null);
+  });
+
+  it("rejects non-/c/<id> paths", () => {
+    assert.equal(parseOmnigentDeepLink("omnigent://localhost:8000/inbox"), null);
+    assert.equal(parseOmnigentDeepLink("omnigent://localhost:8000/settings/appearance"), null);
+    assert.equal(parseOmnigentDeepLink("omnigent://localhost:8000/c/"), null); // empty id
+    assert.equal(parseOmnigentDeepLink("omnigent://localhost:8000/c/a/b"), null); // nested path
+    assert.equal(parseOmnigentDeepLink("omnigent://localhost:8000/"), null);
+  });
+
+  it("rejects unparseable / non-string input", () => {
+    assert.equal(parseOmnigentDeepLink("not a url"), null);
+    assert.equal(parseOmnigentDeepLink(null), null);
+    assert.equal(parseOmnigentDeepLink(undefined), null);
+    assert.equal(parseOmnigentDeepLink(123), null);
+  });
+});
+
+describe("chooseDeepLinkStrategy", () => {
+  const ORIGIN = "https://my-workspace.cloud.databricks.com";
+  const FOREIGN = "https://company.okta.com"; // a mid-auth IdP origin
+
+  /** A window snapshot. */
+  function win(origin, currentOrigin = origin) {
+    return { origin, currentOrigin };
+  }
+
+  it("reuses a pinned window currently on the origin in-place", () => {
+    const decision = chooseDeepLinkStrategy({
+      targetOrigin: ORIGIN,
+      windows: [win(ORIGIN)],
+      knownOrigins: [ORIGIN],
+    });
+    assert.deepEqual(decision, { strategy: "reuse-inplace", windowIndex: 0 });
+  });
+
+  it("reloads a pinned window that is mid-auth (off-origin)", () => {
+    const decision = chooseDeepLinkStrategy({
+      targetOrigin: ORIGIN,
+      windows: [win(ORIGIN, FOREIGN)],
+      knownOrigins: [ORIGIN],
+    });
+    assert.deepEqual(decision, { strategy: "reuse-reload", windowIndex: 0 });
+  });
+
+  it("prefers the focused window among several pinned to the origin", () => {
+    const decision = chooseDeepLinkStrategy({
+      targetOrigin: ORIGIN,
+      windows: [win(ORIGIN), win(ORIGIN)],
+      knownOrigins: [ORIGIN],
+      focusedIndex: 1,
+    });
+    assert.deepEqual(decision, { strategy: "reuse-inplace", windowIndex: 1 });
+  });
+
+  it("prefers a pinned window currently on the origin over a focused one that is mid-auth", () => {
+    // Two windows pinned to the origin: index 0 is on it, index 1 (focused) is mid-auth.
+    // On-origin wins over focus to avoid interrupting the focused window's auth flow.
+    const decision = chooseDeepLinkStrategy({
+      targetOrigin: ORIGIN,
+      windows: [win(ORIGIN), win(ORIGIN, FOREIGN)],
+      knownOrigins: [ORIGIN],
+      focusedIndex: 1,
+    });
+    assert.deepEqual(decision, { strategy: "reuse-inplace", windowIndex: 0 });
+  });
+
+  it("falls back to the first pinned window when none are currently on the origin", () => {
+    const decision = chooseDeepLinkStrategy({
+      targetOrigin: ORIGIN,
+      windows: [win(ORIGIN, FOREIGN), win(ORIGIN, FOREIGN)],
+      knownOrigins: [ORIGIN],
+    });
+    assert.deepEqual(decision, { strategy: "reuse-reload", windowIndex: 0 });
+  });
+
+  it("opens a new window for a known server with no live window", () => {
+    const decision = chooseDeepLinkStrategy({
+      targetOrigin: ORIGIN,
+      windows: [win("https://other.example.com")],
+      knownOrigins: [ORIGIN, "https://other.example.com"],
+    });
+    assert.deepEqual(decision, { strategy: "open-known" });
+  });
+
+  it("requires consent for a never-connected server with no live window", () => {
+    const decision = chooseDeepLinkStrategy({
+      targetOrigin: ORIGIN,
+      windows: [],
+      knownOrigins: ["https://other.example.com"],
+    });
+    assert.deepEqual(decision, { strategy: "consent-unknown" });
+  });
+
+  it("ignores setup-page (unpinned) windows even when the server is unknown", () => {
+    const decision = chooseDeepLinkStrategy({
+      targetOrigin: ORIGIN,
+      windows: [win(null, null)], // a window still on the setup page
+      knownOrigins: [],
+    });
+    assert.deepEqual(decision, { strategy: "consent-unknown" });
+  });
+
+  it("treats a pinned window as reuse even when the server is not in knownOrigins", () => {
+    // A window CAN be pinned to an origin the user connected to this session
+    // only (ephemeral window) — it's still trusted for in-place routing.
+    const decision = chooseDeepLinkStrategy({
+      targetOrigin: ORIGIN,
+      windows: [win(ORIGIN)],
+      knownOrigins: [],
+    });
+    assert.deepEqual(decision, { strategy: "reuse-inplace", windowIndex: 0 });
+  });
+});

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -156,3 +156,174 @@ describe("OAuth popup COOP-strip wiring (src/main.js)", () => {
     );
   });
 });
+
+// Guard for the deep-link path join in createWindow. A basename-less SPA path
+// (/c/<id>) lives UNDER the server's workspace mount (/ml/omnigents), so it
+// must be string-concatenated (resolveServerPath) — NOT resolved with
+// `new URL(path, serverUrl)`, which would anchor against the ORIGIN and drop
+// the mount, opening the wrong URL for every workspace deep link. This catches
+// a "simplification" the behavior tests can't (createWindow isn't unit-tested).
+describe("deep-link path join wiring (src/main.js)", () => {
+  it("joins opts.path onto opts.serverUrl via resolveServerPath as live code", () => {
+    assert.match(
+      liveCode,
+      /resolveServerPath\(serverUrl, opts\.path\)/,
+      [
+        "createWindow no longer joins opts.path onto opts.serverUrl via",
+        "resolveServerPath. A deep link to a workspace server (origin + /ml/omnigents",
+        "mount) would lose the mount and 404. Restore the mount-aware join (see",
+        "resolveServerPath); do not replace it with `new URL(path, serverUrl)`.",
+      ].join(" "),
+    );
+  });
+
+  it("stores the clean serverUrl (no conversation path) separately from loadUrl", () => {
+    // The window's server IDENTITY (for `omnigent host --server` etc.) must not
+    // carry the /c/<id> path. Guard that createWindow sets `serverUrl: serverUrl`
+    // (the clean value), not `serverUrl: destination`/`loadUrl`.
+    assert.match(
+      liveCode,
+      /serverUrl:\s*destination\s*\?\s*serverUrl\s*:\s*null/,
+      [
+        "createWindow no longer stores the clean serverUrl as the window's server",
+        "identity — it must keep the /c/<id> path out of `omnigent host --server`.",
+        "Restore `serverUrl: destination ? serverUrl : null` in the windows.set call.",
+      ].join(" "),
+    );
+  });
+});
+
+// Guards for the deep-link INGESTION + ORCHESTRATION wiring. The pure
+// decision logic is unit-tested in deepLink.test.js; these guard that main.js
+// still wires the OS entry points (open-url / second-instance / argv), the
+// serialized queue, the protocol registration, and the orchestrator — the
+// half no behavior test can see. Losing any silently reopens the readiness
+// race (macOS open-url before whenReady) or the single-instance funnel.
+describe("deep-link ingestion wiring (src/main.js)", () => {
+  it("registers open-url with preventDefault + enqueueDeepLink as live code", () => {
+    assert.match(
+      liveCode,
+      /app\.on\("open-url"[\s\S]{0,120}event\.preventDefault\(\)[\s\S]{0,80}enqueueDeepLink\(/,
+      [
+        "main.js no longer handles the macOS `open-url` event. Without preventDefault",
+        "the OS also hands the URL to the default browser, and without enqueueDeepLink",
+        "the pre-ready race (open-url can fire before whenReady) touches windows that",
+        "don't exist yet. Restore app.on('open-url') → preventDefault + enqueueDeepLink.",
+      ].join(" "),
+    );
+  });
+
+  it("scans second-instance argv for omnigent:// and enqueues as live code", () => {
+    assert.match(
+      liveCode,
+      /app\.on\("second-instance"[\s\S]{0,220}startsWith\("omnigent:\/\/"\)[\s\S]{0,60}enqueueDeepLink\(/,
+      [
+        "main.js no longer scans second-instance argv for omnigent://. Windows/Linux",
+        "warm-start deep links (a second launch funneled by the single-instance lock)",
+        "would be ignored. Restore the argv scan → enqueueDeepLink inside second-instance.",
+      ].join(" "),
+    );
+  });
+
+  it("registers the omnigent:// scheme as live code", () => {
+    assert.match(
+      liveCode,
+      /setAsDefaultProtocolClient\("omnigent"\)/,
+      [
+        "main.js no longer calls app.setAsDefaultProtocolClient('omnigent'), so dev",
+        "(`electron .`) clicks on an omnigent:// link won't route to the running dev",
+        "instance. The packaged build's manifest registration is separate (package.json",
+        "build.protocols). Restore the runtime call.",
+      ].join(" "),
+    );
+  });
+
+  it("gates the launch window on pending deep links as live code", () => {
+    assert.match(
+      liveCode,
+      /pendingDeepLinks\.length > 0[\s\S]{0,80}drainPendingDeepLinks\(\)/,
+      [
+        "main.js no longer drains pending deep links instead of opening the default",
+        "launch window, so a startup deep link would open a redundant default window",
+        "next to the deep-link window. Restore the pendingDeepLinks gate in whenReady.",
+      ].join(" "),
+    );
+  });
+
+  it("drains the queue serialized via handleDeepLink as live code", () => {
+    assert.match(
+      liveCode,
+      /void handleDeepLink\(/,
+      [
+        "main.js no longer calls handleDeepLink from the drain, so queued deep links",
+        "would never be opened. Restore `void handleDeepLink(next)` in drainPendingDeepLinks.",
+      ].join(" "),
+    );
+  });
+
+  it("routes in-place navigation through the omnigent:open-path channel", () => {
+    assert.match(
+      liveCode,
+      /send\("omnigent:open-path"/,
+      [
+        "main.js no longer sends omnigent:open-path to the SPA, so reuse-inplace deep",
+        "links would focus a window without navigating it. Restore sendOpenPath's",
+        "webContents.send('omnigent:open-path', path).",
+      ].join(" "),
+    );
+  });
+
+  it("decides via chooseDeepLinkStrategy as live code", () => {
+    assert.match(
+      liveCode,
+      /chooseDeepLinkStrategy\(\{[\s\S]{0,80}targetOrigin[\s\S]{0,260}knownOrigins:/,
+      [
+        "main.js no longer drives deep-link window selection through the PURE",
+        "chooseDeepLinkStrategy (unit-tested in deepLink.test.js). Inlining the",
+        "decision would lose the reuse/reload/consent table. Restore the call.",
+      ].join(" "),
+    );
+  });
+
+  it("reloads/repoints via loadServerUrl(..., parsed.path) as live code", () => {
+    assert.match(
+      liveCode,
+      /loadServerUrl\(\w+, \w+, parsed\.path\)/,
+      [
+        "main.js no longer reloads/repoints through loadServerUrl, so the mount-aware",
+        "join and the clean-serverUrl identity (no /c/<id>) could be bypassed by a",
+        "raw win.loadURL. Restore a loadServerUrl(<win>, <serverUrl>, parsed.path) call.",
+      ].join(" "),
+    );
+  });
+
+  it("runs the workspace mount probe only AFTER consent (no pre-consent SSRF)", () => {
+    // The probe (expandDatabricksWorkspaceUrl) makes an HTTP request to the
+    // link's host. For an UNKNOWN server that host is attacker-chosen, so the
+    // probe must not run until the user has consented — otherwise clicking a
+    // link probes an arbitrary host (SSRF / info disclosure) with no approval.
+    // Guard that the probe call follows confirmOpenDeepLink inside the
+    // consent-unknown branch, and does NOT appear before chooseDeepLinkStrategy.
+    assert.match(
+      liveCode,
+      /confirmOpenDeepLink\(parent, targetOrigin\)[\s\S]{0,300}expandDatabricksWorkspaceUrl\(targetOrigin\)/,
+      [
+        "handleDeepLink no longer defers expandDatabricksWorkspaceUrl until AFTER",
+        "confirmOpenDeepLink. A deep link to an unknown (attacker-chosen) server would",
+        "make a pre-consent HTTP request to that host (SSRF / info disclosure). Move the",
+        "probe into the consent-unknown branch, after confirmOpenDeepLink — the consent",
+        "decision can run on parsed.origin (no fetch) since the probe only appends a path",
+        "under the same origin.",
+      ].join(" "),
+    );
+    assert.doesNotMatch(
+      liveCode,
+      /function handleDeepLink\(raw\)\s*\{[\s\S]{0,500}expandDatabricksWorkspaceUrl\(/,
+      [
+        "expandDatabricksWorkspaceUrl reappeared in the pre-decision section of",
+        "handleDeepLink, reopening the pre-consent SSRF. The probe must run only after",
+        "confirmOpenDeepLink (in the consent-unknown branch), not before chooseDeepLinkStrategy.",
+      ].join(" "),
+    );
+  });
+});

--- a/web/src/hooks/useIdleNotifications.test.tsx
+++ b/web/src/hooks/useIdleNotifications.test.tsx
@@ -24,6 +24,9 @@ vi.mock("@/lib/nativeBridge", () => ({
   // Returns an unsubscribe fn; tests that exercise native click routing
   // capture the registered callback via this mock's calls.
   onNativeNotificationActivated: vi.fn().mockReturnValue(() => {}),
+  // Deep-link routing reuses the same navigate; tests don't assert on it,
+  // but the hook calls it on mount, so it must be a no-op fn (not undefined).
+  onOpenPath: vi.fn().mockReturnValue(() => {}),
 }));
 
 // The turn-end notification body is enriched by an async fetch of the agent's

--- a/web/src/hooks/useIdleNotifications.ts
+++ b/web/src/hooks/useIdleNotifications.ts
@@ -47,6 +47,7 @@ import {
   type BadgeActivation,
   isNativeShell,
   onNativeNotificationActivated,
+  onOpenPath,
   setBadgeCount,
 } from "@/lib/nativeBridge";
 import { fetchLastAssistantText } from "@/lib/lastAssistantText";
@@ -180,6 +181,16 @@ export function useIdleNotifications(activeConversationId?: string): void {
   useEffect(() => {
     return onNativeNotificationActivated((path) => navigateRef.current(path));
     // navigateRef is stable; the listener is mounted once for the app's life.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Desktop shell only: clicking an `omnigent://.../c/<id>` deep link for a
+  // server this window is already on sends the in-app path here (no reload —
+  // the main process only forwards it for a window currently on its pinned
+  // server), so we route to it with the same navigate the notification path
+  // uses. basename-less `/c/<id>` is rebased under the mount by the router.
+  useEffect(() => {
+    return onOpenPath((path) => navigateRef.current(path));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -70,6 +70,14 @@ interface NativeShellApi {
    */
   onNotificationActivated?: (callback: (path: string) => void) => () => void;
   /**
+   * Subscribe to deep-link navigations from the desktop shell. When the user
+   * clicks an `omnigent://.../c/<id>` link for a server this window is already
+   * on, the main process sends the in-app path here so the SPA routes to it
+   * in-place (no reload). Same path shape as onNotificationActivated. Absent
+   * on older shells / outside Electron; returns an unsubscribe.
+   */
+  onOpenPath?: (callback: (path: string) => void) => () => void;
+  /**
    * Subscribe to native sidebar-drag events. The iOS shell streams a left-edge
    * swipe here (the gesture it repurposed from back-navigation) so the renderer
    * can drive its sidebar as an interactive drawer: `begin`/`move` carry a 0→1
@@ -332,6 +340,29 @@ export function onNativeNotificationActivated(callback: (path: string) => void):
     return native.onNotificationActivated(callback);
   } catch (err) {
     console.warn("[nativeBridge] native onNotificationActivated failed:", err);
+    return () => {};
+  }
+}
+
+/**
+ * Subscribe to deep-link navigations from the desktop shell. When the user
+ * clicks an `omnigent://.../c/<id>` link for a server this window is already
+ * on, the main process sends the in-app path here so the SPA can route to it
+ * in-place (no reload) — reusing the same router `navigate` a notification
+ * click uses. The path is basename-less (`/c/<id>`); the embedded build's
+ * `basenamedRouting` rebases it under the mount.
+ *
+ * Returns an unsubscribe function. A no-op (returning a no-op unsubscribe)
+ * outside the Electron shell or under a shell too old to support deep-link
+ * routing, so callers can register it unconditionally.
+ */
+export function onOpenPath(callback: (path: string) => void): () => void {
+  const native = nativeApi();
+  if (!native?.onOpenPath) return () => {};
+  try {
+    return native.onOpenPath(callback);
+  } catch (err) {
+    console.warn("[nativeBridge] native onOpenPath failed:", err);
     return () => {};
   }
 }


### PR DESCRIPTION

## Related issue

N/A

## Summary

- Adds `omnigent://<hostname>/c/<session_id>` deep links to the Electron desktop shell: an OS-clicked link opens that session on that server, reusing an existing window in-place when one is already on it.
- Window handling is the careful part — a pure, unit-tested `chooseDeepLinkStrategy` picks reuse-in-place (focus + tell the SPA router to navigate, no reload), reuse-with-reload (pinned but mid-SSO), open-known (frictionless new window), or consent-unknown (native dialog, since pinning a new origin is a privilege grant). The workspace mount probe runs only AFTER consent, so a link to an attacker-chosen server makes no pre-consent network request.
- The window's server identity (`serverUrl`, used by `omnigent host --server`) is kept clean of the `/c/<id>` path while the load URL carries it; the mount-aware join keeps `/ml/omnigents` from being dropped.

## Test Plan

- `cd web/electron && node --test` — 195 tests (19 new deep-link decision tests + wiring guards).
- `cd web && npx tsc -b` clean; `npx vitest run src/hooks/useIdleNotifications.test.tsx src/lib/nativeBridge.test.ts src/shell/AppShell.test.tsx` — 160 pass.
- Manual (dev, local server `127.0.0.1:6767`): warm-start reuse-in-place — with the app connected and viewing conversation A, `npm start -- 'omnigent://127.0.0.1:6767/c/<B>'` (second terminal) switches the existing window to B in-place, no reload. Confirmed via the diagnostic logs: `strategy=reuse-inplace ... send open-path /c/<B>`. Requires the web UI rebuilt (`cd web && npm run build`) since the desktop loads the server's built SPA.

## Demo

N/A — no visible UI change beyond in-app navigation triggered by an external link.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the pure decision logic (`web/electron/test/deepLink.test.js`: parse + the reuse/reload/open-known/consent-unknown table) and `web/electron/test/main.test.js` wiring guards (open-url/second-instance/argv ingestion, serialized queue, scheme registration, mount-aware path join, clean serverUrl, and the post-consent probe placement). The OS-dispatch + window orchestration can't be unit-tested without an Electron launch, so it was verified manually with the local server (warm-start reuse-in-place confirmed via logs).

## Changelog

`omnigent://<hostname>/c/<session_id>` links open that session in the desktop app, reusing an open window on that server in-place

