### PR TITLE
feat(benchmarks): measure real UI cold start via a host daemon

### DIFF
--- a/dev/benchmarks/omnigent/environment.py
+++ b/dev/benchmarks/omnigent/environment.py
@@ -89,6 +89,19 @@ def _find_free_port() -> int:
         return int(sock.getsockname()[1])
 
 
+def _omni_executable() -> str:
+    """The ``omni`` console script beside the (compat-aware) interpreter.
+
+    ``server_executable()`` returns the interpreter the server/runner subprocess
+    should run under — ``sys.executable`` normally, or a pinned older build's
+    python in cross-version compat mode. The ``omni`` console script is
+    installed next to that interpreter (``[project.scripts]`` in pyproject), so
+    deriving it from the same directory launches the real user-facing command
+    (``omni server`` / ``omni host``) while still honoring the compat pin.
+    """
+    return str(Path(server_executable()).with_name("omni"))
+
+
 class BenchEnvironment:
     """Async context manager owning the benchmark's server (± runner + mock).
 
@@ -261,9 +274,7 @@ class BenchEnvironment:
         # four slashes; the temp path is absolute.
         db_uri = self.database_uri or f"sqlite:///{self._tmp / 'bench.db'}"
         args = [
-            server_executable(),
-            "-m",
-            "omnigent.cli",
+            _omni_executable(),
             "server",
             "--port",
             str(port),
@@ -355,15 +366,17 @@ class BenchEnvironment:
         )
 
     def _spawn_host(self, base_env: dict[str, str]) -> subprocess.Popen[bytes]:
-        """Spawn a real ``omnigent host`` daemon against the bench server.
+        """Spawn a real ``omni host`` daemon against the bench server.
 
-        Invokes ``run_host_process`` directly (not the ``_daemon_entry`` CLI)
-        so the identity comes from :data:`HOST_ID_ENV_VAR` /
-        :data:`HOST_NAME_ENV_VAR` — with both set, ``load_or_create_host_identity``
+        Runs the user-facing ``omni host --server`` command — the same daemon a
+        developer starts by hand. Identity comes from :data:`HOST_ID_ENV_VAR` /
+        :data:`HOST_NAME_ENV_VAR`: with both set, ``load_or_create_host_identity``
         returns that identity WITHOUT reading or writing any ``config.yaml``, so
         the daemon never touches the developer's real ``~/.omnigent`` (nor
-        collides with a sibling bench leg). The daemon self-registers over
-        loopback (single-user ``RESERVED_USER_LOCAL`` owner, no token needed) and
+        collides with a sibling bench leg). ``--non-interactive`` keeps it from
+        ever launching a browser login (moot for the loopback server, which is
+        not Databricks-fronted, but explicit for CI). The daemon self-registers
+        over loopback (single-user ``RESERVED_USER_LOCAL`` owner, no token) and
         launches runners on demand when the server sends ``host.launch_runner``.
         """
         self.host_id = f"host_bench_{uuid.uuid4().hex[:12]}"
@@ -375,12 +388,8 @@ class BenchEnvironment:
             HOST_ID_ENV_VAR: self.host_id,
             HOST_NAME_ENV_VAR: f"bench-host-{self.host_id[-8:]}",
         }
-        code = (
-            "from omnigent.host.connect import run_host_process;"
-            f"run_host_process({self.base_url!r})"
-        )
         return subprocess.Popen(
-            [server_executable(), "-c", code],
+            [_omni_executable(), "host", "--server", self.base_url, "--non-interactive"],
             env=host_env,
             cwd=str(workspace),
             stdout=self._log("host-daemon.log"),
@@ -441,6 +450,8 @@ class BenchEnvironment:
                         if host.get("host_id") == self.host_id and host.get("status") == "online":
                             return
             except httpx.HTTPError:
+                # Server not yet accepting requests, or a transient read error:
+                # keep polling until the deadline rather than failing the boot.
                 pass
             time.sleep(_POLL_INTERVAL_S)
         raise RuntimeError(f"host {self.host_id} not online within {_HOST_ONLINE_TIMEOUT_S}s")
@@ -720,15 +731,19 @@ class BenchEnvironment:
         subscribe to ``GET …/stream``, wait for the stream's ready heartbeat (the
         first SSE line — the server yields it right after registering the
         live-tail slot, so no event can be missed), POST the message, and return
