### PR TITLE
fix(cli): add a Windows msvcrt branch to the interactive select() menu

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,6 +62,7 @@ jobs:
           uv run pytest
           tests/inner/test_proc_and_platform.py
           tests/runtime/test_process_manager.py
+          tests/onboarding/test_interactive.py
           -p no:cacheprovider -q
 
       - name: Broader unit sweep (non-blocking)

--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -9,11 +9,12 @@ future configure noun). The look reproduces
 - one row per option (selected → ``❯  <label>`` in bold accent, others
   normal weight; non-selectable sub-lines dim italic and indented beneath),
 - a muted footer hint line (``↑/↓ move  ·  Enter select  ·  Esc back``),
-- a raw-termios keypress loop with in-place redraw (move up, clear,
-  reprint), and
+- a raw keypress loop with in-place redraw (move up, clear, reprint) —
+  ``termios``/``tty`` on POSIX, ``msvcrt`` on Windows, both decoded into
+  one platform-free key vocabulary, and
 - a non-TTY numbered fallback so pipes / CI / tests work.
 
-The raw-termios reading and redraw mechanics are deliberately ported
+The raw reading and redraw mechanics are deliberately ported
 from :mod:`omnigent.repl._theme_picker` rather than imported: that
 module exposes only private helpers, and this module is the generic,
 reusable version. The duplication is intentional for now — a future
@@ -27,8 +28,16 @@ from __future__ import annotations
 import io
 import os
 import sys
+
+# termios/tty are POSIX-only and drive the raw-key menu loop; Windows uses
+# msvcrt instead (imported inside the win32 branch). Guard the import
+# (special-cased by mypy, which type-checks on Linux) so importing this module
+# never crashes the CLI there.
+if sys.platform != "win32":
+    import termios
+    import tty
 from collections.abc import Callable
-from typing import Protocol, cast
+from typing import Literal, Protocol, cast
 
 import click
 from rich.cells import cell_len
@@ -103,7 +112,7 @@ def _render_menu(
     window_start: int = 0,
     compact: bool = False,
 ) -> str:
-    """Render the menu frame to an ANSI string for the termios redraw.
+    """Render the menu frame to an ANSI string for the in-place redraw.
 
     A bold accent header, one row per option (selected → bold accent with the
     ``❯`` pointer, others normal weight aligned under it), an optional dim
