### PR TITLE
fix(cli): survive non-UTF-8 consoles when rendering provider glyphs

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1386,6 +1386,30 @@ def _should_skip_update_check(argv: list[str]) -> bool:
     }
 
 
+def _ensure_utf8_stdio() -> None:
+    """Force UTF-8 on Windows stdio so emoji output can't abort a command.
+
+    A Windows shell on a legacy ANSI codepage (e.g. cp1252) hands Python
+    stdio streams that can't encode the provider-kind glyphs, so a plain
+    ``print`` raises ``UnicodeEncodeError`` mid-command. Reconfiguring the
+    already-open streams to UTF-8 with ``errors="replace"`` keeps output
+    flowing; ``PYTHONUTF8`` can't help here since PEP 540 reads it only at
+    interpreter startup.
+    """
+    if sys.platform != "win32":
+        return
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        if (getattr(stream, "encoding", "") or "").lower() in {"utf-8", "utf8"}:
+            continue
+        # Detached/replaced streams (or a test's capture object) can't be
+        # reconfigured; the glyph fallback still guards the actual writes.
+        with contextlib.suppress(ValueError, OSError):
+            reconfigure(encoding="utf-8", errors="replace")
+
+
 def main() -> None:
     """
     Console-script entry point for ``omnigent``.
@@ -1410,6 +1434,10 @@ def main() -> None:
     cwd = os.getcwd()
     if cwd not in sys.path:
         sys.path.insert(0, cwd)
+
+    # Legacy-codepage Windows stdio can't encode the provider glyphs; force
+    # UTF-8 before any command renders so the write doesn't abort.
+    _ensure_utf8_stdio()
 
     # Relocate pre-rename ~/.omniagents state before anything reads ~/.omnigent
     # (update-check cache, diagnostics logs, config). No-op once migrated.

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 
 from omnigent.onboarding.ambient import DetectedProvider
 from omnigent.onboarding.databricks_config import databricks_sdk_installed
-from omnigent.onboarding.interactive import ACCENT, console
+from omnigent.onboarding.interactive import ACCENT, console, encodable
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
     BEDROCK_KIND,
@@ -48,9 +48,9 @@ from omnigent.onboarding.provider_config import (
     surface_default_provider,
 )
 
-# A short glyph per kind for the grouped listing. ASCII-safe fallbacks are
-# not needed — the rest of the REPL/CLI already emits emoji freely — but
-# the glyph is purely decorative: the kind word follows it.
+# A short glyph per kind for the grouped listing. The glyph is purely
+# decorative — the kind word follows it — and degrades to an ASCII stand-in
+# (see _KIND_ASCII_GLYPH) on a console that can't encode emoji.
 # The ADMISSION TICKETS glyph (subscription) carries a VARIATION SELECTOR-16 so
 # terminals render it as a 2-cell emoji (matching 🔑 / 🌐 / 🧱 and the 🎟️ in
 # README.oss.md) instead of a cramped 1-cell text glyph — that VS16, not extra
@@ -68,6 +68,21 @@ _KIND_GLYPH: dict[str, str] = {
     CLI_CONFIG_KIND: "\N{GEAR}\N{VARIATION SELECTOR-16}",
     # CLOUD for Bedrock-style gateways (AWS Bedrock, corporate AI gateways)
     BEDROCK_KIND: "\N{CLOUD}",
+}
+
+
+# Stand-ins for a console whose encoding can't carry the emoji above — a
+# Windows shell on a legacy ANSI codepage (cp1252) raises UnicodeEncodeError
+# on the write instead of rendering it. Each token is 2 ASCII cells, matching
+# the emoji's display width so the listing's columns stay aligned.
+_KIND_ASCII_GLYPH: dict[str, str] = {
+    KEY_KIND: "Ky",
+    SUBSCRIPTION_KIND: "Sb",
+    GATEWAY_KIND: "Gw",
+    LOCAL_KIND: "Lc",
+    DATABRICKS_KIND: "Db",
+    CLI_CONFIG_KIND: "Cf",
+    BEDROCK_KIND: "Cl",
 }
 
 
@@ -290,12 +305,19 @@ def kind_glyph(kind: str) -> str:
     subscription ticket via its VARIATION SELECTOR-16), so a single space
     separates it from the following label.
 
+    A console that can't encode the emoji — a Windows shell on a legacy
+    ANSI codepage — gets the kind's 2-cell ASCII stand-in instead, so the
+    listing degrades rather than dying on the write.
+
     :param kind: A provider kind, e.g. ``"key"``, ``"subscription"``,
         ``"gateway"``, ``"local"``, or ``"databricks"``.
     :returns: The kind's glyph (e.g. ``"🔑"`` for ``"key"``), or an
         empty string for an unknown kind.
     """