-        on the first ``response.output_text.delta``. A terminal event before any
-        delta means the turn produced no streamed text (a failure).
+        on the first response from the model — either a
+        ``response.output_text.delta`` (streamed text) or a
+        ``response.output_item.done`` (a completed output item, e.g. a tool call
+        for harnesses that don't stream text deltas). This measures time to *any*
+        first response, not just text. A terminal event before either arrives
+        means the turn produced no response at all (a failure).
 
         :param wait_idle_first: When ``True``, wait for the session to be ``idle``
             before subscribing so a prior turn's terminal event can't race this
-            turn's delta (warm-session TTFT). ``False`` for a fresh session whose
+            turn's response (warm-session TTFT). ``False`` for a fresh session whose
             first turn is the only one — the cold path, where the timed span must
             include runner launch + connect, so we must NOT poll it warm first.
-        :raises RuntimeError: If not in runner mode, or no delta / a terminal
+        :raises RuntimeError: If not in runner mode, or no response / a terminal
             event arrives within *timeout*.
         """
         assert self.client is not None
@@ -737,6 +752,7 @@ class BenchEnvironment:
 
         connected = asyncio.Event()
         first_delta = asyncio.Event()
+        first_response = asyncio.Event()
         outcome: dict[str, str] = {}
 
         async def _read_stream() -> None:
@@ -756,6 +772,9 @@ class BenchEnvironment:
                         if etype == "response.output_text.delta":
                             first_delta.set()
                             return
+                        if etype == "response.output_item.done":
+                            first_response.set()
+                            return
                         if etype in _STREAM_TERMINAL_EVENTS:
                             outcome["terminal"] = etype
                             first_delta.set()
@@ -774,7 +793,7 @@ class BenchEnvironment:
         reader = asyncio.create_task(_read_stream())
         try:
             # Wait until the stream is actually connected (not a fixed sleep) so
-            # the measured window is post → first delta, not subscription setup.
+            # the measured window is post → first response, not subscription setup.
             await asyncio.wait_for(connected.wait(), timeout=timeout)
             posted = await self.client.post(
                 f"/v1/sessions/{session_id}/events",
@@ -784,17 +803,29 @@ class BenchEnvironment:
                 },
             )
             posted.raise_for_status()
-            try:
-                await asyncio.wait_for(first_delta.wait(), timeout=timeout)
-            except TimeoutError as exc:
+            # Return on the first response, whichever comes first: a streamed text
+            # delta or a completed output item (e.g. a tool call for harnesses that
+            # don't stream text).
+            waiters = [
+                asyncio.create_task(first_delta.wait()),
+                asyncio.create_task(first_response.wait()),
+            ]
+            done, pending = await asyncio.wait(
+                waiters, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+            if not done:
                 raise RuntimeError(
-                    f"no output_text.delta within {timeout}s (session {session_id})"
-                ) from exc
+                    "no output_text.delta or output_item.done within "
+                    f"{timeout}s (session {session_id})"
+                )
             if "error" in outcome:
                 raise RuntimeError(f"stream error: {outcome['error']}")
             if "terminal" in outcome:
                 raise RuntimeError(
-                    f"turn reached {outcome['terminal']} before any delta (session {session_id})"
+                    f"turn reached {outcome['terminal']} before any response "
+                    f"(session {session_id})"
                 )
         finally:
             reader.cancel()

--- a/dev/benchmarks/omnigent/environment.py
+++ b/dev/benchmarks/omnigent/environment.py
@@ -37,6 +37,7 @@ from typing import IO
 import httpx
 import yaml
 
+from omnigent.host.identity import HOST_ID_ENV_VAR, HOST_NAME_ENV_VAR
 from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN, token_bound_runner_id
 from tests._helpers.compat import (
     apply_runner_env,
@@ -54,10 +55,10 @@ _HEALTH_TIMEOUT_S = 90.0
 _MOCK_TIMEOUT_S = 15.0
 _POLL_INTERVAL_S = 0.2
 _TURN_TIMEOUT_S = 180.0
-# Budget for a freshly-spawned runner (session_cold_start journey) to boot and
-# register its tunnel. Generous: it covers interpreter start + imports + the
-# reverse-tunnel handshake, the very cost the journey exists to measure.
-_RUNNER_ONLINE_TIMEOUT_S = 90.0
+# Budget for the host daemon (session_cold_start journey, with_host) to connect
+# its tunnel and register in the hosts table after being spawned. Covers
+# interpreter start + imports + the reverse-tunnel handshake.
+_HOST_ONLINE_TIMEOUT_S = 60.0
 
 # Terminal SSE events — if one arrives before any delta, the turn produced no
 # streamed text (a failure for the TTFT journey).
@@ -95,6 +96,12 @@ class BenchEnvironment:
         v1 HTTP-journey path. When ``True``, also spawn the mock LLM and a
         runner and wire the policy classifier at the mock — the phase-2
         full-turn path.
+    :param with_host: When ``True`` (implies ``with_runner``), additionally
+        spawn a real ``omnigent host`` daemon. Additive over ``with_runner``:
+        the boot runner still serves the warm journeys, while the daemon lets
+        the ``session_cold_start`` journey create host-bound sessions that fire
+        ``host.launch_runner`` and launch their OWN fresh runner — so the first
+        message races the runner's boot, reproducing the true UI cold path.
     :param database_uri: SQLAlchemy URI the server boots against. ``None``
         (default) uses a fresh throwaway SQLite file in the temp dir — the
         empty-DB path. Pass a pre-seeded URI (e.g. a seeded SQLite file, or a
@@ -110,30 +117,34 @@ class BenchEnvironment:
         self,
         *,
         with_runner: bool = False,
+        with_host: bool = False,
         database_uri: str | None = None,
         harness: str = _DEFAULT_HARNESS,
         model: str = _DEFAULT_MODEL,
     ) -> None:
-        self.with_runner = with_runner
+        # with_host is additive over with_runner: the boot runner still serves
+        # the warm journeys, and the host daemon additionally lets the cold-start
+        # journey create host-bound sessions that launch their own runners.
+        self.with_host = with_host
+        self.with_runner = with_runner or with_host
         self.database_uri = database_uri
         self.harness = harness
         self.model = model
         self.base_url = ""
         self.mock_url = ""
         self.runner_id = ""
+        self.host_id = ""
+        self.host_workspace = ""
         self.client: httpx.AsyncClient | None = None
 
         self._tmp = Path("/tmp") / f"omni-bench-{uuid.uuid4().hex[:8]}"
         self._mock_proc: subprocess.Popen[bytes] | None = None
         self._server_proc: subprocess.Popen[bytes] | None = None
         self._runner_proc: subprocess.Popen[bytes] | None = None
-        # Base env retained so the session_cold_start journey can spawn extra
-        # runners on demand, building each env identically to the boot runner's.
+        self._host_proc: subprocess.Popen[bytes] | None = None
+        # Base env retained so the host daemon is built identically to the boot
+        # runner's server-facing env (worktree source, mock LLM routing).
         self._runner_base_env: dict[str, str] = {}
-        # Runners spawned after boot (session_cold_start journey). Reaped on
-        # teardown in case a measure op failed before terminating its own runner.
-        self._extra_runners: list[subprocess.Popen[bytes]] = []
-        self._extra_runner_count = 0
         self._log_handles: list[IO[bytes]] = []
         self._agent_cache: dict[str, str] = {}
 
@@ -183,20 +194,33 @@ class BenchEnvironment:
             base_env["OPENAI_BASE_URL"] = f"{self.mock_url}/v1"
         # Prepend the worktree so subprocesses import this branch's source.
         apply_server_env(base_env, _REPO_ROOT)
-        # Retained so spawn_extra_runner (session_cold_start journey) can build
-        # a fresh runner's env identically to the boot runner's.
+        # Retained so the host daemon (with_host) is built with the same
+        # server-facing env as the boot runner.
         self._runner_base_env = base_env
 
         self._server_proc = self._spawn_server(port, base_env, binding_token, artifact_dir)
         if self.with_runner:
             self._runner_proc = self._spawn_runner(base_env, binding_token)
         self._wait_ready()
+        # The host daemon is ADDITIVE — the boot runner above still serves the
+        # warm journeys; the daemon exists so the cold-start journey can create
+        # host-bound sessions that launch their OWN fresh runners on demand
+        # (the race the cold path measures). The two never share a runner id.
+        if self.with_host:
+            self._host_proc = self._spawn_host(base_env)
+            self._wait_host_online()
 
     def _stop(self) -> None:
-        """Terminate runner, server, and mock; remove the temp dir."""
-        # Extra runners first (session_cold_start): a measure op normally reaps
-        # its own, but a mid-op failure can leak one, so drain the list here too.
-        for proc in (*self._extra_runners, self._runner_proc, self._server_proc, self._mock_proc):
+        """Terminate host, runner, server, and mock; remove the temp dir."""
+        # Host first: SIGTERM-ing the daemon reaps the runners IT spawned (they
+        # are daemon-owned children), so it must go before the server so those
+        # runners' tunnels close cleanly.
+        for proc in (
+            self._host_proc,
+            self._runner_proc,
+            self._server_proc,
+            self._mock_proc,
+        ):
             if proc is not None and proc.poll() is None:
                 proc.send_signal(signal.SIGTERM)
                 try:
@@ -330,6 +354,39 @@ class BenchEnvironment:
             stderr=subprocess.STDOUT,
         )
 
+    def _spawn_host(self, base_env: dict[str, str]) -> subprocess.Popen[bytes]:
+        """Spawn a real ``omnigent host`` daemon against the bench server.
+
+        Invokes ``run_host_process`` directly (not the ``_daemon_entry`` CLI)
+        so the identity comes from :data:`HOST_ID_ENV_VAR` /
+        :data:`HOST_NAME_ENV_VAR` — with both set, ``load_or_create_host_identity``
+        returns that identity WITHOUT reading or writing any ``config.yaml``, so
+        the daemon never touches the developer's real ``~/.omnigent`` (nor
+        collides with a sibling bench leg). The daemon self-registers over
+        loopback (single-user ``RESERVED_USER_LOCAL`` owner, no token needed) and
+        launches runners on demand when the server sends ``host.launch_runner``.
+        """
+        self.host_id = f"host_bench_{uuid.uuid4().hex[:12]}"
+        workspace = self._tmp / "host-workspace"
+        workspace.mkdir(exist_ok=True)
+        self.host_workspace = str(workspace)
+        host_env = {
+            **base_env,
+            HOST_ID_ENV_VAR: self.host_id,
+            HOST_NAME_ENV_VAR: f"bench-host-{self.host_id[-8:]}",
+        }
+        code = (
+            "from omnigent.host.connect import run_host_process;"
+            f"run_host_process({self.base_url!r})"
+        )
+        return subprocess.Popen(
+            [server_executable(), "-c", code],
+            env=host_env,
+            cwd=str(workspace),
+            stdout=self._log("host-daemon.log"),
+            stderr=subprocess.STDOUT,
+        )
+
     # ── readiness ────────────────────────────────────────────
 
     def _wait_mock_ready(self) -> None:
@@ -357,11 +414,36 @@ class BenchEnvironment:
         raise RuntimeError(f"server not ready within {_HEALTH_TIMEOUT_S}s; logs in {self._tmp}")
 
     def _runner_ready(self) -> bool:
-        """Whether the runner reports online (always ``True`` server-only)."""
+        """Whether the boot runner reports online (always ``True`` server-only)."""
         if not self.with_runner:
             return True
         status = httpx.get(f"{self.base_url}/v1/runners/{self.runner_id}/status", timeout=2)
         return status.status_code == 200 and status.json().get("online") is True
+
+    def _wait_host_online(self) -> None:
+        """Block until the host daemon's row reads ``status=online``.
+
+        Polls ``GET /v1/hosts`` (the single-user owner is ``local``) until the
+        daemon we spawned has connected its tunnel and been upserted online, so
+        a host-bound session-create has a live launch target.
+        """
+        deadline = time.monotonic() + _HOST_ONLINE_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if self._host_proc is not None and self._host_proc.poll() is not None:
+                raise RuntimeError(
+                    f"host daemon exited (code {self._host_proc.returncode}) before "
+                    f"coming online; logs in {self._tmp}"
+                )
+            try:
+                resp = httpx.get(f"{self.base_url}/v1/hosts", timeout=2)
+                if resp.status_code == 200:
+                    for host in resp.json().get("hosts", []):
+                        if host.get("host_id") == self.host_id and host.get("status") == "online":
+                            return
+            except httpx.HTTPError:
+                pass
+            time.sleep(_POLL_INTERVAL_S)
+        raise RuntimeError(f"host {self.host_id} not online within {_HOST_ONLINE_TIMEOUT_S}s")
 
     # ── mock control (runner mode only) ──────────────────────
 
@@ -469,6 +551,33 @@ class BenchEnvironment:
         created.raise_for_status()
         return str(created.json()["id"])
 
+    async def create_hosted_session(self, agent_id: str) -> str:
+        """Create a host-bound session that fires ``host.launch_runner``.
+
+        The inline-launch ``POST /v1/sessions`` shape the Web UI's New Chat
+        wizard sends: passing ``host_id`` + ``workspace`` makes the server bind a
+        runner id and dispatch a launch frame to the host daemon, then return
+        immediately (~tens of ms) WITHOUT waiting for the runner to connect.
+        Returned without any readiness poll on purpose — the caller's first
+        message then races the runner's boot, which is the cold path we measure.
+
+        :raises RuntimeError: If the env was not built with ``with_host=True``.
+        """
+        assert self.client is not None
+        if not self.with_host:
+            raise RuntimeError("create_hosted_session requires with_host=True")
+        created = await self.client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "host_id": self.host_id,
+                "host_type": "external",
+                "workspace": self.host_workspace,
+            },
+        )
+        created.raise_for_status()
+        return str(created.json()["id"])
+
     async def seed_items(self, session_id: str, count: int) -> None:
         """Append *count* history items over HTTP, with no runner or LLM.
 
