### PR TITLE
fix(ios): system-browser OIDC login to fix disallowed_useragent (#2549)

### DIFF
--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		B10000000000000000000008 /* NativeNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000008 /* NativeNotificationManager.swift */; };
 		B10000000000000000000009 /* WebShellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000009 /* WebShellView.swift */; };
 		B1000000000000000000000A /* WebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000A /* WebViewModel.swift */; };
+		B100000000000000000000FF /* OidcLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000FF /* OidcLoginManager.swift */; };
 		B1000000000000000000000B /* OmnigentWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000B /* OmnigentWebView.swift */; };
 		B1000000000000000000000C /* URL+Omnigent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000C /* URL+Omnigent.swift */; };
 		B10000000000000000000011 /* ChatTerminalBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000011 /* ChatTerminalBar.swift */; };
@@ -25,6 +26,7 @@
 		B1000000000000000000000E /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000E /* AppIcon.icon */; };
 		B10000000000000000000013 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000013 /* PrivacyInfo.xcprivacy */; };
 		B20000000000000000000001 /* ServerURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* ServerURLTests.swift */; };
+		B200000000000000000000FF /* OidcLoginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000000000000000000FF /* OidcLoginManagerTests.swift */; };
 		B20000000000000000000002 /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* SettingsStoreTests.swift */; };
 		B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */; };
 		B40000000000000000000001 /* OmnigentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000001 /* OmnigentUITests.swift */; };
@@ -59,6 +61,7 @@
 		A10000000000000000000008 /* NativeNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeNotificationManager.swift; sourceTree = "<group>"; };
 		A10000000000000000000009 /* WebShellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebShellView.swift; sourceTree = "<group>"; };
 		A1000000000000000000000A /* WebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewModel.swift; sourceTree = "<group>"; };
+		A100000000000000000000FF /* OidcLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcLoginManager.swift; sourceTree = "<group>"; };
 		A1000000000000000000000B /* OmnigentWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnigentWebView.swift; sourceTree = "<group>"; };
 		A1000000000000000000000C /* URL+Omnigent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Omnigent.swift"; sourceTree = "<group>"; };
 		A10000000000000000000011 /* ChatTerminalBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTerminalBar.swift; sourceTree = "<group>"; };
@@ -69,6 +72,7 @@
 		A10000000000000000000010 /* Info-Release.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Release.plist"; sourceTree = "<group>"; };
 		A10000000000000000000013 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A20000000000000000000001 /* ServerURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerURLTests.swift; sourceTree = "<group>"; };
+		A200000000000000000000FF /* OidcLoginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcLoginManagerTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000002 /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpanderTests.swift; sourceTree = "<group>"; };
 		A30000000000000000000003 /* OmnigentUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -137,6 +141,7 @@
 				A10000000000000000000008 /* NativeNotificationManager.swift */,
 				A10000000000000000000009 /* WebShellView.swift */,
 				A1000000000000000000000A /* WebViewModel.swift */,
+				A100000000000000000000FF /* OidcLoginManager.swift */,
 				A1000000000000000000000B /* OmnigentWebView.swift */,
 				A1000000000000000000000C /* URL+Omnigent.swift */,
 				A10000000000000000000011 /* ChatTerminalBar.swift */,
@@ -153,6 +158,7 @@
 			isa = PBXGroup;
 			children = (
 				A20000000000000000000001 /* ServerURLTests.swift */,
+				A200000000000000000000FF /* OidcLoginManagerTests.swift */,
 				A20000000000000000000002 /* SettingsStoreTests.swift */,
 				A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */,
 			);
@@ -317,6 +323,7 @@
 				B10000000000000000000008 /* NativeNotificationManager.swift in Sources */,
 				B10000000000000000000009 /* WebShellView.swift in Sources */,
 				B1000000000000000000000A /* WebViewModel.swift in Sources */,
+				B100000000000000000000FF /* OidcLoginManager.swift in Sources */,
 				B1000000000000000000000B /* OmnigentWebView.swift in Sources */,
 				B1000000000000000000000C /* URL+Omnigent.swift in Sources */,
 				B10000000000000000000011 /* ChatTerminalBar.swift in Sources */,
