### PR TITLE
feat(files): serve session filesystem from host when runner is offline

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -30,6 +30,8 @@ from omnigent.host.frames import (
     HostCreateDirResultFrame,
     HostCreateWorktreeFrame,
     HostCreateWorktreeResultFrame,
+    HostFsRequestFrame,
+    HostFsResultFrame,
     HostHelloFrame,
     HostLaunchRunnerFrame,
     HostLaunchRunnerResultFrame,
@@ -1485,6 +1487,120 @@ class HostProcess:
             path=created,
         )
 
+    def _handle_fs_request(self, frame: HostFsRequestFrame) -> HostFsResultFrame:
+        """Serve a read-only workspace filesystem request from the host.
+
+        Runs :class:`omnigent.workspace_fs.WorkspaceReader` against the
+        session's workspace so the web UI's file panel keeps working when
+        the runner is offline but the host still holds the workspace on
+        disk. Read-only and confined to the workspace root; never writes
+        or runs a shell. Called inside a worker thread by the dispatcher
+        because git / directory-walk work can block.
+
+        :param frame: The fs request frame (op + workspace + params).
+        :returns: A result frame with the runner-shaped payload, or an
+            error frame mirroring the status the runner would return.
+        """
+        from pathlib import Path
+
+        from omnigent.workspace_fs import WorkspaceReader, WorkspaceReaderError
+
+        try:
+            expanded = os.path.expanduser(frame.workspace)
+        except (TypeError, ValueError) as exc:
+            return HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=400,
+                error_code="invalid_workspace",
+                error=f"workspace path expansion failed: {exc}",
+            )
+        if not os.path.isdir(expanded):
+            return HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=404,
+                error_code="not_found",
+                error="workspace directory does not exist on host",
+            )
+
+        reader = WorkspaceReader(Path(expanded))
+        params = frame.params or {}
+        try:
+            payload = self._dispatch_fs_op(reader, frame.op, frame.session_id, params)
+        except WorkspaceReaderError as exc:
+            return HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=exc.status,
+                error_code=exc.code,
+                error=exc.message,
+            )
+        except ValueError as exc:
+            return HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=400,
+                error_code="invalid_request",
+                error=str(exc),
+            )
+        except Exception as exc:
+            _logger.exception("host fs_request op %r failed", frame.op)
+            return HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=500,
+                error_code="fs_read_failed",
+                error=str(exc),
+            )
+        return HostFsResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            payload=payload,
+        )
+
+    @staticmethod
+    def _dispatch_fs_op(
+        reader: object,
+        op: str,
+        session_id: str,
+        params: dict[str, object],
+    ) -> dict[str, object]:
+        """Route an fs op to the matching :class:`WorkspaceReader` method.
+
+        :param reader: The workspace reader bound to the workspace root.
+        :param op: Operation name from the request frame.
+        :param session_id: Session id forwarded to change-registry ops.
+        :param params: Operation-specific arguments.
+        :returns: The runner-shaped result dict.
+        :raises ValueError: On an unknown op.
+        """
+        from typing import cast
+
+        from omnigent.workspace_fs import WorkspaceReader
+
+        r = cast("WorkspaceReader", reader)
+        if op == "list_or_read":
+            return r.list_or_read(
+                str(params.get("path", "")),
+                limit=int(params.get("limit", 20)),
+                after=cast("str | None", params.get("after")),
+                before=cast("str | None", params.get("before")),
+                order=str(params.get("order", "desc")),
+            )
+        if op == "changes":
+            return r.changes(session_id)
+        if op == "diff":
+            return r.diff(session_id, str(params.get("path", "")))
+        if op == "search":
+            return r.search(
+                str(params.get("q", "")),
+                include=cast("str | None", params.get("include")),
+                exclude=cast("str | None", params.get("exclude")),
+                limit=int(params.get("limit", 500)),
+            )
+        raise ValueError(f"unknown fs op: {op!r}")
+
     async def _handle_create_worktree(
         self,
         frame: HostCreateWorktreeFrame,
@@ -1964,6 +2080,11 @@ class HostProcess:
             await ws.send(encode_host_frame(await self._handle_remove_worktree(frame)))
         elif isinstance(frame, HostListWorktreesFrame):
             await ws.send(encode_host_frame(await self._handle_list_worktrees(frame)))
+        elif isinstance(frame, HostFsRequestFrame):
+            # Git status and directory walks can block, so run the read
+            # off the event loop and reply when it completes.
+            result = await asyncio.to_thread(self._handle_fs_request, frame)
+            await ws.send(encode_host_frame(result))
 
 
 def run_host_process(

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -55,6 +55,8 @@ class HostFrameKind(str, Enum):
     LIST_WORKTREES_RESULT = "host.list_worktrees_result"
     CREATE_DIR = "host.create_dir"
     CREATE_DIR_RESULT = "host.create_dir_result"
+    FS_REQUEST = "host.fs_request"
+    FS_RESULT = "host.fs_result"
 
 
 # ── Frame dataclasses ────────────────────────────────────
@@ -520,6 +522,59 @@ class HostCreateDirResultFrame:
     error: str | None = None
 
 
+@dataclass
+class HostFsRequestFrame:
+    """Server → host: read-only workspace filesystem request.
+
+    Serves the web UI's file panel (directory browse, changed files,
+    diffs, search, file content) from the host when the session's runner
+    is offline but the host still holds the workspace on disk. The host
+    runs :class:`omnigent.workspace_fs.WorkspaceReader` against
+    ``workspace`` and returns the same JSON the runner's filesystem
+    endpoints would.
+
+    :param request_id: Correlates the result, e.g. ``"req_fs_1"``.
+    :param op: Operation name — one of ``"list_or_read"``, ``"changes"``,
+        ``"diff"``, ``"search"``.
+    :param workspace: Absolute path to the session's workspace on the
+        host, e.g. ``"/Users/alice/project"``.
+    :param session_id: Session id, forwarded to the change registry.
+    :param params: Operation-specific arguments (relative path, glob
+        filters, pagination cursors), e.g.
+        ``{"path": "src", "limit": 100, "order": "asc"}``.
+    """
+
+    request_id: str
+    op: str
+    workspace: str
+    session_id: str
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HostFsResultFrame:
+    """Host → server: outcome of a workspace filesystem request.
+
+    :param request_id: Correlates to the :class:`HostFsRequestFrame`.
+    :param status: ``"ok"`` when ``payload`` carries the runner-shaped
+        result, or ``"error"`` when the read failed.
+    :param payload: The runner-shaped JSON result on success, ``None`` on
+        error.
+    :param error_status: HTTP status the runner would have returned on
+        failure (e.g. ``404``), or ``None`` on success.
+    :param error_code: Machine-readable error code on failure (e.g.
+        ``"not_found"``), or ``None`` on success.
+    :param error: Human-readable error detail on failure, or ``None``.
+    """
+
+    request_id: str
+    status: str
+    payload: dict[str, Any] | None = None
+    error_status: int | None = None
+    error_code: str | None = None
+    error: str | None = None
+
+
 HostFrame = (
     HostHelloFrame
     | HostLaunchRunnerFrame
@@ -539,6 +594,8 @@ HostFrame = (
     | HostListWorktreesResultFrame
     | HostCreateDirFrame
     | HostCreateDirResultFrame
+    | HostFsRequestFrame
+    | HostFsResultFrame
 )
 
 
@@ -763,6 +820,29 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "error": frame.error,
             }
         )
+    if isinstance(frame, HostFsRequestFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.FS_REQUEST.value,
+                "request_id": frame.request_id,
+                "op": frame.op,
+                "workspace": frame.workspace,
+                "session_id": frame.session_id,
+                "params": frame.params,
+            }
+        )
+    if isinstance(frame, HostFsResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.FS_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "payload": frame.payload,
+                "error_status": frame.error_status,
+                "error_code": frame.error_code,
+                "error": frame.error,
+            }
+        )
     raise TypeError(f"unknown host frame type: {type(frame).__name__}")
 
 
@@ -859,6 +939,10 @@ def _decode_known_host_frame(
             return _decode_create_dir(msg)
         case HostFrameKind.CREATE_DIR_RESULT:
             return _decode_create_dir_result(msg)
+        case HostFrameKind.FS_REQUEST:
+            return _decode_fs_request(msg)
+        case HostFrameKind.FS_RESULT:
+            return _decode_fs_result(msg)
     raise ValueError(f"unhandled host frame kind: {kind.value!r}")  # pragma: no cover
 
 
@@ -1165,6 +1249,48 @@ def _decode_create_dir_result(msg: dict[str, Any]) -> HostCreateDirResultFrame:
         request_id=_required_str(msg, "request_id"),
         status=_required_str(msg, "status"),
         path=_optional_nullable_str(msg, "path"),
+        error=_optional_nullable_str(msg, "error"),
+    )
+
+
+def _decode_fs_request(msg: dict[str, Any]) -> HostFsRequestFrame:
+    """Decode a host.fs_request request frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.fs_request frame.
+    """
+    params = msg.get("params", {})
+    if not isinstance(params, dict):
+        raise ValueError("frame field must be a JSON object: 'params'")
+    return HostFsRequestFrame(
+        request_id=_required_str(msg, "request_id"),
+        op=_required_str(msg, "op"),
+        workspace=_required_str(msg, "workspace"),
+        session_id=_required_str(msg, "session_id"),
+        params=params,
+    )
+
+
+def _decode_fs_result(msg: dict[str, Any]) -> HostFsResultFrame:
+    """Decode a host.fs_result frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.fs_result frame.
+    """
+    payload = msg.get("payload")
+    if payload is not None and not isinstance(payload, dict):
+        raise ValueError("frame field must be a JSON object or null: 'payload'")
+    error_status = msg.get("error_status")
+    if error_status is not None and (
+        not isinstance(error_status, int) or isinstance(error_status, bool)
+    ):
+        raise ValueError("frame field must be an int or null: 'error_status'")
+    return HostFsResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        payload=payload,
+        error_status=error_status,
+        error_code=_optional_nullable_str(msg, "error_code"),
         error=_optional_nullable_str(msg, "error"),
     )
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2075,6 +2075,10 @@ def create_app(
             # (host.runner_exited) as last_task_error so a reload still
             # renders the error banner after the live push is gone.
             runner_exit_reports=runner_exit_reports,
+            # Lets the filesystem endpoints fall back to reading the
+            # workspace over the host tunnel when the runner is offline
+            # (the file panel stays live without waking the agent).
+            host_registry=host_registry,
         ),
         prefix="/v1",
         tags=["sessions"],

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -185,6 +185,12 @@ class HostConnection:
         host sends ``host.create_dir_result``. Values carry the
         result fields (``status``, ``path``, ``error``). Same
         ``Any`` typing rationale as ``pending_stats``.
