### PR TITLE
fix(claude-native): send image tool results as blocks on cold resume

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3671,13 +3671,21 @@ def _claude_transcript_record_from_session_item(
         if not isinstance(output, str):
             output = "" if output is None else json.dumps(output, separators=(",", ":"))
         record_type = "user"
+        # Image (and other structured) tool results are persisted as a
+        # stringified content-block array. Rehydrate them into real blocks
+        # so ``claude --resume`` sends screenshots as images — not as ~250K
+        # tokens of base64 text — and the model actually sees them again.
+        content_blocks = _claude_tool_result_content_blocks(output)
+        content: str | list[dict[str, Any]] = (
+            content_blocks if content_blocks is not None else output
+        )
         message = {
             "role": "user",
             "content": [
                 {
                     "type": "tool_result",
                     "tool_use_id": call_id,
-                    "content": output,
+                    "content": content,
                 }
             ],
         }
@@ -3829,6 +3837,42 @@ def _json_safe_tool_use_result(output: str) -> str:
     except (json.JSONDecodeError, ValueError):
         return json.dumps(output)
     return output
+
+
+def _claude_tool_result_content_blocks(output: str) -> list[dict[str, Any]] | None:
+    """
+    Rehydrate a stringified content-block array into real blocks.
+
+    Tool results that return image content are persisted as a JSON *string*
+    like ``'[{"type":"image","source":{...}}]'``. Passing that string
+    straight into a ``tool_result`` content block makes ``claude --resume``
+    send the base64 to the API as plain text — a single screenshot balloons
+    to ~250K text tokens instead of the ~1.5K an image block costs, which is
+    what pushes a resumed conversation over the context limit.
+
+    Only ``text`` and ``image`` blocks are rehydrated: those are the block
+    types the API accepts inside a ``tool_result``. Anything else (plain
+    text, or a JSON array of some other shape) stays a raw string so the
+    resume request keeps sending exactly what it did before.
+
+    :param output: The persisted tool-result string, e.g.
+        ``'[{"type":"image","source":{"type":"base64","data":"..."}}]'``
+        or plain text like ``"file written"``.
+    :returns: A list of content blocks when *output* parses to a non-empty
+        list of ``text``/``image`` block dicts; ``None`` otherwise, so the
+        caller keeps the raw string as the block content.
+    """
+    try:
+        parsed = json.loads(output)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, list) or not parsed:
+        return None
+    if not all(
+        isinstance(block, dict) and block.get("type") in ("text", "image") for block in parsed
+    ):
+        return None
+    return parsed
 
 
 def _preflight_local_tools(command: str) -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -6301,8 +6301,15 @@ def test_claude_transcript_tool_use_result_is_json_parseable(
     record = records[0]
     # toolUseResult must parse without raising, and preserve the value.
     assert json.loads(record["toolUseResult"]) == expected_parsed
-    # The tool_result content block keeps the raw string unchanged.
-    assert record["message"]["content"][0]["content"] == output
+    # Plain-text results keep the raw string as the content block; a
+    # content-block array (e.g. images) is rehydrated into real blocks so
+    # ``claude --resume`` sends them as blocks, not text (see the dedicated
+    # rehydration test below).
+    content = record["message"]["content"][0]["content"]
+    if isinstance(expected_parsed, list):
+        assert content == expected_parsed
+    else:
+        assert content == output
 
 
 def test_json_safe_tool_use_result_wraps_non_json() -> None:
@@ -6314,6 +6321,75 @@ def test_json_safe_tool_use_result_wraps_non_json() -> None:
     assert claude_native._json_safe_tool_use_result("42") == "42"
     # A JSON object string passes through unchanged.
     assert claude_native._json_safe_tool_use_result('{"a":1}') == '{"a":1}'
+
+
+def test_claude_tool_result_content_blocks_rehydrates_only_block_arrays() -> None:
+    """Only a non-empty list of text/image block dicts rehydrates; else ``None``."""
+    fn = claude_native._claude_tool_result_content_blocks
+    # An image content-block array rehydrates to the parsed list.
+    assert fn('[{"type":"image","source":{"type":"base64","data":"AAA"}}]') == [
+        {"type": "image", "source": {"type": "base64", "data": "AAA"}}
+    ]
+    # A text block array rehydrates too.
+    assert fn('[{"type":"text","text":"hi"}]') == [{"type": "text", "text": "hi"}]
+    # Plain text is not JSON → keep the raw string.
+    assert fn("file written") is None
+    # A JSON string / number / object is not a block array → keep raw.
+    assert fn('"just a string"') is None
+    assert fn("42") is None
+    assert fn('{"type":"image"}') is None
+    # An empty array carries nothing to rehydrate.
+    assert fn("[]") is None
+    # A list whose entries are not typed block dicts is not a block array.
+    assert fn('["a","b"]') is None
+    assert fn('[{"no_type":1}]') is None
+    # A typed block the API does not accept in a tool_result stays a raw
+    # string, so resume keeps sending exactly what it sent before.
+    assert fn('[{"type":"file","path":"/x"}]') is None
+
+
+def test_claude_transcript_image_result_sent_as_blocks_not_text() -> None:
+    """
+    Image tool results resume as real content blocks, not base64 text.
+
+    A screenshot tool result is persisted as a stringified content-block
+    array. The old code dropped that string straight into the
+    ``tool_result`` content, so ``claude --resume`` re-sent ~250K tokens of
+    base64 as plain text and blew the context limit. The synthesizer must
+    rehydrate it into image blocks so the API tokenizes it as an image.
+    """
+    # ~4K chars of base64 stands in for a real screenshot payload.
+    big_b64 = "A" * 4096
+    output = json.dumps(
+        [
+            {
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/png", "data": big_b64},
+            }
+        ]
+    )
+    items: list[dict[str, Any]] = [
+        {
+            "id": "fco_1",
+            "response_id": "resp_1",
+            "type": "function_call_output",
+            "call_id": "toolu_1",
+            "output": output,
+        }
+    ]
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+    )
+    assert len(records) == 1
+    block = records[0]["message"]["content"][0]
+    assert block["type"] == "tool_result"
+    # content is a real content-block list — an image block, not a string.
+    assert isinstance(block["content"], list)
+    assert block["content"][0]["type"] == "image"
+    assert block["content"][0]["source"]["data"] == big_b64
 
 
 def test_tool_use_result_regression_old_flatten_would_crash_resume() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- A **claude-native cold resume** rebuilds Claude Code's local transcript from Omnigent's stored items. Image tool results (screenshots) are persisted as a *stringified* content-block array, and the rebuild dropped that string straight into the `tool_result.content`. On `claude --resume`, Claude sent the base64 to the API as plain **text** — a single screenshot cost ~250K tokens instead of the ~1.5K an image block costs.
