### PR TITLE
fix(ci): release branches follow the existing release/vX.Y.0 convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
       - main
       # Release branches: release.yml's green-CI gate reads check runs off the
       # branch head, so cherry-picks and release-bump commits must run CI.
-      - 'branch-[0-9]*'
+      - 'release/v[0-9]*'
     paths-ignore: ['web/**', 'tests/e2e_ui/**', 'CHANGELOG.md']
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ on:
       - main
       # Release branches: release.yml's green-CI gate reads check runs off the
       # branch head, so cherry-picks and release-bump commits must run checks.
-      - 'branch-[0-9]*'
+      - 'release/v[0-9]*'
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 # Cut or advance a release deterministically (designs/RELEASE-AUTOMATION.md):
 #
-#   dispatch with version=0.6.0rc1  ->  create branch-0.6 from `ref`, stamp the
+#   dispatch with version=0.6.0rc1  ->  create release/v0.6.0 from `ref`, stamp the
 #   lockstep version (scripts/update_versions.py + `uv lock`), tag v0.6.0rc1,
 #   push branch + tag. Later dispatches (0.6.0rc2, 0.6.0, 0.6.1) reuse the
-#   existing branch-0.6 head and ignore `ref`.
+#   existing release/v0.6.0 head and ignore `ref`.
 #
 # The branch + tag are pushed with the omnigent-ci App token, NOT GITHUB_TOKEN:
 # GITHUB_TOKEN-pushed tags trigger no workflows by GitHub policy, and the whole
@@ -28,7 +28,7 @@ on:
         required: true
         type: string
       ref:
-        description: "Branch/tag/SHA to cut branch-X.Y from. Only consulted when the branch does not exist yet (rc1); later phases build from the existing branch head."
+        description: "Branch/tag/SHA to cut release/vX.Y.0 from. Only consulted when the branch does not exist yet (rc1); later phases build from the existing branch head."
         required: false
         default: main
         type: string
@@ -48,7 +48,7 @@ permissions:
   contents: read
 
 # Serialize all release runs: two concurrent cuts (even of different versions)
-# could race the same branch-X.Y head.
+# could race the same release/vX.Y.0 head.
 concurrency:
   group: release
   cancel-in-progress: false
@@ -108,7 +108,7 @@ jobs:
           {
             echo "version=${VERSION}"
             echo "tag=v${VERSION}"
-            echo "branch=branch-${major}.${minor}"
+            echo "branch=release/v${major}.${minor}.0"
             echo "prerelease=${prerelease}"
           } >> "$GITHUB_OUTPUT"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,9 +43,9 @@ never double-publishes. Use the secure repo for real releases.
   (e.g. `0.6.0.dev0`) — never a clean released number. This matches
   MLflow / Delta / Unity Catalog and keeps every `main` build PEP 440-ordered as
   "ahead of the last release, not yet the next one".
-- Releases are cut on **per-minor release branches** (`branch-X.Y`) and tagged
+- Releases are cut on **per-minor release branches** (`release/vX.Y.0`) and tagged
   there (`vX.Y.Z`, rc tags `vX.Y.ZrcN`); patches (`vX.Y.1`, `vX.Y.2`, …) are
-  cherry-picked onto the same `branch-X.Y`. `main` is never tagged.
+  cherry-picked onto the same `release/vX.Y.0`. `main` is never tagged.
 - Every release ships as an **rc first** (`0.6.0rc1` → … → `0.6.0`). rcs go to
   **real PyPI** as PEP 440 pre-releases — a default `pip install omnigent`
   never resolves them, and testers install with exact pins. TestPyPI is no
@@ -78,7 +78,7 @@ live site. At finalize time, the whole batch goes live at once (step 4 below).
 ```bash
 gh workflow run release.yml --repo omnigent-ai/omnigent \
   -f version=0.6.0rc1 -f dry_run=false
-# optional: -f ref=<sha> to cut branch-0.6 from a specific commit (rc1 only);
+# optional: -f ref=<sha> to cut release/v0.6.0 from a specific commit (rc1 only);
 # dry_run defaults to true — run once without -f dry_run to preview the plan.
 ```
 
@@ -87,7 +87,7 @@ What it does (all idempotent):
 - asserts green CI on the base commit (escape hatch: `-f skip_ci_check=true`,
   use deliberately — needed for a flaky check, or when the base commit ran no
   checks at all, e.g. a cherry-pick that only touched `paths-ignore`d files);
