### PR TITLE
feat(web): add find-in-file to the markdown rich-text editor

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1122,6 +1122,15 @@
   border-radius: 2px;
 }
 
+/* Find-in-file matches in the markdown editor — all matches dim, current match strong */
+.md-search-match {
+  background-color: color-mix(in oklch, var(--warning) 30%, transparent);
+  border-radius: 2px;
+}
+.md-search-match-current {
+  background-color: color-mix(in oklch, var(--warning) 70%, transparent);
+}
+
 /* TipTap editor prose styling */
 .tiptap-md-content .ProseMirror {
   outline: none;

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -376,12 +376,32 @@ export function CodeViewer({
     matchLineRefs.current.get(idx)?.scrollIntoView({ block: "center", behavior: "smooth" });
   }, [searchQuery, currentMatchIdx]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Open search on Cmd+F / Ctrl+F.
-  // Don't intercept in markdown editor mode — the custom search bar isn't
-  // available there, so let the browser's native find handle it instead.
   const isMarkdownEditor = viewMode === "editor" && lang === "markdown";
+
+  // Markdown editor mode has its own find bar (MarkdownSearchBar), driven by the
+  // shared `searchOpen` toggle. Cmd+F opens it and Escape closes it; the bar
+  // also handles Escape while its input is focused, but this covers the case
+  // where focus is in the editor body.
   useEffect(() => {
-    // Skip in Monaco mode too — Monaco owns Cmd+F (native find).
+    if (!panelOpen || !isMarkdownEditor) return;
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        setSearchOpen(true);
+        setTimeout(() => searchInputRef.current?.focus(), 0);
+      } else if (e.key === "Escape" && searchOpen) {
+        e.preventDefault();
+        setSearchOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [panelOpen, isMarkdownEditor, searchOpen, setSearchOpen, searchInputRef]);
+
+  // Open search on Cmd+F / Ctrl+F in the Shiki source view.
+  useEffect(() => {
+    // Skip in Monaco mode (Monaco owns Cmd+F) and markdown editor mode (handled
+    // above with its own find bar).
     if (!panelOpen || isMarkdownEditor || showMonaco) return;
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "f") {
@@ -569,6 +589,9 @@ export function CodeViewer({
         activeSelection={activeSelection}
         onSetActiveSelection={onSetActiveSelection}
         pendingBodyRef={pendingBodyRef}
+        searchOpen={searchOpen}
+        onSearchHandled={handleSearchHandled}
+        searchInputRef={searchInputRef}
       />
     );
   }

--- a/web/src/shell/MarkdownRichTextViewer.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.tsx
@@ -32,10 +32,15 @@ import { TruncatedBanner } from "./TruncatedBanner";
 import { useMarkdownEditorSync } from "./useMarkdownEditorSync";
 import { useEditorAutoSave } from "./useEditorAutoSave";
 import { MarkdownCommentPlugin } from "./MarkdownCommentPlugin";
+import { MarkdownSearchBar } from "./MarkdownSearchBar";
 import {
   createCommentDecorationExtension,
   type CommentDecorationState,
 } from "./TipTapCommentExtension";
+import {
+  createSearchDecorationExtension,
+  type SearchDecorationState,
+} from "./TipTapSearchExtension";
 import { createWorkspaceImageExtension, ImageAwareLink } from "./TipTapWorkspaceImage";
 import { GitHubAlertBlockquote } from "./TipTapGitHubAlert";
 import { HtmlPassthrough } from "./TipTapHtmlPassthrough";
@@ -81,6 +86,11 @@ interface MarkdownRichTextViewerProps {
   onSetActiveSelection: (sel: ActiveSelection | null) => void;
   /** Ref to the in-progress comment body; forwarded to MarkdownCommentPlugin. */
   pendingBodyRef?: React.RefObject<string>;
+  /** True when the toolbar "Find in file" toggle wants the search bar open. */
+  searchOpen?: boolean;
+  /** Called when the search bar is closed (Escape / ✕) so the parent can reset the toggle. */
+  onSearchHandled?: () => void;
+  searchInputRef?: React.RefObject<HTMLInputElement | null>;
 }
 
 export function MarkdownRichTextViewer({
@@ -94,6 +104,9 @@ export function MarkdownRichTextViewer({
   activeSelection,
   onSetActiveSelection,
   pendingBodyRef,
+  searchOpen,
+  onSearchHandled,
+  searchInputRef,
 }: MarkdownRichTextViewerProps) {
   // A truncated buffer must never be editable, regardless of permission.
   const canEdit = useCanEdit(conversationId) && !truncated;
@@ -123,6 +136,8 @@ export function MarkdownRichTextViewer({
 
   // This ref is shared across remounts — the ProseMirror plugin reads it.
   const commentStateRef = useRef<CommentDecorationState | null>(null);
+  // Shared with the search plugin (find-in-file highlights).
+  const searchStateRef = useRef<SearchDecorationState | null>(null);
 
   return (
     <MarkdownRichTextViewerInner
@@ -148,6 +163,10 @@ export function MarkdownRichTextViewer({
       onSetActiveSelection={onSetActiveSelection}
       pendingBodyRef={pendingBodyRef}
       commentStateRef={commentStateRef}
+      searchStateRef={searchStateRef}
+      searchOpen={searchOpen ?? false}
+      onSearchHandled={onSearchHandled}
+      searchInputRef={searchInputRef}
       setContentRef={setContentRef}
     />
   );
@@ -175,6 +194,10 @@ interface InnerProps {
   onSetActiveSelection: (sel: ActiveSelection | null) => void;
   pendingBodyRef?: React.RefObject<string>;
   commentStateRef: React.RefObject<CommentDecorationState | null>;
+  searchStateRef: React.RefObject<SearchDecorationState | null>;
+  searchOpen: boolean;
+  onSearchHandled?: () => void;
+  searchInputRef?: React.RefObject<HTMLInputElement | null>;
   setContentRef: React.RefObject<((content: string) => void) | null>;
 }
 
@@ -196,6 +219,10 @@ function MarkdownRichTextViewerInner({
   onSetActiveSelection,
   pendingBodyRef,
   commentStateRef,
+  searchStateRef,
+  searchOpen,
+  onSearchHandled,
+  searchInputRef,
   setContentRef,
 }: InnerProps) {
   const [isCopied, setIsCopied] = useState(false);
@@ -207,6 +234,10 @@ function MarkdownRichTextViewerInner({
     [],
   );
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Fall back to a local ref when the parent doesn't pass one (the toolbar
+  // path always does; this keeps the bar usable in isolation/tests).
+  const fallbackSearchInputRef = useRef<HTMLInputElement>(null);
+  const localSearchInputRef = searchInputRef ?? fallbackSearchInputRef;
 
   const handleCopyContent = useCallback(() => {
     if (!navigator?.clipboard?.writeText) return;
@@ -303,6 +334,7 @@ function MarkdownRichTextViewerInner({
       Markdown,
       createWorkspaceImageExtension(conversationId, path),
       createCommentDecorationExtension(commentStateRef),
+      createSearchDecorationExtension(searchStateRef),
     ],
     // commentStateRef is stable and a path change remounts this component
     // (editorKey), so the closed-over conversationId/path can't go stale;
@@ -398,6 +430,13 @@ function MarkdownRichTextViewerInner({
   return (
     <div className="relative flex flex-col h-full">
       {truncated && <TruncatedBanner />}
+      <MarkdownSearchBar
+        editor={editor}
+        searchStateRef={searchStateRef}
+        open={searchOpen}
+        onClose={() => onSearchHandled?.()}
+        inputRef={localSearchInputRef}
+      />
       {canEdit && (
         <ToolbarPlugin
           editor={editor}

--- a/web/src/shell/MarkdownSearchBar.test.tsx
+++ b/web/src/shell/MarkdownSearchBar.test.tsx
@@ -1,0 +1,168 @@
+// Tests for the markdown editor's find-in-file bar (MarkdownSearchBar).
+//
+// Uses a REAL headless TipTap editor wired with the search extension, so the
+// bar's query → match-count → highlight → navigation flow is exercised
+// end-to-end against actual ProseMirror decorations.
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import { Markdown } from "@tiptap/markdown";
+import StarterKit from "@tiptap/starter-kit";
+import { createRef } from "react";
+import type { RefObject } from "react";
+import { MarkdownSearchBar } from "./MarkdownSearchBar";
+import {
+  createSearchDecorationExtension,
+  type SearchDecorationState,
+} from "./TipTapSearchExtension";
+
+const CONTENT = "The quick brown fox jumps over the lazy dog.";
+
+let editor: Editor | null = null;
+let searchStateRef: RefObject<SearchDecorationState | null>;
+
+beforeEach(() => {
+  // scrollIntoView isn't implemented in jsdom.
+  Element.prototype.scrollIntoView = vi.fn();
+  searchStateRef = { current: null };
+  editor = new Editor({
+    element: document.createElement("div"),
+    extensions: [StarterKit, createSearchDecorationExtension(searchStateRef), Markdown],
+    content: CONTENT,
+    contentType: "markdown",
+  });
+});
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  vi.restoreAllMocks();
+});
+
+function renderBar(props: { open?: boolean; onClose?: () => void } = {}) {
+  const inputRef = createRef<HTMLInputElement>();
+  const onClose = props.onClose ?? vi.fn();
+  const utils = render(
+    <MarkdownSearchBar
+      editor={editor}
+      searchStateRef={searchStateRef}
+      open={props.open ?? true}
+      onClose={onClose}
+      inputRef={inputRef}
+    />,
+  );
+  return { ...utils, onClose };
+}
+
+function type(value: string) {
+  const input = screen.getByPlaceholderText("Find…");
+  fireEvent.change(input, { target: { value } });
+  return input;
+}
+
+describe("MarkdownSearchBar", () => {
+  it("renders nothing when closed", () => {
+    renderBar({ open: false });
+    expect(screen.queryByPlaceholderText("Find…")).toBeNull();
+  });
+
+  it("shows the match count and highlights matches as the user types", async () => {
+    renderBar();
+    await act(async () => {
+      type("the");
+    });
+    // Two case-insensitive matches of "the".
+    expect(screen.getByText("1 / 2")).toBeDefined();
+    expect(editor!.view.dom.querySelectorAll(".md-search-match")).toHaveLength(2);
+    expect(editor!.view.dom.querySelectorAll(".md-search-match-current")).toHaveLength(1);
+  });
+
+  it("shows 'No results' when nothing matches", async () => {
+    renderBar();
+    await act(async () => {
+      type("zzz");
+    });
+    expect(screen.getByText("No results")).toBeDefined();
+    expect(editor!.view.dom.querySelectorAll(".md-search-match")).toHaveLength(0);
+  });
+
+  it("advances to the next match on Enter and wraps around", async () => {
+    renderBar();
+    const input = await act(async () => type("the"));
+    expect(screen.getByText("1 / 2")).toBeDefined();
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+    expect(screen.getByText("2 / 2")).toBeDefined();
+
+    // Wrap back to the first match.
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+    expect(screen.getByText("1 / 2")).toBeDefined();
+  });
+
+  it("goes to the previous match on Shift+Enter", async () => {
+    renderBar();
+    const input = await act(async () => type("the"));
+    // From match 1, Shift+Enter wraps to the last (2 / 2).
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+    });
+    expect(screen.getByText("2 / 2")).toBeDefined();
+  });
+
+  it("navigates with the up/down buttons", async () => {
+    renderBar();
+    await act(async () => type("the"));
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Next match"));
+    });
+    expect(screen.getByText("2 / 2")).toBeDefined();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Previous match"));
+    });
+    expect(screen.getByText("1 / 2")).toBeDefined();
+  });
+
+  it("calls onClose on Escape and clears highlights", async () => {
+    const { onClose } = renderBar();
+    const input = await act(async () => type("the"));
+    expect(editor!.view.dom.querySelectorAll(".md-search-match")).toHaveLength(2);
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Escape" });
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the ✕ button is clicked", async () => {
+    const { onClose } = renderBar();
+    await act(async () => type("the"));
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Close search"));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears highlights when the bar is reopened after a prior query", async () => {
+    const { rerender } = renderBar();
+    await act(async () => type("the"));
+    expect(editor!.view.dom.querySelectorAll(".md-search-match")).toHaveLength(2);
+
+    // Close the bar — the query resets, so highlights clear.
+    await act(async () => {
+      rerender(
+        <MarkdownSearchBar
+          editor={editor}
+          searchStateRef={searchStateRef}
+          open={false}
+          onClose={vi.fn()}
+          inputRef={createRef<HTMLInputElement>()}
+        />,
+      );
+    });
+    expect(editor!.view.dom.querySelectorAll(".md-search-match")).toHaveLength(0);
+  });
+});

--- a/web/src/shell/MarkdownSearchBar.test.tsx
+++ b/web/src/shell/MarkdownSearchBar.test.tsx
@@ -78,6 +78,18 @@ describe("MarkdownSearchBar", () => {
     expect(editor!.view.dom.querySelectorAll(".md-search-match-current")).toHaveLength(1);
   });
 
+  it("keeps the count and highlights consistent when the query has surrounding whitespace", async () => {
+    renderBar();
+    // The plugin highlights against the trimmed query, so the count must trim
+    // too — otherwise "the " would count differently than it highlights.
+    await act(async () => {
+      type("the ");
+    });
+    const highlighted = editor!.view.dom.querySelectorAll(".md-search-match").length;
+    expect(highlighted).toBe(2);
+    expect(screen.getByText(`1 / ${highlighted}`)).toBeDefined();
+  });
+
   it("shows 'No results' when nothing matches", async () => {
     renderBar();
     await act(async () => {

--- a/web/src/shell/MarkdownSearchBar.tsx
+++ b/web/src/shell/MarkdownSearchBar.tsx
@@ -1,0 +1,162 @@
+// Find-in-file bar for the markdown rich-text (TipTap) editor.
+//
+// The source view and Monaco own their own find; this brings the same
+// affordance to the default markdown editor mode. It owns the query + current
+// match, drives TipTapSearchExtension's shared state ref to paint highlights,
+// and scrolls the active match into view. The visual matches the source-view
+// find bar in CodeViewer.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDownIcon, ChevronUpIcon, SearchIcon, XIcon } from "lucide-react";
+import type { Editor } from "@tiptap/react";
+import type { ReactElement, RefObject } from "react";
+import {
+  findMatches,
+  searchDecorationKey,
+  type SearchDecorationState,
+} from "./TipTapSearchExtension";
+
+interface MarkdownSearchBarProps {
+  editor: Editor | null;
+  /** Shared mutable ref read by TipTapSearchExtension's plugin. */
+  searchStateRef: RefObject<SearchDecorationState | null>;
+  open: boolean;
+  /** Called when the bar closes (Escape / ✕) so the toolbar toggle stays in sync. */
+  onClose: () => void;
+  inputRef: RefObject<HTMLInputElement | null>;
+}
+
+export function MarkdownSearchBar({
+  editor,
+  searchStateRef,
+  open,
+  onClose,
+  inputRef,
+}: MarkdownSearchBarProps): ReactElement | null {
+  const [query, setQuery] = useState("");
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  // Recount matches whenever the query changes or the document is edited, so
+  // "n / m" and navigation stay accurate.
+  const [docVersion, setDocVersion] = useState(0);
+  useEffect(() => {
+    if (!editor) return;
+    const bump = () => setDocVersion((v) => v + 1);
+    editor.on("update", bump);
+    return () => {
+      editor.off("update", bump);
+    };
+  }, [editor]);
+
+  const matchCount = useMemo(() => {
+    if (!editor || !editor.state || !query.trim()) return 0;
+    return findMatches(editor.state.doc, query).length;
+    // docVersion forces a recount after edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, query, docVersion]);
+
+  // Reset to the first match on every new query.
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [query]);
+
+  // Clear the query when the bar closes so a reopen starts fresh.
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
+
+  // Push query + current match into the plugin's shared state and repaint.
+  useEffect(() => {
+    if (!editor || editor.isDestroyed || !editor.view) return;
+    searchStateRef.current = { query: query.trim().toLowerCase(), currentIndex };
+    editor.view.dispatch(editor.state.tr.setMeta(searchDecorationKey, "rebuild"));
+  }, [editor, query, currentIndex, matchCount, searchStateRef]);
+
+  // Scroll the active match into view.
+  useEffect(() => {
+    if (!editor || !editor.view || matchCount === 0) return;
+    const rafId = requestAnimationFrame(() => {
+      editor.view.dom
+        .querySelector(".md-search-match-current")
+        ?.scrollIntoView({ block: "center", behavior: "smooth" });
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [editor, currentIndex, matchCount, query]);
+
+  // Focus the input when the bar opens.
+  useEffect(() => {
+    if (open) {
+      const id = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(id);
+    }
+  }, [open, inputRef]);
+
+  const goNext = useCallback(() => {
+    if (matchCount > 0) setCurrentIndex((i) => (i + 1) % matchCount);
+  }, [matchCount]);
+  const goPrev = useCallback(() => {
+    if (matchCount > 0) setCurrentIndex((i) => (i - 1 + matchCount) % matchCount);
+  }, [matchCount]);
+
+  const close = useCallback(() => {
+    setQuery("");
+    onClose();
+  }, [onClose]);
+
+  if (!open) return null;
+
+  const safeIndex = matchCount > 0 ? currentIndex % matchCount : 0;
+
+  return (
+    <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-card/90 px-3 py-1.5 backdrop-blur">
+      <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            if (e.shiftKey) goPrev();
+            else goNext();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            close();
+          }
+        }}
+        placeholder="Find…"
+        className="min-w-0 flex-1 bg-transparent text-xs outline-none"
+      />
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {query.trim() ? (matchCount > 0 ? `${safeIndex + 1} / ${matchCount}` : "No results") : ""}
+      </span>
+      <button
+        type="button"
+        aria-label="Previous match"
+        className="rounded p-0.5 text-muted-foreground hover:bg-muted disabled:opacity-40"
+        disabled={matchCount === 0}
+        onClick={goPrev}
+      >
+        <ChevronUpIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Next match"
+        className="rounded p-0.5 text-muted-foreground hover:bg-muted disabled:opacity-40"
+        disabled={matchCount === 0}
+        onClick={goNext}
+      >
+        <ChevronDownIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Close search"
+        className="rounded p-0.5 text-muted-foreground hover:bg-muted"
+        onClick={close}
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/shell/MarkdownSearchBar.tsx
+++ b/web/src/shell/MarkdownSearchBar.tsx
@@ -49,8 +49,11 @@ export function MarkdownSearchBar({
   }, [editor]);
 
   const matchCount = useMemo(() => {
-    if (!editor || !editor.state || !query.trim()) return 0;
-    return findMatches(editor.state.doc, query).length;
+    const trimmed = query.trim();
+    if (!editor || !editor.state || !trimmed) return 0;
+    // Match the trimmed query the plugin highlights against (searchStateRef
+    // below), so the "n / m" count and the highlighted spans never disagree.
+    return findMatches(editor.state.doc, trimmed).length;
     // docVersion forces a recount after edits.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, query, docVersion]);

--- a/web/src/shell/TipTapSearchExtension.test.ts
+++ b/web/src/shell/TipTapSearchExtension.test.ts
@@ -1,0 +1,188 @@
+// Unit tests for the find-in-file search-decoration ProseMirror plugin.
+//
+// Coverage:
+//   - searchDecorationKey is a stable PluginKey.
+//   - findMatches returns case-insensitive, per-text-node ranges.
+//   - A real headless Editor wired with createSearchDecorationExtension renders
+//     .md-search-match spans for every match and .md-search-match-current on the
+//     active one, follows currentIndex, clears when the query is empty, and
+//     re-runs the search after a "rebuild" meta dispatch.
+//
+// Uses a real TipTap Editor (real schema + real @tiptap/markdown parsing) so
+// regressions in decoration / remap behaviour fail the test.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import { Markdown } from "@tiptap/markdown";
+import StarterKit from "@tiptap/starter-kit";
+import { PluginKey } from "@tiptap/pm/state";
+import type { RefObject } from "react";
+import {
+  createSearchDecorationExtension,
+  findMatches,
+  searchDecorationKey,
+  type SearchDecorationState,
+} from "./TipTapSearchExtension";
+
+let editor: Editor | null = null;
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+// "the" appears twice (case-insensitively): "The" at the start and "the" before "lazy".
+const CONTENT = "The quick brown fox jumps over the lazy dog.";
+
+function makeStateRef(
+  state: SearchDecorationState | null,
+): RefObject<SearchDecorationState | null> {
+  return { current: state };
+}
+
+function makeEditor(stateRef: RefObject<SearchDecorationState | null>, content = CONTENT): Editor {
+  return new Editor({
+    element: document.createElement("div"),
+    extensions: [StarterKit, createSearchDecorationExtension(stateRef), Markdown],
+    content,
+    contentType: "markdown",
+  });
+}
+
+/** Re-run the search plugin against the current stateRef. */
+function rebuild(ed: Editor) {
+  ed.view.dispatch(ed.state.tr.setMeta(searchDecorationKey, "rebuild"));
+}
+
+// ---------------------------------------------------------------------------
+// searchDecorationKey
+// ---------------------------------------------------------------------------
+
+describe("searchDecorationKey", () => {
+  it("is a PluginKey", () => {
+    expect(searchDecorationKey).toBeInstanceOf(PluginKey);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findMatches
+// ---------------------------------------------------------------------------
+
+describe("findMatches", () => {
+  it("finds all case-insensitive occurrences", () => {
+    const stateRef = makeStateRef(null);
+    editor = makeEditor(stateRef);
+    // "the" matches "The" (start) and "the" (before lazy) — 2 hits.
+    expect(findMatches(editor.state.doc, "the")).toHaveLength(2);
+  });
+
+  it("returns an empty array for an empty query", () => {
+    const stateRef = makeStateRef(null);
+    editor = makeEditor(stateRef);
+    expect(findMatches(editor.state.doc, "")).toEqual([]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    const stateRef = makeStateRef(null);
+    editor = makeEditor(stateRef);
+    expect(findMatches(editor.state.doc, "zzz")).toEqual([]);
+  });
+
+  it("finds multiple occurrences within a single text node", () => {
+    const stateRef = makeStateRef(null);
+    editor = makeEditor(stateRef, "aaa");
+    // "aa" at offset 0 and 2 do NOT overlap (search advances past each match),
+    // so only one non-overlapping match is found in "aaa".
+    expect(findMatches(editor.state.doc, "aa")).toHaveLength(1);
+    expect(findMatches(editor.state.doc, "a")).toHaveLength(3);
+  });
+
+  it("matches a term spanning a formatting boundary", () => {
+    const stateRef = makeStateRef(null);
+    // "Hello" split across a bold boundary → two adjacent inline text nodes
+    // "Hel" and "lo". The visible-text map concatenates them within the block.
+    editor = makeEditor(stateRef, "Hel**lo** world");
+    const matches = findMatches(editor.state.doc, "hello");
+    expect(matches).toHaveLength(1);
+    // The mapped range must round-trip to the original visible text.
+    const { from, to } = matches[0];
+    expect(editor.state.doc.textBetween(from, to)).toBe("Hello");
+  });
+
+  it("does not match across a block boundary", () => {
+    const stateRef = makeStateRef(null);
+    // "foobar" split across two paragraphs — a block separator sits between
+    // them, so the concatenated "foo\nbar" must not yield a "foobar" match.
+    editor = makeEditor(stateRef, "foo\n\nbar");
+    expect(findMatches(editor.state.doc, "foobar")).toHaveLength(0);
+    // Each half still matches on its own.
+    expect(findMatches(editor.state.doc, "foo")).toHaveLength(1);
+    expect(findMatches(editor.state.doc, "bar")).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decoration rendering
+// ---------------------------------------------------------------------------
+
+describe("createSearchDecorationExtension decorations", () => {
+  it("renders a .md-search-match span for every match", () => {
+    const stateRef = makeStateRef({ query: "the", currentIndex: 0 });
+    editor = makeEditor(stateRef);
+    const spans = editor.view.dom.querySelectorAll(".md-search-match");
+    expect(spans).toHaveLength(2);
+  });
+
+  it("marks the current match with .md-search-match-current", () => {
+    const stateRef = makeStateRef({ query: "the", currentIndex: 0 });
+    editor = makeEditor(stateRef);
+    const current = editor.view.dom.querySelectorAll(".md-search-match-current");
+    expect(current).toHaveLength(1);
+    // currentIndex 0 → the first "The".
+    expect(current[0].textContent?.toLowerCase()).toBe("the");
+  });
+
+  it("advances the current match with currentIndex", () => {
+    const stateRef = makeStateRef({ query: "the", currentIndex: 1 });
+    editor = makeEditor(stateRef);
+    const all = Array.from(editor.view.dom.querySelectorAll(".md-search-match"));
+    const currentIdx = all.findIndex((el) => el.classList.contains("md-search-match-current"));
+    // Second match is the current one.
+    expect(currentIdx).toBe(1);
+  });
+
+  it("wraps currentIndex modulo the match count", () => {
+    // currentIndex 2 with 2 matches wraps back to the first.
+    const stateRef = makeStateRef({ query: "the", currentIndex: 2 });
+    editor = makeEditor(stateRef);
+    const all = Array.from(editor.view.dom.querySelectorAll(".md-search-match"));
+    const currentIdx = all.findIndex((el) => el.classList.contains("md-search-match-current"));
+    expect(currentIdx).toBe(0);
+  });
+
+  it("renders nothing for an empty query", () => {
+    const stateRef = makeStateRef({ query: "", currentIndex: 0 });
+    editor = makeEditor(stateRef);
+    expect(editor.view.dom.querySelectorAll(".md-search-match")).toHaveLength(0);
+  });
+
+  it("re-runs the search after a rebuild meta dispatch", () => {
+    const stateRef = makeStateRef({ query: "", currentIndex: 0 });
+    editor = makeEditor(stateRef);
+    expect(editor.view.dom.querySelectorAll(".md-search-match")).toHaveLength(0);
+
+    // Mutate the shared state, then rebuild — the new query must paint.
+    stateRef.current = { query: "fox", currentIndex: 0 };
+    rebuild(editor);
+    expect(editor.view.dom.querySelectorAll(".md-search-match")).toHaveLength(1);
+  });
+
+  it("clears highlights when the query is reset to empty via rebuild", () => {
+    const stateRef = makeStateRef({ query: "the", currentIndex: 0 });
+    editor = makeEditor(stateRef);
+    expect(editor.view.dom.querySelectorAll(".md-search-match")).toHaveLength(2);
+
+    stateRef.current = { query: "", currentIndex: 0 };
+    rebuild(editor);
+    expect(editor.view.dom.querySelectorAll(".md-search-match")).toHaveLength(0);
+  });
+});

--- a/web/src/shell/TipTapSearchExtension.test.ts
+++ b/web/src/shell/TipTapSearchExtension.test.ts
@@ -118,6 +118,19 @@ describe("findMatches", () => {
     expect(findMatches(editor.state.doc, "foo")).toHaveLength(1);
     expect(findMatches(editor.state.doc, "bar")).toHaveLength(1);
   });
+
+  it("keeps positions aligned after a length-changing case-fold character", () => {
+    const stateRef = makeStateRef(null);
+    // "İ" (U+0130) lowercases to two UTF-16 units ("i" + combining U+0307).
+    // A plain toLowerCase() haystack would desync from the original-text
+    // coordinate map and shift/invalidate the match after it. The word
+    // following it must still map to its exact original range.
+    editor = makeEditor(stateRef, "İstanbul word");
+    const matches = findMatches(editor.state.doc, "word");
+    expect(matches).toHaveLength(1);
+    const { from, to } = matches[0];
+    expect(editor.state.doc.textBetween(from, to)).toBe("word");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/shell/TipTapSearchExtension.ts
+++ b/web/src/shell/TipTapSearchExtension.ts
@@ -1,0 +1,169 @@
+// ProseMirror Plugin + TipTap Extension for find-in-file search highlights.
+//
+// Mirrors TipTapCommentExtension: matches are drawn as ProseMirror Decorations
+// (not marks) so they never affect markdown serialisation and remap through
+// editing transactions. The current match gets an extra class so the find bar
+// can style/scroll it.
+//
+// stateRef is closed over directly in createSearchDecorationExtension() rather
+// than passed through configure()/addOptions(): TipTap deep-merges options,
+// which clones the ref object and breaks the shared-ref contract.
+
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { RefObject } from "react";
+
+export const searchDecorationKey = new PluginKey<DecorationSet>("searchDecoration");
+
+export interface SearchDecorationState {
+  /** Lowercased search term; empty string means "no highlights". */
+  query: string;
+  /** Index of the active match within findMatches(), clamped by the caller. */
+  currentIndex: number;
+}
+
+// One run of visible text in the doc, paired with its ProseMirror position so a
+// match found in the flattened string can be mapped back to a doc range.
+// `separator` runs (block boundaries) carry a newline in the visible text but
+// zero doc width; a match touching one is rejected so highlights never span
+// blocks.
+interface VisibleSegment {
+  text: string;
+  /** Absolute PM position where this run's text begins. */
+  from: number;
+  /** Offset of this run within the concatenated visible text. */
+  visibleFrom: number;
+  separator: boolean;
+}
+
+/**
+ * Flatten the doc into one visible-text string plus segments mapping each run
+ * back to PM positions. Adjacent text nodes inside a block concatenate (so a
+ * match can cross a formatting boundary like `**bold**`); a newline separator
+ * is inserted between blocks so a match can't span two blocks.
+ */
+function buildVisibleTextMap(doc: ProseMirrorNode): { text: string; segments: VisibleSegment[] } {
+  const segments: VisibleSegment[] = [];
+  let text = "";
+  let sawBlock = false;
+  doc.descendants((node, pos) => {
+    if (node.isTextblock) {
+      if (sawBlock) {
+        segments.push({ text: "\n", from: pos, visibleFrom: text.length, separator: true });
+        text += "\n";
+      }
+      sawBlock = true;
+      return true; // descend into inline children
+    }
+    if (node.isText && node.text) {
+      segments.push({ text: node.text, from: pos, visibleFrom: text.length, separator: false });
+      text += node.text;
+      return false;
+    }
+    return true;
+  });
+  return { text, segments };
+}
+
+/**
+ * Case-insensitive plain-text matches of `query` across the doc, as absolute PM
+ * ranges. Matches span adjacent inline nodes within a block (e.g. across a bold
+ * boundary) via the visible-text map, but never cross a block boundary.
+ */
+export function findMatches(doc: ProseMirrorNode, query: string): { from: number; to: number }[] {
+  const q = query.toLowerCase();
+  if (!q) return [];
+  const { text, segments } = buildVisibleTextMap(doc);
+  const haystack = text.toLowerCase();
+
+  const matches: { from: number; to: number }[] = [];
+  let idx = haystack.indexOf(q);
+  while (idx !== -1) {
+    const start = idx;
+    const end = idx + q.length;
+    idx = haystack.indexOf(q, end);
+
+    // Locate the segments the match starts and ends in. A match that touches a
+    // separator run spans a block boundary and is skipped.
+    let touchesSeparator = false;
+    let first: VisibleSegment | undefined;
+    let last: VisibleSegment | undefined;
+    for (const seg of segments) {
+      const segEnd = seg.visibleFrom + seg.text.length;
+      if (segEnd <= start || seg.visibleFrom >= end) continue; // no overlap
+      if (seg.separator) {
+        touchesSeparator = true;
+        break;
+      }
+      if (!first) first = seg;
+      last = seg;
+    }
+    if (touchesSeparator || !first || !last) continue;
+
+    matches.push({
+      from: first.from + (start - first.visibleFrom),
+      to: last.from + (end - last.visibleFrom),
+    });
+  }
+  return matches;
+}
+
+function buildDecorations(
+  doc: ProseMirrorNode,
+  state: SearchDecorationState | null,
+): DecorationSet {
+  if (!state || !state.query) return DecorationSet.empty;
+  const matches = findMatches(doc, state.query);
+  if (matches.length === 0) return DecorationSet.empty;
+  const current = ((state.currentIndex % matches.length) + matches.length) % matches.length;
+  const decos = matches.map((m, i) =>
+    Decoration.inline(m.from, m.to, {
+      class: i === current ? "md-search-match md-search-match-current" : "md-search-match",
+    }),
+  );
+  return DecorationSet.create(doc, decos);
+}
+
+/**
+ * Creates a TipTap Extension that overlays search-match highlights.
+ *
+ * After mutating stateRef.current, trigger a redraw by dispatching:
+ *   editor.state.tr.setMeta(searchDecorationKey, 'rebuild')
+ */
+export function createSearchDecorationExtension(stateRef: RefObject<SearchDecorationState | null>) {
+  return Extension.create({
+    name: "searchDecoration",
+
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: searchDecorationKey,
+          state: {
+            init(_, { doc }) {
+              return buildDecorations(doc, stateRef.current);
+            },
+            apply(tr, decorations, _, newState) {
+              // Explicit rebuild (query/current-match changed).
+              if (tr.getMeta(searchDecorationKey)) {
+                return buildDecorations(newState.doc, stateRef.current);
+              }
+              // An edit while a query is active re-runs the search against the
+              // new doc so match offsets stay correct; otherwise just remap.
+              if (tr.docChanged && stateRef.current?.query) {
+                return buildDecorations(newState.doc, stateRef.current);
+              }
+              return decorations.map(tr.mapping, newState.doc);
+            },
+          },
+          props: {
+            decorations(state) {
+              return this.getState(state) ?? DecorationSet.empty;
+            },
+          },
+        }),
+      ];
+    },
+  });
+}

--- a/web/src/shell/TipTapSearchExtension.ts
+++ b/web/src/shell/TipTapSearchExtension.ts
@@ -68,15 +68,34 @@ function buildVisibleTextMap(doc: ProseMirrorNode): { text: string; segments: Vi
 }
 
 /**
+ * Lowercase without changing string length: fold each character, but keep the
+ * original whenever its lowercase form has a different UTF-16 length (e.g. `İ`
+ * U+0130 → `i` + combining U+0307). A plain `toLowerCase()` would desync the
+ * haystack from the original-text coordinate map, shifting or invalidating the
+ * mapped PM positions; preserving length keeps every offset aligned. Such
+ * length-changing characters simply don't case-fold (a rare, acceptable
+ * trade-off); applying the same fold to both haystack and query keeps matching
+ * symmetric.
+ */
+function lowerPreservingLength(s: string): string {
+  let out = "";
+  for (const ch of s) {
+    const lower = ch.toLowerCase();
+    out += lower.length === ch.length ? lower : ch;
+  }
+  return out;
+}
+
+/**
  * Case-insensitive plain-text matches of `query` across the doc, as absolute PM
  * ranges. Matches span adjacent inline nodes within a block (e.g. across a bold
  * boundary) via the visible-text map, but never cross a block boundary.
  */
 export function findMatches(doc: ProseMirrorNode, query: string): { from: number; to: number }[] {
-  const q = query.toLowerCase();
+  const q = lowerPreservingLength(query);
   if (!q) return [];
   const { text, segments } = buildVisibleTextMap(doc);
-  const haystack = text.toLowerCase();
+  const haystack = lowerPreservingLength(text);
 
   const matches: { from: number; to: number }[] = [];
   let idx = haystack.indexOf(q);


### PR DESCRIPTION
## Related issue

N/A

## Summary

**Find in file** worked in Monaco (code files) and the markdown **Source** view, but did nothing in markdown's default **Editor** mode — the toolbar's `searchOpen` toggle wasn't consumed by the TipTap editor, so clicking Find (or Cmd+F) was a no-op.

This PR brings find to the markdown rich-text editor:

- **`TipTapSearchExtension.ts`** — a ProseMirror search-decoration plugin, mirroring the existing comment extension. Matches are drawn as `Decoration`s (not marks), so they never touch markdown serialization and remap automatically through edits. All matches get `.md-search-match`; the current one gets `.md-search-match-current`.
- **`MarkdownSearchBar.tsx`** — the find bar (same UI as the source-view bar): owns the query + current match, drives the extension's shared state ref, scrolls the active match into view, cycles with Enter / Shift+Enter / ↑ / ↓, and closes on Escape / ✕ / a second Find click — keeping the toolbar toggle in sync.
- **`MarkdownRichTextViewer.tsx` / `CodeViewer.tsx`** — register the extension, render the bar, thread the existing `searchOpen` toggle into the markdown-editor branch, and add a Cmd+F/Escape handler for editor mode.

**Cross-boundary matching:** `findMatches` flattens each block's inline nodes into a visible-text map, so a term split across a formatting boundary (e.g. `Hel**lo**` → "Hello") is found. A block separator in the map prevents matches from spanning paragraphs (`foo\n\nbar` never matches `foobar`).

**No Monaco changes** — Monaco owns its own native find (shipped in #2621). Scope here is the TipTap editor only; **preview-mode find is a deferred follow-up** that can reuse this same matcher.

## Test Plan

- Added `TipTapSearchExtension.test.ts` (14 tests, real headless TipTap editor): case-insensitive matching, empty/no-match, non-overlapping, **cross-formatting-boundary match**, **no cross-block match**, decoration rendering, current-match marking + wraparound, rebuild-on-meta, clear-on-empty.
- Added `MarkdownSearchBar.test.tsx` (9 tests): match count, No results, Enter/Shift+Enter navigation + wrap, up/down buttons, Escape + ✕ close, highlight clearing on reopen.
- `cd web && npm test` → **4073 passed** (full suite green).
- `cd web && npm run build` → clean. Typecheck / prettier / oxlint clean.
- Manually verified in the running app: Find opens on the toolbar button and Cmd+F, highlights + cycles matches, and closes on Escape / ✕ / second click.

## Demo

_UI change._ Verified locally in the markdown editor (highlighting, navigation, cross-boundary match, close). Screen recording to be attached.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the matcher (including cross-boundary and block-boundary behavior) and the full find-bar state machine against a real headless TipTap editor. Manual verification confirmed the live open/navigate/close flow and cross-boundary highlighting, which the unit tests can't render.

## Changelog

Find in file now works in the markdown editor — highlights and cycles matches, including terms split across bold/italic formatting

This pull request and its description were written by Isaac.