### PR TITLE
fix(codex,claude): server-workspace resume alignment + resumable Codex threads across credential-default switch

### DIFF
--- a/omnigent/_native_session_workspace.py
+++ b/omnigent/_native_session_workspace.py
@@ -1,0 +1,60 @@
+"""Server-side workspace lookup for native-wrapper resume alignment.
+
+The native Claude/Codex wrappers record the launch cwd client-side at
+session creation, but sessions created elsewhere (desktop app, another
+machine) have no local record. The server session snapshot
+(``GET /v1/sessions/{id}``) carries an authoritative ``workspace``
+field for those sessions; this helper fetches it so resume can align
+the wrapper cwd instead of silently adopting whatever directory the
+CLI happens to run from.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from omnigent.native_terminal import url_component
+
+_logger = logging.getLogger(__name__)
+
+
+def fetch_session_workspace(
+    *,
+    base_url: str | None,
+    headers: dict[str, str],
+    session_id: str,
+) -> str | None:
+    """
+    Fetch a session's server-recorded workspace path.
+
+    Best-effort: any transport or payload problem returns ``None`` so
+    resume falls back to the wrapper's current cwd, matching the
+    behavior before server-side alignment existed.
+
+    :param base_url: Omnigent server base URL, or ``None`` when unavailable.
+    :param headers: HTTP auth headers for the Omnigent request.
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :returns: Absolute workspace path recorded on the server, e.g.
+        ``"/home/me/repo"``, or ``None`` when unknown.
+    """
+    if base_url is None:
+        return None
+    try:
+        with httpx.Client(base_url=base_url, headers=headers, timeout=10.0) as client:
+            resp = client.get(f"/v1/sessions/{url_component(session_id)}")
+        if resp.status_code >= 400:
+            return None
+        payload = resp.json()
+    except Exception:  # noqa: BLE001 - optional resume preflight
+        _logger.warning(
+            "failed to fetch server workspace for resume alignment; session=%s",
+            session_id,
+            exc_info=True,
+        )
+        return None
+    workspace = payload.get("workspace") if isinstance(payload, dict) else None
+    if not isinstance(workspace, str) or not workspace:
+        return None
+    return workspace

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -47,6 +47,7 @@ from websockets.exceptions import ConnectionClosed, ConnectionClosedError, WebSo
 from websockets.frames import Close
 
 from omnigent._native_resume_hint import echo_native_resume_hint
+from omnigent._native_session_workspace import fetch_session_workspace
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._startup_profile import StartupProfiler
 from omnigent._terminal_picker_theme import (
@@ -516,19 +517,18 @@ def _align_working_directory_with_session(
 
     * A user resuming on the same machine they created the session
       on gets the chdir prompt; this is the common path.
-    * A user resuming from a different machine has no recorded
-      state for this conv id locally -- the helper silently
-      proceeds (no prompt) and Claude will likely exit, at which
-      point the user knows to start a fresh session. The wrapper
-      cannot fabricate the cwd; only the original client knew it.
+    * A user resuming from a different machine (or a session created
+      by the desktop app) has no recorded state for this conv id
+      locally -- the helper falls back to the server session
+      snapshot's ``workspace`` field, which the server records at
+      session create.
 
     Decision table:
 
-    - **No state recorded**: silent no-op. Either a legacy session
-      created before this tracking landed, or a session created on
-      a different machine. Echoing a hint here would be noisy on
-      every legacy resume; the user finds out via Claude's own
-      "session not found / cwd mismatch" message if it matters.
+    - **No state recorded**: fall back to the server-recorded
+      ``workspace`` (see :func:`_align_with_server_workspace`).
+      When the server knows no workspace either, silent no-op --
+      a legacy session created before workspace tracking landed.
     - **Recorded cwd matches current cwd**: silent no-op.
     - **Recorded cwd differs, recorded path exists**: offer
       ``switch`` (default), ``move``, or ``leave``. ``switch``
@@ -556,6 +556,7 @@ def _align_working_directory_with_session(
     """
     state = read_launch_state(session_id)
     if state is None:
+        _align_with_server_workspace(session_id, base_url=base_url, headers=headers)
         return
     current = Path.cwd().resolve()
     recorded_path = Path(state.working_directory).resolve()
@@ -581,6 +582,90 @@ def _align_working_directory_with_session(
     )
     if action == _RESUME_ACTION_SWITCH:
         _switch_to_recorded_working_directory(recorded_path)
