### PR TITLE
fix: disable native agents unsupported by the target host

### DIFF
--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -5,11 +5,11 @@ web agent picker can warn) and re-checks the session's harness before
 spawning a runner (so an unconfigured launch fails with a clear,
 actionable error instead of dying inside the executor).
 
-"Configured" here is deliberately narrow: the **only** thing the daemon
-can reliably determine locally is whether a harness's wrapped CLI binary
-is on ``PATH``. That gates the native CLI harnesses (Claude Code / Codex
-via ``claude`` / ``codex``) and ``pi`` — the common "I picked Claude Code
-but never ran ``omnigent setup`` to install it" case.
+"Configured" here is deliberately narrow: the daemon reports whether the
+selected platform can launch a harness and whether its wrapped CLI binary is
+on ``PATH``. That gates native TUI harnesses on Windows, where tmux/PTY support
+is unavailable, and native CLI harnesses (Claude Code / Codex via ``claude`` /
+``codex``) and ``pi`` when their binaries are missing.
 
 In-process SDK harnesses (``claude-sdk``, ``openai-agents``) run without
 any CLI and resolve their model credentials at runtime from sources the
@@ -29,8 +29,9 @@ import shutil
 from collections.abc import Callable
 
 import omnigent.onboarding.gemini_auth as _gemini_auth
