### PR TITLE
perf(web): enrich session-discovered agents in background after initial render (re-land)

### DIFF
--- a/web/src/hooks/useAvailableAgents.test.tsx
+++ b/web/src/hooks/useAvailableAgents.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useAvailableAgents } from "./useAvailableAgents";
+import { useAvailableAgents, prefetchAvailableAgentDetails } from "./useAvailableAgents";
 
 // The hook unions the built-in agent list from GET /v1/agents with
 // custom agents discovered on the caller's sessions via
@@ -700,5 +700,145 @@ describe("useAvailableAgents", () => {
         skills: [],
       },
     ]);
+  });
+});
+
+describe("prefetchAvailableAgentDetails", () => {
+  it("patches harness, description, and skills into the cache on success", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const agent = {
+      id: "ag_doc",
+      name: "doc-writer",
+      display_name: "Doc-writer",
+      description: null,
+      harness: null,
+      skills: [],
+      sessionId: "conv_3",
+    };
+    queryClient.setQueryData(["available-agents"], [agent]);
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        id: "ag_doc",
+        object: "agent",
+        name: "doc-writer",
+        description: "Documentation specialist",
+        harness: "claude-sdk",
+        skills: [{ name: "humanizer", description: "Remove AI writing patterns" }],
+      }),
+    );
+
+    await prefetchAvailableAgentDetails(agent, queryClient);
+
+    expect(queryClient.getQueryData(["available-agents"])).toEqual([
+      {
+        id: "ag_doc",
+        name: "doc-writer",
+        display_name: "Doc-writer",
+        description: "Documentation specialist",
+        harness: "claude-sdk",
+        sessionId: "conv_3",
+        skills: [{ name: "humanizer", description: "Remove AI writing patterns" }],
+      },
+    ]);
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/sessions/conv_3/agent");
+  });
+
+  it("is a no-op when harness is already populated", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const agent = {
+      id: "ag_doc",
+      name: "doc-writer",
+      display_name: "Doc-writer",
+      description: null,
+      harness: "claude-sdk",
+      skills: [],
+      sessionId: "conv_3",
+    };
+    queryClient.setQueryData(["available-agents"], [agent]);
+
+    await prefetchAvailableAgentDetails(agent, queryClient);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(["available-agents"])).toEqual([agent]);
+  });
+
+  it("is a no-op when sessionId is absent (catalog agent)", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const agent = {
+      id: "ag_native",
+      name: "claude-native-ui",
+      display_name: "Claude Code",
+      description: null,
+      harness: null,
+      skills: [],
+    };
+    queryClient.setQueryData(["available-agents"], [agent]);
+
+    await prefetchAvailableAgentDetails(agent, queryClient);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the agent name-only when the enrich fetch fails", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const agent = {
+      id: "ag_doc",
+      name: "doc-writer",
+      display_name: "Doc-writer",
+      description: null,
+      harness: null,
+      skills: [],
+      sessionId: "conv_3",
+    };
+    queryClient.setQueryData(["available-agents"], [agent]);
+
+    fetchMock.mockResolvedValueOnce(mockResponse({ detail: "boom" }, { ok: false, status: 500 }));
+
+    await prefetchAvailableAgentDetails(agent, queryClient);
+
+    // Cache unchanged — agent stays with scan-only fields.
+    expect(queryClient.getQueryData(["available-agents"])).toEqual([agent]);
+  });
+
+  it("removes a session agent when enrichment reveals it is a native shadow", async () => {
+    // A session bound a kiro agent with a non-canonical name ("kiro-naitive"
+    // typo). On initial load harness is null so it passes the kiro filter.
+    // prefetchAvailableAgentDetails detects harness: "kiro-native" after
+    // enrichment and removes the agent since a seeded kiro built-in exists.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const kiroBuiltin = {
+      id: "ag_kiro",
+      name: "kiro-native-ui",
+      display_name: "Kiro",
+      description: null,
+      harness: "kiro-native",
+      skills: [],
+    };
+    const kiroShadow = {
+      id: "ag_session_kiro",
+      name: "kiro-naitive",
+      display_name: "Kiro-naitive",
+      description: null,
+      harness: null,
+      skills: [],
+      sessionId: "conv_kiro",
+    };
+    queryClient.setQueryData(["available-agents"], [kiroBuiltin, kiroShadow]);
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        id: "ag_session_kiro",
+        object: "agent",
+        name: "kiro-naitive",
+        harness: "kiro-native",
+        skills: [],
+      }),
+    );
+
+    await prefetchAvailableAgentDetails(kiroShadow, queryClient);
+
+    // Shadow removed; only the seeded built-in remains.
+    expect(queryClient.getQueryData(["available-agents"])).toEqual([kiroBuiltin]);
   });
 });

