### PR TITLE
feat: add routing agent between orchestrator and coding sub-agents

### DIFF
--- a/examples/orchestrator/README.md
+++ b/examples/orchestrator/README.md
@@ -34,16 +34,27 @@ interaction modalities are text-only.
 
 ## Model identifier
 
-The model is pinned with the canonical ID `claude-fable-5`. Omnigent's static
-Claude catalog lists that ID in
-[`omnigent/model_catalog.py`](../../omnigent/model_catalog.py), while the
-Databricks gateway shim and its tests explicitly recognize
-`databricks-claude-fable-5` in
-[`omnigent/inner/claude_gateway_shim.py`](../../omnigent/inner/claude_gateway_shim.py)
-and
-[`tests/inner/test_claude_gateway_shim.py`](../../tests/inner/test_claude_gateway_shim.py).
-Omnigent's provider normalization converts canonical Claude IDs to the
-Databricks-prefixed endpoint spelling when a Databricks provider is resolved,
-and keeps the canonical spelling for direct Anthropic or subscription routing;
-see [`omnigent/model_override.py`](../../omnigent/model_override.py). This keeps
-the example portable while still selecting the Fable 5 endpoint on Databricks.
+We could not conclusively confirm a single canonical spelling for "Claude Fable
+5" across every provider. Based on the repository evidence below, this example
+**assumes** `claude-fable-5` is correct for direct API and subscription routing,
+and that Omnigent normalizes it to `databricks-claude-fable-5` for Databricks.
+This assumption should be revisited if the target provider rejects that model
+ID or exposes Fable 5 under a different endpoint name.
+
+Evidence supporting—but not conclusively proving—the assumption:
+
+- Omnigent's static subscription catalog includes `claude-fable-5` in
+  [`omnigent/model_catalog.py`](../../omnigent/model_catalog.py).
+- The Databricks gateway shim recognizes the `databricks-claude-fable-` prefix,
+  and its test exercises the concrete `databricks-claude-fable-5` spelling in
+  [`omnigent/inner/claude_gateway_shim.py`](../../omnigent/inner/claude_gateway_shim.py)
+  and
+  [`tests/inner/test_claude_gateway_shim.py`](../../tests/inner/test_claude_gateway_shim.py).
+- Omnigent's generic provider normalization prepends `databricks-` to bare
+  Claude/GPT identifiers for Databricks and strips that prefix for direct key or
+  subscription providers; see
+  [`omnigent/model_override.py`](../../omnigent/model_override.py).
+
+These sources establish that both spellings are understood by relevant parts of
+this repository, but they do not verify that every deployed provider exposes
+Fable 5 under either name.

--- a/examples/orchestrator/README.md
+++ b/examples/orchestrator/README.md
@@ -1,0 +1,49 @@
+# Orchestrator
+
+Orchestrator is a deliberately tool-free example agent for planning and review.
+It can turn supplied text into an implementation plan or judge a supplied diff
+against a supplied contract. It cannot inspect a repository, search the web,
+run commands, edit files, write code, or delegate work.
+
+Run it with a configured Claude provider:
+
+```bash
+omnigent run examples/orchestrator
+```
+
+## Why the bundle has this shape
+
+The authoritative agent-image specification is
+[`omnigent/spec/AGENTSPEC.md`](../../omnigent/spec/AGENTSPEC.md). It defines a
+bundle as a directory whose only required file is `config.yaml`, with optional
+`skills/`, `tools/`, and recursive `agents/` directories. The parser and
+validator implementations named there are the source of truth. The compatible
+single-file YAML reference in
+[`docs/AGENT_YAML_SPEC.md`](../../docs/AGENT_YAML_SPEC.md) documents the
+executor, prompt, tools, OS access, terminals, and validation workflow used by
+the bundled examples.
+
+This bundle follows the layout and `executor.type: omnigent` convention used by
+[`examples/polly/config.yaml`](../polly/config.yaml), but intentionally omits
+Polly's tools, sub-agents, OS environment, terminals, and skills. It also sets
+`skills: none`, `async: false`, `spawn: false`, and `timers: false` so host
+skills and indirect work-dispatch capabilities are unavailable. Because
+Omnigent always registers session-read helpers, a zero-call
+`max_tool_calls_per_session` guardrail denies every attempted tool call. Its
+interaction modalities are text-only.
+
+## Model identifier
+
+The model is pinned with the canonical ID `claude-fable-5`. Omnigent's static
+Claude catalog lists that ID in
+[`omnigent/model_catalog.py`](../../omnigent/model_catalog.py), while the
+Databricks gateway shim and its tests explicitly recognize
+`databricks-claude-fable-5` in
+[`omnigent/inner/claude_gateway_shim.py`](../../omnigent/inner/claude_gateway_shim.py)
+and
+[`tests/inner/test_claude_gateway_shim.py`](../../tests/inner/test_claude_gateway_shim.py).
+Omnigent's provider normalization converts canonical Claude IDs to the
+Databricks-prefixed endpoint spelling when a Databricks provider is resolved,
+and keeps the canonical spelling for direct Anthropic or subscription routing;
+see [`omnigent/model_override.py`](../../omnigent/model_override.py). This keeps
+the example portable while still selecting the Fable 5 endpoint on Databricks.

--- a/examples/orchestrator/config.yaml
+++ b/examples/orchestrator/config.yaml
@@ -15,6 +15,7 @@ description: >-
 
 executor:
   type: omnigent
+  # ASSUMPTION: canonical ID unconfirmed — see README § Model identifier.
   model: claude-fable-5
   config:
     harness: claude-sdk

--- a/examples/orchestrator/config.yaml
+++ b/examples/orchestrator/config.yaml
@@ -1,0 +1,81 @@
+# Orchestrator — a tool-free planner and reviewer.
+#
+# Usage:
+#   omnigent run examples/orchestrator
+#
+# This bundle intentionally contains no tools, sub-agents, OS environment,
+# terminals, or skills. It can only reason over text supplied in the conversation.
+
+spec_version: 1
+name: orchestrator
+description: >-
+  A tool-free planning and review agent. Produces implementation plans from a
+  supplied brief and reviews supplied work against a supplied contract, without
+  researching, inspecting, editing, or writing code.
+
+executor:
+  type: omnigent
+  model: claude-fable-5
+  config:
+    harness: claude-sdk
+
+interaction:
+  conversational: true
+  modalities:
+    input: [text]
+    output: [text]
+
+# Do not expose host- or project-scoped skills that could add tools or workflows.
+skills: none
+
+# Disable capabilities that could create work or acquire tools indirectly.
+async: false
+cancellable: true
+spawn: false
+timers: false
+
+# Session read helpers are platform-provided even when no tools are declared.
+# Deny every tool call so the runtime enforces the text-only boundary as well
+# as the capability omissions above.
+guardrails:
+  policies:
+    deny_all_tools:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.policies.builtins.safety.max_tool_calls_per_session
+        arguments:
+          limit: 0
+
+prompt: |
+  You are Orchestrator, a tool-free planner and reviewer. You have exactly two
+  allowed activities:
+
+  1. PLAN — Turn a plan brief and any context supplied in the conversation into
+     a clear, ordered implementation plan. Identify assumptions, dependencies,
+     risks, validation steps, and acceptance criteria. Ask for missing context
+     when it would materially change the plan.
+
+  2. REVIEW — Critique work supplied in the conversation against a supplied
+     contract, specification, or acceptance criteria. Base every finding only
+     on that supplied material. Separate blocking findings from non-blocking
+     observations, cite the relevant supplied excerpt or diff location, and
+     give a clear verdict.
+
+  You must never research or investigate a codebase, repository, file, URL, or
+  external system. You must never use or request tools, shell commands, file
+  reads, search, browsing, sub-agents, or external retrieval. You must never
+  write or edit code, tests, configuration, documentation, or files of any kind;
+  code-like patches, replacement snippets, and commands intended to perform
+  changes are also forbidden. Describe planned changes in prose only.
+
+  Treat only text explicitly supplied in the conversation as evidence. Never
+  claim or imply that you inspected a file, ran a command, searched a source,
+  or verified behavior that was not included in that text. If a request needs
+  investigation, implementation, or evidence that was not supplied, explain
+  the limitation and ask the user to provide the relevant brief, contract,
+  diff, or excerpts. Do not guess to fill an evidentiary gap.
+
+  Stay within planning and review. If asked to implement, edit, write code, or
+  research, refuse that portion concisely and offer either a prose plan or a
+  review of material the user supplies.

--- a/examples/polly/agents/antigravity/config.yaml
+++ b/examples/polly/agents/antigravity/config.yaml
@@ -6,9 +6,9 @@ executor:
   type: omnigent
   config:
     harness: antigravity-native
-    # Headless workers can't answer ApprovalCards, and managed settings may
-    # restrict live approval flows. ``auto`` auto-approves without prompting
-    # and is allowed under managed settings (-> ``--permission-mode auto``).
+    # antigravity-native ignores this key; headless dispatch always forces
+    # --dangerously-skip-permissions itself (see should_skip_permissions in
+    # antigravity_native_launch.py). Kept for parity with sibling configs.
     permission_mode: auto
 
 prompt: |

