### PR TITLE
feat(codex-native): stream command output to web

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -388,6 +388,7 @@ class _CodexForwarderState:
     subscribed_child_threads: set[str] = field(default_factory=set)
     synced_item_keys: set[str] = field(default_factory=set)
     posted_user_turns: set[str] = field(default_factory=set)
+    posted_tool_calls: set[str] = field(default_factory=set)
     partial_text_by_turn: dict[str, list[_PartialTextBuffer]] = field(default_factory=dict)
     _anon_item_counters: dict[tuple[str, str], int] = field(default_factory=dict)
     completed_plan_text_by_turn: dict[str, str] = field(default_factory=dict)
@@ -601,6 +602,17 @@ class _CodexForwarderState:
         :returns: ``True`` when the turn's user message has been posted.
         """
         return turn_id in self.posted_user_turns
+
+    def note_tool_call_posted(self, call_id: str) -> None:
+        """Record that a command's live function-call item was posted."""
+        self.posted_tool_calls.add(call_id)
+
+    def take_posted_tool_call(self, call_id: str) -> bool:
+        """Consume a function call posted before command completion."""
+        if call_id not in self.posted_tool_calls:
+            return False
+        self.posted_tool_calls.remove(call_id)
+        return True
 
     def record_partial_text_delta(
         self,
@@ -950,10 +962,13 @@ class _DeltaChunk:
         ``"codex:thread_123:turn_123:agentMessage:item_agent"``, or
         ``None`` for generic unscoped deltas.
     :param delta: Text fragment, e.g. ``"hel"``.
+    :param tool_call_id: Codex command item id when this is a live
+        command-output chunk, otherwise ``None``.
     """
 
     message_id: str | None
     delta: str
+    tool_call_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -982,9 +997,9 @@ class _DeltaFlushStop:
 
 class _OutputTextDeltaCoalescer:
     """
-    Coalesce high-frequency Codex text deltas before posting to AP.
+    Coalesce high-frequency Codex text and command-output deltas.
 
-    Codex can emit many tiny ``item/agentMessage/delta`` notifications.
+    Codex can emit many tiny text and command-output notifications.
     Posting each one through Omnigent as an awaited HTTP request makes the
     forwarder drain behind Codex. This worker keeps event ingestion
     cheap while preserving the order of flushed text relative to
@@ -1040,6 +1055,18 @@ class _OutputTextDeltaCoalescer:
         self._ensure_worker()
         self._queue.put_nowait(_DeltaChunk(message_id=message_id, delta=delta))
 
+    async def append_tool_output(self, delta: str, *, call_id: str) -> None:
+        """Queue command output for coalesced delivery.
+
+        :param delta: Command stdout/stderr fragment, e.g. ``"collecting..."``.
+        :param call_id: Codex ``commandExecution`` item id.
+        :returns: None.
+        """
+        if not delta or not call_id:
+            return
+        self._ensure_worker()
+        self._queue.put_nowait(_DeltaChunk(message_id=None, delta=delta, tool_call_id=call_id))
+
     async def flush(self) -> None:
         """
         Flush all deltas queued before this call.
@@ -1087,7 +1114,7 @@ class _OutputTextDeltaCoalescer:
         :returns: None after a stop marker is processed.
         """
         buffer: list[str] = []
-        buffer_message_id: str | None = None
+        buffer_chunk: _DeltaChunk | None = None
         buffered_chars = 0
         flush_deadline: float | None = None
         loop = asyncio.get_running_loop()
@@ -1098,67 +1125,90 @@ class _OutputTextDeltaCoalescer:
             try:
                 item = await asyncio.wait_for(self._queue.get(), timeout=timeout)
             except TimeoutError:
-                await self._flush_buffer(buffer, message_id=buffer_message_id)
+                await self._flush_buffer(buffer, chunk=buffer_chunk)
                 buffer = []
-                buffer_message_id = None
+                buffer_chunk = None
                 buffered_chars = 0
                 flush_deadline = None
                 continue
             if isinstance(item, _DeltaChunk):
-                if buffer and item.message_id != buffer_message_id:
-                    await self._flush_buffer(buffer, message_id=buffer_message_id)
+                if (
+                    buffer
+                    and buffer_chunk is not None
+                    and (
+                        item.message_id != buffer_chunk.message_id
+                        or item.tool_call_id != buffer_chunk.tool_call_id
+                    )
+                ):
+                    await self._flush_buffer(buffer, chunk=buffer_chunk)
                     buffer = []
-                    buffer_message_id = None
+                    buffer_chunk = None
                     buffered_chars = 0
                     flush_deadline = None
                 if not buffer:
                     flush_deadline = loop.time() + self._flush_interval_seconds
-                    buffer_message_id = item.message_id
+                    buffer_chunk = item
                 buffer.append(item.delta)
                 buffered_chars += len(item.delta)
                 if "\n" in item.delta or buffered_chars >= self._flush_char_threshold:
-                    await self._flush_buffer(buffer, message_id=buffer_message_id)
+                    await self._flush_buffer(buffer, chunk=buffer_chunk)
                     buffer = []
-                    buffer_message_id = None
+                    buffer_chunk = None
                     buffered_chars = 0
                     flush_deadline = None
                 continue
             if isinstance(item, _DeltaFlushBarrier):
-                await self._flush_buffer(buffer, message_id=buffer_message_id)
+                await self._flush_buffer(buffer, chunk=buffer_chunk)
                 buffer = []
-                buffer_message_id = None
+                buffer_chunk = None
                 buffered_chars = 0
                 flush_deadline = None
                 item.done.set_result(None)
                 continue
-            await self._flush_buffer(buffer, message_id=buffer_message_id)
+            await self._flush_buffer(buffer, chunk=buffer_chunk)
             item.done.set_result(None)
             return
 
-    async def _flush_buffer(self, buffer: list[str], *, message_id: str | None) -> None:
+    async def _flush_buffer(
+        self,
+        buffer: list[str],
+        *,
+        chunk: _DeltaChunk | None,
+    ) -> None:
         """
         Post a non-empty coalesced delta buffer to AP.
 
         :param buffer: Buffered text fragments, e.g. ``["hel", "lo"]``.
-        :param message_id: Stable native message stream id for the
-            buffer, e.g. ``"codex:thread_123:turn_123:agentMessage:item"``.
+        :param chunk: First chunk in the buffer, which carries its stream ids.
         :returns: None.
         """
         if not buffer:
             return
+        assert chunk is not None
         delta = "".join(buffer)
+        if chunk.tool_call_id is not None:
+            try:
+                await _post_tool_output_delta(
+                    self._client,
+                    self._session_id,
+                    delta,
+                    call_id=chunk.tool_call_id,
+                )
+            except Exception:  # noqa: BLE001 - preserve the long-lived forwarder.
+                _logger.warning("Codex forwarder tool-output delta flush failed", exc_info=True)
+            return
         index: int | None = None
         final: bool | None = None
-        if message_id is not None:
-            index = self._next_index_by_message_id.get(message_id, 0)
-            self._next_index_by_message_id[message_id] = index + 1
+        if chunk.message_id is not None:
+            index = self._next_index_by_message_id.get(chunk.message_id, 0)
+            self._next_index_by_message_id[chunk.message_id] = index + 1
             final = False
         try:
             await _post_output_text_delta(
                 self._client,
                 self._session_id,
                 delta,
-                message_id=message_id,
+                message_id=chunk.message_id,
                 index=index,
                 final=final,
             )
@@ -2361,6 +2411,10 @@ async def _handle_event(
             # ``item/completed`` guard below remains the backstop for the
             # resume-backfill path, which replays only ``item/completed``.
             await _ensure_user_message_posted(client, route_session_id, params, forwarder_state)
+        elif isinstance(item, dict) and item.get("type") == "commandExecution":
+            call_id = await _post_tool_call_item(client, route_session_id, params, item)
+            if call_id is not None:
+                forwarder_state.note_tool_call_posted(call_id)
         return
     if method == _CODEX_SERVER_REQUEST_RESOLVED_METHOD:
         # Resolve on the session the elicitation was published on (a child
@@ -2828,7 +2882,7 @@ async def _maybe_handle_delta_event(
     forwarder_state: _CodexForwarderState | None,
 ) -> bool:
     """
-    Handle Codex streaming text/plan delta events.
+    Handle Codex streaming delta events.
 
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
@@ -2867,6 +2921,25 @@ async def _maybe_handle_delta_event(
             delta_coalescer,
             forwarder_state,
         )
+        return True
+    if method == "item/commandExecution/outputDelta":
+        if delta_coalescer is None:
+            raise RuntimeError(
+                "Codex command-output delta handling requires a text-delta coalescer"
+            )
+        call_id = _item_id_from_delta_params(params)
+        delta = params.get("delta")
+        if not isinstance(call_id, str) or not call_id:
+            _logger.warning("Codex command output delta missing item id")
+            return True
+        if not isinstance(delta, str):
+            _logger.warning("Codex command output delta missing string delta: call_id=%s", call_id)
+            return True
+        turn_id = _turn_id_from_payload(params)
+        if not _is_active_turn_delta(bridge_dir, turn_id):
+            _logger.info("Codex forwarder ignored stale command output delta: turn_id=%s", turn_id)
+            return True
+        await delta_coalescer.append_tool_output(delta, call_id=call_id)
         return True
     if method in {"item/reasoning/textDelta", "item/reasoning/summaryTextDelta"}:
         # Flush any buffered assistant text first so a reasoning delta never
@@ -4123,7 +4196,13 @@ async def _handle_completed_item(
         await _post_review_mode_marker(client, session_id, params, item)
         return
     if item_type in _TOOL_ITEM_TYPES:
-        await _post_tool_item(client, session_id, params, item)
+        await _post_tool_item(
+            client,
+            session_id,
+            params,
+            item,
+            forwarder_state=forwarder_state,
+        )
 
 
 async def _maybe_persist_interrupted_partial_text(
@@ -5046,11 +5125,46 @@ async def _post_agent_message(
     )
 
 
+async def _post_tool_call_item(
+    client: httpx.AsyncClient,
+    session_id: str,
+    params: dict[str, Any],
+    item: dict[str, Any],
+) -> str | None:
+    """Persist the function-call half of a Codex built-in tool item."""
+    tool_call = _codex_tool_call_from_item(item)
+    if tool_call is None:
+        return None
+    arguments_text = _json_string(tool_call.arguments)
+    if arguments_text is None:
+        _logger.warning(
+            "Codex tool call arguments are not JSON serializable: call_id=%s tool=%s",
+            tool_call.call_id,
+            tool_call.name,
+        )
+        return None
+    await _post_external_item(
+        client,
+        session_id,
+        item_type="function_call",
+        item_data={
+            "agent": _AGENT_NAME,
+            "name": tool_call.name,
+            "arguments": arguments_text,
+            "call_id": tool_call.call_id,
+        },
+        response_id=_response_id(params),
+    )
+    return tool_call.call_id
+
+
 async def _post_tool_item(
     client: httpx.AsyncClient,
     session_id: str,
     params: dict[str, Any],
     item: dict[str, Any],
+    *,
+    forwarder_state: _CodexForwarderState | None,
 ) -> None:
     """
     Mirror one completed Codex built-in tool call into Omnigent history.
@@ -5068,31 +5182,15 @@ async def _post_tool_item(
         ``{"type": "commandExecution", "id": "call_abc",
         "command": "/bin/zsh -lc 'pwd'", "aggregatedOutput": "/repo\n",
         "exitCode": 0}``.
+    :param forwarder_state: Optional state tracking calls posted at item start.
     :returns: None.
     """
     tool_call = _codex_tool_call_from_item(item)
     if tool_call is None:
         return
-    arguments_text = _json_string(tool_call.arguments)
-    if arguments_text is None:
-        _logger.warning(
-            "Codex tool call arguments are not JSON serializable: call_id=%s tool=%s",
-            tool_call.call_id,
-            tool_call.name,
-        )
-        return
-    await _post_external_item(
-        client,
-        session_id,
-        item_type="function_call",
-        item_data={
-            "agent": _AGENT_NAME,
-            "name": tool_call.name,
-            "arguments": arguments_text,
-            "call_id": tool_call.call_id,
-        },
-        response_id=_response_id(params),
-    )
+    if forwarder_state is None or not forwarder_state.take_posted_tool_call(tool_call.call_id):
+        if await _post_tool_call_item(client, session_id, params, item) is None:
+            return
     await _post_external_item(
         client,
         session_id,
@@ -5608,6 +5706,30 @@ async def _post_output_text_delta(
         data=data,
     )
     _log_failed_session_event_post("external_output_text_delta", response)
+
+
+async def _post_tool_output_delta(
+    client: httpx.AsyncClient,
+    session_id: str,
+    delta: str,
+    *,
+    call_id: str,
+) -> None:
+    """Publish a transient Codex command-output delta.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param session_id: Omnigent conversation id.
+    :param delta: Command stdout/stderr fragment.
+    :param call_id: Codex ``commandExecution`` item id.
+    :returns: None.
+    """
+    response = await _post_session_event(
+        client,
+        session_id,
+        event_type="external_tool_output_delta",
+        data={"call_id": call_id, "delta": delta},
+    )
+    _log_failed_session_event_post("external_tool_output_delta", response)
 
 
 async def _post_compaction_status(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -265,6 +265,7 @@ from omnigent.server.schemas import (
     SessionTodosEvent,
     SessionUsageEvent,
     SkillSummary,
+    ToolOutputDeltaEvent,
     UpdateSessionRequest,
 )
 from omnigent.session_lifecycle import (
@@ -353,6 +354,10 @@ _EXTERNAL_CONVERSATION_ITEM_TYPE: str = "external_conversation_item"
 # corresponding completed message still arrives later via
 # ``external_conversation_item``.
 _EXTERNAL_OUTPUT_TEXT_DELTA_TYPE: str = "external_output_text_delta"
+
+# Internal transient update for output produced by a terminal-observed
+# function call before its completed ``function_call_output`` item arrives.
+_EXTERNAL_TOOL_OUTPUT_DELTA_TYPE: str = "external_tool_output_delta"
 
 # Internal input used by terminal-backed integrations to publish a transient
 # reasoning (chain-of-thought) delta observed before the completed message is
@@ -899,6 +904,7 @@ _ALLOWED_EVENT_TYPES: frozenset[str] = frozenset(ITEM_TYPE_TO_DATA_CLS.keys()) |
     _EXTERNAL_ASSISTANT_MESSAGE_TYPE,
     _EXTERNAL_CONVERSATION_ITEM_TYPE,
     _EXTERNAL_OUTPUT_TEXT_DELTA_TYPE,
+    _EXTERNAL_TOOL_OUTPUT_DELTA_TYPE,
     _EXTERNAL_OUTPUT_REASONING_DELTA_TYPE,
     _EXTERNAL_SESSION_INTERRUPTED_TYPE,
     _EXTERNAL_SESSION_SUPERSEDED_TYPE,
@@ -4043,6 +4049,34 @@ def _publish_external_output_text_delta(session_id: str, body: SessionEventInput
         message_id=message_id,
         index=index,
         final=final,
+    )
+    session_stream.publish(session_id, event.model_dump(exclude_none=True))
+
+
+def _publish_external_tool_output_delta(session_id: str, body: SessionEventInput) -> None:
+    """Broadcast a terminal-observed function-call output delta.
+
+    :param session_id: Session/conversation identifier.
+    :param body: Event body containing string ``call_id`` and ``delta`` values.
+    :returns: None.
+    :raises OmnigentError: If either required value is missing or not a string.
+    """
+    call_id = body.data.get("call_id")
+    delta = body.data.get("delta")
+    if not isinstance(call_id, str) or not call_id:
+        raise OmnigentError(
+            "external_tool_output_delta requires non-empty string data.call_id",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    if not isinstance(delta, str):
+        raise OmnigentError(
+            "external_tool_output_delta requires string data.delta",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    event = ToolOutputDeltaEvent(
+        type="response.function_call_output.delta",
+        call_id=call_id,
+        delta=delta,
     )
     session_stream.publish(session_id, event.model_dump(exclude_none=True))
 
@@ -19320,6 +19354,8 @@ def create_sessions_router(
           ``response.output_text.delta`` event observed outside the
           Omnigent task runtime, without persisting an item or starting /
           steering a task.
+        - ``"external_tool_output_delta"`` publishes transient output for
+          an in-progress function call without persisting an item.
         - ``"external_output_reasoning_delta"`` publishes a transient
           ``response.reasoning_text.delta`` event (preceded by one
           ``response.reasoning.started`` when ``data.started`` is true)
@@ -19416,6 +19452,7 @@ def create_sessions_router(
             _EXTERNAL_ASSISTANT_MESSAGE_TYPE,
             _EXTERNAL_CONVERSATION_ITEM_TYPE,
             _EXTERNAL_OUTPUT_TEXT_DELTA_TYPE,
+            _EXTERNAL_TOOL_OUTPUT_DELTA_TYPE,
             _EXTERNAL_OUTPUT_REASONING_DELTA_TYPE,
             _EXTERNAL_SESSION_INTERRUPTED_TYPE,
             _EXTERNAL_SESSION_SUPERSEDED_TYPE,
@@ -19803,6 +19840,9 @@ def create_sessions_router(
             return {"queued": False, "item_id": item_id}
         if body.type == _EXTERNAL_OUTPUT_TEXT_DELTA_TYPE:
             _publish_external_output_text_delta(session_id, body)
+            return {"queued": False}
+        if body.type == _EXTERNAL_TOOL_OUTPUT_DELTA_TYPE:
+            _publish_external_tool_output_delta(session_id, body)
             return {"queued": False}
         if body.type == _EXTERNAL_OUTPUT_REASONING_DELTA_TYPE:
             _publish_external_output_reasoning_delta(session_id, body)

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -3018,6 +3018,19 @@ class OutputTextDeltaEvent(_SSEEventBase):
     final: bool | None = None
 
 
+class ToolOutputDeltaEvent(_SSEEventBase):
+    """Incremental output from an in-progress function call.
+
+    :param type: Always ``"response.function_call_output.delta"``.
+    :param call_id: Function-call correlation id.
+    :param delta: Command stdout/stderr fragment.
+    """
+
+    type: Literal["response.function_call_output.delta"]
+    call_id: str
+    delta: str
+
+
 class ReasoningStartedEvent(_SSEEventBase):
     """
     Marker emitted once when a reasoning block begins.
@@ -3949,6 +3962,7 @@ ServerStreamEvent = Annotated[
     | SessionTerminalActivityEvent
     # ── Transient (SSE-only) — incremental token deltas ────────
     | OutputTextDeltaEvent
+    | ToolOutputDeltaEvent
     | ReasoningStartedEvent
     | ReasoningTextDeltaEvent
     | ReasoningSummaryTextDeltaEvent

--- a/openapi.json
+++ b/openapi.json
@@ -3007,6 +3007,7 @@
             "response.elicitation_resolved": "#/components/schemas/ElicitationResolvedEvent",
             "response.error": "#/components/schemas/ErrorEvent",
             "response.failed": "#/components/schemas/FailedEvent",
+            "response.function_call_output.delta": "#/components/schemas/ToolOutputDeltaEvent",
             "response.heartbeat": "#/components/schemas/HeartbeatEvent",
             "response.in_progress": "#/components/schemas/InProgressEvent",
             "response.incomplete": "#/components/schemas/IncompleteEvent",
@@ -3118,6 +3119,9 @@
           },
           {
             "$ref": "#/components/schemas/OutputTextDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ToolOutputDeltaEvent"
           },
           {
             "$ref": "#/components/schemas/ReasoningStartedEvent"
@@ -5563,6 +5567,46 @@
           "kind"
         ],
         "title": "TerminalCommandData",
+        "type": "object"
+      },
+      "ToolOutputDeltaEvent": {
+        "description": "Incremental output from an in-progress function call.",
+        "properties": {
+          "call_id": {
+            "description": "Function-call correlation id.",
+            "title": "Call Id",
+            "type": "string"
+          },
+          "delta": {
+            "description": "Command stdout/stderr fragment.",
+            "title": "Delta",
+            "type": "string"
+          },
+          "sequence_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sequence Number"
+          },
+          "type": {
+            "const": "response.function_call_output.delta",
+            "description": "Always `\"response.function_call_output.delta\"`.",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "delta"
+        ],
+        "title": "ToolOutputDeltaEvent",
         "type": "object"
       },
       "TurnCancelledEvent": {

--- a/tests/e2e_ui/chat/test_working_indicator_reload.py
+++ b/tests/e2e_ui/chat/test_working_indicator_reload.py
@@ -82,6 +82,19 @@ def _seed_function_call(
     resp.raise_for_status()
 
 
+def _publish_tool_output(base_url: str, session_id: str, call_id: str, delta: str) -> None:
+    """Publish live output for an in-flight native tool call."""
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_tool_output_delta",
+            "data": {"call_id": call_id, "delta": delta},
+        },
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
 def _snapshot_active_response_id(base_url: str, session_id: str) -> str | None:
     """Return ``active_response_id`` from the session snapshot.
 
@@ -179,3 +192,39 @@ def test_running_empty_session_reload_keeps_working_indicator(
         expect(page.get_by_text("What should we work on?")).to_have_count(0)
     finally:
         _publish_status(base_url, session_id, "idle")
+
+
+def test_live_tool_output_updates_running_card(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A native command output delta appears before the command completes."""
+    base_url, session_id = seeded_session
+    response_id = "resp_live_output_1"
+    call_id = "call_live_output_1"
+
+    try:
+        page.goto(f"{base_url}/c/{session_id}")
+        expect(page.get_by_role("textbox", name="Message the agent")).to_be_visible(timeout=20_000)
+
+        _publish_status(base_url, session_id, "running", response_id=response_id)
+        expect(page.locator('[data-testid="working-indicator"]')).to_be_visible(timeout=10_000)
+        _seed_function_call(
+            base_url,
+            session_id,
+            response_id=response_id,
+            call_id=call_id,
+            name="shell",
+            arguments='{"command": "pytest -q"}',
+        )
+
+        trigger = page.locator('button[title^="shell"]').first
+        expect(trigger).to_be_visible(timeout=10_000)
+        expect(trigger.locator(".animate-spin")).to_be_visible(timeout=10_000)
+
+        _publish_tool_output(base_url, session_id, call_id, "collecting tests...")
+
+        trigger.click()
+        expect(page.get_by_text("collecting tests...", exact=True)).to_be_visible(timeout=10_000)
+    finally:
+        _publish_status(base_url, session_id, "idle", response_id=response_id)

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -3311,6 +3311,48 @@ async def test_post_external_output_text_delta_rejects_malformed_delta(
     assert published == []
 
 
+async def test_post_external_tool_output_delta_publishes_transient_delta(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Command output deltas publish without changing session history."""
+    published: list[tuple[str, dict[str, Any]]] = []
+
+    def capture_publish(session_id: str, event: dict[str, Any]) -> None:
+        published.append((session_id, event))
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        capture_publish,
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_tool_output_delta",
+            "data": {"call_id": "call_123", "delta": "collecting..."},
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"queued": False}
+    assert published == [
+        (
+            session["id"],
+            {
+                "type": "response.function_call_output.delta",
+                "call_id": "call_123",
+                "delta": "collecting...",
+            },
+        )
+    ]
+
+    snap = await client.get(f"/v1/sessions/{session['id']}")
+    assert snap.status_code == 200, snap.text
+    assert snap.json()["items"] == []
+
+
 async def test_post_external_output_reasoning_delta_started_publishes_started_then_delta(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -40,6 +40,7 @@ from omnigent.server.schemas import (
     ResponseObject,
     ServerStreamEvent,
     SessionHeartbeatEvent,
+    ToolOutputDeltaEvent,
 )
 
 # ── Round-trip serialization ──────────────────────────────────
@@ -270,6 +271,14 @@ def test_response_envelope_event_carries_real_response_object(
             {"type": "response.output_text.delta", "delta": "x"},
             OutputTextDeltaEvent,
         ),
+        (
+            {
+                "type": "response.function_call_output.delta",
+                "call_id": "call_123",
+                "delta": "x",
+            },
+            ToolOutputDeltaEvent,
+        ),
         ({"type": "response.reasoning.started"}, ReasoningStartedEvent),
         (
             {"type": "response.reasoning_text.delta", "delta": "x"},
@@ -390,6 +399,10 @@ def test_response_stream_event_rejects_unknown_type() -> None:
         # producing one of these without text means the producer is
         # broken; fail loud at parse time.
         (OutputTextDeltaEvent, {"type": "response.output_text.delta"}),
+        (
+            ToolOutputDeltaEvent,
+            {"type": "response.function_call_output.delta", "call_id": "call_123"},
+        ),
         (
             ReasoningTextDeltaEvent,
             {"type": "response.reasoning_text.delta"},

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -5435,6 +5435,117 @@ def test_forwarder_posts_codex_command_execution_tool_call() -> None:
     ]
 
 
+def test_forwarder_streams_codex_command_output_before_completed_item(tmp_path: Path) -> None:
+    """Command output deltas update the live tool before its final result."""
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id="turn_123",
+        ),
+    )
+    posted: list[dict[str, Any]] = []
+    state = codex_native_forwarder._CodexForwarderState()
+    started_item = {
+        "type": "commandExecution",
+        "id": "call_abc123",
+        "command": "pytest -q",
+        "cwd": "/repo",
+        "status": "inProgress",
+    }
+    completed_item = {
+        **started_item,
+        "status": "completed",
+        "aggregatedOutput": "collecting tests...\n1 passed\n",
+        "exitCode": 0,
+    }
+
+    async def run() -> None:
+        """Replay command start, output chunks, and completion."""
+        async with httpx.AsyncClient(
+            base_url="http://127.0.0.1:8000",
+            transport=httpx.MockTransport(_capture_handler(posted)),
+        ) as client:
+            coalescer = codex_native_forwarder._OutputTextDeltaCoalescer(
+                client,
+                "conv_123",
+                flush_interval_seconds=60.0,
+                flush_char_threshold=1000,
+            )
+            events = [
+                {
+                    "method": "item/started",
+                    "params": {
+                        "threadId": "thread_123",
+                        "turnId": "turn_123",
+                        "item": started_item,
+                    },
+                },
+                {
+                    "method": "item/commandExecution/outputDelta",
+                    "params": {
+                        "threadId": "thread_123",
+                        "turnId": "turn_123",
+                        "itemId": "call_abc123",
+                        "delta": "collecting ",
+                    },
+                },
+                {
+                    "method": "item/commandExecution/outputDelta",
+                    "params": {
+                        "threadId": "thread_123",
+                        "turnId": "turn_123",
+                        "itemId": "call_abc123",
+                        "delta": "tests...",
+                    },
+                },
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": "thread_123",
+                        "turnId": "turn_123",
+                        "item": completed_item,
+                    },
+                },
+            ]
+            for event in events:
+                await codex_native_forwarder._handle_event(
+                    client,
+                    session_id="conv_123",
+                    bridge_dir=tmp_path,
+                    usage_coalescer=_usage_coalescer(client),
+                    elicitation_tracker=_elicitation_tracker(),
+                    event=event,
+                    delta_coalescer=coalescer,
+                    forwarder_state=state,
+                )
+            await coalescer.close()
+
+    asyncio.run(run())
+
+    assert [payload["type"] for payload in posted] == [
+        "external_conversation_item",
+        "external_tool_output_delta",
+        "external_conversation_item",
+    ]
+    assert posted[0]["data"]["item_type"] == "function_call"
+    assert posted[1] == {
+        "type": "external_tool_output_delta",
+        "data": {"call_id": "call_abc123", "delta": "collecting tests..."},
+    }
+    assert posted[2]["data"] == {
+        "item_type": "function_call_output",
+        "item_data": {
+            "call_id": "call_abc123",
+            "output": "collecting tests...\n1 passed\n",
+        },
+        "response_id": "codex_turn_123",
+    }
+
+
 def test_forwarder_surfaces_failed_command_exit_code() -> None:
     """
     A non-zero command exit is surfaced in the mirrored output.

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -141,6 +141,13 @@ export interface ToolResult {
   responseId: string;
 }
 
+/** `response.function_call_output.delta` — live output from a running tool. */
+export interface ToolOutputDelta {
+  type: "tool_output_delta";
+  callId: string;
+  delta: string;
+}
+
 /**
  * A server-initiated elicitation, MCP shape.
  *
@@ -862,6 +869,7 @@ export type StreamEvent =
   | ReasoningSummaryDelta
   | ToolCall
   | ToolResult
+  | ToolOutputDelta
   | NativeToolCall
   | SlashCommand
   | RoutingDecision

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -63,6 +63,7 @@ import type {
   StreamEvent,
   TextDelta,
   ToolCall,
+  ToolOutputDelta,
   ToolResult,
 } from "./events";
 import { NATIVE_TOOL_TYPES } from "./events";
@@ -321,6 +322,12 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
     const index = typeof data.index === "number" ? data.index : undefined;
     const final = typeof data.final === "boolean" ? data.final : undefined;
     return { type: "text_delta", delta, messageId, index, final } satisfies TextDelta;
+  }
+  if (eventType === "response.function_call_output.delta") {
+    const callId = data.call_id;
+    const delta = data.delta;
+    if (typeof callId !== "string" || !callId || typeof delta !== "string") return null;
+    return { type: "tool_output_delta", callId, delta } satisfies ToolOutputDelta;
   }
 
   // Reasoning.

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -24,6 +24,7 @@ import type {
   ErrorBlock,
   NativeToolBlock,
   TextDone,
+  ToolGroup,
   UserMessageBlock,
 } from "@/lib/blocks";
 import type { ConversationItem } from "@/lib/conversationItems";
@@ -5752,6 +5753,48 @@ describe("chatStore — pumpStreamEvents frame batching", () => {
     const order = after.map(chunkText).filter((c): c is string => c !== null);
     // Exactly A,B,C in order — coalesced append preserved arrival order.
     expect(order).toEqual(["A", "B", "C"]);
+
+    controller.abort();
+  });
+
+  it("appends live command output to the running tool card", async () => {
+    useChatStore.setState({ conversationId: "conv_tool_delta", blocks: [] });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    void pumpStreamEvents("conv_tool_delta", sink.stream, controller, setState, getState);
+
+    sink.push(sse("response.created", { id: "resp_tool", status: "in_progress", output: [] }));
+    sink.push(
+      sse("response.output_item.done", {
+        item: {
+          id: "item_call",
+          type: "function_call",
+          response_id: "resp_tool",
+          call_id: "call_123",
+          name: "shell",
+          arguments: '{"command":"pytest"}',
+          status: "in_progress",
+        },
+      }),
+    );
+    sink.push(
+      sse("response.function_call_output.delta", {
+        call_id: "call_123",
+        delta: "collecting ",
+      }),
+    );
+    sink.push(
+      sse("response.function_call_output.delta", {
+        call_id: "call_123",
+        delta: "tests...",
+      }),
+    );
+    await tick();
+
+    const group = useChatStore
+      .getState()
+      .blocks.find((b): b is ToolGroup => b.type === "tool_group");
+    expect(group?.executions[0]?.output).toBe("collecting tests...");
 
     controller.abort();
   });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -50,6 +50,7 @@ import type {
   ErrorBlock,
   MessageContentBlock,
   TextDone,
+  ToolGroup,
   UserMessageBlock,
 } from "@/lib/blocks";
 import { BlockStream } from "@/lib/blockStream";
@@ -3363,6 +3364,26 @@ function applyLiveDelta(
   });
 }
 
+/** Append live output to the matching in-progress tool execution. */
+function applyLiveToolOutputDelta(set: Setter, callId: string, delta: string): void {
+  set((s) => {
+    const at = s.blocks.findIndex(
+      (b): b is ToolGroup =>
+        b.type === "tool_group" && b.executions.some((execution) => execution.callId === callId),
+    );
+    if (at === -1) return {};
+    const group = s.blocks[at] as ToolGroup;
+    const executions = group.executions.map((execution) =>
+      execution.callId === callId
+        ? { ...execution, output: (execution.output ?? "") + delta }
+        : execution,
+    );
+    const next = s.blocks.slice();
+    next[at] = { ...group, executions };
+    return { blocks: next };
+  });
+}
+
 /**
  * Wrap a parsed event stream, diverting terminal-observed live deltas.
  *
@@ -3405,6 +3426,10 @@ async function* tapLiveDeltas(
       if (get().conversationId === id && !retired.has(ev.messageId)) {
         applyLiveDelta(set, ev.messageId, ev.index ?? 0, ev.delta, lastIndex);
       }
+      continue;
+    }
+    if (ev.type === "tool_output_delta") {
+      if (get().conversationId === id) applyLiveToolOutputDelta(set, ev.callId, ev.delta);
       continue;
     }
     yield ev;


### PR DESCRIPTION
## Related issue

Closes #1257

## Summary

- Forward Codex `item/commandExecution/outputDelta` notifications through a transient, typed session event.
- Append coalesced output to the matching running tool card while keeping the completed `function_call_output` authoritative.

ELI5: long-running commands now show what they are printing instead of appearing frozen until they finish.

```text
Codex outputDelta -> forwarder coalescer -> session SSE -> running tool card
```

## Test Plan

- `uv run pytest -q tests/test_codex_native.py tests/server/test_schemas.py` (270 passed)
- `uv run pytest -q tests/server/integration/test_sessions_endpoints.py::test_post_external_tool_output_delta_publishes_transient_delta`
- `npm test` (4,091 passed)
- `npm run type-check`
- `npm run build`
- `uv run pytest -q tests/e2e_ui/chat/test_working_indicator_reload.py::test_live_tool_output_updates_running_card --browser chromium`
- `uv run pre-commit run --all-files`
- Changed frontend files pass Oxlint; repository-wide `npm run lint` still reports unrelated pre-existing errors.

## Demo

<img width="1280" height="720" alt="Live command output demo" src="https://github.com/user-attachments/assets/793544a8-abbb-4afb-8e81-1feb21be94a3" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Covers command start, coalesced output deltas, final result persistence, transient server publication, and browser rendering before command completion.

## Changelog

Long-running Codex commands now stream their output into the web tool card while they run.
