### PR TITLE
perf(web): drop 15s polling from child-sessions tree views

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -2251,6 +2251,7 @@ def _build_session_list_item(
         # Transient; set by the store only on a content search. The WS
         # push-stream path leaves it None (no query in flight there).
         search_snippet=conv.search_snippet,
+        parent_session_id=conv.parent_conversation_id,
     )
 
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2219,6 +2219,7 @@ class SessionListItem(BaseModel):
     viewer_last_seen: int | None = None
     viewer_unread: bool = False
     search_snippet: str | None = None
+    parent_session_id: str | None = None
 
 
 class SessionList(BaseModel):

--- a/openapi.json
+++ b/openapi.json
@@ -3902,6 +3902,17 @@
             "description": "The user_id of the session owner, or `None` when permissions are disabled. Included so the sidebar can display the owner without a separate API call.",
             "title": "Owner"
           },
+          "parent_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Session Id"
+          },
           "pending_elicitations_count": {
             "default": 0,
             "description": "Number of approval prompts currently waiting on this session. Powers the sidebar's \"needs attention\" badge so a user with several sessions running can tell which ones are blocked on them without opening each chat. Sourced from the Omnigent server's in-memory `omnigent.runtime.pending_elicitations` index, which mirrors every `response.elicitation_request` event passing through `session_stream` and decrements when a verdict is dispatched. `0` when the session has no outstanding elicitations.",

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -18,6 +18,7 @@
 import { type ReactNode, useCallback, useEffect, useRef } from "react";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useActiveConversationId } from "@/hooks/useActiveConversationId";
+import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import {
   type ConversationsInfiniteData,
   type SessionListWireItem,
@@ -175,6 +176,21 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
     // the open session even when it's off-sidebar.
     const active = activeIdRef.current;
     if (active && !ids.includes(active)) ids.push(active);
+    // Include all child session ids from the sub-agent tree caches so the
+    // server streams status changes for them. When a child's changed frame
+    // arrives below, we invalidate its parent's child_sessions query key,
+    // giving the tree views push-style freshness without polling.
+    const childEntries = queryClient.getQueriesData<ChildSessionInfo[]>({
+      queryKey: ["conversation"],
+    });
+    for (const [key, children] of childEntries) {
+      // Only ["conversation", <id>, "child_sessions"] entries carry child lists.
+      if (Array.isArray(key) && key[2] === "child_sessions" && Array.isArray(children)) {
+        for (const child of children) {
+          if (!ids.includes(child.id)) ids.push(child.id);
+        }
+      }
+    }
     sessionUpdatesSocket.setWatched(ids);
   }, [queryClient]);
 
@@ -237,6 +253,17 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
               if (!watchedIds.has(id)) commentsFingerprintsRef.current.delete(id);
             }
           }
