### PR TITLE
docs(release): the secure publish is write-only — no already-published skip

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -249,9 +249,13 @@ The examples below use `0.0.1rc2`; substitute the next free number.
      -f ref=v0.0.1rc2 -f destination=pypi -f dry-run=false   # publish + validate
    ```
 
-5. **Publish idempotency**: re-dispatch step 4's second command — all three
-   legs must skip as already published (twine `--skip-existing`) and the run
-   stays green.
+5. **No-double-publish check** (optional): re-dispatching step 4's second
+   command must FAIL every leg with "File already exists" — PyPI
+   immutability doing its job. The publish is deliberately **write-only**:
+   the release runners cannot read the index, so there is no
+   already-published skip (a curl probe and twine's `--skip-existing` both
+   failed live for exactly that reason). A real partial publish is recovered
+   by yank + next version (see "If a publish goes wrong").
 6. **Finalize gates (no side effects)**:
    `gh workflow run finalize-release.yml -f tag=v0.0.1rc2` must fail fast
    ("not a final tag"), and `-f tag=v0.5.1` (any already-published release)

--- a/designs/RELEASE-AUTOMATION.md
+++ b/designs/RELEASE-AUTOMATION.md
@@ -454,8 +454,21 @@ effects. Worth stealing:
 
 ## Decisions (2026-07-14)
 
+> **Correction (2026-07-16, after two live failures):** the
+> skip-existing / partial-publish-healing idea below is **withdrawn**. Every
+> skip mechanism must first *read* the index, and the release runners have
+> no egress to pypi.org's JSON API — the curl probe silently never matched,
+> and twine's `--skip-existing` pre-checks that same API client-side and
+> crashed every upload (secure-repo run 29459796204), including brand-new
+> versions. The publish leg is **write-only**: re-uploads hard-fail
+> ("File already exists") and a partial publish is recovered by yank + next
+> version, as it always was. The peer-survey skip-existing citations stand
+> as facts about those projects; they don't transfer to egress-restricted
+> runners.
+
 1. **Secure-repo restructure: approved direction** — gates → env-approval →
-   publish (skip-existing) → validate, one dispatch per phase.
+   publish (skip-existing — *withdrawn, see correction above*) → validate,
+   one dispatch per phase.
 2. **rc GH drafts are never published** — keep today's pattern exactly.
 3. **bump PRs move to the App token** so CI runs on them (empty-commit
    workaround retired).


### PR DESCRIPTION
## Related issue

N/A (docs correction from the rehearsal; companion to databricks/secure-public-registry-releases-eng#174)

## Summary

Both already-published-skip mechanisms tried on the secure repo's publish leg failed live for one structural reason: **any skip must first read the index, and the release runners have no egress to pypi.org's JSON API** — the curl probe silently never matched, and twine's `--skip-existing` pre-checks that same API client-side and crashed every upload (secure-repo run 29459796204), including brand-new versions. The publish leg is therefore write-only, and the companion PR reverts it to the exact invocation that shipped v0.4.x–v0.5.x.

Docs updated to match reality: the rehearsal's "publish idempotency" step becomes a **no-double-publish check** (re-dispatching an already-published version must fail every leg with "File already exists"), and the design doc's skip-existing decision is marked withdrawn with a dated correction. Partial-publish recovery is unchanged and was already documented: yank + next version.

## Test Plan

- `pre-commit` passes on both files.
- Prose-only change; the described behavior is exactly what the two rehearsal runs demonstrated and what the companion secure-repo PR restores.

## Demo

N/A (docs only).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only; no executable surface.

This pull request and its description were written by Isaac.