### PR TITLE
feat(qwen-native): live tool-call cards for qwen-native sessions

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -126,6 +126,23 @@ comments; this is the *what*, not the *how*.)
     already done and the `control_response` just cleans up. Still worth a live
     E2E to confirm timing under a real `qwen --acp` turn.
 
+- [x] **Live tool-call cards (spinner + elapsed timer).** Implemented — the
+  forwarder now mirrors qwen's `tool_use` blocks as `function_call` items and its
+  `tool_result` blocks (which arrive as `user` events in the Anthropic envelope)
+  as `function_call_output` items, and brackets each turn with an id-bearing
+  `external_session_status` `running`/`idle`/`failed` edge. A prose-bearing `user`
+  event opens the turn and mints a per-turn `qwen:turn:{uuid}` response id stamped
+  on every item; a `tool_result`-only `user` event does **not** open a new turn
+  (that would flicker the spinner on the long tool calls the card exists for).
+  `result` closes it (`subtype != "success"` → `failed`), with a belt-and-braces
+  close on a prose-only assistant step and a minutes-scale stalled-turn backstop
+  for a turn killed by a TUI interrupt/crash. The open turn id + live flag ride in
+  the durable state file so a supervisor restart mid-turn keeps the cards in one
+  group and still closes an orphaned `running`. The runner's PTY-activity watcher
+  still owns the coarse id-less session badge (as for goose-/cursor-native); these
+  id-bearing edges drive only the tool-bubble streaming lifecycle. Server/web
+  shipped harness-agnostic in #1499.
+
 - [ ] **Composer status line: real model + context ring (Web UI).** For
   native-qwen the composer's model/effort chip is currently **hidden** (web UI
   flag `nativeVendorOwnsModel` in `chatStore.sessionBindingPatch` →

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -16,9 +16,13 @@ event (which also seeds the session title).
 
 Event shapes consumed (others are ignored defensively):
 
-- ``{"type":"user","message":{"role":"user","content":[{"type":"text","text":...}]}}``
+- ``{"type":"user","message":{"role":"user","content":[{"type":"text","text":...}|
+  {"type":"tool_result","tool_use_id":...,"content":...}]}}`` — prose blocks become
+  a user bubble; ``tool_result`` blocks become ``function_call_output`` items.
 - ``{"type":"assistant","message":{"role":"assistant","content":[{"type":"text"|
-  "thinking"|"tool_use",...}]}}`` — only ``text`` blocks are mirrored.
+  "thinking"|"tool_use",...}]}}`` — ``text`` blocks become the assistant bubble and
+  ``tool_use`` blocks become ``function_call`` items; ``thinking`` is skipped.
+- ``{"type":"result","subtype":"success"|...}`` — qwen's explicit turn terminator.
 - ``{"type":"control_request","request":{"subtype":"can_use_tool",...},
   "request_id":...}`` and the matching ``control_response`` — the permission
   control plane. NOT handled here: the tool-approval mirror
@@ -26,9 +30,14 @@ Event shapes consumed (others are ignored defensively):
   these as web elicitation cards. This forwarder ignores them (they carry no
   transcript prose to mirror).
 
-Status (``running``/``idle``) is intentionally NOT posted here: the runner's
-PTY-activity watcher owns those edges for qwen-native (see
-:mod:`omnigent.runner.app`), exactly as for goose-/cursor-native.
+Turn lifecycle: a prose-bearing ``user`` event opens a turn, minting a
+``qwen:turn:{uuid}`` response id that every item of the turn carries. The
+forwarder POSTs an id-bearing ``external_session_status`` ``running`` edge before
+the turn's first assistant item and an ``idle``/``failed`` edge when it closes, so
+ap-web renders the turn's mirrored tool cards LIVE (spinner + elapsed timer) rather
+than as static completed cards. These id-bearing edges drive only that streaming
+lifecycle — the coarse, id-less session badge stays owned by the runner's
+PTY-activity watcher (see :mod:`omnigent.runner.app`), as for goose-/cursor-native.
 
 This module also hosts the **compaction mirror** (:func:`supervise_qwen_compaction_mirror`).
 qwen compaction (its *compression*) is invisible on the ``--json-file`` stream
@@ -57,6 +66,7 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_post_delivery import post_external_session_status
 from omnigent.qwen_native_bridge import events_file_path
 
 _logger = logging.getLogger(__name__)
@@ -73,6 +83,12 @@ _SUPERVISOR_HEALTHY_UPTIME_S = 60.0
 
 _STATE_FILE = "qwen_forwarder.json"
 
+#: How long an open turn may go without a single stream event before the
+#: forwarder closes it anyway. Only a turn killed without its terminator (TUI
+#: interrupt, qwen crash) reaches this; a live turn writes events constantly.
+#: Minutes-scale so a genuinely slow tool call never trips it.
+_STALLED_TURN_IDLE_S = 300.0
+
 # Dedup window: the number of most-recently-posted event uuids persisted so a
 # truncation/relaunch re-read (offset rewinds to 0) doesn't re-post them. The
 # window must keep the *most recent* uuids, so ``seen`` is an insertion-ordered
@@ -80,6 +96,11 @@ _STATE_FILE = "qwen_forwarder.json"
 # hash-ordered, which would make the ``[-_DEDUP_WINDOW:]`` cap keep an arbitrary
 # subset and re-post recent history on a long-session relaunch.
 _DEDUP_WINDOW = 512
+
+
+def _monotonic() -> float:
+    """Indirection so tests can stub the stalled-turn backstop's clock."""
+    return time.monotonic()
 
 
 def _new_seen(uuids: Iterable[str] | None = None) -> dict[str, None]:
@@ -103,10 +124,18 @@ class _ForwardState:
         which we detect as ``size < offset`` and reset to 0.
     :param seen_uuids: Recently posted event uuids, for idempotent dedup across a
         truncation/restart. Bounded to the most recent entries.
