### PR TITLE
🐛 fix(docker): wire policy_store so the policy API works in Docker deploys

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -289,6 +289,9 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     from omnigent.stores.permission_store.sqlalchemy_store import (
         SqlAlchemyPermissionStore,
     )
+    from omnigent.stores.policy_store.sqlalchemy_store import (
+        SqlAlchemyPolicyStore,
+    )
 
     telemetry.init()
 
@@ -297,6 +300,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     conversation_store = SqlAlchemyConversationStore(database_url)
     comment_store = SqlAlchemyCommentStore(database_url)
     permission_store = SqlAlchemyPermissionStore(database_url)
+    policy_store = SqlAlchemyPolicyStore(database_url)
     host_store = HostStore(database_url)
     # Fail startup loud on a malformed `sandbox:` section (an operator
     # typo should not surface as a runtime 502 on the first managed
@@ -343,6 +347,12 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         agent_cache=agent_cache,
         comment_store=comment_store,
         permission_store=permission_store,
+        # Without this, create_app leaves policy_store=None, which disables the
+        # session-policy and default-policy CRUD endpoints for every Docker
+        # deploy — see the router guards in omnigent/server/app.py. The CLI
+        # (`omnigent server`) already wires this store; the Docker entrypoint
+        # is the odd one out.
+        policy_store=policy_store,
         host_store=host_store,
         auth_provider=auth_provider,
         account_store=account_store,


### PR DESCRIPTION
## Problem

The OSS Docker image runs `python /app/entrypoint.py` (`deploy/docker/Dockerfile`). Its `build_app()` constructs every store and calls `create_app(...)` — but never passes `policy_store`.

`create_app`'s own docstring is explicit about the consequence:

> `policy_store`: Store for server-persisted policies (session-scoped and server-wide defaults). `None` disables both the session policy and default policy CRUD endpoints.

and `omnigent/server/app.py` guards them:

```python
if policy_store is not None:
    app.include_router(create_session_policies_router(...), prefix="/v1", tags=["session_policies"])
    app.include_router(create_default_policies_router(...), prefix="/v1", ...)
```

So on **every Docker deploy** `policy_store` is `None` and these never mount:

- `/v1/sessions/{session_id}/policies` (+ `/{policy_id}`)
- `/v1/policies` (+ `/{policy_id}`)

Observed on a self-hosted `omnigent-server` container: `POST /v1/sessions/{id}/policies` returns **405**, and the server's own `/openapi.json` contains only `GET /v1/policy-registry` and `POST /v1/sessions/{session_id}/policies/evaluate`. Notably `/v1/sessions/{id}/comments` and `/v1/sessions/{id}/permissions` *are* present — exactly the stores the entrypoint does pass — which pins the cause to this omission rather than to config or auth.

The `omnigent server` CLI already does the right thing (`policy_store = SqlAlchemyPolicyStore(db_uri)` → `create_app(policy_store=policy_store, ...)`); the Docker entrypoint is the only path that omits it.

Net effect: anyone self-hosting via the official image silently loses the entire policy API — and the v0.5.0 fix *"default policies created via the API now take effect on sessions"* (#2333) is unreachable for them, since the API that creates those policies isn't mounted.

## Fix

Construct `SqlAlchemyPolicyStore(database_url)` alongside the other stores and pass it to `create_app`, mirroring the CLI. Three lines plus a comment.

## Notes

- The import is **deferred inside `build_app()`**, consistent with the surrounding store imports, so the no-import-side-effects guard in `tests/deploy/test_docker_entrypoint_import.py` still holds.
- **No config or env change required**: it reuses the same `database_url` the other stores already take, and the policy tables are part of the same schema/migrations that `main()` already runs.

## Verification

- `python -m py_compile deploy/docker/entrypoint.py` passes.
- The diff mirrors the existing CLI wiring exactly.

I have not booted a patched image or run the full suite locally (my environment isn't set up for the `uv` dev flow), so a CI run would be worth having. Happy to add a regression test asserting `create_app` receives a non-`None` `policy_store` — just point me at the preferred location and I'll push it.