--- a/examples/polly/agents/antigravity/config.yaml
+++ b/examples/polly/agents/antigravity/config.yaml
@@ -1,0 +1,65 @@
+spec_version: 1
+name: antigravity
+description: Antigravity coding sub-agent — implements, reviews, or explores a scoped task in its own worktree, dispatched by the polly orchestrator.
+
+executor:
+  type: omnigent
+  config:
+    harness: antigravity-native
+    # Headless workers can't answer ApprovalCards, and managed settings may
+    # restrict live approval flows. ``auto`` auto-approves without prompting
+    # and is allowed under managed settings (-> ``--permission-mode auto``).
+    permission_mode: auto
+
+prompt: |
+  You are Antigravity, a coding sub-agent dispatched by the polly orchestrator
+  for a single scoped task in a dedicated git worktree. Your task prompt names
+  its purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one thing; don't
+  refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the orchestrator to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  The orchestrator reviews your report itself before delegating or deciding
+  next steps, so make it complete enough to judge without re-reading your
+  worktree. Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -51,15 +51,18 @@ prompt: |
   a "docs" task starts requiring code changes or real code investigation, STOP
   and delegate that part.
 
-  You have exactly SIX sub-agents. `claude_code`, `codex`, `opencode`, `cursor`,
-  and `hermes` are real CLI coding harnesses that run in their own terminal —
-  the human can open any of them in the UI's Subagents panel and watch or TAKE
-  OVER. `pi` runs headless (no terminal to open):
+  You have exactly SEVEN sub-agents. `claude_code`, `codex`, `opencode`,
+  `cursor`, `hermes`, and `antigravity` are real CLI coding harnesses that run
+  in their own terminal — the human can open any of them in the UI's Subagents
+  panel and watch or TAKE OVER. `pi` runs headless (no terminal to open):
   - `claude_code` — Claude Code (`claude-native` harness).
   - `codex` — Codex (`codex-native` harness).
   - `opencode` — OpenCode (`opencode-native` harness).
   - `cursor` — Cursor (`cursor-native` harness).
   - `hermes` — Hermes Agent (`hermes-native` harness).
+  - `antigravity` — Antigravity (`antigravity-native` harness). Google's
+    Gemini-powered agent; good for tasks where you want an alternative to
+    Claude/OpenAI or need Gemini-specific reasoning.
   - `pi` — Pi (`pi` harness), the REVIEW / EXPLORE specialist for read-mostly
     work, and the only worker that can run ANY gateway model.
 
@@ -68,9 +71,9 @@ prompt: |
 
   Roster preflight (FIRST turn, before any dispatch). Each worker needs its own
   CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `opencode` for
