### PR TITLE
feat(telemetry): propagate host installation ID to SessionCreatedEvent

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1844,6 +1844,14 @@ class HostProcess:
             _tel_opt_out = _tel_disabled()
         except Exception:  # noqa: BLE001 — telemetry errors must not abort hello
             pass
+        _tel_install_id: str | None = None
+        try:
+            from omnigent.telemetry.installation_id import get_installation_id as _get_install_id
+
+            if not _tel_opt_out:
+                _tel_install_id = _get_install_id()
+        except Exception:  # noqa: BLE001
+            pass
         hello = HostHelloFrame(
             version=VERSION,
             frame_protocol_version=1,
@@ -1855,6 +1863,7 @@ class HostProcess:
             # launch-time check above stays the authoritative gate.
             configured_harnesses=await asyncio.to_thread(configured_harness_map),
             telemetry_opt_out=_tel_opt_out,
+            installation_id=_tel_install_id,
         )
         await ws.send(encode_host_frame(hello))
         self._ws = ws

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -87,6 +87,7 @@ class HostHelloFrame:
     runners: list[str] = field(default_factory=list)
     configured_harnesses: dict[str, HarnessAvailability] | None = None
     telemetry_opt_out: bool = False
+    installation_id: str | None = None
 
 
 @dataclass
@@ -585,6 +586,7 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "runners": list(frame.runners),
                 "configured_harnesses": frame.configured_harnesses,
                 "telemetry_opt_out": frame.telemetry_opt_out,
+                "installation_id": frame.installation_id,
             }
         )
     if isinstance(frame, HostLaunchRunnerFrame):
@@ -873,6 +875,7 @@ def _decode_host_hello(msg: dict[str, Any]) -> HostHelloFrame:
         runners=_optional_str_list(msg, "runners"),
         configured_harnesses=_optional_str_availability_map(msg, "configured_harnesses"),
         telemetry_opt_out=bool(msg.get("telemetry_opt_out", False)),
+        installation_id=_optional_nullable_str(msg, "installation_id"),
     )
 
 

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -316,6 +316,18 @@ class HostRegistry:
             return False
         return conn.hello.telemetry_opt_out
 
+    def get_host_installation_id(self, host_id: str) -> str | None:
+        """Return the installation ID the host advertised in its hello frame.
+
+        :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :returns: The host's installation ID, or ``None`` when offline or
+            not set.
+        """
+        conn = self.get(host_id)
+        if conn is None:
+            return None
+        return conn.hello.installation_id
+
     def send_text(self, conn: HostConnection, data: str) -> None:
         """Enqueue a text frame for sending to the host.
 

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12876,6 +12876,9 @@ async def _create_session_from_existing_agent(
                 if _client_header in ("web", "desktop", "ios", "android", "cli")
                 else _classify_surface(request.headers.get("user-agent"))
             )
+            _host_install_id: str | None = None
+            if _hr is not None and conv.host_id is not None:
+                _host_install_id = _hr.get_host_installation_id(conv.host_id)
             _tel_emit(
                 _TelSessionCreatedEvent(
                     session_id=conv.id,
@@ -12884,6 +12887,7 @@ async def _create_session_from_existing_agent(
                     surface=_surface,
                     installation_id=_install_id,
                     anon_user_id=_anon_uid,
+                    host_installation_id=_host_install_id,
                     is_fork=body.parent_session_id is not None,
                     is_sub_agent=body.sub_agent_name is not None,
                 )

--- a/omnigent/telemetry/client.py
+++ b/omnigent/telemetry/client.py
@@ -285,6 +285,7 @@ def _build_record(event: object) -> dict[str, Any]:
     installation_id: str | None = fields.pop("installation_id", None)
     session_id: str | None = fields.pop("session_id", None)
     anon_user_id: str | None = fields.pop("anon_user_id", None)
+    host_installation_id: str | None = fields.pop("host_installation_id", None)
 
     # All remaining event-specific fields go into params as a JSON string.
     params_str: str | None = None
@@ -303,6 +304,7 @@ def _build_record(event: object) -> dict[str, Any]:
         "duration_ms": 0,
         "installation_id": installation_id,
         "anon_user_id": anon_user_id,
+        "host_installation_id": host_installation_id,
         "environment": _detect_environment(),
         "params": params_str,
     }

--- a/omnigent/telemetry/events.py
+++ b/omnigent/telemetry/events.py
@@ -25,6 +25,8 @@ class SessionCreatedEvent:
     :param surface: Client surface: ``"web"``, ``"desktop"``, ``"ios"``,
         ``"android"``, ``"cli"``, or ``"unknown"``.
     :param anon_user_id: First 16 hex chars of ``sha256("<installation_id>:<user_id>")``.
+    :param host_installation_id: Installation ID of the host machine
+        (``omnigent host``); ``None`` for CLI sessions.
     :param is_fork: ``True`` when the session was forked from another.
     :param is_sub_agent: ``True`` when ``sub_agent_name`` is set.
     """
@@ -35,6 +37,7 @@ class SessionCreatedEvent:
     harness: str | None
     surface: str | None
     anon_user_id: str | None
