### PR TITLE
fix(policies): show all policies in Add Global Policy dialog

### DIFF
--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -45,12 +45,10 @@ import { coercePolicyParams } from "@/lib/policyParams";
 
 function AddDefaultPolicyDialog({
   registry,
-  appliedHandlers,
   open,
   onOpenChange,
 }: {
   registry: PolicyRegistryEntry[];
-  appliedHandlers: Set<string>;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -158,15 +156,14 @@ function AddDefaultPolicyDialog({
         <div className="min-w-0 space-y-3 pt-1">
           {!selected &&
             (() => {
-              const available = registry.filter((r) => !appliedHandlers.has(r.handler));
               const lowerFilter = filter.toLowerCase();
               const filtered = lowerFilter
-                ? available.filter(
+                ? registry.filter(
                     (r) =>
                       r.name.toLowerCase().includes(lowerFilter) ||
                       r.description?.toLowerCase().includes(lowerFilter),
                   )
-                : available;
+                : registry;
               return (
                 <>
                   <input
@@ -196,9 +193,7 @@ function AddDefaultPolicyDialog({
                     ))}
                     {filtered.length === 0 && (
                       <p className="py-2 text-center text-xs text-muted-foreground">
-                        {available.length === 0
-                          ? "All available policies are already applied."
-                          : "No policies match your filter."}
+                        No policies match your filter.
                       </p>
                     )}
                   </div>
@@ -445,7 +440,6 @@ export function PoliciesPage() {
   const [actionError, setActionError] = useState<string | null>(null);
 
   const registryByHandler = new Map(registry.map((r) => [r.handler, r]));
-  const appliedHandlers = new Set(policies.map((p) => p.handler));
 
   const refresh = useCallback(() => {
     void refetch();
@@ -600,12 +594,7 @@ export function PoliciesPage() {
         </Button>
       </div>
 
-      <AddDefaultPolicyDialog
-        registry={registry}
-        appliedHandlers={appliedHandlers}
-        open={addOpen}
-        onOpenChange={setAddOpen}
-      />
+      <AddDefaultPolicyDialog registry={registry} open={addOpen} onOpenChange={setAddOpen} />
 
       {/* Delete confirmation */}
       <Dialog


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Removed the filter that hid already-applied policies from the **Add Global Policy** dialog
- Users can now select any policy regardless of whether it is already configured (e.g. to add a second instance)
- Cleaned up the now-unused `appliedHandlers` prop and variable

## Test Plan

1. Navigate to the Policies page with at least one policy already applied.
2. Click **Add Global Policy** — confirm all policies appear in the list, including any already applied.
3. Verify the filter input still narrows results correctly.
4. Verify the "No policies match your filter" empty state still shows when the filter has no matches.

## Demo

N/A (behavior change: previously-applied policies now appear in the picker)

## Type of change

- [x] Bug fix
- [x] UI / frontend change

## Test coverage

- [x] Manual verification completed

## Coverage notes

Manually verified that all policies show in the dialog regardless of applied state, and that the filter still works correctly.

## Changelog

The Add Global Policy dialog now shows all available policies, including ones already applied.