+    :param pending_fs_requests: Per-``request_id`` futures for
+        in-flight ``host.fs_request`` reads (the workspace file
+        panel served from the host while the runner is offline).
+        Resolved when the host sends ``host.fs_result``. Values
+        carry ``status``, ``payload``, ``error_status``,
+        ``error_code``, and ``error``.
     """
 
     host_id: str
@@ -216,6 +222,9 @@ class HostConnection:
         default_factory=dict,
     )
     pending_create_dirs: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
+    pending_fs_requests: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
 

--- a/omnigent/server/routes/_host_filesystem.py
+++ b/omnigent/server/routes/_host_filesystem.py
@@ -1,0 +1,127 @@
+"""
+Server-side proxy for the host workspace-filesystem tunnel frames.
+
+When a session's runner is offline but the host that holds the workspace
+on disk is still connected, the filesystem endpoints fall back to reading
+the workspace over the host tunnel instead of returning 502. This module
+mirrors ``_host_worktree``: enqueue a ``host.fs_request`` frame, register
+a future on the host connection, and await the ``host.fs_result``.
+
+The host runs :class:`omnigent.workspace_fs.WorkspaceReader` and returns
+the same JSON the runner's filesystem endpoints would, so the endpoint
+layer and the frontend cannot tell which side answered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from typing import Any
+
+from omnigent.host.frames import HostFsRequestFrame, encode_host_frame
+from omnigent.server.host_registry import HostConnection, HostRegistry
+
+_logger = logging.getLogger(__name__)
+
+# The host runs git status / directory walks synchronously; keep this
+# above the reader's own git timeout (5s) so a slow read surfaces the
+# host's specific error rather than a generic server timeout.
+_FS_TIMEOUT_S: float = 20.0
+
+
+class HostFsError(Exception):
+    """A host-served filesystem read failed with a mappable outcome.
+
+    Carries the ``status``/``code``/``message`` the runner would have
+    returned so the endpoint layer can reproduce the same HTTP response.
+
+    :param status: HTTP status, e.g. ``404``.
+    :param code: Machine-readable error code, e.g. ``"not_found"``.
+    :param message: Human-readable detail.
+    """
+
+    def __init__(self, status: int, code: str, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+
+
+class HostFsUnavailableError(Exception):
+    """The host could not be reached for a filesystem read.
+
+    Connection loss or no reply within the timeout — an infrastructure
+    condition. Callers treat it like a runner-offline result (fall
+    through to the next resolver link / 502).
+    """
+
+
+async def read_workspace_from_host(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    op: str,
+    workspace: str,
+    session_id: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Send a ``host.fs_request`` frame and await its result.
+
+    :param host_registry: Registry used to enqueue the outbound frame.
+    :param host_conn: Live host connection for the session's host.
+    :param op: Operation name — ``"list_or_read"`` / ``"changes"`` /
+        ``"diff"`` / ``"search"``.
+    :param workspace: Absolute workspace path on the host.
+    :param session_id: Session id, forwarded to the change registry.
+    :param params: Operation-specific arguments.
+    :returns: The runner-shaped result payload on success.
+    :raises HostFsError: When the host reports a filesystem failure
+        (404/400/500) — reproduces the runner's response.
+    :raises HostFsUnavailableError: On connection loss or timeout.
+    """
+    request_id = secrets.token_hex(8)
+    frame = encode_host_frame(
+        HostFsRequestFrame(
+            request_id=request_id,
+            op=op,
+            workspace=workspace,
+            session_id=session_id,
+            params=params,
+        )
+    )
+    future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+    host_conn.pending_fs_requests[request_id] = future
+    try:
+        try:
+            host_registry.send_text(host_conn, frame)
+        except ConnectionError as exc:
+            raise HostFsUnavailableError(
+                f"host '{host_conn.host_id}' connection lost during fs read"
+            ) from exc
+        try:
+            result = await asyncio.wait_for(future, timeout=_FS_TIMEOUT_S)
+        except asyncio.TimeoutError as exc:
+            raise HostFsUnavailableError(
+                f"host '{host_conn.host_id}' did not respond to fs read within "
+                f"{_FS_TIMEOUT_S:.0f}s (it may be running an older version)"
+            ) from exc
+    finally:
+        host_conn.pending_fs_requests.pop(request_id, None)
+
+    if result.get("status") == "ok":
+        payload = result.get("payload")
+        if not isinstance(payload, dict):
+            raise HostFsUnavailableError(
+                f"host '{host_conn.host_id}' returned an incomplete fs result"
+            )
+        return payload
+
+    # The host reported a filesystem failure — reproduce the runner's
+    # HTTP shape from the error fields it sent back.
+    status = result.get("error_status")
+    code = result.get("error_code") or "fs_read_failed"
+    message = result.get("error") or "host filesystem read failed"
+    if not isinstance(status, int):
+        status = 500
+    raise HostFsError(status, str(code), str(message))

--- a/omnigent/server/routes/_host_filesystem.py
+++ b/omnigent/server/routes/_host_filesystem.py
@@ -102,6 +102,12 @@ async def read_workspace_from_host(
         try:
             result = await asyncio.wait_for(future, timeout=_FS_TIMEOUT_S)
         except asyncio.TimeoutError as exc:
+            _logger.warning(
+                "host '%s' did not answer fs op %r within %.0fs",
+                host_conn.host_id,
+                op,
+                _FS_TIMEOUT_S,
+            )
             raise HostFsUnavailableError(
                 f"host '{host_conn.host_id}' did not respond to fs read within "
                 f"{_FS_TIMEOUT_S:.0f}s (it may be running an older version)"

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -29,6 +29,7 @@ from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
 from omnigent.host.frames import (
     HostCreateDirResultFrame,
     HostCreateWorktreeResultFrame,
+    HostFsResultFrame,
     HostHelloFrame,
     HostLaunchRunnerResultFrame,
     HostListDirResultFrame,
@@ -561,6 +562,20 @@ async def _receive_loop(
                     {
                         "status": frame.status,
                         "path": frame.path,
+                        "error": frame.error,
+                    }
+                )
+            continue
+
+        if isinstance(frame, HostFsResultFrame):
+            fs_future = conn.pending_fs_requests.pop(frame.request_id, None)
+            if fs_future is not None and not fs_future.done():
+                fs_future.set_result(
+                    {
+                        "status": frame.status,
+                        "payload": frame.payload,
+                        "error_status": frame.error_status,
+                        "error_code": frame.error_code,
                         "error": frame.error,
                     }
                 )

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -14359,6 +14359,7 @@ def create_sessions_router(
     comment_store: CommentStore | None = None,
     runner_tunnel_tokens: frozenset[str] | None = None,
     runner_exit_reports: RunnerExitReports | None = None,
+    host_registry: HostRegistry | None = None,
 ) -> APIRouter:
     """
     Factory that builds the sessions router.
@@ -14414,6 +14415,11 @@ def create_sessions_router(
         labels on ``PATCH /v1/sessions/{id}``. ``None`` when the
         server has no allow-list (token-bound runner ids are then the
         only accepted proof).
+    :param host_registry: Live host tunnels. Lets the filesystem
+        endpoints read a session's workspace over its host tunnel when
+        the runner is offline, so the file panel stays live without
+        waking the agent. ``None`` disables the fallback (the endpoints
+        then 503 on an offline runner, as before).
     :returns: A configured :class:`APIRouter` exposing the
         ``/sessions`` endpoints.
     """
@@ -17715,6 +17721,97 @@ def create_sessions_router(
             raise HTTPException(status_code=502, detail=msg)
         return resp.json()
 
+    async def _fs_get_with_host_fallback(
+        session_id: str,
+        *,
+        op: str,
+        host_params: dict[str, Any],
+        runner_path: str,
+        runner_params: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Serve a filesystem read, falling back to the host when offline.
+
+        Proxies the read to the session's runner as usual. When the
+        runner is offline (``RUNNER_UNAVAILABLE``) but the session's host
+        is still connected, the read is served from the workspace over
+        the host tunnel instead — the file panel stays live without
+        waking the agent. The host runs
+        :class:`omnigent.workspace_fs.WorkspaceReader` and returns the
+        same JSON the runner would, so the response shape is identical.
+
+        :param session_id: Session/conversation identifier.
+        :param op: Host-side op name — ``"list_or_read"`` / ``"changes"``
+            / ``"diff"`` / ``"search"``.
+        :param host_params: Op-specific args for the host reader.
+        :param runner_path: Runner-relative URL for the live path.
+        :param runner_params: Optional query params for the runner path.
+        :returns: The runner-shaped filesystem result.
+        :raises OmnigentError: Re-raised runner-offline error when the
+            host cannot serve the read either.
+        :raises HTTPException: On host-reported filesystem failures.
+        """
+        try:
+            return await _proxy_get_to_runner(session_id, runner_path, params=runner_params)
+        except OmnigentError as exc:
+            # Only the runner-offline case is a candidate for the host
+            # fallback; a real 404 / git error from a live runner must
+            # surface unchanged.
+            if exc.code != ErrorCode.RUNNER_UNAVAILABLE:
+                raise
+            runner_offline = exc
+
+        payload = await _read_workspace_via_host(session_id, op, host_params)
+        if payload is None:
+            # No reachable host either — surface the original offline
+            # error (503) so the client shows its reconnect affordance.
+            raise runner_offline
+        return payload
+
+    async def _read_workspace_via_host(
+        session_id: str,
+        op: str,
+        host_params: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Read the session's workspace over its host tunnel.
+
+        :param session_id: Session/conversation identifier.
+        :param op: Host-side op name.
+        :param host_params: Op-specific args for the host reader.
+        :returns: The runner-shaped result, or ``None`` when no host is
+            bound / connected / reachable (caller falls back to 503).
+        :raises HTTPException: On host-reported filesystem failures,
+            reproducing the runner's status.
+        """
+        from omnigent.server.routes._host_filesystem import (
+            HostFsError,
+            HostFsUnavailableError,
+            read_workspace_from_host,
+        )
+
+        if host_registry is None:
+            return None
+        conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+        if conv is None or not conv.host_id or not conv.workspace:
+            return None
+        host_conn = host_registry.get(conv.host_id)
+        if host_conn is None:
+            return None
+        try:
+            return await read_workspace_from_host(
+                host_registry=host_registry,
+                host_conn=host_conn,
+                op=op,
+                workspace=conv.workspace,
+                session_id=session_id,
+                params=host_params,
+            )
+        except HostFsUnavailableError:
+            return None
+        except HostFsError as exc:
+            if exc.status == 404:
+                raise OmnigentError(exc.message, code=ErrorCode.NOT_FOUND) from exc
+            raise HTTPException(status_code=exc.status, detail=exc.message) from exc
+
     async def _proxy_post_to_runner(
         session_id: str,
         path: str,
@@ -17887,7 +17984,49 @@ def create_sessions_router(
         """
         await _validate_session(session_id, request, LEVEL_READ)
         path = f"/v1/sessions/{session_id}/resources/environments/{environment_id}"
-        return await _proxy_get_to_runner(session_id, path)
+        try:
+            return await _proxy_get_to_runner(session_id, path)
+        except OmnigentError as exc:
+            if exc.code != ErrorCode.RUNNER_UNAVAILABLE:
+                raise
+            # Runner offline but host-bound: synthesize the default
+            # environment so the file panel (which gates on this metadata)
+            # keeps browsing the host-served workspace at ``conv.workspace``.
+            synthesized = await _synthesize_offline_environment(session_id, environment_id)
+            if synthesized is None:
+                raise
+            return synthesized
+
+    async def _synthesize_offline_environment(
+        session_id: str,
+        environment_id: str,
+    ) -> dict[str, Any] | None:
+        """Build a default-environment resource from the bound workspace.
+
+        Used when the runner is offline but the session is host-bound, so
+        the file panel's environment probe resolves and browsing can
+        proceed against the host-served workspace.
+
+        :param session_id: Session/conversation identifier.
+        :param environment_id: Requested environment id; only the default
+            environment is synthesized.
+        :returns: A minimal environment resource dict with
+            ``metadata.root`` set to the workspace path, or ``None`` when
+            not applicable (non-default env, no host, no workspace).
+        """
+        if environment_id != "default" or host_registry is None:
+            return None
+        conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+        if conv is None or not conv.host_id or not conv.workspace:
+            return None
+        if host_registry.get(conv.host_id) is None:
+            return None
+        return {
+            "id": environment_id,
+            "object": "session.resource",
+            "type": "environment",
+            "metadata": {"root": conv.workspace},
+        }
 
     @router.get(
         "/sessions/{session_id}/resources/terminals",
@@ -18686,7 +18825,18 @@ def create_sessions_router(
         qs = urllib.parse.urlencode(params)
         path = f"/v1/sessions/{session_id}/resources/environments/{environment_id}/filesystem?{qs}"
         await _validate_session(session_id, request, LEVEL_READ)
-        return await _proxy_get_to_runner(session_id, path)
+        return await _fs_get_with_host_fallback(
+            session_id,
+            op="list_or_read",
+            host_params={
+                "path": "",
+                "limit": limit,
+                "after": after,
+                "before": before,
+                "order": order,
+            },
+            runner_path=path,
+        )
 
     @router.get(
         "/sessions/{session_id}/resources/environments/{environment_id}/search",
@@ -18732,7 +18882,12 @@ def create_sessions_router(
         qs = urllib.parse.urlencode(params)
         path = f"/v1/sessions/{session_id}/resources/environments/{environment_id}/search?{qs}"
         await _validate_session(session_id, request, LEVEL_READ)
-        return await _proxy_get_to_runner(session_id, path)
+        return await _fs_get_with_host_fallback(
+            session_id,
+            op="search",
+            host_params={"q": q, "include": include, "exclude": exclude, "limit": limit},
+            runner_path=path,
+        )
 
     @router.get(
         "/sessions/{session_id}/resources/environments/{environment_id}/changes",
@@ -18757,7 +18912,12 @@ def create_sessions_router(
         """
         path = f"/v1/sessions/{session_id}/resources/environments/{environment_id}/changes"
         await _validate_session(session_id, request, LEVEL_READ)
-        return await _proxy_get_to_runner(session_id, path)
+        return await _fs_get_with_host_fallback(
+            session_id,
+            op="changes",
+            host_params={},
+            runner_path=path,
+        )
 
     @router.get(
         "/sessions/{session_id}/resources/environments/{environment_id}/diff/{relative_path:path}",
@@ -18789,7 +18949,12 @@ def create_sessions_router(
             f"/{environment_id}/diff/{relative_path}"
         )
         await _validate_session(session_id, request, LEVEL_READ)
-        return await _proxy_get_to_runner(session_id, path)
+        return await _fs_get_with_host_fallback(
+            session_id,
+            op="diff",
+            host_params={"path": relative_path},
+            runner_path=path,
+        )
 
     @router.get(
         "/sessions/{session_id}/resources/environments"
@@ -18831,7 +18996,18 @@ def create_sessions_router(
             f"/{environment_id}/filesystem/{relative_path}?{qs}"
         )
         await _validate_session(session_id, request, LEVEL_READ)
-        return await _proxy_get_to_runner(session_id, path)
+        return await _fs_get_with_host_fallback(
+            session_id,
+            op="list_or_read",
+            host_params={
+                "path": relative_path,
+                "limit": limit,
+                "after": after,
+                "before": before,
+                "order": order,
+            },
+            runner_path=path,
+        )
 
     @router.put(
         "/sessions/{session_id}/resources/environments"

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -17810,7 +17810,13 @@ def create_sessions_router(
         except HostFsError as exc:
             if exc.status == 404:
                 raise OmnigentError(exc.message, code=ErrorCode.NOT_FOUND) from exc
-            raise HTTPException(status_code=exc.status, detail=exc.message) from exc
+            if exc.status == 400:
+                # Invalid path is a client error; surface it verbatim like the
+                # runner's 400 rather than collapsing it to a 502.
+                raise HTTPException(status_code=400, detail=exc.message) from exc
+            # Any other host FS failure (e.g. git_status_failed 500) mirrors the
+            # runner proxy, which wraps non-200/404 responses as a 502.
+            raise HTTPException(status_code=502, detail=exc.message) from exc
 
     async def _proxy_post_to_runner(
         session_id: str,

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -1,0 +1,413 @@
+"""Process-agnostic, read-only workspace filesystem reader.
+
+The runner serves the web UI's file panel (directory browse, changed
+files, diffs, search, file content) by reading its sandboxed
+workspace.  When the runner process dies but the host that holds the
+workspace on disk is still connected, the host serves the same panel by
+running this module against the workspace directory directly.
+
+This reader is deliberately *read-only* and *sandbox-free*: it never
+writes, never runs a shell, and confines every path to the workspace
+root.  It reuses the runner's pure helpers (glob translation, path
+validation, pagination, the git/edit change registry) so the JSON it
+returns is byte-identical to the runner's filesystem endpoints — the
+server proxy layer and the frontend cannot tell which side answered.
+
+The returned dicts match, one-to-one, the runner endpoints in
+``omnigent/runner/app.py``:
+
+- :meth:`WorkspaceReader.list_or_read` → ``_fs_list_or_read``
+- :meth:`WorkspaceReader.changes`      → ``list_filesystem_changes``
+- :meth:`WorkspaceReader.diff`         → ``read_environment_file_diff``
+- :meth:`WorkspaceReader.search`       → ``search_environment_files``
+
+Change-tracking caveat: in a **git** workspace the changed-files list
+and diff baselines come from ``git status`` / ``git show`` and are fully
+reconstructable from disk, so the host serves them exactly like the
+runner.  In a **non-git** workspace the runner tracks changes from the
+live agent's tool calls (in-memory), which the host does not have — so
+the host returns an empty changed-files list there.  Directory browse,
+search, and file content work identically in both modes.
+"""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from omnigent.entities.environment_filesystem import InvalidPath
+from omnigent.entities.pagination import paginate_in_memory
+from omnigent.inner.os_env import _DEFAULT_READ_LIMIT
+from omnigent.runner.environment_filesystem import (
+    _glob_to_regex,
+    _validate_path,
+    split_glob_list,
+)
+from omnigent.runtime.filesystem_registry import (
+    GitStatusUnavailable,
+    create_filesystem_registry,
+)
+
+# Match the runner's caps so a host-served read is truncated identically.
+_MAX_READ_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+
+class WorkspaceReaderError(Exception):
+    """A workspace read failed with a specific HTTP-mappable outcome.
+
+    Carries a ``status`` code and an error ``code``/``message`` so the
+    host handler can echo the same shape the runner endpoints return
+    (404 not-found, 400 invalid-path, 500 git-status-failed).
+
+    :param status: HTTP status the runner would have returned.
+    :param code: Machine-readable error code, e.g. ``"not_found"``.
+    :param message: Human-readable detail.
+    """
+
+    def __init__(self, status: int, code: str, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+
+
+class WorkspaceReader:
+    """Read-only view of a workspace directory, confined to its root.
+
+    :param root: Absolute path to the workspace directory on disk, e.g.
+        ``Path("/Users/alice/project")``.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root = Path(root).resolve()
+        # The change registry (git or edit-tracking) is chosen the same
+        # way the runner chooses it, so git workspaces get git-status
+        # semantics and everything else degrades to an empty list.
+        self._registry = create_filesystem_registry(self._root)
+
+    # ── Path confinement ──────────────────────────────────────────
+
+    def _resolve(self, path: str) -> Path:
+        """Resolve a relative path to an absolute path under the root.
+
+        :param path: Relative path within the workspace (``""`` = root).
+        :returns: Resolved absolute path guaranteed under the root.
+        :raises WorkspaceReaderError: 400 when the path escapes the root
+            or is otherwise invalid.
+        """
+        try:
+            validated = _validate_path(path) if path else ""
+        except InvalidPath as exc:
+            raise WorkspaceReaderError(400, "invalid_path", str(exc)) from exc
+        if not validated:
+            return self._root
+        full = (self._root / validated).resolve()
+        try:
+            full.relative_to(self._root)
+        except ValueError as exc:
+            raise WorkspaceReaderError(
+                400, "invalid_path", f"Path {path!r} escapes the workspace root"
+            ) from exc
+        return full
+
+    # ── Directory listing / file content ──────────────────────────
+
+    def list_or_read(
+        self,
+        path: str,
+        *,
+        limit: int = 20,
+        after: str | None = None,
+        before: str | None = None,
+        order: str = "desc",
+    ) -> dict[str, Any]:
+        """List a directory or read a file, mirroring ``_fs_list_or_read``.
+
+        :param path: Relative path (``""`` for the workspace root).
+        :param limit: Max entries for a directory listing.
+        :param after: Forward-pagination cursor entry id.
+        :param before: Backward-pagination cursor entry id.
+        :param order: Sort order, ``"asc"`` or ``"desc"``.
+        :returns: A directory-listing dict or a file-content dict.
+        :raises WorkspaceReaderError: On invalid path or missing file.
+        """
+        resolved = self._resolve(path)
+        if resolved.is_dir():
+            return self._list_dir(path, resolved, limit, after, before, order)
+        return self._read_file(path, resolved)
+
+    def _list_dir(
+        self,
+        rel: str,
+        resolved: Path,
+        limit: int,
+        after: str | None,
+        before: str | None,
+        order: str,
+    ) -> dict[str, Any]:
+        """Build the directory-listing payload for a resolved directory.
+
+        Classifies entries by target type (follows symlinks) and skips
+        per-entry ``OSError`` (e.g. a broken symlink) so one bad entry
+        does not fail the listing — matching the runner's ``list_dir``.
+        """
+        validated = _validate_path(rel) if rel else ""
+        entries: list[dict[str, Any]] = []
+        try:
+            names = sorted(os.listdir(resolved))
+        except OSError as exc:
+            raise WorkspaceReaderError(
+                404, "not_found", f"Directory {rel!r} not found or not accessible"
+            ) from exc
+        for name in names:
+            full = resolved / name
+            child_rel = os.path.join(validated, name) if validated else name
+            try:
+                st = full.stat()  # follows symlinks, like the runner
+                is_dir = full.is_dir()
+            except OSError:
+                continue
+            entry_type = "directory" if is_dir else "file"
+            entries.append(
+                {
+                    "id": child_rel,
+                    "object": "session.environment.filesystem.entry",
+                    "name": name,
+                    "path": child_rel,
+                    "type": entry_type,
+                    "bytes": st.st_size if entry_type == "file" else None,
+                    "modified_at": int(st.st_mtime),
+                }
+            )
+        page = paginate_in_memory(
+            entries,
+            id_fn=lambda e: e["id"],
+            limit=limit,
+            after=after,
+            before=before,
+            order=order,
+        )
+        return {
+            "object": "list",
+            "data": page.data,
+            "first_id": page.first_id,
+            "last_id": page.last_id,
+            "has_more": page.has_more,
+        }
+
+    def _read_file(
+        self,
+        rel: str,
+        resolved: Path,
+        *,
+        limit: int | None = _DEFAULT_READ_LIMIT,
+    ) -> dict[str, Any]:
+        """Build the file-content payload for a resolved file.
+
+        Text files are UTF-8 decoded and line-capped at ``limit``; binary
+        files are base64-encoded.  Both are byte-capped at
+        :data:`_MAX_READ_BYTES`.  Shape matches the runner's file-content
+        response, including the mimetype guess.
+        """
+        try:
+            raw = resolved.read_bytes()
+        except OSError as exc:
+            raise WorkspaceReaderError(404, "not_found", f"Path {rel!r} not found") from exc
+
+        return self._file_content_payload(rel, raw, limit=limit)
+
+    def _file_content_payload(
+        self,
+        rel: str,
+        raw: bytes,
+        *,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        """Assemble the file-content dict from raw bytes."""
+        content_type_guess, _ = mimetypes.guess_type(rel)
+        truncated = False
+        capped = raw
+        if len(capped) > _MAX_READ_BYTES:
+            capped = capped[:_MAX_READ_BYTES]
+            truncated = True
+
+        try:
+            text = capped.decode("utf-8")
+            is_text = True
+        except UnicodeDecodeError:
+            is_text = False
+            text = ""
+
+        payload: dict[str, Any] = {
+            "object": "session.environment.filesystem.file_content",
+            "path": rel,
+            "content_type": content_type_guess,
+        }
+        if is_text:
+            if limit is not None:
+                lines = text.splitlines(keepends=True)
+                if len(lines) > limit:
+                    text = "".join(lines[:limit])
+                    truncated = True
+            data = text.encode("utf-8")
+            payload["bytes"] = len(data)
+            payload["truncated"] = truncated
+            payload["encoding"] = "utf-8"
+            payload["content"] = text
+        else:
+            payload["bytes"] = len(capped)
+            payload["truncated"] = truncated
+            payload["encoding"] = "base64"
+            payload["content"] = base64.b64encode(capped).decode()
+        return payload
+
+    # ── Search ─────────────────────────────────────────────────────
+
+    def search(
+        self,
+        query: str,
+        *,
+        include: str | None = None,
+        exclude: str | None = None,
+        limit: int = 500,
+    ) -> dict[str, Any]:
+        """Search files by substring + glob filters, like the runner.
+
+        :param query: Case-insensitive substring matched against name and
+            relative path.  Whitespace-only yields an empty result.
+        :param include: Comma-separated include globs (VSCode/Cursor
+            subset), e.g. ``"*.ts,src/**"``.
+        :param exclude: Comma-separated exclude globs.
+        :param limit: Maximum results (capped at 500 by the caller).
+        :returns: A list payload of matching file entries.
+        """
+        q = query.strip().lower()
+        if not q:
+            return {"object": "list", "data": [], "has_more": False}
+
+        inc = [re.compile(_glob_to_regex(p), re.IGNORECASE) for p in split_glob_list(include)]
+        exc = [re.compile(_glob_to_regex(p), re.IGNORECASE) for p in split_glob_list(exclude)]
+
+        results: list[dict[str, Any]] = []
+        for dirpath, dirnames, filenames in os.walk(self._root):
+            rel_dir = os.path.relpath(dirpath, self._root)
+            # Prune excluded subtrees so a "**/node_modules" pattern
+            # avoids descending, matching the runner's search walk.
+            kept = []
+            for d in sorted(dirnames):
+                dp = os.path.normpath(os.path.join("" if rel_dir == "." else rel_dir, d))
+                if any(r.match(dp) for r in exc):
+                    continue
+                kept.append(d)
+            dirnames[:] = kept
+            for fname in sorted(filenames):
+                p = os.path.normpath(os.path.join("" if rel_dir == "." else rel_dir, fname))
+                if exc and any(r.match(p) for r in exc):
+                    continue
+                if inc and not any(r.match(p) for r in inc):
+                    continue
+                if q not in fname.lower() and q not in p.lower():
+                    continue
+                try:
+                    st = (Path(dirpath) / fname).stat()
+                    size: int | None = st.st_size
+                    mtime: int | None = int(st.st_mtime)
+                except OSError:
+                    size = None
+                    mtime = None
+                results.append(
+                    {
+                        "id": p,
+                        "object": "session.environment.filesystem.entry",
+                        "name": fname,
+                        "path": p,
+                        "type": "file",
+                        "bytes": size,
+                        "modified_at": mtime,
+                    }
+                )
+                if len(results) >= limit:
+                    break
+            if len(results) >= limit:
+                break
+        results.sort(key=lambda e: e["path"])
+        return {"object": "list", "data": results, "has_more": len(results) >= limit}
+
+    # ── Changed files / diff ───────────────────────────────────────
+
+    def changes(self, session_id: str) -> dict[str, Any]:
+        """List changed files, mirroring ``list_filesystem_changes``.
+
+        Git workspaces report the working-tree diff (``git status``);
+        non-git workspaces report an empty list because the host has no
+        access to the live agent's in-memory edit history.
+
+        :param session_id: Session id (used only by the edit-tracking
+            registry; ignored in git mode).
+        :returns: A list payload of changed-file entries.
+        :raises WorkspaceReaderError: 500 when ``git status`` fails.
+        """
+        try:
+            raw_changes = self._registry.list_changed_files(session_id, limit=10_000)
+        except GitStatusUnavailable as exc:
+            raise WorkspaceReaderError(500, "git_status_failed", exc.reason) from exc
+        data = [
+            {
+                "object": "session.environment.filesystem.entry",
+                "path": rec["path"],
+                "name": rec["path"].split("/")[-1],
+                "status": rec["status"],
+                "bytes": rec.get("bytes"),
+                "modified_at": rec.get("modified_at"),
+            }
+            for rec in raw_changes
+        ]
+        return {"object": "list", "data": data, "has_more": False}
+
+    def diff(self, session_id: str, relative_path: str) -> dict[str, Any]:
+        """Return before/after content, mirroring the runner diff endpoint.
+
+        :param session_id: Session id (git mode ignores it).
+        :param relative_path: Path relative to the workspace root.
+        :returns: A file-diff dict with ``before``/``after`` strings.
+        :raises WorkspaceReaderError: On invalid path, git failure, or a
+            path not in the changed-files registry (404).
+        """
+        try:
+            relative_path = _validate_path(relative_path)
+        except InvalidPath as exc:
+            raise WorkspaceReaderError(400, "invalid_path", str(exc)) from exc
+        if not relative_path:
+            raise WorkspaceReaderError(400, "invalid_path", "Cannot diff the workspace root")
+
+        try:
+            record = self._registry.get_changed_file(session_id, relative_path)
+        except GitStatusUnavailable as exc:
+            raise WorkspaceReaderError(500, "git_status_failed", exc.reason) from exc
+        if record is None:
+            raise WorkspaceReaderError(
+                404,
+                "not_found",
+                f"Path {relative_path!r} is not in the changed-files registry for this session",
+            )
+
+        is_deleted = record.get("status") == "deleted"
+        before: str | None = self._registry.get_baseline(relative_path)
+        after: str | None = None
+        if not is_deleted:
+            resolved = self._resolve(relative_path)
+            try:
+                raw = resolved.read_bytes()
+                after = raw.decode("utf-8", errors="replace")
+            except OSError:
+                after = None
+        return {
+            "object": "session.environment.filesystem.file_diff",
+            "path": relative_path,
+            "before": before,
+            "after": after,
+        }

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -256,8 +256,21 @@ class WorkspaceReader:
         try:
             text = capped.decode("utf-8")
             is_text = True
-        except UnicodeDecodeError:
-            is_text = False
+        except UnicodeDecodeError as exc:
+            # A byte-cap truncation can split a multi-byte codepoint at the very
+            # end, which would otherwise flip an oversize *text* file to base64.
+            # When the only invalid bytes are a partial trailing codepoint (the
+            # error starts within the last 3 bytes of the truncated buffer),
+            # drop them and retry — matching the runner's boundary-safe
+            # truncation so the same file serves as text from either side. A
+            # genuinely binary file has invalid bytes earlier in the buffer, so
+            # this guard doesn't rescue it and it falls through to base64.
+            if truncated and exc.start >= len(capped) - 3:
+                capped = capped[: exc.start]
+                text = capped.decode("utf-8")
+                is_text = True
+            else:
+                is_text = False
 
         payload: dict[str, Any] = {
             "object": "session.environment.filesystem.file_content",

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -169,9 +169,20 @@ class WorkspaceReader:
             try:
                 st = full.stat()  # follows symlinks, like the runner
                 is_dir = full.is_dir()
+                entry_type = "directory" if is_dir else "file"
+                size = st.st_size if entry_type == "file" else None
+                mtime = int(st.st_mtime)
             except OSError:
-                continue
-            entry_type = "directory" if is_dir else "file"
+                # Broken symlink (target gone): fall back to lstat and list it
+                # as a file with no size, matching the runner's list_dir rather
+                # than dropping the entry.
+                try:
+                    ls = full.lstat()
+                except OSError:
+                    continue
+                entry_type = "file"
+                size = None
+                mtime = int(ls.st_mtime)
             entries.append(
                 {
                     "id": child_rel,
@@ -179,8 +190,8 @@ class WorkspaceReader:
                     "name": name,
                     "path": child_rel,
                     "type": entry_type,
-                    "bytes": st.st_size if entry_type == "file" else None,
-                    "modified_at": int(st.st_mtime),
+                    "bytes": size,
+                    "modified_at": mtime,
                 }
             )
         page = paginate_in_memory(
@@ -212,13 +223,20 @@ class WorkspaceReader:
         files are base64-encoded.  Both are byte-capped at
         :data:`_MAX_READ_BYTES`.  Shape matches the runner's file-content
         response, including the mimetype guess.
+
+        Reads at most ``_MAX_READ_BYTES`` from disk (like the runner's
+        bounded read) rather than slurping the whole file, so opening a
+        multi-GB file in the viewer can't OOM the host process.
         """
         try:
-            raw = resolved.read_bytes()
+            with resolved.open("rb") as fh:
+                # One extra byte lets us detect (and flag) truncation
+                # without loading the rest of a large file into memory.
+                capped = fh.read(_MAX_READ_BYTES + 1)
         except OSError as exc:
             raise WorkspaceReaderError(404, "not_found", f"Path {rel!r} not found") from exc
 
-        return self._file_content_payload(rel, raw, limit=limit)
+        return self._file_content_payload(rel, capped, limit=limit)
 
     def _file_content_payload(
         self,
@@ -240,7 +258,6 @@ class WorkspaceReader:
             is_text = True
         except UnicodeDecodeError:
             is_text = False
-            text = ""
 
         payload: dict[str, Any] = {
             "object": "session.environment.filesystem.file_content",
@@ -401,7 +418,10 @@ class WorkspaceReader:
         if not is_deleted:
             resolved = self._resolve(relative_path)
             try:
-                raw = resolved.read_bytes()
+                # Bounded read (like _read_file) so a huge changed file can't
+                # OOM the host; the diff view caps at _MAX_READ_BYTES anyway.
+                with resolved.open("rb") as fh:
+                    raw = fh.read(_MAX_READ_BYTES)
                 after = raw.decode("utf-8", errors="replace")
             except OSError:
                 after = None

--- a/tests/e2e_ui/files/test_offline_runner_host_served.py
+++ b/tests/e2e_ui/files/test_offline_runner_host_served.py
@@ -1,0 +1,180 @@
+"""E2E: with the runner offline but the host alive, the Files panel stays live.
+
+When a session's runner process dies but the host that holds the workspace on
+disk is still connected, the server reads the file panel (browse / changed
+files / file content / diff) over the host tunnel instead of returning 503.
+The web app must then keep the panel working — showing files and a passive
+"Asleep — files shown live from the host" badge — rather than falling back to
+the "agent is asleep, send a message to reconnect" dead-end.
+
+The frontend cannot tell which side served the bytes; it decides purely from
+the ``/health`` liveness (``runner_online`` / ``host_online``) plus whether the
+filesystem queries succeed. So this drives the real SPA against a real
+server-backed session (whose live runner actually serves the seeded files),
+but patches the browser's *view* of liveness into the runner-offline /
+host-online shape — exactly the state the host-served path produces in
+production. Mirrors ``sessions/test_host_badge.py``'s liveness patching.
+
+No LLM is involved: the file is seeded via the filesystem PUT endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+from playwright.sync_api import Page, Route, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# Filesystem PUTs land in ``<repo-root>/<session_id>/`` (os_env.cwd: .), so
+# clean that per-session dir up in teardown.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_FILE_PATH = "asleep_notes.txt"
+_FILE_CONTENT = "Content served from the host while the agent is asleep."
+_FAKE_HOST_ID = "host_offline_served"
+# Unix seconds well before now so an offline runner is outside the startup
+# grace and the session reads host-served (not "starting").
+_OLD_CREATED_AT = 1_700_000_000
+
+
+def _seed_file(base_url: str, session_id: str, path: str, content: str) -> None:
+    """PUT a file into the session workspace via the filesystem API."""
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem/{path}",
+        json={"content": content, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+@pytest.fixture
+def seeded_offline_file(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    """Seed ``_FILE_PATH`` and yield ``(base_url, session_id)``."""
+    base_url, session_id = seeded_session
+    _seed_file(base_url, session_id, _FILE_PATH, _FILE_CONTENT)
+    try:
+        yield (base_url, session_id)
+    finally:
+        # Seeded files land under <repo-root>/<session_id>/ (os_env.cwd: .),
+        # but a bare-name PUT can also land at the repo root — clean both.
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+        (_REPO_ROOT / _FILE_PATH).unlink(missing_ok=True)
+
+
+def _patch_runner_offline_host_online(page: Page, session_id: str) -> None:
+    """Patch the browser's view of ``session_id`` into runner-offline / host-online.
+
+    The runner really is alive in the harness (so the filesystem endpoints
+    return real data), but the SPA is told ``runner_online: false`` +
+    ``host_online: true`` via ``/health`` — the exact liveness the host-served
+    fallback produces in production. The snapshot is patched host-bound (with an
+    old ``created_at`` + ``host_resumable``) so the chat view renders normally
+    rather than entering a host-offline reconnect dead-end, and the sessions
+    ``updates`` WS is blocked so a stream push can't revert liveness to the real
+    (runner-online) values.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch.
+    """
+
+    def _patch_snapshot(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        payload["host_id"] = _FAKE_HOST_ID
+        payload["host_resumable"] = True
+        payload["created_at"] = _OLD_CREATED_AT
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_health(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/health":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        live = {"runner_online": False, "host_online": True}
+        if isinstance(payload.get("sessions"), dict):
+            payload["sessions"][session_id] = live
+        if isinstance(payload.get("session"), dict):
+            payload["session"] = {**payload["session"], **live}
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    # Snapshot route registered last so it wins for /v1/sessions/{id}
+    # (Playwright matches most-recently-registered first); /health falls
+    # through via continue_() for anything it doesn't own.
+    page.route(re.compile(r"/health(\?|$)"), _patch_health)
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: None)
+
+
+def test_offline_runner_host_served_files_panel_stays_live(
+    page: Page,
+    seeded_offline_file: tuple[str, str],
+) -> None:
+    """Runner offline + host online: the file list renders with the Asleep badge.
+
+    Asserts the panel does NOT collapse to the reconnect dead-end: the seeded
+    file appears in the All-files list, and the passive "Asleep" host-served
+    badge is shown. A regression that re-gated the queries on runner liveness
+    would leave the list empty and the badge absent.
+    """
+    base_url, session_id = seeded_offline_file
+    _patch_runner_offline_host_online(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}?view=explore")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+
+    # The passive host-served badge renders because the runner reads offline
+    # while the host reads online — no wake-up, panel stays usable.
+    expect(rail.get_by_test_id("files-host-served-badge")).to_be_visible(timeout=30_000)
+
+    # The seeded file is listed even though the runner is (from the UI's view)
+    # offline — proving the FS query fired and rendered host-served data.
+    expect(rail.get_by_role("button", name=re.compile(re.escape(_FILE_PATH))).first).to_be_visible(
+        timeout=30_000
+    )
+
+
+def test_offline_runner_host_served_file_content_opens(
+    page: Page,
+    seeded_offline_file: tuple[str, str],
+) -> None:
+    """Runner offline + host online: opening a file shows real content.
+
+    This is the specific bug the fix addresses — the file-content viewer used
+    to be gated on runner liveness, so opening a file while the agent was
+    asleep left the viewer blank. Deep-links ``?file=`` to open the viewer and
+    asserts the seeded body renders.
+    """
+    base_url, session_id = seeded_offline_file
+    _patch_runner_offline_host_online(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}?file={_FILE_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible(timeout=30_000)
+    # Real body proves the content query fetched host-served bytes, not an
+    # empty shell keyed off the path.
+    expect(file_viewer.get_by_text(_FILE_CONTENT).first).to_be_visible(timeout=30_000)

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -12,6 +12,8 @@ from omnigent.host.frames import (
     HostCreateDirResultFrame,
     HostCreateWorktreeFrame,
     HostCreateWorktreeResultFrame,
+    HostFsRequestFrame,
+    HostFsResultFrame,
     HostHelloFrame,
     HostLaunchRunnerFrame,
     HostLaunchRunnerResultFrame,
@@ -986,3 +988,117 @@ def test_create_dir_result_error_round_trip() -> None:
     assert decoded.status == "ok"
     assert decoded.path is None
     assert decoded.error == "directory already exists"
+
+
+def test_fs_request_round_trip() -> None:
+    """
+    Verify an fs request round-trips with op, workspace, session, and params.
+
+    The host reads a session's workspace from disk to serve the file panel
+    when the runner is offline; a dropped ``params`` would silently read the
+    root / default page instead of what the client asked for.
+    """
+    original = HostFsRequestFrame(
+        request_id="req_fs_1",
+        op="list_or_read",
+        workspace="/Users/corey/project",
+        session_id="conv_abc123",
+        params={"path": "src", "limit": 100, "order": "asc"},
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostFsRequestFrame)
+    assert decoded == original
+
+
+def test_fs_request_defaults_empty_params() -> None:
+    """
+    Verify an fs request with no ``params`` decodes to an empty dict.
+
+    The ``changes`` op carries no params; it must not fail to decode nor
+    surface ``None`` where the handler expects a dict.
+    """
+    decoded = decode_host_frame(
+        '{"kind": "host.fs_request", "request_id": "r", "op": "changes", '
+        '"workspace": "/w", "session_id": "s"}'
+    )
+    assert isinstance(decoded, HostFsRequestFrame)
+    assert decoded.params == {}
+
+
+def test_fs_request_missing_op_raises() -> None:
+    """
+    Verify decoding an fs request without ``op`` raises ValueError.
+
+    Without an op the host cannot route the read; failing loud beats
+    guessing an operation.
+    """
+    with pytest.raises(ValueError, match="missing required string field"):
+        decode_host_frame(
+            '{"kind": "host.fs_request", "request_id": "r", "workspace": "/w", "session_id": "s"}'
+        )
+
+
+def test_fs_request_non_object_params_raises() -> None:
+    """
+    Verify a non-object ``params`` is rejected rather than silently dropped.
+
+    A malformed peer sending ``params: []`` should fail decode instead of
+    reaching the handler as the wrong type.
+    """
+    with pytest.raises(ValueError, match="must be a JSON object: 'params'"):
+        decode_host_frame(
+            '{"kind": "host.fs_request", "request_id": "r", "op": "changes", '
+            '"workspace": "/w", "session_id": "s", "params": []}'
+        )
+
+
+def test_fs_result_success_round_trip() -> None:
+    """
+    Verify a successful fs result round-trips with the payload intact.
+
+    The payload is the runner-shaped JSON the panel renders; a dropped
+    field would blank the viewer even though the host read succeeded.
+    """
+    original = HostFsResultFrame(
+        request_id="req_fs_2",
+        status="ok",
+        payload={"object": "list", "data": [], "has_more": False},
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostFsResultFrame)
+    assert decoded == original
+
+
+def test_fs_result_error_round_trip() -> None:
+    """
+    Verify an fs error result round-trips with the status/code/message.
+
+    The server reproduces the runner's HTTP response from these fields; a
+    404 that arrived as a 500 would mislead the client's error handling.
+    """
+    original = HostFsResultFrame(
+        request_id="req_fs_3",
+        status="error",
+        error_status=404,
+        error_code="not_found",
+        error="Path 'missing.py' not found",
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostFsResultFrame)
+    assert decoded == original
+
+
+def test_fs_result_null_payload_round_trip() -> None:
+    """
+    Verify an fs result with a null payload decodes cleanly.
+
+    Error results carry no payload; ``null`` must not be coerced into a
+    dict nor raise during decode.
+    """
+    decoded = decode_host_frame(
+        '{"kind": "host.fs_result", "request_id": "r", "status": "error", '
+        '"payload": null, "error_status": 500, "error_code": "boom", "error": "x"}'
+    )
+    assert isinstance(decoded, HostFsResultFrame)
+    assert decoded.payload is None
+    assert decoded.error_status == 500

--- a/tests/server/integration/test_session_host_launch.py
+++ b/tests/server/integration/test_session_host_launch.py
@@ -1469,3 +1469,206 @@ async def test_health_reports_online_for_host_on_other_replica(
         "registry instead of the hosts DB."
     )
     assert batch.json()["sessions"][session_id]["runner_online"] is False
+
+
+async def _serve_fs_requests(
+    comm: ApplicationCommunicator,
+    workspace_root: str,
+    *,
+    max_frames: int = 60,
+) -> None:
+    """Answer the host's ``host.fs_request`` round-trips from a real dir.
+
+    Runs the production :class:`omnigent.workspace_fs.WorkspaceReader`
+    against ``workspace_root`` — a real on-disk directory the test
+    controls — for each fs request the server proxies, replying with the
+    same ``host.fs_result`` shape the real host daemon sends. This is the
+    fake host standing in for a machine that still holds the workspace on
+    disk after its runner died.
+
+    Runs until cancelled; drive it as a background task while issuing the
+    filesystem requests, then cancel it.
+
+    :param comm: The connected host communicator.
+    :param workspace_root: Absolute path to a real directory to read.
+    :param max_frames: Frame budget so a routing bug fails fast.
+    """
+    from pathlib import Path
+
+    from omnigent.host.frames import HostFsRequestFrame, HostFsResultFrame
+    from omnigent.workspace_fs import WorkspaceReader, WorkspaceReaderError
+
+    reader = WorkspaceReader(Path(workspace_root))
+    for _ in range(max_frames):
+        output = await comm.receive_output(timeout=3.0)
+        if output["type"] != "websocket.send":
+            continue
+        frame = decode_host_frame(output["text"])
+        if not isinstance(frame, HostFsRequestFrame):
+            continue
+        params = frame.params or {}
+        try:
+            if frame.op == "list_or_read":
+                payload = reader.list_or_read(
+                    str(params.get("path", "")),
+                    limit=int(params.get("limit", 20)),
+                    after=params.get("after"),
+                    before=params.get("before"),
+                    order=str(params.get("order", "desc")),
+                )
+            elif frame.op == "changes":
+                payload = reader.changes(frame.session_id)
+            elif frame.op == "diff":
+                payload = reader.diff(frame.session_id, str(params.get("path", "")))
+            elif frame.op == "search":
+                payload = reader.search(
+                    str(params.get("q", "")),
+                    include=params.get("include"),
+                    exclude=params.get("exclude"),
+                    limit=int(params.get("limit", 500)),
+                )
+            else:  # pragma: no cover - defensive
+                raise AssertionError(f"unexpected fs op {frame.op!r}")
+        except WorkspaceReaderError as exc:
+            result = HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=exc.status,
+                error_code=exc.code,
+                error=exc.message,
+            )
+        else:
+            result = HostFsResultFrame(request_id=frame.request_id, status="ok", payload=payload)
+        await comm.send_input({"type": "websocket.receive", "text": encode_host_frame(result)})
+
+
+async def test_offline_runner_serves_file_content_and_changes_from_host(
+    client: httpx.AsyncClient,
+    app: FastAPI,
+    tmp_path,
+) -> None:
+    """With the runner offline but the host alive, the filesystem panel
+    is served from the host over the tunnel — no runner, no wake-up.
+
+    End-to-end: a real host over the WS tunnel, a real inline-launched
+    session (host_id + a token-bound runner_id that never connects, so
+    resource access raises ``RUNNER_UNAVAILABLE``), and a real git
+    workspace on disk. Asserts that ``/changes``, the file-content read,
+    and ``/diff`` all return host-served data with the same shapes the
+    runner would return — the passive "agent asleep, files from host"
+    experience. Mutation check: drop the host fallback in
+    ``_fs_get_with_host_fallback`` and every request 503s.
+    """
+    import subprocess
+
+    # A real git workspace on disk: committed baseline + a modification,
+    # so git-mode changes/diff have something to report from disk alone.
+    ws = tmp_path / "hostws"
+    ws.mkdir()
+    env = {
+        **__import__("os").environ,
+        "GIT_AUTHOR_NAME": "T",
+        "GIT_AUTHOR_EMAIL": "t@e.com",
+        "GIT_COMMITTER_NAME": "T",
+        "GIT_COMMITTER_EMAIL": "t@e.com",
+    }
+    subprocess.run(["git", "init"], cwd=ws, check=True, capture_output=True, env=env)
+    (ws / "hello.txt").write_text("original\n")
+    subprocess.run(["git", "add", "."], cwd=ws, check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=ws, check=True, capture_output=True, env=env
+    )
+    (ws / "hello.txt").write_text("changed on disk\n")
+    (ws / "new.txt").write_text("brand new\n")
+
+    from omnigent.errors import ErrorCode, OmnigentError
+    from omnigent.runtime import _globals, set_runner_router
+
+    comm = await _connect_host(app)
+    session = await _inline_launch_session(client, comm)
+    session_id = session["id"]
+
+    # The inline-launched runner never connected, so its RunnerRouter would
+    # raise RUNNER_UNAVAILABLE (the host-fallback trigger). The test client
+    # runs no lifespan, so install a router that reproduces that signal.
+    class _OfflineRunnerRouter:
+        def client_for_session_resources(self, session_id: str) -> object:
+            del session_id
+            raise OmnigentError("runner is offline", code=ErrorCode.RUNNER_UNAVAILABLE)
+
+    prior_router = _globals._runner_router
+    set_runner_router(_OfflineRunnerRouter())  # type: ignore[arg-type]
+
+    # The server must fall back to reading the workspace over the still-open
+    # host tunnel.
+    responder = asyncio.create_task(_serve_fs_requests(comm, str(ws)))
+    try:
+        env_id = "default"
+        base = f"/v1/sessions/{session_id}/resources/environments/{env_id}"
+
+        # 1. Changed files: the git working-tree diff, served from disk.
+        changes = await client.get(f"{base}/changes")
+        assert changes.status_code == 200, changes.text
+        by_path = {e["path"]: e for e in changes.json()["data"]}
+        assert by_path["hello.txt"]["status"] == "modified"
+        assert by_path["new.txt"]["status"] == "created"
+
+        # 2. File content: the actual bytes on disk (the bug we fixed —
+        #    an offline runner used to leave this blank).
+        content = await client.get(f"{base}/filesystem/hello.txt")
+        assert content.status_code == 200, content.text
+        body = content.json()
+        assert body["encoding"] == "utf-8"
+        assert body["content"] == "changed on disk\n"
+
+        # 3. Diff: committed baseline vs current on-disk content.
+        diff = await client.get(f"{base}/diff/hello.txt")
+        assert diff.status_code == 200, diff.text
+        assert diff.json()["before"] == "original\n"
+        assert diff.json()["after"] == "changed on disk\n"
+    finally:
+        set_runner_router(prior_router)
+        responder.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await responder
+
+
+async def test_offline_runner_no_host_still_returns_503(
+    client: httpx.AsyncClient,
+    app: FastAPI,
+) -> None:
+    """With the runner offline AND no host connected, the panel 503s.
+
+    The resolver's last link: when neither the runner nor a host can read
+    the workspace, the original runner-offline error surfaces (503) so the
+    client shows its reconnect affordance rather than a blank success.
+    Guards against the fallback masking a genuinely unreachable workspace.
+    """
+    from omnigent.errors import ErrorCode, OmnigentError
+    from omnigent.runtime import _globals, set_runner_router
+
+    comm = await _connect_host(app)
+    session = await _inline_launch_session(client, comm)
+    session_id = session["id"]
+
+    class _OfflineRunnerRouter:
+        def client_for_session_resources(self, session_id: str) -> object:
+            del session_id
+            raise OmnigentError("runner is offline", code=ErrorCode.RUNNER_UNAVAILABLE)
+
+    prior_router = _globals._runner_router
+    set_runner_router(_OfflineRunnerRouter())  # type: ignore[arg-type]
+
+    # Drop the host tunnel so no fallback source remains.
+    await comm.send_input({"type": "websocket.disconnect", "code": 1000})
+    registry = app.state.host_registry
+    while registry.get(_HOST_ID) is not None:
+        await asyncio.sleep(0.01)
+
+    try:
+        resp = await client.get(
+            f"/v1/sessions/{session_id}/resources/environments/default/changes"
+        )
+    finally:
+        set_runner_router(prior_router)
+    assert resp.status_code == 503, resp.text

--- a/tests/server/routes/test_host_filesystem.py
+++ b/tests/server/routes/test_host_filesystem.py
@@ -1,0 +1,216 @@
+"""
+Tests for ``omnigent.server.routes._host_filesystem``.
+
+Drives the workspace-read proxy with a fake host that auto-replies to the
+outbound ``host.fs_request`` frame — verifies the request_id/future
+plumbing, success payload unpacking, error surfacing (reproducing the
+runner's HTTP status), and the connection-lost path. Mirrors
+``test_host_worktree.py``; no live host process is involved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from omnigent.host.frames import HostFsRequestFrame, HostHelloFrame, decode_host_frame
+from omnigent.server.host_registry import HostRegistry
+from omnigent.server.routes._host_filesystem import (
+    HostFsError,
+    HostFsUnavailableError,
+    read_workspace_from_host,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_HOST_ID = "host_fs_test"
+
+
+class _FakeWebSocket:
+    """Minimal WebSocket stand-in capturing outbound frames."""
+
+    def __init__(self) -> None:
+        """Initialize with an empty outbound capture."""
+        self.sent: list[str] = []
+
+    async def send_text(self, data: str) -> None:
+        """Capture an outbound frame.
+
+        :param data: JSON-encoded frame text.
+        """
+        self.sent.append(data)
+
+
+def _hello_frame() -> HostHelloFrame:
+    """Construct a hello frame for registry registration.
+
+    :returns: Hello frame with default version + empty runners.
+    """
+    return HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name="fs-host")
+
+
+@pytest.fixture()
+async def host_setup() -> AsyncIterator[HostRegistry]:
+    """Register a host plus a background auto-replier for fs frames.
+
+    Tests set ``registry._fs_reply_for_test`` before calling the proxy;
+    the drain task resolves the matching pending future with that reply,
+    mimicking ``host_tunnel.py``'s receive loop.
+
+    :returns: Async iterator yielding the registry.
+    """
+    registry = HostRegistry()
+    ws = _FakeWebSocket()
+    conn = registry.register(
+        host_id=_HOST_ID,
+        ws=ws,  # type: ignore[arg-type] — duck-typed
+        hello=_hello_frame(),
+        owner=None,
+    )
+
+    fs_reply: dict[str, Any] = {}
+    sent_frames: list[Any] = []
+
+    async def _drain() -> None:
+        """Read outbound frames, record them, and resolve the future."""
+        while True:
+            frame_text = await conn.outbound_queue.get()
+            if frame_text is None:
+                return
+            frame = decode_host_frame(frame_text)
+            sent_frames.append(frame)
+            if isinstance(frame, HostFsRequestFrame):
+                fut = conn.pending_fs_requests.pop(frame.request_id, None)
+                if fut is not None and not fut.done():
+                    fut.set_result(dict(fs_reply))
+
+    drain_task = asyncio.create_task(_drain())
+    registry._fs_reply_for_test = fs_reply  # type: ignore[attr-defined]
+    registry._sent_frames_for_test = sent_frames  # type: ignore[attr-defined]
+
+    try:
+        yield registry
+    finally:
+        conn.outbound_queue.put_nowait(None)
+        try:
+            await asyncio.wait_for(drain_task, timeout=1.0)
+        except asyncio.TimeoutError:
+            drain_task.cancel()
+
+
+async def test_read_success_returns_payload(host_setup: HostRegistry) -> None:
+    """A successful host reply returns the runner-shaped payload verbatim.
+
+    The payload is what the panel renders; it must thread through unchanged
+    so the host-served response is indistinguishable from the runner's.
+    """
+    registry = host_setup
+    payload = {"object": "list", "data": [{"path": "a.txt"}], "has_more": False}
+    registry._fs_reply_for_test.update({"status": "ok", "payload": payload})  # type: ignore[attr-defined]
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+
+    result = await read_workspace_from_host(
+        host_registry=registry,
+        host_conn=conn,
+        op="list_or_read",
+        workspace="/Users/alice/project",
+        session_id="conv_x",
+        params={"path": "", "limit": 100},
+    )
+
+    assert result == payload
+    # The frame the proxy sent carries the op + workspace + params.
+    sent = registry._sent_frames_for_test[-1]  # type: ignore[attr-defined]
+    assert isinstance(sent, HostFsRequestFrame)
+    assert sent.op == "list_or_read"
+    assert sent.workspace == "/Users/alice/project"
+    assert sent.params == {"path": "", "limit": 100}
+
+
+async def test_read_error_reproduces_runner_status(host_setup: HostRegistry) -> None:
+    """A host error reply raises ``HostFsError`` with the runner's status/code.
+
+    The server maps this back to the same HTTP response a live runner would
+    have returned, so a 404 stays a 404 rather than collapsing to a 500.
+    """
+    registry = host_setup
+    registry._fs_reply_for_test.update(  # type: ignore[attr-defined]
+        {
+            "status": "error",
+            "payload": None,
+            "error_status": 404,
+            "error_code": "not_found",
+            "error": "Path 'nope.py' not found",
+        }
+    )
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+
+    with pytest.raises(HostFsError) as excinfo:
+        await read_workspace_from_host(
+            host_registry=registry,
+            host_conn=conn,
+            op="list_or_read",
+            workspace="/w",
+            session_id="conv_x",
+            params={"path": "nope.py"},
+        )
+    assert excinfo.value.status == 404
+    assert excinfo.value.code == "not_found"
+
+
+async def test_read_incomplete_ok_result_rejected(host_setup: HostRegistry) -> None:
+    """An ``ok`` reply with no payload is treated as unavailable, not empty.
+
+    A missing payload means the host couldn't actually answer; surfacing it
+    as unavailable lets the caller fall through to 503 rather than rendering
+    a blank panel as if the workspace were empty.
+    """
+    registry = host_setup
+    registry._fs_reply_for_test.update({"status": "ok", "payload": None})  # type: ignore[attr-defined]
+    conn = registry.get(_HOST_ID)
+    assert conn is not None
+
+    with pytest.raises(HostFsUnavailableError):
+        await read_workspace_from_host(
+            host_registry=registry,
+            host_conn=conn,
+            op="changes",
+            workspace="/w",
+            session_id="conv_x",
+            params={},
+        )
+
+
+async def test_read_connection_lost_raises_unavailable() -> None:
+    """A send failure raises ``HostFsUnavailableError`` (host went away).
+
+    The registry raises ``ConnectionError`` when the queue is closed; the
+    proxy must translate that into the unavailable signal the resolver
+    treats like an offline runner.
+    """
+    registry = HostRegistry()
+    ws = _FakeWebSocket()
+    conn = registry.register(
+        host_id=_HOST_ID,
+        ws=ws,  # type: ignore[arg-type]
+        hello=_hello_frame(),
+        owner=None,
+    )
+    # Close the outbound queue so send_text fails like a dropped tunnel.
+    conn.outbound_queue.put_nowait(None)
+    registry.deregister(_HOST_ID)
+
+    with pytest.raises(HostFsUnavailableError):
+        await read_workspace_from_host(
+            host_registry=registry,
+            host_conn=conn,
+            op="changes",
+            workspace="/w",
+            session_id="conv_x",
+            params={},
+        )

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -131,6 +131,43 @@ def test_read_oversize_file_is_capped_and_flagged(tmp_path: Path, monkeypatch) -
     assert result["bytes"] == 8
 
 
+def test_oversize_text_split_on_codepoint_stays_text(tmp_path: Path, monkeypatch) -> None:
+    """A text file truncated mid-codepoint still serves as UTF-8, not base64.
+
+    The byte cap can fall inside a multi-byte character; dropping the partial
+    trailing codepoint keeps the file classified as text (matching the runner's
+    boundary-safe truncation) instead of flipping it to base64.
+    """
+    monkeypatch.setattr("omnigent.workspace_fs._MAX_READ_BYTES", 4)
+    # "aé" → b"a\xc3\xa9"; cap 4 keeps "aé" whole, so pad so the cap lands
+    # inside the é: 3 ASCII + é = b"abc\xc3\xa9", cap 4 splits the é.
+    (tmp_path / "u.txt").write_text("abcé")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.list_or_read("u.txt")
+
+    assert result["encoding"] == "utf-8"
+    assert result["truncated"] is True
+    assert result["content"] == "abc"  # partial é dropped, not corrupted
+
+
+def test_oversize_binary_still_serves_base64(tmp_path: Path, monkeypatch) -> None:
+    """A truncated genuinely-binary file stays base64, not rescued as text.
+
+    The codepoint-split rescue must only apply to a partial trailing sequence;
+    a binary file has invalid bytes earlier in the buffer and must fall through
+    to base64.
+    """
+    monkeypatch.setattr("omnigent.workspace_fs._MAX_READ_BYTES", 4)
+    (tmp_path / "b.bin").write_bytes(b"\xff\xfe\x00\x01\x02\x03")  # 6 bytes > cap 4
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.list_or_read("b.bin")
+
+    assert result["encoding"] == "base64"
+    assert result["truncated"] is True
+
+
 def test_list_dir_includes_broken_symlink_as_file(tmp_path: Path) -> None:
     """A broken symlink is listed as ``type="file"`` with no size, like the runner.
 

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -113,6 +113,42 @@ def test_read_missing_file_raises_not_found(tmp_path: Path) -> None:
     assert excinfo.value.status == 404
 
 
+def test_read_oversize_file_is_capped_and_flagged(tmp_path: Path, monkeypatch) -> None:
+    """A file larger than the byte cap is truncated and marked ``truncated``.
+
+    The reader reads at most the cap (+1 sentinel byte) from disk rather than
+    slurping the whole file, so a huge file can't OOM the host. Uses a tiny cap
+    so the test writes only a few bytes.
+    """
+    monkeypatch.setattr("omnigent.workspace_fs._MAX_READ_BYTES", 8)
+    (tmp_path / "big.txt").write_text("0123456789abcdef")  # 16 bytes > cap 8
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.list_or_read("big.txt")
+
+    assert result["truncated"] is True
+    assert result["content"] == "01234567"  # exactly the first cap bytes
+    assert result["bytes"] == 8
+
+
+def test_list_dir_includes_broken_symlink_as_file(tmp_path: Path) -> None:
+    """A broken symlink is listed as ``type="file"`` with no size, like the runner.
+
+    ``stat`` (follows the link) raises for a dangling target; the reader falls
+    back to ``lstat`` and still lists the entry rather than silently dropping
+    it — matching the runner's ``list_dir``.
+    """
+    (tmp_path / "dangling").symlink_to(tmp_path / "does_not_exist")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.list_or_read("", limit=100, order="asc")
+
+    by_path = {e["path"]: e for e in result["data"]}
+    assert "dangling" in by_path, "broken symlink must still appear in the listing"
+    assert by_path["dangling"]["type"] == "file"
+    assert by_path["dangling"]["bytes"] is None
+
+
 # ── Path confinement (read-only, workspace-root only) ─────────────────
 
 

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -1,0 +1,267 @@
+"""Tests for :mod:`omnigent.workspace_fs`.
+
+The :class:`WorkspaceReader` serves the web file panel (browse, changed
+files, diffs, search, file content) directly from disk when a session's
+runner is offline but its host still holds the workspace. These tests
+cover the four ops plus the read-only path-confinement guarantee, using a
+real temp directory (and a real git repo for the change-tracking ops) so
+the subprocess/os codepaths are exercised end to end.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from omnigent.workspace_fs import WorkspaceReader, WorkspaceReaderError
+
+
+def _git_env() -> dict[str, str]:
+    """Env with a dummy git identity so ``git commit`` never prompts.
+
+    :returns: Copy of the current environment with author/committer set.
+    """
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+
+def _git_repo(path: Path) -> None:
+    """Initialize a git repo at *path* with one committed file.
+
+    :param path: Directory to turn into a git working tree.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, env=env)
+    (path / "committed.txt").write_text("original\n")
+    subprocess.run(
+        ["git", "add", "committed.txt"], cwd=path, check=True, capture_output=True, env=env
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=path, check=True, capture_output=True, env=env
+    )
+
+
+# ── list_or_read ──────────────────────────────────────────────────────
+
+
+def test_list_dir_returns_entries(tmp_path: Path) -> None:
+    """Listing the root returns each entry with its type and size.
+
+    Mirrors the runner's ``/filesystem`` listing so the "All files"
+    tab renders identically when served from the host.
+    """
+    (tmp_path / "a.txt").write_text("hello")
+    (tmp_path / "sub").mkdir()
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.list_or_read("", limit=100, order="asc")
+
+    assert result["object"] == "list"
+    by_path = {e["path"]: e for e in result["data"]}
+    assert by_path["a.txt"]["type"] == "file"
+    assert by_path["a.txt"]["bytes"] == 5
+    assert by_path["sub"]["type"] == "directory"
+
+
+def test_read_text_file_returns_utf8_content(tmp_path: Path) -> None:
+    """Reading a text file returns its UTF-8 content inline.
+
+    This is exactly the payload the file viewer renders; if it were
+    empty the viewer would show a blank file while the agent is asleep.
+    """
+    (tmp_path / "note.md").write_text("# Title\nbody\n")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.list_or_read("note.md")
+
+    assert result["object"] == "session.environment.filesystem.file_content"
+    assert result["encoding"] == "utf-8"
+    assert result["content"] == "# Title\nbody\n"
+
+
+def test_read_binary_file_returns_base64(tmp_path: Path) -> None:
+    """Reading a non-UTF-8 file returns base64-encoded content.
+
+    Matches the runner: binary files can't decode as text, so the panel
+    receives them base64 to download/preview rather than corrupting them.
+    """
+    (tmp_path / "blob.bin").write_bytes(b"\xff\xfe\x00\x01")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.list_or_read("blob.bin")
+
+    assert result["encoding"] == "base64"
+
+
+def test_read_missing_file_raises_not_found(tmp_path: Path) -> None:
+    """A missing path raises a 404 ``WorkspaceReaderError``.
+
+    The server reproduces the runner's 404 from this, so a client sees
+    the same "not found" it would with a live runner.
+    """
+    reader = WorkspaceReader(tmp_path)
+    with pytest.raises(WorkspaceReaderError) as excinfo:
+        reader.list_or_read("nope.txt")
+    assert excinfo.value.status == 404
+
+
+# ── Path confinement (read-only, workspace-root only) ─────────────────
+
+
+def test_path_traversal_is_rejected(tmp_path: Path) -> None:
+    """A ``../`` escape is rejected with a 400 rather than reading outside.
+
+    The host serves files without the harness sandbox, so confinement to
+    the workspace root must live in the reader itself — a leak here would
+    expose arbitrary host files.
+    """
+    reader = WorkspaceReader(tmp_path)
+    with pytest.raises(WorkspaceReaderError) as excinfo:
+        reader.list_or_read("../secret")
+    assert excinfo.value.status == 400
+
+
+def test_absolute_path_is_rejected(tmp_path: Path) -> None:
+    """An absolute path is rejected rather than escaping the root."""
+    reader = WorkspaceReader(tmp_path)
+    with pytest.raises(WorkspaceReaderError) as excinfo:
+        reader.list_or_read("/etc/passwd")
+    assert excinfo.value.status == 400
+
+
+def test_symlink_escaping_root_is_rejected(tmp_path: Path) -> None:
+    """A symlink pointing outside the root resolves out and is rejected.
+
+    ``_resolve`` canonicalizes then checks containment, so a symlink can't
+    smuggle a read of a file outside the workspace.
+    """
+    outside = tmp_path.parent / "outside_secret.txt"
+    outside.write_text("secret")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "link.txt").symlink_to(outside)
+    reader = WorkspaceReader(workspace)
+
+    with pytest.raises(WorkspaceReaderError) as excinfo:
+        reader.list_or_read("link.txt")
+    assert excinfo.value.status == 400
+
+
+# ── search ────────────────────────────────────────────────────────────
+
+
+def test_search_matches_by_substring(tmp_path: Path) -> None:
+    """Search returns files whose name/path contains the query.
+
+    Same semantics as the runner's ``/search`` so the Explore tab's
+    results match when served from the host.
+    """
+    (tmp_path / "alpha.py").write_text("x")
+    (tmp_path / "beta.py").write_text("y")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.search("alpha")
+
+    paths = {e["path"] for e in result["data"]}
+    assert paths == {"alpha.py"}
+
+
+def test_search_blank_query_returns_empty(tmp_path: Path) -> None:
+    """A whitespace-only query returns nothing instead of walking the tree.
+
+    Matches the runner's guard against an accidental full-tree scan.
+    """
+    (tmp_path / "a.py").write_text("x")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.search("   ")
+
+    assert result["data"] == []
+
+
+def test_search_exclude_glob_prunes_results(tmp_path: Path) -> None:
+    """An exclude glob drops matching files from the results."""
+    (tmp_path / "keep.py").write_text("x")
+    node_modules = tmp_path / "node_modules"
+    node_modules.mkdir()
+    (node_modules / "keep.py").write_text("y")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.search("keep", exclude="**/node_modules")
+
+    paths = {e["path"] for e in result["data"]}
+    assert paths == {"keep.py"}
+
+
+# ── changes / diff (git mode) ─────────────────────────────────────────
+
+
+def test_changes_lists_git_working_tree_modifications(tmp_path: Path) -> None:
+    """In a git workspace, ``changes`` reports working-tree modifications.
+
+    This is the "Changed" tab. Git mode reconstructs it purely from disk,
+    so it works identically whether the runner or the host answers.
+    """
+    _git_repo(tmp_path)
+    (tmp_path / "committed.txt").write_text("modified\n")
+    (tmp_path / "new.txt").write_text("added\n")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.changes("conv_x")
+
+    by_path = {e["path"]: e for e in result["data"]}
+    assert by_path["committed.txt"]["status"] == "modified"
+    assert by_path["new.txt"]["status"] == "created"
+
+
+def test_diff_returns_before_and_after_for_modified_file(tmp_path: Path) -> None:
+    """``diff`` returns committed ``before`` and on-disk ``after`` content.
+
+    Backs the before/after diff view; ``before`` comes from ``git show``
+    and ``after`` from disk — both readable without a runner.
+    """
+    _git_repo(tmp_path)
+    (tmp_path / "committed.txt").write_text("modified\n")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.diff("conv_x", "committed.txt")
+
+    assert result["before"] == "original\n"
+    assert result["after"] == "modified\n"
+
+
+def test_diff_unchanged_file_raises_not_found(tmp_path: Path) -> None:
+    """A file with no working-tree change is not in the registry → 404.
+
+    Matches the runner's diff endpoint, which 404s for a path that was
+    never modified this session.
+    """
+    _git_repo(tmp_path)
+    reader = WorkspaceReader(tmp_path)
+
+    with pytest.raises(WorkspaceReaderError) as excinfo:
+        reader.diff("conv_x", "committed.txt")
+    assert excinfo.value.status == 404
+
+
+def test_changes_non_git_workspace_is_empty(tmp_path: Path) -> None:
+    """A non-git workspace reports no changes from the host.
+
+    The host has no access to the live agent's in-memory edit history, so
+    the changed-files list is empty (documented degradation) — but the
+    call must succeed, not error.
+    """
+    (tmp_path / "a.txt").write_text("x")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.changes("conv_x")
+
+    assert result["data"] == []

--- a/web/src/hooks/useFileContent.test.tsx
+++ b/web/src/hooks/useFileContent.test.tsx
@@ -5,12 +5,13 @@ import type { ReactNode } from "react";
 
 vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useSessionRunnerOnline: vi.fn(),
+  useSessionHostOnline: vi.fn(),
 }));
 vi.mock("@/store/chatStore", () => ({
   useChatStore: vi.fn(),
 }));
 
-import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { useChatStore } from "@/store/chatStore";
 import {
   downloadWorkspaceFile,
@@ -21,6 +22,7 @@ import {
 import type { FileContentResponse } from "./useFileContent";
 
 const onlineMock = vi.mocked(useSessionRunnerOnline);
+const hostOnlineMock = vi.mocked(useSessionHostOnline);
 const chatStoreMock = vi.mocked(useChatStore);
 const fetchMock = vi.fn();
 
@@ -282,8 +284,9 @@ describe("downloadWorkspaceFile", () => {
 // ---------------------------------------------------------------------------
 
 describe("useFileContent gating", () => {
-  it("does not fetch when the runner is offline", async () => {
+  it("does not fetch when the runner is offline and the host is also down", async () => {
     onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(false);
     stubChatStore();
 
     render(
@@ -294,6 +297,26 @@ describe("useFileContent gating", () => {
     await flushMicrotasks();
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches when the runner is offline but the host can serve the file", async () => {
+    // Regression: opening a file while the agent is asleep must still fetch
+    // — the server reads the bytes over the host tunnel. A blank viewer here
+    // is exactly the bug this gate fix addresses.
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(true);
+    stubChatStore();
+
+    render(
+      <Wrap>
+        <Probe id="conv_asleep" path="src/a.txt" />
+      </Wrap>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/v1/sessions/conv_asleep/resources/environments/default/filesystem/src/a.txt",
+    );
   });
 
   it("does not fetch when path is null", async () => {

--- a/web/src/hooks/useFileContent.ts
+++ b/web/src/hooks/useFileContent.ts
@@ -7,8 +7,8 @@
 
 import { useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { authenticatedFetch } from "@/lib/identity";
+import { useWorkspaceServeable } from "@/hooks/useWorkspaceChangedFiles";
 import { useChatStore } from "@/store/chatStore";
 
 // The primary workspace environment is always "default".  This hook targets
@@ -120,7 +120,10 @@ export function useFileContent(conversationId: string | undefined, path: string 
     !!conversationId &&
     conversationId === focusedId &&
     (sessionStatus === "running" || sessionStatus === "waiting");
-  const runnerOnline = useSessionRunnerOnline(conversationId);
+  // Serveable when the runner is online OR (runner offline but) the host can
+  // read the workspace from disk — keeps the viewer live while the agent is
+  // asleep. `false` only when neither source can answer.
+  const serveable = useWorkspaceServeable(conversationId);
   const queryClient = useQueryClient();
 
   const prevRef = useRef<{ id: string | undefined; active: boolean }>({
@@ -141,7 +144,7 @@ export function useFileContent(conversationId: string | undefined, path: string 
   return useQuery({
     queryKey: ["file-content", conversationId, path],
     queryFn: () => fetchFileContent(conversationId!, path!),
-    enabled: !!conversationId && !!path && runnerOnline !== false,
+    enabled: !!conversationId && !!path && serveable !== false,
     staleTime: 5_000,
   });
 }

--- a/web/src/hooks/useFileDiff.test.ts
+++ b/web/src/hooks/useFileDiff.test.ts
@@ -1,24 +1,27 @@
 // Unit tests for useFileDiff: the enable gate (only fires when a session,
-// a path, an online runner, and a changed-files match all line up), the
+// a path, a serveable workspace, and a changed-files match all line up), the
 // per-segment path encoding of the diff URL, and the throw-on-non-2xx guard.
 //
 // The two source hooks are mocked so we exercise the gate and URL builder
 // directly without standing up the RunnerHealthProvider or the changed-files
-// query.
+// query. `useWorkspaceServeable` is the runner-OR-host serve gate: the diff
+// fires when the runner is online OR (runner offline but) the host can read
+// the workspace from disk.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/hooks/RunnerHealthProvider", () => ({ useSessionRunnerOnline: vi.fn() }));
-vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({ useWorkspaceChangedFiles: vi.fn() }));
+vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({
+  useWorkspaceChangedFiles: vi.fn(),
+  useWorkspaceServeable: vi.fn(),
+}));
 
-import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
-import { useWorkspaceChangedFiles } from "@/hooks/useWorkspaceChangedFiles";
+import { useWorkspaceChangedFiles, useWorkspaceServeable } from "@/hooks/useWorkspaceChangedFiles";
 import { useFileDiff } from "./useFileDiff";
 
-const runnerOnlineMock = vi.mocked(useSessionRunnerOnline);
+const serveableMock = vi.mocked(useWorkspaceServeable);
 const changedFilesMock = vi.mocked(useWorkspaceChangedFiles);
 
 function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
@@ -32,12 +35,9 @@ function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): 
 
 const fetchMock = vi.fn();
 
-/** Wire the two source hooks: runner online state + changed-files paths. */
-function setHooks(opts: {
-  runnerOnline?: boolean | undefined;
-  changedPaths?: string[] | undefined;
-}) {
-  runnerOnlineMock.mockReturnValue(opts.runnerOnline);
+/** Wire the two source hooks: serveable state + changed-files paths. */
+function setHooks(opts: { serveable?: boolean | undefined; changedPaths?: string[] | undefined }) {
+  serveableMock.mockReturnValue(opts.serveable);
   changedFilesMock.mockReturnValue({
     data:
       opts.changedPaths === undefined
@@ -48,7 +48,7 @@ function setHooks(opts: {
 
 beforeEach(() => {
   fetchMock.mockReset();
-  runnerOnlineMock.mockReset();
+  serveableMock.mockReset();
   changedFilesMock.mockReset();
   vi.stubGlobal("fetch", fetchMock);
 });
@@ -67,30 +67,47 @@ function renderDiff(conversationId: string | undefined, path: string | null) {
 describe("useFileDiff — enable gate", () => {
   it("does not fetch when conversationId is missing", () => {
     // No session means there is no diff endpoint to call.
-    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    setHooks({ serveable: true, changedPaths: ["a.ts"] });
     renderDiff(undefined, "a.ts");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("does not fetch when path is null", () => {
     // Nothing is selected; firing a request would build a malformed URL.
-    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    setHooks({ serveable: true, changedPaths: ["a.ts"] });
     renderDiff("conv_1", null);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("does not fetch when the runner is offline", () => {
-    // An offline runner has no live filesystem to diff against; the query
+  it("does not fetch when the workspace is not serveable (runner + host both down)", () => {
+    // Neither the runner nor the host can read the workspace, so the query
     // must stay disabled rather than hammer a dead endpoint.
-    setHooks({ runnerOnline: false, changedPaths: ["a.ts"] });
+    setHooks({ serveable: false, changedPaths: ["a.ts"] });
     renderDiff("conv_1", "a.ts");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches when the runner is offline but the host can serve the diff", async () => {
+    // Serveable is true when the host holds the workspace even with the
+    // runner asleep; the before/after diff must still load.
+    setHooks({ serveable: true, changedPaths: ["a.ts"] });
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        object: "session.environment.filesystem.file_diff",
+        path: "a.ts",
+        before: "old",
+        after: "new",
+      }),
+    );
+    const { result } = renderDiff("conv_1", "a.ts");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not fetch when the file is not in the changed-files list", () => {
     // Only created/modified/deleted files have diff data; an unchanged file
     // would 404, so the gate keeps it disabled.
-    setHooks({ runnerOnline: true, changedPaths: ["other.ts"] });
+    setHooks({ serveable: true, changedPaths: ["other.ts"] });
     renderDiff("conv_1", "a.ts");
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -98,13 +115,13 @@ describe("useFileDiff — enable gate", () => {
   it("treats an unresolved changed-files list as not-yet-matched (no fetch)", () => {
     // Before the changed-files query resolves, data is undefined; the gate
     // must wait rather than fetch a diff for a file it can't confirm changed.
-    setHooks({ runnerOnline: true, changedPaths: undefined });
+    setHooks({ serveable: true, changedPaths: undefined });
     renderDiff("conv_1", "a.ts");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("fetches when session + path + online runner + changed-file match all hold", async () => {
-    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    setHooks({ serveable: true, changedPaths: ["a.ts"] });
     fetchMock.mockResolvedValueOnce(
       mockResponse({
         object: "session.environment.filesystem.file_diff",
@@ -122,7 +139,7 @@ describe("useFileDiff — enable gate", () => {
     // The gate only blocks on an explicit `false`; an unknown (undefined)
     // runner state must not stop the diff, or the panel would stay blank
     // during the brief window before health resolves.
-    setHooks({ runnerOnline: undefined, changedPaths: ["a.ts"] });
+    setHooks({ serveable: undefined, changedPaths: ["a.ts"] });
     fetchMock.mockResolvedValueOnce(
       mockResponse({
         object: "session.environment.filesystem.file_diff",
@@ -142,7 +159,7 @@ describe("useFileDiff — request URL", () => {
     // Per-segment encoding keeps "/" as the directory separator while
     // escaping spaces/specials; whole-string encoding would turn slashes
     // into %2F and break the FastAPI {path:path} route.
-    setHooks({ runnerOnline: true, changedPaths: ["src/a b.ts"] });
+    setHooks({ serveable: true, changedPaths: ["src/a b.ts"] });
     fetchMock.mockResolvedValueOnce(
       mockResponse({
         object: "session.environment.filesystem.file_diff",
@@ -161,7 +178,7 @@ describe("useFileDiff — request URL", () => {
 
 describe("useFileDiff — error handling", () => {
   it("surfaces an error on non-2xx", async () => {
-    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    setHooks({ serveable: true, changedPaths: ["a.ts"] });
     fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
     const { result } = renderDiff("conv_1", "a.ts");
     await waitFor(() => expect(result.current.isError).toBe(true));
@@ -172,7 +189,7 @@ describe("useFileDiff — error handling", () => {
     // A git_status_failed 500 carries the real cause in error.message; the
     // hook must propagate it so the diff view shows what went wrong rather
     // than a bare status code.
-    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    setHooks({ serveable: true, changedPaths: ["a.ts"] });
     fetchMock.mockResolvedValueOnce(
       mockResponse(
         { error: { code: "git_status_failed", message: "git status timed out after 5.0s" } },

--- a/web/src/hooks/useFileDiff.ts
+++ b/web/src/hooks/useFileDiff.ts
@@ -11,9 +11,8 @@
 // data) and the runner is online.
 
 import { useQuery } from "@tanstack/react-query";
-import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { authenticatedFetch } from "@/lib/identity";
-import { useWorkspaceChangedFiles } from "@/hooks/useWorkspaceChangedFiles";
+import { useWorkspaceChangedFiles, useWorkspaceServeable } from "@/hooks/useWorkspaceChangedFiles";
 
 // The primary workspace environment is always "default".
 const DEFAULT_ENVIRONMENT_ID = "default";
@@ -59,14 +58,14 @@ async function fetchFileDiff(conversationId: string, path: string): Promise<File
  * - the file does not appear in the session's changed-files list
  */
 export function useFileDiff(conversationId: string | undefined, path: string | null) {
-  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const serveable = useWorkspaceServeable(conversationId);
   const changedFiles = useWorkspaceChangedFiles(conversationId);
   const isInChangedFiles = changedFiles.data?.data.some((f) => f.path === path) ?? false;
 
   return useQuery({
     queryKey: ["file-diff", conversationId, path],
     queryFn: () => fetchFileDiff(conversationId!, path!),
-    enabled: !!conversationId && !!path && runnerOnline !== false && isInChangedFiles,
+    enabled: !!conversationId && !!path && serveable !== false && isInChangedFiles,
     staleTime: 5_000,
   });
 }

--- a/web/src/hooks/useWorkspaceChangedFiles.test.tsx
+++ b/web/src/hooks/useWorkspaceChangedFiles.test.tsx
@@ -6,12 +6,13 @@ import type { ReactNode } from "react";
 
 vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useSessionRunnerOnline: vi.fn(),
+  useSessionHostOnline: vi.fn(),
 }));
 vi.mock("@/store/chatStore", () => ({
   useChatStore: vi.fn(),
 }));
 
-import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { useChatStore } from "@/store/chatStore";
 import {
   MAX_RUNNER_OFFLINE_RETRIES,
@@ -30,6 +31,7 @@ import {
 } from "./useWorkspaceChangedFiles";
 
 const onlineMock = vi.mocked(useSessionRunnerOnline);
+const hostOnlineMock = vi.mocked(useSessionHostOnline);
 const chatStoreMock = vi.mocked(useChatStore);
 const fetchMock = vi.fn();
 
@@ -164,8 +166,9 @@ afterEach(() => {
 });
 
 describe("useWorkspaceChangedFiles gating", () => {
-  it("does not fetch when the runner is offline", async () => {
+  it("does not fetch when the runner is offline and the host is also down", async () => {
     onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(false);
     fetchMock.mockResolvedValue(jsonResponse({ object: "list", data: [] }));
 
     render(
@@ -176,6 +179,46 @@ describe("useWorkspaceChangedFiles gating", () => {
     await flushMicrotasks();
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches when the runner is offline but the host can serve the workspace", async () => {
+    // Runner-offline no longer disables the panel: the server reads the
+    // workspace over the host tunnel, so the query must still fire.
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(true);
+    fetchMock
+      .mockResolvedValueOnce(environmentResponse())
+      .mockResolvedValueOnce(changedFilesResponse());
+
+    render(
+      <Wrap>
+        <ChangedFilesProbe id="conv_asleep" />
+      </Wrap>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "/v1/sessions/conv_asleep/resources/environments/default/changes",
+    );
+  });
+
+  it("fetches when the runner is offline but host liveness is still unknown", async () => {
+    // Transient window (e.g. a stream push flipped the runner before host
+    // liveness resolved): host `undefined` stays "unknown → serve" so the
+    // query fires rather than blanking the panel; if the host is really
+    // down it just 503s and shows the reconnect hint.
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(undefined);
+    fetchMock
+      .mockResolvedValueOnce(environmentResponse())
+      .mockResolvedValueOnce(changedFilesResponse());
+
+    render(
+      <Wrap>
+        <ChangedFilesProbe id="conv_unknown_host" />
+      </Wrap>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 
   it("fetches when the runner is online", async () => {
@@ -285,8 +328,9 @@ describe("useWorkspaceChangedFiles gating", () => {
 });
 
 describe("useWorkspaceAllFiles gating", () => {
-  it("does not fetch when the runner is offline", async () => {
+  it("does not fetch when the runner is offline and the host is also down", async () => {
     onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(false);
 
     render(
       <Wrap>
@@ -440,8 +484,9 @@ describe("useWorkspaceEnvironment gating", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("does not fetch when the runner is offline", async () => {
+  it("does not fetch when the runner is offline and the host is also down", async () => {
     onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(false);
 
     render(
       <Wrap>
@@ -455,10 +500,11 @@ describe("useWorkspaceEnvironment gating", () => {
 });
 
 describe("useWorkspaceDirectory gating", () => {
-  it("does not fetch when the runner is offline (on-demand expand)", async () => {
-    // Lazy expand path — not poll spam, but still 503s on a dead
-    // runner. Gated for consistency with the other workspace hooks.
+  it("does not fetch when the runner is offline and the host is also down (on-demand expand)", async () => {
+    // Lazy expand path — not poll spam, but still unserveable when both
+    // the runner and host are down. Gated like the other workspace hooks.
     onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(false);
 
     render(
       <Wrap>

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -16,7 +16,7 @@
 
 import { useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { authenticatedFetch } from "@/lib/identity";
 import { useChatStore } from "@/store/chatStore";
 
@@ -26,6 +26,31 @@ function useSessionActive(conversationId: string | undefined): boolean {
   const sessionStatus = useChatStore((s) => s.sessionStatus);
   if (!conversationId || conversationId !== focusedId) return false;
   return sessionStatus === "running" || sessionStatus === "waiting";
+}
+
+/**
+ * Whether the workspace file panel can be served for this session.
+ *
+ * `false` only when we *know* neither source can answer: the runner is
+ * offline AND the host is offline or not host-bound. While either liveness
+ * is still unknown the query is allowed to fire — an offline runner with a
+ * live host is served over the host tunnel, and if the host turns out to be
+ * down the query just 503s and shows the reconnect hint anyway.
+ *
+ * Returns `false` to disable the query, or `true`/`undefined` (unknown)
+ * to let it run — matching the tri-state semantics the query `enabled`
+ * gates expect.
+ */
+export function useWorkspaceServeable(conversationId: string | undefined): boolean | undefined {
+  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const hostOnline = useSessionHostOnline(conversationId);
+  if (runnerOnline !== false) return runnerOnline; // online or unknown → serve
+  // Runner known-offline: block only when the host is *known* unavailable
+  // (`false` down, `null` not host-bound). While host liveness is still
+  // `undefined` (e.g. a stream push flipped the runner before host resolved),
+  // stay unknown so the query fires — the host may serve it.
+  if (hostOnline === undefined) return undefined;
+  return hostOnline === true;
 }
 
 /**
@@ -212,7 +237,7 @@ export function useWorkspaceChangedFiles(
   options: WorkspaceQueryOptions = {},
 ) {
   const queryEnabled = options.enabled ?? true;
-  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const serveable = useWorkspaceServeable(conversationId);
   const environmentQuery = useWorkspaceEnvironment(conversationId, {
     enabled: queryEnabled,
   });
@@ -224,7 +249,7 @@ export function useWorkspaceChangedFiles(
     enabled:
       queryEnabled &&
       !!conversationId &&
-      runnerOnline !== false &&
+      serveable !== false &&
       environmentQuery.data?.available === true,
     // Capped-backoff retry of the runner-offline case (see
     // shouldRetryRunnerOffline). Whether the eventual error reads as
@@ -310,7 +335,7 @@ export function useWorkspaceAllFiles(
   options: WorkspaceQueryOptions = {},
 ) {
   const queryEnabled = options.enabled ?? true;
-  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const serveable = useWorkspaceServeable(conversationId);
   const environmentQuery = useWorkspaceEnvironment(conversationId, {
     enabled: queryEnabled,
   });
@@ -322,7 +347,7 @@ export function useWorkspaceAllFiles(
     enabled:
       queryEnabled &&
       !!conversationId &&
-      runnerOnline !== false &&
+      serveable !== false &&
       environmentQuery.data?.available === true,
     // Capped-backoff retry of the runner-offline case (see
     // shouldRetryRunnerOffline). The asleep-vs-empty decision is made by
@@ -377,7 +402,7 @@ export function useWorkspaceFileSearch(
   exclude: string | undefined = undefined,
   options: WorkspaceQueryOptions = {},
 ) {
-  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const serveable = useWorkspaceServeable(conversationId);
   const trimmed = query.trim();
   const trimmedInclude = include?.trim() ?? "";
   const trimmedExclude = exclude?.trim() ?? "";
@@ -386,7 +411,7 @@ export function useWorkspaceFileSearch(
     queryFn: () =>
       fetchWorkspaceFileSearch(conversationId!, trimmed, trimmedInclude, trimmedExclude),
     enabled:
-      (options.enabled ?? true) && !!conversationId && trimmed.length > 0 && runnerOnline !== false,
+      (options.enabled ?? true) && !!conversationId && trimmed.length > 0 && serveable !== false,
     staleTime: 5_000,
     placeholderData: (prev) => prev,
   });
@@ -552,7 +577,7 @@ export function useWorkspaceFileExists(
   path: string | null,
   trusted = false,
 ): boolean {
-  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const serveable = useWorkspaceServeable(conversationId);
   const candidate = path && (trusted || looksLikeWorkspaceFilePath(path)) ? path : null;
   // Parent of a root-level file (no slash) is "" — the workspace root listing.
   const parentDir = candidate
@@ -566,7 +591,7 @@ export function useWorkspaceFileExists(
     // cache entry with conflicting queryFns.
     queryKey: ["workspace-dir-listing", conversationId, parentDir],
     queryFn: () => fetchDirEntriesTolerant(conversationId!, parentDir!),
-    enabled: !!conversationId && parentDir !== null && runnerOnline !== false,
+    enabled: !!conversationId && parentDir !== null && serveable !== false,
     // Longer TTL than the root/changed-files queries (5s): a referenced file's
     // existence rarely changes mid-conversation, and this fires per inline
     // path span, so a 30s cache keeps repeated mentions from re-listing.
@@ -617,11 +642,11 @@ export function useWorkspaceEnvironment(
   conversationId: string | undefined,
   options: WorkspaceQueryOptions = {},
 ) {
-  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const serveable = useWorkspaceServeable(conversationId);
   return useQuery({
     queryKey: ["workspace-environment", conversationId],
     queryFn: () => fetchWorkspaceEnvironment(conversationId!),
-    enabled: (options.enabled ?? true) && !!conversationId && runnerOnline !== false,
+    enabled: (options.enabled ?? true) && !!conversationId && serveable !== false,
     retry: shouldRetryRunnerOffline,
     retryDelay: runnerOfflineRetryDelay,
     staleTime: 60_000,
@@ -636,11 +661,11 @@ export function useWorkspaceEnvironment(
  * `dirPath` is null (collapsed or not yet requested).
  */
 export function useWorkspaceDirectory(conversationId: string | undefined, dirPath: string | null) {
-  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const serveable = useWorkspaceServeable(conversationId);
   return useQuery({
     queryKey: ["workspace-dir", conversationId, dirPath],
     queryFn: () => fetchWorkspaceDirectory(conversationId!, dirPath!),
-    enabled: !!conversationId && !!dirPath && runnerOnline !== false,
+    enabled: !!conversationId && !!dirPath && serveable !== false,
     staleTime: 5_000,
   });
 }

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -7,12 +7,14 @@ import {
   FileTypeIcon,
   FolderTreeIcon,
   ListIcon,
+  MoonIcon,
   SearchIcon,
   SlidersHorizontalIcon,
   XIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useParams } from "@/lib/routing";
+import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { useChatStore } from "@/store/chatStore";
 import {
   useWorkspaceChangedFiles,
@@ -283,6 +285,15 @@ export function FilesPanel({
   const runnerWentOffline = useChatStore(
     (s) => s.conversationId === conversationId && s.sessionStatus === "failed",
   );
+  // The runner is offline but the host still holds the workspace on disk,
+  // so the server serves the panel by reading the workspace over the host
+  // tunnel. Show a passive "served from host" badge — the panel keeps
+  // working and no message/agent wake-up is triggered. Only when the host
+  // is also down (or the session isn't host-bound) do the file queries
+  // surface RunnerOfflineError and fall back to the reconnect hint.
+  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const hostOnline = useSessionHostOnline(conversationId);
+  const servedFromHost = runnerOnline === false && hostOnline === true;
   const [changedSearch, setChangedSearch] = useState("");
   const [treeSearch, setTreeSearch] = useState("");
   const [debouncedTreeSearch, setDebouncedTreeSearch] = useState("");
@@ -359,6 +370,24 @@ export function FilesPanel({
       <div className="flex shrink-0 items-center gap-2 px-3 py-2">
         <span className="shrink-0 font-medium text-sm">Working folder</span>
         {workingDir && <WorkingDirLabel dir={workingDir} />}
+        {servedFromHost && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  data-testid="files-host-served-badge"
+                  className="flex shrink-0 items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                >
+                  <MoonIcon className="size-3 shrink-0" />
+                  Asleep
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                Agent is asleep — files shown live from the host. Send a message to wake it.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
         <div className="ml-auto flex items-center gap-1">
           <HiddenFilesToggle
             showHidden={showHidden}


### PR DESCRIPTION
## Related issue

N/A

## Summary

When a session's runner process dies but its host is still connected, the right-panel file views (browse / changed files / diffs / search / file content) used to go dark: every request 502/503'd, the panel showed "agent is asleep — send a message to reconnect", and the user had to wake a new runner (spinning up the LLM) just to look at files. This was significant friction.

This PR makes the server **fall back to reading the workspace over the existing host tunnel** when the pinned runner is offline. The panel stays live with a passive *"Asleep — files shown live from host"* badge — no LLM, no wake-up.

**ELI5:** the machine that holds your files (the host) is usually still around even when the little worker process (the runner) has died. So instead of giving up, the server just asks the host to read the files directly.

```
web ──GET /…/filesystem──▶ SERVER  _fs_get_with_host_fallback()
                             ├─ 1. live runner?  ──▶ runner ──▶ [disk]   (today)
                             ├─ 2. runner offline + host up? ──▶ host tunnel ──▶ [disk]   (this PR)
                             └─ 3. neither ──▶ 503 (reconnect hint)
```

- **`omnigent/workspace_fs.py`** — a read-only `WorkspaceReader` confined to the workspace root (list / read / search / changes / diff), reusing the runner's path-validation, glob, pagination, and git change-registry helpers so its JSON is byte-identical to the runner's endpoints. The direct-disk list/read loops are necessarily separate from the runner's sandboxed-subprocess reads; everything semantically load-bearing is shared, and parity is pinned by tests.
- **Host tunnel** — new `host.fs_request` / `host.fs_result` frames, a host-side handler running the reader off the event loop, and server-side proxy + pending-future routing (mirrors the existing worktree RPC).
- **Server** — `_fs_get_with_host_fallback` wraps the 5 filesystem GET endpoints (live runner → host → 503, only falling back on `RUNNER_UNAVAILABLE`); offline env-metadata is synthesized from the bound workspace so the panel's environment probe resolves.
- **Web** — a tri-state-aware `useWorkspaceServeable` gate (runner-online **OR** host-online) replaces the runner-only gate across the FS hooks (`useWorkspaceChangedFiles`, `useFileContent`, `useFileDiff`); host-served badge in `FilesPanel`.

Built as a resolver chain so a future host-death **snapshot** source drops in as an additive third link without touching endpoints or the frontend.

## Test Plan

- **Backend unit** — `tests/test_workspace_fs.py` (list/read/binary/search/git changes+diff + path-escape/symlink confinement), `tests/host/test_frames.py` (frame round-trips + malformed rejection), `tests/server/routes/test_host_filesystem.py` (proxy: payload passthrough, 404-stays-404, both-down → unavailable).
- **Backend integration** — `tests/server/integration/test_session_host_launch.py`: a real host over the WS tunnel + an offline runner + a real git workspace on disk → asserts `/changes`, file content, and `/diff` all serve host-read data; plus the runner+host-both-down → 503 guard.
- **Frontend unit** — the three FS hook test files, including the runner-offline/host-online and unknown-host tri-state cases.
- **E2E (real browser)** — `tests/e2e_ui/files/test_offline_runner_host_served.py`: patches `/health` to runner-offline/host-online and asserts the file list + the "Asleep" badge render and the file-content viewer shows real bytes.

Commands: `cd web && npm test && npm run build` (4111 web tests pass, build clean); `pytest tests/test_workspace_fs.py tests/host/test_frames.py tests/server/routes/test_host_filesystem.py tests/server/integration/test_session_host_launch.py`; `pytest tests/e2e_ui/files/test_offline_runner_host_served.py` (real Chromium, 2 passed).

## Demo

The change is visible in-app (the "Asleep — files shown live from host" badge and a working file panel while the agent is asleep). E2E coverage exercises it in a real browser; a screen recording will be added on request.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the local server on this branch and confirmed that with a disconnected runner the right panel lists files and opens file content (the empty-content case was found and fixed this way — the file-content/diff hooks needed the same gate change as the list hooks). Automated coverage spans unit → integration (real host tunnel) → e2e (real browser).

## Changelog

The file panel (changed files, browsing, diffs, and file contents) stays viewable when a session's runner is offline but its host is still connected — no need to send a message to wake it.
