### PR TITLE
perf(web): replace GET /v1/hosts 10s poll with WS push

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -70,6 +70,7 @@ from omnigent.server.routes.session_mcp_servers import create_session_mcp_server
 from omnigent.server.routes.session_policies import create_session_policies_router
 from omnigent.server.routes.sessions import (
     SessionLiveness,
+    announce_hosts_changed,
     create_sessions_router,
     set_server_runner_router,
 )
@@ -2458,6 +2459,12 @@ def create_app(
         from omnigent.server.routes.host_tunnel import create_host_tunnel_router
         from omnigent.server.routes.hosts import create_hosts_router
 
+        async def _on_host_connect(_host_id: str, owner: str | None) -> None:
+            announce_hosts_changed(owner)
+
+        async def _on_host_disconnect(_host_id: str, owner: str | None) -> None:
+            announce_hosts_changed(owner)
+
         app.include_router(
             create_host_tunnel_router(
                 host_registry,
@@ -2465,6 +2472,8 @@ def create_app(
                 auth_provider=auth_provider,
                 runner_exit_reports=runner_exit_reports,
                 on_runner_exited=_on_runner_exited,
+                on_host_connect=_on_host_connect,
+                on_host_disconnect=_on_host_disconnect,
             ),
             prefix="/v1",
             tags=["hosts"],

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -66,8 +66,8 @@ def create_host_tunnel_router(
     host_store: HostStore,
     *,
     auth_provider: AuthProvider | None = None,
-    on_host_connect: Callable[[str], Awaitable[None]] | None = None,
-    on_host_disconnect: Callable[[str], Awaitable[None]] | None = None,
+    on_host_connect: Callable[[str, str | None], Awaitable[None]] | None = None,
+    on_host_disconnect: Callable[[str, str | None], Awaitable[None]] | None = None,
     on_runner_exited: Callable[[str, str], Awaitable[None]] | None = None,
     local_single_user: bool | None = None,
     runner_exit_reports: RunnerExitReports | None = None,
@@ -273,7 +273,7 @@ def create_host_tunnel_router(
             if on_host_connect is not None:
                 try:
                     await asyncio.wait_for(
-                        on_host_connect(host_id),
+                        on_host_connect(host_id, tunnel_owner),
                         timeout=30.0,
                     )
                 except asyncio.TimeoutError:
@@ -309,7 +309,7 @@ def create_host_tunnel_router(
                 await asyncio.to_thread(host_store.set_offline, host_id)
                 if on_host_disconnect is not None:
                     try:
-                        await on_host_disconnect(host_id)
+                        await on_host_disconnect(host_id, tunnel_owner)
                     except Exception:
                         _logger.exception(
                             "on_host_disconnect callback failed for %s",
@@ -328,7 +328,7 @@ def create_host_tunnel_router(
                 await asyncio.to_thread(host_store.set_offline, host_id)
                 if on_host_disconnect is not None:
                     try:
-                        await on_host_disconnect(host_id)
+                        await on_host_disconnect(host_id, tunnel_owner)
                     except Exception:
                         _logger.exception(
                             "on_host_disconnect callback failed for %s",

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -1106,6 +1106,20 @@ def _announce_session_added(user_id: str | None, session_id: str) -> None:
     )
 
 
+def announce_hosts_changed(user_id: str | None) -> None:
+    """
+    Push a ``hosts_changed`` event to a user's session-updates streams.
+
+    Called when a host owned by ``user_id`` connects or disconnects so the
+    client invalidates its hosts cache without polling. A no-op when the user
+    has no stream connected.
+
+    :param user_id: Owner of the host that changed, or ``None`` in
+        single-user mode.
+    """
+    user_session_stream.publish(_discovery_key(user_id), {"type": "hosts_changed"})
+
+
 # Per-session todo cache updated by external_session_todos events from the
 # claude-native forwarder. Used by _build_session_response to populate the
 # ``todos`` snapshot field so the panel survives page refresh.
@@ -15503,32 +15517,45 @@ def create_sessions_router(
             like any normal watched row. Idle users with no new sessions
             receive nothing — so the zero-traffic property holds."""
             async for evt in user_session_stream.subscribe(_discovery_key(user_id)):
-                if not isinstance(evt, dict) or evt.get("type") != "session_added":
+                if not isinstance(evt, dict):
                     continue
-                sid = evt.get("session_id")
-                if not isinstance(sid, str):
-                    continue
-                async with emit_lock:
-                    # Already watched ⇒ the normal diff already covers it.
-                    if sid in watched:
+                evt_type = evt.get("type")
+                if evt_type == "session_added":
+                    sid = evt.get("session_id")
+                    if not isinstance(sid, str):
                         continue
-                    try:
-                        items = await _fetch_watched_items([sid], user_id)
-                        if items:
-                            await _send({"type": "changed", "items": items})
-                    except WebSocketDisconnect:
-                        # Client gone mid-send — propagate to tear the stream down.
-                        raise
-                    except Exception:  # noqa: BLE001 — a failed discovery push must not kill a live stream
-                        # A transient read/send failure for one announcement
-                        # must not drop the whole stream; the session is still
-                        # discoverable on the client's next list reconcile.
-                        _logger.warning(
-                            "session-updates discovery push failed for %r; "
-                            "falling back to list reconcile",
-                            sid,
-                            exc_info=True,
-                        )
+                    async with emit_lock:
+                        # Already watched ⇒ the normal diff already covers it.
+                        if sid in watched:
+                            continue
+                        try:
+                            items = await _fetch_watched_items([sid], user_id)
+                            if items:
+                                await _send({"type": "changed", "items": items})
+                        except WebSocketDisconnect:
+                            # Client gone mid-send — propagate to tear the stream down.
+                            raise
+                        except Exception:  # noqa: BLE001 — a failed discovery push must not kill a live stream
+                            # A transient read/send failure for one announcement
+                            # must not drop the whole stream; the session is still
+                            # discoverable on the client's next list reconcile.
+                            _logger.warning(
+                                "session-updates discovery push failed for %r; "
+                                "falling back to list reconcile",
+                                sid,
+                                exc_info=True,
+                            )
+                elif evt_type == "hosts_changed":
+                    async with emit_lock:
+                        try:
+                            await _send({"type": "hosts_changed"})
+                        except WebSocketDisconnect:
+                            raise
+                        except Exception:  # noqa: BLE001
+                            _logger.warning(
+                                "hosts-changed push failed; client will rely on fallback poll",
+                                exc_info=True,
+                            )
 
         reader_task = asyncio.create_task(_reader(), name="session-updates-reader")
         ticker_task = asyncio.create_task(_ticker(), name="session-updates-ticker")

--- a/tests/e2e_ui/sessions/test_hosts_changed_push.py
+++ b/tests/e2e_ui/sessions/test_hosts_changed_push.py
@@ -1,0 +1,251 @@
+"""E2E: ``hosts_changed`` WS frame drives host badge updates without polling.
+
+Two tests that together cover the headline claim of the hosts-push change:
+
+- ``test_hosts_changed_frame_updates_host_badge`` — injecting a
+  ``hosts_changed`` frame over the session-updates WS causes the host
+  badge to reflect a new host status within the WS round-trip, far
+  below the 60 s fallback-poll cadence. A broken push path (frame not
+  forwarded by ``_discovery()``, cache not invalidated in
+  ``SessionUpdatesProvider``, ``useHosts`` not refetching on invalidate)
+  would leave the badge stale until the 60 s poll fires — timing out
+  this assertion.
+
+- ``test_host_badge_not_polled_frequently`` — after the page settles,
+  ``GET /v1/hosts`` is not called every 10 s. The old code had
+  ``refetchInterval: 10_000``; the new code uses 60 s. Zero requests
+  during a 12 s observation window distinguishes these (a restored 10 s
+  cadence produces at least one).
+
+Route-interception approach mirrors ``test_host_badge.py``:
+
+- ``GET /v1/sessions/{id}`` (snapshot) patched to inject ``host_id`` so
+  ``HostBadge`` has a host to resolve.
+- ``GET /v1/hosts`` stubbed to a controlled list so the badge name and
+  status come from a known payload that the test can swap mid-run.
+- ``GET /v1/sessions`` (list) drops the test session so the off-sidebar
+  badge renders from the patched snapshot path.
+- ``WS /v1/sessions/updates`` intercepted (not connected to the real
+  server) so the stream never pushes a live ``host_online`` signal —
+  keeping ``liveOnline === undefined`` and letting the badge fall back
+  to the ``useHosts`` status field we control. The interceptor stores
+  the ``WebSocketRoute`` object so the test can inject a
+  ``hosts_changed`` frame at will.
+- ``GET /health`` is NOT patched: the live health poll's
+  ``runner_online`` / ``host_online`` comes from the real server, but
+  since the session is not host-bound there, both fields are absent or
+  false — ``useSessionHostOnline`` will be ``undefined`` and won't
+  override the ``useHosts``-derived status.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Request, WebSocketRoute, expect
+
+_FAKE_HOST_ID = "host_push_e2e"
+_OLD_CREATED_AT = 1_700_000_000  # far in the past → outside the host-asleep grace window
+
+
+# ---------------------------------------------------------------------------
+# Shared route helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hosts_body(status: str) -> str:
+    return json.dumps(
+        {
+            "hosts": [
+                {
+                    "host_id": _FAKE_HOST_ID,
+                    "name": "push-e2e-host",
+                    "owner": "e2e",
+                    "status": status,
+                    "sandbox_provider": None,
+                }
+            ]
+        }
+    )
+
+
+def _patch_session_snapshot(page: Page, session_id: str) -> None:
+    """Inject ``host_id`` into ``GET /v1/sessions/{session_id}``."""
+
+    def _handler(route):  # type: ignore[no-untyped-def]
+        req = route.request
+        if req.method != "GET" or urlparse(req.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+        resp = route.fetch()
+        payload = resp.json()
+        payload["host_id"] = _FAKE_HOST_ID
+        payload["host_resumable"] = True
+        payload["created_at"] = _OLD_CREATED_AT
+        route.fulfill(
+            status=200,
+            headers={**resp.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _handler)
+
+
+def _patch_session_list(page: Page, session_id: str) -> None:
+    """Drop ``session_id`` from ``GET /v1/sessions`` list responses."""
+
+    def _handler(route):  # type: ignore[no-untyped-def]
+        req = route.request
+        if req.method != "GET" or urlparse(req.url).path != "/v1/sessions":
+            route.continue_()
+            return
+        resp = route.fetch()
+        payload = resp.json()
+        rows = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(rows, list):
+            payload["data"] = [r for r in rows if r.get("id") != session_id]
+        route.fulfill(
+            status=200,
+            headers={**resp.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route(re.compile(r"/v1/sessions(\?|$)"), _handler)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_hosts_changed_frame_updates_host_badge(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A ``hosts_changed`` WS frame causes the host badge to update immediately.
+
+    The test patches the browser into a host-bound view, waits for the badge
+    to reflect the initial "online" state from ``GET /v1/hosts``, then swaps
+    the stub to "offline" and injects a ``hosts_changed`` frame. The badge must
+    update to "offline" well within the 60 s fallback-poll window — proving
+    that cache invalidation (not the poll) drove the change.
+
+    A failure means the ``hosts_changed`` frame is not forwarded or not handled:
+    the badge would stay "online" until the 60 s fallback poll fires, timing
+    out this assertion.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a server-backed session.
+    """
+    base_url, session_id = seeded_session
+
+    # Capture the WS route object so we can inject frames mid-test.
+    ws_routes: list[WebSocketRoute] = []
+
+    def _handle_ws(ws: WebSocketRoute) -> None:
+        ws_routes.append(ws)
+        # Swallow client messages (watch-set frames) without connecting to the
+        # real server. The stream never pushes host_online, so liveOnline stays
+        # undefined and the badge falls back to the useHosts status field.
+        ws.on_message(lambda _msg: None)
+
+    # Register routes before navigation so they're active on first request.
+    _patch_session_snapshot(page, session_id)
+    _patch_session_list(page, session_id)
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), _handle_ws)
+
+    # Start with "online" so we can observe a transition to "offline".
+    hosts_status = {"current": "online"}
+
+    def _hosts_route(route):  # type: ignore[no-untyped-def]
+        req = route.request
+        if req.method != "GET" or urlparse(req.url).path != "/v1/hosts":
+            route.continue_()
+            return
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=_make_hosts_body(hosts_status["current"]),
+        )
+
+    page.route(re.compile(r"/v1/hosts(\?|$)"), _hosts_route)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    badge = page.get_by_test_id("host-badge")
+    expect(badge).to_be_visible(timeout=15_000)
+    expect(badge).to_have_attribute("title", "Host push-e2e-host, online", timeout=15_000)
+
+    # Flip the stub to "offline" before pushing the invalidation frame.
+    # The client will re-fetch /v1/hosts on invalidation and see the new value.
+    hosts_status["current"] = "offline"
+
+    # Inject the hosts_changed frame via the intercepted WS.
+    assert ws_routes, "WS /v1/sessions/updates never connected"
+    ws_routes[0].send(json.dumps({"type": "hosts_changed"}))
+
+    # KEY ASSERTION: badge reflects the new status well below the 60 s fallback.
+    # Only the WS-push → invalidate → refetch path delivers this fast; a dead
+    # push path would leave the badge stale and time out here.
+    expect(badge).to_have_attribute("title", "Host push-e2e-host, offline", timeout=15_000)
+
+
+def test_host_badge_not_polled_frequently(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """``GET /v1/hosts`` is not called every 10 s while the page is idle.
+
+    The old ``useHosts`` had ``refetchInterval: 10_000``; the new code uses
+    60 s. Over a 12 s observation window (comfortably inside 60 s, multiple
+    times the old 10 s cadence) an idle page must make zero list requests
+    after the initial load settles. A restored 10 s poll would produce at
+    least one.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the fixture.
+    """
+    base_url, session_id = seeded_session
+
+    hits: list[str] = []
+
+    def _track(req: Request) -> None:
+        parsed = urlparse(req.url)
+        if req.method == "GET" and parsed.path == "/v1/hosts":
+            hits.append(req.url)
+
+    page.on("request", _track)
+
+    _patch_session_snapshot(page, session_id)
+    _patch_session_list(page, session_id)
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: ws.on_message(lambda _: None))
+    page.route(
+        re.compile(r"/v1/hosts(\?|$)"),
+        lambda r: r.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=_make_hosts_body("online"),
+        ),
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    badge = page.get_by_test_id("host-badge")
+    expect(badge).to_be_visible(timeout=15_000)
+
+    # Let the initial-load burst settle (useHosts fetch + possible staleTime
+    # mount refetch) before measuring.
+    page.wait_for_timeout(5_000)
+    baseline = len(hits)
+
+    # Observe over a window longer than the old 10 s cadence but shorter than
+    # the new 60 s fallback.
+    page.wait_for_timeout(12_000)
+    new_hits = hits[baseline:]
+
+    assert new_hits == [], (
+        f"expected no GET /v1/hosts polls during 12 s idle window "
+        f"(refetchInterval should be 60 s, not 10 s), but saw {len(new_hits)}: {new_hits}"
+    )

--- a/tests/e2e_ui/sessions/test_hosts_changed_push.py
+++ b/tests/e2e_ui/sessions/test_hosts_changed_push.py
@@ -220,7 +220,9 @@ def test_host_badge_not_polled_frequently(
 
     _patch_session_snapshot(page, session_id)
     _patch_session_list(page, session_id)
-    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: ws.on_message(lambda _: None))
+    page.route_web_socket(
+        re.compile(r"/v1/sessions/updates"), lambda ws: ws.on_message(lambda _: None)
+    )
     page.route(
         re.compile(r"/v1/hosts(\?|$)"),
         lambda r: r.fulfill(

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -240,6 +240,9 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
       switch (frame.type) {
         case "heartbeat":
           return;
+        case "hosts_changed":
+          void queryClient.invalidateQueries({ queryKey: ["hosts"] });
+          return;
         case "removed":
           for (const id of frame.ids) commentsFingerprintsRef.current.delete(id);
           if (removeIdsFromCache(queryClient, frame.ids)) scheduleInvalidate();

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -54,7 +54,9 @@ export function useHosts(options: UseHostsOptions = {}) {
     queryKey: ["hosts", { includeSandbox }],
     queryFn: () => fetchHosts(includeSandbox),
     enabled,
-    staleTime: 10_000,
-    refetchInterval: enabled ? 10_000 : false,
+    staleTime: 30_000,
+    // Host status is pushed via WS (hosts_changed frame in SessionUpdatesProvider).
+    // 60 s fallback poll catches any missed events (tab backgrounded, reconnect gap).
+    refetchInterval: enabled ? 60_000 : false,
   });
 }

--- a/web/src/lib/sessionUpdatesSocket.ts
+++ b/web/src/lib/sessionUpdatesSocket.ts
@@ -24,6 +24,7 @@ export type SessionUpdatesFrame =
   | { type: "snapshot"; items: SessionListWireItem[] }
   | { type: "changed"; items: SessionListWireItem[] }
   | { type: "removed"; ids: string[] }
+  | { type: "hosts_changed" }
   | { type: "heartbeat" };
 
 type FrameListener = (frame: SessionUpdatesFrame) => void;


### PR DESCRIPTION
## Summary

`GET /v1/hosts` was polled every 10 seconds by `useHosts` (called from `HostBadge` on every session detail page and `NewChatLandingScreen`). This PR replaces the aggressive poll with a push-based approach using the existing `WS /v1/sessions/updates` stream, keeping a 60s fallback poll for resilience.

- **`host_tunnel.py`**: `on_host_connect`/`on_host_disconnect` callback signatures extended to include the host owner, avoiding a DB lookup in the callback
- **`sessions.py`**: new `announce_hosts_changed(user_id)` publishes a `hosts_changed` event via `user_session_stream`; `_discovery()` extended to forward it as a `{ type: "hosts_changed" }` WS frame to the client
- **`app.py`**: wires `on_host_connect`/`on_host_disconnect` to call `announce_hosts_changed` so the owner's open tabs invalidate their hosts cache immediately on connect/disconnect
- **`sessionUpdatesSocket.ts`**: adds `hosts_changed` to the `SessionUpdatesFrame` union
- **`SessionUpdatesProvider.tsx`**: invalidates `["hosts"]` on `hosts_changed`
- **`useHosts.ts`**: `refetchInterval` 10s → 60s (WS push handles connect/disconnect; poll catches events missed during reconnect gaps), `staleTime` 10s → 30s

## Test Plan

- Connect a host → host picker in New Chat dialog updates immediately without waiting up to 10s
- Disconnect a host → host badge on session detail page reflects offline state within the WS round-trip (~250ms) instead of up to 10s
- Verify network tab shows `GET /v1/hosts` firing once on load, then only every 60s (not 10s)
- Kill the WS connection and reconnect → hosts cache refetches via the 60s fallback

## Demo

<img width="744" height="296" alt="image" src="https://github.com/user-attachments/assets/fffda3d7-1b0c-48b2-b757-e74543df0627" />


## Type of change

- [x] Performance improvement

## Test coverage

- [x] Manual verification completed

## Coverage notes

Tested manually: host connect/disconnect events propagate via WS and invalidate the client cache. The 60s fallback poll ensures correctness if a push event is missed during a reconnect gap.