### PR TITLE
feat(db): switch scheduled_tasks trigger from cron to RRULE 

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1217,14 +1217,15 @@ class SqlScheduledTask(OmnigentBase):
     SQLAlchemy model for the ``scheduled_tasks`` table.
 
     A scheduled task is a saved, scheduled instruction that fires an agent
-    session on a recurring cron schedule (``cron_expression``).
+    session on a recurring schedule (``rrule``).
 
     :param id: UUID primary key stored as 16 raw bytes (see :class:`Uuid16`),
         surfaced as a bare 32-char hex string (no dashes).
     :param name: Human-readable task name, e.g. ``"nightly triage"``.
     :param prompt: The instruction dispatched to the agent on each firing.
-    :param cron_expression: The required cron string for the recurring trigger,
-        e.g. ``"0 9 * * *"``.
+    :param rrule: The required RFC 5545 recurrence rule for the recurring
+        trigger, e.g. ``"FREQ=DAILY;BYHOUR=9;BYMINUTE=0"``. Evaluated in
+        ``timezone``.
     :param owner_user_id: User the spawned session's ``LEVEL_OWNER`` grant is
         written for — who the run belongs to, e.g. ``"alice@example.com"``.
         ``None`` in single-user / OSS mode; the fire path resolves it to the
@@ -1287,8 +1288,8 @@ class SqlScheduledTask(OmnigentBase):
     name: Mapped[str] = mapped_column(String(256), nullable=False)
     # Opaque free text, never SQL-queried — stored compressed (CompressedText).
     prompt: Mapped[str] = mapped_column(CompressedText, nullable=False)
-    # e.g. "0 9 * * *"
-    cron_expression: Mapped[str] = mapped_column(String(255), nullable=False)
+    # RFC 5545 recurrence rule, e.g. "FREQ=DAILY;BYHOUR=9;BYMINUTE=0".
+    rrule: Mapped[str] = mapped_column(String(512), nullable=False)
     # Session-owner identity: the spawned run's LEVEL_OWNER grant is written
     # for this user. Nullable — None in single-user/OSS mode (the fire path
     # resolves null to the reserved "local" user). String(128) to match

--- a/omnigent/db/migrations/versions/a7b3c4d5e6f7_scheduled_tasks_cron_to_rrule.py
+++ b/omnigent/db/migrations/versions/a7b3c4d5e6f7_scheduled_tasks_cron_to_rrule.py
@@ -1,0 +1,56 @@
+"""switch scheduled_tasks trigger from cron_expression to rrule
+
+Revision ID: a7b3c4d5e6f7
+Revises: z8a2b3c4d5e6
+Create Date: 2026-07-16 00:00:00.000000
+
+Replaces the ``scheduled_tasks.cron_expression`` column with ``rrule``, an
+RFC 5545 recurrence rule string (e.g. ``"FREQ=DAILY;BYHOUR=9;BYMINUTE=0"``).
+The recurrence engine moves from cron expressions to RRULE; RRULE strings are
+longer, so the column widens from ``String(255)`` to ``String(512)``.
+
+The ``scheduled_tasks`` table holds zero rows in every deployment (the feature
+is inert — no create endpoint and no fire path exist yet), so this is a pure
+DDL swap: no backfill and no row transformation. The new column is added
+``NOT NULL`` with an empty-string ``server_default`` purely to satisfy the
+constraint for the (zero) existing rows; the default is dropped in the same
+batch so future inserts must supply an explicit ``rrule``.
+
+Batch mode (``op.batch_alter_table``) is mandatory: this repo runs Alembic with
+``render_as_batch=True`` so SQLite — which cannot ``ALTER TABLE ... DROP
+COLUMN`` in place — rebuilds the table via the copy-and-swap batch path. The
+``timezone`` column is untouched: RRULE still needs a timezone anchor for
+``DTSTART``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7b3c4d5e6f7"
+down_revision: str | None = "z8a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``rrule`` and drop ``cron_expression`` on ``scheduled_tasks``."""
+    with op.batch_alter_table("scheduled_tasks") as batch_op:
+        batch_op.add_column(sa.Column("rrule", sa.String(512), nullable=False, server_default=""))
+        batch_op.drop_column("cron_expression")
+        # The server_default only existed to satisfy NOT NULL for existing rows;
+        # drop it so future inserts must supply an explicit rrule.
+        batch_op.alter_column("rrule", server_default=None)
+
+
+def downgrade() -> None:
+    """Restore ``cron_expression`` and drop ``rrule`` on ``scheduled_tasks``."""
+    with op.batch_alter_table("scheduled_tasks") as batch_op:
+        batch_op.add_column(
+            sa.Column("cron_expression", sa.String(255), nullable=False, server_default="")
+        )
+        batch_op.drop_column("rrule")
+        batch_op.alter_column("cron_expression", server_default=None)

