### PR TITLE
fix(host): trust a CA bundle for the tunnel and fail loud on TLS verify

### DIFF
--- a/docs/databricks.md
+++ b/docs/databricks.md
@@ -612,6 +612,7 @@ explicit consent and PII handling in place.
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Workspace URL (same as `DATABRICKS_HOST`) | Apps env |
 | `OTEL_EXPORTER_OTLP_HEADERS` | `Authorization=Bearer $DATABRICKS_TOKEN` | Apps env |
 | `OMNIGENT_OTEL_CAPTURE_CONTENT` | `true` to include message bodies in traces | Apps env (default off) |
+| `OMNIGENT_CA_BUNDLE` | PEM CA bundle the host/runner tunnel trusts, for a TLS-inspecting proxy or private CA | Local shell where you run `omnigent host` |
 
 ---
 
@@ -672,6 +673,22 @@ fresh Lakebase project per omnigent app rather than sharing one.
 The External Model's underlying provider key (stored in workspace
 secrets) has expired or rotated. Update the secret value, then update
 the endpoint config via `databricks serving-endpoints update`.
+
+### `omnigent host` loops on "CERTIFICATE_VERIFY_FAILED"
+
+The host tunnel is a `wss://` connection. When a corporate
+TLS-inspecting proxy (Zscaler / Netskope) or a private CA re-signs it,
+the certificate isn't in your system trust store and the handshake
+fails to verify. Export your organisation's CA bundle as a PEM file and
+point `OMNIGENT_CA_BUNDLE` at it:
+
+```bash
+OMNIGENT_CA_BUNDLE=/path/to/corp-ca.pem omnigent host --server https://<workspace>.databricks.com
+```
+
+`SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` are honoured too if already
+set. The bundle is forwarded to spawned runners so their tunnels trust
+the same CA.
 
 ---
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import logging
 import os
+import ssl
 import subprocess
 import sys
 from collections.abc import Iterator, Mapping