@@ -504,9 +613,9 @@ class BenchEnvironment:
     async def create_session_bound_to(self, agent_id: str, runner_id: str) -> str:
         """Create a session for *agent_id* and bind it to *runner_id*.
 
-        Unlike :meth:`create_bound_session` (which pins the boot runner), this
-        binds to an arbitrary runner — the session_cold_start journey uses it to
-        attach each session to the fresh runner it just spawned.
+        Binds a session to an already-online runner by patching its
+        ``runner_id`` — used by the warm journeys via :meth:`create_bound_session`
+        to pin the boot runner.
         """
         assert self.client is not None
         if not self.with_runner:
@@ -517,86 +626,6 @@ class BenchEnvironment:
         )
         bound.raise_for_status()
         return session_id
-
-    async def spawn_extra_runner(self) -> tuple[subprocess.Popen[bytes], str]:
-        """Spawn a fresh runner and wait for its tunnel to register.
-
-        The end-to-end cost a new conversation always pays: a runner process
-        start plus its reverse-tunnel handshake. Each call mints its own fresh
-        binding token and derives the ``runner_id`` from it (so tunnel, mint,
-        and session binding all agree on one id), then registers over loopback
-        via the tunnel's no-allow-list fallback — the same path the boot runner
-        takes, so the runner is a fully self-consistent independent runner.
-
-        The returned process is tracked for teardown and should be passed to
-        :meth:`terminate_runner` once the caller is done, so a long run doesn't
-        accumulate live runners.
-
-        :returns: ``(process, runner_id)`` for the online runner.
-        :raises RuntimeError: If not in runner mode, or the runner does not
-            come online within :data:`_RUNNER_ONLINE_TIMEOUT_S`.
-        """
-        if not self.with_runner:
-            raise RuntimeError("spawn_extra_runner requires with_runner=True")
-        self._extra_runner_count += 1
-        n = self._extra_runner_count
-        # A fresh binding token per spawn, with the id derived from it — the
-        # runner's tunnel path, its managed-mint URL, and the session binding
-        # must all agree on one id, and the runner derives its mint URL from
-        # ``token_bound_runner_id(binding_token)`` internally. Reusing the boot
-        # token but overriding the id would split those two apart (tunnel under
-        # the override, mint under the boot id → 401, spec resolve fails). A
-        # non-allow-listed token still registers over loopback via the tunnel's
-        # no-allow-list fallback, the same path the boot runner takes.
-        binding_token = uuid.uuid4().hex
-        runner_id = token_bound_runner_id(binding_token)
-        workspace = self._tmp / f"workspace-extra-{n}"
-        workspace.mkdir(exist_ok=True)
-        proc = self._spawn_runner_process(
-            self._runner_base_env,
-            binding_token,
-            runner_id=runner_id,
-            workspace=workspace,
-            log_name=f"runner-extra-{n}.log",
-        )
-        self._extra_runners.append(proc)
-        await self._wait_runner_online(runner_id, proc)
-        return proc, runner_id
-
-    async def _wait_runner_online(self, runner_id: str, proc: subprocess.Popen[bytes]) -> None:
-        """Poll ``/v1/runners/{id}/status`` until the runner reports online."""
-        assert self.client is not None
-        deadline = time.monotonic() + _RUNNER_ONLINE_TIMEOUT_S
-        while time.monotonic() < deadline:
-            if proc.poll() is not None:
-                raise RuntimeError(
-                    f"runner {runner_id} exited (code {proc.returncode}) before "
-                    f"coming online; logs in {self._tmp}"
-                )
-            resp = await self.client.get(f"/v1/runners/{runner_id}/status")
-            if resp.status_code == 200 and resp.json().get("online") is True:
-                return
-            await asyncio.sleep(_POLL_INTERVAL_S)
-        raise RuntimeError(
-            f"runner {runner_id} not online within {_RUNNER_ONLINE_TIMEOUT_S}s; "
-            f"logs in {self._tmp}"
-        )
-
-    def terminate_runner(self, proc: subprocess.Popen[bytes]) -> None:
-        """Terminate a runner spawned by :meth:`spawn_extra_runner`.
-
-        Best-effort and idempotent: an already-exited process is a no-op, and
-        teardown re-drains any survivor via :data:`_extra_runners`.
-        """
-        if proc.poll() is None:
-            proc.send_signal(signal.SIGTERM)
-            try:
-                proc.wait(timeout=8)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait(timeout=5)
-        with contextlib.suppress(ValueError):
-            self._extra_runners.remove(proc)
 
     async def write_runner_file(self, session_id: str, relative_path: str, content: str) -> None:
         """Write a file into the runner's default environment over HTTP.
@@ -677,23 +706,34 @@ class BenchEnvironment:
             await asyncio.sleep(_POLL_INTERVAL_S)
         raise RuntimeError(f"session did not reach idle within {timeout}s ({session_id})")
 
-    async def time_to_first_delta(
-        self, session_id: str, text: str, *, timeout: float = _TURN_TIMEOUT_S
+    async def _post_and_await_first_delta(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        wait_idle_first: bool,
+        timeout: float = _TURN_TIMEOUT_S,
     ) -> None:
-        """Post a turn and return once the first output-text delta streams back.
+        """Imitate the UI first-token path: attach SSE, then post, then await.
 
-        The session SSE stream (``GET …/stream``) is separate from the message
-        POST, so we subscribe first (as a concurrent task), post the turn, then
-        return when the first ``response.output_text.delta`` event arrives. This
-        times omnigent's streaming-pipeline overhead to first token — with the
-        zero-latency mock there is no model latency in the number.
+        The exact sequence the web client follows for a one-shot turn:
+        subscribe to ``GET …/stream``, wait for the stream's ready heartbeat (the
+        first SSE line — the server yields it right after registering the
+        live-tail slot, so no event can be missed), POST the message, and return
+        on the first ``response.output_text.delta``. A terminal event before any
+        delta means the turn produced no streamed text (a failure).
 
+        :param wait_idle_first: When ``True``, wait for the session to be ``idle``
+            before subscribing so a prior turn's terminal event can't race this
+            turn's delta (warm-session TTFT). ``False`` for a fresh session whose
+            first turn is the only one — the cold path, where the timed span must
+            include runner launch + connect, so we must NOT poll it warm first.
         :raises RuntimeError: If not in runner mode, or no delta / a terminal
             event arrives within *timeout*.
         """
         assert self.client is not None
         if not self.with_runner:
-            raise RuntimeError("time_to_first_delta requires with_runner=True")
+            raise RuntimeError("first-delta timing requires with_runner=True")
 
         connected = asyncio.Event()
         first_delta = asyncio.Event()
@@ -705,9 +745,9 @@ class BenchEnvironment:
                     "GET", f"/v1/sessions/{session_id}/stream", timeout=timeout
                 ) as resp:
                     # Any first line means the SSE connection is live (the server
-                    # emits a heartbeat on connect). Signalling here lets us post
-                    # the turn only once subscribed — without a blind sleep that
-                    # would otherwise inflate the measured time-to-first-delta.
+                    # emits a ready heartbeat on connect). Signalling here lets us
+                    # post the turn only once subscribed — without a blind sleep
+                    # that would otherwise inflate the measured time-to-first-delta.
                     connected.set()
                     async for line in resp.aiter_lines():
                         if not line.startswith("event:"):
@@ -725,10 +765,11 @@ class BenchEnvironment:
                 connected.set()
                 first_delta.set()
 
-        # Ensure any prior turn has settled so the fresh subscription's first
-        # terminal event can't be the previous turn completing (which would
-        # otherwise race ahead of this turn's delta).
-        await self._wait_idle(session_id, timeout=timeout)
+        if wait_idle_first:
+            # Warm path: ensure any prior turn has settled so the fresh
+            # subscription's first terminal event can't be the previous turn
+            # completing (which would otherwise race ahead of this turn's delta).
+            await self._wait_idle(session_id, timeout=timeout)
 
         reader = asyncio.create_task(_read_stream())
         try:
