### PR TITLE
feat(db): add created_at to the conversation_items PK for partition-readiness

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -749,7 +749,10 @@ class SqlConversationItem(ConversationBase):
     )
     id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
     response_id: Mapped[str] = mapped_column(String(64))
-    created_at: Mapped[int] = mapped_column(Integer)
+    # In the PK so deployments can PARTITION BY (created_at) with pure DDL —
+    # both PostgreSQL and MySQL require the partition key in the PK and in
+    # every unique index. Immutable: items are insert/delete-only.
+    created_at: Mapped[int] = mapped_column(Integer, primary_key=True)
     # Enum stored as a stable int code (see omnigent.db.enum_codecs
     # ITEM_STATUS: completed=1). Only "completed" is written today, but the
     # CHECK admits the wider OpenAI-style status vocabulary reserved there.
@@ -764,11 +767,16 @@ class SqlConversationItem(ConversationBase):
     created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     __table_args__ = (
+        # created_at trails for partition-readiness (unique indexes must
+        # contain the partition key). Position uniqueness is per-second at
+        # the DB level; the next_position counter under _lock_conversation
+        # is the real allocator and never reuses a position.
         Index(
             "ix_conversation_items_conversation_id_position",
             "workspace_id",
             "conversation_id",
             "position",
+            "created_at",
             unique=True,
         ),
         # Fork-truncation looks up by workspace_id + conversation_id +

--- a/omnigent/db/migrations/versions/z8a2b3c4d5e6_widen_conversation_items_pk_with_created_at.py
+++ b/omnigent/db/migrations/versions/z8a2b3c4d5e6_widen_conversation_items_pk_with_created_at.py
@@ -1,0 +1,129 @@
+"""Add created_at to the conversation_items primary key (partition-ready).
+
+Revision ID: z8a2b3c4d5e6
+Revises: z7a2b3c4d5e6
+Create Date: 2026-07-16 00:00:00.000000
+
+Widens the ``conversation_items`` primary key from
+``(workspace_id, conversation_id, id)`` to
+``(workspace_id, conversation_id, id, created_at)`` and adds ``created_at``
+to the ``ix_conversation_items_conversation_id_position`` unique index.
+
+This deployment does not partition the table. The change makes the schema
+*partition-ready*: PostgreSQL and MySQL both require the partition key to be
+part of the primary key and of every unique index, so a deployment that needs
+``PARTITION BY (created_at)`` can do it with pure DDL — no key migration.
+``created_at`` trails in both keys so existing per-conversation prefix scans
+are unchanged.
+
+``created_at`` is already NOT NULL on every row and is never updated (items
+are insert/delete-only), so the rebuild is a pure key change with no
+backfill. There are no FK constraints in the schema (see ``p1a2b3c4d5e6``).
+
+Position-uniqueness note: with ``created_at`` in the unique index, the DB
+blocks duplicate ``(workspace_id, conversation_id, position)`` only within
+the same epoch second. The ``next_position`` counter allocated under
+``_lock_conversation`` is (and already was) the real guarantor; it is
+monotonic and never reuses a position.
+
+SQLite note: the index is dropped before the ``recreate="always"`` batch
+rebuild (so reflection does not recreate the stale shape) and re-created
+after. MySQL folds the PK swap and index swap into one ``ALTER TABLE`` so
+the copying rebuild happens once.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import warnings
+from collections.abc import Iterator, Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "z8a2b3c4d5e6"
+down_revision: str | None = "z7a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "conversation_items"
+_POSITION_INDEX = "ix_conversation_items_conversation_id_position"
+# Primary key and unique-index columns before this migration and after it.
+_OLD_PK = ["workspace_id", "conversation_id", "id"]
+_NEW_PK = ["workspace_id", "conversation_id", "id", "created_at"]
+_OLD_INDEX = ["workspace_id", "conversation_id", "position"]
+_NEW_INDEX = ["workspace_id", "conversation_id", "position", "created_at"]
+
+
+def _existing_pk_name(table: str) -> str | None:
+    """Reflect the current primary-key constraint name (PostgreSQL path)."""
+    return sa.inspect(op.get_bind()).get_pk_constraint(table).get("name")
+
+
+@contextlib.contextmanager
+def _quiet_pk_override() -> Iterator[None]:
+    """
+    Silence the expected SQLite batch-rebuild warning about the reflected
+    primary key not matching the wider one we install. The override is
+    intentional here, and this fires on every fresh DB.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*not matching locally specified columns.*",
+            category=sa.exc.SAWarning,
+        )
+        yield
+
+
+def _rebuild(pk: list[str], index: list[str]) -> None:
+    """Install ``pk`` and the ``index`` shape of the unique position index."""
+    dialect = op.get_bind().dialect.name
+    sqlite = dialect == "sqlite"
+
+    if dialect == "mysql":
+        # MySQL PKs are unnamed; raw DDL folds the PK swap and the unique
+        # index swap into a single copying rebuild.
+        pk_cols = ", ".join(f"`{c}`" for c in pk)
+        index_cols = ", ".join(f"`{c}`" for c in index)
+        op.execute(
+            sa.text(
+                f"ALTER TABLE `{_TABLE}` "
+                f"DROP PRIMARY KEY, "
+                f"ADD CONSTRAINT `pk_{_TABLE}` PRIMARY KEY ({pk_cols}), "
+                f"DROP INDEX `{_POSITION_INDEX}`, "
+                f"ADD UNIQUE INDEX `{_POSITION_INDEX}` ({index_cols})"
+            )
+        )
+        return
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = OFF"))
+
+    # Drop the unique index first so the SQLite batch rebuild does not
+    # recreate the stale shape from reflection.
+    op.drop_index(_POSITION_INDEX, table_name=_TABLE)
+
+    old_pk_name = None if sqlite else _existing_pk_name(_TABLE)
+    with (
+        _quiet_pk_override(),
+        op.batch_alter_table(_TABLE, recreate="always" if sqlite else "auto") as batch_op,
+    ):
+        if old_pk_name is not None:
+            batch_op.drop_constraint(old_pk_name, type_="primary")
+        batch_op.create_primary_key(f"pk_{_TABLE}", pk)
+
+    op.create_index(_POSITION_INDEX, _TABLE, index, unique=True)
+
+    if sqlite:
+        op.execute(sa.text("PRAGMA foreign_keys = ON"))
+
+
+def upgrade() -> None:
+    """Widen the PK and unique position index with ``created_at``."""
+    _rebuild(_NEW_PK, _NEW_INDEX)
+
+
+def downgrade() -> None:
+    """Restore the ``(workspace_id, conversation_id, id)`` key shapes."""
+    _rebuild(_OLD_PK, _OLD_INDEX)

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -483,6 +483,7 @@ class TestSqlConversationItem:
 
         conv = _make_conversation()
         item = _make_item()
