### PR TITLE
feat(deploy): host-scoped git credentials for managed sandboxes

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -349,7 +349,9 @@ secret to name the extra vars the host should forward to runners.
 session workspace; for private ones, store an HTTPS token as `GIT_TOKEN` in
 a Modal secret (GitLab: add `GIT_USERNAME=oauth2`). The host image's git
 credential helper picks it up for the clone and for the agent's later
-fetch/push.
+fetch/push. Remotes on a second host take their own host-scoped
+`GIT_TOKEN_GIT_EXAMPLE_COM` — see [multiple git
+hosts](modal/README.md#multiple-git-hosts).
 
 The full Modal guide (CLI sandboxes, custom images, LLM and git credentials,
 troubleshooting) lives at [`modal/README.md`](modal/README.md); the Daytona

--- a/deploy/cwsandbox/README.md
+++ b/deploy/cwsandbox/README.md
@@ -232,7 +232,9 @@ Inject an HTTPS token as `GIT_TOKEN` (GitLab: add `GIT_USERNAME=oauth2`) via
 credential helper answers HTTPS auth from it for both the launch-time clone and
 the agent's later `fetch` / `push`, writing nothing to disk. Use HTTPS repository
 URLs. Details by provider match the [Modal git
-guide](../modal/README.md#git-credentials-private-repositories).
+guide](../modal/README.md#git-credentials-private-repositories). For a second
+host with its own token, add a host-scoped `GIT_TOKEN_GIT_EXAMPLE_COM` — see
+[multiple git hosts](../modal/README.md#multiple-git-hosts).
 
 ## Security considerations
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -214,16 +214,14 @@ RUN groupadd -g 1000660000 sandbox \
  && useradd -m -d /sandbox -u 1000660000 -g sandbox sandbox
 
 # Git credential helper for private repositories over HTTPS: answers
-# `git credential get` from GIT_TOKEN / GIT_USERNAME in the
-# environment (injected via Modal secrets — see deploy/modal/README.md
-# "Git credentials"), so the managed launch's repository clone AND the
-# agent's later fetch/push authenticate without writing credentials to
-# disk. Emits nothing when GIT_TOKEN is unset, leaving anonymous
-# clones of public repositories untouched. GIT_USERNAME defaults to
-# x-access-token (GitHub's token-auth username; GitLab users set
-# GIT_USERNAME=oauth2). --system so it applies to any sandbox user.
-RUN git config --system credential.helper \
-      '!f() { [ "$1" = get ] || return 0; [ -n "$GIT_TOKEN" ] || return 0; printf "username=%s\npassword=%s\n" "${GIT_USERNAME:-x-access-token}" "$GIT_TOKEN"; }; f'
+# `git credential get` from GIT_TOKEN / GIT_USERNAME in the environment
+# (injected via Modal secrets — see deploy/modal/README.md "Git
+# credentials"), with per-host GIT_TOKEN_<HOST> / GIT_USERNAME_<HOST>
+# overrides so remotes on different hosts each get their own token. The
+# script documents the lookup. --system so it applies to any sandbox
+# user; 0755 so the non-root OpenShell user can exec it.
+COPY --chmod=0755 deploy/docker/git-credential-omnigent /usr/local/bin/git-credential-omnigent
+RUN git config --system credential.helper omnigent
 
 # Node runtime for the harness CLIs, copied from the official image
 # (same Debian base as python-slim, so the binary is ABI-compatible)

--- a/deploy/docker/Dockerfile.ubi
+++ b/deploy/docker/Dockerfile.ubi
@@ -86,8 +86,10 @@ USER 0
 RUN dnf install -y --nodocs git tmux unzip \
  && dnf clean all
 
-RUN git config --system credential.helper \
-      '!f() { [ "$1" = get ] || return 0; [ -n "$GIT_TOKEN" ] || return 0; printf "username=%s\npassword=%s\n" "${GIT_USERNAME:-x-access-token}" "$GIT_TOKEN"; }; f'
+# Git credential helper for private HTTPS remotes — see the note in
+# deploy/docker/Dockerfile. Per-host GIT_TOKEN_<HOST> overrides GIT_TOKEN.
+COPY --chmod=0755 deploy/docker/git-credential-omnigent /usr/local/bin/git-credential-omnigent
+RUN git config --system credential.helper omnigent
 
 # Node runtime from the UBI Node image.
 COPY --from=node-runtime /usr/bin/node /usr/local/bin/node

--- a/deploy/docker/git-credential-omnigent
+++ b/deploy/docker/git-credential-omnigent
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Git credential helper for private repositories over HTTPS, wired into the
+# managed host images as `credential.helper omnigent` (see deploy/docker/
+# Dockerfile). Answers `git credential get` from the environment so the
+# managed launch's clone AND the agent's later fetch/push authenticate
+# without writing credentials to disk.
+#
+# git passes the target host on stdin, so each remote can carry its own
+# credential — a github.com PAT and a self-hosted Forgejo/GitLab token
+# coexist without either being offered to the other's host:
+#
+#   GIT_TOKEN / GIT_USERNAME                          default, any host
+#   GIT_TOKEN_<HOST> / GIT_USERNAME_<HOST>            that host only, wins
+#
+# <HOST> is git's `host=` attribute (which includes `:port` when the remote
+# has one) uppercased with every non-alphanumeric character replaced by `_`
+# — git.example.com -> GIT_EXAMPLE_COM, git.example.com:8443 ->
+# GIT_EXAMPLE_COM_8443. Hosts differing only in punctuation therefore share
+# a variable.
+#
+# Emits nothing when no token matches, leaving anonymous clones of public
+# repositories untouched. GIT_USERNAME defaults to x-access-token (GitHub's
+# token-auth username; GitLab users set oauth2).
+
+set -u
+
+# store/erase stay no-ops: this helper is read-only.
+[ "${1:-}" = get ] || exit 0
+
+# Read git's credential attributes until the blank-line terminator or EOF.
+host=
+while IFS= read -r line; do
+    [ -n "$line" ] || break
+    case "$line" in
+        host=*) host=${line#host=} ;;
+    esac
+done
+
+username=
+token=
+if [ -n "$host" ]; then
+    suffix=$(printf '%s' "$host" | tr '[:lower:]' '[:upper:]' | tr -c '[:alnum:]' '_')
+    token=$(printenv "GIT_TOKEN_$suffix" || true)
+    if [ -n "$token" ]; then
+        username=$(printenv "GIT_USERNAME_$suffix" || true)
+    fi
+fi
+
+# No host-scoped token: fall back to the default pair.
+[ -n "$token" ] || token=${GIT_TOKEN:-}
+[ -n "$token" ] || exit 0
+[ -n "$username" ] || username=${GIT_USERNAME:-x-access-token}
+
+printf 'username=%s\npassword=%s\n' "$username" "$token"

--- a/deploy/islo/README.md
+++ b/deploy/islo/README.md
@@ -428,7 +428,10 @@ via `OMNIGENT_ISLO_SANDBOX_ENV` / `sandbox.islo.env`. The host image's git
 credential helper answers HTTPS auth from it for both the launch-time
 clone and the agent's later `fetch` / `push`, writing nothing to disk. Use
 HTTPS repository URLs. Details by provider match the [Modal git
-guide](../modal/README.md#git-credentials-private-repositories).
+guide](../modal/README.md#git-credentials-private-repositories). For a
+second host with its own token, add a host-scoped
+`GIT_TOKEN_GIT_EXAMPLE_COM` — see [multiple git
+hosts](../modal/README.md#multiple-git-hosts).
 
 ## Security considerations
 

--- a/deploy/kubernetes/overlays/sandbox-runners/README.md
+++ b/deploy/kubernetes/overlays/sandbox-runners/README.md
@@ -122,6 +122,9 @@ Inject an HTTPS token as `GIT_TOKEN` (GitLab: add `GIT_USERNAME=oauth2`) into th
 from it for both the launch-time clone and the agent's later `fetch` / `push`,
 writing nothing to disk — use HTTPS repository URLs. Details by provider match the
 [Modal git guide](../../../modal/README.md#git-credentials-private-repositories).
+For a second host with its own token, add a host-scoped
+`GIT_TOKEN_GIT_EXAMPLE_COM` key to the same Secret — see [multiple git
+hosts](../../../modal/README.md#multiple-git-hosts).
 
 ## Configuration (`sandbox-config.yaml`)
 

--- a/deploy/modal/README.md
+++ b/deploy/modal/README.md
@@ -411,6 +411,30 @@ URL ever embeds the token. Details by provider:
 - **Other HTTPS remotes** — any server accepting basic auth works;
   set `GIT_USERNAME` if it requires a specific username.
 
+#### Multiple git hosts
+
+`GIT_TOKEN` answers every host, which breaks down as soon as an agent
+needs two remotes with different credentials (github.com plus a
+self-hosted Forgejo/Gitea/GitLab). Add a **host-scoped** key alongside
+it and the helper prefers it for that host, falling back to `GIT_TOKEN`
+everywhere else:
+
+```bash
+modal secret create omnigent-git \
+  GIT_TOKEN=github_pat_… \
+  GIT_TOKEN_GIT_EXAMPLE_COM=forgejo_token_… \
+  GIT_USERNAME_GIT_EXAMPLE_COM=oauth2
+```
+
+The suffix is the remote's host uppercased with every non-alphanumeric
+character replaced by `_` — `git.example.com` → `GIT_EXAMPLE_COM`, and a
+non-default port is part of it (`git.example.com:8443` →
+`GIT_EXAMPLE_COM_8443`). Hosts that differ only in punctuation
+(`git-example.com` vs `git.example.com`) therefore map to the same key.
+`GIT_USERNAME_<HOST>` is optional; without it the scoped token pairs with
+`GIT_USERNAME` (or `x-access-token`). The extra keys ride the same secret
+and forward host→runner like `GIT_TOKEN` does — no new plumbing.
+
 Use HTTPS repository URLs (`https://github.com/org/repo`) for private
 workspaces — SSH URLs (`git@github.com:…`) would need a key and
 known-hosts setup inside the sandbox, which the managed flow does not
@@ -433,6 +457,7 @@ or a custom image.
 | `OMNIGENT_RUNNER_ENV_PASSTHROUGH` | inside the sandbox (set via a Modal secret) | Extra env var names the host forwards to runners |
 | `GIT_TOKEN` | inside the sandbox (set via a Modal secret) | HTTPS token for private repository clone / fetch / push |
 | `GIT_USERNAME` | inside the sandbox (set via a Modal secret) | Auth username paired with `GIT_TOKEN` (default `x-access-token`; GitLab uses `oauth2`) |
+| `GIT_TOKEN_<HOST>` / `GIT_USERNAME_<HOST>` | inside the sandbox (set via a Modal secret) | Host-scoped overrides of the pair above, e.g. `GIT_TOKEN_GIT_EXAMPLE_COM` (see "Multiple git hosts") |
 
 All of the above are supported public configuration. The variables the
 managed launcher itself sets inside the sandbox —

--- a/deploy/openshell/README.md
+++ b/deploy/openshell/README.md
@@ -309,6 +309,9 @@ Inject an HTTPS token as `GIT_TOKEN` (GitLab: add `GIT_USERNAME=oauth2`) via
 HTTPS auth from it for both the launch-time clone and the agent's later `fetch` /
 `push`, writing nothing to disk. Use HTTPS repository URLs. Details by provider
 match the [Modal git guide](../modal/README.md#git-credentials-private-repositories).
+For a second host with its own token, add a host-scoped
+`GIT_TOKEN_GIT_EXAMPLE_COM` — see [multiple git
+hosts](../modal/README.md#multiple-git-hosts).
 
 ## How it works
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -426,7 +426,9 @@ _RUNNER_ENV_ALLOWLIST_PREFIXES: tuple[str, ...] = ("LC_", "MLFLOW_", "OTEL_", "O
 # gemini family. GIT_TOKEN / GIT_USERNAME feed the sandbox host
 # image's git credential helper (deploy/docker/Dockerfile `host`
 # target) so the agent's own fetch/push against a private repository
-# authenticates, not just the launch-time clone. Unlike the rest of
+# authenticates, not just the launch-time clone — their host-scoped
+# GIT_TOKEN_<HOST> forms ride _HARNESS_CREDENTIAL_ENV_PREFIXES below.
+# Unlike the rest of
 # the host's environment, these are credentials the host owner sets
 # PRECISELY so their runners can use them (on a laptop: exported keys;
 # on a server-managed sandbox: the deployment's injected provider
@@ -452,6 +454,17 @@ _BASE_HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
 HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
     name
     for canonical in _BASE_HARNESS_CREDENTIAL_ENV_VARS
+    for name in env_names_with_omnigent_prefix(canonical)
+)
+
+# Host-scoped git credentials the sandbox image's credential helper reads
+# per remote host (GIT_TOKEN_GIT_EXAMPLE_COM and friends — see
+# deploy/docker/git-credential-omnigent). The host suffix is open-ended, so
+# these forward by prefix rather than by name; the prefixes stay narrow so
+# the allowlist doesn't become a hole for unrelated GIT_* secrets.
+_HARNESS_CREDENTIAL_ENV_PREFIXES: tuple[str, ...] = tuple(
+    name
+    for canonical in ("GIT_TOKEN_", "GIT_USERNAME_")
     for name in env_names_with_omnigent_prefix(canonical)
 )
 
@@ -541,6 +554,7 @@ def _build_runner_env(
         if key in _RUNNER_ENV_ALLOWLIST
         or key.startswith(_RUNNER_ENV_ALLOWLIST_PREFIXES)
         or key in forwarded
+        or key.startswith(_HARNESS_CREDENTIAL_ENV_PREFIXES)
     }
     env["RUNNER_SERVER_URL"] = server_url
     env[RUNNER_ID_ENV_VAR] = runner_id

--- a/tests/deploy/test_host_image_git_credential_helper.py
+++ b/tests/deploy/test_host_image_git_credential_helper.py
@@ -1,0 +1,180 @@
+"""Tests for the managed host image's host-scoped git credential helper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_HELPER = _ROOT / "deploy/docker/git-credential-omnigent"
+
+
+def _run(operation: str, stdin: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run the helper script under ``sh`` with a scrubbed environment.
+
+    :param operation: The git credential operation argument, e.g. ``"get"``.
+    :param stdin: The credential attributes git would feed the helper.
+    :param env: Environment variables to expose to the helper.
+    :returns: The completed subprocess.
+    """
+    return subprocess.run(
+        ["sh", str(_HELPER), operation],
+        input=stdin,
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), **env},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_helper_script_is_posix_sh_and_executable() -> None:
+    """The helper ships as an executable POSIX ``sh`` script.
+
+    The images' ``/bin/sh`` is dash (Debian slim) or bash-as-sh (UBI9), and the
+    OpenShell non-root user must be able to exec it.
+    """
+    assert _HELPER.read_text().startswith("#!/bin/sh\n")
+    assert os.access(_HELPER, os.X_OK)
+
+
+def test_host_scoped_token_wins_over_default_and_default_never_leaks() -> None:
+    """A host-scoped token answers that host — the default must not be offered.
+
+    The reported bug: with only ``GIT_TOKEN`` set, a GitHub PAT is handed
+    verbatim to an unrelated self-hosted remote.
+    """
+    result = _run(
+        "get",
+        "protocol=https\nhost=git.example.com\n\n",
+        {"GIT_TOKEN": "github-pat", "GIT_TOKEN_GIT_EXAMPLE_COM": "forgejo-token"},
+    )
+
+    assert result.returncode == 0
+    assert "password=forgejo-token" in result.stdout
+    assert "github-pat" not in result.stdout
+
+
+def test_default_token_still_answers_unscoped_hosts() -> None:
+    """Hosts without a scoped var keep falling back to GIT_TOKEN / GIT_USERNAME."""
+    result = _run(
+        "get",
+        "protocol=https\nhost=github.com\n\n",
+        {"GIT_TOKEN": "github-pat", "GIT_TOKEN_GIT_EXAMPLE_COM": "forgejo-token"},
+    )
+
+    assert result.returncode == 0
+    assert "username=x-access-token" in result.stdout
+    assert "password=github-pat" in result.stdout
+    assert "forgejo-token" not in result.stdout
+
+
+def test_host_scoped_username_overrides_the_default_username() -> None:
+    """GitLab-style per-host usernames override the global one."""
+    result = _run(
+        "get",
+        "protocol=https\nhost=git.example.com\n\n",
+        {
+            "GIT_TOKEN": "github-pat",
+            "GIT_USERNAME": "octocat",
+            "GIT_TOKEN_GIT_EXAMPLE_COM": "forgejo-token",
+            "GIT_USERNAME_GIT_EXAMPLE_COM": "oauth2",
+        },
+    )
+
+    assert result.returncode == 0
+    assert "username=oauth2" in result.stdout
+    assert "password=forgejo-token" in result.stdout
+
+
+def test_host_scoped_token_without_scoped_username_uses_the_default_username() -> None:
+    """A scoped token pairs with GIT_USERNAME when no scoped username is set."""
+    result = _run(
+        "get",
+        "protocol=https\nhost=git.example.com\n\n",
+        {
+            "GIT_TOKEN": "github-pat",
+            "GIT_USERNAME": "octocat",
+            "GIT_TOKEN_GIT_EXAMPLE_COM": "forgejo-token",
+        },
+    )
+
+    assert result.returncode == 0
+    assert "username=octocat" in result.stdout
+    assert "password=forgejo-token" in result.stdout
+
+
+def test_port_in_host_becomes_part_of_the_env_suffix() -> None:
+    """git's ``host=`` carries ``:port``; the suffix encodes it too."""
+    result = _run(
+        "get",
+        "protocol=https\nhost=git.example.com:8443\n\n",
+        {"GIT_TOKEN_GIT_EXAMPLE_COM_8443": "ported-token"},
+    )
+
+    assert result.returncode == 0
+    assert "password=ported-token" in result.stdout
+
+
+def test_no_token_at_all_emits_nothing() -> None:
+    """Anonymous clones of public repositories stay untouched."""
+    result = _run("get", "protocol=https\nhost=github.com\n\n", {})
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_scoped_token_for_another_host_does_not_answer() -> None:
+    """A scoped var must not answer a host it was not scoped to."""
+    result = _run(
+        "get",
+        "protocol=https\nhost=github.com\n\n",
+        {"GIT_TOKEN_GIT_EXAMPLE_COM": "forgejo-token"},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize("operation", ["store", "erase"])
+def test_non_get_operations_are_no_ops(operation: str) -> None:
+    """store/erase stay silent no-ops, as the inline helper was."""
+    result = _run(
+        operation,
+        "protocol=https\nhost=github.com\n\n",
+        {"GIT_TOKEN": "github-pat"},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_helper_terminates_on_eof_without_a_trailing_blank_line() -> None:
+    """A caller that closes stdin without a blank line must not hang the helper."""
+    result = _run("get", "protocol=https\nhost=github.com\n", {"GIT_TOKEN": "github-pat"})
+
+    assert result.returncode == 0
+    assert "password=github-pat" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "dockerfile",
+    [
+        _ROOT / "deploy/docker/Dockerfile",
+        _ROOT / "deploy/docker/Dockerfile.ubi",
+    ],
+)
+def test_host_images_install_the_helper_on_path(dockerfile: Path) -> None:
+    """Both host images ship the script and point git's system config at it.
+
+    ``credential.helper omnigent`` resolves to ``git-credential-omnigent`` on
+    PATH; the old inline one-liner ignored git's ``host=`` attribute.
+    """
+    text = dockerfile.read_text()
+
+    assert "deploy/docker/git-credential-omnigent" in text
+    assert "/usr/local/bin/git-credential-omnigent" in text
+    assert "git config --system credential.helper omnigent" in text
+    assert "!f() {" not in text

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1392,6 +1392,42 @@ def test_build_runner_env_forwards_omnigent_prefixed_harness_credentials() -> No
     assert "ANTHROPIC_API_KEY" not in env
 
 
+def test_build_runner_env_forwards_host_scoped_git_credentials() -> None:
+    """
+    Host-scoped git credential vars forward without the operator naming
+    each one in OMNIGENT_RUNNER_ENV_PASSTHROUGH — the sandbox image's
+    credential helper resolves them per remote host. The prefix stays
+    narrow so unrelated GIT_* secrets keep sitting behind the allowlist.
+    """
+    base = {
+        "PATH": "/usr/bin",
+        "HOME": "/root",
+        "GIT_TOKEN": "default-pat",
+        "GIT_TOKEN_GIT_EXAMPLE_COM": "forgejo-token",
+        "GIT_USERNAME_GIT_EXAMPLE_COM": "oauth2",
+        "OMNIGENT_GIT_TOKEN_GIT_EXAMPLE_COM": "prefixed-forgejo-token",
+        "OMNIGENT_GIT_USERNAME_GIT_EXAMPLE_COM": "prefixed-oauth2",
+        # Neither a scoped credential nor on the allowlist.
+        "GIT_SECRET_STUFF": "leak-me-not",
+    }
+
+    env = _build_runner_env(
+        base,
+        server_url="http://server",
+        runner_id="runner_abc",
+        binding_token="tok",
+        workspace="/ws",
+        parent_pid=42,
+    )
+
+    assert env["GIT_TOKEN"] == "default-pat"
+    assert env["GIT_TOKEN_GIT_EXAMPLE_COM"] == "forgejo-token"
+    assert env["GIT_USERNAME_GIT_EXAMPLE_COM"] == "oauth2"
+    assert env["OMNIGENT_GIT_TOKEN_GIT_EXAMPLE_COM"] == "prefixed-forgejo-token"
+    assert env["OMNIGENT_GIT_USERNAME_GIT_EXAMPLE_COM"] == "prefixed-oauth2"
+    assert "GIT_SECRET_STUFF" not in env
+
+
 def test_build_runner_env_passthrough_extends_forwarded_set() -> None:
     """
     OMNIGENT_RUNNER_ENV_PASSTHROUGH names EXTRA vars to forward (for


### PR DESCRIPTION
## Related issue

Closes #2125

## Summary

- Managed sandboxes could only hold one HTTPS git credential: the host image's baked helper answered every host from a single GIT_TOKEN/GIT_USERNAME pair, so github.com and a self-hosted Forgejo/GitLab couldn't coexist (and a GitHub PAT could be handed to the other host).
- Extracts the inline helper into a real POSIX sh script (deploy/docker/git-credential-omnigent) that reads git's host= attribute from stdin and prefers a host-scoped GIT_TOKEN_<HOST>/GIT_USERNAME_<HOST> before falling back to the default pair — fully backward compatible, no new Secret plumbing. Both host images copy it onto PATH and set credential.helper=omnigent.
- Forwards the new host-scoped vars host→runner by narrow prefix so operators don't have to enumerate each one in OMNIGENT_RUNNER_ENV_PASSTHROUGH.

## Test Plan

Ran `.venv/bin/python -m pytest tests/deploy/test_host_image_git_credential_helper.py tests/host/test_connect.py -q` — 83 passed. New tests execute the real helper script under sh (host-scoped hit with no default leak, default fallback, per-host username, port suffix, unset=empty, store/erase no-ops, EOF termination) and assert both Dockerfiles wire it up; the connect test asserts host-scoped vars forward while unrelated GIT_* stays behind the allowlist. TDD red→green captured (reverted impl → 14 failed incl. the exact leak assertion + KeyError; restored → all pass). `uv run pre-commit run --files <changed>` clean. No Docker image build performed — real in-image `git credential fill` is unverified.

## Demo

N/A — no UI surface in this diff.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

See above.

## Changelog

Managed sandboxes now support per-host git credentials (GIT_TOKEN_<HOST>/GIT_USERNAME_<HOST>) so GitHub and a self-hosted Forgejo/GitLab can authenticate with different tokens.
