### PR TITLE
[cli] Import Claude Code and Codex chats

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1330,6 +1330,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "goose",
         "hermes",
         "host",
+        "import",
         "_internal",
         "kimi",
         "kiro",
@@ -5947,6 +5948,118 @@ def resume(
     )
 
 
+@cli.command("import")
+@click.option(
+    "--harness",
+    type=click.Choice(["claude", "codex", "cursor"], case_sensitive=False),
+    required=True,
+    help="Local coding harness that owns the source session.",
+)
+@click.option(
+    "--session",
+    "source_session_id",
+    required=True,
+    metavar="SESSION_ID",
+    help="Harness-native session ID to import.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Replace the previously imported source history on the same Omnigent session.",
+)
+@click.option(
+    "--server",
+    default=None,
+    help=(
+        "Omnigent server URL. Defaults to the configured server, an existing "
+        "local server, or a newly started local server."
+    ),
+)
+def import_session_command(
+    harness: str,
+    source_session_id: str,
+    force: bool,
+    server: str | None,
+) -> None:
+    """Import one local Claude Code, Codex, or Cursor chat.
+
+    The source transcript is converted to ordinary Omnigent items and stored
+    as a normal session. Re-running the command is idempotent; use ``--force``
+    to refresh the imported history while preserving later Omnigent turns.
+
+    \b
+    Examples:
+      omnigent import --harness claude --session <session-id>
+      omnigent import --harness codex --session <session-id> --force
+      omnigent import --harness cursor --session <session-id>
+    """
+    import httpx
+
+    from omnigent.chat import _remote_headers
+    from omnigent.session_import import (
+        ImportSource,
+        SessionImportNotFoundError,
+    )
+    from omnigent.session_import.local import load_local_session
+
+    try:
+        imported = load_local_session(cast(ImportSource, harness.lower()), source_session_id)
+    except SessionImportNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    cfg = _load_effective_config()
+    base_url = _resolve_attach_server(server, cfg.get("server"))
+    if base_url is None:
+        base_url = ensure_local_omnigent_server().url
+    base_url = base_url.rstrip("/")
+    payload = {
+        "source": imported.source,
+        "external_session_id": imported.external_session_id,
+        "workspace": imported.workspace,
+        "force": force,
+        "items": [
+            {
+                "type": item.type,
+                "response_id": item.response_id,
+                "data": item.data.model_dump(mode="json", exclude_none=True),
+            }
+            for item in imported.items
+        ],
+    }
+    try:
+        response = httpx.post(
+            f"{base_url}/v1/imports",
+            json=payload,
+            headers=_remote_headers(server_url=base_url),
+            timeout=120.0,
+        )
+    except httpx.RequestError as exc:
+        raise click.ClickException(f"Could not reach the Omnigent server: {exc}") from exc
+    if response.is_error:
+        try:
+            body = response.json()
+            detail = body.get("error", {}).get("message") or body.get("detail")
+        except (ValueError, AttributeError):
+            detail = None
+        raise click.ClickException(
+            f"Import failed ({response.status_code}): {detail or response.text}"
+        )
+
+    result = response.json()
+    session_id = result["session_id"]
+    item_count = result["item_count"]
+    status = result["status"]
+    if status == "already_imported":
+        click.echo(
+            f"Session {source_session_id} is already imported as {session_id} "
+            f"({item_count} item(s))."
+        )
+    elif status == "replaced":
+        click.echo(f"Replaced imported history in {session_id} with {item_count} item(s).")
+    else:
+        click.echo(f"Imported {item_count} item(s) into {session_id}.")
+
+
 @cli.group("session", invoke_without_command=True)
 @click.pass_context
 def session(ctx: click.Context) -> None:
@@ -5993,7 +6106,7 @@ def session_export(session_id: str, output: str | None, server: str | None) -> N
     the session metadata (``"record_type": "session_meta"``); every
     subsequent line is one conversation item
     (``"record_type": "item"``).  The file preserves full turn order
