### PR TITLE
fix(web): keep terminal session links in-app

### DIFF
--- a/tests/e2e_ui/shells/test_terminal_session_links.py
+++ b/tests/e2e_ui/shells/test_terminal_session_links.py
@@ -1,0 +1,76 @@
+"""E2E: terminal session links stay in the current web app tab.
+
+The embedded xterm makes URLs in TUI / shell output clickable via
+``WebLinksAddon``. Same-origin Omnigent session URLs are app navigation, not
+external content: clicking one should update the current SPA route instead of
+opening a duplicate browser tab/window for the same chat.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from tests.e2e_ui.conftest import open_right_rail
+
+
+def _open_new_shell(page: Page) -> None:
+    """Open a user shell in the main terminal surface."""
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("Shells")).click()
+    rail.get_by_role("button", name="New shell").click()
+
+
+def _print_url_at_terminal_origin(page: Page, url: str) -> None:
+    """Print *url* at row 1/column 1 of the active xterm."""
+    terminal_view = page.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=60_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+
+    textarea = terminal_view.locator("textarea.xterm-helper-textarea")
+    textarea.focus()
+    page.keyboard.type(f"printf '\\033[2J\\033[H%s\\n' '{url}'")
+    page.keyboard.press("Enter")
+    page.wait_for_timeout(500)
+
+
+def _click_first_terminal_row(page: Page) -> None:
+    """Click near the start of row 1 in the active xterm screen."""
+    terminal_view = page.get_by_test_id("terminal-view").last
+    screen = terminal_view.locator(".xterm-screen").first
+    expect(screen).to_be_visible(timeout=20_000)
+    box = screen.bounding_box()
+    assert box is not None, "xterm screen should have a clickable bounding box"
+    page.mouse.click(box["x"] + 16, box["y"] + 10)
+
+
+def test_same_origin_terminal_session_link_navigates_in_app(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """Clicking a terminal-printed session URL does not open a duplicate tab.
+
+    The query string makes the destination visibly different from the current
+    URL while still targeting the same session. That proves the click hit the
+    xterm link: a missed click leaves the URL unchanged, while the old behavior
+    opens a popup/new tab and also leaves the current URL unchanged.
+    """
+    base_url, session_id = terminal_session
+    target_path = f"/c/{session_id}?terminal-link-e2e=1"
+    target_url = f"{base_url}{target_path}"
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+    _print_url_at_terminal_origin(page, target_url)
+
+    try:
+        with page.expect_popup(timeout=1_000):
+            _click_first_terminal_row(page)
+    except PlaywrightTimeoutError:
+        pass
+    else:
+        raise AssertionError("same-origin terminal session link opened a popup")
+
+    expect(page).to_have_url(f"{base_url}{target_path}")

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -45,6 +45,31 @@ describe("openTerminalLink", () => {
     );
   });
 
+  it("routes same-origin session links in-place without opening a new tab", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const pushSpy = vi.spyOn(window.history, "pushState");
+    const event = new MouseEvent("click");
+    const preventSpy = vi.spyOn(event, "preventDefault");
+
+    openTerminalLink(event, `${window.location.origin}/c/conv_next`);
+
+    expect(preventSpy).toHaveBeenCalledOnce();
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(pushSpy).toHaveBeenCalledWith(null, "", "/c/conv_next");
+  });
+
+  it("does not reopen the current same-origin session link", () => {
+    window.history.replaceState(null, "", "/c/conv_current");
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const pushSpy = vi.spyOn(window.history, "pushState");
+    const event = new MouseEvent("click");
+
+    openTerminalLink(event, `${window.location.origin}/c/conv_current`);
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
   it("prevents the addon's default in-place navigation", () => {
     vi.spyOn(window, "open").mockReturnValue(null);
     const event = new MouseEvent("click");

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -74,7 +74,28 @@ export function terminalTheme(isDark: boolean): ITheme {
  */
 export function openTerminalLink(event: MouseEvent, uri: string): void {
   event.preventDefault();
+  const sameOriginSessionPath = sameOriginSessionLink(uri);
+  if (sameOriginSessionPath) {
+    const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    if (sameOriginSessionPath !== currentPath) {
+      window.history.pushState(null, "", sameOriginSessionPath);
+      window.dispatchEvent(new PopStateEvent("popstate", { state: window.history.state }));
+    }
+    return;
+  }
   window.open(uri, "_blank", "noopener,noreferrer");
+}
+
+function sameOriginSessionLink(uri: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(uri, window.location.href);
+  } catch {
+    return null;
+  }
+  if (url.origin !== window.location.origin) return null;
+  if (!/(^|\/)c\/[^/]+\/?$/.test(url.pathname)) return null;
+  return `${url.pathname}${url.search}${url.hash}`;
 }
 
 /**


### PR DESCRIPTION
## Related issue

N/A

## Summary

Terminal-first sessions can print Omnigent session URLs inside the embedded TUI. The web terminal link handler treated every detected URL as external, so clicking a same-origin session URL opened another browser window/tab instead of staying in the web app.

- Detect same-origin `/c/<session>` links from terminal output and route them through browser history in-place.
- No-op when the terminal link points at the session already open in the current tab, avoiding duplicate same-chat popups.
- Keep external terminal links opening in a hardened new tab with `noopener,noreferrer`.

## Test Plan

- Added Playwright e2e coverage: `tests/e2e_ui/shells/test_terminal_session_links.py`
- Attempted: `cd web && npx vitest run src/components/blocks/TerminalSession.test.ts`
  - Could not start because this worktree does not have web dev dependencies installed (`@tailwindcss/vite`, `@vitejs/plugin-react`, `vitest/config`).
- Attempted: `REPO=omnigent-ai/omnigent PR=2639 MAINTAINERS="$(cat .github/MAINTAINER)" ... bash .github/scripts/e2e-ui-required/check.sh`
  - Could not complete locally because `OPENAI_BASE_URL` / `OPENAI_API_KEY` are not configured; CI provides these for the e2e_ui judge.

## Demo

N/A — non-visual link-routing fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage verifies external-link behavior, same-origin session routing, and current-session no-op behavior in the terminal link handler. Playwright coverage prints a same-origin session URL inside a real embedded terminal, clicks it, and asserts the current web app URL changes without opening a popup.

## Changelog

Clicking an Omnigent session URL printed inside the embedded terminal now stays in the web app instead of opening a duplicate browser tab/window.
