### PR TITLE
fix(cursor): map permission_mode onto SDK approval stance for headless shell

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -489,8 +489,10 @@ class CursorExecutor(Executor):
         :param skills_filter: Accepted for parity; cursor has no skill mechanism here.
         :param permission_mode: Omnigent permission stance. ``"auto"`` (default)
             and ``"bypassPermissions"`` skip web-UI elicitation for native
-            tools (policy DENY still blocks). Any other value keeps the
-            interactive per-tool approval card.
+            tools (policy DENY still blocks) and select the SDK's headless
+            approval stance (no auto_review, sandbox disabled) so native shell
+            /edit calls run without an interactive approval. Any other value
+            keeps ``auto_review`` on and the interactive per-tool approval card.
         """
         self._cwd = cwd or (os_env.cwd if os_env is not None else None)
         self._os_env_spec = os_env
@@ -685,7 +687,12 @@ class CursorExecutor(Executor):
         if state.agent is not None:
             return
         try:
-            from cursor_sdk import AsyncAgent, AsyncClient, LocalAgentOptions
+            from cursor_sdk import (
+                AsyncAgent,
+                AsyncClient,
+                LocalAgentOptions,
+                SandboxOptions,
+            )
         except ImportError as exc:
             from omnigent.onboarding.cursor_auth import CURSOR_EXTRA
             from omnigent.onboarding.extra_install import extra_install_display
@@ -715,13 +722,18 @@ class CursorExecutor(Executor):
             local_kwargs: dict[str, Any] = {
                 "cwd": cwd,
                 "custom_tools": self._make_custom_tools(tools, loop) or None,
-                # Bypass cursor's own TUI approval prompts so native tool calls
-                # reach the executor's event stream and can be gated via the
-                # web-UI elicitation card (see _evaluate_native_tool_policy).
-                # Without this cursor may pause internally for its own approval
-                # before emitting a ToolCallRequest event.
-                "auto_review": True,
             }
+            if self._permission_mode in ("auto", "bypassPermissions"):
+                # Headless stance: cursor's Local SDK cannot answer an interactive
+                # approval, so auto_review (and any host sandbox policy) makes every
+                # native shell/edit self-reject. Disable the sandbox and leave
+                # auto_review off so native tools execute; policy gates via hooks.
+                local_kwargs["sandbox_options"] = SandboxOptions(enabled=False)
+            else:
+                # Interactive stance: keep cursor's own TUI approval bypassed so
+                # native tool calls surface on the executor's event stream and are
+                # gated via the web-UI elicitation card (_evaluate_native_tool_policy).
+                local_kwargs["auto_review"] = True
             # Tell the SDK to read project-level settings (including hooks.json).
             if state.hooks_file is not None:
                 local_kwargs["setting_sources"] = ["project"]

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -156,13 +156,23 @@ def _install_fake_sdk(
             self.description = description
             self.input_schema = input_schema
 
+    class _FakeSandboxOptions:
+        def __init__(self, enabled: Any = None, **_kw: Any) -> None:
+            self.enabled = enabled
+
     class _FakeLocalAgentOptions:
         def __init__(
-            self, cwd: Any = None, custom_tools: Any = None, auto_review: Any = None, **_kw: Any
+            self,
+            cwd: Any = None,
+            custom_tools: Any = None,
+            auto_review: Any = None,
+            sandbox_options: Any = None,
+            **_kw: Any,
         ) -> None:
             self.cwd = cwd
             self.custom_tools = custom_tools
             self.auto_review = auto_review
+            self.sandbox_options = sandbox_options
             state.setdefault("local_options", []).append(self)
 
     class _FakeSendOptions:
@@ -174,6 +184,7 @@ def _install_fake_sdk(
     fake.AsyncAgent = _FakeAsyncAgent  # type: ignore[attr-defined]
     fake.CustomTool = _FakeCustomTool  # type: ignore[attr-defined]
     fake.LocalAgentOptions = _FakeLocalAgentOptions  # type: ignore[attr-defined]
+    fake.SandboxOptions = _FakeSandboxOptions  # type: ignore[attr-defined]
     fake.SendOptions = _FakeSendOptions  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "cursor_sdk", fake)
     return state
@@ -1556,6 +1567,63 @@ async def test_run_turn_native_tool_auto_mode_skips_elicitation(
 
 
 # ---------------------------------------------------------------------------
+# permission_mode -> SDK LocalAgentOptions approval stance
+# ---------------------------------------------------------------------------
+
+
+async def _local_options_for(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+    **executor_kwargs: Any,
+) -> Any:
+    """Run one turn and return the LocalAgentOptions the SDK was handed."""
+    sdk_state = _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
+    monkeypatch.delenv("RUNNER_SERVER_URL", raising=False)
+    executor = CursorExecutor(api_key="crsr_x", cwd=str(tmp_path), **executor_kwargs)
+    try:
+        _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+    local_opts = sdk_state.get("local_options", [])
+    assert local_opts, "LocalAgentOptions was never constructed"
+    return local_opts[0]
+
+
+async def test_auto_mode_disables_sdk_auto_review_and_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Default auto mode must not arm cursor's approval provider: with auto_review
+    (or a sandbox policy) on, headless SDK runs auto-reject every shell call."""
+    local = await _local_options_for(monkeypatch, tmp_path)
+    assert local.auto_review is None
+    assert local.sandbox_options is not None
+    assert local.sandbox_options.enabled is False
+
+
+async def test_bypass_permissions_disables_sdk_auto_review_and_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """bypassPermissions takes the same headless stance as auto."""
+    local = await _local_options_for(monkeypatch, tmp_path, permission_mode="bypassPermissions")
+    assert local.auto_review is None
+    assert local.sandbox_options is not None
+    assert local.sandbox_options.enabled is False
+
+
+async def test_default_mode_keeps_sdk_auto_review(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Interactive mode keeps auto_review so cursor's own TUI prompts stay
+    bypassed in favour of the executor's web-UI elicitation card."""
+    local = await _local_options_for(monkeypatch, tmp_path, permission_mode="default")
+    assert local.auto_review is True
+    assert local.sandbox_options is None
+
+
+# ---------------------------------------------------------------------------
 # preToolUse hook: .cursor/hooks.json writing and cleanup
 # ---------------------------------------------------------------------------
 
@@ -1600,11 +1668,11 @@ async def test_ensure_session_writes_hooks_json(
     # ...so it must be owner-only (the baked token is never world-readable).
     assert wrapper.stat().st_mode & 0o777 == 0o700
 
-    # auto_review=True must be passed so cursor's own TUI approval prompts
-    # are bypassed in favour of the executor's native elicitation card.
+    # The hooks wiring must not disturb the permission stance: this executor
+    # uses the default auto mode, which stays out of cursor's approval flow.
     local_opts = sdk_state.get("local_options", [])
     assert local_opts, "LocalAgentOptions was never constructed"
-    assert local_opts[0].auto_review is True
+    assert local_opts[0].auto_review is None
 
     await executor.close()
     # Both files are cleaned up on close.


### PR DESCRIPTION
## Related issue

Closes #2110

## Summary

- Map the cursor harness's existing `permission_mode` onto the SDK's LocalAgentOptions approval stance. Previously `auto_review=True` was hard-coded, so headless Local SDK runs (which cannot answer cursor's interactive approval) self-rejected every native shell/edit call regardless of permission_mode.
- Under the headless stances (`auto` default, `bypassPermissions`): omit `auto_review` and pass `SandboxOptions(enabled=False)` so native tools execute; policy DENY and the .cursor/hooks.json gate remain the backstops. Interactive (`default`) mode keeps `auto_review=True`, leaving the web-UI elicitation path untouched.
- Scope is claim #1 of the issue only. Claim #2 (stage-2 gate ignoring POLICY_ACTION_ALLOW) is already fixed on main by #2493. The issue's `SendOptions(local={"force": True})` patch was deliberately not implemented — the SDK typedoc documents `force` as a recovery path for wedged persisted runs, not an approvals bypass.

## Test Plan

Automated (offline, fake cursor_sdk): `.venv/bin/python -m pytest tests/inner/test_cursor_executor.py tests/inner/test_cursor_harness.py tests/runtime/test_cursor_spawn_env.py -q` → 104 passed. New tests assert auto/bypassPermissions pass no auto_review + SandboxOptions(enabled=False), and default mode keeps auto_review=True. pre-commit run on both changed files: clean. Manual verification of the live symptom (headless session runs `uname -a`) NOT done — requires a real CURSOR_API_KEY and live Cursor backend (cursor-sdk-e2e-dev skill); the auto-reject lives in the vendored Node bridge and is not exercisable offline. Reviewers with cursor credentials should confirm end-to-end.

## Demo

N/A — no UI surface in this diff.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Wiring-level only — see below.

## Changelog

Cursor harness headless sessions can now run shell and edit tools instead of self-rejecting every native tool call.
