### PR TITLE
perf(web): share session-agent cache between enrichment and useSessionAgent

### DIFF
--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -50,6 +50,8 @@ export interface Agent {
   mcp_servers_editable?: boolean;
   /** Guardrails policies declared on the agent. Empty when none configured. */
   policies?: PolicySummary[];
+  /** Skills bundled in the agent spec. Populated by `useSessionAgent`. */
+  skills?: { name: string; description: string }[];
   /** Terminal names declared in the spec's `terminals:` block, in
    * declaration order (e.g. ["shell"], or ["zsh", "bash"] for a native
    * session offering the host's installed shells, default first). Gates
@@ -121,6 +123,7 @@ interface AgentObjectWire {
   name: string;
   description?: string | null;
   harness?: string | null;
+  skills?: { name: string; description: string }[];
   mcp_servers?: McpServerSummary[];
   mcp_servers_editable?: boolean;
   policies?: PolicySummary[];
@@ -133,7 +136,7 @@ interface AgentObjectWire {
  *
  * :param sessionId: The session whose bound agent to retrieve.
  */
-async function fetchSessionAgent(sessionId: string): Promise<Agent> {
+export async function fetchSessionAgent(sessionId: string): Promise<Agent> {
   const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sessionId)}/agent`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const json = (await res.json()) as AgentObjectWire;
@@ -142,6 +145,7 @@ async function fetchSessionAgent(sessionId: string): Promise<Agent> {
     name: json.name,
     description: json.description,
     harness: json.harness ?? null,
+    skills: json.skills ?? [],
     mcp_servers: json.mcp_servers,
     mcp_servers_editable: json.mcp_servers_editable,
     policies: json.policies,

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -1,5 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
+import { fetchSessionAgent } from "./useAgents";
 import { agentRootName } from "@/lib/forkHarness";
 import { capitalizeAgentName } from "@/lib/agentLabels";
 import {
@@ -184,15 +185,6 @@ async function scanSessionAgents(): Promise<ScannedSessionAgent[]> {
   return Array.from(seen.values());
 }
 
-/** Wire shape of `GET /v1/sessions/{id}/agent` (AgentObject). */
-interface AgentObjectWire {
-  id: string;
-  name: string;
-  description?: string | null;
-  harness?: string | null;
-  skills?: { name: string; description: string }[];
-}
-
 /**
  * Enrich one scanned session agent into the picker's AvailableAgent
  * shape via `GET /v1/sessions/{id}/agent` (description, harness,
@@ -201,7 +193,10 @@ interface AgentObjectWire {
  * `_to_agent_object` degradation: one unloadable bundle must not
  * break discovery.
  */
-async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<AvailableAgent> {
+async function enrichSessionAgent(
+  scanned: ScannedSessionAgent,
+  queryClient: QueryClient,
+): Promise<AvailableAgent> {
   const fallback: AvailableAgent = {
     id: scanned.agentId,
     name: scanned.agentName,
@@ -214,17 +209,20 @@ async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<Availab
     // createdAt (used directly in the dedup), not from this object.
   };
   try {
-    const res = await authenticatedFetch(
-      `/v1/sessions/${encodeURIComponent(scanned.sessionId)}/agent`,
-    );
-    if (!res.ok) return fallback;
-    const json = (await res.json()) as AgentObjectWire;
+    // fetchQuery shares the ["session-agent", id] cache with useSessionAgent,
+    // so the open session's agent is a cache hit and other sessions populate
+    // the cache for free — avoiding duplicate fetches if useSessionAgent mounts.
+    const agent = await queryClient.fetchQuery({
+      queryKey: ["session-agent", scanned.sessionId],
+      queryFn: () => fetchSessionAgent(scanned.sessionId),
+      staleTime: Infinity,
+    });
     return {
       ...fallback,
-      display_name: displayNameForAgent(json.name, json.harness),
-      description: json.description ?? null,
-      harness: json.harness ?? null,
-      skills: json.skills ?? [],
+      display_name: displayNameForAgent(agent.name, agent.harness),
+      description: agent.description ?? null,
+      harness: agent.harness ?? null,
+      skills: agent.skills ?? [],
     };
   } catch {
     // Network-level failure — same best-effort degradation as the
@@ -266,7 +264,7 @@ async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<Availab
  * rather than blanking the picker — catalog availability must not be hostage
  * to the discovery extension.
  */
-async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
+async function fetchAvailableAgents(queryClient: QueryClient): Promise<AvailableAgent[]> {
   const [catalog, scanned] = await Promise.all([
     fetchBuiltinAgents(),
     scanSessionAgents().catch(() => [] as ScannedSessionAgent[]),
@@ -329,7 +327,9 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
   const resolved = (
     await Promise.all(
       Array.from(byName.values()).map((c) =>
-        c.template !== null ? Promise.resolve(c.template) : enrichSessionAgent(c.scanned!),
+        c.template !== null
+          ? Promise.resolve(c.template)
+          : enrichSessionAgent(c.scanned!, queryClient),
       ),
     )
   ).filter((agent) => {
@@ -348,9 +348,10 @@ interface UseAvailableAgentsOptions {
 }
 
 export function useAvailableAgents(options: UseAvailableAgentsOptions = {}) {
+  const queryClient = useQueryClient();
   return useQuery({
     queryKey: ["available-agents"],
-    queryFn: fetchAvailableAgents,
+    queryFn: () => fetchAvailableAgents(queryClient),
     enabled: options.enabled ?? true,
     staleTime: 30_000,
   });


### PR DESCRIPTION
## Related issue

N/A

## Summary

`useAvailableAgents` enriches each session-discovered agent by calling `GET /v1/sessions/{id}/agent` via a bare `authenticatedFetch`, completely bypassing TanStack Query's cache. Meanwhile, `useSessionAgent` (used in `ChatPage`, `AppShell`, `NewTerminalButton`, etc.) queries the **same endpoint** under the `["session-agent", id]` key with `staleTime: Infinity`. Every enrichment call was therefore a duplicate fetch.

Fix:
- Export `fetchSessionAgent` from `useAgents.ts` so it can be reused.
- Add `skills` to `Agent` and `AgentObjectWire` so the cached `Agent` shape carries all fields `enrichSessionAgent` needs (`description`, `harness`, `skills`).
- Thread `QueryClient` into `enrichSessionAgent` / `fetchAvailableAgents` and call `queryClient.fetchQuery(["session-agent", sessionId])` instead of a bare fetch.

Results:
- The currently-open session's agent is a **free cache hit** (already fetched by `useSessionAgent`).
- All other enriched agents are **written into the cache** — so any subsequent `useSessionAgent` call for those IDs costs nothing.
- Concurrent enrichment calls for the same session ID are **deduplicated** by TanStack Query's in-flight dedup.

## Test Plan

1. Open a session with several custom agents visible in the new-chat picker.
2. Network tab → filter for `/agent` — verify the enrichment calls still fire (no regression on first load), but the currently-open session's agent does **not** fire a duplicate (cache hit).
3. Open the new-chat dialog, pick a session-discovered agent — confirm it renders description/harness/skills correctly.

## Demo

N/A — network-layer change only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The enrichment logic is covered by existing `useAvailableAgents` / `NewChatDialog` tests. The cache-sharing path relies on TanStack Query's own dedup semantics which are well-tested upstream.