### PR TITLE
fix(codex): resolve gateway host from the profile so token & base URL agree

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -43,7 +43,7 @@ from omnigent.inner.codex_executor import (
     _populate_codex_home_config,
     _provider_codex_config_overrides,
 )
-from omnigent.inner.databricks_executor import _read_databrickscfg, _read_databrickscfg_host
+from omnigent.inner.databricks_executor import _databricks_gateway_host
 
 _logger = logging.getLogger(__name__)
 
@@ -1115,8 +1115,10 @@ def build_codex_native_server(
     env = _clean_codex_env()
     config_overrides: list[str] = []
     if profile is not None:
-        creds = _read_databrickscfg(profile)
-        host = creds.host if creds is not None else _read_databrickscfg_host(profile)
+        # Use the profile's own host so the gateway base URL matches the token
+        # the profile-pinned auth command mints; a DATABRICKS_HOST override in
+        # the runner env must not point the base URL at another workspace.
+        host = _databricks_gateway_host(profile)
         if not host:
             raise OSError(
                 f"Native Codex with Databricks profile {profile!r} (from your "

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -30,8 +30,7 @@ from omnigent.spec.types import RetryPolicy
 from . import _proc
 from ._subprocess_lifecycle import close_subprocess_transport
 from .databricks_executor import (
-    _read_databrickscfg,
-    _read_databrickscfg_host,
+    _databricks_gateway_host,
 )
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec
 from .executor import (
@@ -2180,12 +2179,10 @@ class CodexExecutor(Executor):
             if host is None:
                 # No gateway host supplied directly: derive the transport from
                 # a Databricks profile (the Databricks producer's fallback).
-                creds = _read_databrickscfg(databricks_profile)
-                host = (
-                    creds.host
-                    if creds is not None
-                    else _read_databrickscfg_host(databricks_profile)
-                )
+                # Use the profile's own host so the base URL matches the token
+                # the profile-pinned auth command mints (not a DATABRICKS_HOST
+                # override that would point the base URL at another workspace).
+                host = _databricks_gateway_host(databricks_profile)
                 if not host:
                     raise OSError(
                         "CodexExecutor(gateway=True) requires gateway credentials via "

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -278,6 +278,38 @@ def _read_databrickscfg_host(profile: str | None = None) -> str | None:
     return None
 
 
+def _databricks_gateway_host(profile: str | None = None) -> str | None:
+    """Resolve the gateway workspace host that matches *profile*'s minted token.
+
+    Codex/Pi gateway launches derive the base URL from the profile host but
+    mint the bearer with ``databricks auth token --profile <profile>``, which
+    reads the profile section only and ignores ``DATABRICKS_HOST``. The SDK
+    resolver (:func:`_read_databrickscfg`) instead lets ``DATABRICKS_HOST``
+    override the profile host, so on a machine whose environment or ``DEFAULT``
+    section points at a different workspace, the base URL and the token would
+    target two workspaces and the gateway rejects the token ("Invalid Token").
+
+    So for an explicit profile, read the profile section host directly
+    (env-independent, same as the token) and only fall back to the SDK/ambient
+    chain when the section has no host — e.g. a spec authored with a profile
+    that is absent on a Databricks App container, which authenticates through
+    ambient env/OIDC credentials. Without a profile there is no profile-pinned
+    token to diverge from, so the SDK path (which the ``--host`` auth command
+    matches) is used directly.
+
+    :param profile: Databricks config profile name, or ``None``.
+    :returns: Workspace host URL, or ``None`` when none can be resolved.
+    """
+    if profile is not None:
+        host = _read_databrickscfg_host(profile)
+        if host:
+            return host
+    creds = _read_databrickscfg(profile)
+    if creds is not None:
+        return creds.host
+    return _read_databrickscfg_host(profile)
+
+
 class DatabricksAuthError(OSError):
     """Raised when Databricks credential resolution or token refresh fails.
 

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -24,7 +24,6 @@ from omnigent.inner.codex_executor import (
     _prompt_for_turn,
     _to_codex_input_items,
 )
-from omnigent.inner.databricks_executor import DatabricksCredentials
 from omnigent.inner.executor import (
     ExecutorError,
     ReasoningChunk,
@@ -179,11 +178,8 @@ class TestCodexExecutor(unittest.TestCase):
         with (
             patch("omnigent.inner.codex_executor._find_codex_cli", return_value="/usr/bin/codex"),
             patch(
-                "omnigent.inner.codex_executor._read_databrickscfg",
-                return_value=DatabricksCredentials(
-                    host="https://example.cloud.databricks.com",
-                    token="dapi_test_token",
-                ),
+                "omnigent.inner.codex_executor._databricks_gateway_host",
+                return_value="https://example.cloud.databricks.com",
             ),
         ):
             executor = CodexExecutor(gateway=True)
@@ -211,11 +207,8 @@ class TestCodexExecutor(unittest.TestCase):
             patch("omnigent.inner.codex_executor._find_codex_cli", return_value="/usr/bin/codex"),
             patch.dict("os.environ", {}, clear=True),
             patch(
-                "omnigent.inner.codex_executor._read_databrickscfg",
-                return_value=DatabricksCredentials(
-                    host="https://example-profile-workspace.cloud.databricks.com",
-                    token="profile_token",
-                ),
+                "omnigent.inner.codex_executor._databricks_gateway_host",
+                return_value="https://example-profile-workspace.cloud.databricks.com",
             ),
         ):
             executor = CodexExecutor(
@@ -256,7 +249,7 @@ class TestCodexExecutor(unittest.TestCase):
         with (
             patch("omnigent.inner.codex_executor._find_codex_cli", return_value="/usr/bin/codex"),
             patch.dict("os.environ", {}, clear=True),
-            patch("omnigent.inner.codex_executor._read_databrickscfg") as read_cfg,
+            patch("omnigent.inner.codex_executor._databricks_gateway_host") as gateway_host,
         ):
             executor = CodexExecutor(
                 gateway=True,
@@ -267,7 +260,7 @@ class TestCodexExecutor(unittest.TestCase):
                 model="databricks-gpt-5-4-mini",
             )
 
-        read_cfg.assert_not_called()
+        gateway_host.assert_not_called()
         self.assertEqual(
             executor._env["DATABRICKS_HOST"],
             "https://example.databricks.com",
@@ -310,8 +303,7 @@ class TestCodexExecutor(unittest.TestCase):
         with (
             patch("omnigent.inner.codex_executor._find_codex_cli", return_value="/usr/bin/codex"),
             patch.dict("os.environ", {}, clear=True),
-            patch("omnigent.inner.codex_executor._read_databrickscfg", return_value=None),
-            patch("omnigent.inner.codex_executor._read_databrickscfg_host", return_value=None),
+            patch("omnigent.inner.codex_executor._databricks_gateway_host", return_value=None),
         ):
             with self.assertRaises(EnvironmentError):
                 CodexExecutor(gateway=True)
@@ -407,11 +399,8 @@ class TestCodexExecutor(unittest.TestCase):
         async def _t():
             fake_session = _FakeAppSession([[TurnComplete(response="done")]])
             with patch(
-                "omnigent.inner.codex_executor._read_databrickscfg",
-                return_value=DatabricksCredentials(
-                    host="https://example.cloud.databricks.com",
-                    token="dapi_test_token",
-                ),
+                "omnigent.inner.codex_executor._databricks_gateway_host",
+                return_value="https://example.cloud.databricks.com",
             ):
                 executor = CodexExecutor(
                     codex_path="/bin/echo",

--- a/tests/inner/test_databricks_executor.py
+++ b/tests/inner/test_databricks_executor.py
@@ -871,6 +871,67 @@ def test_read_databrickscfg_host_missing_named_profile_does_not_fallback(
     assert _read_databrickscfg_host("missing-profile") is None
 
 
+def test_databricks_gateway_host_ignores_env_override_for_explicit_profile(
+    tmp_path: _Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_databricks_env: None,
+) -> None:
+    """An explicit profile's gateway host must match its ``--profile`` token.
+
+    ``databricks auth token --profile P`` mints a bearer for P's own workspace
+    and ignores ``DATABRICKS_HOST``. If the gateway base URL were resolved via
+    the SDK (which lets ``DATABRICKS_HOST`` override the profile host), the base
+    URL and the token would target different workspaces and the gateway rejects
+    the token. So the host must come from the profile section directly.
+    """
+    from omnigent.inner.databricks_executor import _databricks_gateway_host
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        textwrap.dedent(
+            """
+        [oss]
+        host = https://profile-workspace.cloud.databricks.com
+        auth_type = databricks-cli
+        """
+        ).lstrip()
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    monkeypatch.setenv("DATABRICKS_HOST", "https://other-workspace.cloud.databricks.com")
+
+    assert _databricks_gateway_host("oss") == "https://profile-workspace.cloud.databricks.com"
+
+
+def test_databricks_gateway_host_missing_profile_falls_back_to_ambient(
+    tmp_path: _Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_databricks_env: None,
+) -> None:
+    """A profile absent from the file falls back to the ambient/env chain.
+
+    Mirrors a spec authored with ``profile: P`` that now runs on a Databricks
+    App container with no matching section: there is no profile-pinned token to
+    diverge from, so ambient ``DATABRICKS_HOST`` is the right host.
+    """
+    from omnigent.inner.databricks_executor import _databricks_gateway_host
+
+    # Stub the SDK's host-metadata probe (a real HTTP GET with retries) so the
+    # ambient-credential resolution stays offline and fast.
+    monkeypatch.setattr(
+        "databricks.sdk.config.get_host_metadata",
+        _raise_offline_host_metadata,
+    )
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text("# no matching profile\n")
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    monkeypatch.setenv("DATABRICKS_HOST", "https://ambient-workspace.cloud.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-ambient-token")
+
+    assert _databricks_gateway_host("missing-profile") == (
+        "https://ambient-workspace.cloud.databricks.com"
+    )
+
+
 def test_codex_executor_gateway_uses_host_only_oauth_profile(
     tmp_path: _Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -894,10 +955,6 @@ def test_codex_executor_gateway_uses_host_only_oauth_profile(
         ).lstrip()
     )
     monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
-    monkeypatch.setattr(
-        "omnigent.inner.codex_executor._read_databrickscfg",
-        lambda _profile: None,
-    )
 
     from omnigent.inner.codex_executor import CodexExecutor
 
@@ -1530,17 +1587,10 @@ def test_codex_executor_uses_cli_auth_command_not_env_token(
     def _counting_read(profile=None):
         nonlocal call_count
         call_count += 1
-        return type(
-            "Creds",
-            (),
-            {
-                "host": "https://host",
-                "token": f"tok-{call_count}",
-            },
-        )()
+        return "https://host"
 
     monkeypatch.setattr(
-        "omnigent.inner.codex_executor._read_databrickscfg",
+        "omnigent.inner.codex_executor._databricks_gateway_host",
         _counting_read,
     )
 

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -157,7 +157,7 @@ def test_build_codex_native_server_profile_error_names_profile(
         lambda: sys.executable,
     )
     monkeypatch.setattr(
-        "omnigent.codex_native_app_server._read_databrickscfg",
+        "omnigent.codex_native_app_server._databricks_gateway_host",
         lambda _profile: None,
     )
     monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(tmp_path / "missing-databrickscfg"))
@@ -183,18 +183,13 @@ def test_build_codex_native_server_uses_profile_host_without_static_token(
     Native Codex accepts Databricks CLI OAuth profiles without static tokens.
 
     A default Omnigent install may not include ``databricks-sdk`` in the
-    runner process. In that case ``_read_databrickscfg`` cannot mint a bearer
-    at startup, but the profile's host is still enough: Codex gets an
-    ``auth.command`` that runs ``databricks auth token --profile`` at request
-    time.
+    runner process. In that case a bearer cannot be minted at startup, but the
+    profile's host is still enough: Codex gets an ``auth.command`` that runs
+    ``databricks auth token --profile`` at request time.
     """
     monkeypatch.setattr(
         "omnigent.codex_native_app_server._find_codex_cli",
         lambda: sys.executable,
-    )
-    monkeypatch.setattr(
-        "omnigent.codex_native_app_server._read_databrickscfg",
-        lambda _profile: None,
     )
     cfg_path = tmp_path / "databrickscfg"
     cfg_path.write_text(


### PR DESCRIPTION
## Related issue

N/A

## Summary

A native Codex session routed through a Databricks profile could fail **every turn** with a gateway `400 "Invalid Token"` — even though `databricks auth token --profile <p>` mints a perfectly valid bearer.

Root cause: the gateway **base URL** and the **auth token** were resolved from two different sources that can disagree on the workspace:

- **base URL host** came from the databricks-sdk resolver, which lets a `DATABRICKS_HOST` env var (or a different `[DEFAULT]` section) **override** the profile's host.
- **token** came from `databricks auth token --profile <p>`, which pins `--profile` and **ignores** `DATABRICKS_HOST`.

On a machine whose environment/`[DEFAULT]` points at workspace A while the profile points at workspace B, the base URL targeted A and the minted token was for B → the gateway rejected the token. (Reproduced live: `e2e_test` token → `e2-dogfood` gateway = 400; → matching `ai-oss-ecosystem` gateway = 200.)

This is Codex-specific: Pi already reads the profile host env-independently, and Pi's SDK path derives host+token from the *same* `Config`, so they can't diverge.

Fix: add `_databricks_gateway_host(profile)` in `databricks_executor.py`. For an explicit profile, it reads the host straight from that profile's config section (env-independent, the same source the token comes from); it only falls back to the SDK/ambient chain when the section has no host (e.g. a Databricks App container authenticating via ambient env/OIDC). Both Codex gateway call sites (`codex_executor.py`, `codex_native_app_server.py`) now use it.

## Test Plan

- `pytest tests/inner/test_databricks_executor.py tests/inner/test_codex_executor.py tests/test_codex_native_app_server.py` — **174 passed**, lint clean (`ruff format` + `ruff check`).
- Added two regression tests: an explicit profile ignores a conflicting `DATABRICKS_HOST` env override; a profile absent from the file falls back to the ambient chain.
- Live-reproduced the mismatch against the running session, then verified with `DATABRICKS_HOST` set to the wrong workspace the resolved base URL now matches the profile's token workspace.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified end-to-end against a live runner: reproduced the workspace mismatch that produced the gateway `400 "Invalid Token"`, then confirmed the fix resolves the base URL to the profile's own workspace even when `DATABRICKS_HOST` points elsewhere, so the base URL and the profile-pinned token always target the same workspace.

## Changelog

Codex sessions through a Databricks gateway profile no longer fail with "Invalid Token" when the environment's `DATABRICKS_HOST` points at a different workspace than the profile

This pull request and its description were written by Isaac.
