### PR TITLE
feat(telemetry): add X-Omnigent-Client header for precise client surface detection

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12867,12 +12867,18 @@ async def _create_session_from_existing_agent(
             if user_id is not None:
                 _salt = f"{_install_id}:{user_id}" if _install_id else user_id
                 _anon_uid = _hashlib.sha256(_salt.encode()).hexdigest()[:16]
+            _client_header = request.headers.get("x-omnigent-client")
+            _surface = (
+                _client_header
+                if _client_header in ("web", "desktop", "ios", "android", "cli")
+                else _classify_surface(request.headers.get("user-agent"))
+            )
             _tel_emit(
                 _TelSessionCreatedEvent(
                     session_id=conv.id,
                     agent_id=agent.id,
                     harness=native_agent.harness if native_agent is not None else None,
-                    surface=_classify_surface(request.headers.get("user-agent")),
+                    surface=_surface,
                     installation_id=_install_id,
                     anon_user_id=_anon_uid,
                     is_fork=body.parent_session_id is not None,

--- a/omnigent/telemetry/surface.py
+++ b/omnigent/telemetry/surface.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 def classify_surface(user_agent: str | None) -> str:
     """Return a surface label for the given User-Agent string.
 
+    Used as a fallback when the ``X-Omnigent-Client`` request header is absent
+    or unrecognised.
+
     Mapping:
     * ``None`` or absent → ``"unknown"``
     * ``"Electron"`` in UA → ``"desktop"``

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -15,6 +15,7 @@ import { isMessageItem } from "./conversationItems";
 import type { MessageContentBlock } from "./blocks";
 import type { McpServerStartup } from "./events";
 import { authenticatedFetch } from "./identity";
+import { isAndroidShell, isElectronShell, isIOSShell } from "@/lib/nativeBridge";
 import type {
   CodexModelOption,
   ModelUsage,
@@ -26,6 +27,14 @@ import type {
   SessionStatus,
   SkillSummary,
 } from "./types";
+
+/** Returns the client surface label for the X-Omnigent-Client telemetry header. */
+function getClientSurface(): string {
+  if (isElectronShell()) return "desktop";
+  if (isIOSShell()) return "ios";
+  if (isAndroidShell()) return "android";
+  return "web";
+}
 
 /**
  * MCP-shape elicitation response, used as the `result` argument to
@@ -428,7 +437,7 @@ export async function createSession(
   }
   const res = await authenticatedFetch("/v1/sessions", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "X-Omnigent-Client": getClientSurface() },
     body: JSON.stringify(body),
   });
   return sessionFromWire(await readJsonOrThrow<SessionResponseWire>(res));
@@ -464,6 +473,7 @@ export async function createBundledSession(
   form.append("bundle", bundle);
   const res = await authenticatedFetch("/v1/sessions", {
     method: "POST",
+    headers: { "X-Omnigent-Client": getClientSurface() },
     body: form,
   });
   if (!res.ok) {
@@ -516,7 +526,7 @@ export async function forkSession(
   }
   const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sourceId)}/fork`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "X-Omnigent-Client": getClientSurface() },
     body: JSON.stringify(body),
   });
   return sessionFromWire(await readJsonOrThrow<SessionResponseWire>(res));


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Web UI now sends an explicit `X-Omnigent-Client` header (`web`, `desktop`, `ios`, `android`) on session-creation (`createSession`, `createBundledSession`) and fork (`forkSession`) requests.
- The server's `_create_session_from_existing_agent` prefers this header over User-Agent heuristics when classifying the surface for the `TelSessionCreatedEvent`. Falls back to `_classify_surface(user-agent)` when the header is absent or carries an unrecognised value.
- Added a note to `classify_surface`'s docstring clarifying its fallback role.

## Test Plan

- Existing unit tests for `classify_surface` continue to pass (no logic changed there).
- The server-side preference logic is a pure conditional — readable in code review.
- Manual: opening a session from the web UI sends `X-Omnigent-Client: web`; Electron shell sends `desktop`; iOS/Android shells send their respective labels.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

The header preference logic in sessions.py is a two-line conditional with no branching paths that require a new test fixture. The `classify_surface` fallback is already tested; the new code only gates when to call it.

## Changelog

Session creation requests from the web UI now send an explicit `X-Omnigent-Client` header, enabling the server to record the exact client surface (web/desktop/ios/android) in telemetry without relying on User-Agent parsing.