@@ -271,7 +280,7 @@ def _select_fallback(
 ) -> int:
     """Non-TTY numbered fallback for :func:`select`.
 
-    Gives pipes / CI / tests a numbered prompt instead of a raw-termios
+    Gives pipes / CI / tests a numbered prompt instead of a raw-keypress
     loop they cannot drive. Non-selectable rows are printed as plain
     section labels (no number); only selectable rows are numbered, and the
     returned value is the original index into *options*.
@@ -312,6 +321,158 @@ def _select_fallback(
         console.print("  [red]Invalid selection.[/red]")
 
 
+# The platform-free key vocabulary the menu loop consumes. Each platform's
+# reader decodes its own console bytes down to one of these.
+Key = Literal["up", "down", "enter", "cancel", "eof", "ignore"]
+
+
+def _posix_key_reader(fd: int) -> Callable[[], Key]:
+    """Build a reader that decodes one keypress from a cbreak-mode POSIX *fd*.
+
+    Arrows arrive as the ``ESC [ A`` / ``ESC [ B`` escape sequence, so a bare
+    Escape is told apart from an arrow by peeking for a follow-on byte.
+
+    :param fd: The raw file descriptor to read from, already in cbreak mode.
+    :returns: A callable returning one :data:`Key` per invocation.
+    """
+
+    def read_key() -> Key:
+        ch = os.read(fd, 1)
+        if not ch:
+            return "eof"
+        if ch in (b"\x03", b"\x04"):
+            # Ctrl-C / Ctrl-D — abort the menu.
+            return "cancel"
+        if ch == b"\x1b":
+            # Escape alone, or the start of an arrow sequence.
+            import select as _select
+
+            if _select.select([fd], [], [], 0.05)[0]:
+                nxt = os.read(fd, 1)
+                if nxt == b"[":
+                    arrow = os.read(fd, 1)
+                    if arrow == b"A":  # Up
+                        return "up"
+                    if arrow == b"B":  # Down
+                        return "down"
+                # Ignore other escape sequences.
+                return "ignore"
+            # Bare Escape — abort the menu.
+            return "cancel"
+        if ch in (b"\r", b"\n"):
+            return "enter"
+        if ch in (b"k", b"K"):  # vi-style up
+            return "up"
+        if ch in (b"j", b"J"):  # vi-style down
+            return "down"
+        return "ignore"
+
+    return read_key
+
+
+def _windows_key_reader(getch: Callable[[], bytes]) -> Callable[[], Key]:
+    """Build a reader that decodes one keypress from the Windows console.
+
+    ``msvcrt.getch`` reports arrows as a ``\\x00`` or ``\\xe0`` prefix byte
+    followed by a scan code (``H`` up, ``P`` down) — no escape sequence and so
+    no timeout needed to disambiguate a bare Escape.
+
+    :param getch: The blocking single-byte reader, normally ``msvcrt.getch``;
+        injectable so the decoding is testable off Windows.
+    :returns: A callable returning one :data:`Key` per invocation.
+    """
+
+    def read_key() -> Key:
+        ch = getch()
+        if not ch:
+            return "eof"
+        if ch in (b"\x00", b"\xe0"):
+            # Prefixed scan code: consume the second byte so it is never
+            # re-read as a literal key.
+            code = getch()
+            if code == b"H":  # Up
+                return "up"
+            if code == b"P":  # Down
+                return "down"
+            return "ignore"
+        if ch in (b"\x03", b"\x04"):
+            # Ctrl-C / Ctrl-D — abort the menu.
+            return "cancel"
+        if ch == b"\x1b":
+            # Escape — abort the menu.
+            return "cancel"
+        if ch in (b"\r", b"\n"):
+            return "enter"
+        if ch in (b"k", b"K"):  # vi-style up
+            return "up"
+        if ch in (b"j", b"J"):  # vi-style down
+            return "down"
+        return "ignore"
+
+    return read_key
+
+
+def _run_key_loop(
+    read_key: Callable[[], Key],
+    redraw: Callable[[], None],
+    selectable: list[bool],
+    selected: int,
+) -> tuple[int, bool]:
+    """Drive the menu cursor from decoded keys until confirm or abort.
+
+    Platform-free: every console difference is already resolved by the
+    reader, so this owns only the cursor arithmetic and the redraw.
+
+    :param read_key: Blocking source of the next :data:`Key`.
+    :param redraw: Reprints the menu frame in place after a cursor move.
+    :param selectable: The per-row selectable mask (at least one ``True``).
+    :param selected: The starting (selectable) cursor index.
+    :returns: ``(selected, cancelled)`` — the final index, and whether the
+        user aborted rather than confirmed.
+    """
+    while True:
+        key = read_key()
+        if key == "cancel":
+            return selected, True
+        if key in ("enter", "eof"):
+            return selected, False
+        if key == "up":
+            selected = _step_selectable(selectable, selected, -1)
+            redraw()
+        elif key == "down":
+            selected = _step_selectable(selectable, selected, +1)
+            redraw()
+
+
+def _enable_windows_vt() -> bool:
+    """Switch the Windows console into ANSI (virtual terminal) mode.
+
+    Windows Terminal enables this by default, but legacy conhost does not and
+    the in-place redraw is pure escape sequences — without VT the menu would
+    print as literal escape codes.
+
+    :returns: ``True`` when ANSI output is usable, ``False`` when the console
+        refuses (the caller then degrades to the numbered fallback).
+    """
+    import ctypes
+
+    enable_virtual_terminal_processing = 0x0004
+    std_output_handle = -11
+    try:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.GetStdHandle(std_output_handle)
+        mode = ctypes.c_uint32()
+        if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            return False
+        if mode.value & enable_virtual_terminal_processing:
+            return True
+        return bool(
+            kernel32.SetConsoleMode(handle, mode.value | enable_virtual_terminal_processing)
+        )
+    except Exception:
+        return False
+
+
 def _term_width() -> int:
     """Return the terminal width clamped to a sane minimum.
 
@@ -338,8 +499,9 @@ def select(
 ) -> int:
     """Show a theme-picker-styled arrow-key menu and return the choice.
 
-    On a TTY this draws the menu via raw termios (accent ``❯`` pointer,
-    dimmed others, footer hints) and redraws in place on ↑/↓. Enter
+    On a TTY this draws the menu via a raw keypress loop (termios on POSIX,
+    msvcrt on Windows) with an accent ``❯`` pointer, dimmed others and footer
+    hints, and redraws in place on ↑/↓. Enter
     confirms the highlighted option. Esc (or Ctrl-C / Ctrl-D) **aborts**
     and returns ``-1`` so the caller can cancel / go back; callers must
     check for ``< 0`` before indexing ``options``.
@@ -401,12 +563,7 @@ def select(
     if not sys.stdin.isatty():
         return _select_fallback(title, options, default=default, selectable=mask)
 
-    import termios
-    import tty
-
-    fd = sys.stdin.fileno()
     selected = _first_selectable(mask, default)
-    cancelled = False
     width = _term_width()
     # Single-element list tracks how many lines the previous frame
     # occupied so the next redraw can move up and overwrite it
@@ -445,52 +602,30 @@ def select(
         sys.stdout.flush()
         prev_lines[0] = rendered.count("\n")
 
-    try:
-        old_attrs = termios.tcgetattr(fd)
-    except termios.error:
-        # Cannot enter raw mode — degrade to the numbered fallback.
-        return _select_fallback(title, options, default=default, selectable=mask)
+    if sys.platform == "win32":
+        import msvcrt
 
-    try:
+        if not _enable_windows_vt():
+            # An ANSI-less console would render the frame as escape garbage.
+            return _select_fallback(title, options, default=default, selectable=mask)
         _redraw()
-        tty.setcbreak(fd)
-        while True:
-            ch = os.read(fd, 1)
-            if not ch:
-                break
-            if ch in (b"\x03", b"\x04"):
-                # Ctrl-C / Ctrl-D — abort the menu.
-                cancelled = True
-                break
-            if ch == b"\x1b":
-                # Escape alone, or the start of an arrow sequence.
-                import select as _select
+        selected, cancelled = _run_key_loop(
+            _windows_key_reader(msvcrt.getch), _redraw, mask, selected
+        )
+    else:
+        fd = sys.stdin.fileno()
+        try:
+            old_attrs = termios.tcgetattr(fd)
+        except termios.error:
+            # Cannot enter raw mode — degrade to the numbered fallback.
+            return _select_fallback(title, options, default=default, selectable=mask)
 
-                if _select.select([fd], [], [], 0.05)[0]:
-                    nxt = os.read(fd, 1)
-                    if nxt == b"[":
-                        arrow = os.read(fd, 1)
-                        if arrow == b"A":  # Up
-                            selected = _step_selectable(mask, selected, -1)
-                            _redraw()
-                        elif arrow == b"B":  # Down
-                            selected = _step_selectable(mask, selected, +1)
-                            _redraw()
-                    # Ignore other escape sequences.
-                    continue
-                # Bare Escape — abort the menu.
-                cancelled = True
-                break
-            if ch in (b"\r", b"\n"):
-                break
-            if ch in (b"k", b"K"):  # vi-style up
-                selected = _step_selectable(mask, selected, -1)
-                _redraw()
-            elif ch in (b"j", b"J"):  # vi-style down
-                selected = _step_selectable(mask, selected, +1)
-                _redraw()
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
+        try:
+            _redraw()
+            tty.setcbreak(fd)
+            selected, cancelled = _run_key_loop(_posix_key_reader(fd), _redraw, mask, selected)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
 
     if clear_on_exit and prev_lines[0] > 0:
         # Erase the rendered frame so a re-rendering loop doesn't leave a

--- a/tests/onboarding/test_interactive.py
+++ b/tests/onboarding/test_interactive.py
@@ -360,6 +360,150 @@ def test_clear_screen_emits_clear_sequence_only_on_a_tty(monkeypatch: pytest.Mon
     assert pipe.getvalue() == ""  # no escape sequences leak into non-TTY output
 
 
+class _FakeMsvcrt:
+    """Stand-in for the ``msvcrt`` module that replays scripted keypresses.
+
+    Lets the Windows raw-key path be driven from a POSIX test runner: the
+    real console bytes are well-defined, so replaying them proves the
+    decoding without a Windows box.
+    """
+
+    def __init__(self, keys: list[bytes]) -> None:
+        self._keys = iter(keys)
+
+    def getch(self) -> bytes:
+        return next(self._keys)
+
+
+def _win_reader(keys: list[bytes]) -> object:
+    """Build the Windows key reader over a scripted byte stream."""
+    return interactive._windows_key_reader(_FakeMsvcrt(keys).getch)
+
+
+def test_windows_key_reader_decodes_arrow_prefix() -> None:
+    """Both msvcrt arrow prefixes (``\\x00`` and ``\\xe0``) decode to up/down.
+
+    A Windows console reports arrows as a two-byte sequence: a ``\\x00`` or
+    ``\\xe0`` prefix followed by a scan code (``H`` up, ``P`` down). Getting
+    this wrong means arrow keys silently do nothing on Windows.
+    """
+    read = _win_reader([b"\xe0", b"H"])
+    assert read() == "up"
+    read = _win_reader([b"\x00", b"P"])
+    assert read() == "down"
+
+
+def test_windows_key_reader_ignores_unknown_prefixed_codes() -> None:
+    """A prefixed non-arrow scan code (e.g. ← ) consumes both bytes and is ignored.
+
+    If the prefix byte were not paired with its scan code, the trailing
+    ``K`` would be re-read as a literal key and mis-navigate the menu.
+    """
+    read = _win_reader([b"\xe0", b"K"])
+    assert read() == "ignore"
+
+
+def test_windows_key_reader_decodes_enter_cancel_and_vi_keys() -> None:
+    """Enter confirms; Esc / Ctrl-C / Ctrl-D abort; j/k move — same as POSIX.
+
+    The Windows branch must honor the exact key contract the POSIX branch
+    documents, otherwise the menu behaves differently per platform.
+    """
+    assert _win_reader([b"\r"])() == "enter"
+    assert _win_reader([b"\n"])() == "enter"
+    assert _win_reader([b"\x1b"])() == "cancel"
+    assert _win_reader([b"\x03"])() == "cancel"
+    assert _win_reader([b"\x04"])() == "cancel"
+    assert _win_reader([b"k"])() == "up"
+    assert _win_reader([b"K"])() == "up"
+    assert _win_reader([b"j"])() == "down"
+    assert _win_reader([b"J"])() == "down"
+    assert _win_reader([b"x"])() == "ignore"
+
+
+def test_key_loop_skips_header_rows_and_returns_selection() -> None:
+    """The platform-free key loop glides ↑/↓ over headers and Enter confirms.
+
+    Mask ``[F, T, T, F, T]`` starting at index 1: two downs must land on 2
+    then 4 (skipping the header at 3), and Enter returns that row without
+    cancelling.
+    """
+    keys = iter(["down", "down", "enter"])
+    redraws = []
+    selected, cancelled = interactive._run_key_loop(
+        lambda: next(keys),
+        lambda: redraws.append(1),
+        [False, True, True, False, True],
+        1,
+    )
+    assert (selected, cancelled) == (4, False)
+    # One redraw per move; Enter does not redraw.
+    assert len(redraws) == 2
+
+
+def test_key_loop_cancel_returns_cancelled() -> None:
+    """A ``cancel`` key aborts the loop so ``select`` can return ``-1``."""
+    keys = iter(["down", "cancel"])
+    _selected, cancelled = interactive._run_key_loop(
+        lambda: next(keys), lambda: None, [True, True], 0
+    )
+    assert cancelled is True
+
+
+def test_key_loop_eof_confirms_current_row() -> None:
+    """An exhausted input stream confirms the highlighted row, as POSIX does today."""
+    keys = iter(["eof"])
+    selected, cancelled = interactive._run_key_loop(
+        lambda: next(keys), lambda: None, [True, True], 1
+    )
+    assert (selected, cancelled) == (1, False)
+
+
+def test_select_on_win32_uses_msvcrt_and_never_imports_termios(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``select`` on a Windows TTY drives msvcrt instead of the POSIX modules.
+
+    This is the direct regression for ``omnigent setup`` crashing with
+    ``ModuleNotFoundError: No module named 'termios'``: ``termios``/``tty``
+    are poisoned in ``sys.modules`` to mimic a Windows interpreter where
+    they do not exist. Feeding ``↓`` then Enter must return index 1 — if
+    ``select`` still reaches for a POSIX-only module, this raises instead.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setitem(sys.modules, "termios", None)
+    monkeypatch.setitem(sys.modules, "tty", None)
+    monkeypatch.setitem(sys.modules, "msvcrt", _FakeMsvcrt([b"\xe0", b"P", b"\r"]))
+    monkeypatch.setattr(interactive, "_enable_windows_vt", lambda: True, raising=False)
+
+    result = interactive.select("Pick one", ["alpha", "beta", "gamma"])
+
+    assert result == 1
+
+
+def test_select_on_win32_falls_back_when_ansi_cannot_be_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A console that refuses VT mode gets the numbered fallback, not escape garbage.
+
+    The in-place redraw is pure ANSI, so on a legacy console that cannot be
+    switched into VT mode the menu would render as literal escape codes.
+    Degrade to the numbered prompt instead.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setitem(sys.modules, "termios", None)
+    monkeypatch.setitem(sys.modules, "tty", None)
+    monkeypatch.setitem(sys.modules, "msvcrt", _FakeMsvcrt([]))
+    monkeypatch.setattr(interactive, "_enable_windows_vt", lambda: False, raising=False)
+    _feed(monkeypatch, ["2"])
+
+    result = interactive.select("Pick one", ["alpha", "beta", "gamma"])
+
+    assert result == 1
+
+
 def test_render_menu_windows_long_list_to_viewport() -> None:
     """``max_visible`` renders only the window slice + scroll markers."""
     options = [f"item-{i}" for i in range(20)]


### PR DESCRIPTION
## Related issue

Closes #2269

## Summary

- `omnigent setup` and every interactive `select()` picker crashed on a real Windows terminal with `ModuleNotFoundError: No module named 'termios'` because the raw-key menu unconditionally imported the POSIX-only `termios`/`tty` whenever stdin was a TTY, with no Windows reader.
- Split key decoding from the menu loop: `_posix_key_reader` and `_windows_key_reader` each decode their console bytes into one small key vocabulary, and the new platform-free `_run_key_loop` owns cursor arithmetic + redraw (POSIX behavior byte-identical). The Windows branch reads arrows via `msvcrt.getch`, enables VT mode first, and degrades to the numbered fallback if a legacy console refuses ANSI. The module-level `termios`/`tty` import is now guarded behind `sys.platform`, mirroring `claude_native.py`.
- Added `tests/onboarding/test_interactive.py` to the Windows CI hard unit list so the msvcrt decoding runs natively on windows-latest.

## Test Plan

`.venv/bin/python -m pytest tests/onboarding/test_interactive.py -q` (29 passed) — includes a win32-simulated regression test that poisons `termios`/`tty` in `sys.modules` and drives a fake `msvcrt`, plus reader/loop decoding tests. `.venv/bin/python -m pytest tests/onboarding -q` (743 passed) confirms no regression in setup flows. `.venv/bin/python -m mypy omnigent/onboarding/interactive.py` passes (verifies the win32 guard type-checks on Linux). `uv run pre-commit run --files ...` clean. Real-Windows behavior relies on the non-blocking `windows.yml` job.

## Demo

N/A — no UI surface in this diff.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The POSIX path is genuinely exercised on this Linux box and the full onboarding suite plus mypy pass, proving the refactor does not regress the working termios menu. The Windows path is verified by simulation only (poisoned sys.modules + injected fake msvcrt replaying documented console bytes): this proves the reported ModuleNotFoundError is gone and the byte decoding matches the stdlib encoding, but does not prove real Windows console byte delivery, ctypes VT-enable, or ANSI redraw on legacy conhost, none of which can run on Linux. Windows CI is the backstop but did not run here.

## Changelog

Fixed omnigent setup crashing on Windows with "No module named 'termios'" by adding a Windows arrow-key path to the interactive menu.
