### PR TITLE
fix(web): keep mobile comment box above the iOS keyboard

### DIFF
--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -279,7 +279,71 @@ function installContentWidth(width: number): void {
   } as DOMRect);
 }
 
+/**
+ * Simulate the iOS native shell and its live visual viewport. The keyboard
+ * "opens" by shrinking the visual viewport below the layout viewport
+ * (window.innerHeight); useIOSNativeKeyboardInset reads the delta. Pass
+ * visibleHeight === layoutHeight to model a closed keyboard (inset 0).
+ */
+function setIOSViewport(layoutHeight: number, visibleHeight: number): void {
+  (window as unknown as Record<string, unknown>).omnigentNative = { kind: "ios" };
+  vi.stubGlobal("innerHeight", layoutHeight);
+  vi.stubGlobal("visualViewport", {
+    offsetTop: 0,
+    height: visibleHeight,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+}
+
+function clearIOSViewport(): void {
+  delete (window as unknown as Record<string, unknown>).omnigentNative;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+// The mobile viewer is a `fixed inset-0` overlay that the iOS shell-lock (which
+// only resizes flow content inside .app-shell) can't lift above the soft
+// keyboard. It pads its own bottom by the keyboard inset so the comments panel
+// and its auto-focused textarea stay visible instead of hiding behind the
+// keyboard.
+describe("FileViewer mobile keyboard inset", () => {
+  afterEach(() => {
+    clearIOSViewport();
+  });
+
+  it("pads the overlay bottom by the keyboard inset when the iOS keyboard is open", () => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+    setIOSViewport(800, 500); // keyboard covers 300px of the 800px layout
+    renderViewer({ open: true });
+
+    expect(screen.getByTestId("file-viewer")).toHaveStyle({ paddingBottom: "300px" });
+  });
+
+  it("applies no bottom padding when the keyboard is closed", () => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+    setIOSViewport(800, 800); // visible viewport fills the layout — no keyboard
+    renderViewer({ open: true });
+
+    expect(screen.getByTestId("file-viewer").style.paddingBottom).toBe("");
+  });
+
+  it("applies no bottom padding off the iOS shell even when the viewport shrinks", () => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+    // A shrunk visual viewport but no iOS shell marker: the browser/Electron
+    // keyboard is handled by normal layout, so the overlay must not pad itself.
+    vi.stubGlobal("innerHeight", 800);
+    vi.stubGlobal("visualViewport", {
+      offsetTop: 0,
+      height: 500,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    renderViewer({ open: true });
+
+    expect(screen.getByTestId("file-viewer").style.paddingBottom).toBe("");
+  });
+});
 
 describe("FileViewer comments panel open/close semantics", () => {
   it("keeps the panel closed on fresh open even when the file has comments", () => {

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -78,6 +78,7 @@ import { CommentSenderProvider, useOptionalCommentSender } from "@/hooks/Comment
 import { markCommentsSeen } from "@/hooks/useSeenComments";
 import { useChatStore } from "@/store/chatStore";
 import { useResizablePanel } from "@/hooks/useResizablePanel";
+import { useIOSNativeKeyboardInset } from "@/hooks/useIOSNativeKeyboardInset";
 import { useWorkspaceChangedFiles } from "@/hooks/useWorkspaceChangedFiles";
 import { cn } from "@/lib/utils";
 import { readFileViewPreferences, writeFileViewPreferences } from "@/lib/fileViewPreferences";
@@ -353,6 +354,13 @@ function FileViewerBody({
     50,
     frameless ? undefined : minWidthPx,
   );
+  // The mobile viewer is a `fixed inset-0` overlay, so the iOS shell-lock
+  // (useIOSViewportLock) — which only resizes flow content inside .app-shell —
+  // doesn't lift it above the soft keyboard. Pad the overlay's bottom by the
+  // keyboard inset so the comments panel and its (auto-focused) textarea stay
+  // visible. No-op off iOS / with the keyboard closed. Not needed frameless
+  // (embedded in the desktop aside, never a fixed overlay).
+  const keyboardInset = useIOSNativeKeyboardInset(!frameless && open);
   const fileQuery = useFileContent(conversationId, path);
   const diffQuery = useFileDiff(conversationId, path);
   const changedFiles = useWorkspaceChangedFiles(conversationId);
@@ -1493,7 +1501,7 @@ function FileViewerBody({
   return (
     <aside
       data-testid="file-viewer"
-      style={{ width: panelWidth }}
+      style={{ width: panelWidth, paddingBottom: keyboardInset || undefined }}
       className={cn(
         "flex flex-col overflow-hidden bg-card transition-[translate,border-color,border-width] duration-150 ease-out",
         // Mobile (default): fixed full-screen overlay, slide via translate-x.


### PR DESCRIPTION
## Related issue

N/A

## Summary

On the iOS native app, commenting on a file was nearly impossible: when you selected text to comment, the on-screen keyboard covered the bottom half of the screen — including the comments panel and its auto-focused textarea — and the page couldn't be scrolled far enough to bring the input into view.

- The mobile file viewer is a `position: fixed; inset-0` overlay. The existing iOS keyboard handling (`useIOSViewportLock`) only resizes flow content inside `.app-shell`, so it can't lift a fixed overlay above the keyboard — the overlay's bottom (where the comments panel lives) stays behind it.
- Fix: pad the mobile overlay's bottom by the keyboard inset, using the existing `useIOSNativeKeyboardInset` hook that `TerminalsPanel` already uses for exactly this "fixed, full-viewport overlay the shell-lock doesn't resize" case. The flex-col overlay then shrinks its content box, pushing the comments panel and textarea up into the visible area.
- No-op off the iOS shell, on desktop, and when the keyboard is closed (inset is `0`).

## Test Plan

- Added 3 unit tests in `FileViewer.test.tsx` simulating the iOS shell + a keyboard-shrunk `visualViewport`: asserts the overlay gets `padding-bottom` equal to the keyboard inset when open, no padding when the keyboard is closed, and no padding off the iOS shell even if the viewport shrinks.
- `cd web && npm test` — full suite green (4172 passed).
- `cd web && npm run build` — `tsc -b && vite build` clean.
- `npm run type-check`, `npx oxlint`, `npx prettier --check` clean (only a pre-existing `no-shadow` warning unrelated to this change).

This only affects the iOS-native app path (`isIOSShell()`); plain mobile-web Safari/Chrome and Android have no equivalent viewport lock and would need a separate change.

## Demo

N/A — behavior only reproduces on the iOS native app (WKWebView + soft keyboard); covered by unit tests simulating the visual viewport. Recommend an on-device check: open a file, select text to comment, confirm the comment box rises above the keyboard.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the padding logic across all three states (keyboard open on iOS, keyboard closed, non-iOS). The visual result on a real device isn't automatable in this repo's web test env; on-device verification is recommended before release.

## Changelog

Fixed the comment box being hidden behind the keyboard when commenting on a file in the iOS app

This pull request and its description were written by Isaac.