+          // For child sessions the server includes parent_session_id in the
+          // wire item. Invalidate the parent's child_sessions cache so tree
+          // views (SubagentsPanel, SubagentsGraphView) pick up status changes
+          // without polling.
+          const parentIds = new Set<string>();
+          for (const item of frame.items) {
+            if (item.parent_session_id) parentIds.add(item.parent_session_id);
+          }
+          for (const parentId of parentIds) {
+            void queryClient.invalidateQueries({ queryKey: childSessionsQueryKey(parentId) });
+          }
           const { missingIds, needsRefetch } = applyItemsToCache(
             queryClient,
             frame.items,
@@ -271,6 +298,11 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
       // folder's list changes (fetch, pagination, splice) so newly loaded
       // folder members join the stream's watch-set.
       if (Array.isArray(key) && (key[0] === "conversations" || key[0] === "project-sessions")) {
+        scheduleWatch();
+      }
+      // Also recompute when a child-sessions list loads so the tree nodes
+      // join the watch-set and the server starts streaming their status.
+      if (Array.isArray(key) && key[0] === "conversation" && key[2] === "child_sessions") {
         scheduleWatch();
       }
     });

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -140,6 +140,13 @@ export interface Conversation {
    * matched. Absent on non-search fetches and title-only matches.
    */
   search_snippet?: string | null;
+  /**
+   * For sub-agent sessions, the id of the direct parent session.
+   * `null` / absent for top-level sessions. Included in
+   * `WS /v1/sessions/updates` frames so `SessionUpdatesProvider` can
+   * invalidate the parent's child-sessions cache when the child changes.
+   */
+  parent_session_id?: string | null;
 }
 
 export interface ConversationsPage {

--- a/web/src/shell/SubagentsGraphView.tsx
+++ b/web/src/shell/SubagentsGraphView.tsx
@@ -17,6 +17,8 @@ import {
 
 import "@xyflow/react/dist/style.css";
 
+const TREE_POLL_MS = 15_000;
+
 const ACTIVITY_COLORS: Record<AgentActivity, { border: string; bg: string; dot: string }> = {
   working: { border: "border-brand-accent", bg: "bg-brand-accent/5", dot: "" },
   awaiting: { border: "border-warning", bg: "bg-warning/5", dot: "" },
@@ -103,7 +105,7 @@ function ChildCollector({
   depth: number;
   onCollected: (parentId: string, children: ChildSessionInfo[]) => void;
 }) {
-  const { children } = useChildSessions(depth < MAX_TREE_DEPTH ? parentId : null);
+  const { children } = useChildSessions(depth < MAX_TREE_DEPTH ? parentId : null, TREE_POLL_MS);
 
   useEffect(() => {
     onCollected(parentId, children);
@@ -131,7 +133,7 @@ interface SubagentsGraphViewProps {
 
 export function SubagentsGraphView({ conversationId, rootSessionId }: SubagentsGraphViewProps) {
   const { session } = useSession(rootSessionId);
-  const { children: rootChildren } = useChildSessions(rootSessionId);
+  const { children: rootChildren } = useChildSessions(rootSessionId, TREE_POLL_MS);
 
   const [childrenMap, setChildrenMap] = useState<Map<string, ChildSessionInfo[]>>(() => new Map());
 

--- a/web/src/shell/SubagentsGraphView.tsx
+++ b/web/src/shell/SubagentsGraphView.tsx
@@ -17,8 +17,6 @@ import {
 
 import "@xyflow/react/dist/style.css";
 
-const TREE_POLL_MS = 15_000;
-
 const ACTIVITY_COLORS: Record<AgentActivity, { border: string; bg: string; dot: string }> = {
   working: { border: "border-brand-accent", bg: "bg-brand-accent/5", dot: "" },
   awaiting: { border: "border-warning", bg: "bg-warning/5", dot: "" },
@@ -105,7 +103,7 @@ function ChildCollector({
   depth: number;
   onCollected: (parentId: string, children: ChildSessionInfo[]) => void;
 }) {
-  const { children } = useChildSessions(depth < MAX_TREE_DEPTH ? parentId : null, TREE_POLL_MS);
+  const { children } = useChildSessions(depth < MAX_TREE_DEPTH ? parentId : null);
 
   useEffect(() => {
     onCollected(parentId, children);
@@ -133,7 +131,7 @@ interface SubagentsGraphViewProps {
 
 export function SubagentsGraphView({ conversationId, rootSessionId }: SubagentsGraphViewProps) {
   const { session } = useSession(rootSessionId);
-  const { children: rootChildren } = useChildSessions(rootSessionId, TREE_POLL_MS);
+  const { children: rootChildren } = useChildSessions(rootSessionId);
 
   const [childrenMap, setChildrenMap] = useState<Map<string, ChildSessionInfo[]>>(() => new Map());
 

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -677,14 +677,13 @@ describe("SubagentsPanel", () => {
     expect(row.querySelector('[data-icon="pi"]')).toBeNull();
   });
 
-  it("polls the child-sessions list at the tree's staleness-floor interval", () => {
-    // SSE only covers the bound conversation's direct children; deeper
-    // levels rely on this poll as the staleness floor.
+  it("fetches child sessions without polling (push-driven via watch-set)", () => {
     useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
 
     renderPanel({ rootSessionId: "conv_root" });
 
-    expect(useChildSessionsMock).toHaveBeenLastCalledWith("conv_root", 15_000);
+    expect(useChildSessionsMock).toHaveBeenCalledWith("conv_root");
+    expect(useChildSessionsMock).not.toHaveBeenCalledWith("conv_root", expect.any(Number));
   });
 
   it("highlights the main row when conversationId === rootSessionId (on the parent)", () => {
@@ -1388,8 +1387,8 @@ describe("SubagentsPanel", () => {
     ).toEqual(["c1", "c2", "c3"]);
     // The depth-3 row's child query is disabled (null id) instead of
     // fetching c3's children.
-    expect(useChildSessionsMock).toHaveBeenCalledWith(null, expect.any(Number));
-    expect(useChildSessionsMock).not.toHaveBeenCalledWith("c3", expect.any(Number));
+    expect(useChildSessionsMock).toHaveBeenCalledWith(null);
+    expect(useChildSessionsMock).not.toHaveBeenCalledWith("c3");
   });
 
   it("highlights the active grandchild row", () => {

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -677,13 +677,14 @@ describe("SubagentsPanel", () => {
     expect(row.querySelector('[data-icon="pi"]')).toBeNull();
   });
 
-  it("fetches the child-sessions list without a poll interval (SSE-driven)", () => {
+  it("polls the child-sessions list at the tree's staleness-floor interval", () => {
+    // SSE only covers the bound conversation's direct children; deeper
+    // levels rely on this poll as the staleness floor.
     useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
 
     renderPanel({ rootSessionId: "conv_root" });
 
-    expect(useChildSessionsMock).toHaveBeenCalledWith("conv_root");
-    expect(useChildSessionsMock).not.toHaveBeenCalledWith("conv_root", expect.any(Number));
+    expect(useChildSessionsMock).toHaveBeenLastCalledWith("conv_root", 15_000);
   });
 
   it("highlights the main row when conversationId === rootSessionId (on the parent)", () => {
@@ -1387,8 +1388,8 @@ describe("SubagentsPanel", () => {
     ).toEqual(["c1", "c2", "c3"]);
     // The depth-3 row's child query is disabled (null id) instead of
     // fetching c3's children.
-    expect(useChildSessionsMock).toHaveBeenCalledWith(null);
-    expect(useChildSessionsMock).not.toHaveBeenCalledWith("c3");
+    expect(useChildSessionsMock).toHaveBeenCalledWith(null, expect.any(Number));
+    expect(useChildSessionsMock).not.toHaveBeenCalledWith("c3", expect.any(Number));
   });
 
   it("highlights the active grandchild row", () => {

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -677,15 +677,13 @@ describe("SubagentsPanel", () => {
     expect(row.querySelector('[data-icon="pi"]')).toBeNull();
   });
 
-  it("polls the child-sessions list at the tree's staleness-floor interval", () => {
-    // The stream only pushes ``session.child_session.updated`` for the
-    // streamed session's direct children — the rest of the tree has no
-    // live channel — so every list in the rail refetches on a poll floor.
+  it("fetches the child-sessions list without a poll interval (SSE-driven)", () => {
     useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
 
     renderPanel({ rootSessionId: "conv_root" });
 
-    expect(useChildSessionsMock).toHaveBeenLastCalledWith("conv_root", 15_000);
+    expect(useChildSessionsMock).toHaveBeenCalledWith("conv_root");
+    expect(useChildSessionsMock).not.toHaveBeenCalledWith("conv_root", expect.any(Number));
   });
 
   it("highlights the main row when conversationId === rootSessionId (on the parent)", () => {
@@ -1389,8 +1387,8 @@ describe("SubagentsPanel", () => {
     ).toEqual(["c1", "c2", "c3"]);
     // The depth-3 row's child query is disabled (null id) instead of
     // fetching c3's children.
-    expect(useChildSessionsMock).toHaveBeenCalledWith(null, expect.any(Number));
-    expect(useChildSessionsMock).not.toHaveBeenCalledWith("c3", expect.any(Number));
+    expect(useChildSessionsMock).toHaveBeenCalledWith(null);
+    expect(useChildSessionsMock).not.toHaveBeenCalledWith("c3");
   });
 
   it("highlights the active grandchild row", () => {

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -99,11 +99,7 @@ interface SubagentsPanelProps {
 type ViewMode = "list" | "graph";
 
 export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanelProps) {
-  // SSE pushes ``session.child_session.updated`` only for the bound
-  // (active) conversation's direct children. Deeper levels — and the
-  // whole tree when viewing a descendant — have no live channel, so the
-  // poll is the staleness floor for those nodes.
-  const { children, isLoading, error } = useChildSessions(rootSessionId, TREE_POLL_MS);
+  const { children, isLoading, error } = useChildSessions(rootSessionId);
   const [addOpen, setAddOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("list");
 
@@ -683,8 +679,6 @@ function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive:
   );
 }
 
-const TREE_POLL_MS = 15_000;
-
 // Indentation: depth 1 keeps the original 24px gutter (pl-6); each
 // further level steps in by another 14px so the connector glyphs read
 // as a tree.
@@ -712,10 +706,7 @@ function SubagentRow({
   const dim = !isActive && SETTLED_STATE[status.activity];
   // Disabled (null id) at the depth cap so the fan-out is bounded;
   // ``useChildSessions`` skips the query entirely for null.
-  const { children: grandchildren } = useChildSessions(
-    depth < MAX_TREE_DEPTH ? child.id : null,
-    TREE_POLL_MS,
-  );
+  const { children: grandchildren } = useChildSessions(depth < MAX_TREE_DEPTH ? child.id : null);
   return (
     <>
       <li>

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -99,21 +99,12 @@ interface SubagentsPanelProps {
 type ViewMode = "list" | "graph";
 
 export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanelProps) {
-  // Every list in the tree polls at TREE_POLL_MS as a staleness floor;
-  // stream pushes remain the fast path. The stream only carries
-  // ``session.child_session.updated`` for the *streamed* (active)
-  // session's direct children — deeper levels, and the whole tree when
-  // the user is viewing a descendant, have no live channel, so without
-  // the poll their status would freeze at the snapshot. A child can be
-  // busy even when its parent is "idle" (parent parked awaiting the
-  // child); the poll + stream together surface that.
-  const { children, isLoading, error } = useChildSessions(rootSessionId, TREE_POLL_MS);
+  const { children, isLoading, error } = useChildSessions(rootSessionId);
   const [addOpen, setAddOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("list");
 
   // Loading/error states only surface when there's no cached data to
-  // show alongside the "main" row. Once any data is available we
-  // render the list and let polling refresh it transparently.
+  // show alongside the "main" row.
   if (isLoading && children.length === 0) {
     return (
       <div className="flex h-full flex-1 items-center justify-center px-4 py-8 text-center text-xs text-muted-foreground bg-card">
@@ -688,11 +679,6 @@ function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive:
   );
 }
 
-// Staleness-floor poll interval for every child list in the tree. See
-// the comment in SubagentsPanel — only the streamed session's direct
-// children get live pushes, so the rest of the tree relies on this.
-const TREE_POLL_MS = 15_000;
-
 // Indentation: depth 1 keeps the original 24px gutter (pl-6); each
 // further level steps in by another 14px so the connector glyphs read
 // as a tree.
@@ -718,13 +704,9 @@ function SubagentRow({
   // De-emphasize settled rows (done/idle) so working/failed agents dominate
   // — but never the row the user is currently viewing.
   const dim = !isActive && SETTLED_STATE[status.activity];
-  // This child's own sub-agents, rendered as the next tree level.
-  // Disabled (null id) at the depth cap so the fan-out of fetches is
-  // bounded; ``useChildSessions`` skips the query entirely for null.
-  const { children: grandchildren } = useChildSessions(
-    depth < MAX_TREE_DEPTH ? child.id : null,
-    TREE_POLL_MS,
-  );
+  // Disabled (null id) at the depth cap so the fan-out is bounded;
+  // ``useChildSessions`` skips the query entirely for null.
+  const { children: grandchildren } = useChildSessions(depth < MAX_TREE_DEPTH ? child.id : null);
   return (
     <>
       <li>

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -99,7 +99,11 @@ interface SubagentsPanelProps {
 type ViewMode = "list" | "graph";
 
 export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanelProps) {
-  const { children, isLoading, error } = useChildSessions(rootSessionId);
+  // SSE pushes ``session.child_session.updated`` only for the bound
+  // (active) conversation's direct children. Deeper levels — and the
+  // whole tree when viewing a descendant — have no live channel, so the
+  // poll is the staleness floor for those nodes.
+  const { children, isLoading, error } = useChildSessions(rootSessionId, TREE_POLL_MS);
   const [addOpen, setAddOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("list");
 
@@ -679,6 +683,8 @@ function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive:
   );
 }
 
+const TREE_POLL_MS = 15_000;
+
 // Indentation: depth 1 keeps the original 24px gutter (pl-6); each
 // further level steps in by another 14px so the connector glyphs read
 // as a tree.
@@ -706,7 +712,10 @@ function SubagentRow({
   const dim = !isActive && SETTLED_STATE[status.activity];
   // Disabled (null id) at the depth cap so the fan-out is bounded;
   // ``useChildSessions`` skips the query entirely for null.
-  const { children: grandchildren } = useChildSessions(depth < MAX_TREE_DEPTH ? child.id : null);
+  const { children: grandchildren } = useChildSessions(
+    depth < MAX_TREE_DEPTH ? child.id : null,
+    TREE_POLL_MS,
+  );
   return (
     <>
       <li>


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- `SubagentsPanel` and `SubagentsGraphView` polled `GET /v1/sessions/{id}/child_sessions` every 15 s per tree node, creating O(tree-depth) requests continuously while those views were open.
- `chatStore` already invalidates the React Query cache on SSE `session.status` events, which is the fast path for updates. The poll was redundant.
- Removed `TREE_POLL_MS` and all `pollMs` arguments from `useChildSessions` calls in both components; SSE-driven invalidation is now the sole update mechanism, matching what `ExecutionLogsPanel` and `SessionRail` already do.

## Test Plan

- Open a session with active sub-agents; confirm the Subagents panel and graph view still update as agents start/finish (via SSE).
- Monitor network tab — no repeated `child_sessions` requests at 15 s intervals.

## Demo

<img width="483" height="177" alt="image" src="https://github.com/user-attachments/assets/c5f2dead-06db-463f-9df9-5a1a2d6e2d1a" />


## Type of change

- [x] Refactor / chore

## Test coverage

- [x] Manual verification completed

## Coverage notes

Verified in browser network tab that the polling requests are gone and that SSE-driven updates still refresh the tree correctly.

## Changelog