### PR TITLE
fix(server): do not fail a session on runner disconnect after idle

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2339,6 +2339,16 @@ def create_app(
             len(affected),
         )
         for session_id in affected:
+            # A session that already settled to ``idle`` completed its turn
+            # (the client saw it finish); a subsequent runner teardown is
+            # benign, not a failure. This is the norm for a headless one-shot
+            # ``omni run -p`` in a bwrap sandbox with ``--as-pid-1``: the CLI
+            # (PID 1) exit SIGKILLs the runner, dropping its tunnel right after
+            # a successful turn. Flipping the terminal ``idle`` to ``failed``
+            # here mislabels a completed session. A disconnect while
+            # running/waiting is a real mid-turn death and still fails.
+            if _session_status_cache.get(session_id) == "idle":
+                continue
             _session_status_cache[session_id] = "failed"
             _publish_status(session_id, "failed")
 

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -10718,6 +10718,31 @@ async def _relay_runner_stream(
             session_id,
             exc_info=True,
         )
+        # A runner that dies AFTER the turn already settled to ``idle`` is
+        # benign, not a failure: the client already saw the turn complete.
+        # This is the norm for a headless one-shot ``omni run -p`` in a
+        # bwrap sandbox with ``--as-pid-1`` — when the CLI (PID 1) exits the
+        # kernel SIGKILLs the runner mid-tunnel, so this handler fires on
+        # every successful run. Overwriting the terminal ``idle`` with a
+        # spurious ``runner_disconnected`` mislabels a completed session as
+        # Failed. Only ``idle`` is suppressed: a close while the cache is
+        # ``running``/``waiting`` (mid-turn death) or unset (a setup-phase
+        # failure that never published a status — the #1114 case) is a REAL
+        # failure and must still surface.
+        #
+        # Checked BEFORE the intentional-stop branch below: a session that
+        # already reached the terminal ``idle`` needs no further publish
+        # either way, and a user Stop lands here while the cache is
+        # ``running``/``waiting``, so that branch keeps its own case. The
+        # ``finally`` block discards the stop marker unconditionally, so
+        # returning early cannot strand it.
+        if _session_status_cache.get(session_id) == "idle":
+            _logger.info(
+                "Relay: runner transport lost after turn completed for "
+                "session=%s; treating as benign (session already idle).",
+                session_id,
+            )
+            return
         if session_id in _intentional_stop_sessions:
             # User clicked Stop: the Stop handler brought this runner's tunnel
             # down on purpose (see _stop_session_host_runner), so the drop is

--- a/tests/cli/test_crash_handler.py
+++ b/tests/cli/test_crash_handler.py
@@ -13,6 +13,7 @@ developer's real ``~/.omnigent``.
 
 from __future__ import annotations
 
+import datetime
 import io
 import os
 import re