-- creates `branch-0.6` from `ref` (rc1) or reuses the existing branch head
+- creates `release/v0.6.0` from `ref` (rc1) or reuses the existing branch head
   (rc2+, final, patches — `ref` is ignored then);
 - stamps the lockstep version via `scripts/update_versions.py` and regenerates
   `uv.lock` with a clean public-PyPI resolution — **never hand-edit `uv.lock`
@@ -126,13 +126,13 @@ python -m venv /tmp/omni-rc && /tmp/omni-rc/bin/pip install \
 ```
 
 The rc's GitHub draft stays **unpublished** — rc drafts are never published.
-Need another candidate? Repeat with `0.6.0rc2` (fixes land on `branch-0.6`
-first, via cherry-pick PRs or direct pushes; CI runs on `branch-*` pushes).
+Need another candidate? Repeat with `0.6.0rc2` (fixes land on `release/v0.6.0`
+first, via cherry-pick PRs or direct pushes; CI runs on `release/v*` pushes).
 
 ### Final phase (example: `0.6.0`)
 
 1. **Cut + tag**: `gh workflow run release.yml -f version=0.6.0 -f dry_run=false`
-   — same as above; builds from the `branch-0.6` head.
+   — same as above; builds from the `release/v0.6.0` head.
 2. **Publish to PyPI**: same secure-repo dispatches on `ref=v0.6.0`.
 3. **Curate**: merge the `CHANGELOG.md` PR that `draft-release-notes.yml`
    opened, and review/trim the curated notes in the `v0.6.0` draft on the
@@ -157,7 +157,7 @@ first, via cherry-pick PRs or direct pushes; CI runs on `branch-*` pushes).
 
 ### Patch release (example: `0.6.1`)
 
-Cherry-pick the fixes onto `branch-0.6` (CI runs on the push), then run the
+Cherry-pick the fixes onto `release/v0.6.0` (CI runs on the push), then run the
 same flow with `version=0.6.1` — an rc first if the patch warrants one. `main`
 does not change for a patch, and a patch never needs a new branch.
 
@@ -198,62 +198,76 @@ can never be reused. So:
 
 ---
 
-## Rehearsing the pipeline (throwaway release to TestPyPI)
+## Rehearsing the pipeline (throwaway rc release)
 
 To exercise the whole flow end to end without touching users, release a
-deliberately **below-latest** rc (e.g. `0.0.1rc1`) and publish it to
-**TestPyPI**. A below-latest rc is inert everywhere that matters: the GitHub
-draft stays unpublished, Docker publishes only the immutable `:v0.0.1rc1`
-image tag (`:latest` / `:latest-rc` only move for the highest version), the
-notes/site/homebrew workflows ignore rc tags, `bump-main` skips itself (the
-version sorts below main's), and nothing on TestPyPI is ever resolved by a
-default `pip install`.
+deliberately **below-latest** rc on the dead `0.0` line. A below-latest rc is
+inert everywhere that matters: the GitHub draft stays unpublished, Docker
+publishes only the immutable version image tag (`:latest` / `:latest-rc` only
+move for the highest version), the notes/site/homebrew workflows ignore rc
+tags, `bump-main` skips itself (the version sorts below main's), and a
+PEP 440 pre-release is never resolved by a default `pip install` — on real
+PyPI or TestPyPI alike.
+
+**Pick a version that has never touched the destination index.** PyPI
+filenames are burned forever — even for yanked releases — so reusing a number
+fails the upload with "File already exists". (`0.0.1rc1` itself is spent: it
+reserved the PyPI project names in June 2026.) Confirm before starting; a 404
+means the version is free:
+
+```bash
+curl -fsS https://pypi.org/pypi/omnigent/0.0.1rc2/json   # expect 404
+```
+
+The examples below use `0.0.1rc2`; substitute the next free number.
 
 1. **Plan (read-only)** — dry run is the default:
 
    ```bash
