### PR TITLE
feat(codex-native): surface Codex plans in the TodoPanel

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -152,6 +152,9 @@ _CODEX_APPLY_PATCH_APPROVAL_METHOD = "applyPatchApproval"
 _CODEX_SERVER_REQUEST_RESOLVED_METHOD = "serverRequest/resolved"
 _EXTERNAL_SESSION_INTERRUPTED_TYPE = "external_session_interrupted"
 _EXTERNAL_ELICITATION_RESOLVED_TYPE = "external_elicitation_resolved"
+# Sessions event carrying a Codex plan mapped to the todo-list schema so the
+# web TodoPanel renders it like Claude's TodoWrite output.
+_EXTERNAL_SESSION_TODOS_TYPE = "external_session_todos"
 # Codex AgentControl collab-agent spawn event fields.
 _CODEX_COLLAB_AGENT_ITEM_TYPE = "collabAgentToolCall"
 _CODEX_COLLAB_SPAWN_TOOL = "spawnAgent"
@@ -3009,18 +3012,26 @@ async def _handle_turn_plan_updated(
     params: dict[str, Any],
 ) -> None:
     """
-    Mirror a Codex plan update as a visible assistant message.
+    Mirror a Codex plan update in both the transcript and the todo panel.
 
     Codex emits plan changes as app-server notifications rather than
-    ordinary assistant text. Omnigent web currently renders persisted message
-    items, not a dedicated plan item type, so the native bridge converts
-    the structured plan into a compact assistant message.
+    ordinary assistant text. The forwarder posts the structured plan as an
+    ``external_session_todos`` event so the web ``TodoPanel`` renders it like
+    Claude's todo list, and also mirrors it as a compact assistant message so
+    the plan stays visible inline in the transcript.
 
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param params: Codex ``turn/plan/updated`` params.
     :returns: None.
     """
+    todos = _plan_todos_from_update(params)
+    if todos is not None:
+        await _post_external_session_todos(
+            client,
+            session_id=session_id,
+            todos=todos,
+        )
     text = _plan_text_from_update(params)
     if not text:
         return