@@ -84,6 +85,13 @@ from omnigent.runner.transports.ws_tunnel.frames import (
 from omnigent.runner.transports.ws_tunnel.limits import (
     TUNNEL_KEEPALIVE_PING_INTERVAL_S,
     TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+)
+from omnigent.runner.transports.ws_tunnel.tls import (
+    CA_BUNDLE_ENV_VAR,
+    TunnelTLSError,
+    ca_bundle_fix_hint,
+    is_tls_verification_failure,
+    tunnel_ssl_context,
 )
 from omnigent.version import VERSION
 
@@ -272,6 +280,10 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         "TERMINFO",
         "TERMINFO_DIRS",
         "LANG",
+        # A runner opens its own tunnel back to the server, so a host
+        # behind a TLS-inspecting proxy or private CA must pass its
+        # bundle down or the runner tunnel fails to verify.
+        CA_BUNDLE_ENV_VAR,
         "SSL_CERT_FILE",
         "SSL_CERT_DIR",
         "REQUESTS_CA_BUNDLE",
@@ -915,6 +927,23 @@ class HostProcess:
         return (
             "If this server uses Omnigent accounts or OIDC login, run "
             f"`omnigent login {self._server_url}` to authenticate."
+        )
+
+    def _fatal_tls_error(self, exc: ssl.SSLError) -> HostConnectError:
+        """Explain a TLS certificate-verification failure on the tunnel.
+
+        The bare OpenSSL string ("self-signed certificate in certificate
+        chain") names the symptom but not the cause or the fix, so the
+        message spells out both.
+
+        :param exc: The verification failure raised by the handshake.
+        :returns: A fatal error carrying the cause and the remedy.
+        """
+        return HostConnectError(
+            f"TLS verification failed for {self._tunnel_url()}: {exc}. This usually "
+            "means a TLS-inspecting corporate proxy (Zscaler/Netskope) or a private "
+            "CA is re-signing the connection with a certificate your system trust "
+            f"store doesn't know. {ca_bundle_fix_hint()}"
         )
 
     def _fatal_upgrade_error(self, exc: InvalidURI | InvalidStatus) -> HostConnectError | None:
@@ -1734,6 +1763,16 @@ class HostProcess:
 
         _logger.info("Connecting to %s", url)
         try:
+            ssl_context = tunnel_ssl_context(url, os.environ)
+        except TunnelTLSError as exc:
+            # A configured-but-broken bundle can never be fixed by
+            # retrying — fail loud instead of silently using the system
+            # store the operator meant to override.
+            raise HostConnectError(str(exc)) from exc
+        # Omit ``ssl`` entirely when there's no override so websockets keeps
+        # its own default handling (and never sees ssl= on a ws:// URL).
+        tls_kwargs = {"ssl": ssl_context} if ssl_context is not None else {}
+        try:
             ws_cm = websockets.asyncio.client.connect(
                 url,
                 additional_headers=headers,
@@ -1744,8 +1783,19 @@ class HostProcess:
                 # Symmetric with serve.py's runner-side connect().
                 ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
                 ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+                # Only carries ``ssl`` when a CA bundle override is set; the
+                # default path passes nothing so websockets keeps its own
+                # ``ssl=True`` handling untouched.
+                **tls_kwargs,  # type: ignore[arg-type]
             )
             ws = await ws_cm.__aenter__()
+        except ssl.SSLError as exc:
+            # A trust failure is permanent — retrying can never teach the
+            # process to trust the certificate. Other TLS errors (e.g. a
+            # mid-handshake EOF from a bounced ingress) stay retryable.
+            if is_tls_verification_failure(exc):
+                raise self._fatal_tls_error(exc) from exc
+            raise
         except (InvalidURI, InvalidStatus) as exc:
             # The upgrade itself was rejected. Fail loud on permanent
             # failures (auth / authorization / outdated server); let the

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -17,7 +17,9 @@ import base64
 import binascii
 import contextlib
 import logging
+import os
 import random
+import ssl
 from collections.abc import Awaitable, Callable
 from typing import Any
 from urllib.parse import quote, urlsplit, urlunsplit
@@ -49,6 +51,12 @@ from omnigent.runner.transports.ws_tunnel.limits import (
     RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
     TUNNEL_KEEPALIVE_PING_INTERVAL_S,
     TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+)
+from omnigent.runner.transports.ws_tunnel.tls import (
+    TunnelTLSError,
+    ca_bundle_fix_hint,
+    is_tls_verification_failure,
+    tunnel_ssl_context,
 )
 
 _logger = logging.getLogger(__name__)
@@ -309,6 +317,24 @@ async def serve_tunnel(
             delay_s = _INITIAL_RECONNECT_DELAY_S
         except asyncio.CancelledError:
             raise
+        except TunnelTLSError as exc:
+            # A configured-but-broken CA bundle (missing path, not a PEM) can
+            # never be fixed by retrying — fail loud with the clean message
+            # instead of crashing the runner with a raw traceback.
+            raise RuntimeError(str(exc)) from exc
+        except ssl.SSLError as exc:
+            # A certificate-verification failure is permanent: reconnecting can
+            # never teach the process to trust the cert, so fail loud with the
+            # bundle hint. Other TLS errors (a mid-handshake EOF from a bounced
+            # ingress) stay on the retry path below.
+            if is_tls_verification_failure(exc):
+                raise RuntimeError(
+                    f"TLS verification failed for {tunnel_url}: {exc}. This usually "
+                    "means a TLS-inspecting corporate proxy (Zscaler/Netskope) or a "
+                    "private CA is re-signing the connection with a certificate your "
+                    f"system trust store doesn't know. {ca_bundle_fix_hint()}"
+                ) from exc
+            retry_reason = str(exc)
         except WebSocketException as exc:
             redirect_url = _websocket_auth_redirect_url(exc)
             if redirect_url is not None:
@@ -544,6 +570,10 @@ async def _serve_tunnel_once(
     headers.update(databricks_request_headers(server_url, bearer_token=auth_token))
     if tunnel_token:
         headers[RUNNER_TUNNEL_TOKEN_HEADER] = tunnel_token
+    # Omit ``ssl`` entirely when no CA bundle is configured so websockets
+    # keeps its own default handling (and never sees ssl= on a ws:// URL).
+    ssl_context = tunnel_ssl_context(tunnel_url, os.environ)
+    tls_kwargs = {"ssl": ssl_context} if ssl_context is not None else {}
     async with websockets.connect(
         tunnel_url,
         additional_headers=headers,
@@ -554,6 +584,9 @@ async def _serve_tunnel_once(
         # Also the runner's only liveness probe for a silently-dead server.
         ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
         ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+        # Only carries ``ssl`` when a CA bundle override is set; the default
+        # path passes nothing so websockets keeps its own default handling.
+        **tls_kwargs,  # type: ignore[arg-type]
     ) as ws:
         await _send_hello(ws.send, runner_version)
         _logger.info("runner %s connected to %s", runner_id, tunnel_url)

--- a/omnigent/runner/transports/ws_tunnel/tls.py
+++ b/omnigent/runner/transports/ws_tunnel/tls.py
@@ -1,0 +1,128 @@
+"""TLS trust-store resolution shared by the host and runner WebSocket tunnels.
+
+A corporate TLS-inspecting proxy (Zscaler/Netskope) or a private CA
+re-signs the ``wss://`` handshake with a certificate the system trust
+store doesn't know, so the tunnel fails with ``CERTIFICATE_VERIFY_FAILED``
+and no way to supply the organisation's bundle. These helpers resolve a
+bundle from the environment and build the ``ssl`` context both tunnels
+hand to ``websockets``.
+"""
+
+from __future__ import annotations
+
+import logging
+import ssl
+from collections.abc import Mapping
+from pathlib import Path
+from urllib.parse import urlparse
+
+_logger = logging.getLogger(__name__)
+
+CA_BUNDLE_ENV_VAR = "OMNIGENT_CA_BUNDLE"
+
+# Checked in order, first one set wins. OMNIGENT_CA_BUNDLE is the dedicated
+# knob; the rest are the conventional trust-store vars the surrounding
+# toolchain (requests, curl) already honours, so an operator who configured
+# those for a corporate proxy gets a working tunnel for free.
+_CA_BUNDLE_ENV_VARS: tuple[str, ...] = (
+    CA_BUNDLE_ENV_VAR,
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+)
+
+
+class TunnelTLSError(Exception):
+    """A configured CA bundle is unusable (missing path, or not a PEM).
+
+    The message is the full user-facing explanation including the fix.
+    """
+
+
+def ca_bundle_fix_hint() -> str:
+    """Build the remedy for a TLS trust failure on the tunnel.
+
+    :returns: A sentence naming the env var and an example invocation.
+    """
+    return (
+        f"Export your organisation's CA bundle and point {CA_BUNDLE_ENV_VAR} "
+        "(or SSL_CERT_FILE) at the PEM file, e.g. "
+        f"`{CA_BUNDLE_ENV_VAR}=/path/to/corp-ca.pem omnigent host --server <url>`."
+    )
+
+
+def _resolve_ca_bundle(env: Mapping[str, str]) -> tuple[str, Path] | None:
+    """Find the first CA bundle override set in *env*.
+
+    :param env: Environment mapping to read, e.g. ``os.environ``.
+    :returns: The ``(var_name, path)`` that won, or ``None`` when no
+        override is configured.
+    """
+    for name in _CA_BUNDLE_ENV_VARS:
+        value = env.get(name, "").strip()
+        if value:
+            return name, Path(value)
+    return None
+
+
+def tunnel_ssl_context(
+    tunnel_url: str,
+    env: Mapping[str, str],
+) -> ssl.SSLContext | None:
+    """Build the ``ssl`` context for a tunnel handshake, if one is needed.
+
+    Returns ``None`` unless a CA bundle override is configured, so the
+    default install keeps ``websockets``' own ``ssl=True`` handling and
+    the system trust store. ``ws://`` never gets a context — ``websockets``
+    rejects ``ssl=`` on a plaintext URI.
+
+    :param tunnel_url: The tunnel URL, e.g.
+        ``"wss://acme.databricks.com/v1/hosts/host_abc/tunnel"``.
+    :param env: Environment mapping to read the override from, e.g.
+        ``os.environ``.
+    :returns: A context trusting the configured bundle, or ``None`` to
+        leave the library default alone.
+    :raises TunnelTLSError: If the configured bundle is missing or
+        unreadable — a typo'd path must fail loud, not silently fall back
+        to the system store.
+    """
+    if urlparse(tunnel_url).scheme != "wss":
+        return None
+    resolved = _resolve_ca_bundle(env)
+    if resolved is None:
+        return None
+    var_name, path = resolved
+    if not path.is_file():
+        raise TunnelTLSError(
+            f"{var_name}={path} does not point at a readable file, so the TLS "
+            f"trust store for {tunnel_url} could not be built. "
+            f"{ca_bundle_fix_hint()}"
+        )
+    try:
+        # Add the bundle ON TOP of the system trust store, not instead of it.
+        # A bundle set for one purpose (an internal PyPI mirror via
+        # REQUESTS_CA_BUNDLE) must not stop the tunnel trusting the public
+        # roots that sign a normal wss:// host.
+        context = ssl.create_default_context()
+        context.load_verify_locations(cafile=str(path))
+    except (ssl.SSLError, OSError) as exc:
+        raise TunnelTLSError(
+            f"{var_name}={path} could not be loaded as a CA bundle: {exc}. "
+            f"It must be a PEM file containing one or more certificates. "
+            f"{ca_bundle_fix_hint()}"
+        ) from exc
+    _logger.info("Using CA bundle from %s=%s for %s", var_name, path, tunnel_url)
+    return context
+
+
+def is_tls_verification_failure(exc: BaseException) -> bool:
+    """Whether *exc* is a permanent TLS trust failure.
+
+    Only certificate verification is permanent: reconnecting can never
+    teach the process to trust a certificate. Other ``ssl.SSLError``
+    subtypes (a mid-handshake ``SSLEOFError`` from a bounced ingress, say)
+    are transient and belong on the retry path.
+
+    :param exc: The exception raised by the handshake.
+    :returns: ``True`` for a certificate-verification failure.
+    """
+    return isinstance(exc, ssl.SSLCertVerificationError)

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import ssl
 import subprocess
 import time
 from pathlib import Path
@@ -1981,16 +1982,19 @@ class _ConnectSpy:
         """
         self._exceptions = exceptions
         self.call_count = 0
+        self.kwargs: list[dict[str, object]] = []
 
     def __call__(self, url: str, **kwargs: object) -> _HandshakeFailingConnect | _AcceptingConnect:
         """Return an async-CM scripting the handshake for this call.
 
         :param url: Tunnel URL passed by production (ignored).
-        :param kwargs: Connect kwargs passed by production (ignored).
+        :param kwargs: Connect kwargs passed by production; recorded on
+            :attr:`kwargs` so tests can assert what production requested.
         :returns: A context manager whose ``__aenter__`` raises the
             queued exception, or completes the handshake for a ``None``
             entry.
         """
+        self.kwargs.append(dict(kwargs))
         exc = self._exceptions[min(self.call_count, len(self._exceptions) - 1)]
         self.call_count += 1
         if exc is None:
@@ -2382,3 +2386,177 @@ def test_run_host_process_announces_session_log_dir_on_start(
     out = capsys.readouterr().out
     assert "Session logs: ~/.omnigent/logs/runner/" in out
     assert "This host's log: ~/.omnigent/logs/host/host-" in out
+
+
+@pytest.fixture
+def _no_ca_bundle_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear every CA-bundle override so the ambient shell can't skew a test.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :returns: None.
+    """
+    for name in ("OMNIGENT_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _ca_bundle_pem(tmp_path: Path) -> Path:
+    """Write a real single-certificate PEM usable as a CA bundle.
+
+    :param tmp_path: The pytest tmp_path fixture.
+    :returns: Path to the PEM file.
+    """
+    from omnigent.inner.egress.ca import ensure_ca
+
+    cert_path, _key_path = ensure_ca(cache_dir=tmp_path)
+    return cert_path
+
+
+async def test_ssl_verify_failure_fails_loud(
+    monkeypatch: pytest.MonkeyPatch, _no_ca_bundle_env: None
+) -> None:
+    """A certificate-verification failure fails loud with the CA-bundle fix.
+
+    A TLS-inspecting corporate proxy re-signs the wss:// handshake, so
+    verification fails against the system trust store. Retrying can never
+    teach the process to trust that certificate — before this, the host
+    looped on backoff forever logging only the raw OpenSSL string, with
+    no hint that a bundle could be supplied.
+    """
+    spy = _ConnectSpy(
+        [
+            ssl.SSLCertVerificationError(
+                "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: "
+                "self-signed certificate in certificate chain (_ssl.c:1028)"
+            )
+        ]
+    )
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with pytest.raises(HostConnectError) as excinfo:
+        await host.run()
+
+    message = str(excinfo.value)
+    # Names the real cause, not just the raw OpenSSL string...
+    assert "CERTIFICATE_VERIFY_FAILED" in message
+    # ...and the actionable remedy the user could not previously discover.
+    assert "OMNIGENT_CA_BUNDLE" in message
+    # Exactly one attempt → the infinite reconnect loop is gone.
+    assert spy.call_count == 1
+
+
+async def test_transient_ssl_error_still_retries(
+    monkeypatch: pytest.MonkeyPatch, _no_ca_bundle_env: None
+) -> None:
+    """A non-verification TLS error stays on the retry path.
+
+    A mid-handshake SSLEOFError is what a bounced Apps ingress looks like;
+    treating every ssl.SSLError as fatal would kill live hosts on a blip.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    spy = _ConnectSpy(
+        [ssl.SSLEOFError("EOF occurred in violation of protocol"), asyncio.CancelledError()]
+    )
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    # Returns normally (no HostConnectError): the blip was retried and the
+    # 2nd-attempt CancelledError broke the loop.
+    await host.run()
+
+    assert spy.call_count == 2
+
+
+async def test_ca_bundle_env_passed_as_ssl_context(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _no_ca_bundle_env: None
+) -> None:
+    """OMNIGENT_CA_BUNDLE reaches the handshake as an ssl context."""
+    monkeypatch.setenv("OMNIGENT_CA_BUNDLE", str(_ca_bundle_pem(tmp_path)))
+    spy = _ConnectSpy([asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    await host.run()
+
+    assert spy.call_count == 1
+    assert isinstance(spy.kwargs[0]["ssl"], ssl.SSLContext)
+
+
+async def test_missing_ca_bundle_fails_loud(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _no_ca_bundle_env: None
+) -> None:
+    """A CA bundle pointing at a nonexistent path fails loud, naming it.
+
+    Silently falling back to the system store would reproduce the original
+    verify failure while the operator believes their bundle is in use.
+    """
+    missing = tmp_path / "typo-ca.pem"
+    monkeypatch.setenv("OMNIGENT_CA_BUNDLE", str(missing))
+    spy = _ConnectSpy([asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with pytest.raises(HostConnectError) as excinfo:
+        await host.run()
+
+    message = str(excinfo.value)
+    assert str(missing) in message
+    assert "OMNIGENT_CA_BUNDLE" in message
+    # Never even attempted the handshake → no backoff loop on a typo.
+    assert spy.call_count == 0
+
+
+async def test_no_ca_bundle_env_leaves_ssl_default(
+    monkeypatch: pytest.MonkeyPatch, _no_ca_bundle_env: None
+) -> None:
+    """With no override, no ``ssl`` kwarg is passed at all.
+
+    Regression guard: passing an explicit context on the default path
+    would replace the library's own ``ssl=True`` handling for every
+    working install.
+    """
+    spy = _ConnectSpy([asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    await host.run()
+
+    assert spy.call_count == 1
+    assert "ssl" not in spy.kwargs[0]
+
+
+async def test_ca_bundle_not_passed_on_plaintext_ws(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _no_ca_bundle_env: None
+) -> None:
+    """A ws:// tunnel gets no ssl kwarg even with a bundle configured.
+
+    ``websockets`` rejects ``ssl=`` on a plaintext URI, so an ambient
+    SSL_CERT_FILE must not break a local http:// server.
+    """
+    monkeypatch.setenv("SSL_CERT_FILE", str(_ca_bundle_pem(tmp_path)))
+    spy = _ConnectSpy([asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host(server_url="http://127.0.0.1:6767")
+
+    await host.run()
+
+    assert spy.call_count == 1
+    assert "ssl" not in spy.kwargs[0]
+
+
+def test_ca_bundle_env_forwarded_to_runner() -> None:
+    """OMNIGENT_CA_BUNDLE survives the runner env allowlist.
+
+    A host behind a corporate CA spawns runners that open their own
+    tunnel back to the server — they need the same bundle.
+    """
+    env = _build_runner_env(
+        {"OMNIGENT_CA_BUNDLE": "/etc/ssl/corp-ca.pem"},
+        server_url="https://app.example.databricks.com",
+        runner_id="runner_abc",
+        binding_token="tok",
+        workspace="/tmp/ws",
+        parent_pid=1234,
+    )
+
+    assert env["OMNIGENT_CA_BUNDLE"] == "/etc/ssl/corp-ca.pem"

--- a/tests/runner/transports/ws_tunnel/test_serve.py
+++ b/tests/runner/transports/ws_tunnel/test_serve.py
@@ -1210,3 +1210,246 @@ async def test_serve_tunnel_reconnect_uses_fresh_token_not_stale(
         f"If both are the same, the factory was cached. If either is "
         f"'tok-initial', the factory was not called before reconnect."
     )
+
+
+async def test_serve_tunnel_once_omits_ssl_without_ca_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no CA bundle configured, no ``ssl`` kwarg reaches ``connect``.
+
+    Regression guard: the runner tunnel must keep websockets' own default
+    handling on the normal path.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    for name in ("OMNIGENT_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+        monkeypatch.delenv(name, raising=False)
+    captured = await _capture_connect_kwargs(monkeypatch, tunnel_url="wss://srv/tunnel")
+
+    assert "ssl" not in captured
+
+
+async def test_serve_tunnel_once_passes_ca_bundle_as_ssl_context(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """A configured CA bundle reaches the runner handshake as an ssl context.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Pytest tmp_path fixture.
+    :returns: None.
+    """
+    import ssl
+
+    from omnigent.inner.egress.ca import ensure_ca
+
+    for name in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+        monkeypatch.delenv(name, raising=False)
+    cert_path, _key = ensure_ca(cache_dir=tmp_path)
+    monkeypatch.setenv("OMNIGENT_CA_BUNDLE", str(cert_path))
+    captured = await _capture_connect_kwargs(monkeypatch, tunnel_url="wss://srv/tunnel")
+
+    assert isinstance(captured["ssl"], ssl.SSLContext)
+
+
+@pytest.mark.asyncio
+async def test_serve_tunnel_fails_loud_on_cert_verify_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A certificate-verification failure exits fatally, never retrying.
+
+    A runner behind a TLS-inspecting proxy without a CA bundle would
+    otherwise catch the ``SSLCertVerificationError`` under the generic
+    ``OSError`` branch and reconnect forever — the exact infinite loop the
+    issue reports. It must fail loud with the bundle hint instead.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import ssl
+
+    async def _serve_once(
+        app: Any,
+        *,
+        tunnel_url: str,
+        server_url: str = "",
+        runner_id: str,
+        runner_version: str,
+        auth_token: str | None = None,
+        tunnel_token: str | None = None,
+    ) -> None:
+        """Raise a TLS certificate-verification failure.
+
+        :raises ssl.SSLCertVerificationError: Always.
+        """
+        del app, tunnel_url, runner_id, runner_version, auth_token, tunnel_token
+        raise ssl.SSLCertVerificationError("self-signed certificate in certificate chain")
+
+    async def _sleep(delay: float) -> None:
+        """Fail if a permanent trust failure ever backs off for a retry.
+
+        :raises AssertionError: Always.
+        """
+        raise AssertionError(f"cert-verify failure should not sleep before retry: {delay}")
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await serve_tunnel(
+            _noop_app,
+            server_url="https://example.databricksapps.com",
+            runner_id="runner_cert_verify",
+            runner_version="0.1.0",
+        )
+    message = str(exc_info.value)
+    assert "TLS verification failed" in message
+    assert "OMNIGENT_CA_BUNDLE" in message
+
+
+@pytest.mark.asyncio
+async def test_serve_tunnel_retries_transient_ssl_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-verification TLS error stays on the reconnect path.
+
+    A mid-handshake ``SSLEOFError`` from a bounced ingress is transient, so
+    the runner must back off and retry rather than fail loud.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import ssl
+
+    calls = {"n": 0}
+
+    async def _serve_once(
+        app: Any,
+        *,
+        tunnel_url: str,
+        server_url: str = "",
+        runner_id: str,
+        runner_version: str,
+        auth_token: str | None = None,
+        tunnel_token: str | None = None,
+    ) -> None:
+        """First attempt hits a transient EOF; the second is cancelled to
+        break the loop.
+
+        :raises ssl.SSLEOFError: On the first call.
+        :raises asyncio.CancelledError: On the second call.
+        """
+        del app, tunnel_url, runner_id, runner_version, auth_token, tunnel_token
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ssl.SSLEOFError("EOF occurred in violation of protocol")
+        raise asyncio.CancelledError
+
+    slept: list[float] = []
+
+    async def _sleep(delay: float) -> None:
+        """Record that the retry path backed off."""
+        slept.append(delay)
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await serve_tunnel(
+            _noop_app,
+            server_url="https://example.databricksapps.com",
+            runner_id="runner_transient_ssl",
+            runner_version="0.1.0",
+        )
+    # The transient error backed off and reconnected instead of failing loud.
+    assert slept
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_serve_tunnel_fails_loud_on_bad_ca_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A misconfigured CA bundle exits with a clean message, not a traceback.
+
+    ``tunnel_ssl_context`` raises ``TunnelTLSError`` (a plain ``Exception``,
+    not ``OSError``) when the forwarded bundle path is absent or not a PEM.
+    ``serve_tunnel`` must convert it to a fatal ``RuntimeError`` rather than
+    letting the raw traceback crash the runner — retrying can't fix it.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    from omnigent.runner.transports.ws_tunnel.tls import TunnelTLSError
+
+    async def _serve_once(
+        app: Any,
+        *,
+        tunnel_url: str,
+        server_url: str = "",
+        runner_id: str,
+        runner_version: str,
+        auth_token: str | None = None,
+        tunnel_token: str | None = None,
+    ) -> None:
+        """Raise the TLS-config error the ssl-context builder emits.
+
+        :raises TunnelTLSError: Always.
+        """
+        del app, tunnel_url, runner_id, runner_version, auth_token, tunnel_token
+        raise TunnelTLSError("OMNIGENT_CA_BUNDLE=/gone.pem does not point at a readable file")
+
+    async def _sleep(delay: float) -> None:
+        """Fail if a permanent config error ever backs off for a retry.
+
+        :raises AssertionError: Always.
+        """
+        raise AssertionError(f"bad CA bundle should not sleep before retry: {delay}")
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await serve_tunnel(
+            _noop_app,
+            server_url="https://example.databricksapps.com",
+            runner_id="runner_bad_bundle",
+            runner_version="0.1.0",
+        )
+    assert "OMNIGENT_CA_BUNDLE=/gone.pem" in str(exc_info.value)
+
+
+async def _capture_connect_kwargs(
+    monkeypatch: pytest.MonkeyPatch, *, tunnel_url: str
+) -> dict[str, Any]:
+    """Run one ``_serve_tunnel_once`` and capture the ``connect`` kwargs.
+
+    Stubs ``websockets.connect`` with a recorder that aborts the handshake
+    so no socket is opened.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tunnel_url: Tunnel URL to hand production.
+    :returns: The keyword arguments production passed to ``connect``.
+    """
+    import websockets
+
+    captured: dict[str, Any] = {}
+
+    class _Abort(Exception):
+        pass
+
+    def _fake_connect(url: str, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        raise _Abort
+
+    monkeypatch.setattr(websockets, "connect", _fake_connect)
+
+    with pytest.raises(_Abort):
+        await _serve_tunnel_once(
+            _noop_app,
+            tunnel_url=tunnel_url,
+            server_url="https://srv",
+            runner_id="runner_tls",
+            runner_version="0.1.0",
+        )
+    return captured

--- a/tests/runner/transports/ws_tunnel/test_tls.py
+++ b/tests/runner/transports/ws_tunnel/test_tls.py
@@ -1,0 +1,104 @@
+"""Unit tests for the tunnel TLS trust-store helpers."""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner.egress.ca import ensure_ca
+from omnigent.runner.transports.ws_tunnel.tls import (
+    TunnelTLSError,
+    is_tls_verification_failure,
+    tunnel_ssl_context,
+)
+
+
+def test_no_override_returns_none() -> None:
+    """No CA-bundle env → no context, so the library default is kept."""
+    assert tunnel_ssl_context("wss://srv/tunnel", {}) is None
+
+
+def test_plaintext_ws_never_gets_context(tmp_path: Path) -> None:
+    """A ws:// URL returns None even when a bundle is configured.
+
+    websockets rejects ``ssl=`` on a plaintext URI, so an ambient bundle
+    must not break a local http:// server.
+    """
+    cert_path, _key = ensure_ca(cache_dir=tmp_path)
+    assert (
+        tunnel_ssl_context("ws://127.0.0.1:6767/tunnel", {"OMNIGENT_CA_BUNDLE": str(cert_path)})
+        is None
+    )
+
+
+def test_bundle_builds_context(tmp_path: Path) -> None:
+    """A readable PEM produces a verifying SSL context."""
+    cert_path, _key = ensure_ca(cache_dir=tmp_path)
+    ctx = tunnel_ssl_context("wss://srv/tunnel", {"OMNIGENT_CA_BUNDLE": str(cert_path)})
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_bundle_is_additive_to_system_store(tmp_path: Path) -> None:
+    """The bundle is trusted ON TOP of the system store, not instead of it.
+
+    A user with REQUESTS_CA_BUNDLE pointed at an internal PyPI mirror CA
+    (not behind a TLS-inspecting proxy) must still verify the public roots
+    that sign a normal wss:// host — the override must not shrink trust to
+    the single custom cert.
+    """
+    cert_path, _key = ensure_ca(cache_dir=tmp_path)
+    ctx = tunnel_ssl_context("wss://srv/tunnel", {"REQUESTS_CA_BUNDLE": str(cert_path)})
+    assert isinstance(ctx, ssl.SSLContext)
+    system_only = ssl.create_default_context()
+    # System roots plus exactly the one custom CA — a bundle-only context
+    # would hold just the single cert.
+    assert ctx.cert_store_stats()["x509"] == system_only.cert_store_stats()["x509"] + 1
+
+
+def test_env_precedence_prefers_dedicated_var(tmp_path: Path) -> None:
+    """OMNIGENT_CA_BUNDLE wins over the conventional trust-store vars."""
+    dedicated, _k1 = ensure_ca(cache_dir=tmp_path / "a")
+    fallback, _k2 = ensure_ca(cache_dir=tmp_path / "b")
+    ctx = tunnel_ssl_context(
+        "wss://srv/tunnel",
+        {"OMNIGENT_CA_BUNDLE": str(dedicated), "SSL_CERT_FILE": str(fallback)},
+    )
+    assert isinstance(ctx, ssl.SSLContext)
+
+
+def test_ssl_cert_file_used_as_fallback(tmp_path: Path) -> None:
+    """SSL_CERT_FILE is honoured when the dedicated var is unset."""
+    cert_path, _key = ensure_ca(cache_dir=tmp_path)
+    ctx = tunnel_ssl_context("wss://srv/tunnel", {"SSL_CERT_FILE": str(cert_path)})
+    assert isinstance(ctx, ssl.SSLContext)
+
+
+def test_missing_bundle_raises_naming_path(tmp_path: Path) -> None:
+    """A nonexistent bundle path fails loud rather than falling back."""
+    missing = tmp_path / "nope.pem"
+    with pytest.raises(TunnelTLSError) as excinfo:
+        tunnel_ssl_context("wss://srv/tunnel", {"OMNIGENT_CA_BUNDLE": str(missing)})
+    assert str(missing) in str(excinfo.value)
+    assert "OMNIGENT_CA_BUNDLE" in str(excinfo.value)
+
+
+def test_non_pem_bundle_raises(tmp_path: Path) -> None:
+    """A file that isn't a PEM fails loud with a readable message."""
+    junk = tmp_path / "junk.pem"
+    junk.write_text("not a certificate")
+    with pytest.raises(TunnelTLSError):
+        tunnel_ssl_context("wss://srv/tunnel", {"OMNIGENT_CA_BUNDLE": str(junk)})
+
+
+def test_verification_failure_is_fatal() -> None:
+    """A certificate-verification error is classified permanent."""
+    assert is_tls_verification_failure(ssl.SSLCertVerificationError("verify failed"))
+
+
+def test_other_ssl_errors_are_transient() -> None:
+    """A non-verification TLS error stays retryable."""
+    assert not is_tls_verification_failure(ssl.SSLEOFError("eof"))
+    assert not is_tls_verification_failure(ssl.SSLError("generic"))


### PR DESCRIPTION
## Related issue

Closes #2524

## Summary

- The wss:// host (and runner) tunnel now builds an ssl context from a CA bundle env var (OMNIGENT_CA_BUNDLE, else SSL_CERT_FILE / REQUESTS_CA_BUNDLE) so a corporate TLS-inspecting proxy or private CA no longer breaks registration; with no override the ssl kwarg is omitted entirely, keeping the default install byte-identical.
- A certificate-verification failure is now fatal with an actionable message naming the bundle env var, instead of an OSError that fell through to the reconnect loop and retried forever (the reported symptom). Other ssl.SSLError subtypes stay retryable. The bundle is added to the runner env allowlist so spawned runners trust the same CA.
- No --insecure/skip-verify escape hatch was added (deliberate, per the maintainer security decision).

An internal adversarial review pass caught and fixed follow-up correctness issues before submission:
- omnigent/runner/transports/ws_tunnel/tls.py:101 — bundle now additive to system store (create_default_context() + load_verify_locations) instead of cafile-only
- omnigent/runner/transports/ws_tunnel/serve.py:362 — added `except ssl.SSLError` before the OSError branch: fatal RuntimeError on cert-verify failure, transient SSLErrors stay on retry path
- omnigent/runner/transports/ws_tunnel/serve.py:551 — added `except TunnelTLSError` in serve_tunnel converting a broken CA bundle to a fatal RuntimeError instead of an uncaught traceback

## Test Plan

uv run pre-commit run --files <changed files> (all hooks pass). Offline pytest, no network/Databricks: `.venv/bin/python -m pytest tests/host/test_connect.py tests/runner/transports/ws_tunnel/test_serve.py tests/runner/transports/ws_tunnel/test_tls.py --timeout=120 --timeout-method=signal -q` → 115 passed. New tests cover the fatal verify path (fails on first attempt, message names OMNIGENT_CA_BUNDLE), the bundle-as-ssl-context path on host and runner tunnels, the unchanged default path (no ssl kwarg), the ws:// guard, transient-TLS retry, missing-bundle fail-loud, and the runner env forwarding. Red→green captured: pre-fix the verify test hangs in an infinite reconnect loop (killed by pytest-timeout) reproducing the issue's exact log lines; post-fix it exits immediately raising HostConnectError.

**Post-review verification:** .venv/bin/python -m pytest tests/runner/transports/ws_tunnel/test_tls.py tests/runner/transports/ws_tunnel/test_serve.py tests/host/test_connect.py -q → 119 passed, 44 warnings in 2.35s

## Demo

N/A — no UI surface in this diff.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

What the tests prove vs. not is detailed above; summarizing: mechanism and error message are fully verified offline, but the reporter's live corporate-MITM + Databricks-vanity-URL chain is not reproducible in this environment, so the specific end-to-end handshake against their proxy is unverified.

## Changelog

`omnigent host` now trusts a CA bundle from OMNIGENT_CA_BUNDLE (or SSL_CERT_FILE/REQUESTS_CA_BUNDLE) for the tunnel and fails with a clear fix instead of looping forever behind a TLS-inspecting proxy or private CA.
