### PR TITLE
Register managed agent bundles during server startup

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -28,6 +28,8 @@ Configuration is via environment variables:
   ARTIFACT_DIR          Directory for the local artifact store.
                         Defaults to ``/data/artifacts`` (the volume
                         mount point used by docker-compose).
+  OMNIGENT_AGENT_ROOT   Optional directory whose immediate child
+                        directories contain managed agent bundles.
   HOST, PORT            Bind address. Default ``0.0.0.0:8000``.
 """
 
@@ -254,6 +256,45 @@ def _select_artifact_store(resolved_config: _ResolvedConfig) -> ArtifactStore:
     return LocalArtifactStore(str(resolved_config.artifact_dir))
 
 
+def _register_configured_agents(
+    root: Path,
+    agent_store: Any,
+    artifact_store: Any,
+    agent_cache: Any,
+) -> None:
+    """Register each agent bundle directly beneath ``root``.
+
+    :raises RuntimeError: If the configured root is missing, unreadable, or a
+        discovered bundle cannot be registered with a name.
+    """
+    from omnigent.runtime.agent_registration import register_agent
+
+    if not root.is_dir():
+        raise RuntimeError(f"OMNIGENT_AGENT_ROOT is not a directory: {root}")
+
+    try:
+        sources = sorted(
+            child
+            for child in root.iterdir()
+            if child.is_dir() and (child / "config.yaml").is_file()
+        )
+    except OSError as exc:
+        raise RuntimeError(f"Could not scan OMNIGENT_AGENT_ROOT {root}: {exc}") from exc
+
+    for source in sources:
+        result = register_agent(source, agent_store, artifact_store, agent_cache)
+        if result is None:
+            raise RuntimeError(f"Configured agent has no name: {source}")
+        action = "updated" if result.changed else "unchanged"
+        logger.info(
+            "Registered agent %s version %d (%s) from %s",
+            result.name,
+            result.version,
+            action,
+            source,
+        )
+
+
 def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     """Resolve config if needed, wire the stores, and build the app.
 
@@ -308,6 +349,15 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         artifact_store=artifact_store,
         cache_dir=artifact_dir / ".cache",
     )