@@ -5571,6 +5582,35 @@ async def _post_external_elicitation_resolved(
     return response is not None and response.status_code < 400
 
 
+async def _post_external_session_todos(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    todos: list[dict[str, Any]],
+) -> None:
+    """
+    Post one ``external_session_todos`` event to the Sessions API.
+
+    Drives the web ``TodoPanel`` from a Codex plan update. The server caches
+    the list and broadcasts a ``session.todos`` SSE event, so the panel
+    replaces its contents with the full current plan.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param todos: Plan mapped to todo items, e.g.
+        ``[{"content": "Inspect", "status": "in_progress",
+        "activeForm": "Inspect"}]``.
+    :returns: None.
+    """
+    response = await _post_session_event(
+        client,
+        session_id,
+        event_type=_EXTERNAL_SESSION_TODOS_TYPE,
+        data={"todos": todos},
+    )
+    _log_failed_session_event_post(_EXTERNAL_SESSION_TODOS_TYPE, response)
+
+
 async def _post_output_text_delta(
     client: httpx.AsyncClient,
     session_id: str,
@@ -6720,6 +6760,52 @@ def _plan_text_from_update(params: dict[str, Any]) -> str | None:
     return "\n".join(lines)
 
 
+def _plan_todos_from_update(params: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """
+    Map a Codex ``turn/plan/updated`` payload to the todo-list schema.
+
+    Produces items shaped like Claude's ``TodoWrite`` output so the web
+    ``TodoPanel`` can render Codex plans through the same pipeline. Codex
+    steps have no gerund ``activeForm``, so the step text is reused there.
+
+    :param params: Codex plan update params.
+    :returns: List of ``{"content", "status", "activeForm"}`` items, or
+        ``None`` when no valid plan steps are present.
+    """
+    plan = params.get("plan")
+    if not isinstance(plan, list) or not plan:
+        return None
+    todos: list[dict[str, Any]] = []
+    for entry in plan:
+        if not isinstance(entry, dict):
+            continue
+        step = entry.get("step")
+        if not isinstance(step, str) or not step:
+            continue
+        todos.append(
+            {
+                "content": step,
+                "status": _plan_todo_status(entry.get("status")),
+                "activeForm": step,
+            }
+        )
+    return todos or None
+
+
+def _plan_todo_status(status: Any) -> str:
+    """
+    Normalize a Codex plan step status to the todo-list vocabulary.
+
+    :param status: Codex step status value.
+    :returns: One of ``"pending"``, ``"in_progress"``, ``"completed"``.
+    """
+    if status == "completed":
+        return "completed"
+    if status in {"inProgress", "in_progress"}:
+        return "in_progress"
+    return "pending"
+
+
 def _plan_status_marker(status: Any) -> str:
     """
     Return a readable Markdown marker for a Codex plan step status.
@@ -6727,11 +6813,11 @@ def _plan_status_marker(status: Any) -> str:
     :param status: Codex step status value.
     :returns: Markdown list marker.
     """
-    if status == "completed":
-        return "- [x]"
-    if status in {"inProgress", "in_progress"}:
-        return "- [~]"
-    return "- [ ]"
+    return {
+        "completed": "- [x]",
+        "in_progress": "- [~]",
+        "pending": "- [ ]",
+    }[_plan_todo_status(status)]
 
 
 def _response_id(params: dict[str, Any]) -> str:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -3913,7 +3913,11 @@ def _handle_external_session_todos(
     body: SessionEventInput,
 ) -> None:
     """
-    Cache and broadcast a todo-list update from the claude-native forwarder.
+    Cache and broadcast a todo-list update from a native forwarder.
+
+    Sent by the claude-native forwarder (from ``TodoWrite``) and the
+    codex-native forwarder (from Codex plan updates); the panel is
+    harness-agnostic.
 
     Updates the in-memory ``_session_todos_cache`` so subsequent
     ``GET /v1/sessions/{id}`` snapshot calls can populate the ``todos``

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -5261,9 +5261,29 @@ def test_forwarder_posts_codex_turn_plan_update(tmp_path: Path) -> None:
 
     asyncio.run(run())
 
-    assert len(posted) == 1
-    assert posted[0]["type"] == "external_conversation_item"
-    data = posted[0]["data"]
+    # The plan is mirrored to the todo panel and inline in the transcript.
+    assert len(posted) == 2
+    todos_post = next(p for p in posted if p["type"] == "external_session_todos")
+    assert todos_post["data"]["todos"] == [
+        {
+            "content": "Inspect Codex plan events",
+            "status": "completed",
+            "activeForm": "Inspect Codex plan events",
+        },
+        {
+            "content": "Mirror plans to web",
+            "status": "in_progress",
+            "activeForm": "Mirror plans to web",
+        },
+        {
+            "content": "Run checks",
+            "status": "pending",
+            "activeForm": "Run checks",
+        },
+    ]
+
+    message_post = next(p for p in posted if p["type"] == "external_conversation_item")
+    data = message_post["data"]
     assert data["item_type"] == "message"
     assert data["response_id"] == "codex_turn_123"
     assert data["item_data"] == {
@@ -5281,6 +5301,57 @@ def test_forwarder_posts_codex_turn_plan_update(tmp_path: Path) -> None:
             }
         ],
     }
+
+
+def test_plan_todos_from_update_maps_steps_and_statuses() -> None:
+    """
+    ``_plan_todos_from_update`` maps Codex plan steps to the todo schema.
+
+    Each step becomes ``{"content", "status", "activeForm"}`` with the
+    status vocabulary normalized (``inProgress`` -> ``in_progress``) and the
+    step text reused for ``activeForm`` since Codex has no gerund form.
+    """
+    todos = codex_native_forwarder._plan_todos_from_update(
+        {
+            "plan": [
+                {"step": "Inspect", "status": "completed"},
+                {"step": "Mirror", "status": "inProgress"},
+                {"step": "Verify", "status": "in_progress"},
+                {"step": "Ship", "status": "pending"},
+                {"step": "Unknown", "status": "weird"},
+            ]
+        }
+    )
+
+    assert todos == [
+        {"content": "Inspect", "status": "completed", "activeForm": "Inspect"},
+        {"content": "Mirror", "status": "in_progress", "activeForm": "Mirror"},
+        {"content": "Verify", "status": "in_progress", "activeForm": "Verify"},
+        {"content": "Ship", "status": "pending", "activeForm": "Ship"},
+        {"content": "Unknown", "status": "pending", "activeForm": "Unknown"},
+    ]
+
+
+def test_plan_todos_from_update_skips_malformed_and_empty() -> None:
+    """
+    ``_plan_todos_from_update`` drops malformed steps and empty plans.
+
+    Non-dict entries and steps without a usable ``step`` string are
+    skipped; a plan that is missing, not a list, or yields no valid
+    items returns ``None`` so the caller posts nothing.
+    """
+    assert codex_native_forwarder._plan_todos_from_update({}) is None
+    assert codex_native_forwarder._plan_todos_from_update({"plan": []}) is None
+    assert codex_native_forwarder._plan_todos_from_update({"plan": "nope"}) is None
+    assert (
+        codex_native_forwarder._plan_todos_from_update(
+            {"plan": ["bad", {"step": ""}, {"status": "pending"}]}
+        )
+        is None
+    )
+    assert codex_native_forwarder._plan_todos_from_update(
+        {"plan": ["bad", {"step": "Keep me", "status": "pending"}]}
+    ) == [{"content": "Keep me", "status": "pending", "activeForm": "Keep me"}]
 
 
 def test_forwarder_posts_completed_codex_plan_item() -> None:

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -2645,6 +2645,40 @@ describe("Mobile session menu", () => {
     expect(screen.getByTestId("todo-panel")).toBeInTheDocument();
   });
 
+  it("opens the Tasks drawer for a codex-native session with todos", () => {
+    // Codex-native maps its plan updates to the same todo schema, so the
+    // Tasks entry must gate on codex-native too — not just claude-native.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([
+      {
+        id: "conv_codex",
+        permission_level: null,
+        labels: { "omnigent.wrapper": "codex-native-ui" },
+      },
+    ]);
+    useChatStore.setState({
+      todos: [
+        { content: "Locate CLI parser", status: "in_progress", activeForm: "Locate CLI parser" },
+      ],
+    });
+
+    renderShell("/c/conv_codex");
+
+    expect(screen.getByTestId("todos-panel-drawer")).toHaveAttribute("data-state", "closed");
+    expect(screen.queryByTestId("todo-panel")).toBeNull();
+
+    openSessionMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Tasks/i }));
+
+    // A codex-native session with a non-empty plan opens the Tasks drawer,
+    // the same as a claude-native session with todos.
+    expect(screen.getByTestId("todos-panel-drawer")).toHaveAttribute("data-state", "open");
+    expect(screen.getByTestId("todo-panel")).toBeInTheDocument();
+  });
+
   it("keeps the FAB with only the Agents entry for a minimal agent", () => {
     // available:false → no files; no shells, no todos, no debug. The
     // Agents entry is unconditional (badge = 1, the main agent), so the

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/hooks/useWorkspaceChangedFiles";
 import { cn } from "@/lib/utils";
 import { isNativeWrapper as isNativeWrapperLabel } from "@/lib/nativeCodingAgents";
+import { isCodexNativeSession } from "@/lib/codexPlanMode";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { isSingleUserMode } from "@/lib/capabilities";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
@@ -345,6 +346,10 @@ export function AppShell() {
   const sessionLabels = { ...activeConv?.labels, ...activeSession?.labels };
   const terminalFirst = sessionLabels["omnigent.ui"] === "terminal";
   const isClaudeNative = sessionLabels["omnigent.wrapper"] === "claude-code-native-ui";
+  // Harnesses that publish a todo list to the TodoPanel: Claude via
+  // TodoWrite, and Codex which maps its plan updates to the same schema.
+  const isCodexNative = isCodexNativeSession({ labels: sessionLabels });
+  const todosSupported = isClaudeNative || isCodexNative;
   // Native-CLI wrapper of either family. Keys harness behavior gates
   // (composer slash commands, `/model`); terminal-first SDK sessions
   // (embedded Omnigent REPL terminal) have NO wrapper label and must
@@ -513,14 +518,14 @@ export function AppShell() {
         // empty and ``agentSupportsShells`` starts false while the agent
         // loads, so native sessions don't flash the tab.
         terminals: !hideTerminalsTab && (railTerminals.length > 0 || agentSupportsShells),
-        todos: isClaudeNative && todos.length > 0,
+        todos: todosSupported && todos.length > 0,
       }) as const,
     [
       showFilesPanel,
       hideTerminalsTab,
       railTerminals.length,
       agentSupportsShells,
-      isClaudeNative,
+      todosSupported,
       todos.length,
     ],
   );
@@ -1298,7 +1303,7 @@ export function AppShell() {
                     hideTerminalsTab,
                     showShellsTab: railTabsAvailable.terminals,
                     terminalsLength: railTerminals.length,
-                    isClaudeNative,
+                    todosSupported,
                     todosCompleted,
                     todosTotal: todos.length,
                     debugMode,
@@ -1347,7 +1352,7 @@ export function AppShell() {
                       terminalsLength={railTerminals.length}
                       subagentsWorking={subagentsWorking}
                       agentCount={agentCount}
-                      isClaudeNative={isClaudeNative}
+                      todosSupported={todosSupported}
                       todosCompleted={todosCompleted}
                       todosTotal={todos.length}
                       rootSessionId={rootSessionId}

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -20,7 +20,7 @@ const mobileMenu = {
   hideTerminalsTab: false,
   showShellsTab: false,
   terminalsLength: 0,
-  isClaudeNative: false,
+  todosSupported: false,
   todosCompleted: 0,
   todosTotal: 0,
   debugMode: false,

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -56,8 +56,8 @@ interface MobileSessionMenuProps {
   showShellsTab: boolean;
   /** Number of open terminals (entry badge). */
   terminalsLength: number;
-  /** Whether this is a claude-native session (gates the Tasks entry). */
-  isClaudeNative: boolean;
+  /** Whether the session publishes a todo list (gates the Tasks entry). */
+  todosSupported: boolean;
   /** Completed todo count (Tasks entry badge numerator). */
   todosCompleted: number;
   /** Total todo count (Tasks entry badge denominator + visibility). */
@@ -468,7 +468,7 @@ export function ChatHeader({
                     )}
                   </DropdownMenuItem>
                 )}
-                {mobileMenu.isClaudeNative && mobileMenu.todosTotal > 0 && (
+                {mobileMenu.todosSupported && mobileMenu.todosTotal > 0 && (
                   <DropdownMenuItem
                     onSelect={mobileMenu.onOpenTodos}
                     className="gap-2.5 px-2.5 py-2 text-base"

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -65,7 +65,7 @@ function renderWorkspace(
       terminalsLength={0}
       subagentsWorking={0}
       agentCount={1}
-      isClaudeNative={false}
+      todosSupported={false}
       todosCompleted={0}
       todosTotal={0}
       rootSessionId={null}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -164,8 +164,8 @@ interface WorkspacePanelProps {
    * badge denominator) — starts at 1 for a lone agent.
    */
   agentCount: number;
-  /** Whether this is a claude-native session (gates the Tasks tab). */
-  isClaudeNative: boolean;
+  /** Whether the session publishes a todo list (gates the Tasks tab). */
+  todosSupported: boolean;
   /** Number of completed todos (Tasks tab badge numerator). */
   todosCompleted: number;
   /** Total todo count (Tasks tab badge denominator + visibility gate). */
@@ -236,7 +236,7 @@ export function WorkspacePanel({
   terminalsLength,
   subagentsWorking,
   agentCount,
-  isClaudeNative,
+  todosSupported,
   todosCompleted,
   todosTotal,
   rootSessionId,
@@ -363,7 +363,7 @@ export function WorkspacePanel({
                 )}
               </TabsTrigger>
             )}
-            {isClaudeNative && todosTotal > 0 && (
+            {todosSupported && todosTotal > 0 && (
               <TabsTrigger
                 value="todos"
                 className="h-[32px] gap-[6px] rounded-[8px] px-[12px] text-[13px] leading-5"
@@ -443,7 +443,7 @@ export function WorkspacePanel({
           <BrowserPane conversationId={conversationId} className="min-h-0 flex-1" />
         ) : rightRailTab === "subagents" && rootSessionId ? (
           <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
-        ) : rightRailTab === "todos" && isClaudeNative ? (
+        ) : rightRailTab === "todos" && todosSupported ? (
           <TodoPanel frameless />
         ) : rightRailTab === "terminals" && showShellsTab ? (
           <InlineTerminalsSection conversationId={conversationId} onExpand={openTerminalsPanel} />


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Codex-native sessions expose their plan through `turn/plan/updated` app-server notifications, which the forwarder previously mirrored **only** as an inline assistant message. This maps those plan steps to the same todo-list schema Claude produces via `TodoWrite` and posts them as an `external_session_todos` event, so the web **TodoPanel** renders a Codex plan the same way it renders a Claude todo list.
- The plan still also appears inline in the transcript (both places).
- Web side: the Tasks tab/drawer gate moves from `isClaudeNative` to a `todosSupported = isClaudeNative || isCodexNative` flag. The `TodoPanel` and the `external_session_todos` server handler were already harness-agnostic, so no changes there beyond the gate.

Status vocabulary is normalized (`inProgress` → `in_progress`); Codex has no gerund form, so the step text is reused for `activeForm`.

## Test Plan

- `python -m pytest tests/test_codex_native.py -k plan` — 10 passed (new unit tests for `_plan_todos_from_update` mapping + malformed/empty handling; extended the `turn/plan/updated` test to assert both the todos post and the inline message).
- `cd web && npm test` — full suite green (4170 passed); new `AppShell` test asserts a codex-native session with a non-empty plan opens the Tasks drawer.
- `cd web && npm run build` — clean.
- Manual: ran a real coding task in a codex-native session (`"Add a --dry-run flag … Use a plan to track the steps"`); Codex called `update_plan`, and the four steps populated the Tasks panel with correct in-progress/pending statuses (see Demo).

## Demo

Codex plan rendered in the right-rail **Tasks 0/4** panel (and inline in the transcript):

<img width="1591" height="842" alt="image" src="https://github.com/user-attachments/assets/3d72fbef-6b71-4338-86fe-c24f333c095e" />

<img width="1535" height="597" alt="image" src="https://github.com/user-attachments/assets/86f8b287-7df1-4e2c-b114-4da764bfa0e5" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: drove a codex-native session through a real multi-step coding task so Codex emitted `update_plan` / `turn/plan/updated`, and confirmed the Tasks panel populated with the correct step statuses and the plan still rendered inline. Automated tests cover the plan→todo mapping, the forwarder's dual post, and the web Tasks-tab gate for codex-native.

## Changelog

Codex plans now show up in the Tasks panel, the same way Claude Code todos do

This pull request and its description were written by Isaac.