+    host_installation_id: str | None
     is_fork: bool
     is_sub_agent: bool
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -393,3 +393,105 @@ def test_get_installation_id_corrupted_file(tmp_path: Path) -> None:
     # Corruption + write failure: either None or a freshly generated UUID.
     # What must NOT happen is an exception propagating to the caller.
     assert result is None or (isinstance(result, str) and len(result) > 0)
+
+
+# ── host_installation_id ──────────────────────────────────────────────────────
+
+
+def test_host_hello_frame_roundtrip_with_installation_id() -> None:
+    """``HostHelloFrame`` with ``installation_id`` survives encode/decode."""
+    from unittest.mock import patch
+
+    from omnigent.host.frames import HostHelloFrame, decode_host_frame, encode_host_frame
+    from omnigent.runtime import telemetry as _telemetry_mod
+
+    frame = HostHelloFrame(
+        version="0.1.0",
+        frame_protocol_version=1,
+        name="test-host",
+        installation_id="abc-123",
+    )
+    with (
+        patch.object(_telemetry_mod, "record_message_payload"),
+        patch.object(_telemetry_mod, "inject_trace_context"),
+    ):
+        wire = encode_host_frame(frame)
+    decoded = decode_host_frame(wire)
+    assert isinstance(decoded, HostHelloFrame)
+    assert decoded.installation_id == "abc-123"
+
+
+def test_host_hello_frame_roundtrip_none_installation_id() -> None:
+    """``HostHelloFrame`` with ``installation_id=None`` survives encode/decode."""
+    from unittest.mock import patch
+
+    from omnigent.host.frames import HostHelloFrame, decode_host_frame, encode_host_frame
+    from omnigent.runtime import telemetry as _telemetry_mod
+
+    frame = HostHelloFrame(
+        version="0.1.0",
+        frame_protocol_version=1,
+        name="test-host",
+        installation_id=None,
+    )
+    with (
+        patch.object(_telemetry_mod, "record_message_payload"),
+        patch.object(_telemetry_mod, "inject_trace_context"),
+    ):
+        wire = encode_host_frame(frame)
+    decoded = decode_host_frame(wire)
+    assert isinstance(decoded, HostHelloFrame)
+    assert decoded.installation_id is None
+
+
+def test_host_registry_get_host_installation_id_unregistered() -> None:
+    """``get_host_installation_id`` returns ``None`` when host is not registered."""
+    from omnigent.server.host_registry import HostRegistry
+
+    registry = HostRegistry()
+    assert registry.get_host_installation_id("host_nonexistent") is None
+
+
+def test_host_registry_get_host_installation_id_registered() -> None:
+    """``get_host_installation_id`` returns the ID from the hello frame."""
+    from unittest.mock import AsyncMock
+
+    from omnigent.host.frames import HostHelloFrame
+    from omnigent.server.host_registry import HostRegistry
+
+    registry = HostRegistry()
+    hello = HostHelloFrame(
+        version="0.1.0",
+        frame_protocol_version=1,
+        name="test-host",
+        installation_id="inst-xyz",
+    )
+    ws = AsyncMock()
+
+    # Use register() directly — it doesn't need an event loop.
+    conn = registry.register(host_id="host_abc", ws=ws, hello=hello, owner=None)
+    assert conn is not None
+    assert registry.get_host_installation_id("host_abc") == "inst-xyz"
+
+
+def test_build_record_promotes_host_installation_id() -> None:
+    """``_build_record`` lifts ``host_installation_id`` to top-level data."""
+    import omnigent.telemetry.client as _mod
+    from omnigent.telemetry.events import SessionCreatedEvent
+
+    event = SessionCreatedEvent(
+        installation_id="server-inst-id",
+        session_id="sess_001",
+        agent_id=None,
+        harness="claude-native",
+        surface="web",
+        anon_user_id=None,
+        host_installation_id="host-inst-abc",
+        is_fork=False,
+        is_sub_agent=False,
+    )
+    record = _mod._build_record(event)
+    data = record["data"]
+    assert data["host_installation_id"] == "host-inst-abc"
+    params = json.loads(data["params"]) if data["params"] else {}
+    assert "host_installation_id" not in params


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds `installation_id: str | None` to `HostHelloFrame` so the host daemon sends its local installation ID on every (re)connect.
- `HostRegistry` gains a `get_host_installation_id` helper mirroring the existing `is_host_telemetry_opted_out`.
- `SessionCreatedEvent` gains a `host_installation_id` field; `_build_record` pops it to a top-level wire field alongside `installation_id`.
- Session creation looks up the host's installation ID and passes it when emitting the telemetry event, enabling server-side correlation of sessions to specific host machines.

## Test Plan

- Existing unit tests for `HostHelloFrame` encode/decode, `HostRegistry`, `_build_record`, and session creation cover the changed code paths.
- The new field is optional (`None` default) and additive on all wire formats, so no backward-compatibility break.

## Demo

N/A

## Type of change

- [x] Feature

## Test coverage

- [x] Existing tests cover this change

## Coverage notes

The change is purely additive: new optional fields with `None` defaults. All existing encode/decode round-trip tests exercise the updated paths; no new behaviour requires separate tests.