+from omnigent._platform import IS_WINDOWS
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
-from omnigent.harness_plugins import harness_install_keys, valid_harnesses
+from omnigent.harness_plugins import harness_install_keys, native_harnesses, valid_harnesses
 from omnigent.onboarding.harness_install import (
     COPILOT_KEY,
     CURSOR_KEY,
@@ -289,6 +290,8 @@ def harness_is_configured(harness: str) -> bool:
 
 def _harness_availability(canonical: str) -> HarnessAvailability:
     """Return picker-facing availability for one canonical harness spelling."""
+    if IS_WINDOWS and canonical in native_harnesses():
+        return "platform-unsupported"
     if (
         canonical in {"codex", "codex-native", "native-codex"}
         and _HARNESS_FAMILY.get(canonical) == OPENAI_FAMILY
@@ -306,8 +309,10 @@ def configured_harness_map() -> dict[str, HarnessAvailability]:
     spelling it holds — canonical ids, executor-type spellings, the
     ``claude`` alias, and ``pi``. SDK and unknown harnesses map to
     ``True`` (never gated); CLI-wrapping harnesses map to whether their
-    binary is on ``PATH``. Codex entries use a structured string reason when
-    unavailable: ``"binary-missing"`` or ``"needs-auth"``.
+    binary is on ``PATH``. Native TUI harnesses report
+    ``"platform-unsupported"`` on Windows, where their tmux/PTY runtime cannot
+    launch. Codex entries use a structured string reason when unavailable:
+    ``"binary-missing"`` or ``"needs-auth"``.
 
     :returns: Mapping of harness spelling to readiness, e.g.
         ``{"claude-native": False, "codex-native": "needs-auth",

--- a/tests/e2e_ui/chat/test_codex_auth_availability.py
+++ b/tests/e2e_ui/chat/test_codex_auth_availability.py
@@ -119,6 +119,32 @@ def _codex_native_agents_body() -> str:
     )
 
 
+def _windows_agents_body() -> str:
+    """Stub one unsupported native agent and one runnable SDK alternative."""
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_claude_native_e2e",
+                    "name": "claude-native-ui",
+                    "display_name": "Claude Code",
+                    "description": "Claude's native terminal",
+                    "harness": "claude-native",
+                    "skills": [],
+                },
+                {
+                    "id": "ag_claude_sdk_e2e",
+                    "name": "claude-sdk-e2e",
+                    "display_name": "Claude SDK",
+                    "description": "Claude through the SDK harness",
+                    "harness": "claude-sdk",
+                    "skills": [],
+                },
+            ]
+        }
+    )
+
+
 def _polly_codex_agents_body() -> str:
     """Stub body for ``GET /v1/agents``: a bundle agent on the codex brain harness.
 
@@ -290,6 +316,54 @@ async def _drive_codex_needs_auth(base_url: str) -> None:
             # leaves no warning. count()==0 (not "not visible") because the
             # element is conditionally rendered, never just hidden.
             await expect(page.get_by_test_id("new-chat-landing-harness-warning")).to_have_count(0)
+        finally:
+            await browser.close()
+
+
+def test_platform_unsupported_native_agent_cannot_be_selected(
+    seeded_session: tuple[str, str],
+) -> None:
+    """The new-session picker disables native agents unsupported by the host."""
+    base_url, session_id = seeded_session
+    del session_id
+    _run_in_fresh_loop(_drive_platform_unsupported_native_agent(base_url))
+
+
+async def _drive_platform_unsupported_native_agent(base_url: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(
+                page,
+                agents_body=_windows_agents_body(),
+                configured_harnesses={
+                    "claude-native": "platform-unsupported",
+                    "claude-sdk": True,
+                },
+            )
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            picker = page.get_by_test_id("new-chat-landing-agent-select")
+            await expect(picker).to_be_visible(timeout=30_000)
+            # The catalog's first row is native, but host readiness makes the
+            # runnable SDK sibling the automatic selection.
+            await expect(picker).to_contain_text("Claude-sdk-e2e")
+
+            await picker.click()
+            native_row = page.get_by_test_id("new-chat-landing-agent-ag_claude_native_e2e")
+            await expect(native_row).to_have_attribute("aria-disabled", "true")
+            await expect(native_row).to_be_disabled()
+            await expect(
+                page.get_by_test_id("new-chat-landing-agent-warning-ag_claude_native_e2e")
+            ).to_have_text("not supported")
+            await expect(picker).to_contain_text("Claude-sdk-e2e")
         finally:
             await browser.close()
 

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 import omnigent.onboarding.harness_install as hi
+import omnigent.onboarding.harness_readiness as hr
 from omnigent.onboarding.harness_readiness import (
     configured_harness_map,
     harness_is_configured,
@@ -244,6 +245,41 @@ def test_configured_harness_map_gates_only_cli_harnesses(
         assert result[cli] is False, f"{cli} should be gated on its CLI binary"
     for codex in ("codex", "codex-native", "native-codex"):
         assert result[codex] == "binary-missing", f"{codex} should name the missing Codex binary"
+
+
+def test_configured_harness_map_rejects_native_tuis_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows hosts report native TUI harnesses as impossible to launch.
+
+    Native wrappers require tmux/PTY support that the runner deliberately does
+    not provide on Windows. SDK and headless harnesses remain available so the
+    web picker can offer a working alternative on the same host.
+    """
+    monkeypatch.setattr(hr, "IS_WINDOWS", True)
+    _all_clis_installed(monkeypatch)
+
+    result = configured_harness_map()
+
+    for native in (
+        "claude-native",
+        "codex-native",
+        "opencode-native",
+        "pi-native",
+        "cursor-native",
+        "kiro-native",
+        "antigravity-native",
+        "goose-native",
+        "qwen-native",
+        "kimi-native",
+        "hermes-native",
+    ):
+        assert result[native] == "platform-unsupported"
+
+    for supported in ("claude-sdk", "openai-agents"):
+        assert result[supported] is True
+    for headless_cli in ("codex", "cursor"):
+        assert result[headless_cli] != "platform-unsupported"
 
 
 def test_configured_harness_map_all_true_with_clis(

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -474,6 +474,18 @@ describe("harnessUnconfiguredOnHost", () => {
     );
   });
 