-   gh workflow run release.yml --repo omnigent-ai/omnigent -f version=0.0.1rc1
+   gh workflow run release.yml --repo omnigent-ai/omnigent -f version=0.0.1rc2
    ```
 
-2. **Execute**: re-run with `-f dry_run=false`. Expect `branch-0.0` + tag
-   `v0.0.1rc1` pushed, the tag firing the draft-release and image workflows,
+2. **Execute**: re-run with `-f dry_run=false`. Expect `release/v0.0.0` + tag
+   `v0.0.1rc2` pushed, the tag firing the draft-release and image workflows,
    and CI running on the branch push. If the CI gate rejects main's head
    (failing or still-pending checks), that's the gate working — wait, or
    re-dispatch with `-f ref=<green sha>` / `-f skip_ci_check=true`.
    Cancelled (superseded) runs only warn.
 3. **Idempotency**: dispatch the exact same command again — it must no-op
    ("already at the converged release commit").
-4. **Secure-repo publish**, pointed at TestPyPI instead of PyPI:
+4. **Secure-repo publish.** Real PyPI is safe for a below-latest rc and is
+   the only destination that exercises the post-publish `validate` job — so
+   rehearse against `destination=pypi` (it binds the per-package reviewer
+   environments; approve all three). `destination=test-pypi` also works, but
+   skips the prod tag gate and `validate`, and needs TestPyPI Trusted
+   Publishers configured.
 
    ```bash
    gh workflow run omnigent.yml --repo databricks/secure-public-registry-releases-eng \
-     -f ref=v0.0.1rc1 -f destination=test-pypi -f dry-run=true    # gates only
+     -f ref=v0.0.1rc2 -f destination=pypi -f dry-run=true    # gates only
    gh workflow run omnigent.yml --repo databricks/secure-public-registry-releases-eng \
-     -f ref=v0.0.1rc1 -f destination=test-pypi -f dry-run=false   # real TestPyPI upload
+     -f ref=v0.0.1rc2 -f destination=pypi -f dry-run=false   # publish + validate
    ```
 
-   test-pypi runs skip the tag/version prod gate and the post-publish
-   `validate` job (TestPyPI lacks the dependency closure) and bind the shared
-   `test-pypi` environment. If an upload leg fails with an invalid-publisher
-   error, add the missing TestPyPI Trusted Publisher for that package and
-   re-dispatch — already-uploaded legs are skipped.
 5. **Publish idempotency**: re-dispatch step 4's second command — all three
-   packages must skip as already published.
+   legs must skip as already published (twine `--skip-existing`) and the run
+   stays green.
 6. **Finalize gates (no side effects)**:
-   `gh workflow run finalize-release.yml -f tag=v0.0.1rc1` must fail fast
+   `gh workflow run finalize-release.yml -f tag=v0.0.1rc2` must fail fast
    ("not a final tag"), and `-f tag=v0.5.1` (any already-published release)
    must no-op as already published.
 
-Cleanup — delete everything the rehearsal minted:
+Cleanup — delete everything the rehearsal minted on GitHub:
 
 ```bash
-gh release delete v0.0.1rc1 --repo omnigent-ai/omnigent --cleanup-tag --yes
-gh api -X DELETE repos/omnigent-ai/omnigent/git/refs/heads/branch-0.0
+gh release delete v0.0.1rc2 --repo omnigent-ai/omnigent --cleanup-tag --yes
+gh api -X DELETE 'repos/omnigent-ai/omnigent/git/refs/heads/release/v0.0.0'
 ```
 
-Optionally delete the `v0.0.1rc1` image versions from GHCR. TestPyPI needs no
-cleanup — the version number is burned there only, which is what TestPyPI is
-for.
+Optionally delete the rehearsal image versions from GHCR. The PyPI side needs
+no cleanup: the rc is invisible to default installs and only the version
+number is spent — optionally yank it (*Manage → Releases → Yank*) for
+tidiness.
 
 ---
 
@@ -263,7 +277,7 @@ If the workflows are unavailable, the flow can be driven by hand — but keep tw
 rules even then:
 
 1. **Never hand-edit `uv.lock` and never run `uv lock` behind a proxy.** Use
-   `bump-version.yml` (mode `pre-release`, `base_branch=branch-X.Y`) to
+   `bump-version.yml` (mode `pre-release`, `base_branch=release/vX.Y.0`) to
    produce the bump as a PR with a cleanly regenerated lockfile, and merge it.
 2. **Push tags from an account, not automation you improvised** — the tag push
    must fire `github-release.yml` et al., which a `GITHUB_TOKEN`-authored push
@@ -271,11 +285,11 @@ rules even then:
 
 ```bash
 gh auth switch --user <oss-account>
