### PR TITLE
feat(slash-menu): substring-match slash commands by name

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -8308,12 +8308,25 @@ class _SlashCommandCompleter(Completer):
         # ``/superpowers:using-superpowers``). Name only, not the
         # description — kept identical to the web menu, which never shows
         # descriptions inline.
+        #
+        # Prefix matches rank ahead of mid-string matches (mirrors the web
+        # menu's ``rankedSlashCommandNames``): ``/e`` surfaces ``/effort``
+        # (a prefix) before ``/context`` (which merely contains "e"), so
+        # the first, auto-selectable completion is the intended one. Each
+        # tier keeps ``COMMANDS`` insertion order (an empty query — lone
+        # "/" — puts every command in the prefix tier, unchanged).
         query = text_before[1:].lower()
+        prefix_hits: list[tuple[str, str]] = []
+        substring_hits: list[tuple[str, str]] = []
         for name, (desc, _) in COMMANDS.items():
             if name in _SLASH_COMMAND_ALIASES:
                 continue
-            if query not in name[1:].lower():
-                continue
+            body = name[1:].lower()
+            if body.startswith(query):
+                prefix_hits.append((name, desc))
+            elif query in body:
+                substring_hits.append((name, desc))
+        for name, desc in (*prefix_hits, *substring_hits):
             yield Completion(
                 text=name,
                 # Replace everything typed so far so the splice

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -8301,11 +8301,18 @@ class _SlashCommandCompleter(Completer):
         if "/" in text_before[1:]:
             return
 
-        prefix = text_before.lower()
+        # Match the web UI's rule (slashCommandMatches in
+        # SlashCommandMenu.tsx): a case-insensitive substring of the
+        # command name (sans the leading "/"), so a namespaced skill is
+        # reachable by its leaf name (``/using-superpowers`` ->
+        # ``/superpowers:using-superpowers``). Name only, not the
+        # description — kept identical to the web menu, which never shows
+        # descriptions inline.
+        query = text_before[1:].lower()
         for name, (desc, _) in COMMANDS.items():
             if name in _SLASH_COMMAND_ALIASES:
                 continue
-            if not name.startswith(prefix):
+            if query not in name[1:].lower():
                 continue
             yield Completion(
                 text=name,

--- a/tests/e2e_ui/chat/test_slash_command_menu_matching.py
+++ b/tests/e2e_ui/chat/test_slash_command_menu_matching.py
@@ -1,0 +1,134 @@
+"""E2E: substring matching in the slash-command suggestions menu.
+
+Covers the user-facing behavior added by the substring-matching change:
+the ``/`` menu matches a query as a case-insensitive **substring** of a
+command's name, not just a prefix. Before the change the menu
+prefix-matched the full (namespaced) name, so typing the leaf a user
+remembers — e.g. ``/using-superpowers`` for
+``/superpowers:using-superpowers`` — surfaced nothing. The mechanism is
+identical for any mid-name substring, which is what these tests exercise
+end-to-end in a real browser (a colon-namespaced skill can't be bundled
+from a spec — ``SkillSpec.name`` is ``[a-z0-9-]+`` — but ``/review``
+matching ``code-review`` is the same leaf/mid-string substring path).
+
+Two surfaces own separate copies of the filter, so both are driven:
+
+- **In-session composer** (``ChatPage`` ``menuMatches`` + the shared
+  ``SlashCommandMenu`` render filter): a built-in is matched by a
+  mid-name fragment. Asserting the matched row is *highlighted*
+  (``data-active``) proves the render filter AND ``menuMatches`` agree —
+  the highlight is driven by ``menuMatches`` (keyboard index), the row by
+  the render filter, so a divergence would mis-place the highlight.
+- **New-chat landing composer** (``NewChatDialog`` ``slashMenuMatches``):
+  a bundled skill is matched by a mid-name fragment, then Tab completes
+  it to its full canonical name — covering keyboard completion too.
+
+Selectors mirror the component: rows are
+``data-testid="slash-menu-item-<name-sans-slash>"`` and the highlighted
+row carries ``data-active="true"`` (see ``SlashCommandMenu.tsx``).
+"""
+
+from __future__ import annotations
+
+import json
+
+from playwright.sync_api import Page, Route, expect
+
+
+def test_in_session_composer_matches_builtin_by_substring(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The in-session ``/`` menu surfaces a built-in matched mid-name.
+
+    ``/ontext`` is a substring of ``/context`` but a prefix of no command,
+    so under the old prefix filter it matched nothing. The row must appear
+    AND be the highlighted (auto-selected first) match — the highlight is
+    driven by ``menuMatches`` (the keyboard-nav filter) while the row is
+    rendered by ``SlashCommandMenu``'s own filter, so a passing assertion
+    proves both filters substring-match in lockstep.
+
+    :param page: Playwright page (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` from the fixture.
+    """
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+    # Mid-name fragment of "/context": prefix of nothing, so this only
+    # surfaces a row under substring matching.
+    composer.fill("/ontext")
+
+    context_row = page.get_by_test_id("slash-menu-item-context")
+    expect(context_row).to_be_visible()
+    # The first (only) match is auto-highlighted; the highlight comes from
+    # menuMatches, so this pins the keyboard-nav filter to the rendered row.
+    expect(context_row).to_have_attribute("data-active", "true")
+
+
+def test_landing_composer_matches_skill_and_tab_completes(
+    page: Page,
+    live_server: str,
+) -> None:
+    """The new-chat landing ``/`` menu matches a skill mid-name, and Tab completes it.
+
+    Stubs ``GET /v1/agents`` with a single non-native agent bundling a
+    ``code-review`` skill (the landing menu lists the selected agent's
+    skills only, and suppresses entirely for native-terminal agents). The
+    session list is stubbed empty so no agent discovered by the
+    ``kind=any`` scan sorts ahead and steals auto-selection.
+
+    ``/review`` is a substring of ``code-review`` but a prefix of no
+    command — it surfaces the row only under substring matching. Tab then
+    completes the highlighted match to its full canonical name with a
+    trailing space (skills fill rather than execute), covering keyboard
+    completion on this surface.
+
+    :param page: Playwright page (fresh context per test).
+    :param live_server: Base URL of the spawned server serving the SPA.
+    """
+    agents_body = {
+        "data": [
+            {
+                "id": "ag_helper_e2e",
+                "name": "helper",
+                "display_name": "Helper",
+                "description": "A helper agent",
+                # Non-native brain harness: keeps the slash menu enabled
+                # (native-terminal agents suppress it) and off the
+                # permission-mode / native-wrapper paths.
+                "harness": "claude-sdk",
+                "skills": [{"name": "code-review", "description": "Review a pull request"}],
+            }
+        ]
+    }
+    empty_list = {"object": "list", "data": [], "has_more": False}
+
+    def _fulfill(route: Route, body: dict[str, object]) -> None:
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(body))
+
+    page.route("**/v1/agents", lambda r: _fulfill(r, agents_body))
+    # Neutralize the sidebar list + kind=any agent-discovery scan so only
+    # the stubbed agent feeds the picker (and auto-selects).
+    page.route("**/v1/sessions", lambda r: _fulfill(r, empty_list))
+
+    page.goto(f"{live_server}/")
+
+    landing_input = page.get_by_test_id("new-chat-landing-input")
+    expect(landing_input).to_be_visible(timeout=30_000)
+    # Wait for the stubbed agent to resolve + auto-select, so its skills
+    # populate the menu's command map before we type.
+    expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+        "Helper", timeout=30_000
+    )
+
+    # Mid-name fragment of "code-review": prefix of nothing.
+    landing_input.fill("/review")
+    skill_row = page.get_by_test_id("slash-menu-item-code-review")
+    expect(skill_row).to_be_visible()
+
+    # Tab completes the highlighted match to the full canonical name; skills
+    # fill (with a trailing space for args) rather than execute.
+    landing_input.press("Tab")
+    expect(landing_input).to_have_value("/code-review ")

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -2158,6 +2158,20 @@ def test_completer_plain_text_yields_nothing() -> None:
     assert _completions_for("hello world") == []
 
 
+def _noop_handler(*_args: object, **_kwargs: object) -> None:
+    """Stand-in handler for synthetic COMMANDS entries in completer tests."""
+    return None
+
+
+_FAKE_COMMANDS = {
+    "/superpowers:using-superpowers": (
+        "Establishes how to find and use skills",
+        _noop_handler,
+    ),
+    "/context": ("Show context window usage", _noop_handler),
+}
+
+
 def test_completer_lone_slash_lists_all_canonical_commands() -> None:
     """
     Claim: hitting ``/`` shows every canonical command in
@@ -2185,49 +2199,80 @@ def test_completer_lone_slash_lists_all_canonical_commands() -> None:
     assert actual == expected
 
 
-def test_completer_filters_by_prefix() -> None:
+def test_completer_substring_filters_real_registry() -> None:
     """
-    Claim: typing ``/h`` narrows the popup to commands whose
-    canonical name starts with ``/h``. With the current command
-    set that is ``/help`` and ``/history``.
+    Claim: the substring filter narrows the REAL ``COMMANDS`` registry
+    (not just a monkeypatched fake) and matches mid-name, not only as a
+    prefix. ``heme`` sits inside ``/theme`` but is a prefix of no
+    command, so a hit proves substring matching runs against the live
+    registry the REPL actually ships.
 
-    Failure modes:
-      - Empty result → the prefix-startswith filter is broken
-        (e.g. the completer is comparing against the description).
-      - Returning every command → the filter is being bypassed.
-      - Including ``/quit`` or ``/cancel`` → the prefix match
-        is doing substring matching instead of startswith.
+    The monkeypatched tests below replace ``COMMANDS`` wholesale, so this
+    is the only filtering test that touches the real set. It uses
+    membership assertions rather than an exact list so it stays green as
+    commands are added or removed — the claim is "filtering happens and
+    narrows," not "these exact commands exist."
     """
-    actual = _completions_for("/h")
+    all_names = [name for name, _, _ in _completions_for("/")]
+    names = [name for name, _, _ in _completions_for("/heme")]
+    # Mid-name match against the live registry (substring, not prefix).
+    assert "/theme" in names
+    # A command with no "heme" is excluded — the filter really narrows.
+    assert "/quit" not in names
+    # Narrowing genuinely happened: a non-empty strict subset of the full
+    # list. Catches both "filter bypassed" (== all) and "filter too
+    # greedy" (empty) regressions against the real registry.
+    assert 0 < len(names) < len(all_names)
+
+
+def test_completer_matches_name_leaf_after_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Claim: typing a namespaced skill's leaf name surfaces the full
+    command — the core fix. `/using-superpowers` must find
+    `/superpowers:using-superpowers` even though the name starts with
+    `superpowers:`. Failure means the completer is still prefix-only.
+    """
+    monkeypatch.setattr("omnigent.repl._repl.COMMANDS", _FAKE_COMMANDS)
+    actual = _completions_for("/using-superpowers")
     names = [name for name, _, _ in actual]
-    assert names == ["/help", "/history"], (
-        f"expected ['/help', '/history'] for prefix '/h', got {names}. "
-        f"If empty, the prefix filter no longer matches; if longer, "
-        f"the filter is broader than startswith."
-    )
-    # Every match replaces the full typed prefix (``/h`` == 2 chars).
-    # If start_position drifts, the completion will splice into the
-    # buffer wrong (e.g. produce ``//help``).
+    assert names == ["/superpowers:using-superpowers"]
+    # The completion replaces the full typed prefix so the splice
+    # yields the canonical name, not a doubled slash.
     for _, _, start in actual:
-        assert start == -2
+        assert start == -len("/using-superpowers")
 
 
-def test_completer_exact_match_still_yields_itself() -> None:
+def test_completer_does_not_match_description(monkeypatch: pytest.MonkeyPatch) -> None:
     """
-    Claim: when the user has typed an entire command (``/help``),
-    that command itself is still offered — picking it from the
-    popup is a no-op replacement that lets the user press Enter
-    to submit without retyping.
-
-    Failure here would mean the popup vanishes the moment the
-    typed text equals a command, which is jarring during
-    keyboard-driven completion.
+    Claim: matching is name-only — a query that appears only in a command's
+    description does NOT surface it. Kept identical to the web menu, which
+    never shows descriptions inline, so a description-driven hit would look
+    unexplained. `window` appears in `/context`'s blurb but not its name, so
+    it must yield nothing.
     """
-    actual = _completions_for("/help")
-    names = [name for name, _, _ in actual]
-    # ``/help`` is a strict prefix of itself; no other current
-    # command starts with the full string ``/help``.
-    assert names == ["/help"]
+    monkeypatch.setattr("omnigent.repl._repl.COMMANDS", _FAKE_COMMANDS)
+    assert _completions_for("/window") == []
+
+
+def test_completer_no_match_yields_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Claim: a query present in no command name yields no rows (the popup
+    closes) — proves matching is a real containment test, not "always show
+    everything".
+    """
+    monkeypatch.setattr("omnigent.repl._repl.COMMANDS", _FAKE_COMMANDS)
+    assert _completions_for("/zzz") == []
+
+
+def test_completer_full_name_still_yields_itself(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Claim: a fully-typed command name still offers itself, so the user
+    can press Enter to submit without the popup vanishing. `/context`
+    is a substring of its own name.
+    """
+    monkeypatch.setattr("omnigent.repl._repl.COMMANDS", _FAKE_COMMANDS)
+    names = [name for name, _, _ in _completions_for("/context")]
+    assert names == ["/context"]
 
 
 def test_completer_display_meta_matches_command_help() -> None:

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -2225,6 +2225,41 @@ def test_completer_substring_filters_real_registry() -> None:
     assert 0 < len(names) < len(all_names)
 
 
+def test_completer_ranks_prefix_before_substring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Claim: prefix matches surface before mid-string matches (mirrors the
+    web menu's ``rankedSlashCommandNames``). Typing ``/e`` offers
+    ``/effort`` (a prefix) before ``/context`` (which merely contains
+    "e"), so the first completion is the one the user most likely meant —
+    not an unrelated command that happens to contain the letter.
+    """
+    fake = {
+        "/compact": ("Compact", _noop_handler),
+        "/context": ("Context", _noop_handler),
+        "/effort": ("Effort", _noop_handler),
+        "/model": ("Model", _noop_handler),
+    }
+    monkeypatch.setattr("omnigent.repl._repl.COMMANDS", fake)
+    names = [name for name, _, _ in _completions_for("/e")]
+    # /effort is the only prefix match; /context and /model merely contain
+    # "e" (/compact has none), so they rank after it.
+    assert names[0] == "/effort"
+    assert set(names) == {"/effort", "/context", "/model"}
+
+
+def test_completer_ranks_prefix_first_real_registry() -> None:
+    """
+    Claim: against the live registry, ``/m`` surfaces a prefix match
+    (e.g. ``/model``) first, ahead of commands that merely contain "m"
+    (e.g. ``/theme``, ``/compact``). Pins prefix-priority on the real
+    command set without coupling to the exact command list.
+    """
+    names = [name for name, _, _ in _completions_for("/m")]
+    assert "/model" in names
+    # The top completion is a genuine prefix match, not a mid-string one.
+    assert names[0][1:].lower().startswith("m")
+
+
 def test_completer_matches_name_leaf_after_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Claim: typing a namespaced skill's leaf name surfaces the full

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -2160,7 +2160,7 @@ def test_completer_plain_text_yields_nothing() -> None:
 
 def _noop_handler(*_args: object, **_kwargs: object) -> None:
     """Stand-in handler for synthetic COMMANDS entries in completer tests."""
-    return None
+    return
 
 
 _FAKE_COMMANDS = {

--- a/web/src/components/SlashCommandMenu.tsx
+++ b/web/src/components/SlashCommandMenu.tsx
@@ -39,6 +39,19 @@ export function isSlashCommandText(text: string): boolean {
   return SLASH_COMMAND_RE.test(text.trim());
 }
 
+/**
+ * True when `query` is a case-insensitive substring of the command name
+ * (sans the leading `/`). Matches on the name only — not the description —
+ * because the web menu never shows descriptions inline, so a
+ * description-driven match would look unexplained. Shared by the menu
+ * render filter here and the two composers' keyboard-nav filters (ChatPage
+ * `menuMatches`, NewChatDialog `slashMenuMatches`) so the visible list and
+ * the keyboard index can't drift apart.
+ */
+export function slashCommandMatches(name: string, query: string): boolean {
+  return name.slice(1).toLowerCase().includes(query.toLowerCase());
+}
+
 interface SlashCommandMenuProps {
   /** The text typed after the leading ``/``, used to filter suggestions. */
   query: string;
@@ -115,7 +128,8 @@ function MenuRowButton({
  * layout: a narrow panel with "Commands" / "Skills" section headers and
  * icon + name rows, plus a detail card beside the panel showing the
  * highlighted entry's full description (hidden on small screens).
- * Only commands whose name starts with the current query are shown.
+ * Only commands whose name (sans ``/``) contains the current query as a
+ * case-insensitive substring are shown.
  * Positioned via ``absolute bottom-full`` relative to the rounded
  * composer container. Exported for direct unit testing.
  */
@@ -125,8 +139,7 @@ export function SlashCommandMenu({
   onSelect,
   commands,
 }: SlashCommandMenuProps) {
-  const lower = query.toLowerCase();
-  const matches = Object.entries(commands).filter(([name]) => name.slice(1).startsWith(lower));
+  const matches = Object.entries(commands).filter(([name]) => slashCommandMatches(name, query));
   const listRef = useRef<HTMLDivElement>(null);
   // Keep the keyboard-highlighted row visible as the user arrows past the
   // visible window of this capped-height, scrollable list. Without this the

--- a/web/src/components/SlashCommandMenu.tsx
+++ b/web/src/components/SlashCommandMenu.tsx
@@ -43,13 +43,44 @@ export function isSlashCommandText(text: string): boolean {
  * True when `query` is a case-insensitive substring of the command name
  * (sans the leading `/`). Matches on the name only — not the description —
  * because the web menu never shows descriptions inline, so a
- * description-driven match would look unexplained. Shared by the menu
- * render filter here and the two composers' keyboard-nav filters (ChatPage
- * `menuMatches`, NewChatDialog `slashMenuMatches`) so the visible list and
- * the keyboard index can't drift apart.
+ * description-driven match would look unexplained. `name` is expected to
+ * carry the leading `/` (the leading char is dropped before matching).
  */
 export function slashCommandMatches(name: string, query: string): boolean {
   return name.slice(1).toLowerCase().includes(query.toLowerCase());
+}
+
+/**
+ * Filter `commands` to those matching `query`, then rank them for display:
+ * built-in commands before skills (so the "Commands" section stays above
+ * "Skills" and the flat keyboard index walks the same order that's
+ * rendered), and within each group, prefix matches before mid-string
+ * matches. The sort is stable, so commands that tie keep their insertion
+ * order. Returns the ranked, slash-prefixed names.
+ *
+ * Prefix-priority matters because the first match is auto-highlighted and
+ * Tab/Enter acts on it — executing no-arg built-ins immediately. Without
+ * it a short query like `e` would highlight `/context` (it contains "e")
+ * ahead of `/effort` (a prefix), so Enter could run an unrelated command
+ * as a side effect. Shared by the menu render filter here and the two
+ * composers' keyboard-nav filters (ChatPage `menuMatches`, NewChatDialog
+ * `slashMenuMatches`) so the visible list and the keyboard index stay
+ * aligned.
+ */
+export function rankedSlashCommandNames(commands: Record<string, string>, query: string): string[] {
+  const q = query.toLowerCase();
+  // Lower rank sorts first: built-in (0) before skill (2), and within each,
+  // prefix (0) before mid-string (1). Skills are anything not in the
+  // built-in map (the landing menu passes skills only, so all rank equally
+  // there — prefix-vs-substring still applies).
+  const rank = (name: string): number => {
+    const group = name in BUILTIN_SLASH_COMMANDS ? 0 : 2;
+    const prefix = name.slice(1).toLowerCase().startsWith(q) ? 0 : 1;
+    return group + prefix;
+  };
+  return Object.keys(commands)
+    .filter((name) => slashCommandMatches(name, query))
+    .sort((a, b) => rank(a) - rank(b));
 }
 
 interface SlashCommandMenuProps {
@@ -139,7 +170,7 @@ export function SlashCommandMenu({
   onSelect,
   commands,
 }: SlashCommandMenuProps) {
-  const matches = Object.entries(commands).filter(([name]) => slashCommandMatches(name, query));
+  const matchedNames = rankedSlashCommandNames(commands, query);
   const listRef = useRef<HTMLDivElement>(null);
   // Keep the keyboard-highlighted row visible as the user arrows past the
   // visible window of this capped-height, scrollable list. Without this the
@@ -149,15 +180,15 @@ export function SlashCommandMenu({
     if (activeIndex < 0 || !listRef.current) return;
     listRef.current.querySelector('[data-active="true"]')?.scrollIntoView({ block: "nearest" });
   }, [activeIndex]);
-  if (matches.length === 0) return null;
+  if (matchedNames.length === 0) return null;
 
-  // Split into sections WITHOUT reordering: the flat match order drives the
-  // caller's keyboard index, and built-ins are inserted before skills (the
-  // landing menu passes skills only), so the partition is contiguous and
-  // rendering Commands above Skills preserves the visual = keyboard order.
-  const rows: MenuRow[] = matches.map(([name, description], flatIndex) => ({
+  // The flat match order (from rankedSlashCommandNames) drives the caller's
+  // keyboard index. It ranks built-ins before skills, so the partition below
+  // stays contiguous and rendering Commands above Skills preserves the
+  // visual = keyboard order.
+  const rows: MenuRow[] = matchedNames.map((name, flatIndex) => ({
     name,
-    description,
+    description: commands[name] ?? "",
     flatIndex,
   }));
   const builtinRows = rows.filter((r) => r.name in BUILTIN_SLASH_COMMANDS);

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -44,7 +44,7 @@ import type { ElicitationBlock } from "@/lib/blocks";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Composer, shouldQueueSend } from "./ChatPage";
 import type { QueuedMessage } from "@/store/chatStore";
-import { SlashCommandMenu } from "@/components/SlashCommandMenu";
+import { SlashCommandMenu, slashCommandMatches } from "@/components/SlashCommandMenu";
 
 // These tests pin the slash-command suggestions menu UX in the composer:
 // (1) the first match is highlighted as soon as the menu opens, so Tab/Enter
@@ -133,6 +133,20 @@ describe("Composer slash-command menu", () => {
 
     fireEvent.keyDown(ta, { key: "Tab" });
     // Skills fill "/name " and keep focus so the user can append args.
+    expect(ta.value).toBe("/deslop ");
+  });
+
+  it("Tab completes a match found only mid-name (exercises menuMatches, not just the render filter)", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    // "slop" is a substring of "deslop" but a prefix of no command. The menu
+    // render filter would show the row either way; Tab-completion reads
+    // menuMatches[menuIndex], so this only completes if the keyboard-nav
+    // filter is substring-based. Guards menuMatches from silently reverting
+    // to prefix matching and diverging from the rendered list.
+    fireEvent.change(ta, { target: { value: "/slop" } });
+    expect(activeRow()?.textContent).toContain("/deslop");
+    fireEvent.keyDown(ta, { key: "Tab" });
     expect(ta.value).toBe("/deslop ");
   });
 
@@ -842,6 +856,31 @@ describe("Composer Codex Plan-mode control", () => {
   });
 });
 
+describe("slashCommandMatches", () => {
+  it("matches the leaf segment after a namespace prefix", () => {
+    expect(slashCommandMatches("/superpowers:using-superpowers", "using-superpowers")).toBe(true);
+  });
+
+  it("matches a substring in the middle of the name", () => {
+    expect(slashCommandMatches("/cross-review", "rev")).toBe(true);
+  });
+
+  it("does not match a word that only appears in the description", () => {
+    // Matching is name-only — the web menu never shows descriptions inline,
+    // so a description-driven hit would look unexplained. "window" is in this
+    // command's blurb but not its name, so it must NOT match.
+    expect(slashCommandMatches("/context", "window")).toBe(false);
+  });
+
+  it("is case-insensitive on both name and query", () => {
+    expect(slashCommandMatches("/Superpowers:Using", "USING")).toBe(true);
+  });
+
+  it("returns false when the query is nowhere in the name", () => {
+    expect(slashCommandMatches("/context", "zzz")).toBe(false);
+  });
+});
+
 describe("SlashCommandMenu", () => {
   const COMMANDS = {
     "/alpha": "First",
@@ -906,6 +945,18 @@ describe("SlashCommandMenu", () => {
     expect(detail.textContent).toContain("/beta");
     expect(detail.textContent).toContain("Second");
     expect(detail.textContent).not.toContain("First");
+  });
+
+  it("surfaces a namespaced skill by its leaf name", () => {
+    render(
+      <SlashCommandMenu
+        query="using-superpowers"
+        activeIndex={0}
+        onSelect={vi.fn()}
+        commands={{ "/superpowers:using-superpowers": "Establishes how to find and use skills" }}
+      />,
+    );
+    expect(screen.getByTestId("slash-menu-item-superpowers:using-superpowers")).toBeDefined();
   });
 });
 

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -44,7 +44,12 @@ import type { ElicitationBlock } from "@/lib/blocks";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Composer, shouldQueueSend } from "./ChatPage";
 import type { QueuedMessage } from "@/store/chatStore";
-import { SlashCommandMenu, slashCommandMatches } from "@/components/SlashCommandMenu";
+import {
+  BUILTIN_SLASH_COMMANDS,
+  rankedSlashCommandNames,
+  SlashCommandMenu,
+  slashCommandMatches,
+} from "@/components/SlashCommandMenu";
 
 // These tests pin the slash-command suggestions menu UX in the composer:
 // (1) the first match is highlighted as soon as the menu opens, so Tab/Enter
@@ -148,6 +153,19 @@ describe("Composer slash-command menu", () => {
     expect(activeRow()?.textContent).toContain("/deslop");
     fireEvent.keyDown(ta, { key: "Tab" });
     expect(ta.value).toBe("/deslop ");
+  });
+
+  it("ranks a prefix built-in ahead of mid-string matches so a short query can't execute the wrong command", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    // "/e": /effort is a prefix match; /context and /help merely contain "e".
+    // Before prefix-priority ranking, /context (a no-arg builtin) was
+    // highlighted first and Tab/Enter executed it — a side-effecting
+    // regression. /effort must win and Tab fills it (it takes an argument).
+    fireEvent.change(ta, { target: { value: "/e" } });
+    expect(activeRow()?.textContent).toContain("/effort");
+    fireEvent.keyDown(ta, { key: "Tab" });
+    expect(ta.value).toBe("/effort ");
   });
 
   it("Enter completes the highlighted command instead of sending", () => {
@@ -878,6 +896,42 @@ describe("slashCommandMatches", () => {
 
   it("returns false when the query is nowhere in the name", () => {
     expect(slashCommandMatches("/context", "zzz")).toBe(false);
+  });
+});
+
+describe("rankedSlashCommandNames", () => {
+  it("ranks a prefix match ahead of commands that merely contain the query", () => {
+    // "/e": /effort is a prefix; /context, /model, /help only contain "e".
+    // Prefix-priority keeps /effort first so its auto-highlight + Enter can't
+    // execute an unrelated no-arg builtin (/context) as a side effect.
+    expect(rankedSlashCommandNames(BUILTIN_SLASH_COMMANDS, "e")[0]).toBe("/effort");
+  });
+
+  it("ranks /model ahead of commands that merely contain 'm'", () => {
+    // "/m": /model is a prefix; /compact contains "m". Was /compact first.
+    expect(rankedSlashCommandNames(BUILTIN_SLASH_COMMANDS, "m")[0]).toBe("/model");
+  });
+
+  it("keeps built-ins ahead of skills so the Commands section stays on top", () => {
+    const commands = { ...BUILTIN_SLASH_COMMANDS, "/superpowers:effort-helper": "x" };
+    const ranked = rankedSlashCommandNames(commands, "effort");
+    // Both /effort (builtin, prefix) and the skill (mid-string) match; the
+    // builtin must rank first so the render partition stays contiguous.
+    expect(ranked[0]).toBe("/effort");
+    expect(ranked.indexOf("/effort")).toBeLessThan(ranked.indexOf("/superpowers:effort-helper"));
+  });
+
+  it("ranks a prefix skill ahead of a mid-string skill, stably", () => {
+    // Insertion order is deep-research, research; ranking promotes the prefix
+    // match (research) above the mid-string one (deep-research contains "res").
+    const commands = { "/deep-research": "a", "/research": "b" };
+    expect(rankedSlashCommandNames(commands, "res")).toEqual(["/research", "/deep-research"]);
+  });
+
+  it("returns everything in insertion order for an empty query (lone '/')", () => {
+    expect(rankedSlashCommandNames(BUILTIN_SLASH_COMMANDS, "")).toEqual(
+      Object.keys(BUILTIN_SLASH_COMMANDS),
+    );
   });
 });
 

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { RenderItem } from "@/lib/renderItems";
 import type { ToolExecution } from "@/lib/blocks";
 import type { Bubble } from "@/lib/renderItems";
-import { BUILTIN_SLASH_COMMANDS, isSlashCommandText, slashCommandMatches } from "@/components/SlashCommandMenu";
+import {
+  BUILTIN_SLASH_COMMANDS,
+  isSlashCommandText,
+  slashCommandMatches,
+} from "@/components/SlashCommandMenu";
 import { isSessionSharedWithOthers } from "@/lib/permissionsApi";
 import {
   buildPendingBubbles,
@@ -1019,7 +1023,9 @@ describe("buildSlashCommandMap", () => {
       true,
     );
     // A namespaced skill is found by its leaf name — the exact bug this fixes.
-    const matches = Object.keys(map).filter((name) => slashCommandMatches(name, "using-superpowers"));
+    const matches = Object.keys(map).filter((name) =>
+      slashCommandMatches(name, "using-superpowers"),
+    );
     expect(matches).toEqual(["/superpowers:using-superpowers"]);
   });
 });

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { RenderItem } from "@/lib/renderItems";
 import type { ToolExecution } from "@/lib/blocks";
 import type { Bubble } from "@/lib/renderItems";
-import { BUILTIN_SLASH_COMMANDS, isSlashCommandText } from "@/components/SlashCommandMenu";
+import { BUILTIN_SLASH_COMMANDS, isSlashCommandText, slashCommandMatches } from "@/components/SlashCommandMenu";
 import { isSessionSharedWithOthers } from "@/lib/permissionsApi";
 import {
   buildPendingBubbles,
@@ -1006,20 +1006,21 @@ describe("buildSlashCommandMap", () => {
     expect(map["/mlflow-bug"]).toBe("File an MLflow bug.");
   });
 
-  it("matches skills via the same prefix filter the menu uses", () => {
-    // The menu (SlashCommandMenu) filters keys whose ``name.slice(1)``
-    // starts with the typed query. Verify the merged map plays nicely
-    // with that filter for a partially-typed skill name.
+  it("matches skills via the shared substring matcher the menu uses", () => {
     const map = buildSlashCommandMap(
       [
-        { name: "triage-issues", description: "Triage issues." },
+        {
+          name: "superpowers:using-superpowers",
+          description: "Establishes how to find and use skills",
+        },
         { name: "mlflow-bug", description: "File an MLflow bug." },
       ],
       true,
       true,
     );
-    const matches = Object.keys(map).filter((name) => name.slice(1).startsWith("tri"));
-    expect(matches).toEqual(["/triage-issues"]);
+    // A namespaced skill is found by its leaf name — the exact bug this fixes.
+    const matches = Object.keys(map).filter((name) => slashCommandMatches(name, "using-superpowers"));
+    expect(matches).toEqual(["/superpowers:using-superpowers"]);
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -145,6 +145,7 @@ import { HostBadge } from "@/components/HostBadge";
 import {
   BUILTIN_SLASH_COMMANDS,
   isSlashCommandText,
+  slashCommandMatches,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
 import { FileMentionMenu } from "@/components/FileMentionMenu";
@@ -4029,7 +4030,7 @@ export function Composer({
   // Filtered matches — kept in sync with what SlashCommandMenu renders so
   // keyboard nav indexes into the same list.
   const menuMatches = menuOpen
-    ? Object.keys(slashCommands).filter((name) => name.slice(1).startsWith(menuQuery.toLowerCase()))
+    ? Object.keys(slashCommands).filter((name) => slashCommandMatches(name, menuQuery))
     : [];
 
   // Pre-select the first match whenever the filtered list changes — both

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -145,7 +145,7 @@ import { HostBadge } from "@/components/HostBadge";
 import {
   BUILTIN_SLASH_COMMANDS,
   isSlashCommandText,
-  slashCommandMatches,
+  rankedSlashCommandNames,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
 import { FileMentionMenu } from "@/components/FileMentionMenu";
@@ -4029,9 +4029,7 @@ export function Composer({
   };
   // Filtered matches — kept in sync with what SlashCommandMenu renders so
   // keyboard nav indexes into the same list.
-  const menuMatches = menuOpen
-    ? Object.keys(slashCommands).filter((name) => slashCommandMatches(name, menuQuery))
-    : [];
+  const menuMatches = menuOpen ? rankedSlashCommandNames(slashCommands, menuQuery) : [];
 
   // Pre-select the first match whenever the filtered list changes — both
   // when the menu first opens (matches go [] → non-empty) and as the query

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1809,16 +1809,19 @@ describe("NewChatLandingScreen skills menu", () => {
     expect(screen.getByText("Cross-vendor review")).toBeTruthy();
   });
 
-  it("filters by the typed query and fills the draft on click", () => {
+  it("filters by the typed query (substring) and fills the draft on click", () => {
     mockAgents([skilledAgent()]);
     renderLanding();
+    // Substring match: both skills contain "rev" (review-pr, cross-review).
     typeMessage("/rev");
-    // The query narrows the list to the prefix match only.
+    expect(screen.getByTestId("slash-menu-item-review-pr")).toBeTruthy();
+    expect(screen.getByTestId("slash-menu-item-cross-review")).toBeTruthy();
+    // A more specific substring narrows to one.
+    typeMessage("/pr");
     expect(screen.getByTestId("slash-menu-item-review-pr")).toBeTruthy();
     expect(screen.queryByTestId("slash-menu-item-cross-review")).toBeNull();
     fireEvent.click(screen.getByTestId("slash-menu-item-review-pr"));
-    // Selection fills "/name " (trailing space, caret ready for args) —
-    // skills never auto-submit from the menu.
+    // Selection fills "/name " (trailing space, caret ready for args).
     expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
       "/review-pr ",
     );
@@ -1831,6 +1834,20 @@ describe("NewChatLandingScreen skills menu", () => {
     fireEvent.keyDown(screen.getByTestId("new-chat-landing-input"), { key: "Tab" });
     // The first match is pre-selected on open, so Tab completes it without
     // arrowing down first (same UX as the in-session composer).
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "/review-pr ",
+    );
+  });
+
+  it("Tab completes a match found only mid-name (exercises slashMenuMatches, not just the render filter)", () => {
+    mockAgents([skilledAgent()]);
+    renderLanding();
+    // "pr" is a substring of "review-pr" but a prefix of no command. Tab
+    // completion reads slashMenuMatches/slashMenuIndex, so this only
+    // completes if the keyboard-nav filter is substring-based — guarding it
+    // from reverting to prefix matching and diverging from the rendered list.
+    typeMessage("/pr");
+    fireEvent.keyDown(screen.getByTestId("new-chat-landing-input"), { key: "Tab" });
     expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
       "/review-pr ",
     );

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -55,7 +55,7 @@ import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { sandboxOptionLabel } from "@/lib/capabilities";
 import {
   isSlashCommandText,
-  slashCommandMatches,
+  rankedSlashCommandNames,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
 import { setPendingInitialPrompt } from "@/store/chatStore";
@@ -2525,7 +2525,7 @@ export function NewChatLandingScreen() {
   // Kept in sync with what SlashCommandMenu renders so keyboard nav
   // indexes into the same list.
   const slashMenuMatches = slashMenuOpen
-    ? Object.keys(skillCommands).filter((name) => slashCommandMatches(name, slashMenuQuery))
+    ? rankedSlashCommandNames(skillCommands, slashMenuQuery)
     : [];
   // Pre-select the first match whenever the filtered list changes, so
   // Tab/Enter complete the top item without arrowing down first (same

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -53,7 +53,11 @@ import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { sandboxOptionLabel } from "@/lib/capabilities";
-import { isSlashCommandText, slashCommandMatches, SlashCommandMenu } from "@/components/SlashCommandMenu";
+import {
+  isSlashCommandText,
+  slashCommandMatches,
+  SlashCommandMenu,
+} from "@/components/SlashCommandMenu";
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -53,7 +53,7 @@ import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { sandboxOptionLabel } from "@/lib/capabilities";
-import { isSlashCommandText, SlashCommandMenu } from "@/components/SlashCommandMenu";
+import { isSlashCommandText, slashCommandMatches, SlashCommandMenu } from "@/components/SlashCommandMenu";
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
@@ -2521,9 +2521,7 @@ export function NewChatLandingScreen() {
   // Kept in sync with what SlashCommandMenu renders so keyboard nav
   // indexes into the same list.
   const slashMenuMatches = slashMenuOpen
-    ? Object.keys(skillCommands).filter((name) =>
-        name.slice(1).startsWith(slashMenuQuery.toLowerCase()),
-      )
+    ? Object.keys(skillCommands).filter((name) => slashCommandMatches(name, slashMenuQuery))
     : [];
   // Pre-select the first match whenever the filtered list changes, so
   // Tab/Enter complete the top item without arrowing down first (same


### PR DESCRIPTION


## Summary

- The slash-command menu matched a query as a **prefix of the full, namespaced command name**, so `/using-superpowers` surfaced nothing (the name starts with `superpowers:`). It now matches a **case-insensitive substring of the command name**, so `/using-superpowers` finds `/superpowers:using-superpowers`.- One shared helper `slashCommandMatches(name, query)` backs all three web filter sites (menu render, `ChatPage` `menuMatches`, `NewChatDialog` `slashMenuMatches`) so the visible list and keyboard-nav index can't drift apart; the omnigent REPL completer mirrors the same rule in Python for CLI/web parity.- Deliberately **name-only** (the menu never shows descriptions inline, so a description match would look unexplained), **insertion order preserved** (keeps the Commands/Skills split contiguous), and **submit routing unchanged** (menu completion still fills the canonical name first).
**ELI5:** You used to have to type the *start* of a command's full name, including its `plugin:` prefix, or it wouldn't show up. Now you can type any piece of the name you remember and it'll find it.


## Demo

<img width="789" height="268" alt="Screenshot 2026-07-15 at 5 27 15 PM" src="https://github.com/user-attachments/assets/fe88b52d-c576-4821-bc45-adaef2fd2833" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the web composer and confirmed `/using-superpowers` surfaces `/superpowers:using-superpowers`, mid-name substrings match, and Tab/Enter completes to the canonical name. Automated coverage: TS unit tests for `slashCommandMatches` (leaf-after-namespace, mid-string, description-does-not-match, case-insensitivity, miss) plus keyboard-nav Tab-completion tests in both composers using non-prefix queries; Python completer tests including a real-registry substring test (`/heme` → `/theme`) against the live `COMMANDS`.

## Changelog

Slash-command menus now match any part of a command's name, so `/using-superpowers` finds `/superpowers:using-superpowers`