+        return
+    if action == _RESUME_ACTION_MOVE:
+        if external_session_id is None:
+            raise click.ClickException(
+                "Cannot move Claude transcript: no external session id was found."
+            )
+        _redirect_claude_transcript_to_current_project(
+            session_id=session_id,
+            external_session_id=external_session_id,
+            current=current,
+        )
+        return
+    raise click.ClickException("Resume cancelled.")
+
+
+def _align_with_server_workspace(
+    session_id: str,
+    *,
+    base_url: str | None,
+    headers: dict[str, str] | None,
+) -> None:
+    """
+    Align cwd with the server-recorded session workspace on resume.
+
+    Fallback for resumes with no client-side launch state: sessions
+    created by the desktop app or on another machine. The server
+    session snapshot's ``workspace`` is authoritative there; without
+    this, resume silently samples whatever directory the CLI happens
+    to run from and Claude exits on the cwd mismatch. Best-effort by
+    design -- an unknown workspace, or one that does not exist on
+    this machine with no local transcript to move, falls back to the
+    current cwd (with a warning for the latter) so legacy sessions
+    keep resuming as before.
+
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param base_url: Omnigent server base URL, or ``None`` when
+        unavailable (skips the lookup).
+    :param headers: HTTP auth headers for *base_url*, or ``None``.
+    :returns: None. Side-effect-only; may change process cwd, move a
+        Claude transcript, and record launch state for subsequent
+        resumes.
+    :raises click.ClickException: If the user leaves, or a chosen
+        move fails.
+    """
+    workspace = fetch_session_workspace(
+        base_url=base_url,
+        headers=headers or {},
+        session_id=session_id,
+    )
+    if workspace is None:
+        return
+    current = Path.cwd().resolve()
+    server_path = Path(workspace).resolve()
+    if current == server_path:
+        _record_launch_for_fresh_session(session_id)
+        return
+    external_session_id = _fetch_external_session_id_for_redirect(
+        base_url=base_url,
+        headers=headers or {},
+        session_id=session_id,
+    )
+    redirect_available = _redirect_available(external_session_id)
+    if not server_path.is_dir():
+        if not redirect_available:
+            click.echo(
+                f"Warning: session {session_id} has server workspace {server_path}, "
+                "which does not exist on this machine. Resuming from the current "
+                f"directory ({current}).",
+                err=True,
+            )
+            return
+    elif not _stream_is_tty(sys.stdin):
+        # Non-interactive resume: prefer the authoritative server workspace.
+        _switch_to_recorded_working_directory(server_path)
+        _record_launch_for_fresh_session(session_id)
+        return
+    action = _prompt_resume_workspace_action(
+        recorded_path=server_path,
+        current=current,
+        redirect_available=redirect_available,
+    )
+    if action == _RESUME_ACTION_SWITCH:
+        _switch_to_recorded_working_directory(server_path)
+        _record_launch_for_fresh_session(session_id)
         return
     if action == _RESUME_ACTION_MOVE:
         if external_session_id is None:

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -11,6 +11,7 @@ import re
 import secrets
 import shutil
 import socket
+import sys
 import time
 import uuid
 from dataclasses import dataclass
@@ -24,6 +25,7 @@ import httpx
 import yaml
 
 from omnigent._native_resume_hint import echo_native_resume_hint
+from omnigent._native_session_workspace import fetch_session_workspace
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._wrapper_labels import (
     CODEX_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE,
@@ -393,7 +395,12 @@ def _record_launch_for_fresh_session(session_id: str) -> None:
         )
 
 
