### PR TITLE
feat(ios): add omnigent:// deep links to open a session

### DIFF
--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		B10000000000000000000004 /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000004 /* DesignTokens.swift */; };
 		B10000000000000000000005 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000005 /* SettingsStore.swift */; };
 		B10000000000000000000006 /* ServerURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000006 /* ServerURL.swift */; };
+		B10000000000000000000014 /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000014 /* DeepLink.swift */; };
 		B10000000000000000000007 /* WorkspaceURLExpander.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000007 /* WorkspaceURLExpander.swift */; };
 		B10000000000000000000008 /* NativeNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000008 /* NativeNotificationManager.swift */; };
 		B10000000000000000000009 /* WebShellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000009 /* WebShellView.swift */; };
@@ -27,6 +28,7 @@
 		B20000000000000000000001 /* ServerURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* ServerURLTests.swift */; };
 		B20000000000000000000002 /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* SettingsStoreTests.swift */; };
 		B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */; };
+		B20000000000000000000004 /* DeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* DeepLinkTests.swift */; };
 		B40000000000000000000001 /* OmnigentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000001 /* OmnigentUITests.swift */; };
 		B40000000000000000000002 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000002 /* SnapshotHelper.swift */; };
 /* End PBXBuildFile section */
@@ -55,6 +57,7 @@
 		A10000000000000000000004 /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		A10000000000000000000005 /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		A10000000000000000000006 /* ServerURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerURL.swift; sourceTree = "<group>"; };
+		A10000000000000000000014 /* DeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLink.swift; sourceTree = "<group>"; };
 		A10000000000000000000007 /* WorkspaceURLExpander.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpander.swift; sourceTree = "<group>"; };
 		A10000000000000000000008 /* NativeNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeNotificationManager.swift; sourceTree = "<group>"; };
 		A10000000000000000000009 /* WebShellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebShellView.swift; sourceTree = "<group>"; };
@@ -71,6 +74,7 @@
 		A20000000000000000000001 /* ServerURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerURLTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000002 /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpanderTests.swift; sourceTree = "<group>"; };
+		A20000000000000000000004 /* DeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkTests.swift; sourceTree = "<group>"; };
 		A30000000000000000000003 /* OmnigentUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A40000000000000000000001 /* OmnigentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnigentUITests.swift; sourceTree = "<group>"; };
 		A40000000000000000000002 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
@@ -133,6 +137,7 @@
 				A10000000000000000000004 /* DesignTokens.swift */,
 				A10000000000000000000005 /* SettingsStore.swift */,
 				A10000000000000000000006 /* ServerURL.swift */,
+				A10000000000000000000014 /* DeepLink.swift */,
 				A10000000000000000000007 /* WorkspaceURLExpander.swift */,
 				A10000000000000000000008 /* NativeNotificationManager.swift */,
 				A10000000000000000000009 /* WebShellView.swift */,
@@ -155,6 +160,7 @@
 				A20000000000000000000001 /* ServerURLTests.swift */,
 				A20000000000000000000002 /* SettingsStoreTests.swift */,
 				A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */,
+				A20000000000000000000004 /* DeepLinkTests.swift */,
 			);
 			path = OmnigentTests;
 			sourceTree = "<group>";
@@ -313,6 +319,7 @@
 				B10000000000000000000004 /* DesignTokens.swift in Sources */,
 				B10000000000000000000005 /* SettingsStore.swift in Sources */,
 				B10000000000000000000006 /* ServerURL.swift in Sources */,
+				B10000000000000000000014 /* DeepLink.swift in Sources */,
 				B10000000000000000000007 /* WorkspaceURLExpander.swift in Sources */,
 				B10000000000000000000008 /* NativeNotificationManager.swift in Sources */,
 				B10000000000000000000009 /* WebShellView.swift in Sources */,
@@ -331,6 +338,7 @@
 				B20000000000000000000001 /* ServerURLTests.swift in Sources */,
 				B20000000000000000000002 /* SettingsStoreTests.swift in Sources */,
 				B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */,