-    return _KIND_GLYPH.get(kind, "")
+    glyph = _KIND_GLYPH.get(kind, "")
+    if glyph and not encodable(glyph, console):
+        return _KIND_ASCII_GLYPH.get(kind, "")
+    return glyph
 
 
 def credential_label(
@@ -417,7 +439,7 @@ def add_menu_options() -> list[AddOption]:
     def _opt(text: str, description: str, kind: str, **kw: object) -> AddOption:
         """Build an :class:`AddOption` whose label is glyph-prefixed for *kind*."""
         return AddOption(
-            label=f"{_KIND_GLYPH[kind]} {text}",
+            label=f"{kind_glyph(kind)} {text}",
             description=description,
             kind=kind,
             **kw,  # type: ignore[arg-type]  # provider/cli/other forwarded to AddOption
@@ -618,7 +640,7 @@ def render_provider_listing_by_harness(
             console.print("    [dim](none configured)[/dim]")
             continue
         for name, entry in serving:
-            glyph = _KIND_GLYPH.get(entry.kind, "")
+            glyph = kind_glyph(entry.kind)
             kind_style = _KIND_STYLE.get(entry.kind, "white")
             summary = _entry_models_summary(entry)
             line = (
@@ -715,7 +737,7 @@ def render_provider_listing(
     if providers:
         console.print(f"[{ACCENT}]Configured providers[/]")
         for name, entry in providers.items():
-            glyph = _KIND_GLYPH.get(entry.kind, "")
+            glyph = kind_glyph(entry.kind)
             kind_style = _KIND_STYLE.get(entry.kind, "white")
             summary = _entry_models_summary(entry)
             default_families = _provider_default_families(entry, config)

--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -44,6 +44,34 @@ MUTED = "#6a6a6a"
 # singleton so all callers render through one surface.
 console = Console()
 
+# Text encodings that cover every codepoint, so the probe below can
+# short-circuit instead of round-tripping the string.
+_UNIVERSAL_ENCODINGS = frozenset({"utf-8", "utf8", "utf-16", "utf16", "utf-32", "utf32"})
+
+
+def encodable(text: str, target: Console | None = None) -> bool:
+    """Report whether *text* can be written to a console without blowing up.
+
+    A Windows shell on a legacy ANSI codepage (e.g. cp1252) hands Python a
+    stdio stream that cannot encode emoji, and the write raises
+    ``UnicodeEncodeError`` mid-render, aborting the command. Callers probe
+    with this first and substitute an ASCII stand-in when it returns False.
+
+    :param text: The string about to be printed.
+    :param target: The console to probe; defaults to the module singleton.
+    :returns: True when the console's encoding covers *text* — including when
+        the encoding is unknown, since there is nothing to check against.
+    """
+    file = (target if target is not None else console).file
+    encoding = getattr(file, "encoding", None)
+    if not encoding or encoding.lower().replace("_", "-") in _UNIVERSAL_ENCODINGS:
+        return True
+    try:
+        text.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
 
 class _TermUIWithHiddenPrompt(Protocol):
     hidden_prompt_func: Callable[[str], str]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -31,6 +31,7 @@ from omnigent.cli import (
     _dispatch_native_terminal_harness,
     _dispatch_run,
     _ensure_sqlite_parent_dir,
+    _ensure_utf8_stdio,
     _expand_config_env_vars,
     _extract_global_logging_flags,
     _HostHttpResult,
@@ -4157,6 +4158,70 @@ def test_run_bare_omnigent_with_harness_only_config(
     # harness default must be forwarded; no target was set
     assert dispatched["harness"] == "claude-sdk"
     assert dispatched["target"] is None
+
+
+class _FakeStream:
+    """A stdio stub recording ``reconfigure`` calls for the stdio-hardening test."""
+
+    def __init__(self, encoding: str, *, raises: bool = False) -> None:
+        self.encoding = encoding
+        self.raises = raises
+        self.reconfigured: dict[str, object] | None = None
+
+    def reconfigure(self, **kwargs: object) -> None:
+        if self.raises:
+            raise ValueError("stream detached")
+        self.reconfigured = kwargs
+        self.encoding = str(kwargs.get("encoding", self.encoding))
+
+
+def test_ensure_utf8_stdio_reconfigures_legacy_windows_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On Windows, non-UTF-8 stdio is reconfigured to utf-8/replace."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    out, err = _FakeStream("cp1252"), _FakeStream("cp1252")
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+
+    _ensure_utf8_stdio()
+
+    assert out.reconfigured == {"encoding": "utf-8", "errors": "replace"}
+    assert err.reconfigured == {"encoding": "utf-8", "errors": "replace"}
+
+
+def test_ensure_utf8_stdio_noop_on_posix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On non-Windows platforms the streams are left untouched."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    out = _FakeStream("cp1252")
+    monkeypatch.setattr(sys, "stdout", out)
+
+    _ensure_utf8_stdio()
+
+    assert out.reconfigured is None
+
+
+def test_ensure_utf8_stdio_skips_already_utf8(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A UTF-8 stream is not reconfigured again."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    out = _FakeStream("utf-8")
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", _FakeStream("utf-8"))
+
+    _ensure_utf8_stdio()
+
+    assert out.reconfigured is None
+
+
+def test_ensure_utf8_stdio_tolerates_reconfigure_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stream whose ``reconfigure`` raises does not abort startup."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys, "stdout", _FakeStream("cp1252", raises=True))
+    monkeypatch.setattr(sys, "stderr", _FakeStream("cp1252", raises=True))
+
+    _ensure_utf8_stdio()  # must not raise
 
 
 def test_bare_omnigent_harness_flag_dispatches_to_run(

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -3083,3 +3083,111 @@ def test_credential_label_bedrock_not_duplicated() -> None:
 
     assert credential_label(BEDROCK_KIND, "bedrock") == "AWS Bedrock"
     assert credential_label(BEDROCK_KIND, "nexus") == "AWS Bedrock (nexus)"
+
+
+def _cp1252_console():
+    """Build a Rich console whose file encodes as cp1252, like a legacy Windows shell.
+
+    :returns: A ``(console, buffer)`` pair; decode *buffer* as cp1252 after
+        flushing the console's file to read what was rendered.
+    """
+    import io
+
+    from rich.console import Console
+
+    buffer = io.BytesIO()
+    stream = io.TextIOWrapper(buffer, encoding="cp1252", newline="")
+    return Console(file=stream, force_terminal=True, width=100), buffer
+
+
+@pytest.mark.parametrize(
+    "kind", ["key", "subscription", "gateway", "local", "databricks", "cli-config", "bedrock"]
+)
+def test_kind_glyph_falls_back_to_ascii_on_non_utf8_console(
+    kind: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a cp1252 console every kind glyph degrades to an encodable 2-cell token.
+
+    A legacy-codepage Windows console cannot encode the emoji glyphs, and the
+    raw write raises UnicodeEncodeError. The fallback must both survive the
+    encode and keep the listing's columns aligned (2 display cells, same as
+    the emoji it replaces).
+    """
+    from omnigent.inner.banner import _display_width
+
+    legacy, _ = _cp1252_console()
+    monkeypatch.setattr("omnigent.onboarding.configure_models.console", legacy)
+
+    glyph = kind_glyph(kind)
+    glyph.encode("cp1252")  # raises UnicodeEncodeError if the fallback didn't kick in
+    assert _display_width(glyph) == 2, f"fallback for {kind!r} must stay 2 cells; got {glyph!r}"
+
+
+def test_kind_glyph_keeps_emoji_on_utf8_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A UTF-8 console still gets the real emoji — the fallback is Windows-only fallout."""
+    import io
+
+    from rich.console import Console
+
+    from omnigent.onboarding.configure_models import _KIND_GLYPH
+
+    utf8 = Console(file=io.TextIOWrapper(io.BytesIO(), encoding="utf-8"), force_terminal=True)
+    monkeypatch.setattr("omnigent.onboarding.configure_models.console", utf8)
+
+    for kind, expected in _KIND_GLYPH.items():
+        assert kind_glyph(kind) == expected
+
+
+def test_render_listing_by_harness_survives_non_utf8_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``config list`` renders on a cp1252 console instead of dying on the glyph.
+
+    Reproduces the Windows crash: the shared console's file encodes with the
+    legacy ANSI codepage, so writing the emoji kind glyph raised
+    UnicodeEncodeError and aborted the whole command.
+    """
+    from omnigent.onboarding.configure_models import render_provider_listing_by_harness
+    from omnigent.onboarding.provider_config import load_providers
+
+    legacy, buffer = _cp1252_console()
+    monkeypatch.setattr("omnigent.onboarding.configure_models.console", legacy)
+
+    config: dict[str, object] = {
+        "providers": {"claude-subscription": {"kind": "subscription", "cli": "claude"}}
+    }
+    render_provider_listing_by_harness(config, load_providers(config))
+
+    legacy.file.flush()
+    out = buffer.getvalue().decode("cp1252")
+    assert "claude-subscription" in out
+    assert "subscription" in out
+
+
+def test_render_listing_survives_non_utf8_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The flat provider listing survives a legacy-codepage console too."""
+    from omnigent.onboarding.configure_models import render_provider_listing
+    from omnigent.onboarding.provider_config import load_providers
+
+    legacy, buffer = _cp1252_console()
+    monkeypatch.setattr("omnigent.onboarding.configure_models.console", legacy)
+
+    config: dict[str, object] = {
+        "providers": {"claude-subscription": {"kind": "subscription", "cli": "claude"}}
+    }
+    render_provider_listing(config, load_providers(config), [])
+
+    legacy.file.flush()
+    out = buffer.getvalue().decode("cp1252")
+    assert "claude-subscription" in out
+
+
+def test_add_menu_labels_survive_non_utf8_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ``+ Add a credential`` menu labels are cp1252-encodable as well."""
+    from omnigent.onboarding.configure_models import add_menu_options
+
+    legacy, _ = _cp1252_console()
+    monkeypatch.setattr("omnigent.onboarding.configure_models.console", legacy)
+
+    for option in add_menu_options():
+        option.label.encode("cp1252")

--- a/tests/onboarding/test_interactive.py
+++ b/tests/onboarding/test_interactive.py
@@ -464,3 +464,35 @@ def test_render_menu_compact_truncates_long_description_to_one_line() -> None:
     assert len(hint_lines) == 1
     assert "…" in hint_lines[0]
     assert len(hint_lines[0]) <= 40
+
+
+def _console_with_encoding(encoding: str | None):
+    """Build a Rich console whose file reports *encoding* (or lacks the attr)."""
+    from rich.console import Console
+
+    if encoding is None:
+        buffer = io.BytesIO()  # a raw binary stream has no ``encoding`` attribute
+        return Console(file=buffer, force_terminal=True)  # type: ignore[arg-type]
+    stream = io.TextIOWrapper(io.BytesIO(), encoding=encoding)
+    return Console(file=stream, force_terminal=True)
+
+
+@pytest.mark.parametrize(
+    "encoding,expected",
+    [
+        ("utf-8", True),
+        ("utf-16", True),
+        ("cp1252", False),
+        ("ascii", False),
+        (None, True),  # unknown encoding: nothing to check against, assume ok
+    ],
+)
+def test_encodable_probes_console_encoding(encoding: str | None, expected: bool) -> None:
+    """``encodable`` reports whether the emoji glyph survives the console's encoding."""
+    glyph = "\N{ADMISSION TICKETS}\N{VARIATION SELECTOR-16}"
+    assert interactive.encodable(glyph, _console_with_encoding(encoding)) is expected
+
+
+def test_encodable_ascii_text_always_true() -> None:
+    """Plain ASCII text is encodable even on a legacy codepage console."""
+    assert interactive.encodable("subscription", _console_with_encoding("cp1252")) is True


### PR DESCRIPTION
## Related issue

Closes #2270

## Summary

- `omnigent config list` (and other surfaces printing provider-kind glyphs) crashed with UnicodeEncodeError on Windows shells using a legacy ANSI codepage (cp1252), because the emoji in `_KIND_GLYPH` can't be encoded to that codepage.
- Layer 1 (real fix): `kind_glyph()` now probes the console encoding via a new `interactive.encodable()` helper and returns a 2-cell ASCII stand-in when the emoji isn't encodable, keeping the listing aligned; the three direct glyph-read sites route through it so the whole family (listing, add-menu, CLI harness menu, REPL /model) inherits the fallback.
- Layer 2 (broad hardening): `main()` calls `_ensure_utf8_stdio()` to reconfigure Windows stdout/stderr to utf-8/replace at startup (guarded no-op on posix / already-utf8 / undetachable streams). Not PYTHONUTF8 — that's a startup-only no-op post-launch.

## Test Plan

Ran the new cp1252 TextIOWrapper tests with the source fix reverted to confirm they fail with the exact reported UnicodeEncodeError, then with the fix to confirm green (red→green). Ran the full touched suites: tests/cli/test_configure_models.py + tests/onboarding/test_interactive.py (147 passed), tests/cli/test_cli.py (224 passed), and the REPL model/glyph/cred tests (16 passed) since kind_glyph feeds /model. pre-commit (ruff format/check) clean on all changed files; mypy clean on the two onboarding modules (cli.py has only pre-existing unrelated errors far from the change).

## Demo

N/A — no UI surface in this diff.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The load-bearing test (Rich Console pointed at an io.TextIOWrapper encoded cp1252) faithfully reproduces the RAISING FRAME from the traceback — the charmap encode inside file.write — on Linux, and I confirmed red (UnicodeEncodeError) → green. That proves the glyph-fallback layer actually prevents the crash. What it does NOT exercise: rich's Windows-specific legacy_windows detection / LegacyWindowsTerm code path (only reachable on a real Windows console), and the sys.stdout.reconfigure() call in main() is verified only via a fake-stream mock (platform monkeypatched to 'win32') — no real Windows machine was available. The glyph layer is encoding-path-agnostic (fixes the source, not the console wrapper), so it is the robust part; the stdio layer is a broad belt-and-suspenders fix I could not eyeball on actual cp1252 hardware.

## Changelog

Fixed a crash when listing providers on Windows shells using a non-UTF-8 system codepage.