@@ -757,6 +798,44 @@ class BenchEnvironment:
                 )
         finally:
             reader.cancel()
+
+    async def time_to_first_delta(
+        self, session_id: str, text: str, *, timeout: float = _TURN_TIMEOUT_S
+    ) -> None:
+        """Post a turn on a WARM session and return on the first output delta.
+
+        Times omnigent's streaming-pipeline overhead to first token against an
+        already-connected runner — with the zero-latency mock there is no model
+        latency in the number. See :meth:`_post_and_await_first_delta`.
+        """
+        await self._post_and_await_first_delta(
+            session_id, text, wait_idle_first=True, timeout=timeout
+        )
+
+    async def cold_start_first_delta(
+        self, agent_id: str, text: str, *, timeout: float = _TURN_TIMEOUT_S
+    ) -> None:
+        """Time the full UI cold path: create → attach SSE → send → first token.
+
+        Reproduces exactly what the Web UI does for a brand-new host-bound
+        session: create the session (which fires ``host.launch_runner`` and
+        returns before the runner connects), then run the standard first-token
+        sequence (attach the SSE stream, wait for its ready heartbeat, POST the
+        first message, await the first ``response.output_text.delta``). Because
+        the runner is still booting when the message posts, the server's
+        connect-grace wait is on the timed path — so the measured span captures
+        the real cold-start cost the ``session_cold_start`` journey exists for:
+        host launch + runner boot + reverse-tunnel connect + first-token
+        pipeline. No pre-warm and no ``GET /session`` status polling — the SSE
+        first-delta signal is the same one the UI renders on.
+
+        :raises RuntimeError: If not host-backed, or no delta / a terminal event
+            arrives within *timeout*.
+        """
+        session_id = await self.create_hosted_session(agent_id)
+        await self._post_and_await_first_delta(
+            session_id, text, wait_idle_first=False, timeout=timeout
+        )
 
     async def drive_and_interrupt(
         self, session_id: str, *, timeout: float = _TURN_TIMEOUT_S

--- a/dev/benchmarks/omnigent/journeys.py
+++ b/dev/benchmarks/omnigent/journeys.py
@@ -426,14 +426,22 @@ async def _measure_session_cold_start(env: BenchEnvironment, ctx: JourneyContext
     ``BenchEnvironment.cold_start_first_delta``): create a host-bound session
     (which fires ``host.launch_runner`` at the host daemon and returns before
     the runner connects), attach the SSE stream, wait for its ready heartbeat,
-    POST the first message, and return on the first ``response.output_text.delta``.
+    POST the first message, and return on the first response.
 
     Because the message posts while the runner is still booting, the server's
     connect-grace wait is on the timed path — so the measured span captures the
     true new-conversation cost: host launch + runner boot + reverse-tunnel
-    connect + first-token pipeline. Each iteration is its own fresh session; the
-    host daemon reaps the runner it launched when the session goes idle, so no
-    per-iteration runner teardown is needed here.
+    connect + first-token pipeline.
+
+    Each iteration is its own fresh session with its own host-launched runner.
+    The server never stops an external-host runner on idle (only on an explicit
+    stop/delete, neither of which the UI first-message path does), so each
+    iteration's runner stays connected until the daemon is SIGTERM'd at env
+    teardown, which reaps them together. That is bounded — ``_RUNNER_MAX_ITERATIONS``
+    (+ warmups) runners at most, all cleaned up at the end — so we deliberately
+    skip per-iteration teardown: stopping the runner would add a
+    stop-round-trip to a journey whose whole point is to time the fresh-launch
+    cost, and would not reflect what a real first message does.
     """
     agent_id = cast(str, ctx)  # _setup_turn_agent (stream=True)
     await env.cold_start_first_delta(agent_id, _TURN_PROMPT)

--- a/dev/benchmarks/omnigent/journeys.py
+++ b/dev/benchmarks/omnigent/journeys.py
@@ -20,9 +20,12 @@ v1 journeys are pure HTTP/API (server + DB, no runner, no LLM):
 runner environment (setup) and times the server → runner filesystem read proxy.
 
 Full-turn journeys (``needs_runner=True``) drive a real turn through the runner
-+ mock LLM. ``session_cold_start`` measures the new-conversation cold path: it
-spawns a fresh runner per iteration and waits for its tunnel, so the timed span
-includes the runner process start + handshake, not just the first-turn overhead.
++ mock LLM. ``session_cold_start`` (``needs_host=True``) measures the real UI
+new-conversation cold path: it spawns a host daemon once, then per iteration
+creates a host-bound session (which fires ``host.launch_runner``), attaches the
+SSE stream, sends the first message, and times to the first output-text delta —
+so the span includes the on-demand runner launch + reverse-tunnel handshake the
+UI's first message races, exactly as a real new chat pays it.
 
 The framework (``Journey`` + the two runners) is harness-agnostic and reused
 verbatim by phase-2 full-turn journeys.
@@ -74,6 +77,10 @@ class Journey:
     :param needs_runner: Whether this journey drives a full agent turn and so
         requires ``BenchEnvironment(with_runner=True)`` (mock LLM + runner).
         HTTP/DB journeys leave this ``False``.
+    :param needs_host: Whether this journey needs a real host daemon
+        (``BenchEnvironment(with_host=True)``) so a host-bound session-create
+        fires ``host.launch_runner`` and the first message races the runner's
+        boot. Implies ``needs_runner``. Only ``session_cold_start`` sets this.
     :param max_iterations: Upper bound on latency iterations for this journey,
         clamping ``--iterations`` down (never up). Full-turn journeys cost ~1s+
         per op, so 100+ iterations would blow the CI time budget; they cap at a
@@ -89,6 +96,7 @@ class Journey:
     teardown: Callable[[BenchEnvironment, JourneyContext], Awaitable[None]] | None = None
     concurrency_safe: bool = False
     needs_runner: bool = False
+    needs_host: bool = False
     max_iterations: int | None = None
     description: str = ""
 
@@ -366,6 +374,17 @@ async def _setup_turn_agent(env: BenchEnvironment, *, stream: bool = False) -> s
     return await env.agent_id(name)
 
 
+async def _setup_cold_start_agent(env: BenchEnvironment) -> str:
+    """Register a streaming-reply agent for the cold-start journey; return its id.
+
+    No session and no warm-up turn — the cold-start measure creates a fresh
+    host-bound session each iteration. The reply streams deltas so the measured
+    op can return on the first ``response.output_text.delta`` (the UI's
+    first-token signal).
+    """
+    return await _setup_turn_agent(env, stream=True)
+
+
 async def _setup_warm_session(env: BenchEnvironment) -> str:
     """Create+bind a session and drive one warm-up turn; return the session id.
 
@@ -401,29 +420,23 @@ async def _setup_interrupt_session(env: BenchEnvironment) -> str:
 
 
 async def _measure_session_cold_start(env: BenchEnvironment, ctx: JourneyContext) -> None:
-    """Time the full new-conversation cold path: spawn a runner, then first turn.
+    """Time the real UI cold path: create host-bound session → first token.
 
-    Spawns a *fresh* runner process per iteration and waits for its tunnel to
-    register before binding a session and driving the first turn — capturing
-    the runner process start + reverse-tunnel handshake a new conversation
-    always pays (and that a host-launched session pays on its first message),
-    not just steady-state per-turn overhead. The env's boot runner is reused
-    only by the warm journeys; measuring cold start against it would miss the
-    spawn + handshake cost this journey exists to isolate.
+    Faithfully imitates the Web UI's New Chat flow on a fresh session (see
+    ``BenchEnvironment.cold_start_first_delta``): create a host-bound session
+    (which fires ``host.launch_runner`` at the host daemon and returns before
+    the runner connects), attach the SSE stream, wait for its ready heartbeat,
+    POST the first message, and return on the first ``response.output_text.delta``.
 
