### PR TITLE
ci(homebrew): auto-PR the homebrew-tap formula on release

### DIFF
--- a/.github/scripts/homebrew/generate_formula.py
+++ b/.github/scripts/homebrew/generate_formula.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Generate the `omnigent` Homebrew formula for a released PyPI version.
+
+Splices the volatile parts of `Formula/omnigent.rb` — the stable `url`/`sha256`
+and every dependency `resource` stanza — into the hand-tuned template
+(`omnigent.rb.template`). The structural parts (desc, depends_on, install, test)
+are owned by the template; this script owns the bits that change every release.
+
+Resolution: `uv pip compile` computes the exact transitive closure of
+`omnigent[<extras>]==<version>` for each target platform (macOS arm + intel by
+default — the brew tap's `brew test-bot` matrix). The per-platform closures are
+unioned; for each package we then fetch the sdist URL + sha256 from the PyPI JSON
+API and emit a `resource` stanza. Packages with no sdist (e.g. `cel-expr-python`,
+which is Bazel-built and has no PyPI sdist) are skipped — omnigent degrades
+gracefully without them, matching the hand-tuned formula.
+
+Excluded from `resource` generation (provided by the brewed Python environment,
+NOT built as virtualenv resources — keep in sync with the template's
+`depends_on ... => :no_linkage` and the brewed packages' transitive build deps
+like cffi/pycparser, which need libffi that this formula doesn't depend on):
+``omnigent`` (the stable url itself) and ``certifi, cryptography, pydantic,
+pydantic-core, rpds-py, cffi, pycparser``.
+
+Run by `.github/workflows/homebrew-tap-pr.yml` on `release: published`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Default brew build matrix: macOS Apple Silicon + Intel (the tap's
+# `brew test-bot` runs on macos-15 / macos-15-intel / macos-26). The union of the
+# two closures captures platform-marker deps needed on either arch. Add
+# `x86_64-unknown-linux-gnu` here if the tap re-enables Linux builds.
+DEFAULT_PLATFORMS = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
+# Extras bundled as resources. The base install already pulls the Claude and
+# OpenAI Agents harnesses; this adds the opt-in `cursor` harness (pure-Python
+# sdist). antigravity is NOT bundled — no sdist (platform wheels only), no
+# Intel-macOS build; `pip install omnigent[antigravity]` instead.
+DEFAULT_EXTRAS = ["cursor"]
+# Resolve for the brewed Python so `requires-python` markers match the formula's
+# `python@3.14` (and the `virtualenv_create(libexec, "python3.14")` in install).
+DEFAULT_PYTHON_VERSION = "3.14"
+DEFAULT_INDEX_URL = "https://pypi.org/simple"
+PYPI_JSON_API = "https://pypi.org/pypi"
+
+# Packages provided by the brewed Python environment (system site-packages),
+# not built as virtualenv resources. `cffi`/`pycparser` are listed because cffi
+# builds against libffi (not a dep of this formula) — they come from the brewed
+# `cryptography`/`cffi` formulae instead. See module docstring.
+BREWED_EXCLUSIONS = {
+    "certifi",
+    "cryptography",
+    "pydantic",
+    "pydantic-core",
+    "rpds-py",
+    "cffi",
+    "pycparser",
+}
+# omnigent is the stable `url` itself, so it's never a resource.
+SELF_EXCLUSIONS = {"omnigent"}
+
+_PLACEHOLDERS = (
+    "__OMNIGENT_URL__",
+    "__OMNIGENT_SHA256__",
+    "__RESOURCES__",
+)
+
+
+def normalize_name(name: str) -> str:
+    """PEP 503 normalized project name (lowercase, runs of [-_.] -> -)."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _http_get_json(url: str, retries: int = 5, timeout: int = 30) -> dict:
+    """GET a JSON document with simple retry/backoff."""
+    last_err: Exception | None = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, headers={"Accept": "application/json"})
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.load(resp)
+        except urllib.error.HTTPError as e:
+            last_err = e
+            # 404 is a hard "not on PyPI" — don't retry into a 5-minute wait.
+            if e.code == 404:
+                raise
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
+            last_err = e
+        time.sleep(2**attempt)
+    raise RuntimeError(f"fetch failed for {url}: {last_err}")
+
+
+def pypi_release_files(name: str, version: str, api_base: str = PYPI_JSON_API) -> list[dict]:
+    """Return the `urls` list for a (name, version) release from the PyPI JSON API.
+
+    `api_base` defaults to the public PyPI JSON API; point it at a mirror's
+    `/pypi` (via `--pypi-api` / `--proxy`) to fetch sdist URLs + sha256 through
+    a proxy. Download URLs fetched from a mirror are then host-rewritten to
+    `files.pythonhosted.org` (see `rewrite_url`) so the formula pins public URLs.
+    """
+    data = _http_get_json(f"{api_base}/{normalize_name(name)}/{version}/json")
+    return data.get("urls", [])
+
+
+def pick_sdist(files: list[dict]) -> tuple[str, str] | None:
+    """Pick the sdist (url, sha256). Prefer .tar.gz; take the only sdist if one."""
+    sdists = [f for f in files if f.get("packagetype") == "sdist"]
+    if not sdists:
+        return None
+    for f in sdists:
+        if f["url"].endswith(".tar.gz"):
+            return f["url"], f["digests"]["sha256"]
+    f = sdists[0]
+    return f["url"], f["digests"]["sha256"]
+
+
+def rewrite_url(url: str, rewrites: list[tuple[str, str]]) -> str:
+    """Apply `from -> to` substitutions to a download URL, in order.
+
+    Used to turn an internal PyPI proxy's download URLs back into public
+    `files.pythonhosted.org` URLs so the formula pins installable public URLs
+    even when resolution + metadata fetch went through the proxy (the proxy
+    mirrors PyPI's `/packages/<2>/<2>/<hash>/file` path verbatim, only the host
+    differs; the sha256 is the file's content hash, so it's valid for the public
+    URL too).
+    """
+    for old, new in rewrites:
+        url = url.replace(old, new)
+    return url
+
+
+def resource_stanza(name: str, url: str, sha256: str, indent: int = 2) -> str:
+    """A `resource "<name>" do … end` stanza, class-body indented."""
+    pad = " " * indent
+    return f'{pad}resource "{name}" do\n{pad}  url "{url}"\n{pad}  sha256 "{sha256}"\n{pad}end'
+
+
+def resolve_closure(
+    version: str,
+    platforms: list[str],
+    extras: list[str],
+    python_version: str,
+    index_url: str,
+    uv: str,
+) -> dict[str, str]:
+    """Union of `uv pip compile` resolutions per platform -> {name: version}.
+
+    Runs `uv pip compile` with `--no-config` (ignore the repo's uv.toml cooldown,
+    which would block the just-released version) against the public index. If a
+    package resolves to different versions across platforms, the highest PEP 440
+    version wins and a warning is printed (rare for sdists).
+    """
+    extras_spec = f"[{','.join(extras)}]" if extras else ""
+    requirement = f"omnigent{extras_spec}=={version}"
+    closure: dict[str, str] = {}
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        (tmp / "req.in").write_text(requirement + "\n")
+        for plat in platforms:
+            out = tmp / f"req.{plat.replace('-', '_')}.out"
+            cmd = [
+                uv,
+                "pip",
+                "compile",
+                "--no-config",
+                "--no-header",
+                "--no-annotate",
+                "--python-version",
+                python_version,
+                "--python-platform",
+                plat,
+                "--default-index",
+                index_url,
+                str(tmp / "req.in"),
+                "-o",
+                str(out),
+            ]
+            # Surface uv's output on failure instead of swallowing it — a
+            # resolution failure (version conflict, a dep with no Python 3.14
+            # distribution, a requires-python cap, or no network to PyPI) is
+            # otherwise undebuggable. Raise a RuntimeError (one clean line) rather
+            # than letting CalledProcessError dump the full subprocess traceback.
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            if proc.returncode != 0:
+                detail = (proc.stderr or proc.stdout or "(no output)").strip()
+                raise RuntimeError(
+                    f"`uv pip compile` failed for {plat} (python {python_version}); "
+                    f"requirement: {requirement}\n{detail}"
+                )
+            for line in out.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or "==" not in line:
+                    continue
+                name, ver = line.split("==", 1)
+                # uv strips extras and markers by default, but defend against
+                # `name[extra]==ver` (take the bare name before '[') and against
+                # a trailing ` ; marker` on the version.
+                name = name.split("[", 1)[0].strip()
+                name = normalize_name(name)
+                ver = ver.split(";", 1)[0].strip()
+                if name in closure and closure[name] != ver:
+                    kept = max(closure[name], ver, key=_pep440_key)
+                    print(
+                        f"::warning::{name} resolved to {closure[name]} on one "
+                        f"platform and {ver} on {plat}; keeping {kept}.",
+                        file=sys.stderr,
+                    )
+                    ver = kept
+                closure[name] = ver
+    return closure
+
+
+def _pep440_key(version: str):
+    """A best-effort PEP 440 sort key for picking the max of two versions."""
+    nums = re.findall(r"\d+", version)
+    return tuple(int(n) for n in nums)
+
+
+def render_template(template: str, url: str, sha256: str, resources: str) -> str:
+    # Catch a drifted template up front: every placeholder must be present before
+    # we substitute, and none must remain after (the latter is belt-and-suspenders
+    # since str.replace removes all occurrences, but it guards against a future
+    # placeholder that contains regex-special chars or partial overlaps).
+    missing = [p for p in _PLACEHOLDERS if p not in template]
+    if missing:
+        raise RuntimeError(f"template missing placeholder(s): {missing}")
+    out = template
+    out = out.replace("__OMNIGENT_URL__", url)
+    out = out.replace("__OMNIGENT_SHA256__", sha256)
+    out = out.replace("__RESOURCES__", resources)
+    leftover = [p for p in _PLACEHOLDERS if p in out]
+    if leftover:
+        raise RuntimeError(f"template placeholders left unsubstituted: {leftover}")
+    return out
+
+
+def generate(
+    version: str,
+    template_path: Path,
+    platforms: list[str],
+    extras: list[str],
+    python_version: str,
+    index_url: str,
+    uv: str,
+    exclude: set[str],
+    api_base: str = PYPI_JSON_API,
+    url_rewrites: list[tuple[str, str]] | None = None,
+) -> str:
+    template = template_path.read_text()
+
+    # Defensive: accept a leading `v` even though the workflow strips it.
+    if version.startswith("v"):
+        version = version[1:]
+
+    extras_spec = f"[{','.join(extras)}]" if extras else ""
+    print(
+        f"Resolving omnigent{extras_spec}=={version} for {', '.join(platforms)} "
+        f"(python {python_version})…",
+        file=sys.stderr,
+    )
+    closure = resolve_closure(version, platforms, extras, python_version, index_url, uv)
+    print(f"Resolved {len(closure)} packages.", file=sys.stderr)
+
+    rewrites = url_rewrites or []
+    if rewrites:
+        print(f"URL rewrites: {rewrites}", file=sys.stderr)
+
+    # Stable sdist for omnigent itself.
+    omnigent_files = pypi_release_files("omnigent", version, api_base)
+    sdist = pick_sdist(omnigent_files)
+    if not sdist:
+        raise RuntimeError(
+            f"omnigent=={version} has no sdist on PyPI — cannot set the stable url."
+        )
+    stable_url, stable_sha = sdist
+    stable_url = rewrite_url(stable_url, rewrites)
+    print(f"omnigent {version}: {stable_url}", file=sys.stderr)
+
+    # Every resolved package (other than omnigent itself and the brewed set) ->
+    # a sdist resource stanza. `exclude` is the caller-supplied set (CLI --exclude);
+    # it augments the built-in brewed set and the always-excluded self package.
+    excluded = BREWED_EXCLUSIONS | exclude | SELF_EXCLUSIONS
+    resources: list[tuple[str, str, str]] = []
+    for name, ver in sorted(closure.items()):
+        if name in excluded:
+            continue
+        files = pypi_release_files(name, ver, api_base)
+        sdist = pick_sdist(files)
+        if not sdist:
+            # No sdist (e.g. cel-expr-python, Bazel-built) — skip. omnigent
+            # degrades gracefully without it, matching the hand-tuned formula.
+            print(
+                f"::warning::{name}=={ver} has no sdist on PyPI — skipping (no resource).",
+                file=sys.stderr,
+            )
+            continue
+        resources.append((name, rewrite_url(sdist[0], rewrites), sdist[1]))
+
+    # No trailing newline: the template's blank lines frame the resource block.
+    resources_str = "\n".join(resource_stanza(n, u, s) for n, u, s in resources)
+
+    return render_template(template, stable_url, stable_sha, resources_str)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--version", required=True, help="Released version (e.g. 0.3.0), no leading 'v'."
+    )
+    ap.add_argument(
+        "--template",
+        type=Path,
+        default=Path(__file__).with_name("omnigent.rb.template"),
+        help="Path to the formula template.",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=Path("Formula/omnigent.rb"),
+        help="Where to write the rendered formula.",
+    )
+    ap.add_argument(
+        "--python-platform",
+        action="append",
+        default=None,
+        help="uv target platform (repeatable). Default: macOS arm + intel.",
+    )
+    ap.add_argument(
+        "--extra",
+        action="append",
+        default=None,
+        help="Extras to bundle (repeatable). Default: cursor.",
+    )
+    ap.add_argument(
+        "--python-version",
+        default=DEFAULT_PYTHON_VERSION,
+        help=f"uv --python-version (default {DEFAULT_PYTHON_VERSION}).",
+    )
+    ap.add_argument(
+        "--index-url",
+        default=None,
+        help="PyPI simple index URL for `uv pip compile` (default https://pypi.org/simple; "
+        "--proxy presets this).",
+    )
+    ap.add_argument(
+        "--pypi-api",
+        default=None,
+        help="PyPI JSON API base for sdist URL/sha256 fetch (default https://pypi.org/pypi; "
+        "--proxy presets this).",
+    )
+    ap.add_argument(
+        "--url-rewrite",
+        nargs=2,
+        action="append",
+        default=None,
+        metavar=("FROM", "TO"),
+        help="Rewrite FROM->TO in download URLs (repeatable). For proxy mirrors: "
+        "rewrites the mirror host back to files.pythonhosted.org.",
+    )
+    ap.add_argument(
+        "--proxy",
+        default=None,
+        metavar="HOST",
+        help="Convenience preset for an internal PyPI mirror host (e.g. "
+        "pypi-proxy.cloud.databricks.com): sets --index-url to https://HOST/simple, "
+        "--pypi-api to https://HOST/pypi, and rewrites HOST -> files.pythonhosted.org "
+        "in download URLs. Explicit --index-url/--pypi-api/--url-rewrite override.",
+    )
+    ap.add_argument(
+        "--exclude",
+        action="append",
+        default=None,
+        help="Package name to exclude from resources (repeatable; "
+        "added to the built-in brewed set).",
+    )
+    ap.add_argument("--uv", default="uv", help="uv binary path.")
+    args = ap.parse_args(argv)
+
+    # --proxy HOST presets the index, the JSON API, and a host rewrite so a
+    # local run behind an internal mirror produces a formula with public
+    # files.pythonhosted.org URLs (the mirror serves the same /packages/<..>/
+    # path, only the host differs). Explicit flags override the preset.
+    proxy = args.proxy
+    index_url = args.index_url or (f"https://{proxy}/simple" if proxy else DEFAULT_INDEX_URL)
+    api_base = args.pypi_api or (f"https://{proxy}/pypi" if proxy else PYPI_JSON_API)
+    url_rewrites = [tuple(r) for r in (args.url_rewrite or [])]
+    if proxy and (proxy, "files.pythonhosted.org") not in url_rewrites:
+        url_rewrites.insert(0, (proxy, "files.pythonhosted.org"))
+
+    formula = generate(
+        version=args.version,
+        template_path=args.template,
+        platforms=args.python_platform or DEFAULT_PLATFORMS,
+        extras=args.extra or DEFAULT_EXTRAS,
+        python_version=args.python_version,
+        index_url=index_url,
+        uv=args.uv,
+        exclude={normalize_name(n) for n in (args.exclude or [])},
+        api_base=api_base,
+        url_rewrites=url_rewrites,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(formula)
+    print(f"Wrote {args.out} ({len(formula)} bytes).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/homebrew/omnigent.rb.template
+++ b/.github/scripts/homebrew/omnigent.rb.template
@@ -1,0 +1,83 @@
+# Homebrew formula TEMPLATE for the Omnigent CLI (`omnigent` / `omni`).
+#
+# The volatile parts of this formula are regenerated on every release by
+# `generate_formula.py` (run from `.github/workflows/homebrew-tap-pr.yml`) and
+# spliced into this file via three placeholders that live ONLY in the class body
+# below — keep them out of this comment or the splicer will mangle it:
+#   * the stable `url` / `sha256` lines  -> the released omnigent sdist on PyPI
+#   * the per-dependency `resource` stanzas (one per PyPI sdist in the closure)
+#
+# Edit the hand-tuned STRUCTURAL parts here (desc, depends_on, install, test).
+# Edit the dependency set in omnigent-ai/omnigent's `pyproject.toml`
+# (`[project.dependencies]` and the bundled `cursor` extra).
+# When you change the brewed `depends_on ... => :no_linkage` set, also update the
+# `BREWED_EXCLUSIONS` in `generate_formula.py` so those packages are emitted as
+# resources (or not) to match.
+#
+# `bottle do … end` and `revision` are deliberately NOT here: Homebrew's
+# `brew pr-pull` adds the bottle block after `brew test-bot` builds it, and
+# bumps `revision` on each rebuild. A new version starts at revision 0
+# (omitted).
+class Omnigent < Formula
+  include Language::Python::Virtualenv
+
+  desc "Meta-harness for AI agents"
+  homepage "https://github.com/omnigent-ai/omnigent"
+  url "__OMNIGENT_URL__"
+  sha256 "__OMNIGENT_SHA256__"
+  license "Apache-2.0"
+
+  # The Rust toolchain builds jiter and watchfiles from source.
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  # certifi, cryptography, pydantic (which bundles pydantic-core), and rpds-py
+  # are provided by Homebrew formulae rather than built as virtualenv resources.
+  # The compiled ones would otherwise need a Rust/C build, and their transitive
+  # deps (cffi, pycparser) come along for free. The virtualenv is created with
+  # system site-packages, so it imports them from the brewed python. :no_linkage
+  # because they are Python imports, not libraries this formula links against.
+  depends_on "certifi" => :no_linkage
+  depends_on "cryptography" => :no_linkage
+  depends_on "libyaml"
+  depends_on "pydantic" => :no_linkage
+  depends_on "python@3.14"
+  depends_on "rpds-py" => :no_linkage
+  depends_on "tmux"
+
+__RESOURCES__
+
+  def install
+    venv = virtualenv_create(libexec, "python3.14")
+
+    # The Rust extensions (jiter, watchfiles) must leave Mach-O header padding so
+    # Homebrew can rewrite their install names to the Cellar path during
+    # relocation (macOS only; the flag breaks Linux ld).
+    ENV.append_to_rustflags "-C link-args=-Wl,-headerpad_max_install_names" if OS.mac?
+
+    # argon2-cffi-bindings' sdist ships an unprocessed .git_archival.txt that the
+    # (build-isolated, latest) setuptools-scm parses instead of falling back to
+    # PKG-INFO, so version detection fails. Pin the version it should report.
+    ENV["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ARGON2_CFFI_BINDINGS"] =
+      resource("argon2-cffi-bindings").version.to_s
+
+    venv.pip_install resources
+
+    venv.pip_install_and_link buildpath
+
+    bin.install_symlink libexec/"bin/omnigent", libexec/"bin/omni"
+
+    %w[omnigent omni].each do |cmd|
+      generate_completions_from_executable(libexec/"bin/#{cmd}",
+                                           base_name: cmd, shell_parameter_format: :click)
+    end
+  end
+
+  test do
+    system bin/"omnigent", "--help"
+
+    # certifi, cryptography, pydantic (with pydantic-core), and rpds-py are
+    # provided by Homebrew formulae and imported from the brewed python through
+    # the virtualenv's system site-packages; confirm they resolve in the venv.
+    system libexec/"bin/python", "-c", "import certifi, cryptography, pydantic, rpds"
+  end
+end

--- a/.github/workflows/homebrew-tap-pr.yml
+++ b/.github/workflows/homebrew-tap-pr.yml
@@ -1,0 +1,200 @@
+name: Homebrew tap PR
+
+# When a final GitHub Release is PUBLISHED, open a PR to
+# omnigent-ai/homebrew-tap bumping the `omnigent` formula to the released
+# version. The PR regenerates the stable `url`/`sha256` and every dependency
+# `resource` stanza from the PyPI dependency tree of the just-published
+# `omnigent==X.Y.Z` (resolved with `uv pip compile` for the tap's macOS
+# arm/intel build matrix), splices them into the hand-tuned template at
+# `.github/scripts/homebrew/omnigent.rb.template`, and pushes a branch for
+# review. The tap's own `brew test-bot` then builds the bottles; a maintainer
+# labels the PR `pr-pull` so the tap's `brew pr-pull` workflow commits the
+# `bottle do` block and merges (see the tap's `.github/workflows/`).
+#
+# We trigger on `release: published` (not the tag push) for the same reason as
+# publish-changelog.yml: that's the moment the version is installable from PyPI
+# — the secure-release repo publishes to PyPI before the GitHub Release goes
+# public (see RELEASING.md), so the sdist we pin the formula to actually exists.
+#
+# Cross-repo writes can't use the workflow's own GITHUB_TOKEN (scoped to this
+# repo), so we mint a short-lived token from the omnigent-ci GitHub App scoped to
+# homebrew-tap — the same App used by publish-changelog.yml / doc-sync.yml. One
+# prerequisite: the omnigent-ci App must be installed on omnigent-ai/homebrew-tap
+# with contents:write + pull-requests:write.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Final release tag to (re)open the tap PR for, e.g. v0.3.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# Serialize per tag so two triggers can't race the same formula PR.
+concurrency:
+  group: homebrew-tap-pr-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.r.outputs.tag }}
+      version: ${{ steps.r.outputs.version }}
+      is_final: ${{ steps.r.outputs.is_final }}
+    steps:
+      - name: Resolve tag, version, and finality
+        id: r
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG:-$EVENT_TAG}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          is_final=true
+          # Only final vX.Y.Z tags; exclude rc/dev/alpha/beta and the event's
+          # prerelease flag (homebrew users get stable releases from the tap).
+          case "$tag" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) is_final=false ;;
+          esac
+          case "$tag" in
+            *rc*|*dev*|*a[0-9]*|*b[0-9]*) is_final=false ;;
+          esac
+          if [ "${PRERELEASE}" = "true" ]; then is_final=false; fi
+          echo "is_final=${is_final}" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=${tag} is_final=${is_final}" | tee -a "$GITHUB_STEP_SUMMARY"
+
+  pr:
+    name: Open homebrew-tap formula PR
+    needs: resolve
+    runs-on: ubuntu-latest
+    # Canonical repo only — forks/mirrors have no PyPI release or the App token.
+    if: needs.resolve.outputs.is_final == 'true' && github.repository == 'omnigent-ai/omnigent'
+    env:
+      TAG: ${{ needs.resolve.outputs.tag }}
+      VERSION: ${{ needs.resolve.outputs.version }}
+      TAP_REPO: ${{ github.repository_owner }}/homebrew-tap
+      BRANCH: auto/formula/${{ needs.resolve.outputs.tag }}
+    steps:
+      - name: Checkout omnigent (template + generator)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+
+      - name: Wait for the released sdist to land on PyPI
+        # The GitHub Release is published after the prod PyPI publish, but the
+        # secure-release publish can lag a few minutes; poll so a slightly-early
+        # release (or a rerun right at publish time) doesn't fail the whole job.
+        run: |
+          set -euo pipefail
+          python3 - "$VERSION" <<'PY'
+          import json, sys, time, urllib.request
+          ver = sys.argv[1]
+          url = f"https://pypi.org/pypi/omnigent/{ver}/json"
+          deadline = time.time() + 15 * 60
+          while time.time() < deadline:
+              try:
+                  with urllib.request.urlopen(url, timeout=20) as r:
+                      data = json.load(r)
+                  if any(f.get("packagetype") == "sdist" for f in data.get("urls", [])):
+                      print(f"omnigent=={ver} sdist is on PyPI.")
+                      sys.exit(0)
+              except Exception as e:
+                  print(f"waiting for {url}: {e}")
+              time.sleep(30)
+          print(f"::error::omnigent=={ver} sdist not found on PyPI after 15m")
+          sys.exit(1)
+          PY
+
+      - name: Generate the formula
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/homebrew/generate_formula.py \
+            --version "$VERSION" \
+            --template .github/scripts/homebrew/omnigent.rb.template \
+            --out /tmp/omnigent.rb
+          {
+            echo "### Generated \`Formula/omnigent.rb\` for $TAG"
+            echo '```ruby'
+            cat /tmp/omnigent.rb
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mint homebrew-tap App token
+        id: app-token
+        if: vars.OMNIGENT_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
+          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: homebrew-tap
+
+      - name: Checkout homebrew-tap (PR target)
+        if: steps.app-token.outputs.token != ''
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ env.TAP_REPO }}
+          token: ${{ steps.app-token.outputs.token }}
+          path: tap
+
+      - name: Open or update the formula PR
+        if: steps.app-token.outputs.token != ''
+        working-directory: tap
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p Formula
+          cp /tmp/omnigent.rb Formula/omnigent.rb
+
+          if [ -z "$(git status --porcelain -- Formula/omnigent.rb)" ]; then
+            echo "Formula already at $TAG — nothing to do." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git config user.name "omnigent-ci[bot]"
+          git config user.email "294685417+omnigent-ci[bot]@users.noreply.github.com"
+          git switch -C "$BRANCH"
+          git add Formula/omnigent.rb
+          git commit -m "omnigent $VERSION"
+          git push --force origin "$BRANCH"
+
+          if [ -n "$(gh pr list --repo "$TAP_REPO" --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            echo "Formula PR already open for $BRANCH — force-push updated it." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          body="$(printf 'Bumps the **omnigent** formula to **%s**.\n\nRegenerates the stable `url`/`sha256` and every `resource` stanza from the PyPI dependency tree of `omnigent==%s` (resolved with `uv pip compile` for macOS arm + intel), spliced into the hand-tuned template in `omnigent-ai/omnigent` (`.github/scripts/homebrew/omnigent.rb.template`). The structural parts (`depends_on`, `install`, `test`) are unchanged.\n\nOnce `brew test-bot` builds the bottles, label this PR **`pr-pull`** so the tap'"'"'s `brew pr-pull` workflow commits the `bottle do` block and merges.\n\nGenerated by `omnigent-ai/omnigent` `.github/workflows/homebrew-tap-pr.yml` on the **%s** release.' "$VERSION" "$VERSION" "$TAG")"
+          gh pr create \
+            --repo "$TAP_REPO" \
+            --base main \
+            --head "$BRANCH" \
+            --title "omnigent $VERSION" \
+            --body "$body"
+
+      - name: Note skipped (no App token)
+        if: steps.app-token.outputs.token == ''
+        run: |
+          echo "::warning::OMNIGENT_BOT_APP_ID/KEY missing, or the omnigent-ci App isn't installed on $TAP_REPO with contents:write + pull-requests:write. The formula was generated (see the job summary) but the PR was not opened."
+          echo "### Homebrew tap PR skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "The omnigent-ci App token couldn't be minted — install the App on \`$TAP_REPO\` with contents:write + pull-requests:write and rerun." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/homebrew-tap-pr.yml
+++ b/.github/workflows/homebrew-tap-pr.yml
@@ -31,30 +31,13 @@ on:
         description: Final release tag to (re)open the tap PR for, e.g. v0.3.0
         required: true
         type: string
-  # Iterate on a branch without merging. `pull_request` runs the workflow
-  # definition from the PR head, so the branch's version is what runs. Two
-  # modes:
-  #   - opened/synchronize/reopened (paths-filtered to the homebrew files):
-  #     the `validate` dry-run regenerates the formula against the latest final
-  #     release on public PyPI and uploads it as an artifact — no cross-repo
-  #     PR. Mirrors the CI-test-on-PR pattern in release-omnigent.yml.
-  #   - labeled with `homebrew-test` (NOT paths-filtered): a maintainer opts in
-  #     to opening a REAL PR on omnigent-ai/homebrew-tap so the tap's
-  #     `brew test-bot` builds the bottles. Deliberate, so it doesn't fire on
-  #     every push; remove + re-add the label to retrigger.
-  pull_request:
-    paths:
-      - ".github/workflows/homebrew-tap-pr.yml"
-      - ".github/scripts/homebrew/**"
-    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
 
-# Serialize per tag (or per PR for the label-triggered branch test) so two
-# triggers can't race the same formula PR.
+# Serialize per tag so two triggers can't race the same formula PR.
 concurrency:
-  group: homebrew-tap-pr-${{ github.event.release.tag_name || inputs.tag || github.event.pull_request.number }}
+  group: homebrew-tap-pr-${{ github.event.release.tag_name || inputs.tag }}
   cancel-in-progress: false
 
 jobs:
@@ -72,18 +55,9 @@ jobs:
           EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.tag }}
           PRERELEASE: ${{ github.event.release.prerelease }}
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           tag="${INPUT_TAG:-$EVENT_TAG}"
-          # On a pull_request (e.g. the `homebrew-test` label to test the real
-          # PR-open path) there's no release/input tag — fall back to the latest
-          # final release so generation has a real, installable target.
-          if [ -z "$tag" ]; then
-            tag="$(gh release list --repo "$GITHUB_REPOSITORY" \
-              --exclude-drafts --exclude-pre-releases --limit 1 \
-              --json tagName --jq '.[0].tagName')"
-            fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           is_final=true
@@ -100,90 +74,12 @@ jobs:
           echo "is_final=${is_final}" >> "$GITHUB_OUTPUT"
           echo "Resolved tag=${tag} is_final=${is_final}" | tee -a "$GITHUB_STEP_SUMMARY"
 
-  validate:
-    name: Generate formula (PR dry-run)
-    # Branch iteration loop: run the generator against the latest final release
-    # on public PyPI on PR code changes (opened/synchronize/reopened) — no
-    # merge needed, no cross-repo PR. Not gated on the repo so it runs on forks
-    # too; it opens no PR anywhere. Skipped on `labeled` (the label runs the
-    # real `pr` job instead).
-    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout omnigent (template + generator)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: false
-
-      - name: Resolve latest final release tag
-        # Generate against the newest final release on the repo (not the .dev
-        # main version), so the dry-run exercises a real, installable closure.
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          TAG="$(gh release list --repo "$GITHUB_REPOSITORY" \
-            --exclude-drafts --exclude-pre-releases --limit 1 \
-            --json tagName --jq '.[0].tagName')"
-          if [ -z "$TAG" ]; then
-            echo "::error::No final GitHub Release found to dry-run against." | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-          echo "Dry-running against latest final release: $TAG" | tee -a "$GITHUB_STEP_SUMMARY"
-          echo "TAG=$TAG" >> "$GITHUB_ENV"
-
-      - name: Generate the formula
-        run: |
-          set -euo pipefail
-          python3 .github/scripts/homebrew/generate_formula.py \
-            --version "${TAG#v}" \
-            --template .github/scripts/homebrew/omnigent.rb.template \
-            --out /tmp/omnigent.rb
-          {
-            echo "### Generated \`Formula/omnigent.rb\` for $TAG (dry-run)"
-            echo '```ruby'
-            cat /tmp/omnigent.rb
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Ruby syntax check
-        # ubuntu-latest ships Ruby; `ruby -c` validates the formula parses
-        # without a Homebrew install (the build itself is the tap's job).
-        run: ruby -c /tmp/omnigent.rb
-
-      - name: Upload generated formula
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: omnigent-formula-dry-run
-          path: /tmp/omnigent.rb
-
   pr:
     name: Open homebrew-tap formula PR
     needs: resolve
     runs-on: ubuntu-latest
-    # Runs on a real release (release: published) or a manual dispatch, OR when
-    # a maintainer labels a PR `homebrew-test` to open a REAL tap PR from a
-    # branch (so the tap's brew test-bot builds the bottles). Canonical repo
-    # only — forks/mirrors have no PyPI release or the App token.
-    if: >-
-      needs.resolve.outputs.is_final == 'true' &&
-      github.repository == 'omnigent-ai/omnigent' &&
-      (
-        github.event_name == 'release' ||
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' &&
-         github.event.action == 'labeled' &&
-         contains(github.event.pull_request.labels.*.name, 'homebrew-test'))
-      )
+    # Canonical repo only — forks/mirrors have no PyPI release or the App token.
+    if: needs.resolve.outputs.is_final == 'true' && github.repository == 'omnigent-ai/omnigent'
     env:
       TAG: ${{ needs.resolve.outputs.tag }}
       VERSION: ${{ needs.resolve.outputs.version }}

--- a/.github/workflows/homebrew-tap-pr.yml
+++ b/.github/workflows/homebrew-tap-pr.yml
@@ -31,6 +31,15 @@ on:
         description: Final release tag to (re)open the tap PR for, e.g. v0.3.0
         required: true
         type: string
+  # Iterate on a branch without merging: on PRs touching the homebrew files,
+  # run the generator against the latest final release on public PyPI (no
+  # cross-repo PR) and upload the formula as an artifact. Mirrors the
+  # CI-test-on-PR pattern in release-omnigent.yml. `pull_request` runs the
+  # workflow definition from the PR head, so the branch's version is what runs.
+  pull_request:
+    paths:
+      - ".github/workflows/homebrew-tap-pr.yml"
+      - ".github/scripts/homebrew/**"
 
 permissions:
   contents: read
@@ -73,6 +82,70 @@ jobs:
           if [ "${PRERELEASE}" = "true" ]; then is_final=false; fi
           echo "is_final=${is_final}" >> "$GITHUB_OUTPUT"
           echo "Resolved tag=${tag} is_final=${is_final}" | tee -a "$GITHUB_STEP_SUMMARY"
+
+  validate:
+    name: Generate formula (PR dry-run)
+    # Branch iteration loop: run the generator against the latest final release
+    # on public PyPI on every PR touching the homebrew files — no merge needed.
+    # Not gated on the repo so it runs on forks too; it opens no PR anywhere.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout omnigent (template + generator)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+
+      - name: Resolve latest final release tag
+        # Generate against the newest final release on the repo (not the .dev
+        # main version), so the dry-run exercises a real, installable closure.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="$(gh release list --repo "$GITHUB_REPOSITORY" \
+            --exclude-drafts --exclude-pre-releases --limit 1 \
+            --json tagName --jq '.[0].tagName')"
+          if [ -z "$TAG" ]; then
+            echo "::error::No final GitHub Release found to dry-run against." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "Dry-running against latest final release: $TAG" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+      - name: Generate the formula
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/homebrew/generate_formula.py \
+            --version "${TAG#v}" \
+            --template .github/scripts/homebrew/omnigent.rb.template \
+            --out /tmp/omnigent.rb
+          {
+            echo "### Generated \`Formula/omnigent.rb\` for $TAG (dry-run)"
+            echo '```ruby'
+            cat /tmp/omnigent.rb
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Ruby syntax check
+        # ubuntu-latest ships Ruby; `ruby -c` validates the formula parses
+        # without a Homebrew install (the build itself is the tap's job).
+        run: ruby -c /tmp/omnigent.rb
+
+      - name: Upload generated formula
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: omnigent-formula-dry-run
+          path: /tmp/omnigent.rb
 
   pr:
     name: Open homebrew-tap formula PR

--- a/.github/workflows/homebrew-tap-pr.yml
+++ b/.github/workflows/homebrew-tap-pr.yml
@@ -31,22 +31,30 @@ on:
         description: Final release tag to (re)open the tap PR for, e.g. v0.3.0
         required: true
         type: string
-  # Iterate on a branch without merging: on PRs touching the homebrew files,
-  # run the generator against the latest final release on public PyPI (no
-  # cross-repo PR) and upload the formula as an artifact. Mirrors the
-  # CI-test-on-PR pattern in release-omnigent.yml. `pull_request` runs the
-  # workflow definition from the PR head, so the branch's version is what runs.
+  # Iterate on a branch without merging. `pull_request` runs the workflow
+  # definition from the PR head, so the branch's version is what runs. Two
+  # modes:
+  #   - opened/synchronize/reopened (paths-filtered to the homebrew files):
+  #     the `validate` dry-run regenerates the formula against the latest final
+  #     release on public PyPI and uploads it as an artifact — no cross-repo
+  #     PR. Mirrors the CI-test-on-PR pattern in release-omnigent.yml.
+  #   - labeled with `homebrew-test` (NOT paths-filtered): a maintainer opts in
+  #     to opening a REAL PR on omnigent-ai/homebrew-tap so the tap's
+  #     `brew test-bot` builds the bottles. Deliberate, so it doesn't fire on
+  #     every push; remove + re-add the label to retrigger.
   pull_request:
     paths:
       - ".github/workflows/homebrew-tap-pr.yml"
       - ".github/scripts/homebrew/**"
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
 
-# Serialize per tag so two triggers can't race the same formula PR.
+# Serialize per tag (or per PR for the label-triggered branch test) so two
+# triggers can't race the same formula PR.
 concurrency:
-  group: homebrew-tap-pr-${{ github.event.release.tag_name || inputs.tag }}
+  group: homebrew-tap-pr-${{ github.event.release.tag_name || inputs.tag || github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
@@ -64,9 +72,18 @@ jobs:
           EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.tag }}
           PRERELEASE: ${{ github.event.release.prerelease }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           tag="${INPUT_TAG:-$EVENT_TAG}"
+          # On a pull_request (e.g. the `homebrew-test` label to test the real
+          # PR-open path) there's no release/input tag — fall back to the latest
+          # final release so generation has a real, installable target.
+          if [ -z "$tag" ]; then
+            tag="$(gh release list --repo "$GITHUB_REPOSITORY" \
+              --exclude-drafts --exclude-pre-releases --limit 1 \
+              --json tagName --jq '.[0].tagName')"
+            fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           is_final=true
@@ -86,9 +103,11 @@ jobs:
   validate:
     name: Generate formula (PR dry-run)
     # Branch iteration loop: run the generator against the latest final release
-    # on public PyPI on every PR touching the homebrew files — no merge needed.
-    # Not gated on the repo so it runs on forks too; it opens no PR anywhere.
-    if: github.event_name == 'pull_request'
+    # on public PyPI on PR code changes (opened/synchronize/reopened) — no
+    # merge needed, no cross-repo PR. Not gated on the repo so it runs on forks
+    # too; it opens no PR anywhere. Skipped on `labeled` (the label runs the
+    # real `pr` job instead).
+    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -151,8 +170,20 @@ jobs:
     name: Open homebrew-tap formula PR
     needs: resolve
     runs-on: ubuntu-latest
-    # Canonical repo only — forks/mirrors have no PyPI release or the App token.
-    if: needs.resolve.outputs.is_final == 'true' && github.repository == 'omnigent-ai/omnigent'
+    # Runs on a real release (release: published) or a manual dispatch, OR when
+    # a maintainer labels a PR `homebrew-test` to open a REAL tap PR from a
+    # branch (so the tap's brew test-bot builds the bottles). Canonical repo
+    # only — forks/mirrors have no PyPI release or the App token.
+    if: >-
+      needs.resolve.outputs.is_final == 'true' &&
+      github.repository == 'omnigent-ai/omnigent' &&
+      (
+        github.event_name == 'release' ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' &&
+         github.event.action == 'labeled' &&
+         contains(github.event.pull_request.labels.*.name, 'homebrew-test'))
+      )
     env:
       TAG: ${{ needs.resolve.outputs.tag }}
       VERSION: ${{ needs.resolve.outputs.version }}


### PR DESCRIPTION
## Related issue

N/A — release/release-automation infrastructure.

## Summary

- On a final GitHub Release, automatically regenerate the `omnigent` Homebrew formula from the released PyPI sdist closure and open a PR to `omnigent-ai/homebrew-tap`, so the tap stays in sync with releases without manual formula bumps.
- New workflow `.github/workflows/homebrew-tap-pr.yml` (`release: published` + `workflow_dispatch`) resolves the dep tree, mints an `omnigent-ci` App token scoped to the tap, and opens a rerun-safe PR. The tap's own `brew test-bot` builds bottles; a maintainer labels `pr-pull` to merge.
- New generator `.github/scripts/homebrew/generate_formula.py` + template `omnigent.rb.template`: `uv pip compile` resolves `omnigent[cursor]==<ver>` for the macOS arm+intel matrix; each sdist becomes a `resource` via the PyPI JSON API. Brewed packages (`certifi`, `cryptography`, `pydantic`, `rpds-py`, `cffi`, `pycparser`) are excluded since the formula's `depends_on` provides them.

## Test Plan

- [x] Generator: pure-function + mocked end-to-end tests pass (resource sorting, brewed exclusions, no-sdist skip, template placeholder guard).
- [x] `ruff check` + `ruff format` clean; pre-commit file-hygiene hooks pass (yaml syntax, trailing whitespace, newline, merge-conflict, large-file, case-conflict, line-endings).
- [x] Locally generated a formula for an existing release through the internal PyPI proxy (`--proxy`), confirmed it pins public `files.pythonhosted.org` URLs and `ruby -c` passes.
- [ ] **CI (post-merge):** GitHub Actions only dispatches workflows on the default branch, so this can't be run from the feature branch. After merge, dispatch with `gh workflow run homebrew-tap-pr.yml -f tag=v0.2.0` (a released tag) to validate the full PyPI resolution + PR-open path in CI; the tap's `brew test-bot` then validates the build.

## Demo

N/A — CI/release automation, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

CI/release-automation infrastructure (a GitHub Actions workflow + a Python generator script), not product code. The generator's resolution/sdist-fetch logic is validated by mocked end-to-end tests and by a local run against a real released PyPI version; the workflow itself can only be exercised in CI once on the default branch.

## Prerequisite

The `omnigent-ci` GitHub App (already used for `omnigent-site`) must be installed on `omnigent-ai/homebrew-tap` with `contents:write` + `pull-requests:write`. Without it the job still generates the formula (visible in the run summary) but warns instead of opening a PR.
