### PR TITLE
fix(policies): show all policies in Add Policy session dialog

### DIFF
--- a/web/src/components/AgentInfo.test.tsx
+++ b/web/src/components/AgentInfo.test.tsx
@@ -708,9 +708,7 @@ describe("SessionPoliciesSection", () => {
     expect(payload.factory_params).toEqual({ expensive_models: ["sonnet"] });
   });
 
-  it("shows the all-applied empty message when every registry policy is already added", () => {
-    // WHY: when appliedHandlers covers the whole registry the filtered list is
-    // empty AND available.length === 0, so the dialog says all are applied.
+  it("shows all registry policies even when already applied", () => {
     registryData.current = [
       { handler: "h.alpha", kind: "callable", name: "Alpha Guard", description: "blocks alpha" },
     ];
@@ -721,9 +719,7 @@ describe("SessionPoliciesSection", () => {
 
     fireEvent.click(screen.getByTitle("Add policy"));
     const dialog = screen.getByRole("dialog");
-    expect(
-      within(dialog).getByText("All available policies are already applied."),
-    ).toBeInTheDocument();
+    expect(within(dialog).getByText("Alpha Guard")).toBeInTheDocument();
   });
 });
 

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -261,13 +261,11 @@ function ModelUsageBreakdown({ usageByModel }: { usageByModel: Record<string, Mo
 function AddPolicyDialog({
   sessionId,
   registry,
-  appliedHandlers,
   open,
   onOpenChange,
 }: {
   sessionId: string;
   registry: PolicyRegistryEntry[];
-  appliedHandlers: Set<string>;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -389,15 +387,14 @@ function AddPolicyDialog({
         <div className="min-w-0 space-y-3 pt-1">
           {!selected &&
             (() => {
-              const available = registry.filter((r) => !appliedHandlers.has(r.handler));
               const lowerFilter = filter.toLowerCase();
               const filtered = lowerFilter
-                ? available.filter(
+                ? registry.filter(
                     (r) =>
                       r.name.toLowerCase().includes(lowerFilter) ||
                       r.description?.toLowerCase().includes(lowerFilter),
                   )
-                : available;
+                : registry;
               return (
                 <>
                   <input
@@ -427,9 +424,7 @@ function AddPolicyDialog({
                     ))}
                     {filtered.length === 0 && (
                       <p className="py-2 text-center text-xs text-muted-foreground">
-                        {available.length === 0
-                          ? "All available policies are already applied."
-                          : "No policies match your filter."}
+                        No policies match your filter.
                       </p>
                     )}
                   </div>
@@ -1067,9 +1062,6 @@ function SessionPoliciesSection({ sessionId }: { sessionId: string }) {
 
   const userPolicies = sessionPolicies.filter((p) => p.source === "session");
   const registryByHandler = new Map(registry.map((r) => [r.handler, r]));
-  const appliedHandlers = new Set(
-    sessionPolicies.map((p) => p.handler).filter((h): h is string => h != null),
-  );
 
   return (
     <div className="flex flex-col gap-1.5 py-3">
@@ -1136,7 +1128,6 @@ function SessionPoliciesSection({ sessionId }: { sessionId: string }) {
       <AddPolicyDialog
         sessionId={sessionId}
         registry={registry}
-        appliedHandlers={appliedHandlers}
         open={addOpen}
         onOpenChange={setAddOpen}
       />


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Removed the filter that hid already-applied policies from the per-session **Add Policy** dialog in `AgentInfo`
- Same fix as #2668, applied to the session-level policy picker
- Users can now select any policy regardless of whether it is already configured on the session

## Test Plan

1. Open a session with at least one policy already applied.
2. Click the **+** button in the Policies section of the agent info panel.
3. Confirm all policies appear, including any already applied.
4. Verify the filter input still narrows results correctly.
5. Verify "No policies match your filter." shows when the filter has no matches.

## Demo

N/A (non-visual behavior change)

## Type of change

- [x] Bug fix
- [x] UI / frontend change

## Test coverage

- [x] Manual verification completed

## Coverage notes

Manually verified that all policies show in the session dialog regardless of applied state.

## Changelog

The Add Policy dialog for sessions now shows all available policies, including ones already applied.