-git fetch origin && git checkout -b branch-0.6 origin/main   # rc1 only
+git fetch origin && git checkout -b release/v0.6.0 origin/main   # rc1 only
 gh workflow run bump-version.yml -f mode=pre-release -f new_version=0.6.0rc1 \
-  -f base_branch=branch-0.6                                  # then merge the PR
-git fetch origin && git checkout branch-0.6 && git pull
-git tag v0.6.0rc1 && git push origin branch-0.6 v0.6.0rc1    # explicit tag, NOT --tags
+  -f base_branch=release/v0.6.0                                  # then merge the PR
+git fetch origin && git checkout release/v0.6.0 && git pull
+git tag v0.6.0rc1 && git push origin release/v0.6.0 v0.6.0rc1    # explicit tag, NOT --tags
 ```
 
 Then continue from step 2 of the standard flow (secure-repo dispatches). If the

--- a/designs/RELEASE-AUTOMATION.md
+++ b/designs/RELEASE-AUTOMATION.md
@@ -21,7 +21,7 @@ suggests. Per release step:
 
 | Step | Mechanism today | Deterministic? |
 | --- | --- | --- |
-| Cut `branch-X.Y` from green main/SHA | human CLI | ❌ manual |
+| Cut `release/vX.Y.0` from green main/SHA | human CLI | ❌ manual |
 | Lockstep bump (3 `pyproject.toml` + `omnigent/version.py` + `uv.lock`) | `scripts/update_versions.py` (+ `bump-version.yml` wrapper) | ✅ exists, but human-invoked; RELEASING.md still says "hand-edit `uv.lock`" (CI `uv lock` has no proxy problem) |
 | Tag `vX.Y.Z[rcN]` + push | human CLI | ❌ manual |
 | Bump main to next `.dev0` | human CLI (or `bump-version.yml` post-release) | 🟡 semi |
@@ -75,8 +75,8 @@ click. Rejected.
 
 - `version` — `0.6.0rc1` | `0.6.0` | `0.6.1` (no leading `v`; `.dev` rejected)
 - `ref` — default `main`; branch/tag/SHA to cut from. **Only consulted when
-  `branch-X.Y` does not exist yet** (i.e. at rc1). Later rcs, the final, and
-  patches always build from the existing `branch-X.Y` head; passing a `ref` that
+  `release/vX.Y.0` does not exist yet** (i.e. at rc1). Later rcs, the final, and
+  patches always build from the existing `release/vX.Y.0` head; passing a `ref` that
   disagrees with it fails loudly instead of silently retargeting.
 - `dry_run` — default `true` (repo convention, matches the vscode workflows):
   run the whole plan, print it, push nothing.
@@ -84,14 +84,14 @@ click. Rejected.
 Jobs:
 
 1. **plan** (always): validate version shape (reuse `bump-version.yml`'s PEP 440
-   regex minus `.dev`); derive `branch-X.Y` + `vX.Y.Z[rcN]`; resolve the base SHA
+   regex minus `.dev`); derive `release/vX.Y.0` + `vX.Y.Z[rcN]`; resolve the base SHA
    (existing branch head, else `ref`); assert the tag doesn't exist (or already
    points at the fully-converged state → declare no-op); assert the resolved
    SHA's check suites are green (not just "some run on main succeeded"); for a
    final, warn if no `vX.Y.*rc*` tag exists on the branch. Write the plan to the
    step summary.
 2. **execute** (`dry_run == false`): mint the omnigent-ci App token; create
-   `branch-X.Y` at the base SHA if missing; `update_versions.py pre-release
+   `release/vX.Y.0` at the base SHA if missing; `update_versions.py pre-release
    --new-version $VERSION`; `uv lock` (runner resolves against real PyPI — this
    *retires the hand-edit-uv.lock ritual entirely*); `update_versions.py check`;
    commit `release: vX.Y.Z` (skip when already stamped); tag; push branch + tag
@@ -319,7 +319,7 @@ unattended. Relevant mechanics:
   the just-published artifact + run it). The `validate` job in the secure repo
   puts omnigent ahead of both, not just at parity.
 - **Neither has an rc→final concept** — both rebuild rather than promote.