+        item_created_at = item.created_at
         with managed() as session:
             session.add(conv)
             session.add(item)
@@ -490,7 +491,12 @@ class TestSqlConversationItem:
         with managed() as session:
             loaded = session.get(
                 SqlConversationItem,
-                (0, "a9930027fd3e2e979e65844f7af7bf88", "a47da81d0587d7c42e53978d629c5ab8"),
+                (
+                    0,
+                    "a9930027fd3e2e979e65844f7af7bf88",
+                    "a47da81d0587d7c42e53978d629c5ab8",
+                    item_created_at,
+                ),
             )
             assert loaded is not None
             assert loaded.conversation_id == "a9930027fd3e2e979e65844f7af7bf88"
@@ -528,6 +534,7 @@ class TestSqlConversationItem:
             id="79770462a714e18289f416144611383e",
             conversation_id="553a265445caf1cdb034abe0b449485d",
         )
+        item_created_at = item.created_at
         with managed() as session:
             session.add(conv)
             session.add(item)
@@ -542,7 +549,12 @@ class TestSqlConversationItem:
             assert (
                 session.get(
                     SqlConversationItem,
-                    (0, "553a265445caf1cdb034abe0b449485d", "79770462a714e18289f416144611383e"),
+                    (
+                        0,
+                        "553a265445caf1cdb034abe0b449485d",
+                        "79770462a714e18289f416144611383e",
+                        item_created_at,
+                    ),
                 )
                 is not None
             )

