### PR TITLE
fix(web): make Monaco find a real toggle and suppress its keyboard-hint tooltip

### DIFF
--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -412,9 +412,10 @@ export function CodeViewer({
     return () => window.removeEventListener("keydown", handler);
   }, [panelOpen, isMarkdownEditor, showMonaco, searchOpen, setSearchOpen, searchInputRef]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // In Monaco mode the custom search bar isn't rendered; the editor opens its
-  // native find when `searchOpen` is set (once it has mounted), then calls this
-  // to reset the flag so the next Find click re-triggers it.
+  // In Monaco mode the custom search bar isn't rendered; the editor mirrors its
+  // native find widget to `searchOpen` (open when set, close when cleared). This
+  // resets the flag when find is closed from within Monaco (Escape or the
+  // widget's ✕) so the toolbar toggle stays in sync with the visible widget.
   const handleSearchHandled = useCallback(() => setSearchOpen(false), [setSearchOpen]);
 
   // Show "Add Comment" button after the user finishes a text selection

--- a/web/src/shell/MonacoCodeEditor.autosave.test.tsx
+++ b/web/src/shell/MonacoCodeEditor.autosave.test.tsx
@@ -37,6 +37,7 @@ interface FakeEditor {
   saveViewState: () => null;
   restoreViewState: () => void;
   getAction: () => { run: () => void };
+  getContribution: () => null;
   /** Test-only: set getValue() without firing onChange (mirrors a user keystroke
    *  landing in the buffer; the test fires onChange separately). */
   __set: (v: string) => void;
@@ -63,6 +64,7 @@ function makeFakeEditor(initial: string): FakeEditor {
     saveViewState: () => null,
     restoreViewState: () => {},
     getAction: () => ({ run: () => {} }),
+    getContribution: () => null,
     __set: (v) => {
       value = v;
     },

--- a/web/src/shell/MonacoCodeEditor.find.test.tsx
+++ b/web/src/shell/MonacoCodeEditor.find.test.tsx
@@ -1,0 +1,256 @@
+// Tests for the MonacoCodeEditor "Find in file" toggle wiring.
+//
+// The toolbar's Find button flips a `searchOpen` prop; the editor mirrors
+// Monaco's native find widget to it (open when set, close when cleared) and
+// reports back via onSearchHandled when find is closed from within Monaco
+// (Escape / the widget's ✕) so the toolbar toggle stays in sync.
+//
+// Monaco can't mount in jsdom, so @monaco-editor/react's Editor is mocked to
+// invoke onMount with a thin fake editor exposing the slice of API the find
+// wiring drives: getAction("actions.find").run(), and getContribution(...) →
+// a fake find controller (getState().isRevealed, closeFindWidget,
+// onFindReplaceStateChange). The comment layer and save wiring are irrelevant
+// here, so they're mocked out.
+
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+const h = vi.hoisted(() => ({
+  onChange: null as ((value: string | undefined, ev: unknown) => void) | null,
+}));
+
+const fakeMonaco = {
+  editor: { EndOfLineSequence: { LF: 1, CRLF: 2 } },
+  KeyMod: { CtrlCmd: 2048 },
+  KeyCode: { KeyS: 49 },
+};
+
+// Fake find controller. `isRevealed` is mutable so tests can model the widget's
+// real open/close state; onFindReplaceStateChange captures the listener so a
+// test can simulate a Monaco-initiated close.
+interface FakeFindController {
+  isRevealed: boolean;
+  run: Mock<() => void>;
+  closeFindWidget: Mock<() => void>;
+  getState: () => {
+    isRevealed: boolean;
+    onFindReplaceStateChange: (listener: (e: { isRevealed: boolean }) => void) => {
+      dispose: () => void;
+    };
+  };
+  fireStateChange: (e: { isRevealed: boolean }) => void;
+  dispose: Mock<() => void>;
+}
+
+function makeFakeController(): FakeFindController {
+  let listener: ((e: { isRevealed: boolean }) => void) | null = null;
+  const dispose = vi.fn(() => {
+    listener = null;
+  });
+  const controller: FakeFindController = {
+    isRevealed: false,
+    run: vi.fn(() => {
+      controller.isRevealed = true;
+    }),
+    closeFindWidget: vi.fn(() => {
+      controller.isRevealed = false;
+    }),
+    getState: () => ({
+      get isRevealed() {
+        return controller.isRevealed;
+      },
+      onFindReplaceStateChange: (l) => {
+        listener = l;
+        return { dispose };
+      },
+    }),
+    fireStateChange: (e) => listener?.(e),
+    dispose,
+  };
+  return controller;
+}
+
+let fakeController: FakeFindController;
+
+interface FakeEditor {
+  getValue: () => string;
+  setValue: (v: string) => void;
+  getModel: () => { setEOL: () => void };
+  addCommand: () => void;
+  onDidBlurEditorWidget: () => { dispose: () => void };
+  saveViewState: () => null;
+  restoreViewState: () => void;
+  getAction: (id: string) => { run: () => void } | undefined;
+  getContribution: (id: string) => FakeFindController | null;
+}
+
+function makeFakeEditor(initial: string): FakeEditor {
+  let value = initial;
+  return {
+    getValue: () => value,
+    setValue: (v) => {
+      value = v;
+    },
+    getModel: () => ({ setEOL: () => {} }),
+    addCommand: () => {},
+    onDidBlurEditorWidget: () => ({ dispose: () => {} }),
+    saveViewState: () => null,
+    restoreViewState: () => {},
+    // Only the find action is exercised here.
+    getAction: (id) => (id === "actions.find" ? { run: fakeController.run } : undefined),
+    getContribution: () => fakeController,
+  };
+}
+
+let fakeEditor: FakeEditor | null = null;
+
+vi.mock("@monaco-editor/react", async () => {
+  const { useEffect } = await import("react");
+  return {
+    Editor: (props: {
+      onMount?: (editor: unknown, monaco: unknown) => void;
+      onChange?: (value: string | undefined, ev: unknown) => void;
+    }) => {
+      h.onChange = props.onChange ?? null;
+      useEffect(() => {
+        props.onMount?.(fakeEditor, fakeMonaco);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return null;
+    },
+  };
+});
+
+vi.mock("./monacoSetup", () => ({
+  ensureMonacoReady: vi.fn(() => Promise.resolve()),
+  ensureLanguage: vi.fn(() => Promise.resolve()),
+  monacoLanguageId: vi.fn((lang: string) => lang),
+  resolvedThemeToMonaco: vi.fn(() => "github-light"),
+}));
+vi.mock("./useMonacoCommentLayer", () => ({ useMonacoCommentLayer: () => null }));
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+vi.mock("@/hooks/usePermissions", () => ({ useCanEdit: vi.fn().mockReturnValue(true) }));
+vi.mock("@/hooks/useWriteFileContent", () => ({ useWriteFileContent: vi.fn() }));
+vi.mock("@/hooks/RunnerHealthProvider", () => ({ useSessionRunnerOnline: vi.fn() }));
+
+import { MonacoCodeEditor } from "./MonacoCodeEditor";
+import * as writeHook from "@/hooks/useWriteFileContent";
+import * as runnerHook from "@/hooks/RunnerHealthProvider";
+
+const PATH = "src/a.ts";
+const INITIAL = "const x = 1;\n";
+
+function makeEditor(props: { searchOpen?: boolean; onSearchHandled?: () => void } = {}) {
+  return (
+    <MonacoCodeEditor
+      content={INITIAL}
+      conversationId="conv_monaco_find"
+      path={PATH}
+      isSettled={true}
+      comments={[]}
+      activeSelection={null}
+      onSetActiveSelection={() => {}}
+      {...props}
+    />
+  );
+}
+
+// Render and flush the ready promise so <Editor> mounts and onMount fires.
+async function renderMounted(el: React.ReactElement) {
+  const utils = render(el);
+  await act(async () => {});
+  return utils;
+}
+
+beforeEach(() => {
+  fakeEditor = makeFakeEditor(INITIAL);
+  fakeController = makeFakeController();
+  h.onChange = null;
+
+  vi.mocked(writeHook.useWriteFileContent).mockReturnValue({
+    isPending: false,
+    isError: false,
+    reset: vi.fn(),
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ReturnType<typeof writeHook.useWriteFileContent>);
+  vi.mocked(runnerHook.useSessionRunnerOnline).mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  fakeEditor = null;
+});
+
+describe("MonacoCodeEditor find toggle", () => {
+  it("opens Monaco's native find when searchOpen is set", async () => {
+    await renderMounted(makeEditor({ searchOpen: true }));
+    // The toolbar Find button (searchOpen=true) runs Monaco's find action.
+    expect(fakeController.run).toHaveBeenCalledTimes(1);
+    expect(fakeController.closeFindWidget).not.toHaveBeenCalled();
+  });
+
+  it("does not open find while searchOpen is false", async () => {
+    await renderMounted(makeEditor({ searchOpen: false }));
+    expect(fakeController.run).not.toHaveBeenCalled();
+    // No open widget → nothing to close.
+    expect(fakeController.closeFindWidget).not.toHaveBeenCalled();
+  });
+
+  it("closes the open find widget when searchOpen flips back to false", async () => {
+    const { rerender } = await renderMounted(makeEditor({ searchOpen: true }));
+    expect(fakeController.run).toHaveBeenCalledTimes(1);
+    // Widget is now open (run() set isRevealed). Re-clicking Find toggles the
+    // prop to false, which must close the widget — not open a second time.
+    await act(async () => {
+      rerender(makeEditor({ searchOpen: false }));
+    });
+    expect(fakeController.closeFindWidget).toHaveBeenCalledTimes(1);
+    expect(fakeController.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call closeFindWidget when the widget is already closed", async () => {
+    const { rerender } = await renderMounted(makeEditor({ searchOpen: false }));
+    // Flip false→true→false but simulate the widget never actually revealing
+    // (controller stays closed). The close guard reads isRevealed, so no
+    // redundant close fires.
+    fakeController.isRevealed = false;
+    await act(async () => {
+      rerender(makeEditor({ searchOpen: false }));
+    });
+    expect(fakeController.closeFindWidget).not.toHaveBeenCalled();
+  });
+
+  it("reports back via onSearchHandled when find is closed from within Monaco", async () => {
+    const onSearchHandled = vi.fn();
+    await renderMounted(makeEditor({ searchOpen: true, onSearchHandled }));
+    // Widget is open. Simulate the user pressing Escape / clicking the widget's
+    // ✕: Monaco flips isRevealed to false and fires a state change whose
+    // isRevealed flag marks that field as changed.
+    fakeController.isRevealed = false;
+    act(() => {
+      fakeController.fireStateChange({ isRevealed: true });
+    });
+    // The toolbar toggle is reset so the next click re-opens instead of no-op.
+    expect(onSearchHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores state changes that are not a find-widget close", async () => {
+    const onSearchHandled = vi.fn();
+    await renderMounted(makeEditor({ searchOpen: true, onSearchHandled }));
+    // A match-count/position change (isRevealed flag not set) must not reset the
+    // toggle — only an actual close does.
+    act(() => {
+      fakeController.fireStateChange({ isRevealed: false });
+    });
+    expect(onSearchHandled).not.toHaveBeenCalled();
+  });
+
+  it("disposes the state-change subscription on unmount", async () => {
+    const { unmount } = await renderMounted(makeEditor({ searchOpen: false }));
+    await act(async () => {
+      unmount();
+    });
+    expect(fakeController.dispose).toHaveBeenCalled();
+  });
+});

--- a/web/src/shell/MonacoCodeEditor.teardown.test.tsx
+++ b/web/src/shell/MonacoCodeEditor.teardown.test.tsx
@@ -37,6 +37,7 @@ interface FakeEditor {
   saveViewState: () => null;
   restoreViewState: () => void;
   getAction: () => { run: () => void };
+  getContribution: () => null;
   __set: (v: string) => void;
 }
 
@@ -54,6 +55,7 @@ function makeFakeEditor(initial: string): FakeEditor {
     saveViewState: () => null,
     restoreViewState: () => {},
     getAction: () => ({ run: () => {} }),
+    getContribution: () => null,
     __set: (v) => {
       value = v;
     },

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -40,10 +40,25 @@ import {
   monacoLanguageId,
   resolvedThemeToMonaco,
 } from "./monacoSetup";
+import type { monaco } from "./monacoSetup";
 import { useMonacoCommentLayer, type CodeEditorInstance } from "./useMonacoCommentLayer";
 import "./monacoCodeEditor.css";
 
 type EditorOptions = EditorProps["options"];
+
+// Monaco's find contribution isn't a public export, so we reach it by its
+// registered id and describe only the slice of its API we drive: read whether
+// the find widget is open, close it, and subscribe to open/close changes.
+const FIND_CONTROLLER_ID = "editor.contrib.findController";
+interface FindController extends monaco.editor.IEditorContribution {
+  getState(): {
+    readonly isRevealed: boolean;
+    onFindReplaceStateChange(listener: (e: { isRevealed: boolean }) => void): {
+      dispose(): void;
+    };
+  };
+  closeFindWidget(): void;
+}
 
 // How long the transient "Saved" badge stays up before the status chip clears
 // itself back to idle — long enough to register, short enough not to linger.
@@ -74,12 +89,16 @@ interface MonacoCodeEditorProps extends CommentProps {
   /** Reports the auto-save lifecycle up to FileViewer's toolbar status chip. */
   onSaveStatusChange?: (status: SaveStatus) => void;
   /**
-   * True when the FileViewer "Find in file" button wants Monaco's native find
-   * opened. The editor opens find once it has mounted (so a request made while
-   * the lazy chunk is still loading isn't dropped), then calls onSearchHandled.
+   * Toolbar "Find in file" toggle. The editor mirrors Monaco's native find
+   * widget to this flag once mounted (so a request made while the lazy chunk is
+   * still loading isn't dropped): true opens find, false closes it.
    */
   searchOpen?: boolean;
-  /** Called after the editor has opened find, so the parent can reset the flag. */
+  /**
+   * Called when the find widget is closed from within Monaco (Escape or the
+   * widget's ✕) so the parent can reset the toggle and keep the toolbar button
+   * in sync — otherwise the next click would no-op instead of re-opening.
+   */
   onSearchHandled?: () => void;
 }
 
@@ -320,16 +339,38 @@ function MonacoCodeEditorInner({
     [setContentRef],
   );
 
-  // Open Monaco's native find when the toolbar requests it. Gated on `mounted`
-  // so a Find pressed while the lazy chunk was still loading isn't dropped —
-  // when the editor mounts, `mounted` flips and this re-runs with searchOpen
-  // still true. Calling getAction before the find contribution loads would
-  // no-op, which is why we wait for the editor instance.
+  // Mirror Monaco's native find widget to the toolbar toggle. Gated on `mounted`
+  // so a Find pressed while the lazy chunk was still loading isn't dropped — when
+  // the editor mounts, `mounted` flips and this re-runs with the current flag.
+  // `searchOpen` true opens find; false closes it (so re-clicking the toolbar
+  // button, which toggles the flag, hides the widget). The controller drives the
+  // close directly rather than the open action so it's a real toggle, not a
+  // second open.
   useEffect(() => {
-    if (!mounted || !searchOpen) return;
-    editorInstanceRef.current?.getAction("actions.find")?.run();
-    onSearchHandled?.();
-  }, [mounted, searchOpen, onSearchHandled]);
+    if (!mounted) return;
+    const editor = editorInstanceRef.current;
+    if (!editor) return;
+    if (searchOpen) {
+      editor.getAction("actions.find")?.run();
+    } else {
+      const controller = editor.getContribution<FindController>(FIND_CONTROLLER_ID);
+      if (controller?.getState().isRevealed) controller.closeFindWidget();
+    }
+  }, [mounted, searchOpen]);
+
+  // Reflect a find close initiated inside Monaco (Escape or the widget's ✕) back
+  // to the toolbar toggle, so its state matches the visible widget and the next
+  // click re-opens instead of no-opping.
+  useEffect(() => {
+    if (!mounted) return;
+    const controller =
+      editorInstanceRef.current?.getContribution<FindController>(FIND_CONTROLLER_ID);
+    if (!controller) return;
+    const sub = controller.getState().onFindReplaceStateChange((e) => {
+      if (e.isRevealed && !controller.getState().isRevealed) onSearchHandled?.();
+    });
+    return () => sub.dispose();
+  }, [mounted, onSearchHandled]);
 
   const handleChange: OnChange = useCallback(
     (value) => {

--- a/web/src/shell/monacoCodeEditor.css
+++ b/web/src/shell/monacoCodeEditor.css
@@ -36,3 +36,14 @@
   --vscode-editor-background: var(--card);
   --vscode-editorGutter-background: var(--card);
 }
+
+/* Suppress the keyboard-hint tooltips Monaco attaches to its widget buttons
+   (e.g. the find widget's "Close (Escape)"). They render detached on <body> and
+   overlap the small floating find widget, reading as flaky. Monaco is the only
+   source of .monaco-hover in this app (the rest of the UI uses its own tooltip),
+   and this editor ships no language services, so no useful content hovers are
+   lost. The pointer caret element is hidden alongside it. */
+.monaco-hover.workbench-hover,
+.workbench-hover-pointer {
+  display: none !important;
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

The file viewer's **Find in file** action opened Monaco's native find widget but then immediately reset the internal `searchOpen` flag, so the toolbar toggle never tracked the widget's real state. Three visible bugs resulted:

- Re-clicking **Find in file** re-opened the widget instead of closing it (it was never a real toggle).
- Closing find from inside Monaco (Escape or the widget's ✕) left the toolbar toggle stuck `true`, so the next click no-oped.
- Monaco's own `(Escape)` hint tooltip floated over the small find widget and read as flaky.

This PR:

- **Mirrors** the native find widget to `searchOpen` — `true` opens find, `false` closes it via the find controller (`closeFindWidget`) — so re-clicking the toolbar button now closes it.
- **Subscribes** to the find controller's state changes and resets the toggle (`onSearchHandled`) when find is closed from within Monaco, keeping the button in sync so the next click reliably re-opens.
- **Suppresses** Monaco's detached keyboard-hint tooltips (`.monaco-hover.workbench-hover`), scoped in `monacoCodeEditor.css`. Safe here: Monaco is the only source of `.monaco-hover` in the app and this editor ships no language services, so no useful content hovers are lost.

The find controller isn't a public Monaco export, so it's reached by its registered id (`editor.contrib.findController`) with a minimal local `FindController` type.

## Test Plan

- Added `web/src/shell/MonacoCodeEditor.find.test.tsx` (7 tests) driving a fake editor + fake find controller through `onMount`: opens on `searchOpen`, doesn't open when false, closes on toggle-back, no redundant close when already closed, reports back via `onSearchHandled` on a Monaco-initiated close, ignores non-close state changes, and disposes the subscription on unmount.
- `cd web && npm test` → 4022 passed (full suite green).
- `cd web && npm run build` → clean (`tsc -b && vite build`).
- Typecheck (`tsc -p tsconfig.app.json --noEmit`), prettier, and oxlint all clean on changed files.

## Demo

N/A — behavioural fix to an existing widget (open/close toggle + tooltip suppression); no new UI surface. Verified via the added unit tests and the manual flow described above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the full find open/close/toggle/report state machine against a fake find controller. Manual verification of the tooltip suppression and the live widget open/close was done against the running editor; the CSS suppression itself is not unit-testable (detached Monaco DOM).

## Changelog

Find in file now toggles the editor's find bar closed on a second click, and its close button no longer shows a stray keyboard-hint tooltip

This pull request and its description were written by Isaac.