### PR TITLE
feat(cli): render cursor-native tool calls as live cards

### DIFF
--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -19,16 +19,26 @@ that store, extract new user/assistant messages, and POST them as
 ``external_conversation_item`` events — which also seeds the session title from
 the first user message (the same hook claude/codex rely on).
 
-The web-facing ``running``/``idle`` *spinner* edges are intentionally NOT posted
-here: the runner's PTY-activity watcher owns those ``session.status`` edges for
-cursor-native (see ``_publish_turn_status`` in :mod:`omnigent.runner.app`),
-exactly as for claude-native and pi-native. That watcher drives only the web
-"Working…" spinner, though — it never wakes a parent orchestrator. So this
-forwarder additionally POSTs an ``external_session_status: idle`` event once per
-completed turn (the cursor ``stop`` hook's turn-end markers, tailed via
+The generic, turn-agnostic "Working…" *spinner* badge is still owned by the
+runner's PTY-activity watcher for cursor-native (see ``_publish_turn_status`` in
+:mod:`omnigent.runner.app`), exactly as for claude-native and pi-native — that
+id-less edge never wakes a parent orchestrator, so this forwarder additionally
+POSTs an ``external_session_status: idle`` event once per completed turn (the
+cursor ``stop`` hook's turn-end markers, tailed via
 :mod:`omnigent.cursor_native_status`) — the SAME server contract
 claude-/codex-/opencode-native use to mark a sub-agent turn terminal and wake its
 parent's inbox.
+
+**Live tool-call cards**: the forwarder also mirrors cursor's committed
+``tool-call`` / ``tool-result`` content parts as ``function_call`` /
+``function_call_output`` items, stamps every item of one assistant turn with a
+shared per-turn ``response_id`` (``cursor:turn:<blob_id>``), and POSTs a
+``running`` status edge carrying that id before the turn's first item. That
+id-bearing edge is what makes the web UI render cursor's in-flight tool calls
+LIVE (spinner + ticking timer) instead of as static completed cards; the closing
+``idle`` edge (driven by the ``stop`` hook) carries the same id so the cards
+settle. The open turn is rebuilt from persisted state on a supervisor restart so
+a resumed turn rejoins its streaming group without re-posting ``running``.
 """
 
 from __future__ import annotations
@@ -42,13 +52,16 @@ import os
 import re
 import sqlite3
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import httpx
 
 from omnigent import cursor_native_status
-from omnigent._native_post_delivery import post_may_have_been_delivered
+from omnigent._native_post_delivery import (
+    post_external_session_status,
+    post_may_have_been_delivered,
+)
 from omnigent.cursor_native_bridge import FORK_HISTORY_CLOSE_TAG, FORK_HISTORY_OPEN_TAG
 
 _logger = logging.getLogger(__name__)
@@ -70,6 +83,16 @@ _POST_TIMEOUT_S = 30.0
 #: theory alias two blobs onto one id — that only groups two messages under one UI
 #: response, never data loss.
 _RESPONSE_ID_MAX_LEN = 64
+
+#: Prefix for the per-turn ``response_id`` shared by every item of one assistant
+#: turn (the user bubble keeps its own per-blob id). Stamping a turn's mirrored
+#: ``function_call`` items with this id — and posting a ``running`` status edge
+#: carrying the same id before the turn's first item — is what makes the web UI
+#: render cursor's in-flight tool calls LIVE (spinner + ticking timer) instead of
+#: as static, already-completed cards. ``cursor:turn:`` + a 64-char blob hash
+#: overflows the ``VARCHAR(64)`` column, so the id is capped exactly like the
+#: per-blob one (see :data:`_RESPONSE_ID_MAX_LEN`).
+_TURN_ID_PREFIX = "cursor:turn:"
 
 #: Consecutive server rejections (a 4xx, or a 5xx such as a failed DB insert) of
 #: a single mirror item the poll loop tolerates before it logs and skips past
@@ -156,12 +179,21 @@ class _ForwardState:
     :param heartbeat_ms: Wall-clock ms of the last persist. A sibling reads this
         to tell a live owner from a dead session's leftover claim (see
         :func:`_chat_claimed_by_other`). Stamped by :func:`_write_state`.
+    :param turn_response_id: The open assistant turn's shared ``response_id``
+        (``cursor:turn:<blob_id>``), or ``None`` when no turn is open. Persisted
+        so a supervisor restart rejoins the in-flight turn's streaming group and
+        keeps stamping the same id on its remaining items.
+    :param turn_live: Whether a ``running`` status edge for ``turn_response_id``
+        was posted and not yet closed. Persisted so a restart does not re-post a
+        ``running`` edge the previous run already opened.
     """
 
     store_path: str | None = None
     last_rowid: int = 0
     launch_epoch_ms: int = 0
     heartbeat_ms: int = 0
+    turn_response_id: str | None = None
+    turn_live: bool = False
 
 
 @dataclass
@@ -192,11 +224,15 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
     last_rowid = data.get("last_rowid")
     launch_epoch_ms = data.get("launch_epoch_ms")
     heartbeat_ms = data.get("heartbeat_ms")
+    turn_response_id = data.get("turn_response_id")
+    turn_live = data.get("turn_live")
     return _ForwardState(
         store_path=store_path if isinstance(store_path, str) else None,
         last_rowid=last_rowid if isinstance(last_rowid, int) else 0,
         launch_epoch_ms=launch_epoch_ms if isinstance(launch_epoch_ms, int) else 0,
         heartbeat_ms=heartbeat_ms if isinstance(heartbeat_ms, int) else 0,
+        turn_response_id=turn_response_id if isinstance(turn_response_id, str) else None,
+        turn_live=bool(turn_live),
     )
 
 
@@ -217,6 +253,8 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> bool:
                     "store_path": state.store_path,
                     "last_rowid": state.last_rowid,
                     "launch_epoch_ms": state.launch_epoch_ms,
+                    "turn_response_id": state.turn_response_id,
+                    "turn_live": state.turn_live,
                     # Stamp the heartbeat at persist time so every poll refreshes
                     # the chat claim; a peer treats a claim older than
                     # ``_CLAIM_FRESH_MS`` as a dead session it may take over.
@@ -446,6 +484,85 @@ def _content_text(content: object) -> str:
     return ""
 
 