--- a/web/src/hooks/useAvailableAgents.test.tsx
+++ b/web/src/hooks/useAvailableAgents.test.tsx
@@ -349,34 +349,15 @@ describe("useAvailableAgents", () => {
             agent_id: "ag_clone2",
             agent_name: "claude-native-ui (fork conv_9) (fork conv_10)",
           },
-          // Genuinely custom agent; survives and is enriched below.
+          // Genuinely custom agent; survives with scan-only fields on initial
+          // load (harness/description filled on hover via prefetchAvailableAgentDetails).
           { id: "conv_3", agent_id: "ag_doc", agent_name: "doc-writer" },
-          // Same custom agent on an older session — deduped by id, and
-          // the enrich fetch must use the newest session (conv_3).
+          // Same custom agent on an older session — deduped by id.
           { id: "conv_4", agent_id: "ag_doc", agent_name: "doc-writer" },
           // Orphaned row (agent deleted) — skipped.
           { id: "conv_5", agent_id: "ag_gone", agent_name: null },
         ],
         has_more: false,
-      }),
-      "/v1/sessions/conv_3/agent": mockResponse({
-        id: "ag_doc",
-        object: "agent",
-        name: "doc-writer",
-        description: "Documentation specialist",
-        harness: "claude-sdk",
-        skills: [{ name: "humanizer", description: "Remove AI writing patterns" }],
-      }),
-      // Reached only if the fork-of-fork leaks (i.e. the fix regressed):
-      // its claude-native harness would resolve to "Claude Code", proving
-      // the leak renders as a duplicate built-in. With the fix conv_6 is
-      // dropped before enrichment, so this mock is never hit.
-      "/v1/sessions/conv_6/agent": mockResponse({
-        id: "ag_clone2",
-        object: "agent",
-        name: "claude-native-ui (fork conv_9) (fork conv_10)",
-        harness: "claude-native",
-        skills: [],
       }),
     });
 