--- a/omnigent/entities/scheduled_task.py
+++ b/omnigent/entities/scheduled_task.py
@@ -2,7 +2,7 @@
 ``scheduled_task_runs`` tables.
 
 A :class:`ScheduledTask` is a saved, scheduled instruction that fires an agent
-session on a recurring cron schedule (``cron_expression``). A
+session on a recurring schedule (``rrule``). A
 :class:`ScheduledTaskRun` records one firing of a task (its run history). This
 module holds the plain dataclasses the store converts ORM rows into; the store
 owns the JSON (de)serialization of the Text-backed columns.
@@ -18,13 +18,14 @@ class ScheduledTask:
     """
     A scheduled task persisted in the ``scheduled_tasks`` table.
 
-    A task's trigger is a required recurring ``cron_expression``.
+    A task's trigger is a required recurring ``rrule``.
 
     :param id: UUID primary key (bare 32-char hex string, no dashes).
     :param name: Human-readable task name, e.g. ``"nightly triage"``.
     :param prompt: The instruction dispatched to the agent on each firing.
-    :param cron_expression: The required cron string for the recurring trigger,
-        e.g. ``"0 9 * * *"``.
+    :param rrule: The required RFC 5545 recurrence rule for the recurring
+        trigger, e.g. ``"FREQ=DAILY;BYHOUR=9;BYMINUTE=0"``. Evaluated in
+        ``timezone``.
     :param owner_user_id: User the spawned session's ``LEVEL_OWNER`` grant is
         written for, e.g. ``"alice@example.com"``. ``None`` in single-user mode.
     :param agent_id: The agent bound to this task, e.g. ``"ag_..."``.
@@ -57,7 +58,7 @@ class ScheduledTask:
     id: str
     name: str
     prompt: str
-    cron_expression: str
+    rrule: str
     owner_user_id: str | None
     agent_id: str
     timezone: str

--- a/omnigent/stores/scheduled_task_store/__init__.py
+++ b/omnigent/stores/scheduled_task_store/__init__.py
@@ -1,7 +1,7 @@
 """Scheduled-task store — persists scheduled tasks and their run history.
 
 A scheduled task is a saved instruction that fires an agent session on a
