### PR TITLE
feat: add tool-free planning and review orchestrator

### DIFF
--- a/examples/orchestrator/README.md
+++ b/examples/orchestrator/README.md
@@ -34,16 +34,27 @@ interaction modalities are text-only.
 
 ## Model identifier
 
-The model is pinned with the canonical ID `claude-fable-5`. Omnigent's static
-Claude catalog lists that ID in
-[`omnigent/model_catalog.py`](../../omnigent/model_catalog.py), while the
-Databricks gateway shim and its tests explicitly recognize
-`databricks-claude-fable-5` in
-[`omnigent/inner/claude_gateway_shim.py`](../../omnigent/inner/claude_gateway_shim.py)
-and
-[`tests/inner/test_claude_gateway_shim.py`](../../tests/inner/test_claude_gateway_shim.py).
-Omnigent's provider normalization converts canonical Claude IDs to the
-Databricks-prefixed endpoint spelling when a Databricks provider is resolved,
-and keeps the canonical spelling for direct Anthropic or subscription routing;
-see [`omnigent/model_override.py`](../../omnigent/model_override.py). This keeps
-the example portable while still selecting the Fable 5 endpoint on Databricks.
+We could not conclusively confirm a single canonical spelling for "Claude Fable
+5" across every provider. Based on the repository evidence below, this example
+**assumes** `claude-fable-5` is correct for direct API and subscription routing,
+and that Omnigent normalizes it to `databricks-claude-fable-5` for Databricks.
+This assumption should be revisited if the target provider rejects that model
+ID or exposes Fable 5 under a different endpoint name.
+
+Evidence supporting—but not conclusively proving—the assumption:
+
+- Omnigent's static subscription catalog includes `claude-fable-5` in
+  [`omnigent/model_catalog.py`](../../omnigent/model_catalog.py).
+- The Databricks gateway shim recognizes the `databricks-claude-fable-` prefix,
+  and its test exercises the concrete `databricks-claude-fable-5` spelling in
+  [`omnigent/inner/claude_gateway_shim.py`](../../omnigent/inner/claude_gateway_shim.py)
+  and
+  [`tests/inner/test_claude_gateway_shim.py`](../../tests/inner/test_claude_gateway_shim.py).
+- Omnigent's generic provider normalization prepends `databricks-` to bare
+  Claude/GPT identifiers for Databricks and strips that prefix for direct key or
+  subscription providers; see
+  [`omnigent/model_override.py`](../../omnigent/model_override.py).
+
+These sources establish that both spellings are understood by relevant parts of
+this repository, but they do not verify that every deployed provider exposes
+Fable 5 under either name.

--- a/examples/orchestrator/README.md
+++ b/examples/orchestrator/README.md
@@ -1,0 +1,49 @@
+# Orchestrator
+
+Orchestrator is a deliberately tool-free example agent for planning and review.
+It can turn supplied text into an implementation plan or judge a supplied diff
+against a supplied contract. It cannot inspect a repository, search the web,
+run commands, edit files, write code, or delegate work.
+
+Run it with a configured Claude provider:
+
+```bash
+omnigent run examples/orchestrator
+```
+
+## Why the bundle has this shape
+
+The authoritative agent-image specification is
+[`omnigent/spec/AGENTSPEC.md`](../../omnigent/spec/AGENTSPEC.md). It defines a
+bundle as a directory whose only required file is `config.yaml`, with optional
+`skills/`, `tools/`, and recursive `agents/` directories. The parser and
+validator implementations named there are the source of truth. The compatible
+single-file YAML reference in
+[`docs/AGENT_YAML_SPEC.md`](../../docs/AGENT_YAML_SPEC.md) documents the
+executor, prompt, tools, OS access, terminals, and validation workflow used by
+the bundled examples.
+
+This bundle follows the layout and `executor.type: omnigent` convention used by
+[`examples/polly/config.yaml`](../polly/config.yaml), but intentionally omits
+Polly's tools, sub-agents, OS environment, terminals, and skills. It also sets
+`skills: none`, `async: false`, `spawn: false`, and `timers: false` so host
+skills and indirect work-dispatch capabilities are unavailable. Because
+Omnigent always registers session-read helpers, a zero-call
+`max_tool_calls_per_session` guardrail denies every attempted tool call. Its
+interaction modalities are text-only.
+
+## Model identifier
+
+The model is pinned with the canonical ID `claude-fable-5`. Omnigent's static
+Claude catalog lists that ID in
+[`omnigent/model_catalog.py`](../../omnigent/model_catalog.py), while the
+Databricks gateway shim and its tests explicitly recognize
+`databricks-claude-fable-5` in
+[`omnigent/inner/claude_gateway_shim.py`](../../omnigent/inner/claude_gateway_shim.py)
+and
+[`tests/inner/test_claude_gateway_shim.py`](../../tests/inner/test_claude_gateway_shim.py).
+Omnigent's provider normalization converts canonical Claude IDs to the
+Databricks-prefixed endpoint spelling when a Databricks provider is resolved,
+and keeps the canonical spelling for direct Anthropic or subscription routing;
+see [`omnigent/model_override.py`](../../omnigent/model_override.py). This keeps
+the example portable while still selecting the Fable 5 endpoint on Databricks.