@@ -388,6 +369,8 @@ describe("useAvailableAgents", () => {
     // ag_clone2 specifically guards the nested fork-of-fork case that
     // surfaces as a duplicate built-in; ag_doc missing means kind=any
     // discovery broke; two ag_doc rows mean the by-id dedup broke.
+    // description/harness are null on initial load — enriched on hover
+    // via prefetchAvailableAgentDetails.
     expect(result.current.data).toEqual([
       {
         id: "ag_native",
@@ -401,18 +384,17 @@ describe("useAvailableAgents", () => {
         id: "ag_doc",
         name: "doc-writer",
         display_name: "Doc-writer",
-        description: "Documentation specialist",
-        harness: "claude-sdk",
-        skills: [{ name: "humanizer", description: "Remove AI writing patterns" }],
+        description: null,
+        harness: null,
+        sessionId: "conv_3",
+        skills: [],
       },
     ]);
-    // The enrich fetch ran once, against the newest session the agent
-    // was seen on — not the older duplicate (conv_4) and not the
-    // shadowed rows (which must not be enriched at all).
+    // No enrich fetches on initial load — enrichment is deferred to hover.
     const enrichCalls = fetchMock.mock.calls
       .map((c) => c[0] as string)
       .filter((u) => u.endsWith("/agent"));
-    expect(enrichCalls).toEqual(["/v1/sessions/conv_3/agent"]);
+    expect(enrichCalls).toEqual([]);
   });
 
   it("dedupes native built-ins and hides session-discovered native shadows", async () => {
@@ -438,8 +420,10 @@ describe("useAvailableAgents", () => {
       [SCAN_URL]: mockResponse({
         object: "list",
         data: [
-          // This distinct session-bound id used to enrich into a second
-          // Kiro row because it did not shadow the built-in by name/id.
+          // Session-bound id with a non-canonical kiro name (server typo).
+          // On initial load harness is null (lazy enrichment), so it appears
+          // in the list; prefetchAvailableAgentDetails removes it once enriched
+          // to harness: "kiro-native" and a kiro built-in already exists.
           { id: "conv_kiro", agent_id: "ag_session_kiro", agent_name: "kiro-naitive" },
           // Legacy failed Kiro attempts used a plain "kiro" agent name and
           // no harness; that row must not surface as a custom Kiro picker row.
@@ -447,17 +431,15 @@ describe("useAvailableAgents", () => {
         ],
         has_more: false,
       }),
-      "/v1/sessions/conv_kiro/agent": mockResponse({
-        id: "ag_session_kiro",
-        object: "agent",
-        name: "kiro-naitive",
-        harness: "kiro-native",
-      }),
     });
 
     const { result } = renderHook(() => useAvailableAgents(), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
+    // ag_session_kiro appears on initial load with harness: null because
+    // enrichment is deferred. prefetchAvailableAgentDetails (called on picker
+    // open) would later detect harness: "kiro-native" and remove the duplicate.
+    // ag_legacy_kiro is filtered by kiroLegacyNames (name: "kiro").
     expect(result.current.data).toEqual([
       {
         id: "ag_codex",
@@ -481,6 +463,15 @@ describe("useAvailableAgents", () => {
         display_name: "Kiro",
         description: null,
         harness: "kiro-native",
+        skills: [],
+      },
+      {
+        id: "ag_session_kiro",
+        name: "kiro-naitive",
+        display_name: "Kiro-naitive",
+        description: null,
+        harness: null,
+        sessionId: "conv_kiro",
         skills: [],
       },
     ]);
@@ -510,23 +501,6 @@ describe("useAvailableAgents", () => {
         ],
         has_more: false,
       }),
-      // Only the newest session per name may be enriched. An enrich
-      // fetch for conv_mid/conv_old is unrouted and rejects loudly,
-      // failing the test if the by-name collapse regresses.
-      "/v1/sessions/conv_new/agent": mockResponse({
-        id: "ag_run3",
-        object: "agent",
-        name: "elise_working_agent",
-        description: "Elise's agent",
-        harness: "claude-sdk",
-      }),
-      "/v1/sessions/conv_doc/agent": mockResponse({
-        id: "ag_doc",
-        object: "agent",
-        name: "doc-writer",
-        description: null,
-        harness: "codex",
-      }),
     });
 
     const { result } = renderHook(() => useAvailableAgents(), { wrapper });
@@ -535,13 +509,15 @@ describe("useAvailableAgents", () => {
     // Exactly one elise row (the newest mint, ag_run3) plus doc-writer.
     // Three elise rows would mean the by-name collapse regressed to
     // by-id-only dedup; zero would mean customs were over-collapsed.
+    // description/harness are null on initial load (enriched on hover).
     expect(result.current.data).toEqual([
       {
         id: "ag_run3",
         name: "elise_working_agent",
         display_name: "Elise_working_agent",
-        description: "Elise's agent",
-        harness: "claude-sdk",
+        description: null,
+        harness: null,
+        sessionId: "conv_new",
         skills: [],
       },
       {
@@ -549,7 +525,8 @@ describe("useAvailableAgents", () => {
         name: "doc-writer",
         display_name: "Doc-writer",
         description: null,
-        harness: "codex",
+        harness: null,
+        sessionId: "conv_doc",
         skills: [],
       },
     ]);
@@ -589,13 +566,6 @@ describe("useAvailableAgents", () => {
         ],
         has_more: false,
       }),
-      "/v1/sessions/conv_b/agent": mockResponse({
-        id: "ag_upload_v2",
-        object: "agent",
-        name: "agent-a",
-        description: "version 2",
-        harness: "claude-sdk",
-      }),
     });
 
     const { result } = renderHook(() => useAvailableAgents(), { wrapper });
@@ -607,11 +577,11 @@ describe("useAvailableAgents", () => {
     // mean the template and upload both leaked.
     const ids = result.current.data?.map((a) => a.id);
     expect(ids).toEqual(["ag_debby", "ag_upload_v2"]);
-    // The enrich ran against the upload's session, not the template-bound one.
+    // No enrich fetches on initial load — enrichment is deferred to hover.
     const enrichCalls = fetchMock.mock.calls
       .map((c) => c[0] as string)
       .filter((u) => u.endsWith("/agent"));
-    expect(enrichCalls).toEqual(["/v1/sessions/conv_b/agent"]);
+    expect(enrichCalls).toEqual([]);
   });
 
   it("keeps a user-registered template when no newer upload exists", async () => {
@@ -712,15 +682,13 @@ describe("useAvailableAgents", () => {
         data: [{ id: "conv_3", agent_id: "ag_doc", agent_name: "doc-writer" }],
         has_more: false,
       }),
-      // The agent's bundle can't be loaded (or the fetch 500s) — the
-      // agent must still be listed from scan fields, mirroring the
-      // server's own spec-load degradation, just without harness/skills.
-      "/v1/sessions/conv_3/agent": mockResponse({ detail: "boom" }, { ok: false, status: 500 }),
     });
 
     const { result } = renderHook(() => useAvailableAgents(), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
+    // Agent is listed with scan-only fields (no enrich fetch on initial load).
+    // harness/description filled on hover via prefetchAvailableAgentDetails.
     expect(result.current.data).toEqual([
       {
         id: "ag_doc",
@@ -728,6 +696,7 @@ describe("useAvailableAgents", () => {
         display_name: "Doc-writer",
         description: null,
         harness: null,
+        sessionId: "conv_3",
         skills: [],
       },
     ]);

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, type QueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 import { agentRootName } from "@/lib/forkHarness";
 import { capitalizeAgentName } from "@/lib/agentLabels";
@@ -39,6 +39,10 @@ export interface AvailableAgent {
   // immutable, so it is the stable signal. Omitted on older servers and on
   // session-derived agents (whose recency comes from the scanned session).
   created_at?: number | null;
+  // Session id used to fetch the full agent spec on hover. Only set on
+  // session-discovered agents (custom uploads); absent on catalog agents
+  // whose full data is already present from GET /v1/agents.
+  sessionId?: string;
 }
 
 const DISPLAY_NAMES: Record<string, string> = {
@@ -194,42 +198,57 @@ interface AgentObjectWire {
 }
 
 /**
- * Enrich one scanned session agent into the picker's AvailableAgent
- * shape via `GET /v1/sessions/{id}/agent` (description, harness,
- * bundled skills). On failure the agent is still listed with the
- * name-only fields from the scan — mirroring the server's own
- * `_to_agent_object` degradation: one unloadable bundle must not
- * break discovery.
+ * Build an AvailableAgent from session scan data alone — no extra fetch.
+ * description, harness, and skills are null/empty and filled in on hover
+ * via prefetchAvailableAgentDetails.
  */
-async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<AvailableAgent> {
-  const fallback: AvailableAgent = {
+function sessionAgentFromScan(scanned: ScannedSessionAgent): AvailableAgent {
+  return {
     id: scanned.agentId,
     name: scanned.agentName,
     display_name: displayNameForAgent(scanned.agentName),
     description: null,
     harness: null,
     skills: [],
+    sessionId: scanned.sessionId,
     // builtin/created_at intentionally omitted: session-derived agents never
     // seed the catalog, and their recency comes from the scanned session's
     // createdAt (used directly in the dedup), not from this object.
   };
+}
+
+/**
+ * Fetch harness, description, and skills for a session-discovered agent and
+ * patch them into the ["available-agents"] cache. Call on hover so the data
+ * is ready before the user clicks — zero cost for agents they never hover.
+ */
+export async function prefetchAvailableAgentDetails(
+  agent: AvailableAgent,
+  queryClient: QueryClient,
+): Promise<void> {
+  if (!agent.sessionId || agent.harness !== null || agent.description !== null) return;
   try {
     const res = await authenticatedFetch(
-      `/v1/sessions/${encodeURIComponent(scanned.sessionId)}/agent`,
+      `/v1/sessions/${encodeURIComponent(agent.sessionId)}/agent`,
     );
-    if (!res.ok) return fallback;
+    if (!res.ok) return;
     const json = (await res.json()) as AgentObjectWire;
-    return {
-      ...fallback,
-      display_name: displayNameForAgent(json.name, json.harness),
-      description: json.description ?? null,
-      harness: json.harness ?? null,
-      skills: json.skills ?? [],
-    };
+    queryClient.setQueryData<AvailableAgent[]>(["available-agents"], (prev) => {
+      if (!prev) return prev;
+      return prev.map((a) =>
+        a.id !== agent.id
+          ? a
+          : {
+              ...a,
+              display_name: displayNameForAgent(json.name, json.harness),
+              description: json.description ?? null,
+              harness: json.harness ?? null,
+              skills: json.skills ?? [],
+            },
+      );
+    });
   } catch {
-    // Network-level failure — same best-effort degradation as the
-    // non-ok branch above: list the agent from scan fields.
-    return fallback;
+    // Best-effort — agent stays name-only on failure.
   }
 }
 
@@ -326,16 +345,12 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
     }
   }
 
-  const resolved = (
-    await Promise.all(
-      Array.from(byName.values()).map((c) =>
-        c.template !== null ? Promise.resolve(c.template) : enrichSessionAgent(c.scanned!),
-      ),
-    )
-  ).filter((agent) => {
-    const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
-    return nativeKey !== "kiro" || !hasKiroBuiltin;
-  });
+  const resolved = Array.from(byName.values())
+    .map((c) => (c.template !== null ? c.template : sessionAgentFromScan(c.scanned!)))
+    .filter((agent) => {
+      const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
+      return nativeKey !== "kiro" || !hasKiroBuiltin;
+    });
   // Seeded built-ins first; user templates / custom uploads follow, newest
   // first. NewChatDialog's display-order sort is stable, so unranked names
   // keep this relative order.

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -136,11 +136,11 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
     description: a.description ?? null,
     harness: a.harness ?? null,
     skills: a.skills ?? [],
-    // Raw passthrough (not coerced): an absent value stays undefined so
-    // older servers degrade to "protected" and existing strict-equality
-    // tests (which ignore undefined props) are unaffected.
-    builtin: a.builtin,
-    created_at: a.created_at,
+    // Omit rather than set to undefined so toEqual comparisons aren't
+    // sensitive to absent-vs-undefined. Logic that reads builtin treats
+    // undefined as "protected" (same as true), so omission is safe.
+    ...(a.builtin !== undefined ? { builtin: a.builtin } : {}),
+    ...(a.created_at !== undefined ? { created_at: a.created_at } : {}),
   }));
 }
 
@@ -235,7 +235,7 @@ export async function prefetchAvailableAgentDetails(
     const json = (await res.json()) as AgentObjectWire;
     queryClient.setQueryData<AvailableAgent[]>(["available-agents"], (prev) => {
       if (!prev) return prev;
-      return prev.map((a) =>
+      const enriched = prev.map((a) =>
         a.id !== agent.id
           ? a
           : {
@@ -246,6 +246,21 @@ export async function prefetchAvailableAgentDetails(
               skills: json.skills ?? [],
             },
       );
+      // If enrichment reveals this agent is a native coding agent (e.g. a
+      // kiro-native session with a non-canonical name), remove it when a
+      // seeded built-in with the same native key already exists so it doesn't
+      // surface as a duplicate picker row.
+      const enrichedAgent = enriched.find((a) => a.id === agent.id);
+      const enrichedKey = enrichedAgent
+        ? nativeCodingAgentForAvailableAgent(enrichedAgent)?.key
+        : undefined;
+      if (enrichedKey) {
+        const builtinExists = enriched.some(
+          (a) => a.id !== agent.id && nativeCodingAgentForAvailableAgent(a)?.key === enrichedKey,
+        );
+        if (builtinExists) return enriched.filter((a) => a.id !== agent.id);
+      }
+      return enriched;
     });
   } catch {
     // Best-effort — agent stays name-only on failure.

--- a/web/src/shell/AddAgentDialog.test.tsx
+++ b/web/src/shell/AddAgentDialog.test.tsx
@@ -12,7 +12,10 @@ vi.mock("react-router-dom", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-router-dom")>();
   return { ...actual, useNavigate: () => navigateMock };
 });
-vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
+vi.mock("@/hooks/useAvailableAgents", () => ({
+  useAvailableAgents: vi.fn(),
+  prefetchAvailableAgentDetails: vi.fn(),
+}));
 vi.mock("@/lib/sessionsApi", () => ({ createSession: vi.fn() }));
 
 const useAvailableAgentsMock = vi.mocked(useAvailableAgents);

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -19,7 +19,10 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual, useNavigate: () => navigateMock };
 });
 vi.mock("@/lib/sessionsApi", () => ({ forkSession: vi.fn(), launchRunner: vi.fn() }));
-vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
+vi.mock("@/hooks/useAvailableAgents", () => ({
+  useAvailableAgents: vi.fn(),
+  prefetchAvailableAgentDetails: vi.fn(),
+}));
 vi.mock("@/hooks/useAgents", () => ({ useSessionAgent: vi.fn() }));
 vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
 vi.mock("@/hooks/useDirectorySessions", () => ({ useDirectorySessions: vi.fn() }));

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -50,7 +50,10 @@ vi.mock("@/store/chatStore", () => ({
 
 vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
 vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
-vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
+vi.mock("@/hooks/useAvailableAgents", () => ({
+  useAvailableAgents: vi.fn(),
+  prefetchAvailableAgentDetails: vi.fn(),
+}));
 // The home listing is only consulted when there's no recent; the recent is
 // always set here, so keep this inert (returns no listing).
 vi.mock("@/hooks/useHostFilesystem", () => ({

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -42,7 +42,10 @@ vi.mock("@/lib/identity", async (importOriginal) => ({
   authenticatedFetch: vi.fn(),
 }));
 vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
-vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
+vi.mock("@/hooks/useAvailableAgents", () => ({
+  useAvailableAgents: vi.fn(),
+  prefetchAvailableAgentDetails: vi.fn(),
+}));
 vi.mock("@/hooks/useHostFilesystem", () => ({
   useHostFilesystem: vi.fn(),
   // WorkspacePicker (rendered by the file browser) reads this on mount;

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -88,7 +88,11 @@ import {
   onHostStatusChanged,
   type HostIdentity,
 } from "@/lib/nativeBridge";
-import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
+import {
+  useAvailableAgents,
+  prefetchAvailableAgentDetails,
+  type AvailableAgent,
+} from "@/hooks/useAvailableAgents";
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
@@ -1300,6 +1304,7 @@ function AgentHarnessPicker({
   // Controlled so clicking a knobbed row can commit the pick and close the
   // menu (see the sub-trigger onClick below) without diving into the submenu.
   const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
 
   // Touch devices can't hover, so the desktop knob flyout (a Radix sub-menu
   // that opens on hover) is unreachable there. On mobile we instead swap the
@@ -1575,6 +1580,11 @@ function AgentHarnessPicker({
           // tall list, so the later drill-in (shorter page) can't flip it.
           const rect = triggerRef.current?.getBoundingClientRect();
           if (rect) setMobileSide(window.innerHeight - rect.bottom >= rect.top ? "bottom" : "top");
+          // Prefetch harness/description/skills for all session-discovered
+          // agents so hasKnobs is stable before the user reads the list.
+          for (const agent of [...harnessEntries, ...agentEntries]) {
+            void prefetchAvailableAgentDetails(agent, queryClient);
+          }
         } else {
           // Closing resets the in-place page so the menu always reopens on the
           // agent list, never a stale knobs page.

--- a/web/src/shell/SwitchAgentDialog.test.tsx
+++ b/web/src/shell/SwitchAgentDialog.test.tsx
@@ -8,7 +8,10 @@ import { useAvailableAgents } from "@/hooks/useAvailableAgents";
 import { useSessionAgent } from "@/hooks/useAgents";
 
 vi.mock("@/lib/sessionsApi", () => ({ switchSessionAgent: vi.fn() }));
-vi.mock("@/hooks/useAvailableAgents", () => ({ useAvailableAgents: vi.fn() }));
+vi.mock("@/hooks/useAvailableAgents", () => ({
+  useAvailableAgents: vi.fn(),
+  prefetchAvailableAgentDetails: vi.fn(),
+}));
 vi.mock("@/hooks/useAgents", () => ({ useSessionAgent: vi.fn() }));
 
 const switchSessionAgentMock = vi.mocked(switchSessionAgent);


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Re-lands #2616 (reverted in #2623 due to CI test failures) with three fixes:

- **`builtin`/`created_at` as explicit `undefined`**: `fetchBuiltinAgents` was setting these via direct property assignment even when absent from the wire, making `toEqual` comparisons fail since `{builtin: undefined}` ≠ `{}`. Changed to conditional spread so absent fields are omitted entirely.

- **Tests expecting eager enrichment**: Tests assumed `GET /v1/sessions/{id}/agent` would be called on initial load. Updated to expect scan-only fields (`description: null`, `harness: null`, `sessionId`) and no enrich calls at render time.

- **Missing `prefetchAvailableAgentDetails` in mocks**: Four test files mocked `useAvailableAgents` without the new export, causing runtime errors when `NewChatDialog` called it on picker open. Added to all four mocks.

**Bonus fix**: `prefetchAvailableAgentDetails` now removes an agent from the cache if enrichment reveals it has a native harness that duplicates a seeded built-in (e.g. a `kiro-naitive` typo session agent resolving to `kiro-native`). Previously this filtering only happened at initial load via harness detection, which doesn't work with lazy enrichment.

## Test Plan

- All 4043 web tests pass
- No enrich fetches fire on picker open (network tab)
- Harness-dependent UI (model picker, routing) appears after picker open prefetch completes

## Demo

N/A (perf change; behavior same as before revert)

## Type of change

- [x] Bug fix
- [x] Refactor / chore

## Test coverage

- [x] Unit tests added / updated
- [x] Existing tests cover this change

## Coverage notes

N/A