@@ -329,6 +336,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B20000000000000000000001 /* ServerURLTests.swift in Sources */,
+				B200000000000000000000FF /* OidcLoginManagerTests.swift in Sources */,
 				B20000000000000000000002 /* SettingsStoreTests.swift in Sources */,
 				B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */,
 			);

--- a/web/ios/Omnigent/OidcLoginManager.swift
+++ b/web/ios/Omnigent/OidcLoginManager.swift
@@ -1,0 +1,225 @@
+import Foundation
+import UIKit
+import os
+
+private let authLogger = Logger(subsystem: "ai.omnigent.ios", category: "auth")
+
+/// Log an auth-flow breadcrumb. Callers pass origins, statuses, and lengths
+/// only — NEVER a full URL or token, which carry OAuth state/PKCE/session
+/// material — so the message is safe to log `.public`.
+func authLog(_ message: String) {
+  authLogger.log("\(message, privacy: .public)")
+}
+
+/// Drives the RFC 8252 login flow for the iOS shell: authenticate in the
+/// **system browser** — a real browser, so Google sign-in (which blocks embedded
+/// `WKWebView`s with `disallowed_useragent`) and passkeys (which need the
+/// browser / a password manager) both work — then bridge the resulting session
+/// back into the `WKWebView`, whose cookie store is isolated from the browser's.
+///
+/// This is the iOS mirror of Android's `OidcLoginManager` (see
+/// `web/android/.../OidcLoginManager.kt`, merged in #1704) and needs **no server
+/// change** — it reuses the same browser-login endpoints the `omnigent login`
+/// CLI uses:
+///   1. `POST /auth/cli-login` -> `{ticket, login_url}`
+///   2. open `origin + login_url` in the system browser; the user authenticates;
+///      the OIDC callback fulfills the ticket server-side
+///   3. `GET /auth/cli-poll?ticket=...` -> 202 while pending, 200 `{token}` once
+///      fulfilled, 410 if expired/unknown
+///
+/// That `token` is exactly the session-cookie JWT (the server validates the same
+/// HS256 JWT as either the session cookie or a `Bearer`), so the caller injects
+/// it into the WebView's `WKHTTPCookieStore` and reloads — authenticated.
+///
+/// Fixes omnigent-ai/omnigent#2549 (iOS parity for the Android fix #1704/#1708).
+@MainActor
+final class OidcLoginManager {
+  /// Backing task for an in-flight login; nil when idle. Held so `shutdown()`
+  /// can cancel a poll that would otherwise run up to `pollTimeout` after the
+  /// host WebView is gone.
+  private var task: Task<Void, Never>?
+  private var inFlight = false
+
+  /// Begin a login against `origin` (the pinned server, e.g.
+  /// `https://agents.example.com`). Opens the system browser and polls in the
+  /// background; `onSession` is invoked on the main actor with the session JWT
+  /// once the browser flow completes.
+  ///
+  /// Returns `true` if this call started a flow, or `false` if one was already
+  /// in flight (a second concurrent call is ignored) — a multi-hop OIDC redirect
+  /// can re-enter before the first hand-off settles, and the caller uses the
+  /// result so a no-op call isn't counted against its retry budget.
+  @discardableResult
+  func start(origin: String, onSession: @escaping (String) -> Void) -> Bool {
+    guard !inFlight else { return false }
+    inFlight = true
+    task = Task { [weak self] in
+      var session: String?
+      defer {
+        self?.inFlight = false
+        // Never invoke into a torn-down host: shutdown() cancels the task, and a
+        // cancelled task must not deliver a session.
+        if let session, !Task.isCancelled { onSession(session) }
+      }
+      guard let ticket = await Self.requestTicket(origin: origin) else {
+        authLog("cli-login -> FAILED")
+        return
+      }
+      authLog("cli-login -> ticket ok")
+      guard let url = URL(string: origin + ticket.loginPath) else { return }
+      await UIApplication.shared.open(url)
+      authLog("opening login in system browser")  // URL carries a one-time ticket — not logged
+      guard let token = await Self.pollForToken(origin: origin, ticket: ticket.id) else {
+        authLog("poll -> no token")
+        return
+      }
+      authLog("poll -> token (len=\(token.count))")
+      session = token
+    }
+    return true
+  }
+
+  /// Cancel an in-flight login and release the host. Call from the coordinator's
+  /// `detach()` so a poll can't outlive the WebView.
+  func shutdown() {
+    task?.cancel()
+    task = nil
+    inFlight = false
+  }
+
+  // MARK: - Ticket + poll (pure networking, testable helpers below)
+
+  struct Ticket: Equatable {
+    let id: String
+    let loginPath: String
+  }
+
+  private static func requestTicket(origin: String) async -> Ticket? {
+    guard let url = URL(string: origin + "/auth/cli-login") else { return nil }
+    var request = URLRequest(url: url, timeoutInterval: httpTimeout)
+    request.httpMethod = "POST"
+    // Bodyless POST — set Content-Length explicitly; some servers/WAFs reject a
+    // POST without it (411 Length Required). Mirrors the Android client.
+    request.setValue("0", forHTTPHeaderField: "Content-Length")
+    guard let (data, response) = try? await URLSession.shared.data(for: request),
+      (response as? HTTPURLResponse)?.statusCode == 200
+    else { return nil }
+    return parseTicket(data)
+  }
+
+  private static func pollForToken(origin: String, ticket: String) async -> String? {
+    let deadline = Date().addingTimeInterval(pollTimeout)
+    guard let url = pollURL(origin: origin, ticket: ticket) else { return nil }
+    while Date() < deadline {
+      // Throws CancellationError on shutdown() — the loop then exits via the
+      // catch, delivering no token.
+      do { try await Task.sleep(nanoseconds: pollInterval) } catch { return nil }
+      var request = URLRequest(url: url, timeoutInterval: httpTimeout)
+      request.httpMethod = "GET"
+      guard let (data, response) = try? await URLSession.shared.data(for: request),
+        let http = response as? HTTPURLResponse
+      else {
+        continue  // transient network error — keep polling until the deadline
+      }
+      switch parsePoll(status: http.statusCode, data: data) {
+      case .pending: continue
+      case .token(let token): return token
+      case .failed: return nil
+      }
+    }
+    return nil
+  }
+
+  // MARK: - Pure helpers (unit-tested standalone; no I/O)
+
+  enum PollResult: Equatable {
+    case pending
+    case token(String)
+    case failed
+  }
+
+  /// Parse a `POST /auth/cli-login` body into a `Ticket`, or nil if malformed.
+  ///
+  /// The `login_url` MUST be a server-relative path (`start` concatenates it onto
+  /// the pinned origin): a scheme-relative `//host` or an absolute URL would send
+  /// the one-time ticket flow to an attacker-chosen destination, so both are
+  /// rejected here — the browser hand-off can never leave the pinned origin.
+  static func parseTicket(_ data: Data) -> Ticket? {
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let id = json["ticket"] as? String, !id.isEmpty,
+      let loginPath = json["login_url"] as? String,
+      isSafeRelativeLoginPath(loginPath)
+    else { return nil }
+    return Ticket(id: id, loginPath: loginPath)
+  }
+
+  /// True for a same-origin relative path: starts with a single `/` (not `//`,
+  /// which is scheme-relative and points at a foreign host).
+  static func isSafeRelativeLoginPath(_ path: String) -> Bool {
+    path.hasPrefix("/") && !path.hasPrefix("//")
+  }
+
+  /// Map a `GET /auth/cli-poll` response to a `PollResult`: 202 pending, 200 with
+  /// a non-empty `token` -> token, anything else (410 expired/unknown, or a 200
+  /// without a token) -> failed.
+  static func parsePoll(status: Int, data: Data) -> PollResult {
+    switch status {
+    case 202: return .pending
+    case 200:
+      guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let token = json["token"] as? String, !token.isEmpty
+      else { return .failed }
+      return .token(token)
+    default: return .failed
+    }
+  }
+
+  static func pollURL(origin: String, ticket: String) -> URL? {
+    var components = URLComponents(string: origin + "/auth/cli-poll")
+    components?.queryItems = [URLQueryItem(name: "ticket", value: ticket)]
+    return components?.url
+  }
+
+  /// True if `token` is shaped like a JWT — three non-empty base64url
+  /// (`[A-Za-z0-9_-]`) segments. A real session token always is, and this shape
+  /// can never carry the `;`, whitespace, or control chars that would let the
+  /// value break out of a cookie and smuggle in attributes (e.g. `Domain=`,
+  /// defeating the `__Host-` prefix). Rejects only a malformed/hostile value.
+  static func isJwtShaped(_ token: String) -> Bool {
+    let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3 else { return false }
+    let base64url = CharacterSet(charactersIn: "-_").union(.alphanumerics)
+    return parts.allSatisfy { part in
+      !part.isEmpty && CharacterSet(charactersIn: String(part)).isSubset(of: base64url)
+    }
+  }
+
+  /// Build the session cookie to inject into the WebView so a reload lands
+  /// authenticated. Mirrors the server's `session_cookie_name`: the `__Host-`
+  /// prefix on HTTPS (host-only + `Secure` + `Path=/`, which the properties
+  /// below satisfy), a plain name on HTTP (local/debug). Returns nil if `origin`
+  /// has no host or the token isn't JWT-shaped.
+  static func sessionCookie(forOrigin origin: String, token: String) -> HTTPCookie? {
+    guard isJwtShaped(token),
+      let url = URL(string: origin), let host = url.host
+    else { return nil }
+    let secure = url.scheme?.lowercased() == "https"
+    let name = secure ? "__Host-ap_session" : "ap_session"
+    var properties: [HTTPCookiePropertyKey: Any] = [
+      .name: name,
+      .value: token,
+      // Host-only (no leading dot) — required by the `__Host-` prefix, which
+      // forbids a Domain attribute.
+      .domain: host,
+      .path: "/",
+    ]
+    if secure { properties[.secure] = "TRUE" }
+    return HTTPCookie(properties: properties)
+  }
+
+  // MARK: - Tunables (mirror the Android client / the CLI's 5-minute window)
+
+  private static let pollInterval: UInt64 = 2_000_000_000  // 2s
+  private static let pollTimeout: TimeInterval = 5 * 60  // 5 min
+  private static let httpTimeout: TimeInterval = 10  // connect + read
+}