+				B20000000000000000000004 /* DeepLinkTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/web/ios/Omnigent/AppRootView.swift
+++ b/web/ios/Omnigent/AppRootView.swift
@@ -2,7 +2,15 @@ import SwiftUI
 
 struct AppRootView: View {
   @EnvironmentObject private var settings: SettingsStore
+  @EnvironmentObject private var router: AppRouter
   @State private var mode: Mode
+
+  /// A deep link to a server the user has never connected to, awaiting the
+  /// consent prompt's answer. Connecting pins a new origin (notifications,
+  /// badge, mic), so a clicked link must not silently pin an attacker-chosen
+  /// server — the alert is the one surface a page-click can't forge.
+  @State private var consentDeepLink: DeepLink?
+  @State private var showDeepLinkConsent = false
 
   init() {
     _mode = State(initialValue: .setup(prefill: nil, error: nil))
@@ -14,42 +22,70 @@ struct AppRootView: View {
       case .setup(let prefill, let error):
         ConnectView(prefill: prefill ?? settings.serverURL, error: error) { url in
           settings.serverURL = url.absoluteString
-          mode = .web(url)
+          mode = .web(serverURL: url, path: nil)
         }
-      case .web(let url):
+      case .web(let serverURL, let path):
         WebShellView(
-          initialURL: url,
+          initialURL: path.map { conversationURL(for: serverURL, path: $0) } ?? serverURL,
           connectToNewServer: {
             mode = .setup(prefill: settings.serverURL, error: nil)
           },
           switchToServer: { nextURL in
             settings.serverURL = nextURL.absoluteString
-            mode = .web(nextURL)
+            mode = .web(serverURL: nextURL, path: nil)
           },
           loadFailed: { failedURL, message in
             mode = .setup(
               prefill: failedURL.omnigentOrigin ?? failedURL.absoluteString, error: message)
           },
-          loadSucceeded: { loadedURL in
-            settings.rememberRecentServer(loadedURL)
+          // Record the CLEAN server URL (no /c/<id>) — the conversation path
+          // lives only in the load URL, never in recents, so a later deep link
+          // resolves against an un-polluted server identity.
+          loadSucceeded: { _ in
+            settings.rememberRecentServer(serverURL)
           }
         )
       }
     }
     .task {
       guard shouldAutoOpenSavedServer else { return }
+      // A deep link that arrived before this task ran already moved us off the
+      // setup page (mode is .web), so this guard skips the auto-open and the
+      // deep link drives — no redundant default-server load.
       if case .setup(nil, nil) = mode,
         let saved = settings.serverURL,
         let url = URL(string: saved)
       {
-        mode = .web(url)
+        mode = .web(serverURL: url, path: nil)
+      }
+    }
+    .onOpenURL { url in handleDeepLink(url) }
+    .alert(
+      "Open this Omnigent link?",
+      isPresented: $showDeepLinkConsent
+    ) {
+      Button("Cancel", role: .cancel) { consentDeepLink = nil }
+      Button("Open") { confirmUnknownDeepLink() }
+    } message: {
+      if let consentDeepLink {
+        Text(
+          """
+          This link will connect Omnigent to \(consentDeepLink.origin.hostLabel) and open a conversation.
+
+          Only open links from a server you trust.
+          """
+        )
       }
     }
   }
 
   private enum Mode: Equatable {
     case setup(prefill: String?, error: String?)
-    case web(URL)
+    // serverURL: the window's server identity (origin or origin + workspace
+    // mount), with NO conversation path — used for recents and origin
+    // matching. path: an optional deep-link conversation path loaded on top of
+    // it (nil for a normal connect / server switch).
+    case web(serverURL: URL, path: String?)
   }
 
   private var shouldAutoOpenSavedServer: Bool {
@@ -60,5 +96,91 @@ struct AppRootView: View {
     #else
       true
     #endif
+  }
+}
+
+// MARK: Deep links
+
+extension AppRootView {
+  /// Handle an `omnigent://` URL the system routed to the app. The window
+  /// handling mirrors the desktop shell (designs/desktop-deep-link.md):
+  ///   - SAME server (this window is already on the link's origin) → navigate
+  ///     in-place via the SPA router (no reload, no dropped stream), deferred
+  ///     by WebShellView until the page finishes loading.
+  ///   - KNOWN server (previously connected, no live window on it) → switch to
+  ///     it, loading the conversation directly; no consent (the user already
+  ///     chose this server).
+  ///   - UNKNOWN server → consent, since pinning a new origin is a privilege
+  ///     grant; the workspace-mount probe runs only AFTER consent, so a link to
+  ///     an attacker-chosen host makes no pre-consent network request.
+  private func handleDeepLink(_ url: URL) {
+    guard let deepLink = DeepLink.parse(url) else { return }
+    let targetOrigin = deepLink.origin
+
+    if currentWebOrigin == targetOrigin {
+      // Same server — route in-place. WebShellView defers the path until the
+      // SPA finishes loading, so this also covers a cold-start link to the
+      // saved server (the SPA is still booting).
+      router.requestOpenPath(deepLink.path)
+      return
+    }
+
+    if let known = settings.knownServerURL(forOrigin: targetOrigin) {
+      openServer(serverURL: known, path: deepLink.path)
+      return
+    }
+
+    consentDeepLink = deepLink
+    showDeepLinkConsent = true
+  }
+
+  /// Switch this window to a (clean) server URL and load an optional deep-link
+  /// conversation path on top of it. `settings.serverURL` and recents stay free
+  /// of the `/c/<id>` path — only the load URL carries it.
+  private func openServer(serverURL: URL, path: String?) {
+    settings.serverURL = serverURL.absoluteString
+    mode = .web(serverURL: serverURL, path: path)
+  }
+
+  /// Consent was given for an unknown server — discover the workspace mount
+  /// (the only network request, AFTER consent), then switch. The origin is
+  /// unchanged by the probe (it only appends `/ml/omnigents` under it), so the
+  /// consent decision stands. Recording the server happens on load success
+  /// (loadSucceeded), so a server that fails to load isn't remembered.
+  private func confirmUnknownDeepLink() {
+    guard let deepLink = consentDeepLink else { return }
+    consentDeepLink = nil
+    Task {
+      guard let originURL = URL(string: deepLink.origin) else { return }
+      let expanded = await WorkspaceURLExpander.expandIfNeeded(originURL)
+      await MainActor.run {
+        openServer(serverURL: expanded, path: deepLink.path)
+      }
+    }
+  }
+
+  /// The origin this window is currently connected to, or nil while it shows
+  /// the bundled connect page. Derived from `mode`'s clean serverURL (stable
+  /// across in-app SPA navigation), not the live web-view URL.
+  private var currentWebOrigin: String? {
+    if case .web(let serverURL, _) = mode { return serverURL.omnigentOrigin }
+    return nil
+  }
+
+  /// Join a basename-less SPA path (`/c/<id>`) onto a server URL that may carry
+  /// a workspace mount (`/ml/omnigents`). The path lives UNDER the mount, so it
+  /// is string-concatenated (not URL-resolved, which would anchor against the
+  /// origin and drop the mount) — mirroring the desktop's `resolveServerPath`.
+  private func conversationURL(for serverURL: URL, path: String) -> URL {
+    let base = serverURL.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    return URL(string: base + path) ?? serverURL
+  }
+}
+
+extension String {
+  /// A short host[:port] label for the consent prompt, parsed from an origin
+  /// string like `"https://host"` or `"http://localhost:8000"`.
+  fileprivate var hostLabel: String {
+    URL(string: self)?.omnigentHostLabel ?? self
   }
 }

--- a/web/ios/Omnigent/DeepLink.swift
+++ b/web/ios/Omnigent/DeepLink.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// A parsed `omnigent://<hostname>/c/<session_id>` deep link — the iOS analog
+/// of the desktop shell's `parseOmnigentDeepLink` (web/electron/src/deepLink.js),
+/// kept pure so it unit-tests without a WKWebView. See designs/desktop-deep-link.md
+/// for the shared design (URL shape, scheme inference, security rationale).
+///
+/// The link names a server by **host** (with port if non-default) and a
+/// conversation by the SPA's own `/c/:id` route. It carries no `http`/`https` —
+/// the scheme is inferred with the same rule the setup page and desktop use
+/// (`http` for loopback, `https` for a remote host), so a deep link and a pasted
+/// URL never disagree on scheme. The Databricks workspace mount (`/ml/omnigents`)
+/// is deliberately NOT in the link; it is server-determined and discovered by
+/// `WorkspaceURLExpander` (after consent, for an unknown server).
+struct DeepLink: Equatable {
+  /// The inferred http(s) origin with NO trailing slash, e.g. `"http://localhost:8000"`
+  /// or `"https://my-workspace.cloud.databricks.com"`. Built manually (not via
+  /// `URL.omnigentOrigin`, which returns nil for IPv6 hosts) so IPv6 loopback
+  /// links still produce a valid `http://[::1]:<port>` origin.
+  let origin: String
+
+  /// The basename-less SPA conversation path, e.g. `"/c/conv_abc"`. Foundation
+  /// strips a trailing slash from `URL.path`, so this is always `/c/<id>` with
+  /// no trailing slash — the shape the SPA's react-router matches.
+  let path: String
+
+  /// Hostnames that resolve to the local machine — default to `http` for these
+  /// (local dev is plain http, and ATS exempts loopback), `https` for everything
+  /// else. Mirrors the desktop shell's `LOCAL_HOSTS` / `defaultSchemeFor` so the
+  /// two shells never disagree on what a deep link to `localhost` means.
+  private static let localHosts: Set<String> = ["localhost", "127.0.0.1", "::1", "[::1]"]
+
+  /// Parse an `omnigent://` URL. Returns nil for anything that isn't a valid
+  /// `omnigent://<host>/c/<id>` link (wrong scheme, no host, non-`/c/` path,
+  /// empty/nested id, unparseable input) — an unrecognized deep link must never
+  /// crash or mis-navigate.
+  static func parse(_ raw: URL) -> DeepLink? {
+    guard raw.scheme?.lowercased() == "omnigent" else { return nil }
+    guard let host = raw.host, !host.isEmpty else { return nil }
+
+    // v1 accepts only `/c/<id>`: a single path segment after `/c/`, with no
+    // nested path. Foundation already strips a trailing slash, so `raw.path`
+    // is `/c/<id>`; the manual check also tolerates a trailing slash in case a
+    // future iOS version keeps it. Anything else (other routes, nested paths,
+    // empty id) is dropped — the SPA's own router stays the authority on ids.
+    let path = raw.path
+    guard path.hasPrefix("/c/") else { return nil }
+    var id = path.dropFirst(3)
+    if id.hasSuffix("/") { id = id.dropLast() }
+    guard !id.isEmpty, !id.contains("/") else { return nil }
+
+    let scheme = defaultScheme(for: host)
+    guard let origin = makeOrigin(scheme: scheme, host: host, port: raw.port) else { return nil }
+    return DeepLink(origin: origin, path: "/c/\(id)")
+  }
+
+  /// Infer `http` for loopback hosts, `https` otherwise — matching the setup
+  /// page and the desktop shell, and aligned with iOS App Transport Security
+  /// (loopback http is exempt; remote http would be blocked in release anyway).
+  private static func defaultScheme(for host: String) -> String {
+    localHosts.contains(host.lowercased()) ? "http" : "https"
+  }
+
+  /// Build an origin string `scheme://host[:port]` with NO trailing slash,
+  /// bracketing IPv6 hosts (whose `URL.host` comes back without brackets).
+  private static func makeOrigin(scheme: String, host: String, port: Int?) -> String? {
+    let hostPart = host.contains(":") ? "[\(host)]" : host
+    if let port {
+      return URL(string: "\(scheme)://\(hostPart):\(port)")?.absoluteString
+        .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    }
+    return URL(string: "\(scheme)://\(hostPart)")?.absoluteString
+      .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+  }
+}

--- a/web/ios/Omnigent/Info-Debug.plist
+++ b/web/ios/Omnigent/Info-Debug.plist
@@ -20,6 +20,17 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>ai.omnigent.ios.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>omnigent</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/web/ios/Omnigent/Info-Release.plist
+++ b/web/ios/Omnigent/Info-Release.plist
@@ -20,6 +20,17 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>ai.omnigent.ios.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>omnigent</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/web/ios/Omnigent/OmnigentApp.swift
+++ b/web/ios/Omnigent/OmnigentApp.swift
@@ -26,6 +26,12 @@ struct OmnigentApp: App {
 @MainActor
 final class AppRouter: ObservableObject {
   @Published private(set) var pendingNotificationPath: String?
+  /// An in-app path (`/c/<id>`) a deep link asked the SPA to open in-place.
+  /// Consumed by WebShellView, which emits it to the page via
+  /// `__omnigentNativeEmitOpenPath` (deferred until the page finishes loading —
+  /// see WebShellView). Mirrors `pendingNotificationPath` on a separate channel
+  /// so a deep link isn't mislabeled as a notification.
+  @Published private(set) var pendingOpenPath: String?
 
   func routeNotification(_ path: String) {
     guard path.starts(with: "/") else { return }
@@ -35,5 +41,15 @@ final class AppRouter: ObservableObject {
   func consumeNotificationPath() -> String? {
     defer { pendingNotificationPath = nil }
     return pendingNotificationPath
+  }
+
+  func requestOpenPath(_ path: String) {
+    guard path.starts(with: "/") else { return }
+    pendingOpenPath = path
+  }
+
+  func consumeOpenPath() -> String? {
+    defer { pendingOpenPath = nil }
+    return pendingOpenPath
   }
 }

--- a/web/ios/Omnigent/OmnigentWebView.swift
+++ b/web/ios/Omnigent/OmnigentWebView.swift
@@ -123,6 +123,7 @@ struct OmnigentWebView: UIViewRepresentable {
         document.addEventListener("DOMContentLoaded", ensureViewportFit, { once: true });
       }
       const callbacks = new Set();
+      const openPathCallbacks = new Set();
       const viewModeCallbacks = new Set();
       const defineEmit = (name, fn) => {
         Object.defineProperty(window, name, {
@@ -135,6 +136,12 @@ struct OmnigentWebView: UIViewRepresentable {
       defineEmit("__omnigentNativeEmitNotificationActivated", (path) => {
         if (typeof path !== "string" || !path.startsWith("/")) return;
         for (const callback of callbacks) {
+          try { callback(path); } catch {}
+        }
+      });
+      defineEmit("__omnigentNativeEmitOpenPath", (path) => {
+        if (typeof path !== "string" || !path.startsWith("/")) return;
+        for (const callback of openPathCallbacks) {
           try { callback(path); } catch {}
         }
       });
@@ -199,6 +206,11 @@ struct OmnigentWebView: UIViewRepresentable {
           if (typeof callback !== "function") return () => {};
           callbacks.add(callback);
           return () => callbacks.delete(callback);
+        },
+        onOpenPath(callback) {
+          if (typeof callback !== "function") return () => {};
+          openPathCallbacks.add(callback);
+          return () => openPathCallbacks.delete(callback);
         },
         onSidebarDrag(callback) {
           if (typeof callback !== "function") return () => {};

--- a/web/ios/Omnigent/SettingsStore.swift
+++ b/web/ios/Omnigent/SettingsStore.swift
@@ -32,6 +32,20 @@ final class SettingsStore: ObservableObject {
     recentServers = Array(deduped.prefix(maxRecentServers))
   }
 
+  /// The full server URL (origin, or origin + workspace mount) of a server the
+  /// user previously connected to whose origin matches `origin`; nil when none.
+  /// Reusing the recorded URL means a deep link to a KNOWN workspace server opens
+  /// WITHOUT the network probe — the mount is already in the saved URL. Mirrors
+  /// the desktop shell's `findKnownServerUrl` (web/electron/src/main.js).
+  func knownServerURL(forOrigin origin: String) -> URL? {
+    let candidates = (serverURL.map { [$0] } ?? []) + recentServers
+    for value in candidates {
+      guard let url = URL(string: value), url.omnigentOrigin == origin else { continue }
+      return url
+    }
+    return nil
+  }
+
   func isProtocolAllowed(_ scheme: String, from origin: String) -> Bool {
     allowedProtocols()[origin]?.contains(scheme.lowercased()) == true
   }

--- a/web/ios/Omnigent/WebShellView.swift
+++ b/web/ios/Omnigent/WebShellView.swift
@@ -11,6 +11,11 @@ struct WebShellView: View {
   @EnvironmentObject private var settings: SettingsStore
   @EnvironmentObject private var router: AppRouter
   @StateObject private var model = WebViewModel()
+  /// A deep-link path that arrived while the page was still loading — emitted
+  /// to the SPA once `isLoading` flips false, so a cold-start / mid-load deep
+  /// link to the current server isn't lost (its `onOpenPath` subscriber isn't
+  /// mounted until the SPA finishes booting).
+  @State private var deferredOpenPath: String?
 
   var body: some View {
     GeometryReader { geometry in
@@ -67,6 +72,24 @@ struct WebShellView: View {
     .onChange(of: router.pendingNotificationPath) { _, _ in
       if let path = router.consumeNotificationPath() {
         model.emitNotificationActivation(path)
+      }
+    }
+    .onChange(of: router.pendingOpenPath) { _, _ in
+      guard let path = router.consumeOpenPath() else { return }
+      // If the SPA is still booting (a cold-start deep link to the current
+      // server, or one that arrived mid-navigation), defer the path until the
+      // page finishes loading — emitting now would fire into a page whose
+      // `onOpenPath` subscriber isn't mounted yet and be lost.
+      if model.isLoading {
+        deferredOpenPath = path
+      } else {
+        model.emitOpenPath(path)
+      }
+    }
+    .onChange(of: model.isLoading) { _, loading in
+      if !loading, let path = deferredOpenPath {
+        deferredOpenPath = nil
+        model.emitOpenPath(path)
       }
     }
     .onChange(of: model.isLoading) { _, loading in

--- a/web/ios/Omnigent/WebViewModel.swift
+++ b/web/ios/Omnigent/WebViewModel.swift
@@ -64,6 +64,18 @@ final class WebViewModel: ObservableObject {
     webView?.evaluateJavaScript(script)
   }
 
+  /// Push a deep-link in-app path (`/c/<id>`) to the SPA so it routes to it
+  /// in-place, without a reload — the deep-link analog of
+  /// `emitNotificationActivation`, kept on a separate JS channel so a deep
+  /// link isn't mislabeled as a notification. Only the main process / app
+  /// shell invokes this for a window currently on its pinned server, so the
+  /// SPA's `onOpenPath` subscriber (mounted once the SPA loads) is the receiver.
+  func emitOpenPath(_ path: String) {
+    guard path.starts(with: "/") else { return }
+    let script = "window.__omnigentNativeEmitOpenPath?.(\(Self.javascriptString(path)));"
+    webView?.evaluateJavaScript(script)
+  }
+
   /// Push the footprint (in CSS px, excluding the OS safe area which the web
   /// layer adds via `env()`) of the native floating bars to the web app. The
   /// web side folds these into its `--omnigent-inset-*` variables so page

--- a/web/ios/OmnigentTests/DeepLinkTests.swift
+++ b/web/ios/OmnigentTests/DeepLinkTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import Omnigent
+
+final class DeepLinkTests: XCTestCase {
+  func testParsesLoopbackHostWithPortAsHTTP() {
+    let dl = DeepLink.parse(URL(string: "omnigent://localhost:8000/c/conv_abc")!)
+    XCTAssertEqual(dl?.origin, "http://localhost:8000")
+    XCTAssertEqual(dl?.path, "/c/conv_abc")
+
+    let dl2 = DeepLink.parse(URL(string: "omnigent://127.0.0.1:8000/c/x")!)
+    XCTAssertEqual(dl2?.origin, "http://127.0.0.1:8000")
+    XCTAssertEqual(dl2?.path, "/c/x")
+  }
+
+  func testParsesRemoteHostAsHTTPS() {
+    let dl = DeepLink.parse(URL(string: "omnigent://my-workspace.cloud.databricks.com/c/x")!)
+    XCTAssertEqual(dl?.origin, "https://my-workspace.cloud.databricks.com")
+    XCTAssertEqual(dl?.path, "/c/x")
+  }
+
+  func testPreservesNonDefaultPortOnRemoteHost() {
+    let dl = DeepLink.parse(URL(string: "omnigent://example.com:8443/c/x")!)
+    XCTAssertEqual(dl?.origin, "https://example.com:8443")
+    XCTAssertEqual(dl?.path, "/c/x")
+  }
+
+  func testParsesIPv6LoopbackAsHTTP() {
+    let dl = DeepLink.parse(URL(string: "omnigent://[::1]:8000/c/x")!)
+    XCTAssertEqual(dl?.origin, "http://[::1]:8000")
+    XCTAssertEqual(dl?.path, "/c/x")
+  }
+
+  func testStripsTrailingSlashFromPath() {
+    // Foundation already strips it; the parser normalizes regardless so the
+    // forwarded path is always `/c/<id>` (react-router matches that exactly).
+    let dl = DeepLink.parse(URL(string: "omnigent://localhost:8000/c/conv_abc/")!)
+    XCTAssertEqual(dl?.path, "/c/conv_abc")
+  }
+
+  func testRejectsNonOmnigentScheme() {
+    XCTAssertNil(DeepLink.parse(URL(string: "https://localhost:8000/c/x")!))
+    XCTAssertNil(DeepLink.parse(URL(string: "vscode://localhost/c/x")!))
+  }
+
+  func testRejectsLinkWithNoHost() {
+    XCTAssertNil(DeepLink.parse(URL(string: "omnigent://")!))
+    XCTAssertNil(DeepLink.parse(URL(string: "omnigent:///c/x")!))
+  }
+
+  func testRejectsNonConversationPaths() {
+    XCTAssertNil(DeepLink.parse(URL(string: "omnigent://localhost:8000/inbox")!))
+    XCTAssertNil(DeepLink.parse(URL(string: "omnigent://localhost:8000/settings/appearance")!))
+    XCTAssertNil(DeepLink.parse(URL(string: "omnigent://localhost:8000/c/")!))
+    XCTAssertNil(DeepLink.parse(URL(string: "omnigent://localhost:8000/c/a/b")!))
+    XCTAssertNil(DeepLink.parse(URL(string: "omnigent://localhost:8000/")!))
+  }
+}

--- a/web/ios/OmnigentTests/SettingsStoreTests.swift
+++ b/web/ios/OmnigentTests/SettingsStoreTests.swift
@@ -39,4 +39,24 @@ final class SettingsStoreTests: XCTestCase {
     XCTAssertTrue(store.isProtocolAllowed("vscode", from: "https://one.example.com"))
     XCTAssertFalse(store.isProtocolAllowed("vscode", from: "https://two.example.com"))
   }
+
+  func testKnownServerURLMatchesByOrigin() {
+    // A recorded server URL carries the workspace mount (/ml/omnigents); a deep
+    // link matches by ORIGIN and reuses that recorded URL so the mount is
+    // already present — no probe needed.
+    let store = SettingsStore(defaults: defaults)
+    store.rememberRecentServer(
+      URL(string: "https://my-workspace.cloud.databricks.com/ml/omnigents")!)
+
+    let known = store.knownServerURL(forOrigin: "https://my-workspace.cloud.databricks.com")
+    XCTAssertEqual(
+      known?.absoluteString, "https://my-workspace.cloud.databricks.com/ml/omnigents")
+  }
+
+  func testKnownServerURLReturnsNilForNeverConnectedOrigin() {
+    let store = SettingsStore(defaults: defaults)
+    store.rememberRecentServer(URL(string: "https://other.example.com")!)
+
+    XCTAssertNil(store.knownServerURL(forOrigin: "https://never-seen.example.com"))
+  }
 }

--- a/web/ios/README.md
+++ b/web/ios/README.md
@@ -18,3 +18,41 @@ The first version provides native setup chrome, recent servers, WKWebView
 loading, foreground local notifications, app badge updates, and notification
 tap routing back into the SPA. It does not implement APNs, background polling,
 or localhost proxy/CORS behavior.
+
+## Deep links
+
+An `omnigent://<hostname>/c/<session_id>` URL opens that session on that server
+in the app, mirroring the Electron desktop shell (see
+`designs/desktop-deep-link.md` for the shared design):
+
+```
+omnigent://localhost:8000/c/conv_abc              → http://localhost:8000/c/conv_abc
+omnigent://my-workspace.cloud.databricks.com/c/x → https://…/ml/omnigents/c/x
+```
+
+The link names a server by **host** (with port if non-default) and carries no
+`http`/`https`; the scheme is inferred with the same rule as the setup page
+(`http` for loopback, `https` for a remote host), so a deep link and a pasted
+URL never disagree. The Databricks workspace mount (`/ml/omnigents`) is **not**
+in the link; it is discovered by `WorkspaceURLExpander`. v1 accepts only
+`/c/<session_id>`.
+
+**Handling** (single window, unlike the desktop's multi-window):
+
+- If the app is already on the link's server, the SPA router navigates
+  **in-place** (no reload) — the path is deferred until the page finishes
+  loading, so a cold-start link to the saved server isn't lost.
+- A **known** server (in recents or the saved default) the app isn't currently
+  on is switched to, loading the conversation directly; no prompt.
+- A **never-connected** server prompts with a native confirmation — pinning a
+  new origin is a privilege grant (notifications, badge, mic), so a clicked
+  link must not silently connect to an attacker-chosen server. The workspace
+  probe runs only **after** consent, so a link to an unknown host makes no
+  pre-consent network request.
+
+The conversation path never enters the saved server URL or recents (only the
+load URL carries it), so a later deep link resolves against a clean server
+identity. The scheme is registered via `CFBundleURLSchemes` in both Info plists;
+test from the simulator with `xcrun simctl openurl booted 'omnigent://...'`.
+The web UI must be rebuilt (`cd web && npm run build`) for the SPA's `onOpenPath`
+subscriber to be present in the served bundle.


### PR DESCRIPTION
N/A

## Summary

- Adds `omnigent://<hostname>/c/<session_id>` deep links to the iOS app, mirroring the Electron desktop shell (`designs/desktop-deep-link.md`): an OS-routed link opens that session on that server.
- Window handling: same-server → navigate in-place via the SPA router (no reload), deferred until the page finishes loading so a cold-start link isn't lost; known server (in recents / saved) → switch + load the conversation directly, no prompt; unknown server → native confirmation (pinning a new origin is a privilege grant), with the workspace-mount probe running ONLY after consent so a link to an attacker-chosen host makes no pre-consent network request.
- The conversation path never enters the saved server URL or recents (only the load URL carries it), so a later deep link resolves against a clean server identity; a new `omnigent:open-path` main→renderer channel (separate from the notification channel) routes in-place.

## Test Plan

- `xcodebuild build -project web/ios/Omnigent.xcodeproj -scheme Omnigent -destination 'platform=iOS Simulator,name=iPhone 17'` → BUILD SUCCEEDED.
- `xcodebuild test -only-testing:OmnigentTests ...` → TEST SUCCEEDED; 21 tests pass (8 new DeepLinkTests, 2 new SettingsStoreTests for knownServerURL, 11 existing), 0 failures.
- swift-format + swift-format lint + prettier pre-commit hooks pass on all changed files.
- Manual (simulator): `xcrun simctl openurl booted 'omnigent://<reachable-https-host>/c/<id>'` — same-server navigates in-place; a known server switches to it; an unknown server shows the consent alert. Requires the web UI rebuilt (`cd web && npm run build`) so the served SPA has the `onOpenPath` subscriber.

## Demo

N/A — no visible UI change beyond in-app navigation / a consent alert triggered by an external link. (QR-code scanning routes through the same `.onOpenURL` path, so a QR encoding the link opens the installed app identically.)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the pure parser (`DeepLinkTests`: scheme inference, port preservation, IPv6, trailing-slash normalization, rejections) and the known-server lookup (`SettingsStoreTests.knownServerURL`). The orchestration (`AppRootView.handleDeepLink`, the SwiftUI `.onOpenURL`/alert wiring, in-place deferral in `WebShellView`) isn't unit-testable without a UI harness, so it was verified by a clean build + simulator `simctl openurl` dispatch on a reachable https server.

## Changelog

`omnigent://<hostname>/c/<session_id>` links open that session in the iOS app, reusing the open window on that server in-place