-  Rebuilding the final from the same `branch-X.Y` (rather than promoting rc
+  Rebuilding the final from the same `release/vX.Y.0` (rather than promoting rc
   artifacts) is also what our model does; PyPI's no-reupload rule makes
   rebuild-and-restamp the pragmatic norm.
 - Both decouple docs publishing from the release pipeline structurally — which
@@ -364,7 +364,7 @@ PR is the approval gate; `publish-jetbrains.yml` fires on the merge, with a
 dispatch fallback for re-runs; rc tags chain `-rc.1 … -rc.15 → stable`.
 
 **Considered variant for omnigent** (from the JetBrains pattern): have
-`release.yml` open a bump *PR* onto `branch-X.Y` instead of pushing directly,
+`release.yml` open a bump *PR* onto `release/vX.Y.0` instead of pushing directly,
 making the merge a second-person cut-approval and running CI on the bump
 commit. Rejected as the default: the bump is deterministic robot output
 (`update_versions.py` + `check`), the cut is fully reversible, the secure
@@ -426,7 +426,7 @@ effects. Worth stealing:
 - **Nobody has versioned docs** — all continuous-deploy latest-only. The
   `X.Y-docs` staging design has no prior art to borrow; it's already built and
   just needs the sweep gate.
-- **Nobody has a backport/patch-branch story** as good as `branch-X.Y` +
+- **Nobody has a backport/patch-branch story** as good as `release/vX.Y.0` +
   cherry-pick; cline maintains one frozen legacy branch, kilocode has nothing.
 - Pre-publish smoke against built artifacts (kilocode) ≈ the secure repo's
   existing smoke-install gate. Parity, not a gap.
@@ -436,7 +436,7 @@ effects. Worth stealing:
 - rc→final promotion is rebuild-from-the-pinned-ref everywhere it exists at
   all (goose canary→stable, kilocode JetBrains) — never artifact relabeling.
   Validates our model: the final independently re-runs build+scan+publish
-  from `branch-X.Y`, which the mandatory dependency scan requires anyway.
+  from `release/vX.Y.0`, which the mandatory dependency scan requires anyway.
 - omnigent's mandatory scan-gates-publish + separate-org publisher is
   **stricter than every peer surveyed** (goose's scan isn't a gate; hermes's
   review gate was self-merged around; opencode/kilocode publish unattended).


### PR DESCRIPTION
## Related issue

N/A (follow-up to #2580, found during the first pipeline rehearsal)

## Summary

Two lessons from the first live rehearsal of the release pipeline, both folded back in:

- **Release branches now follow the repo's actual naming convention.** `release.yml` derived `branch-X.Y` names (taken from RELEASING.md's wording), but every real release branch in this repo is `release/vX.Y.0` — `release/v0.2.0` through `release/v0.5.0` — so the old doc was drift, not practice. The derive step now produces `release/v${major}.${minor}.0`, the `ci.yml`/`lint.yml` push triggers match `release/v[0-9]*`, and RELEASING.md + the design doc are updated throughout. (The rehearsal's mis-named `branch-0.0` is being deleted as part of rehearsal cleanup.)
- **The rehearsal runbook now requires a never-used version number.** The first rehearsal picked `0.0.1rc1`, which was already on real PyPI — it was spent reserving the PyPI project names in June 2026 — so the secure-repo publish failed with "File already exists" (PyPI filenames are burned forever, even after yank/delete). The runbook now says to confirm the version 404s on the index first, uses `0.0.1rc2` as the example, and prefers `destination=pypi` for rehearsals since a below-latest rc is inert there and only that destination exercises the new `validate` job. Companion fix in the secure repo passes twine `--skip-existing` so a collision/partial publish heals instead of hard-failing.

## Test Plan

- `actionlint` clean on all three touched workflows (the `ci.yml:193` matrix-timeout finding is pre-existing on main); `pre-commit` passes.
- `rg 'branch-'` across the pipeline files confirms no stale references remain (only prose like "branch-named dist-tag" in the peer survey).
- Live verification comes with the second rehearsal (`0.0.1rc2`) immediately after merge: it exercises the new branch name end to end (cut, CI trigger on the `release/v0.0.0` push, idempotent re-dispatch).

## Demo

N/A (CI + docs only).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Workflow-file rename with no unit-test surface; static checks above plus the staged second rehearsal (which runs the renamed derivation live, dry-run first) are the verification.

This pull request and its description were written by Isaac.