--- a/tests/db/test_migration_conversation_items_created_at_pk.py
+++ b/tests/db/test_migration_conversation_items_created_at_pk.py
@@ -1,0 +1,126 @@
+"""Tests for the conversation_items created_at PK-widening migration (z8a2b3c4d5e6).
+
+The migration makes the table partition-ready: ``created_at`` joins the
+primary key and the unique position index so a deployment can
+``PARTITION BY (created_at)`` with pure DDL. Partition-readiness leans on
+``created_at`` being immutable, so that invariant is pinned here too.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+from omnigent.entities.conversation import MessageData, NewConversationItem
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+_TABLE = "conversation_items"
+_POSITION_INDEX = "ix_conversation_items_conversation_id_position"
+_HEAD_PK = ["workspace_id", "conversation_id", "id", "created_at"]
+_PRIOR_PK = ["workspace_id", "conversation_id", "id"]
+_HEAD_INDEX = ["workspace_id", "conversation_id", "position", "created_at"]
+_PRIOR_INDEX = ["workspace_id", "conversation_id", "position"]
+
+# An UPDATE targeting the items table itself (not the FTS shadow table).
+_ITEMS_UPDATE_RE = re.compile(r'^\s*UPDATE\s+["\'`]?conversation_items["\'`]?\b', re.IGNORECASE)
+
+
+def _pk(engine: Engine) -> list[str]:
+    return sa.inspect(engine).get_pk_constraint(_TABLE)["constrained_columns"]
+
+
+def _position_index(engine: Engine) -> dict[str, Any]:
+    indexes = sa.inspect(engine).get_indexes(_TABLE)
+    return next(ix for ix in indexes if ix["name"] == _POSITION_INDEX)
+
+
+def _message(text: str, response_id: str = "resp_1") -> NewConversationItem:
+    return NewConversationItem(
+        type="message",
+        response_id=response_id,
+        data=MessageData(role="user", content=[{"type": "input_text", "text": text}]),
+    )
+
+
+def test_head_pk_and_unique_index_include_created_at(tmp_path: Path) -> None:
+    """At head both the PK and the unique position index end in created_at."""
+    uri = f"sqlite:///{tmp_path / 'head.db'}"
+    engine = get_or_create_engine(uri)
+    try:
+        assert _pk(engine) == _HEAD_PK
+        index = _position_index(engine)
+        assert index["column_names"] == _HEAD_INDEX
+        assert index["unique"]
+    finally:
+        engine.dispose()
+        clear_engine_cache()
+
+
+def test_downgrade_restores_prior_key_shapes(tmp_path: Path) -> None:
+    """Downgrading one step drops created_at back out of both keys."""
+    uri = f"sqlite:///{tmp_path / 'downgrade.db'}"
+    engine = get_or_create_engine(uri)
+    try:
+        assert _pk(engine) == _HEAD_PK
+
+        config = _build_alembic_config(uri)
+        with engine.begin() as conn:
+            config.attributes["connection"] = conn
+            command.downgrade(config, "z7a2b3c4d5e6")
+
+        assert _pk(engine) == _PRIOR_PK
+        index = _position_index(engine)
+        assert index["column_names"] == _PRIOR_INDEX
+        assert index["unique"]
+    finally:
+        engine.dispose()
+        clear_engine_cache()
+
+
+def test_item_created_at_is_immutable(tmp_path: Path) -> None:
+    """
+    No store operation UPDATEs conversation_items or changes an item's
+    created_at. A future partitioned deployment routes rows by created_at,
+    so a post-insert write would silently relocate rows between partitions.
+    """
+    uri = f"sqlite:///{tmp_path / 'immutable.db'}"
+    engine = get_or_create_engine(uri)
+    item_updates: list[str] = []
+
+    @sa.event.listens_for(engine, "before_cursor_execute")
+    def _capture(_conn, _cursor, statement, _params, _context, _executemany):  # type: ignore[no-untyped-def]
+        if _ITEMS_UPDATE_RE.match(statement):
+            item_updates.append(statement)
+
+    try:
+        store = SqlAlchemyConversationStore(str(engine.url))
+        conv = store.create_conversation()
+        store.append(conv.id, [_message("first"), _message("second")])
+        before = {item.id: item.created_at for item in store.list_items(conv.id).data}
+
+        # Operations that touch the conversation and its items.
+        store.update_conversation(conv.id, title="renamed")
+        store.update_conversation(conv.id, archived=True)
+        store.append(conv.id, [_message("third", response_id="resp_2")])
+
+        after = {item.id: item.created_at for item in store.list_items(conv.id).data}
+        assert all(after[item_id] == ts for item_id, ts in before.items())
+        assert item_updates == [], (
+            f"conversation_items must be insert/delete-only; saw UPDATE(s): {item_updates!r}"
+        )
+    finally:
+        sa.event.remove(engine, "before_cursor_execute", _capture)
+        engine.dispose()
+        clear_engine_cache()

--- a/tests/db/test_migration_conversation_items_pk.py
+++ b/tests/db/test_migration_conversation_items_pk.py
@@ -15,7 +15,8 @@ from omnigent.db.utils import (
 )
 
 _TABLE = "conversation_items"
-_HEAD_PK = ["workspace_id", "conversation_id", "id"]
+# z8a2b3c4d5e6 later widened the PK again with created_at (partition-ready).
+_HEAD_PK = ["workspace_id", "conversation_id", "id", "created_at"]
 _PRIOR_PK = ["workspace_id", "id"]
 
 
@@ -24,7 +25,7 @@ def _pk(engine: Engine) -> list[str]:
 
 
 def test_head_widens_conversation_items_pk(tmp_path: Path) -> None:
-    """At head the PK is ``(workspace_id, conversation_id, id)``."""
+    """At head the PK is ``(workspace_id, conversation_id, id, created_at)``."""
     uri = f"sqlite:///{tmp_path / 'head.db'}"
     engine = get_or_create_engine(uri)
     try:

--- a/tests/db/test_migration_workspace_id.py
+++ b/tests/db/test_migration_workspace_id.py
@@ -47,8 +47,9 @@ _LATER_PK_OVERRIDES: dict[str, list[str]] = {
     # (workspace_id, host_id) for the hosts table.
     "hosts": ["workspace_id", "host_id"],
     # y1a2b3c4d5e6 widened conversation_items to insert conversation_id
-    # between workspace_id and id.
-    "conversation_items": ["workspace_id", "conversation_id", "id"],
+    # between workspace_id and id; z8a2b3c4d5e6 appended created_at for
+    # partition-readiness.
+    "conversation_items": ["workspace_id", "conversation_id", "id", "created_at"],
 }
 
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -622,10 +622,13 @@ def test_unique_position_constraint(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
     """