-recurring cron schedule. This store owns the ``scheduled_tasks``
+recurring schedule. This store owns the ``scheduled_tasks``
 table and its ``scheduled_task_runs`` history table.
 """
 
@@ -42,7 +42,7 @@ class ScheduledTaskStore(ABC):
         scheduled_task_id: str,
         name: str,
         prompt: str,
-        cron_expression: str,
+        rrule: str,
         owner_user_id: str | None,
         agent_id: str,
         timezone: str,
@@ -61,8 +61,8 @@ class ScheduledTaskStore(ABC):
         :param scheduled_task_id: Pre-generated unique task id (a UUID string).
         :param name: Human-readable task name.
         :param prompt: The instruction dispatched to the agent on each firing.
-        :param cron_expression: The required cron string for the recurring
-            trigger, e.g. ``"0 9 * * *"``.
+        :param rrule: The required RFC 5545 recurrence rule for the recurring
+            trigger, e.g. ``"FREQ=DAILY;BYHOUR=9;BYMINUTE=0"``.
         :param owner_user_id: User the spawned session's ``LEVEL_OWNER`` grant
             is written for; ``None`` in single-user mode.
         :param agent_id: The agent bound to this task.
@@ -121,7 +121,7 @@ class ScheduledTaskStore(ABC):
         *,
         name: str | None = None,
         prompt: str | None = None,
-        cron_expression: str | None = None,
+        rrule: str | None = None,
         timezone: str | None = None,
         model_override: str | None = None,
         reasoning_effort: str | None = None,
@@ -142,7 +142,7 @@ class ScheduledTaskStore(ABC):
         to NULL (e.g. to clear a host binding or to null out the last-run
         conversation after it is deleted).
 
-        Passing ``cron_expression`` updates the recurring trigger; ``None``
+        Passing ``rrule`` updates the recurring trigger; ``None``
         leaves it unchanged.
 
         Returns ``None`` if the task does not exist.

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -47,7 +47,7 @@ def _to_entity(row: SqlScheduledTask) -> ScheduledTask:
         agent_id=row.agent_id,
         timezone=row.timezone,
         created_at=row.created_at,
-        cron_expression=row.cron_expression,
+        rrule=row.rrule,
         model_override=row.model_override,
         reasoning_effort=row.reasoning_effort,
         workspace=row.workspace,
@@ -110,7 +110,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         scheduled_task_id: str,
         name: str,
         prompt: str,
-        cron_expression: str,
+        rrule: str,
         owner_user_id: str | None,
         agent_id: str,
         timezone: str,
@@ -123,12 +123,12 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         host_id: str | None = None,
         state: str = "active",
     ) -> ScheduledTask:
-        """Insert a new scheduled task with a required recurring ``cron_expression``."""
+        """Insert a new scheduled task with a required recurring ``rrule``."""
         row = SqlScheduledTask(
             id=scheduled_task_id,
             name=name,
             prompt=prompt,
-            cron_expression=cron_expression,
+            rrule=rrule,
             owner_user_id=owner_user_id,
             agent_id=agent_id,
             timezone=timezone,
@@ -186,7 +186,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         *,
         name: str | None = None,
         prompt: str | None = None,
-        cron_expression: str | None = None,
+        rrule: str | None = None,
         timezone: str | None = None,
         model_override: str | None = None,
         reasoning_effort: str | None = None,
@@ -203,7 +203,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         ``None`` leaves most fields unchanged. For ``host_id`` and
         ``last_run_conversation_id``, the sentinel default means "not provided
         / leave unchanged"; passing ``None`` explicitly sets the column to NULL.
-        Passing ``cron_expression`` updates the recurring trigger; ``None``
+        Passing ``rrule`` updates the recurring trigger; ``None``
         leaves it unchanged.
         """
         with self._session() as session:
@@ -217,8 +217,8 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
             if prompt is not None and row.prompt != prompt:
                 row.prompt = prompt
                 changed = True
-            if cron_expression is not None and row.cron_expression != cron_expression:
-                row.cron_expression = cron_expression
+            if rrule is not None and row.rrule != rrule:
+                row.rrule = rrule
                 changed = True
             if timezone is not None and row.timezone != timezone:
                 row.timezone = timezone