+def _extract_tool_calls(content: object) -> list[tuple[str, str, str]]:
+    """Extract committed tool calls from a cursor assistant blob's ``content``.
+
+    cursor records a tool call as a ``{"type": "tool-call", "toolCallId": …,
+    "toolName": …, "args": …}`` content part (verified against cursor-agent's
+    ``store.db``). An auto-run / approved call lands as clean JSON in a
+    ``blobs`` row, so the forwarder's existing ``json.loads`` already sees it.
+
+    :param content: The parsed ``content`` value (a part list, or anything else
+        which yields no calls).
+    :returns: ``(tool_call_id, tool_name, arguments_json)`` triples in order.
+    """
+    if not isinstance(content, list):
+        return []
+    calls: list[tuple[str, str, str]] = []
+    for part in content:
+        if not isinstance(part, dict) or part.get("type") != "tool-call":
+            continue
+        call_id = part.get("toolCallId")
+        if not isinstance(call_id, str) or not call_id:
+            continue
+        name = part.get("toolName")
+        if not isinstance(name, str) or not name:
+            name = "tool"
+        args = part.get("args")
+        if args is None:
+            args = {}
+        try:
+            args_json = args if isinstance(args, str) else json.dumps(args, ensure_ascii=True)
+        except (TypeError, ValueError):
+            args_json = "{}"
+        calls.append((call_id, name, args_json))
+    return calls
+
+
+def _extract_tool_results(content: object) -> list[tuple[str, str]]:
+    """Extract tool results from a cursor ``role="tool"`` blob's ``content``.
+
+    cursor records a result as a ``{"type": "tool-result", "toolCallId": …,
+    "result": …}`` content part; the ``toolCallId`` matches the originating
+    ``tool-call`` so the web UI can settle the right card.
+
+    :param content: The parsed ``content`` value.
+    :returns: ``(tool_call_id, output_text)`` pairs in order; a structured
+        ``result`` is JSON-encoded so the card always shows text.
+    """
+    if not isinstance(content, list):
+        return []
+    results: list[tuple[str, str]] = []
+    for part in content:
+        if not isinstance(part, dict) or part.get("type") != "tool-result":
+            continue
+        call_id = part.get("toolCallId")
+        if not isinstance(call_id, str) or not call_id:
+            continue
+        raw = part.get("result")
+        if raw is None:
+            output = ""
+        elif isinstance(raw, str):
+            output = raw
+        else:
+            try:
+                output = json.dumps(raw, ensure_ascii=True)
+            except (TypeError, ValueError):
+                output = str(raw)
+        results.append((call_id, output))
+    return results
+
+
+def _turn_response_id(blob_id: str) -> str:
+    """Return the per-turn ``response_id`` minted from a turn's first blob id.
+
+    Capped at the ``conversation_items.response_id`` column width, exactly as the
+    per-blob id is, so a 64-char content-hash blob id can't overflow it and wedge
+    the mirror POST (see :data:`_RESPONSE_ID_MAX_LEN`).
+    """
+    return f"{_TURN_ID_PREFIX}{blob_id}"[:_RESPONSE_ID_MAX_LEN]
+
+
 def _strip_control_chars(text: str) -> str:
     """Drop C0 control bytes cursor embeds in stored prompts (keep \\n and \\t)."""
     return "".join(ch for ch in text if ch >= " " or ch in "\n\t")
@@ -474,6 +591,31 @@ class _MirrorItem:
     item_type: str
     item_data: dict[str, object]
     response_id: str
+
+
+@dataclass
+class _TurnState:
+    """Per-turn grouping state, threaded through :func:`_read_new_items`.
+
+    A turn opens on the first assistant/tool blob after a user blob and closes on
+    the next user blob; every assistant/tool item in between is stamped with one
+    shared :data:`response_id`, so the web UI groups them (and drives their live
+    streaming lifecycle) as a single response.
+
+    :param response_id: The open turn's shared id (``cursor:turn:<blob_id>``), or
+        ``None`` when no turn is open.
+    :param seen_call_ids: ``toolCallId``s already mirrored this turn — cursor can
+        write a gated call twice (a framed pending frame, then a committed row),
+        so dedup on the id keeps one card per call.
+    """
+
+    response_id: str | None = None
+    seen_call_ids: set[str] = field(default_factory=set)
+
+    def reset(self) -> None:
+        """Forget the turn (a new user blob closed it)."""
+        self.response_id = None
+        self.seen_call_ids.clear()
 
 
 def _read_blob_rows(store_path: Path, last_rowid: int) -> list[tuple[int, str, object]]:
@@ -619,39 +761,17 @@ async def _post_model_change_if_new(
         )
 
 
-def _read_new_items(store_path: Path, last_rowid: int, agent_name: str) -> list[_MirrorItem]:
-    """Read role-bearing blobs with ``rowid > last_rowid`` as conversation items.
+def _blob_role(data: object) -> str | None:
+    """Peek a blob's ``role`` (``"user"`` / ``"assistant"`` / ``"tool"``) or ``None``.
 
