### PR TITLE
fix(telemetry): rename opt-out env var OMNIGENT_TELEMETRY to OMNIGENT_ANALYTICS

### DIFF
--- a/omnigent/runner/transports/ws_tunnel/frames.py
+++ b/omnigent/runner/transports/ws_tunnel/frames.py
@@ -58,7 +58,7 @@ class HelloFrame:
     :param harnesses: Names of harness kinds the runner can spawn.
     :param envs: Names of OS env types the runner supports.
     :param telemetry_opt_out: ``True`` when the runner's host has
-        opted out of telemetry (``OMNIGENT_TELEMETRY=0``,
+        opted out of telemetry (``OMNIGENT_ANALYTICS=0``,
         ``DISABLE_TELEMETRY=true``, or ``telemetry: false`` in
         config.yaml).  The server honours this on a best-effort basis
         by skipping telemetry events for sessions on this runner.

--- a/omnigent/telemetry/client.py
+++ b/omnigent/telemetry/client.py
@@ -220,7 +220,7 @@ def is_disabled() -> bool:
     per-request I/O overhead.
 
     Checks (in order):
-    1. ``OMNIGENT_TELEMETRY=0``
+    1. ``OMNIGENT_ANALYTICS=0``
     2. ``DISABLE_TELEMETRY=true`` or ``OMNIGENT_DISABLE_TELEMETRY=true``
     3. ``DO_NOT_TRACK=1``
     4. Any CI environment variable from :data:`_CI_ENV_VARS`
@@ -240,7 +240,7 @@ def is_disabled() -> bool:
 
 def _compute_is_disabled() -> bool:
     """Compute whether telemetry is disabled (uncached)."""
-    if os.environ.get("OMNIGENT_TELEMETRY", "").strip() == "0":
+    if os.environ.get("OMNIGENT_ANALYTICS", "").strip() == "0":
         return True
     for var in ("DISABLE_TELEMETRY", "OMNIGENT_DISABLE_TELEMETRY"):
         if os.environ.get(var, "").strip().lower() in ("1", "true", "yes"):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -73,9 +73,9 @@ def _reset_is_disabled_cache():
     _mod._IS_DISABLED_CACHE[0] = None
 
 
-def test_is_disabled_omnigent_telemetry_zero(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``OMNIGENT_TELEMETRY=0`` disables telemetry."""
-    monkeypatch.setenv("OMNIGENT_TELEMETRY", "0")
+def test_is_disabled_omnigent_analytics_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``OMNIGENT_ANALYTICS=0`` disables telemetry."""
+    monkeypatch.setenv("OMNIGENT_ANALYTICS", "0")
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
@@ -86,7 +86,7 @@ def test_is_disabled_omnigent_telemetry_zero(monkeypatch: pytest.MonkeyPatch) ->
 
 def test_is_disabled_do_not_track(monkeypatch: pytest.MonkeyPatch) -> None:
     """``DO_NOT_TRACK=1`` disables telemetry."""
-    monkeypatch.delenv("OMNIGENT_TELEMETRY", raising=False)
+    monkeypatch.delenv("OMNIGENT_ANALYTICS", raising=False)
     monkeypatch.delenv("OMNIGENT_DISABLE_TELEMETRY", raising=False)
     monkeypatch.setenv("DO_NOT_TRACK", "1")
     monkeypatch.delenv("CI", raising=False)
@@ -99,7 +99,7 @@ def test_is_disabled_do_not_track(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_is_disabled_ci_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """``CI=true`` disables telemetry."""
-    monkeypatch.delenv("OMNIGENT_TELEMETRY", raising=False)
+    monkeypatch.delenv("OMNIGENT_ANALYTICS", raising=False)
     monkeypatch.delenv("OMNIGENT_DISABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
     monkeypatch.setenv("CI", "true")
@@ -112,7 +112,7 @@ def test_is_disabled_ci_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_is_disabled_github_actions(monkeypatch: pytest.MonkeyPatch) -> None:
     """``GITHUB_ACTIONS=true`` disables telemetry."""
-    monkeypatch.delenv("OMNIGENT_TELEMETRY", raising=False)
+    monkeypatch.delenv("OMNIGENT_ANALYTICS", raising=False)
     monkeypatch.delenv("OMNIGENT_DISABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
     monkeypatch.delenv("CI", raising=False)
@@ -126,7 +126,7 @@ def test_is_disabled_github_actions(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_is_disabled_none_set(monkeypatch: pytest.MonkeyPatch) -> None:
     """When none of the opt-out vars are set, telemetry is enabled."""
     _ci_vars = [
-        "OMNIGENT_TELEMETRY",
+        "OMNIGENT_ANALYTICS",
         "OMNIGENT_DISABLE_TELEMETRY",
         "DO_NOT_TRACK",
         "CI",
@@ -154,7 +154,7 @@ def test_is_disabled_none_set(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_is_disabled_disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
     """``DISABLE_TELEMETRY=true`` disables telemetry."""
-    monkeypatch.delenv("OMNIGENT_TELEMETRY", raising=False)
+    monkeypatch.delenv("OMNIGENT_ANALYTICS", raising=False)
     monkeypatch.setenv("DISABLE_TELEMETRY", "true")
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
@@ -166,7 +166,7 @@ def test_is_disabled_disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_is_disabled_omnigent_disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
     """``OMNIGENT_DISABLE_TELEMETRY=1`` disables telemetry."""
-    monkeypatch.delenv("OMNIGENT_TELEMETRY", raising=False)
+    monkeypatch.delenv("OMNIGENT_ANALYTICS", raising=False)
     monkeypatch.setenv("OMNIGENT_DISABLE_TELEMETRY", "1")
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
@@ -180,7 +180,7 @@ def test_is_disabled_omnigent_disable_telemetry(monkeypatch: pytest.MonkeyPatch)
 
 
 _ALL_OPT_OUT_VARS = [
-    "OMNIGENT_TELEMETRY",
+    "OMNIGENT_ANALYTICS",
     "DISABLE_TELEMETRY",
     "OMNIGENT_DISABLE_TELEMETRY",
     "DO_NOT_TRACK",
@@ -233,7 +233,7 @@ def test_init_client_server_config_disabled(monkeypatch: pytest.MonkeyPatch) -> 
     import omnigent.telemetry.client as _mod
 
     for var in [
-        "OMNIGENT_TELEMETRY",
+        "OMNIGENT_ANALYTICS",
         "DISABLE_TELEMETRY",
         "OMNIGENT_DISABLE_TELEMETRY",
         "DO_NOT_TRACK",


### PR DESCRIPTION
## Summary

Renames the analytics opt-out env var `OMNIGENT_TELEMETRY=0` → `OMNIGENT_ANALYTICS=0` to avoid confusion with the existing OTel tracing infrastructure (`OMNIGENT_TELEMETRY_ENABLED`, `OMNIGENT_OTEL_*`). Pure rename — no logic changes.

Files changed: `omnigent/telemetry/client.py`, `omnigent/runner/transports/ws_tunnel/frames.py`, `tests/test_telemetry.py`.

## Test Plan

- `pre-commit run --all-files` passes
- `tests/test_telemetry.py` updated and passing (22 tests)

## Demo

N/A

## Type of change

- [x] Refactor / chore

## Test coverage

- [x] Existing tests updated
- [x] Existing tests cover this change

## Coverage notes

`test_is_disabled_omnigent_analytics_zero` (renamed from `test_is_disabled_omnigent_telemetry_zero`) covers the renamed env var.