### PR TITLE
perf(web): reduce GET /v1/sessions calls on session detail page

### DIFF
--- a/tests/e2e_ui/sessions/test_archived_project_filter.py
+++ b/tests/e2e_ui/sessions/test_archived_project_filter.py
@@ -31,7 +31,7 @@ from tests.e2e_ui.conftest import _build_hello_world_bundle
 _PROJECT_LABEL_KEY = "omni_project"
 
 # Server page size for ``GET /v1/sessions`` (see ``fetchConversationsPage``).
-_PAGE_SIZE = 20
+_PAGE_SIZE = 30
 
 
 def _seed_archived_session(base_url: str, *, title: str, project: str | None) -> str:

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -277,7 +277,15 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
           // position we can't place locally. Membership-affecting deltas
           // (archive/search/connected filters) and updated_at resorting need
           // the same server-side reconciliation.
-          if (missingIds.length > 0 || needsRefetch) scheduleInvalidate();
+          //
+          // Skip the active session: its updated_at bumps on open before the
+          // initial list fetch returns, so it lands in missingIds even though
+          // it isn't a genuinely new session. Its data is covered by
+          // useSession and it's pinned in the sidebar via ActiveChatOverride.
+          const sidebarMissingIds = activeIdRef.current
+            ? missingIds.filter((id) => id !== activeIdRef.current)
+            : missingIds;
+          if (sidebarMissingIds.length > 0 || needsRefetch) scheduleInvalidate();
           return;
         }
       }

--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -99,14 +99,14 @@ async function fetchAgents(): Promise<Agent[]> {
 /**
  * Fetch the agents list, derived from active sessions.
  *
- * Refetches every 30 seconds so new agents from recently created
- * sessions appear without a manual refresh.
+ * Intended for the landing page (no active session); the session
+ * detail page uses `useSessionAgent` for the bound agent instead.
  */
 export function useAgents({ enabled = true }: { enabled?: boolean } = {}) {
   return useQuery({
     queryKey: ["agents"],
     queryFn: fetchAgents,
-    staleTime: 30_000,
+    staleTime: Infinity,
     enabled,
   });
 }

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -221,7 +221,7 @@ async function fetchConversationsPage({
   const params = new URLSearchParams({
     order: "desc",
     sort_by: "updated_at",
-    limit: "20",
+    limit: "30",
   });
   if (after) params.set("after", after);
   if (searchQuery) params.set("search_query", searchQuery);
@@ -288,6 +288,11 @@ export function useConversations(
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) =>
       lastPage.has_more ? (lastPage.last_id ?? undefined) : undefined,
+    // Data is kept fresh for 30 s so components that mount in quick
+    // succession after the initial fetch (AppShell, Sidebar, ChatPage)
+    // share the cache instead of each triggering a background refetch.
+    // The WS stream handles real-time updates within that window.
+    staleTime: 30_000,
     refetchInterval: streamConnected
       ? options.reconcileWhileConnected
         ? CONNECTED_STREAM_REFETCH_INTERVAL_MS

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -599,7 +599,7 @@ export function ChatPage() {
     isLoading: agentsLoading,
     error: agentsError,
     refetch: refetchAgents,
-  } = useAgents({ enabled: !!urlConvId });
+  } = useAgents({ enabled: !urlConvId });
   const { data: conversationsData } = useConversations("", true);
   const conversations = useMemo(
     () => conversationsData?.pages.flatMap((p) => p.data),
@@ -739,10 +739,9 @@ export function ChatPage() {
   // for legacy conversations without an agent binding — leave the
   // picker alone in those cases.
   //
-  // If the bound agent isn't in the cached list (e.g. a new agent was
-  // registered by a fresh `omnigent run` after the page loaded),
-  // refetch so the list stays current. staleTime: Infinity means the
-  // query won't self-update, so we do it manually on demand.
+  // On the landing page, if the bound agent isn't in the cached list
+  // (e.g. a new agent registered by a fresh `omnigent run` after load),
+  // refetch on demand — useAgents is only enabled there.
   useEffect(() => {
     if (boundAgentId === null) return;
     setSelectedAgentId(boundAgentId);


### PR DESCRIPTION
## Summary

The session detail page was triggering multiple redundant `GET /v1/sessions` calls on load and on window focus. Four concurrent calls were observed in network logs; this PR reduces them.

- **Duplicate page-1 fetches (calls 1 & 3):** `useConversations` had no `staleTime`, defaulting to 0. Components mounting in quick succession after the initial fetch (AppShell, Sidebar, ChatPage) each saw data as immediately stale and triggered their own background refetch. Added `staleTime: 30_000` — the WS stream handles real-time updates within that window.
- **Page-2 fetch (call 4):** Sidebar infinite scroll was loading a second page for most users. Bumped page limit 20 → 30 to cover a typical sidebar without a second request.
- **`sessions?limit=100` on every session open (call 2):** `useAgents` was enabled whenever a conversation was open (`enabled: !!urlConvId`), fetching all sessions just to derive agent names. On the session detail page, `useSessionAgent` already provides the bound agent — `useAgents` is only needed on the landing page picker. Flipped to `enabled: !urlConvId` and set `staleTime: Infinity` so the landing page fetches once and only refetches on demand.

## Test Plan

- Open a session detail page and inspect network calls — should see one `GET /v1/sessions` on load (sidebar), not 3–4
- Tab away and back — no extra `GET /v1/sessions` calls on focus
- Open the landing page (`/`) — agent picker still populates via `useAgents`
- Open New Chat / Fork dialog — directory conflict hint still works

## Demo

before
<img width="623" height="72" alt="image" src="https://github.com/user-attachments/assets/2c1886cf-3eca-4062-a4e4-ef641910c177" />

after
<img width="417" height="41" alt="image" src="https://github.com/user-attachments/assets/b001189a-c2f2-47ef-abad-1f08995cf50b" />


## Type of change

- [x] Performance improvement

## Test coverage

- [ ] No tests needed — behavioral change only (React Query config)

## Coverage notes

Manual verification completed — network waterfall confirms reduction from 4 concurrent calls to 1 on session detail page load.