-    Reads the latest WAL-committed state each call so new messages surface while
-    the TUI keeps writing.
-
-    :param store_path: The cursor chat store to read.
-    :param last_rowid: High-water rowid already processed.
-    :param agent_name: Agent label stamped on assistant items.
-    :returns: New items in conversation (rowid) order; the caller advances its
-        cursor to the max rowid returned even for skipped (system/context) rows.
+    Used to open/close a turn before mapping the blob to items; a binary Merkle
+    node or non-message row yields ``None``.
     """
-    items: list[_MirrorItem] = []
-    rows = _read_blob_rows(store_path, last_rowid)
-    for rowid, blob_id, data in rows:
-        item = _blob_to_item(rowid, blob_id, data, agent_name)
-        if item is not None:
-            items.append(item)
-        else:
-            # A skipped row (system prompt, context dump, non-JSON Merkle node)
-            # still advances the cursor so it is never reconsidered: emit a
-            # sentinel carrying just the rowid.
-            items.append(_MirrorItem(rowid=rowid, item_type="", item_data={}, response_id=""))
-    return items
-
-
-def _blob_to_item(rowid: int, blob_id: str, data: object, agent_name: str) -> _MirrorItem | None:
-    """Convert one ``blobs`` row to a mirror item, or ``None`` to skip it."""
     if isinstance(data, (bytes, bytearray)):
         try:
             data = data.decode("utf-8")
         except UnicodeDecodeError:
-            return None  # binary Merkle-tree node, not a message
+            return None
     if not isinstance(data, str):
         return None
     try:
@@ -661,7 +781,89 @@ def _blob_to_item(rowid: int, blob_id: str, data: object, agent_name: str) -> _M
     if not isinstance(obj, dict):
         return None
     role = obj.get("role")
-    response_id = f"cursor:{blob_id}"[:_RESPONSE_ID_MAX_LEN]
+    return role if isinstance(role, str) else None
+
+
+def _read_new_items(
+    store_path: Path,
+    last_rowid: int,
+    agent_name: str,
+    turn: _TurnState | None = None,
+) -> list[_MirrorItem]:
+    """Read role-bearing blobs with ``rowid > last_rowid`` as conversation items.
+
+    Reads the latest WAL-committed state each call so new messages surface while
+    the TUI keeps writing. When *turn* is provided its per-turn grouping id is
+    minted on the first assistant/tool blob of a turn and stamped on every
+    assistant/tool item until the next user blob closes it, so a turn's prose,
+    tool-call and tool-result items share one ``response_id`` (the id-bearing
+    edges that drive live tool-call cards). Without *turn* every item keeps its
+    per-blob id (the pre-live behaviour).
+
+    :param store_path: The cursor chat store to read.
+    :param last_rowid: High-water rowid already processed.
+    :param agent_name: Agent label stamped on assistant items.
+    :param turn: Mutable per-turn grouping state, or ``None`` for per-blob ids.
+    :returns: New items in conversation (rowid) order; the caller advances its
+        cursor to the max rowid returned even for skipped (system/context) rows.
+    """
+    items: list[_MirrorItem] = []
+    rows = _read_blob_rows(store_path, last_rowid)
+    for rowid, blob_id, data in rows:
+        turn_rid: str | None = None
+        seen: set[str] | None = None
+        if turn is not None:
+            role = _blob_role(data)
+            if role == "user":
+                turn.reset()
+            elif role in ("assistant", "tool") and turn.response_id is None:
+                turn.response_id = _turn_response_id(blob_id)
+            turn_rid = turn.response_id
+            seen = turn.seen_call_ids
+        blob_items = _blob_to_items(rowid, blob_id, data, agent_name, turn_rid, seen)
+        if blob_items:
+            items.extend(blob_items)
+        else:
+            # A skipped row (system prompt, context dump, non-JSON Merkle node)
+            # still advances the cursor so it is never reconsidered: emit a
+            # sentinel carrying just the rowid.
+            items.append(_MirrorItem(rowid=rowid, item_type="", item_data={}, response_id=""))
+    return items
+
+
+def _blob_to_items(
+    rowid: int,
+    blob_id: str,
+    data: object,
+    agent_name: str,
+    turn_response_id: str | None = None,
+    seen_call_ids: set[str] | None = None,
+) -> list[_MirrorItem]:
+    """Convert one ``blobs`` row to zero or more mirror items.
+
+    A user blob yields at most one bubble (or a compaction-completed signal); an
+    assistant blob yields its prose bubble (if any) followed by one
+    ``function_call`` per committed ``tool-call`` part; a ``tool`` blob yields a
+    ``function_call_output`` per ``tool-result`` part. ``turn_response_id`` (when
+    set) is stamped on the assistant/tool items so a turn's cards stream live;
+    the user bubble always keeps its own per-blob id.
+    """
+    if isinstance(data, (bytes, bytearray)):
+        try:
+            data = data.decode("utf-8")
+        except UnicodeDecodeError:
+            return []  # binary Merkle-tree node, not a message
+    if not isinstance(data, str):
+        return []
+    try:
+        obj = json.loads(data)
+    except ValueError:
+        return []
+    if not isinstance(obj, dict):
+        return []
+    role = obj.get("role")
+    per_blob_id = f"cursor:{blob_id}"[:_RESPONSE_ID_MAX_LEN]
+    rid = turn_response_id or per_blob_id
     if role == "user":
         content = obj.get("content")
         # cursor writes the post-/summarize history rollup as a user blob with a
@@ -669,36 +871,72 @@ def _blob_to_item(rowid: int, blob_id: str, data: object, agent_name: str) -> _M
         # Surface it as a compaction-completed signal, not a chat bubble, so the
         # forwarder can tell the web UI the compaction actually finished.
         if isinstance(content, str) and content.startswith(_COMPACTION_SUMMARY_PREFIX):
-            return _MirrorItem(
-                rowid=rowid,
-                item_type="compaction_completed",
-                item_data={},
-                response_id=response_id,
-            )
+            return [
+                _MirrorItem(
+                    rowid=rowid,
+                    item_type="compaction_completed",
+                    item_data={},
+                    response_id=per_blob_id,
+                )
+            ]
         prompt = _unwrap_user_query(_content_text(content))
         if not prompt:
-            return None
-        return _MirrorItem(
-            rowid=rowid,
-            item_type="message",
-            item_data={"role": "user", "content": [{"type": "input_text", "text": prompt}]},
-            response_id=response_id,
-        )
+            return []
+        return [
+            _MirrorItem(
+                rowid=rowid,
+                item_type="message",
+                item_data={"role": "user", "content": [{"type": "input_text", "text": prompt}]},
+                response_id=per_blob_id,
+            )
+        ]
     if role == "assistant":
-        text = _content_text(obj.get("content")).strip()
-        if not text:
-            return None  # reasoning-only / tool-only turn with no prose
-        return _MirrorItem(
-            rowid=rowid,
-            item_type="message",
-            item_data={
-                "role": "assistant",
-                "agent": agent_name,
-                "content": [{"type": "output_text", "text": text}],
-            },
-            response_id=response_id,
-        )
-    return None  # system or other scaffolding
+        content = obj.get("content")
+        items: list[_MirrorItem] = []
+        text = _content_text(content).strip()
+        if text:
+            items.append(
+                _MirrorItem(
+                    rowid=rowid,
+                    item_type="message",
+                    item_data={
+                        "role": "assistant",
+                        "agent": agent_name,
+                        "content": [{"type": "output_text", "text": text}],
+                    },
+                    response_id=rid,
+                )
+            )
+        for call_id, name, args_json in _extract_tool_calls(content):
+            if seen_call_ids is not None:
+                if call_id in seen_call_ids:
+                    continue
+                seen_call_ids.add(call_id)
+            items.append(
+                _MirrorItem(
+                    rowid=rowid,
+                    item_type="function_call",
+                    item_data={
+                        "agent": agent_name,
+                        "name": name,
+                        "arguments": args_json,
+                        "call_id": call_id,
+                    },
+                    response_id=rid,
+                )
+            )
+        return items
+    if role == "tool":
+        return [
+            _MirrorItem(
+                rowid=rowid,
+                item_type="function_call_output",
+                item_data={"call_id": call_id, "output": output},
+                response_id=rid,
+            )
+            for call_id, output in _extract_tool_results(obj.get("content"))
+        ]
+    return []  # system or other scaffolding
 
 
 async def _patch_external_session_id(
@@ -726,30 +964,6 @@ async def _patch_external_session_id(
             "Transient error PATCHing external_session_id; session=%s — will not retry",
             session_id,
         )
-
-
-async def _post_external_session_status(
-    client: httpx.AsyncClient, *, session_id: str, status: str
-) -> None:
-    """POST one ``external_session_status`` event to the Sessions API.
-
-    For a sub-agent conversation the server maps an ``idle`` edge to a terminal
-    completion that wakes the parent orchestrator's inbox — the SAME contract
-    claude-/codex-/opencode-native use (see their ``_post_external_session_status``
-    / ``_post_status``). cursor-agent exposes turn completion only through its
-    ``stop`` hook, which records a marker
-    (:func:`omnigent.cursor_native_status.record_turn_end`); this turns that
-    marker into the authoritative wake signal. The PTY-activity watcher's
-    ``session.status: idle`` edge only drives the web spinner and never wakes a
-    parent, which is why this explicit post is required.
-
-    :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
-    """
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "external_session_status", "data": {"status": status}},
-    )
-    resp.raise_for_status()
 
 
 async def _post_conversation_item(
@@ -918,12 +1132,37 @@ async def forward_cursor_store_to_session(
     # so the cold-resume path can pass ``--resume <chatId>`` to cursor-agent.
     chat_id_patched = False
     model_state = _ModelMirrorState()
+    # Per-turn grouping + live-card lifecycle. ``turn`` mints/stamps the shared
+    # ``response_id``; ``running_posted_for`` is the turn id whose ``running``
+    # status edge is already open, so the edge posts once per turn and a restart
+    # mid-turn rejoins it without re-posting. Both are rebuilt from persisted
+    # state so a supervisor restart resumes the open turn.
+    turn = _TurnState()
+    turn.response_id = persisted.turn_response_id
+    running_posted_for: str | None = persisted.turn_response_id if persisted.turn_live else None
+
+    def _turn_state(rowid: int) -> _ForwardState:
+        """Build the persistable state for *rowid*, carrying the open-turn fields."""
+        return _ForwardState(
+            store_path=str(store_path),
+            last_rowid=rowid,
+            launch_epoch_ms=launch_epoch_ms,
+            turn_response_id=turn.response_id,
+            turn_live=running_posted_for is not None and running_posted_for == turn.response_id,
+        )
+
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
         while True:
             try:
+                # Whether this poll drained every owed item (running edge +
+                # each chat item). A ``break`` out of the mirror loop leaves the
+                # turn half-posted; the idle block below must not then consume
+                # the turn-end marker, or the still-open running card never gets
+                # its matching idle and spins forever.
+                drained_cleanly = True
                 if store_path is None or not store_path.exists():
                     # On cold resume the runner pre-seeds the bridge state with
                     # the known store path (see ``preseed_resume_state``), so we
@@ -934,14 +1173,7 @@ async def forward_cursor_store_to_session(
                     if persisted.store_path and Path(persisted.store_path).exists():
                         store_path = Path(persisted.store_path)
                         last_rowid = persisted.last_rowid
-                        _write_state(
-                            bridge_dir,
-                            _ForwardState(
-                                store_path=str(store_path),
-                                last_rowid=last_rowid,
-                                launch_epoch_ms=launch_epoch_ms,
-                            ),
-                        )
+                        _write_state(bridge_dir, _turn_state(last_rowid))
                         persisted = _ForwardState()  # consumed
                         if not chat_id_patched:
                             chat_id_val = store_path.parent.name
@@ -964,16 +1196,12 @@ async def forward_cursor_store_to_session(
                                 # A fresh store (cold resume) is a new chat:
                                 # reset the model dedupe so the new chat's
                                 # current model is re-posted (server no-ops if
-                                # unchanged).
+                                # unchanged), and drop any open-turn state left
+                                # over from the prior store.
                                 model_state = _ModelMirrorState()
-                            _write_state(
-                                bridge_dir,
-                                _ForwardState(
-                                    store_path=str(resolved),
-                                    last_rowid=last_rowid,
-                                    launch_epoch_ms=launch_epoch_ms,
-                                ),
-                            )
+                                turn.reset()
+                                running_posted_for = None
+                            _write_state(bridge_dir, _turn_state(last_rowid))
                             persisted = _ForwardState()  # consumed
                             # Persist the cursor chat id as external_session_id so
                             # a later cold resume can pass ``--resume <chatId>``
@@ -1002,7 +1230,7 @@ async def forward_cursor_store_to_session(
                         store_path = None
                     else:
                         items = await asyncio.to_thread(
-                            _read_new_items, store_path, last_rowid, agent_name
+                            _read_new_items, store_path, last_rowid, agent_name, turn
                         )
                         for item in items:
                             if item.item_type == "compaction_completed":
@@ -1048,16 +1276,41 @@ async def forward_cursor_store_to_session(
                                     )
                                 failed_rowid = failed_attempts = 0
                                 last_rowid = item.rowid
-                                _write_state(
-                                    bridge_dir,
-                                    _ForwardState(
-                                        store_path=str(store_path),
-                                        last_rowid=last_rowid,
-                                        launch_epoch_ms=launch_epoch_ms,
-                                    ),
-                                )
+                                _write_state(bridge_dir, _turn_state(last_rowid))
                                 continue
                             if item.item_type:
+                                # Open the turn's live card once, before its first
+                                # mirrored item: a ``running`` status edge carrying
+                                # the turn id makes the web UI stream that turn's
+                                # tool cards live (spinner + timer) instead of
+                                # rendering them already-completed. Only turn items
+                                # (assistant/tool) carry the ``cursor:turn:`` id; the
+                                # user bubble and compaction signal do not.
+                                if (
+                                    item.response_id.startswith(_TURN_ID_PREFIX)
+                                    and item.response_id != running_posted_for
+                                ):
+                                    try:
+                                        await post_external_session_status(
+                                            client,
+                                            session_id=session_id,
+                                            status="running",
+                                            response_id=item.response_id,
+                                        )
+                                        running_posted_for = item.response_id
+                                    except httpx.HTTPError:
+                                        # Best-effort: retry the whole item (and its
+                                        # running edge) next poll rather than mirror
+                                        # the card without the edge that makes it live.
+                                        _logger.warning(
+                                            "cursor forwarder could not post running "
+                                            "edge; retrying; session=%s rowid=%s",
+                                            session_id,
+                                            item.rowid,
+                                            exc_info=True,
+                                        )
+                                        drained_cleanly = False
+                                        break
                                 try:
                                     await _post_conversation_item(
                                         client, session_id=session_id, item=item
@@ -1097,6 +1350,7 @@ async def forward_cursor_store_to_session(
                                                 item.rowid,
                                                 failed_attempts,
                                             )
+                                            drained_cleanly = False
                                             break  # retry this item before any after it
                                         _logger.error(
                                             "cursor forwarder dropping item after %s "
@@ -1120,31 +1374,18 @@ async def forward_cursor_store_to_session(
                                             item.rowid,
                                             exc_info=True,
                                         )
+                                        drained_cleanly = False
                                         break
                             # Reached on a successful post, an ambiguous-delivery
                             # skip, a quarantine, or a non-posted sentinel row:
                             # advance past this item and reset the failure counter.
                             failed_rowid = failed_attempts = 0
                             last_rowid = item.rowid
-                            _write_state(
-                                bridge_dir,
-                                _ForwardState(
-                                    store_path=str(store_path),
-                                    last_rowid=last_rowid,
-                                    launch_epoch_ms=launch_epoch_ms,
-                                ),
-                            )
+                            _write_state(bridge_dir, _turn_state(last_rowid))
                         # Refresh the claim heartbeat every poll (even with no new
                         # items) so an idle owner keeps its claim and a peer can
                         # detect a dead session.
-                        _write_state(
-                            bridge_dir,
-                            _ForwardState(
-                                store_path=str(store_path),
-                                last_rowid=last_rowid,
-                                launch_epoch_ms=launch_epoch_ms,
-                            ),
-                        )
+                        _write_state(bridge_dir, _turn_state(last_rowid))
                         # Mirror a terminal-side model switch (TUI ``/model``)
                         # back to the web picker. Polled alongside messages so
                         # the pill tracks the same cadence as the chat view.
@@ -1169,15 +1410,23 @@ async def forward_cursor_store_to_session(
                 total_turn_ends = await asyncio.to_thread(
                     cursor_native_status.count_turn_ends, bridge_dir
                 )
-                if total_turn_ends > await asyncio.to_thread(
+                if drained_cleanly and total_turn_ends > await asyncio.to_thread(
                     cursor_native_status.read_posted_count, bridge_dir
                 ):
-                    await _post_external_session_status(
-                        client, session_id=session_id, status="idle"
+                    # Close the open turn's live card with the SAME id its running
+                    # edge carried, so the web UI settles that turn's tool cards
+                    # (spinner → done) rather than leaving them spinning; a bare
+                    # turn-agnostic edge (no open turn) still wakes the parent inbox.
+                    await post_external_session_status(
+                        client,
+                        session_id=session_id,
+                        status="idle",
+                        response_id=running_posted_for,
                     )
                     await asyncio.to_thread(
                         cursor_native_status.write_posted_count, bridge_dir, total_turn_ends
                     )
+                    running_posted_for = None
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -22,6 +22,7 @@ import httpx
 import pytest
 
 from omnigent import cursor_native_forwarder as fwd
+from omnigent import cursor_native_status
 from omnigent.cursor_native_forwarder import _persist_native_compaction_item
 
 # Real cursor chat ids are UUIDs. Use UUID-shaped ids in fixtures so the
@@ -61,6 +62,19 @@ def _user(text: str) -> dict:
 
 def _assistant(parts: list[dict]) -> dict:
     return {"role": "assistant", "content": parts}
+
+
+def _tool_call_part(call_id: str, name: str, args: dict) -> dict:
+    """One committed (auto-run / approved) cursor ``tool-call`` content part."""
+    return {"type": "tool-call", "toolCallId": call_id, "toolName": name, "args": args}
+
+
+def _tool_result(call_id: str, result: object = "ok") -> dict:
+    """A cursor ``role="tool"`` blob carrying one ``tool-result`` part."""
+    return {
+        "role": "tool",
+        "content": [{"type": "tool-result", "toolCallId": call_id, "result": result}],
+    }
 
 
 class TestUnwrapUserQuery:
@@ -143,38 +157,90 @@ class TestContentText:
         assert fwd._content_text({"weird": 1}) == ""
 
 
-class TestBlobToItem:
-    # _blob_to_item receives the raw blob payload (a JSON string, as stored).
+class TestExtractToolParts:
+    def test_extracts_each_tool_call_part(self) -> None:
+        content = [
+            {"type": "text", "text": "running it"},
+            _tool_call_part("call_1", "Shell", {"command": "ls"}),
+            _tool_call_part("call_2", "Read", {"path": "/x"}),
+        ]
+        assert fwd._extract_tool_calls(content) == [
+            ("call_1", "Shell", json.dumps({"command": "ls"})),
+            ("call_2", "Read", json.dumps({"path": "/x"})),
+        ]
+
+    def test_missing_args_become_empty_object(self) -> None:
+        content = [{"type": "tool-call", "toolCallId": "c", "toolName": "Read"}]
+        assert fwd._extract_tool_calls(content) == [("c", "Read", "{}")]
+
+    def test_missing_tool_name_falls_back(self) -> None:
+        content = [{"type": "tool-call", "toolCallId": "c", "args": {}}]
+        assert fwd._extract_tool_calls(content) == [("c", "tool", "{}")]
+
+    def test_non_dict_and_id_less_parts_are_ignored(self) -> None:
+        content = [
+            "junk",
+            {"type": "tool-call", "toolName": "Read"},
+            {"type": "text", "text": "x"},
+        ]
+        assert fwd._extract_tool_calls(content) == []
+
+    def test_string_content_has_no_tool_calls(self) -> None:
+        assert fwd._extract_tool_calls("just prose") == []
+
+    def test_extracts_tool_results(self) -> None:
+        content = [{"type": "tool-result", "toolCallId": "call_1", "result": "done"}]
+        assert fwd._extract_tool_results(content) == [("call_1", "done")]
+
+    def test_structured_tool_result_is_json_encoded(self) -> None:
+        content = [{"type": "tool-result", "toolCallId": "c", "result": {"exit": 0}}]
+        assert fwd._extract_tool_results(content) == [("c", json.dumps({"exit": 0}))]
+
+    def test_tool_result_without_payload_is_empty_text(self) -> None:
+        content = [{"type": "tool-result", "toolCallId": "c"}]
+        assert fwd._extract_tool_results(content) == [("c", "")]
+
+
+class TestBlobToItems:
+    # _blob_to_items receives the raw blob payload (a JSON string, as stored).
     @staticmethod
     def _blob(obj: object) -> str:
         return json.dumps(obj)
 
     def test_user_query_becomes_input_text_item(self) -> None:
-        item = fwd._blob_to_item(
+        items = fwd._blob_to_items(
             5, "bid", self._blob(_user("<user_query>\nhi\n</user_query>")), "cursor-native-ui"
         )
-        assert item is not None
-        assert item.item_type == "message"
-        assert item.item_data == {
+        assert len(items) == 1
+        assert items[0].item_type == "message"
+        assert items[0].item_data == {
             "role": "user",
             "content": [{"type": "input_text", "text": "hi"}],
         }
-        assert item.response_id == "cursor:bid"
+        assert items[0].response_id == "cursor:bid"
 
     def test_response_id_capped_at_column_width(self) -> None:
         # cursor's blob id is a 64-char content hash, so an un-capped
         # ``cursor:<blob_id>`` (71 chars) overflows the VARCHAR(64) column and
         # 500s the mirror POST. The response_id must stay within the column.
         blob_id = "b" * 64
-        item = fwd._blob_to_item(
+        items = fwd._blob_to_items(
             5, blob_id, self._blob(_user("<user_query>\nhi\n</user_query>")), "cursor-native-ui"
         )
-        assert item is not None
-        assert len(item.response_id) <= fwd._RESPONSE_ID_MAX_LEN
-        assert item.response_id == f"cursor:{blob_id}"[: fwd._RESPONSE_ID_MAX_LEN]
+        assert len(items) == 1
+        assert len(items[0].response_id) <= fwd._RESPONSE_ID_MAX_LEN
+        assert items[0].response_id == f"cursor:{blob_id}"[: fwd._RESPONSE_ID_MAX_LEN]
+
+    def test_turn_response_id_capped_at_column_width(self) -> None:
+        # ``cursor:turn:`` + a 64-char blob hash overflows the same column, so
+        # the per-turn id must be capped exactly like the per-blob one.
+        blob_id = "c" * 64
+        rid = fwd._turn_response_id(blob_id)
+        assert len(rid) <= fwd._RESPONSE_ID_MAX_LEN
+        assert rid == f"{fwd._TURN_ID_PREFIX}{blob_id}"[: fwd._RESPONSE_ID_MAX_LEN]
 
     def test_assistant_text_becomes_output_text_item(self) -> None:
-        item = fwd._blob_to_item(
+        items = fwd._blob_to_items(
             9,
             "bid",
             self._blob(
@@ -182,31 +248,89 @@ class TestBlobToItem:
             ),
             "agentx",
         )
-        assert item is not None
-        assert item.item_data == {
+        assert len(items) == 1
+        assert items[0].item_data == {
             "role": "assistant",
             "agent": "agentx",
             "content": [{"type": "output_text", "text": "answer"}],
         }
 
-    def test_assistant_without_prose_is_skipped(self) -> None:
-        # reasoning/tool-only turn with no text part → nothing to mirror
+    def test_tool_only_assistant_blob_yields_a_function_call(self) -> None:
+        # Regression guard: a tool-only assistant blob used to mirror NOTHING,
+        # so cursor tool calls never reached the web UI as cards at all.
+        items = fwd._blob_to_items(
+            9,
+            "bid",
+            self._blob(_assistant([_tool_call_part("call_1", "Shell", {"command": "ls"})])),
+            "agentx",
+        )
+        assert len(items) == 1
+        assert items[0].item_type == "function_call"
+        assert items[0].item_data == {
+            "agent": "agentx",
+            "name": "Shell",
+            "arguments": json.dumps({"command": "ls"}),
+            "call_id": "call_1",
+        }
+
+    def test_prose_then_tool_calls_are_emitted_in_order(self) -> None:
+        items = fwd._blob_to_items(
+            9,
+            "bid",
+            self._blob(
+                _assistant(
+                    [
+                        {"type": "text", "text": "let me look"},
+                        _tool_call_part("call_1", "Read", {"path": "/a"}),
+                        _tool_call_part("call_2", "Read", {"path": "/b"}),
+                    ]
+                )
+            ),
+            "agentx",
+            turn_response_id="cursor:turn:abc",
+        )
+        assert [it.item_type for it in items] == ["message", "function_call", "function_call"]
+        assert all(it.response_id == "cursor:turn:abc" for it in items)
+
+    def test_tool_result_blob_yields_function_call_output(self) -> None:
+        items = fwd._blob_to_items(
+            10,
+            "bid",
+            self._blob(_tool_result("call_1", "file contents")),
+            "agentx",
+            turn_response_id="cursor:turn:abc",
+        )
+        assert len(items) == 1
+        assert items[0].item_type == "function_call_output"
+        assert items[0].item_data == {"call_id": "call_1", "output": "file contents"}
+        assert items[0].response_id == "cursor:turn:abc"
+
+    def test_already_mirrored_call_id_is_not_re_emitted(self) -> None:
+        # cursor writes a gated call twice (framed pending, then committed).
+        # Only the committed row parses as clean JSON today, but dedupe on
+        # toolCallId so a schema change can't double-render the card.
+        seen: set[str] = set()
+        blob = self._blob(_assistant([_tool_call_part("call_1", "Shell", {})]))
+        assert len(fwd._blob_to_items(9, "b1", blob, "a", seen_call_ids=seen)) == 1
+        assert fwd._blob_to_items(10, "b2", blob, "a", seen_call_ids=seen) == []
+
+    def test_assistant_without_prose_or_tools_is_skipped(self) -> None:
+        # reasoning-only step with no text and no tool part → nothing to mirror
         assert (
-            fwd._blob_to_item(
+            fwd._blob_to_items(
                 9, "bid", self._blob(_assistant([{"type": "redacted-reasoning"}])), "a"
             )
-            is None
+            == []
         )
 
     def test_system_and_context_dump_are_skipped(self) -> None:
         assert (
-            fwd._blob_to_item(1, "bid", self._blob({"role": "system", "content": "x"}), "a")
-            is None
+            fwd._blob_to_items(1, "bid", self._blob({"role": "system", "content": "x"}), "a") == []
         )
-        assert fwd._blob_to_item(2, "bid", self._blob(_user("<user_info>\nbig dump")), "a") is None
+        assert fwd._blob_to_items(2, "bid", self._blob(_user("<user_info>\nbig dump")), "a") == []
 
     def test_binary_merkle_node_is_skipped(self) -> None:
-        assert fwd._blob_to_item(3, "bid", b"\n \x92\xc0\xa6w\xef&", "a") is None
+        assert fwd._blob_to_items(3, "bid", b"\n \x92\xc0\xa6w\xef&", "a") == []
 
     def test_summary_rollup_becomes_compaction_completed(self) -> None:
         # After /summarize finishes, cursor collapses the prior history into a
@@ -217,17 +341,78 @@ class TestBlobToItem:
         blob = self._blob(
             {"role": "user", "content": f"{fwd._COMPACTION_SUMMARY_PREFIX} Summary:\n1. ..."}
         )
-        item = fwd._blob_to_item(12, "bid", blob, "cursor-native-ui")
-        assert item is not None
-        assert item.item_type == "compaction_completed"
-        assert item.item_data == {}
+        items = fwd._blob_to_items(12, "bid", blob, "cursor-native-ui")
+        assert len(items) == 1
+        assert items[0].item_type == "compaction_completed"
+        assert items[0].item_data == {}
 
     def test_plain_string_user_without_marker_is_skipped(self) -> None:
         # A bare-string user content that ISN'T the summary rollup has no
         # <user_query> wrapper, so it is neither a chat bubble nor a compaction
         # signal — skipped, exactly as before.
         blob = self._blob({"role": "user", "content": "just some unwrapped context"})
-        assert fwd._blob_to_item(2, "bid", blob, "a") is None
+        assert fwd._blob_to_items(2, "bid", blob, "a") == []
+
+
+class TestTurnGrouping:
+    """``_read_new_items`` groups a turn's items under one ``response_id``."""
+
+    def test_turn_items_share_the_first_assistant_blobs_id(self, tmp_path: Path) -> None:
+        store = tmp_path / "store.db"
+        writer = _make_store(
+            store,
+            [
+                ("u1", _user("<user_query>\nlist files\n</user_query>")),
+                ("a1", _assistant([_tool_call_part("call_1", "Shell", {"command": "ls"})])),
+                ("t1", _tool_result("call_1", "a.txt")),
+                ("a2", _assistant([{"type": "text", "text": "there is a.txt"}])),
+            ],
+        )
+        try:
+            turn = fwd._TurnState()
+            items = fwd._read_new_items(store, 0, "agentx", turn)
+        finally:
+            writer.close()
+        posted = [it for it in items if it.item_type]
+        assert [it.item_type for it in posted] == [
+            "message",
+            "function_call",
+            "function_call_output",
+            "message",
+        ]
+        # The user bubble keeps its per-blob id; the turn's items share the id
+        # minted from the FIRST assistant blob.
+        assert posted[0].response_id == "cursor:u1"
+        assert {it.response_id for it in posted[1:]} == {"cursor:turn:a1"}
+        assert turn.response_id == "cursor:turn:a1"
+
+    def test_new_user_blob_starts_a_new_turn(self, tmp_path: Path) -> None:
+        store = tmp_path / "store.db"
+        writer = _make_store(
+            store,
+            [
+                ("u1", _user("<user_query>\none\n</user_query>")),
+                ("a1", _assistant([{"type": "text", "text": "first"}])),
+                ("u2", _user("<user_query>\ntwo\n</user_query>")),
+                ("a2", _assistant([{"type": "text", "text": "second"}])),
+            ],
+        )
+        try:
+            items = fwd._read_new_items(store, 0, "agentx", fwd._TurnState())
+        finally:
+            writer.close()
+        posted = [it for it in items if it.item_type]
+        assert posted[1].response_id == "cursor:turn:a1"
+        assert posted[3].response_id == "cursor:turn:a2"
+
+    def test_without_turn_state_ids_stay_per_blob(self, tmp_path: Path) -> None:
+        store = tmp_path / "store.db"
+        writer = _make_store(store, [("a1", _assistant([{"type": "text", "text": "hi"}]))])
+        try:
+            items = fwd._read_new_items(store, 0, "agentx")
+        finally:
+            writer.close()
+        assert items[0].response_id == "cursor:a1"
 
 
 class TestReadNewItems:
@@ -637,7 +822,7 @@ async def _drive_forwarder(
     condition is never reached within *max_ticks* — i.e. the loop wedged.
     """
     bridge_dir = tmp_path / "cursor-native" / "sess"
-    bridge_dir.mkdir(parents=True)
+    bridge_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(fwd, "_discover_store", lambda workspace, launch_ms: store)
     monkeypatch.setattr(fwd, "_chat_claimed_by_other", lambda *a, **k: False)
     monkeypatch.setattr(fwd, "_post_conversation_item", poster)
@@ -1253,3 +1438,222 @@ async def test_persist_native_compaction_item_no_store_skips_messages() -> None:
     assert body["type"] == "compaction"
     assert body["data"]["last_item_id"] == "item_abc"
     assert "compacted_messages" not in body["data"]
+
+
+class _StatusRecorder:
+    """Records ``post_external_session_status`` calls made by the poll loop."""
+
+    def __init__(self) -> None:
+        self.edges: list[tuple[str, str | None]] = []
+
+    async def __call__(
+        self,
+        client: object,
+        *,
+        session_id: str,
+        status: str,
+        response_id: str | None = None,
+        **_kw,
+    ) -> None:
+        self.edges.append((status, response_id))
+
+
+class TestForwardLoopLiveToolCards:
+    """The id-bearing status edges that make mirrored tool cards render live.
+
+    ap-web renders a ``function_call`` as an in-flight card (spinner + ticking
+    timer) only while a ``running`` status edge carrying the SAME ``response_id``
+    is open. These drive the real poll loop to pin that contract.
+    """
+
+    @staticmethod
+    def _seed_tool_turn(store: Path) -> None:
+        writer = _make_store(
+            store,
+            [
+                ("u1", _user("<user_query>\nlist files\n</user_query>")),
+                ("a1", _assistant([_tool_call_part("call_1", "Shell", {"command": "ls"})])),
+                ("t1", _tool_result("call_1", "a.txt")),
+            ],
+        )
+        writer.close()
+
+    @pytest.mark.asyncio
+    async def test_running_precedes_the_turns_first_item_and_shares_its_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = tmp_path / "store.db"
+        self._seed_tool_turn(store)
+        status = _StatusRecorder()
+        monkeypatch.setattr(fwd, "post_external_session_status", status)
+        poster = _FakePoster(lambda item: None)
+        await _drive_forwarder(
+            monkeypatch,
+            tmp_path,
+            store,
+            poster,
+            until=lambda b: fwd._read_state(b).last_rowid >= 3,
+        )
+        calls = [it for it in poster.delivered if it.item_type == "function_call"]
+        assert len(calls) == 1
+        assert calls[0].item_data["name"] == "Shell"
+        # Exactly one running edge, carrying the turn id every mirrored tool
+        # item of that turn is stamped with.
+        assert status.edges == [("running", "cursor:turn:a1")]
+        assert calls[0].response_id == "cursor:turn:a1"
+        outputs = [it for it in poster.delivered if it.item_type == "function_call_output"]
+        assert outputs[0].response_id == "cursor:turn:a1"
+        # The running edge is posted before the item it makes live.
+        assert poster.calls[0].item_data["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_stop_hook_idle_carries_the_turn_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = tmp_path / "store.db"
+        self._seed_tool_turn(store)
+        status = _StatusRecorder()
+        monkeypatch.setattr(fwd, "post_external_session_status", status)
+        poster = _FakePoster(lambda item: None)
+        marked: list[bool] = []
+
+        def until(bridge_dir: Path) -> bool:
+            # Fire the cursor stop hook's turn-end marker once the turn's items
+            # are mirrored — the authoritative close for a cursor turn.
+            if not marked and fwd._read_state(bridge_dir).last_rowid >= 3:
+                cursor_native_status.record_turn_end(bridge_dir)
+                marked.append(True)
+            return ("idle", "cursor:turn:a1") in status.edges
+
+        await _drive_forwarder(monkeypatch, tmp_path, store, poster, until=until)
+        assert status.edges == [("running", "cursor:turn:a1"), ("idle", "cursor:turn:a1")]
+
+    @pytest.mark.asyncio
+    async def test_failed_running_edge_does_not_consume_the_turn_end_marker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Draining a turn whose stop-hook turn-end marker is already present
+        # (count=1, posted=0) while the running edge's first POST fails: the
+        # idle block must NOT settle the turn on that poll (no bare
+        # ``idle(None)``), or the next poll re-opens the running card with no
+        # idle left to close it and it spins forever. Once the running edge
+        # finally posts, its matching id-bearing idle must still fire.
+        store = tmp_path / "store.db"
+        self._seed_tool_turn(store)
+        bridge_dir = tmp_path / "cursor-native" / "sess"
+        bridge_dir.mkdir(parents=True)
+        # Turn-end marker already drained from a fully-completed backlog turn.
+        cursor_native_status.record_turn_end(bridge_dir)
+
+        class _FailFirstRunning:
+            def __init__(self) -> None:
+                self.edges: list[tuple[str, str | None]] = []
+                self._running_seen = 0
+
+            async def __call__(self, client, *, session_id, status, response_id=None, **_kw):
+                if status == "running":
+                    self._running_seen += 1
+                    if self._running_seen == 1:
+                        raise httpx.ConnectError(
+                            "server unreachable", request=httpx.Request("POST", "http://test")
+                        )
+                self.edges.append((status, response_id))
+
+        status = _FailFirstRunning()
+        monkeypatch.setattr(fwd, "post_external_session_status", status)
+        poster = _FakePoster(lambda item: None)
+
+        def until(bridge_dir: Path) -> bool:
+            return (
+                fwd._read_state(bridge_dir).last_rowid >= 3
+                and cursor_native_status.read_posted_count(bridge_dir) >= 1
+            )
+
+        # Reuse the caller's pre-created bridge_dir so the seeded marker survives.
+        monkeypatch.setattr(fwd, "_discover_store", lambda workspace, launch_ms: store)
+        monkeypatch.setattr(fwd, "_chat_claimed_by_other", lambda *a, **k: False)
+        monkeypatch.setattr(fwd, "_post_conversation_item", poster)
+        task = asyncio.create_task(
+            fwd.forward_cursor_store_to_session(
+                base_url="http://test",
+                headers={},
+                session_id="conv_1",
+                bridge_dir=bridge_dir,
+                agent_name="cursor-native-ui",
+                workspace="/ws",
+                launch_epoch_ms=1_000,
+                poll_interval_s=0.001,
+            )
+        )
+        try:
+            for _ in range(2000):
+                if until(bridge_dir):
+                    break
+                await asyncio.sleep(0.001)
+            else:
+                raise AssertionError("forwarder never settled the turn (wedged?)")
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        # The turn settled with the SAME id its running edge carried, and no
+        # premature turn-agnostic idle ever leaked.
+        assert ("idle", "cursor:turn:a1") in status.edges
+        assert ("idle", None) not in status.edges
+        assert status.edges.count(("running", "cursor:turn:a1")) == 1
+        assert status.edges.count(("idle", "cursor:turn:a1")) == 1
+
+    @pytest.mark.asyncio
+    async def test_running_is_not_reposted_across_polls(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = tmp_path / "store.db"
+        self._seed_tool_turn(store)
+        status = _StatusRecorder()
+        monkeypatch.setattr(fwd, "post_external_session_status", status)
+        poster = _FakePoster(lambda item: None)
+        # Idle past the last row for many polls; the loop must not re-open the turn.
+        ticks = [0]
+
+        def until(bridge_dir: Path) -> bool:
+            if fwd._read_state(bridge_dir).last_rowid >= 3:
+                ticks[0] += 1
+            return ticks[0] > 20
+
+        await _drive_forwarder(monkeypatch, tmp_path, store, poster, until=until)
+        assert status.edges.count(("running", "cursor:turn:a1")) == 1
+
+    @pytest.mark.asyncio
+    async def test_restart_mid_turn_rejoins_id_without_reposting_running(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Turn state is persisted, so a supervisor restart mid-turn must keep
+        # stamping the SAME id on the rest of the turn (one streaming group) and
+        # must not re-POST a running edge the previous run already opened.
+        store = tmp_path / "store.db"
+        self._seed_tool_turn(store)
+        bridge_dir = tmp_path / "cursor-native" / "sess"
+        bridge_dir.mkdir(parents=True)
+        fwd._write_state(
+            bridge_dir,
+            fwd._ForwardState(
+                store_path=str(store),
+                last_rowid=2,  # the assistant tool-call row was already mirrored
+                launch_epoch_ms=1_000,
+                turn_response_id="cursor:turn:a1",
+                turn_live=True,
+            ),
+        )
+        status = _StatusRecorder()
+        monkeypatch.setattr(fwd, "post_external_session_status", status)
+        poster = _FakePoster(lambda item: None)
+        await _drive_forwarder(
+            monkeypatch,
+            tmp_path,
+            store,
+            poster,
+            until=lambda b: fwd._read_state(b).last_rowid >= 3,
+        )
+        assert [it.item_type for it in poster.delivered] == ["function_call_output"]
+        assert poster.delivered[0].response_id == "cursor:turn:a1"
+        assert status.edges == []

--- a/tests/test_cursor_native_status.py
+++ b/tests/test_cursor_native_status.py
@@ -96,12 +96,20 @@ def test_cli_record_usage_records_turn_end_on_empty_stdin(tmp_path: Path, monkey
 
 
 class _StatusRecorder:
-    """Async stub for ``_post_external_session_status`` capturing posted statuses."""
+    """Async stub for ``post_external_session_status`` capturing posted statuses."""
 
     def __init__(self) -> None:
         self.statuses: list[str] = []
 
-    async def __call__(self, client: object, *, session_id: str, status: str) -> None:
+    async def __call__(
+        self,
+        client: object,
+        *,
+        session_id: str,
+        status: str,
+        response_id: str | None = None,
+        **_kwargs: object,
+    ) -> None:
         self.statuses.append(status)
 
 
@@ -124,7 +132,7 @@ async def _drive_idle_loop(
 ) -> None:
     """Run the real poll loop with store discovery disabled so only the idle path runs."""
     monkeypatch.setattr(fwd, "_discover_store", lambda *a, **k: None)
-    monkeypatch.setattr(fwd, "_post_external_session_status", recorder)
+    monkeypatch.setattr(fwd, "post_external_session_status", recorder)
     task = asyncio.create_task(
         fwd.forward_cursor_store_to_session(
             base_url="http://test",
@@ -171,7 +179,7 @@ async def test_idle_dedupes_and_posts_per_new_turn(tmp_path: Path, monkeypatch) 
     bridge.mkdir(parents=True)
     recorder = _StatusRecorder()
     monkeypatch.setattr(fwd, "_discover_store", lambda *a, **k: None)
-    monkeypatch.setattr(fwd, "_post_external_session_status", recorder)
+    monkeypatch.setattr(fwd, "post_external_session_status", recorder)
     status.record_turn_end(bridge)  # turn 1 completes
     task = asyncio.create_task(
         fwd.forward_cursor_store_to_session(
@@ -208,7 +216,7 @@ async def test_idle_restart_safe_does_not_rewake(tmp_path: Path, monkeypatch) ->
     status.write_posted_count(bridge, 1)  # already reported this turn before the "restart"
     recorder = _StatusRecorder()
     monkeypatch.setattr(fwd, "_discover_store", lambda *a, **k: None)
-    monkeypatch.setattr(fwd, "_post_external_session_status", recorder)
+    monkeypatch.setattr(fwd, "post_external_session_status", recorder)
     task = asyncio.create_task(
         fwd.forward_cursor_store_to_session(
             base_url="http://test",


### PR DESCRIPTION
## Related issue

Closes #1873

## Summary

- cursor-native forwarder now mirrors cursor's committed `tool-call`/`tool-result` content parts as `function_call`/`function_call_output` conversation items (previously only message text was mirrored, so tool cards never appeared in the web chat).
- Every item of one assistant turn is grouped under a shared per-turn `response_id` (`cursor:turn:<blob_id>`, capped to the VARCHAR(64) column), and a `running` status edge carrying that id is posted before the turn's first item; the stop-hook-driven `idle` edge carries the same id — this is what makes the web UI render cursor's in-flight tool calls live (spinner + ticking timer) instead of as static completed cards.
- Turn state (`turn_response_id`/`turn_live`) is persisted so a supervisor restart mid-turn rejoins the streaming group without re-posting `running`; the shared `post_external_session_status` (with `response_id`) replaces the local id-less status poster.

An internal adversarial review pass caught and fixed follow-up correctness issues before submission:
- omnigent/cursor_native_forwarder.py:1306

## Test Plan

Ran `.venv/bin/python -m pytest tests/test_cursor_native_forwarder.py tests/test_cursor_native_status.py tests/test_cursor_native_permissions.py tests/test_goose_native_forwarder.py -q` → 144 passed. TDD red→green confirmed by stashing the forwarder implementation (5 new tests fail with AttributeError / assertion errors) and restoring it (all pass). `uv run pre-commit run --files <changed files>` passes (ruff format + check, etc.). No live cursor-agent / server / browser run — the live-render path is harness-agnostic and already shipped for claude-/goose-native.

**Post-review verification:** .venv/bin/python -m pytest tests/test_cursor_native_forwarder.py tests/test_cursor_native_status.py -q → 92 passed in 34.15s

## Demo

N/A — no UI surface in this diff.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

See the dedicated field above.

## Changelog

Cursor terminal tool calls now show as live cards (spinner + timer) in the web chat while they run.
