### PR TITLE
feat(web): gate sidebar row actions on ownership, not permission level

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_ownership_gating.py
+++ b/tests/e2e_ui/sessions/test_sidebar_ownership_gating.py
@@ -1,0 +1,176 @@
+"""Browser e2e for the sidebar's owner-vs-not row gating and tab placement.
+
+This is the end-to-end companion to the mocked ``Sidebar`` unit tests, and the
+coverage the ``E2E UI Required`` gate asks for: the sidebar derives ownership
+(and every owner-only row action) from the session's ``owner`` — the creator's
+user id carried on each list row — NOT from an effective ``permission_level``.
+The behavior under test:
+
+- A session's **owner** sees it under the **"My sessions"** tab, with the
+  kebab's **Rename** and **Share** items **enabled**.
+- A **non-owner the session is shared with** (even at EDIT) sees it under the
+  **"Shared with me"** tab, with **Rename** and **Share** **disabled**
+  ("Only the session owner can …"). Editing shared *content* still happens in
+  the open session — that path reads the real level from the single-session
+  snapshot and is unaffected — but the sidebar affordances are owner-only.
+
+Runs against a dedicated multi-user server: the shared ``live_server`` is
+single-user (``OMNIGENT_LOCAL_SINGLE_USER=1``), which hides the My/Shared tabs
+AND the Share item entirely, so the ownership split can't be observed there.
+The multi-user server clears that marker and declares an admin identity, exactly
+like a Databricks Apps / SSO-proxy install — the deployment shape this gating
+matters for.
+
+The admin owns the session; a second header identity (the viewer) is granted
+access via the REST API. Both identities' sidebar list loads via the initial
+``GET /v1/sessions`` (a plain authenticatedFetch that carries the context's
+``X-Forwarded-Email``), so the static post-load state asserted here is
+deterministic — unlike the ``WS /v1/sessions/updates`` push, which the
+sharing-journey test notes may not carry the header in all Chromium combos and
+which this test deliberately does not depend on.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Browser, Locator, Page, expect
+
+from tests.e2e_ui.collaboration._multi_user_server import (
+    ADMIN_EMAIL,
+    MultiUserServer,
+    spawn_multi_user_server,
+)
+
+# Edit access (2) is the interesting non-owner case: it proves the sidebar gates
+# on ownership, not level — an EDIT holder still can't rename/share from the
+# sidebar. Mirrors LEVEL_EDIT in omnigent/server/auth.py.
+_LEVEL_EDIT = 2
+
+_TAB_MINE = '[data-testid="sidebar-tab-mine"]'
+_TAB_SHARED = '[data-testid="sidebar-tab-shared"]'
+
+
+@pytest.fixture(scope="module")
+def multi_user_server(
+    built_spa: None,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[MultiUserServer]:
+    """A NON-single-user server so the My/Shared tabs + Share item render."""
+    server_tmp = tmp_path_factory.mktemp("e2e_ui_sidebar_ownership_multi_user")
+    yield from spawn_multi_user_server(mock_llm_server_url, server_tmp)
+
+
+def _grant(server: MultiUserServer, user_id: str, level: int) -> None:
+    """Grant *user_id* *level* on the admin-owned session (admin acts)."""
+    resp = httpx.put(
+        f"{server.base_url}/v1/sessions/{server.session_id}/permissions",
+        json={"user_id": user_id, "level": level},
+        headers={"X-Forwarded-Email": ADMIN_EMAIL},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """The sidebar row (``<li>``) for *session_id*, located by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _open_row_menu(page: Page, session_id: str) -> None:
+    """Right-click the row to open the shared actions menu at the cursor.
+
+    Right-click (Radix ``ContextMenu``) renders the same
+    ``ConversationMenuItems`` body as the kebab, so the item testids and their
+    enabled/disabled state are identical — and it avoids the kebab's
+    pointer-event timing. Mirrors ``test_sidebar_context_menu.py``.
+    """
+    link = page.locator(f'a[href="/c/{session_id}"]')
+    expect(link).to_be_visible(timeout=30_000)
+    link.click(button="right")
+
+
+def test_owner_sees_session_under_my_sessions_with_enabled_actions(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """The owner's own session: "My sessions" tab, Rename + Share enabled.
+
+    The baseline half of the ownership split — nothing about owner affordances
+    regressed when the sidebar moved off ``permission_level``.
+    """
+    server = multi_user_server
+    sid = server.session_id
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": ADMIN_EMAIL})
+    try:
+        page = ctx.new_page()
+        page.goto(f"{server.public_url}/c/{sid}")
+
+        # Owned → shows under the default "My sessions" tab, never "Shared".
+        expect(page.locator(_TAB_MINE)).to_be_visible(timeout=30_000)
+        expect(_row(page, sid)).to_be_visible(timeout=30_000)
+
+        _open_row_menu(page, sid)
+        # Owner → Rename and Share are enabled (no data-disabled marker).
+        expect(page.get_by_test_id("rename-conversation")).not_to_have_attribute(
+            "data-disabled", re.compile(r".*")
+        )
+        expect(page.get_by_test_id("share-conversation")).not_to_have_attribute(
+            "data-disabled", re.compile(r".*")
+        )
+
+        # Rename runs the real inline-edit path from here (proves "enabled" is
+        # not just cosmetic), exactly as the context-menu test asserts.
+        page.get_by_test_id("rename-conversation").click()
+        expect(page.get_by_test_id("rename-conversation-input")).to_be_visible(timeout=15_000)
+    finally:
+        ctx.close()
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_shared_viewer_sees_session_under_shared_tab_with_owner_only_actions(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """A non-owner (granted EDIT): "Shared with me" tab, Rename + Share disabled.
+
+    The behavior this PR introduces: an EDIT grant is enough to open and edit
+    the session, but the sidebar's Rename/Share are owner-only — so a shared
+    session lands on the "Shared with me" tab (never "My sessions"), and its
+    kebab Rename/Share are disabled regardless of the granted level.
+    """
+    server = multi_user_server
+    sid = server.session_id
+    viewer_email = f"viewer-{uuid.uuid4().hex[:6]}@ui.test"
+    _grant(server, viewer_email, _LEVEL_EDIT)
+
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": viewer_email})
+    try:
+        page = ctx.new_page()
+        page.goto(f"{server.public_url}/c/{sid}")
+
+        # The shared session is NOT the viewer's own, so it must not appear on
+        # the default "My sessions" tab...
+        expect(page.locator(_TAB_MINE)).to_be_visible(timeout=30_000)
+        expect(_row(page, sid)).to_have_count(0)
+
+        # ...it lives under "Shared with me".
+        page.locator(_TAB_SHARED).click()
+        expect(_row(page, sid)).to_be_visible(timeout=30_000)
+
+        _open_row_menu(page, sid)
+        # Non-owner → Rename and Share are disabled even though the viewer holds
+        # EDIT. This is the owner-only gating (was edit-/manage-gated before).
+        expect(page.get_by_test_id("rename-conversation")).to_have_attribute(
+            "data-disabled", re.compile(r".*"), timeout=15_000
+        )
+        expect(page.get_by_test_id("share-conversation")).to_have_attribute(
+            "data-disabled", re.compile(r".*")
+        )
+    finally:
+        ctx.close()

--- a/web/src/lib/permissionsApi.test.ts
+++ b/web/src/lib/permissionsApi.test.ts
@@ -240,6 +240,19 @@ describe("derivePermissionLevel — resolution order", () => {
     expect(derivePermissionLevel(null, true, sidebar, "conv_test", true)).toBe(2);
   });
 
+  it("ignores a sidebar row whose level is null and defers to the snapshot fallback", () => {
+    // A deployment whose session list is owner-only (the caller's effective
+    // level omitted, e.g. the Databricks-managed server) returns rows with
+    // permission_level=null. That absence is NOT the permissive null sentinel:
+    // we must not conclude from it, so while the single-fetch loads we return
+    // null (loading, permissive) rather than reading the row's null as a
+    // resolved level — the authoritative snapshot then wins once it lands.
+    const sidebar = makeConv(null);
+    expect(derivePermissionLevel(null, true, sidebar, "conv_test", true)).toBeNull();
+    // And once the snapshot resolves, it — not the null row — decides.
+    expect(derivePermissionLevel(makeSession(1), false, sidebar, "conv_test", true)).toBe(1);
+  });
+
   it("returns null while the single-fetch is still loading and the sidebar has no row", () => {
     // Child session case before the single-fetch resolves: don't flash
     // read-only just because the sidebar doesn't know about this conv.

--- a/web/src/lib/permissionsApi.ts
+++ b/web/src/lib/permissionsApi.ts
@@ -41,10 +41,15 @@ export function isOwnerLevel(level: number | null): boolean {
  *    source. Sub-agent (child) sessions are filtered out of the
  *    sidebar list query, so this is the only place their level is
  *    observable.
- * 2. ``activeConv.permission_level`` — sidebar list row. Available
- *    synchronously the moment the user navigates between top-level
- *    conversations, so we use it as a fast path before the single
- *    fetch resolves.
+ * 2. ``activeConv.permission_level`` — sidebar list row, but ONLY when it
+ *    actually carries a level. Available synchronously the moment the user
+ *    navigates between top-level conversations, so it's a fast path before
+ *    the single fetch resolves. A row whose level is ``null`` (a deployment
+ *    whose session list is owner-only and omits the caller's effective
+ *    level, e.g. the Databricks-managed server) carries no conclusion, so we
+ *    skip it and fall through to the authoritative snapshot / fallback
+ *    rather than mistaking the absent level for the permissive ``null``
+ *    sentinel.
  * 3. ``null`` while the single fetch is still in flight (the UI
  *    treats ``null`` permissively, avoiding a read-only flicker
  *    during the snapshot's first round-trip on child sessions).
@@ -60,7 +65,7 @@ export function derivePermissionLevel(
   conversationsLoaded: boolean,
 ): number | null {
   if (session != null) return session.permissionLevel;
-  if (activeConv != null) return activeConv.permission_level ?? null;
+  if (activeConv != null && activeConv.permission_level != null) return activeConv.permission_level;
   if (sessionLoading) return null;
   if (conversationId && conversationsLoaded) return 1;
   return null;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -924,8 +924,20 @@ export function ChatPage() {
   // session, so a host-bound, host-down session whose host is a resumable
   // managed host classifies as `host_asleep` (composer open, send wakes it)
   // instead of dead-ending on `host_offline`.
+  //
+  // Also prefer the snapshot's `permissionLevel` over the sidebar row's when
+  // it's resolved: the hook derives `host_offline`'s `isOwner` from this
+  // level, and a deployment whose session list is owner-only (the caller's
+  // effective level omitted, e.g. the Databricks-managed server) leaves the
+  // row's `permission_level` null — which would read permissively as "owner"
+  // and offer a non-owner the host-reconnect path. The single-session
+  // snapshot always carries the authoritative level.
   const livenessRow: LivenessRow | null = activeConv
-    ? { ...activeConv, host_resumable: activeSession?.hostResumable ?? false }
+    ? {
+        ...activeConv,
+        permission_level: activeSession?.permissionLevel ?? activeConv.permission_level,
+        host_resumable: activeSession?.hostResumable ?? false,
+      }
     : livenessRowFromSession(activeSession);
   const liveness = useSessionLiveness(urlConvId ?? undefined, livenessRow, {
     turnActive: status === "streaming",

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -2786,9 +2786,11 @@ describe("AppShell clone/fork action", () => {
 
 describe("AppShell share action", () => {
   it("shows the Share button to an owner of a top-level session", () => {
-    // permission_level null = owner. A top-level session can be shared.
+    // permission_level 4 = owner. Share is owner-only; a top-level session
+    // the viewer owns can be shared. (A multi-user owner's list row carries
+    // level 4; null only occurs in single-user mode, where Share is hidden.)
     withWindowOrigin("https://app.example.com", () => {
-      mockConversations([{ id: "conv_top", permission_level: null }]);
+      mockConversations([{ id: "conv_top", permission_level: 4 }]);
 
       renderShell("/c/conv_top");
 
@@ -2800,7 +2802,7 @@ describe("AppShell share action", () => {
 
   it("disables the Share button when the server is local", () => {
     withWindowOrigin("http://localhost:6767", () => {
-      mockConversations([{ id: "conv_top", permission_level: null }]);
+      mockConversations([{ id: "conv_top", permission_level: 4 }]);
 
       renderShell("/c/conv_top");
 
@@ -2819,7 +2821,7 @@ describe("AppShell share action", () => {
     // Non-local origin isolates the reason to the server policy (not the
     // local-server path), so the tooltip must be the sharing-off message.
     withWindowOrigin("https://app.example.com", () => {
-      mockConversations([{ id: "conv_top", permission_level: null }]);
+      mockConversations([{ id: "conv_top", permission_level: 4 }]);
 
       renderShell("/c/conv_top", serverInfo({ sharing_mode: "off" }));
 
@@ -2852,7 +2854,7 @@ describe("AppShell share action", () => {
     // shape as single-user, but single_user is false — the button must stay.
     // This is the regression the single_user signal fixes.
     withWindowOrigin("https://app.example.com", () => {
-      mockConversations([{ id: "conv_top", permission_level: null }]);
+      mockConversations([{ id: "conv_top", permission_level: 4 }]);
 
       renderShell("/c/conv_top", serverInfo({ single_user: false }));
 
@@ -2866,7 +2868,7 @@ describe("AppShell share action", () => {
     // read_only still permits (read) grants, so the affordance stays live —
     // the modal caps the level, the button is not disabled.
     withWindowOrigin("https://app.example.com", () => {
-      mockConversations([{ id: "conv_top", permission_level: null }]);
+      mockConversations([{ id: "conv_top", permission_level: 4 }]);
 
       renderShell("/c/conv_top", serverInfo({ sharing_mode: "read_only" }));
 
@@ -2952,7 +2954,7 @@ describe("Mobile header actions menu", () => {
       mockConversations([
         {
           id: "conv_host",
-          permission_level: null,
+          permission_level: 4,
           labels: {},
           host_id: "host_a1b2",
           runner_id: "runner_token_abc",
@@ -2979,7 +2981,7 @@ describe("Mobile header actions menu", () => {
 
   it("disables the mobile Share item when the server is local", () => {
     withWindowOrigin("http://127.0.0.1:6767", () => {
-      mockConversations([{ id: "conv_host", permission_level: null, labels: {} }]);
+      mockConversations([{ id: "conv_host", permission_level: 4, labels: {} }]);
 
       renderShell("/c/conv_host");
       openActionsMenu();

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -375,17 +375,20 @@ export function AppShell() {
   // three-dot menu render the exact same set (they can't drift apart).
   // Stop session is not a header action — it lives in the sidebar row's
   // kebab menu (see Sidebar's ConversationRow).
-  // Read-write or higher can manage sharing; top-level only. Sharing a
+  // Only the owner can manage sharing; top-level only. Sharing a
   // sub-agent is a no-op anyway — children inherit the parent's grants via
   // the server's parent-delegation path — so we hide the affordance.
   // Also hidden in single-user mode: with no other users to grant to, the
   // affordance is meaningless (unlike the local-server / sharing-off cases
   // below, which stay present-but-disabled with an explanatory tooltip).
+  // ``isOwnerLevel`` is permissive on a null level (single-user / still
+  // loading), matching the sidebar's owner-only Share gate and the terminal
+  // ``readOnly`` gate below; the authoritative snapshot level resolves it.
   const serverInfo = useServerInfo();
   const canShare =
     !!conversationId &&
     isKnownTopLevel &&
-    (permissionLevel === null || permissionLevel >= 3) &&
+    isOwnerLevel(permissionLevel) &&
     !isSingleUserMode(serverInfo);
   // Two independent reasons the Share affordance is present-but-disabled: a
   // local server can't produce openable links, and a deployed server whose

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -94,7 +94,8 @@ const CONV: Conversation = {
   created_at: 1_700_000_000,
   updated_at: 1_700_000_000,
   labels: {},
-  permission_level: null, // owner → can edit + pin
+  permission_level: null,
+  // owner absent → the viewer owns it (rename/share/pin all enabled)
   status: "idle",
 };
 
@@ -335,11 +336,11 @@ describe("double-click to rename", () => {
   });
 
   it("does not enter rename on double-click for a viewer-only row", () => {
-    // permission_level 1 is below the edit threshold (>= 2), so the kebab's
-    // Rename item is disabled and double-click must be inert too. A viewer-only
-    // (non-owner) session lives on the "Shared with me" tab, so switch to it
+    // Rename is owner-only now, so a session owned by another user has its
+    // kebab Rename item disabled and double-click must be inert too. A
+    // non-owner session lives on the "Shared with me" tab, so switch to it
     // before reaching for the row.
-    mockConversations([{ ...CONV, permission_level: 1 }]);
+    mockConversations([{ ...CONV, owner: "other@example.com" }]);
     renderSidebar();
     // Radix Tabs triggers activate on mousedown (primary button), not click.
     fireEvent.mouseDown(screen.getByTestId("sidebar-tab-shared"), { button: 0 });

--- a/web/src/shell/Sidebar.stop.test.tsx
+++ b/web/src/shell/Sidebar.stop.test.tsx
@@ -187,10 +187,10 @@ describe("sidebar Stop session item", () => {
   });
 
   it("is disabled for non-owners even on a stoppable session", () => {
-    // Owner-gated server-side; a shared viewer (level 1) sees it disabled.
-    // A non-owner session lives on the "Shared with me" tab, so switch there
-    // before opening its kebab.
-    mockConversations([{ ...HOST_SPAWNED, permission_level: 1 }]);
+    // Owner-gated server-side; a shared viewer (another user owns it) sees it
+    // disabled. A non-owner session lives on the "Shared with me" tab, so
+    // switch there before opening its kebab.
+    mockConversations([{ ...HOST_SPAWNED, owner: "other@example.com" }]);
     renderSidebar();
     // Radix Tabs triggers activate on mousedown (primary button), not click.
     fireEvent.mouseDown(screen.getByTestId("sidebar-tab-shared"), { button: 0 });

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -361,14 +361,15 @@ describe("Sidebar session list", () => {
 
 // Sidebar grouping: the viewer's own sessions ("My sessions" tab) keep the
 // Pinned / Projects / Sessions structure; sessions shared with the viewer live
-// on a separate "Shared with me" tab. "Shared" = sessions where the caller's
-// permission_level says non-owner (< 4); null/4+ are the viewer's own.
+// on a separate "Shared with me" tab. "Shared" = sessions whose `owner` is
+// another user; a null/absent owner is the viewer's own (single-user / legacy).
+// In tests the resolved viewer id is null, so any non-null owner reads as shared.
 describe("Sidebar sections", () => {
   it("splits owned and shared sessions across the My sessions / Shared with me tabs", () => {
     mockConversations([
-      conv("conv_mine_legacy", "Claude Code"), // permission_level null = owner
-      conv("conv_mine_acl", "Claude Code", { permission_level: 4 }),
-      conv("conv_shared", "Claude Code", { permission_level: 2 }),
+      conv("conv_mine_legacy", "Claude Code"), // owner absent = owned
+      conv("conv_mine_acl", "Claude Code", { owner: null }),
+      conv("conv_shared", "Claude Code", { owner: "other@example.com" }),
     ]);
     renderSidebar();
 
@@ -407,7 +408,7 @@ describe("Sidebar tabs", () => {
   it("keeps New session visible on both tabs and snaps back to My sessions when used", () => {
     mockConversations([
       conv("conv_mine", "Claude Code"),
-      conv("conv_shared", "Claude Code", { permission_level: 2 }),
+      conv("conv_shared", "Claude Code", { owner: "other@example.com" }),
     ]);
     renderSidebar();
     expect(screen.getByTestId("new-chat-button")).toBeInTheDocument();
@@ -431,7 +432,7 @@ describe("Sidebar tabs", () => {
     isServerLocalMock.mockReturnValue(true);
     mockConversations([
       conv("conv_mine", "Claude Code"),
-      conv("conv_shared", "Claude Code", { permission_level: 2 }),
+      conv("conv_shared", "Claude Code", { owner: "other@example.com" }),
     ]);
     renderSidebar();
     expect(screen.queryByTestId("sidebar-tab-mine")).toBeNull();
@@ -448,7 +449,7 @@ describe("Sidebar tabs", () => {
     // sessions (which shows only owned sessions).
     mockConversations([
       conv("conv_mine", "Claude Code"),
-      conv("conv_shared", "Claude Code", { permission_level: 2 }),
+      conv("conv_shared", "Claude Code", { owner: "other@example.com" }),
     ]);
     localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_shared"]));
     renderSidebar();
@@ -472,7 +473,7 @@ describe("Sidebar tabs", () => {
     projectsMock.push("Alpha");
     mockConversations([
       conv("conv_mine", "Claude Code", { labels: { omni_project: "Alpha" } }),
-      conv("conv_shared", "Claude Code", { permission_level: 2 }),
+      conv("conv_shared", "Claude Code", { owner: "other@example.com" }),
     ]);
     renderSidebar();
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -120,7 +120,7 @@ import { useActiveRootSessionId } from "@/hooks/useSession";
 import { useCommentInbox } from "@/hooks/useCommentInbox";
 import { sumPendingApprovals } from "@/lib/inbox";
 import { isSessionStoppable } from "@/lib/sessionStop";
-import { isOwnerLevel } from "@/lib/permissionsApi";
+import { getCurrentUserId, resolveIdentity } from "@/lib/identity";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { getSessionState, type SessionState } from "@/hooks/useSessionState";
 import {
@@ -911,9 +911,48 @@ interface ConversationListProps {
   onVisibleCountChange: (count: number) => void;
 }
 
-// permission_level null (no ACL row / legacy) or >= 4 both mean owner.
-function isOwnedByViewer(conversation: Conversation): boolean {
-  return isOwnerLevel(conversation.permission_level);
+// Ownership drives the My-vs-Shared split and every owner-only row action.
+// It is derived purely from the session's `owner` (the creator's user id),
+// NOT from `permission_level` — the sidebar carries no effective-level info,
+// so the server can list rows without resolving the caller's grant per
+// session. A `null`/absent owner (permissions disabled — the server emits
+// `owner` only when a permission store is wired) reads as owned, matching the
+// prior permissive-on-null stance; otherwise the viewer owns it iff they are
+// the owner. In single-user mode the owner grant is the reserved `"local"`
+// id, and `viewerId` is `"local"` too (see `useViewerId`), so it matches via
+// the equality branch. `viewerId` is `null` until identity resolves — treated
+// as "not the owner" for shared rows so they don't briefly flash into "My
+// sessions" before the id lands.
+function isOwnedByViewer(conversation: Conversation, viewerId: string | null): boolean {
+  const owner = conversation.owner ?? null;
+  if (owner === null) return true;
+  return owner === viewerId;
+}
+
+// The current viewer's user id, resolved reactively. Uses `getCurrentUserId`
+// (NOT `getCurrentAuthorId`): ownership compares against the session's `owner`
+// grant, which in single-user mode is the reserved `"local"` id — and
+// `getCurrentAuthorId` nulls `"local"` out (it's for author labels), which
+// would make the viewer's own sessions read as shared and vanish from the
+// default "My sessions" tab. `getCurrentUserId` keeps `"local"` and is the
+// identical real email in multi-user mode. It is synchronous (populated once
+// `resolveIdentity` has run — which `main.tsx` kicks off at boot), but on a
+// cold mount it can still be null for a tick, so we also await
+// `resolveIdentity()` and re-render when it lands. Keeping this reactive
+// (rather than a bare module read) means the My/Shared split settles correctly
+// the moment identity is known, without a manual refresh.
+function useViewerId(): string | null {
+  const [viewerId, setViewerId] = useState<string | null>(() => getCurrentUserId());
+  useEffect(() => {
+    let cancelled = false;
+    void resolveIdentity().then(() => {
+      if (!cancelled) setViewerId(getCurrentUserId());
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return viewerId;
 }
 
 function ConversationList({
@@ -932,6 +971,8 @@ function ConversationList({
   getVisibleConversationsRef,
   onVisibleCountChange,
 }: ConversationListProps) {
+  // Viewer id for the owner-based My/Shared split below.
+  const viewerId = useViewerId();
   // All loaded conversations from the single paginated list (for pinned
   // backfill, normalization, and the flat session list).
   const allConversations = useMemo(
@@ -977,8 +1018,8 @@ function ConversationList({
     // same section layout with different conversations.
     const tabScoped =
       activeTab === "shared"
-        ? notArchived.filter((c) => !isOwnedByViewer(c))
-        : notArchived.filter(isOwnedByViewer);
+        ? notArchived.filter((c) => !isOwnedByViewer(c, viewerId))
+        : notArchived.filter((c) => isOwnedByViewer(c, viewerId));
 
     // Pinned takes precedence over Project: pinning a session moves it OUT of
     // its project into the flat global Pinned section (no nested pins). Ordered
@@ -1032,6 +1073,7 @@ function ConversationList({
     activeOverride,
     projectNames,
     activeTab,
+    viewerId,
   ]);
 
   // Collapsed section titles — persisted like pins so the preference
@@ -2019,8 +2061,6 @@ function ConversationMenuItems({
   isPinned,
   isArchived,
   isOwner,
-  canEdit,
-  canManage,
   sharingOff,
   isSingleUser,
   canStop,
@@ -2044,10 +2084,8 @@ function ConversationMenuItems({
   isPinned: boolean;
   isArchived: boolean;
   isOwner: boolean;
-  canEdit: boolean;
-  canManage: boolean;
   // Server-wide sharing kill switch (OMNIGENT_SHARING_MODE=off): disables the
-  // Share item for everyone, independent of the per-user manage check.
+  // Share item for everyone, independent of the per-user ownership check.
   sharingOff: boolean;
   // Single-user mode: hide the Share item entirely (no other users to share
   // with), rather than disabling it like sharingOff does.
@@ -2117,7 +2155,7 @@ function ConversationMenuItems({
   // Mobile project sub-view: replaces the entire menu body in place (the
   // "Back" row flips `view` without closing the menu or navigating). Reachable
   // only via the mobile project item below, which sits behind the same
-  // `canEdit && isOwner` gate.
+  // `isOwner` gate.
   if (isMobile && view === "projects") {
     return (
       <>
@@ -2161,7 +2199,7 @@ function ConversationMenuItems({
       {/* Single-user mode has no other users to share with — omit the item
           entirely rather than showing it disabled. */}
       {!isSingleUser &&
-        (canManage && !sharingOff ? (
+        (isOwner && !sharingOff ? (
           <C.Item data-testid="share-conversation" onSelect={() => setShareOpen(true)}>
             <ShareIcon className="size-3.5" />
             Share
@@ -2176,16 +2214,16 @@ function ConversationMenuItems({
                 </C.Item>
               </div>
             </TooltipTrigger>
-            {/* Sharing-off is server-wide, so it outranks the per-user manage
+            {/* Sharing-off is server-wide, so it outranks the per-user owner
                 reason when both apply. */}
             <TooltipContent side="left">
               {sharingOff
                 ? "Sharing has been disabled for this Omnigent server."
-                : "You need manage permissions to share this session"}
+                : "Only the session owner can share this session"}
             </TooltipContent>
           </Tooltip>
         ))}
-      {canEdit ? (
+      {isOwner ? (
         <C.Item data-testid="rename-conversation" onSelect={() => setIsEditing(true)}>
           <PencilIcon className="size-3.5" />
           Rename
@@ -2201,7 +2239,7 @@ function ConversationMenuItems({
             </div>
           </TooltipTrigger>
           <TooltipContent side="left">
-            You need edit permissions to rename this session
+            Only the session owner can rename this session
           </TooltipContent>
         </Tooltip>
       )}
@@ -2221,9 +2259,8 @@ function ConversationMenuItems({
         </C.Item>
       )}
       {/* Projects are a My-sessions-only tool, so filing is owner-only — a
-          shared session (even editable) shows no project affordance. */}
-      {canEdit &&
-        isOwner &&
+          shared session shows no project affordance. */}
+      {isOwner &&
         (isMobile ? (
           // Mobile: no room for a side flyout, so this item swaps the menu
           // body to the project picker in place (see the `view === "projects"`
@@ -2438,9 +2475,11 @@ function ConversationRow({
   // shows nothing while the archive completes.
   const [isArchiving, setIsArchiving] = useState(false);
   const gitBranch = conversation.git_branch ?? null;
-  const isOwner = isOwnedByViewer(conversation);
-  const canEdit = conversation.permission_level === null || conversation.permission_level >= 2;
-  const canManage = conversation.permission_level === null || conversation.permission_level >= 3;
+  // Every row action gates on ownership alone — the sidebar carries no
+  // effective-permission level, so rename/share/move/drag are owner-only and
+  // non-owners get a read-only row. (Finer-grained edit/manage affordances
+  // live on the open-session view, which fetches the caller's real level.)
+  const isOwner = isOwnedByViewer(conversation, useViewerId());
   // Server-wide sharing kill switch (OMNIGENT_SHARING_MODE=off) reported by
   // /v1/info — disables the row's Share item even for managers. Fail open
   // (share enabled) while the capability probe is still loading.
@@ -2503,11 +2542,12 @@ function ConversationRow({
         ? { kind: "unseen" as const }
         : derivedState;
 
-  // Drag-and-drop: a row is grabbable when the viewer can re-file it (edit
-  // permission), outside selection / archive / rename modes. Dragging it onto a
-  // project folder files it there; onto "Chats" unfiles it; onto "Pinned" pins
-  // it. The list-level <DndContext> routes the drop; the row only advertises
-  // itself and its source project + pinned state via the draggable `data`.
+  // Drag-and-drop: a row is grabbable when the viewer owns it (re-filing is
+  // owner-only, like the Move-to-project kebab item), outside selection /
+  // archive / rename modes. Dragging it onto a project folder files it there;
+  // onto "Chats" unfiles it; onto "Pinned" pins it. The list-level <DndContext>
+  // routes the drop; the row only advertises itself and its source project +
+  // pinned state via the draggable `data`.
   const {
     listeners: dragListeners,
     setNodeRef: setDragNodeRef,
@@ -2515,7 +2555,7 @@ function ConversationRow({
   } = useDraggable({
     id: conversation.id,
     data: { type: "session", label, project: currentProject, isPinned },
-    disabled: !canEdit || selectionMode || isArchived || isEditing,
+    disabled: !isOwner || selectionMode || isArchived || isEditing,
   });
   // A drag ends with a synthetic click on the row's <Link> (mousedown + mouseup
   // on the same anchor still fires a click); swallow that one click so a drag
@@ -2656,8 +2696,6 @@ function ConversationRow({
     isPinned,
     isArchived,
     isOwner,
-    canEdit,
-    canManage,
     sharingOff,
     isSingleUser,
     canStop,
@@ -2704,7 +2742,7 @@ function ConversationRow({
       }}
       onDoubleClick={(e) => {
         if (selectionMode) return;
-        if (!canEdit) return;
+        if (!isOwner) return;
         e.preventDefault();
         setIsEditing(true);
       }}
@@ -3549,6 +3587,7 @@ function BulkActionBar({
   const { conversationId: activeId } = useParams<{ conversationId: string }>();
   const bulkArchive = useBulkArchiveConversations();
   const bulkDelete = useBulkDeleteConversations();
+  const viewerId = useViewerId();
 
   const selectedConversations = useMemo(
     () => allConversations.filter((c) => selectedIds.has(c.id)),
@@ -3556,8 +3595,8 @@ function BulkActionBar({
   );
 
   const ownedSelected = useMemo(
-    () => selectedConversations.filter((c) => isOwnedByViewer(c)),
-    [selectedConversations],
+    () => selectedConversations.filter((c) => isOwnedByViewer(c, viewerId)),
+    [selectedConversations, viewerId],
   );
 
   const archivedSelected = useMemo(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/omnigent-ai/omnigent/pull/2671/files) to review incremental changes.
- [stack/sidebar-owner-only](https://github.com/omnigent-ai/omnigent/pull/2671) [[Files changed](https://github.com/omnigent-ai/omnigent/pull/2671/files)]

---------
## What

The session sidebar derived every row affordance (rename, share, move-to-project, drag-to-file) and the **My / Shared with me** tab split from each row's `permission_level`. That coupling forces the backend to resolve the caller's *effective grant* for every listed session on each list build and `/v1/sessions/updates` poll.

The sidebar only ever needs **owner-vs-not**, and every list row already carries `owner`. This PR switches the sidebar to derive ownership from `owner` and gates all row actions on ownership alone.

## Changes

- `isOwnedByViewer(conversation, viewerId)` now compares the row's `owner` against the resolved viewer id, permissive when `owner` is null (single-user / legacy rows). A new `useViewerId` hook resolves the viewer id reactively so the My/Shared split settles as soon as identity is known.
- Row actions are now **owner-only**:
  - **Rename** was edit-gated → owner.
  - **Share** was manage-gated → owner.
  - **Move-to-project** and **drag-to-file** were edit-gated → owner (they were already effectively owner-only, since projects are a My-sessions tool).
  - Delete / Archive / Stop were already owner-gated — unchanged.
- Non-owners get a read-only row. Finer-grained edit/manage affordances remain on the **open-session view**, which fetches the caller's real level via `GET /v1/sessions/{id}` — so nothing that actually needs the level loses it.
- `permission_level` is no longer read anywhere in the sidebar. A backend can now list sessions without a per-session permission lookup.

## Behavior change

In the sidebar kebab, a non-owner who previously held edit/manage on a shared session no longer sees **Rename** or **Share** enabled there (both now say "Only the session owner can …"). Editing shared content is still available from the open session.

## Testing

- Updated the Sidebar suites that seeded "shared" via `permission_level` to seed `owner` instead.
- Full web suite green (`vitest run`), typecheck clean (`tsc -b`), lint + prettier clean on touched files.

manually tested read only + edit permission sessions

rename is now only an owner permission:
<img width="1194" height="462" alt="image" src="https://github.com/user-attachments/assets/97597b0c-8add-42ae-afe0-b116b8537b58" />


This pull request and its description were written by Isaac.