--- a/examples/orchestrator/config.yaml
+++ b/examples/orchestrator/config.yaml
@@ -15,6 +15,7 @@ description: >-
 
 executor:
   type: omnigent
+  # ASSUMPTION: canonical ID unconfirmed — see README § Model identifier.
   model: claude-fable-5
   config:
     harness: claude-sdk

--- a/examples/orchestrator/config.yaml
+++ b/examples/orchestrator/config.yaml
@@ -1,0 +1,81 @@
+# Orchestrator — a tool-free planner and reviewer.
+#
+# Usage:
+#   omnigent run examples/orchestrator
+#
+# This bundle intentionally contains no tools, sub-agents, OS environment,
+# terminals, or skills. It can only reason over text supplied in the conversation.
+
+spec_version: 1
+name: orchestrator
+description: >-
+  A tool-free planning and review agent. Produces implementation plans from a
+  supplied brief and reviews supplied work against a supplied contract, without
+  researching, inspecting, editing, or writing code.
+
+executor:
+  type: omnigent
+  model: claude-fable-5
+  config:
+    harness: claude-sdk
+
+interaction:
+  conversational: true
+  modalities:
+    input: [text]
+    output: [text]
+
+# Do not expose host- or project-scoped skills that could add tools or workflows.
+skills: none
+
+# Disable capabilities that could create work or acquire tools indirectly.
+async: false
+cancellable: true
+spawn: false
+timers: false
+
+# Session read helpers are platform-provided even when no tools are declared.
+# Deny every tool call so the runtime enforces the text-only boundary as well
+# as the capability omissions above.
+guardrails:
+  policies:
+    deny_all_tools:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.policies.builtins.safety.max_tool_calls_per_session
+        arguments:
+          limit: 0
+
+prompt: |
+  You are Orchestrator, a tool-free planner and reviewer. You have exactly two
+  allowed activities:
+
+  1. PLAN — Turn a plan brief and any context supplied in the conversation into
+     a clear, ordered implementation plan. Identify assumptions, dependencies,
+     risks, validation steps, and acceptance criteria. Ask for missing context
+     when it would materially change the plan.
+
+  2. REVIEW — Critique work supplied in the conversation against a supplied
+     contract, specification, or acceptance criteria. Base every finding only
+     on that supplied material. Separate blocking findings from non-blocking
+     observations, cite the relevant supplied excerpt or diff location, and
+     give a clear verdict.
+
+  You must never research or investigate a codebase, repository, file, URL, or
+  external system. You must never use or request tools, shell commands, file
+  reads, search, browsing, sub-agents, or external retrieval. You must never
+  write or edit code, tests, configuration, documentation, or files of any kind;
+  code-like patches, replacement snippets, and commands intended to perform
+  changes are also forbidden. Describe planned changes in prose only.
+
+  Treat only text explicitly supplied in the conversation as evidence. Never
+  claim or imply that you inspected a file, ran a command, searched a source,
+  or verified behavior that was not included in that text. If a request needs
+  investigation, implementation, or evidence that was not supplied, explain
+  the limitation and ask the user to provide the relevant brief, contract,
+  diff, or excerpts. Do not guess to fill an evidentiary gap.
+
+  Stay within planning and review. If asked to implement, edit, write code, or
+  research, refuse that portion concisely and offer either a prose plan or a
+  review of material the user supplies.

--- a/tests/e2e/omnigent/test_example_orchestrator.py
+++ b/tests/e2e/omnigent/test_example_orchestrator.py
@@ -26,7 +26,7 @@ def orchestrator_spec() -> AgentSpec:
 
 
 def test_orchestrator_model_and_harness(orchestrator_spec: AgentSpec) -> None:
-    """Orchestrator pins canonical Claude Fable 5 on the Claude SDK."""
+    """Orchestrator pins the assumed Claude Fable 5 ID on the Claude SDK."""
     assert orchestrator_spec.name == "orchestrator"
     assert orchestrator_spec.executor.model == "claude-fable-5"
     assert orchestrator_spec.executor.config.get("harness") == "claude-sdk"
@@ -63,8 +63,12 @@ def test_orchestrator_denies_every_tool_call(orchestrator_spec: AgentSpec) -> No
     assert policy.function.arguments == {"limit": 0}
     module, _, name = policy.function.path.rpartition(".")
     factory = getattr(importlib.import_module(module), name)
+    # No session_state means the true first-call path: count defaults to zero.
     response = factory(**policy.function.arguments)({"type": "tool_call"})
-    assert response["result"] == "DENY"
+    assert response == {
+        "result": "DENY",
+        "reason": "Exceeded 0 tool calls this session",
+    }
 
 
 def test_orchestrator_prompt_declares_only_plan_and_review(orchestrator_spec: AgentSpec) -> None:

--- a/tests/e2e/omnigent/test_example_orchestrator.py
+++ b/tests/e2e/omnigent/test_example_orchestrator.py
@@ -1,0 +1,74 @@
+"""Structural test for the tool-free Orchestrator example.
+
+The bundle is planning-and-review only. These checks load the production spec
+without starting an LLM and lock down the capability omissions that make the
+agent text-only.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_orchestrator.py -> repo root is 3 parents up.
+_ORCHESTRATOR_BUNDLE = Path(__file__).resolve().parents[3] / "examples" / "orchestrator"
+
+
+@pytest.fixture(scope="module")
+def orchestrator_spec() -> AgentSpec:
+    """Load and validate the Orchestrator bundle once for the module."""
+    return load(_ORCHESTRATOR_BUNDLE, expand_env=False)
+
+
+def test_orchestrator_model_and_harness(orchestrator_spec: AgentSpec) -> None:
+    """Orchestrator pins canonical Claude Fable 5 on the Claude SDK."""
+    assert orchestrator_spec.name == "orchestrator"
+    assert orchestrator_spec.executor.model == "claude-fable-5"
+    assert orchestrator_spec.executor.config.get("harness") == "claude-sdk"
+
+
+def test_orchestrator_has_no_research_or_execution_capabilities(
+    orchestrator_spec: AgentSpec,
+) -> None:
+    """No declared capability can read, search, edit, execute, or delegate."""
+    assert orchestrator_spec.skills_filter == "none"
+    assert orchestrator_spec.tools.builtins == []
+    assert orchestrator_spec.tools.agents == []
+    assert orchestrator_spec.local_tools == []
+    assert orchestrator_spec.mcp_servers == []
+    assert orchestrator_spec.sub_agents == []
+    assert orchestrator_spec.os_env is None
+    assert orchestrator_spec.terminals is None
+    assert orchestrator_spec.async_enabled is False
+    assert orchestrator_spec.spawn is False
+    assert orchestrator_spec.timers is False
+
+
+def test_orchestrator_is_text_only(orchestrator_spec: AgentSpec) -> None:
+    """The interaction contract accepts and produces only text."""
+    assert orchestrator_spec.interaction.modalities.input == ["text"]
+    assert orchestrator_spec.interaction.modalities.output == ["text"]
+
+
+def test_orchestrator_denies_every_tool_call(orchestrator_spec: AgentSpec) -> None:
+    """The zero-call guardrail blocks platform-provided session-read tools."""
+    policies = orchestrator_spec.guardrails.policies
+    assert [policy.name for policy in policies] == ["deny_all_tools"]
+    policy = policies[0]
+    assert policy.function.arguments == {"limit": 0}
+    module, _, name = policy.function.path.rpartition(".")
+    factory = getattr(importlib.import_module(module), name)
+    response = factory(**policy.function.arguments)({"type": "tool_call"})
+    assert response["result"] == "DENY"
+
+
+def test_orchestrator_prompt_declares_only_plan_and_review(orchestrator_spec: AgentSpec) -> None:
+    """The behavioral boundary covers both allowed modes and evidence limits."""
+    prompt = " ".join(orchestrator_spec.instructions.split()).lower()
+    for token in ("plan", "review", "must never research", "never claim or imply"):
+        assert token in prompt


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add `examples/orchestrator`, a text-only Claude Fable 5 agent restricted to producing plans and reviewing supplied work against supplied contracts.
- Remove research and execution capability mechanically: no OS environment, terminals, MCP/local/builtin tools, sub-agents, or bundled skills; host skills are disabled; async work, spawning, and timers are off; and a zero-call guardrail denies platform-provided session-read tools.
- Add a bundle README recording the schema/model research and a structural test that locks down the capability boundary.

ELI5: Orchestrator can think about text placed in front of it, but it has no hands, browser, shell, file access, or assistants.

```text
supplied brief ──> Claude Fable 5 ──> prose plan
supplied diff + contract ───────────> review verdict
                           tools ──X (deny all)
```

### Schema research

- The authoritative agent-image spec says a bundle is a directory with required `config.yaml` and optional `skills/`, `tools/`, and recursive `agents/` directories: [`omnigent/spec/AGENTSPEC.md` lines 1-35](https://github.com/omnigent-ai/omnigent/blob/main/omnigent/spec/AGENTSPEC.md#L1-L35). It also documents `spec_version`, model, interaction, and sub-agent declarations: [lines 39-71](https://github.com/omnigent-ai/omnigent/blob/main/omnigent/spec/AGENTSPEC.md#L39-L71).
- The compatible YAML reference documents prompt/executor/tool/OS/terminal fields and that `os_env` enables local file and shell tools: [`docs/AGENT_YAML_SPEC.md` lines 31-60](https://github.com/omnigent-ai/omnigent/blob/main/docs/AGENT_YAML_SPEC.md#L31-L60) and [lines 174-218](https://github.com/omnigent-ai/omnigent/blob/main/docs/AGENT_YAML_SPEC.md#L174-L218).
- The new directory follows the existing bundled-example convention used by [`examples/polly/config.yaml`](https://github.com/omnigent-ai/omnigent/blob/main/examples/polly/config.yaml), while intentionally omitting Polly's capability-bearing directories and fields.

### Model ID assumption

The config stores the canonical model ID `claude-fable-5`. This is directly listed in Omnigent's Claude catalog ([`omnigent/model_catalog.py` lines 81-92](https://github.com/omnigent-ai/omnigent/blob/main/omnigent/model_catalog.py#L81-L92)). Omnigent's provider normalization adds the mechanical `databricks-` prefix for Databricks providers and removes it for direct providers ([`omnigent/model_override.py` lines 194-232](https://github.com/omnigent-ai/omnigent/blob/main/omnigent/model_override.py#L194-L232)); the gateway path explicitly recognizes the resulting `databricks-claude-fable-5` family ([`omnigent/inner/claude_gateway_shim.py` lines 66-74](https://github.com/omnigent-ai/omnigent/blob/main/omnigent/inner/claude_gateway_shim.py#L66-L74)).

**Assumption for human verification:** the configured Claude provider exposes Fable 5. The canonical spelling should work for direct Claude/subscription routing and normalize for Databricks. If the deployment uses a fixed gateway that does not apply Omnigent's provider normalization, change `executor.model` to that gateway's concrete endpoint name (most plausibly `databricks-claude-fable-5`).

### Applied restrictions

- Text input and output only.
- No `os_env`, terminals, MCP servers, local tools, builtins, sub-agents, or agent directories.
- `skills: none`; no bundled skills.
- `async: false`, `spawn: false`, `timers: false`.
- `max_tool_calls_per_session(limit: 0)` denies every attempted tool call, including always-registered session-read helpers.
- System prompt permits only prose planning and review of supplied material; forbids research, inspection, commands, code/patch writing, edits, unsupported verification claims, and claims of inspecting unsupplied files.

## Test Plan

- `uv run --no-config python ...` production `omnigent.spec.load` validation of `examples/orchestrator`.
- `.venv/bin/pytest -q tests/e2e/omnigent/test_example_orchestrator.py` — 5 passed.
- `.venv/bin/ruff check tests/e2e/omnigent/test_example_orchestrator.py`.
- `.venv/bin/ruff format --check tests/e2e/omnigent/test_example_orchestrator.py`.
- `.venv/bin/pre-commit run --files examples/orchestrator/config.yaml examples/orchestrator/README.md tests/e2e/omnigent/test_example_orchestrator.py`.
- `git diff --check`.

## Demo

N/A — non-visual agent configuration.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The structural E2E test loads the bundle through the production parser/validator and asserts its model, modalities, empty capability surfaces, disabled indirect capabilities, prompt boundaries, and zero-call policy behavior. Manual verification inspected the parsed `AgentSpec` and confirmed no OS, terminal, MCP, local, builtin, or sub-agent capabilities.

## Changelog

Add a tool-free Claude Fable 5 agent for planning supplied work and reviewing supplied diffs against supplied contracts.
