### PR TITLE
ci(benchmark): allow dispatching against a specific commit SHA

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,9 +54,9 @@ env:
 
 concurrency:
   # Never cancel a scheduled run mid-flight (each is a distinct data point).
-  # Manual dispatches get a per-run group (run_id, or the pinned sha) so
-  # repeated ad-hoc runs on the same ref never cancel each other.
-  group: benchmark-${{ github.event_name }}-${{ github.ref }}-${{ inputs.checkout_sha || github.run_id }}
+  # Manual dispatches get a per-run group (unique run_id) so repeated ad-hoc
+  # runs — even on the same ref and same pinned sha — never cancel each other.
+  group: benchmark-${{ github.event_name }}-${{ github.ref }}-${{ github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,6 +17,10 @@ on:
     - cron: "37 7 * * *" # 07:37 UTC nightly (off-peak, off the :00 mark)
   workflow_dispatch:
     inputs:
+      checkout_sha:
+        description: "Commit SHA to benchmark (blank = branch HEAD)"
+        required: false
+        default: ""
       iterations:
         description: "Requests per run"
         required: false
@@ -49,9 +53,10 @@ env:
   ITEMS: ${{ github.event_name == 'workflow_dispatch' && inputs.items_per_session || '200' }}
 
 concurrency:
-  # Never cancel a scheduled run mid-flight (each is a distinct data point);
-  # coalesce manual dispatches per ref.
-  group: benchmark-${{ github.event_name }}-${{ github.ref }}
+  # Never cancel a scheduled run mid-flight (each is a distinct data point).
+  # Manual dispatches get a per-run group (run_id, or the pinned sha) so
+  # repeated ad-hoc runs on the same ref never cancel each other.
+  group: benchmark-${{ github.event_name }}-${{ github.ref }}-${{ inputs.checkout_sha || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
@@ -98,6 +103,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Pin the benchmarked code to a specific commit when dispatched with
+          # checkout_sha; the workflow definition still comes from the trusted
+          # dispatch ref. Blank falls back to the ref's HEAD (schedule/default).
+          ref: ${{ inputs.checkout_sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
## Related issue

N/A

## Summary

Make the nightly **Benchmark** workflow dispatchable against a specific commit, so we can A/B a suspected performance regression on real CI runners instead of guessing from single scheduled runs.

- Add an optional `checkout_sha` `workflow_dispatch` input, wired into the checkout step's `ref`. Blank falls back to the ref HEAD, so the scheduled nightly run is unchanged. The workflow *definition* still comes from the trusted dispatch ref — only the benchmarked code is pinned.
- Key the manual-dispatch concurrency group on `github.run_id` so repeated ad-hoc runs on the same ref (needed to collect multiple data points per commit) no longer cancel each other. Scheduled runs still never cancel mid-flight.

Motivation: investigating a `list_sessions` benchmark swing (~45ms → ~61ms) that turned out to be a uniform ~1.3× slowdown across *all* benchmarks in one run — the signature of a slow shared runner, not a code regression. Pinning + repeat-runs lets us confirm before/after on identical commits.

## Test Plan

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/benchmark.yml'))"` — valid YAML.
- Dispatched the workflow on this branch with `checkout_sha` set to two different commits, 3× each; all 6 runs started concurrently with no cancellation (verified via `gh run list`), confirming the pinned checkout and the concurrency fix.

## Demo

N/A — CI workflow change only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification only — this is a CI workflow change with no application code. Verified by dispatching the workflow with pinned SHAs and confirming (a) the runs check out the requested commit and (b) repeated dispatches on the same ref all run without cancelling each other.

## Changelog

Add a `checkout_sha` input to the Benchmark workflow so nightly benchmarks can be run ad-hoc against a specific commit.
