### PR TITLE
feat(web): add find-in-file to the markdown & notebook preview

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1131,6 +1131,16 @@
   background-color: color-mix(in oklch, var(--warning) 70%, transparent);
 }
 
+/* Find-in-file matches in the rendered markdown / notebook preview. The preview
+   is React-owned DOM, so matches are painted with the CSS Custom Highlight API
+   (Range-based, no node mutation) rather than wrapper spans. */
+::highlight(md-preview-search) {
+  background-color: color-mix(in oklch, var(--warning) 30%, transparent);
+}
+::highlight(md-preview-search-current) {
+  background-color: color-mix(in oklch, var(--warning) 70%, transparent);
+}
+
 /* TipTap editor prose styling */
 .tiptap-md-content .ProseMirror {
   outline: none;

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -60,6 +60,7 @@ import {
   lineOverlapsSelection,
 } from "./codeViewerHelpers";
 import { NotebookPreview } from "./NotebookPreview";
+import { PreviewSearchBar } from "./PreviewSearchBar";
 import { renderLineTokens } from "./codeViewerRendering";
 import { HtmlCommentViewer } from "./HtmlCommentViewer";
 import { TruncatedBanner } from "./TruncatedBanner";
@@ -140,9 +141,19 @@ const MARKDOWN_COMPONENTS: Components = {
   },
 };
 
