### PR TITLE
fix(web): migrate legacy pinned-session ids to bare hex

### DIFF
--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -143,7 +143,9 @@ import {
   COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY,
   computeNextActiveOverride,
   conversationDisplayLabel,
+  dedupeConversationsById,
   EXPANDED_PROJECT_SECTIONS_STORAGE_KEY,
+  migratePinnedConversationIds,
   normalizePinnedConversationIds,
   orderByPinnedSequence,
   PINNED_CONVERSATION_IDS_STORAGE_KEY,
@@ -965,7 +967,9 @@ function ConversationList({
   // me"); a pinned-then-archived session shows under Archived, not Pinned.
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
   const sections = useMemo(() => {
-    const allWithBackfill = [...allConversations, ...pinnedBackfill];
+    // Dedupe by id: the pinned-backfill can return a session already present in
+    // the paginated list, and merging both would render the row twice.
+    const allWithBackfill = dedupeConversationsById([...allConversations, ...pinnedBackfill]);
     const notArchived = allWithBackfill.filter((c) => c.archived !== true);
     // Each tab shows a disjoint slice — "mine" is the sessions the viewer owns,
     // "shared" is the ones others shared with them. The Pinned / Projects /
@@ -1329,7 +1333,7 @@ function ConversationList({
   const { fetchNextPage, isFetchingNextPage } = conversationsQuery;
   useEffect(() => {
     if (!conversationsQuery.data || hasMorePages || searchQuery) return;
-    const allLoaded = [...allConversations, ...pinnedBackfill];
+    const allLoaded = dedupeConversationsById([...allConversations, ...pinnedBackfill]);
     const normalized = normalizePinnedConversationIds(pinnedConversationIds, allLoaded);
     if (!sameStringArray(normalized, pinnedConversationIds)) {
       onPinnedConversationIdsChange(normalized);
@@ -3774,7 +3778,12 @@ function readPinnedConversationIds(): string[] {
     if (!raw) return [];
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter((value): value is string => typeof value === "string");
+    // Migrate legacy prefixed ids (``conv_<hex>``) to the bare-hex form the API
+    // returns post id-to-binary migration; the write-back effect re-persists
+    // the migrated ids, so this one-time rewrite is durable across reloads.
+    return migratePinnedConversationIds(
+      parsed.filter((value): value is string => typeof value === "string"),
+    );
   } catch {
     // Browser storage is user-editable and can contain stale/corrupt values.
     // Treat bad pin state as "no pins" instead of breaking navigation.

--- a/web/src/shell/sidebarNav.test.ts
+++ b/web/src/shell/sidebarNav.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 import type { Conversation } from "@/hooks/useConversations";
 import {
   type ActiveChatOverride,
+  bareConversationId,
   computeNextActiveOverride,
   conversationDisplayLabel,
+  dedupeConversationsById,
   filterConversations,
   getConversationIconKind,
   getConversationAgentType,
+  migratePinnedConversationIds,
   normalizePinnedConversationIds,
   orderByPinnedSequence,
   resolveSidebarDrop,
@@ -115,6 +118,55 @@ describe("pin helpers", () => {
     expect(
       normalizePinnedConversationIds(["conv_a", "missing", "conv_a", "conv_b"], conversations),
     ).toEqual(["conv_a", "conv_b"]);
+  });
+});
+
+describe("bareConversationId", () => {
+  const hex = "0123456789abcdef0123456789abcdef";
+
+  it("strips a legacy prefix down to the bare hex tail", () => {
+    expect(bareConversationId(`conv_${hex}`)).toBe(hex);
+    expect(bareConversationId(`ag_${hex}`)).toBe(hex);
+  });
+
+  it("strips dashes from a canonical uuid and lowercases", () => {
+    expect(bareConversationId("01234567-89AB-CDEF-0123-456789ABCDEF")).toBe(hex);
+  });
+
+  it("is idempotent on an already-bare id", () => {
+    expect(bareConversationId(hex)).toBe(hex);
+  });
+
+  it("leaves a non-uuid value unchanged", () => {
+    expect(bareConversationId("not-a-uuid")).toBe("not-a-uuid");
+  });
+});
+
+describe("migratePinnedConversationIds", () => {
+  const hex = "0123456789abcdef0123456789abcdef";
+
+  it("rewrites legacy prefixed pins to bare hex", () => {
+    expect(migratePinnedConversationIds([`conv_${hex}`])).toEqual([hex]);
+  });
+
+  it("collapses a legacy id and its bare twin into one, keeping order", () => {
+    const other = "fedcba9876543210fedcba9876543210";
+    expect(migratePinnedConversationIds([`conv_${other}`, `conv_${hex}`, hex])).toEqual([
+      other,
+      hex,
+    ]);
+  });
+});
+
+describe("dedupeConversationsById", () => {
+  it("keeps the first occurrence of each id", () => {
+    const first = conversation("conv_a", "list copy", new Date(2026, 4, 14, 9));
+    const dup = conversation("conv_a", "backfill copy", new Date(2026, 4, 14, 8));
+    const other = conversation("conv_b", "B", new Date(2026, 4, 14, 7));
+
+    const deduped = dedupeConversationsById([first, other, dup]);
+    expect(deduped.map((c) => c.id)).toEqual(["conv_a", "conv_b"]);
+    expect(deduped[0].title).toBe("list copy");
   });
 });
 

--- a/web/src/shell/sidebarNav.ts
+++ b/web/src/shell/sidebarNav.ts
@@ -136,6 +136,52 @@ export function togglePinnedConversationId(
   return [conversationId, ...pinnedIds];
 }
 
+// A bare 32-char lowercase-hex conversation id — the shape the API returns now
+// that ids are stored as 16-byte binary uuids (legacy prefixes dropped).
+const BARE_CONVERSATION_ID_RE = /^[0-9a-f]{32}$/i;
+
+// Reduce a possibly-legacy conversation id to the bare hex form the server now
+// emits: drop dashes and any legacy prefix (``conv_``/``ag_``/…) and keep the
+// trailing 32 hex chars, mirroring the id-to-binary DB migration's transform.
+// A value that isn't a uuid tail (hand-crafted junk) is returned unchanged.
+export function bareConversationId(id: string): string {
+  const tail = id.replace(/-/g, "").slice(-32);
+  return BARE_CONVERSATION_ID_RE.test(tail) ? tail.toLowerCase() : id;
+}
+
+// Migrate stored pin ids to the bare-hex form, dropping duplicates that collapse
+// together (a legacy ``conv_<hex>`` and its bare twin). Pins are persisted in
+// localStorage keyed by the conversation id, so ids pinned before the migration
+// still carry the old prefix. Without this, a returning user's pins no longer
+// match the ids the API returns: the pinned session loses its Pinned slot, and
+// the pinned-backfill re-fetches it under the bare id — surfacing a duplicate
+// row alongside the copy already in the loaded list.
+export function migratePinnedConversationIds(ids: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const migrated: string[] = [];
+  for (const id of ids) {
+    const bare = bareConversationId(id);
+    if (seen.has(bare)) continue;
+    seen.add(bare);
+    migrated.push(bare);
+  }
+  return migrated;
+}
+
+// Drop conversations whose id already appeared, keeping the first occurrence.
+// The pinned-backfill fetches a session by id and can return a copy that is
+// also present in the paginated list; merging both would render the row twice.
+export function dedupeConversationsById(conversations: readonly Conversation[]): Conversation[] {
+  const seen = new Set<string>();
+  const deduped: Conversation[] = [];
+  for (const conversation of conversations) {
+    if (seen.has(conversation.id)) continue;
+    seen.add(conversation.id);
+    deduped.push(conversation);
+  }
+  return deduped;
+}
+
 // Order pinned conversations by when they were pinned, not by `updated_at` —
 // a pinned session holds its slot even when a new message bumps its
 // `updated_at`. `pinnedIds` is kept most-recently-pinned-first (see


### PR DESCRIPTION
## Related issue

N/A — follow-up to the id-to-binary migration (#2228).

## Summary

Pinned sessions started showing **duplicate rows** in the sidebar after #2228 merged and apps redeployed. The cause is client-side, not the migration: pins live in browser `localStorage` (`omnigent:pinned-conversation-ids`) keyed by the conversation-id **string**. Those strings were the prefixed ids (`conv_<hex>`); the migration made the API return **bare** `<hex>`, so returning users' stored pins no longer matched the ids the UI receives.

- `pinnedSet.has(c.id)` missed (`conv_<hex>` vs bare) → the session wasn't recognized as pinned and fell into the normal list.
- The pinned-backfill treated the prefixed pin as *missing from the loaded set* and re-fetched it via `GET /v1/sessions/conv_<hex>`; the server resolves it (prefix-tolerant `uuid_to_bytes`) and returns it under its **bare** id, which was merged into the list **un-deduped** → a second copy of the same session.

Fix:
- **Migrate stored pins to bare hex on read** (`migratePinnedConversationIds` in `readPinnedConversationIds`) — mirrors the DB transform (strip dashes + legacy prefix, keep trailing 32 hex). The existing write-back effect re-persists them, so it's a durable one-time rewrite: pins match `c.id` again, the backfill stops firing spuriously, and pins reappear in the Pinned group.
- **Dedupe the merged list by id** (`dedupeConversationsById`) at both merge points — defense-in-depth so any list/backfill collision can't render a row twice again.

## Test Plan

- `npx vitest run src/shell/sidebarNav.test.ts` — 46 passed (8 new: `bareConversationId`, `migratePinnedConversationIds`, `dedupeConversationsById`).
- `npx vitest run src/shell/Sidebar` — all 10 Sidebar test files, 152 passed.
- `npx tsc --noEmit` clean; prettier clean; no new lint findings in the changed files.

## Demo

N/A (no capture tooling in this environment). Before → after, for a user with a pre-migration pin:

- **Before:** the pinned session appears twice in "Chats" and is absent from "Pinned".
- **After:** the stored `conv_<hex>` pin is rewritten to `<hex>` on load; the session appears exactly once, under "Pinned".

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Pure helpers (`migratePinnedConversationIds`, `bareConversationId`, `dedupeConversationsById`) are unit-tested directly; the existing Sidebar component suite (152 tests) exercises the pinned/backfill/normalize wiring these plug into.

## Changelog

Pinned sessions no longer show duplicate rows after upgrading — legacy pin ids are migrated to the new id format automatically.