+  it("surfaces platform-unsupported for native harnesses", () => {
+    const testHost = hostWith({ "claude-native": "platform-unsupported" });
+    const reason = harnessUnavailableReasonOnHost("claude-native", testHost);
+
+    expect(reason).toBe("platform-unsupported");
+    expect(harnessUnconfiguredOnHost("claude-native", testHost)).toBe(true);
+    expect(harnessWarningBadgeText(reason)).toBe("not supported");
+    expect(harnessWarningMessageText("Claude Code", "windows-host", reason)).toBe(
+      "Claude Code is not supported on windows-host. Choose an SDK-based agent or another host.",
+    );
+  });
+
   it("ignores unknown future reason strings", () => {
     expect(harnessUnavailableReasonOnHost("codex", hostWith({ codex: "future-reason" }))).toBe(
       null,
@@ -901,6 +913,55 @@ describe("NewChatLandingScreen", () => {
     expect(screen.queryByTestId("new-chat-landing-harness-cursor")).toBeNull();
     expect(screen.queryByTestId("new-chat-landing-harness-pi")).toBeNull();
     expect(screen.queryByTestId("new-chat-landing-harness-copilot")).toBeNull();
+  });
+
+  it("disables native agents unsupported by the selected host", async () => {
+    mockHosts([
+      {
+        ...host("online"),
+        configured_harnesses: {
+          "claude-native": "platform-unsupported",
+          "claude-sdk": true,
+        },
+      },
+    ]);
+    mockAgents([
+      {
+        id: "a_native",
+        name: "claude-native-ui",
+        display_name: "Claude Code",
+        description: null,
+        harness: "claude-native",
+        skills: [],
+      },
+      {
+        id: "a_sdk",
+        name: "sdk-agent",
+        display_name: "Claude SDK",
+        description: null,
+        harness: "claude-sdk",
+        skills: [],
+      },
+    ]);
+
+    renderLanding();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain(
+        "Claude SDK",
+      ),
+    );
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    const nativeRow = screen.getByTestId("new-chat-landing-agent-a_native");
+    expect(nativeRow.getAttribute("aria-disabled")).toBe("true");
+    expect(nativeRow.getAttribute("title")).toContain("not supported on machine-1");
+    expect(screen.getByTestId("new-chat-landing-agent-warning-a_native").textContent).toBe(
+      "not supported",
+    );
+
+    fireEvent.click(nativeRow);
+    expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain("Claude SDK");
+    expect(localStorage.getItem("omnigent:last-agent-id")).not.toBe("a_native");
   });
 
   it("seeds the working directory from the host's most-recent path", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -520,9 +520,9 @@ export async function describeCreateError(res: Response): Promise<string> {
 /**
  * Whether an agent's harness is known to be unconfigured on a host.
  *
- * Warning-only signal for the agent picker: `true` only when the host
- * explicitly reported the harness as not ready (CLI missing or no
- * default credential — see `omnigent setup`). A missing readiness map
+ * Host-readiness signal for the agent picker: `true` only when the host
+ * explicitly reported the harness as not ready (unsupported platform, CLI
+ * missing, or no default credential — see `omnigent setup`). A missing readiness map
  * (older host build) or an unknown harness yields `false`, so unknown
  * never warns; the host re-checks authoritatively at launch time.
  *
@@ -550,6 +550,7 @@ export function harnessUnavailableReasonOnHost(
 ): string | null {
   if (!harness || !host?.configured_harnesses) return null;
   const availability = host.configured_harnesses[harness];
+  if (availability === "platform-unsupported") return availability;
   if (availability === false) return isCodexHarness(harness) ? "binary-missing" : "unconfigured";
   if (
     isCodexHarness(harness) &&
@@ -562,6 +563,7 @@ export function harnessUnavailableReasonOnHost(
 }
 
 export function harnessWarningBadgeText(reason: string | null): string {
+  if (reason === "platform-unsupported") return "not supported";
   if (reason === "binary-missing") return "binary missing";
   if (reason === "needs-auth") return "needs auth";
   return "needs setup";
@@ -572,6 +574,9 @@ export function harnessWarningMessageText(
   hostName: string | undefined,
   reason: string | null,
 ): string {
+  if (reason === "platform-unsupported") {
+    return `${agentName} is not supported on ${hostName}. Choose an SDK-based agent or another host.`;
+  }
   if (reason === "needs-auth") {
     return `${agentName} needs Codex authentication on ${hostName} — run codex login on that machine.`;
   }
@@ -586,6 +591,13 @@ function harnessWarningMessage(
   hostName: string | undefined,
   reason: string | null,
 ): ReactNode {
+  if (reason === "platform-unsupported") {
+    return (
+      <>
+        {agentName} is not supported on {hostName}. Choose an SDK-based agent or another host.
+      </>
+    );
+  }
   if (reason === "needs-auth") {
     return (
       <>
@@ -1378,16 +1390,23 @@ function AgentHarnessPicker({
     return withTooltip ? <AgentRowTooltip agent={agent}>{inner}</AgentRowTooltip> : inner;
   };
 
-  const renderBadge = (agent: AvailableAgent) =>
-    harnessUnconfiguredOnHost(agent.harness, host) ? (
+  const renderBadge = (agent: AvailableAgent) => {
+    const reason = harnessUnavailableReasonOnHost(agent.harness, host);
+    return reason ? (
       <Badge
         variant="outline"
-        className="ml-auto self-center border-amber-300 bg-amber-50 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
+        className={cn(
+          "ml-auto self-center text-[11px]",
+          reason === "platform-unsupported"
+            ? "border-border bg-muted text-muted-foreground"
+            : "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400",
+        )}
         data-testid={`new-chat-landing-agent-warning-${agent.id}`}
       >
-        {harnessWarningBadgeText(harnessUnavailableReasonOnHost(agent.harness, host))}
+        {harnessWarningBadgeText(reason)}
       </Badge>
     ) : null;
+  };
 
   // The knob sections for one entry, keyed off that entry's OWN capabilities
   // (so e.g. Codex's submenu shows Codex knobs even while Claude is selected).
@@ -1520,6 +1539,27 @@ function AgentHarnessPicker({
 
   const renderEntry = (agent: AvailableAgent): ReactNode => {
     const active = agent.id === effectiveAgentId;
+    const hostReadinessReason = harnessUnavailableReasonOnHost(agent.harness, host);
+    const unavailableReason =
+      isNativeCodingAgent(agent) && hostReadinessReason === "platform-unsupported"
+        ? hostReadinessReason
+        : null;
+    if (unavailableReason) {
+      return (
+        <DropdownMenuItem
+          key={agent.id}
+          data-testid={`new-chat-landing-agent-${agent.id}`}
+          data-unavailable="true"
+          aria-disabled="true"
+          title={harnessWarningMessageText(agent.display_name, host?.name, unavailableReason)}
+          onSelect={(event) => event.preventDefault()}
+          className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground opacity-60 focus:bg-transparent focus:text-muted-foreground"
+        >
+          {renderRowInner(agent, false)}
+          {renderBadge(agent)}
+        </DropdownMenuItem>
+      );
+    }
     if (!hasKnobs(agent)) {
       return (
         <DropdownMenuItem
@@ -2210,14 +2250,24 @@ export function NewChatLandingScreen() {
     setWorkspace((cur) => (cur === "" ? candidate : cur));
   }, [selectedHostId, recent, derivedHome, prefillSettled]);
 
-  // A pick only wins while it exists in the list — a persisted id whose
-  // agent has since been unregistered (or hidden) falls back to the default.
-  // The pending custom agent sentinel also wins when set.
+  const selectedHost = allHosts.find((h) => h.host_id === selectedHostId);
+  // Host readiness applies only to connected hosts. Managed sandboxes
+  // provision their own tooling and do not use the selected host's map.
+  const harnessWarningHost = !sandboxSelected ? selectedHost : undefined;
+  const agentUnavailableOnHost = (agent: AvailableAgent): boolean =>
+    isNativeCodingAgent(agent) &&
+    harnessUnavailableReasonOnHost(agent.harness, harnessWarningHost) === "platform-unsupported";
+
+  // A pick only wins while it exists and can launch on the target host. A
+  // persisted id whose agent disappeared or became unavailable falls back to
+  // the first runnable entry. The pending custom agent sentinel still wins.
+  const pickedAgent = agentList.find((agent) => agent.id === pickedAgentId);
   const effectiveAgentId =
     pickedAgentId === PENDING_AGENT_ID
       ? PENDING_AGENT_ID
-      : ((agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ??
-        null);
+      : ((pickedAgent && !agentUnavailableOnHost(pickedAgent)
+          ? pickedAgent.id
+          : agentList.find((agent) => !agentUnavailableOnHost(agent))?.id) ?? null);
   const selectedAgent = useMemo(
     () =>
       effectiveAgentId === PENDING_AGENT_ID && pendingAgent
@@ -2297,12 +2347,6 @@ export function NewChatLandingScreen() {
   // (the runner injects the text verbatim), so the landing composer must
   // not intercept them — no skills menu, no slash_command routing.
   const isNativeTerminalAgent = isNativeCodingAgent(selectedAgent);
-  const selectedHost = allHosts.find((h) => h.host_id === selectedHostId);
-  // Warn-only readiness signal for the agent picker: only meaningful when
-  // a connected host is selected (a sandbox provisions its own tooling).
-  // Selection stays allowed — the host re-checks at launch and the create
-  // call surfaces a specific error if the harness really can't run.
-  const harnessWarningHost = !sandboxSelected ? selectedHost : undefined;
   const selectedAgentUnconfigured = harnessUnconfiguredOnHost(
     selectedAgent?.harness,
     harnessWarningHost,
@@ -2655,9 +2699,11 @@ export function NewChatLandingScreen() {
       ? "Please enter a valid repository URL"
       : !sandboxSelected && (!selectedHostId || !workspaceValid)
         ? "Please choose a host and working directory"
-        : message.trim().length === 0
-          ? "Enter a message to get started"
-          : null;
+        : selectedAgent == null
+          ? "Select an agent available on this host"
+          : message.trim().length === 0
+            ? "Enter a message to get started"
+            : null;
 
   // Chip display labels.
   const workspaceLabel = workspaceTrimmed
@@ -2702,6 +2748,7 @@ export function NewChatLandingScreen() {
   // returning user lands on the harness they used last); explicit picks
   // persist via localStorage.
   const handleSelectAgent = (agent: AvailableAgent) => {
+    if (agentUnavailableOnHost(agent)) return;
     if (agent.id !== effectiveAgentId) setPickedHarness(readLastHarness(agent.id));
     setPickedAgentId(agent.id);
     writeLastAgentId(agent.id);


### PR DESCRIPTION
## Related issue

Addresses #2423 (Part A)

## Summary

- Report native TUI harnesses as `platform-unsupported` in Windows host readiness.
- Disable unsupported native agents in the host-aware new-session picker and explain why on hover.
- Fall back from a persisted unsupported native agent to the first runnable SDK/headless agent.

ELI5: the picker now checks the selected computer before offering an agent. If that computer cannot run terminal agents, those entries remain visible but cannot be selected, and a runnable agent is chosen instead.

```text
selected host -> configured_harnesses -> new-session picker
                                      -> disable native TUI entry
                                      -> select runnable SDK/headless entry
```

## Test Plan

- `.venv/bin/pytest -q -p no:rerunfailures tests/onboarding/test_harness_readiness.py` (27 passed)
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/shell/NewChatDialog.test.tsx` (135 passed)
- Playwright: `test_platform_unsupported_native_agent_cannot_be_selected` (passed)
- `npm run type-check` (passed)
- `npm run build` (passed)
- Pre-commit hooks on all five changed files (passed)

## Demo

<img width="1280" height="720" alt="Omnigent new-session picker showing a Windows-unsupported native agent disabled while the SDK agent is selected" src="https://github.com/user-attachments/assets/91f21582-ac66-40c6-9895-0386919bd80c" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The backend readiness reason, host-aware picker fallback, disabled row behavior, and browser interaction are covered by focused Python, Vitest, and Playwright tests.

## Changelog

Unsupported native terminal agents are now disabled when the selected host cannot launch them.