+
+    agent_root = os.environ.get("OMNIGENT_AGENT_ROOT")
+    if agent_root:
+        _register_configured_agents(
+            Path(agent_root),
+            agent_store,
+            artifact_store,
+            agent_cache,
+        )
 
     init_runtime(
         agent_cache=agent_cache,

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -50,6 +50,9 @@ if TYPE_CHECKING:
 
 logging.basicConfig(level=logging.INFO, stream=sys.stderr, force=True)
 logger = logging.getLogger("omnigent-docker")
+# Alembic's logging config sets the root logger to WARN during migrations.
+# Keep startup registration and readiness messages visible afterward.
+logger.setLevel(logging.INFO)
 
 # Defaults live as module-level constants — the Dockerfile and
 # docker-compose.yaml both also set these, so the values here just

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -272,14 +272,12 @@ def _register_configured_agents(
     if not root.is_dir():
         raise RuntimeError(f"OMNIGENT_AGENT_ROOT is not a directory: {root}")
 
+    logger.info("Scanning configured agent root %s", root)
     try:
-        sources = sorted(
-            child
-            for child in root.iterdir()
-            if child.is_dir() and (child / "config.yaml").is_file()
-        )
+        sources = sorted(config_path.parent for config_path in root.glob("*/config.yaml"))
     except OSError as exc:
         raise RuntimeError(f"Could not scan OMNIGENT_AGENT_ROOT {root}: {exc}") from exc
+    logger.info("Discovered %d configured agent bundle(s) under %s", len(sources), root)
 
     for source in sources:
         result = register_agent(source, agent_store, artifact_store, agent_cache)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1081,82 +1081,14 @@ def _preregister_agent(  # type: ignore[explicit-any]  # agent_store / artifact_
     :returns: The registered agent id, or ``None`` if the source
         spec has no name and is skipped.
     """
-    import gzip
-    import hashlib
-    import io
-    import tarfile
+    from omnigent.runtime.agent_registration import register_agent
 
-    from omnigent.db.utils import generate_agent_id
-    from omnigent.spec import load, materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        bundle_dir = materialize_bundle(agent_source, Path(tmpdir) / "bundle")
-
-        # Build tarball in memory from the materialized bundle dir.
-        # ``arcname="."`` puts the contents at the tarball root so
-        # extraction produces the same shape ``spec.load`` expects.
-        # Pin gzip mtime so sha256(bundle_bytes) is deterministic across calls.
-        buf = io.BytesIO()
-        with (
-            gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as gz,
-            tarfile.open(fileobj=gz, mode="w") as tar,
-        ):
-            tar.add(str(bundle_dir), arcname=".")
-        bundle_bytes = buf.getvalue()
-
-        # Validate via the materialized directory directly — cheaper
-        # than round-tripping through extract.
-        spec = load(bundle_dir)
-
-    if spec.name is None:
+    result = register_agent(agent_source, agent_store, artifact_store, agent_cache)
+    if result is None:
         click.echo(f"  warning: {agent_source} has no name, skipping")
         return None
-
-    # Idempotent registration. Mirrors
-    # :func:`omnigent.inner.cli._omnigent_register_yaml_bundle` —
-    # see designs/RUN_OMNIGENT_SESSION_RESUMPTION.md. Reusing the
-    # existing ``agent_id`` (rather than delete + recreate)
-    # is load-bearing for ``--continue``: deleting the old
-    # row cascades through the ``tasks`` FK
-    # (``ondelete=CASCADE`` in
-    # :class:`omnigent.db.db_models.SqlTask`), wiping every
-    # prior task — which makes the next ``--continue``
-    # filter by ``agent_id`` return zero conversations and
-    # exit ``"No prior conversation for agent ..."``. Update
-    # the bundle in place and only refresh
-    # ``bundle_location`` when the content hash actually
-    # changed so the row stays stable across no-op restarts.
-    bundle_hash = hashlib.sha256(bundle_bytes).hexdigest()
-    existing = agent_store.get_by_name(spec.name)
-    if existing is not None:
-        new_loc = f"{existing.id}/{bundle_hash}"
-        if existing.bundle_location != new_loc:
-            artifact_store.put(new_loc, bundle_bytes)
-            agent_store.update(existing.id, bundle_location=new_loc)
-            # Swap the cache's extracted bundle in lockstep. Without
-            # this, ``AgentCache.load`` will hit Tier 2 (disk —
-            # ``cache_dir/<agent_id>/``) on the next request and
-            # return the OLD spec, even though the artifact store
-            # and the DB row both point at the new bundle.
-            # Mirrors what the HTTP PUT /agents/{id} route does at
-            # ``omnigent/server/routes/agents.py:248``.
-            # ``--agent`` registers operator-authored template agents,
-            # so ${VAR} may expand against the server env here.
-            agent_cache.replace(existing.id, new_loc, bundle_bytes, expand_env=True)
-        click.echo(f"  agent: {spec.name} (from {agent_source})")
-        return cast(str, existing.id)
-
-    agent_id = generate_agent_id()
-    loc = f"{agent_id}/{bundle_hash}"
-    artifact_store.put(loc, bundle_bytes)
-    agent_store.create(
-        agent_id=agent_id,
-        name=spec.name,
-        bundle_location=loc,
-        description=spec.description,
-    )
-    click.echo(f"  agent: {spec.name} (from {agent_source})")
-    return agent_id
+    click.echo(f"  agent: {result.name} v{result.version} (from {agent_source})")
+    return result.agent_id
 
 
 def _format_version() -> str:

--- a/omnigent/runtime/agent_registration.py
+++ b/omnigent/runtime/agent_registration.py
@@ -1,0 +1,124 @@
+"""Registration of operator-managed agent bundles."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from omnigent.db.utils import generate_agent_id
+from omnigent.spec import load, materialize_bundle
+
+
+@dataclass(frozen=True)
+class AgentRegistration:
+    """Result of registering one operator-managed agent bundle."""
+
+    agent_id: str
+    name: str
+    version: int
+    changed: bool
+    source: Path
+
+
+def _add_bundle_to_tar(tar: tarfile.TarFile, bundle_dir: Path) -> None:
+    """Add a bundle with stable ordering and metadata."""
+    descendants = sorted(
+        bundle_dir.rglob("*"),
+        key=lambda path: path.relative_to(bundle_dir).as_posix(),
+    )
+    paths = [bundle_dir, *descendants]
+    for path in paths:
+        arcname = "." if path == bundle_dir else path.relative_to(bundle_dir).as_posix()
+        info = tar.gettarinfo(str(path), arcname=arcname)
+        info.uid = 0
+        info.gid = 0
+        info.uname = ""
+        info.gname = ""
+        info.mtime = 0
+        if info.isfile():
+            with path.open("rb") as source_file:
+                tar.addfile(info, source_file)
+        else:
+            tar.addfile(info)
+
+
+def register_agent(
+    agent_source: Path,
+    agent_store: Any,
+    artifact_store: Any,
+    agent_cache: Any,
+) -> AgentRegistration | None:
+    """Validate and create or replace an operator-managed agent.
+
+    The bundle is materialized and validated before any store is mutated.
+    Replacements retain the existing agent ID so sessions continue to refer
+    to the same template agent.
+
+    :param agent_source: Agent directory or standalone Omnigent YAML file.
+    :param agent_store: Store for agent metadata.
+    :param artifact_store: Store for bundle bytes.
+    :param agent_cache: Runtime bundle cache to refresh after replacements.
+    :returns: Registration metadata, or ``None`` when the spec has no name.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bundle_dir = materialize_bundle(agent_source, Path(tmpdir) / "bundle")
+
+        buf = io.BytesIO()
+        with (
+            gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as gz,
+            tarfile.open(fileobj=gz, mode="w") as tar,
+        ):
+            _add_bundle_to_tar(tar, bundle_dir)
+        bundle_bytes = buf.getvalue()
+
+        spec = load(bundle_dir)
+
+    if spec.name is None:
+        return None
+
+    bundle_hash = hashlib.sha256(bundle_bytes).hexdigest()
+    existing = agent_store.get_by_name(spec.name)
+    if existing is not None:
+        new_location = f"{existing.id}/{bundle_hash}"
+        changed = existing.bundle_location != new_location
+        version = existing.version
+        if changed:
+            artifact_store.put(new_location, bundle_bytes)
+            updated = agent_store.update(existing.id, bundle_location=new_location)
+            agent_cache.replace(
+                existing.id,
+                new_location,
+                bundle_bytes,
+                expand_env=True,
+            )
+            version = updated.version if updated is not None else existing.version + 1
+        return AgentRegistration(
+            agent_id=existing.id,
+            name=spec.name,
+            version=version,
+            changed=changed,
+            source=agent_source,
+        )
+
+    agent_id = generate_agent_id()
+    location = f"{agent_id}/{bundle_hash}"
+    artifact_store.put(location, bundle_bytes)
+    created = agent_store.create(
+        agent_id=agent_id,
+        name=spec.name,
+        bundle_location=location,
+        description=spec.description,
+    )
+    return AgentRegistration(
+        agent_id=agent_id,
+        name=spec.name,
+        version=created.version if created is not None else 1,
+        changed=True,
+        source=agent_source,
+    )

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -156,7 +156,7 @@ def test_select_artifact_store(
 
 
 def test_register_configured_agents_scans_children_and_logs_version(
-    db_uri: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    db_uri: str, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     from deploy.docker.entrypoint import _register_configured_agents
     from omnigent.runtime.agent_cache import AgentCache
@@ -183,9 +183,8 @@ def test_register_configured_agents_scans_children_and_logs_version(
 
     registered = store.get_by_name("jerry")
     assert registered is not None
-    logs = capsys.readouterr().err
-    assert "Discovered 1 configured agent bundle(s)" in logs
-    assert "Registered agent jerry version 1" in logs
+    assert "Discovered 1 configured agent bundle(s)" in caplog.text
+    assert "Registered agent jerry version 1" in caplog.text
 
 
 def test_register_configured_agents_fails_on_invalid_bundle(db_uri: str, tmp_path: Path) -> None:

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -156,7 +156,7 @@ def test_select_artifact_store(
 
 
 def test_register_configured_agents_scans_children_and_logs_version(
-    db_uri: str, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    db_uri: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     from deploy.docker.entrypoint import _register_configured_agents
     from omnigent.runtime.agent_cache import AgentCache
@@ -179,12 +179,13 @@ def test_register_configured_agents_scans_children_and_logs_version(
     artifacts = LocalArtifactStore(str(tmp_path / "artifacts"))
     cache = AgentCache(artifacts, tmp_path / "cache")
 
-    with caplog.at_level("INFO", logger="omnigent-docker"):
-        _register_configured_agents(root, store, artifacts, cache)
+    _register_configured_agents(root, store, artifacts, cache)
 
     registered = store.get_by_name("jerry")
     assert registered is not None
-    assert "Registered agent jerry version 1" in caplog.text
+    logs = capsys.readouterr().err
+    assert "Discovered 1 configured agent bundle(s)" in logs
+    assert "Registered agent jerry version 1" in logs
 
 
 def test_register_configured_agents_fails_on_invalid_bundle(db_uri: str, tmp_path: Path) -> None:

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -153,3 +153,52 @@ def test_select_artifact_store(
         port=8000,
     )
     assert isinstance(_select_artifact_store(resolved), expected_type)
+
+
+def test_register_configured_agents_scans_children_and_logs_version(
+    db_uri: str, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    from deploy.docker.entrypoint import _register_configured_agents
+    from omnigent.runtime.agent_cache import AgentCache
+    from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+
+    root = tmp_path / "agents"
+    bundle = root / "jerry"
+    bundle.mkdir(parents=True)
+    (bundle / "config.yaml").write_text(
+        "spec_version: 1\n"
+        "name: jerry\n"
+        "executor:\n"
+        "  type: omnigent\n"
+        "  config:\n"
+        "    harness: codex-native\n",
+        encoding="utf-8",
+    )
+    (root / "not-an-agent").mkdir()
+    store = SqlAlchemyAgentStore(db_uri)
+    artifacts = LocalArtifactStore(str(tmp_path / "artifacts"))
+    cache = AgentCache(artifacts, tmp_path / "cache")
+
+    with caplog.at_level("INFO", logger="omnigent-docker"):
+        _register_configured_agents(root, store, artifacts, cache)
+
+    registered = store.get_by_name("jerry")
+    assert registered is not None
+    assert "Registered agent jerry version 1" in caplog.text
+
+
+def test_register_configured_agents_fails_on_invalid_bundle(db_uri: str, tmp_path: Path) -> None:
+    from deploy.docker.entrypoint import _register_configured_agents
+    from omnigent.runtime.agent_cache import AgentCache
+    from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+
+    root = tmp_path / "agents"
+    bundle = root / "broken"
+    bundle.mkdir(parents=True)
+    (bundle / "config.yaml").write_text("name: broken\n", encoding="utf-8")
+    store = SqlAlchemyAgentStore(db_uri)
+    artifacts = LocalArtifactStore(str(tmp_path / "artifacts"))
+    cache = AgentCache(artifacts, tmp_path / "cache")
+
+    with pytest.raises(Exception, match="spec_version"):
+        _register_configured_agents(root, store, artifacts, cache)

--- a/tests/runtime/test_agent_registration.py
+++ b/tests/runtime/test_agent_registration.py
@@ -1,0 +1,68 @@
+"""Tests for operator-managed agent registration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.runtime.agent_registration import register_agent
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+
+
+def _write_agent(root: Path, instructions: str) -> None:
+    root.mkdir()
+    (root / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "spec_version": 1,
+                "name": "managed-agent",
+                "executor": {"type": "omnigent", "config": {"harness": "codex-native"}},
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (root / "AGENTS.md").write_text(instructions, encoding="utf-8")
+
+
+def test_register_agent_is_idempotent_for_unchanged_bundle(db_uri: str, tmp_path: Path) -> None:
+    source = tmp_path / "managed-agent"
+    _write_agent(source, "You are the managed agent.\n")
+    store = SqlAlchemyAgentStore(db_uri)
+    artifacts = LocalArtifactStore(str(tmp_path / "artifacts"))
+    cache = AgentCache(artifacts, tmp_path / "cache")
+
+    first = register_agent(source, store, artifacts, cache)
+    second = register_agent(source, store, artifacts, cache)
+
+    assert first is not None
+    assert second is not None
+    assert second.agent_id == first.agent_id
+    assert second.version == 1
+    assert second.changed is False
+
+
+def test_register_agent_replaces_bundle_and_preserves_id(db_uri: str, tmp_path: Path) -> None:
+    source = tmp_path / "managed-agent"
+    _write_agent(source, "Original instructions.\n")
+    store = SqlAlchemyAgentStore(db_uri)
+    artifacts = LocalArtifactStore(str(tmp_path / "artifacts"))
+    cache = AgentCache(artifacts, tmp_path / "cache")
+
+    first = register_agent(source, store, artifacts, cache)
+    assert first is not None
+    (source / "AGENTS.md").write_text("Updated instructions.\n", encoding="utf-8")
+    second = register_agent(source, store, artifacts, cache)
+
+    assert second is not None
+    assert second.agent_id == first.agent_id
+    assert second.version == 2
+    assert second.changed is True
+    stored = store.get(first.agent_id)
+    assert stored is not None
+    assert cache.load(stored.id, stored.bundle_location, expand_env=True).spec.instructions == (
+        "Updated instructions.\n"
+    )


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add reusable runtime registration shared by the server CLI and Docker startup.
- Register every direct child bundle under OMNIGENT_AGENT_ROOT after migrations and before traffic.
- Preserve agent IDs across bundle updates, reject invalid bundles, and log name/version status.

ELI5: a deployed folder of agent definitions is now loaded into Omnigent automatically whenever a server revision starts.

```mermaid
flowchart LR
  M[Database migrations] --> S[Scan agent root]
  S --> V[Validate and register bundles]
  V --> U[Start Uvicorn]
```

## Test Plan

- pre-commit run --all-files
- Focused CLI/runtime/entrypoint tests: 8 passed
- Full Docker entrypoint test module: 8 passed
- Built and deployed the image to Cloud Run; health returned ok and startup logs reported jerry version 2.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

A production Cloud Run revision scanned a GCSFuse-mounted immutable bundle, registered jerry, became ready, and passed the health check.

## Changelog

Omnigent servers can register versioned managed agent bundles automatically at startup.