### PR TITLE
fix(cursor): fail closed in the policy hook when evaluation is unavailable

### DIFF
--- a/omnigent/inner/cursor_policy_hook.py
+++ b/omnigent/inner/cursor_policy_hook.py
@@ -65,7 +65,7 @@ def main() -> None:
 
         headers = policy_hook_request_headers()
         reauth = policy_hook_reauth(server_url, headers)
-        resp, _ = post_evaluate_with_retry(
+        resp, api_error = post_evaluate_with_retry(
             url=url,
             headers=headers,
             eval_request=eval_body,
@@ -82,15 +82,25 @@ def main() -> None:
         return
 
     if resp is None:
-        # Network error / retry budget exhausted -- fail open (allow) so a
-        # transient server outage doesn't block the Cursor turn.
-        json.dump({"permission": "allow"}, sys.stdout)
+        # Network error / retry budget exhausted -- fail closed so a
+        # transient server outage doesn't skip DENY/ASK enforcement.
+        detail = api_error or reauth.failure_reason
+        message = f"Tool '{tool_name}' blocked: Omnigent policy evaluation unavailable"
+        if detail:
+            message += f" ({detail})"
+        json.dump({"permission": "deny", "agent_message": message}, sys.stdout)
         return
 
     try:
         result = resp.json()
     except Exception:  # noqa: BLE001
-        json.dump({"permission": "allow"}, sys.stdout)
+        json.dump(
+            {
+                "permission": "deny",
+                "agent_message": f"Tool '{tool_name}' blocked: malformed Omnigent policy response",
+            },
+            sys.stdout,
+        )
         return
 
     action = result.get("result", "POLICY_ACTION_ALLOW")

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1726,8 +1726,8 @@ def test_cursor_policy_hook_deny(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Bash" in result["agent_message"]
 
 
-def test_cursor_policy_hook_network_error_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
-    """post_evaluate_with_retry returning None (network error) causes the hook to fail open."""
+def test_cursor_policy_hook_network_error_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """None from post_evaluate_with_retry (network error) fails closed with deny."""
     import io
     from unittest.mock import patch
 
@@ -1750,7 +1750,44 @@ def test_cursor_policy_hook_network_error_fails_open(monkeypatch: pytest.MonkeyP
         cursor_policy_hook.main()
 
     result = json.loads(stdout.getvalue())
-    assert result["permission"] == "allow"
+    assert result["permission"] == "deny"
+    assert "unavailable" in result["agent_message"]
+    assert "connection error: simulated" in result["agent_message"]
+
+
+def test_cursor_policy_hook_malformed_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A policy response whose body isn't valid JSON fails closed with deny."""
+    import io
+    from unittest.mock import patch
+
+    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "http://localhost:6767")
+    monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
+
+    stdin_data = json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}})
+
+    from omnigent.inner import cursor_policy_hook
+
+    def _raise() -> dict[str, object]:
+        raise ValueError("not json")
+
+    resp = SimpleNamespace()
+    resp.json = _raise
+
+    stdout = io.StringIO()
+    with (
+        patch.object(sys, "stdin", io.StringIO(stdin_data)),
+        patch.object(sys, "stdout", stdout),
+        patch(
+            "omnigent.native_policy_hook.post_evaluate_with_retry",
+            return_value=(resp, None),
+        ),
+    ):
+        cursor_policy_hook.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["permission"] == "deny"
+    assert "malformed" in result["agent_message"]
+    assert "Bash" in result["agent_message"]
 
 
 def test_cursor_policy_hook_no_env_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

`omnigent/inner/cursor_policy_hook.py` is the `preToolUse` policy gate for the Cursor SDK harness's native tools. On two failure branches it returned `{"permission": "allow"}`:

- `resp is None` — the Omnigent server was unreachable / the retry budget was exhausted
- `resp.json()` raised — the policy response body was malformed

So during a transient server outage or a bad response, a policy that should `DENY` (e.g. `rm -rf`) or `ASK` for human approval was silently skipped and the tool ran unreviewed. This is the only native policy hook that fails open here: `hermes_policy_hook` and the claude/codex native hooks (via `native_policy_hook.fail_closed_hook_output`) all fail **closed** on these branches per the convention in #163, and `post_evaluate_with_retry`'s docstring states the caller is responsible for fail-closed handling on `None`.

This makes both branches fail closed with `deny` (surfacing the failure detail in `agent_message`, like the sibling hooks). The no-server, unparseable-stdin, and import-error branches keep failing open, exactly as `hermes_policy_hook` does — only the two branches that diverged from the convention change.

Fixes #2663.

## Test plan

- [x] Renamed `test_cursor_policy_hook_network_error_fails_open` → `_fails_closed`: `post_evaluate_with_retry` returning `(None, err)` now asserts `deny` (the old test asserted `allow`, encoding the bug)
- [x] Added `test_cursor_policy_hook_malformed_fails_closed`: a response whose `.json()` raises now asserts `deny`
- [x] Both new assertions fail on the pre-fix code (`allow != deny`) and pass with the fix
- [x] All 7 `cursor_policy_hook` unit tests pass; full `tests/inner/test_cursor_executor.py` is green apart from one pre-existing Windows-only failure (`test_ensure_session_writes_hooks_json`, a `.sh` exec-bit assertion, fails identically on clean `main`)
- [x] `ruff check` / `ruff format` clean; `mypy` clean on the changed hook
