### PR TITLE
perf(web): enrich session-discovered agents in background after initial render

### DIFF
--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -184,25 +184,16 @@ async function scanSessionAgents(): Promise<ScannedSessionAgent[]> {
   return Array.from(seen.values());
 }
 
-/** Wire shape of `GET /v1/sessions/{id}/agent` (AgentObject). */
-interface AgentObjectWire {
-  id: string;
-  name: string;
-  description?: string | null;
-  harness?: string | null;
-  skills?: { name: string; description: string }[];
-}
-
 /**
- * Enrich one scanned session agent into the picker's AvailableAgent
- * shape via `GET /v1/sessions/{id}/agent` (description, harness,
- * bundled skills). On failure the agent is still listed with the
- * name-only fields from the scan — mirroring the server's own
- * `_to_agent_object` degradation: one unloadable bundle must not
- * break discovery.
+ * Build an AvailableAgent from session scan data alone — no extra fetch.
+ * description, harness, and skills are omitted; they can be loaded lazily
+ * via useSessionAgent once the user has selected an agent.
+ *
+ * Session-discovered agents are always custom uploads, never native coding
+ * agents, so a null harness doesn't affect display or classification.
  */
-async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<AvailableAgent> {
-  const fallback: AvailableAgent = {
+function sessionAgentFromScan(scanned: ScannedSessionAgent): AvailableAgent {
+  return {
     id: scanned.agentId,
     name: scanned.agentName,
     display_name: displayNameForAgent(scanned.agentName),
@@ -213,24 +204,6 @@ async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<Availab
     // seed the catalog, and their recency comes from the scanned session's
     // createdAt (used directly in the dedup), not from this object.
   };
-  try {
-    const res = await authenticatedFetch(
-      `/v1/sessions/${encodeURIComponent(scanned.sessionId)}/agent`,
-    );
-    if (!res.ok) return fallback;
-    const json = (await res.json()) as AgentObjectWire;
-    return {
-      ...fallback,
-      display_name: displayNameForAgent(json.name, json.harness),
-      description: json.description ?? null,
-      harness: json.harness ?? null,
-      skills: json.skills ?? [],
-    };
-  } catch {
-    // Network-level failure — same best-effort degradation as the
-    // non-ok branch above: list the agent from scan fields.
-    return fallback;
-  }
 }
 
 /**
@@ -326,16 +299,12 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
     }
   }
 
-  const resolved = (
-    await Promise.all(
-      Array.from(byName.values()).map((c) =>
-        c.template !== null ? Promise.resolve(c.template) : enrichSessionAgent(c.scanned!),
-      ),
-    )
-  ).filter((agent) => {
-    const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
-    return nativeKey !== "kiro" || !hasKiroBuiltin;
-  });
+  const resolved = Array.from(byName.values())
+    .map((c) => (c.template !== null ? c.template : sessionAgentFromScan(c.scanned!)))
+    .filter((agent) => {
+      const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
+      return nativeKey !== "kiro" || !hasKiroBuiltin;
+    });
   // Seeded built-ins first; user templates / custom uploads follow, newest
   // first. NewChatDialog's display-order sort is stable, so unranked names
   // keep this relative order.

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 import { agentRootName } from "@/lib/forkHarness";
 import { capitalizeAgentName } from "@/lib/agentLabels";
@@ -184,13 +184,19 @@ async function scanSessionAgents(): Promise<ScannedSessionAgent[]> {
   return Array.from(seen.values());
 }
 
+/** Wire shape of `GET /v1/sessions/{id}/agent` (AgentObject). */
+interface AgentObjectWire {
+  id: string;
+  name: string;
+  description?: string | null;
+  harness?: string | null;
+  skills?: { name: string; description: string }[];
+}
+
 /**
  * Build an AvailableAgent from session scan data alone — no extra fetch.
- * description, harness, and skills are omitted; they can be loaded lazily
- * via useSessionAgent once the user has selected an agent.
- *
- * Session-discovered agents are always custom uploads, never native coding
- * agents, so a null harness doesn't affect display or classification.
+ * description, harness, and skills are null/empty; enrichInBackground fills
+ * them in asynchronously so the picker renders immediately.
  */
 function sessionAgentFromScan(scanned: ScannedSessionAgent): AvailableAgent {
   return {
@@ -204,6 +210,59 @@ function sessionAgentFromScan(scanned: ScannedSessionAgent): AvailableAgent {
     // seed the catalog, and their recency comes from the scanned session's
     // createdAt (used directly in the dedup), not from this object.
   };
+}
+
+/**
+ * Fetch description, harness, and skills for each session-discovered agent
+ * in the background and patch the ["available-agents"] cache when done.
+ * The picker has already rendered with name-only data; this update fills in
+ * harness-dependent UI (model picker, routing, unconfigured-host warnings)
+ * without blocking the initial render.
+ */
+async function enrichInBackground(
+  candidates: ScannedSessionAgent[],
+  queryClient: QueryClient,
+): Promise<void> {
+  if (candidates.length === 0) return;
+  const results = await Promise.allSettled(
+    candidates.map(async (scanned) => {
+      const res = await authenticatedFetch(
+        `/v1/sessions/${encodeURIComponent(scanned.sessionId)}/agent`,
+      );
+      if (!res.ok) return null;
+      const json = (await res.json()) as AgentObjectWire;
+      return { agentId: scanned.agentId, json };
+    }),
+  );
+  const enriched = new Map<
+    string,
+    { description: string | null; harness: string | null; skills: { name: string; description: string }[] }
+  >();
+  for (const r of results) {
+    if (r.status === "fulfilled" && r.value) {
+      const { agentId, json } = r.value;
+      enriched.set(agentId, {
+        description: json.description ?? null,
+        harness: json.harness ?? null,
+        skills: json.skills ?? [],
+      });
+    }
+  }
+  if (enriched.size === 0) return;
+  queryClient.setQueryData<AvailableAgent[]>(["available-agents"], (prev) => {
+    if (!prev) return prev;
+    return prev.map((agent) => {
+      const data = enriched.get(agent.id);
+      if (!data) return agent;
+      return {
+        ...agent,
+        display_name: displayNameForAgent(agent.name, data.harness),
+        description: data.description,
+        harness: data.harness,
+        skills: data.skills,
+      };
+    });
+  });
 }
 
 /**
@@ -239,7 +298,7 @@ function sessionAgentFromScan(scanned: ScannedSessionAgent): AvailableAgent {
  * rather than blanking the picker — catalog availability must not be hostage
  * to the discovery extension.
  */
-async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
+async function fetchAvailableAgents(queryClient: QueryClient): Promise<AvailableAgent[]> {
   const [catalog, scanned] = await Promise.all([
     fetchBuiltinAgents(),
     scanSessionAgents().catch(() => [] as ScannedSessionAgent[]),
@@ -299,8 +358,13 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
     }
   }
 
+  const scannedCandidates: ScannedSessionAgent[] = [];
   const resolved = Array.from(byName.values())
-    .map((c) => (c.template !== null ? c.template : sessionAgentFromScan(c.scanned!)))
+    .map((c) => {
+      if (c.template !== null) return c.template;
+      scannedCandidates.push(c.scanned!);
+      return sessionAgentFromScan(c.scanned!);
+    })
     .filter((agent) => {
       const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
       return nativeKey !== "kiro" || !hasKiroBuiltin;
@@ -309,6 +373,12 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
   // first. NewChatDialog's display-order sort is stable, so unranked names
   // keep this relative order.
   resolved.sort((a, b) => recencyOf(b) - recencyOf(a));
+
+  // Fire enrichment in the background — don't await. The picker renders
+  // immediately with name-only data; harness/description/skills fill in
+  // once the per-session fetches complete.
+  void enrichInBackground(scannedCandidates, queryClient);
+
   return [...seeded, ...resolved];
 }
 
@@ -317,9 +387,10 @@ interface UseAvailableAgentsOptions {
 }
 
 export function useAvailableAgents(options: UseAvailableAgentsOptions = {}) {
+  const queryClient = useQueryClient();
   return useQuery({
     queryKey: ["available-agents"],
-    queryFn: fetchAvailableAgents,
+    queryFn: () => fetchAvailableAgents(queryClient),
     enabled: options.enabled ?? true,
     staleTime: 30_000,
   });

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -236,7 +236,11 @@ async function enrichInBackground(
   );
   const enriched = new Map<
     string,
-    { description: string | null; harness: string | null; skills: { name: string; description: string }[] }
+    {
+      description: string | null;
+      harness: string | null;
+      skills: { name: string; description: string }[];
+    }
   >();
   for (const r of results) {
     if (r.status === "fulfilled" && r.value) {

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { useQuery, type QueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 import { agentRootName } from "@/lib/forkHarness";
 import { capitalizeAgentName } from "@/lib/agentLabels";
@@ -39,6 +39,10 @@ export interface AvailableAgent {
   // immutable, so it is the stable signal. Omitted on older servers and on
   // session-derived agents (whose recency comes from the scanned session).
   created_at?: number | null;
+  // Session id used to fetch the full agent spec on hover. Only set on
+  // session-discovered agents (custom uploads); absent on catalog agents
+  // whose full data is already present from GET /v1/agents.
+  sessionId?: string;
 }
 
 const DISPLAY_NAMES: Record<string, string> = {
@@ -195,8 +199,8 @@ interface AgentObjectWire {
 
 /**
  * Build an AvailableAgent from session scan data alone — no extra fetch.
- * description, harness, and skills are null/empty; enrichInBackground fills
- * them in asynchronously so the picker renders immediately.
+ * description, harness, and skills are null/empty and filled in on hover
+ * via prefetchAvailableAgentDetails.
  */
 function sessionAgentFromScan(scanned: ScannedSessionAgent): AvailableAgent {
   return {
@@ -206,6 +210,7 @@ function sessionAgentFromScan(scanned: ScannedSessionAgent): AvailableAgent {
     description: null,
     harness: null,
     skills: [],
+    sessionId: scanned.sessionId,
     // builtin/created_at intentionally omitted: session-derived agents never
     // seed the catalog, and their recency comes from the scanned session's
     // createdAt (used directly in the dedup), not from this object.
@@ -213,60 +218,38 @@ function sessionAgentFromScan(scanned: ScannedSessionAgent): AvailableAgent {
 }
 
 /**
- * Fetch description, harness, and skills for each session-discovered agent
- * in the background and patch the ["available-agents"] cache when done.
- * The picker has already rendered with name-only data; this update fills in
- * harness-dependent UI (model picker, routing, unconfigured-host warnings)
- * without blocking the initial render.
+ * Fetch harness, description, and skills for a session-discovered agent and
+ * patch them into the ["available-agents"] cache. Call on hover so the data
+ * is ready before the user clicks — zero cost for agents they never hover.
  */
-async function enrichInBackground(
-  candidates: ScannedSessionAgent[],
+export async function prefetchAvailableAgentDetails(
+  agent: AvailableAgent,
   queryClient: QueryClient,
 ): Promise<void> {
-  if (candidates.length === 0) return;
-  const results = await Promise.allSettled(
-    candidates.map(async (scanned) => {
-      const res = await authenticatedFetch(
-        `/v1/sessions/${encodeURIComponent(scanned.sessionId)}/agent`,
+  if (!agent.sessionId || agent.harness !== null || agent.description !== null) return;
+  try {
+    const res = await authenticatedFetch(
+      `/v1/sessions/${encodeURIComponent(agent.sessionId)}/agent`,
+    );
+    if (!res.ok) return;
+    const json = (await res.json()) as AgentObjectWire;
+    queryClient.setQueryData<AvailableAgent[]>(["available-agents"], (prev) => {
+      if (!prev) return prev;
+      return prev.map((a) =>
+        a.id !== agent.id
+          ? a
+          : {
+              ...a,
+              display_name: displayNameForAgent(json.name, json.harness),
+              description: json.description ?? null,
+              harness: json.harness ?? null,
+              skills: json.skills ?? [],
+            },
       );
-      if (!res.ok) return null;
-      const json = (await res.json()) as AgentObjectWire;
-      return { agentId: scanned.agentId, json };
-    }),
-  );
-  const enriched = new Map<
-    string,
-    {
-      description: string | null;
-      harness: string | null;
-      skills: { name: string; description: string }[];
-    }
-  >();
-  for (const r of results) {
-    if (r.status === "fulfilled" && r.value) {
-      const { agentId, json } = r.value;
-      enriched.set(agentId, {
-        description: json.description ?? null,
-        harness: json.harness ?? null,
-        skills: json.skills ?? [],
-      });
-    }
-  }
-  if (enriched.size === 0) return;
-  queryClient.setQueryData<AvailableAgent[]>(["available-agents"], (prev) => {
-    if (!prev) return prev;
-    return prev.map((agent) => {
-      const data = enriched.get(agent.id);
-      if (!data) return agent;
-      return {
-        ...agent,
-        display_name: displayNameForAgent(agent.name, data.harness),
-        description: data.description,
-        harness: data.harness,
-        skills: data.skills,
-      };
     });
-  });
+  } catch {
+    // Best-effort — agent stays name-only on failure.
+  }
 }
 
 /**
@@ -302,7 +285,7 @@ async function enrichInBackground(
  * rather than blanking the picker — catalog availability must not be hostage
  * to the discovery extension.
  */
-async function fetchAvailableAgents(queryClient: QueryClient): Promise<AvailableAgent[]> {
+async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
   const [catalog, scanned] = await Promise.all([
     fetchBuiltinAgents(),
     scanSessionAgents().catch(() => [] as ScannedSessionAgent[]),
@@ -362,13 +345,8 @@ async function fetchAvailableAgents(queryClient: QueryClient): Promise<Available
     }
   }
 
-  const scannedCandidates: ScannedSessionAgent[] = [];
   const resolved = Array.from(byName.values())
-    .map((c) => {
-      if (c.template !== null) return c.template;
-      scannedCandidates.push(c.scanned!);
-      return sessionAgentFromScan(c.scanned!);
-    })
+    .map((c) => (c.template !== null ? c.template : sessionAgentFromScan(c.scanned!)))
     .filter((agent) => {
       const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
       return nativeKey !== "kiro" || !hasKiroBuiltin;
@@ -377,12 +355,6 @@ async function fetchAvailableAgents(queryClient: QueryClient): Promise<Available
   // first. NewChatDialog's display-order sort is stable, so unranked names
   // keep this relative order.
   resolved.sort((a, b) => recencyOf(b) - recencyOf(a));
-
-  // Fire enrichment in the background — don't await. The picker renders
-  // immediately with name-only data; harness/description/skills fill in
-  // once the per-session fetches complete.
-  void enrichInBackground(scannedCandidates, queryClient);
-
   return [...seeded, ...resolved];
 }
 
@@ -391,10 +363,9 @@ interface UseAvailableAgentsOptions {
 }
 
 export function useAvailableAgents(options: UseAvailableAgentsOptions = {}) {
-  const queryClient = useQueryClient();
   return useQuery({
     queryKey: ["available-agents"],
-    queryFn: () => fetchAvailableAgents(queryClient),
+    queryFn: fetchAvailableAgents,
     enabled: options.enabled ?? true,
     staleTime: 30_000,
   });

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -42,7 +42,10 @@ vi.mock("@/lib/identity", async (importOriginal) => ({
   authenticatedFetch: vi.fn(),
 }));
 vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
-vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
+vi.mock("@/hooks/useAvailableAgents", () => ({
+  useAvailableAgents: vi.fn(),
+  prefetchAvailableAgentDetails: vi.fn(),
+}));
 vi.mock("@/hooks/useHostFilesystem", () => ({
   useHostFilesystem: vi.fn(),
   // WorkspacePicker (rendered by the file browser) reads this on mount;

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1508,7 +1508,6 @@ function AgentHarnessPicker({
           data-testid={`new-chat-landing-agent-${agent.id}`}
           data-active={active ? "true" : undefined}
           onSelect={() => onSelectAgent(agent)}
-          onMouseEnter={() => void prefetchAvailableAgentDetails(agent, queryClient)}
           className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
         >
           {renderRowInner(agent, true)}
@@ -1536,7 +1535,6 @@ function AgentHarnessPicker({
             onSelectAgent(agent);
             setMobileKnobsAgentId(agent.id);
           }}
-          onMouseEnter={() => void prefetchAvailableAgentDetails(agent, queryClient)}
           className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
         >
           {renderRowInner(agent, false)}
@@ -1560,7 +1558,6 @@ function AgentHarnessPicker({
             onSelectAgent(agent);
             setOpen(false);
           }}
-          onMouseEnter={() => void prefetchAvailableAgentDetails(agent, queryClient)}
           className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
         >
           {renderRowInner(agent, false)}
@@ -1583,6 +1580,11 @@ function AgentHarnessPicker({
           // tall list, so the later drill-in (shorter page) can't flip it.
           const rect = triggerRef.current?.getBoundingClientRect();
           if (rect) setMobileSide(window.innerHeight - rect.bottom >= rect.top ? "bottom" : "top");
+          // Prefetch harness/description/skills for all session-discovered
+          // agents so hasKnobs is stable before the user reads the list.
+          for (const agent of [...harnessEntries, ...agentEntries]) {
+            void prefetchAvailableAgentDetails(agent, queryClient);
+          }
         } else {
           // Closing resets the in-place page so the menu always reopens on the
           // agent list, never a stale knobs page.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -88,7 +88,11 @@ import {
   onHostStatusChanged,
   type HostIdentity,
 } from "@/lib/nativeBridge";
-import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
+import {
+  useAvailableAgents,
+  prefetchAvailableAgentDetails,
+  type AvailableAgent,
+} from "@/hooks/useAvailableAgents";
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
@@ -1300,6 +1304,7 @@ function AgentHarnessPicker({
   // Controlled so clicking a knobbed row can commit the pick and close the
   // menu (see the sub-trigger onClick below) without diving into the submenu.
   const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
 
   // Touch devices can't hover, so the desktop knob flyout (a Radix sub-menu
   // that opens on hover) is unreachable there. On mobile we instead swap the
@@ -1503,6 +1508,7 @@ function AgentHarnessPicker({
           data-testid={`new-chat-landing-agent-${agent.id}`}
           data-active={active ? "true" : undefined}
           onSelect={() => onSelectAgent(agent)}
+          onMouseEnter={() => void prefetchAvailableAgentDetails(agent, queryClient)}
           className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
         >
           {renderRowInner(agent, true)}
@@ -1530,6 +1536,7 @@ function AgentHarnessPicker({
             onSelectAgent(agent);
             setMobileKnobsAgentId(agent.id);
           }}
+          onMouseEnter={() => void prefetchAvailableAgentDetails(agent, queryClient)}
           className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
         >
           {renderRowInner(agent, false)}
@@ -1553,6 +1560,7 @@ function AgentHarnessPicker({
             onSelectAgent(agent);
             setOpen(false);
           }}
+          onMouseEnter={() => void prefetchAvailableAgentDetails(agent, queryClient)}
           className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
         >
           {renderRowInner(agent, false)}


### PR DESCRIPTION
## Related issue

N/A

## Summary

The picker was blocking on N \`GET /v1/sessions/{id}/agent\` calls (one per session-discovered custom agent) before it could render. These fetch \`description\`, \`harness\`, and \`skills\` — none of which are needed to display the picker initially, but \`harness\` is needed for harness-dependent UI once the user selects an agent (model/effort picker, routing support, unconfigured-host warnings).

**New approach — background enrichment:**

1. \`fetchAvailableAgents\` returns immediately with name-only scan data so the picker renders in a single round-trip (2 parallel requests: \`GET /v1/agents\` + \`GET /v1/sessions?kind=any\`).
2. \`enrichInBackground\` fires the per-session fetches in parallel _without blocking_. When they land, \`queryClient.setQueryData\` patches \`harness\`/\`description\`/\`skills\` into the \`["available-agents"]\` cache, triggering a re-render with full data.

The picker is visible instantly; harness-dependent UI (model picker, routing card, host warnings) fills in asynchronously.

## Test Plan

1. Open the new-chat landing page with custom (session-discovered) agents that have a non-null harness (e.g. a \`claude-sdk\` agent from \`omnigent run\`).
2. Network tab — verify the picker renders before the \`/agent\` enrichment calls complete.
3. Confirm the model/effort picker and routing UI appear once enrichment lands.
4. Confirm \`description\` and \`skills\` also populate after enrichment.

## Demo

N/A — timing change only, no visual difference in final state.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing \`NewChatDialog\` tests cover the picker render and agent selection paths. The background enrichment path is a fire-and-forget that degrades gracefully on failure (agents remain name-only).