-function MarkdownPreview({ content }: { content: string }) {
+function MarkdownPreview({
+  content,
+  rootRef,
+}: {
+  content: string;
+  rootRef?: RefObject<HTMLDivElement | null>;
+}) {
   return (
-    <div className="markdown-preview px-6 py-4 overflow-auto h-full prose dark:prose-invert prose-sm max-w-none">
+    <div
+      ref={rootRef}
+      data-preview-scroll
+      className="markdown-preview px-6 py-4 overflow-auto h-full prose dark:prose-invert prose-sm max-w-none"
+    >
       <ReactMarkdown
         remarkPlugins={MARKDOWN_REMARK_PLUGINS}
         rehypePlugins={MARKDOWN_REHYPE_PLUGINS}
@@ -150,6 +161,51 @@ function MarkdownPreview({ content }: { content: string }) {
       >
         {content}
       </ReactMarkdown>
+    </div>
+  );
+}
+
+// Markdown / notebook preview with find-in-file. The preview is React-owned
+// DOM, so PreviewSearchBar highlights matches via the CSS Custom Highlight API
+// (no node mutation). `contentVersion` = content string, so the match ranges
+// recompute when the rendered document changes.
+function PreviewWithSearch({
+  content,
+  isNotebook,
+  truncated,
+  searchOpen,
+  onSearchHandled,
+  searchInputRef,
+}: {
+  content: string;
+  isNotebook: boolean;
+  truncated: boolean;
+  searchOpen: boolean;
+  onSearchHandled: () => void;
+  searchInputRef: RefObject<HTMLInputElement | null>;
+}) {
+  const previewRef = useRef<HTMLDivElement>(null);
+  const bar = (
+    <PreviewSearchBar
+      containerRef={previewRef}
+      contentVersion={content}
+      open={searchOpen}
+      onClose={onSearchHandled}
+      inputRef={searchInputRef}
+    />
+  );
+  const preview = isNotebook ? (
+    <NotebookPreview content={content} rootRef={previewRef} />
+  ) : (
+    <MarkdownPreview content={content} rootRef={previewRef} />
+  );
+  // The find bar sits above the preview; a truncated preview also shows the
+  // banner. The bar renders nothing when closed, so layout is unchanged then.
+  return (
+    <div className="flex h-full flex-col">
+      {bar}
+      {truncated && <TruncatedBanner />}
+      <div className="min-h-0 flex-1">{preview}</div>
     </div>
   );
 }
@@ -613,19 +669,15 @@ export function CodeViewer({
   }
 
   if (viewMode === "preview" && (lang === "markdown" || isNotebookPath(path))) {
-    const preview = isNotebookPath(path) ? (
-      <NotebookPreview content={content} />
-    ) : (
-      <MarkdownPreview content={content} />
-    );
-    // A truncated preview renders incomplete content; warn the user (the editor
-    // and source surfaces already do). No layout change when not truncated.
-    if (!truncated) return preview;
     return (
-      <div className="flex h-full flex-col">
-        <TruncatedBanner />
-        <div className="min-h-0 flex-1">{preview}</div>
-      </div>
+      <PreviewWithSearch
+        content={content}
+        isNotebook={isNotebookPath(path)}
+        truncated={truncated}
+        searchOpen={searchOpen}
+        onSearchHandled={handleSearchHandled}
+        searchInputRef={searchInputRef}
+      />
     );
   }
 

--- a/web/src/shell/NotebookPreview.tsx
+++ b/web/src/shell/NotebookPreview.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from "react";
 import type { BundledLanguage } from "shiki";
 import AnsiDefault from "ansi-to-react";
 import ReactMarkdown from "react-markdown";
@@ -214,7 +215,7 @@ export function NotebookPreview({
   rootRef,
 }: {
   content: string;
-  rootRef?: React.RefObject<HTMLDivElement | null>;
+  rootRef?: RefObject<HTMLDivElement | null>;
 }) {
   const { notebook, error } = parseNotebook(content);
 

--- a/web/src/shell/NotebookPreview.tsx
+++ b/web/src/shell/NotebookPreview.tsx
@@ -209,7 +209,13 @@ function CodeCell({ cell, language }: { cell: NotebookCell; language: BundledLan
   );
 }
 
-export function NotebookPreview({ content }: { content: string }) {
+export function NotebookPreview({
+  content,
+  rootRef,
+}: {
+  content: string;
+  rootRef?: React.RefObject<HTMLDivElement | null>;
+}) {
   const { notebook, error } = parseNotebook(content);
 
   if (error || !notebook) {
@@ -227,7 +233,7 @@ export function NotebookPreview({ content }: { content: string }) {
   const language = langName as BundledLanguage;
 
   return (
-    <div className="h-full space-y-4 overflow-auto px-6 py-4">
+    <div ref={rootRef} data-preview-scroll className="h-full space-y-4 overflow-auto px-6 py-4">
       {(notebook.cells ?? []).map((cell, i) => {
         if (cell.cell_type === "markdown") {
           return (

--- a/web/src/shell/PreviewSearchBar.test.tsx
+++ b/web/src/shell/PreviewSearchBar.test.tsx
@@ -1,0 +1,143 @@
+// Tests for the rendered-preview find bar (PreviewSearchBar).
+//
+// jsdom implements neither the CSS Custom Highlight API nor layout
+// (getBoundingClientRect returns zeros), so both are stubbed: a fake
+// CSS.highlights/Highlight records what would be painted, letting us assert the
+// query → count → paint → navigate flow against a real preview DOM subtree.
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRef } from "react";
+import { PreviewSearchBar } from "./PreviewSearchBar";
+
+// Records the ranges set under each highlight name.
+const painted = new Map<string, number>();
+
+class FakeHighlight {
+  ranges: unknown[];
+  constructor(...ranges: unknown[]) {
+    this.ranges = ranges;
+  }
+}
+
+beforeEach(() => {
+  painted.clear();
+  // getBoundingClientRect is used only for scroll-into-view; zeros make it a no-op.
+  Element.prototype.scrollBy = vi.fn();
+  Range.prototype.getBoundingClientRect = vi.fn(
+    () => ({ top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0 }) as DOMRect,
+  );
+  vi.stubGlobal("Highlight", FakeHighlight);
+  vi.stubGlobal("CSS", {
+    highlights: {
+      set: (name: string, hl: FakeHighlight) => painted.set(name, hl.ranges.length),
+      delete: (name: string) => painted.delete(name),
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// Renders a fixed preview subtree plus the bar pointing at it.
+function renderBar(props: { open?: boolean; onClose?: () => void } = {}) {
+  const onClose = props.onClose ?? vi.fn();
+  const containerRef = createRef<HTMLDivElement>();
+  const inputRef = createRef<HTMLInputElement>();
+  const utils = render(
+    <div>
+      <div ref={containerRef}>
+        <p>The quick brown fox jumps over the lazy dog.</p>
+      </div>
+      <PreviewSearchBar
+        containerRef={containerRef}
+        contentVersion="v1"
+        open={props.open ?? true}
+        onClose={onClose}
+        inputRef={inputRef}
+      />
+    </div>,
+  );
+  return { ...utils, onClose };
+}
+
+function type(value: string) {
+  const input = screen.getByPlaceholderText("Find…");
+  fireEvent.change(input, { target: { value } });
+  return input;
+}
+
+describe("PreviewSearchBar", () => {
+  it("renders nothing when closed", () => {
+    renderBar({ open: false });
+    expect(screen.queryByPlaceholderText("Find…")).toBeNull();
+  });
+
+  it("shows the match count and paints highlights as the user types", async () => {
+    renderBar();
+    await act(async () => {
+      type("the");
+    });
+    // Two matches of "the"; current is painted separately from the rest.
+    expect(screen.getByText("1 / 2")).toBeDefined();
+    expect(painted.get("md-preview-search")).toBe(1); // the non-current match
+    expect(painted.get("md-preview-search-current")).toBe(1);
+  });
+
+  it("shows 'No results' and paints nothing when nothing matches", async () => {
+    renderBar();
+    await act(async () => {
+      type("zzz");
+    });
+    expect(screen.getByText("No results")).toBeDefined();
+    expect(painted.has("md-preview-search")).toBe(false);
+  });
+
+  it("advances to the next match on Enter and wraps around", async () => {
+    renderBar();
+    const input = await act(async () => type("the"));
+    expect(screen.getByText("1 / 2")).toBeDefined();
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+    expect(screen.getByText("2 / 2")).toBeDefined();
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+    expect(screen.getByText("1 / 2")).toBeDefined();
+  });
+
+  it("navigates with the up/down buttons", async () => {
+    renderBar();
+    await act(async () => type("the"));
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Next match"));
+    });
+    expect(screen.getByText("2 / 2")).toBeDefined();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Previous match"));
+    });
+    expect(screen.getByText("1 / 2")).toBeDefined();
+  });
+
+  it("calls onClose and clears highlights on Escape", async () => {
+    const { onClose } = renderBar();
+    const input = await act(async () => type("the"));
+    expect(painted.size).toBeGreaterThan(0);
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Escape" });
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the ✕ button is clicked", async () => {
+    const { onClose } = renderBar();
+    await act(async () => type("the"));
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Close search"));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/shell/PreviewSearchBar.test.tsx
+++ b/web/src/shell/PreviewSearchBar.test.tsx
@@ -69,6 +69,27 @@ function type(value: string) {
   return input;
 }
 
+// Harness whose preview text + contentVersion can be updated, to exercise the
+// "rendered content changes while the bar is open" recompute path.
+function Harness({ text, version }: { text: string; version: string }) {
+  const containerRef = createRef<HTMLDivElement>();
+  const inputRef = createRef<HTMLInputElement>();
+  return (
+    <div>
+      <div ref={containerRef}>
+        <p>{text}</p>
+      </div>
+      <PreviewSearchBar
+        containerRef={containerRef}
+        contentVersion={version}
+        open
+        onClose={vi.fn()}
+        inputRef={inputRef}
+      />
+    </div>
+  );
+}
+
 describe("PreviewSearchBar", () => {
   it("renders nothing when closed", () => {
     renderBar({ open: false });
@@ -139,5 +160,23 @@ describe("PreviewSearchBar", () => {
       fireEvent.click(screen.getByLabelText("Close search"));
     });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("recomputes matches against the new DOM when content changes while open", async () => {
+    // One "cat" initially.
+    const { rerender } = render(<Harness text="cat" version="v1" />);
+    await act(async () => {
+      type("cat");
+    });
+    expect(screen.getByText("1 / 1")).toBeDefined();
+
+    // The rendered content changes while the bar stays open (new version). The
+    // recompute must walk the committed DOM, not the replaced nodes — so the
+    // count reflects the new text ("cat cat" → 2), proving ranges rebuilt
+    // post-commit rather than during render against stale nodes.
+    await act(async () => {
+      rerender(<Harness text="cat cat" version="v2" />);
+    });
+    expect(screen.getByText("1 / 2")).toBeDefined();
   });
 });

--- a/web/src/shell/PreviewSearchBar.tsx
+++ b/web/src/shell/PreviewSearchBar.tsx
@@ -6,7 +6,7 @@
 // content changes, and scrolls the active match into view. Its UI matches the
 // source-view and editor find bars.
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import { ChevronDownIcon, ChevronUpIcon, SearchIcon, XIcon } from "lucide-react";
 import type { ReactElement, RefObject } from "react";
 import { clearPreviewHighlights, findTextRanges, paintPreviewHighlights } from "./previewSearch";
@@ -31,14 +31,20 @@ export function PreviewSearchBar({
 }: PreviewSearchBarProps): ReactElement | null {
   const [query, setQuery] = useState("");
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [ranges, setRanges] = useState<Range[]>([]);
 
   // Recompute match ranges when the query, the open state, or the rendered
-  // content changes. Ranges are DOM Ranges into the live preview nodes, so they
-  // must be rebuilt after a re-render replaces those nodes.
-  const ranges = useMemo(() => {
+  // content changes. Ranges are DOM Ranges into the live preview nodes, so this
+  // runs in useLayoutEffect (post-commit) rather than during render: on a
+  // content change the new react-markdown/notebook DOM must be committed first,
+  // otherwise the walker would build Ranges into nodes about to be replaced.
+  useLayoutEffect(() => {
     const container = containerRef.current;
-    if (!open || !container || !query.trim()) return [];
-    return findTextRanges(container, query.trim());
+    if (!open || !container || !query.trim()) {
+      setRanges([]);
+      return;
+    }
+    setRanges(findTextRanges(container, query.trim()));
     // contentVersion forces a rebuild after the preview re-renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef, open, query, contentVersion]);

--- a/web/src/shell/PreviewSearchBar.tsx
+++ b/web/src/shell/PreviewSearchBar.tsx
@@ -1,0 +1,160 @@
+// Find-in-file bar for the rendered markdown / notebook preview.
+//
+// The preview is React-owned DOM, so matches are painted with the CSS Custom
+// Highlight API (see previewSearch.ts) rather than by wrapping nodes. This bar
+// owns the query + current match, recomputes ranges when the query or rendered
+// content changes, and scrolls the active match into view. Its UI matches the
+// source-view and editor find bars.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDownIcon, ChevronUpIcon, SearchIcon, XIcon } from "lucide-react";
+import type { ReactElement, RefObject } from "react";
+import { clearPreviewHighlights, findTextRanges, paintPreviewHighlights } from "./previewSearch";
+
+interface PreviewSearchBarProps {
+  /** The rendered-preview container whose text is searched + highlighted. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Bumped by the caller whenever the rendered content changes, so ranges recompute. */
+  contentVersion: unknown;
+  open: boolean;
+  /** Called when the bar closes (Escape / ✕) so the toolbar toggle stays in sync. */
+  onClose: () => void;
+  inputRef: RefObject<HTMLInputElement | null>;
+}
+
+export function PreviewSearchBar({
+  containerRef,
+  contentVersion,
+  open,
+  onClose,
+  inputRef,
+}: PreviewSearchBarProps): ReactElement | null {
+  const [query, setQuery] = useState("");
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  // Recompute match ranges when the query, the open state, or the rendered
+  // content changes. Ranges are DOM Ranges into the live preview nodes, so they
+  // must be rebuilt after a re-render replaces those nodes.
+  const ranges = useMemo(() => {
+    const container = containerRef.current;
+    if (!open || !container || !query.trim()) return [];
+    return findTextRanges(container, query.trim());
+    // contentVersion forces a rebuild after the preview re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [containerRef, open, query, contentVersion]);
+
+  const matchCount = ranges.length;
+  const safeIndex = matchCount > 0 ? currentIndex % matchCount : 0;
+
+  // Reset to the first match on every new query.
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [query]);
+
+  // Clear the query when the bar closes so a reopen starts fresh.
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
+
+  // Paint the highlights and keep them cleared when the bar is closed or empty.
+  useEffect(() => {
+    if (!open || matchCount === 0) {
+      clearPreviewHighlights();
+      return;
+    }
+    paintPreviewHighlights(ranges, safeIndex);
+    return () => clearPreviewHighlights();
+  }, [open, ranges, safeIndex, matchCount]);
+
+  // Scroll the active match into view. Ranges have no scrollIntoView, so use the
+  // client rect of the current range.
+  useEffect(() => {
+    if (!open || matchCount === 0) return;
+    const rect = ranges[safeIndex]?.getBoundingClientRect();
+    if (!rect || (rect.width === 0 && rect.height === 0)) return;
+    const container = containerRef.current;
+    const scroller = container?.closest("[data-preview-scroll]") ?? container;
+    if (!scroller) return;
+    const box = scroller.getBoundingClientRect();
+    if (rect.top >= box.top && rect.bottom <= box.bottom) return; // already visible
+    scroller.scrollBy({
+      top: rect.top - box.top - box.height / 2 + rect.height / 2,
+      behavior: "smooth",
+    });
+  }, [open, ranges, safeIndex, matchCount, containerRef]);
+
+  // Focus the input when the bar opens.
+  useEffect(() => {
+    if (open) {
+      const id = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(id);
+    }
+  }, [open, inputRef]);
+
+  const goNext = useCallback(() => {
+    setCurrentIndex((i) => (matchCount > 0 ? (i + 1) % matchCount : 0));
+  }, [matchCount]);
+  const goPrev = useCallback(() => {
+    setCurrentIndex((i) => (matchCount > 0 ? (i - 1 + matchCount) % matchCount : 0));
+  }, [matchCount]);
+
+  const close = useCallback(() => {
+    setQuery("");
+    onClose();
+  }, [onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-card/90 px-3 py-1.5 backdrop-blur">
+      <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            if (e.shiftKey) goPrev();
+            else goNext();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            close();
+          }
+        }}
+        placeholder="Find…"
+        className="min-w-0 flex-1 bg-transparent text-xs outline-none"
+      />
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {query.trim() ? (matchCount > 0 ? `${safeIndex + 1} / ${matchCount}` : "No results") : ""}
+      </span>
+      <button
+        type="button"
+        aria-label="Previous match"
+        className="rounded p-0.5 text-muted-foreground hover:bg-muted disabled:opacity-40"
+        disabled={matchCount === 0}
+        onClick={goPrev}
+      >
+        <ChevronUpIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Next match"
+        className="rounded p-0.5 text-muted-foreground hover:bg-muted disabled:opacity-40"
+        disabled={matchCount === 0}
+        onClick={goNext}
+      >
+        <ChevronDownIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Close search"
+        className="rounded p-0.5 text-muted-foreground hover:bg-muted"
+        onClick={close}
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/shell/previewSearch.test.ts
+++ b/web/src/shell/previewSearch.test.ts
@@ -1,0 +1,78 @@
+// Unit tests for the rendered-preview find matcher (findTextRanges).
+//
+// The paint/clear helpers use the CSS Custom Highlight API, which jsdom doesn't
+// implement, so those are exercised in the app; here we cover the matcher — the
+// risk-bearing logic that walks the preview DOM into DOM Ranges. jsdom provides
+// TreeWalker + Range, so ranges round-trip to their matched text.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { findTextRanges } from "./previewSearch";
+
+let container: HTMLElement | null = null;
+
+function mount(html: string): HTMLElement {
+  container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+afterEach(() => {
+  container?.remove();
+  container = null;
+});
+
+describe("findTextRanges", () => {
+  it("returns [] for an empty query", () => {
+    expect(findTextRanges(mount("<p>hello world</p>"), "")).toEqual([]);
+  });
+
+  it("returns [] when nothing matches", () => {
+    expect(findTextRanges(mount("<p>hello world</p>"), "zzz")).toEqual([]);
+  });
+
+  it("finds all case-insensitive occurrences and each range maps to the match text", () => {
+    const el = mount("<p>The quick brown fox jumps over the lazy dog.</p>");
+    const ranges = findTextRanges(el, "the");
+    expect(ranges).toHaveLength(2);
+    for (const r of ranges) expect(r.toString().toLowerCase()).toBe("the");
+  });
+
+  it("matches a term split across inline formatting within a block", () => {
+    // "Hello" spans a text node, a <strong>, and another text node.
+    const el = mount("<p>Hel<strong>lo</strong> world</p>");
+    const ranges = findTextRanges(el, "hello");
+    expect(ranges).toHaveLength(1);
+    // The range spans the two text nodes but still reads as the matched text.
+    expect(ranges[0].toString()).toBe("Hello");
+  });
+
+  it("does not match across a block boundary", () => {
+    const el = mount("<p>foo</p><p>bar</p>");
+    expect(findTextRanges(el, "foobar")).toHaveLength(0);
+    // Each half still matches within its own block.
+    expect(findTextRanges(el, "foo")).toHaveLength(1);
+    expect(findTextRanges(el, "bar")).toHaveLength(1);
+  });
+
+  it("does not merge text across list items", () => {
+    const el = mount("<ul><li>ab</li><li>cd</li></ul>");
+    expect(findTextRanges(el, "abcd")).toHaveLength(0);
+  });
+
+  it("keeps positions aligned after a length-changing case-fold character", () => {
+    // "İ" (U+0130) lowercases to two UTF-16 units; a naive toLowerCase() haystack
+    // would shift every offset after it. The trailing word must still map exactly.
+    const el = mount("<p>İstanbul word</p>");
+    const ranges = findTextRanges(el, "word");
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0].toString()).toBe("word");
+  });
+
+  it("finds non-overlapping repeats within a single text node", () => {
+    const el = mount("<p>aaa</p>");
+    // "aa" advances past each match, so "aaa" yields one non-overlapping hit.
+    expect(findTextRanges(el, "aa")).toHaveLength(1);
+    expect(findTextRanges(el, "a")).toHaveLength(3);
+  });
+});

--- a/web/src/shell/previewSearch.ts
+++ b/web/src/shell/previewSearch.ts
@@ -1,0 +1,163 @@
+// Find-in-file matching for the rendered markdown / notebook preview.
+//
+// The preview is React-owned DOM (react-markdown output), so match highlights
+// must NOT mutate the node tree — that would fight React's reconciliation.
+// Instead we locate matches as DOM `Range`s and paint them with the CSS Custom
+// Highlight API (the same approach htmlCommentBridge uses for the HTML preview),
+// which overlays styling without touching the nodes.
+//
+// Matching mirrors the editor's TipTapSearchExtension: text is flattened across
+// inline nodes so a term split by formatting (e.g. `<em>`) still matches, while
+// a block boundary inserts a separator so a match never spans two blocks.
+
+// Block-level tags whose boundary breaks a run of visible text. A match may
+// span inline formatting within one block, but never cross into another.
+const BLOCK_TAGS = new Set([
+  "ADDRESS",
+  "ARTICLE",
+  "ASIDE",
+  "BLOCKQUOTE",
+  "DD",
+  "DIV",
+  "DL",
+  "DT",
+  "FIGCAPTION",
+  "FIGURE",
+  "FOOTER",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "HEADER",
+  "HR",
+  "LI",
+  "MAIN",
+  "NAV",
+  "OL",
+  "P",
+  "PRE",
+  "SECTION",
+  "TABLE",
+  "TBODY",
+  "TD",
+  "TFOOT",
+  "TH",
+  "THEAD",
+  "TR",
+  "UL",
+]);
+
+/**
+ * Lowercase without changing string length: fold each character, but keep the
+ * original whenever its lowercase form has a different UTF-16 length (e.g. `İ`
+ * U+0130 → `i` + combining U+0307). Preserving length keeps the search offsets
+ * aligned with the original-text coordinate map used to build Ranges.
+ */
+function lowerPreservingLength(s: string): string {
+  let out = "";
+  for (const ch of s) {
+    const lower = ch.toLowerCase();
+    out += lower.length === ch.length ? lower : ch;
+  }
+  return out;
+}
+
+/** Nearest block-level ancestor of `node` within `root` (root itself if none). */
+function nearestBlock(node: Node, root: Element): Element {
+  let el = node.parentElement;
+  while (el && el !== root) {
+    if (BLOCK_TAGS.has(el.tagName)) return el;
+    el = el.parentElement;
+  }
+  return root;
+}
+
+interface TextSegment {
+  node: Text;
+  /** Offset of this run's text within the flattened string. */
+  visibleFrom: number;
+  length: number;
+}
+
+/**
+ * Case-insensitive plain-text matches of `query` within `container`, returned as
+ * DOM Ranges ready to paint. Matches span adjacent text nodes inside one block
+ * but never cross a block boundary. Returns [] for an empty query or when no
+ * text matches.
+ */
+export function findTextRanges(container: Element, query: string): Range[] {
+  const q = lowerPreservingLength(query);
+  if (!q) return [];
+
+  const segments: TextSegment[] = [];
+  const separators: number[] = []; // flattened-string indices that break blocks
+  let text = "";
+  let prevBlock: Element | null = null;
+
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const value = node.nodeValue;
+    if (!value) continue;
+    const block = nearestBlock(node, container);
+    if (prevBlock !== null && block !== prevBlock) {
+      separators.push(text.length);
+      text += "\n";
+    }
+    prevBlock = block;
+    segments.push({ node: node as Text, visibleFrom: text.length, length: value.length });
+    text += value;
+  }
+
+  const haystack = lowerPreservingLength(text);
+  const ranges: Range[] = [];
+  let idx = haystack.indexOf(q);
+  while (idx !== -1) {
+    const start = idx;
+    const end = idx + q.length;
+    idx = haystack.indexOf(q, end);
+
+    // A match touching a block separator spans two blocks — skip it.
+    if (separators.some((s) => s >= start && s < end)) continue;
+
+    const startSeg = segments.find(
+      (s) => s.visibleFrom <= start && start < s.visibleFrom + s.length,
+    );
+    const endSeg = segments.find((s) => s.visibleFrom < end && end <= s.visibleFrom + s.length);
+    if (!startSeg || !endSeg) continue;
+
+    const range = document.createRange();
+    range.setStart(startSeg.node, start - startSeg.visibleFrom);
+    range.setEnd(endSeg.node, end - endSeg.visibleFrom);
+    ranges.push(range);
+  }
+  return ranges;
+}
+
+const HIGHLIGHT_ALL = "md-preview-search";
+const HIGHLIGHT_CURRENT = "md-preview-search-current";
+
+/** True when the browser supports the CSS Custom Highlight API. */
+function highlightsSupported(): boolean {
+  return typeof CSS !== "undefined" && !!CSS.highlights && typeof Highlight !== "undefined";
+}
+
+/**
+ * Paint the given ranges as the "all matches" highlight, with `ranges[current]`
+ * promoted to the "current match" highlight. No-op where the API is missing.
+ */
+export function paintPreviewHighlights(ranges: Range[], current: number): void {
+  if (!highlightsSupported()) return;
+  const currentRange = ranges[current];
+  const rest = ranges.filter((_, i) => i !== current);
+  CSS.highlights.set(HIGHLIGHT_ALL, new Highlight(...rest));
+  CSS.highlights.set(HIGHLIGHT_CURRENT, new Highlight(...(currentRange ? [currentRange] : [])));
+}
+
+/** Remove both preview-search highlights. */
+export function clearPreviewHighlights(): void {
+  if (!highlightsSupported()) return;
+  CSS.highlights.delete(HIGHLIGHT_ALL);
+  CSS.highlights.delete(HIGHLIGHT_CURRENT);
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

**Find in file** worked in the markdown **editor** (#2628), **source** view, and **Monaco** (#2621), but did nothing in **Preview** mode — the toolbar toggle (and Cmd+F) opened a bar that nothing consumed on the rendered-preview surface. This closes that last gap for markdown and notebook previews.

- The preview is **React-owned DOM** (react-markdown / notebook output), so matches can't be wrapped in `<span>`s without fighting React's reconciliation. Instead, `previewSearch.ts` locates matches as DOM `Range`s and paints them with the **CSS Custom Highlight API** — the same approach `htmlCommentBridge` already uses for the HTML preview — which overlays styling without mutating the node tree.
- **`previewSearch.ts`** — `findTextRanges(container, query)` walks the preview with a `TreeWalker`, flattens text across inline nodes (so a term split by formatting like `<em>` still matches) while inserting a separator at block-tag boundaries (so a match never spans two blocks). Uses the same length-preserving case-fold as the editor matcher so Unicode offsets stay aligned. Plus `paint`/`clear` helpers over `CSS.highlights`.
- **`PreviewSearchBar.tsx`** — the find bar (same UI as the editor/source bars): owns query + current match, recomputes ranges when the query or rendered content changes, and scrolls the active match into view.
- **`CodeViewer.tsx`** — wraps the preview branch in `PreviewWithSearch`, consuming the existing `searchOpen` toggle (Cmd+F already opened it in preview mode — nothing consumed it before). `MarkdownPreview` / `NotebookPreview` gained a `rootRef`.
- **Graceful degradation:** where the Highlight API is unavailable, count/navigation still work and only the paint is skipped (mirrors `htmlCommentBridge`).

This keeps preview find consistent with the editor's `TipTapSearchExtension` (cross-formatting match, no cross-block match). No Monaco or editor changes.

## Test Plan

- Added `previewSearch.test.ts` (8 tests): empty/no-match, case-insensitive multi-match with range round-trip, cross-formatting match, no cross-block match, no cross-list-item merge, length-changing case-fold (`İstanbul`), non-overlapping repeats.
- Added `PreviewSearchBar.test.tsx` (7 tests): match count + paint (stubbed Highlight API), No results, Enter/wrap navigation, up/down buttons, Escape + ✕ close.
- `cd web && npm test` → **4157 passed** (full suite green).
- `cd web && npm run build` → clean. Typecheck / prettier / oxlint clean.
- Manually verified in the running app: markdown Preview and `.ipynb` preview — highlight, cycle, scroll, and close.

## Demo

_UI change._ Verified locally in markdown Preview and notebook preview (highlight all matches, current match stronger, ↑/↓/Enter cycle + scroll, Escape/✕ close). Screen recording to be attached.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the matcher (cross-formatting, cross-block, cross-list-item, and Unicode cases) and the full find-bar state machine against a real preview DOM subtree with a stubbed Highlight API. Manual verification confirmed the live paint + scroll flow, which jsdom can't exercise (no CSS Custom Highlight API or layout).

## Changelog

Find in file now works in the markdown and notebook preview — highlights and cycles matches in the rendered document

This pull request and its description were written by Isaac.