### PR TITLE
docs(release): post-publish validation is manual — the CI validate job is gone

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -116,7 +116,10 @@ token exchange without uploading. The real run binds the per-package
 Trusted-Publisher environments (may gate on reviewer approval) and re-verifies
 that `ref` is exactly the tag and points at the built commit.
 
-**3. Validate from PyPI** (clean venv; exact pins resolve pre-releases):
+**3. Validate from PyPI** (clean venv; exact pins resolve pre-releases;
+behind a corporate network, point `--index-url` at your PyPI mirror
+instead — this is a manual step on purpose: the secure repo's runners
+cannot see a fresh index view, so no CI job can do it):
 
 ```bash
 python -m venv /tmp/omni-rc && /tmp/omni-rc/bin/pip install \
@@ -235,18 +238,19 @@ The examples below use `0.0.1rc2`; substitute the next free number.
    Cancelled (superseded) runs only warn.
 3. **Idempotency**: dispatch the exact same command again — it must no-op
    ("already at the converged release commit").
-4. **Secure-repo publish.** Real PyPI is safe for a below-latest rc and is
-   the only destination that exercises the post-publish `validate` job — so
-   rehearse against `destination=pypi` (it binds the per-package reviewer
-   environments; approve all three). `destination=test-pypi` also works, but
-   skips the prod tag gate and `validate`, and needs TestPyPI Trusted
-   Publishers configured.
+4. **Secure-repo publish.** Real PyPI is safe for a below-latest rc and
+   exercises the full prod path (the tag gate + the per-package reviewer
+   environments; approve all three) — so rehearse against
+   `destination=pypi`. `destination=test-pypi` also works, but skips the
+   prod tag gate and needs TestPyPI Trusted Publishers configured. Then
+   validate the published rc manually, exactly like a real release (step 3
+   of the standard flow).
 
    ```bash
    gh workflow run omnigent.yml --repo databricks/secure-public-registry-releases-eng \
      -f ref=v0.0.1rc2 -f destination=pypi -f dry-run=true    # gates only
    gh workflow run omnigent.yml --repo databricks/secure-public-registry-releases-eng \
-     -f ref=v0.0.1rc2 -f destination=pypi -f dry-run=false   # publish + validate
+     -f ref=v0.0.1rc2 -f destination=pypi -f dry-run=false   # real publish
    ```
 
 5. **No-double-publish check** (optional): re-dispatching step 4's second

--- a/designs/RELEASE-AUTOMATION.md
+++ b/designs/RELEASE-AUTOMATION.md
@@ -464,7 +464,11 @@ effects. Worth stealing:
 > ("File already exists") and a partial publish is recovered by yank + next
 > version, as it always was. The peer-survey skip-existing citations stand
 > as facts about those projects; they don't transfer to egress-restricted
-> runners.
+> runners. The **`validate` job is withdrawn for the same reason**: the
+> runners' only index view is a JFrog mirror whose metadata lags weeks
+> behind PyPI (its first live run couldn't see the version it had just
+> published — nor even 0.5.x), so post-publish validation stays the manual
+> runbook step, run from a network with a fresh PyPI view.
 
 1. **Secure-repo restructure: approved direction** — gates → env-approval →
    publish (skip-existing — *withdrawn, see correction above*) → validate,


### PR DESCRIPTION
## Related issue

N/A (companion to databricks/secure-public-registry-releases-eng#175)

## Summary

The secure repo's `validate` job red-flagged its first-ever successful publish (run 29461083910): its runners' only index view is the JFrog PyPI mirror, whose `omnigent` metadata lags **weeks** behind (during the run it listed nothing newer than 0.4.0 while 0.5.1 shipped July 10), so a just-published version can never become visible from that CI — the same no-fresh-index-view constraint that killed the already-published skip. The companion PR removes the job, restoring the secure workflow to the exact build → scan → publish shape that released v0.4.x–v0.5.x.

This PR aligns the docs: the rehearsal's step 4 no longer promises a CI validate, and the standard flow's manual clean-venv validation step is explicitly THE validation (with a note to use a PyPI mirror on corporate networks). The design doc's dated correction block records why. The 0.0.1rc2 rehearsal artifacts passed exactly this manual check: clean py3.12 venv via a fresh mirror, exact pins, `omnigent --version` → `0.0.1rc2`.

## Test Plan

- `pre-commit` passes; prose-only.
- The described behavior is what run 29461083910 demonstrated live.

## Demo

N/A (docs only).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only; no executable surface.

This pull request and its description were written by Isaac.