### PR TITLE
feat(web): add PDF text selection comments with highlight overlays

### DIFF
--- a/tests/e2e_ui/comments/test_pdf_comments.py
+++ b/tests/e2e_ui/comments/test_pdf_comments.py
@@ -122,7 +122,9 @@ def test_pdf_text_selection_add_comment_and_highlight(
 
     # Wait for pdf.js to render the canvas and text layer.
     expect(file_viewer.locator("canvas").first).to_be_visible(timeout=30_000)
-    expect(file_viewer.locator(".pdf-viewer").get_by_text(_ANCHOR_TEXT)).to_be_visible(timeout=30_000)
+    expect(file_viewer.locator(".pdf-viewer").get_by_text(_ANCHOR_TEXT)).to_be_visible(
+        timeout=30_000
+    )
     _select_pdf_text(page, file_viewer, _ANCHOR_TEXT)
 
     add_comment_btn = page.get_by_role("button", name=re.compile("Add comment", re.IGNORECASE))

--- a/tests/e2e_ui/comments/test_pdf_comments.py
+++ b/tests/e2e_ui/comments/test_pdf_comments.py
@@ -1,0 +1,177 @@
+"""E2E: commenting on a rendered PDF file (the PdfViewer text-layer path).
+
+PDFs render inline via react-pdf/pdf.js with a selectable text layer. Unlike
+code/markdown/HTML, anchors are page-relative geometry encoded in
+``anchor_content`` (``__pdf__{...}``), and highlights are browser-only overlay
+divs (``.pdf-comment``). This test pins the full round-trip:
+
+  1. A minimal ``.pdf`` is seeded via the filesystem resources API (no agent
+     run), with a short phrase pdf.js renders into the text layer.
+  2. The FileViewer opens the PDF in ``PdfViewer``.
+  3. The user selects that phrase in the text layer; the floating "Add comment"
+     button (portalled to the parent document) appears.
+  4. Clicking it opens the CommentsPanel with the selection as the pending
+     anchor and paints a pending highlight overlay (``.pdf-comment-active``).
+  5. The user fills the body and saves; the comment card appears and a saved
+     highlight overlay (``.pdf-comment``) remains on the page.
+  6. Via the REST API, the stored comment carries a PDF geometry anchor whose
+     decoded text matches the selection.
+
+If this goes red, the regression is most likely in PdfViewer's selection capture,
+floating-button portal, highlight overlay positioning, or PDF anchor encoding.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+_PDF_FILE_PATH = "sample.pdf"
+
+# Rendered by the fixture PDF into pdf.js's text layer — kept ASCII so the file
+# survives the filesystem PUT endpoint's UTF-8 text path.
+_ANCHOR_TEXT = "Hello PDF"
+
+_PDF_CONTENT = """\
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]
+/Resources<</Font<</F1 4 0 R>>>>/Contents 5 0 R>>endobj
+4 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+5 0 obj<</Length 44>>stream
+BT /F1 24 Tf 72 700 Td (Hello PDF) Tj ET
+endstream endobj
+trailer<</Root 1 0 R>>
+%%EOF
+"""
+
+_PDF_ANCHOR_PREFIX = "__pdf__"
+
+
+def _select_pdf_text(page: Page, file_viewer, text: str) -> None:
+    """Drag-select ``text`` in the pdf.js text layer.
+
+    ``Locator.select_text()`` does not reliably fire the ``mouseup`` handler
+    on ``PdfViewer``'s scroll container in headless Chromium, so drive a real
+    drag across the rendered glyph bounds instead.
+    """
+    layer = file_viewer.locator(".pdf-viewer .textLayer")
+    expect(layer).to_be_visible(timeout=30_000)
+    target = layer.get_by_text(text, exact=True)
+    expect(target).to_be_visible()
+    target.scroll_into_view_if_needed()
+    box = target.bounding_box()
+    assert box is not None, f"{text!r} has no bounding box"
+    y = box["y"] + box["height"] / 2
+    page.mouse.move(box["x"] + 1, y)
+    page.mouse.down()
+    page.mouse.move(box["x"] + box["width"] - 1, y, steps=6)
+    page.mouse.up()
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded_pdf_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed the PDF file and yield ``(base_url, session_id, path)``."""
+    base_url, session_id = seeded_session
+    file_url = (
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_PDF_FILE_PATH}"
+    )
+    resp = httpx.put(
+        file_url,
+        json={"content": _PDF_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    yield (base_url, session_id, _PDF_FILE_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_pdf_text_selection_add_comment_and_highlight(
+    page: Page,
+    seeded_pdf_session: tuple[str, str, str],
+) -> None:
+    """Select PDF text, add a comment, and verify the highlight overlay persists."""
+    base_url, session_id, file_path = seeded_pdf_session
+    page.set_viewport_size({"width": 1600, "height": 900})
+    page.goto(f"{base_url}/c/{session_id}?file={_PDF_FILE_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+
+    # Wait for pdf.js to render the canvas and text layer.
+    expect(file_viewer.locator("canvas").first).to_be_visible(timeout=30_000)
+    expect(file_viewer.locator(".pdf-viewer").get_by_text(_ANCHOR_TEXT)).to_be_visible(timeout=30_000)
+    _select_pdf_text(page, file_viewer, _ANCHOR_TEXT)
+
+    add_comment_btn = page.get_by_role("button", name=re.compile("Add comment", re.IGNORECASE))
+    expect(add_comment_btn).to_be_visible(timeout=10_000)
+    add_comment_btn.click()
+
+    expect(file_viewer.locator("span.font-semibold", has_text="Comments")).to_be_visible()
+
+    # Pending selection paints an active overlay before the comment is saved.
+    pending_highlight = file_viewer.locator(".pdf-viewer .pdf-comment.pdf-comment-active")
+    expect(pending_highlight.first).to_be_visible()
+    pending_box = pending_highlight.first.bounding_box()
+    assert pending_box is not None, "pending PDF comment highlight has no bounding box"
+    assert pending_box["width"] > 0 and pending_box["height"] > 0
+
+    comment_body = "Needs a citation in the PDF."
+    comment_textarea = file_viewer.locator("textarea[placeholder='Add a comment…']")
+    expect(comment_textarea).to_be_visible()
+    comment_textarea.fill(comment_body)
+    file_viewer.get_by_role("button", name="Add Comment").click()
+
+    expect(file_viewer).to_contain_text(comment_body)
+
+    # Saved comments keep a non-active overlay on the page.
+    saved_highlight = file_viewer.locator(".pdf-viewer .pdf-comment")
+    expect(saved_highlight.first).to_be_visible()
+    saved_box = saved_highlight.first.bounding_box()
+    assert saved_box is not None, "saved PDF comment highlight has no bounding box"
+    assert saved_box["width"] > 0 and saved_box["height"] > 0
+
+    comments_resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/comments?path={file_path}",
+        timeout=10.0,
+    )
+    comments_resp.raise_for_status()
+    comments = comments_resp.json()
+    assert len(comments) == 1, f"Expected 1 comment, got {len(comments)}: {comments}"
+
+    comment = comments[0]
+    assert comment["body"] == comment_body
+    anchor_content = comment["anchor_content"]
+    assert anchor_content is not None
+    assert anchor_content.startswith(_PDF_ANCHOR_PREFIX), (
+        f"expected PDF geometry anchor, got {anchor_content!r}"
+    )
+    payload = json.loads(anchor_content[len(_PDF_ANCHOR_PREFIX) :])
+    assert payload["text"] == _ANCHOR_TEXT, (
+        f"decoded anchor text {payload['text']!r} != selected text {_ANCHOR_TEXT!r}"
+    )
+    assert payload["page"] == 1
+    assert len(payload["rects"]) >= 1
+    assert comment["end_index"] > comment["start_index"]

--- a/tests/e2e_ui/files/test_pdf_rendering.py
+++ b/tests/e2e_ui/files/test_pdf_rendering.py
@@ -6,8 +6,8 @@ A file the server classifies as ``application/pdf`` (via
 "Preview not available for binary files." placeholder.
 
 The new toolbar behaviour is also asserted here (it is user-facing and specific
-to PDFs): the diff (Δ) and comments buttons are hidden because a rendered PDF
-has no text surface to diff against or anchor comments to, and the zoom
+to PDFs): the diff (Δ) button is hidden because a rendered PDF has no text
+surface to diff against. Comments are supported via the pdf.js text layer.
 percentage doubles as the reset control.
 
 The fixture seeds a minimal but valid PDF. It is pure ASCII, so it round-trips
@@ -113,11 +113,11 @@ def test_pdf_file_renders_inline(
     expect(file_viewer.get_by_text(re.compile(r"^\d+ pages?$"))).to_be_visible()
 
 
-def test_pdf_toolbar_hides_diff_and_comments(
+def test_pdf_toolbar_hides_diff_but_shows_comments(
     page: Page,
     seeded_pdf_session: tuple[str, str, str],
 ) -> None:
-    """The diff and comments toggles are hidden for PDFs (no text surface)."""
+    """The diff toggle is hidden for PDFs; comments are available."""
     base_url, session_id, _file_path = seeded_pdf_session
     page.goto(f"{base_url}/c/{session_id}?view=explore")
 
@@ -130,10 +130,9 @@ def test_pdf_toolbar_hides_diff_and_comments(
     # Wait until the PDF has actually rendered so the toolbar is in its final state.
     expect(file_viewer.locator("canvas").first).to_be_visible(timeout=30_000)
 
-    # PDFs render through PdfViewer, which has no text/selection surface — so the
-    # diff (Δ) and comments toggles are suppressed. (Both appear for text files.)
+    # PDFs render through PdfViewer — no diff surface, but comments are supported.
     expect(file_viewer.get_by_role("button", name="Show diff")).to_have_count(0)
-    expect(file_viewer.get_by_role("button", name="Show comments")).to_have_count(0)
+    expect(file_viewer.get_by_role("button", name="Show comments")).to_be_visible()
 
 
 def test_pdf_zoom_percentage_resets(

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -582,7 +582,13 @@ export function CodeViewer({
           </div>
         }
       >
-        <PdfViewer data={fileQuery.data} />
+        <PdfViewer
+          data={fileQuery.data}
+          conversationId={conversationId}
+          comments={comments}
+          activeSelection={activeSelection}
+          onSetActiveSelection={onSetActiveSelection}
+        />
       </Suspense>
     );
   }

--- a/web/src/shell/CommentsPanel.tsx
+++ b/web/src/shell/CommentsPanel.tsx
@@ -7,6 +7,7 @@ import { getCurrentAuthorId } from "@/lib/identity";
 import { cn } from "@/lib/utils";
 import type { Comment } from "@/hooks/useComments";
 import type { ActiveSelection } from "./codeViewerHelpers";
+import { displayAnchorContent } from "./pdfCommentHelpers";
 
 function avatarStyle(name: string): { backgroundColor: string; color: string } {
   let hash = 0;
@@ -223,7 +224,7 @@ export function CommentsPanel({
               {activeSelection.anchor_content && (
                 <div className="truncate rounded bg-muted/40 px-2 py-1 font-mono text-[10px] text-muted-foreground">
                   <span className="text-foreground/60">Selection: </span>
-                  {activeSelection.anchor_content.trim().split("\n")[0]}
+                  {displayAnchorContent(activeSelection.anchor_content).split("\n")[0]}
                 </div>
               )}
               <textarea
@@ -409,7 +410,7 @@ function CommentCard({
       {/* Anchor */}
       {c.anchor_content && (
         <p className="truncate font-mono text-[11px] text-muted-foreground">
-          {c.anchor_content.trim()}
+          {displayAnchorContent(c.anchor_content)}
         </p>
       )}
 

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -146,6 +146,7 @@ import { useFileDiff } from "@/hooks/useFileDiff";
 import { getSeenCommentIds } from "@/hooks/useSeenComments";
 import { useWorkspaceChangedFiles } from "@/hooks/useWorkspaceChangedFiles";
 import { classifyAndRemapComments, FileViewer } from "./FileViewer";
+import { encodePdfAnchor } from "./pdfCommentHelpers";
 import { writeFileViewPreferences } from "@/lib/fileViewPreferences";
 import type { ChangedSort } from "./FlatFileList";
 
@@ -789,6 +790,21 @@ describe("classifyAndRemapComments", () => {
 
     expect(result.open).toHaveLength(1);
     expect(result.open[0].id).toBe("c6");
+  });
+
+  it("skips remapping for PDF geometry anchors", () => {
+    const anchor = encodePdfAnchor(1, [{ x: 0.1, y: 0.2, w: 0.3, h: 0.04 }], "Hello PDF");
+    const c = makeAnchoredComment({
+      id: "c_pdf",
+      start_index: anchor.start_index,
+      end_index: anchor.end_index,
+      anchor_content: anchor.anchor_content,
+    });
+
+    const result = classifyAndRemapComments([c], "%PDF-1.4 binary bytes");
+
+    expect(result.open).toHaveLength(1);
+    expect(result.open[0]).toEqual(c);
   });
 
   // Spec/xfail: a draft comment whose anchor can no longer be found

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -93,6 +93,7 @@ import {
   openHtmlArtifactInNewTab,
 } from "./codeViewerHelpers";
 import { CommentsPanel, type ActiveSelection } from "./CommentsPanel";
+import { isPdfAnchor } from "./pdfCommentHelpers";
 
 // Monaco diff is heavy (~MBs + worker); load it only when the diff view is
 // actually shown.
@@ -127,6 +128,12 @@ export function classifyAndRemapComments(
     }
     // Draft with no anchor — keep as-is.
     if (!c.anchor_content) {
+      open.push(c);
+      continue;
+    }
+    // PDF anchors store geometry in anchor_content; byte-offset remapping does
+    // not apply to binary PDF content.
+    if (isPdfAnchor(c.anchor_content)) {
       open.push(c);
       continue;
     }
@@ -873,21 +880,18 @@ function FileViewerBody({
       onSelect: openHtmlInNewTab,
     });
   }
-  // PDFs render through PdfViewer, which has no text/selection surface to
-  // anchor comments to, so hide the comments toggle for them.
-  if (!isPdf) {
-    toolbarActions.push({
-      key: "comments",
-      label: commentsOpen ? "Hide comments" : "Show comments",
-      icon: <MessageSquareTextIcon className="size-4" />,
-      active: commentsOpen,
-      onSelect: () => {
-        commentsInitializedRef.current = true;
-        setCommentsOpen((prev) => !prev);
-      },
-    });
-  }
-  if (isDiffAvailable) {
+  // PDFs render through PdfViewer with text-layer comment anchors.
+  toolbarActions.push({
+    key: "comments",
+    label: commentsOpen ? "Hide comments" : "Show comments",
+    icon: <MessageSquareTextIcon className="size-4" />,
+    active: commentsOpen,
+    onSelect: () => {
+      commentsInitializedRef.current = true;
+      setCommentsOpen((prev) => !prev);
+    },
+  });
+  if (!isPdf && isDiffAvailable) {
     toolbarActions.push({
       key: "diff",
       label: viewMode === "diff" ? "Exit diff view" : "Show diff",

--- a/web/src/shell/PdfViewer.tsx
+++ b/web/src/shell/PdfViewer.tsx
@@ -6,15 +6,35 @@
 // small toolbar for zoom and page count. This module is lazy-loaded from
 // CodeViewer, so the react-pdf/pdf.js bundle and its worker only load when a PDF
 // is actually opened.
+//
+// Comment support: text-layer selections open the comments panel (same flow as
+// code/markdown/HTML). Saved comments paint browser-only highlight overlays on
+// top of the rendered pages — nothing is written into the PDF bytes.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
-import { MinusIcon, PlusIcon } from "lucide-react";
+import { MessageSquarePlusIcon, MinusIcon, PlusIcon } from "lucide-react";
 import { fileContentToBlob, type FileContentResponse } from "@/hooks/useFileContent";
+import { type Comment } from "@/hooks/useComments";
+import { useCanEdit } from "@/hooks/usePermissions";
 import { Button } from "@/components/ui/button";
+import { getEmbedRoot } from "@/lib/host";
+import { cn } from "@/lib/utils";
+import { type ActiveSelection } from "./codeViewerHelpers";
+import {
+  commentsMatchOffsets,
+  decodePdfAnchor,
+  encodePdfAnchor,
+  findPageElement,
+  getPageNumber,
+  getSelectionNormalizedRects,
+  highlightRectsForPage,
+} from "./pdfCommentHelpers";
 import { TruncatedBanner } from "./TruncatedBanner";
+import "./pdfViewer.css";
 
 // Point pdf.js at its worker. `new URL(..., import.meta.url)` lets Vite fingerprint
 // and serve the worker as an asset; running it at module scope is fine because the
@@ -27,6 +47,20 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
 const MIN_SCALE = 0.5;
 const MAX_SCALE = 3;
 const SCALE_STEP = 0.25;
+
+interface FloatingAnchor {
+  x: number;
+  y: number;
+  selection: ActiveSelection;
+}
+
+export interface PdfViewerProps {
+  data: FileContentResponse;
+  conversationId: string;
+  comments?: Comment[];
+  activeSelection?: ActiveSelection | null;
+  onSetActiveSelection?: (sel: ActiveSelection | null) => void;
+}
 
 function centered(message: string, tone: "muted" | "error" = "muted") {
   return (
@@ -42,13 +76,66 @@ function centered(message: string, tone: "muted" | "error" = "muted") {
   );
 }
 
-export function PdfViewer({ data }: { data: FileContentResponse }) {
+function PdfCommentHighlights({
+  page,
+  comments,
+  activeSelection,
+  onCommentClick,
+}: {
+  page: number;
+  comments: Comment[];
+  activeSelection: ActiveSelection | null;
+  onCommentClick: (comment: Comment) => void;
+}) {
+  const highlights = highlightRectsForPage(page, comments, activeSelection);
+  if (highlights.length === 0) return null;
+
+  return (
+    <div className="pdf-comment-layer" aria-hidden>
+      {highlights.map((h) =>
+        h.rects.map((rect, i) => (
+          <div
+            key={`${h.key}-${i}`}
+            className={cn("pdf-comment", h.active && "pdf-comment-active")}
+            style={{
+              left: `${rect.x * 100}%`,
+              top: `${rect.y * 100}%`,
+              width: `${rect.w * 100}%`,
+              height: `${rect.h * 100}%`,
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (h.comment) onCommentClick(h.comment);
+            }}
+          />
+        )),
+      )}
+    </div>
+  );
+}
+
+export function PdfViewer({
+  data,
+  conversationId,
+  comments = [],
+  activeSelection = null,
+  onSetActiveSelection,
+}: PdfViewerProps) {
+  const canEdit = useCanEdit(conversationId);
   const [url, setUrl] = useState<string | null>(null);
   const [numPages, setNumPages] = useState(0);
   const [errored, setErrored] = useState(false);
   const [scale, setScale] = useState(1);
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState<number | null>(null);
+  const [floating, setFloating] = useState<FloatingAnchor | null>(null);
+
+  const commentsRef = useRef(comments);
+  commentsRef.current = comments;
+  const onSetActiveSelectionRef = useRef(onSetActiveSelection);
+  onSetActiveSelectionRef.current = onSetActiveSelection;
+  const activeSelectionRef = useRef(activeSelection);
+  activeSelectionRef.current = activeSelection;
 
   // Build/revoke the object URL when the file changes. A truncated PDF is a
   // partial byte stream that pdf.js can't parse, so skip the blob and show the
@@ -87,6 +174,107 @@ export function PdfViewer({ data }: { data: FileContentResponse }) {
   const zoomIn = () => setScale((s) => Math.min(MAX_SCALE, s + SCALE_STEP));
   const resetZoom = () => setScale(1);
 
+  const handleCommentClick = useCallback((comment: Comment) => {
+    onSetActiveSelectionRef.current?.({
+      start_index: comment.start_index,
+      end_index: comment.end_index,
+      anchor_content: comment.anchor_content ?? "",
+    });
+    setFloating(null);
+  }, []);
+
+  // Scroll the page containing the active comment into view.
+  useEffect(() => {
+    if (!activeSelection) return;
+    const anchor = decodePdfAnchor(activeSelection.anchor_content);
+    if (!anchor) return;
+    const pageEl = containerRef.current?.querySelector(
+      `[data-page-number="${anchor.page}"]`,
+    ) as HTMLElement | null;
+    pageEl?.scrollIntoView({ block: "center" });
+  }, [activeSelection]);
+
+  // Drop the native selection once our overlay covers it — otherwise the app
+  // theme's ::selection highlight stacks underneath and looks misaligned.
+  useEffect(() => {
+    if (!activeSelection) return;
+    const sel = window.getSelection();
+    if (sel && !sel.isCollapsed) sel.removeAllRanges();
+  }, [activeSelection]);
+
+  // Capture text-layer selections and show the floating "Add comment" button.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !onSetActiveSelection) return;
+
+    const handleMouseUp = (e: MouseEvent) => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return;
+      const range = sel.getRangeAt(0);
+
+      if (sel.isCollapsed) {
+        if (!container.contains(range.commonAncestorContainer)) return;
+        // Highlight overlays activate comments on click; don't clear here.
+        if ((e.target as Element).closest(".pdf-comment")) return;
+        onSetActiveSelectionRef.current?.(null);
+        setFloating(null);
+        return;
+      }
+
+      if (!canEdit) return;
+      if (!container.contains(range.commonAncestorContainer)) return;
+      const text = sel.toString();
+      if (!text.trim()) return;
+
+      const pageEl = findPageElement(range.commonAncestorContainer, container);
+      if (!pageEl) return;
+      const rects = getSelectionNormalizedRects(range, pageEl);
+      if (rects.length === 0) return;
+
+      const page = getPageNumber(pageEl);
+      const selection = encodePdfAnchor(page, rects, text);
+
+      const existing = commentsRef.current.find((c) => commentsMatchOffsets(selection, c));
+      if (existing) {
+        onSetActiveSelectionRef.current?.({
+          start_index: existing.start_index,
+          end_index: existing.end_index,
+          anchor_content: existing.anchor_content ?? "",
+        });
+        setFloating(null);
+        return;
+      }
+
+      const firstRect = range.getClientRects()[0] ?? range.getBoundingClientRect();
+      setFloating({
+        x: firstRect.left,
+        y: firstRect.top - 6,
+        selection,
+      });
+    };
+
+    container.addEventListener("mouseup", handleMouseUp);
+    return () => container.removeEventListener("mouseup", handleMouseUp);
+  }, [canEdit, onSetActiveSelection]);
+
+  // Dismiss the floating button on mousedown outside or scroll.
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (!(e.target as HTMLElement).closest("[data-add-comment-btn]")) setFloating(null);
+    };
+    const handleScroll = () => setFloating(null);
+    document.addEventListener("mousedown", handleMouseDown);
+    window.addEventListener("scroll", handleScroll, true);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      window.removeEventListener("scroll", handleScroll, true);
+    };
+  }, []);
+
+  useEffect(() => {
+    setFloating(null);
+  }, [scale, data]);
+
   if (errored) {
     const body = centered(
       data.truncated
@@ -120,8 +308,6 @@ export function PdfViewer({ data }: { data: FileContentResponse }) {
           >
             <MinusIcon className="size-4" />
           </Button>
-          {/* The percentage doubles as the reset control — click it to return
-              to 100%. */}
           <Button
             type="button"
             variant="ghost"
@@ -147,7 +333,7 @@ export function PdfViewer({ data }: { data: FileContentResponse }) {
         </div>
       </div>
 
-      <div ref={containerRef} className="min-h-0 flex-1 overflow-auto bg-muted/30 p-4">
+      <div ref={containerRef} className="pdf-viewer min-h-0 flex-1 overflow-auto bg-muted/30 p-4">
         {url && (
           <Document
             file={url}
@@ -157,18 +343,49 @@ export function PdfViewer({ data }: { data: FileContentResponse }) {
             error={centered("Unable to render PDF.", "error")}
             className="flex flex-col items-center gap-4"
           >
-            {Array.from({ length: numPages }, (_, i) => (
-              <Page
-                key={i + 1}
-                pageNumber={i + 1}
-                width={pageWidth}
-                className="shadow-md"
-                loading=""
-              />
-            ))}
+            {Array.from({ length: numPages }, (_, i) => {
+              const pageNumber = i + 1;
+              return (
+                <Page
+                  key={pageNumber}
+                  pageNumber={pageNumber}
+                  width={pageWidth}
+                  className="shadow-md"
+                  loading=""
+                >
+                  <PdfCommentHighlights
+                    page={pageNumber}
+                    comments={comments}
+                    activeSelection={activeSelection}
+                    onCommentClick={handleCommentClick}
+                  />
+                </Page>
+              );
+            })}
           </Document>
         )}
       </div>
+
+      {floating &&
+        canEdit &&
+        onSetActiveSelection &&
+        createPortal(
+          <button
+            data-add-comment-btn
+            type="button"
+            className="fixed z-50 flex items-center gap-1.5 rounded-md border border-border bg-popover backdrop-blur-xl backdrop-saturate-150 px-2.5 py-1 text-xs font-medium text-foreground shadow-md hover:bg-secondary transition-colors"
+            style={{ left: floating.x, top: floating.y, transform: "translateY(-100%)" }}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => {
+              onSetActiveSelection(floating.selection);
+              setFloating(null);
+            }}
+          >
+            <MessageSquarePlusIcon className="size-3.5" />
+            Add comment
+          </button>,
+          getEmbedRoot() ?? document.body,
+        )}
     </div>
   );
 }

--- a/web/src/shell/pdfCommentHelpers.test.ts
+++ b/web/src/shell/pdfCommentHelpers.test.ts
@@ -98,11 +98,11 @@ describe("highlightRectsForPage", () => {
 
 describe("commentsMatchOffsets", () => {
   it("matches on start and end indices", () => {
-    expect(commentsMatchOffsets({ start_index: 1, end_index: 5 }, { start_index: 1, end_index: 5 })).toBe(
-      true,
-    );
-    expect(commentsMatchOffsets({ start_index: 1, end_index: 5 }, { start_index: 2, end_index: 5 })).toBe(
-      false,
-    );
+    expect(
+      commentsMatchOffsets({ start_index: 1, end_index: 5 }, { start_index: 1, end_index: 5 }),
+    ).toBe(true);
+    expect(
+      commentsMatchOffsets({ start_index: 1, end_index: 5 }, { start_index: 2, end_index: 5 }),
+    ).toBe(false);
   });
 });

--- a/web/src/shell/pdfCommentHelpers.test.ts
+++ b/web/src/shell/pdfCommentHelpers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  PDF_ANCHOR_PREFIX,
+  commentsMatchOffsets,
+  decodePdfAnchor,
+  displayAnchorContent,
+  encodePdfAnchor,
+  highlightRectsForPage,
+  isPdfAnchor,
+} from "./pdfCommentHelpers";
+import type { Comment } from "@/hooks/useComments";
+
+function makeComment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: "c1",
+    conversation_id: "s1",
+    path: "doc.pdf",
+    start_index: 0,
+    end_index: 5,
+    body: "note",
+    status: "draft",
+    created_at: 0,
+    updated_at: 0,
+    anchor_content: null,
+    created_by: null,
+    ...overrides,
+  };
+}
+
+describe("encodePdfAnchor / decodePdfAnchor", () => {
+  const rects = [{ x: 0.1, y: 0.2, w: 0.3, h: 0.04 }];
+
+  it("round-trips page, rects, and text", () => {
+    const sel = encodePdfAnchor(2, rects, "Hello PDF");
+    expect(sel.anchor_content.startsWith(PDF_ANCHOR_PREFIX)).toBe(true);
+    expect(decodePdfAnchor(sel.anchor_content)).toEqual({
+      page: 2,
+      rects,
+      text: "Hello PDF",
+    });
+  });
+
+  it("end_index is greater than start_index", () => {
+    const sel = encodePdfAnchor(1, rects, "Hi");
+    expect(sel.end_index).toBeGreaterThan(sel.start_index);
+  });
+});
+
+describe("displayAnchorContent", () => {
+  it("returns the selected text for PDF anchors", () => {
+    const sel = encodePdfAnchor(1, [{ x: 0, y: 0, w: 1, h: 0.1 }], "Hello");
+    expect(displayAnchorContent(sel.anchor_content)).toBe("Hello");
+  });
+
+  it("passes through plain-text anchors unchanged", () => {
+    expect(displayAnchorContent("plain anchor")).toBe("plain anchor");
+  });
+});
+
+describe("isPdfAnchor", () => {
+  it("detects the PDF prefix", () => {
+    expect(isPdfAnchor(`${PDF_ANCHOR_PREFIX}{}`)).toBe(true);
+    expect(isPdfAnchor("plain")).toBe(false);
+    expect(isPdfAnchor(null)).toBe(false);
+  });
+});
+
+describe("highlightRectsForPage", () => {
+  it("returns saved comments and the pending selection on the matching page", () => {
+    const anchor = encodePdfAnchor(1, [{ x: 0.1, y: 0.2, w: 0.3, h: 0.04 }], "Hello");
+    const comment = makeComment({
+      start_index: anchor.start_index,
+      end_index: anchor.end_index,
+      anchor_content: anchor.anchor_content,
+    });
+    const pending = encodePdfAnchor(1, [{ x: 0.5, y: 0.6, w: 0.1, h: 0.02 }], "World");
+
+    const saved = highlightRectsForPage(1, [comment], null);
+    expect(saved).toHaveLength(1);
+    expect(saved[0]!.comment?.id).toBe("c1");
+
+    const withPending = highlightRectsForPage(1, [comment], pending);
+    expect(withPending).toHaveLength(2);
+    expect(withPending.some((h) => h.key === "pending")).toBe(true);
+  });
+
+  it("marks the active saved comment", () => {
+    const anchor = encodePdfAnchor(2, [{ x: 0, y: 0, w: 1, h: 0.1 }], "Hi");
+    const comment = makeComment({
+      start_index: anchor.start_index,
+      end_index: anchor.end_index,
+      anchor_content: anchor.anchor_content,
+    });
+    const active = highlightRectsForPage(2, [comment], anchor);
+    expect(active[0]!.active).toBe(true);
+  });
+});
+
+describe("commentsMatchOffsets", () => {
+  it("matches on start and end indices", () => {
+    expect(commentsMatchOffsets({ start_index: 1, end_index: 5 }, { start_index: 1, end_index: 5 })).toBe(
+      true,
+    );
+    expect(commentsMatchOffsets({ start_index: 1, end_index: 5 }, { start_index: 2, end_index: 5 })).toBe(
+      false,
+    );
+  });
+});

--- a/web/src/shell/pdfCommentHelpers.ts
+++ b/web/src/shell/pdfCommentHelpers.ts
@@ -1,0 +1,137 @@
+// PDF comment anchoring: encode page-relative highlight geometry and selected
+// text into the existing Comment fields. Highlights are browser-only overlays
+// (not written into the PDF bytes); anchor_content carries the geometry the
+// viewer needs to repaint them after reload.
+
+import type { Comment } from "@/hooks/useComments";
+import type { ActiveSelection } from "./codeViewerHelpers";
+
+/** Prefix that marks anchor_content as a PDF geometry payload, not raw text. */
+export const PDF_ANCHOR_PREFIX = "__pdf__";
+
+/** Rectangle relative to the page container (0–1 fractions). */
+export interface PdfNormalizedRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface PdfAnchorData {
+  page: number;
+  rects: PdfNormalizedRect[];
+  text: string;
+}
+
+export function isPdfAnchor(anchorContent: string | null | undefined): boolean {
+  return !!anchorContent?.startsWith(PDF_ANCHOR_PREFIX);
+}
+
+export function decodePdfAnchor(anchorContent: string | null | undefined): PdfAnchorData | null {
+  if (!isPdfAnchor(anchorContent)) return null;
+  try {
+    return JSON.parse(anchorContent!.slice(PDF_ANCHOR_PREFIX.length)) as PdfAnchorData;
+  } catch {
+    return null;
+  }
+}
+
+/** Human-readable anchor text for the comments panel and agent messages. */
+export function displayAnchorContent(anchorContent: string | null | undefined): string {
+  const decoded = decodePdfAnchor(anchorContent);
+  if (decoded) return decoded.text;
+  return anchorContent?.trim() ?? "";
+}
+
+function computePdfStartIndex(page: number, rects: PdfNormalizedRect[]): number {
+  const first = rects[0];
+  if (!first) return (page - 1) * 1_000_000;
+  const xPart = Math.round(first.x * 10_000);
+  const yPart = Math.round(first.y * 10_000);
+  return (page - 1) * 1_000_000 + yPart * 10_000 + xPart;
+}
+
+/** Build an ActiveSelection from a PDF text-layer selection. */
+export function encodePdfAnchor(
+  page: number,
+  rects: PdfNormalizedRect[],
+  text: string,
+): ActiveSelection {
+  const data: PdfAnchorData = { page, rects, text };
+  const start_index = computePdfStartIndex(page, rects);
+  return {
+    start_index,
+    end_index: start_index + text.length,
+    anchor_content: PDF_ANCHOR_PREFIX + JSON.stringify(data),
+  };
+}
+
+export function getSelectionNormalizedRects(range: Range, pageEl: HTMLElement): PdfNormalizedRect[] {
+  const pageRect = pageEl.getBoundingClientRect();
+  if (pageRect.width <= 0 || pageRect.height <= 0) return [];
+  const rects: PdfNormalizedRect[] = [];
+  for (let i = 0; i < range.getClientRects().length; i++) {
+    const r = range.getClientRects()[i]!;
+    if (r.width <= 0 || r.height <= 0) continue;
+    rects.push({
+      x: (r.left - pageRect.left) / pageRect.width,
+      y: (r.top - pageRect.top) / pageRect.height,
+      w: r.width / pageRect.width,
+      h: r.height / pageRect.height,
+    });
+  }
+  return rects;
+}
+
+/** Walk up from a selection node to the react-pdf page root (`[data-page-number]`). */
+export function findPageElement(node: Node, container: HTMLElement): HTMLElement | null {
+  let el: Node | null = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as Element);
+  while (el && el !== container) {
+    if (el instanceof HTMLElement && el.hasAttribute("data-page-number")) return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+export function getPageNumber(pageEl: HTMLElement): number {
+  return parseInt(pageEl.getAttribute("data-page-number") ?? "1", 10);
+}
+
+export function commentsMatchOffsets(
+  a: { start_index: number; end_index: number },
+  b: { start_index: number; end_index: number },
+): boolean {
+  return a.start_index === b.start_index && a.end_index === b.end_index;
+}
+
+/** Collect highlight rects for a comment or pending selection on a given page. */
+export function highlightRectsForPage(
+  page: number,
+  comments: Comment[],
+  activeSelection: ActiveSelection | null,
+): Array<{ key: string; rects: PdfNormalizedRect[]; active: boolean; comment?: Comment }> {
+  const out: Array<{
+    key: string;
+    rects: PdfNormalizedRect[];
+    active: boolean;
+    comment?: Comment;
+  }> = [];
+
+  for (const c of comments) {
+    const anchor = decodePdfAnchor(c.anchor_content);
+    if (!anchor || anchor.page !== page) continue;
+    const active =
+      activeSelection != null && commentsMatchOffsets(activeSelection, c);
+    out.push({ key: c.id, rects: anchor.rects, active, comment: c });
+  }
+
+  if (activeSelection) {
+    const pending = decodePdfAnchor(activeSelection.anchor_content);
+    const alreadySaved = comments.some((c) => commentsMatchOffsets(activeSelection, c));
+    if (pending && pending.page === page && !alreadySaved) {
+      out.push({ key: "pending", rects: pending.rects, active: true });
+    }
+  }
+
+  return out;
+}

--- a/web/src/shell/pdfCommentHelpers.ts
+++ b/web/src/shell/pdfCommentHelpers.ts
@@ -66,7 +66,10 @@ export function encodePdfAnchor(
   };
 }
 
-export function getSelectionNormalizedRects(range: Range, pageEl: HTMLElement): PdfNormalizedRect[] {
+export function getSelectionNormalizedRects(
+  range: Range,
+  pageEl: HTMLElement,
+): PdfNormalizedRect[] {
   const pageRect = pageEl.getBoundingClientRect();
   if (pageRect.width <= 0 || pageRect.height <= 0) return [];
   const rects: PdfNormalizedRect[] = [];
@@ -120,8 +123,7 @@ export function highlightRectsForPage(
   for (const c of comments) {
     const anchor = decodePdfAnchor(c.anchor_content);
     if (!anchor || anchor.page !== page) continue;
-    const active =
-      activeSelection != null && commentsMatchOffsets(activeSelection, c);
+    const active = activeSelection != null && commentsMatchOffsets(activeSelection, c);
     out.push({ key: c.id, rects: anchor.rects, active, comment: c });
   }
 

--- a/web/src/shell/pdfViewer.css
+++ b/web/src/shell/pdfViewer.css
@@ -1,0 +1,41 @@
+/* Browser-only highlight overlays for PDF comment anchors. Colors mirror the
+   Monaco/Shiki comment decorations (yellow wash). */
+
+.pdf-viewer .textLayer *::selection {
+  /* pdf.js text spans are transparent; keep selection yellow so it doesn't
+     clash with the app-wide brand-accent ::selection styling. */
+  background: rgba(250, 204, 21, 0.4);
+  color: transparent;
+}
+
+.dark .pdf-viewer .textLayer *::selection {
+  background: rgba(250, 204, 21, 0.35);
+  color: transparent;
+}
+
+.pdf-comment-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.pdf-comment {
+  position: absolute;
+  background-color: rgba(250, 204, 21, 0.25);
+  border-radius: 2px;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.pdf-comment-active {
+  background-color: rgba(250, 204, 21, 0.45);
+}
+
+.dark .pdf-comment {
+  background-color: rgba(250, 204, 21, 0.22);
+}
+
+.dark .pdf-comment-active {
+  background-color: rgba(250, 204, 21, 0.38);
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

PDFs previously rendered inline but had no comment support — the comments toggle was hidden because there was no text-selection surface. This adds parity with code, markdown, and HTML preview:

- Select text in the pdf.js text layer to get a floating **Add comment** button
- Comments persist through the existing comments API using page-relative anchor geometry encoded in `anchor_content`
- Saved and pending comments render as browser-only yellow highlight overlays (nothing is written into the PDF bytes)
- Highlight positioning uses the react-pdf page coordinate space; PDF-specific `::selection` styling avoids clashing with the app theme

## Test Plan

- [x] `npm test -- --run src/shell/pdfCommentHelpers.test.ts`
- [x] `npm test -- --run src/shell/FileViewer.test.tsx` (includes `classifyAndRemapComments` PDF anchor case)
- [x] `pre-commit run --all-files`
- [ ] Manual: open a PDF, select text, add a comment, verify highlight aligns with selection and survives zoom

## Demo

https://github.com/user-attachments/assets/d0d869d4-7b10-4403-8e31-8cef23346144

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified locally: PDF text selection shows the add-comment button, comments panel opens, and yellow overlays align with selected text after the coordinate-space fix. E2E test updated to expect the comments toggle on PDFs (diff toggle remains hidden).

## Changelog

Select text in a PDF preview to add review comments with inline highlight overlays.