### PR TITLE
fix(openai): respect use_responses false in standard bundles

### DIFF
--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1574,6 +1574,13 @@ def _load_global_auth() -> ApiKeyAuth | DatabricksAuth | None:
     return None
 
 
+def _config_flag_is_true(value: object) -> bool:
+    """Interpret a free-form executor config value as a boolean flag."""
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes"}
+
+
 def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
     """
     Build the env-var dict the openai-agents harness wrap reads.
@@ -1625,7 +1632,9 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
         configure_agent_harness_with_provider(env, provider, harness_type="openai-agents-sdk")
         use_responses = spec.executor.config.get("use_responses")
         if use_responses is not None:
-            env["HARNESS_OPENAI_AGENTS_USE_RESPONSES"] = "true" if use_responses else "false"
+            env["HARNESS_OPENAI_AGENTS_USE_RESPONSES"] = (
+                "true" if _config_flag_is_true(use_responses) else "false"
+            )
         return env
 
     # Global config auth is only consulted when the spec declares NO
@@ -1681,7 +1690,9 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
 
     use_responses = spec.executor.config.get("use_responses")
     if use_responses is not None:
-        env["HARNESS_OPENAI_AGENTS_USE_RESPONSES"] = "true" if use_responses else "false"
+        env["HARNESS_OPENAI_AGENTS_USE_RESPONSES"] = (
+            "true" if _config_flag_is_true(use_responses) else "false"
+        )
     configure_agent_harness_with_ucode(
         env,
         ucode_profile,

--- a/tests/runtime/test_openai_agents_sdk_spawn_env.py
+++ b/tests/runtime/test_openai_agents_sdk_spawn_env.py
@@ -48,7 +48,7 @@ def _make_spec(
     *,
     model: str | None = "databricks-gpt-5-4-mini",
     profile: str | None = None,
-    use_responses: bool | None = None,
+    use_responses: object | None = None,
     auth: ApiKeyAuth | DatabricksAuth | None = None,
 ) -> AgentSpec:
     """
@@ -60,7 +60,8 @@ def _make_spec(
     :param profile: ``spec.executor.config["profile"]``; ``None``
         omits it (no profile declared in YAML).
     :param use_responses: ``spec.executor.config["use_responses"]``;
-        ``None`` omits it (executor default applies).
+        ``None`` omits it (executor default applies). The parser normally
+        supplies this as a string, while direct callers may provide a bool.
     :param auth: Typed auth object placed on ``spec.executor.auth``;
         ``None`` omits it (harness falls back to legacy/env-var paths).
     :returns: A populated :class:`AgentSpec`.
@@ -85,6 +86,29 @@ def test_model_threads_into_env_var() -> None:
     """``executor.config["model"]`` is encoded into ``HARNESS_OPENAI_AGENTS_MODEL``."""
     env = _build_openai_agents_sdk_spawn_env(_make_spec(model="databricks-gpt-5-4-mini"))
     assert env["HARNESS_OPENAI_AGENTS_MODEL"] == "databricks-gpt-5-4-mini"
+
+
+@pytest.mark.parametrize(
+    ("use_responses", "expected"),
+    [
+        ("False", "false"),
+        ("True", "true"),
+        (False, "false"),
+        (True, "true"),
+    ],
+)
+def test_use_responses_config_value_is_interpreted_as_boolean(
+    monkeypatch: pytest.MonkeyPatch, use_responses: object, expected: str
+) -> None:
+    """Stringified YAML booleans must not be evaluated by Python truthiness."""
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_provider_for_build",
+        lambda *args, **kwargs: None,
+    )
+    env = _build_openai_agents_sdk_spawn_env(
+        _make_spec(model="gpt-4o", use_responses=use_responses)
+    )
+    assert env["HARNESS_OPENAI_AGENTS_USE_RESPONSES"] == expected
 
 
 def test_explicit_profile_threads_into_env_var() -> None:

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -94,6 +94,7 @@ def _make_spec(
     harness: str,
     model: str | None = None,
     profile: str | None = None,
+    use_responses: object | None = None,
     auth: ApiKeyAuth | DatabricksAuth | ProviderAuth | None = None,
     os_env: object | None = None,
 ) -> AgentSpec:
@@ -105,6 +106,8 @@ def _make_spec(
     :param model: Spec-level model, e.g. ``"my-model"``. ``None`` omits it
         so the provider family's ``models.default`` supplies the model.
     :param profile: Legacy ``executor.config["profile"]``. ``None`` omits it.
+    :param use_responses: ``executor.config["use_responses"]``. ``None`` omits
+        it; strings model values produced by standard bundle parsing.
     :param auth: Typed auth on ``spec.executor.auth``. ``None`` omits it, so
         the no-auth global-default provider path applies.
     :returns: A populated :class:`AgentSpec`.
@@ -114,6 +117,8 @@ def _make_spec(
         config["model"] = model
     if profile is not None:
         config["profile"] = profile
+    if use_responses is not None:
+        config["use_responses"] = use_responses
     return AgentSpec(
         spec_version=1,
         name=f"test-{harness}",
@@ -424,6 +429,26 @@ def test_openai_agents_uses_openai_global_default(config_home: Path) -> None:
     assert env["HARNESS_OPENAI_AGENTS_MODEL"] == "gpt-default-model"
     # No DATABRICKS enable flag for this harness (executor takes key directly).
     assert "HARNESS_OPENAI_AGENTS_DATABRICKS" not in env
+
+
+@pytest.mark.parametrize(
+    ("use_responses", "expected"),
+    [("False", "false"), ("True", "true")],
+)
+def test_openai_agents_provider_preserves_use_responses_flag(
+    config_home: Path, use_responses: str, expected: str
+) -> None:
+    """The provider early-return path also interprets stringified flags."""
+    _write_config(config_home, _openai_default_config())
+    spec = _make_spec(
+        harness="openai-agents",
+        model="gpt-test",
+        use_responses=use_responses,
+    )
+
+    env = _build_openai_agents_sdk_spawn_env(spec)
+
+    assert env["HARNESS_OPENAI_AGENTS_USE_RESPONSES"] == expected
 
 
 def test_pi_uses_anthropic_global_default(config_home: Path) -> None:


### PR DESCRIPTION
## Related issue

Closes #2501

## Summary

`executor.config` scalar values are intentionally stringified during standard bundle parsing. The openai-agents spawn-env builder previously evaluated the string `"False"` with Python truthiness, silently enabling the Responses API when the bundle requested Chat Completions.

This change parses `use_responses` explicitly at both spawn-env paths and adds regression coverage for parser-produced strings and native booleans.

ELI5: the setting was reading the word `"False"` as if it meant “yes”; it now reads the value by meaning instead of by whether the string is non-empty.

## Test Plan

- `HOME=/private/tmp/omnigent-issue2501-home uv run --extra dev pytest tests/runtime/test_openai_agents_sdk_spawn_env.py -q` — 28 passed.
- `HOME=/private/tmp/omnigent-issue2501-home uv run --extra dev pytest tests/runtime/test_openai_agents_sdk_spawn_env.py tests/runtime/test_provider_spawn_env.py -k use_responses -q` — 9 passed, covering both spawn-env paths.
- Ruff format/check, repository test-lint checks, and `git diff --check` pass for the changed files.

## Demo

N/A — non-visual runtime/configuration fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression tests cover the standard-bundle string values (`"False"` / `"True"`) and native boolean values in both the legacy/ucode and resolved-provider spawn-env paths.

## Changelog

`use_responses: false` now correctly selects the Chat Completions API in standard `config.yaml` bundles.