- The result: a conversation that fit comfortably while live overflowed the context limit on reconnect (`Prompt is too long · the request is ~1.1M tokens ... this conversation is only ~331K tokens`), and the model no longer saw the screenshots as images.
- Fix: rehydrate `text`/`image` block arrays back into real content blocks before building the `tool_result`, so the resumed request sends images as images. Non-block outputs (plain text, other JSON shapes, API-unsupported block types) stay raw strings, so their resume behavior is unchanged.

### ELI5

When you disconnect and reconnect a native Claude session, Omnigent rebuilds the chat history from its database. Screenshots are stored as a blob of text (base64). The old code pasted that text blob back in as-is, so Claude counted a screenshot as a quarter-million words instead of one picture. Enough screenshots and the conversation blows past the model's size limit on reconnect. The fix turns those text blobs back into real image attachments.

```
                         cold resume rebuild
stored item              ── before ──▶  tool_result.content = "[{...250K base64 text...}]"   → ~253K TEXT tokens ❌
'[{"type":"image",...}]' ── after  ──▶  tool_result.content = [{"type":"image", ...}]        → ~1.5K image tokens ✅
```

## Test Plan

- New unit tests in `tests/test_claude_native.py`:
  - `test_claude_tool_result_content_blocks_rehydrates_only_block_arrays` — only non-empty `text`/`image` block arrays rehydrate; plain text, other JSON shapes, and API-unsupported block types stay raw strings.
  - `test_claude_transcript_image_result_sent_as_blocks_not_text` — an image tool result resumes as a real image block, not base64 text.
  - Updated `test_claude_transcript_tool_use_result_is_json_parseable` for the rehydrated-content case.
- Replayed the actual failing conversation through the new code:
  - base64-as-text: **~253K tokens → 0**
  - all **6 screenshots restored as real image blocks**
- `pre-commit run --files ...` clean (ruff format + check). Full `tests/test_claude_native.py` passes except two `test_resolve_native_claude_config_ambient_*` tests that also fail on a clean `main` in this shell (they pick up an ambient `ANTHROPIC_BASE_URL`), unrelated to this change.

## Demo

Before:
<img width="737" height="132" alt="image" src="https://github.com/user-attachments/assets/f7cc3274-9707-4d68-9a53-84280efd8099" />

After:
I can resume the session
<img width="739" height="280" alt="image" src="https://github.com/user-attachments/assets/5cd0abba-05dd-4f46-bb4d-4bac4a0ea843" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification replayed the reported conversation (`conv_d87b5c15...`) through `_claude_transcript_records_from_session_items` and confirmed base64-as-text dropped from ~253K tokens to 0 while all 6 screenshots became real image blocks. Unit tests pin both the rehydration helper's accept/reject boundary and the end-to-end transcript record shape.

## Changelog

Fix native Claude sessions overflowing the context limit on reconnect when the conversation contained screenshots

This pull request and its description were written by Isaac.
