### PR TITLE
fix: macOS seatbelt sandbox blocks claude-sdk subscription runs (Bun fstat + OAuth-token daemon allowlist)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -353,6 +353,17 @@ _LOCAL_DAEMON_ENV_ALLOWLIST: frozenset[str] = frozenset(
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_BEDROCK_BASE_URL",
         "AWS_BEARER_TOKEN_BEDROCK",
+        # M8 (security 2026-07-15): CLAUDE_CODE_OAUTH_TOKEN is listed in
+        # HARNESS_CREDENTIAL_ENV_VARS (connect.py) for forwarding host->runner,
+        # but _build_host_daemon_env (this file) only allows _RUNNER_ENV_ALLOWLIST
+        # + _LOCAL_DAEMON_ENV_ALLOWLIST. CLAUDE_CODE_OAUTH_TOKEN is in neither,
+        # so it is STRIPPED from the daemon env at launch. The daemon starts without it,
+        # so _build_runner_env has no token to forward even though HARNESS_CREDENTIAL_ENV_VARS
+        # includes it. Net effect: `claude setup-token` subscription auth never reaches
+        # the claude subprocess under the claude-sdk harness on macOS local (non-cloud) runs.
+        # Fix: add to the daemon allowlist so it survives the cli->daemon env strip.
+        # Security: it's a credential, same class as ANTHROPIC_API_KEY which is already here.
+        "CLAUDE_CODE_OAUTH_TOKEN",
         "CLAUDE_CODE_USE_BEDROCK",
         "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
         "COHERE_API_KEY",

--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -712,6 +712,19 @@ def _build_profile(
             "(allow ipc-posix-sem)",
             "(allow sysctl-read)",
             "(allow file-ioctl)",
+            # M7 (security 2026-07-15): Bun's WriteStream constructor calls fstat(2) on
+            # its inherited pipe file descriptors (stdout/stderr) at startup for ANSI
+            # color/TTY detection (internal:util/colors, fs/streams:244). Pipe fds have no
+            # filesystem vnode path, so they don't match any path-scoped file-read-metadata
+            # literal. Under deny-default this returns EPERM, crashing the Bun process
+            # before any stream-json output is produced — the root cause of the 60s connect
+            # timeout. Granting file-read-metadata globally (no path filter) allows fstat()
+            # on any fd including pipes. This does NOT grant file data access (file-read*),
+            # only inode metadata (stat/fstat/access/getattrlist). Risk: stat-oracle —
+            # sandboxed agent can confirm file existence on the whole filesystem without
+            # reading content. Acceptable for single-tenant developer use; flag for
+            # multi-tenant deployments. Analogous to the existing global (allow file-ioctl).
+            "(allow file-read-metadata)",
             "",
             ";; /dev access. Read-only for the whole tree (device-node",
             ";; metadata, /dev/null content, /dev/urandom, /dev/fd/N for",


### PR DESCRIPTION
Two small fixes that let the claude-sdk harness run on macOS under the darwin_seatbelt sandbox with a Claude subscription (CLAUDE_CODE_OAUTH_TOKEN, no API key). Found while running claude-sdk agents sandboxed on macOS; verified against current main (re-located from the same fixes on 0.5.1). Additive only (+24 lines, two files), each file still parses, neither fix already present on main.

1) omnigent/inner/seatbelt_sandbox.py — grant file-read-metadata globally in the SBPL baseline.
The claude CLI is a Bun binary; on startup it fstat(2)s inherited pipe FDs. The baseline only allowed path-scoped file-read-metadata, so those fstat calls returned EPERM and the Claude-SDK client never connected — the run died with a 60s connect timeout. A global (allow file-read-metadata) (metadata only: fstat/lstat/realpath — no file content) fixes it, matches reference seatbelt profiles, and is low-risk.

2) omnigent/cli.py — add CLAUDE_CODE_OAUTH_TOKEN to _LOCAL_DAEMON_ENV_ALLOWLIST.
HARNESS_CREDENTIAL_ENV_VARS already includes CLAUDE_CODE_OAUTH_TOKEN (and connect.py notes it's needed for subscription auth), and _build_runner_env forwards it — but the local daemon strips env vars not in _LOCAL_DAEMON_ENV_ALLOWLIST, so the token was dropped one layer up and the daemon couldn't authenticate on the subscription lane. Adding it to the allowlist lets the token reach the runner.