-    The (conversation_id, position) pair has a unique index.
+    The (conversation_id, position, created_at) tuple has a unique index.
 
-    Verify that manually inserting a duplicate position raises
-    IntegrityError, confirming the safety net is in place.
+    created_at joined the index for partition-readiness (unique indexes must
+    contain a partition key), so the DB safety net blocks duplicate positions
+    only within the same epoch second — which still covers the concurrent
+    double-append race. Slower duplicates are prevented by the next_position
+    allocator, not the index.
     """
     from sqlalchemy.exc import IntegrityError
 
@@ -647,23 +650,30 @@ def test_unique_position_constraint(
             ),
         ],
     )
-    # Directly insert a row at position 0 (already taken) to
-    # confirm the unique constraint rejects it.
+    existing_created_at = conversation_store.list_items(conv.id).data[0].created_at
+
+    def _duplicate_position_row(created_at: int) -> SqlConversationItem:
+        return SqlConversationItem(
+            id=generate_item_id("message"),
+            conversation_id=conv.id,
+            response_id="resp_dup",
+            created_at=created_at,
+            status=encode_item_status("completed"),
+            position=0,  # duplicate
+            type=encode_item_type("message"),
+            data='{"role":"user","content":[]}',
+            search_text="",
+        )
+
+    # Same second (the double-append race shape): the index rejects it.
     with pytest.raises(IntegrityError):
         with conversation_store._session() as session:
-            session.add(
-                SqlConversationItem(
-                    id=generate_item_id("message"),
-                    conversation_id=conv.id,
-                    response_id="resp_dup",
-                    created_at=0,
-                    status=encode_item_status("completed"),
-                    position=0,  # duplicate
-                    type=encode_item_type("message"),
-                    data='{"role":"user","content":[]}',
-                    search_text="",
-                )
-            )
+            session.add(_duplicate_position_row(existing_created_at))
+
+    # A different second slips past the index; only the next_position
+    # allocator prevents this in real appends.
+    with conversation_store._session() as session:
+        session.add(_duplicate_position_row(existing_created_at + 1))
 
 
 def test_concurrent_appends_do_not_collide_on_position(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Widens the `conversation_items` primary key from `(workspace_id, conversation_id, id)` to `(workspace_id, conversation_id, id, created_at)` and adds `created_at` to the `ix_conversation_items_conversation_id_position` unique index (migration `z8a2b3c4d5e6`, modeled on `y1a2b3c4d5e6`, which widened this same PK once before).
- **Nothing is partitioned by this PR.** The change makes the schema *partition-ready*: PostgreSQL and MySQL both require the partition key to be part of the PK and of every unique index, so a deployment whose item volume demands it can `PARTITION BY (created_at)` (weekly ranges, hash ring, …) with pure DDL — no key migration, no application changes.
- `created_at` already exists on every row, is NOT NULL, and is never written after insert (items are insert/delete-only), so the rebuild is a pure key change with no backfill. It trails in both keys, so the per-conversation prefix scans that dominate item reads are unchanged.

ELI5: to slice a table into partitions, the database insists the slicing column is part of every "no duplicates" rule on the table. We add the timestamp column to those two rules now, while the table is small enough to rebuild cheaply, so partitioning later is a config change instead of a schema surgery.

```
PK:      (workspace_id, conversation_id, id)            → (workspace_id, conversation_id, id, created_at)
UNIQUE:  (workspace_id, conversation_id, position)      → (workspace_id, conversation_id, position, created_at)
```

Semantics note: DB-level position uniqueness becomes per-epoch-second (same-second duplicates — the concurrent double-append race the index exists for — are still rejected). The `next_position` counter allocated under `_lock_conversation` is, and already was, the real position allocator; a store test now pins both halves of that contract, and a new test pins `created_at` immutability (a future partitioned deployment routes rows by it).

## Test Plan

- New `tests/db/test_migration_conversation_items_created_at_pk.py`: head PK/index shape, one-step downgrade restores the prior shapes, and an immutability test asserting no store operation ever UPDATEs `conversation_items` or changes an item's `created_at`.
- Updated shape assertions in `test_migration_conversation_items_pk.py` (head PK) and `test_migration_workspace_id.py` (PK override table); updated `test_unique_position_constraint` to pin the new per-second semantics (same-second duplicate raises `IntegrityError`, different-second is allocator-guarded).
- Full `tests/db/` + `tests/stores/` suites pass locally (823 tests; SQLite path). `pre-commit` clean; single alembic head (`z8a2b3c4d5e6`).

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The MySQL branch of the migration (single `ALTER TABLE` folding the PK and index swap into one rebuild) follows the same convention as `y1`/`z7` and is not exercised by the local or CI test paths, which cover SQLite; the PostgreSQL path exercises the same batch-alter code as SQLite's minus the table recreate.

This pull request and its description were written by Isaac.