+    :param active_turn_id: Response id of the turn still open at the cursor, so a
+        supervisor restart mid-turn rejoins it instead of splitting the streaming
+        group across two ids. ``None`` when no turn is open.
+    :param turn_live: Whether a ``running`` edge for :attr:`active_turn_id` is still
+        unclosed. Persisted so a restart still emits the closing ``idle`` for a
+        running the prior process posted.
     """
 
     offset: int = 0
     seen_uuids: list[str] | None = None
+    active_turn_id: str | None = None
+    turn_live: bool = False
 
 
 def _read_state(bridge_dir: Path) -> _ForwardState:
@@ -118,9 +147,12 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
         return _ForwardState(offset=0, seen_uuids=[])
     offset = data.get("offset")
     seen = data.get("seen_uuids")
+    turn_id = data.get("active_turn_id")
     return _ForwardState(
         offset=offset if isinstance(offset, int) and offset >= 0 else 0,
         seen_uuids=[u for u in seen if isinstance(u, str)] if isinstance(seen, list) else [],
+        active_turn_id=turn_id if isinstance(turn_id, str) and turn_id else None,
+        turn_live=bool(data.get("turn_live")),
     )
 
 
@@ -134,7 +166,14 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> bool:
         # _DEDUP_WINDOW uuids — the ones a relaunch re-read is most likely to hit.
         seen = (state.seen_uuids or [])[-_DEDUP_WINDOW:]
         tmp.write_text(
-            json.dumps({"offset": state.offset, "seen_uuids": seen}),
+            json.dumps(
+                {
+                    "offset": state.offset,
+                    "seen_uuids": seen,
+                    "active_turn_id": state.active_turn_id,
+                    "turn_live": state.turn_live,
+                }
+            ),
             encoding="utf-8",
         )
         os.replace(tmp, bridge_dir / _STATE_FILE)
@@ -157,15 +196,56 @@ class _MirrorItem:
     uuid: str
     item_type: str
     item_data: dict[str, object]
-    response_id: str
+    #: The turn's ``qwen:turn:{uuid}`` id, or ``None`` for a stray item whose turn
+    #: could not be identified (e.g. a tool result read before any turn opened).
+    response_id: str | None
+
+
+@dataclass
+class _TurnAction:
+    """One ordered step the poll loop performs for a batch of stream events.
+
+    :param kind: ``"item"`` (POST :attr:`item`) or ``"status"`` (POST
+        :attr:`status` carrying :attr:`turn_id`).
+    :param turn_id: Response id the action belongs to.
+    :param item: The mirror item, for ``kind == "item"``.
+    :param status: The session status, for ``kind == "status"``.
+    :param output: Optional detail attached to a ``failed`` status.
+    """
+
+    kind: str
+    turn_id: str | None
+    item: _MirrorItem | None = None
+    status: str | None = None
+    output: str | None = None
+
+
+def _blocks_of_type(content: object, block_type: str) -> list[dict[str, object]]:
+    """Return the *block_type* blocks of a stream-json message ``content`` array."""
+    if not isinstance(content, list):
+        return []
+    return [b for b in content if isinstance(b, dict) and b.get("type") == block_type]
 
 
 def _text_from_content(content: object) -> str:
     """Join the ``text`` blocks of a stream-json message ``content`` array.
 