--- a/tests/db/test_migration_scheduled_tasks.py
+++ b/tests/db/test_migration_scheduled_tasks.py
@@ -3,7 +3,7 @@
 Verifies the migration creates both tables with the expected shape, that
 neither carries a database-level foreign key (schema Rule R032 — the
 ``agent_id`` / ``conversation_id`` / ``scheduled_task_id`` relationships are
-application-owned), that ``scheduled_tasks.cron_expression`` is NOT NULL and the
+application-owned), that ``scheduled_tasks.rrule`` is NOT NULL and the
 ``scheduled_task_runs.status`` CHECK is enforced, and that a downgrade drops both
 tables cleanly.
 """
@@ -55,7 +55,7 @@ def test_scheduled_tasks_columns(db_engine: Engine) -> None:
         "id",
         "name",
         "prompt",
-        "cron_expression",
+        "rrule",
         "owner_user_id",
         "agent_id",
         "model_override",
@@ -151,10 +151,10 @@ def test_state_default_on_omitted_insert(db_engine: Engine) -> None:
         conn.execute(
             sa.text(
                 "INSERT INTO scheduled_tasks "
-                "(id, name, prompt, cron_expression, owner_user_id, agent_id, "
+                "(id, name, prompt, rrule, owner_user_id, agent_id, "
                 " timezone, created_at) "
                 "VALUES (X'00000000000000000000000000000de1', 'n', 'p', "
-                "'0 9 * * *', 'u', 'ag_1', 'UTC', 1)"
+                "'FREQ=DAILY;BYHOUR=9;BYMINUTE=0', 'u', 'ag_1', 'UTC', 1)"
             )
         )
         state, workspace_id, execution_target = conn.execute(
@@ -180,30 +180,30 @@ def test_execution_target_check_rejects_bad_code(db_engine: Engine) -> None:
             conn.execute(
                 sa.text(
                     "INSERT INTO scheduled_tasks "
-                    "(id, name, prompt, cron_expression, owner_user_id, agent_id, "
+                    "(id, name, prompt, rrule, owner_user_id, agent_id, "
                     " timezone, execution_target, created_at) "
                     "VALUES (X'00000000000000000000000000e6bad0', 'n', 'p', "
-                    "'0 9 * * *', 'u', 'ag', 'UTC', 99, 1)"
+                    "'FREQ=DAILY;BYHOUR=9;BYMINUTE=0', 'u', 'ag', 'UTC', 99, 1)"
                 )
             )
 
 
-def test_cron_expression_accepts_recurring_row(db_engine: Engine) -> None:
-    """A row with ``cron_expression`` set inserts cleanly (the recurring trigger)."""
+def test_rrule_accepts_recurring_row(db_engine: Engine) -> None:
+    """A row with ``rrule`` set inserts cleanly (the recurring trigger)."""
     with db_engine.begin() as conn:
         conn.execute(
             sa.text(
                 "INSERT INTO scheduled_tasks "
-                "(id, name, prompt, cron_expression, owner_user_id, agent_id, "
+                "(id, name, prompt, rrule, owner_user_id, agent_id, "
                 " timezone, created_at) "
                 "VALUES (X'0000000000000000000000000000c40e', 'n', 'p', "
-                "'0 9 * * *', 'u', 'ag', 'UTC', 1)"
+                "'FREQ=DAILY;BYHOUR=9;BYMINUTE=0', 'u', 'ag', 'UTC', 1)"
             )
         )
 
 
-def test_cron_expression_is_not_null(db_engine: Engine) -> None:
-    """A row omitting ``cron_expression`` fails the NOT NULL constraint."""
+def test_rrule_is_not_null(db_engine: Engine) -> None:
+    """A row omitting ``rrule`` fails the NOT NULL constraint."""
     with pytest.raises(IntegrityError):
         with db_engine.begin() as conn:
             conn.execute(
@@ -234,10 +234,10 @@ def test_state_check_rejects_bad_code(db_engine: Engine) -> None:
             conn.execute(
                 sa.text(
                     "INSERT INTO scheduled_tasks "
-                    "(id, name, prompt, cron_expression, owner_user_id, agent_id, "
+                    "(id, name, prompt, rrule, owner_user_id, agent_id, "
                     " timezone, state, created_at) "
                     "VALUES (X'00000000000000000000000000badc0d', 'n', 'p', "
-                    "'0 9 * * *', 'u', 'ag', 'UTC', 99, 1)"
+                    "'FREQ=DAILY;BYHOUR=9;BYMINUTE=0', 'u', 'ag', 'UTC', 99, 1)"
                 )
             )
 

--- a/tests/stores/test_scheduled_task_store.py
+++ b/tests/stores/test_scheduled_task_store.py
@@ -45,7 +45,7 @@ def test_create_returns_scheduled_task_with_all_fields(
         scheduled_task_id=_uid("st_1"),
         name="nightly triage",
         prompt="Triage the inbox",
-        cron_expression="0 9 * * *",
+        rrule="FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
         owner_user_id="alice@example.com",
         agent_id=_uid("ag_abc"),
         timezone="America/Los_Angeles",
@@ -59,7 +59,7 @@ def test_create_returns_scheduled_task_with_all_fields(
     assert task.id == _uid("st_1")
     assert task.name == "nightly triage"
     assert task.prompt == "Triage the inbox"
-    assert task.cron_expression == "0 9 * * *"
+    assert task.rrule == "FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
     assert task.owner_user_id == "alice@example.com"
     assert task.agent_id == _uid("ag_abc")
     assert task.timezone == "America/Los_Angeles"
@@ -82,7 +82,7 @@ def test_create_minimal_defaults(store: SqlAlchemyScheduledTaskStore) -> None:
         scheduled_task_id=_uid("st_min"),
         name="minimal",
         prompt="do a thing",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="bob@example.com",
         agent_id=_uid("ag_min"),
         timezone="UTC",
@@ -109,7 +109,7 @@ def test_state_round_trips_as_string(store: SqlAlchemyScheduledTaskStore) -> Non
             scheduled_task_id=_uid(f"st_state_{i}"),
             name="n",
             prompt="p",
-            cron_expression="* * * * *",
+            rrule="FREQ=MINUTELY",
             owner_user_id="u",
             agent_id=_uid("ag"),
             timezone="UTC",
@@ -126,7 +126,7 @@ def test_create_rejects_invalid_state(store: SqlAlchemyScheduledTaskStore) -> No
             scheduled_task_id=_uid("st_badstate"),
             name="n",
             prompt="p",
-            cron_expression="* * * * *",
+            rrule="FREQ=MINUTELY",
             owner_user_id="u",
             agent_id=_uid("ag"),
             timezone="UTC",
@@ -148,7 +148,7 @@ def test_execution_target_round_trips_as_string(store: SqlAlchemyScheduledTaskSt
             scheduled_task_id=_uid(f"st_target_{i}"),
             name="n",
             prompt="p",
-            cron_expression="* * * * *",
+            rrule="FREQ=MINUTELY",
             owner_user_id="u",
             agent_id=_uid("ag"),
             timezone="UTC",
@@ -165,7 +165,7 @@ def test_create_rejects_invalid_execution_target(store: SqlAlchemyScheduledTaskS
             scheduled_task_id=_uid("st_badtarget"),
             name="n",
             prompt="p",
-            cron_expression="* * * * *",
+            rrule="FREQ=MINUTELY",
             owner_user_id="u",
             agent_id=_uid("ag"),
             timezone="UTC",
@@ -181,7 +181,7 @@ def test_update_execution_target_and_host_id_read_back(
         scheduled_task_id=_uid("st_upd_target"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -200,7 +200,7 @@ def test_update_state_reads_back(store: SqlAlchemyScheduledTaskStore) -> None:
         scheduled_task_id=_uid("st_upd_state"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -210,37 +210,37 @@ def test_update_state_reads_back(store: SqlAlchemyScheduledTaskStore) -> None:
     assert updated.state == "paused"
 
 
-# ── recurring trigger (cron_expression) ───────────────────────────────────────
+# ── recurring trigger (rrule) ─────────────────────────────────────────────────
 
 
 def test_create_recurring_task(store: SqlAlchemyScheduledTaskStore) -> None:
-    """A recurring task sets ``cron_expression``."""
+    """A recurring task sets ``rrule``."""
     task = store.create(
         scheduled_task_id=_uid("st_recur"),
         name="recurring",
         prompt="p",
-        cron_expression="0 9 * * *",
+        rrule="FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
     )
-    assert task.cron_expression == "0 9 * * *"
+    assert task.rrule == "FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
 
 
-def test_update_changes_cron_expression(store: SqlAlchemyScheduledTaskStore) -> None:
-    """Updating with a new ``cron_expression`` reschedules the recurring trigger."""
+def test_update_changes_rrule(store: SqlAlchemyScheduledTaskStore) -> None:
+    """Updating with a new ``rrule`` reschedules the recurring trigger."""
     store.create(
         scheduled_task_id=_uid("st_recron"),
         name="n",
         prompt="p",
-        cron_expression="0 9 * * *",
+        rrule="FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
     )
-    updated = store.update(_uid("st_recron"), cron_expression="0 0 * * *")
+    updated = store.update(_uid("st_recron"), rrule="FREQ=DAILY;BYHOUR=0;BYMINUTE=0")
     assert updated is not None
-    assert updated.cron_expression == "0 0 * * *"
+    assert updated.rrule == "FREQ=DAILY;BYHOUR=0;BYMINUTE=0"
 
 
 def test_get_returns_created_task(store: SqlAlchemyScheduledTaskStore) -> None:
@@ -249,7 +249,7 @@ def test_get_returns_created_task(store: SqlAlchemyScheduledTaskStore) -> None:
         scheduled_task_id=_uid("st_get"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag_1"),
         timezone="UTC",
@@ -281,7 +281,7 @@ def test_list_orders_by_created_at_then_id(store: SqlAlchemyScheduledTaskStore) 
         scheduled_task_id=id_a,
         name="a",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -290,7 +290,7 @@ def test_list_orders_by_created_at_then_id(store: SqlAlchemyScheduledTaskStore) 
         scheduled_task_id=id_b,
         name="b",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -305,7 +305,7 @@ def test_list_active_excludes_non_active(store: SqlAlchemyScheduledTaskStore) ->
         scheduled_task_id=_uid("st_active"),
         name="active",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -316,7 +316,7 @@ def test_list_active_excludes_non_active(store: SqlAlchemyScheduledTaskStore) ->
             scheduled_task_id=_uid(f"st_{other_state}"),
             name=other_state,
             prompt="p",
-            cron_expression="* * * * *",
+            rrule="FREQ=MINUTELY",
             owner_user_id="u",
             agent_id=_uid("ag"),
             timezone="UTC",
@@ -335,7 +335,7 @@ def test_update_changes_fields_and_stamps_updated_at(store: SqlAlchemyScheduledT
         scheduled_task_id=_uid("st_u"),
         name="before",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -343,7 +343,7 @@ def test_update_changes_fields_and_stamps_updated_at(store: SqlAlchemyScheduledT
     updated = store.update(
         _uid("st_u"),
         name="after",
-        cron_expression="0 0 * * *",
+        rrule="FREQ=DAILY;BYHOUR=0;BYMINUTE=0",
         base_branch="develop",
         state="paused",
         last_run_at=1700000000,
@@ -351,7 +351,7 @@ def test_update_changes_fields_and_stamps_updated_at(store: SqlAlchemyScheduledT
     )
     assert updated is not None
     assert updated.name == "after"
-    assert updated.cron_expression == "0 0 * * *"
+    assert updated.rrule == "FREQ=DAILY;BYHOUR=0;BYMINUTE=0"
     assert updated.base_branch == "develop"
     assert updated.state == "paused"
     assert updated.last_run_at == 1700000000
@@ -365,7 +365,7 @@ def test_update_noop_leaves_updated_at_none(store: SqlAlchemyScheduledTaskStore)
         scheduled_task_id=_uid("st_noop"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -389,7 +389,7 @@ def test_delete_removes_task(store: SqlAlchemyScheduledTaskStore) -> None:
         scheduled_task_id=_uid("st_del"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -412,7 +412,7 @@ def test_create_run_and_list_runs(store: SqlAlchemyScheduledTaskStore) -> None:
         scheduled_task_id=_uid("st_runs"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -452,7 +452,7 @@ def test_list_runs_scoped_to_task(store: SqlAlchemyScheduledTaskStore) -> None:
             scheduled_task_id=_uid(rid),
             name=rid,
             prompt="p",
-            cron_expression="* * * * *",
+            rrule="FREQ=MINUTELY",
             owner_user_id="u",
             agent_id=_uid("ag"),
             timezone="UTC",
@@ -482,7 +482,7 @@ def test_run_status_round_trips_as_string(store: SqlAlchemyScheduledTaskStore) -
         scheduled_task_id=_uid("st_rt"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -504,7 +504,7 @@ def test_create_run_rejects_invalid_status_name(store: SqlAlchemyScheduledTaskSt
         scheduled_task_id=_uid("st_bad"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -527,7 +527,7 @@ def test_update_host_id_can_be_cleared_to_null(store: SqlAlchemyScheduledTaskSto
         scheduled_task_id=_uid("st_clear_host"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -551,7 +551,7 @@ def test_update_last_run_conversation_id_can_be_cleared_to_null(
         scheduled_task_id=_uid("st_clear_conv"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -573,7 +573,7 @@ def test_update_omitting_nullable_param_leaves_field_unchanged(
         scheduled_task_id=_uid("st_omit"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -595,7 +595,7 @@ def test_update_clearing_already_null_field_is_noop_for_updated_at(
         scheduled_task_id=_uid("st_null_noop"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -615,7 +615,7 @@ def test_delete_also_removes_associated_runs(store: SqlAlchemyScheduledTaskStore
         scheduled_task_id=_uid("st_del_runs"),
         name="n",
         prompt="p",
-        cron_expression="* * * * *",
+        rrule="FREQ=MINUTELY",
         owner_user_id="u",
         agent_id=_uid("ag"),
         timezone="UTC",
@@ -644,7 +644,7 @@ def test_delete_does_not_remove_other_tasks_runs(store: SqlAlchemyScheduledTaskS
             scheduled_task_id=_uid(tid),
             name=tid,
             prompt="p",
-            cron_expression="* * * * *",
+            rrule="FREQ=MINUTELY",
             owner_user_id="u",
             agent_id=_uid("ag"),
             timezone="UTC",


### PR DESCRIPTION
## Related issue

N/A — tracked in Linear ([OMNI-1193](https://linear.app/omnigent/issue/OMNI-1193/)).

## Summary

Move the `scheduled_tasks` recurring trigger from a cron expression to an RFC 5545 recurrence rule (RRULE).

- **`db_models.py`:** rename column `cron_expression String(255)` → `rrule String(512)` (RRULE strings are longer than cron), update docstrings.
- **New Alembic migration `a7b3c4d5e6f7`** (down_revision `z8a2b3c4d5e6`): batch-mode add `rrule` NOT NULL, drop `cron_expression`. The table holds **zero rows** (the feature is inert — no create endpoint or fire path yet), so this is a pure DDL swap with no backfill.
- **`entities/scheduled_task.py`:** rename field `cron_expression` → `rrule`.
- **`scheduled_task_store`** (abstract + SQLAlchemy impl): rename create/update params and the row↔entity mapping.
- Update store and migration tests to use RRULE strings.

The store does **not** validate the trigger string (it did not validate cron either); next-fire/floor validation is owned by the scheduler-engine PR.

**ELI5:** the table that remembers "run this on a schedule" used to store the schedule as a cron string (`0 9 * * 1-5`). We're swapping that single column for an RRULE string (`FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=9`), the same recurrence format calendars use. Nothing has saved a schedule yet, so we just change the column — nothing to convert.

```mermaid
sequenceDiagram
    participant Mig as Alembic a7b3c4d5e6f7
    participant Tbl as scheduled_tasks (0 rows)
    Mig->>Tbl: add column rrule String(512) NOT NULL
    Mig->>Tbl: drop column cron_expression
    Note over Tbl: pure DDL — no rows to backfill
```

## Test Plan

- Store + migration tests updated to construct `ScheduledTask(rrule=...)` and call `create(rrule=...)`; all pass.
- `alembic upgrade head` applies `a7b3c4d5e6f7` cleanly on a fresh DB (and auto-runs on boot); `downgrade` reverses it.

```
pytest tests/stores tests/db -q   # scheduled-task store + migration coverage
```

## Demo

N/A — schema/store-layer change, no user-visible behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Store round-trip (create/get/update) and the migration are covered by unit tests. The trigger string is stored opaquely — semantic RRULE validation (next-fire computation, the minimum-interval floor) lives in the scheduler-engine PR and is tested there.

<!--
Changelog section intentionally omitted: the scheduled-tasks feature is still
inert (no create endpoint or fire path), so this schema swap has no user-observable
behavior yet. The user-facing changelog line lands with the fire path + UI.
-->