### PR TITLE
fix(sessions): guard terminal snapshot against null runner_client

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -20515,26 +20515,27 @@ def create_sessions_router(
                     )
             except Exception:  # noqa: BLE001 -- best-effort snapshot; never block live tail
                 _logger.debug("snapshot: child sessions failed for %s", session_id, exc_info=True)
-            try:
-                resp = await asyncio.wait_for(
-                    # order=asc: the web cache appends each replayed
-                    # ``created`` event, so the replay must arrive in
-                    # creation order or the session's own terminal (always
-                    # created first) lands behind later agent-launched
-                    # ones. limit=1000 (the runner endpoint max) keeps the
-                    # oldest-first window from dropping the newest
-                    # terminals past the default page of 20.
-                    runner_client.get(
-                        f"/v1/sessions/{session_id}/resources/terminals",
-                        params={"order": "asc", "limit": "1000"},
-                    ),
-                    timeout=_SNAPSHOT_RUNNER_TIMEOUT_S,
-                )
-                if resp.status_code == 200:
-                    for item in resp.json().get("data", []):
-                        events.append({"type": "session.resource.created", "resource": item})
-            except Exception:  # noqa: BLE001 -- best-effort snapshot; never block live tail
-                _logger.debug("snapshot: terminals failed for %s", session_id, exc_info=True)
+            if runner_client is not None:
+                try:
+                    resp = await asyncio.wait_for(
+                        # order=asc: the web cache appends each replayed
+                        # ``created`` event, so the replay must arrive in
+                        # creation order or the session's own terminal (always
+                        # created first) lands behind later agent-launched
+                        # ones. limit=1000 (the runner endpoint max) keeps the
+                        # oldest-first window from dropping the newest
+                        # terminals past the default page of 20.
+                        runner_client.get(
+                            f"/v1/sessions/{session_id}/resources/terminals",
+                            params={"order": "asc", "limit": "1000"},
+                        ),
+                        timeout=_SNAPSHOT_RUNNER_TIMEOUT_S,
+                    )
+                    if resp.status_code == 200:
+                        for item in resp.json().get("data", []):
+                            events.append({"type": "session.resource.created", "resource": item})
+                except Exception:  # noqa: BLE001 -- best-effort snapshot; never block live tail
+                    _logger.debug("snapshot: terminals failed for %s", session_id, exc_info=True)
             # Tell the client to (re)fetch the changed-files list rather
             # than fetching it here (avoids a second runner round-trip).
             events.append(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `_resource_snapshot` (a closure inside `create_sessions_router` in `sessions.py`) fetched terminals from `runner_client` without first checking whether `runner_client` is `None`.
- When no runner is bound to a session, this caused `AttributeError: 'NoneType' object has no attribute 'get'`, breaking the snapshot for those sessions.
- Fix wraps the entire terminals try/except block with `if runner_client is not None:` so the fetch is simply skipped when there is no runner.

## Test Plan

- Code review: the guard mirrors the pattern used elsewhere for optional runner access.
- The `except Exception` block already suppressed errors best-effort; this change prevents the error from ever being raised in the no-runner case.

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Not applicable

## Coverage notes

The terminals snapshot is a best-effort background fetch; the `None` check is the minimal safe guard and does not require a dedicated test. Existing tests cover the broader session snapshot flow.