@@ -100,13 +101,26 @@ def test_command_line_redacts_tokens_in_argv(
 # --------------------------------------------------------------------------- #
 # Save + rotation
 # --------------------------------------------------------------------------- #
-def test_save_report_writes_and_rotates(data_dir: Path) -> None:
+def test_save_report_writes_and_rotates(data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     ch.install_crash_handler("omnigent", "omnigent-ai/omnigent", keep_reports=2)
+    # Report names carry a whole-second stamp, so five real-clock saves usually
+    # collapse onto two filenames and never exercise rotation. Step the clock a
+    # second per save to get five distinct reports.
+    ticks = iter(range(5))
+
+    class _SteppedClock(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
+            return datetime.datetime(2026, 1, 1, tzinfo=tz) + datetime.timedelta(
+                seconds=next(ticks)
+            )
+
+    monkeypatch.setattr(ch.datetime, "datetime", _SteppedClock)
     paths = [ch._save_report(f"report {i}\n") for i in range(5)]
-    assert all(p.exists() for p in paths)
+    assert len(set(paths)) == 5
     # Only the newest 2 remain on disk.
     remaining = sorted((data_dir / "crashes").glob("crash-*.md"))
-    assert len(remaining) == 2
+    assert remaining == paths[-2:]
     # Permissions are tight.
     assert all((p.stat().st_mode & 0o077) == 0 for p in remaining)
 

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -474,6 +474,67 @@ async def test_relay_publishes_failed_status_on_tunnel_close() -> None:
         session_stream.close(session_id)
 
 
+async def test_relay_tunnel_close_after_idle_is_benign() -> None:
+    """
+    A tunnel close AFTER the session settled to ``idle`` must NOT publish a
+    spurious ``runner_disconnected`` failure.
+
+    This is the norm for a headless one-shot ``omni run -p`` in a bwrap
+    sandbox with ``--as-pid-1``: the turn completes (status → ``idle``), the
+    CLI (PID 1) exits, and the kernel SIGKILLs the runner mid-tunnel — so the
+    relay's transport-lost handler fires on every SUCCESSFUL run. It must
+    leave the terminal ``idle`` intact rather than overwrite it with a red
+    ``Failed`` pill. Contrast with
+    ``test_relay_publishes_failed_status_on_tunnel_close`` (unset/running
+    cache → real failure still surfaces, #1114).
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    fake_runner = _TunnelCloseRunnerClient(gate)
+    session_id = "conv_tunnel_close_after_idle"
+
+    # Simulate the completed turn: the relay published ``idle`` from the
+    # runner's session.status event before the tunnel dropped.
+    sessions_module._publish_status(session_id, "idle")
+
+    collector = None
+    try:
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_tunnel_close_after_idle",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=None,
+        )
+        assert handle is not None
+
+        collector = await start_session_stream_collector(session_id)
+        gate.set()
+
+        # The relay returns benignly on the ConnectionError.
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        # No failed status should arrive; the session stays idle.
+        with pytest.raises(asyncio.TimeoutError):
+            event = await asyncio.wait_for(collector.queue.get(), timeout=0.5)
+            raise AssertionError(f"unexpected event after benign close: {event}")
+        assert sessions_module._session_status_cache.get(session_id) == "idle"
+    finally:
+        gate.set()
+        if collector is not None:
+            await collector.stop()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)
+
+
 class _RecordingLabelStore:
     """Minimal conversation store that records ``set_labels`` calls.
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

A headless one-shot session (`omni run <agent> --server … -p "…"`) stayed marked **failed / `runner_disconnected`** even when the turn completed successfully. This is the norm when the runner is co-located with the CLI in a PID namespace that dies with the CLI, e.g. a bwrap sandbox launched with `--unshare-pid --as-pid-1`: when the CLI (PID 1) exits after a completed turn, the kernel SIGKILLs the runner mid-tunnel and the server records that abrupt drop as a task failure.

Two server-side paths marked a session failed on **any** tunnel teardown, with no check for whether the turn had already finished:

1. `_relay_runner_stream` (`server/routes/sessions.py`) publishes a `runner_disconnected` failure whenever the in-flight `/stream` read errors on tunnel close.
2. `_on_runner_disconnect` (`server/app.py`) marks every runner-bound session `failed` on disconnect.

Both publishes are now gated on the cached session status, suppressing the failure only when the session is already `idle`. A disconnect while `running` / `waiting` (a real mid-turn death), or with no cached status (a setup-phase failure that never published one, the #1114 case), still surfaces as `failed`.

**ELI5:** The job had already finished. Then the program that launched it shut down, which killed its helper process. The server noticed the helper vanish and stamped the job "failed" even though it had succeeded. Now the server checks whether the job already finished before blaming the disconnect.

```text
turn completes ──> session.status: idle
CLI (PID 1) exits ──> kernel SIGKILLs co-located runner ──> tunnel drops

Before: tunnel drops ──> publish failed / runner_disconnected ──> red Failed pill
After:  tunnel drops ──> cached status is idle ──> suppressed ──> stays idle
```

## Test Plan

- [x] New unit test `test_relay_tunnel_close_after_idle_is_benign` (`tests/server/routes/test_sessions_runner_relay.py`): a tunnel close after `idle` publishes no failure
- [x] Existing `test_relay_publishes_failed_status_on_tunnel_close` (unset cache) still passes, proving the #1114 setup-phase failure path is preserved. Full relay test file: 6 passed
- [x] Verified live end to end on a real deployment (server behind Docker, external runner in a bwrap `--as-pid-1` sandbox). Before, a completed one-shot session ended `failed` / `runner_disconnected`. With the `sessions.py` guard alone the label cleared but the session was still `failed` via `_on_runner_disconnect`, which is how the second guard was found. With both guards, a completed run ends `idle` with no error
- [x] Ran all repository pre-commit hooks

```bash
uv run pytest -q tests/server/routes/test_sessions_runner_relay.py
uv run pre-commit run --all-files
```

## Demo

Before/after of the status transition, from a scripted reproduction that drives the **real** `_relay_runner_stream` path. Only the runner tunnel is faked (`_TunnelCloseRunnerClient`, the helper the existing relay tests already use); the server code under test is unmodified. The two runs differ only by whether this PR's guards are applied.

Both runs follow the same scenario: the turn completes and the relay publishes `session.status: idle`, the runner's tunnel then drops with `ConnectionError`, and every subsequent `session.status` event is printed along with the final cached status the sessions list endpoint would serve.

**Before** (guards reverted, `HEAD~1`):

```text
  turn completed        -> session.status: idle
  CLI exits, runner SIGKILLed, tunnel drops mid-relay
  client receives       -> {'type': 'session.status', 'conversation_id': 'conv_oneshot_bwrap_demo',
                            'status': 'failed', 'error': {'code': 'runner_disconnected',
                            'message': 'Runner disconnected unexpectedly.'}}

  FINAL SESSION STATUS  -> failed
```

**After** (this PR):

```text
  turn completed        -> session.status: idle
  CLI exits, runner SIGKILLed, tunnel drops mid-relay
  client receives       -> (no further events)

  FINAL SESSION STATUS  -> idle
```

This isolates the status transition so reviewers can confirm the behavior without standing up a server plus an external runner in a bwrap sandbox. The end-to-end run on a real deployment is the third item under **Test Plan**. Full transcript: https://github.com/omnigent-ai/omnigent/pull/2645#issuecomment-5035874645

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran a real deployment (server in Docker, external runner in a bwrap `--unshare-pid --as-pid-1` sandbox) and compared the final session status of a completed one-shot run before and after each guard. That setup is what surfaced the second code path: the `sessions.py` guard alone cleared the error label while `_on_runner_disconnect` still left the session `failed`. The unit tests cover both directions of the status gate, and `test_relay_publishes_failed_status_on_tunnel_close` keeps the unset-cache (#1114) failure path covered.

## Changelog

A completed one-shot run no longer ends up marked failed when its co-located runner is killed as the CLI exits.