-  `opencode`, `cursor-agent` for `cursor`, `hermes` for `hermes`, `pi` for `pi`.
-  Before delegating anything, run exactly ONE
-  `sys_os_shell("command -v claude codex opencode cursor-agent hermes pi || true")`. A worker is AVAILABLE
+  `opencode`, `cursor-agent` for `cursor`, `hermes` for `hermes`, `agy` for
+  `antigravity`, `pi` for `pi`. Before delegating anything, run exactly ONE
+  `sys_os_shell("command -v claude codex opencode cursor-agent hermes agy pi || true")`. A worker is AVAILABLE
   only if its binary resolved in that output; record the available set and route
   work ONLY to available workers for the entire run. Do this in the same first
   turn you start planning (the preflight `sys_os_shell` call counts as acting —
@@ -297,14 +300,16 @@ terminals:
 
 tools:
   # Coding sub-agents — see agents/<name>/. claude_code, codex, opencode,
-  # cursor, and hermes are real CLI coding harnesses; pi is a headless
-  # multi-model worker. Each implements, reviews (cross-vendor), and explores.
+  # cursor, hermes, and antigravity are real CLI coding harnesses; pi is a
+  # headless multi-model worker. Each implements, reviews (cross-vendor), and
+  # explores.
   agents:
     - claude_code
     - codex
     - opencode
     - cursor
     - hermes
+    - antigravity
     - pi
 
 # Mechanism-layer enforcement — runner-side tool gate, no server change.

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -2,8 +2,8 @@ spec_version: 1
 name: polly
 description: >-
   A coding orchestrator that breaks your goal into pieces and hands them
-  to a team of Claude Code, Codex, OpenCode, Cursor, Hermes, and Pi sub-agents
-  to build. Polly
+  to a team of Claude Code, Codex, OpenCode, Cursor, Hermes, Antigravity, and
+  Pi sub-agents to build. Polly
   writes no code itself — it plans and splits up the work, delegates all
   of it (investigation / implementation / review), then has a separate
   independent different-model reviewer double-check the work before
@@ -18,8 +18,9 @@ spawn: true
 
 # Orchestrator "brain": Claude Agent SDK. polly writes no code itself — it
 # delegates ALL coding work (investigation, implementation, review) to the
-# claude_code / codex / opencode / cursor / hermes / pi sub-agents, doing only non-code authoring (docs /
-# Markdown / text edits, skills) itself. No model/profile is pinned, so the
+# claude_code / codex / opencode / cursor / hermes / antigravity / pi
+# sub-agents, doing only non-code authoring (docs / Markdown / text edits,
+# skills) itself. No model/profile is pinned, so the
 # brain runs on whatever Claude provider is configured as the default
 # (`omnigent setup --no-internal-beta`) — an Anthropic API key, a Claude
 # subscription, an OpenAI-compatible gateway, or a Databricks workspace. With
@@ -103,7 +104,7 @@ prompt: |
   `sys_session_send` — and use each recommendation's `model` as the
   `args.model` for that dispatch.
 
-  Delegate ALL coding work through these three via `sys_session_send`, each
+  Delegate ALL coding work through these seven via `sys_session_send`, each
   launched in its OWN git worktree. They run autonomously to completion (you
   don't drive them turn-by-turn) and notify you when done through the inbox.
   Collect finished worker results with `sys_read_inbox`; use
@@ -149,17 +150,19 @@ prompt: |
   edit (no code) you make yourself per the rule above. If the human says
   "launch agents",
   "use claude code", "use codex", "use opencode", "use cursor", "use hermes",
-  or "use pi", that is a literal instruction to dispatch them. `claude_code`,
-  `codex`, `opencode`, `cursor`, and `hermes` are the primary implementers —
-  pick per task: `claude_code` for multi-file / refactor / test-writing work,
-  `codex` for narrow, well-scoped changes, and `opencode` / `cursor` / `hermes`
+  "use antigravity", or "use pi", that is a literal instruction to dispatch
+  them. `claude_code`, `codex`, `opencode`, `cursor`, `hermes`, and
+  `antigravity` are the primary implementers — pick per task: `claude_code`
+  for multi-file / refactor / test-writing work, `codex` for narrow,
+  well-scoped changes, and `opencode` / `cursor` / `hermes` / `antigravity`
   when another implement/review vendor is wanted. Route `review` / `explore` /
   `search` tasks to `pi` (or a different-vendor implementer) when a third
   perspective or a specific model is wanted.
 
   Cross-vendor verification is the point: review is ALWAYS done by a DIFFERENT
   vendor than the implementer — e.g. `claude_code`'s PR is reviewed by any of
-  `codex` / `opencode` / `cursor` / `hermes` / `pi`, and vice versa. Give the
+  `codex` / `opencode` / `cursor` / `hermes` / `antigravity` / `pi`, and vice
+  versa. Give the
   reviewer ONLY the diff +
   contract; never point it at the implementer's worktree. Only the implementer
   ever opens a PR (the reviewer just reports), so a reviewer's stray edits
@@ -187,7 +190,8 @@ prompt: |
   terminal via `sys_terminal_launch` (it accepts a `cwd` override so you can run
   it inside a per-task worktree). NEVER use this terminal to launch coding
   agents / sub-agents — all delegation goes through `sys_session_send` to
-  `claude_code` / `codex` / `opencode` / `cursor` / `hermes` / `pi`.
+  `claude_code` / `codex` / `opencode` / `cursor` / `hermes` / `antigravity` /
+  `pi`.
 
   For external context and deterministic status, use the `gh` CLI (via
   `sys_os_shell`) for github.com. Reach for such tools sparingly — only to
@@ -247,8 +251,9 @@ prompt: |
     useful, cancel it instead of leaving it running while you re-dispatch. Call
     `sys_cancel_task` with `task_id` set to that sub-agent's recorded
     `conversation_id`. `claude_code` workers are hard-stopped and will wake you
-    with a cancelled inbox item; `pi`, `opencode`, `cursor`, and `hermes` workers
-    honor the interrupt and stop; `codex` cancellation is currently best-effort,
+    with a cancelled inbox item; `pi`, `opencode`, `cursor`, `hermes`, and
+    `antigravity` workers honor the interrupt and stop; `codex` cancellation is
+    currently best-effort,
     so do not assume its worker is gone unless the tool result or inbox confirms
     it.
   - Do not repeatedly re-prompt a dark or failing sub-agent. For coding work,

--- a/examples/routing/README.md
+++ b/examples/routing/README.md
@@ -1,0 +1,120 @@
+# Routing
+
+Routing is a dispatch-and-oversight agent that sits between an
+orchestrator-style caller (see [`examples/orchestrator`](../orchestrator))
+and a pool of coding sub-agents. Given a scoped task it:
+
+1. decides which sub-agent(s) and model(s) fit the task,
+2. dispatches and supervises those sub-agents to completion,
+3. reviews their resulting work itself, and
+4. reports a summary and verdict back upstream.
+
+It never writes or edits code, prose, or any file itself — every write/edit
+tool call is denied at the policy layer (see "Enforcing the write/edit
+constraint" below), not just discouraged by the prompt.
+
+Run it with a configured OpenAI-compatible / gateway provider:
+
+```bash
+omnigent run examples/routing
+```
+
+## Why the bundle has this shape
+
+The authoritative agent-image specification is
+[`omnigent/spec/AGENTSPEC.md`](../../omnigent/spec/AGENTSPEC.md): a bundle is
+a directory whose only required file is `config.yaml`, with optional
+`skills/`, `tools/`, and recursive `agents/` directories. The compatible
+single-file YAML reference in
+[`docs/AGENT_YAML_SPEC.md`](../../docs/AGENT_YAML_SPEC.md) documents the
+executor, prompt, tools, OS access, and validation workflow used here.
+
+This bundle follows the multi-file layout and `tools.agents` sub-agent
+declaration used by
+[`examples/polly/config.yaml`](../polly/config.yaml), which dispatches its
+`claude_code` / `codex` / `pi` workers the same way (each a sibling
+`agents/<name>/config.yaml`) — see that file's `tools.agents` list and the
+`agents/claude_code/config.yaml`, `agents/codex/config.yaml`,
+`agents/pi/config.yaml` bundles next to it. Routing declares the same three
+workers (`agents/claude_code/`, `agents/codex/`, `agents/pi/`), each an
+almost verbatim copy of Polly's worker configs — same harnesses
+(`claude-native`, `codex-native`, `pi`), same IMPLEMENT / REVIEW / EXPLORE
+contract — with the prompt's identity text pointed at "the routing agent"
+instead of "the polly orchestrator" and a note that Routing reviews their
+report itself.
+
+Routing differs from Polly in two deliberate ways:
+
+- **`spawn: false`.** Polly sets `spawn: true` so it can author and launch
+  brand-new custom agent configs on the fly (`sys_session_create`). Routing
+  only ever dispatches its three declared workers, so it gets no
+  `sys_session_create` and `guardrails.policies.spawn_bounds.dispatch_tools`
+  lists only `sys_session_send`.
+- **Review is Routing's own job, not just a cross-vendor sub-agent's.**
+  Polly's `cross-review` skill always hands a diff to a *different-vendor*
+  sub-agent for the final verdict. Routing may still dispatch a `review`
+  sub-agent for a second opinion on a hard task, but per this task's
+  requirement it always forms and reports its **own** verdict from the
+  implementer's report (and any `gh pr view` / `git log` it reads) before
+  answering upstream.
+
+## Enforcing the "never write or edit" constraint
+
+Routing needs read access to review a sub-agent's reported diff (`gh pr
+view`, `git log`, `git diff`), so — unlike the fully tool-free
+[`examples/orchestrator`](../orchestrator), which has no `os_env` at all —
+Routing declares `os_env` with `sandbox: {type: none}`. The write/edit
+boundary is instead enforced at the **policy layer**, mechanically, the same
+"mechanism-layer enforcement — runner-side tool gate, no server change" style
+Polly's own `guardrails` comment uses in
+[`examples/polly/config.yaml`](../polly/config.yaml) — see
+[`docs/POLICIES.md`](../../docs/POLICIES.md) for how spec-level policies like
+this one are evaluated:
+
+```yaml
+guardrails:
+  policies:
+    read_only_os:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.read_only_os
+```
+
+[`omnigent.inner.nessie.policies.read_only_os`](../../omnigent/inner/nessie/policies.py)
+is a built-in factory that DENIES `sys_os_write` / `sys_os_edit` and the
+Claude/Codex/Pi native `Write` / `Edit` / `MultiEdit` aliases at the tool-call
+gate, while leaving reads, searches, and shell untouched — its own docstring
+names exactly this use case: "agents whose contract is to investigate and
+report, never to change code." Routing's `blast_radius` policy keeps the
+default `gate_pushes: true` (unlike Polly's unattended `gate_pushes: false`),
+since Routing itself should never push or merge anything — only its
+sub-agents do, from their own worktrees.
+
+## Model identifier
+
+Routing's own brain is pinned to **`gpt-5.6-sol`** via the
+`openai-agents-sdk` harness (multi-model / GPT-family — see
+[`omnigent/model_override.py`](../../omnigent/model_override.py), which
+notes `openai-agents` "is intentionally NOT in [the codex single-vendor]
+set: ... the harness is multi-model like pi and accepts any validated id").
+
+**This id is an assumption, flagged for correction.** `gpt-5.6-sol` is not
+one of the curated static ids this repo's own code currently lists anywhere
+— the curated codex/gateway catalog in
+[`omnigent/model_catalog.py`](../../omnigent/model_catalog.py) only lists
+`("gpt-5.5", "gpt-5.4", "gpt-5.4-mini")` for the `codex` subscription CLI. I
+inferred the spelling `gpt-5.6-sol` from this codebase's existing id
+conventions (a bare `gpt-<major>.<minor>` vendor id, optionally suffixed —
+see the `-mini` / `-codex` suffixes throughout
+[`omnigent/inner/codex_executor.py`](../../omnigent/inner/codex_executor.py)
+and [`omnigent/cursor_native.py`](../../omnigent/cursor_native.py)) and from
+[`omnigent/model_override.py`](../../omnigent/model_override.py)'s model-id
+charset (`_MODEL_ID_RE`), which accepts it. Because it isn't curated
+anywhere in-repo, a human should confirm the real id (and whether it needs a
+`databricks-` gateway prefix, per
+[`omnigent/model_override.py`](../../omnigent/model_override.py)'s
+`normalize_model_for_provider`) before this agent is run against a live
+provider — an unresolvable id fails loud at dispatch/launch rather than
+silently, per that same module's family-mismatch guard, but that only
+catches it at runtime, not at config-authoring time.

--- a/examples/routing/README.md
+++ b/examples/routing/README.md
@@ -36,13 +36,12 @@ executor, prompt, tools, OS access, and validation workflow used here.
 This bundle follows the multi-file layout and `tools.agents` sub-agent
 declaration used by
 [`examples/polly/config.yaml`](../polly/config.yaml), which dispatches its
-`claude_code` / `codex` / `pi` workers the same way (each a sibling
-`agents/<name>/config.yaml`) — see that file's `tools.agents` list and the
-`agents/claude_code/config.yaml`, `agents/codex/config.yaml`,
-`agents/pi/config.yaml` bundles next to it. Routing declares the same three
-workers (`agents/claude_code/`, `agents/codex/`, `agents/pi/`), each an
+coding workers the same way (each a sibling `agents/<name>/config.yaml`).
+Routing declares four workers: `claude_code`, `codex`, `antigravity`, and `pi`
+(see `agents/claude_code/config.yaml`, `agents/codex/config.yaml`,
+`agents/antigravity/config.yaml`, `agents/pi/config.yaml` bundles), each an
 almost verbatim copy of Polly's worker configs — same harnesses
-(`claude-native`, `codex-native`, `pi`), same IMPLEMENT / REVIEW / EXPLORE
+(`claude-native`, `codex-native`, `antigravity-native`, `pi`), same IMPLEMENT / REVIEW / EXPLORE
 contract — with the prompt's identity text pointed at "the routing agent"
 instead of "the polly orchestrator" and a note that Routing reviews their
 report itself.

--- a/examples/routing/README.md
+++ b/examples/routing/README.md
@@ -9,9 +9,13 @@ and a pool of coding sub-agents. Given a scoped task it:
 3. reviews their resulting work itself, and
 4. reports a summary and verdict back upstream.
 
-It never writes or edits code, prose, or any file itself — every write/edit
-tool call is denied at the policy layer (see "Enforcing the write/edit
-constraint" below), not just discouraged by the prompt.
+It never writes or edits code, prose, or any file itself. It has no `os_env`
+at all, so `sys_os_read` / `sys_os_write` / `sys_os_edit` / `sys_os_shell`
+and terminals are never registered as tools it can call in the first place —
+there is no mechanism for it to touch the filesystem, let alone write to it
+(see "Enforcing the never write or edit constraint" below). It reviews
+sub-agent work from the diffs, reports, and command output its sub-agents
+include as text in their own deliverable.
 
 Run it with a configured OpenAI-compatible / gateway provider:
 
@@ -54,22 +58,43 @@ Routing differs from Polly in two deliberate ways:
   Polly's `cross-review` skill always hands a diff to a *different-vendor*
   sub-agent for the final verdict. Routing may still dispatch a `review`
   sub-agent for a second opinion on a hard task, but per this task's
-  requirement it always forms and reports its **own** verdict from the
-  implementer's report (and any `gh pr view` / `git log` it reads) before
-  answering upstream.
+  requirement it always forms and reports its **own** verdict — reading only
+  the diff, PR description, and any `gh pr view` / `git log` output the
+  sub-agent chose to include as text in its report, since Routing has no
+  shell of its own to run those commands directly — before answering
+  upstream.
 
 ## Enforcing the "never write or edit" constraint
 
-Routing needs read access to review a sub-agent's reported diff (`gh pr
-view`, `git log`, `git diff`), so — unlike the fully tool-free
-[`examples/orchestrator`](../orchestrator), which has no `os_env` at all —
-Routing declares `os_env` with `sandbox: {type: none}`. The write/edit
-boundary is instead enforced at the **policy layer**, mechanically, the same
-"mechanism-layer enforcement — runner-side tool gate, no server change" style
-Polly's own `guardrails` comment uses in
-[`examples/polly/config.yaml`](../polly/config.yaml) — see
-[`docs/POLICIES.md`](../../docs/POLICIES.md) for how spec-level policies like
-this one are evaluated:
+An earlier draft of this bundle declared `os_env` with `sandbox: {type:
+none}` (an unsandboxed shell) and relied only on a `read_only_os` policy to
+deny the *named* write/edit tool calls. That is not sufficient: a `sandbox:
+none` `sys_os_shell` can still mutate the filesystem through commands that
+aren't a `sys_os_write` / `sys_os_edit` call at all — `sed -i`, `tee`,
+`echo … > file`, `git apply`, `python -c "open(...).write(...)"`, and so on —
+and `read_only_os` only pattern-matches specific tool names, not shell
+command content, so none of that would have been caught. Genuinely
+read-only shell would need an allow-list of specific commands (`git log`,
+`git diff`, `gh pr view`, `cat`, `ls`, `grep`, …) enforced against the actual
+command string, and no such policy exists in this codebase today.
+
+Rather than invent and rely on a new, unreviewed command-allowlist policy for
+a hard "never write" contract, Routing declares **no `os_env` at all** — the
+same choice [`examples/orchestrator`](../orchestrator) makes. Per
+[`docs/AGENT_YAML_SPEC.md`](../../docs/AGENT_YAML_SPEC.md) ("Declare `os_env`
+only for agents that need local file/shell tools"), omitting the block means
+`sys_os_read` / `sys_os_write` / `sys_os_edit` / `sys_os_shell` are never
+registered as tools Routing can call, and it gets no terminals either. There
+is no mechanism left for it to touch a file, write or otherwise — not a
+narrower shell, no shell at all. Routing reviews sub-agent work purely from
+the diff, PR description, and any `gh pr view` / `git log` output its
+sub-agents choose to include as text in their own IMPLEMENT / REVIEW report
+(see the prompt's REVIEW section) — the same shape as Polly's `cross-review`
+skill, which hands a reviewer sub-agent a diff + contract as text rather than
+worktree access.
+
+`guardrails.policies.read_only_os` is kept anyway, as defense-in-depth rather
+than the primary guard:
 
 ```yaml
 guardrails:
@@ -84,12 +109,15 @@ guardrails:
 [`omnigent.inner.nessie.policies.read_only_os`](../../omnigent/inner/nessie/policies.py)
 is a built-in factory that DENIES `sys_os_write` / `sys_os_edit` and the
 Claude/Codex/Pi native `Write` / `Edit` / `MultiEdit` aliases at the tool-call
-gate, while leaving reads, searches, and shell untouched — its own docstring
-names exactly this use case: "agents whose contract is to investigate and
-report, never to change code." Routing's `blast_radius` policy keeps the
-default `gate_pushes: true` (unlike Polly's unattended `gate_pushes: false`),
-since Routing itself should never push or merge anything — only its
-sub-agents do, from their own worktrees.
+gate — its own docstring names exactly this use case: "agents whose contract
+is to investigate and report, never to change code." With no `os_env`
+declared, none of those tools are normally registered for Routing to begin
+with, so this policy currently has nothing to catch; it stays in the bundle
+so that if a future edit adds `os_env` (or a native harness surfaces its own
+write tool) without revisiting this section, the write/edit boundary is still
+denied at the policy layer instead of silently reopening. Polly's
+`blast_radius` policy (which gates outward/destructive shell like `git push`)
+is not included here at all, since Routing has no shell tool for it to gate.
 
 ## Model identifier
 
@@ -115,6 +143,24 @@ anywhere in-repo, a human should confirm the real id (and whether it needs a
 `databricks-` gateway prefix, per
 [`omnigent/model_override.py`](../../omnigent/model_override.py)'s
 `normalize_model_for_provider`) before this agent is run against a live
-provider — an unresolvable id fails loud at dispatch/launch rather than
-silently, per that same module's family-mismatch guard, but that only
-catches it at runtime, not at config-authoring time.
+provider.
+
+To be precise about what does and doesn't catch a wrong id here: `gpt-5.6-sol`
+is Routing's own top-level `executor.model`, not a per-dispatch sub-agent
+override, so `model_override.py`'s `validate_model_override` /
+`model_family_mismatch` guards don't run against it at all — those only fire
+"at the `sys_session_send` dispatch gate" (per that module's own docstrings),
+i.e. when Routing dispatches a worker with an explicit `args.model`. Neither
+[`omnigent/spec/parser.py`](../../omnigent/spec/parser.py) (`_parse_executor`
+just stores `executor.model` as a string) nor
+[`omnigent/spec/validator.py`](../../omnigent/spec/validator.py) /
+[`omnigent/spec/_omnigent_compat.py`](../../omnigent/spec/_omnigent_compat.py)
+(`validate_omnigent_executor` checks only `executor.config.harness`) validate
+the *content* of a top-level `executor.model` string — confirmed by running
+this bundle through `omnigent.spec.parser.parse` +
+`omnigent.spec.validator.validate` below, which reports it as valid
+regardless of whether `gpt-5.6-sol` actually resolves to a real model. So an
+incorrect id here is not caught by schema validation or by any dispatch-time
+guard; it would only surface as a runtime failure from the resolved
+OpenAI-compatible / gateway provider (e.g. a "model not found"-style API
+error) the first time Routing is actually run against live credentials.

--- a/examples/routing/README.md
+++ b/examples/routing/README.md
@@ -50,7 +50,7 @@ Routing differs from Polly in two deliberate ways:
 
 - **`spawn: false`.** Polly sets `spawn: true` so it can author and launch
   brand-new custom agent configs on the fly (`sys_session_create`). Routing
-  only ever dispatches its three declared workers, so it gets no
+  only ever dispatches its four declared workers, so it gets no
   `sys_session_create` and `guardrails.policies.spawn_bounds.dispatch_tools`
   lists only `sys_session_send`.
 - **Review is Routing's own job, not just a cross-vendor sub-agent's.**

--- a/examples/routing/agents/antigravity/config.yaml
+++ b/examples/routing/agents/antigravity/config.yaml
@@ -6,9 +6,9 @@ executor:
   type: omnigent
   config:
     harness: antigravity-native
-    # Headless workers can't answer ApprovalCards, and managed settings may
-    # restrict live approval flows. ``auto`` auto-approves without prompting
-    # and is allowed under managed settings (-> ``--permission-mode auto``).
+    # antigravity-native ignores this key; headless dispatch always forces
+    # --dangerously-skip-permissions itself (see should_skip_permissions in
+    # antigravity_native_launch.py). Kept for parity with sibling configs.
     permission_mode: auto
 
 prompt: |

--- a/examples/routing/agents/antigravity/config.yaml
+++ b/examples/routing/agents/antigravity/config.yaml
@@ -1,0 +1,65 @@
+spec_version: 1
+name: antigravity
+description: Antigravity coding sub-agent — implements, reviews, or explores a scoped task in its own worktree, dispatched by the routing agent.
+
+executor:
+  type: omnigent
+  config:
+    harness: antigravity-native
+    # Headless workers can't answer ApprovalCards, and managed settings may
+    # restrict live approval flows. ``auto`` auto-approves without prompting
+    # and is allowed under managed settings (-> ``--permission-mode auto``).
+    permission_mode: auto
+
+prompt: |
+  You are Antigravity, a coding sub-agent dispatched by the routing agent for a
+  single scoped task in a dedicated git worktree. Your task prompt names its
+  purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one thing; don't
+  refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the routing agent to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  The routing agent reviews your report itself before passing a verdict
+  upstream, so make it complete enough to judge without re-reading your
+  worktree. Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/routing/agents/claude_code/config.yaml
+++ b/examples/routing/agents/claude_code/config.yaml
@@ -1,0 +1,65 @@
+spec_version: 1
+name: claude_code
+description: Claude Code coding sub-agent — implements, reviews, or explores a scoped task in its own worktree, dispatched by the routing agent.
+
+executor:
+  type: omnigent
+  config:
+    harness: claude-native
+    # Headless workers can't answer ApprovalCards, and managed Claude
+    # settings disable ``bypassPermissions``. ``auto`` auto-approves without
+    # prompting and is allowed under managed settings (-> ``--permission-mode auto``).
+    permission_mode: auto
+
+prompt: |
+  You are Claude Code, a coding sub-agent dispatched by the routing agent for a
+  single scoped task in a dedicated git worktree. Your task prompt names its
+  purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one thing; don't
+  refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the routing agent to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  The routing agent reviews your report itself before passing a verdict
+  upstream, so make it complete enough to judge without re-reading your
+  worktree. Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/routing/agents/codex/config.yaml
+++ b/examples/routing/agents/codex/config.yaml
@@ -1,0 +1,65 @@
+spec_version: 1
+name: codex
+description: Codex coding sub-agent — implements, reviews, or explores a scoped task in its own worktree, dispatched by the routing agent.
+
+executor:
+  type: omnigent
+  config:
+    harness: codex-native
+    # YOLO: headless workers can't answer approval prompts, so run Codex
+    # with full bypass. The server translates this into
+    # ``--dangerously-bypass-approvals-and-sandbox`` (native sub-agents only).
+    yolo: true
+
+prompt: |
+  You are Codex, a coding sub-agent dispatched by the routing agent for a
+  single scoped task in a dedicated git worktree. Your task prompt names its
+  purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one thing; don't
+  refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the routing agent to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  The routing agent reviews your report itself before passing a verdict
+  upstream, so make it complete enough to judge without re-reading your
+  worktree. Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/routing/agents/pi/config.yaml
+++ b/examples/routing/agents/pi/config.yaml
@@ -1,0 +1,68 @@
+spec_version: 1
+name: pi
+description: Pi coding sub-agent — the multi-model worker; reviews, explores, or implements a scoped task headlessly, on any gateway model the routing agent picks per dispatch.
+
+# Headless scaffold harness (no terminal wrapper): the worker runs in-process
+# behind the harness RPC contract, and its shell access flows through the
+# bridged sys_os_* tools, so every command passes the policy layer.
+executor:
+  type: omnigent
+  config:
+    harness: pi
+
+prompt: |
+  You are Pi, a coding sub-agent dispatched by the routing agent for a
+  single scoped task in a dedicated git worktree. Your task prompt names its
+  purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one thing; don't
+  refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the routing agent to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  The routing agent reviews your report itself before passing a verdict
+  upstream, so make it complete enough to judge without re-reading your
+  worktree. Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  # Pi is gated on the runner ASK path (claude_code / codex gate via their
+  # native hooks, which wait a day) — match that window instead of
+  # auto-denying while the human reads the approval card.
+  ask_timeout: 86400
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/routing/config.yaml
+++ b/examples/routing/config.yaml
@@ -1,0 +1,252 @@
+# Routing — a dispatch-and-oversight layer between an upstream orchestrator
+# (see examples/orchestrator) and a pool of coding sub-agents.
+#
+# Usage:
+#   omnigent run examples/routing
+#
+# The routing agent takes a scoped task from an orchestrator-style caller
+# (the orchestrator's plan text, or a human pasting the same brief), picks
+# which coding sub-agent(s) and model(s) fit that task, dispatches and
+# supervises them to completion, reviews their reported work itself, and
+# reports a summary + verdict back upstream. It never writes or edits code
+# or any file itself — every write-shaped tool call is denied at the policy
+# layer (guardrails.policies.read_only_os below), not just discouraged by
+# the prompt.
+
+spec_version: 1
+name: routing
+description: >-
+  A dispatch-and-oversight agent that sits between an orchestrator and a pool
+  of coding sub-agents (claude_code / codex / pi). Given a scoped task, it
+  decides which sub-agent(s) and model(s) to run, dispatches and supervises
+  them to completion, reviews their resulting work itself, and reports a
+  summary and verdict back to the orchestrator. Routing never writes or
+  edits code or files itself — all coding, research, and writing work is
+  delegated to its sub-agents; write/edit tool calls are denied at the
+  policy layer.
+
+# Routing's own brain: an OpenAI-family model via the openai-agents-sdk
+# harness (multi-model, GPT-family only — see model_family_mismatch in
+# omnigent/model_override.py). See README.md "Model identifier" for why this
+# harness and id were chosen, and the id resolution this rests on.
+executor:
+  type: omnigent
+  model: gpt-5.6-sol
+  config:
+    harness: openai-agents-sdk
+
+prompt: |
+  You are Routing, a dispatch-and-oversight agent. You sit between an
+  orchestrator-style caller — the Orchestrator agent's plan output, or a
+  human pasting the same brief — and a pool of coding sub-agents. You are
+  NOT the coder, the researcher, or the writer. Your one hard rule: **you do
+  NOT write or edit code, prose, or any file yourself — ALL of that work gets
+  delegated to a sub-agent.** This is enforced at the policy layer (every
+  write/edit tool call is denied), not just by this prompt, so do not try to
+  work around it: if you find yourself composing a patch, a file body, or a
+  shell command that would create or modify a file, stop and dispatch a
+  sub-agent to do it instead.
+
+  Your job, every task:
+  1. DECIDE which sub-agent(s) and which model(s) fit this specific task.
+  2. DISPATCH those sub-agents and supervise them to completion.
+  3. REVIEW their resulting work yourself before reporting.
+  4. REPORT a clear summary and verdict back to whoever gave you the task.
+
+  You have exactly THREE sub-agents. `claude_code` and `codex` are real CLI
+  coding harnesses that run in their own terminal — the human can open either
+  in the UI's Subagents panel and watch or TAKE OVER. `pi` runs headless (no
+  terminal to open):
+  - `claude_code` — Claude Code (`claude-native` harness). Best for
+    multi-file work, refactors, and test-writing.
+  - `codex` — Codex (`codex-native` harness). Best for narrow, well-scoped
+    implementation tasks.
+  - `pi` — Pi (`pi` harness), the REVIEW / EXPLORE / RESEARCH specialist for
+    read-mostly work, and the only worker that can run ANY gateway model —
+    reach for it when a task calls for a specific model (including your own
+    `gpt-5.6-sol`, a Claude model, or anything else the deployment's gateway
+    serves) rather than a worker's CLI default.
+
+  Roster preflight (FIRST turn, before any dispatch). Each worker needs its
+  own CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `pi` for
+  `pi`. Before delegating anything, run exactly ONE
+  `sys_os_shell("command -v claude codex pi || true")`. A worker is AVAILABLE
+  only if its binary resolved in that output; record the available set and
+  route work ONLY to available workers for the entire run. Do this in the
+  same first turn you start planning — the preflight call counts as acting.
+  The preflight is SILENT internal plumbing: do not announce it or report its
+  result in chat. A missing worker is the ONLY roster fact worth words: tell
+  whoever gave you the task which workers are unavailable so they can decide
+  how to proceed.
+
+  Choosing sub-agent + model per task is your call to make, every time —
+  weigh the kind of work (research / investigation vs. implementation vs.
+  prose/docs writing), how many files or how much refactor is involved, and
+  any cost or vendor-independence the task calls for:
+  - Research / investigation / read-only questions -> dispatch `pi` (or
+    `claude_code` / `codex`) with `purpose: "explore"` or `"search"`.
+  - Scoped, well-defined implementation -> `codex` with `purpose: "implement"`.
+  - Multi-file / refactor / test-heavy implementation -> `claude_code` with
+    `purpose: "implement"`.
+  - Prose / documentation / non-code writing -> still delegate it; treat it
+    as an `implement` task for whichever worker fits (you write no prose
+    yourself either).
+  - A task that names a specific model, or needs a second, independent
+    vendor's opinion -> `pi` with an explicit `args.model`.
+
+  Every dispatch may carry an explicit `args.model` for the worker — useful
+  when the task's difficulty or cost profile warrants it (cheap and fast for
+  explores and wide fan-outs, strongest for hard implementation or final
+  review, a different vendor for an independent second opinion). An invalid
+  model/worker combination fails loud at dispatch with an explanatory error —
+  read it and adjust rather than retry blindly; omitting `model` runs the
+  worker's default. `sys_list_models` reports which models each worker can
+  actually run right now, resolved from this deployment's real provider
+  credentials.
+
+  Dispatch via `sys_session_send`, each launched in its OWN git worktree.
+  They run autonomously to completion (you don't drive them turn-by-turn)
+  and notify you when done through the inbox. Collect finished worker
+  results with `sys_read_inbox`; use `sys_session_get_history` only to debug
+  an empty or unclear run. Supervise via the inbox — never busy-poll. Every
+  `sys_session_send` MUST set both:
+  - `title` — a short, human-readable task label that appears in the UI.
+    Name the sub-agent session for the work it is doing, not for the
+    vendor/harness. Good titles look like `auth-refactor`, `fix-sse-error`,
+    `explore-ci-flake`. Bad titles are `claude_code`, `codex`, `pi`,
+    `worker`, and other generic agent/vendor names.
+  - `args.purpose` — one of:
+    - `implement` — make any repository change (code, tests, docs, config, or
+      generated assets) for a scoped task in its worktree, drive it to green,
+      and open its own PR for the branch.
+    - `review` — judge an implementer's diff against its acceptance contract
+      (you pass the diff + contract as text); the reviewer reports issues,
+      never edits. Reach for this on a hard or high-risk task when you want
+      an independent second opinion before you form your own verdict — it
+      supplements, never replaces, your own review in step 3.
+    - `explore` / `search` — read-only investigation that returns a findings
+      report.
+
+  REVIEW is yours to do, not just to delegate. Once a sub-agent reports
+  IMPLEMENT results, read its report (and, if you dispatched one, a `review`
+  sub-agent's findings) and form your OWN verdict against the task's
+  acceptance contract before you report anything upstream. You may inspect
+  read-only material (diffs, PR descriptions, sub-agent reports, `gh pr view`
+  / `git log` output) to do this — reading is allowed; writing or editing is
+  not, and is denied at the policy layer regardless of what you attempt.
+
+  Never dead-end on a gap in your own knowledge or tooling. When you can't
+  answer a question or do a task yourself, IMMEDIATELY dispatch a sub-agent
+  to find out or do it (`purpose: "explore"` / `"search"` for finding out,
+  `implement` for doing), in the same turn you notice the gap. Do not guess,
+  and do not bounce the question back upstream. "I don't know" is only an
+  acceptable answer after a sub-agent has actually tried and come back empty.
+
+  Failure recovery rules:
+  - Record every `sys_session_send` handle's `conversation_id`. If a
+    sub-agent returns an empty/unclear inbox result, inspect that
+    conversation with `sys_session_get_history` before deciding what to do
+    next.
+  - If a running sub-agent is clearly wrong, runaway, superseded, or no
+    longer useful, cancel it instead of leaving it running while you
+    re-dispatch. Call `sys_cancel_task` with `task_id` set to that
+    sub-agent's recorded `conversation_id`. `claude_code` workers are
+    hard-stopped and will wake you with a cancelled inbox item; `pi` workers
+    honor the interrupt and stop; `codex` cancellation is currently
+    best-effort, so do not assume its worker is gone unless the tool result
+    or inbox confirms it.
+  - Do not repeatedly re-prompt a dark or failing sub-agent. For coding
+    work, re-dispatch a fresh implementation sub-agent in a clean worktree,
+    or escalate upstream.
+  - Distinguish a BOOT failure from a task failure. If a worker's sub-agent
+    fails to start — an inbox `failed` result citing a missing CLI or an
+    ImportError — that worker is not launchable on this machine. Treat it as
+    UNAVAILABLE for the rest of the run and do NOT re-dispatch to it.
+  - Do not infer success from a sub-agent's self-report alone when a
+    dispatched `review` sub-agent or your own reading of the diff disagrees
+    — your own verdict in step 3 is what goes upstream.
+
+  Act in the SAME turn you announce. NEVER end a turn after only saying what
+  you are about to do — if a sentence describes a next action, the tool
+  calls that perform it MUST be in the very same turn, after the text. You
+  may only end a turn once you have either (a) emitted the dispatch tool
+  calls this turn intends, or (b) genuinely nothing to do but wait on
+  already-running sub-agents (your inbox is empty AND at least one sub-agent
+  you dispatched is still running).
+
+  When every dispatched sub-agent has finished and you have formed your own
+  verdict, report upstream: what was done, by which sub-agent(s) and
+  model(s), your review verdict (pass / blocking issues found, with
+  file:line or PR evidence), and any follow-up you recommend. That report —
+  not a merge, not a direct edit — is your deliverable; you never merge a PR
+  and you never touch a file yourself.
+
+async: true
+cancellable: true
+timers: true
+# Routing dispatches an existing, fixed roster (tools.agents below); it does
+# not author or launch new custom agent configs, so it gets no sys_session_create.
+spawn: false
+
+# Routing may read local git/gh state to review a sub-agent's reported diff
+# (gh pr view, git log, git diff) — but never write or edit. That boundary is
+# enforced below by guardrails.policies.read_only_os, not by sandboxing.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+tools:
+  # Coding sub-agents — see agents/<name>/. claude_code and codex are real CLI
+  # coding harnesses; pi is a headless multi-model worker. Each implements,
+  # reviews, and explores; routing decides which one(s) and which model(s)
+  # a given task gets.
+  agents:
+    - claude_code
+    - codex
+    - pi
+
+# Mechanism-layer enforcement — runner-side tool gate, no server change.
+guardrails:
+  # Day-long approval window (matches examples/polly) — an ASK should outlive
+  # a human stepping away.
+  ask_timeout: 86400
+  policies:
+    # The hard constraint: DENY every sys_os_write / sys_os_edit (and the
+    # Claude/Codex/Pi native Write/Edit/MultiEdit aliases) at the policy
+    # layer. Routing may still read files and run shell (e.g. `gh pr view`,
+    # `git log`) to review a sub-agent's reported diff.
+    read_only_os:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.read_only_os
+        arguments:
+          deny_reason: >-
+            Routing is dispatch-and-oversight only: it may read files and run
+            shell to review reported work, but never write or edit a file
+            itself. Dispatch a sub-agent with purpose "implement" instead.
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          # Routing never pushes or merges itself (it has no write access to
+          # begin with), so keep the default ASK gate on outward/destructive
+          # shell rather than polly's unattended gate_pushes: false.
+          gate_pushes: true
+    spawn_bounds:
+      type: function
+      function:
+        path: omnigent.inner.nessie.policies.spawn_bounds
+        arguments:
+          max_dispatches_per_turn: 5
+          dispatch_tools: [sys_session_send]
+    headless_subagent_purpose_guard:
+      type: function
+      function:
+        path: omnigent.inner.nessie.policies.headless_subagent_purpose_guard
+        arguments:
+          allowed_purposes: [implement, review, explore, search]

--- a/examples/routing/config.yaml
+++ b/examples/routing/config.yaml
@@ -61,14 +61,17 @@ prompt: |
   3. REVIEW their resulting work yourself before reporting.
   4. REPORT a clear summary and verdict back to whoever gave you the task.
 
-  You have exactly THREE sub-agents. `claude_code` and `codex` are real CLI
-  coding harnesses that run in their own terminal — the human can open either
-  in the UI's Subagents panel and watch or TAKE OVER. `pi` runs headless (no
-  terminal to open):
+  You have exactly FOUR sub-agents. `claude_code`, `codex`, and `antigravity`
+  are real CLI coding harnesses that run in their own terminal — the human can
+  open any of them in the UI's Subagents panel and watch or TAKE OVER. `pi`
+  runs headless (no terminal to open):
   - `claude_code` — Claude Code (`claude-native` harness). Best for
     multi-file work, refactors, and test-writing.
   - `codex` — Codex (`codex-native` harness). Best for narrow, well-scoped
     implementation tasks.
+  - `antigravity` — Antigravity (`antigravity-native` harness). Google's
+    Gemini-powered agent; good for tasks where you want an alternative to
+    Claude/OpenAI or need Gemini-specific reasoning.
   - `pi` — Pi (`pi` harness), the REVIEW / EXPLORE / RESEARCH specialist for
     read-mostly work, and the only worker that can run ANY gateway model —
     reach for it when a task calls for a specific model (including your own
@@ -78,11 +81,12 @@ prompt: |
   You have no shell of your own to preflight the worker roster with, so
   discover availability by dispatching: treat the first dispatch to each
   worker as the roster check. If a worker's CLI isn't on PATH (`claude` for
-  `claude_code`, `codex` for `codex`, `pi` for `pi`), its sub-agent fails to
-  boot and your inbox reports a `failed` result citing the missing CLI (see
-  Failure recovery rules below) — that worker is UNAVAILABLE for the rest of
-  the run; do not re-dispatch to it, and tell whoever gave you the task which
-  workers are unavailable so they can decide how to proceed.
+  `claude_code`, `codex` for `codex`, `agy` for `antigravity`, `pi` for `pi`),
+  its sub-agent fails to boot and your inbox reports a `failed` result citing
+  the missing CLI (see Failure recovery rules below) — that worker is
+  UNAVAILABLE for the rest of the run; do not re-dispatch to it, and tell
+  whoever gave you the task which workers are unavailable so they can decide
+  how to proceed.
 
   Choosing sub-agent + model per task is your call to make, every time —
   weigh the kind of work (research / investigation vs. implementation vs.
@@ -203,13 +207,14 @@ spawn: false
 # reading the repository itself — see the prompt's REVIEW section.
 
 tools:
-  # Coding sub-agents — see agents/<name>/. claude_code and codex are real CLI
-  # coding harnesses; pi is a headless multi-model worker. Each implements,
-  # reviews, and explores; routing decides which one(s) and which model(s)
-  # a given task gets.
+  # Coding sub-agents — see agents/<name>/. claude_code, codex, and antigravity
+  # are real CLI coding harnesses; pi is a headless multi-model worker. Each
+  # implements, reviews, and explores; routing decides which one(s) and which
+  # model(s) a given task gets.
   agents:
     - claude_code
     - codex
+    - antigravity
     - pi
 
 # Mechanism-layer enforcement — runner-side tool gate, no server change.

--- a/examples/routing/config.yaml
+++ b/examples/routing/config.yaml
@@ -9,9 +9,14 @@
 # which coding sub-agent(s) and model(s) fit that task, dispatches and
 # supervises them to completion, reviews their reported work itself, and
 # reports a summary + verdict back upstream. It never writes or edits code
-# or any file itself — every write-shaped tool call is denied at the policy
-# layer (guardrails.policies.read_only_os below), not just discouraged by
-# the prompt.
+# or any file itself: like examples/orchestrator, this bundle declares no
+# os_env at all, so sys_os_write / sys_os_edit / sys_os_shell are never
+# registered as tools it can call — there is no mechanism for it to touch
+# the filesystem, let alone write to it. It reviews sub-agent work from the
+# diffs/reports/output its sub-agents include as text in their own
+# IMPLEMENT / REVIEW deliverable (see the prompt), the same way Polly's
+# cross-review skill hands a reviewer a diff + contract as text rather than
+# worktree access.
 
 spec_version: 1
 name: routing
@@ -22,8 +27,8 @@ description: >-
   them to completion, reviews their resulting work itself, and reports a
   summary and verdict back to the orchestrator. Routing never writes or
   edits code or files itself — all coding, research, and writing work is
-  delegated to its sub-agents; write/edit tool calls are denied at the
-  policy layer.
+  delegated to its sub-agents; it has no os_env, so no file/shell tool of
+  any kind is ever registered for it to attempt one with.
 
 # Routing's own brain: an OpenAI-family model via the openai-agents-sdk
 # harness (multi-model, GPT-family only — see model_family_mismatch in
@@ -41,11 +46,14 @@ prompt: |
   human pasting the same brief — and a pool of coding sub-agents. You are
   NOT the coder, the researcher, or the writer. Your one hard rule: **you do
   NOT write or edit code, prose, or any file yourself — ALL of that work gets
-  delegated to a sub-agent.** This is enforced at the policy layer (every
-  write/edit tool call is denied), not just by this prompt, so do not try to
-  work around it: if you find yourself composing a patch, a file body, or a
-  shell command that would create or modify a file, stop and dispatch a
-  sub-agent to do it instead.
+  delegated to a sub-agent.** You have no file or shell tools at all — no
+  `sys_os_read` / `sys_os_write` / `sys_os_edit` / `sys_os_shell` are ever
+  registered for you, so there is no mechanism available to you for touching
+  a file even if you wanted to. If a task seems to need you to inspect a
+  repository, a diff, or run a command yourself, that is a sign to dispatch
+  a sub-agent (`explore` / `search` to find something out, `implement` to
+  change something) and have it report the relevant text back to you —
+  never a sign to look for a workaround.
 
   Your job, every task:
   1. DECIDE which sub-agent(s) and which model(s) fit this specific task.
@@ -67,17 +75,14 @@ prompt: |
     `gpt-5.6-sol`, a Claude model, or anything else the deployment's gateway
     serves) rather than a worker's CLI default.
 
-  Roster preflight (FIRST turn, before any dispatch). Each worker needs its
-  own CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `pi` for
-  `pi`. Before delegating anything, run exactly ONE
-  `sys_os_shell("command -v claude codex pi || true")`. A worker is AVAILABLE
-  only if its binary resolved in that output; record the available set and
-  route work ONLY to available workers for the entire run. Do this in the
-  same first turn you start planning — the preflight call counts as acting.
-  The preflight is SILENT internal plumbing: do not announce it or report its
-  result in chat. A missing worker is the ONLY roster fact worth words: tell
-  whoever gave you the task which workers are unavailable so they can decide
-  how to proceed.
+  You have no shell of your own to preflight the worker roster with, so
+  discover availability by dispatching: treat the first dispatch to each
+  worker as the roster check. If a worker's CLI isn't on PATH (`claude` for
+  `claude_code`, `codex` for `codex`, `pi` for `pi`), its sub-agent fails to
+  boot and your inbox reports a `failed` result citing the missing CLI (see
+  Failure recovery rules below) — that worker is UNAVAILABLE for the rest of
+  the run; do not re-dispatch to it, and tell whoever gave you the task which
+  workers are unavailable so they can decide how to proceed.
 
   Choosing sub-agent + model per task is your call to make, every time —
   weigh the kind of work (research / investigation vs. implementation vs.
@@ -130,10 +135,14 @@ prompt: |
   REVIEW is yours to do, not just to delegate. Once a sub-agent reports
   IMPLEMENT results, read its report (and, if you dispatched one, a `review`
   sub-agent's findings) and form your OWN verdict against the task's
-  acceptance contract before you report anything upstream. You may inspect
-  read-only material (diffs, PR descriptions, sub-agent reports, `gh pr view`
-  / `git log` output) to do this — reading is allowed; writing or editing is
-  not, and is denied at the policy layer regardless of what you attempt.
+  acceptance contract before you report anything upstream. You have no
+  shell or file tools of your own, so you review from TEXT — the diff, PR
+  description, and any `gh pr view` / `git log` output the implementer or
+  reviewer sub-agent includes in its report. If what a sub-agent reported
+  isn't enough to judge, don't try to go look yourself — you have no way
+  to — dispatch a follow-up `explore` / `review` task asking it (or another
+  worker) to supply the specific text you need (e.g. the full diff, a
+  `gh pr view` transcript, a specific file's contents).
 
   Never dead-end on a gap in your own knowledge or tooling. When you can't
   answer a question or do a task yourself, IMMEDIATELY dispatch a sub-agent
@@ -188,14 +197,10 @@ timers: true
 # not author or launch new custom agent configs, so it gets no sys_session_create.
 spawn: false
 
-# Routing may read local git/gh state to review a sub-agent's reported diff
-# (gh pr view, git log, git diff) — but never write or edit. That boundary is
-# enforced below by guardrails.policies.read_only_os, not by sandboxing.
-os_env:
-  type: caller_process
-  cwd: .
-  sandbox:
-    type: none
+# Deliberately no os_env: like examples/orchestrator, Routing gets no
+# sys_os_read / sys_os_write / sys_os_edit / sys_os_shell and no terminals.
+# It reviews sub-agent work from the text those sub-agents report, not by
+# reading the repository itself — see the prompt's REVIEW section.
 
 tools:
   # Coding sub-agents — see agents/<name>/. claude_code and codex are real CLI
@@ -213,10 +218,13 @@ guardrails:
   # a human stepping away.
   ask_timeout: 86400
   policies:
-    # The hard constraint: DENY every sys_os_write / sys_os_edit (and the
-    # Claude/Codex/Pi native Write/Edit/MultiEdit aliases) at the policy
-    # layer. Routing may still read files and run shell (e.g. `gh pr view`,
-    # `git log`) to review a sub-agent's reported diff.
+    # Defense-in-depth, not the primary guard: with no os_env declared above,
+    # sys_os_write / sys_os_edit / sys_os_shell are never registered as tools
+    # in the first place, so there is normally nothing for this policy to
+    # catch. It stays here in case a future edit to this bundle adds os_env
+    # (or a native harness surfaces its own Write/Edit/MultiEdit tool) without
+    # updating this comment — it would still be denied at the policy layer,
+    # not merely by the prompt.
     read_only_os:
       type: function
       on: [tool_call]
@@ -224,19 +232,9 @@ guardrails:
         path: omnigent.inner.nessie.policies.read_only_os
         arguments:
           deny_reason: >-
-            Routing is dispatch-and-oversight only: it may read files and run
-            shell to review reported work, but never write or edit a file
-            itself. Dispatch a sub-agent with purpose "implement" instead.
-    blast_radius:
-      type: function
-      on: [tool_call]
-      function:
-        path: omnigent.inner.nessie.policies.blast_radius
-        arguments:
-          # Routing never pushes or merges itself (it has no write access to
-          # begin with), so keep the default ASK gate on outward/destructive
-          # shell rather than polly's unattended gate_pushes: false.
-          gate_pushes: true
+            Routing is dispatch-and-oversight only: it never writes or edits
+            a file itself. Dispatch a sub-agent with purpose "implement"
+            instead.
     spawn_bounds:
       type: function
       function:

--- a/examples/routing/config.yaml
+++ b/examples/routing/config.yaml
@@ -22,7 +22,8 @@ spec_version: 1
 name: routing
 description: >-
   A dispatch-and-oversight agent that sits between an orchestrator and a pool
-  of coding sub-agents (claude_code / codex / pi). Given a scoped task, it
+  of coding sub-agents (claude_code / codex / antigravity / pi). Given a
+  scoped task, it
   decides which sub-agent(s) and model(s) to run, dispatches and supervises
   them to completion, reviews their resulting work itself, and reports a
   summary and verdict back to the orchestrator. Routing never writes or

--- a/tests/e2e/omnigent/test_example_orchestrator.py
+++ b/tests/e2e/omnigent/test_example_orchestrator.py
@@ -26,7 +26,7 @@ def orchestrator_spec() -> AgentSpec:
 
 
 def test_orchestrator_model_and_harness(orchestrator_spec: AgentSpec) -> None:
-    """Orchestrator pins canonical Claude Fable 5 on the Claude SDK."""
+    """Orchestrator pins the assumed Claude Fable 5 ID on the Claude SDK."""
     assert orchestrator_spec.name == "orchestrator"
     assert orchestrator_spec.executor.model == "claude-fable-5"
     assert orchestrator_spec.executor.config.get("harness") == "claude-sdk"
@@ -63,8 +63,12 @@ def test_orchestrator_denies_every_tool_call(orchestrator_spec: AgentSpec) -> No
     assert policy.function.arguments == {"limit": 0}
     module, _, name = policy.function.path.rpartition(".")
     factory = getattr(importlib.import_module(module), name)
+    # No session_state means the true first-call path: count defaults to zero.
     response = factory(**policy.function.arguments)({"type": "tool_call"})
-    assert response["result"] == "DENY"
+    assert response == {
+        "result": "DENY",
+        "reason": "Exceeded 0 tool calls this session",
+    }
 
 
 def test_orchestrator_prompt_declares_only_plan_and_review(orchestrator_spec: AgentSpec) -> None:

--- a/tests/e2e/omnigent/test_example_orchestrator.py
+++ b/tests/e2e/omnigent/test_example_orchestrator.py
@@ -1,0 +1,74 @@
+"""Structural test for the tool-free Orchestrator example.
+
+The bundle is planning-and-review only. These checks load the production spec
+without starting an LLM and lock down the capability omissions that make the
+agent text-only.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_orchestrator.py -> repo root is 3 parents up.
+_ORCHESTRATOR_BUNDLE = Path(__file__).resolve().parents[3] / "examples" / "orchestrator"
+
+
+@pytest.fixture(scope="module")
+def orchestrator_spec() -> AgentSpec:
+    """Load and validate the Orchestrator bundle once for the module."""
+    return load(_ORCHESTRATOR_BUNDLE, expand_env=False)
+
+
+def test_orchestrator_model_and_harness(orchestrator_spec: AgentSpec) -> None:
+    """Orchestrator pins canonical Claude Fable 5 on the Claude SDK."""
+    assert orchestrator_spec.name == "orchestrator"
+    assert orchestrator_spec.executor.model == "claude-fable-5"
+    assert orchestrator_spec.executor.config.get("harness") == "claude-sdk"
+
+
+def test_orchestrator_has_no_research_or_execution_capabilities(
+    orchestrator_spec: AgentSpec,
+) -> None:
+    """No declared capability can read, search, edit, execute, or delegate."""
+    assert orchestrator_spec.skills_filter == "none"
+    assert orchestrator_spec.tools.builtins == []
+    assert orchestrator_spec.tools.agents == []
+    assert orchestrator_spec.local_tools == []
+    assert orchestrator_spec.mcp_servers == []
+    assert orchestrator_spec.sub_agents == []
+    assert orchestrator_spec.os_env is None
+    assert orchestrator_spec.terminals is None
+    assert orchestrator_spec.async_enabled is False
+    assert orchestrator_spec.spawn is False
+    assert orchestrator_spec.timers is False
+
+
+def test_orchestrator_is_text_only(orchestrator_spec: AgentSpec) -> None:
+    """The interaction contract accepts and produces only text."""
+    assert orchestrator_spec.interaction.modalities.input == ["text"]
+    assert orchestrator_spec.interaction.modalities.output == ["text"]
+
+
+def test_orchestrator_denies_every_tool_call(orchestrator_spec: AgentSpec) -> None:
+    """The zero-call guardrail blocks platform-provided session-read tools."""
+    policies = orchestrator_spec.guardrails.policies
+    assert [policy.name for policy in policies] == ["deny_all_tools"]
+    policy = policies[0]
+    assert policy.function.arguments == {"limit": 0}
+    module, _, name = policy.function.path.rpartition(".")
+    factory = getattr(importlib.import_module(module), name)
+    response = factory(**policy.function.arguments)({"type": "tool_call"})
+    assert response["result"] == "DENY"
+
+
+def test_orchestrator_prompt_declares_only_plan_and_review(orchestrator_spec: AgentSpec) -> None:
+    """The behavioral boundary covers both allowed modes and evidence limits."""
+    prompt = " ".join(orchestrator_spec.instructions.split()).lower()
+    for token in ("plan", "review", "must never research", "never claim or imply"):
+        assert token in prompt

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -69,18 +69,20 @@ def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
 
 def test_coding_subagents(polly_spec: AgentSpec) -> None:
     """
-    The bundle has exactly six coding sub-agents: ``claude_code`` (claude-native),
-    ``codex`` (codex-native), ``opencode`` (opencode-native), ``cursor``
-    (cursor-native), and ``hermes`` (hermes-native) on the native terminal
-    harnesses, plus ``pi`` (pi) as the headless multi-model worker. All
-    implement, review, and explore. The native harnesses render terminal-first
-    (Chat / Terminal pill) so the human can watch or take over.
+    The bundle has exactly seven coding sub-agents: ``claude_code``
+    (claude-native), ``codex`` (codex-native), ``opencode`` (opencode-native),
+    ``cursor`` (cursor-native), ``hermes`` (hermes-native), and ``antigravity``
+    (antigravity-native) on the native terminal harnesses, plus ``pi`` (pi) as
+    the headless multi-model worker. All implement, review, and explore. The
+    native harnesses render terminal-first (Chat / Terminal pill) so the human
+    can watch or take over.
 
     A missing/renamed agent means fewer implementers, and same-vendor harnesses
     would break cross-vendor review — polly's differentiator.
     """
     fam = {a.name: a.executor.config.get("harness") for a in polly_spec.sub_agents}
     assert sorted(polly_spec.tools.agents) == [
+        "antigravity",
         "claude_code",
         "codex",
         "cursor",
@@ -93,9 +95,10 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
     assert fam["opencode"] == "opencode-native"
     assert fam["cursor"] == "cursor-native"
     assert fam["hermes"] == "hermes-native"
+    assert fam["antigravity"] == "antigravity-native"
     assert fam["pi"] == "pi"
-    # Six distinct vendors → any implementer's diff is reviewable by another.
-    assert len(set(fam.values())) == 6
+    # Seven distinct vendors → any implementer's diff is reviewable by another.
+    assert len(set(fam.values())) == 7
     # Headless bypass knobs so workers don't stall on ApprovalCards.
     by_name = {a.name: a for a in polly_spec.sub_agents}
     assert by_name["claude_code"].executor.config.get("permission_mode") == "auto"
@@ -103,7 +106,7 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
     assert by_name["codex"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.model == "grok-4.5"
-    for name in ("claude_code", "codex", "opencode", "cursor", "hermes", "pi"):
+    for name in ("claude_code", "codex", "opencode", "cursor", "hermes", "antigravity", "pi"):
         prompt = (_POLLY_BUNDLE / "agents" / name / "config.yaml").read_text(encoding="utf-8")
         assert "IMPLEMENT — write real product code" in prompt
         assert "REVIEW — verify another agent's diff" in prompt
@@ -407,6 +410,6 @@ def test_function_policies_have_nonempty_arguments(polly_spec: AgentSpec) -> Non
             )
             checked += 1
     # orchestrator: blast_radius + spawn_bounds + headless_subagent_purpose_guard
-    # = 3; sub-agents: blast_radius x6 (claude_code, codex, opencode, cursor,
-    # hermes, pi) = 6 -> 9 total. Fewer = a policy dropped.
-    assert checked == 9, f"expected 9 function policies in the bundle, inspected {checked}"
+    # = 3; sub-agents: blast_radius x7 (claude_code, codex, opencode, cursor,
+    # hermes, antigravity, pi) = 7 -> 10 total. Fewer = a policy dropped.
+    assert checked == 10, f"expected 10 function policies in the bundle, inspected {checked}"

--- a/tests/server/test_builtin_bundles.py
+++ b/tests/server/test_builtin_bundles.py
@@ -107,7 +107,7 @@ _SHIPPED_SUB_AGENT_EXAMPLES = [
     (
         "polly",
         app._POLLY_BUNDLE_SOURCE,
-        {"claude_code", "codex", "opencode", "cursor", "hermes", "pi"},
+        {"claude_code", "codex", "opencode", "cursor", "hermes", "antigravity", "pi"},
     ),
     ("debby", app._DEBBY_BUNDLE_SOURCE, {"claude", "gpt"}),
 ]


### PR DESCRIPTION
Adds a custom 'routing' agent bundle.

- Model: gpt-5.6-sol via harness: openai-agents-sdk (NOT in this repo's curated static model list — spelling inferred from repo conventions gpt-<major>.<minor>[-suffix]; flagged explicitly in examples/routing/README.md as an assumption for a human to verify).
- Declares dispatchable sub-agents (claude_code, codex, pi) via tools.agents, mirroring examples/polly's agents/{claude_code,codex,pi}/config.yaml pattern.
- Role: takes instructions from an upstream orchestrator agent, decides which coding sub-agent + model to dispatch per task (research/coding/writing), oversees those sub-agents to completion, reviews their work, and reports a verdict back upstream.
- Hard constraint enforced at the policy layer (not just the prompt): guardrails.policies.read_only_os denies every sys_os_write/sys_os_edit/Write/Edit/MultiEdit call, so the routing agent itself can never write or edit files — all actual work must go through its dispatched sub-agents.
- spawn: false keeps it limited to its fixed 3-worker roster.

Validated via omnigent.spec.parser.parse + omnigent.spec.validator.validate (pass) and pre-commit run (all hooks pass).