--- a/web/ios/Omnigent/OmnigentWebView.swift
+++ b/web/ios/Omnigent/OmnigentWebView.swift
@@ -251,6 +251,13 @@ struct OmnigentWebView: UIViewRepresentable {
     private(set) var pinnedURL: URL?
     private var pinnedOrigin: String?
 
+    // Drives system-browser OIDC login (fix for #2549). Capped retries so a
+    // rejected/expired injected cookie can't relaunch the browser forever; the
+    // counter resets in didFinish once a pinned-origin page actually loads.
+    private let loginManager = OidcLoginManager()
+    private var loginAttempts = 0
+    private static let maxLoginAttempts = 3
+
     init(_ parent: OmnigentWebView) {
       self.parent = parent
     }
@@ -260,8 +267,50 @@ struct OmnigentWebView: UIViewRepresentable {
     }
 
     func detach() {
+      loginManager.shutdown()
       parent.model.cancelServerSwitcherWatchdog()
       webView = nil
+    }
+
+    /// Run the RFC 8252 login: authenticate in the system browser (Google
+    /// sign-in and passkeys work there, not in a `WKWebView`), then bridge the
+    /// session cookie back into this WebView and reload — authenticated.
+    /// Triggered when the server redirects the top-level frame to the IdP.
+    private func startLogin() {
+      guard let pinnedOrigin else { return }
+      guard loginAttempts < Self.maxLoginAttempts else {
+        authLog("login attempts exhausted (\(loginAttempts)) — not retrying")
+        return
+      }
+      // start() no-ops while a login is already in flight, so a multi-hop OIDC
+      // redirect that re-enters here can't burn the retry budget without ever
+      // relaunching the browser. Count only a call that actually starts a flow.
+      guard
+        loginManager.start(
+          origin: pinnedOrigin,
+          onSession: { [weak self] token in self?.applySession(token, origin: pinnedOrigin) }
+        )
+      else { return }
+      loginAttempts += 1
+    }
+
+    /// Bridge the browser session into the WebView: the polled JWT is exactly the
+    /// session-cookie value (the browser's cookie store is isolated from the
+    /// WebView's), so set it as the `__Host-ap_session` / `ap_session` cookie and
+    /// reload. `sessionCookie` re-validates the token is JWT-shaped, so a
+    /// malformed/hostile value can never smuggle in cookie attributes.
+    private func applySession(_ token: String, origin: String) {
+      guard let webView, let pinnedURL,
+        let cookie = OidcLoginManager.sessionCookie(forOrigin: origin, token: token)
+      else {
+        authLog("applySession: no cookie (bad token/origin) — skipping")
+        return
+      }
+      authLog("applySession: injecting \(cookie.name) (token len=\(token.count))")
+      webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie) {
+        [weak webView] in
+        webView?.load(URLRequest(url: pinnedURL))
+      }
     }
 
     // A left-edge swipe drives the web app's sidebar as an interactive drawer.