-    and can be re-imported with a future ``omnigent session import``.
+    and is independent of ``omnigent import``, which reads native harness history.
 
     \b
     Examples:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5963,11 +5963,6 @@ def resume(
     help="Harness-native session ID to import.",
 )
 @click.option(
-    "--force",
-    is_flag=True,
-    help="Replace the previously imported source history on the same Omnigent session.",
-)
-@click.option(
     "--server",
     default=None,
     help=(
@@ -5978,19 +5973,17 @@ def resume(
 def import_session_command(
     harness: str,
     source_session_id: str,
-    force: bool,
     server: str | None,
 ) -> None:
     """Import one local Claude Code, Codex, or Cursor chat.
 
     The source transcript is converted to ordinary Omnigent items and stored
-    as a normal session. Re-running the command is idempotent; use ``--force``
-    to refresh the imported history while preserving later Omnigent turns.
+    as a normal session. A source session can only be imported once.
 
     \b
     Examples:
       omnigent import --harness claude --session <session-id>
-      omnigent import --harness codex --session <session-id> --force
+      omnigent import --harness codex --session <session-id>
       omnigent import --harness cursor --session <session-id>
     """
     import httpx
@@ -6016,7 +6009,6 @@ def import_session_command(
         "source": imported.source,
         "external_session_id": imported.external_session_id,
         "workspace": imported.workspace,
-        "force": force,
         "items": [
             {
                 "type": item.type,
@@ -6048,16 +6040,7 @@ def import_session_command(
     result = response.json()
     session_id = result["session_id"]
     item_count = result["item_count"]
-    status = result["status"]
-    if status == "already_imported":
-        click.echo(
-            f"Session {source_session_id} is already imported as {session_id} "
-            f"({item_count} item(s))."
-        )
-    elif status == "replaced":
-        click.echo(f"Replaced imported history in {session_id} with {item_count} item(s).")
-    else:
-        click.echo(f"Imported {item_count} item(s) into {session_id}.")
+    click.echo(f"Imported {item_count} item(s) into {session_id}.")
 
 
 @cli.group("session", invoke_without_command=True)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5951,7 +5951,7 @@ def resume(
 @cli.command("import")
 @click.option(
     "--harness",
-    type=click.Choice(["claude", "codex", "cursor"], case_sensitive=False),
+    type=click.Choice(["claude", "codex"], case_sensitive=False),
     required=True,
     help="Local coding harness that owns the source session.",
 )
@@ -5975,7 +5975,7 @@ def import_session_command(
     source_session_id: str,
     server: str | None,
 ) -> None:
-    """Import one local Claude Code, Codex, or Cursor chat.
+    """Import one local Claude Code or Codex chat.
 
     The source transcript is converted to ordinary Omnigent items and stored
     as a normal session. A source session can only be imported once.
@@ -5984,7 +5984,6 @@ def import_session_command(
     Examples:
       omnigent import --harness claude --session <session-id>
       omnigent import --harness codex --session <session-id>
-      omnigent import --harness cursor --session <session-id>
     """
     import httpx
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -3524,9 +3524,9 @@ async def _auto_create_codex_terminal(
     # ``codex resume <our_thread_id>``. The app-server boots from this
     # CODEX_HOME just below, so the rollout must be written first. Only
     # viable when the source rollout exists on THIS host (same-host fork —
-    # CUJ 1 same-user); else fall through and launch fresh. This mirrors the
-    # claude-native fork-resume branch in _auto_create_claude_terminal. See
-    # designs/FORK_SESSION_UX.md.
+    # CUJ 1 same-user); otherwise the item-history fallback below runs. This
+    # mirrors the claude-native fork-resume branch in
+    # _auto_create_claude_terminal. See designs/FORK_SESSION_UX.md.
     if (
         launch_config.external_session_id is None
         and launch_config.fork_source_external_id is not None
@@ -3544,10 +3544,11 @@ async def _auto_create_codex_terminal(
                 clone_codex_home=codex_home,
                 clone_workspace=clone_workspace,
             )
-        except Exception:  # noqa: BLE001 — best-effort; launch fresh on failure
+        except Exception:  # noqa: BLE001 — best-effort; fall back to stored items
             cloned_rollout = None
             _logger.warning(
-                "Could not clone source rollout for forked codex clone %s; launching fresh",
+                "Could not clone source rollout for forked codex clone %s; "
+                "trying item-history fallback",
                 session_id,
                 exc_info=True,
             )
@@ -3589,19 +3590,17 @@ async def _auto_create_codex_terminal(
                         session_id,
                         exc_info=True,
                     )
-    elif (
+    if (
         launch_config.external_session_id is None
         and launch_config.fork_carry_history
-        and launch_config.fork_source_external_id is None
         and server_client is not None
     ):
-        # Forked clone bound to a codex-native target with NO source
-        # rollout to clone (an SDK or cross-family source): build the clone's
-        # rollout from its OWN copied Omnigent items under a thread id we mint, then flip
-        # launch_config so the resume path below launches ``codex resume
-        # <our_thread_id>``. Reuses the same server-items→rollout converter
-        # the cross-machine cold resume uses, so the clone opens with the
-        # prior conversation (messages + tool history) as Codex context.
+        # Forked clone bound to a codex-native target with no source rollout
+        # available: build the clone's rollout from its own copied Omnigent
+        # items under a thread id we mint, then flip launch_config so the
+        # resume path below launches ``codex resume <our_thread_id>``. Reuses
+        # the same server-items→rollout converter the cross-machine cold resume
+        # uses, so the clone opens with the prior conversation as Codex context.
         # Best-effort: launch fresh on failure. See designs/FORK_SESSION_UX.md.
         from omnigent.codex_native import (
             _ensure_local_codex_resume_rollout,

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -61,6 +61,7 @@ from omnigent.server.routes.builtin_agents import create_builtin_agents_router
 from omnigent.server.routes.comments import create_comments_router
 from omnigent.server.routes.default_policies import create_default_policies_router
 from omnigent.server.routes.harnesses import create_harnesses_router
+from omnigent.server.routes.imports import create_imports_router
 from omnigent.server.routes.policy_registry import create_policy_registry_router
 from omnigent.server.routes.runner_tunnel import create_runner_tunnel_router
 from omnigent.server.routes.session_mcp_servers import create_session_mcp_servers_router
@@ -2034,6 +2035,16 @@ def create_app(
         ),
         prefix="/v1",
         tags=["sessions"],
+    )
+    app.include_router(
+        create_imports_router(
+            conversation_store,
+            agent_store,
+            auth_provider=auth_provider,
+            permission_store=permission_store,
+        ),
+        prefix="/v1",
+        tags=["imports"],
     )
     # Read-only built-in agent discovery (designs/BUILTIN_AGENTS.md).
     # Successor to the removed GET /api/agents list; lists only

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -19,16 +19,12 @@ from omnigent.server.auth import LEVEL_OWNER, AuthProvider
 from omnigent.server.routes._auth_helpers import require_access, require_user
 from omnigent.server.routes._content_type import require_json_content_type
 from omnigent.session_import import (
-    IMPORT_DIGEST_LABEL_KEY,
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
-    IMPORT_ITEM_COUNT_LABEL_KEY,
     IMPORT_SOURCE_LABEL_KEY,
     ImportSource,
-    conversation_items_digest,
     title_from_items,
 )
 from omnigent.stores import AgentStore, ConversationStore
-from omnigent.stores.conversation_store import ImportedPrefixMismatchError
 from omnigent.stores.permission_store import PermissionStore
 
 
@@ -58,7 +54,6 @@ class ImportSessionRequest(BaseModel):
     external_session_id: str = Field(min_length=1, max_length=128)
     workspace: str | None = Field(default=None, max_length=2048)
     items: list[ImportItemInput] = Field(max_length=100_000)
-    force: bool = False
 
     @field_validator("external_session_id")
     @classmethod
@@ -74,7 +69,7 @@ class ImportSessionResponse(BaseModel):
     """Result of importing or locating one source session."""
 
     session_id: str
-    status: Literal["imported", "already_imported", "replaced"]
+    status: Literal["imported"]
     item_count: int
 
 
@@ -129,7 +124,7 @@ def create_imports_router(
         request: Request,
         response: Response,
     ) -> ImportSessionResponse:
-        """Import one normalized transcript or return its existing session."""
+        """Import one normalized transcript, rejecting duplicate sources."""
         user_id = require_user(request, auth_provider)
         items = [item.to_item() for item in body.items]
         existing = await asyncio.to_thread(
@@ -145,36 +140,9 @@ def create_imports_router(
                 permission_store,
                 conversation_store,
             )
-            if not body.force:
-                response.status_code = 200
-                return ImportSessionResponse(
-                    session_id=existing.id,
-                    status="already_imported",
-                    item_count=int(existing.labels.get(IMPORT_ITEM_COUNT_LABEL_KEY, "0")),
-                )
-            try:
-                expected_count = int(existing.labels[IMPORT_ITEM_COUNT_LABEL_KEY])
-                expected_digest = existing.labels[IMPORT_DIGEST_LABEL_KEY]
-            except (KeyError, ValueError) as exc:
-                raise OmnigentError(
-                    "This session has incomplete import provenance and cannot be replaced safely",
-                    code=ErrorCode.CONFLICT,
-                ) from exc
-            try:
-                await asyncio.to_thread(
-                    conversation_store.replace_imported_prefix,
-                    existing.id,
-                    items,
-                    expected_count=expected_count,
-                    expected_digest=expected_digest,
-                )
-            except ImportedPrefixMismatchError as exc:
-                raise OmnigentError(str(exc), code=ErrorCode.CONFLICT) from exc
-            response.status_code = 200
-            return ImportSessionResponse(
-                session_id=existing.id,
-                status="replaced",
-                item_count=len(items),
+            raise OmnigentError(
+                f"This {body.source} session has already been imported as {existing.id}",
+                code=ErrorCode.CONFLICT,
             )
 
         native_agent = native_coding_agent_for_harness(f"{body.source}-native")
@@ -207,8 +175,6 @@ def create_imports_router(
                 **native_agent.presentation_labels,
                 IMPORT_SOURCE_LABEL_KEY: body.source,
                 IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: body.external_session_id,
-                IMPORT_ITEM_COUNT_LABEL_KEY: str(len(items)),
-                IMPORT_DIGEST_LABEL_KEY: conversation_items_digest(items),
             }
             await asyncio.to_thread(conversation_store.set_labels, conversation.id, labels)
             if permission_store is not None and user_id is not None:

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -1,0 +1,233 @@
+"""API route for importing normalized local harness transcripts."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Request, Response
+from pydantic import BaseModel, Field, field_validator
+
+from omnigent.db.utils import builtin_agent_id
+from omnigent.entities import NewConversationItem, parse_item_data
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.native_coding_agents import native_coding_agent_for_harness
+from omnigent.server.auth import LEVEL_OWNER, AuthProvider
+from omnigent.server.routes._auth_helpers import require_access, require_user
+from omnigent.server.routes._content_type import require_json_content_type
+from omnigent.session_import import (
+    IMPORT_DIGEST_LABEL_KEY,
+    IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
+    IMPORT_ITEM_COUNT_LABEL_KEY,
+    IMPORT_SOURCE_LABEL_KEY,
+    ImportSource,
+    conversation_items_digest,
+    title_from_items,
+)
+from omnigent.stores import AgentStore, ConversationStore
+from omnigent.stores.conversation_store import ImportedPrefixMismatchError
+from omnigent.stores.permission_store import PermissionStore
+
+
+class ImportItemInput(BaseModel):
+    """One normalized existing Omnigent item received from the CLI."""
+
+    type: str
+    response_id: str = Field(min_length=1, max_length=64)
+    data: dict[str, object]
+
+    def to_item(self) -> NewConversationItem:
+        """Validate the type-specific payload and return a new item entity."""
+        try:
+            data = parse_item_data(self.type, self.data)
+            return NewConversationItem(type=self.type, response_id=self.response_id, data=data)
+        except (TypeError, ValueError) as exc:
+            raise OmnigentError(
+                f"Invalid imported {self.type!r} item: {exc}",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
+
+
+class ImportSessionRequest(BaseModel):
+    """Request body for importing one local harness session."""
+
+    source: ImportSource
+    external_session_id: str = Field(min_length=1, max_length=128)
+    workspace: str | None = Field(default=None, max_length=2048)
+    items: list[ImportItemInput] = Field(max_length=100_000)
+    force: bool = False
+
+    @field_validator("external_session_id")
+    @classmethod
+    def strip_external_session_id(cls, value: str) -> str:
+        """Reject a source session id that is only whitespace."""
+        value = value.strip()
+        if not value:
+            raise ValueError("external_session_id must not be blank")
+        return value
+
+
+class ImportSessionResponse(BaseModel):
+    """Result of importing or locating one source session."""
+
+    session_id: str
+    status: Literal["imported", "already_imported", "replaced"]
+    item_count: int
+
+
+@dataclass
+class _ImportLockEntry:
+    """One process-local source lock and its active/waiting user count."""
+
+    lock: asyncio.Lock
+    users: int = 0
+
+
+_IMPORT_LOCKS: dict[tuple[ImportSource, str], _ImportLockEntry] = {}
+_IMPORT_LOCKS_GUARD = threading.Lock()
+
+
+async def _serialize_source_import(body: ImportSessionRequest) -> AsyncIterator[None]:
+    """Serialize concurrent imports for one source identity in this server."""
+    key = (body.source, body.external_session_id)
+    with _IMPORT_LOCKS_GUARD:
+        entry = _IMPORT_LOCKS.setdefault(key, _ImportLockEntry(lock=asyncio.Lock()))
+        entry.users += 1
+    try:
+        async with entry.lock:
+            yield
+    finally:
+        with _IMPORT_LOCKS_GUARD:
+            entry.users -= 1
+            if entry.users == 0:
+                _IMPORT_LOCKS.pop(key, None)
+
+
+def create_imports_router(
+    conversation_store: ConversationStore,
+    agent_store: AgentStore,
+    *,
+    auth_provider: AuthProvider | None = None,
+    permission_store: PermissionStore | None = None,
+) -> APIRouter:
+    """Create the local-session import router."""
+    router = APIRouter()
+
+    @router.post(
+        "/imports",
+        response_model=ImportSessionResponse,
+        dependencies=[
+            Depends(require_json_content_type),
+            Depends(_serialize_source_import),
+        ],
+    )
+    async def import_session(
+        body: ImportSessionRequest,
+        request: Request,
+        response: Response,
+    ) -> ImportSessionResponse:
+        """Import one normalized transcript or return its existing session."""
+        user_id = require_user(request, auth_provider)
+        items = [item.to_item() for item in body.items]
+        existing = await asyncio.to_thread(
+            conversation_store.find_imported_conversation,
+            body.source,
+            body.external_session_id,
+        )
+        if existing is not None:
+            await require_access(
+                user_id,
+                existing.id,
+                LEVEL_OWNER,
+                permission_store,
+                conversation_store,
+            )
+            if not body.force:
+                response.status_code = 200
+                return ImportSessionResponse(
+                    session_id=existing.id,
+                    status="already_imported",
+                    item_count=int(existing.labels.get(IMPORT_ITEM_COUNT_LABEL_KEY, "0")),
+                )
+            try:
+                expected_count = int(existing.labels[IMPORT_ITEM_COUNT_LABEL_KEY])
+                expected_digest = existing.labels[IMPORT_DIGEST_LABEL_KEY]
+            except (KeyError, ValueError) as exc:
+                raise OmnigentError(
+                    "This session has incomplete import provenance and cannot be replaced safely",
+                    code=ErrorCode.CONFLICT,
+                ) from exc
+            try:
+                await asyncio.to_thread(
+                    conversation_store.replace_imported_prefix,
+                    existing.id,
+                    items,
+                    expected_count=expected_count,
+                    expected_digest=expected_digest,
+                )
+            except ImportedPrefixMismatchError as exc:
+                raise OmnigentError(str(exc), code=ErrorCode.CONFLICT) from exc
+            response.status_code = 200
+            return ImportSessionResponse(
+                session_id=existing.id,
+                status="replaced",
+                item_count=len(items),
+            )
+
+        native_agent = native_coding_agent_for_harness(f"{body.source}-native")
+        if native_agent is None:
+            raise OmnigentError(
+                f"Unsupported import source: {body.source}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        agent_id = builtin_agent_id(native_agent.agent_name)
+        if await asyncio.to_thread(agent_store.get, agent_id) is None:
+            raise OmnigentError(
+                f"The {native_agent.display_name} built-in agent is unavailable",
+                code=ErrorCode.INTERNAL_ERROR,
+            )
+
+        conversation = await asyncio.to_thread(
+            conversation_store.create_conversation,
+            title=title_from_items(items),
+            agent_id=agent_id,
+            workspace=body.workspace,
+        )
+        try:
+            await asyncio.to_thread(
+                conversation_store.set_external_session_id,
+                conversation.id,
+                body.external_session_id,
+            )
+            await asyncio.to_thread(conversation_store.append, conversation.id, items)
+            labels = {
+                **native_agent.presentation_labels,
+                IMPORT_SOURCE_LABEL_KEY: body.source,
+                IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: body.external_session_id,
+                IMPORT_ITEM_COUNT_LABEL_KEY: str(len(items)),
+                IMPORT_DIGEST_LABEL_KEY: conversation_items_digest(items),
+            }
+            await asyncio.to_thread(conversation_store.set_labels, conversation.id, labels)
+            if permission_store is not None and user_id is not None:
+                await asyncio.to_thread(permission_store.ensure_user, user_id)
+                await asyncio.to_thread(
+                    permission_store.grant,
+                    user_id,
+                    conversation.id,
+                    LEVEL_OWNER,
+                )
+        except Exception:
+            await conversation_store.delete_conversation(conversation.id)
+            raise
+
+        response.status_code = 201
+        return ImportSessionResponse(
+            session_id=conversation.id,
+            status="imported",
+            item_count=len(items),
+        )
+
+    return router

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import threading
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -25,6 +26,7 @@ from omnigent.session_import import (
     title_from_items,
 )
 from omnigent.stores import AgentStore, ConversationStore
+from omnigent.stores.conversation_store import ConversationAlreadyExistsError
 from omnigent.stores.permission_store import PermissionStore
 
 
@@ -53,7 +55,7 @@ class ImportSessionRequest(BaseModel):
     source: ImportSource
     external_session_id: str = Field(min_length=1, max_length=128)
     workspace: str | None = Field(default=None, max_length=2048)
-    items: list[ImportItemInput] = Field(max_length=100_000)
+    items: list[ImportItemInput] = Field(min_length=1, max_length=100_000)
 
     @field_validator("external_session_id")
     @classmethod
@@ -83,6 +85,12 @@ class _ImportLockEntry:
 
 _IMPORT_LOCKS: dict[tuple[ImportSource, str], _ImportLockEntry] = {}
 _IMPORT_LOCKS_GUARD = threading.Lock()
+
+
+def _import_conversation_id(source: ImportSource, external_session_id: str) -> str:
+    """Derive one stable database identity for an imported source session."""
+    value = f"import:{source}:{external_session_id}"
+    return hashlib.sha256(value.encode()).hexdigest()[:32]
 
 
 async def _serialize_source_import(body: ImportSessionRequest) -> AsyncIterator[None]:
@@ -158,12 +166,19 @@ def create_imports_router(
                 code=ErrorCode.INTERNAL_ERROR,
             )
 
-        conversation = await asyncio.to_thread(
-            conversation_store.create_conversation,
-            title=title_from_items(items),
-            agent_id=agent_id,
-            workspace=body.workspace,
-        )
+        try:
+            conversation = await asyncio.to_thread(
+                conversation_store.create_conversation,
+                title=title_from_items(items),
+                agent_id=agent_id,
+                workspace=body.workspace,
+                conversation_id=_import_conversation_id(body.source, body.external_session_id),
+            )
+        except ConversationAlreadyExistsError as exc:
+            raise OmnigentError(
+                "This source session has already been imported",
+                code=ErrorCode.CONFLICT,
+            ) from exc
         try:
             await asyncio.to_thread(
                 conversation_store.set_external_session_id,

--- a/omnigent/session_import/__init__.py
+++ b/omnigent/session_import/__init__.py
@@ -1,27 +1,21 @@
 """Shared models for importing local coding-harness sessions."""
 
 from omnigent.session_import.models import (
-    IMPORT_DIGEST_LABEL_KEY,
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
-    IMPORT_ITEM_COUNT_LABEL_KEY,
     IMPORT_PROVENANCE_LABEL_KEYS,
     IMPORT_SOURCE_LABEL_KEY,
     ImportSource,
     LocalSessionImport,
     SessionImportNotFoundError,
-    conversation_items_digest,
     title_from_items,
 )
 
 __all__ = [
-    "IMPORT_DIGEST_LABEL_KEY",
     "IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY",
-    "IMPORT_ITEM_COUNT_LABEL_KEY",
     "IMPORT_PROVENANCE_LABEL_KEYS",
     "IMPORT_SOURCE_LABEL_KEY",
     "ImportSource",
     "LocalSessionImport",
     "SessionImportNotFoundError",
-    "conversation_items_digest",
     "title_from_items",
 ]

--- a/omnigent/session_import/__init__.py
+++ b/omnigent/session_import/__init__.py
@@ -1,0 +1,27 @@
+"""Shared models for importing local coding-harness sessions."""
+
+from omnigent.session_import.models import (
+    IMPORT_DIGEST_LABEL_KEY,
+    IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
+    IMPORT_ITEM_COUNT_LABEL_KEY,
+    IMPORT_PROVENANCE_LABEL_KEYS,
+    IMPORT_SOURCE_LABEL_KEY,
+    ImportSource,
+    LocalSessionImport,
+    SessionImportNotFoundError,
+    conversation_items_digest,
+    title_from_items,
+)
+
+__all__ = [
+    "IMPORT_DIGEST_LABEL_KEY",
+    "IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY",
+    "IMPORT_ITEM_COUNT_LABEL_KEY",
+    "IMPORT_PROVENANCE_LABEL_KEYS",
+    "IMPORT_SOURCE_LABEL_KEY",
+    "ImportSource",
+    "LocalSessionImport",
+    "SessionImportNotFoundError",
+    "conversation_items_digest",
+    "title_from_items",
+]

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -1,0 +1,302 @@
+"""Read and normalize local coding-harness transcripts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+from omnigent.claude_native_bridge import read_transcript_items_from_offset
+from omnigent.codex_native import _find_codex_rollout
+from omnigent.cursor_native_forwarder import _blob_to_item, _read_blob_rows
+from omnigent.entities import NewConversationItem, parse_item_data
+from omnigent.session_import.models import (
+    ImportSource,
+    LocalSessionImport,
+    SessionImportNotFoundError,
+)
+
+
+def _find_transcript(root: Path, session_id: str) -> Path | None:
+    """Return the newest parent JSONL transcript whose stem matches the id."""
+    matches = [
+        path
+        for path in root.rglob("*.jsonl")
+        if path.stem == session_id and "subagents" not in path.parts and path.is_file()
+    ]
+    return max(matches, key=lambda path: path.stat().st_mtime) if matches else None
+
+
+def _claude_workspace(transcript_path: Path) -> str | None:
+    """Read the first usable cwd recorded in a Claude transcript."""
+    with transcript_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            cwd_value = record.get("cwd") if isinstance(record, dict) else None
+            if isinstance(cwd_value, str):
+                cwd = cwd_value.strip()
+                if cwd:
+                    return cwd
+    return None
+
+
+def load_claude_session(
+    session_id: str,
+    *,
+    claude_home: Path | None = None,
+) -> LocalSessionImport:
+    """Load one Claude Code parent session from its local JSONL transcript."""
+    configured_home = os.environ.get("CLAUDE_CONFIG_DIR")
+    home = claude_home or (Path(configured_home).expanduser() if configured_home else None)
+    root = (home or Path.home() / ".claude") / "projects"
+    transcript_path = _find_transcript(root, session_id)
+    if transcript_path is None:
+        raise SessionImportNotFoundError(f"Claude Code session {session_id!r} was not found")
+
+    parsed = read_transcript_items_from_offset(
+        transcript_path,
+        0,
+        start_line=0,
+        agent_name="claude-native-ui",
+    )
+    items = tuple(
+        NewConversationItem(
+            type=item.item_type,
+            response_id=item.response_id,
+            data=parse_item_data(item.item_type, item.data),
+        )
+        for item in parsed.items
+    )
+    return LocalSessionImport(
+        source="claude",
+        external_session_id=session_id,
+        workspace=_claude_workspace(transcript_path),
+        items=items,
+    )
+
+
+def _codex_message_data(payload: dict[str, object]) -> dict[str, object] | None:
+    """Convert a visible Codex message payload to Omnigent message data."""
+    role = payload.get("role")
+    if role not in {"user", "assistant"}:
+        return None
+    expected_type = "input_text" if role == "user" else "output_text"
+    raw_content = payload.get("content")
+    if not isinstance(raw_content, list):
+        return None
+    content: list[dict[str, object]] = []
+    for block in raw_content:
+        if not isinstance(block, dict):
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and text:
+            content.append({"type": expected_type, "text": text})
+        elif role == "user" and block.get("type") in {"input_image", "input_file"}:
+            content.append(dict(block))
+    if not content:
+        return None
+    data: dict[str, object] = {"role": role, "content": content}
+    if role == "assistant":
+        data["agent"] = "codex-native-ui"
+    elif _codex_internal_user_message(content):
+        data["is_meta"] = True
+    return data
+
+
+_CODEX_INTERNAL_USER_PREFIXES = (
+    "# AGENTS.md instructions for ",
+    "<app-context>",
+    "<collaboration_mode>",
+    "<environment_context>",
+    "<permissions instructions>",
+    "<plugins_instructions>",
+    "<skill>",
+    "<skills_instructions>",
+    "The following is the Codex agent history ",
+    "The following is the Codex agent history added ",
+)
+
+
+def _codex_internal_user_message(content: list[dict[str, object]]) -> bool:
+    """Identify Codex-injected user-role context that should stay hidden."""
+    text = next(
+        (block.get("text") for block in content if isinstance(block.get("text"), str)),
+        None,
+    )
+    return isinstance(text, str) and text.lstrip().startswith(_CODEX_INTERNAL_USER_PREFIXES)
+
+
+def _codex_tool_output(value: object) -> str | None:
+    """Flatten Codex string or typed-text-block tool output."""
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, list):
+        return None
+    text = "".join(
+        block["text"]
+        for block in value
+        if isinstance(block, dict) and isinstance(block.get("text"), str)
+    )
+    return text or None
+
+
+def _codex_response_item(
+    payload: dict[str, object],
+    *,
+    response_id: str,
+) -> NewConversationItem | None:
+    """Convert one supported Codex response item to an Omnigent item."""
+    item_type = payload.get("type")
+    normalized_type = item_type
+    data: dict[str, object] | None = None
+    if item_type == "message":
+        data = _codex_message_data(payload)
+    elif item_type in {"function_call", "custom_tool_call"}:
+        name = payload.get("name")
+        arguments = payload.get("arguments" if item_type == "function_call" else "input")
+        call_id = payload.get("call_id")
+        if all(isinstance(value, str) for value in (name, arguments, call_id)):
+            data = {
+                "agent": "codex-native-ui",
+                "name": name,
+                "arguments": arguments,
+                "call_id": call_id,
+            }
+            normalized_type = "function_call"
+    elif item_type in {"function_call_output", "custom_tool_call_output"}:
+        call_id = payload.get("call_id")
+        output = _codex_tool_output(payload.get("output"))
+        if isinstance(call_id, str) and output is not None:
+            data = {"call_id": call_id, "output": output}
+            normalized_type = "function_call_output"
+    if data is None or not isinstance(normalized_type, str):
+        return None
+    return NewConversationItem(
+        type=normalized_type,
+        response_id=response_id[:64],
+        data=parse_item_data(normalized_type, data),
+    )
+
+
+def load_codex_session(
+    session_id: str,
+    *,
+    codex_home: Path | None = None,
+) -> LocalSessionImport:
+    """Load one Codex session from its local rollout JSONL file."""
+    configured_home = os.environ.get("CODEX_HOME")
+    home = codex_home or (Path(configured_home).expanduser() if configured_home else None)
+    home = home or Path.home() / ".codex"
+    rollout_path = _find_codex_rollout(home, session_id)
+    if rollout_path is None:
+        raise SessionImportNotFoundError(f"Codex session {session_id!r} was not found")
+
+    workspace: str | None = None
+    turn_id = "history"
+    items: list[NewConversationItem] = []
+    with rollout_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict) or not isinstance(record.get("payload"), dict):
+                continue
+            payload = record["payload"]
+            if record.get("type") == "session_meta":
+                cwd = payload.get("cwd")
+                if isinstance(cwd, str) and cwd.strip():
+                    workspace = cwd.strip()
+                continue
+            if record.get("type") == "turn_context":
+                candidate = payload.get("turn_id")
+                if isinstance(candidate, str) and candidate:
+                    turn_id = candidate
+                continue
+            if record.get("type") != "response_item":
+                continue
+            item = _codex_response_item(payload, response_id=f"codex:{turn_id}")
+            if item is not None:
+                items.append(item)
+
+    return LocalSessionImport(
+        source="codex",
+        external_session_id=session_id,
+        workspace=workspace,
+        items=tuple(items),
+    )
+
+
+def load_cursor_session(
+    session_id: str,
+    *,
+    cursor_home: Path | None = None,
+    workspace: Path | None = None,
+) -> LocalSessionImport:
+    """Load one Cursor session from its local chat blob store."""
+    root = (cursor_home or Path.home() / ".cursor") / "chats"
+    matches = [
+        path
+        for path in root.glob("*/*/store.db")
+        if path.parent.name == session_id and path.is_file()
+    ]
+    if not matches:
+        raise SessionImportNotFoundError(f"Cursor session {session_id!r} was not found")
+    store_path = max(matches, key=lambda path: path.stat().st_mtime)
+    workspace_path = _cursor_workspace_for_store(store_path, workspace or Path.cwd())
+    if workspace_path is None:
+        raise SessionImportNotFoundError(
+            f"Cursor session {session_id!r} was found, but its workspace could not be "
+            "identified. Run the import command from that session's original workspace."
+        )
+
+    items: list[NewConversationItem] = []
+    for rowid, blob_id, data in _read_blob_rows(store_path, 0):
+        mirrored = _blob_to_item(rowid, blob_id, data, "cursor-native-ui")
+        if mirrored is None or mirrored.item_type == "compaction_completed":
+            continue
+        items.append(
+            NewConversationItem(
+                type=mirrored.item_type,
+                response_id=mirrored.response_id,
+                data=parse_item_data(mirrored.item_type, mirrored.item_data),
+            )
+        )
+
+    return LocalSessionImport(
+        source="cursor",
+        external_session_id=session_id,
+        workspace=workspace_path,
+        items=tuple(items),
+    )
+
+
+def _cursor_workspace_for_store(store_path: Path, workspace: Path) -> str | None:
+    """Match Cursor's workspace hash against the current directory or an ancestor."""
+    workspace_hash = store_path.parent.parent.name
+    for candidate in (workspace, *workspace.parents):
+        resolved = os.path.realpath(candidate)
+        if hashlib.md5(resolved.encode("utf-8")).hexdigest() == workspace_hash:
+            return resolved
+    return None
+
+
+def load_local_session(source: ImportSource, session_id: str) -> LocalSessionImport:
+    """Load one local session from the selected first-party harness."""
+    if source == "claude":
+        return load_claude_session(session_id)
+    if source == "codex":
+        return load_codex_session(session_id)
+    return load_cursor_session(session_id)
+
+
+__all__ = [
+    "load_claude_session",
+    "load_codex_session",
+    "load_cursor_session",
+    "load_local_session",
+]

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -71,6 +71,10 @@ def load_claude_session(
         )
         for item in parsed.items
     )
+    if not items:
+        raise SessionImportNotFoundError(
+            f"Claude Code session {session_id!r} has no importable history"
+        )
     return LocalSessionImport(
         source="claude",
         external_session_id=session_id,
@@ -136,12 +140,12 @@ def _codex_tool_output(value: object) -> str | None:
         return value
     if not isinstance(value, list):
         return None
-    text = "".join(
+    text_blocks = [
         block["text"]
         for block in value
         if isinstance(block, dict) and isinstance(block.get("text"), str)
-    )
-    return text or None
+    ]
+    return "".join(text_blocks) if text_blocks else None
 
 
 def _codex_response_item(
@@ -182,6 +186,20 @@ def _codex_response_item(
     )
 
 
+def _find_archived_codex_rollout(codex_home: Path, session_id: str) -> Path | None:
+    """Return the newest archived Codex rollout matching a session id."""
+    archived_sessions = codex_home / "archived_sessions"
+    if not archived_sessions.is_dir():
+        return None
+    suffix = f"-{session_id}.jsonl"
+    matches = [
+        path
+        for path in archived_sessions.glob("rollout-*.jsonl")
+        if path.name.endswith(suffix) and path.is_file()
+    ]
+    return max(matches, key=lambda path: path.stat().st_mtime) if matches else None
+
+
 def load_codex_session(
     session_id: str,
     *,
@@ -191,7 +209,9 @@ def load_codex_session(
     configured_home = os.environ.get("CODEX_HOME")
     home = codex_home or (Path(configured_home).expanduser() if configured_home else None)
     home = home or Path.home() / ".codex"
-    rollout_path = _find_codex_rollout(home, session_id)
+    rollout_path = _find_codex_rollout(home, session_id) or _find_archived_codex_rollout(
+        home, session_id
+    )
     if rollout_path is None:
         raise SessionImportNotFoundError(f"Codex session {session_id!r} was not found")
 
@@ -223,6 +243,8 @@ def load_codex_session(
             if item is not None:
                 items.append(item)
 
+    if not items:
+        raise SessionImportNotFoundError(f"Codex session {session_id!r} has no importable history")
     return LocalSessionImport(
         source="codex",
         external_session_id=session_id,
@@ -267,6 +289,10 @@ def load_cursor_session(
             )
         )
 
+    if not items:
+        raise SessionImportNotFoundError(
+            f"Cursor session {session_id!r} has no importable history"
+        )
     return LocalSessionImport(
         source="cursor",
         external_session_id=session_id,

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 from pathlib import Path
 
 from omnigent.claude_native_bridge import read_transcript_items_from_offset
 from omnigent.codex_native import _find_codex_rollout
-from omnigent.cursor_native_forwarder import _blob_to_item, _read_blob_rows
 from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.session_import.models import (
     ImportSource,
@@ -253,76 +251,15 @@ def load_codex_session(
     )
 
 
-def load_cursor_session(
-    session_id: str,
-    *,
-    cursor_home: Path | None = None,
-    workspace: Path | None = None,
-) -> LocalSessionImport:
-    """Load one Cursor session from its local chat blob store."""
-    root = (cursor_home or Path.home() / ".cursor") / "chats"
-    matches = [
-        path
-        for path in root.glob("*/*/store.db")
-        if path.parent.name == session_id and path.is_file()
-    ]
-    if not matches:
-        raise SessionImportNotFoundError(f"Cursor session {session_id!r} was not found")
-    store_path = max(matches, key=lambda path: path.stat().st_mtime)
-    workspace_path = _cursor_workspace_for_store(store_path, workspace or Path.cwd())
-    if workspace_path is None:
-        raise SessionImportNotFoundError(
-            f"Cursor session {session_id!r} was found, but its workspace could not be "
-            "identified. Run the import command from that session's original workspace."
-        )
-
-    items: list[NewConversationItem] = []
-    for rowid, blob_id, data in _read_blob_rows(store_path, 0):
-        mirrored = _blob_to_item(rowid, blob_id, data, "cursor-native-ui")
-        if mirrored is None or mirrored.item_type == "compaction_completed":
-            continue
-        items.append(
-            NewConversationItem(
-                type=mirrored.item_type,
-                response_id=mirrored.response_id,
-                data=parse_item_data(mirrored.item_type, mirrored.item_data),
-            )
-        )
-
-    if not items:
-        raise SessionImportNotFoundError(
-            f"Cursor session {session_id!r} has no importable history"
-        )
-    return LocalSessionImport(
-        source="cursor",
-        external_session_id=session_id,
-        workspace=workspace_path,
-        items=tuple(items),
-    )
-
-
-def _cursor_workspace_for_store(store_path: Path, workspace: Path) -> str | None:
-    """Match Cursor's workspace hash against the current directory or an ancestor."""
-    workspace_hash = store_path.parent.parent.name
-    for candidate in (workspace, *workspace.parents):
-        resolved = os.path.realpath(candidate)
-        if hashlib.md5(resolved.encode("utf-8")).hexdigest() == workspace_hash:
-            return resolved
-    return None
-
-
 def load_local_session(source: ImportSource, session_id: str) -> LocalSessionImport:
     """Load one local session from the selected first-party harness."""
     if source == "claude":
         return load_claude_session(session_id)
-    if source == "codex":
-        return load_codex_session(session_id)
-    return load_cursor_session(session_id)
+    return load_codex_session(session_id)
 
 
 __all__ = [
     "load_claude_session",
     "load_codex_session",
-    "load_cursor_session",
     "load_local_session",
 ]

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -2,27 +2,21 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
 
-from omnigent.entities import ConversationItem, MessageData, NewConversationItem
+from omnigent.entities import MessageData, NewConversationItem
 from omnigent.entities.conversation import synthesize_conversation_title
 
 ImportSource = Literal["claude", "codex", "cursor"]
 
 IMPORT_SOURCE_LABEL_KEY = "omnigent.import.source"
 IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY = "omnigent.import.external_session_id"
-IMPORT_ITEM_COUNT_LABEL_KEY = "omnigent.import.item_count"
-IMPORT_DIGEST_LABEL_KEY = "omnigent.import.digest"
 IMPORT_PROVENANCE_LABEL_KEYS = frozenset(
     {
         IMPORT_SOURCE_LABEL_KEY,
         IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
-        IMPORT_ITEM_COUNT_LABEL_KEY,
-        IMPORT_DIGEST_LABEL_KEY,
     }
 )
 
@@ -56,23 +50,3 @@ def title_from_items(items: Sequence[NewConversationItem]) -> str | None:
         ):
             return synthesize_conversation_title(item.data.content)
     return None
-
-
-def conversation_items_digest(
-    items: Sequence[NewConversationItem | ConversationItem],
-    *,
-    include_created_by: bool = True,
-) -> str:
-    """Return a stable digest of item content, excluding database identity."""
-    normalized: list[dict[str, object]] = []
-    for item in items:
-        value: dict[str, object] = {
-            "type": item.type,
-            "response_id": item.response_id,
-            "data": item.data.model_dump(mode="json", exclude_none=True),
-        }
-        if include_created_by:
-            value["created_by"] = item.created_by
-        normalized.append(value)
-    payload = json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -1,0 +1,78 @@
+"""Models and provenance metadata shared by session import layers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from omnigent.entities import ConversationItem, MessageData, NewConversationItem
+from omnigent.entities.conversation import synthesize_conversation_title
+
+ImportSource = Literal["claude", "codex", "cursor"]
+
+IMPORT_SOURCE_LABEL_KEY = "omnigent.import.source"
+IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY = "omnigent.import.external_session_id"
+IMPORT_ITEM_COUNT_LABEL_KEY = "omnigent.import.item_count"
+IMPORT_DIGEST_LABEL_KEY = "omnigent.import.digest"
+IMPORT_PROVENANCE_LABEL_KEYS = frozenset(
+    {
+        IMPORT_SOURCE_LABEL_KEY,
+        IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
+        IMPORT_ITEM_COUNT_LABEL_KEY,
+        IMPORT_DIGEST_LABEL_KEY,
+    }
+)
+
+
+class SessionImportNotFoundError(FileNotFoundError):
+    """Raised when a requested local harness session cannot be found."""
+
+
+@dataclass(frozen=True)
+class LocalSessionImport:
+    """One local transcript normalized for the import API."""
+
+    source: ImportSource
+    external_session_id: str
+    workspace: str | None
+    items: tuple[NewConversationItem, ...]
+
+    @property
+    def title(self) -> str | None:
+        """Return a sidebar title derived from the first user message."""
+        return title_from_items(self.items)
+
+
+def title_from_items(items: Sequence[NewConversationItem]) -> str | None:
+    """Return a sidebar title derived from the first user message."""
+    for item in items:
+        if (
+            isinstance(item.data, MessageData)
+            and item.data.role == "user"
+            and not item.data.is_meta
+        ):
+            return synthesize_conversation_title(item.data.content)
+    return None
+
+
+def conversation_items_digest(
+    items: Sequence[NewConversationItem | ConversationItem],
+    *,
+    include_created_by: bool = True,
+) -> str:
+    """Return a stable digest of item content, excluding database identity."""
+    normalized: list[dict[str, object]] = []
+    for item in items:
+        value: dict[str, object] = {
+            "type": item.type,
+            "response_id": item.response_id,
+            "data": item.data.model_dump(mode="json", exclude_none=True),
+        }
+        if include_created_by:
+            value["created_by"] = item.created_by
+        normalized.append(value)
+    payload = json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/omnigent/session_import/models.py
+++ b/omnigent/session_import/models.py
@@ -9,7 +9,7 @@ from typing import Literal
 from omnigent.entities import MessageData, NewConversationItem
 from omnigent.entities.conversation import synthesize_conversation_title
 
-ImportSource = Literal["claude", "codex", "cursor"]
+ImportSource = Literal["claude", "codex"]
 
 IMPORT_SOURCE_LABEL_KEY = "omnigent.import.source"
 IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY = "omnigent.import.external_session_id"

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -169,10 +169,6 @@ class ConversationNotFoundError(Exception):
     """
 
 
-class ImportedPrefixMismatchError(Exception):
-    """Raised when forced import can no longer identify its original prefix."""
-
-
 class NameAlreadyExistsError(Exception):
     """
     Raised by ``create_conversation`` when the requested
@@ -491,27 +487,6 @@ class ConversationStore(ABC):
             to persist.
         :returns: The persisted :class:`ConversationItem` list
             with store-assigned IDs and timestamps.
-        """
-        ...
-
-    @abstractmethod
-    def replace_imported_prefix(
-        self,
-        conversation_id: str,
-        items: list[NewConversationItem],
-        *,
-        expected_count: int,
-        expected_digest: str,
-    ) -> list[ConversationItem]:
-        """Replace a verified imported item prefix and preserve later items.
-
-        :param conversation_id: Existing imported conversation id.
-        :param items: Replacement normalized source items.
-        :param expected_count: Number of items in the prior imported prefix.
-        :param expected_digest: Digest recorded for that prior prefix.
-        :returns: Newly persisted replacement items.
-        :raises ImportedPrefixMismatchError: If the stored prefix no longer
-            matches the recorded import boundary.
         """
         ...
 

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -11,6 +11,7 @@ from omnigent.entities import (
     NewConversationItem,
     PagedList,
 )
+from omnigent.session_import import IMPORT_PROVENANCE_LABEL_KEYS
 
 # Label set on a fork of a session that had a working directory. Its
 # value is the source session id. Presence marks the (unbound) clone as
@@ -112,6 +113,10 @@ _INSTANCE_SCOPED_LABEL_KEYS = frozenset(
     }
 )
 
+# Source identity belongs only to the original imported session. Unlike runtime
+# instance labels, these survive an in-place agent switch but never a fork.
+_FORK_ONLY_DROPPED_LABEL_KEYS = IMPORT_PROVENANCE_LABEL_KEYS
+
 
 @dataclass(frozen=True)
 class CreatedSession:
@@ -162,6 +167,10 @@ class ConversationNotFoundError(Exception):
     Store methods use this when absence is not a benign
     no-op and the route layer must return a typed 404.
     """
+
+
+class ImportedPrefixMismatchError(Exception):
+    """Raised when forced import can no longer identify its original prefix."""
 
 
 class NameAlreadyExistsError(Exception):
@@ -310,6 +319,20 @@ class ConversationStore(ABC):
             e.g. ``"conv_abc123"``.
         :returns: The :class:`Conversation` if found, otherwise
             ``None``.
+        """
+        ...
+
+    @abstractmethod
+    def find_imported_conversation(
+        self,
+        source: str,
+        external_session_id: str,
+    ) -> Conversation | None:
+        """Find the original session imported from one external transcript.
+
+        :param source: Import source key, e.g. ``"claude"``.
+        :param external_session_id: Source harness session id.
+        :returns: The matching conversation, or ``None``.
         """
         ...
 
@@ -468,6 +491,27 @@ class ConversationStore(ABC):
             to persist.
         :returns: The persisted :class:`ConversationItem` list
             with store-assigned IDs and timestamps.
+        """
+        ...
+
+    @abstractmethod
+    def replace_imported_prefix(
+        self,
+        conversation_id: str,
+        items: list[NewConversationItem],
+        *,
+        expected_count: int,
+        expected_digest: str,
+    ) -> list[ConversationItem]:
+        """Replace a verified imported item prefix and preserve later items.
+
+        :param conversation_id: Existing imported conversation id.
+        :param items: Replacement normalized source items.
+        :param expected_count: Number of items in the prior imported prefix.
+        :param expected_digest: Digest recorded for that prior prefix.
+        :returns: Newly persisted replacement items.
+        :raises ImportedPrefixMismatchError: If the stored prefix no longer
+            matches the recorded import boundary.
         """
         ...
 

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -169,6 +169,10 @@ class ConversationNotFoundError(Exception):
     """
 
 
+class ConversationAlreadyExistsError(Exception):
+    """Raised when a caller-supplied conversation id is already in use."""
+
+
 class NameAlreadyExistsError(Exception):
     """
     Raised by ``create_conversation`` when the requested
@@ -243,6 +247,7 @@ class ConversationStore(ABC):
         workspace: str | None = None,
         git_branch: str | None = None,
         terminal_launch_args: list[str] | None = None,
+        conversation_id: str | None = None,
     ) -> Conversation:
         """
         Create a new conversation. Generates a unique
@@ -295,6 +300,9 @@ class ConversationStore(ABC):
             the column NULL; a list (including ``[]``) is persisted
             so the runner applies it when it auto-launches the
             terminal.
+        :param conversation_id: Optional caller-supplied identifier.
+            ``None`` generates a new random id. Reserved for flows that
+            require database-enforced idempotency.
         :returns: The newly created :class:`Conversation`.
         :raises NameAlreadyExistsError: If
             ``parent_conversation_id`` is not ``None`` and a
@@ -303,6 +311,8 @@ class ConversationStore(ABC):
         :raises ConversationNotFoundError: If
             ``parent_conversation_id`` is set but the parent
             row does not exist (root id can't be inherited).
+        :raises ConversationAlreadyExistsError: If a caller-supplied
+            ``conversation_id`` is already in use.
         """
         ...
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from collections import defaultdict, deque
 from typing import Any
 
 from sqlalchemy import (
@@ -71,11 +70,8 @@ from omnigent.entities import (
     parse_item_data,
 )
 from omnigent.session_import.models import (
-    IMPORT_DIGEST_LABEL_KEY,
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
-    IMPORT_ITEM_COUNT_LABEL_KEY,
     IMPORT_SOURCE_LABEL_KEY,
-    conversation_items_digest,
 )
 from omnigent.stores.conversation_store import (
     _FORK_ONLY_DROPPED_LABEL_KEYS,
@@ -88,7 +84,6 @@ from omnigent.stores.conversation_store import (
     ConversationNotFoundError,
     ConversationStore,
     CreatedSession,
-    ImportedPrefixMismatchError,
     SessionConnectivity,
 )
 
@@ -603,41 +598,6 @@ def _to_item(row: SqlConversationItem) -> ConversationItem:
         data=parse_item_data(item_type, json.loads(row.data)),
         created_by=row.created_by,
     )
-
-
-def _build_item_row(
-    conversation_id: str,
-    item: NewConversationItem,
-    *,
-    position: int,
-    created_at: int,
-) -> tuple[SqlConversationItem, ConversationItem, str]:
-    """Build one persisted item row, entity, and searchable text."""
-    data = strip_nul_bytes(json.dumps(item.data.model_dump(exclude_none=True)))
-    search = strip_nul_bytes(extract_search_text(item))
-    item_id = generate_item_id(item.type)
-    row = SqlConversationItem(
-        id=item_id,
-        conversation_id=conversation_id,
-        response_id=item.response_id,
-        created_at=created_at,
-        status=encode_item_status("completed"),
-        position=position,
-        type=encode_item_type(item.type),
-        data=data,
-        search_text=search,
-        created_by=item.created_by,
-    )
-    entity = ConversationItem(
-        id=item_id,
-        type=item.type,
-        status="completed",
-        response_id=item.response_id,
-        created_at=created_at,
-        data=item.data,
-        created_by=item.created_by,
-    )
-    return row, entity, search
 
 
 def _ranked_latest_message_items(conversation_ids: list[str]) -> Subquery:
@@ -1884,134 +1844,48 @@ class SqlAlchemyConversationStore(ConversationStore):
             for item in items:
                 position = next_pos
                 next_pos += 1
-                row, entity, search = _build_item_row(
-                    conversation_id,
-                    item,
-                    position=position,
+                data_dict = item.data.model_dump(exclude_none=True)
+                # Strip NUL bytes before they reach a Postgres text
+                # column, which rejects them outright. Tool output can
+                # embed NUL (e.g. reading a binary file); without this
+                # the whole INSERT aborts and the item never persists.
+                data = strip_nul_bytes(json.dumps(data_dict))
+                search = strip_nul_bytes(extract_search_text(item))
+                item_id = generate_item_id(item.type)
+                row = SqlConversationItem(
+                    id=item_id,
+                    conversation_id=conversation_id,
+                    response_id=item.response_id,
                     created_at=now,
+                    status=encode_item_status("completed"),  # items are final on append
+                    position=position,
+                    type=encode_item_type(item.type),
+                    data=data,
+                    search_text=search,
+                    created_by=item.created_by,
                 )
                 session.add(row)
-                insert_fts(session, row.id, conversation_id, search)
-                persisted.append(entity)
+                insert_fts(session, item_id, conversation_id, search)
+                persisted.append(
+                    ConversationItem(
+                        id=row.id,
+                        # The row stores int codes; the entity carries the
+                        # string names. item.type is the source string and
+                        # the status was just written as "completed".
+                        type=item.type,
+                        status="completed",
+                        response_id=row.response_id,
+                        created_at=row.created_at,
+                        data=item.data,
+                        created_by=item.created_by,
+                    )
+                )
 
             # Persist the advanced counter so the next append reads it instead
             # of scanning; this also lazily backfills a pre-counter conversation.
             if conv_row is not None:
                 conv_row.next_position = next_pos
 
-        return persisted
-
-    def replace_imported_prefix(
-        self,
-        conversation_id: str,
-        items: list[NewConversationItem],
-        *,
-        expected_count: int,
-        expected_digest: str,
-    ) -> list[ConversationItem]:
-        """Replace a verified imported prefix while retaining later turns."""
-        now = now_epoch()
-        persisted: list[ConversationItem] = []
-        with self._conv_session() as session:
-            self._lock_conversation(session, conversation_id)
-            conversation = session.get(
-                SqlConversation,
-                (current_workspace_id(), conversation_id),
-            )
-            if conversation is None:
-                raise ConversationNotFoundError(f"conversation {conversation_id!r} does not exist")
-            rows = list(
-                session.execute(
-                    select(SqlConversationItem)
-                    .where(
-                        SqlConversationItem.workspace_id == current_workspace_id(),
-                        SqlConversationItem.conversation_id == conversation_id,
-                    )
-                    .order_by(SqlConversationItem.position)
-                )
-                .scalars()
-                .all()
-            )
-            if expected_count < 0 or len(rows) < expected_count:
-                raise ImportedPrefixMismatchError(
-                    "the previously imported transcript boundary is no longer present"
-                )
-            prefix = rows[:expected_count]
-            if conversation_items_digest([_to_item(row) for row in prefix]) != expected_digest:
-                raise ImportedPrefixMismatchError(
-                    "the previously imported transcript was modified after import"
-                )
-
-            preserved = rows[expected_count:]
-            source_positions: dict[str, deque[int]] = defaultdict(deque)
-            for index, item in enumerate(items[expected_count:]):
-                source_positions[
-                    conversation_items_digest([item], include_created_by=False)
-                ].append(index)
-            source_cursor = 0
-            retained: list[SqlConversationItem] = []
-            represented: list[SqlConversationItem] = []
-            for row in preserved:
-                candidates = source_positions[
-                    conversation_items_digest([_to_item(row)], include_created_by=False)
-                ]
-                while candidates and candidates[0] < source_cursor:
-                    candidates.popleft()
-                if candidates:
-                    source_cursor = candidates.popleft() + 1
-                    represented.append(row)
-                else:
-                    retained.append(row)
-            preserved = retained
-            delete_fts_by_conversation(session, conversation_id)
-            for row in [*prefix, *represented]:
-                session.delete(row)
-            # Move retained rows out of the non-negative position range before
-            # compacting them behind a replacement prefix. This avoids transient
-            # unique-position collisions on databases with immediate constraints.
-            for index, row in enumerate(preserved):
-                row.position = -(index + 1)
-            session.flush()
-            for index, row in enumerate(preserved):
-                row.position = len(items) + index
-            session.flush()
-
-            for position, item in enumerate(items):
-                row, entity, search = _build_item_row(
-                    conversation_id,
-                    item,
-                    position=position,
-                    created_at=now,
-                )
-                session.add(row)
-                insert_fts(session, row.id, conversation_id, search)
-                persisted.append(entity)
-            for row in preserved:
-                insert_fts(session, row.id, conversation_id, row.search_text)
-
-            conversation.next_position = len(items) + len(preserved)
-            conversation.updated_at = now
-            import_labels = {
-                IMPORT_ITEM_COUNT_LABEL_KEY: str(len(items)),
-                IMPORT_DIGEST_LABEL_KEY: conversation_items_digest(items),
-            }
-            for key, value in import_labels.items():
-                label = session.get(
-                    SqlConversationLabel,
-                    (current_workspace_id(), conversation_id, key),
-                )
-                if label is None:
-                    session.add(
-                        SqlConversationLabel(
-                            conversation_id=conversation_id,
-                            key=key,
-                            value=value,
-                            updated_at=now,
-                        )
-                    )
-                else:
-                    label.value = value
-                    label.updated_at = now
         return persisted
 
     def list_projects(

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import defaultdict, deque
 from typing import Any
 
 from sqlalchemy import (
@@ -20,7 +21,7 @@ from sqlalchemy import (
     text,
     update,
 )
-from sqlalchemy.orm import QueryableAttribute, Session
+from sqlalchemy.orm import QueryableAttribute, Session, aliased
 from sqlalchemy.sql.selectable import Subquery
 
 from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY
@@ -69,7 +70,15 @@ from omnigent.entities import (
     PagedList,
     parse_item_data,
 )
+from omnigent.session_import.models import (
+    IMPORT_DIGEST_LABEL_KEY,
+    IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
+    IMPORT_ITEM_COUNT_LABEL_KEY,
+    IMPORT_SOURCE_LABEL_KEY,
+    conversation_items_digest,
+)
 from omnigent.stores.conversation_store import (
+    _FORK_ONLY_DROPPED_LABEL_KEYS,
     _INSTANCE_SCOPED_LABEL_KEYS,
     FORK_CARRY_HISTORY_LABEL_KEY,
     FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
@@ -79,6 +88,7 @@ from omnigent.stores.conversation_store import (
     ConversationNotFoundError,
     ConversationStore,
     CreatedSession,
+    ImportedPrefixMismatchError,
     SessionConnectivity,
 )
 
@@ -595,6 +605,41 @@ def _to_item(row: SqlConversationItem) -> ConversationItem:
     )
 
 
+def _build_item_row(
+    conversation_id: str,
+    item: NewConversationItem,
+    *,
+    position: int,
+    created_at: int,
+) -> tuple[SqlConversationItem, ConversationItem, str]:
+    """Build one persisted item row, entity, and searchable text."""
+    data = strip_nul_bytes(json.dumps(item.data.model_dump(exclude_none=True)))
+    search = strip_nul_bytes(extract_search_text(item))
+    item_id = generate_item_id(item.type)
+    row = SqlConversationItem(
+        id=item_id,
+        conversation_id=conversation_id,
+        response_id=item.response_id,
+        created_at=created_at,
+        status=encode_item_status("completed"),
+        position=position,
+        type=encode_item_type(item.type),
+        data=data,
+        search_text=search,
+        created_by=item.created_by,
+    )
+    entity = ConversationItem(
+        id=item_id,
+        type=item.type,
+        status="completed",
+        response_id=item.response_id,
+        created_at=created_at,
+        data=item.data,
+        created_by=item.created_by,
+    )
+    return row, entity, search
+
+
 def _ranked_latest_message_items(conversation_ids: list[str]) -> Subquery:
     """
     Build a ranked latest-message subquery for multiple conversations.
@@ -981,6 +1026,39 @@ class SqlAlchemyConversationStore(ConversationStore):
             return _to_conversation(
                 row, meta, _fetch_labels(session, conversation_id), agent_config
             )
+
+    def find_imported_conversation(
+        self,
+        source: str,
+        external_session_id: str,
+    ) -> Conversation | None:
+        """Find the original conversation carrying an import provenance pair."""
+        source_label = aliased(SqlConversationLabel)
+        external_label = aliased(SqlConversationLabel)
+        with self._conv_session() as session:
+            conversation_id = session.execute(
+                select(SqlConversation.id)
+                .join(
+                    source_label,
+                    (source_label.workspace_id == SqlConversation.workspace_id)
+                    & (source_label.conversation_id == SqlConversation.id),
+                )
+                .join(
+                    external_label,
+                    (external_label.workspace_id == SqlConversation.workspace_id)
+                    & (external_label.conversation_id == SqlConversation.id),
+                )
+                .where(
+                    SqlConversation.workspace_id == current_workspace_id(),
+                    source_label.key == IMPORT_SOURCE_LABEL_KEY,
+                    source_label.value == source,
+                    external_label.key == IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
+                    external_label.value == external_session_id,
+                )
+                .order_by(SqlConversation.created_at, SqlConversation.id)
+                .limit(1)
+            ).scalar_one_or_none()
+        return self.get_conversation(conversation_id) if conversation_id is not None else None
 
     def get_runner_ids(self, conversation_ids: list[str]) -> dict[str, str | None]:
         """
@@ -1806,48 +1884,134 @@ class SqlAlchemyConversationStore(ConversationStore):
             for item in items:
                 position = next_pos
                 next_pos += 1
-                data_dict = item.data.model_dump(exclude_none=True)
-                # Strip NUL bytes before they reach a Postgres text
-                # column, which rejects them outright. Tool output can
-                # embed NUL (e.g. reading a binary file); without this
-                # the whole INSERT aborts and the item never persists.
-                data = strip_nul_bytes(json.dumps(data_dict))
-                search = strip_nul_bytes(extract_search_text(item))
-                item_id = generate_item_id(item.type)
-                row = SqlConversationItem(
-                    id=item_id,
-                    conversation_id=conversation_id,
-                    response_id=item.response_id,
-                    created_at=now,
-                    status=encode_item_status("completed"),  # items are final on append
+                row, entity, search = _build_item_row(
+                    conversation_id,
+                    item,
                     position=position,
-                    type=encode_item_type(item.type),
-                    data=data,
-                    search_text=search,
-                    created_by=item.created_by,
+                    created_at=now,
                 )
                 session.add(row)
-                insert_fts(session, item_id, conversation_id, search)
-                persisted.append(
-                    ConversationItem(
-                        id=row.id,
-                        # The row stores int codes; the entity carries the
-                        # string names. item.type is the source string and
-                        # the status was just written as "completed".
-                        type=item.type,
-                        status="completed",
-                        response_id=row.response_id,
-                        created_at=row.created_at,
-                        data=item.data,
-                        created_by=item.created_by,
-                    )
-                )
+                insert_fts(session, row.id, conversation_id, search)
+                persisted.append(entity)
 
             # Persist the advanced counter so the next append reads it instead
             # of scanning; this also lazily backfills a pre-counter conversation.
             if conv_row is not None:
                 conv_row.next_position = next_pos
 
+        return persisted
+
+    def replace_imported_prefix(
+        self,
+        conversation_id: str,
+        items: list[NewConversationItem],
+        *,
+        expected_count: int,
+        expected_digest: str,
+    ) -> list[ConversationItem]:
+        """Replace a verified imported prefix while retaining later turns."""
+        now = now_epoch()
+        persisted: list[ConversationItem] = []
+        with self._conv_session() as session:
+            self._lock_conversation(session, conversation_id)
+            conversation = session.get(
+                SqlConversation,
+                (current_workspace_id(), conversation_id),
+            )
+            if conversation is None:
+                raise ConversationNotFoundError(f"conversation {conversation_id!r} does not exist")
+            rows = list(
+                session.execute(
+                    select(SqlConversationItem)
+                    .where(
+                        SqlConversationItem.workspace_id == current_workspace_id(),
+                        SqlConversationItem.conversation_id == conversation_id,
+                    )
+                    .order_by(SqlConversationItem.position)
+                )
+                .scalars()
+                .all()
+            )
+            if expected_count < 0 or len(rows) < expected_count:
+                raise ImportedPrefixMismatchError(
+                    "the previously imported transcript boundary is no longer present"
+                )
+            prefix = rows[:expected_count]
+            if conversation_items_digest([_to_item(row) for row in prefix]) != expected_digest:
+                raise ImportedPrefixMismatchError(
+                    "the previously imported transcript was modified after import"
+                )
+
+            preserved = rows[expected_count:]
+            source_positions: dict[str, deque[int]] = defaultdict(deque)
+            for index, item in enumerate(items[expected_count:]):
+                source_positions[
+                    conversation_items_digest([item], include_created_by=False)
+                ].append(index)
+            source_cursor = 0
+            retained: list[SqlConversationItem] = []
+            represented: list[SqlConversationItem] = []
+            for row in preserved:
+                candidates = source_positions[
+                    conversation_items_digest([_to_item(row)], include_created_by=False)
+                ]
+                while candidates and candidates[0] < source_cursor:
+                    candidates.popleft()
+                if candidates:
+                    source_cursor = candidates.popleft() + 1
+                    represented.append(row)
+                else:
+                    retained.append(row)
+            preserved = retained
+            delete_fts_by_conversation(session, conversation_id)
+            for row in [*prefix, *represented]:
+                session.delete(row)
+            # Move retained rows out of the non-negative position range before
+            # compacting them behind a replacement prefix. This avoids transient
+            # unique-position collisions on databases with immediate constraints.
+            for index, row in enumerate(preserved):
+                row.position = -(index + 1)
+            session.flush()
+            for index, row in enumerate(preserved):
+                row.position = len(items) + index
+            session.flush()
+
+            for position, item in enumerate(items):
+                row, entity, search = _build_item_row(
+                    conversation_id,
+                    item,
+                    position=position,
+                    created_at=now,
+                )
+                session.add(row)
+                insert_fts(session, row.id, conversation_id, search)
+                persisted.append(entity)
+            for row in preserved:
+                insert_fts(session, row.id, conversation_id, row.search_text)
+
+            conversation.next_position = len(items) + len(preserved)
+            conversation.updated_at = now
+            import_labels = {
+                IMPORT_ITEM_COUNT_LABEL_KEY: str(len(items)),
+                IMPORT_DIGEST_LABEL_KEY: conversation_items_digest(items),
+            }
+            for key, value in import_labels.items():
+                label = session.get(
+                    SqlConversationLabel,
+                    (current_workspace_id(), conversation_id, key),
+                )
+                if label is None:
+                    session.add(
+                        SqlConversationLabel(
+                            conversation_id=conversation_id,
+                            key=key,
+                            value=value,
+                            updated_at=now,
+                        )
+                    )
+                else:
+                    label.value = value
+                    label.updated_at = now
         return persisted
 
     def list_projects(
@@ -3157,7 +3321,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             fork_labels = {
                 key: value
                 for key, value in _fetch_labels(session, source_conversation_id).items()
-                if key not in _INSTANCE_SCOPED_LABEL_KEYS
+                if key not in (_INSTANCE_SCOPED_LABEL_KEYS | _FORK_ONLY_DROPPED_LABEL_KEYS)
             }
             source_workspace = source_meta_ref.workspace if source_meta_ref else None
             source_ext_session = source_meta_ref.external_session_id if source_meta_ref else None

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -948,7 +948,14 @@ class SqlAlchemyConversationStore(ConversationStore):
             is_id_unique_violation = conversation_id is not None and (
                 "conversations_pkey" in msg
                 or "agent_configuration_pkey" in msg
-                or ("duplicate entry" in msg and "for key 'primary'" in msg)
+                or (
+                    "duplicate entry" in msg
+                    and (
+                        "for key 'primary'" in msg
+                        or "for key 'conversations.primary'" in msg
+                        or "for key 'agent_configuration.primary'" in msg
+                    )
+                )
                 or (
                     "unique" in msg
                     and (

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -81,6 +81,7 @@ from omnigent.stores.conversation_store import (
     FORK_SOURCE_LABEL_KEY,
     PROJECT_LABEL_KEY,
     SWITCH_PREVIOUS_BUILTIN_LABEL_KEY,
+    ConversationAlreadyExistsError,
     ConversationNotFoundError,
     ConversationStore,
     CreatedSession,
@@ -820,6 +821,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         workspace: str | None = None,
         git_branch: str | None = None,
         terminal_launch_args: list[str] | None = None,
+        conversation_id: str | None = None,
     ) -> Conversation:
         """
         Create a new conversation in the database.
@@ -866,12 +868,16 @@ class SqlAlchemyConversationStore(ConversationStore):
             the column NULL; a list (including ``[]``) is JSON-encoded
             so the runner applies it when it auto-launches the
             terminal.
+        :param conversation_id: Optional caller-supplied identifier.
+            ``None`` generates a new random id.
         :returns: The newly created :class:`Conversation`.
         :raises NameAlreadyExistsError: If
             ``parent_conversation_id`` is set and a sibling row
             with the same ``title`` already exists.
         :raises IntegrityError: If ``host_id`` is set without
             ``workspace`` (the check constraint catches it).
+        :raises ConversationAlreadyExistsError: If a caller-supplied
+            ``conversation_id`` is already in use.
         """
         from sqlalchemy.exc import IntegrityError
 
@@ -881,7 +887,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         )
 
         now = now_epoch()
-        new_id = generate_conversation_id()
+        new_id = conversation_id if conversation_id is not None else generate_conversation_id()
         try:
             # Get parent's root from AP, then write AP row and Omnigent meta separately.
             root_id = new_id
@@ -939,6 +945,29 @@ class SqlAlchemyConversationStore(ConversationStore):
             # check, which would misclassify any future unique
             # constraint added to the conversations table.
             msg = str(exc).lower()
+            is_id_unique_violation = conversation_id is not None and (
+                "conversations_pkey" in msg
+                or "agent_configuration_pkey" in msg
+                or ("duplicate entry" in msg and "for key 'primary'" in msg)
+                or (
+                    "unique" in msg
+                    and (
+                        (
+                            "conversations.workspace_id" in msg
+                            and "conversations.id" in msg
+                            and "parent_conversation_id" not in msg
+                        )
+                        or (
+                            "agent_configuration.workspace_id" in msg
+                            and "agent_configuration.conversation_id" in msg
+                        )
+                    )
+                )
+            )
+            if is_id_unique_violation:
+                raise ConversationAlreadyExistsError(
+                    f"conversation id {conversation_id!r} already exists"
+                ) from exc
             is_title_unique_violation = "ix_conversations_parent_title_unique" in msg or (
                 "unique" in msg and "parent_conversation_id" in msg and "title" in msg
             )

--- a/openapi.json
+++ b/openapi.json
@@ -1689,11 +1689,6 @@
             "title": "External Session Id",
             "type": "string"
           },
-          "force": {
-            "default": false,
-            "title": "Force",
-            "type": "boolean"
-          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/ImportItemInput"
@@ -1744,11 +1739,7 @@
             "type": "string"
           },
           "status": {
-            "enum": [
-              "imported",
-              "already_imported",
-              "replaced"
-            ],
+            "const": "imported",
             "title": "Status",
             "type": "string"
           }
@@ -6978,7 +6969,7 @@
     },
     "/v1/imports": {
       "post": {
-        "description": "Import one normalized transcript or return its existing session.",
+        "description": "Import one normalized transcript, rejecting duplicate sources.",
         "operationId": "import_session_v1_imports_post",
         "requestBody": {
           "content": {

--- a/openapi.json
+++ b/openapi.json
@@ -1653,6 +1653,114 @@
         "title": "HeartbeatEvent",
         "type": "object"
       },
+      "ImportItemInput": {
+        "description": "One normalized existing Omnigent item received from the CLI.",
+        "properties": {
+          "data": {
+            "additionalProperties": true,
+            "title": "Data",
+            "type": "object"
+          },
+          "response_id": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Response Id",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "response_id",
+          "data"
+        ],
+        "title": "ImportItemInput",
+        "type": "object"
+      },
+      "ImportSessionRequest": {
+        "description": "Request body for importing one local harness session.",
+        "properties": {
+          "external_session_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "External Session Id",
+            "type": "string"
+          },
+          "force": {
+            "default": false,
+            "title": "Force",
+            "type": "boolean"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ImportItemInput"
+            },
+            "maxItems": 100000,
+            "title": "Items",
+            "type": "array"
+          },
+          "source": {
+            "enum": [
+              "claude",
+              "codex",
+              "cursor"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "workspace": {
+            "anyOf": [
+              {
+                "maxLength": 2048,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace"
+          }
+        },
+        "required": [
+          "source",
+          "external_session_id",
+          "items"
+        ],
+        "title": "ImportSessionRequest",
+        "type": "object"
+      },
+      "ImportSessionResponse": {
+        "description": "Result of importing or locating one source session.",
+        "properties": {
+          "item_count": {
+            "title": "Item Count",
+            "type": "integer"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "imported",
+              "already_imported",
+              "replaced"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "status",
+          "item_count"
+        ],
+        "title": "ImportSessionResponse",
+        "type": "object"
+      },
       "InProgressEvent": {
         "description": "Event emitted once the task transitions to in-progress.\n\nAlways follows `response.created` (and `response.queued`\nfor background tasks).",
         "properties": {
@@ -6865,6 +6973,48 @@
         "summary": "List Host Worktrees",
         "tags": [
           "hosts"
+        ]
+      }
+    },
+    "/v1/imports": {
+      "post": {
+        "description": "Import one normalized transcript or return its existing session.",
+        "operationId": "import_session_v1_imports_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Import Session",
+        "tags": [
+          "imports"
         ]
       }
     },

--- a/openapi.json
+++ b/openapi.json
@@ -1701,8 +1701,7 @@
           "source": {
             "enum": [
               "claude",
-              "codex",
-              "cursor"
+              "codex"
             ],
             "title": "Source",
             "type": "string"

--- a/openapi.json
+++ b/openapi.json
@@ -1694,6 +1694,7 @@
               "$ref": "#/components/schemas/ImportItemInput"
             },
             "maxItems": 100000,
+            "minItems": 1,
             "title": "Items",
             "type": "array"
           },

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -1,0 +1,70 @@
+"""Tests for the top-level ``omnigent import`` command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import respx
+from click.testing import CliRunner
+
+from omnigent.cli import _CLICK_SUBCOMMANDS, cli
+
+_BASE = "http://localhost:6767"
+
+
+@respx.mock
+def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path: Path) -> None:
+    """The CLI reads local history and submits only Omnigent item shapes."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    transcript = tmp_path / ".claude" / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "uuid": "user-1",
+                "cwd": "/repo",
+                "message": {"role": "user", "content": "inspect TODO.md"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        return_value=httpx.Response(
+            201,
+            json={"session_id": "conv_imported", "status": "imported", "item_count": 1},
+        )
+    )
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "claude", "--session", session_id, "--force"],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "import" in _CLICK_SUBCOMMANDS
+    assert "conv_imported" in result.output
+    request = route.calls.last.request
+    payload = json.loads(request.content)
+    assert payload == {
+        "source": "claude",
+        "external_session_id": session_id,
+        "workspace": "/repo",
+        "force": True,
+        "items": [
+            {
+                "type": "message",
+                "response_id": "resp_claude_c6c289e49e9c05b2145860387b73bcb1",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "inspect TODO.md"}],
+                },
+            }
+        ],
+    }

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -43,7 +43,7 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
     with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
         result = CliRunner().invoke(
             cli,
-            ["import", "--harness", "claude", "--session", session_id, "--force"],
+            ["import", "--harness", "claude", "--session", session_id],
             env={"HOME": str(tmp_path)},
         )
 
@@ -56,7 +56,6 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
         "source": "claude",
         "external_session_id": session_id,
         "workspace": "/repo",
-        "force": True,
         "items": [
             {
                 "type": "message",

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -67,3 +67,14 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
             }
         ],
     }
+
+
+def test_import_command_rejects_cursor() -> None:
+    """The v0 import command accepts only Claude Code and Codex."""
+    result = CliRunner().invoke(
+        cli,
+        ["import", "--harness", "cursor", "--session", "cursor-session"],
+    )
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--harness'" in result.output

--- a/tests/e2e/test_chat_import_e2e.py
+++ b/tests/e2e/test_chat_import_e2e.py
@@ -1,0 +1,89 @@
+"""End-to-end coverage for importing a local harness chat."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+
+
+def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Path) -> None:
+    """The real CLI and server create a readable session from Claude JSONL."""
+    source_session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    transcript = tmp_path / ".claude" / "projects" / "-repo" / f"{source_session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        "".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "uuid": "user-1",
+                        "cwd": "/repo",
+                        "message": {"role": "user", "content": "inspect TODO.md"},
+                    }
+                ),
+                "\n",
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "uuid": "assistant-1",
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Done."}],
+                        },
+                    }
+                ),
+                "\n",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "OMNIGENT_CONFIG_HOME": str(tmp_path / "config"),
+            "OMNIGENT_DATA_DIR": str(tmp_path / "omnigent-data"),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "import",
+            "--harness",
+            "claude",
+            "--session",
+            source_session_id,
+            "--server",
+            live_server,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    match = re.search(r"conv_[0-9a-f]{32}", result.stdout)
+    assert match is not None, result.stdout
+    session_id = match.group(0)
+    session = httpx.get(
+        f"{live_server}/v1/sessions/{session_id}",
+        params={"include_items": "false", "include_liveness": "false"},
+        timeout=10,
+    )
+    session.raise_for_status()
+    assert session.json()["external_session_id"] == source_session_id
+    assert session.json()["workspace"] == "/repo"
+    items = httpx.get(f"{live_server}/v1/sessions/{session_id}/items", timeout=10)
+    items.raise_for_status()
+    assert [item["type"] for item in items.json()["data"]] == ["message", "message"]

--- a/tests/e2e/test_chat_import_e2e.py
+++ b/tests/e2e/test_chat_import_e2e.py
@@ -73,9 +73,9 @@ def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Pa
         env=env,
     )
 
-    match = re.search(r"conv_[0-9a-f]{32}", result.stdout)
+    match = re.search(r"Imported \d+ item\(s\) into (\S+)\.", result.stdout)
     assert match is not None, result.stdout
-    session_id = match.group(0)
+    session_id = match.group(1)
     session = httpx.get(
         f"{live_server}/v1/sessions/{session_id}",
         params={"include_items": "false", "include_liveness": "false"},

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -2323,21 +2323,24 @@ async def test_auto_create_codex_terminal_fork_clones_rollout_and_resumes(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source_thread",
+    [None, "019e96aa-0be2-7343-8d3b-6f914d60936b"],
+    ids=["sdk-source", "missing-codex-rollout"],
+)
 async def test_auto_create_codex_terminal_fork_builds_rollout_from_items_and_resumes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    source_thread: str | None,
 ) -> None:
-    """A forked codex clone from an SDK source builds its rollout from items.
+    """A forked codex clone builds from items when its source rollout is unavailable.
 
-    When the clone carries the carry-history directive but has NO source
-    Codex thread to clone (an SDK source, so no rollout on disk), the runner
-    must build the clone's rollout from its OWN copied Omnigent items under a
-    freshly minted thread id, pre-set that id on the Omnigent session, and launch
-    ``codex resume <minted_id>``. A regression launches fresh and the clone
-    loses the SDK source's conversation history.
+    This covers both a non-Codex source with no source thread id and an imported
+    Codex source whose rollout lives outside Omnigent's private ``CODEX_HOME``.
 
     :param tmp_path: Temporary directory for isolated bridge state.
     :param monkeypatch: Pytest monkeypatch fixture.
+    :param source_thread: Optional unavailable source Codex thread id.
     :returns: None.
     """
     import omnigent.codex_native_app_server as codex_app_mod
@@ -2346,6 +2349,7 @@ async def test_auto_create_codex_terminal_fork_builds_rollout_from_items_and_res
     from omnigent.codex_native_bridge import bridge_dir_for_bridge_id, codex_home_for_bridge_dir
     from omnigent.stores.conversation_store import (
         FORK_CARRY_HISTORY_LABEL_KEY,
+        FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
         FORK_SOURCE_LABEL_KEY,
     )
 
@@ -2384,16 +2388,17 @@ async def test_auto_create_codex_terminal_fork_builds_rollout_from_items_and_res
             """
             del timeout
             if url == f"/v1/sessions/{session_id}":
-                # SDK source: carry-history set, but NO source external
-                # session id → the runner must build from items, not clone.
+                labels = {
+                    FORK_SOURCE_LABEL_KEY: source_id,
+                    FORK_CARRY_HISTORY_LABEL_KEY: "1",
+                }
+                if source_thread is not None:
+                    labels[FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY] = source_thread
                 return httpx.Response(
                     200,
                     json={
                         "external_session_id": None,
-                        "labels": {
-                            FORK_SOURCE_LABEL_KEY: source_id,
-                            FORK_CARRY_HISTORY_LABEL_KEY: "1",
-                        },
+                        "labels": labels,
                     },
                     request=httpx.Request("GET", url),
                 )

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -1,0 +1,231 @@
+"""Tests for importing normalized local harness sessions."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from omnigent.db.utils import builtin_agent_id
+from omnigent.entities import MessageData, NewConversationItem
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+
+def _seed_claude_agent(db_uri: str) -> str:
+    """Seed the built-in agent because focused app tests skip lifespan startup."""
+    agent_id = builtin_agent_id("claude-native-ui")
+    SqlAlchemyAgentStore(db_uri).create(
+        agent_id,
+        name="claude-native-ui",
+        bundle_location="builtin://claude-native-ui",
+    )
+    return agent_id
+
+
+async def test_import_session_creates_normal_idempotent_session(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """An import creates one native session and a retry returns the same id."""
+    agent_id = _seed_claude_agent(db_uri)
+    payload = {
+        "source": "claude",
+        "external_session_id": "claude-session-1",
+        "workspace": "/repo",
+        "items": [
+            {
+                "type": "message",
+                "response_id": "claude:turn-1",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "inspect TODO.md"}],
+                },
+            },
+            {
+                "type": "message",
+                "response_id": "claude:turn-1",
+                "data": {
+                    "role": "assistant",
+                    "agent": "claude-native-ui",
+                    "content": [{"type": "output_text", "text": "Done."}],
+                },
+            },
+        ],
+    }
+
+    created = await client.post("/v1/imports", json=payload)
+    repeated = await client.post("/v1/imports", json=payload)
+
+    assert created.status_code == 201
+    assert created.json()["status"] == "imported"
+    assert repeated.status_code == 200
+    assert repeated.json()["status"] == "already_imported"
+    assert repeated.json()["session_id"] == created.json()["session_id"]
+
+    session_id = created.json()["session_id"]
+    conversation = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
+    assert conversation is not None
+    assert conversation.agent_id == agent_id
+    assert conversation.external_session_id == "claude-session-1"
+    assert conversation.workspace == "/repo"
+    assert conversation.title == "inspect TODO.md"
+    assert conversation.labels["omnigent.wrapper"] == "claude-code-native-ui"
+    items = await client.get(f"/v1/sessions/{session_id}/items")
+    assert items.status_code == 200
+    assert [item["type"] for item in items.json()["data"]] == ["message", "message"]
+
+
+async def test_force_import_replaces_source_prefix_and_preserves_later_turns(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Force updates the existing conv while retaining Omnigent-authored items."""
+    _seed_claude_agent(db_uri)
+    payload = {
+        "source": "claude",
+        "external_session_id": "claude-force-1",
+        "items": [
+            {
+                "type": "message",
+                "response_id": "claude:turn-1",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "old prompt"}],
+                },
+            }
+        ],
+    }
+    created = await client.post("/v1/imports", json=payload)
+    session_id = created.json()["session_id"]
+    store = SqlAlchemyConversationStore(db_uri)
+    later = store.append(
+        session_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="omnigent:later",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "later prompt"}],
+                ),
+            )
+        ],
+    )[0]
+    payload["items"] = [
+        {
+            "type": "message",
+            "response_id": "claude:turn-1",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "new prompt"}],
+            },
+        },
+        {
+            "type": "message",
+            "response_id": "claude:turn-1",
+            "data": {
+                "role": "assistant",
+                "agent": "claude-native-ui",
+                "content": [{"type": "output_text", "text": "new answer"}],
+            },
+        },
+    ]
+    payload["force"] = True
+
+    replaced = await client.post("/v1/imports", json=payload)
+
+    assert replaced.status_code == 200
+    assert replaced.json() == {
+        "session_id": session_id,
+        "status": "replaced",
+        "item_count": 2,
+    }
+    items = store.list_items(session_id, limit=20).data
+    assert [item.data.content[0]["text"] for item in items] == [  # type: ignore[union-attr]
+        "new prompt",
+        "new answer",
+        "later prompt",
+    ]
+    assert items[-1].id == later.id
+
+
+async def test_force_import_does_not_duplicate_later_turn_already_in_source(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A later mirrored turn represented in fresh source history appears once."""
+    _seed_claude_agent(db_uri)
+    payload = {
+        "source": "claude",
+        "external_session_id": "claude-overlap-1",
+        "items": [
+            {
+                "type": "message",
+                "response_id": "claude:turn-1",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "original"}],
+                },
+            }
+        ],
+    }
+    created = await client.post("/v1/imports", json=payload)
+    session_id = created.json()["session_id"]
+    store = SqlAlchemyConversationStore(db_uri)
+    store.append(
+        session_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="claude:turn-2",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "later"}],
+                ),
+                created_by="owner@example.com",
+            )
+        ],
+    )
+    payload["force"] = True
+    payload["items"] = [
+        payload["items"][0],
+        {
+            "type": "message",
+            "response_id": "claude:turn-2",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "later"}],
+            },
+        },
+    ]
+
+    replaced = await client.post("/v1/imports", json=payload)
+
+    assert replaced.status_code == 200
+    items = store.list_items(session_id, limit=20).data
+    assert [item.data.content[0]["text"] for item in items] == [  # type: ignore[union-attr]
+        "original",
+        "later",
+    ]
+
+
+async def test_concurrent_identical_imports_return_one_session(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Concurrent retries serialize on source identity and return one conv."""
+    _seed_claude_agent(db_uri)
+    payload = {
+        "source": "claude",
+        "external_session_id": "claude-concurrent-1",
+        "items": [],
+    }
+
+    first, second = await asyncio.gather(
+        client.post("/v1/imports", json=payload),
+        client.post("/v1/imports", json=payload),
+    )
+
+    assert {first.status_code, second.status_code} == {200, 201}
+    assert first.json()["session_id"] == second.json()["session_id"]

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -7,7 +7,6 @@ import asyncio
 import httpx
 
 from omnigent.db.utils import builtin_agent_id
-from omnigent.entities import MessageData, NewConversationItem
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 
@@ -23,11 +22,11 @@ def _seed_claude_agent(db_uri: str) -> str:
     return agent_id
 
 
-async def test_import_session_creates_normal_idempotent_session(
+async def test_import_session_creates_normal_session_and_blocks_duplicate(
     client: httpx.AsyncClient,
     db_uri: str,
 ) -> None:
-    """An import creates one native session and a retry returns the same id."""
+    """An import creates one native session and a retry is rejected."""
     agent_id = _seed_claude_agent(db_uri)
     payload = {
         "source": "claude",
@@ -59,9 +58,9 @@ async def test_import_session_creates_normal_idempotent_session(
 
     assert created.status_code == 201
     assert created.json()["status"] == "imported"
-    assert repeated.status_code == 200
-    assert repeated.json()["status"] == "already_imported"
-    assert repeated.json()["session_id"] == created.json()["session_id"]
+    assert repeated.status_code == 409
+    assert created.json()["session_id"] in repeated.text
+    assert "already been imported" in repeated.text
 
     session_id = created.json()["session_id"]
     conversation = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
@@ -76,145 +75,11 @@ async def test_import_session_creates_normal_idempotent_session(
     assert [item["type"] for item in items.json()["data"]] == ["message", "message"]
 
 
-async def test_force_import_replaces_source_prefix_and_preserves_later_turns(
-    client: httpx.AsyncClient,
-    db_uri: str,
-) -> None:
-    """Force updates the existing conv while retaining Omnigent-authored items."""
-    _seed_claude_agent(db_uri)
-    payload = {
-        "source": "claude",
-        "external_session_id": "claude-force-1",
-        "items": [
-            {
-                "type": "message",
-                "response_id": "claude:turn-1",
-                "data": {
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "old prompt"}],
-                },
-            }
-        ],
-    }
-    created = await client.post("/v1/imports", json=payload)
-    session_id = created.json()["session_id"]
-    store = SqlAlchemyConversationStore(db_uri)
-    later = store.append(
-        session_id,
-        [
-            NewConversationItem(
-                type="message",
-                response_id="omnigent:later",
-                data=MessageData(
-                    role="user",
-                    content=[{"type": "input_text", "text": "later prompt"}],
-                ),
-            )
-        ],
-    )[0]
-    payload["items"] = [
-        {
-            "type": "message",
-            "response_id": "claude:turn-1",
-            "data": {
-                "role": "user",
-                "content": [{"type": "input_text", "text": "new prompt"}],
-            },
-        },
-        {
-            "type": "message",
-            "response_id": "claude:turn-1",
-            "data": {
-                "role": "assistant",
-                "agent": "claude-native-ui",
-                "content": [{"type": "output_text", "text": "new answer"}],
-            },
-        },
-    ]
-    payload["force"] = True
-
-    replaced = await client.post("/v1/imports", json=payload)
-
-    assert replaced.status_code == 200
-    assert replaced.json() == {
-        "session_id": session_id,
-        "status": "replaced",
-        "item_count": 2,
-    }
-    items = store.list_items(session_id, limit=20).data
-    assert [item.data.content[0]["text"] for item in items] == [  # type: ignore[union-attr]
-        "new prompt",
-        "new answer",
-        "later prompt",
-    ]
-    assert items[-1].id == later.id
-
-
-async def test_force_import_does_not_duplicate_later_turn_already_in_source(
-    client: httpx.AsyncClient,
-    db_uri: str,
-) -> None:
-    """A later mirrored turn represented in fresh source history appears once."""
-    _seed_claude_agent(db_uri)
-    payload = {
-        "source": "claude",
-        "external_session_id": "claude-overlap-1",
-        "items": [
-            {
-                "type": "message",
-                "response_id": "claude:turn-1",
-                "data": {
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "original"}],
-                },
-            }
-        ],
-    }
-    created = await client.post("/v1/imports", json=payload)
-    session_id = created.json()["session_id"]
-    store = SqlAlchemyConversationStore(db_uri)
-    store.append(
-        session_id,
-        [
-            NewConversationItem(
-                type="message",
-                response_id="claude:turn-2",
-                data=MessageData(
-                    role="user",
-                    content=[{"type": "input_text", "text": "later"}],
-                ),
-                created_by="owner@example.com",
-            )
-        ],
-    )
-    payload["force"] = True
-    payload["items"] = [
-        payload["items"][0],
-        {
-            "type": "message",
-            "response_id": "claude:turn-2",
-            "data": {
-                "role": "user",
-                "content": [{"type": "input_text", "text": "later"}],
-            },
-        },
-    ]
-
-    replaced = await client.post("/v1/imports", json=payload)
-
-    assert replaced.status_code == 200
-    items = store.list_items(session_id, limit=20).data
-    assert [item.data.content[0]["text"] for item in items] == [  # type: ignore[union-attr]
-        "original",
-        "later",
-    ]
-
-
 async def test_concurrent_identical_imports_return_one_session(
     client: httpx.AsyncClient,
     db_uri: str,
 ) -> None:
-    """Concurrent retries serialize on source identity and return one conv."""
+    """Concurrent retries serialize on source identity and one is rejected."""
     _seed_claude_agent(db_uri)
     payload = {
         "source": "claude",
@@ -227,5 +92,8 @@ async def test_concurrent_identical_imports_return_one_session(
         client.post("/v1/imports", json=payload),
     )
 
-    assert {first.status_code, second.status_code} == {200, 201}
-    assert first.json()["session_id"] == second.json()["session_id"]
+    assert {first.status_code, second.status_code} == {201, 409}
+    imported = SqlAlchemyConversationStore(db_uri).find_imported_conversation(
+        "claude", "claude-concurrent-1"
+    )
+    assert imported is not None

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -84,7 +84,16 @@ async def test_concurrent_identical_imports_return_one_session(
     payload = {
         "source": "claude",
         "external_session_id": "claude-concurrent-1",
-        "items": [],
+        "items": [
+            {
+                "type": "message",
+                "response_id": "claude:turn-1",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                },
+            }
+        ],
     }
 
     first, second = await asyncio.gather(
@@ -97,3 +106,17 @@ async def test_concurrent_identical_imports_return_one_session(
         "claude", "claude-concurrent-1"
     )
     assert imported is not None
+
+
+async def test_import_session_rejects_empty_history(client: httpx.AsyncClient) -> None:
+    """An empty parser result cannot create a permanently claimed session."""
+    response = await client.post(
+        "/v1/imports",
+        json={
+            "source": "codex",
+            "external_session_id": "empty-codex-session",
+            "items": [],
+        },
+    )
+
+    assert response.status_code == 422

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -16,113 +16,16 @@ from omnigent.entities import (
 )
 from omnigent.server.auth import RESERVED_USER_LOCAL
 from omnigent.session_import import (
-    IMPORT_DIGEST_LABEL_KEY,
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
-    IMPORT_ITEM_COUNT_LABEL_KEY,
     IMPORT_SOURCE_LABEL_KEY,
-    conversation_items_digest,
 )
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
-from omnigent.stores.conversation_store import ImportedPrefixMismatchError
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.host_store import HostStore
 
 # ── CRUD ──────────────────────────────────────────────
-
-
-def test_replace_imported_prefix_preserves_later_session_state(
-    conversation_store: SqlAlchemyConversationStore,
-) -> None:
-    """Forced re-import replaces only source history on the same session."""
-    original = [
-        NewConversationItem(
-            type="message",
-            response_id="claude:turn-1",
-            data=MessageData(
-                role="user",
-                content=[{"type": "input_text", "text": "old prompt"}],
-            ),
-        ),
-        NewConversationItem(
-            type="message",
-            response_id="claude:turn-1",
-            data=MessageData(
-                role="assistant",
-                content=[{"type": "output_text", "text": "old answer"}],
-                agent="claude-native-ui",
-            ),
-        ),
-    ]
-    replacement = [
-        NewConversationItem(
-            type="message",
-            response_id="claude:turn-1",
-            data=MessageData(
-                role="user",
-                content=[{"type": "input_text", "text": "new prompt"}],
-            ),
-        ),
-        NewConversationItem(
-            type="message",
-            response_id="claude:turn-1",
-            data=MessageData(
-                role="assistant",
-                content=[{"type": "output_text", "text": "new answer"}],
-                agent="claude-native-ui",
-            ),
-        ),
-    ]
-    conversation = conversation_store.create_conversation(title="Kept title")
-    conversation_store.set_external_session_id(conversation.id, "claude-source-id")
-    conversation_store.append(conversation.id, original)
-    conversation_store.set_labels(
-        conversation.id,
-        {
-            IMPORT_SOURCE_LABEL_KEY: "claude",
-            IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: "claude-source-id",
-            IMPORT_ITEM_COUNT_LABEL_KEY: str(len(original)),
-            IMPORT_DIGEST_LABEL_KEY: conversation_items_digest(original),
-            "omni_project": "Kept project",
-        },
-    )
-    later = conversation_store.append(
-        conversation.id,
-        [
-            NewConversationItem(
-                type="message",
-                response_id="omnigent:turn-2",
-                data=MessageData(
-                    role="user",
-                    content=[{"type": "input_text", "text": "later prompt"}],
-                ),
-            )
-        ],
-    )[0]
-
-    conversation_store.replace_imported_prefix(
-        conversation.id,
-        replacement,
-        expected_count=len(original),
-        expected_digest=conversation_items_digest(original),
-    )
-
-    items = conversation_store.list_items(conversation.id, limit=20).data
-    assert [item.data.content[0]["text"] for item in items] == [  # type: ignore[union-attr]
-        "new prompt",
-        "new answer",
-        "later prompt",
-    ]
-    assert items[-1].id == later.id
-    reloaded = conversation_store.get_conversation(conversation.id)
-    assert reloaded is not None
-    assert reloaded.id == conversation.id
-    assert reloaded.title == "Kept title"
-    assert reloaded.external_session_id == "claude-source-id"
-    assert reloaded.labels["omni_project"] == "Kept project"
-    found = conversation_store.find_imported_conversation("claude", "claude-source-id")
-    assert found is not None and found.id == conversation.id
 
 
 def test_fork_drops_import_provenance_labels(
@@ -135,8 +38,6 @@ def test_fork_drops_import_provenance_labels(
         {
             IMPORT_SOURCE_LABEL_KEY: "claude",
             IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: "source-id",
-            IMPORT_ITEM_COUNT_LABEL_KEY: "0",
-            IMPORT_DIGEST_LABEL_KEY: conversation_items_digest([]),
             "kept": "yes",
         },
     )
@@ -146,45 +47,6 @@ def test_fork_drops_import_provenance_labels(
     assert fork.labels["kept"] == "yes"
     assert IMPORT_SOURCE_LABEL_KEY not in fork.labels
     assert IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY not in fork.labels
-    assert IMPORT_ITEM_COUNT_LABEL_KEY not in fork.labels
-    assert IMPORT_DIGEST_LABEL_KEY not in fork.labels
-
-
-def test_replace_imported_prefix_rejects_modified_history(
-    conversation_store: SqlAlchemyConversationStore,
-) -> None:
-    """Force fails closed when the recorded import boundary no longer matches."""
-    conversation = conversation_store.create_conversation()
-    original = NewConversationItem(
-        type="message",
-        response_id="source:turn-1",
-        data=MessageData(
-            role="user",
-            content=[{"type": "input_text", "text": "original"}],
-        ),
-    )
-    stored = conversation_store.append(conversation.id, [original])[0]
-
-    with pytest.raises(ImportedPrefixMismatchError, match="modified"):
-        conversation_store.replace_imported_prefix(
-            conversation.id,
-            [
-                NewConversationItem(
-                    type="message",
-                    response_id="source:turn-1",
-                    data=MessageData(
-                        role="user",
-                        content=[{"type": "input_text", "text": "replacement"}],
-                    ),
-                )
-            ],
-            expected_count=1,
-            expected_digest="not-the-stored-digest",
-        )
-
-    items = conversation_store.list_items(conversation.id).data
-    assert [item.id for item in items] == [stored.id]
-    assert items[0].data == original.data
 
 
 def test_create_and_get(conversation_store: SqlAlchemyConversationStore) -> None:

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -15,13 +15,176 @@ from omnigent.entities import (
     ReasoningData,
 )
 from omnigent.server.auth import RESERVED_USER_LOCAL
+from omnigent.session_import import (
+    IMPORT_DIGEST_LABEL_KEY,
+    IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
+    IMPORT_ITEM_COUNT_LABEL_KEY,
+    IMPORT_SOURCE_LABEL_KEY,
+    conversation_items_digest,
+)
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.conversation_store import ImportedPrefixMismatchError
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.host_store import HostStore
 
 # ── CRUD ──────────────────────────────────────────────
+
+
+def test_replace_imported_prefix_preserves_later_session_state(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Forced re-import replaces only source history on the same session."""
+    original = [
+        NewConversationItem(
+            type="message",
+            response_id="claude:turn-1",
+            data=MessageData(
+                role="user",
+                content=[{"type": "input_text", "text": "old prompt"}],
+            ),
+        ),
+        NewConversationItem(
+            type="message",
+            response_id="claude:turn-1",
+            data=MessageData(
+                role="assistant",
+                content=[{"type": "output_text", "text": "old answer"}],
+                agent="claude-native-ui",
+            ),
+        ),
+    ]
+    replacement = [
+        NewConversationItem(
+            type="message",
+            response_id="claude:turn-1",
+            data=MessageData(
+                role="user",
+                content=[{"type": "input_text", "text": "new prompt"}],
+            ),
+        ),
+        NewConversationItem(
+            type="message",
+            response_id="claude:turn-1",
+            data=MessageData(
+                role="assistant",
+                content=[{"type": "output_text", "text": "new answer"}],
+                agent="claude-native-ui",
+            ),
+        ),
+    ]
+    conversation = conversation_store.create_conversation(title="Kept title")
+    conversation_store.set_external_session_id(conversation.id, "claude-source-id")
+    conversation_store.append(conversation.id, original)
+    conversation_store.set_labels(
+        conversation.id,
+        {
+            IMPORT_SOURCE_LABEL_KEY: "claude",
+            IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: "claude-source-id",
+            IMPORT_ITEM_COUNT_LABEL_KEY: str(len(original)),
+            IMPORT_DIGEST_LABEL_KEY: conversation_items_digest(original),
+            "omni_project": "Kept project",
+        },
+    )
+    later = conversation_store.append(
+        conversation.id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="omnigent:turn-2",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "later prompt"}],
+                ),
+            )
+        ],
+    )[0]
+
+    conversation_store.replace_imported_prefix(
+        conversation.id,
+        replacement,
+        expected_count=len(original),
+        expected_digest=conversation_items_digest(original),
+    )
+
+    items = conversation_store.list_items(conversation.id, limit=20).data
+    assert [item.data.content[0]["text"] for item in items] == [  # type: ignore[union-attr]
+        "new prompt",
+        "new answer",
+        "later prompt",
+    ]
+    assert items[-1].id == later.id
+    reloaded = conversation_store.get_conversation(conversation.id)
+    assert reloaded is not None
+    assert reloaded.id == conversation.id
+    assert reloaded.title == "Kept title"
+    assert reloaded.external_session_id == "claude-source-id"
+    assert reloaded.labels["omni_project"] == "Kept project"
+    found = conversation_store.find_imported_conversation("claude", "claude-source-id")
+    assert found is not None and found.id == conversation.id
+
+
+def test_fork_drops_import_provenance_labels(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """An imported session's fork must not claim the same source identity."""
+    source = conversation_store.create_conversation()
+    conversation_store.set_labels(
+        source.id,
+        {
+            IMPORT_SOURCE_LABEL_KEY: "claude",
+            IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY: "source-id",
+            IMPORT_ITEM_COUNT_LABEL_KEY: "0",
+            IMPORT_DIGEST_LABEL_KEY: conversation_items_digest([]),
+            "kept": "yes",
+        },
+    )
+
+    fork = conversation_store.fork_conversation(source.id)
+
+    assert fork.labels["kept"] == "yes"
+    assert IMPORT_SOURCE_LABEL_KEY not in fork.labels
+    assert IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY not in fork.labels
+    assert IMPORT_ITEM_COUNT_LABEL_KEY not in fork.labels
+    assert IMPORT_DIGEST_LABEL_KEY not in fork.labels
+
+
+def test_replace_imported_prefix_rejects_modified_history(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Force fails closed when the recorded import boundary no longer matches."""
+    conversation = conversation_store.create_conversation()
+    original = NewConversationItem(
+        type="message",
+        response_id="source:turn-1",
+        data=MessageData(
+            role="user",
+            content=[{"type": "input_text", "text": "original"}],
+        ),
+    )
+    stored = conversation_store.append(conversation.id, [original])[0]
+
+    with pytest.raises(ImportedPrefixMismatchError, match="modified"):
+        conversation_store.replace_imported_prefix(
+            conversation.id,
+            [
+                NewConversationItem(
+                    type="message",
+                    response_id="source:turn-1",
+                    data=MessageData(
+                        role="user",
+                        content=[{"type": "input_text", "text": "replacement"}],
+                    ),
+                )
+            ],
+            expected_count=1,
+            expected_digest="not-the-stored-digest",
+        )
+
+    items = conversation_store.list_items(conversation.id).data
+    assert [item.id for item in items] == [stored.id]
+    assert items[0].data == original.data
 
 
 def test_create_and_get(conversation_store: SqlAlchemyConversationStore) -> None:

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -58,6 +58,20 @@ def test_create_and_get(conversation_store: SqlAlchemyConversationStore) -> None
     assert fetched.id == conv.id
 
 
+def test_create_with_existing_caller_supplied_id_raises(db_uri: str) -> None:
+    """A stable caller id turns a retry from another store into a typed conflict."""
+    from omnigent.stores.conversation_store import ConversationAlreadyExistsError
+
+    conversation_id = "a" * 32
+    first_store = SqlAlchemyConversationStore(db_uri)
+    second_store = SqlAlchemyConversationStore(db_uri)
+    created = first_store.create_conversation(conversation_id=conversation_id)
+
+    assert created.id == conversation_id
+    with pytest.raises(ConversationAlreadyExistsError):
+        second_store.create_conversation(conversation_id=conversation_id)
+
+
 def test_get_nonexistent(conversation_store: SqlAlchemyConversationStore) -> None:
     assert conversation_store.get_conversation("conv_none") is None
 

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -1,0 +1,310 @@
+"""Tests for importing local coding-harness sessions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from omnigent.session_import.local import (
+    load_claude_session,
+    load_codex_session,
+    load_cursor_session,
+)
+from omnigent.session_import.models import SessionImportNotFoundError
+
+
+def test_load_claude_session_normalizes_parent_transcript(tmp_path: Path) -> None:
+    """Claude parent messages and tools become ordinary Omnigent items."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {
+            "type": "user",
+            "uuid": "user-1",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": "inspect TODO.md"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "assistant-1",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_read_1",
+                        "name": "Read",
+                        "input": {"file_path": "TODO.md"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "result-1",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_read_1",
+                        "content": "contents",
+                    }
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "uuid": "assistant-2",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Done."}],
+            },
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records),
+        encoding="utf-8",
+    )
+    # A same-id sub-agent transcript must never be selected as the parent.
+    subagent = tmp_path / "projects" / "-repo" / "subagents" / f"{session_id}.jsonl"
+    subagent.parent.mkdir()
+    subagent.write_text("{}\n", encoding="utf-8")
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    assert imported.source == "claude"
+    assert imported.external_session_id == session_id
+    assert imported.workspace == "/repo"
+    assert imported.title == "inspect TODO.md"
+    assert [item.type for item in imported.items] == [
+        "message",
+        "function_call",
+        "function_call_output",
+        "message",
+    ]
+    assert imported.items[1].data.model_dump()["call_id"] == "toolu_read_1"
+    assert imported.items[3].data.model_dump()["agent"] == "claude-native-ui"
+
+
+def test_load_codex_session_normalizes_response_items(tmp_path: Path) -> None:
+    """Codex response items retain turn grouping and omit scaffolding."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    rollout = (
+        tmp_path
+        / "sessions"
+        / "2026"
+        / "07"
+        / "15"
+        / f"rollout-2026-07-15T12-00-00-{session_id}.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    records = [
+        {
+            "type": "session_meta",
+            "payload": {"id": session_id, "cwd": "/repo"},
+        },
+        {
+            "type": "turn_context",
+            "payload": {"turn_id": "turn_1", "cwd": "/repo"},
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": "internal"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "<environment_context>\n<cwd>/repo</cwd>\n</environment_context>",
+                    }
+                ],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "inspect TODO.md"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,abc"},
+                ],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "shell",
+                "arguments": '{"command":"cat TODO.md"}',
+                "call_id": "call_1",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": [
+                    {"type": "input_text", "text": "first line\n"},
+                    {"type": "input_text", "text": "second line"},
+                ],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "apply_patch",
+                "input": "*** Begin Patch",
+                "call_id": "call_2",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_2",
+                "output": [{"type": "output_text", "text": "Done!"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Done."}],
+            },
+        },
+    ]
+    rollout.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records),
+        encoding="utf-8",
+    )
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    assert imported.source == "codex"
+    assert imported.workspace == "/repo"
+    assert imported.title == "inspect TODO.md"
+    assert [item.type for item in imported.items] == [
+        "message",
+        "message",
+        "function_call",
+        "function_call_output",
+        "function_call",
+        "function_call_output",
+        "message",
+    ]
+    assert {item.response_id for item in imported.items} == {"codex:turn_1"}
+    assert imported.items[0].data.model_dump()["is_meta"] is True
+    assert imported.items[1].data.model_dump()["content"][1] == {
+        "type": "input_image",
+        "image_url": "data:image/png;base64,abc",
+    }
+    assert imported.items[2].data.model_dump() == {
+        "agent": "codex-native-ui",
+        "name": "shell",
+        "arguments": '{"command":"cat TODO.md"}',
+        "call_id": "call_1",
+    }
+    assert imported.items[3].data.model_dump() == {
+        "call_id": "call_1",
+        "output": "first line\nsecond line",
+    }
+    assert imported.items[5].data.model_dump() == {
+        "call_id": "call_2",
+        "output": "Done!",
+    }
+
+
+def test_load_cursor_session_normalizes_visible_blobs(tmp_path: Path) -> None:
+    """Cursor chat blobs become messages while internal rollups are skipped."""
+    session_id = "cursor-chat-123"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    workspace_hash = hashlib.md5(os.path.realpath(workspace).encode()).hexdigest()
+    store_path = tmp_path / "chats" / workspace_hash / session_id / "store.db"
+    store_path.parent.mkdir(parents=True)
+    with sqlite3.connect(store_path) as connection:
+        connection.execute("CREATE TABLE blobs (id TEXT, data BLOB)")
+        connection.executemany(
+            "INSERT INTO blobs (id, data) VALUES (?, ?)",
+            [
+                (
+                    "user-1",
+                    json.dumps(
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "<user_query>inspect TODO.md</user_query>",
+                                }
+                            ],
+                        }
+                    ),
+                ),
+                (
+                    "rollup",
+                    json.dumps(
+                        {
+                            "role": "user",
+                            "content": "You have 100 weighted tokens left",
+                        }
+                    ),
+                ),
+                (
+                    "assistant-1",
+                    json.dumps(
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Done."}],
+                        }
+                    ),
+                ),
+            ],
+        )
+
+    imported = load_cursor_session(session_id, cursor_home=tmp_path, workspace=workspace)
+
+    assert imported.source == "cursor"
+    assert imported.workspace == os.path.realpath(workspace)
+    assert imported.title == "inspect TODO.md"
+    assert [item.type for item in imported.items] == ["message", "message"]
+    assert imported.items[1].data.model_dump()["agent"] == "cursor-native-ui"
+
+
+def test_load_cursor_session_requires_original_workspace(tmp_path: Path) -> None:
+    """Cursor import fails instead of creating a session that cannot resume."""
+    session_id = "cursor-chat-123"
+    original_workspace = tmp_path / "original"
+    original_workspace.mkdir()
+    workspace_hash = hashlib.md5(os.path.realpath(original_workspace).encode()).hexdigest()
+    store_path = tmp_path / "chats" / workspace_hash / session_id / "store.db"
+    store_path.parent.mkdir(parents=True)
+    store_path.touch()
+    wrong_workspace = tmp_path / "other"
+    wrong_workspace.mkdir()
+
+    with pytest.raises(SessionImportNotFoundError, match="original workspace"):
+        load_cursor_session(
+            session_id,
+            cursor_home=tmp_path,
+            workspace=wrong_workspace,
+        )

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
-import os
-import sqlite3
 from pathlib import Path
 
 import pytest