-    ``thinking`` and ``tool_use`` blocks are skipped — only user-facing prose is
-    mirrored into the chat bubble. Tolerant of a bare string or odd shapes so a
-    schema tweak degrades to "best available text" rather than dropping the row.
+    ``thinking``, ``tool_use`` and ``tool_result`` blocks are skipped — only
+    user-facing prose belongs in the chat bubble; the tool blocks get their own
+    items. Tolerant of a bare string or odd shapes so a schema tweak degrades to
+    "best available text" rather than dropping the row.
+    """
+    if isinstance(content, str):
+        return content.strip()
+    parts = [b.get("text") for b in _blocks_of_type(content, "text")]
+    return "".join(p for p in parts if isinstance(p, str)).strip()
+
+
+def _tool_result_output(content: object) -> str:
+    """Flatten a ``tool_result`` block's ``content`` to the text the card shows.
+
+    qwen nests it as a string or an Anthropic block array; anything else yields
+    an empty output rather than a dropped card.
     """
     if isinstance(content, str):
         return content.strip()
@@ -173,57 +253,216 @@ def _text_from_content(content: object) -> str:
         return ""
     parts: list[str] = []
     for block in content:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") != "text":
-            continue
-        text = block.get("text")
-        if isinstance(text, str):
-            parts.append(text)
+        if isinstance(block, str):
+            parts.append(block)
+        elif isinstance(block, dict) and isinstance(block.get("text"), str):
+            parts.append(str(block["text"]))
     return "".join(parts).strip()
 
 
-def _event_to_item(event: dict[str, object], agent_name: str) -> _MirrorItem | None:
-    """Convert one qwen stream-json event to a mirror item, or ``None`` to skip it."""
+def _event_prose(event: dict[str, object]) -> str:
+    """The mirrorable prose of a ``user``/``assistant`` event, attachment markers stripped."""
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return ""
+    return _ATTACHMENT_MARKER_RE.sub("", _text_from_content(message.get("content"))).strip()
+
+
+def _event_to_items(
+    event: dict[str, object], agent_name: str, response_id: str | None
+) -> list[_MirrorItem]:
+    """Convert one qwen stream-json event to its mirror items (possibly none).
+
+    An ``assistant`` event yields its prose bubble followed by one
+    ``function_call`` per ``tool_use`` block; a ``user`` event yields its prose
+    bubble and/or a ``function_call_output`` per ``tool_result`` block. Every item
+    carries *response_id* so the web groups the turn's cards under one response.
+    """
     etype = event.get("type")
     if etype not in ("user", "assistant"):
         # control_request / control_response (the permission control plane) carry
         # no transcript prose; the tool-approval mirror
         # (omnigent.qwen_native_permissions) owns them off the same stream.
-        return None
+        return []
     uuid = event.get("uuid")
     if not isinstance(uuid, str) or not uuid:
-        return None
+        return []
     message = event.get("message")
     if not isinstance(message, dict):
-        return None
-    text = _ATTACHMENT_MARKER_RE.sub("", _text_from_content(message.get("content"))).strip()
-    if not text:
-        return None  # tool-only / thinking-only turn with no prose
-    response_id = f"qwen:{uuid}"
+        return []
+    content = message.get("content")
+    text = _event_prose(event)
+    items: list[_MirrorItem] = []
+
     if etype == "user":
-        return _MirrorItem(
-            uuid=uuid,
-            item_type="message",
-            item_data={"role": "user", "content": [{"type": "input_text", "text": text}]},
-            response_id=response_id,
+        if text:
+            items.append(
+                _MirrorItem(
+                    uuid=uuid,
+                    item_type="message",
+                    item_data={"role": "user", "content": [{"type": "input_text", "text": text}]},
+                    response_id=response_id,
+                )
+            )
+        for block in _blocks_of_type(content, "tool_result"):
+            call_id = block.get("tool_use_id")
+            if not isinstance(call_id, str) or not call_id:
+                continue
+            items.append(
+                _MirrorItem(
+                    uuid=uuid,
+                    item_type="function_call_output",
+                    item_data={
+                        "call_id": call_id,
+                        "output": _tool_result_output(block.get("content")),
+                    },
+                    response_id=response_id,
+                )
+            )
+        return items
+
+    # Emit the prose FIRST, then the tool calls made in the same step. That's the
+    # natural reading order ("I'll run X…" then the call), and the web only spins
+    # the TRAILING tool phase — prose emitted after the calls kills the spinner.
+    if text:
+        items.append(
+            _MirrorItem(
+                uuid=uuid,
+                item_type="message",
+                item_data={
+                    "role": "assistant",
+                    "agent": agent_name,
+                    "content": [{"type": "output_text", "text": text}],
+                },
+                response_id=response_id,
+            )
         )
-    return _MirrorItem(
-        uuid=uuid,
-        item_type="message",
-        item_data={
-            "role": "assistant",
-            "agent": agent_name,
-            "content": [{"type": "output_text", "text": text}],
-        },
-        response_id=response_id,
-    )
+    for block in _blocks_of_type(content, "tool_use"):
+        call_id = block.get("id")
+        name = block.get("name")
+        if not isinstance(call_id, str) or not call_id or not isinstance(name, str) or not name:
+            continue
+        try:
+            arguments = json.dumps(block.get("input") or {})
+        except (TypeError, ValueError):
+            arguments = "{}"  # unserializable input degrades to an argument-less card
+        items.append(
+            _MirrorItem(
+                uuid=uuid,
+                item_type="function_call",
+                item_data={
+                    "agent": agent_name,
+                    "name": name,
+                    "arguments": arguments,
+                    "call_id": call_id,
+                },
+                response_id=response_id,
+            )
+        )
+    return items
 
 
-def _read_new_events(
-    events_file: Path, offset: int, seen: Container[str], agent_name: str
-) -> tuple[list[_MirrorItem], int]:
-    """Read NDJSON lines past *offset*, returning new mirror items + the new offset.
+def _event_has_tool_use(event: dict[str, object]) -> bool:
+    """Whether an ``assistant`` event carries at least one ``tool_use`` block."""
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return False
+    return bool(_blocks_of_type(message.get("content"), "tool_use"))
+
+
+def _result_failure_detail(event: dict[str, object]) -> str | None:
+    """The text a non-success ``result`` event surfaces as the session's last error."""
+    for key in ("result", "subtype"):
+        value = event.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _records_to_actions(
+    records: Iterable[dict[str, object]],
+    agent_name: str,
+    seen: Container[str],
+    turn_id: str | None,
+    live: bool,
+) -> tuple[list[_TurnAction], str | None, bool]:
+    """Turn a batch of stream events into ordered post actions + the turn state after it.
+
+    A turn is opened by a **prose-bearing** ``user`` event — tool results also
+    arrive as ``user`` events in the Anthropic envelope, and treating those as
+    delimiters would split every turn at each tool call. ``running`` is posted once
+    per turn, before its first assistant item; ``result`` closes the turn, as does a
+    prose-only assistant step (the belt-and-braces close, for a ``result`` that
+    never lands).
+
+    :param seen: Event uuids already posted, for dedup across a truncation rewind.
+    :param turn_id: Response id of the turn open at the start of the batch.
+    :param live: Whether ``running`` was already posted for *turn_id*.
+    """
+    actions: list[_TurnAction] = []
+    for event in records:
+        etype = event.get("type")
+        uuid = event.get("uuid")
+
+        if etype == "result":
+            if live:
+                if event.get("subtype") == "success":
+                    actions.append(_TurnAction("status", turn_id, status="idle"))
+                else:
+                    actions.append(
+                        _TurnAction(
+                            "status",
+                            turn_id,
+                            status="failed",
+                            output=_result_failure_detail(event),
+                        )
+                    )
+                live = False
+            elif turn_id is not None and event.get("subtype") != "success":
+                # The prose belt-and-braces already settled the card to idle; a
+                # failure landing after it must override that premature success.
+                actions.append(
+                    _TurnAction(
+                        "status",
+                        turn_id,
+                        status="failed",
+                        output=_result_failure_detail(event),
+                    )
+                )
+            turn_id = None
+            continue
+
+        if etype == "user" and _event_prose(event) and isinstance(uuid, str) and uuid:
+            # A new prose user event authoritatively closes the previous turn.
+            if live:
+                actions.append(_TurnAction("status", turn_id, status="idle"))
+                live = False
+            turn_id = f"qwen:turn:{uuid}"
+        elif etype == "assistant" and turn_id is None and isinstance(uuid, str) and uuid:
+            # Missed-start recovery: a forwarder that attached mid-turn still gets
+            # an id, so the rest of the turn's cards render live.
+            turn_id = f"qwen:turn:{uuid}"
+
+        items = [
+            item for item in _event_to_items(event, agent_name, turn_id) if item.uuid not in seen
+        ]
+        if items and etype == "assistant" and not live and turn_id is not None:
+            actions.append(_TurnAction("status", turn_id, status="running"))
+            live = True
+        actions.extend(_TurnAction("item", turn_id, item=item) for item in items)
+
+        # A prose assistant step with no tool call is the turn's final answer —
+        # settle its card now rather than waiting on ``result``. The id is kept so
+        # a further step of the same turn re-opens under it.
+        if etype == "assistant" and live and items and not _event_has_tool_use(event):
+            actions.append(_TurnAction("status", turn_id, status="idle"))
+            live = False
+
+    return actions, turn_id, live
+
+
+def _read_new_records(events_file: Path, offset: int) -> tuple[list[dict[str, object]], int]:
+    """Read NDJSON lines past *offset*, returning the parsed events + the new offset.
 
     Detects a truncated/recreated event file (``size < offset``) and rewinds to 0.
     Only fully terminated lines (ending in ``\\n``) are consumed; a trailing
@@ -249,7 +488,7 @@ def _read_new_events(
         return [], offset  # no complete line yet
     consumed = data[: last_nl + 1]
     new_offset = offset + len(consumed)
-    items: list[_MirrorItem] = []
+    records: list[dict[str, object]] = []
     for raw in consumed.split(b"\n"):
         raw = raw.strip()
         if not raw:
@@ -258,12 +497,9 @@ def _read_new_events(
             event = json.loads(raw.decode("utf-8"))
         except (ValueError, UnicodeDecodeError):
             continue  # tolerate a malformed line rather than stalling the tail
-        if not isinstance(event, dict):
-            continue
-        item = _event_to_item(event, agent_name)
-        if item is not None and item.uuid not in seen:
-            items.append(item)
-    return items, new_offset
+        if isinstance(event, dict):
+            records.append(event)
+    return records, new_offset
 
 
 async def _post_conversation_item(
@@ -295,12 +531,14 @@ async def forward_qwen_events_to_session(
     poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
     auth: httpx.Auth | None = None,
 ) -> None:
-    """Tail qwen's ``--json-file`` and mirror new messages into the AP session.
+    """Tail qwen's ``--json-file`` and mirror new messages + tool calls into the AP session.
 
     Polls the event file past a persisted byte offset, posting each new
-    user/assistant message as an ``external_conversation_item``. The offset +
-    dedup set are persisted to ``bridge_dir`` so a supervisor restart resumes
-    without re-posting.
+    user/assistant message and tool call as an ``external_conversation_item``,
+    bracketed by the turn's id-bearing ``running``/``idle`` status edges so the
+    tool cards render live. The offset, dedup set and open turn id are persisted to
+    ``bridge_dir`` so a supervisor restart resumes without re-posting or splitting
+    the turn.
 
     :param base_url: Omnigent server base URL.
     :param headers: Static HTTP headers (auth normally via ``auth``).
@@ -316,24 +554,63 @@ async def forward_qwen_events_to_session(
     persisted = _read_state(bridge_dir)
     offset = persisted.offset
     seen = _new_seen(persisted.seen_uuids)
+    # Resume the open turn and its live/idle state so the closing ``idle`` still
+    # fires for a ``running`` the prior process posted before a crash/restart.
+    turn_id = persisted.active_turn_id
+    live = persisted.turn_live
+    # Seed the stall clock when resuming a live turn so the backstop can still fire
+    # if the crashed qwen never grows the event file again post-restart.
+    last_activity_ts: float | None = _monotonic() if live else None
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
         while True:
             try:
-                items, new_offset = await asyncio.to_thread(
-                    _read_new_events, target, offset, seen, agent_name
+                records, new_offset = await asyncio.to_thread(_read_new_records, target, offset)
+                actions, turn_id, live = _records_to_actions(
+                    records, agent_name, seen, turn_id, live
                 )
-                for item in items:
-                    await _post_conversation_item(client, session_id=session_id, item=item)
-                    seen[item.uuid] = None
-                if new_offset != offset or items:
+                for action in actions:
+                    if action.kind == "item" and action.item is not None:
+                        await _post_conversation_item(
+                            client, session_id=session_id, item=action.item
+                        )
+                        seen[action.item.uuid] = None
+                    elif action.kind == "status" and action.status is not None:
+                        await post_external_session_status(
+                            client,
+                            session_id=session_id,
+                            status=action.status,
+                            output=action.output,
+                            response_id=action.turn_id,
+                        )
+                if records:
+                    # Any stream event proves qwen is alive; only true silence
+                    # should trip the stalled-turn backstop below.
+                    last_activity_ts = _monotonic()
+                if new_offset != offset or actions:
                     offset = new_offset
                     _write_state(
                         bridge_dir,
-                        _ForwardState(offset=offset, seen_uuids=list(seen)),
+                        _ForwardState(
+                            offset=offset,
+                            seen_uuids=list(seen),
+                            active_turn_id=turn_id,
+                            turn_live=live,
+                        ),
                     )
+                # Backstop: a turn killed without its terminator (TUI interrupt,
+                # qwen crash) must not leave a spinner running forever.
+                if (
+                    live
+                    and last_activity_ts is not None
+                    and _monotonic() - last_activity_ts > _STALLED_TURN_IDLE_S
+                ):
+                    await post_external_session_status(
+                        client, session_id=session_id, status="idle", response_id=turn_id
+                    )
+                    live = False  # keep turn_id: a late resume rejoins the same turn
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/tests/test_qwen_native_forwarder.py
+++ b/tests/test_qwen_native_forwarder.py
@@ -34,12 +34,13 @@ from omnigent.qwen_native_bridge import (
 from omnigent.qwen_native_forwarder import (
     _DEDUP_WINDOW,
     _compaction_status_from_record,
-    _event_to_item,
+    _event_to_items,
     _ForwardState,
     _new_seen,
     _read_new_compaction_statuses,
-    _read_new_events,
+    _read_new_records,
     _read_state,
+    _records_to_actions,
     _write_state,
     clear_qwen_bridge_state,
 )
@@ -63,19 +64,48 @@ def _asst_ev(uuid: str, content: list[dict]) -> dict:
     }
 
 
+def _tool_use_block(block_id: str, name: str, tool_input: dict) -> dict:
+    return {"type": "tool_use", "id": block_id, "name": name, "input": tool_input}
+
+
+def _tool_result_ev(uuid: str, tool_use_id: str, output: str) -> dict:
+    """qwen returns tool results as a ``user`` event in the Anthropic envelope."""
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": [{"type": "text", "text": output}],
+                }
+            ],
+        },
+    }
+
+
+def _result_ev(subtype: str = "success", result: str = "done") -> dict:
+    return {"type": "result", "subtype": subtype, "result": result}
+
+
 def _ev_bytes(obj: dict) -> bytes:
     return (json.dumps(obj) + "\n").encode("utf-8")
 
 
 def test_user_event_maps_to_input_text() -> None:
-    item = _event_to_item(_user_ev("u1", "hi"), _AGENT)
-    assert item is not None
-    assert item.response_id == "qwen:u1"
-    assert item.item_data == {"role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+    items = _event_to_items(_user_ev("u1", "hi"), _AGENT, "qwen:turn:u1")
+    assert len(items) == 1
+    assert items[0].response_id == "qwen:turn:u1"
+    assert items[0].item_data == {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "hi"}],
+    }
 
 
 def test_assistant_text_maps_to_output_text_and_skips_thinking() -> None:
-    item = _event_to_item(
+    items = _event_to_items(
         _asst_ev(
             "a1",
             [
@@ -84,41 +114,278 @@ def test_assistant_text_maps_to_output_text_and_skips_thinking() -> None:
             ],
         ),
         _AGENT,
+        "qwen:turn:u1",
     )
-    assert item is not None
-    assert item.item_data["role"] == "assistant"
-    assert item.item_data["agent"] == _AGENT
-    assert item.item_data["content"] == [{"type": "output_text", "text": "Hi there!"}]
+    assert len(items) == 1
+    assert items[0].item_data["role"] == "assistant"
+    assert items[0].item_data["agent"] == _AGENT
+    assert items[0].item_data["content"] == [{"type": "output_text", "text": "Hi there!"}]
 
 
 def test_thinking_only_assistant_skipped() -> None:
-    item = _event_to_item(_asst_ev("a2", [{"type": "thinking", "thinking": "x"}]), _AGENT)
-    assert item is None
+    assert (
+        _event_to_items(_asst_ev("a2", [{"type": "thinking", "thinking": "x"}]), _AGENT, None)
+        == []
+    )
 
 
 def test_non_message_events_ignored() -> None:
     for etype in ("system", "stream_event", "result"):
-        assert _event_to_item({"type": etype, "uuid": "x"}, _AGENT) is None
+        assert _event_to_items({"type": etype, "uuid": "x"}, _AGENT, None) == []
     # control_request is recognized but produces no mirror item.
     control = {
         "type": "control_request",
         "request": {"subtype": "can_use_tool", "tool_name": "shell"},
         "request_id": "r1",
     }
-    assert _event_to_item(control, _AGENT) is None
+    assert _event_to_items(control, _AGENT, None) == []
 
 
 def test_attachment_marker_stripped() -> None:
-    item = _event_to_item(_user_ev("u2", "[Attached: /tmp/x.png]\n\nlook"), _AGENT)
-    assert item is not None
-    assert item.item_data["content"][0]["text"] == "look"
+    items = _event_to_items(_user_ev("u2", "[Attached: /tmp/x.png]\n\nlook"), _AGENT, None)
+    assert items[0].item_data["content"][0]["text"] == "look"
 
 
-def test_read_new_events_incremental_and_partial_line(tmp_path: Path) -> None:
+# --- tool-call mirroring (live cards) ---------------------------------------
+
+
+def test_assistant_prose_then_tool_uses_emits_message_then_function_calls() -> None:
+    items = _event_to_items(
+        _asst_ev(
+            "a1",
+            [
+                {"type": "text", "text": "I'll look."},
+                _tool_use_block("t1", "read_file", {"path": "/x"}),
+                _tool_use_block("t2", "shell", {"cmd": "ls"}),
+            ],
+        ),
+        _AGENT,
+        "qwen:turn:u1",
+    )
+    # Prose FIRST: the web only spins the TRAILING tool phase.
+    assert [i.item_type for i in items] == ["message", "function_call", "function_call"]
+    assert all(i.response_id == "qwen:turn:u1" for i in items)
+    assert items[1].item_data == {
+        "agent": _AGENT,
+        "name": "read_file",
+        "arguments": json.dumps({"path": "/x"}),
+        "call_id": "t1",
+    }
+    # ``arguments`` is a JSON *string*, matching the function_call item contract.
+    assert isinstance(items[1].item_data["arguments"], str)
+    assert items[2].item_data["call_id"] == "t2"
+
+
+def test_tool_use_only_assistant_emits_function_call() -> None:
+    # Regression: a tool-only assistant event used to be dropped entirely, so the
+    # web never saw the call and could not render a card for it.
+    items = _event_to_items(
+        _asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "ls"})]), _AGENT, "qwen:turn:u1"
+    )
+    assert [i.item_type for i in items] == ["function_call"]
+
+
+def test_tool_result_user_event_emits_function_call_output() -> None:
+    items = _event_to_items(_tool_result_ev("u9", "t1", "file contents"), _AGENT, "qwen:turn:u1")
+    assert [i.item_type for i in items] == ["function_call_output"]
+    assert items[0].item_data == {"call_id": "t1", "output": "file contents"}
+    assert items[0].response_id == "qwen:turn:u1"
+
+
+def test_malformed_tool_blocks_skipped_not_fatal() -> None:
+    # A tool_use missing id/name, and a tool_result missing tool_use_id, degrade to
+    # a dropped card rather than stalling the tail.
+    assert _event_to_items(_asst_ev("a1", [{"type": "tool_use", "input": {}}]), _AGENT, "t") == []
+    bad_result = {
+        "type": "user",
+        "uuid": "u1",
+        "message": {"role": "user", "content": [{"type": "tool_result", "content": "x"}]},
+    }
+    assert _event_to_items(bad_result, _AGENT, "t") == []
+
+
+# --- turn ids + status edges -------------------------------------------------
+
+
+def test_prose_user_event_opens_turn_and_stamps_all_items() -> None:
+    records = [
+        _user_ev("u1", "list files"),
+        _asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "ls"})]),
+        _tool_result_ev("u2", "t1", "a.txt"),
+        _asst_ev("a2", [{"type": "text", "text": "Found a.txt."}]),
+    ]
+    actions, turn_id, live = _records_to_actions(records, _AGENT, set(), None, False)
+    ids = {a.turn_id for a in actions}
+    assert ids == {"qwen:turn:u1"}
+    assert turn_id == "qwen:turn:u1"
+    # running fires once, before the turn's first assistant item.
+    kinds = [(a.kind, a.status or (a.item.item_type if a.item else None)) for a in actions]
+    assert kinds == [
+        ("item", "message"),  # the user prompt bubble
+        ("status", "running"),
+        ("item", "function_call"),
+        ("item", "function_call_output"),
+        ("item", "message"),  # the assistant's answer
+        ("status", "idle"),  # prose-only assistant step closes the card
+    ]
+    assert live is False
+
+
+def test_tool_result_user_event_does_not_open_a_new_turn() -> None:
+    # Regression: tool results arrive as ``user`` events in the Anthropic
+    # envelope. Treating every user event as a turn delimiter would split the turn
+    # at each tool call and kill the spinner on exactly the long calls the live
+    # card exists for.
+    records = [
+        _user_ev("u1", "go"),
+        _asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "ls"})]),
+        _tool_result_ev("u2", "t1", "out"),
+        _asst_ev("a2", [_tool_use_block("t2", "shell", {"cmd": "pwd"})]),
+    ]
+    actions, turn_id, live = _records_to_actions(records, _AGENT, set(), None, False)
+    assert turn_id == "qwen:turn:u1"  # NOT qwen:turn:u2
+    assert {a.turn_id for a in actions} == {"qwen:turn:u1"}
+    # Exactly one running edge for the whole turn — no flicker at the tool result.
+    assert [a.status for a in actions if a.kind == "status"] == ["running"]
+    assert live is True
+
+
+def test_result_success_closes_turn_with_idle() -> None:
+    records = [
+        _user_ev("u1", "go"),
+        _asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "ls"})]),
+        _result_ev("success"),
+    ]
+    actions, turn_id, live = _records_to_actions(records, _AGENT, set(), None, False)
+    statuses = [(a.status, a.turn_id) for a in actions if a.kind == "status"]
+    assert statuses == [("running", "qwen:turn:u1"), ("idle", "qwen:turn:u1")]
+    assert turn_id is None and live is False
+
+
+def test_result_failure_closes_turn_with_failed_and_detail() -> None:
+    records = [
+        _user_ev("u1", "go"),
+        _asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "ls"})]),
+        _result_ev("error_max_turns", result="hit the turn cap"),
+    ]
+    actions, _turn_id, live = _records_to_actions(records, _AGENT, set(), None, False)
+    closing = [a for a in actions if a.kind == "status"][-1]
+    assert closing.status == "failed"
+    assert closing.output == "hit the turn cap"
+    assert live is False
+
+
+def test_result_failure_after_prose_close_still_posts_failed() -> None:
+    # A prose-only final step settles the card to idle; a late failure ``result``
+    # must override that premature idle with ``failed`` + detail rather than drop.
+    records = [
+        _user_ev("u1", "go"),
+        _asst_ev("a1", [{"type": "text", "text": "all done"}]),
+        _result_ev("error_during_execution", result="boom"),
+    ]
+    actions, turn_id, live = _records_to_actions(records, _AGENT, set(), None, False)
+    statuses = [(a.status, a.turn_id, a.output) for a in actions if a.kind == "status"]
+    assert statuses == [
+        ("running", "qwen:turn:u1", None),
+        ("idle", "qwen:turn:u1", None),
+        ("failed", "qwen:turn:u1", "boom"),
+    ]
+    assert turn_id is None and live is False
+
+
+def test_result_success_after_prose_close_does_not_repost_status() -> None:
+    # A success ``result`` after the prose ``idle`` is already settled — no
+    # duplicate idle, and certainly no spurious failed.
+    records = [
+        _user_ev("u1", "go"),
+        _asst_ev("a1", [{"type": "text", "text": "all done"}]),
+        _result_ev("success"),
+    ]
+    actions, turn_id, live = _records_to_actions(records, _AGENT, set(), None, False)
+    statuses = [(a.status, a.turn_id) for a in actions if a.kind == "status"]
+    assert statuses == [("running", "qwen:turn:u1"), ("idle", "qwen:turn:u1")]
+    assert turn_id is None and live is False
+
+
+def test_two_turns_get_disjoint_ids_and_paired_edges() -> None:
+    records = [
+        _user_ev("u1", "one"),
+        _asst_ev("a1", [{"type": "text", "text": "first"}]),
+        _result_ev("success"),
+        _user_ev("u2", "two"),
+        _asst_ev("a2", [{"type": "text", "text": "second"}]),
+        _result_ev("success"),
+    ]
+    actions, _turn_id, _live = _records_to_actions(records, _AGENT, set(), None, False)
+    statuses = [(a.status, a.turn_id) for a in actions if a.kind == "status"]
+    # The prose-only assistant closes each turn; ``result`` then finds it closed.
+    assert statuses == [
+        ("running", "qwen:turn:u1"),
+        ("idle", "qwen:turn:u1"),
+        ("running", "qwen:turn:u2"),
+        ("idle", "qwen:turn:u2"),
+    ]
+
+
+def test_new_prose_user_event_closes_a_still_open_turn() -> None:
+    # A turn interrupted by the next prompt (no ``result``) still gets its idle.
+    records = [_user_ev("u2", "actually, stop")]
+    actions, turn_id, live = _records_to_actions(records, _AGENT, set(), "qwen:turn:u1", True)
+    assert (actions[0].kind, actions[0].status, actions[0].turn_id) == (
+        "status",
+        "idle",
+        "qwen:turn:u1",
+    )
+    assert turn_id == "qwen:turn:u2" and live is False
+
+
+def test_assistant_without_open_turn_mints_one() -> None:
+    # Missed-start recovery: a forwarder attaching mid-turn still gets an id, so
+    # the rest of the turn's cards render live.
+    actions, turn_id, live = _records_to_actions(
+        [_asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "ls"})])],
+        _AGENT,
+        set(),
+        None,
+        False,
+    )
+    assert turn_id == "qwen:turn:a1"
+    assert [a.status for a in actions if a.kind == "status"] == ["running"]
+    assert live is True
+
+
+def test_running_not_re_posted_when_turn_already_live() -> None:
+    actions, _turn_id, live = _records_to_actions(
+        [_asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "ls"})])],
+        _AGENT,
+        set(),
+        "qwen:turn:u1",
+        True,
+    )
+    assert [a.kind for a in actions] == ["item"]
+    assert live is True
+
+
+def test_seen_uuids_suppress_reposted_items() -> None:
+    # A truncation rewind re-reads the file; already-posted uuids must not re-post.
+    actions, _turn_id, _live = _records_to_actions(
+        [_user_ev("u1", "go"), _asst_ev("a1", [{"type": "text", "text": "hi"}])],
+        _AGENT,
+        {"u1", "a1"},
+        None,
+        False,
+    )
+    assert [a for a in actions if a.kind == "item"] == []
+
+
+# --- raw record tail ---------------------------------------------------------
+
+
+def test_read_new_records_incremental_and_partial_line(tmp_path: Path) -> None:
     f = tmp_path / "out.ndjson"
     f.write_bytes(_ev_bytes(_user_ev("u1", "q")))
-    items, off = _read_new_events(f, 0, set(), _AGENT)
-    assert [i.uuid for i in items] == ["u1"]
+    records, off = _read_new_records(f, 0)
+    assert [r["uuid"] for r in records] == ["u1"]
     assert off == f.stat().st_size
 
     # Append a complete assistant line plus a trailing *partial* line.
@@ -128,31 +395,31 @@ def test_read_new_events_incremental_and_partial_line(tmp_path: Path) -> None:
         complete_size = f.stat().st_size
         fh.write(b'{"type":"assistant","uuid":"a2"')  # no newline yet
         fh.flush()
-    items, off2 = _read_new_events(f, off, {"u1"}, _AGENT)
-    assert [i.uuid for i in items] == ["a1"]
+    records, off2 = _read_new_records(f, off)
+    assert [r["uuid"] for r in records] == ["a1"]
     # Offset stops at the last newline — the partial line is not consumed.
     assert off2 == complete_size
 
 
-def test_read_new_events_detects_truncation(tmp_path: Path) -> None:
+def test_read_new_records_detects_truncation(tmp_path: Path) -> None:
     f = tmp_path / "out.ndjson"
     # A long first line so the stale offset exceeds the post-truncation size.
     f.write_bytes(_ev_bytes(_user_ev("u1", "first message, intentionally long " * 4)))
-    _, off = _read_new_events(f, 0, set(), _AGENT)
+    _, off = _read_new_records(f, 0)
     assert off > 0
     # A relaunched terminal truncates + writes a shorter line; size < offset
     # must rewind so the fresh content is not skipped.
     f.write_bytes(_ev_bytes(_user_ev("u2", "fresh")))
     assert f.stat().st_size < off
-    items, _ = _read_new_events(f, off, set(), _AGENT)
-    assert [i.uuid for i in items] == ["u2"]
+    records, _ = _read_new_records(f, off)
+    assert [r["uuid"] for r in records] == ["u2"]
 
 
 def test_malformed_line_tolerated(tmp_path: Path) -> None:
     f = tmp_path / "out.ndjson"
     f.write_bytes(b"not json\n" + _ev_bytes(_user_ev("u1", "ok")))
-    items, _ = _read_new_events(f, 0, set(), _AGENT)
-    assert [i.uuid for i in items] == ["u1"]
+    records, _ = _read_new_records(f, 0)
+    assert [r["uuid"] for r in records] == ["u1"]
 
 
 # --- Compaction mirror (chat-recording tail) -------------------------------
@@ -305,16 +572,20 @@ def test_bridge_submit_and_confirmation_append_jsonl(tmp_path: Path) -> None:
 
 
 def test_forward_state_roundtrip_and_clear(tmp_path: Path) -> None:
-    state = _ForwardState(offset=123, seen_uuids=["a", "b"])
+    state = _ForwardState(offset=123, seen_uuids=["a", "b"], active_turn_id="qwen:turn:u1")
     assert _write_state(tmp_path, state) is True
     loaded = _read_state(tmp_path)
     assert loaded.offset == 123
     assert loaded.seen_uuids == ["a", "b"]
+    # The open turn id survives a restart so a resumed tail rejoins the same turn
+    # instead of splitting its streaming group across two ids.
+    assert loaded.active_turn_id == "qwen:turn:u1"
     # Clearing resets the cursor so a re-created terminal starts clean.
     clear_qwen_bridge_state(tmp_path)
     cleared = _read_state(tmp_path)
     assert cleared.offset == 0
     assert cleared.seen_uuids == []
+    assert cleared.active_turn_id is None
 
 
 def test_forward_state_caps_seen_uuids(tmp_path: Path) -> None:
@@ -476,6 +747,49 @@ async def test_post_conversation_item_shape() -> None:
     }
 
 
+def _install_post_recorders(monkeypatch: pytest.MonkeyPatch, log: list[tuple]) -> None:
+    """Record item + status POSTs into one ordered log, so edge ORDER is assertable."""
+
+    async def _fake_item(_client: object, *, session_id: str, item: object) -> None:
+        log.append(("item", item.item_type, item.response_id))  # type: ignore[attr-defined]
+
+    async def _fake_status(
+        _client: object,
+        *,
+        session_id: str,
+        status: str,
+        output: str | None = None,
+        background_task_count: int | None = None,
+        response_id: str | None = None,
+    ) -> None:
+        log.append(("status", status, response_id))
+
+    monkeypatch.setattr(fwd, "_post_conversation_item", _fake_item)
+    monkeypatch.setattr(fwd, "post_external_session_status", _fake_status)
+
+
+async def _drive_forward_loop(bridge: Path, log: list[tuple], *, until: int) -> None:
+    """Run the poll loop until *until* posts land, then cancel it cleanly."""
+    task = asyncio.create_task(
+        fwd.forward_qwen_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=bridge,
+            agent_name=_AGENT,
+            poll_interval_s=0.01,
+        )
+    )
+    for _ in range(200):
+        if len(log) >= until:
+            break
+        await asyncio.sleep(0.01)
+    task.cancel()
+    # Awaiting the cancelled task must propagate CancelledError (clean teardown).
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+
 async def test_forward_loop_posts_new_events_and_persists(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -483,12 +797,98 @@ async def test_forward_loop_posts_new_events_and_persists(
     bridge.mkdir()
     events_file_path(bridge).write_bytes(_ev_bytes(_user_ev("u1", "hello")))
 
-    posted: list[str] = []
+    log: list[tuple] = []
+    _install_post_recorders(monkeypatch, log)
+    await _drive_forward_loop(bridge, log, until=1)
 
-    async def _fake_post(_client: object, *, session_id: str, item: object) -> None:
-        posted.append(item.response_id)  # type: ignore[attr-defined]
+    assert log == [("item", "message", "qwen:turn:u1")]
+    # Offset + dedup set are persisted so a restart resumes without re-posting.
+    state = _read_state(bridge)
+    assert state.offset > 0
+    assert "u1" in (state.seen_uuids or [])
+    # The turn is still open at the cursor, so its id is persisted too.
+    assert state.active_turn_id == "qwen:turn:u1"
 
-    monkeypatch.setattr(fwd, "_post_conversation_item", _fake_post)
+
+async def test_forward_loop_brackets_tool_calls_with_id_bearing_status_edges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point: a turn's tool cards ride between running/idle on ONE id.
+
+    That pairing is what makes ap-web render the cards live (spinner + elapsed
+    timer) instead of as static, already-completed cards.
+    """
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    events_file_path(bridge).write_bytes(
+        _ev_bytes(_user_ev("u1", "list files"))
+        + _ev_bytes(_asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "ls"})]))
+        + _ev_bytes(_tool_result_ev("u2", "t1", "a.txt"))
+        + _ev_bytes(_result_ev("success"))
+    )
+
+    log: list[tuple] = []
+    _install_post_recorders(monkeypatch, log)
+    await _drive_forward_loop(bridge, log, until=5)
+
+    assert log == [
+        ("item", "message", "qwen:turn:u1"),
+        ("status", "running", "qwen:turn:u1"),
+        ("item", "function_call", "qwen:turn:u1"),
+        ("item", "function_call_output", "qwen:turn:u1"),
+        ("status", "idle", "qwen:turn:u1"),
+    ]
+    # ``result`` closed the turn, so nothing is left open at the cursor.
+    assert _read_state(bridge).active_turn_id is None
+
+
+async def test_forward_loop_resumes_open_turn_after_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A restart mid-turn keeps the turn id, so the cards stay in one group."""
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    events_file_path(bridge).write_bytes(
+        _ev_bytes(_user_ev("u1", "go"))
+        + _ev_bytes(_asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "ls"})]))
+    )
+
+    log: list[tuple] = []
+    _install_post_recorders(monkeypatch, log)
+    await _drive_forward_loop(bridge, log, until=3)
+    assert _read_state(bridge).active_turn_id == "qwen:turn:u1"
+
+    # The turn's tail lands while the forwarder is down; a fresh loop picks it up.
+    with open(events_file_path(bridge), "ab") as fh:
+        fh.write(_ev_bytes(_tool_result_ev("u2", "t1", "a.txt")))
+        fh.write(_ev_bytes(_result_ev("success")))
+
+    log.clear()
+    await _drive_forward_loop(bridge, log, until=2)
+    # Resumed items keep the ORIGINAL turn id, and the orphaned running is closed.
+    assert log == [
+        ("item", "function_call_output", "qwen:turn:u1"),
+        ("status", "idle", "qwen:turn:u1"),
+    ]
+
+
+async def test_forward_loop_stalled_turn_backstop_closes_card(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A turn killed without its terminator must not spin forever."""
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    # A turn that opens a tool call and then goes silent (TUI interrupt / crash).
+    events_file_path(bridge).write_bytes(
+        _ev_bytes(_user_ev("u1", "go"))
+        + _ev_bytes(_asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "sleep 999"})]))
+    )
+
+    log: list[tuple] = []
+    _install_post_recorders(monkeypatch, log)
+    # Stub the clock rather than sleeping out the real minutes-scale backstop.
+    clock = {"t": 0.0}
+    monkeypatch.setattr(fwd, "_monotonic", lambda: clock["t"])
 
     task = asyncio.create_task(
         fwd.forward_qwen_events_to_session(
@@ -501,19 +901,75 @@ async def test_forward_loop_posts_new_events_and_persists(
         )
     )
     for _ in range(200):
-        if posted:
+        if len(log) >= 3:
+            break
+        await asyncio.sleep(0.01)
+    assert [e[1] for e in log] == ["message", "running", "function_call"]
+
+    # Jump past the backstop with no new events — the spinner gets settled.
+    clock["t"] = fwd._STALLED_TURN_IDLE_S + 1.0
+    for _ in range(200):
+        if len(log) >= 4:
             break
         await asyncio.sleep(0.01)
     task.cancel()
-    # Awaiting the cancelled task must propagate CancelledError (clean teardown).
     with pytest.raises(asyncio.CancelledError):
         _ = await task
 
-    assert posted == ["qwen:u1"]
-    # Offset + dedup set are persisted so a restart resumes without re-posting.
-    state = _read_state(bridge)
-    assert state.offset > 0
-    assert "u1" in (state.seen_uuids or [])
+    assert log[-1] == ("status", "idle", "qwen:turn:u1")
+
+
+async def test_forward_loop_backstop_settles_resumed_live_turn_without_new_events(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A crashed live turn resumed on restart must settle even if the file never grows."""
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    # The event file holds the turn's tool call but will not grow (qwen crashed).
+    events_file_path(bridge).write_bytes(
+        _ev_bytes(_user_ev("u1", "go"))
+        + _ev_bytes(_asst_ev("a1", [_tool_use_block("t1", "shell", {"cmd": "sleep 999"})]))
+    )
+    eof = events_file_path(bridge).stat().st_size
+    # Persist the live turn at EOF, exactly as the crashed process left it.
+    _write_state(
+        bridge,
+        _ForwardState(
+            offset=eof,
+            seen_uuids=["u1", "a1", "t1"],
+            active_turn_id="qwen:turn:u1",
+            turn_live=True,
+        ),
+    )
+
+    log: list[tuple] = []
+    _install_post_recorders(monkeypatch, log)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(fwd, "_monotonic", lambda: clock["t"])
+
+    task = asyncio.create_task(
+        fwd.forward_qwen_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=bridge,
+            agent_name=_AGENT,
+            poll_interval_s=0.01,
+        )
+    )
+    # No new events ever arrive; advance past the backstop window.
+    await asyncio.sleep(0.05)
+    clock["t"] = fwd._STALLED_TURN_IDLE_S + 1.0
+    for _ in range(200):
+        if log:
+            break
+        await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    # The orphaned running is closed even though the file never grew post-restart.
+    assert log == [("status", "idle", "qwen:turn:u1")]
 
 
 async def test_compaction_mirror_seeds_at_eof_and_posts_new(


### PR DESCRIPTION
## Related issue

Closes #1875

## Summary

- Extends live tool-call cards (spinner + ticking elapsed timer) to qwen-native sessions, matching claude-native (#1499). The qwen-native forwarder previously mirrored only message text, used a per-message response id, and posted no session status, so qwen's in-flight tool calls rendered as static completed cards.
- The forwarder now mirrors tool_use blocks as function_call items and tool_result blocks (which arrive as user events in the Anthropic envelope) as function_call_output items, groups each turn under a per-turn `qwen:turn:{uuid}` id, and brackets the turn with id-bearing running/idle/failed `external_session_status` edges so ap-web drives the streaming lifecycle. Turn open/close logic gates on prose-bearing user events, closes on `result` (subtype != success -> failed) with a prose-only-assistant belt-and-braces close and a stalled-turn backstop, and persists the open turn id + live flag so a supervisor restart keeps cards in one group and closes an orphaned running.

An internal adversarial review pass caught and fixed follow-up correctness issues before submission:
- omnigent/qwen_native_forwarder.py:550 (MAJOR) — stall clock now seeds to _monotonic() when resuming a live turn, so the backstop can fire on a restart-resumed orphaned running even when the crashed qwen never grows the event file again
- omnigent/qwen_native_forwarder.py:407 (MINOR) — result branch now posts `failed`+detail when subtype != success and turn_id is set even if `live` was already cleared by the prose belt-and-braces idle, so a late failure overrides the premature success

## Test Plan

- `pytest tests/test_qwen_native_forwarder.py -q` — 51 passed (18 new tests covering the converter, per-turn ids, status-edge ordering, state persistence, mid-turn restart resume, and the stalled-turn backstop).
- Regression: `pytest tests/test_qwen_native.py tests/test_qwen_native_bridge.py tests/test_qwen_native_permissions.py tests/test_qwen_native_resume.py tests/test_native_forwarder_health.py tests/test_native_post_delivery.py -q` — 97 passed, 1 skipped.
- Combined run: 148 passed, 1 skipped.
- `pre-commit run --files omnigent/qwen_native_forwarder.py tests/test_qwen_native_forwarder.py docs/QWEN_FOLLOWUPS.md` — clean (ruff format + check pass).
- Demo: N/A — forwarder/server-side change with no direct UI code in this diff (the web rendering shipped harness-agnostic in #1499).

**Post-review verification:** .venv/bin/python -m pytest tests/test_qwen_native_forwarder.py -q → 54 passed in 1.06s

## Demo

N/A — no UI surface in this diff.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

See verification_honesty field above.

## Changelog

Qwen-native sessions now show live tool-call cards (spinner + elapsed timer) while tools run, instead of static completed cards.