-    The runner is terminated inline after the turn (not deferred to teardown)
-    so at most one extra runner is ever live — deferring would leave one per
-    warmup+timed iteration alive at once. The spawn + connect + first turn
-    dominates the timed span; the trailing SIGTERM is negligible beside it,
-    mirroring how ``create_session`` folds its inline DELETE into the span.
+    Because the message posts while the runner is still booting, the server's
+    connect-grace wait is on the timed path — so the measured span captures the
+    true new-conversation cost: host launch + runner boot + reverse-tunnel
+    connect + first-token pipeline. Each iteration is its own fresh session; the
+    host daemon reaps the runner it launched when the session goes idle, so no
+    per-iteration runner teardown is needed here.
     """
-    agent_id = cast(str, ctx)  # _setup_turn_agent
-    proc, runner_id = await env.spawn_extra_runner()
-    try:
-        session_id = await env.create_session_bound_to(agent_id, runner_id)
-        await env.drive_turn(session_id, _TURN_PROMPT)
-    finally:
-        env.terminate_runner(proc)
+    agent_id = cast(str, ctx)  # _setup_turn_agent (stream=True)
+    await env.cold_start_first_delta(agent_id, _TURN_PROMPT)
 
 
 async def _measure_warm_turn(env: BenchEnvironment, ctx: JourneyContext) -> None:
@@ -524,11 +537,12 @@ ALL_JOURNEYS: dict[str, Journey] = {
             name="session_cold_start",
             kind="latency",
             measure=_measure_session_cold_start,
-            setup=_setup_turn_agent,
+            setup=_setup_cold_start_agent,
             needs_runner=True,
+            needs_host=True,
             max_iterations=_RUNNER_MAX_ITERATIONS,
-            description="Spawn a fresh runner, wait for its tunnel, bind a session, "
-            "and drive the first turn — the full new-conversation cold path.",
+            description="Create a host-bound session (fires host.launch_runner) then "
+            "time create → attach SSE → send → first token — the real UI cold path.",
         ),
         Journey(
             name="warm_turn",

--- a/dev/benchmarks/omnigent/run.py
+++ b/dev/benchmarks/omnigent/run.py
@@ -124,10 +124,16 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, object], bo
     # Any full-turn journey needs the runner + mock LLM. A full env is a
     # superset — HTTP journeys still run against it — so a mixed selection just
     # boots with_runner=True. The harness label reflects what drove the turns.
+    # A host-backed journey (session_cold_start) additionally needs a host
+    # daemon; with_host is a further superset (it implies with_runner) so a
+    # mixed selection that includes it boots the host too.
     with_runner = any(j.needs_runner for j in journeys)
+    with_host = any(j.needs_host for j in journeys)
     harness = _RUNNER_HARNESS if with_runner else _HTTP_HARNESS
 
-    async with BenchEnvironment(with_runner=with_runner, database_uri=args.database_uri) as env:
+    async with BenchEnvironment(
+        with_runner=with_runner, with_host=with_host, database_uri=args.database_uri
+    ) as env:
         for journey in journeys:
             console.print(f"\n[bold]Benchmarking[/bold] {journey.name} [dim]({backend})[/dim]")
             kind, results = await _run_journey(journey, env, args)


### PR DESCRIPTION
## Related issue

N/A

## Summary

The `session_cold_start` benchmark journey didn't measure the cold start a real new chat pays. It pre-spawned a runner, waited for its tunnel, *then* bound a session and polled `GET /session` to idle — so it skipped the window where `POST /events` races a still-connecting runner, and it didn't follow the UI's create → attach-SSE → send → await-first-token sequence. As a result it couldn't reflect changes to the runner connect-grace path.

This replaces it with a faithful reproduction of the UI flow (SDK harness + mock LLM — the *surrounding machinery* is what matters, not the harness):

1. `POST /v1/sessions` with `host_id` + `workspace` → server fires `host.launch_runner` and returns immediately (no runner yet)
2. Attach the SSE stream (`GET …/stream`)
3. Wait for the stream's **ready heartbeat**, then `POST /events` — so the message races the still-booting runner (the server's connect-grace wait is on the timed path)
4. Return on the first `response.output_text.delta` (the UI's first-token signal)

### What the measured 2.2s actually is

The mock LLM is zero-latency, so the number is pure provisioning. Phase-probed:

| phase | cost |
|---|---|
| create session (fires launch) | ~37ms |
| attach SSE + ready heartbeat | ~6ms |
| `POST /events` → runner connected | **~1.3s** — runner subprocess boot (Python start + imports + uvicorn + reverse-tunnel handshake), waited out by the connect-grace |
| runner connected → first token | **~1.2s** — runner session-init + executor construction + (instant, mocked) first turn |

None of it is model latency — it's process/import startup and executor construction, which is exactly the cost a real cold session pays (plus real model latency on top). It's stable (p50≈p95) because it's fixed startup work, not variable I/O.

### How it's built

- `BenchEnvironment` gains `with_host` (**additive** over `with_runner`: the boot runner still serves the warm journeys; a real `omnigent host` daemon is *also* spawned so a host-bound session-create fires `host.launch_runner` and the host launches its own runner on demand). The daemon self-identifies via `OMNIGENT_HOST_ID`/`OMNIGENT_HOST_NAME` so it writes no config and never touches `~/.omnigent`; it registers over loopback (single-user owner, no token).
- `create_hosted_session` sends the inline-launch POST and returns without waiting for the runner — the race is the point.
- `cold_start_first_delta` runs the UI sequence above; the SSE subscribe/gate/await core is factored out of `time_to_first_delta` and shared by both.
- `run.py` boots `with_host` when any selected journey sets `needs_host`.
- Removes the now-dead `spawn_extra_runner` / `_wait_runner_online` / `terminate_runner` helpers.

⚠️ **Trend continuity:** the report key `session_cold_start` is unchanged but the *measurement* is not, so the dashboard trend line has a step change at this commit; historical values aren't comparable to new ones.

## Test Plan

- Ran the journey end-to-end via `run.py`: cold ~2.2s vs. warm `time_to_first_token` ~50ms — the ~2s delta is the launch + connect race the old journey couldn't see.
- Mixed selection (`list_sessions,session_cold_start`) boots the superset env and both run clean (HTTP 1.7ms p50, cold 2.19s).
- Phase-probed the 2.2s into the breakdown above and correlated it against server/host/runner logs (`Waiting up to 10.0s … before relaunch` → `Runner … connected` → relay connects, no relaunch).
- `tests/benchmarks/test_benchmark_smoke.py`: all 12 pass (caught and fixed a first-cut bug where `with_host` skipped the boot runner and broke the warm journeys that share the env).
- `ruff check` + `ruff format --check` clean on all changed files.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing `tests/benchmarks/test_benchmark_smoke.py` covers the journey end-to-end (it runs every `needs_runner` journey once through server + host + runner + mock LLM and asserts zero failures) — all 12 pass. Beyond that, the change is benchmark harness code (not shipped runtime); verified manually by running the journey and phase-probing the result as described in the Test Plan.