-def _align_working_directory_with_session(session_id: str) -> None:
+def _align_working_directory_with_session(
+    session_id: str,
+    *,
+    base_url: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> None:
     """
     Resolve cwd mismatch before resuming a Codex-native session.
 
@@ -403,13 +410,24 @@ def _align_working_directory_with_session(session_id: str) -> None:
     present and points at a different existing directory, ask whether
     to switch there before the runner and app-server sample cwd.
 
+    When no client-side launch state exists (session created by the
+    desktop app or another machine), the server session snapshot's
+    ``workspace`` field is consulted instead so resume does not
+    silently adopt an unrelated cwd.
+
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param base_url: Omnigent server base URL used to fetch the
+        session's ``workspace`` when no local launch state exists,
+        e.g. ``"http://127.0.0.1:6767"``. ``None`` skips the lookup.
+    :param headers: HTTP auth headers for *base_url*. ``None`` is
+        treated as no headers.
     :returns: None. Side-effect-only; may change process cwd.
     :raises click.ClickException: If recorded state exists but no
         viable resume directory exists, or if the user cancels.
     """
     state = read_launch_state(session_id)
     if state is None:
+        _align_with_server_workspace(session_id, base_url=base_url, headers=headers)
         return
     current = Path.cwd().resolve()
     recorded_path = Path(state.working_directory).resolve()
@@ -429,6 +447,63 @@ def _align_working_directory_with_session(session_id: str) -> None:
         _switch_to_recorded_working_directory(recorded_path)
         return
     raise click.ClickException("Resume cancelled.")
+
+
+def _align_with_server_workspace(
+    session_id: str,
+    *,
+    base_url: str | None,
+    headers: dict[str, str] | None,
+) -> None:
+    """
+    Align cwd with the server-recorded session workspace on resume.
+
+    Fallback for resumes with no client-side launch state: sessions
+    created by the desktop app or on another machine. The server
+    session snapshot's ``workspace`` is authoritative there; without
+    this, resume silently launches Codex in whatever directory the
+    CLI happens to run from. Best-effort by design — an unknown
+    workspace or one that does not exist on this machine falls back
+    to the current cwd (with a warning for the latter) so legacy and
+    genuinely cross-filesystem resumes keep working.
+
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param base_url: Omnigent server base URL, or ``None`` when
+        unavailable (skips the lookup).
+    :param headers: HTTP auth headers for *base_url*, or ``None``.
+    :returns: None. Side-effect-only; may change process cwd and
+        record launch state for subsequent resumes.
+    :raises click.ClickException: If the user cancels the resume.
+    """
+    workspace = fetch_session_workspace(
+        base_url=base_url,
+        headers=headers or {},
+        session_id=session_id,
+    )
+    if workspace is None:
+        return
+    current = Path.cwd().resolve()
+    server_path = Path(workspace).resolve()
+    if current != server_path:
+        if not server_path.is_dir():
+            click.echo(
+                f"Warning: session {session_id} has server workspace {server_path}, "
+                "which does not exist on this machine. Resuming from the current "
+                f"directory ({current}).",
+                err=True,
+            )
+            return
+        if sys.stdin is not None and sys.stdin.isatty():
+            action = _prompt_codex_resume_workspace_action(
+                recorded_path=server_path,
+                current=current,
+            )
+            if action != _RESUME_ACTION_SWITCH:
+                raise click.ClickException("Resume cancelled.")
+        _switch_to_recorded_working_directory(server_path)
+    # Record the resolved workspace so subsequent resumes align without
+    # another server round-trip.
+    _record_launch_for_fresh_session(session_id)
 
 
 def _prompt_codex_resume_workspace_action(
@@ -584,7 +659,11 @@ def _run_with_local_server(
         if resolved_session_id is None and resume_picker and session_id is None:
             return
         if resolved_session_id is not None:
-            _align_working_directory_with_session(resolved_session_id)
+            _align_working_directory_with_session(
+                resolved_session_id,
+                base_url=base_url,
+                headers={},
+            )
 
         async def _drive() -> None:
             """
@@ -673,7 +752,11 @@ def _run_with_remote_server(
         if resolved_session_id is None and resume_picker and session_id is None:
             return
         if resolved_session_id is not None:
-            _align_working_directory_with_session(resolved_session_id)
+            _align_working_directory_with_session(
+                resolved_session_id,
+                base_url=base_url,
+                headers=headers,
+            )
 
         async def _drive() -> None:
             """

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1058,6 +1058,68 @@ async def trust_native_policy_hooks(client: CodexAppServerClient, *, cwd: str) -
         )
 
 
+# Provider ids Omnigent stamps into Codex rollouts (``session_meta.
+# model_provider``): the generated generic-provider table and the
+# Databricks ucode table. A thread created under one routing decision
+# persists its id; resuming under a different decision must still be
+# able to resolve it at config load.
+_OMNIGENT_CODEX_PROVIDER_IDS = ("omnigent_provider", "omnigent_databricks")
+# Alias body when the current routing carries no provider table of its
+# own (Codex CLI login / subscription): resolve the stale id through
+# Codex's own stored login, exactly like the built-in ``openai``
+# provider (``requires_openai_auth`` selects auth.json credentials).
+_CODEX_LOGIN_ALIAS_TABLE = '{name="OpenAI",requires_openai_auth=true,wire_api="responses"}'
+
+
+def _stale_provider_alias_overrides(config_overrides: list[str]) -> list[str]:
+    """Define Omnigent provider ids the current routing leaves undefined.
+
+    A persisted Codex thread names its ``model_provider`` in the rollout,
+    and ``thread/resume`` fails config load (``Model provider
+    `omnigent_provider` not found``) when that id is not in the launched
+    app-server's provider table — e.g. a thread created while a gateway
+    credential was the Codex default, resumed after the default flipped
+    to the subscription login. The session would be unresumable until the
+    user flips the default back.
+
+    This returns alias ``model_providers.<id>=`` overrides for every
+    Omnigent-stamped id the assembled overrides do not already define,
+    re-mapping stale references to the current routing decision:
+
+    - when the current routing defines its own Omnigent provider table
+      (gateway/key/local → ``omnigent_provider``, Databricks →
+      ``omnigent_databricks``), the alias reuses that table body so a
+      stale id routes through the current credential;
+    - otherwise (Codex CLI login) the alias resolves through Codex's own
+      stored login via ``requires_openai_auth``.
+
+    The reverse direction needs no alias: a thread created under the
+    subscription login references the built-in ``openai`` provider, which
+    Codex always defines.
+
+    :param config_overrides: The assembled ``-c`` overrides for this
+        launch, e.g. ``['model_provider="openai"']``.
+    :returns: Alias override strings to append, possibly empty.
+    """
+    prefix = "model_providers."
+    defined: dict[str, str] = {}
+    for override in config_overrides:
+        if not override.startswith(prefix):
+            continue
+        name, _, table = override.removeprefix(prefix).partition("=")
+        if name and table:
+            defined[name] = table
+    current_table = next(
+        (defined[name] for name in _OMNIGENT_CODEX_PROVIDER_IDS if name in defined),
+        _CODEX_LOGIN_ALIAS_TABLE,
+    )
+    return [
+        f"model_providers.{name}={current_table}"
+        for name in _OMNIGENT_CODEX_PROVIDER_IDS
+        if name not in defined
+    ]
+
+
 def build_codex_native_server(
     *,
     socket_path: Path,
@@ -1134,6 +1196,10 @@ def build_codex_native_server(
         env["DATABRICKS_HOST"] = host
     if extra_config_overrides:
         config_overrides.extend(extra_config_overrides)
+    # Keep threads created under a different credential default resumable:
+    # define every Omnigent-stamped provider id the current routing leaves
+    # undefined, re-mapped to the current routing decision.
+    config_overrides.extend(_stale_provider_alias_overrides(config_overrides))
     if bypass_sandbox:
         # Mirror the --remote TUI's --dangerously-bypass-approvals-and-sandbox
         # on the app-server threads: never prompt for approval, and run

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -6432,3 +6432,156 @@ def test_tool_use_result_regression_old_flatten_would_crash_resume() -> None:
     )
     assert len(records) == 1
     assert json.loads(records[0]["toolUseResult"]) == output
+
+
+# ── _align_with_server_workspace (no local launch state) ──
+#
+# Sessions created by the desktop app or on another machine have no
+# client-side launch state; the server session snapshot's ``workspace``
+# field is the fallback so resume does not sample an unrelated cwd.
+
+
+def test_align_no_state_switches_to_server_workspace_non_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    No local state + server workspace elsewhere → switch (non-tty).
+
+    Cross-machine / desktop-app sessions carry an authoritative
+    ``workspace`` on the server; without a TTY there is nobody to
+    prompt, so the wrapper switches there and records launch state so
+    the next resume uses the normal recorded-state path.
+    """
+    from omnigent.claude_native_state import read_launch_state
+
+    server_ws = tmp_path / "server-ws"
+    server_ws.mkdir()
+    current = tmp_path / "current"
+    current.mkdir()
+    monkeypatch.chdir(current)
+    monkeypatch.setattr(
+        claude_native,
+        "fetch_session_workspace",
+        lambda **_kwargs: str(server_ws),
+    )
+    monkeypatch.setattr(
+        claude_native,
+        "_fetch_external_session_id_for_redirect",
+        lambda **_kwargs: None,
+    )
+
+    claude_native._align_working_directory_with_session(
+        "conv_remote_ws",
+        base_url="http://ap.example",
+        headers={},
+    )
+
+    assert Path.cwd().resolve() == server_ws.resolve()
+    state = read_launch_state("conv_remote_ws")
+    assert state is not None
+    assert state.working_directory == str(server_ws.resolve())
+
+
+def test_align_no_state_interactive_leave_cancels(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    No local state + server workspace elsewhere → prompt on a TTY;
+    ``leave`` cancels before Claude can crash on the cwd mismatch.
+    """
+    server_ws = tmp_path / "server-ws"
+    server_ws.mkdir()
+    current = tmp_path / "current"
+    current.mkdir()
+    monkeypatch.chdir(current)
+    monkeypatch.setattr(
+        claude_native,
+        "fetch_session_workspace",
+        lambda **_kwargs: str(server_ws),
+    )
+    monkeypatch.setattr(
+        claude_native,
+        "_fetch_external_session_id_for_redirect",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(claude_native, "_stream_is_tty", lambda _stream: True)
+    monkeypatch.setattr(
+        claude_native,
+        "_prompt_resume_workspace_action",
+        lambda **_kwargs: claude_native._RESUME_ACTION_LEAVE,
+    )
+
+    with pytest.raises(click.ClickException, match="cancelled"):
+        claude_native._align_working_directory_with_session(
+            "conv_remote_ws", base_url="http://ap.example", headers={}
+        )
+
+    assert Path.cwd().resolve() == current.resolve()
+
+
+def test_align_no_state_missing_server_workspace_warns_and_proceeds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    Server workspace absent locally + no transcript to move → warn,
+    keep the current cwd (the pre-fallback behavior), record nothing.
+    """
+    from omnigent.claude_native_state import read_launch_state
+
+    current = tmp_path / "current"
+    current.mkdir()
+    monkeypatch.chdir(current)
+    missing = tmp_path / "not-here"
+    monkeypatch.setattr(
+        claude_native,
+        "fetch_session_workspace",
+        lambda **_kwargs: str(missing),
+    )
+    monkeypatch.setattr(
+        claude_native,
+        "_fetch_external_session_id_for_redirect",
+        lambda **_kwargs: None,
+    )
+
+    claude_native._align_working_directory_with_session(
+        "conv_remote_ws", base_url="http://ap.example", headers={}
+    )
+
+    assert Path.cwd().resolve() == current.resolve()
+    assert read_launch_state("conv_remote_ws") is None
+    assert "does not exist on this machine" in capsys.readouterr().err
+
+
+def test_align_no_state_matching_server_workspace_records_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Server workspace equal to cwd → no prompt, launch state recorded
+    so subsequent resumes skip the server round-trip.
+    """
+    from omnigent.claude_native_state import read_launch_state
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        claude_native,
+        "fetch_session_workspace",
+        lambda **_kwargs: str(tmp_path),
+    )
+
+    def fail_prompt(**_kwargs: object) -> str:
+        raise AssertionError("matching server workspace should not prompt")
+
+    monkeypatch.setattr(claude_native, "_prompt_resume_workspace_action", fail_prompt)
+
+    claude_native._align_working_directory_with_session(
+        "conv_remote_ws", base_url="http://ap.example", headers={}
+    )
+
+    state = read_launch_state("conv_remote_ws")
+    assert state is not None
+    assert state.working_directory == str(tmp_path.resolve())

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -6790,11 +6790,12 @@ def test_run_with_remote_server_aligns_cwd_before_daemon_prepare(
         lambda **_kwargs: "conv_abc",
     )
 
-    def fake_align_working_directory(_session_id: str) -> None:
+    def fake_align_working_directory(_session_id: str, **_kwargs: object) -> None:
         """
         Simulate resume alignment changing the process cwd.
 
         :param _session_id: Session id being aligned.
+        :param _kwargs: Server coordinates (``base_url`` / ``headers``).
         :returns: None.
         """
         order.append("align")
@@ -9688,3 +9689,185 @@ def test_rollout_records_without_compaction_item_has_no_compacted_entry() -> Non
     )
     types = [r["type"] for r in records]
     assert "compacted" not in types
+
+
+# ── _align_with_server_workspace (no local launch state) ──
+#
+# Sessions created by the desktop app or on another machine have no
+# client-side launch state, so resume used to silently adopt the CLI's
+# current cwd and launch Codex in an unrelated repo. The server session
+# snapshot's ``workspace`` field is authoritative for those sessions.
+
+
+def test_align_no_state_switches_to_server_workspace_non_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    No local state + server workspace elsewhere → switch (non-tty).
+
+    The reported bug: a session with server
+    ``workspace=/…/yang-ai-elements-message`` resumed from a different
+    repo launched the Codex terminal with the unrelated repo's cwd.
+    Without a TTY there is nobody to prompt, so the authoritative
+    server workspace wins — and is recorded client-side so the next
+    resume aligns without a server round-trip.
+    """
+    from omnigent.codex_native_state import read_launch_state
+
+    server_ws = tmp_path / "server-ws"
+    server_ws.mkdir()
+    current = tmp_path / "current"
+    current.mkdir()
+    monkeypatch.chdir(current)
+    monkeypatch.setenv("OMNIGENT_CODEX_NATIVE_STATE_DIR", str(tmp_path / "state"))
+    fetch_calls: list[dict[str, object]] = []
+
+    def fake_fetch(
+        *, base_url: str | None, headers: dict[str, str], session_id: str
+    ) -> str | None:
+        fetch_calls.append({"base_url": base_url, "headers": headers, "session_id": session_id})
+        return str(server_ws)
+
+    monkeypatch.setattr(codex_native, "fetch_session_workspace", fake_fetch)
+
+    codex_native._align_working_directory_with_session(
+        "conv_remote",
+        base_url="http://ap.example",
+        headers={"Authorization": "Bearer t"},
+    )
+
+    assert fetch_calls == [
+        {
+            "base_url": "http://ap.example",
+            "headers": {"Authorization": "Bearer t"},
+            "session_id": "conv_remote",
+        }
+    ]
+    assert Path.cwd().resolve() == server_ws.resolve()
+    state = read_launch_state("conv_remote")
+    assert state is not None
+    assert state.working_directory == str(server_ws.resolve())
+
+
+def test_align_no_state_prompts_when_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    No local state + server workspace elsewhere → prompt on a TTY.
+
+    Interactive resumes keep the same switch/cancel UX as the
+    recorded-state path; cancel aborts before the runner samples cwd.
+    """
+    server_ws = tmp_path / "server-ws"
+    server_ws.mkdir()
+    current = tmp_path / "current"
+    current.mkdir()
+    monkeypatch.chdir(current)
+    monkeypatch.setenv("OMNIGENT_CODEX_NATIVE_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(
+        codex_native,
+        "fetch_session_workspace",
+        lambda **_kwargs: str(server_ws),
+    )
+    monkeypatch.setattr(codex_native.sys, "stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr(
+        codex_native,
+        "_prompt_codex_resume_workspace_action",
+        lambda **_kwargs: "cancel",
+    )
+
+    with pytest.raises(click.ClickException, match="cancelled"):
+        codex_native._align_working_directory_with_session(
+            "conv_remote", base_url="http://ap.example", headers={}
+        )
+
+    assert Path.cwd().resolve() == current.resolve()
+
+
+def test_align_no_state_missing_server_workspace_warns_and_proceeds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    Server workspace absent on this machine → warn, keep current cwd.
+
+    A genuinely cross-filesystem resume (path exists only on the other
+    machine) must fall back to the old behavior instead of failing, and
+    must not record misleading launch state.
+    """
+    from omnigent.codex_native_state import read_launch_state
+
+    current = tmp_path / "current"
+    current.mkdir()
+    monkeypatch.chdir(current)
+    monkeypatch.setenv("OMNIGENT_CODEX_NATIVE_STATE_DIR", str(tmp_path / "state"))
+    missing = tmp_path / "not-here"
+    monkeypatch.setattr(
+        codex_native,
+        "fetch_session_workspace",
+        lambda **_kwargs: str(missing),
+    )
+
+    codex_native._align_working_directory_with_session(
+        "conv_remote", base_url="http://ap.example", headers={}
+    )
+
+    assert Path.cwd().resolve() == current.resolve()
+    assert read_launch_state("conv_remote") is None
+    assert "does not exist on this machine" in capsys.readouterr().err
+
+
+def test_align_no_state_unknown_server_workspace_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Neither local state nor a server workspace → legacy silent no-op.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMNIGENT_CODEX_NATIVE_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(codex_native, "fetch_session_workspace", lambda **_kwargs: None)
+
+    codex_native._align_working_directory_with_session(
+        "conv_legacy", base_url="http://ap.example", headers={}
+    )
+
+    assert Path.cwd().resolve() == tmp_path.resolve()
+
+
+def test_align_no_state_matching_server_workspace_records_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Server workspace equal to cwd → no prompt, launch state recorded.
+
+    Recording on the match path makes subsequent resumes consistent
+    (recorded-state path, no server round-trip) even when the session
+    was created elsewhere.
+    """
+    from omnigent.codex_native_state import read_launch_state
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMNIGENT_CODEX_NATIVE_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(
+        codex_native,
+        "fetch_session_workspace",
+        lambda **_kwargs: str(tmp_path),
+    )
+
+    def fail_prompt(**_kwargs: object) -> str:
+        raise AssertionError("matching server workspace should not prompt")
+
+    monkeypatch.setattr(codex_native, "_prompt_codex_resume_workspace_action", fail_prompt)
+
+    codex_native._align_working_directory_with_session(
+        "conv_remote", base_url="http://ap.example", headers={}
+    )
+
+    state = read_launch_state("conv_remote")
+    assert state is not None
+    assert state.working_directory == str(tmp_path.resolve())

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -862,3 +862,39 @@ class TestPinCodexConfigModel:
         # read_codex_config_model resolves codex-home under the bridge dir.
         _pin_codex_config_model(home, "databricks-gpt-5-4-mini")
         assert read_codex_config_model(bridge_dir) == "databricks-gpt-5-4-mini"
+
+
+def test_build_codex_native_server_aliases_stale_omnigent_providers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The launch config keeps Omnigent-stamped provider ids resolvable.
+
+    A thread created under a gateway default persists
+    ``model_provider="omnigent_provider"`` in its rollout; relaunching
+    its app-server under the subscription login (which pins only
+    ``model_provider="openai"``) must still define that id or
+    ``thread/resume`` hard-fails config load ("Model provider
+    `omnigent_provider` not found") and the session is unresumable.
+    """
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server._find_codex_cli",
+        lambda: sys.executable,
+    )
+    app_server = build_codex_native_server(
+        socket_path=tmp_path / "codex.sock",
+        codex_home=tmp_path / "codex-home",
+        cwd=tmp_path,
+        model=None,
+        profile=None,
+        bridge_dir=tmp_path / "bridge",
+        ap_server_url=None,
+        ap_auth_headers={},
+        extra_config_overrides=['model_provider="openai"'],
+    )
+
+    joined = "\n".join(app_server.config_overrides)
+    assert "model_providers.omnigent_provider={" in joined
+    assert "model_providers.omnigent_databricks={" in joined
+    assert "requires_openai_auth=true" in joined

--- a/tests/test_native_codex_provider.py
+++ b/tests/test_native_codex_provider.py
@@ -15,8 +15,14 @@ from pathlib import Path
 import pytest
 import yaml
 
-from omnigent.codex_native_app_server import resolve_native_codex_launch
-from omnigent.inner.codex_executor import _provider_codex_config_overrides
+from omnigent.codex_native_app_server import (
+    _stale_provider_alias_overrides,
+    resolve_native_codex_launch,
+)
+from omnigent.inner.codex_executor import (
+    _databricks_codex_config_overrides,
+    _provider_codex_config_overrides,
+)
 
 
 @pytest.fixture()
@@ -436,3 +442,74 @@ def test_resolve_native_codex_launch_undismissed_config_provider_routes_via_pin(
 
     assert launch.config_overrides == ['model_provider="Databricks"']
     assert launch.profile is None
+
+
+# ── stale-provider alias overrides (cross-credential resume) ──
+#
+# A persisted Codex thread names its ``model_provider`` in the rollout
+# (e.g. ``omnigent_provider`` for a gateway-created session). Resuming
+# it under a different credential default launches an app-server whose
+# config no longer defines that id, and ``thread/resume`` hard-fails
+# config load ("Model provider `omnigent_provider` not found") — the
+# session is unresumable until the user flips the default back. The
+# alias overrides keep every Omnigent-stamped id loadable regardless of
+# the current routing decision.
+
+
+def test_stale_alias_login_routing_defines_both_omnigent_ids() -> None:
+    """CLI-login routing (no provider tables) aliases both Omnigent ids.
+
+    The observed bug: a gateway-created thread (rollout provider
+    ``omnigent_provider``) resumed while the subscription credential is
+    default. The subscription launch pins ``model_provider="openai"`` but
+    defines no ``omnigent_provider`` table, so thread preload fails.
+    Both ids must resolve through Codex's own stored login
+    (``requires_openai_auth``).
+    """
+    aliases = _stale_provider_alias_overrides(['model_provider="openai"'])
+
+    joined = "\n".join(aliases)
+    assert "model_providers.omnigent_provider={" in joined
+    assert "model_providers.omnigent_databricks={" in joined
+    assert joined.count("requires_openai_auth=true") == 2
+
+
+def test_stale_alias_gateway_routing_maps_databricks_id_to_gateway_table() -> None:
+    """Gateway routing aliases the Databricks id to the gateway table.
+
+    A thread created under a Databricks profile (rollout provider
+    ``omnigent_databricks``) resumed under a gateway default must load —
+    and route through the gateway credential, not a login that may not
+    exist. The already-defined ``omnigent_provider`` must not be
+    redefined.
+    """
+    overrides = _provider_codex_config_overrides(
+        model="gpt-5.5",
+        base_url="https://litellm.example/v1",
+        auth_command="printf %s sk-gw",
+        wire_api="responses",
+    )
+
+    aliases = _stale_provider_alias_overrides(overrides)
+
+    assert len(aliases) == 1
+    (alias,) = aliases
+    assert alias.startswith("model_providers.omnigent_databricks=")
+    assert 'base_url="https://litellm.example/v1"' in alias
+    assert "printf %s sk-gw" in alias
+
+
+def test_stale_alias_databricks_routing_maps_generic_id_to_databricks_table() -> None:
+    """Databricks routing aliases the generic id to the Databricks table."""
+    overrides = _databricks_codex_config_overrides(
+        model="databricks-gpt-5-5",
+        base_url="https://example.databricks.com/ai-gateway/codex/v1",
+        auth_command="databricks auth token",
+    )
+
+    aliases = _stale_provider_alias_overrides(overrides)
+
+    assert len(aliases) == 1
+    (alias,) = aliases
+    assert alias.startswith("model_providers.omnigent_provider=")
+    assert 'base_url="https://example.databricks.com/ai-gateway/codex/v1"' in alias

--- a/tests/test_native_session_workspace.py
+++ b/tests/test_native_session_workspace.py
@@ -1,0 +1,132 @@
+"""Tests for the server-side workspace lookup used by native resume."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from omnigent import _native_session_workspace
+from omnigent._native_session_workspace import fetch_session_workspace
+
+
+class _FakeHttpxClient:
+    """Minimal context-manager stand-in for :class:`httpx.Client`.
+
+    :param response: The response every ``get`` returns.
+    :param calls: Shared list capturing constructor kwargs and URLs.
+    """
+
+    response: httpx.Response = httpx.Response(200, json={})
+    calls: list[dict[str, object]] = []
+
+    def __init__(self, *, base_url: str, headers: dict[str, str], timeout: float) -> None:
+        """Capture construction arguments for later assertions.
+
+        :param base_url: Omnigent server base URL.
+        :param headers: HTTP headers passed by the wrapper.
+        :param timeout: Request timeout in seconds.
+        """
+        type(self).calls.append({"base_url": base_url, "headers": headers, "timeout": timeout})
+
+    def __enter__(self) -> _FakeHttpxClient:
+        """Enter the fake client context.
+
+        :returns: This fake client.
+        """
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        """Exit the fake client context.
+
+        :param exc_type: Exception type, or ``None``.
+        :param exc: Exception instance, or ``None``.
+        :param traceback: Traceback, or ``None``.
+        """
+
+    def get(self, url: str) -> httpx.Response:
+        """Return the canned response for the requested URL.
+
+        :param url: Relative session path, e.g. ``"/v1/sessions/conv_x"``.
+        :returns: The canned HTTP response.
+        """
+        type(self).calls.append({"url": url})
+        return type(self).response
+
+
+@pytest.fixture()
+def _fake_client(monkeypatch: pytest.MonkeyPatch) -> type[_FakeHttpxClient]:
+    """Install the fake httpx client and reset its capture state."""
+    _FakeHttpxClient.calls = []
+    _FakeHttpxClient.response = httpx.Response(200, json={})
+    monkeypatch.setattr(_native_session_workspace.httpx, "Client", _FakeHttpxClient)
+    return _FakeHttpxClient
+
+
+def test_fetch_session_workspace_returns_server_workspace(
+    _fake_client: type[_FakeHttpxClient],
+) -> None:
+    """The session endpoint's ``workspace`` field is returned verbatim."""
+    _fake_client.response = httpx.Response(200, json={"workspace": "/home/me/repo"})
+
+    result = fetch_session_workspace(
+        base_url="http://ap.example",
+        headers={"Authorization": "Bearer t"},
+        session_id="conv with space",
+    )
+
+    assert result == "/home/me/repo"
+    assert _fake_client.calls == [
+        {
+            "base_url": "http://ap.example",
+            "headers": {"Authorization": "Bearer t"},
+            "timeout": 10.0,
+        },
+        {"url": "/v1/sessions/conv%20with%20space"},
+    ]
+
+
+def test_fetch_session_workspace_none_base_url_skips_request(
+    _fake_client: type[_FakeHttpxClient],
+) -> None:
+    """``base_url=None`` (no server context) makes no HTTP request."""
+    result = fetch_session_workspace(base_url=None, headers={}, session_id="conv_x")
+
+    assert result is None
+    assert _fake_client.calls == []
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(404, json={"detail": "not found"}),
+        httpx.Response(200, json={"workspace": None}),
+        httpx.Response(200, json={"workspace": ""}),
+        httpx.Response(200, json={}),
+        httpx.Response(200, json=["not", "a", "dict"]),
+    ],
+)
+def test_fetch_session_workspace_degrades_to_none(
+    _fake_client: type[_FakeHttpxClient],
+    response: httpx.Response,
+) -> None:
+    """Errors and absent/blank workspaces degrade to ``None`` (no raise)."""
+    _fake_client.response = response
+
+    result = fetch_session_workspace(base_url="http://ap.example", headers={}, session_id="conv_x")
+
+    assert result is None
+
+
+def test_fetch_session_workspace_transport_error_degrades_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transport failure is swallowed; resume falls back to current cwd."""
+
+    def boom(**_kwargs: object) -> object:
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(_native_session_workspace.httpx, "Client", boom)
+
+    result = fetch_session_workspace(base_url="http://ap.example", headers={}, session_id="conv_x")
+
+    assert result is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes two ways a codex-native session becomes wrongly-placed or unresumable, both reproduced on omnigent 0.5.1 (macOS client, server 0.5.1):

**Bug 1 — `omni codex --resume` ignores the server-side session workspace.** `_align_working_directory_with_session` only consulted the client-local launch-state file, which is written only when the session is created fresh via the CLI on that machine. For sessions created by the desktop app or on another machine there is no local state, so resume silently adopted the CLI's current cwd — observed: a session with server `workspace=/Users/.../seen-ehr-worktrees/yang-ai-elements-message` resumed from a different repo launched the Codex terminal/tmux in the unrelated repo. The server session snapshot (`GET /v1/sessions/{id}`) carries an authoritative `workspace` field that was never consulted.

Fix: when local launch state is missing, fetch the session's `workspace` from the server (new shared helper `omnigent/_native_session_workspace.py`). If it differs from the current cwd, the existing switch/cancel prompt runs on a TTY; non-interactive resumes prefer switching to the server workspace. If the workspace does not exist on this machine, resume falls back to the old behavior with a warning. After a successful resolution the launch state is recorded client-side so subsequent resumes align without a server round-trip. `omnigent claude --resume` had the same gap (`claude_native.py` decision table: "no state recorded → silent no-op"), so the same fallback is wired there, including the existing move-transcript action when a local Claude transcript exists.

**Bug 2 — gateway-created Codex threads cannot resume under a different credential default.** A codex-native session created while a gateway credential (e.g. LiteLLM) was the Codex default persists `model_provider="omnigent_provider"` in its rollout. Resuming later while the subscription credential is default routes via Codex CLI login, whose launch config pins only `model_provider="openai"` and defines no `omnigent_provider` table — thread preload then hard-fails:

```
RuntimeError: {'code': -32600, 'message': 'failed to load configuration: Model provider `omnigent_provider` not found'}
```

raised from `preload_codex_thread_for_resume`, surfaced to the user as `Codex terminal ensure failed (500): Native Codex terminal failed to start`. The runner retries and fails identically; the session is unresumable until the user flips the credential default back.

Fix: `build_codex_native_server` now appends alias `model_providers.<id>=` overrides for every Omnigent-stamped provider id (`omnigent_provider`, `omnigent_databricks`) the current routing leaves undefined, re-mapped to the current routing decision — when the current routing defines its own provider table (gateway/key/local/Databricks), the alias reuses that table body so stale ids route through the current credential; under Codex CLI login the alias resolves through Codex's own stored login via `requires_openai_auth=true` (verified against codex-cli 0.144.4: the alias makes the previously failing config load succeed). The reverse direction (subscription-created thread referencing `openai`, resumed under a gateway default) needs no alias because `openai` is a Codex built-in provider that always resolves.

### Repro

- Bug 1: create a codex-native session from the desktop app (or another machine) with workspace A → `omni codex --resume <id>` from repo B → Codex launches with cwd B instead of A.
- Bug 2: set a gateway credential as the Codex default → create a codex-native session → switch the default to the Codex subscription login → `omni codex --resume <id>` → `Codex terminal ensure failed (500)` with the ``Model provider `omnigent_provider` not found`` config-load error.

## Test Plan

- New regression tests:
  - `tests/test_native_session_workspace.py` — server workspace fetch (success, no base_url, 4xx/blank/malformed payloads, transport errors all degrade to `None`).
  - `tests/test_codex_native.py` / `tests/test_claude_native.py` — no-local-state alignment: non-interactive switch to the server workspace + launch-state recording, interactive prompt/cancel, missing-directory warning fallback, unknown-workspace no-op, matching-workspace state recording.
  - `tests/test_native_codex_provider.py` / `tests/test_codex_native_app_server.py` — stale-provider aliases: login routing defines both Omnigent ids via `requires_openai_auth`, gateway routing aliases the Databricks id to the gateway table (and vice versa), and the assembled app-server config carries the aliases.
- `uv run pytest` green; `uv run ruff check .` and `uv run ruff format --check .` clean.
- Manually verified the bug-2 mechanism against a real codex CLI (0.144.4): `codex -c 'model_provider="omnigent_provider"' mcp list` reproduces ``Model provider `omnigent_provider` not found``; adding the generated alias override makes config load succeed.

## Demo

N/A (CLI/runner behavior; no UI change).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the codex config-load seam that unit tests cannot reach: reproduced the `Model provider not found` config-load failure with a real codex CLI (0.144.4) and confirmed the generated alias override fixes it. The end-to-end resume flows (desktop-created session resumed from the CLI; gateway→subscription default flip) were reproduced on omnigent 0.5.1 before the fix; the unit tests pin the resolution logic on both paths.

## Changelog

`omni codex --resume` and `omni claude --resume` now follow the session's server-recorded workspace when no local launch state exists, and codex-native sessions stay resumable after switching the default Codex credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
