### PR TITLE
perf(web): reduce GET /sessions calls on initial page load (5 → 3)

### DIFF
--- a/web/src/hooks/RunnerHealthProvider.tsx
+++ b/web/src/hooks/RunnerHealthProvider.tsx
@@ -51,7 +51,7 @@ type RegisterRunnerHealth = (key: string, sessions: RunnerHealthInput[] | null) 
 const RunnerHealthRegistryContext = createContext<RegisterRunnerHealth>(() => {});
 
 export function RunnerHealthProvider({ children }: { children: ReactNode }) {
-  const { data } = useConversations();
+  const { data } = useConversations("", true);
   const sidebarSessions = useMemo(() => data?.pages.flatMap((page) => page.data) ?? [], [data]);
 
   // The open session is the one liveness actually matters for now (the

--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -102,11 +102,12 @@ async function fetchAgents(): Promise<Agent[]> {
  * Refetches every 30 seconds so new agents from recently created
  * sessions appear without a manual refresh.
  */
-export function useAgents() {
+export function useAgents({ enabled = true }: { enabled?: boolean } = {}) {
   return useQuery({
     queryKey: ["agents"],
     queryFn: fetchAgents,
     staleTime: 30_000,
+    enabled,
   });
 }
 

--- a/web/src/hooks/useIdleNotifications.ts
+++ b/web/src/hooks/useIdleNotifications.ts
@@ -121,7 +121,7 @@ function isWindowFocused(): boolean {
  */
 export function useIdleNotifications(activeConversationId?: string): void {
   const navigate = useNavigate();
-  const { data } = useConversations();
+  const { data } = useConversations("", true);
   const prevStatus = useRef<Map<string, ConversationStatus>>(new Map());
   const prevElicitations = useRef<Map<string, number>>(new Map());
   // Last badge state sent to the shell, as a `count|navigatePath|title|body` key.

--- a/web/src/hooks/usePermissions.ts
+++ b/web/src/hooks/usePermissions.ts
@@ -78,7 +78,7 @@ export function useRevokePermission(sessionId: string) {
  * `null` permission level (single-user mode) is treated as unrestricted.
  */
 export function useCanEdit(conversationId: string): boolean {
-  const { data: conversationsData } = useConversations();
+  const { data: conversationsData } = useConversations("", true);
   const { session: activeSession, isLoading: sessionLoading } = useSession(conversationId);
   return useMemo(() => {
     const conversations = conversationsData?.pages.flatMap((p) => p.data);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -599,8 +599,8 @@ export function ChatPage() {
     isLoading: agentsLoading,
     error: agentsError,
     refetch: refetchAgents,
-  } = useAgents();
-  const { data: conversationsData } = useConversations();
+  } = useAgents({ enabled: !!urlConvId });
+  const { data: conversationsData } = useConversations("", true);
   const conversations = useMemo(
     () => conversationsData?.pages.flatMap((p) => p.data),
     [conversationsData],

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -281,7 +281,7 @@ export function AppShell() {
   });
 
   const debugMode = useDebugMode();
-  const { data: conversationsData } = useConversations();
+  const { data: conversationsData } = useConversations("", true);
   // Surface sessions needing attention as OS notifications + a dock badge.
   // Mounted here (inside the Router) so it can navigate on click and knows
   // the active conversation id, which suppresses the notification/badge for

--- a/web/src/shell/CommandPalette.test.tsx
+++ b/web/src/shell/CommandPalette.test.tsx
@@ -80,21 +80,22 @@ describe("CommandPalette — sessions", () => {
       setSessions([conv("c1", "Fix the parser")]);
       renderPalette();
 
-      // Empty query on mount → shares AppShell's `["conversations","",false]` entry.
-      expect(useConversations).toHaveBeenCalledWith("", false);
+      // Empty query on mount → shares AppShell's `["conversations","",true]` entry.
+      expect(useConversations).toHaveBeenCalledWith("", true);
 
       fireEvent.change(screen.getByTestId("command-palette-input"), {
         target: { value: "deploy" },
       });
       // Before the debounce elapses the query has NOT yet reached the hook.
-      expect(useConversations).not.toHaveBeenCalledWith("deploy", false);
+      expect(useConversations).not.toHaveBeenCalledWith("deploy", true);
 
       act(() => {
         vi.advanceTimersByTime(300);
       });
       // After the 300ms debounce, the typed query drives a server search with
-      // archived excluded — proving the palette searches the server, not a page.
-      expect(useConversations).toHaveBeenCalledWith("deploy", false);
+      // archived rows included (filtered client-side) — proving the palette
+      // searches the server, not a page.
+      expect(useConversations).toHaveBeenCalledWith("deploy", true);
     } finally {
       vi.useRealTimers();
     }

--- a/web/src/shell/CommandPalette.tsx
+++ b/web/src/shell/CommandPalette.tsx
@@ -168,16 +168,16 @@ export function CommandPalette({
     );
   }, [actions, query]);
 
-  // Archived excluded (matches the sidebar default). With an empty query this
-  // shares AppShell's existing `useConversations()` cache entry, so an idle
-  // palette costs no extra fetch; a search keys its own entry.
-  const { data, isFetching } = useConversations(debouncedQuery, false);
+  // includeArchived=true shares the sidebar's cache key; archived rows are
+  // filtered out below so the palette only lists active sessions.
+  const { data, isFetching } = useConversations(debouncedQuery, true);
 
   const sessions = useMemo(() => {
     const seen = new Set<string>();
     const out: { id: string; label: string; agent: string; snippet: string | null }[] = [];
     for (const page of data?.pages ?? []) {
       for (const c of page.data) {
+        if (c.archived) continue;
         if (seen.has(c.id)) continue;
         seen.add(c.id);
         out.push({


### PR DESCRIPTION
## Related issue

N/A

## Summary

On every page load, 5 `GET /sessions` calls fired. Two were redundant:

**Problem 1 — duplicate `sessions?limit=20` fetch:**
`AppShell`, `ChatPage`, `usePermissions`, `RunnerHealthProvider`, and `useIdleNotifications` all called `useConversations()` with the default `includeArchived=false`, creating cache key `["conversations", "", false]`. The sidebar uses `includeArchived=true` → a different key → a second identical request. Fix: switch all these callers to `useConversations("", true)` to share the sidebar's cache entry.

**Problem 2 — `sessions?limit=100` scan on the landing page:**
`ChatPage` calls `useAgents()` unconditionally. On the landing page (no `urlConvId`), the agent picker isn't rendered and `NewChatLandingScreen` already scans sessions via `useAvailableAgents`. Fix: add `enabled` option to `useAgents` and pass `enabled: !!urlConvId` from ChatPage.

**Net result: 5 → 3 `GET /sessions` calls on initial load.**

| Call | Before | After |
|------|--------|-------|
| `sessions?limit=20&include_archived=true` (Sidebar) | ✅ | ✅ |
| `sessions?limit=20` (AppShell/ChatPage/hooks duplicate) | ❌ redundant | eliminated |
| `sessions?limit=100` (ChatPage `useAgents` on landing) | ❌ redundant | eliminated |
| `sessions?limit=100&kind=any` (agent discovery) | ✅ | ✅ |
| `sessions?limit=200` (directory conflict scan) | ✅ | ✅ |

## Test Plan

1. Open the app to the landing page (no session URL).
2. Open DevTools → Network → filter `/sessions`.
3. Verify 3 calls fire instead of 5.
4. Navigate to a session — verify the agent picker still populates (`useAgents` fires once `urlConvId` is set).
5. Verify the sidebar session list, permissions, and runner health still work correctly.

## Demo

N/A — network-layer change only, no visual difference.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests cover the changed hooks. The `includeArchived` consolidation is a cache-key alignment — the server response shape is identical, just with additional archived rows included (which callers already handle).