@@ -360,6 +409,20 @@ struct OmnigentWebView: UIViewRepresentable {
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+      // Backstop for a cross-origin *server* redirect that commits without a
+      // fresh decidePolicyForNavigationAction: if the top frame has landed off
+      // the pinned origin, it's the OIDC bounce that slipped the gate — stop and
+      // run system-browser login rather than let the IdP (and its Google
+      // hand-off) render in the embedded WebView. Mirrors Android's onPageStarted.
+      if let pinnedOrigin, let committed = webView.url?.omnigentOrigin,
+        committed != pinnedOrigin,
+        let scheme = webView.url?.scheme?.lowercased(), scheme == "http" || scheme == "https"
+      {
+        authLog("off-origin landing -> login")
+        webView.stopLoading()
+        startLogin()
+        return
+      }
       parent.model.currentURL = webView.url ?? parent.model.currentURL
     }
 
@@ -370,6 +433,7 @@ struct OmnigentWebView: UIViewRepresentable {
         injectWorkspaceChromeCSS(webView)
       }
       if webView.url?.omnigentOrigin == pinnedOrigin, let pinnedURL {
+        loginAttempts = 0  // reached a pinned-origin page — past the login redirect
         parent.loadSucceeded(pinnedURL)
       }
     }
@@ -403,6 +467,27 @@ struct OmnigentWebView: UIViewRepresentable {
 
       if navigationAction.targetFrame == nil {
         openExternal(url)
+        decisionHandler(.cancel)
+        return
+      }
+
+      // Off-origin top-level navigation. A server redirect (no user gesture) is
+      // the OIDC flow bouncing to the IdP -> run system-browser login (RFC 8252:
+      // never authenticate in an embedded WebView; Google blocks it with
+      // `disallowed_useragent` and passkeys don't work). A user-activated link is
+      // an external link -> open it in the system browser. Either way the foreign
+      // page never loads in this WebView, which holds the native bridge.
+      // Subframes (cross-origin iframes: web previews, embeds) are excluded by
+      // the main-frame check and load inline. Mirrors Android's navigation gate.
+      if navigationAction.targetFrame?.isMainFrame == true,
+        scheme == "http" || scheme == "https",
+        let pinnedOrigin, let target = url.omnigentOrigin, target != pinnedOrigin
+      {
+        if navigationAction.navigationType == .linkActivated {
+          openExternal(url)
+        } else {
+          startLogin()
+        }
         decisionHandler(.cancel)
         return
       }

--- a/web/ios/OmnigentTests/OidcLoginManagerTests.swift
+++ b/web/ios/OmnigentTests/OidcLoginManagerTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+
+@testable import Omnigent
+
+/// Unit tests for the pure, I/O-free logic behind the RFC 8252 system-browser
+/// login (#2549): ticket/poll response parsing, the same-origin relative-path
+/// guard, JWT shape validation, poll-endpoint construction, and session-cookie
+/// construction (name/flags/host-only domain for the `__Host-` prefix).
+final class OidcLoginManagerTests: XCTestCase {
+
+  // MARK: parseTicket
+
+  func testParseTicketValid() {
+    let data = Data(#"{"ticket":"abc123","login_url":"/auth/login?ticket=abc123"}"#.utf8)
+    XCTAssertEqual(
+      OidcLoginManager.parseTicket(data),
+      OidcLoginManager.Ticket(id: "abc123", loginPath: "/auth/login?ticket=abc123")
+    )
+  }
+
+  func testParseTicketRejectsOffOriginLoginURL() {
+    // An absolute or scheme-relative login_url would send the one-time ticket
+    // flow to an attacker-chosen host — must be rejected.
+    XCTAssertNil(
+      OidcLoginManager.parseTicket(
+        Data(#"{"ticket":"a","login_url":"https://evil.example/x"}"#.utf8)))
+    XCTAssertNil(
+      OidcLoginManager.parseTicket(Data(#"{"ticket":"a","login_url":"//evil.example/x"}"#.utf8)))
+  }
+
+  func testParseTicketRejectsMalformed() {
+    XCTAssertNil(OidcLoginManager.parseTicket(Data(#"{"ticket":"a"}"#.utf8)))
+    XCTAssertNil(OidcLoginManager.parseTicket(Data(#"{"login_url":"/x"}"#.utf8)))
+    XCTAssertNil(OidcLoginManager.parseTicket(Data(#"{"ticket":"","login_url":"/x"}"#.utf8)))
+    XCTAssertNil(OidcLoginManager.parseTicket(Data("not json".utf8)))
+  }
+
+  // MARK: isSafeRelativeLoginPath
+
+  func testSafeRelativeLoginPath() {
+    XCTAssertTrue(OidcLoginManager.isSafeRelativeLoginPath("/auth/login?ticket=x"))
+    XCTAssertFalse(OidcLoginManager.isSafeRelativeLoginPath("//evil.example"))
+    XCTAssertFalse(OidcLoginManager.isSafeRelativeLoginPath("https://evil.example"))
+    XCTAssertFalse(OidcLoginManager.isSafeRelativeLoginPath("auth/login"))
+    XCTAssertFalse(OidcLoginManager.isSafeRelativeLoginPath(""))
+  }
+
+  // MARK: parsePoll
+
+  func testParsePollPending() {
+    XCTAssertEqual(OidcLoginManager.parsePoll(status: 202, data: Data()), .pending)
+  }
+
+  func testParsePollToken() {
+    let data = Data(#"{"token":"h.p.s","user_id":"a@b.com","expires_in":28800}"#.utf8)
+    XCTAssertEqual(OidcLoginManager.parsePoll(status: 200, data: data), .token("h.p.s"))
+  }
+
+  func testParsePollFailures() {
+    XCTAssertEqual(OidcLoginManager.parsePoll(status: 410, data: Data()), .failed)
+    XCTAssertEqual(OidcLoginManager.parsePoll(status: 500, data: Data()), .failed)
+    XCTAssertEqual(
+      OidcLoginManager.parsePoll(status: 200, data: Data(#"{"user_id":"x"}"#.utf8)), .failed)
+    XCTAssertEqual(
+      OidcLoginManager.parsePoll(status: 200, data: Data(#"{"token":""}"#.utf8)), .failed)
+  }
+
+  // MARK: pollURL
+
+  func testPollURLConstruction() {
+    let url = OidcLoginManager.pollURL(origin: "https://agents.example.com", ticket: "abc-_123")
+    XCTAssertEqual(url?.path, "/auth/cli-poll")
+    let items = url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false)?.queryItems }
+    XCTAssertEqual(items, [URLQueryItem(name: "ticket", value: "abc-_123")])
+  }
+
+  // MARK: isJwtShaped
+
+  func testJwtShapeAccepts() {
+    XCTAssertTrue(OidcLoginManager.isJwtShaped("aGVhZA.cGF5bG9hZA.c2ln"))
+    XCTAssertTrue(OidcLoginManager.isJwtShaped("ab-C_1.d2.e3"))
+  }
+
+  func testJwtShapeRejects() {
+    XCTAssertFalse(OidcLoginManager.isJwtShaped("only.two"))
+    XCTAssertFalse(OidcLoginManager.isJwtShaped("a.b.c.d"))
+    XCTAssertFalse(OidcLoginManager.isJwtShaped("a..c"))
+    XCTAssertFalse(OidcLoginManager.isJwtShaped("a.b c.d"))  // whitespace
+    XCTAssertFalse(OidcLoginManager.isJwtShaped("a.b;Domain=x.c"))  // cookie-attr injection
+    XCTAssertFalse(OidcLoginManager.isJwtShaped(""))
+  }
+
+  // MARK: sessionCookie
+
+  func testSessionCookieHTTPSIsHostPrefixed() {
+    let cookie = OidcLoginManager.sessionCookie(
+      forOrigin: "https://agents.example.com", token: "a.b.c")
+    XCTAssertEqual(cookie?.name, "__Host-ap_session")
+    XCTAssertEqual(cookie?.value, "a.b.c")
+    XCTAssertEqual(cookie?.path, "/")
+    XCTAssertEqual(cookie?.isSecure, true)
+    // Host-only (no leading dot) — required by the __Host- prefix.
+    XCTAssertEqual(cookie?.domain, "agents.example.com")
+    XCTAssertEqual(cookie?.domain.hasPrefix("."), false)
+  }
+
+  func testSessionCookieHTTPIsPlain() {
+    let cookie = OidcLoginManager.sessionCookie(forOrigin: "http://localhost:6767", token: "a.b.c")
+    XCTAssertEqual(cookie?.name, "ap_session")
+    XCTAssertEqual(cookie?.isSecure, false)
+    XCTAssertEqual(cookie?.domain, "localhost")
+  }
+
+  func testSessionCookieRejectsUnsafeToken() {
+    XCTAssertNil(OidcLoginManager.sessionCookie(forOrigin: "https://x.example", token: "not-a-jwt"))
+    XCTAssertNil(
+      OidcLoginManager.sessionCookie(forOrigin: "https://x.example", token: "a.b;Domain=evil.c"))
+  }
+}


### PR DESCRIPTION
## What & why

The iOS shell loads Omnigent in a `WKWebView`. When a server uses OIDC and its identity provider federates to Google, Google rejects the embedded user agent with `disallowed_useragent` ("This browser or app may not be secure"), so users can't connect the iOS app to servers where Google is a sign-in path. Fixes #2549.

This mirrors the accepted **Android** design (#1708 → merged in #1704) on iOS, with **no server change** — it reuses the existing `/auth/cli-login` + `/auth/cli-poll` ticket endpoints (the same ones `omnigent login` uses).

## Approach

- **`OidcLoginManager`** — RFC 8252 hand-off: `POST /auth/cli-login` → open the returned same-origin `login_url` in the **system browser** (Google sign-in and passkeys work there, not in a `WKWebView`) → poll `/auth/cli-poll` → inject the returned session JWT as the `__Host-ap_session` (HTTPS) / `ap_session` (HTTP) cookie into `WKHTTPCookieStore` and reload authenticated.
- **Navigation gate** in `OmnigentWebView` (`decidePolicyFor` + a `didCommit` backstop): a non-user-initiated off-origin top-level navigation — the OIDC bounce — is stopped and routed to system-browser login; a user-activated off-origin link still opens in the browser. Subframes (cross-origin iframes) are unaffected, and the foreign page never loads in the WebView that holds the native bridge.
- **Retry cap** (3) so a rejected/expired injected cookie can't relaunch the browser forever; resets once a pinned-origin page loads.

## Security

- `login_url` must be a **same-origin relative path** (an absolute or `//host` value is rejected), so the one-time ticket flow can't be redirected off-origin.
- The polled token must be **JWT-shaped** (three base64url segments) before it's placed in a cookie — a value carrying `;`/whitespace can't smuggle attributes like `Domain=` and defeat the `__Host-` prefix.
- The `__Host-` cookie is written host-only + `Secure` + `Path=/`.

## Tests

`OmnigentTests/OidcLoginManagerTests.swift` covers ticket/poll response parsing, the same-origin relative-path guard, JWT-shape validation, poll-URL construction, and session-cookie construction (name/flags/host-only domain).

## ⚠️ Validation status (why this is a draft)

Implemented and verified on **Xcode 16.4 / iOS 18.5 SDK**, which is the most I had locally:
- ✅ `OidcLoginManager.swift` and the modified `OmnigentWebView.swift` **type-check clean** against the iOS SDK (whole-module).
- ✅ The pure logic above was **executed** via a standalone harness — 25/25 assertions pass, including the security cases (off-origin `login_url` rejection, token-injection guards, `__Host-` host-only cookie).

I could **not** run the full app build / simulator UI test here: the repo's HEAD requires **Xcode 26 / iOS 26** (`ChatTerminalBar.swift` uses `glassEffect`), which I don't have. So this needs a maintainer to build in the simulator and drive a real Google-federated OIDC login (and confirm WebKit accepts the injected `__Host-` cookie) before merge. Opening as **draft** for that reason.

Happy to adjust — e.g. `SFSafariViewController` instead of the full external browser if you'd prefer in-app UX, though I mirrored the Android "full system browser" decision deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