@@ -13,7 +10,6 @@ import pytest
 from omnigent.session_import.local import (
     load_claude_session,
     load_codex_session,
-    load_cursor_session,
 )
 from omnigent.session_import.models import SessionImportNotFoundError
 
@@ -287,95 +283,3 @@ def test_load_codex_session_rejects_empty_history(tmp_path: Path) -> None:
 
     with pytest.raises(SessionImportNotFoundError, match="no importable history"):
         load_codex_session(session_id, codex_home=tmp_path)
-
-
-def test_load_cursor_session_normalizes_visible_blobs(tmp_path: Path) -> None:
-    """Cursor chat blobs become messages while internal rollups are skipped."""
-    session_id = "cursor-chat-123"
-    workspace = tmp_path / "repo"
-    workspace.mkdir()
-    workspace_hash = hashlib.md5(os.path.realpath(workspace).encode()).hexdigest()
-    store_path = tmp_path / "chats" / workspace_hash / session_id / "store.db"
-    store_path.parent.mkdir(parents=True)
-    with sqlite3.connect(store_path) as connection:
-        connection.execute("CREATE TABLE blobs (id TEXT, data BLOB)")
-        connection.executemany(
-            "INSERT INTO blobs (id, data) VALUES (?, ?)",
-            [
-                (
-                    "user-1",
-                    json.dumps(
-                        {
-                            "role": "user",
-                            "content": [
-                                {
-                                    "type": "text",
-                                    "text": "<user_query>inspect TODO.md</user_query>",
-                                }
-                            ],
-                        }
-                    ),
-                ),
-                (
-                    "rollup",
-                    json.dumps(
-                        {
-                            "role": "user",
-                            "content": "You have 100 weighted tokens left",
-                        }
-                    ),
-                ),
-                (
-                    "assistant-1",
-                    json.dumps(
-                        {
-                            "role": "assistant",
-                            "content": [{"type": "text", "text": "Done."}],
-                        }
-                    ),
-                ),
-            ],
-        )
-
-    imported = load_cursor_session(session_id, cursor_home=tmp_path, workspace=workspace)
-
-    assert imported.source == "cursor"
-    assert imported.workspace == os.path.realpath(workspace)
-    assert imported.title == "inspect TODO.md"
-    assert [item.type for item in imported.items] == ["message", "message"]
-    assert imported.items[1].data.model_dump()["agent"] == "cursor-native-ui"
-
-
-def test_load_cursor_session_requires_original_workspace(tmp_path: Path) -> None:
-    """Cursor import fails instead of creating a session that cannot resume."""
-    session_id = "cursor-chat-123"
-    original_workspace = tmp_path / "original"
-    original_workspace.mkdir()
-    workspace_hash = hashlib.md5(os.path.realpath(original_workspace).encode()).hexdigest()
-    store_path = tmp_path / "chats" / workspace_hash / session_id / "store.db"
-    store_path.parent.mkdir(parents=True)
-    store_path.touch()
-    wrong_workspace = tmp_path / "other"
-    wrong_workspace.mkdir()
-
-    with pytest.raises(SessionImportNotFoundError, match="original workspace"):
-        load_cursor_session(
-            session_id,
-            cursor_home=tmp_path,
-            workspace=wrong_workspace,
-        )
-
-
-def test_load_cursor_session_rejects_empty_history(tmp_path: Path) -> None:
-    """An empty Cursor store cannot create a claimed import."""
-    session_id = "cursor-chat-123"
-    workspace = tmp_path / "repo"
-    workspace.mkdir()
-    workspace_hash = hashlib.md5(os.path.realpath(workspace).encode()).hexdigest()
-    store_path = tmp_path / "chats" / workspace_hash / session_id / "store.db"
-    store_path.parent.mkdir(parents=True)
-    with sqlite3.connect(store_path) as connection:
-        connection.execute("CREATE TABLE blobs (id TEXT, data BLOB)")
-
-    with pytest.raises(SessionImportNotFoundError, match="no importable history"):
-        load_cursor_session(session_id, cursor_home=tmp_path, workspace=workspace)

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -93,6 +93,17 @@ def test_load_claude_session_normalizes_parent_transcript(tmp_path: Path) -> Non
     assert imported.items[3].data.model_dump()["agent"] == "claude-native-ui"
 
 
+def test_load_claude_session_rejects_empty_history(tmp_path: Path) -> None:
+    """An empty Claude transcript cannot create a claimed import."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.touch()
+
+    with pytest.raises(SessionImportNotFoundError, match="no importable history"):
+        load_claude_session(session_id, claude_home=tmp_path)
+
+
 def test_load_codex_session_normalizes_response_items(tmp_path: Path) -> None:
     """Codex response items retain turn grouping and omit scaffolding."""
     session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
@@ -180,7 +191,7 @@ def test_load_codex_session_normalizes_response_items(tmp_path: Path) -> None:
             "payload": {
                 "type": "custom_tool_call_output",
                 "call_id": "call_2",
-                "output": [{"type": "output_text", "text": "Done!"}],
+                "output": [{"type": "output_text", "text": ""}],
             },
         },
         {
@@ -229,8 +240,53 @@ def test_load_codex_session_normalizes_response_items(tmp_path: Path) -> None:
     }
     assert imported.items[5].data.model_dump() == {
         "call_id": "call_2",
-        "output": "Done!",
+        "output": "",
     }
+
+
+def test_load_codex_session_finds_archived_rollout(tmp_path: Path) -> None:
+    """Archived Codex sessions remain importable by their original id."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    rollout = tmp_path / "archived_sessions" / f"rollout-2026-07-15-{session_id}.jsonl"
+    rollout.parent.mkdir()
+    rollout.write_text(
+        "".join(
+            [
+                json.dumps(
+                    {"type": "session_meta", "payload": {"id": session_id, "cwd": "/repo"}}
+                ),
+                "\n",
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "archived prompt"}],
+                        },
+                    }
+                ),
+                "\n",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    assert imported.workspace == "/repo"
+    assert imported.title == "archived prompt"
+
+
+def test_load_codex_session_rejects_empty_history(tmp_path: Path) -> None:
+    """A structurally present but unreadable history must not claim an import."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    rollout = tmp_path / "sessions" / "2026" / "07" / "15" / f"rollout-x-{session_id}.jsonl"
+    rollout.parent.mkdir(parents=True)
+    rollout.write_text("not-json\n", encoding="utf-8")
+
+    with pytest.raises(SessionImportNotFoundError, match="no importable history"):
+        load_codex_session(session_id, codex_home=tmp_path)
 
 
 def test_load_cursor_session_normalizes_visible_blobs(tmp_path: Path) -> None:
@@ -308,3 +364,18 @@ def test_load_cursor_session_requires_original_workspace(tmp_path: Path) -> None
             cursor_home=tmp_path,
             workspace=wrong_workspace,
         )
+
+
+def test_load_cursor_session_rejects_empty_history(tmp_path: Path) -> None:
+    """An empty Cursor store cannot create a claimed import."""
+    session_id = "cursor-chat-123"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    workspace_hash = hashlib.md5(os.path.realpath(workspace).encode()).hexdigest()
+    store_path = tmp_path / "chats" / workspace_hash / session_id / "store.db"
+    store_path.parent.mkdir(parents=True)
+    with sqlite3.connect(store_path) as connection:
+        connection.execute("CREATE TABLE blobs (id TEXT, data BLOB)")
+
+    with pytest.raises(SessionImportNotFoundError, match="no importable history"):
+        load_cursor_session(session_id, cursor_home=tmp_path, workspace=workspace)


### PR DESCRIPTION
## Related issue

N/A

## Summary

Chats started in local coding harnesses should not become stranded history. This adds a top-level `omni import` / `omnigent import` command that turns one existing Claude Code or Codex parent session into a normal database-backed Omnigent session without adding schema columns, tables, migrations, or item types.

- Normalize visible messages, tool calls, tool results, images, and hidden Codex context into existing Omnigent conversation items.
- Bind imported sessions to their native built-in agent so they remain resumable, forkable, and shareable.
- Track source/session provenance and derive a stable conversation ID so duplicate imports are rejected across server workers.
- Import archived Codex rollouts, preserve empty typed tool outputs, and reject transcripts with no importable history.
- Rebuild a forked imported Codex chat from its stored Omnigent items when its original rollout is outside Omnigent's private Codex home.

ELI5: the command reads a local harness transcript, translates it into Omnigent's existing chat vocabulary, and saves it through the same session store used by chats created in Omnigent.

```mermaid
flowchart LR
    A["Claude Code / Codex"] --> B["Normalize existing item types"]
    B --> C["POST /v1/imports"]
    C --> D["Normal Omnigent session"]
    D --> E["Resume"]
    D --> F["Fork"]
    D --> G["Share"]
```

Scope is intentionally v0: Claude Code and Codex only, one parent session per command, no batch import, no import-and-continue shortcut, and no replacement/`--force` path. Re-importing the same source is blocked; Cursor and refreshing existing imports are deferred to follow-ups.

## Test Plan

- [x] Focused parser, CLI, and API suite after the scope change: 10 passed.
- [x] Single-DB and split-DB conversation-store suites: 199 passed before the scope-only cleanup.
- [x] Codex native fork clone and stored-item fallback regressions: 3 passed.
- [x] Real CLI-to-live-server import e2e: 1 passed.
- [x] Manual imports from this machine: real Claude Code session (2 items) and real archived Codex session (660 items).
- [x] OpenAPI drift check passed; regenerated `openapi.json`.
- [x] Ruff format/check, test-quality hooks, file-hygiene hooks, and mypy for the import modules passed.

The full default suite was also run earlier in this PR: 15,148 tests passed. Its remaining failures/errors were in unrelated environment/platform/optional-dependency suites; the affected suites were rerun independently and are green. `pre-commit run --all-files` was attempted, but the external hook bootstrap could not reach PyPI; all applicable local and file-hygiene hooks were then run directly, and the repository commit and push hooks passed.

## Demo

N/A — CLI/backend change.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage includes both transcript adapters, archived and empty-history cases, native agent binding and provenance, database-backed duplicate rejection across store instances, imported Codex fork recovery, the real CLI/server boundary, and real local Claude Code and Codex transcripts. The CLI and API reject Cursor until its current transcript format is implemented.

## Changelog

Import existing Claude Code or Codex chats with `omni import`.
